### PR TITLE
feat: M2 offline-first sync

### DIFF
--- a/[id
+++ b/[id
@@ -1,1 +1,0 @@
-uid=1(DIALUP) gid=1

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,6 +22,7 @@
     "expo-linking": "~57.0.5",
     "expo-local-authentication": "~57.0.2",
     "expo-localization": "~57.0.1",
+    "expo-network": "~57.0.1",
     "expo-router": "~57.0.10",
     "expo-secure-store": "~57.0.1",
     "expo-sharing": "~57.0.8",

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -23,6 +23,7 @@ import {
 import { useGroups, useHomeSummary } from '@/data/hooks';
 import { fill, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { SyncBanner } from '@/components/SyncBanner';
 
 export default function HomeScreen() {
   const theme = useTheme();
@@ -69,6 +70,8 @@ export default function HomeScreen() {
             <Ionicons name="add" size={22} color={theme.color.text} />
           </IconButton>
         </Row>
+
+        <SyncBanner />
 
         {isGuest ? (
           <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.sm }}>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -10,6 +10,7 @@ import { Button, ThemeProvider, Text, useTheme } from '@baaki/ui';
 
 import { AuthProvider, useAuth } from '@/lib/auth';
 import { LockProvider, useLock } from '@/lib/lock';
+import { SyncProvider } from '@/sync';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -27,14 +28,16 @@ export default function RootLayout() {
       <SafeAreaProvider>
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
-            <LockProvider>
-              <ThemeProvider>
-                <StatusBar style="auto" />
-                <LockGate>
-                  <AuthGate />
-                </LockGate>
-              </ThemeProvider>
-            </LockProvider>
+            <SyncProvider>
+              <LockProvider>
+                <ThemeProvider>
+                  <StatusBar style="auto" />
+                  <LockGate>
+                    <AuthGate />
+                  </LockGate>
+                </ThemeProvider>
+              </LockProvider>
+            </SyncProvider>
           </AuthProvider>
         </QueryClientProvider>
       </SafeAreaProvider>

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
@@ -19,10 +20,19 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { useGroup, useWriteExpense } from '@/data/hooks';
+import { useGroup } from '@/data/hooks';
 import { displayName, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { clearDraft, useDraft, useRestoredDraft, useSync } from '@/sync';
+
+interface ExpenseDraft {
+  amount: string;
+  description: string;
+  splitKind: SplitKind;
+  payer: MemberId | null;
+  participants: MemberId[];
+}
 
 type SplitKind = 'equal' | 'shares' | 'percent';
 
@@ -34,9 +44,21 @@ export default function AddExpenseScreen() {
   const { profile } = useAuth();
 
   const { group, members, expenses } = useGroup(groupId);
-  const writeExpense = useWriteExpense(groupId);
+  const { mutate } = useSync();
 
   const editing = expenses.data?.find((expense) => expense.id === expenseId);
+
+  // The id is chosen here, not by the server. It seeds the remainder rotation
+  // (ADR-009), so previewing with one id and writing with another would put the
+  // extra paisa on a different person and the server would rightly reject the
+  // write as a SHARE_MISMATCH. It is also what lets this expense be created
+  // with no network at all (ADR-005).
+  const [newExpenseId] = useState(() => randomUUID());
+  const targetExpenseId = expenseId ?? newExpenseId;
+
+  // ADR-005: a crash mid-entry must not cost the user their typing.
+  const draftKey = `expense:${groupId}:${expenseId ?? 'new'}`;
+  const restored = useRestoredDraft<ExpenseDraft>(draftKey);
 
   const [amount, setAmount] = useState<bigint>(0n);
   const [description, setDescription] = useState('');
@@ -44,6 +66,7 @@ export default function AddExpenseScreen() {
   const [payer, setPayer] = useState<MemberId | null>(null);
   const [participants, setParticipants] = useState<MemberId[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
   const myMemberId = useMemo(
     () => (members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ?? null,
@@ -55,11 +78,21 @@ export default function AddExpenseScreen() {
   // "adjust state when the input changes" pattern) so the form never flashes
   // empty before the data arrives.
   const [seededFor, setSeededFor] = useState<string | null>(null);
-  const seedKey = members.data ? (editing?.currentVersion?.id ?? `new:${groupId}`) : null;
+  const seedKey =
+    members.data && !restored.loading ? (editing?.currentVersion?.id ?? `new:${groupId}`) : null;
   if (seedKey && seedKey !== seededFor) {
     setSeededFor(seedKey);
     const version = editing?.currentVersion;
-    if (version) {
+    const draft = restored.draft;
+    if (draft) {
+      // A draft outranks the saved version: it is what the user was in the
+      // middle of writing when the app went away.
+      setAmount(BigInt(draft.amount));
+      setDescription(draft.description);
+      setSplitKind(draft.splitKind);
+      setPayer(draft.payer ?? myMemberId);
+      setParticipants(draft.participants);
+    } else if (version) {
       setAmount(BigInt(version.amount));
       setDescription(version.description);
       setPayer(version.payers[0]?.member_id ?? myMemberId);
@@ -78,6 +111,13 @@ export default function AddExpenseScreen() {
   }
 
   const currency = group.data?.default_currency ?? 'INR';
+
+  // Every keystroke, debounced just enough to avoid one write per character.
+  useDraft<ExpenseDraft>(
+    draftKey,
+    { amount: amount.toString(), description, splitKind, payer, participants },
+    { enabled: seededFor !== null },
+  );
 
   const splitParams: SplitParams = useMemo(() => {
     if (splitKind === 'shares') {
@@ -106,14 +146,14 @@ export default function AddExpenseScreen() {
         currency,
         params: splitParams,
         participants,
-        seed: expenseId ?? 'draft',
+        seed: targetExpenseId,
       });
     } catch {
       return null;
     }
-  }, [amount, currency, splitParams, participants, expenseId]);
+  }, [amount, currency, splitParams, participants, targetExpenseId]);
 
-  if (group.isLoading || members.isLoading) {
+  if (group.isLoading || members.isLoading || restored.loading) {
     return (
       <Screen>
         <View style={{ padding: theme.spacing.xl }}>
@@ -137,21 +177,31 @@ export default function AddExpenseScreen() {
       setError('Choose who paid');
       return;
     }
+    setSaving(true);
     try {
-      await writeExpense.mutateAsync({
-        expenseId: expenseId ?? undefined,
+      // Straight into the durable queue: this returns as soon as the mutation
+      // is on disk, so the expense is saved whether or not there is a network.
+      await mutate(expenseId ? 'expense.update' : 'expense.create', groupId, {
+        expenseId: targetExpenseId,
         description: description.trim() || 'Expense',
         expenseDate: new Date().toISOString().slice(0, 10),
         currency,
-        amount,
+        amount: amount.toString(),
         splitParams,
         participants,
-        payers: { [payer]: amount },
-        expectedShares: preview ? Object.fromEntries(preview) : undefined,
+        payers: { [payer]: amount.toString() },
+        expectedShares: preview
+          ? Object.fromEntries([...preview].map(([id, share]) => [id, share.toString()]))
+          : undefined,
+        // Lets the server tell a concurrent edit from a normal one (TDR §4.4).
+        baseVersionNo: editing?.currentVersion?.version_no ?? null,
       });
+      await clearDraft(draftKey);
       router.back();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -323,15 +373,15 @@ export default function AddExpenseScreen() {
           label={editing ? 'Save changes' : t.save}
           size="lg"
           fullWidth
-          disabled={amount === 0n || participants.length === 0 || writeExpense.isPending}
+          disabled={amount === 0n || participants.length === 0 || saving}
           onPress={() => void submit()}
         />
 
-        {writeExpense.isPending ? <ActivityIndicator color={theme.color.brand} /> : null}
+        {saving ? <ActivityIndicator color={theme.color.brand} /> : null}
 
         <Text variant="micro" tone="faint" align="center">
-          The server recomputes every share before it is stored, so no device can push a wrong
-          number into the ledger.
+          Saved on this phone straight away, with or without a signal. The server recomputes every
+          share before it is stored, so no device can push a wrong number into the ledger.
         </Text>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -30,6 +30,7 @@ import {
 import { displayName, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { SyncBanner } from '@/components/SyncBanner';
 
 type Tab = 'expenses' | 'balances' | 'activity';
 
@@ -128,6 +129,8 @@ export default function GroupScreen() {
             <Ionicons name="ellipsis-horizontal" size={20} color={theme.color.text} />
           </IconButton>
         </Row>
+
+        <SyncBanner groupId={groupId} />
 
         {/* If the two independent balance computations ever disagree, say so
             rather than showing a number that might be wrong (ADR-004). */}

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -1,0 +1,82 @@
+/**
+ * What the app is doing about the network, said plainly.
+ *
+ * ADR-005 makes offline a normal state rather than an error, so this is not an
+ * alarm. It appears only when there is something the user might otherwise
+ * wonder about — unsent changes, or a change the server refused — and says what
+ * is true: the entry is saved, it just hasn't left the phone yet.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, View } from 'react-native';
+
+import { Card, Row, Text, useTheme } from '@baaki/ui';
+
+import { useSync } from '@/sync';
+
+export function SyncBanner({ groupId }: { groupId?: string }) {
+  const theme = useTheme();
+  const { status, queue, rejected, retry, discard } = useSync();
+
+  const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
+  const refused = groupId ? rejected.filter((item) => item.groupId === groupId) : rejected;
+
+  if (refused.length > 0) {
+    const first = refused[0];
+    return (
+      <Card style={{ backgroundColor: theme.color.negativeSoft, gap: theme.spacing.md }}>
+        <Row style={{ gap: theme.spacing.sm }}>
+          <Ionicons name="alert-circle" size={18} color={theme.color.negative} />
+          <Text variant="subheading" tone="negative">
+            One change could not be saved
+          </Text>
+        </Row>
+        <Text variant="caption" tone="muted">
+          {first?.message ?? 'The server refused this change.'}
+        </Text>
+        <Row style={{ gap: theme.spacing.lg }}>
+          <Pressable
+            onPress={() => first && void retry(first.clientMutationId)}
+            accessibilityRole="button"
+          >
+            <Text variant="caption" tone="brand">
+              Try again
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={() => first && void discard(first.clientMutationId)}
+            accessibilityRole="button"
+          >
+            <Text variant="caption" tone="muted">
+              Discard it
+            </Text>
+          </Pressable>
+        </Row>
+      </Card>
+    );
+  }
+
+  if (pending.length === 0 && status !== 'offline') return null;
+
+  const offline = status === 'offline';
+  return (
+    <Card style={{ backgroundColor: theme.color.brandSoft }}>
+      <Row style={{ gap: theme.spacing.sm }}>
+        <Ionicons
+          name={offline ? 'cloud-offline-outline' : 'sync-outline'}
+          size={18}
+          color={theme.color.brand}
+        />
+        <View style={{ flex: 1 }}>
+          <Text variant="caption" tone="brand">
+            {offline
+              ? pending.length > 0
+                ? `Offline — ${pending.length} ${pending.length === 1 ? 'change' : 'changes'} saved on this phone`
+                : 'Offline — everything here is saved on this phone'
+              : `Syncing ${pending.length} ${pending.length === 1 ? 'change' : 'changes'}…`}
+          </Text>
+        </View>
+      </Row>
+    </Card>
+  );
+}

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -1,0 +1,192 @@
+/**
+ * The native store: real SQLite, as ADR-005 asks for.
+ *
+ * Metro resolves this file everywhere except web, where `driver.web.ts` wins.
+ */
+
+import * as SQLite from 'expo-sqlite';
+
+import type { MirrorRow, QueuedMutation, SyncTable } from '@baaki/core';
+
+import type { LocalStore, StoredRow } from './store';
+
+const SCHEMA = `
+PRAGMA journal_mode = WAL;
+
+CREATE TABLE IF NOT EXISTS mirror_rows (
+  table_name TEXT NOT NULL,
+  id         TEXT NOT NULL,
+  group_id   TEXT NOT NULL,
+  seq        INTEGER NOT NULL,
+  json       TEXT NOT NULL,
+  PRIMARY KEY (table_name, id)
+);
+CREATE INDEX IF NOT EXISTS mirror_rows_group_idx ON mirror_rows (group_id, table_name);
+
+CREATE TABLE IF NOT EXISTS pending_mutations (
+  client_mutation_id TEXT PRIMARY KEY,
+  seq                INTEGER NOT NULL,
+  json               TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sync_cursors (
+  group_id TEXT PRIMARY KEY,
+  seq      INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS drafts (
+  key      TEXT PRIMARY KEY,
+  json     TEXT NOT NULL,
+  saved_at TEXT NOT NULL
+);
+`;
+
+class SqliteStore implements LocalStore {
+  private database: SQLite.SQLiteDatabase | null = null;
+  private opening: Promise<void> | null = null;
+
+  async ready(): Promise<void> {
+    if (this.database) return;
+    this.opening ??= (async () => {
+      const database = await SQLite.openDatabaseAsync('baaki.db');
+      await database.execAsync(SCHEMA);
+      this.database = database;
+    })();
+    await this.opening;
+  }
+
+  private async db(): Promise<SQLite.SQLiteDatabase> {
+    await this.ready();
+    if (!this.database) throw new Error('The local database failed to open');
+    return this.database;
+  }
+
+  async putRows(rows: readonly StoredRow[]): Promise<void> {
+    if (rows.length === 0) return;
+    const database = await this.db();
+    // One transaction: a pull is one fact, and half of it landing after a kill
+    // would leave the mirror ahead of its own cursor.
+    await database.withTransactionAsync(async () => {
+      for (const row of rows) {
+        await database.runAsync(
+          `INSERT INTO mirror_rows (table_name, id, group_id, seq, json)
+           VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT (table_name, id) DO UPDATE SET
+             group_id = excluded.group_id, seq = excluded.seq, json = excluded.json`,
+          [row.table, row.id, row.groupId, row.seq, JSON.stringify(row.row)],
+        );
+      }
+    });
+  }
+
+  async readRows(): Promise<StoredRow[]> {
+    const database = await this.db();
+    const rows = await database.getAllAsync<{
+      table_name: string;
+      id: string;
+      group_id: string;
+      seq: number;
+      json: string;
+    }>(`SELECT table_name, id, group_id, seq, json FROM mirror_rows`);
+    return rows.map((row) => ({
+      table: row.table_name as SyncTable,
+      id: row.id,
+      groupId: row.group_id,
+      seq: row.seq,
+      row: JSON.parse(row.json) as MirrorRow,
+    }));
+  }
+
+  async readCursors(): Promise<Record<string, number>> {
+    const database = await this.db();
+    const rows = await database.getAllAsync<{ group_id: string; seq: number }>(
+      `SELECT group_id, seq FROM sync_cursors`,
+    );
+    return Object.fromEntries(rows.map((row) => [row.group_id, row.seq]));
+  }
+
+  async writeCursors(cursors: Record<string, number>): Promise<void> {
+    const database = await this.db();
+    await database.withTransactionAsync(async () => {
+      for (const [groupId, seq] of Object.entries(cursors)) {
+        await database.runAsync(
+          `INSERT INTO sync_cursors (group_id, seq) VALUES (?, ?)
+           ON CONFLICT (group_id) DO UPDATE SET seq = excluded.seq`,
+          [groupId, seq],
+        );
+      }
+    });
+  }
+
+  async readQueue(): Promise<QueuedMutation[]> {
+    const database = await this.db();
+    const rows = await database.getAllAsync<{ json: string }>(
+      `SELECT json FROM pending_mutations ORDER BY seq ASC`,
+    );
+    return rows.map((row) => JSON.parse(row.json) as QueuedMutation);
+  }
+
+  async writeQueue(queue: readonly QueuedMutation[]): Promise<void> {
+    const database = await this.db();
+    await database.withTransactionAsync(async () => {
+      // `WHERE 1 = 1` for the same reason the server needs it: a bare DELETE is
+      // the kind of statement that is one typo away from deleting everything.
+      await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
+      for (const mutation of queue) {
+        await database.runAsync(
+          `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
+          [mutation.clientMutationId, mutation.seq, JSON.stringify(mutation)],
+        );
+      }
+    });
+  }
+
+  async readDraft<T>(key: string): Promise<T | null> {
+    const database = await this.db();
+    const row = await database.getFirstAsync<{ json: string }>(
+      `SELECT json FROM drafts WHERE key = ?`,
+      [key],
+    );
+    return row ? (JSON.parse(row.json) as T) : null;
+  }
+
+  async writeDraft(key: string, value: unknown): Promise<void> {
+    const database = await this.db();
+    await database.runAsync(
+      `INSERT INTO drafts (key, json, saved_at) VALUES (?, ?, ?)
+       ON CONFLICT (key) DO UPDATE SET json = excluded.json, saved_at = excluded.saved_at`,
+      [key, JSON.stringify(value), new Date().toISOString()],
+    );
+  }
+
+  async clearDraft(key: string): Promise<void> {
+    const database = await this.db();
+    await database.runAsync(`DELETE FROM drafts WHERE key = ?`, [key]);
+  }
+
+  async listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]> {
+    const database = await this.db();
+    const rows = await database.getAllAsync<{ key: string; json: string; saved_at: string }>(
+      `SELECT key, json, saved_at FROM drafts ORDER BY saved_at DESC`,
+    );
+    return rows.map((row) => ({
+      key: row.key,
+      value: JSON.parse(row.json) as unknown,
+      savedAt: row.saved_at,
+    }));
+  }
+
+  async reset(): Promise<void> {
+    const database = await this.db();
+    await database.execAsync(`
+      DELETE FROM mirror_rows WHERE 1 = 1;
+      DELETE FROM pending_mutations WHERE 1 = 1;
+      DELETE FROM sync_cursors WHERE 1 = 1;
+      DELETE FROM drafts WHERE 1 = 1;
+    `);
+  }
+}
+
+export function createLocalStore(): LocalStore {
+  return new SqliteStore();
+}

--- a/apps/mobile/src/sync/driver.web.ts
+++ b/apps/mobile/src/sync/driver.web.ts
@@ -1,0 +1,101 @@
+/**
+ * The web store.
+ *
+ * expo-sqlite's web build is WASM loaded in a worker over OPFS, which needs
+ * `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers that
+ * neither the dev server nor a plain static export sends. A guest opening an
+ * invite link (ADR-006) should not meet a blank screen over that, so web gets
+ * AsyncStorage instead. Same interface, same engine, same tests.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { QueuedMutation } from '@baaki/core';
+
+import type { LocalStore, StoredRow } from './store';
+
+const WEB_KEYS = {
+  rows: 'baaki:mirror',
+  cursors: 'baaki:cursors',
+  queue: 'baaki:queue',
+  drafts: 'baaki:drafts',
+} as const;
+
+class AsyncStorageStore implements LocalStore {
+  async ready(): Promise<void> {}
+
+  private async read<T>(key: string, fallback: T): Promise<T> {
+    const raw = await AsyncStorage.getItem(key);
+    if (!raw) return fallback;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      // A corrupt blob is not worth crashing over; the next pull rebuilds it.
+      return fallback;
+    }
+  }
+
+  async putRows(rows: readonly StoredRow[]): Promise<void> {
+    if (rows.length === 0) return;
+    const existing = await this.readRows();
+    const byKey = new Map(existing.map((row) => [`${row.table}:${row.id}`, row]));
+    for (const row of rows) byKey.set(`${row.table}:${row.id}`, row);
+    await AsyncStorage.setItem(WEB_KEYS.rows, JSON.stringify([...byKey.values()]));
+  }
+
+  readRows(): Promise<StoredRow[]> {
+    return this.read<StoredRow[]>(WEB_KEYS.rows, []);
+  }
+
+  readCursors(): Promise<Record<string, number>> {
+    return this.read<Record<string, number>>(WEB_KEYS.cursors, {});
+  }
+
+  async writeCursors(cursors: Record<string, number>): Promise<void> {
+    await AsyncStorage.setItem(WEB_KEYS.cursors, JSON.stringify(cursors));
+  }
+
+  readQueue(): Promise<QueuedMutation[]> {
+    return this.read<QueuedMutation[]>(WEB_KEYS.queue, []);
+  }
+
+  async writeQueue(queue: readonly QueuedMutation[]): Promise<void> {
+    await AsyncStorage.setItem(WEB_KEYS.queue, JSON.stringify(queue));
+  }
+
+  private drafts(): Promise<Record<string, { value: unknown; savedAt: string }>> {
+    return this.read<Record<string, { value: unknown; savedAt: string }>>(WEB_KEYS.drafts, {});
+  }
+
+  async readDraft<T>(key: string): Promise<T | null> {
+    const drafts = await this.drafts();
+    return (drafts[key]?.value as T | undefined) ?? null;
+  }
+
+  async writeDraft(key: string, value: unknown): Promise<void> {
+    const drafts = await this.drafts();
+    drafts[key] = { value, savedAt: new Date().toISOString() };
+    await AsyncStorage.setItem(WEB_KEYS.drafts, JSON.stringify(drafts));
+  }
+
+  async clearDraft(key: string): Promise<void> {
+    const drafts = await this.drafts();
+    delete drafts[key];
+    await AsyncStorage.setItem(WEB_KEYS.drafts, JSON.stringify(drafts));
+  }
+
+  async listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]> {
+    const drafts = await this.drafts();
+    return Object.entries(drafts)
+      .map(([key, entry]) => ({ key, value: entry.value, savedAt: entry.savedAt }))
+      .sort((a, b) => b.savedAt.localeCompare(a.savedAt));
+  }
+
+  async reset(): Promise<void> {
+    await AsyncStorage.multiRemove(Object.values(WEB_KEYS));
+  }
+}
+
+export function createLocalStore(): LocalStore {
+  return new AsyncStorageStore();
+}

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -1,0 +1,351 @@
+/**
+ * The sync loop (ADR-005 / TDR §4).
+ *
+ * Everything the user does becomes a mutation in a durable queue and an
+ * immediate change on screen. This engine is what eventually reconciles the two
+ * with the server — on reconnect, on foreground, and on a timer while the app
+ * is open.
+ *
+ * The rules about *what* to send and *how* to fold the answer back in live in
+ * @baaki/core, where they are property-tested without a device. What lives here
+ * is the part that genuinely needs a phone: persistence, connectivity, timers
+ * and the network call itself.
+ */
+
+import * as Network from 'expo-network';
+import {
+  applyOutcomes,
+  emptyMirror,
+  enqueue as enqueueMutation,
+  markFailed,
+  nextBatch,
+  reconcile,
+  type MirrorRow,
+  type MirrorState,
+  type MutationEnvelope,
+  type QueuedMutation,
+  type SyncChange,
+  type SyncRejectionCode,
+  type SyncTable,
+} from '@baaki/core';
+
+import { supabase } from '@/lib/supabase';
+
+import { createLocalStore, type LocalStore, type StoredRow } from './store';
+
+export type SyncStatus = 'idle' | 'syncing' | 'offline' | 'error';
+
+export interface RejectedMutation {
+  clientMutationId: string;
+  kind: string;
+  groupId: string;
+  code: SyncRejectionCode | string;
+  message: string;
+}
+
+export interface SyncState {
+  status: SyncStatus;
+  hydrated: boolean;
+  mirror: MirrorState;
+  queue: QueuedMutation[];
+  /** Mutations the server refused. They need a person, not another retry. */
+  rejected: RejectedMutation[];
+  lastSyncedAt: string | null;
+  lastError: string | null;
+}
+
+interface SyncResponseBody {
+  outcomes: {
+    clientMutationId: string;
+    status: 'applied' | 'duplicate' | 'rejected';
+    code?: string;
+    message?: string;
+  }[];
+  changes: SyncChange[];
+  cursors: Record<string, number>;
+  serverTime: string;
+}
+
+/** While the app is open and online, catch anything Realtime missed. */
+const POLL_INTERVAL_MS = 30_000;
+
+export class SyncEngine {
+  private store: LocalStore = createLocalStore();
+  private state: SyncState = {
+    status: 'idle',
+    hydrated: false,
+    mirror: emptyMirror(),
+    queue: [],
+    rejected: [],
+    lastSyncedAt: null,
+    lastError: null,
+  };
+
+  private listeners = new Set<(state: SyncState) => void>();
+  private flushing: Promise<void> | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  subscribe(listener: (state: SyncState) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => this.listeners.delete(listener);
+  }
+
+  getState(): SyncState {
+    return this.state;
+  }
+
+  private set(patch: Partial<SyncState>): void {
+    this.state = { ...this.state, ...patch };
+    for (const listener of this.listeners) listener(this.state);
+  }
+
+  /**
+   * Rebuild the mirror from disk. Until this finishes the app has no local
+   * data, which is why the UI waits on `hydrated` rather than rendering an
+   * empty ledger that would look exactly like a group with no expenses.
+   */
+  async hydrate(): Promise<void> {
+    await this.store.ready();
+    const [rows, cursors, queue] = await Promise.all([
+      this.store.readRows(),
+      this.store.readCursors(),
+      this.store.readQueue(),
+    ]);
+
+    const tables = emptyMirror().tables as Record<SyncTable, Record<string, MirrorRow>>;
+    for (const row of rows) {
+      tables[row.table] ??= {};
+      tables[row.table][row.id] = row.row;
+    }
+
+    this.set({ hydrated: true, mirror: { cursors, tables }, queue });
+  }
+
+  start(): void {
+    this.timer ??= setInterval(() => void this.flush(), POLL_INTERVAL_MS);
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /** Sign-out: nothing of the previous account may survive on the device. */
+  async clear(): Promise<void> {
+    await this.store.reset();
+    this.set({
+      mirror: emptyMirror(),
+      queue: [],
+      rejected: [],
+      status: 'idle',
+      lastError: null,
+      lastSyncedAt: null,
+    });
+  }
+
+  /**
+   * Queue a mutation and show its effect immediately. The write is persisted
+   * before this resolves, so a force-kill on the next line still syncs it.
+   */
+  async enqueue(envelope: MutationEnvelope): Promise<void> {
+    const queue = enqueueMutation(this.state.queue, envelope);
+    this.set({ queue });
+    await this.store.writeQueue(queue);
+    void this.flush();
+  }
+
+  async retry(clientMutationId: string): Promise<void> {
+    const queue = this.state.queue.map((item) =>
+      item.clientMutationId === clientMutationId
+        ? { ...item, attempts: 0, nextAttemptAt: 0, lastError: null }
+        : item,
+    );
+    this.set({
+      queue,
+      rejected: this.state.rejected.filter((item) => item.clientMutationId !== clientMutationId),
+    });
+    await this.store.writeQueue(queue);
+    void this.flush();
+  }
+
+  async discard(clientMutationId: string): Promise<void> {
+    const queue = this.state.queue.filter((item) => item.clientMutationId !== clientMutationId);
+    this.set({
+      queue,
+      rejected: this.state.rejected.filter((item) => item.clientMutationId !== clientMutationId),
+    });
+    await this.store.writeQueue(queue);
+  }
+
+  /** Push the queue and pull whatever changed. Safe to call at any time. */
+  flush(options: { groupIds?: string[] } = {}): Promise<void> {
+    // One in flight at a time: two concurrent flushes would send the same batch
+    // twice. Harmless thanks to idempotency, but it wastes a round trip and
+    // makes the outcome bookkeeping race.
+    this.flushing ??= this.runFlush(options).finally(() => {
+      this.flushing = null;
+    });
+    return this.flushing;
+  }
+
+  private async runFlush(options: { groupIds?: string[] }): Promise<void> {
+    if (!this.state.hydrated) await this.hydrate();
+
+    const online = await isOnline();
+    if (!online) {
+      this.set({ status: 'offline' });
+      return;
+    }
+
+    const now = Date.now();
+    const batch = nextBatch(this.state.queue, { now });
+    const cursors = { ...this.state.mirror.cursors };
+    for (const groupId of options.groupIds ?? []) cursors[groupId] ??= 0;
+
+    // Nothing to push and nowhere to pull from: a first run before any group
+    // exists. Asking the server would just be a round trip for an empty answer.
+    if (batch.length === 0 && Object.keys(cursors).length === 0) {
+      this.set({ status: 'idle' });
+      return;
+    }
+
+    this.set({ status: 'syncing' });
+
+    try {
+      const { data, error } = await supabase.functions.invoke('sync', {
+        body: {
+          deviceId: 'mobile',
+          mutations: batch.map((item) => ({
+            clientMutationId: item.clientMutationId,
+            kind: item.kind,
+            groupId: item.groupId,
+            clientCreatedAt: item.clientCreatedAt,
+            payload: item.payload,
+          })),
+          cursors,
+        },
+      });
+      if (error) throw new Error(await describeFunctionError(error));
+
+      const response = data as SyncResponseBody;
+      const outcomes = response.outcomes ?? [];
+
+      const folded = applyOutcomes(
+        this.state.queue,
+        outcomes.map((outcome) =>
+          outcome.status === 'rejected'
+            ? {
+                clientMutationId: outcome.clientMutationId,
+                status: 'rejected' as const,
+                code: (outcome.code ?? 'VALIDATION_FAILED') as SyncRejectionCode,
+                message: outcome.message ?? 'The server refused this change',
+              }
+            : { clientMutationId: outcome.clientMutationId, status: outcome.status },
+        ),
+      );
+
+      const rejected: RejectedMutation[] = folded.rejected.map((entry) => ({
+        clientMutationId: entry.mutation.clientMutationId,
+        kind: entry.mutation.kind,
+        groupId: entry.mutation.groupId,
+        code: entry.code,
+        message: entry.message,
+      }));
+
+      const merged = reconcile(this.state.mirror, response.changes ?? []);
+      const mirror: MirrorState = {
+        // The server's cursors are authoritative: they also advance past rows
+        // this client is not allowed to see, which stops the cursor stalling.
+        cursors: { ...merged.state.cursors, ...(response.cursors ?? {}) },
+        tables: merged.state.tables,
+      };
+
+      await this.persist(response.changes ?? [], mirror, folded.queue);
+
+      this.set({
+        status: 'idle',
+        mirror,
+        queue: folded.queue,
+        rejected: [...this.state.rejected, ...rejected],
+        lastSyncedAt: response.serverTime ?? new Date().toISOString(),
+        lastError: null,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const queue = markFailed(this.state.queue, batch, message, now);
+      await this.store.writeQueue(queue);
+      this.set({ status: 'error', queue, lastError: message });
+    }
+  }
+
+  private async persist(
+    changes: readonly SyncChange[],
+    mirror: MirrorState,
+    queue: readonly QueuedMutation[],
+  ): Promise<void> {
+    const rows: StoredRow[] = [];
+    for (const change of changes) {
+      const id = typeof change.row.id === 'string' ? change.row.id : null;
+      if (!id) continue;
+      rows.push({
+        table: change.table,
+        id,
+        groupId: change.groupId,
+        seq: change.seq,
+        row: change.row,
+      });
+    }
+    await this.store.putRows(rows);
+    await this.store.writeCursors(mirror.cursors);
+    await this.store.writeQueue(queue);
+  }
+
+  // ───────────────────────────────────────────────────── drafts ──
+  // ADR-005: "drafts autosave to SQLite on every keystroke", so the crash that
+  // loses half an entry — the complaint that made this a requirement — cannot
+  // happen.
+
+  saveDraft(key: string, value: unknown): Promise<void> {
+    return this.store.writeDraft(key, value);
+  }
+
+  readDraft<T>(key: string): Promise<T | null> {
+    return this.store.readDraft<T>(key);
+  }
+
+  clearDraft(key: string): Promise<void> {
+    return this.store.clearDraft(key);
+  }
+
+  listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]> {
+    return this.store.listDrafts();
+  }
+}
+
+async function isOnline(): Promise<boolean> {
+  try {
+    const state = await Network.getNetworkStateAsync();
+    // `isInternetReachable` is undefined on some platforms; a connected
+    // interface is the best signal available there, and a failed request is
+    // handled by the backoff anyway.
+    return state.isInternetReachable ?? state.isConnected ?? true;
+  } catch {
+    return true;
+  }
+}
+
+async function describeFunctionError(error: unknown): Promise<string> {
+  const context = (error as { context?: Response }).context;
+  if (context && typeof context.json === 'function') {
+    try {
+      const body = (await context.json()) as { code?: string; message?: string };
+      if (body?.message) return body.code ? `${body.code}: ${body.message}` : body.message;
+    } catch {
+      /* fall through */
+    }
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export const syncEngine = new SyncEngine();

--- a/apps/mobile/src/sync/hooks.ts
+++ b/apps/mobile/src/sync/hooks.ts
@@ -1,0 +1,128 @@
+/**
+ * Reading local-first (ADR-005).
+ *
+ * "UI reads local-first, always" means the screen renders from the mirror plus
+ * the queue, never from a network response. The sync engine is what eventually
+ * changes the mirror; nothing here waits on a request, so a group opens at the
+ * speed of SQLite whether or not there is any signal.
+ */
+
+import { useMemo } from 'react';
+
+import {
+  computeNetBalances,
+  liveExpenses,
+  materialiseExpenses,
+  rowsFor,
+  simplify,
+  toExpenseSnapshot,
+  type ExpenseSnapshot,
+  type MemberId,
+  type MirrorExpense,
+  type SettlementSnapshot,
+  type Transfer,
+} from '@baaki/core';
+
+import type { GroupRow, MemberRow, SettlementRow } from '@/data/types';
+
+import { useSync } from './provider';
+
+export interface LocalGroup {
+  group: GroupRow | null;
+  members: MemberRow[];
+  expenses: MirrorExpense[];
+  settlements: SettlementRow[];
+  /** Rows we have locally that the server has not confirmed yet. */
+  pending: number;
+}
+
+export function useLocalGroups(): GroupRow[] {
+  const { mirror } = useSync();
+  return useMemo(
+    () =>
+      (rowsFor(mirror, 'groups') as unknown as GroupRow[])
+        .filter((group) => !group.archived_at)
+        .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at))),
+    [mirror],
+  );
+}
+
+export function useLocalGroup(groupId: string): LocalGroup {
+  const { mirror, queue } = useSync();
+
+  return useMemo(() => {
+    const group = (mirror.tables.groups[groupId] as unknown as GroupRow | undefined) ?? null;
+    const members = (rowsFor(mirror, 'group_members', groupId) as unknown as MemberRow[]).filter(
+      (member) => !member.left_at,
+    );
+    const settlements = rowsFor(mirror, 'settlements', groupId) as unknown as SettlementRow[];
+    const expenses = materialiseExpenses(mirror, queue, { groupId });
+
+    return {
+      group,
+      members,
+      expenses,
+      settlements,
+      pending: queue.filter((item) => item.groupId === groupId).length,
+    };
+  }, [mirror, queue, groupId]);
+}
+
+export interface OfflineLedger {
+  balances: Map<MemberId, bigint>;
+  transfers: Transfer[];
+  myMemberId: MemberId | null;
+  myBalance: bigint;
+  expenses: MirrorExpense[];
+  members: MemberRow[];
+  group: GroupRow | null;
+  /** Unsynced mutations touching this group. */
+  pending: number;
+}
+
+/**
+ * The same numbers `useGroupLedger` computes online, from local data instead.
+ * Both call the identical @baaki/core functions, so going offline changes what
+ * the app knows — never what it calculates.
+ */
+export function useOfflineLedger(groupId: string, myProfileId: string | null): OfflineLedger {
+  const local = useLocalGroup(groupId);
+
+  return useMemo(() => {
+    const currency = local.group?.default_currency ?? 'INR';
+
+    const snapshots = liveExpenses(local.expenses)
+      .map(toExpenseSnapshot)
+      .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
+
+    const settlementSnapshots: SettlementSnapshot[] = local.settlements.map((row) => ({
+      id: row.id,
+      from: row.from_member_id,
+      to: row.to_member_id,
+      currency: row.currency,
+      amount: BigInt(row.amount),
+      status: row.status,
+      at: row.initiated_at,
+      allocations: row.allocations?.map((allocation) => ({
+        expenseId: allocation.expense_id,
+        amount: BigInt(allocation.amount),
+      })),
+    }));
+
+    const net = computeNetBalances(snapshots, settlementSnapshots);
+    const balances = net.get(currency) ?? new Map<MemberId, bigint>();
+    const myMemberId =
+      local.members.find((member) => member.profile_id === myProfileId)?.id ?? null;
+
+    return {
+      balances,
+      transfers: simplify(new Map([[currency, balances]])),
+      myMemberId,
+      myBalance: myMemberId ? (balances.get(myMemberId) ?? 0n) : 0n,
+      expenses: local.expenses,
+      members: local.members,
+      group: local.group,
+      pending: local.pending,
+    };
+  }, [local, myProfileId]);
+}

--- a/apps/mobile/src/sync/index.ts
+++ b/apps/mobile/src/sync/index.ts
@@ -1,0 +1,4 @@
+export { SyncProvider, useSync, useDraft, useRestoredDraft, clearDraft } from './provider';
+export { syncEngine, type SyncState, type SyncStatus, type RejectedMutation } from './engine';
+export { createLocalStore, type LocalStore } from './store';
+export { useLocalGroup, useLocalGroups, useOfflineLedger } from './hooks';

--- a/apps/mobile/src/sync/provider.tsx
+++ b/apps/mobile/src/sync/provider.tsx
@@ -1,0 +1,185 @@
+/**
+ * Wiring the sync engine to the app's lifecycle (ADR-005 / TDR §4 step 2).
+ *
+ * The engine syncs "on connectivity, foreground or push". This is where those
+ * three become real events: AppState for foreground, expo-network for the
+ * moment a dead zone ends, and a timer as the backstop for everything else.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { AppState } from 'react-native';
+import * as Network from 'expo-network';
+import { randomUUID } from 'expo-crypto';
+
+import type { MutationEnvelope, MutationKind } from '@baaki/core';
+
+import { useAuth } from '@/lib/auth';
+
+import { syncEngine, type SyncState } from './engine';
+
+interface SyncContextValue extends SyncState {
+  /** Queue a mutation. Resolves once it is durably on disk, not once it syncs. */
+  mutate: (
+    kind: MutationKind,
+    groupId: string,
+    payload: Record<string, unknown>,
+    clientMutationId?: string,
+  ) => Promise<string>;
+  flush: (groupIds?: string[]) => Promise<void>;
+  retry: (clientMutationId: string) => Promise<void>;
+  discard: (clientMutationId: string) => Promise<void>;
+  /** True when there is unsent work — the UI says "syncing" rather than lying. */
+  pendingCount: number;
+}
+
+const SyncContext = createContext<SyncContextValue | null>(null);
+
+export function SyncProvider({ children }: { children: ReactNode }) {
+  const { session } = useAuth();
+  const [state, setState] = useState<SyncState>(() => syncEngine.getState());
+  const signedIn = Boolean(session);
+  const wasSignedIn = useRef(signedIn);
+
+  useEffect(() => syncEngine.subscribe(setState), []);
+
+  useEffect(() => {
+    if (!signedIn) {
+      // Signing out wipes the mirror: the next person to use this phone must
+      // not find the previous account's ledger in it.
+      if (wasSignedIn.current) void syncEngine.clear();
+      wasSignedIn.current = false;
+      syncEngine.stop();
+      return;
+    }
+
+    wasSignedIn.current = true;
+    let cancelled = false;
+    void (async () => {
+      await syncEngine.hydrate();
+      if (cancelled) return;
+      syncEngine.start();
+      void syncEngine.flush();
+    })();
+
+    return () => {
+      cancelled = true;
+      syncEngine.stop();
+    };
+  }, [signedIn]);
+
+  // Coming back to the app is the most likely moment for the world to have
+  // moved on without us.
+  useEffect(() => {
+    if (!signedIn) return;
+    const subscription = AppState.addEventListener('change', (next) => {
+      if (next === 'active') void syncEngine.flush();
+    });
+    return () => subscription.remove();
+  }, [signedIn]);
+
+  // And the moment a dead zone ends.
+  useEffect(() => {
+    if (!signedIn) return;
+    const subscription = Network.addNetworkStateListener((networkState) => {
+      if (networkState.isConnected) void syncEngine.flush();
+    });
+    return () => subscription.remove();
+  }, [signedIn]);
+
+  const mutate = useCallback(
+    async (
+      kind: MutationKind,
+      groupId: string,
+      payload: Record<string, unknown>,
+      clientMutationId?: string,
+    ): Promise<string> => {
+      const envelope: MutationEnvelope = {
+        clientMutationId: clientMutationId ?? randomUUID(),
+        kind,
+        groupId,
+        clientCreatedAt: new Date().toISOString(),
+        payload,
+      };
+      await syncEngine.enqueue(envelope);
+      return envelope.clientMutationId;
+    },
+    [],
+  );
+
+  const value = useMemo<SyncContextValue>(
+    () => ({
+      ...state,
+      mutate,
+      flush: (groupIds?: string[]) => syncEngine.flush({ groupIds }),
+      retry: (id: string) => syncEngine.retry(id),
+      discard: (id: string) => syncEngine.discard(id),
+      pendingCount: state.queue.length,
+    }),
+    [state, mutate],
+  );
+
+  return <SyncContext.Provider value={value}>{children}</SyncContext.Provider>;
+}
+
+export function useSync(): SyncContextValue {
+  const value = useContext(SyncContext);
+  if (!value) throw new Error('useSync must be used inside SyncProvider');
+  return value;
+}
+
+/**
+ * ADR-005: drafts autosave on every keystroke, so a crash mid-entry costs
+ * nothing. Writes are debounced only enough to avoid one disk write per
+ * character; the last value always lands.
+ */
+export function useDraft<T>(key: string, value: T, options: { enabled?: boolean } = {}): void {
+  const enabled = options.enabled ?? true;
+  // Serialised rather than held in a ref: a form rebuilds its value object on
+  // every render, so depending on the object itself would reset the debounce
+  // timer forever and the draft would never actually be written.
+  const serialised = useMemo(() => JSON.stringify(value), [value]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const timer = setTimeout(() => {
+      void syncEngine.saveDraft(key, JSON.parse(serialised) as T);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [key, serialised, enabled]);
+}
+
+/** Read a saved draft once, on mount. */
+export function useRestoredDraft<T>(key: string): { draft: T | null; loading: boolean } {
+  const [draft, setDraft] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    void syncEngine
+      .readDraft<T>(key)
+      .then((value) => {
+        if (active) setDraft(value);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [key]);
+
+  return { draft, loading };
+}
+
+export function clearDraft(key: string): Promise<void> {
+  return syncEngine.clearDraft(key);
+}

--- a/apps/mobile/src/sync/store.ts
+++ b/apps/mobile/src/sync/store.ts
@@ -1,0 +1,49 @@
+/**
+ * The durable half of the offline client (ADR-005).
+ *
+ * ADR-005 asks for a SQLite mirror of the user's groups, a mutation queue that
+ * survives a forced kill, and drafts that autosave on every keystroke. That is
+ * exactly what this file provides — and nothing else: no decisions about what
+ * to sync or when, which live in `engine.ts` and, for the rules worth
+ * property-testing, in @baaki/core.
+ *
+ * There are two implementations behind one interface. Native gets real SQLite.
+ * Web gets an AsyncStorage-backed store, because expo-sqlite's web build needs
+ * cross-origin isolation headers that the dev server and a plain static export
+ * do not send — and a guest opening an invite link (ADR-006) should not meet a
+ * blank screen because of it. Both are exercised by the same engine.
+ */
+
+import type { MirrorRow, QueuedMutation, SyncTable } from '@baaki/core';
+
+export interface StoredRow {
+  table: SyncTable;
+  id: string;
+  groupId: string;
+  seq: number;
+  row: MirrorRow;
+}
+
+export interface LocalStore {
+  ready(): Promise<void>;
+  putRows(rows: readonly StoredRow[]): Promise<void>;
+  readRows(): Promise<StoredRow[]>;
+  readCursors(): Promise<Record<string, number>>;
+  writeCursors(cursors: Record<string, number>): Promise<void>;
+  readQueue(): Promise<QueuedMutation[]>;
+  writeQueue(queue: readonly QueuedMutation[]): Promise<void>;
+  readDraft<T>(key: string): Promise<T | null>;
+  writeDraft(key: string, value: unknown): Promise<void>;
+  clearDraft(key: string): Promise<void>;
+  listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]>;
+  /** Signing out must leave nothing of the previous account behind. */
+  reset(): Promise<void>;
+}
+
+/**
+ * Resolved by Metro per platform: `driver.web.ts` on web, `driver.ts` on
+ * native. The split is not stylistic — a static `expo-sqlite` import pulls its
+ * WASM build into the web bundle even behind a `Platform.OS` check, and that
+ * build needs cross-origin isolation headers a static export cannot send.
+ */
+export { createLocalStore } from './driver';

--- a/docs/split-scenarios.md
+++ b/docs/split-scenarios.md
@@ -1,0 +1,222 @@
+# Splitting an expense — scenarios and guarantees
+
+How Baaki turns one bill into per-person shares, what is checked, and where the
+decision is actually made.
+
+The rules here are set by three ADRs: money is integer minor units and never a
+float (ADR-003), splits are deterministic with a defined remainder rule
+(ADR-009), and the server recomputes every share rather than trusting a client
+(TDR §4). Everything below is enforced by `packages/core/src/split/` and tested
+by `packages/core/test/split.combinations.test.ts`.
+
+---
+
+## 1. The three ways a person divides a bill
+
+| In the app      | `split_params.kind` | What the user supplies                                    | Example              |
+| --------------- | ------------------- | --------------------------------------------------------- | -------------------- |
+| **Percentage**  | `percent`           | Integer basis points per person, summing to exactly 10000 | Asha 60%, Ravi 40%   |
+| **Fixed value** | `exact`             | An exact amount per person, summing to the total          | Asha ₹600, Ravi ₹400 |
+| **Share**       | `shares`            | Non-negative integer weights                              | Asha 3, Ravi 2       |
+
+Three more exist for cases the UI drives rather than the user: `equal` (the
+default), `adjustment` ("Ravi also had the ₹120 beer, split the rest evenly")
+and `itemized` (ADR-008 receipt scanning). They obey the same guarantees and are
+covered by the same property suite.
+
+**Basis points, not percentages.** `percent` takes 6000, not 60 or 60.0. A
+percentage stored as a float is a rounding bug waiting for a big enough bill;
+basis points give one hundredth of a percent of resolution in an integer, which
+is finer than any real split needs.
+
+---
+
+## 2. What is guaranteed
+
+Every split, of every type, satisfies all five:
+
+1. **The shares sum to the total, exactly.** Not to within a paisa — exactly.
+   `computeShares` asserts this before returning and throws `SHARE_MISMATCH` if
+   it ever fails, which would be a bug in Baaki rather than in the input.
+2. **Every participant gets a row**, even when their share is zero, so the
+   screen and the `expense_shares` table always agree on who is involved.
+3. **Nobody pays more than the bill, and nobody pays a negative share** — unless
+   the user explicitly typed a negative fixed value, which is how a credit or a
+   refund is recorded.
+4. **Proportionality.** With weights, each person gets the floor of their exact
+   share, plus at most one extra minor unit from the remainder pass. A zero
+   weight always means zero.
+5. **Determinism.** The same inputs give the same output on every device, on the
+   server, and on every future run. Listing participants in a different order
+   changes nothing.
+
+### The remainder
+
+₹10 between three people is 333.33 paise each, which does not exist. Baaki gives
+everyone 333 and hands out the leftover paisa one unit at a time, in sorted
+member order, **starting at an offset derived from the expense id**
+(FNV-1a hash, ADR-009).
+
+That last part is the point. Always starting at the first member would quietly
+overcharge whoever sorts first, on every bill, forever. Rotating by expense id
+keeps it fair over time while staying perfectly reproducible — the phone that is
+offline computes the same answer the server will.
+
+---
+
+## 3. What is rejected, and what the user is told
+
+Every rejection is a `SplitError` with a machine-readable `code`. The client
+branches on the code; the message is for a person.
+
+| Code                      | When                                                                 | Applies to      |
+| ------------------------- | -------------------------------------------------------------------- | --------------- |
+| `PERCENT_SUM_MISMATCH`    | Basis points do not total 10000                                      | percent         |
+| `EXACT_SUM_MISMATCH`      | Fixed values do not total the expense                                | exact           |
+| `NO_POSITIVE_WEIGHT`      | Every weight is zero                                                 | shares          |
+| `INVALID_WEIGHT`          | A weight or basis point is negative, fractional, `NaN` or `Infinity` | percent, shares |
+| `UNKNOWN_MEMBER`          | A share is given to somebody outside the split                       | all             |
+| `EMPTY_PARTICIPANTS`      | Nobody is in the split                                               | all             |
+| `DUPLICATE_PARTICIPANT`   | The same person listed twice                                         | all             |
+| `NEGATIVE_TOTAL`          | The expense total itself is negative                                 | all             |
+| `UNCLAIMED_ITEM`          | A receipt line nobody has claimed                                    | itemized        |
+| `ITEMIZED_TOTAL_MISMATCH` | Items plus tax/tip/discount ≠ the total                              | itemized        |
+
+A percentage split that comes to 99.99% is **refused, not rounded**. Silently
+absorbing the missing hundredth would mean the app decided who pays it, and the
+one thing an expense splitter cannot do is invent money.
+
+---
+
+## 4. Where the calculation happens
+
+**On the server, always.** The client computes shares too, but only ever as a
+preview and to keep working offline — its numbers are never what gets stored.
+
+```
+ phone                          edge function                       Postgres
+ ─────                          ─────────────                       ────────
+ computeShares(...)  ──┐
+ (preview / offline)   │
+                       ├─▶  computeShares(split_params)   ──▶  baaki_apply_expense
+ expectedShares ───────┘     verifyClientShares(...)            (one transaction)
+                             409 SHARE_MISMATCH on disagreement       │
+                                                                     ▼
+                                                      Σ payers = Σ shares = amount
+                                                      (constraint trigger)
+```
+
+Three separate defences, each of which would catch a wrong number on its own:
+
+1. **The edge functions recompute.** `expense-write` and `sync` both call
+   `computeShares` on `split_params` and use _their_ result. A client's
+   `expectedShares` is only ever compared, never stored. The comparison is
+   `verifyClientShares` in `@baaki/core` — one definition shared by both
+   functions, including the case a hand-written loop tends to miss, where the
+   client invents a share for somebody who is not in the split.
+2. **The database enforces the money invariant.** A constraint trigger checks
+   `Σ payers = Σ shares = amount` inside the same transaction that writes the
+   expense. Even a compromised edge function cannot store an expense that does
+   not balance.
+3. **Balances are derived, never stored as a running total** (ADR-004), and CI
+   asserts the derived tables equal a ground-truth aggregate on every push.
+
+There is no channel through which a caller can supply a share. `computeShares`
+takes only the total, the parameters, the participants and the seed — so "the
+calculation happens in the backend" is structural rather than a matter of
+discipline. A test asserts exactly that by trying to smuggle a `shares` field
+into `split_params` and confirming the result is unchanged.
+
+---
+
+## 5. The test matrix
+
+`packages/core/test/split.combinations.test.ts` walks a defined space
+completely, rather than sampling it. The property suite next to it does the
+random-input half; this one guarantees the same cases run every time.
+
+**The space**
+
+| Dimension       | Values                                                |
+| --------------- | ----------------------------------------------------- |
+| Participants    | 2, 3, 4, 5                                            |
+| Amounts (paise) | 0, 1, 7, 100, 333, 999, 1000, 100000, 123457          |
+| Weight vectors  | every composition of 10 units across the participants |
+
+"Every composition of 10 units" means all the ways ten shares can be handed out:
+`[10,0]`, `[9,1]`, … `[0,10]` for two people, and so on — 11, 66, 286 and 1001
+vectors for 2, 3, 4 and 5 people. For percentages each unit is 1000 basis
+points, so this is every whole multiple of 10% that adds to 100%.
+
+That is **1364 weight vectors × 9 amounts × 2 weighted types**, plus a fixed
+value case derived from each result: roughly 25,000 computations, every one
+checked against all five guarantees above.
+
+The amounts are chosen for their remainders, not their realism: 1000 across 3
+leaves 1 over, 999 across 4 leaves 3, 123457 is prime to everything here, and 0
+and 1 are the edges where an off-by-one hides.
+
+**Cross-type equivalences** — the same instruction expressed two ways must
+produce the same money, down to which person absorbs the leftover paisa:
+
+- 3:1 shares == 75%:25% percentage
+- uniform shares (1:1:1) == an equal split
+- any percentage or share result, fed back as fixed values, reproduces itself
+
+**Fairness** — over 60 different expense ids, an equal three-way split of ₹10
+lands its extra paisa on all three people, not always the same one.
+
+**Server authority** — a client that is one paisa out, omits somebody, invents
+somebody, or sends `"five hundred"` instead of a number is rejected; a client
+that claims nothing is accepted, because an offline device that has not
+recomputed simply takes the server's word.
+
+---
+
+## 6. Worked examples
+
+All amounts in paise. Seed is the expense id.
+
+### Percentage, with a remainder
+
+₹10.00 (1000 paise), Asha 60% / Ravi 30% / Priya 10%.
+
+| Person | Basis points | Exact | Floor | Final |
+| ------ | ------------ | ----- | ----- | ----- |
+| Asha   | 6000         | 600.0 | 600   | 600   |
+| Ravi   | 3000         | 300.0 | 300   | 300   |
+| Priya  | 1000         | 100.0 | 100   | 100   |
+
+No remainder. Change the bill to ₹10.01 (1001) and the exact shares become
+600.6 / 300.3 / 100.1; the floors are 600 / 300 / 100, leaving 1 paisa, which
+goes to whichever member the expense id's hash selects.
+
+### Share
+
+₹100.00 (10000), Asha 3 : Ravi 2. Total weight 5.
+
+| Person | Weight | Exact | Final |
+| ------ | ------ | ----- | ----- |
+| Asha   | 3      | 6000  | 6000  |
+| Ravi   | 2      | 4000  | 4000  |
+
+### Fixed value
+
+₹10.00, Asha ₹6.00 and Ravi ₹4.00 → accepted. Asha ₹6.00 and Ravi ₹4.01 →
+`EXACT_SUM_MISMATCH`, because it comes to ₹10.01 and the bill is ₹10.00.
+
+One person may carry the whole bill (`{ asha: 1000 }`); everybody else appears
+at zero. A negative entry is allowed as long as the set still sums correctly —
+that is how a refund to one person is recorded.
+
+---
+
+## 7. Running it
+
+```bash
+pnpm test:core                                  # every split suite
+pnpm --filter @baaki/core exec vitest run test/split.combinations.test.ts
+```
+
+CI runs these on every push, and a merge is blocked if any of them fail
+(ADR-014).

--- a/e2e/m2-sync.mjs
+++ b/e2e/m2-sync.mjs
@@ -1,0 +1,532 @@
+/**
+ * The M2 acceptance criterion, for real (TDR §10):
+ *
+ *   "Airplane-mode: add 10 expenses on 2 devices, reconnect → identical
+ *    balances, no dupes (idempotency), conflicting edit surfaces in feed."
+ *
+ * The same scenario is a property test in @baaki/core against a model server.
+ * This one runs it against the deployed `/sync` function and real Postgres,
+ * because the two bugs M1 shipped with were both things only a real Supabase
+ * could show: an extension that rejects a bare DELETE, and PostgREST's
+ * autocommit breaking a deferred constraint trigger.
+ *
+ * Airplane mode is simulated honestly — the devices simply do not call `/sync`
+ * until the "reconnect" step, which is exactly what a queued client does.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'node:crypto';
+
+import { computeShares, computeNetBalances } from '../supabase/functions/_shared/core.js';
+
+const URL = process.env.SUPABASE_URL ?? 'https://xvjzbpgcmotoahtqcxve.supabase.co';
+const ANON = process.env.ANON_KEY;
+const SERVICE = process.env.SERVICE_KEY;
+
+if (!ANON || !SERVICE) {
+  console.error('Set ANON_KEY and SERVICE_KEY.');
+  process.exit(2);
+}
+
+const pass = [];
+const fail = [];
+const check = (label, condition, detail = '') => {
+  (condition ? pass : fail).push(label);
+  console.log(`${condition ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`);
+};
+
+async function describe(error) {
+  if (!error) return '';
+  const context = error.context;
+  if (context && typeof context.json === 'function') {
+    try {
+      const body = await context.json();
+      return `${body.code ?? '?'}: ${body.message ?? ''}`;
+    } catch {
+      /* fall through */
+    }
+  }
+  return error.message ?? String(error);
+}
+
+const client = (key) =>
+  createClient(URL, key, { auth: { persistSession: false, autoRefreshToken: false } });
+const service = createClient(URL, SERVICE, { auth: { persistSession: false } });
+
+/** A device: a session, a mutation queue and a cursor. Nothing else. */
+class Device {
+  constructor(name) {
+    this.name = name;
+    this.supabase = client(ANON);
+    this.queue = [];
+    this.cursors = {};
+    this.rows = new Map();
+  }
+
+  async signIn(displayName) {
+    const { data, error } = await this.supabase.auth.signInAnonymously();
+    if (error) throw new Error(`${this.name}: ${error.message}`);
+    this.profileId = data.user.id;
+    await this.supabase.from('profiles').update({ display_name: displayName }).eq('id', this.profileId);
+    return this.profileId;
+  }
+
+  enqueue(kind, groupId, payload) {
+    const clientMutationId = randomUUID();
+    this.queue.push({
+      clientMutationId,
+      kind,
+      groupId,
+      clientCreatedAt: new Date().toISOString(),
+      payload,
+    });
+    return clientMutationId;
+  }
+
+  /** Reconnect: push everything queued, pull everything since the cursor. */
+  async sync(groupIds = []) {
+    const cursors = { ...this.cursors };
+    for (const id of groupIds) cursors[id] ??= 0;
+
+    const { data, error } = await this.supabase.functions.invoke('sync', {
+      body: { deviceId: this.name, mutations: this.queue, cursors },
+    });
+    if (error) throw new Error(`${this.name} sync: ${await describe(error)}`);
+
+    const done = new Set(
+      data.outcomes.filter((o) => o.status !== 'rejected').map((o) => o.clientMutationId),
+    );
+    this.queue = this.queue.filter((m) => !done.has(m.clientMutationId));
+    this.cursors = { ...this.cursors, ...data.cursors };
+    for (const change of data.changes) {
+      this.rows.set(`${change.table}:${change.row.id}`, change.row);
+    }
+    return data;
+  }
+
+  expenses(groupId) {
+    return [...this.rows.values()].filter(
+      (row) => row.group_id === groupId && row.currentVersion !== undefined,
+    );
+  }
+
+  balances(groupId) {
+    const snapshots = this.expenses(groupId)
+      .filter((row) => row.deleted_at === null && row.currentVersion)
+      .map((row) => ({
+        id: row.id,
+        currency: row.currentVersion.currency,
+        amount: BigInt(row.currentVersion.amount),
+        payers: Object.fromEntries(
+          row.currentVersion.payers.map((p) => [p.member_id, BigInt(p.amount)]),
+        ),
+        shares: Object.fromEntries(
+          row.currentVersion.shares.map((s) => [s.member_id, BigInt(s.amount)]),
+        ),
+        date: row.currentVersion.expense_date,
+        deletedAt: row.deleted_at,
+      }));
+    return computeNetBalances(snapshots, []).get('INR') ?? new Map();
+  }
+}
+
+// ── two devices, one group ─────────────────────────────────────────────────
+
+const alpha = new Device('alpha');
+const beta = new Device('beta');
+await alpha.signIn('Asha');
+await beta.signIn('Bharath');
+
+// The group is created online by Asha, then Bharath joins it: the offline part
+// of the test is the expenses, not the membership.
+const groupId = randomUUID();
+{
+  const { error } = await alpha.supabase.rpc('baaki_create_group', {
+    p_name: 'Airplane mode',
+    p_type: 'trip',
+    p_currency: 'INR',
+    p_emoji: '✈️',
+    p_simplify: true,
+    p_group_id: groupId,
+  });
+  check('a group can be created with a client-chosen id', !error, error?.message);
+}
+
+// Replaying the create is free — the whole point of the idempotency key.
+{
+  const { data, error } = await alpha.supabase.rpc('baaki_create_group', {
+    p_name: 'Airplane mode',
+    p_type: 'trip',
+    p_currency: 'INR',
+    p_emoji: '✈️',
+    p_simplify: true,
+    p_group_id: groupId,
+  });
+  check('replaying the create returns the same group', !error && data === groupId, error?.message);
+
+  const { count } = await service
+    .from('group_members')
+    .select('id', { count: 'exact', head: true })
+    .eq('group_id', groupId);
+  check('and does not add a second membership', count === 1, `members=${count}`);
+}
+
+const { data: ashaMemberId } = await alpha.supabase.rpc('baaki_my_member_id', {
+  p_group_id: groupId,
+});
+
+// Bharath joins through the invite loop so both devices are real members.
+const { data: invite, error: inviteError } = await alpha.supabase.functions.invoke('invite-mint', {
+  body: { groupId, expiresInDays: 1 },
+});
+check('an invite can be minted', !inviteError, await describe(inviteError));
+
+const { error: joinError } = await beta.supabase.functions.invoke('invite-accept', {
+  body: { token: invite.token, mode: 'join', displayName: 'Bharath' },
+});
+check('the second device joins', !joinError, await describe(joinError));
+
+const { data: bharathMemberId } = await beta.supabase.rpc('baaki_my_member_id', {
+  p_group_id: groupId,
+});
+
+const members = [ashaMemberId, bharathMemberId];
+
+// ── airplane mode: ten expenses each, nothing sent ──────────────────────────
+
+const queueExpense = (device, payerMemberId, index, amount) => {
+  const expenseId = randomUUID();
+  const shares = computeShares({
+    amount,
+    currency: 'INR',
+    params: { kind: 'equal' },
+    participants: members,
+    seed: expenseId,
+  });
+  device.enqueue('expense.create', groupId, {
+    expenseId,
+    description: `${device.name} #${index}`,
+    expenseDate: '2026-03-01',
+    currency: 'INR',
+    amount: amount.toString(),
+    splitParams: { kind: 'equal' },
+    participants: members,
+    payers: { [payerMemberId]: amount.toString() },
+    expectedShares: Object.fromEntries([...shares].map(([id, share]) => [id, share.toString()])),
+  });
+  return expenseId;
+};
+
+// Deliberately odd amounts: an even split of 333 paise has a remainder, which
+// is where a client and server that seed the rotation differently fall apart.
+for (let index = 0; index < 10; index += 1) {
+  queueExpense(alpha, ashaMemberId, index, BigInt(333 + index));
+  queueExpense(beta, bharathMemberId, index, BigInt(777 + index));
+}
+check('both devices queued ten expenses offline', alpha.queue.length === 10 && beta.queue.length === 10);
+
+// ── reconnect ───────────────────────────────────────────────────────────────
+
+await alpha.sync([groupId]);
+await beta.sync([groupId]);
+// A second round each, so both have pulled the other's work.
+await alpha.sync([groupId]);
+await beta.sync([groupId]);
+
+check('every queued mutation was accepted', alpha.queue.length === 0 && beta.queue.length === 0,
+  `alpha=${alpha.queue.length} beta=${beta.queue.length}`);
+
+const { count: expenseCount } = await service
+  .from('expenses')
+  .select('id', { count: 'exact', head: true })
+  .eq('group_id', groupId);
+check('twenty expenses exist, not more', expenseCount === 20, `count=${expenseCount}`);
+
+const alphaBalances = alpha.balances(groupId);
+const betaBalances = beta.balances(groupId);
+const sameBalances =
+  alphaBalances.size === betaBalances.size &&
+  [...alphaBalances].every(([member, value]) => betaBalances.get(member) === value);
+check('the two devices agree on every balance', sameBalances,
+  `alpha=${JSON.stringify([...alphaBalances].map(([k, v]) => [k.slice(0, 8), String(v)]))}`);
+
+const total = [...alphaBalances.values()].reduce((sum, value) => sum + value, 0n);
+check('balances sum to zero', total === 0n, `sum=${total}`);
+
+// The server's own derived balances must agree with both devices (ADR-004).
+const { data: serverBalances } = await service
+  .from('group_balances')
+  .select('member_id, balance')
+  .eq('group_id', groupId);
+const serverAgrees = serverBalances.every(
+  (row) => (alphaBalances.get(row.member_id) ?? 0n) === BigInt(row.balance),
+);
+check('and the server agrees with the devices', serverAgrees,
+  JSON.stringify(serverBalances.map((r) => [r.member_id.slice(0, 8), r.balance])));
+
+// ── replaying a queue after a crash ─────────────────────────────────────────
+
+{
+  const expenseId = randomUUID();
+  const amount = 5000n;
+  const shares = computeShares({
+    amount,
+    currency: 'INR',
+    params: { kind: 'equal' },
+    participants: members,
+    seed: expenseId,
+  });
+  const mutation = {
+    clientMutationId: randomUUID(),
+    kind: 'expense.create',
+    groupId,
+    clientCreatedAt: new Date().toISOString(),
+    payload: {
+      expenseId,
+      description: 'Crashed mid-sync',
+      expenseDate: '2026-03-02',
+      currency: 'INR',
+      amount: amount.toString(),
+      splitParams: { kind: 'equal' },
+      participants: members,
+      payers: { [ashaMemberId]: amount.toString() },
+      expectedShares: Object.fromEntries([...shares].map(([id, s]) => [id, s.toString()])),
+    },
+  };
+
+  const first = await alpha.supabase.functions.invoke('sync', {
+    body: { deviceId: 'alpha', mutations: [mutation], cursors: {} },
+  });
+  check('the mutation applies', first.data?.outcomes?.[0]?.status === 'applied',
+    JSON.stringify(first.data?.outcomes?.[0]));
+
+  // The app died before it could clear the queue, so it sends the same thing.
+  const replay = await alpha.supabase.functions.invoke('sync', {
+    body: { deviceId: 'alpha', mutations: [mutation], cursors: {} },
+  });
+  check('replaying it reports a duplicate, not a second expense',
+    replay.data?.outcomes?.[0]?.status === 'duplicate',
+    JSON.stringify(replay.data?.outcomes?.[0]));
+
+  const { count } = await service
+    .from('expense_versions')
+    .select('id', { count: 'exact', head: true })
+    .eq('expense_id', expenseId);
+  check('and exactly one version was written', count === 1, `versions=${count}`);
+}
+
+// ── a conflicting edit ──────────────────────────────────────────────────────
+
+{
+  const expenseId = randomUUID();
+  const build = (device, memberId, amount, description, baseVersionNo) => {
+    const shares = computeShares({
+      amount,
+      currency: 'INR',
+      params: { kind: 'equal' },
+      participants: members,
+      seed: expenseId,
+    });
+    return {
+      clientMutationId: randomUUID(),
+      kind: baseVersionNo ? 'expense.update' : 'expense.create',
+      groupId,
+      clientCreatedAt: new Date().toISOString(),
+      payload: {
+        expenseId,
+        description,
+        expenseDate: '2026-03-03',
+        currency: 'INR',
+        amount: amount.toString(),
+        splitParams: { kind: 'equal' },
+        participants: members,
+        payers: { [memberId]: amount.toString() },
+        expectedShares: Object.fromEntries([...shares].map(([id, s]) => [id, s.toString()])),
+        baseVersionNo: baseVersionNo ?? null,
+      },
+    };
+  };
+
+  await alpha.supabase.functions.invoke('sync', {
+    body: { deviceId: 'alpha', mutations: [build(alpha, ashaMemberId, 1000n, 'Dinner')], cursors: {} },
+  });
+
+  // Both devices edited version 1, each believing it was current.
+  const ashaEdit = await alpha.supabase.functions.invoke('sync', {
+    body: {
+      deviceId: 'alpha',
+      mutations: [build(alpha, ashaMemberId, 2000n, "Asha's edit", 1)],
+      cursors: {},
+    },
+  });
+  check("the first edit is not a conflict", ashaEdit.data?.outcomes?.[0]?.result?.superseded === false,
+    JSON.stringify(ashaEdit.data?.outcomes?.[0]?.result));
+
+  const bharathEdit = await beta.supabase.functions.invoke('sync', {
+    body: {
+      deviceId: 'beta',
+      mutations: [build(beta, bharathMemberId, 3000n, "Bharath's edit", 1)],
+      cursors: {},
+    },
+  });
+  check('the second edit is reported as a conflict',
+    bharathEdit.data?.outcomes?.[0]?.result?.superseded === true,
+    JSON.stringify(bharathEdit.data?.outcomes?.[0]?.result));
+
+  const { data: versions } = await service
+    .from('expense_versions')
+    .select('version_no, description')
+    .eq('expense_id', expenseId)
+    .order('version_no');
+  check('all three versions survive (ADR-004)', versions.length === 3,
+    versions.map((v) => v.description).join(' → '));
+
+  const { data: current } = await service
+    .from('expenses')
+    .select('current_version_id, currentVersion:expense_versions!expenses_current_version_id_fkey ( description )')
+    .eq('id', expenseId)
+    .single();
+  check('the later receipt wins', current.currentVersion.description === "Bharath's edit",
+    current.currentVersion.description);
+
+  const { data: superseded } = await service
+    .from('activity_log')
+    .select('payload')
+    .eq('group_id', groupId)
+    .eq('verb', 'superseded')
+    .eq('object_id', expenseId);
+  check('the losing edit is surfaced in the activity feed', superseded.length === 1);
+  check('and names whose edit was replaced',
+    superseded[0]?.payload?.supersededAuthorMemberId === ashaMemberId &&
+      superseded[0]?.payload?.supersededDescription === "Asha's edit",
+    JSON.stringify(superseded[0]?.payload));
+}
+
+// ── the cursor ──────────────────────────────────────────────────────────────
+
+{
+  // A rename changes nothing a client could pull unless the group moves its own
+  // cursor, which is the bug this test exists to keep fixed.
+  const before = { ...alpha.cursors };
+  await alpha.supabase.from('groups').update({ name: 'Airplane mode, renamed' }).eq('id', groupId);
+  const response = await alpha.sync([groupId]);
+  const groupChange = response.changes.find((change) => change.table === 'groups');
+  check('renaming a group is pullable', Boolean(groupChange), JSON.stringify(before));
+  check('and the cursor moved forward', response.cursors[groupId] > (before[groupId] ?? 0),
+    `${before[groupId]} → ${response.cursors[groupId]}`);
+
+  // Syncing again with the new cursor must return nothing new for the group.
+  const quiet = await alpha.sync([groupId]);
+  check('a second pull with an up-to-date cursor returns nothing',
+    quiet.changes.length === 0, `changes=${quiet.changes.length}`);
+}
+
+// ── a rejection does not poison the batch ───────────────────────────────────
+
+{
+  const goodId = randomUUID();
+  const goodShares = computeShares({
+    amount: 1200n,
+    currency: 'INR',
+    params: { kind: 'equal' },
+    participants: members,
+    seed: goodId,
+  });
+
+  const { data } = await alpha.supabase.functions.invoke('sync', {
+    body: {
+      deviceId: 'alpha',
+      cursors: {},
+      mutations: [
+        {
+          clientMutationId: randomUUID(),
+          kind: 'expense.create',
+          groupId,
+          clientCreatedAt: new Date().toISOString(),
+          payload: {
+            expenseId: randomUUID(),
+            description: 'Lying about the shares',
+            expenseDate: '2026-03-04',
+            currency: 'INR',
+            amount: '1000',
+            splitParams: { kind: 'equal' },
+            participants: members,
+            payers: { [ashaMemberId]: '1000' },
+            // Deliberately wrong: the server must not take the client's word.
+            expectedShares: Object.fromEntries(members.map((id) => [id, '900'])),
+          },
+        },
+        {
+          clientMutationId: randomUUID(),
+          kind: 'expense.create',
+          groupId,
+          clientCreatedAt: new Date().toISOString(),
+          payload: {
+            expenseId: goodId,
+            description: 'Perfectly fine',
+            expenseDate: '2026-03-04',
+            currency: 'INR',
+            amount: '1200',
+            splitParams: { kind: 'equal' },
+            participants: members,
+            payers: { [ashaMemberId]: '1200' },
+            expectedShares: Object.fromEntries(
+              [...goodShares].map(([id, s]) => [id, s.toString()]),
+            ),
+          },
+        },
+      ],
+    },
+  });
+
+  check('a client that miscomputes shares is rejected',
+    data?.outcomes?.[0]?.status === 'rejected' && data.outcomes[0].code === 'SHARE_MISMATCH',
+    JSON.stringify(data?.outcomes?.[0]));
+  check('and the rest of the batch still applies', data?.outcomes?.[1]?.status === 'applied',
+    JSON.stringify(data?.outcomes?.[1]));
+}
+
+// ── a stranger cannot sync into someone else's group ────────────────────────
+
+{
+  const mallory = new Device('mallory');
+  await mallory.signIn('Mallory');
+  const { data } = await mallory.supabase.functions.invoke('sync', {
+    body: {
+      deviceId: 'mallory',
+      cursors: { [groupId]: 0 },
+      mutations: [
+        {
+          clientMutationId: randomUUID(),
+          kind: 'expense.create',
+          groupId,
+          clientCreatedAt: new Date().toISOString(),
+          payload: {
+            expenseId: randomUUID(),
+            description: 'Not mine',
+            expenseDate: '2026-03-05',
+            currency: 'INR',
+            amount: '100',
+            splitParams: { kind: 'equal' },
+            participants: members,
+            payers: { [ashaMemberId]: '100' },
+          },
+        },
+      ],
+    },
+  });
+
+  check('a non-member is refused', data?.outcomes?.[0]?.status === 'rejected',
+    JSON.stringify(data?.outcomes?.[0]));
+  check('and pulls nothing from a group they are not in',
+    (data?.changes ?? []).length === 0, `changes=${data?.changes?.length}`);
+}
+
+// ── clean up ────────────────────────────────────────────────────────────────
+
+await service.from('groups').delete().eq('id', groupId);
+
+console.log(`\n${pass.length} passed, ${fail.length} failed`);
+if (fail.length > 0) {
+  console.log('Failed:', fail.join(', '));
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "edge:serve": "pnpm edge:build && supabase functions serve --env-file supabase/functions/.env",
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",
-    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write"
+    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write sync invite-mint invite-accept export-data"
   },
   "devDependencies": {
     "prettier": "^3.4.2",

--- a/packages/core/src/split/index.ts
+++ b/packages/core/src/split/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './remainder';
 export * from './computeShares';
+export * from './verify';

--- a/packages/core/src/split/verify.ts
+++ b/packages/core/src/split/verify.ts
@@ -1,0 +1,69 @@
+/**
+ * The server's check on a client's arithmetic (TDR §4).
+ *
+ * "**Never** trust client-computed shares: server recomputes from
+ * `split_params` and rejects mismatches (`SHARE_MISMATCH`)."
+ *
+ * The recomputation is `computeShares`. This is the comparison that follows it,
+ * and it lives here rather than in each edge function so there is exactly one
+ * definition of what "agrees" means — including the case a hand-written check
+ * tends to miss, where the client claims a share for somebody the server never
+ * computed one for.
+ */
+
+import { SplitError, type MemberId, type ShareMap } from './types';
+
+/**
+ * Compare the authoritative shares against what the client believed.
+ *
+ * `claimed` is the wire form: decimal strings, because JSON has no integers
+ * this size. Passing `undefined` means the client made no claim, which is
+ * allowed — an offline client that has recomputed nothing simply accepts
+ * whatever the server decides.
+ *
+ * Throws `SplitError('SHARE_MISMATCH')` on the first disagreement, naming the
+ * member and both numbers so the client can repair itself rather than guess.
+ */
+export function verifyClientShares(
+  computed: ShareMap,
+  claimed: Readonly<Record<MemberId, string | bigint>> | undefined,
+): void {
+  if (claimed === undefined) return;
+
+  for (const [member, share] of computed) {
+    const raw = claimed[member];
+    if (raw === undefined) {
+      throw new SplitError(
+        'SHARE_MISMATCH',
+        `Server computed ${share} for ${member}, client said nothing`,
+      );
+    }
+    if (toBigInt(raw, member) !== share) {
+      throw new SplitError(
+        'SHARE_MISMATCH',
+        `Server computed ${share} for ${member}, client said ${String(raw)}`,
+      );
+    }
+  }
+
+  // The other direction matters just as much: a client that invents a share for
+  // somebody outside the split is wrong even though every share the server
+  // computed happened to match.
+  for (const member of Object.keys(claimed)) {
+    if (!computed.has(member)) {
+      throw new SplitError(
+        'SHARE_MISMATCH',
+        `Client claimed a share for ${member}, who is not in this split`,
+      );
+    }
+  }
+}
+
+function toBigInt(value: string | bigint, member: MemberId): bigint {
+  if (typeof value === 'bigint') return value;
+  try {
+    return BigInt(value);
+  } catch {
+    throw new SplitError('SHARE_MISMATCH', `Client sent "${value}" as ${member}'s share`);
+  }
+}

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -1,1 +1,3 @@
 export * from './protocol';
+export * from './queue';
+export * from './mirror';

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -1,0 +1,271 @@
+/**
+ * The local mirror and how server changes fold into it (TDR §4 steps 3–4).
+ *
+ * The client keeps two layers, never one:
+ *
+ *   **server**  — exactly what the server last told us, addressed by the
+ *                 per-group `updated_seq` cursor.
+ *   **pending** — the mutation queue, replayed on top at read time.
+ *
+ * Keeping them apart is what makes "UI reads local-first, always" (ADR-005)
+ * survive a pull. If optimistic edits were written into the server layer, a
+ * pull that arrived before our own mutation was applied would revert the screen
+ * under the user's finger. Here the pull only ever replaces the server layer,
+ * and the pending edits are re-applied over the top, so the number on screen
+ * only moves when the server actually disagrees.
+ */
+
+import { computeShares } from '../split/computeShares';
+import type { MemberId, SplitParams, SplitType } from '../split/types';
+import type { CurrencyCode } from '../money/currency';
+import type { ExpenseSnapshot } from '../balances/types';
+
+import type {
+  ExpenseCreatePayload,
+  ExpenseDeletePayload,
+  MutationEnvelope,
+  SyncChange,
+  SyncTable,
+} from './protocol';
+import type { QueuedMutation } from './queue';
+
+/** A row as the server sends it: snake_case, amounts as decimal strings. */
+export type MirrorRow = Readonly<Record<string, unknown>>;
+
+export interface MirrorState {
+  /** Highest `updated_seq` we have applied, per group. */
+  readonly cursors: Readonly<Record<string, number>>;
+  readonly tables: Readonly<Record<SyncTable, Readonly<Record<string, MirrorRow>>>>;
+}
+
+const TABLES: readonly SyncTable[] = [
+  'groups',
+  'group_members',
+  'expenses',
+  'expense_versions',
+  'expense_payers',
+  'expense_shares',
+  'settlements',
+  'settlement_allocations',
+  'activity_log',
+];
+
+export function emptyMirror(): MirrorState {
+  const tables = {} as Record<SyncTable, Record<string, MirrorRow>>;
+  for (const table of TABLES) tables[table] = {};
+  return { cursors: {}, tables };
+}
+
+export interface ReconcileResult {
+  readonly state: MirrorState;
+  /** Changes ignored because we already had them — surfaced so tests can assert replay is free. */
+  readonly skipped: number;
+}
+
+/**
+ * Fold a pull into the mirror.
+ *
+ * Changes at or below the cursor are dropped: the server is allowed to resend
+ * them (Realtime and the pull overlap by design) and re-applying must be a
+ * no-op. Within a batch the highest `seq` wins, so an out-of-order response
+ * cannot resurrect an older row.
+ */
+export function reconcile(state: MirrorState, changes: readonly SyncChange[]): ReconcileResult {
+  const cursors: Record<string, number> = { ...state.cursors };
+  const tables = {} as Record<SyncTable, Record<string, MirrorRow>>;
+  for (const table of TABLES) tables[table] = { ...state.tables[table] };
+
+  // Track the winning seq per row so a batch containing two versions of the
+  // same row resolves the same way regardless of the order it arrived in.
+  const winningSeq = new Map<string, number>();
+  let skipped = 0;
+
+  for (const change of [...changes].sort((a, b) => a.seq - b.seq)) {
+    const cursor = state.cursors[change.groupId] ?? 0;
+    if (change.seq <= cursor) {
+      skipped += 1;
+      continue;
+    }
+
+    const id = idOf(change.row);
+    if (id === undefined) continue;
+
+    const key = `${change.table}:${id}`;
+    if ((winningSeq.get(key) ?? -1) > change.seq) continue;
+    winningSeq.set(key, change.seq);
+
+    if (change.deleted === true) {
+      delete tables[change.table][id];
+    } else {
+      tables[change.table][id] = change.row;
+    }
+    cursors[change.groupId] = Math.max(cursors[change.groupId] ?? 0, change.seq);
+  }
+
+  return { state: { cursors, tables }, skipped };
+}
+
+function idOf(row: MirrorRow): string | undefined {
+  return typeof row.id === 'string' ? row.id : undefined;
+}
+
+export function rowsFor(state: MirrorState, table: SyncTable, groupId?: string): MirrorRow[] {
+  const all = Object.values(state.tables[table]);
+  return groupId === undefined ? all : all.filter((row) => row.group_id === groupId);
+}
+
+// ────────────────────────────────────────── the pending overlay ──
+
+/** The expense shape the app reads, identical to the server's embed. */
+export interface MirrorExpense extends MirrorRow {
+  readonly id: string;
+  readonly group_id: string;
+  readonly deleted_at: string | null;
+  readonly created_at: string;
+  readonly currentVersion: {
+    readonly id: string;
+    readonly version_no: number;
+    readonly description: string;
+    readonly category: string | null;
+    readonly expense_date: string;
+    readonly currency: string;
+    readonly amount: string;
+    readonly split_type: SplitType;
+    readonly split_params: SplitParams;
+    readonly author_member_id: string | null;
+    readonly notes: string | null;
+    readonly created_at: string;
+    readonly payers: readonly { member_id: string; amount: string }[];
+    readonly shares: readonly { member_id: string; amount: string }[];
+  } | null;
+  /** True while this row exists only in the queue. The UI marks it "not synced yet". */
+  readonly pending?: boolean;
+}
+
+export interface MaterialiseOptions {
+  readonly groupId: string;
+  /** Whose membership authored the queued edits. */
+  readonly authorMemberId?: string | null;
+}
+
+/**
+ * The expenses to render: the server's rows with the queue replayed on top.
+ *
+ * Shares are recomputed here with the same function and the same seed the
+ * server uses, so an offline expense shows the exact numbers it will have once
+ * it syncs — no correction flicker when the network comes back.
+ */
+export function materialiseExpenses(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: MaterialiseOptions,
+): MirrorExpense[] {
+  const byId = new Map<string, MirrorExpense>();
+  for (const row of rowsFor(state, 'expenses', options.groupId)) {
+    const expense = row as MirrorExpense;
+    byId.set(expense.id, expense);
+  }
+
+  for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (mutation.groupId !== options.groupId) continue;
+    applyPending(byId, mutation, options);
+  }
+
+  return [...byId.values()].sort((a, b) =>
+    String(b.created_at).localeCompare(String(a.created_at)),
+  );
+}
+
+function applyPending(
+  byId: Map<string, MirrorExpense>,
+  mutation: MutationEnvelope,
+  options: MaterialiseOptions,
+): void {
+  switch (mutation.kind) {
+    case 'expense.create':
+    case 'expense.update': {
+      const payload = mutation.payload as ExpenseCreatePayload;
+      const existing = byId.get(payload.expenseId);
+      byId.set(payload.expenseId, {
+        id: payload.expenseId,
+        group_id: mutation.groupId,
+        deleted_at: null,
+        created_at: existing?.created_at ?? mutation.clientCreatedAt,
+        pending: true,
+        currentVersion: {
+          id: `pending:${mutation.clientMutationId}`,
+          version_no: (existing?.currentVersion?.version_no ?? 0) + 1,
+          description: payload.description,
+          category: payload.category ?? null,
+          expense_date: payload.expenseDate,
+          currency: payload.currency,
+          amount: payload.amount,
+          split_type: payload.splitParams.kind,
+          split_params: payload.splitParams,
+          author_member_id: options.authorMemberId ?? null,
+          notes: payload.notes ?? null,
+          created_at: mutation.clientCreatedAt,
+          payers: Object.entries(payload.payers).map(([member_id, amount]) => ({
+            member_id,
+            amount,
+          })),
+          shares: pendingShares(payload),
+        },
+      });
+      return;
+    }
+    case 'expense.delete': {
+      const { expenseId } = mutation.payload as ExpenseDeletePayload;
+      const existing = byId.get(expenseId);
+      if (existing) {
+        byId.set(expenseId, { ...existing, deleted_at: mutation.clientCreatedAt, pending: true });
+      }
+      return;
+    }
+    case 'expense.restore': {
+      const { expenseId } = mutation.payload as ExpenseDeletePayload;
+      const existing = byId.get(expenseId);
+      if (existing) byId.set(expenseId, { ...existing, deleted_at: null, pending: true });
+      return;
+    }
+    default:
+      // Members, groups and settlements are mirrored but not overlaid: none of
+      // them can be created offline in a way that changes an expense row.
+      return;
+  }
+}
+
+function pendingShares(payload: ExpenseCreatePayload): { member_id: string; amount: string }[] {
+  const shares = computeShares({
+    amount: BigInt(payload.amount),
+    currency: payload.currency as CurrencyCode,
+    params: payload.splitParams,
+    participants: payload.participants as readonly MemberId[],
+    // Same seed the server uses, so the remainder lands on the same person.
+    seed: payload.expenseId,
+  });
+  return [...shares].map(([member_id, amount]) => ({ member_id, amount: amount.toString() }));
+}
+
+/** Non-deleted expenses only — what balances are computed from. */
+export function liveExpenses(expenses: readonly MirrorExpense[]): MirrorExpense[] {
+  return expenses.filter((expense) => expense.deleted_at === null && expense.currentVersion);
+}
+
+/**
+ * Wire row → the shape `computeNetBalances` wants. Amounts cross the network as
+ * decimal strings (JSON has no integers this size) and become bigint here, once.
+ */
+export function toExpenseSnapshot(expense: MirrorExpense): ExpenseSnapshot | null {
+  const version = expense.currentVersion;
+  if (!version) return null;
+  return {
+    id: expense.id,
+    currency: version.currency as CurrencyCode,
+    amount: BigInt(version.amount),
+    payers: Object.fromEntries(version.payers.map((row) => [row.member_id, BigInt(row.amount)])),
+    shares: Object.fromEntries(version.shares.map((row) => [row.member_id, BigInt(row.amount)])),
+    date: version.expense_date,
+    deletedAt: expense.deleted_at,
+  };
+}

--- a/packages/core/src/sync/queue.ts
+++ b/packages/core/src/sync/queue.ts
@@ -1,0 +1,208 @@
+/**
+ * The offline mutation queue (ADR-005 / TDR §4).
+ *
+ * Pure data in, pure data out: the queue is the hardest part of the client, so
+ * it lives here where it can be property-tested in Node rather than on a device
+ * (ADR-014). The mobile app owns persistence (SQLite); this module owns the
+ * rules about what gets sent, in what order, and what happens when it fails.
+ *
+ * Two rules drive everything:
+ *
+ *  1. **Order is preserved within a group.** An edit that follows a create must
+ *     never overtake it, so a stalled mutation blocks everything behind it in
+ *     the same group — and nothing at all in any other group.
+ *  2. **Nothing is ever silently dropped.** A mutation leaves the queue only
+ *     when the server confirms it applied, confirms it is a duplicate, or
+ *     rejects it with a reason the user can be shown.
+ */
+
+import type { MutationEnvelope, SyncMutationOutcome, SyncRejectionCode } from './protocol';
+
+export interface QueuedMutation extends MutationEnvelope {
+  /** Local insertion order. The queue is FIFO and this is the tiebreak. */
+  readonly seq: number;
+  readonly attempts: number;
+  /** Unix ms before which this mutation must not be retried. */
+  readonly nextAttemptAt: number;
+  readonly lastError?: string | null;
+}
+
+/** Mutations that failed this many times stop retrying and ask the user. */
+export const MAX_ATTEMPTS = 8;
+
+/** Roughly 2s, 4s, 8s … capped at five minutes. Deterministic: no jitter, so tests can assert it. */
+export function backoffMs(attempts: number): number {
+  const exponential = 2000 * 2 ** Math.max(0, attempts - 1);
+  return Math.min(exponential, 5 * 60_000);
+}
+
+export function enqueue(
+  queue: readonly QueuedMutation[],
+  envelope: MutationEnvelope,
+): QueuedMutation[] {
+  const seq = queue.reduce((highest, item) => Math.max(highest, item.seq), 0) + 1;
+  const queued: QueuedMutation = {
+    ...envelope,
+    seq,
+    attempts: 0,
+    nextAttemptAt: 0,
+    lastError: null,
+  };
+  return coalesce([...queue, queued]);
+}
+
+/**
+ * Collapse consecutive un-sent edits of the same expense.
+ *
+ * Someone editing offline produces one mutation per save. Every one of those
+ * would become a version nobody ever saw (ADR-004 keeps versions forever), so
+ * the intermediate ones are noise. Only *adjacent* and *never-attempted*
+ * updates of the same expense collapse — anything already in flight has been
+ * seen by the server and must keep its own identity for idempotency.
+ */
+function coalesce(queue: readonly QueuedMutation[]): QueuedMutation[] {
+  const result: QueuedMutation[] = [];
+  for (const item of queue) {
+    const previous = result[result.length - 1];
+    const collapsible =
+      previous !== undefined &&
+      previous.kind === 'expense.update' &&
+      item.kind === 'expense.update' &&
+      previous.attempts === 0 &&
+      item.attempts === 0 &&
+      previous.groupId === item.groupId &&
+      expenseIdOf(previous) !== undefined &&
+      expenseIdOf(previous) === expenseIdOf(item);
+
+    if (collapsible) {
+      // Keep the newest payload and the newest id: the older one was never sent,
+      // so no server has ever heard of it.
+      result[result.length - 1] = { ...item, seq: previous.seq };
+    } else {
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+function expenseIdOf(mutation: MutationEnvelope): string | undefined {
+  const payload = mutation.payload as { expenseId?: unknown } | null;
+  return typeof payload?.expenseId === 'string' ? payload.expenseId : undefined;
+}
+
+export interface BatchOptions {
+  readonly now: number;
+  readonly limit?: number;
+  readonly maxAttempts?: number;
+}
+
+/**
+ * The next mutations to send, in order.
+ *
+ * A group whose head mutation is waiting out a backoff contributes nothing at
+ * all this round — sending its later mutations would apply an edit before the
+ * create it depends on. Other groups are unaffected, so one poisoned expense
+ * cannot stop the rest of the app from syncing.
+ */
+export function nextBatch(
+  queue: readonly QueuedMutation[],
+  options: BatchOptions,
+): QueuedMutation[] {
+  const { now, limit = 50, maxAttempts = MAX_ATTEMPTS } = options;
+  const blocked = new Set<string>();
+  const batch: QueuedMutation[] = [];
+
+  for (const item of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (blocked.has(item.groupId)) continue;
+    if (item.attempts >= maxAttempts || item.nextAttemptAt > now) {
+      blocked.add(item.groupId);
+      continue;
+    }
+    batch.push(item);
+    if (batch.length >= limit) break;
+  }
+  return batch;
+}
+
+/** Mutations that have given up retrying and need the user to decide. */
+export function deadLettered(
+  queue: readonly QueuedMutation[],
+  maxAttempts = MAX_ATTEMPTS,
+): QueuedMutation[] {
+  return queue.filter((item) => item.attempts >= maxAttempts);
+}
+
+export interface OutcomeResult {
+  readonly queue: QueuedMutation[];
+  /** Rejected mutations, so the UI can explain what happened and to what. */
+  readonly rejected: readonly {
+    mutation: QueuedMutation;
+    code: SyncRejectionCode;
+    message: string;
+  }[];
+}
+
+/**
+ * Fold a server response back into the queue.
+ *
+ * `applied` and `duplicate` both mean the server has it, so both remove the
+ * mutation — that is exactly what makes replay after a crash safe.
+ */
+export function applyOutcomes(
+  queue: readonly QueuedMutation[],
+  outcomes: readonly SyncMutationOutcome[],
+): OutcomeResult {
+  const byId = new Map(outcomes.map((outcome) => [outcome.clientMutationId, outcome]));
+  const remaining: QueuedMutation[] = [];
+  const rejected: { mutation: QueuedMutation; code: SyncRejectionCode; message: string }[] = [];
+
+  for (const item of queue) {
+    const outcome = byId.get(item.clientMutationId);
+    if (outcome === undefined) {
+      remaining.push(item);
+      continue;
+    }
+    if (outcome.status === 'applied' || outcome.status === 'duplicate') continue;
+    rejected.push({ mutation: item, code: outcome.code, message: outcome.message });
+  }
+
+  return { queue: remaining, rejected: [...rejected] };
+}
+
+/**
+ * The whole batch failed to reach the server (offline, 500, timeout). Nothing
+ * is dropped; every mutation in the batch waits out its own backoff.
+ */
+export function markFailed(
+  queue: readonly QueuedMutation[],
+  batch: readonly QueuedMutation[],
+  error: string,
+  now: number,
+): QueuedMutation[] {
+  const ids = new Set(batch.map((item) => item.clientMutationId));
+  return queue.map((item) => {
+    if (!ids.has(item.clientMutationId)) return item;
+    const attempts = item.attempts + 1;
+    return { ...item, attempts, nextAttemptAt: now + backoffMs(attempts), lastError: error };
+  });
+}
+
+/** Drop a dead-lettered mutation the user has chosen to abandon. */
+export function discard(
+  queue: readonly QueuedMutation[],
+  clientMutationId: string,
+): QueuedMutation[] {
+  return queue.filter((item) => item.clientMutationId !== clientMutationId);
+}
+
+/** Send it again now, ignoring the backoff — the user tapped "retry". */
+export function retryNow(
+  queue: readonly QueuedMutation[],
+  clientMutationId: string,
+): QueuedMutation[] {
+  return queue.map((item) =>
+    item.clientMutationId === clientMutationId
+      ? { ...item, attempts: 0, nextAttemptAt: 0, lastError: null }
+      : item,
+  );
+}

--- a/packages/core/test/split.combinations.test.ts
+++ b/packages/core/test/split.combinations.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Exhaustive split combinations for the three split types a user picks by hand:
+ * **percentage**, **fixed value** (`exact`) and **share** (`shares`).
+ *
+ * The property suite in `split.property.test.ts` proves the invariants hold for
+ * randomly drawn inputs. This one is the opposite approach: a defined space,
+ * walked completely, so the same numbers are checked on every run rather than
+ * whichever ones fast-check happened to draw. The space is described in
+ * `docs/split-scenarios.md`, and it is:
+ *
+ *   participants  2, 3, 4, 5
+ *   amounts       0, 1, 7, 100, 333, 999, 1000, 100000, 123457 paise
+ *   weights       every composition of 10 units across the participants
+ *                 (11, 66, 286 and 1001 vectors for 2–5 people)
+ *
+ * That is 1364 weight vectors × 9 amounts × 2 weighted types, plus the fixed
+ * value cases derived from each result — roughly 25k computations, all of them
+ * checked against the same five rules.
+ *
+ * Every one of these runs on the server for real: the edge functions recompute
+ * shares from `split_params` with this exact function and reject a client whose
+ * numbers differ (TDR §4).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { computeShares, sumShares } from '../src/split/computeShares.js';
+import { verifyClientShares } from '../src/split/verify.js';
+import {
+  SplitError,
+  type MemberId,
+  type ShareMap,
+  type SplitErrorCode,
+} from '../src/split/types.js';
+
+/**
+ * Assert on the machine-readable code rather than the prose. The message is for
+ * a person and may be reworded; the code is what the client branches on.
+ */
+function expectSplitError(run: () => unknown, code: SplitErrorCode): void {
+  try {
+    run();
+  } catch (error) {
+    expect(error).toBeInstanceOf(SplitError);
+    expect((error as SplitError).code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected a ${code} error, but the split succeeded`);
+}
+
+const INR = 'INR';
+const SEED = 'expense-0001';
+
+const PARTICIPANT_COUNTS = [2, 3, 4, 5] as const;
+
+/** Chosen to cover every remainder class for 2–5 people, plus the edges. */
+const AMOUNTS = [0n, 1n, 7n, 100n, 333n, 999n, 1000n, 100_000n, 123_457n];
+
+/** Ten units to share out — the lattice the weight vectors are drawn from. */
+const WEIGHT_UNITS = 10;
+
+function members(count: number): MemberId[] {
+  return Array.from({ length: count }, (_, index) => `m${index + 1}`);
+}
+
+/** Every way to split `total` into `parts` non-negative integers. */
+function compositions(total: number, parts: number): number[][] {
+  if (parts === 1) return [[total]];
+  const result: number[][] = [];
+  for (let head = 0; head <= total; head += 1) {
+    for (const tail of compositions(total - head, parts - 1)) {
+      result.push([head, ...tail]);
+    }
+  }
+  return result;
+}
+
+function vector(ids: readonly MemberId[], weights: readonly number[]): Record<MemberId, number> {
+  return Object.fromEntries(ids.map((id, index) => [id, weights[index] ?? 0]));
+}
+
+/**
+ * The five rules every split must satisfy, whatever the type.
+ *
+ * The proportionality bound is the interesting one: each member gets the floor
+ * of their exact share, and at most one extra minor unit from the remainder
+ * pass. Anything outside that window means the money moved somewhere it should
+ * not have.
+ */
+function assertWellFormed(
+  shares: ShareMap,
+  amount: bigint,
+  ids: readonly MemberId[],
+  weights?: readonly number[],
+): void {
+  expect(sumShares(shares)).toBe(amount);
+  expect([...shares.keys()].sort()).toEqual([...ids].sort());
+
+  for (const share of shares.values()) {
+    if (amount >= 0n) expect(share).toBeGreaterThanOrEqual(0n);
+    expect(share).toBeLessThanOrEqual(amount > 0n ? amount : 0n);
+  }
+
+  if (weights) {
+    const totalWeight = BigInt(weights.reduce((sum, weight) => sum + weight, 0));
+    if (totalWeight > 0n) {
+      ids.forEach((id, index) => {
+        const exactFloor = (amount * BigInt(weights[index] ?? 0)) / totalWeight;
+        const share = shares.get(id) ?? 0n;
+        expect(share).toBeGreaterThanOrEqual(exactFloor);
+        expect(share).toBeLessThanOrEqual(exactFloor + 1n);
+      });
+      // Nobody with a zero weight pays anything.
+      ids.forEach((id, index) => {
+        if ((weights[index] ?? 0) === 0) expect(shares.get(id)).toBe(0n);
+      });
+    }
+  }
+}
+
+describe('percentage splits — every composition of 100%', () => {
+  for (const count of PARTICIPANT_COUNTS) {
+    const ids = members(count);
+    // Ten units of 1000 basis points each: exhaustive over whole percentages
+    // that are multiples of 10%, which is the lattice the doc describes.
+    const vectors = compositions(WEIGHT_UNITS, count);
+
+    it(`holds for all ${vectors.length} vectors × ${AMOUNTS.length} amounts with ${count} people`, () => {
+      for (const weights of vectors) {
+        const basisPoints = vector(
+          ids,
+          weights.map((weight) => weight * 1000),
+        );
+        for (const amount of AMOUNTS) {
+          const shares = computeShares({
+            amount,
+            currency: INR,
+            params: { kind: 'percent', basisPoints },
+            participants: ids,
+            seed: SEED,
+          });
+          assertWellFormed(shares, amount, ids, weights);
+        }
+      }
+    });
+  }
+
+  it('is deterministic and independent of the order participants are listed in', () => {
+    const ids = members(4);
+    for (const weights of compositions(WEIGHT_UNITS, 4)) {
+      const basisPoints = vector(
+        ids,
+        weights.map((w) => w * 1000),
+      );
+      const forwards = computeShares({
+        amount: 123_457n,
+        currency: INR,
+        params: { kind: 'percent', basisPoints },
+        participants: ids,
+        seed: SEED,
+      });
+      const backwards = computeShares({
+        amount: 123_457n,
+        currency: INR,
+        params: { kind: 'percent', basisPoints },
+        participants: [...ids].reverse(),
+        seed: SEED,
+      });
+      expect([...backwards].sort()).toEqual([...forwards].sort());
+    }
+  });
+
+  it('rejects percentages that do not add up to exactly 100%', () => {
+    const ids = members(3);
+    for (const total of [0, 1, 9999, 10001, 20000]) {
+      const basisPoints = { m1: total, m2: 0, m3: 0 };
+      expectSplitError(
+        () =>
+          computeShares({
+            amount: 1000n,
+            currency: INR,
+            params: { kind: 'percent', basisPoints },
+            participants: ids,
+            seed: SEED,
+          }),
+        'PERCENT_SUM_MISMATCH',
+      );
+    }
+  });
+
+  it('rejects negative and fractional basis points', () => {
+    const ids = members(2);
+    for (const bad of [-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expectSplitError(
+        () =>
+          computeShares({
+            amount: 1000n,
+            currency: INR,
+            params: { kind: 'percent', basisPoints: { m1: bad, m2: 10000 } },
+            participants: ids,
+            seed: SEED,
+          }),
+        'INVALID_WEIGHT',
+      );
+    }
+  });
+});
+
+describe('share splits — every composition of ten shares', () => {
+  for (const count of PARTICIPANT_COUNTS) {
+    const ids = members(count);
+    const vectors = compositions(WEIGHT_UNITS, count).filter((weights) =>
+      weights.some((weight) => weight > 0),
+    );
+
+    it(`holds for all ${vectors.length} vectors × ${AMOUNTS.length} amounts with ${count} people`, () => {
+      for (const weights of vectors) {
+        for (const amount of AMOUNTS) {
+          const shares = computeShares({
+            amount,
+            currency: INR,
+            params: { kind: 'shares', weights: vector(ids, weights) },
+            participants: ids,
+            seed: SEED,
+          });
+          assertWellFormed(shares, amount, ids, weights);
+        }
+      }
+    });
+  }
+
+  it('matches the equivalent percentage split whenever the ratio is the same', () => {
+    const ids = members(4);
+    for (const weights of compositions(WEIGHT_UNITS, 4)) {
+      if (!weights.some((weight) => weight > 0)) continue;
+      const bySh = computeShares({
+        amount: 123_457n,
+        currency: INR,
+        params: { kind: 'shares', weights: vector(ids, weights) },
+        participants: ids,
+        seed: SEED,
+      });
+      const byPct = computeShares({
+        amount: 123_457n,
+        currency: INR,
+        params: {
+          kind: 'percent',
+          basisPoints: vector(
+            ids,
+            weights.map((w) => w * 1000),
+          ),
+        },
+        participants: ids,
+        seed: SEED,
+      });
+      // 3:1 and 75%:25% are the same instruction, so they must be the same
+      // money — including which person absorbs the leftover paisa.
+      expect([...bySh].sort()).toEqual([...byPct].sort());
+    }
+  });
+
+  it('treats a uniform share split as an equal split', () => {
+    for (const count of PARTICIPANT_COUNTS) {
+      const ids = members(count);
+      for (const amount of AMOUNTS) {
+        const byShares = computeShares({
+          amount,
+          currency: INR,
+          params: {
+            kind: 'shares',
+            weights: vector(
+              ids,
+              ids.map(() => 1),
+            ),
+          },
+          participants: ids,
+          seed: SEED,
+        });
+        const byEqual = computeShares({
+          amount,
+          currency: INR,
+          params: { kind: 'equal' },
+          participants: ids,
+          seed: SEED,
+        });
+        expect([...byShares].sort()).toEqual([...byEqual].sort());
+      }
+    }
+  });
+
+  it('refuses a split where nobody has a positive share', () => {
+    const ids = members(3);
+    expectSplitError(
+      () =>
+        computeShares({
+          amount: 1000n,
+          currency: INR,
+          params: { kind: 'shares', weights: { m1: 0, m2: 0, m3: 0 } },
+          participants: ids,
+          seed: SEED,
+        }),
+      'NO_POSITIVE_WEIGHT',
+    );
+  });
+
+  it('rejects negative and fractional weights', () => {
+    const ids = members(2);
+    for (const bad of [-1, 1.5, Number.NaN]) {
+      expectSplitError(
+        () =>
+          computeShares({
+            amount: 1000n,
+            currency: INR,
+            params: { kind: 'shares', weights: { m1: bad, m2: 1 } },
+            participants: ids,
+            seed: SEED,
+          }),
+        'INVALID_WEIGHT',
+      );
+    }
+  });
+});
+
+describe('fixed value splits — exact amounts per person', () => {
+  it('accepts any set of amounts that adds up, across every combination tested above', () => {
+    // Every percentage and share result is, by definition, a valid fixed-value
+    // split of the same expense. Feeding each one back in proves the two ways
+    // of describing the same money agree.
+    for (const count of PARTICIPANT_COUNTS) {
+      const ids = members(count);
+      for (const weights of compositions(WEIGHT_UNITS, count)) {
+        if (!weights.some((weight) => weight > 0)) continue;
+        for (const amount of AMOUNTS) {
+          const weighted = computeShares({
+            amount,
+            currency: INR,
+            params: { kind: 'shares', weights: vector(ids, weights) },
+            participants: ids,
+            seed: SEED,
+          });
+          const asExact = computeShares({
+            amount,
+            currency: INR,
+            params: { kind: 'exact', amounts: Object.fromEntries(weighted) },
+            participants: ids,
+            seed: SEED,
+          });
+          expect([...asExact].sort()).toEqual([...weighted].sort());
+        }
+      }
+    }
+  });
+
+  it('rejects amounts that are a single paisa out, in either direction', () => {
+    const ids = members(3);
+    for (const drift of [-1n, 1n]) {
+      expectSplitError(
+        () =>
+          computeShares({
+            amount: 1000n,
+            currency: INR,
+            params: { kind: 'exact', amounts: { m1: 400n, m2: 300n, m3: 300n + drift } },
+            participants: ids,
+            seed: SEED,
+          }),
+        'EXACT_SUM_MISMATCH',
+      );
+    }
+  });
+
+  it('lets one person carry the whole expense, and lets others carry nothing', () => {
+    const ids = members(3);
+    const shares = computeShares({
+      amount: 1000n,
+      currency: INR,
+      params: { kind: 'exact', amounts: { m1: 1000n } },
+      participants: ids,
+      seed: SEED,
+    });
+    // Members with no entry still appear, at zero, so the UI and the
+    // expense_shares table agree on the row set.
+    expect(shares.get('m1')).toBe(1000n);
+    expect(shares.get('m2')).toBe(0n);
+    expect(shares.get('m3')).toBe(0n);
+  });
+
+  it('allows a negative share only as part of a set that still sums correctly', () => {
+    // Someone was credited back — the total is still the total.
+    const shares = computeShares({
+      amount: 1000n,
+      currency: INR,
+      params: { kind: 'exact', amounts: { m1: 1200n, m2: -200n } },
+      participants: members(2),
+      seed: SEED,
+    });
+    expect(sumShares(shares)).toBe(1000n);
+  });
+});
+
+describe('rules that apply to every split type', () => {
+  const each = [
+    { name: 'percent', params: { kind: 'percent' as const, basisPoints: { m1: 5000, m2: 5000 } } },
+    { name: 'shares', params: { kind: 'shares' as const, weights: { m1: 1, m2: 1 } } },
+    { name: 'exact', params: { kind: 'exact' as const, amounts: { m1: 500n, m2: 500n } } },
+  ];
+
+  for (const { name, params } of each) {
+    it(`${name}: refuses an expense with no participants`, () => {
+      expectSplitError(
+        () => computeShares({ amount: 1000n, currency: INR, params, participants: [], seed: SEED }),
+        'EMPTY_PARTICIPANTS',
+      );
+    });
+
+    it(`${name}: refuses a duplicated participant`, () => {
+      expectSplitError(
+        () =>
+          computeShares({
+            amount: 1000n,
+            currency: INR,
+            params,
+            participants: ['m1', 'm2', 'm1'],
+            seed: SEED,
+          }),
+        'DUPLICATE_PARTICIPANT',
+      );
+    });
+
+    it(`${name}: refuses a negative expense total`, () => {
+      expectSplitError(
+        () =>
+          computeShares({
+            amount: -1000n,
+            currency: INR,
+            params,
+            participants: ['m1', 'm2'],
+            seed: SEED,
+          }),
+        'NEGATIVE_TOTAL',
+      );
+    });
+  }
+
+  it('refuses to give a share to somebody who is not in the split', () => {
+    const outsider = [
+      { kind: 'percent' as const, basisPoints: { m1: 5000, m2: 4000, mallory: 1000 } },
+      { kind: 'shares' as const, weights: { m1: 1, m2: 1, mallory: 1 } },
+      { kind: 'exact' as const, amounts: { m1: 500n, m2: 400n, mallory: 100n } },
+    ];
+    for (const params of outsider) {
+      expectSplitError(
+        () =>
+          computeShares({
+            amount: 1000n,
+            currency: INR,
+            params,
+            participants: ['m1', 'm2'],
+            seed: SEED,
+          }),
+        'UNKNOWN_MEMBER',
+      );
+    }
+  });
+
+  it('gives the same answer every time it is asked', () => {
+    const ids = members(5);
+    for (const weights of compositions(WEIGHT_UNITS, 5).slice(0, 200)) {
+      if (!weights.some((weight) => weight > 0)) continue;
+      const once = computeShares({
+        amount: 123_457n,
+        currency: INR,
+        params: { kind: 'shares', weights: vector(ids, weights) },
+        participants: ids,
+        seed: SEED,
+      });
+      const twice = computeShares({
+        amount: 123_457n,
+        currency: INR,
+        params: { kind: 'shares', weights: vector(ids, weights) },
+        participants: ids,
+        seed: SEED,
+      });
+      expect([...twice]).toEqual([...once]);
+    }
+  });
+
+  it('moves the leftover paisa around as the expense changes, not always onto one person', () => {
+    // ADR-009: the remainder rotates by a hash of the expense id, so the same
+    // person is not quietly overcharged on every bill.
+    const ids = members(3);
+    const absorbers = new Set<string>();
+    for (let index = 0; index < 60; index += 1) {
+      const shares = computeShares({
+        amount: 1000n, // 1000 / 3 = 333 remainder 1
+        currency: INR,
+        params: { kind: 'equal' },
+        participants: ids,
+        seed: `expense-${index}`,
+      });
+      for (const [member, share] of shares) if (share === 334n) absorbers.add(member);
+    }
+    expect(absorbers.size).toBe(3);
+  });
+});
+
+describe('the server is the one that decides (TDR §4)', () => {
+  const ids = members(3);
+  const params = { kind: 'percent' as const, basisPoints: { m1: 5000, m2: 3000, m3: 2000 } };
+  const authoritative = computeShares({
+    amount: 1000n,
+    currency: INR,
+    params,
+    participants: ids,
+    seed: SEED,
+  });
+
+  it('accepts a client that agrees exactly', () => {
+    const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
+    expect(() => verifyClientShares(authoritative, claimed)).not.toThrow();
+  });
+
+  it('accepts a client that claims nothing at all', () => {
+    // An offline client that has not recomputed simply takes the server's word.
+    expect(() => verifyClientShares(authoritative, undefined)).not.toThrow();
+  });
+
+  it('rejects a client that is one paisa out', () => {
+    const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
+    claimed.m1 = (BigInt(claimed.m1 ?? '0') + 1n).toString();
+    expectSplitError(() => verifyClientShares(authoritative, claimed), 'SHARE_MISMATCH');
+  });
+
+  it('rejects a client that omits somebody', () => {
+    const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
+    delete claimed.m3;
+    expectSplitError(() => verifyClientShares(authoritative, claimed), 'SHARE_MISMATCH');
+  });
+
+  it('rejects a client that invents somebody', () => {
+    // Every share the server computed matches; the client has simply added a
+    // person of its own. A per-member loop over the server's map alone would
+    // wave this through.
+    const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
+    claimed.mallory = '0';
+    expectSplitError(() => verifyClientShares(authoritative, claimed), 'SHARE_MISMATCH');
+  });
+
+  it('rejects a client that sends something that is not a number', () => {
+    const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
+    claimed.m1 = 'five hundred';
+    expectSplitError(() => verifyClientShares(authoritative, claimed), 'SHARE_MISMATCH');
+  });
+
+  it('cannot be told what a share should be — it is a function of the inputs only', () => {
+    // There is no channel for a caller to supply a share: the only inputs are
+    // the total, the parameters, the participants and the seed. This is what
+    // makes "the calculation happens in the backend" structural rather than a
+    // matter of discipline.
+    const smuggled = {
+      kind: 'percent' as const,
+      basisPoints: { m1: 5000, m2: 3000, m3: 2000 },
+      // A client adding fields to split_params changes nothing.
+      shares: { m1: 999999n },
+    } as unknown as typeof params;
+
+    const recomputed = computeShares({
+      amount: 1000n,
+      currency: INR,
+      params: smuggled,
+      participants: ids,
+      seed: SEED,
+    });
+    expect([...recomputed]).toEqual([...authoritative]);
+  });
+});

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -1,0 +1,575 @@
+/**
+ * ADR-005 / ADR-014: "sync code is the hardest part of the client — it gets the
+ * deepest test suite."
+ *
+ * The M2 acceptance criterion is stated in TDR §10 as a scenario: *add 10
+ * expenses on 2 devices in airplane mode, reconnect, get identical balances
+ * with no duplicates.* That scenario is a property, so it is written as one
+ * here and run hundreds of times against a model of the server, then again for
+ * real against Postgres in `e2e/m2-sync.mjs`.
+ *
+ * The model server below deliberately mirrors the real one's two guarantees and
+ * nothing else: it dedupes by `client_mutation_id`, and it recomputes every
+ * share itself rather than believing the client (TDR §4).
+ */
+
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+
+import {
+  applyOutcomes,
+  backoffMs,
+  discard,
+  emptyMirror,
+  enqueue,
+  liveExpenses,
+  markFailed,
+  materialiseExpenses,
+  nextBatch,
+  reconcile,
+  retryNow,
+  toExpenseSnapshot,
+  type MirrorState,
+  type QueuedMutation,
+} from '../src/sync/index.js';
+import type {
+  ExpenseCreatePayload,
+  MutationEnvelope,
+  SyncChange,
+  SyncMutationOutcome,
+  SyncRequest,
+  SyncResponse,
+} from '../src/sync/protocol.js';
+import { computeShares } from '../src/split/computeShares.js';
+import { computeNetBalances, balanceSums } from '../src/balances/balances.js';
+import type { ExpenseSnapshot } from '../src/balances/types.js';
+import type { MemberId } from '../src/split/types.js';
+
+const GROUP = 'group-1';
+const INR = 'INR';
+
+// ───────────────────────────────────────────────── the model server ──
+
+interface StoredExpense {
+  [key: string]: unknown;
+  id: string;
+  group_id: string;
+  deleted_at: string | null;
+  created_at: string;
+  updated_seq: number;
+  currentVersion: Record<string, unknown> | null;
+}
+
+class ModelServer {
+  private seq = 0;
+  private readonly expenses = new Map<string, StoredExpense>();
+  /** client_mutation_id → the expense it produced. The idempotency key. */
+  private readonly applied = new Map<string, string>();
+  /** Every version ever written, so we can assert append-only behaviour. */
+  readonly versions: { expenseId: string; versionNo: number }[] = [];
+
+  sync(request: SyncRequest): SyncResponse {
+    const outcomes: SyncMutationOutcome[] = [];
+
+    for (const mutation of request.mutations) {
+      if (this.applied.has(mutation.clientMutationId)) {
+        outcomes.push({ clientMutationId: mutation.clientMutationId, status: 'duplicate' });
+        continue;
+      }
+      try {
+        this.apply(mutation);
+        this.applied.set(mutation.clientMutationId, 'ok');
+        outcomes.push({ clientMutationId: mutation.clientMutationId, status: 'applied' });
+      } catch (error) {
+        outcomes.push({
+          clientMutationId: mutation.clientMutationId,
+          status: 'rejected',
+          code: 'VALIDATION_FAILED',
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const since = request.cursors[GROUP] ?? 0;
+    const changes: SyncChange[] = [...this.expenses.values()]
+      .filter((row) => row.updated_seq > since)
+      .sort((a, b) => a.updated_seq - b.updated_seq)
+      .map((row) => ({ table: 'expenses' as const, groupId: GROUP, seq: row.updated_seq, row }));
+
+    return {
+      outcomes,
+      changes,
+      cursors: { [GROUP]: this.seq },
+      serverTime: new Date(0).toISOString(),
+    };
+  }
+
+  private apply(mutation: MutationEnvelope): void {
+    if (mutation.kind === 'expense.delete') {
+      const payload = mutation.payload as { expenseId: string };
+      const existing = this.expenses.get(payload.expenseId);
+      if (!existing) throw new Error('NOT_FOUND');
+      this.seq += 1;
+      this.expenses.set(payload.expenseId, {
+        ...existing,
+        deleted_at: mutation.clientCreatedAt,
+        updated_seq: this.seq,
+      });
+      return;
+    }
+
+    const payload = mutation.payload as ExpenseCreatePayload;
+    const existing = this.expenses.get(payload.expenseId);
+    const versionNo = ((existing?.currentVersion?.version_no as number) ?? 0) + 1;
+
+    // The server never trusts client-computed shares (TDR §4).
+    const shares = computeShares({
+      amount: BigInt(payload.amount),
+      currency: INR,
+      params: payload.splitParams,
+      participants: payload.participants as readonly MemberId[],
+      seed: payload.expenseId,
+    });
+
+    this.seq += 1;
+    this.versions.push({ expenseId: payload.expenseId, versionNo });
+    this.expenses.set(payload.expenseId, {
+      id: payload.expenseId,
+      group_id: GROUP,
+      deleted_at: existing?.deleted_at ?? null,
+      created_at: existing?.created_at ?? mutation.clientCreatedAt,
+      updated_seq: this.seq,
+      currentVersion: {
+        id: `v:${mutation.clientMutationId}`,
+        version_no: versionNo,
+        description: payload.description,
+        category: null,
+        expense_date: payload.expenseDate,
+        currency: INR,
+        amount: payload.amount,
+        split_type: payload.splitParams.kind,
+        split_params: payload.splitParams,
+        author_member_id: null,
+        notes: null,
+        created_at: mutation.clientCreatedAt,
+        payers: Object.entries(payload.payers).map(([member_id, amount]) => ({
+          member_id,
+          amount,
+        })),
+        shares: [...shares].map(([member_id, amount]) => ({
+          member_id,
+          amount: amount.toString(),
+        })),
+      },
+    });
+  }
+}
+
+// ───────────────────────────────────────────────────── the device ──
+
+class Device {
+  mirror: MirrorState = emptyMirror();
+  queue: QueuedMutation[] = [];
+
+  add(payload: ExpenseCreatePayload, clientMutationId: string, at: string): void {
+    this.queue = enqueue(this.queue, {
+      clientMutationId,
+      kind: 'expense.create',
+      groupId: GROUP,
+      clientCreatedAt: at,
+      payload,
+    });
+  }
+
+  /** One round trip. Returns the batch that was sent, for replay tests. */
+  sync(server: ModelServer, now = 0): QueuedMutation[] {
+    const batch = nextBatch(this.queue, { now });
+    const response = server.sync({
+      deviceId: 'device',
+      mutations: batch,
+      cursors: this.mirror.cursors,
+    });
+    this.queue = applyOutcomes(this.queue, response.outcomes).queue;
+    this.mirror = reconcile(this.mirror, response.changes).state;
+    return batch;
+  }
+
+  snapshots(): ExpenseSnapshot[] {
+    return liveExpenses(materialiseExpenses(this.mirror, this.queue, { groupId: GROUP }))
+      .map(toExpenseSnapshot)
+      .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
+  }
+
+  balances(): Map<MemberId, bigint> {
+    return computeNetBalances(this.snapshots(), []).get(INR) ?? new Map();
+  }
+}
+
+// ──────────────────────────────────────────────────── generators ──
+
+const members: MemberId[] = ['m1', 'm2', 'm3'];
+
+const expenseDraft = (device: string, index: number): fc.Arbitrary<ExpenseCreatePayload> =>
+  fc
+    .record({
+      amount: fc.bigInt({ min: 1n, max: 500_000n }).map(String),
+      payerIndex: fc.integer({ min: 0, max: members.length - 1 }),
+    })
+    .map(({ amount, payerIndex }) => ({
+      expenseId: `${device}-e${index}`,
+      description: `Expense ${index}`,
+      expenseDate: '2026-03-01',
+      currency: INR,
+      amount,
+      splitParams: { kind: 'equal' as const },
+      participants: members,
+      payers: { [members[payerIndex] as MemberId]: amount },
+    }));
+
+// ──────────────────────────────────────────────────────── tests ──
+
+describe('the M2 acceptance scenario (TDR §10)', () => {
+  it('two devices, offline, reconnect: identical balances and no duplicates', () => {
+    fc.assert(
+      fc.property(
+        fc.array(expenseDraft('a', 0), { minLength: 1, maxLength: 10 }),
+        fc.array(expenseDraft('b', 0), { minLength: 1, maxLength: 10 }),
+        (draftsA, draftsB) => {
+          const server = new ModelServer();
+          const alpha = new Device();
+          const beta = new Device();
+
+          // Airplane mode: both queue everything, neither can reach the server.
+          draftsA.forEach((draft, index) => {
+            const payload = { ...draft, expenseId: `a-e${index}` };
+            alpha.add(payload, `a-m${index}`, `2026-03-01T00:00:0${index % 10}.000Z`);
+          });
+          draftsB.forEach((draft, index) => {
+            const payload = { ...draft, expenseId: `b-e${index}` };
+            beta.add(payload, `b-m${index}`, `2026-03-01T00:00:0${index % 10}.000Z`);
+          });
+
+          // Everything is visible locally before any network exists (ADR-005).
+          expect(alpha.snapshots()).toHaveLength(draftsA.length);
+          expect(beta.snapshots()).toHaveLength(draftsB.length);
+
+          // Reconnect. Two rounds each: push mine, then pull yours.
+          alpha.sync(server);
+          beta.sync(server);
+          alpha.sync(server);
+          beta.sync(server);
+
+          expect(alpha.queue).toHaveLength(0);
+          expect(beta.queue).toHaveLength(0);
+
+          const total = draftsA.length + draftsB.length;
+          expect(alpha.snapshots()).toHaveLength(total);
+          expect(beta.snapshots()).toHaveLength(total);
+
+          // The headline assertion: the two devices agree, exactly.
+          expect([...alpha.balances()].sort()).toEqual([...beta.balances()].sort());
+          for (const [, sum] of balanceSums(computeNetBalances(alpha.snapshots(), []))) {
+            expect(sum).toBe(0n);
+          }
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it('replaying a queue after a crash does not double-post', () => {
+    fc.assert(
+      fc.property(fc.array(expenseDraft('a', 0), { minLength: 1, maxLength: 6 }), (drafts) => {
+        const server = new ModelServer();
+        const device = new Device();
+        drafts.forEach((draft, index) => {
+          device.add({ ...draft, expenseId: `a-e${index}` }, `a-m${index}`, '2026-03-01T00:00:00Z');
+        });
+
+        // The app is killed after the request reaches the server but before the
+        // response clears the queue: the mutations are still pending on restart.
+        const sent = nextBatch(device.queue, { now: 0 });
+        server.sync({ deviceId: 'd', mutations: sent, cursors: {} });
+
+        device.sync(server);
+        device.sync(server);
+
+        expect(device.queue).toHaveLength(0);
+        expect(device.snapshots()).toHaveLength(drafts.length);
+        // Every expense has exactly one version: the replay wrote nothing new.
+        expect(server.versions).toHaveLength(drafts.length);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+describe('reconciliation', () => {
+  it('is idempotent — re-applying a pull changes nothing', () => {
+    const changes: SyncChange[] = [
+      { table: 'expenses', groupId: GROUP, seq: 1, row: { id: 'e1', group_id: GROUP } },
+      { table: 'expenses', groupId: GROUP, seq: 2, row: { id: 'e2', group_id: GROUP } },
+    ];
+    const once = reconcile(emptyMirror(), changes);
+    const twice = reconcile(once.state, changes);
+
+    expect(twice.state).toEqual(once.state);
+    expect(twice.skipped).toBe(2);
+    expect(once.state.cursors[GROUP]).toBe(2);
+  });
+
+  it('converges regardless of the order changes arrive in', () => {
+    fc.assert(
+      fc.property(fc.shuffledSubarray([1, 2, 3, 4, 5], { minLength: 5 }), (order) => {
+        const changes: SyncChange[] = order.map((seq) => ({
+          table: 'expenses' as const,
+          groupId: GROUP,
+          seq,
+          row: { id: 'e1', group_id: GROUP, version: seq },
+        }));
+        const state = reconcile(emptyMirror(), changes).state;
+        // The highest seq wins whatever order it was delivered in.
+        expect(state.tables.expenses.e1).toEqual({ id: 'e1', group_id: GROUP, version: 5 });
+        expect(state.cursors[GROUP]).toBe(5);
+      }),
+    );
+  });
+
+  it('never moves a cursor backwards', () => {
+    const ahead = reconcile(emptyMirror(), [
+      { table: 'expenses', groupId: GROUP, seq: 9, row: { id: 'e1', group_id: GROUP } },
+    ]).state;
+    const stale = reconcile(ahead, [
+      { table: 'expenses', groupId: GROUP, seq: 3, row: { id: 'e2', group_id: GROUP } },
+    ]).state;
+
+    expect(stale.cursors[GROUP]).toBe(9);
+    expect(stale.tables.expenses.e2).toBeUndefined();
+  });
+
+  it('applies a soft delete and drops the expense from balances', () => {
+    const device = new Device();
+    const server = new ModelServer();
+    device.add(
+      {
+        expenseId: 'e1',
+        description: 'Dinner',
+        expenseDate: '2026-03-01',
+        currency: INR,
+        amount: '900',
+        splitParams: { kind: 'equal' },
+        participants: members,
+        payers: { m1: '900' },
+      },
+      'm-1',
+      '2026-03-01T00:00:00Z',
+    );
+    device.sync(server);
+    expect(device.balances().get('m1')).toBe(600n);
+
+    device.queue = enqueue(device.queue, {
+      clientMutationId: 'm-2',
+      kind: 'expense.delete',
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-02T00:00:00Z',
+      payload: { expenseId: 'e1' },
+    });
+    // Gone from the UI before the server has heard about it.
+    expect(device.snapshots()).toHaveLength(0);
+
+    device.sync(server);
+    expect(device.snapshots()).toHaveLength(0);
+    expect(device.queue).toHaveLength(0);
+  });
+});
+
+describe('the mutation queue', () => {
+  const envelope = (
+    id: string,
+    groupId: string,
+    kind: MutationEnvelope['kind'],
+  ): MutationEnvelope => ({
+    clientMutationId: id,
+    kind,
+    groupId,
+    clientCreatedAt: '2026-03-01T00:00:00Z',
+    payload: { expenseId: `e-${id}` },
+  });
+
+  it('sends in the order the user made the changes', () => {
+    let queue: QueuedMutation[] = [];
+    for (const id of ['a', 'b', 'c']) queue = enqueue(queue, envelope(id, GROUP, 'expense.create'));
+    expect(nextBatch(queue, { now: 0 }).map((item) => item.clientMutationId)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('holds back a group whose head is in backoff, but not other groups', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, envelope('a1', 'g1', 'expense.create'));
+    queue = enqueue(queue, envelope('a2', 'g1', 'expense.create'));
+    queue = enqueue(queue, envelope('b1', 'g2', 'expense.create'));
+
+    const head = queue.filter((item) => item.clientMutationId === 'a1');
+    queue = markFailed(queue, head, 'network down', 1_000);
+
+    const batch = nextBatch(queue, { now: 1_500 }).map((item) => item.clientMutationId);
+    // a2 must not overtake a1 — it may be an edit of the same expense.
+    expect(batch).toEqual(['b1']);
+
+    // Once the backoff expires the whole group flows again, still in order.
+    expect(
+      nextBatch(queue, { now: 1_000 + backoffMs(1) + 1 }).map((i) => i.clientMutationId),
+    ).toEqual(['a1', 'a2', 'b1']);
+  });
+
+  it('treats applied and duplicate identically — both mean the server has it', () => {
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, envelope('a', GROUP, 'expense.create'));
+    queue = enqueue(queue, envelope('b', GROUP, 'expense.create'));
+    queue = enqueue(queue, envelope('c', GROUP, 'expense.create'));
+
+    const result = applyOutcomes(queue, [
+      { clientMutationId: 'a', status: 'applied' },
+      { clientMutationId: 'b', status: 'duplicate' },
+      { clientMutationId: 'c', status: 'rejected', code: 'SHARE_MISMATCH', message: 'no' },
+    ]);
+
+    expect(result.queue).toHaveLength(0);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]?.code).toBe('SHARE_MISMATCH');
+  });
+
+  it('backs off exponentially and gives up rather than retrying forever', () => {
+    expect(backoffMs(1)).toBe(2000);
+    expect(backoffMs(2)).toBe(4000);
+    expect(backoffMs(99)).toBe(5 * 60_000);
+
+    let queue: QueuedMutation[] = [enqueue([], envelope('a', GROUP, 'expense.create'))[0]!];
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      queue = markFailed(queue, queue, 'offline', 0);
+    }
+    expect(nextBatch(queue, { now: Number.MAX_SAFE_INTEGER })).toHaveLength(0);
+    expect(queue[0]?.lastError).toBe('offline');
+
+    // The user can force it through, or abandon it — nothing is lost silently.
+    expect(nextBatch(retryNow(queue, 'a'), { now: 0 })).toHaveLength(1);
+    expect(discard(queue, 'a')).toHaveLength(0);
+  });
+
+  it('collapses un-sent consecutive edits of the same expense', () => {
+    const edit = (id: string, description: string): MutationEnvelope => ({
+      clientMutationId: id,
+      kind: 'expense.update',
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { expenseId: 'e1', description },
+    });
+
+    let queue: QueuedMutation[] = [];
+    queue = enqueue(queue, edit('m1', 'Dinner'));
+    queue = enqueue(queue, edit('m2', 'Dinner at Anjappar'));
+    queue = enqueue(queue, edit('m3', 'Dinner at Anjappar with Priya'));
+
+    expect(queue).toHaveLength(1);
+    expect((queue[0]?.payload as { description: string }).description).toBe(
+      'Dinner at Anjappar with Priya',
+    );
+  });
+
+  it('never collapses an edit the server has already seen', () => {
+    const edit = (id: string): MutationEnvelope => ({
+      clientMutationId: id,
+      kind: 'expense.update',
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { expenseId: 'e1' },
+    });
+
+    let queue: QueuedMutation[] = enqueue([], edit('m1'));
+    queue = markFailed(queue, queue, 'timeout', 0);
+    queue = enqueue(queue, edit('m2'));
+
+    // m1 may have reached the server; dropping it would lose a version that
+    // other people can already see.
+    expect(queue).toHaveLength(2);
+  });
+
+  it('does not collapse edits of different expenses', () => {
+    const edit = (id: string, expenseId: string): MutationEnvelope => ({
+      clientMutationId: id,
+      kind: 'expense.update',
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-01T00:00:00Z',
+      payload: { expenseId },
+    });
+    let queue: QueuedMutation[] = enqueue([], edit('m1', 'e1'));
+    queue = enqueue(queue, edit('m2', 'e2'));
+    expect(queue).toHaveLength(2);
+  });
+});
+
+describe('the pending overlay', () => {
+  it('shows offline expenses with the shares they will have once synced', () => {
+    const device = new Device();
+    device.add(
+      {
+        expenseId: 'e1',
+        description: 'Chai',
+        expenseDate: '2026-03-01',
+        currency: INR,
+        amount: '1000', // ₹10 across three people: 334 / 333 / 333
+        splitParams: { kind: 'equal' },
+        participants: members,
+        payers: { m1: '1000' },
+      },
+      'm-1',
+      '2026-03-01T00:00:00Z',
+    );
+
+    const [expense] = materialiseExpenses(device.mirror, device.queue, { groupId: GROUP });
+    expect(expense?.pending).toBe(true);
+
+    const shares = expense?.currentVersion?.shares ?? [];
+    const total = shares.reduce((sum, share) => sum + BigInt(share.amount), 0n);
+    expect(total).toBe(1000n);
+
+    // Identical to what the server will compute — same function, same seed.
+    const server = computeShares({
+      amount: 1000n,
+      currency: INR,
+      params: { kind: 'equal' },
+      participants: members,
+      seed: 'e1',
+    });
+    expect(Object.fromEntries(shares.map((s) => [s.member_id, s.amount]))).toEqual(
+      Object.fromEntries([...server].map(([id, amount]) => [id, amount.toString()])),
+    );
+  });
+
+  it('stops overlaying once the server confirms the mutation', () => {
+    const server = new ModelServer();
+    const device = new Device();
+    device.add(
+      {
+        expenseId: 'e1',
+        description: 'Chai',
+        expenseDate: '2026-03-01',
+        currency: INR,
+        amount: '900',
+        splitParams: { kind: 'equal' },
+        participants: members,
+        payers: { m1: '900' },
+      },
+      'm-1',
+      '2026-03-01T00:00:00Z',
+    );
+    device.sync(server);
+
+    const [expense] = materialiseExpenses(device.mirror, device.queue, { groupId: GROUP });
+    expect(expense?.pending).toBeUndefined();
+    expect(device.balances().get('m1')).toBe(600n);
+  });
+});

--- a/packages/db/prisma/migrations/20260805050000_m2_offline_sync/migration.sql
+++ b/packages/db/prisma/migrations/20260805050000_m2_offline_sync/migration.sql
@@ -1,0 +1,359 @@
+-- M2 — offline-first sync (ADR-005 / TDR §4).
+--
+-- Four things the ledger needs before a client can go offline and come back:
+--
+--   1. A cursor that moves when a *group itself* changes, not only its rows.
+--   2. An idempotency ledger, so replaying a queue is free for every mutation
+--      kind rather than only the two that happened to have a natural key.
+--   3. Conflict versioning: two people editing the same expense from two
+--      aeroplanes must both keep their work, with the loser surfaced.
+--   4. Client-chosen primary keys, so a row created offline keeps its identity
+--      when it finally reaches the server.
+
+-- ───────────────────────────── 1. groups move their own cursor ──
+-- `baaki_stamp_seq` covers rows that belong to a group. Renaming the group, or
+-- toggling simplify-debts, changed nothing a client could pull, so a device
+-- that was offline during a rename never learned about it.
+
+CREATE OR REPLACE FUNCTION public.baaki_stamp_group_seq()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- `baaki_next_group_seq` bumps this column directly; when it does, NEW is
+  -- already ahead of OLD and there is nothing left to do. Any other update —
+  -- a rename, an archive — arrives with the two equal and needs a bump.
+  IF NEW.updated_seq IS NOT DISTINCT FROM OLD.updated_seq THEN
+    NEW.updated_seq := OLD.updated_seq + 1;
+  END IF;
+  RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER groups_stamp_seq
+  BEFORE UPDATE ON public.groups
+  FOR EACH ROW EXECUTE FUNCTION public.baaki_stamp_group_seq();
+
+-- ────────────────────────────────── 2. the idempotency ledger ──
+-- ADR-005 makes the client-generated UUID the idempotency key. Expenses and
+-- settlements already store theirs, but a queued "delete this expense" or "add
+-- this ghost" had no record, so a retry after a dropped response re-ran it.
+-- Storing the original result means a replay returns the same answer as the
+-- first attempt rather than merely avoiding damage.
+
+CREATE TABLE public.sync_mutations (
+  client_mutation_id uuid PRIMARY KEY,
+  profile_id         uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  group_id           uuid REFERENCES public.groups(id) ON DELETE CASCADE,
+  kind               text NOT NULL,
+  result             jsonb NOT NULL DEFAULT '{}'::jsonb,
+  applied_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX sync_mutations_profile_idx ON public.sync_mutations (profile_id, applied_at DESC);
+
+-- No policies at all: only the service role (which bypasses RLS) may read or
+-- write this, because it is the edge function's own bookkeeping (ADR-013).
+ALTER TABLE public.sync_mutations ENABLE ROW LEVEL SECURITY;
+
+-- ─────────────────────────────────────── 3. conflict versioning ──
+-- TDR §4.4: two edits to the same expense both become versions; the later
+-- server receipt wins as `current_version_id`, and the loser is surfaced in the
+-- activity feed so the person whose edit was replaced can see and restore it.
+--
+-- The signature changes, so the old one is dropped rather than overloaded —
+-- an ambiguous overload picked at runtime is exactly the kind of surprise a
+-- money path cannot afford.
+
+DROP FUNCTION IF EXISTS public.baaki_apply_expense(
+  uuid, uuid, uuid, text, text, date, char, bigint, text, jsonb, jsonb, jsonb, uuid, text, uuid
+);
+
+CREATE OR REPLACE FUNCTION public.baaki_apply_expense(
+  p_group_id           uuid,
+  p_expense_id         uuid,
+  p_author_member_id   uuid,
+  p_description        text,
+  p_category           text,
+  p_expense_date       date,
+  p_currency           char(3),
+  p_amount             bigint,
+  p_split_type         text,
+  p_split_params       jsonb,
+  p_payers             jsonb,
+  p_shares             jsonb,
+  p_client_mutation_id uuid,
+  p_notes              text DEFAULT NULL,
+  p_receipt_id         uuid DEFAULT NULL,
+  /** The version the client believed it was editing. NULL = an online write. */
+  p_base_version_no    int DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_existing      RECORD;
+  v_version_no    int;
+  v_version_id    uuid;
+  v_is_new        boolean := false;
+  v_row           jsonb;
+  v_member        uuid;
+  v_unknown       int;
+  v_superseded    RECORD;
+  v_conflict      boolean := false;
+BEGIN
+  -- Replay of a mutation we already applied (ADR-005).
+  IF p_client_mutation_id IS NOT NULL THEN
+    SELECT ev.id, ev.expense_id, ev.version_no INTO v_existing
+    FROM public.expense_versions ev
+    WHERE ev.client_mutation_id = p_client_mutation_id;
+    IF FOUND THEN
+      RETURN jsonb_build_object(
+        'expenseId', v_existing.expense_id,
+        'versionId', v_existing.id,
+        'versionNo', v_existing.version_no,
+        'replayed', true
+      );
+    END IF;
+  END IF;
+
+  -- Every member referenced must belong to this group; a caller cannot smuggle
+  -- in somebody else's member id (ADR-013).
+  SELECT count(*) INTO v_unknown
+  FROM (
+    SELECT (value ->> 'memberId')::uuid AS member_id FROM jsonb_array_elements(p_payers)
+    UNION
+    SELECT (value ->> 'memberId')::uuid FROM jsonb_array_elements(p_shares)
+    UNION
+    SELECT p_author_member_id
+  ) referenced
+  WHERE referenced.member_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.id = referenced.member_id AND gm.group_id = p_group_id
+    );
+  IF v_unknown > 0 THEN
+    RAISE EXCEPTION 'UNKNOWN_MEMBER: % member(s) are not in this group', v_unknown
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  IF p_expense_id IS NULL OR NOT EXISTS (SELECT 1 FROM public.expenses WHERE id = p_expense_id) THEN
+    v_is_new := true;
+    INSERT INTO public.expenses (id, group_id, created_by)
+    VALUES (COALESCE(p_expense_id, gen_random_uuid()), p_group_id, p_author_member_id)
+    RETURNING id INTO p_expense_id;
+    v_version_no := 1;
+  ELSE
+    IF (SELECT group_id FROM public.expenses WHERE id = p_expense_id) <> p_group_id THEN
+      RAISE EXCEPTION 'WRONG_GROUP: that expense belongs to another group'
+        USING ERRCODE = 'check_violation';
+    END IF;
+    SELECT COALESCE(max(version_no), 0) + 1 INTO v_version_no
+    FROM public.expense_versions WHERE expense_id = p_expense_id;
+
+    -- Somebody else wrote a version after the one this client was looking at.
+    -- Append-only means both survive; the later receipt — this one — wins.
+    IF p_base_version_no IS NOT NULL AND p_base_version_no < v_version_no - 1 THEN
+      v_conflict := true;
+      SELECT ev.version_no, ev.author_member_id, ev.description
+        INTO v_superseded
+        FROM public.expense_versions ev
+        JOIN public.expenses e ON e.id = ev.expense_id AND e.current_version_id = ev.id
+       WHERE ev.expense_id = p_expense_id;
+    END IF;
+  END IF;
+
+  INSERT INTO public.expense_versions
+    (expense_id, version_no, author_member_id, description, category, expense_date,
+     currency, amount, split_type, split_params, receipt_id, notes, client_mutation_id)
+  VALUES
+    (p_expense_id, v_version_no, p_author_member_id, p_description, p_category, p_expense_date,
+     upper(p_currency), p_amount, p_split_type::"SplitType", p_split_params, p_receipt_id,
+     p_notes, p_client_mutation_id)
+  RETURNING id INTO v_version_id;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_payers) LOOP
+    INSERT INTO public.expense_payers (expense_version_id, member_id, amount)
+    VALUES (v_version_id, (v_row ->> 'memberId')::uuid, (v_row ->> 'amount')::bigint);
+  END LOOP;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_shares) LOOP
+    INSERT INTO public.expense_shares (expense_version_id, member_id, amount)
+    VALUES (v_version_id, (v_row ->> 'memberId')::uuid, (v_row ->> 'amount')::bigint);
+  END LOOP;
+
+  -- Pointing at the new version is what makes the edit live.
+  UPDATE public.expenses SET current_version_id = v_version_id WHERE id = p_expense_id;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (
+    p_group_id, p_author_member_id,
+    CASE WHEN v_is_new THEN 'added' ELSE 'edited' END,
+    'expense', p_expense_id,
+    jsonb_build_object(
+      'description', p_description,
+      'amount', p_amount::text,
+      'currency', upper(p_currency),
+      'versionNo', v_version_no
+    )
+  );
+
+  -- A second entry, so the person whose edit lost can find it. Their version is
+  -- still in `expense_versions` and restoring it is just another edit.
+  IF v_conflict THEN
+    INSERT INTO public.activity_log
+      (group_id, actor_member_id, verb, object_type, object_id, payload)
+    VALUES (
+      p_group_id, p_author_member_id, 'superseded', 'expense', p_expense_id,
+      jsonb_build_object(
+        'supersededVersionNo', v_superseded.version_no,
+        'supersededAuthorMemberId', v_superseded.author_member_id,
+        'supersededDescription', v_superseded.description,
+        'baseVersionNo', p_base_version_no,
+        'winningVersionNo', v_version_no
+      )
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'expenseId', p_expense_id,
+    'versionId', v_version_id,
+    'versionNo', v_version_no,
+    'replayed', false,
+    'superseded', v_conflict,
+    'supersededVersionNo', CASE WHEN v_conflict THEN v_superseded.version_no ELSE NULL END
+  );
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_apply_expense(
+  uuid, uuid, uuid, text, text, date, char, bigint, text, jsonb, jsonb, jsonb, uuid, text, uuid, int
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.baaki_apply_expense(
+  uuid, uuid, uuid, text, text, date, char, bigint, text, jsonb, jsonb, jsonb, uuid, text, uuid, int
+) TO service_role;
+
+-- ──────────────────────────── 4. identities chosen on the client ──
+-- A group or a ghost created in aeroplane mode already has a UUID, and every
+-- queued mutation that references it uses that UUID. If the server minted a
+-- different one on arrival, the rest of the queue would point at nothing.
+-- Passing the id in makes the insert idempotent by primary key.
+
+DROP FUNCTION IF EXISTS public.baaki_create_group(text, text, char, text, boolean);
+
+CREATE OR REPLACE FUNCTION public.baaki_create_group(
+  p_name text,
+  p_type text DEFAULT 'other',
+  p_currency char(3) DEFAULT 'INR',
+  p_emoji text DEFAULT NULL,
+  p_simplify boolean DEFAULT true,
+  /** Client-chosen id, so a group created offline keeps its identity. */
+  p_group_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_group_id   uuid;
+  v_member_id  uuid;
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED: a group needs an owner'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id = v_profile_id) THEN
+    RAISE EXCEPTION 'NO_PROFILE: profile % does not exist', v_profile_id
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+  IF coalesce(trim(p_name), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_NAME: a group needs a name' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying the create half of a queue must return the same group, not a
+  -- second one — and must not let somebody else's id be hijacked.
+  IF p_group_id IS NOT NULL AND EXISTS (SELECT 1 FROM public.groups WHERE id = p_group_id) THEN
+    IF NOT public.is_group_member(p_group_id, v_profile_id) THEN
+      RAISE EXCEPTION 'GROUP_EXISTS: that group id is already taken'
+        USING ERRCODE = 'unique_violation';
+    END IF;
+    RETURN p_group_id;
+  END IF;
+
+  INSERT INTO public.groups (id, name, type, default_currency, cover_emoji, simplify_debts, created_by)
+  VALUES (COALESCE(p_group_id, gen_random_uuid()), trim(p_name), p_type::"GroupType",
+          upper(p_currency), p_emoji, p_simplify, v_profile_id)
+  RETURNING id INTO v_group_id;
+
+  INSERT INTO public.group_members (group_id, profile_id, role, joined_via)
+  VALUES (v_group_id, v_profile_id, 'admin', 'creator')
+  RETURNING id INTO v_member_id;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (v_group_id, v_member_id, 'created', 'group', v_group_id,
+          jsonb_build_object('name', trim(p_name)));
+
+  RETURN v_group_id;
+END
+$$;
+
+-- ADR-006: a ghost is a real participant who simply hasn't joined yet, and one
+-- can be added with no network at all.
+CREATE OR REPLACE FUNCTION public.baaki_add_ghost_member(
+  p_group_id  uuid,
+  p_name      text,
+  p_member_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_member_id  uuid;
+BEGIN
+  IF v_profile_id IS NULL OR NOT public.is_group_member(p_group_id, v_profile_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF coalesce(trim(p_name), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_NAME: a ghost needs a name' USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF p_member_id IS NOT NULL THEN
+    SELECT id INTO v_member_id FROM public.group_members
+     WHERE id = p_member_id AND group_id = p_group_id;
+    IF FOUND THEN
+      RETURN v_member_id;  -- replay
+    END IF;
+  END IF;
+
+  INSERT INTO public.group_members (id, group_id, ghost_name, joined_via)
+  VALUES (COALESCE(p_member_id, gen_random_uuid()), p_group_id, trim(p_name), 'ghost')
+  RETURNING id INTO v_member_id;
+
+  RETURN v_member_id;
+END
+$$;
+
+-- ──────────────────────────────────── 5. what a client may pull ──
+-- The pull is deliberately a plain RLS-scoped read rather than a privileged
+-- function: a client can only ever receive rows it was already allowed to see,
+-- and adding a table to the sync set cannot accidentally widen that.
+--
+-- This index is what keeps "everything since seq N" cheap as a group grows.
+
+CREATE INDEX IF NOT EXISTS expenses_group_seq_idx
+  ON public.expenses (group_id, updated_seq);
+CREATE INDEX IF NOT EXISTS group_members_group_seq_idx
+  ON public.group_members (group_id, updated_seq);
+CREATE INDEX IF NOT EXISTS settlements_group_seq_idx
+  ON public.settlements (group_id, updated_seq);
+CREATE INDEX IF NOT EXISTS activity_log_group_seq_idx
+  ON public.activity_log (group_id, updated_seq);

--- a/packages/db/prisma/migrations/20260805053000_m2_sync_naming/migration.sql
+++ b/packages/db/prisma/migrations/20260805053000_m2_sync_naming/migration.sql
@@ -1,0 +1,28 @@
+-- Follow-up to 20260805050000_m2_offline_sync, kept separate because that
+-- migration had already been applied and editing an applied migration breaks
+-- its checksum for every other environment.
+--
+-- Nothing here changes behaviour. It aligns the hand-written SQL with the names
+-- and referential actions Prisma generates, so `prisma migrate diff` reports a
+-- clean schema and the drift check keeps its value (TDR §2.0). Found by that
+-- check, which is exactly what it is for.
+
+ALTER INDEX public.expenses_group_seq_idx RENAME TO expenses_group_id_updated_seq_idx;
+ALTER INDEX public.group_members_group_seq_idx RENAME TO group_members_group_id_updated_seq_idx;
+ALTER INDEX public.settlements_group_seq_idx RENAME TO settlements_group_id_updated_seq_idx;
+ALTER INDEX public.activity_log_group_seq_idx RENAME TO activity_log_group_id_updated_seq_idx;
+
+-- Prisma's default for a relation scalar is ON UPDATE CASCADE; a plain
+-- REFERENCES leaves it NO ACTION. Primary keys here are never updated, so this
+-- is a naming-parity change rather than a functional one.
+ALTER TABLE public.sync_mutations
+  DROP CONSTRAINT sync_mutations_profile_id_fkey,
+  DROP CONSTRAINT sync_mutations_group_id_fkey;
+
+ALTER TABLE public.sync_mutations
+  ADD CONSTRAINT sync_mutations_profile_id_fkey
+    FOREIGN KEY (profile_id) REFERENCES public.profiles(id)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT sync_mutations_group_id_fkey
+    FOREIGN KEY (group_id) REFERENCES public.groups(id)
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260805054500_m2_conflict_return_fix/migration.sql
+++ b/packages/db/prisma/migrations/20260805054500_m2_conflict_return_fix/migration.sql
@@ -1,0 +1,174 @@
+-- Fix for 20260805050000_m2_offline_sync, forward-only because that migration
+-- has already been applied elsewhere.
+--
+-- The conflict branch declared `v_superseded` as a RECORD and read it back in
+-- the RETURN:
+--
+--   CASE WHEN v_conflict THEN v_superseded.version_no ELSE NULL END
+--
+-- plpgsql prepares the whole expression before evaluating the CASE, so the
+-- field reference is resolved even on the non-conflict path — and an unassigned
+-- RECORD raises `record "v_superseded" is not assigned yet`. Every expense
+-- write failed, conflict or not. The M1 RPC suite caught it on the first run
+-- (ADR-014).
+--
+-- Scalar variables have no such trap: they are simply NULL until assigned.
+
+CREATE OR REPLACE FUNCTION public.baaki_apply_expense(
+  p_group_id           uuid,
+  p_expense_id         uuid,
+  p_author_member_id   uuid,
+  p_description        text,
+  p_category           text,
+  p_expense_date       date,
+  p_currency           char(3),
+  p_amount             bigint,
+  p_split_type         text,
+  p_split_params       jsonb,
+  p_payers             jsonb,
+  p_shares             jsonb,
+  p_client_mutation_id uuid,
+  p_notes              text DEFAULT NULL,
+  p_receipt_id         uuid DEFAULT NULL,
+  p_base_version_no    int DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_existing        RECORD;
+  v_version_no      int;
+  v_version_id      uuid;
+  v_is_new          boolean := false;
+  v_row             jsonb;
+  v_unknown         int;
+  v_conflict        boolean := false;
+  v_superseded_no   int;
+  v_superseded_by   uuid;
+  v_superseded_desc text;
+BEGIN
+  -- Replay of a mutation we already applied (ADR-005).
+  IF p_client_mutation_id IS NOT NULL THEN
+    SELECT ev.id, ev.expense_id, ev.version_no INTO v_existing
+    FROM public.expense_versions ev
+    WHERE ev.client_mutation_id = p_client_mutation_id;
+    IF FOUND THEN
+      RETURN jsonb_build_object(
+        'expenseId', v_existing.expense_id,
+        'versionId', v_existing.id,
+        'versionNo', v_existing.version_no,
+        'replayed', true
+      );
+    END IF;
+  END IF;
+
+  -- Every member referenced must belong to this group; a caller cannot smuggle
+  -- in somebody else's member id (ADR-013).
+  SELECT count(*) INTO v_unknown
+  FROM (
+    SELECT (value ->> 'memberId')::uuid AS member_id FROM jsonb_array_elements(p_payers)
+    UNION
+    SELECT (value ->> 'memberId')::uuid FROM jsonb_array_elements(p_shares)
+    UNION
+    SELECT p_author_member_id
+  ) referenced
+  WHERE referenced.member_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.id = referenced.member_id AND gm.group_id = p_group_id
+    );
+  IF v_unknown > 0 THEN
+    RAISE EXCEPTION 'UNKNOWN_MEMBER: % member(s) are not in this group', v_unknown
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  IF p_expense_id IS NULL OR NOT EXISTS (SELECT 1 FROM public.expenses WHERE id = p_expense_id) THEN
+    v_is_new := true;
+    INSERT INTO public.expenses (id, group_id, created_by)
+    VALUES (COALESCE(p_expense_id, gen_random_uuid()), p_group_id, p_author_member_id)
+    RETURNING id INTO p_expense_id;
+    v_version_no := 1;
+  ELSE
+    IF (SELECT group_id FROM public.expenses WHERE id = p_expense_id) <> p_group_id THEN
+      RAISE EXCEPTION 'WRONG_GROUP: that expense belongs to another group'
+        USING ERRCODE = 'check_violation';
+    END IF;
+    SELECT COALESCE(max(version_no), 0) + 1 INTO v_version_no
+    FROM public.expense_versions WHERE expense_id = p_expense_id;
+
+    -- Somebody else wrote a version after the one this client was looking at.
+    -- Append-only means both survive; the later receipt — this one — wins.
+    IF p_base_version_no IS NOT NULL AND p_base_version_no < v_version_no - 1 THEN
+      v_conflict := true;
+      SELECT ev.version_no, ev.author_member_id, ev.description
+        INTO v_superseded_no, v_superseded_by, v_superseded_desc
+        FROM public.expense_versions ev
+        JOIN public.expenses e ON e.id = ev.expense_id AND e.current_version_id = ev.id
+       WHERE ev.expense_id = p_expense_id;
+    END IF;
+  END IF;
+
+  INSERT INTO public.expense_versions
+    (expense_id, version_no, author_member_id, description, category, expense_date,
+     currency, amount, split_type, split_params, receipt_id, notes, client_mutation_id)
+  VALUES
+    (p_expense_id, v_version_no, p_author_member_id, p_description, p_category, p_expense_date,
+     upper(p_currency), p_amount, p_split_type::"SplitType", p_split_params, p_receipt_id,
+     p_notes, p_client_mutation_id)
+  RETURNING id INTO v_version_id;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_payers) LOOP
+    INSERT INTO public.expense_payers (expense_version_id, member_id, amount)
+    VALUES (v_version_id, (v_row ->> 'memberId')::uuid, (v_row ->> 'amount')::bigint);
+  END LOOP;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_shares) LOOP
+    INSERT INTO public.expense_shares (expense_version_id, member_id, amount)
+    VALUES (v_version_id, (v_row ->> 'memberId')::uuid, (v_row ->> 'amount')::bigint);
+  END LOOP;
+
+  -- Pointing at the new version is what makes the edit live.
+  UPDATE public.expenses SET current_version_id = v_version_id WHERE id = p_expense_id;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (
+    p_group_id, p_author_member_id,
+    CASE WHEN v_is_new THEN 'added' ELSE 'edited' END,
+    'expense', p_expense_id,
+    jsonb_build_object(
+      'description', p_description,
+      'amount', p_amount::text,
+      'currency', upper(p_currency),
+      'versionNo', v_version_no
+    )
+  );
+
+  -- A second entry, so the person whose edit lost can find it. Their version is
+  -- still in `expense_versions` and restoring it is just another edit.
+  IF v_conflict THEN
+    INSERT INTO public.activity_log
+      (group_id, actor_member_id, verb, object_type, object_id, payload)
+    VALUES (
+      p_group_id, p_author_member_id, 'superseded', 'expense', p_expense_id,
+      jsonb_build_object(
+        'supersededVersionNo', v_superseded_no,
+        'supersededAuthorMemberId', v_superseded_by,
+        'supersededDescription', v_superseded_desc,
+        'baseVersionNo', p_base_version_no,
+        'winningVersionNo', v_version_no
+      )
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'expenseId', p_expense_id,
+    'versionId', v_version_id,
+    'versionNo', v_version_no,
+    'replayed', false,
+    'superseded', v_conflict,
+    'supersededVersionNo', v_superseded_no
+  );
+END
+$$;

--- a/packages/db/prisma/migrations/20260805060000_m2_membership_check_arity/migration.sql
+++ b/packages/db/prisma/migrations/20260805060000_m2_membership_check_arity/migration.sql
@@ -1,0 +1,111 @@
+-- Fix for 20260805050000_m2_offline_sync.
+--
+-- `baaki_create_group` and `baaki_add_ghost_member` called
+-- `is_group_member(group_id, profile_id)`, but that function takes one argument
+-- and reads the caller from `request.jwt.claims` itself — so both raised
+-- `function public.is_group_member(uuid, uuid) does not exist` and neither
+-- offline-created groups nor offline-added ghosts could ever sync.
+--
+-- Postgres resolves function calls at execution time, not at CREATE FUNCTION
+-- time, so nothing complained until the M2 suite ran it.
+
+CREATE OR REPLACE FUNCTION public.baaki_create_group(
+  p_name text,
+  p_type text DEFAULT 'other',
+  p_currency char(3) DEFAULT 'INR',
+  p_emoji text DEFAULT NULL,
+  p_simplify boolean DEFAULT true,
+  p_group_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_group_id   uuid;
+  v_member_id  uuid;
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED: a group needs an owner'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id = v_profile_id) THEN
+    RAISE EXCEPTION 'NO_PROFILE: profile % does not exist', v_profile_id
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+  IF coalesce(trim(p_name), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_NAME: a group needs a name' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying the create half of a queue must return the same group, not a
+  -- second one — and must not let somebody else's id be hijacked.
+  IF p_group_id IS NOT NULL AND EXISTS (SELECT 1 FROM public.groups WHERE id = p_group_id) THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = p_group_id AND gm.profile_id = v_profile_id AND gm.left_at IS NULL
+    ) THEN
+      RAISE EXCEPTION 'GROUP_EXISTS: that group id is already taken'
+        USING ERRCODE = 'unique_violation';
+    END IF;
+    RETURN p_group_id;
+  END IF;
+
+  INSERT INTO public.groups (id, name, type, default_currency, cover_emoji, simplify_debts, created_by)
+  VALUES (COALESCE(p_group_id, gen_random_uuid()), trim(p_name), p_type::"GroupType",
+          upper(p_currency), p_emoji, p_simplify, v_profile_id)
+  RETURNING id INTO v_group_id;
+
+  INSERT INTO public.group_members (group_id, profile_id, role, joined_via)
+  VALUES (v_group_id, v_profile_id, 'admin', 'creator')
+  RETURNING id INTO v_member_id;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (v_group_id, v_member_id, 'created', 'group', v_group_id,
+          jsonb_build_object('name', trim(p_name)));
+
+  RETURN v_group_id;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION public.baaki_add_ghost_member(
+  p_group_id  uuid,
+  p_name      text,
+  p_member_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_member_id  uuid;
+BEGIN
+  IF v_profile_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.group_members gm
+    WHERE gm.group_id = p_group_id AND gm.profile_id = v_profile_id AND gm.left_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF coalesce(trim(p_name), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_NAME: a ghost needs a name' USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF p_member_id IS NOT NULL THEN
+    SELECT id INTO v_member_id FROM public.group_members
+     WHERE id = p_member_id AND group_id = p_group_id;
+    IF FOUND THEN
+      RETURN v_member_id;  -- replay
+    END IF;
+  END IF;
+
+  INSERT INTO public.group_members (id, group_id, ghost_name, joined_via)
+  VALUES (COALESCE(p_member_id, gen_random_uuid()), p_group_id, trim(p_name), 'ghost')
+  RETURNING id INTO v_member_id;
+
+  RETURN v_member_id;
+END
+$$;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -128,6 +128,7 @@ model Profile {
   emailEvents       EmailEvent[]
   createdInvites    Invite[]        @relation("InviteCreatedBy")
   usageEvents       UsageEvent[]
+  syncMutations     SyncMutation[]
 
   @@map("profiles")
   @@schema("public")
@@ -161,6 +162,7 @@ model Group {
   pairwise        PairwiseBalance[]
   notifications   Notification[]
   usageEvents     UsageEvent[]
+  syncMutations   SyncMutation[]
 
   @@index([archivedAt])
   @@map("groups")
@@ -204,6 +206,7 @@ model GroupMember {
 
   @@unique([groupId, profileId])
   @@index([groupId])
+  @@index([groupId, updatedSeq])
   @@map("group_members")
   @@schema("public")
 }
@@ -252,6 +255,8 @@ model Expense {
   allocations    SettlementAllocation[]
 
   @@index([groupId, deletedAt])
+  /// The sync pull is "everything in this group since seq N" (TDR §4).
+  @@index([groupId, updatedSeq])
   @@map("expenses")
   @@schema("public")
 }
@@ -389,6 +394,7 @@ model Settlement {
   allocations SettlementAllocation[]
 
   @@index([groupId, status])
+  @@index([groupId, updatedSeq])
   @@map("settlements")
   @@schema("public")
 }
@@ -425,6 +431,7 @@ model ActivityLog {
   actor GroupMember? @relation(fields: [actorMemberId], references: [id], onDelete: SetNull)
 
   @@index([groupId, createdAt])
+  @@index([groupId, updatedSeq])
   @@map("activity_log")
   @@schema("public")
 }
@@ -566,5 +573,25 @@ model PairwiseBalance {
 
   @@id([groupId, fromMemberId, toMemberId, currency])
   @@map("pairwise_balances")
+  @@schema("public")
+}
+
+/// ADR-005: the idempotency ledger. Every queued mutation is recorded by its
+/// client-generated UUID together with the result it produced, so replaying a
+/// queue after a crash returns the original answer instead of acting twice.
+/// Service-role only — RLS is on with no policies at all.
+model SyncMutation {
+  clientMutationId String   @id @map("client_mutation_id") @db.Uuid
+  profileId        String   @map("profile_id") @db.Uuid
+  groupId          String?  @map("group_id") @db.Uuid
+  kind             String
+  result           Json     @default("{}")
+  appliedAt        DateTime @default(now()) @map("applied_at") @db.Timestamptz(6)
+
+  profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  group   Group?  @relation(fields: [groupId], references: [id], onDelete: Cascade)
+
+  @@index([profileId, appliedAt(sort: Desc)], map: "sync_mutations_profile_idx")
+  @@map("sync_mutations")
   @@schema("public")
 }

--- a/packages/db/test/m2-sync.test.ts
+++ b/packages/db/test/m2-sync.test.ts
@@ -1,0 +1,487 @@
+/**
+ * M2: what the database has to guarantee before a client is allowed to go
+ * offline (ADR-005 / TDR §4).
+ *
+ * The client-side rules — queue ordering, backoff, reconciliation — are
+ * property-tested in @baaki/core. These are the server-side halves that only
+ * real Postgres can prove: that the cursor never skips a change, that a
+ * replayed mutation is free, and that two people editing the same expense from
+ * two dead zones both keep their work.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { big, connect, expectDenied, seedGroup } from './helpers.js';
+
+let client: Client;
+
+async function createProfile(name: string): Promise<string> {
+  const id = randomUUID();
+  await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, $2)`, [id, name]);
+  return id;
+}
+
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+interface ApplyResult {
+  expenseId: string;
+  versionId: string;
+  versionNo: number;
+  replayed: boolean;
+  superseded: boolean;
+  supersededVersionNo: number | null;
+}
+
+async function applyExpense(params: {
+  groupId: string;
+  author: string;
+  amount: bigint;
+  payers: { memberId: string; amount: string }[];
+  shares: { memberId: string; amount: string }[];
+  expenseId?: string | null;
+  mutationId?: string | null;
+  baseVersionNo?: number | null;
+  description?: string;
+}): Promise<ApplyResult> {
+  const result = await client.query(
+    `SELECT baaki_apply_expense($1, $2, $3, $8, NULL, '2026-03-01', 'INR', $4,
+                                'equal', '{"kind":"equal"}'::jsonb, $5::jsonb, $6::jsonb, $7,
+                                NULL, NULL, $9)
+       AS out`,
+    [
+      params.groupId,
+      params.expenseId ?? null,
+      params.author,
+      params.amount.toString(),
+      JSON.stringify(params.payers),
+      JSON.stringify(params.shares),
+      params.mutationId ?? null,
+      params.description ?? 'Dinner',
+      params.baseVersionNo ?? null,
+    ],
+  );
+  return result.rows[0]?.out as ApplyResult;
+}
+
+/** An even two-way split, which is all these tests need. */
+const halves = (a: string, b: string, amount: bigint) => ({
+  payers: [{ memberId: a, amount: amount.toString() }],
+  shares: [
+    { memberId: a, amount: (amount / 2n).toString() },
+    { memberId: b, amount: (amount - amount / 2n).toString() },
+  ],
+});
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+describe('the sync cursor (TDR §4)', () => {
+  it('advances for anything a client could pull, including the group itself', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+
+    const seqOf = async (): Promise<bigint> =>
+      big(
+        (await client.query(`SELECT updated_seq FROM groups WHERE id = $1`, [groupId])).rows[0]
+          ?.updated_seq,
+      );
+
+    const start = await seqOf();
+
+    // Renaming a group used to change nothing a client could see, so a device
+    // that was offline during the rename never learned about it.
+    await client.query(`UPDATE groups SET name = 'Goa trip, revised' WHERE id = $1`, [groupId]);
+    const afterRename = await seqOf();
+    expect(afterRename).toBeGreaterThan(start);
+
+    await applyExpense({ groupId, author: a, amount: 1000n, ...halves(a, b, 1000n) });
+    const afterExpense = await seqOf();
+    expect(afterExpense).toBeGreaterThan(afterRename);
+
+    // Every row carries a seq no higher than the group's own high-water mark,
+    // which is what makes "pull everything above my cursor" complete.
+    const rows = await client.query(
+      `SELECT max(updated_seq) AS high FROM (
+         SELECT updated_seq FROM expenses WHERE group_id = $1
+         UNION ALL SELECT updated_seq FROM group_members WHERE group_id = $1
+         UNION ALL SELECT updated_seq FROM activity_log WHERE group_id = $1
+       ) all_rows`,
+      [groupId],
+    );
+    expect(big(rows.rows[0]?.high)).toBeLessThanOrEqual(afterExpense);
+  });
+
+  it('never issues the same sequence number twice in a group', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+
+    for (let index = 0; index < 5; index += 1) {
+      await applyExpense({ groupId, author: a, amount: 1000n, ...halves(a, b, 1000n) });
+    }
+
+    const { rows } = await client.query(
+      `SELECT updated_seq, count(*) AS n FROM expenses WHERE group_id = $1
+        GROUP BY updated_seq HAVING count(*) > 1`,
+      [groupId],
+    );
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe('conflict versioning (TDR §4.4)', () => {
+  it('keeps both edits and lets the later receipt win', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+
+    const created = await applyExpense({
+      groupId,
+      author: a,
+      amount: 1000n,
+      description: 'Dinner',
+      ...halves(a, b, 1000n),
+    });
+    expect(created.versionNo).toBe(1);
+
+    // Asha edits v1 while online.
+    const asha = await applyExpense({
+      groupId,
+      author: a,
+      expenseId: created.expenseId,
+      amount: 2000n,
+      description: "Asha's edit",
+      baseVersionNo: 1,
+      ...halves(a, b, 2000n),
+    });
+    expect(asha.superseded).toBe(false);
+
+    // Bharath was in a dead zone and edited the same v1. His mutation arrives
+    // second, so it wins — but Asha's version is not destroyed.
+    const bharath = await applyExpense({
+      groupId,
+      author: b,
+      expenseId: created.expenseId,
+      amount: 3000n,
+      description: "Bharath's edit",
+      baseVersionNo: 1,
+      ...halves(b, a, 3000n),
+    });
+
+    expect(bharath.superseded).toBe(true);
+    expect(bharath.supersededVersionNo).toBe(asha.versionNo);
+    expect(bharath.versionNo).toBe(3);
+
+    // Later receipt is what the group sees.
+    const current = await client.query(
+      `SELECT ev.description, ev.amount FROM expenses e
+         JOIN expense_versions ev ON ev.id = e.current_version_id
+        WHERE e.id = $1`,
+      [created.expenseId],
+    );
+    expect(current.rows[0]?.description).toBe("Bharath's edit");
+
+    // Nothing was lost: all three versions are still there (ADR-004).
+    const versions = await client.query(
+      `SELECT version_no, description FROM expense_versions
+        WHERE expense_id = $1 ORDER BY version_no`,
+      [created.expenseId],
+    );
+    expect(versions.rows.map((row) => row.description)).toEqual([
+      'Dinner',
+      "Asha's edit",
+      "Bharath's edit",
+    ]);
+  });
+
+  it('surfaces the losing edit in the activity feed', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+
+    const created = await applyExpense({
+      groupId,
+      author: a,
+      amount: 1000n,
+      ...halves(a, b, 1000n),
+    });
+    await applyExpense({
+      groupId,
+      author: a,
+      expenseId: created.expenseId,
+      amount: 2000n,
+      description: "Asha's edit",
+      baseVersionNo: 1,
+      ...halves(a, b, 2000n),
+    });
+    await applyExpense({
+      groupId,
+      author: b,
+      expenseId: created.expenseId,
+      amount: 3000n,
+      baseVersionNo: 1,
+      ...halves(b, a, 3000n),
+    });
+
+    const { rows } = await client.query(
+      `SELECT payload FROM activity_log
+        WHERE group_id = $1 AND verb = 'superseded' AND object_id = $2`,
+      [groupId, created.expenseId],
+    );
+    expect(rows).toHaveLength(1);
+    // Enough for "Asha's edit replaced yours — view/restore" (TDR §4.4).
+    expect(rows[0]?.payload).toMatchObject({
+      supersededVersionNo: 2,
+      supersededAuthorMemberId: a,
+      supersededDescription: "Asha's edit",
+      baseVersionNo: 1,
+      winningVersionNo: 3,
+    });
+  });
+
+  it('does not cry conflict when the edit was based on the current version', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+
+    const created = await applyExpense({
+      groupId,
+      author: a,
+      amount: 1000n,
+      ...halves(a, b, 1000n),
+    });
+    const second = await applyExpense({
+      groupId,
+      author: a,
+      expenseId: created.expenseId,
+      amount: 2000n,
+      baseVersionNo: 1,
+      ...halves(a, b, 2000n),
+    });
+    const third = await applyExpense({
+      groupId,
+      author: b,
+      expenseId: created.expenseId,
+      amount: 3000n,
+      baseVersionNo: second.versionNo,
+      ...halves(b, a, 3000n),
+    });
+
+    expect(third.superseded).toBe(false);
+    const { rows } = await client.query(
+      `SELECT count(*) AS n FROM activity_log WHERE group_id = $1 AND verb = 'superseded'`,
+      [groupId],
+    );
+    expect(Number(rows[0]?.n)).toBe(0);
+  });
+
+  it('leaves balances correct after a conflict', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+
+    const created = await applyExpense({
+      groupId,
+      author: a,
+      amount: 1000n,
+      ...halves(a, b, 1000n),
+    });
+    await applyExpense({
+      groupId,
+      author: a,
+      expenseId: created.expenseId,
+      amount: 2000n,
+      baseVersionNo: 1,
+      ...halves(a, b, 2000n),
+    });
+    await applyExpense({
+      groupId,
+      author: b,
+      expenseId: created.expenseId,
+      amount: 3000n,
+      baseVersionNo: 1,
+      ...halves(b, a, 3000n),
+    });
+
+    // Only the winning version counts: Bharath paid 3000, they split it evenly.
+    const { rows } = await client.query(
+      `SELECT member_id, balance FROM group_balances WHERE group_id = $1 ORDER BY balance`,
+      [groupId],
+    );
+    const balances = new Map(rows.map((row) => [String(row.member_id), big(row.balance)]));
+    expect(balances.get(b)).toBe(1500n);
+    expect(balances.get(a)).toBe(-1500n);
+    expect([...balances.values()].reduce((sum, value) => sum + value, 0n)).toBe(0n);
+  });
+});
+
+describe('replaying a queue is free (ADR-005)', () => {
+  it('returns the original group instead of creating a second one', async () => {
+    const profileId = await createProfile('Asha');
+    const groupId = randomUUID();
+
+    const create = async (): Promise<string> =>
+      asUser(profileId, async () => {
+        const result = await client.query(
+          `SELECT baaki_create_group('Goa trip', 'trip', 'INR', NULL, true, $1) AS id`,
+          [groupId],
+        );
+        return String(result.rows[0]?.id);
+      });
+
+    expect(await create()).toBe(groupId);
+    expect(await create()).toBe(groupId);
+
+    const { rows } = await client.query(`SELECT count(*) AS n FROM groups WHERE id = $1`, [
+      groupId,
+    ]);
+    expect(Number(rows[0]?.n)).toBe(1);
+    // And exactly one membership, not two.
+    const members = await client.query(
+      `SELECT count(*) AS n FROM group_members WHERE group_id = $1`,
+      [groupId],
+    );
+    expect(Number(members.rows[0]?.n)).toBe(1);
+  });
+
+  it('will not let one person claim a group id somebody else already used', async () => {
+    const owner = await createProfile('Asha');
+    const stranger = await createProfile('Mallory');
+    const groupId = randomUUID();
+
+    await asUser(owner, () =>
+      client.query(`SELECT baaki_create_group('Goa trip', 'trip', 'INR', NULL, true, $1)`, [
+        groupId,
+      ]),
+    );
+
+    const message = await asUser(stranger, () =>
+      expectDenied(
+        client.query(`SELECT baaki_create_group('Mine now', 'trip', 'INR', NULL, true, $1)`, [
+          groupId,
+        ]),
+      ),
+    );
+    expect(message).toMatch(/GROUP_EXISTS/);
+  });
+
+  it('adds a ghost once, however many times the mutation is retried', async () => {
+    const profileId = await createProfile('Asha');
+    const groupId = randomUUID();
+    await asUser(profileId, () =>
+      client.query(`SELECT baaki_create_group('Goa trip', 'trip', 'INR', NULL, true, $1)`, [
+        groupId,
+      ]),
+    );
+
+    const ghostId = randomUUID();
+    const add = async (): Promise<string> =>
+      asUser(profileId, async () => {
+        const result = await client.query(`SELECT baaki_add_ghost_member($1, 'Priya', $2) AS id`, [
+          groupId,
+          ghostId,
+        ]);
+        return String(result.rows[0]?.id);
+      });
+
+    expect(await add()).toBe(ghostId);
+    expect(await add()).toBe(ghostId);
+
+    const { rows } = await client.query(
+      `SELECT count(*) AS n FROM group_members WHERE group_id = $1 AND ghost_name = 'Priya'`,
+      [groupId],
+    );
+    expect(Number(rows[0]?.n)).toBe(1);
+  });
+
+  it('refuses to add a ghost to a group you are not in', async () => {
+    const owner = await createProfile('Asha');
+    const stranger = await createProfile('Mallory');
+    const groupId = randomUUID();
+    await asUser(owner, () =>
+      client.query(`SELECT baaki_create_group('Goa trip', 'trip', 'INR', NULL, true, $1)`, [
+        groupId,
+      ]),
+    );
+
+    const message = await asUser(stranger, () =>
+      expectDenied(client.query(`SELECT baaki_add_ghost_member($1, 'Priya', NULL)`, [groupId])),
+    );
+    expect(message).toMatch(/NOT_A_MEMBER/);
+  });
+
+  it('replays an expense to the same version rather than appending another', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+    const mutationId = randomUUID();
+
+    const first = await applyExpense({
+      groupId,
+      author: a,
+      amount: 1000n,
+      mutationId,
+      ...halves(a, b, 1000n),
+    });
+    const replay = await applyExpense({
+      groupId,
+      author: a,
+      amount: 1000n,
+      mutationId,
+      expenseId: first.expenseId,
+      ...halves(a, b, 1000n),
+    });
+
+    expect(replay.replayed).toBe(true);
+    expect(replay.versionId).toBe(first.versionId);
+
+    const { rows } = await client.query(
+      `SELECT count(*) AS n FROM expense_versions WHERE expense_id = $1`,
+      [first.expenseId],
+    );
+    expect(Number(rows[0]?.n)).toBe(1);
+  });
+});
+
+describe('the idempotency ledger', () => {
+  it('is invisible to everyone but the service role (ADR-013)', async () => {
+    const profileId = await createProfile('Asha');
+    await client.query(
+      `INSERT INTO sync_mutations (client_mutation_id, profile_id, kind, result)
+       VALUES ($1, $2, 'expense.create', '{"ok":true}'::jsonb)`,
+      [randomUUID(), profileId],
+    );
+
+    // Even the profile the row belongs to cannot read it: this is the edge
+    // function's own bookkeeping, not user data.
+    const rows = await asUser(profileId, async () => {
+      const result = await client.query(`SELECT * FROM sync_mutations`);
+      return result.rows;
+    });
+    expect(rows).toHaveLength(0);
+
+    const message = await asUser(profileId, () =>
+      expectDenied(
+        client.query(
+          `INSERT INTO sync_mutations (client_mutation_id, profile_id, kind)
+           VALUES ($1, $2, 'expense.create')`,
+          [randomUUID(), profileId],
+        ),
+      ),
+    );
+    expect(message).toMatch(/row-level security|permission denied/i);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       expo-localization:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.10)(react@19.2.3)
+      expo-network:
+        specifier: ~57.0.1
+        version: 57.0.1(expo@57.0.10)(react@19.2.3)
       expo-router:
         specifier: ~57.0.10
         version: 57.0.10(e33838f6b09842139d08e3cb6f1aeab7)
@@ -2892,6 +2895,12 @@ packages:
     resolution: {integrity: sha512-vt7FyqUqqFXiRVnBqYD7y+GSPTgeua5Ocoy0+SYt+RSHkZEA2Fyop7If3g1TYDzQObYybPRo7TG2Rle1XLaWFw==}
     peerDependencies:
       react-native: '*'
+
+  expo-network@57.0.1:
+    resolution: {integrity: sha512-ndg+FbDDlz6XTpQ6aVuVgyvrYQwMkpcUAvZIXbwrGBbLTSWNzYC/gawYu1BAeDN7O6JTGY98GBVJBov/JH7LgQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
 
   expo-router@57.0.10:
     resolution: {integrity: sha512-E6Cjudl4wQ86KdEHqLGhBmfOFRdtzXTtRzEEDmqOvqtkAc9C637u0us7CGKkkee9m+kwuHqfhn779ww85rn/Pg==}
@@ -8034,6 +8043,11 @@ snapshots:
   expo-modules-jsi@57.0.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)):
     dependencies:
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
+
+  expo-network@57.0.1(expo@57.0.10)(react@19.2.3):
+    dependencies:
+      expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      react: 19.2.3
 
   expo-router@57.0.10(e33838f6b09842139d08e3cb6f1aeab7):
     dependencies:

--- a/supabase/functions/expense-write/index.ts
+++ b/supabase/functions/expense-write/index.ts
@@ -10,7 +10,7 @@
  * `clientMutationId` makes a replay a no-op (ADR-005).
  */
 
-import { computeShares, type SplitParams } from '../_shared/core.js';
+import { computeShares, verifyClientShares, type SplitParams } from '../_shared/core.js';
 import {
   asCaller,
   asService,
@@ -97,17 +97,12 @@ Deno.serve(async (request) => {
       seed: expenseId,
     });
 
-    if (body.expectedShares) {
-      for (const [member, share] of shares) {
-        const claimed = body.expectedShares[member];
-        if (claimed === undefined || BigInt(claimed) !== share) {
-          throw new HttpError(
-            409,
-            'SHARE_MISMATCH',
-            `Server computed ${share} for ${member}, client said ${claimed ?? 'nothing'}`,
-          );
-        }
-      }
+    // One definition of "the client agrees with us", shared with /sync and
+    // property-tested in @baaki/core rather than written out twice here.
+    try {
+      verifyClientShares(shares, body.expectedShares);
+    } catch (mismatch) {
+      throw new HttpError(409, 'SHARE_MISMATCH', (mismatch as Error).message);
     }
 
     // One RPC, one transaction. Writing the version, the payers and the shares

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -1,0 +1,476 @@
+/**
+ * sync — the offline queue's other half (ADR-005 / TDR §4).
+ *
+ * One POST does both directions: it applies the client's queued mutations in
+ * the order they were made, then returns everything that has changed in the
+ * client's groups since its cursor. Push and pull share a request because they
+ * have to share an instant — pulling separately would let a client see its own
+ * write land twice, or not at all.
+ *
+ * Three invariants this function exists to hold:
+ *
+ *   **Replay is free.** Every mutation is keyed by a client-generated UUID and
+ *   recorded in `sync_mutations` with the result it produced. A queue replayed
+ *   after a crash gets the original answers back, not a second expense.
+ *
+ *   **The client never computes money.** Shares are recomputed here from
+ *   `split_params` with the same @baaki/core the app uses, and a client whose
+ *   arithmetic disagrees is rejected with SHARE_MISMATCH rather than believed.
+ *
+ *   **One bad mutation is not a broken app.** A rejection is reported per
+ *   mutation; the rest of the batch still applies, and the client is told
+ *   exactly which one failed and why.
+ */
+
+import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
+
+import { computeShares, type SplitParams } from '../_shared/core.js';
+import {
+  asCaller,
+  asService,
+  CORS_HEADERS,
+  errorResponse,
+  HttpError,
+  json,
+} from '../_shared/auth.ts';
+
+type MutationKind =
+  | 'expense.create'
+  | 'expense.update'
+  | 'expense.delete'
+  | 'expense.restore'
+  | 'settlement.create'
+  | 'settlement.transition'
+  | 'member.add_ghost'
+  | 'group.create'
+  | 'group.update';
+
+interface MutationEnvelope {
+  clientMutationId: string;
+  kind: MutationKind;
+  groupId: string;
+  clientCreatedAt: string;
+  payload: Record<string, unknown>;
+}
+
+interface SyncRequest {
+  deviceId?: string;
+  mutations?: MutationEnvelope[];
+  cursors?: Record<string, number>;
+}
+
+type Outcome =
+  | { clientMutationId: string; status: 'applied'; result?: unknown }
+  | { clientMutationId: string; status: 'duplicate'; result?: unknown }
+  | { clientMutationId: string; status: 'rejected'; code: string; message: string };
+
+interface SyncChange {
+  table: string;
+  groupId: string;
+  seq: number;
+  row: Record<string, unknown>;
+}
+
+/** A batch bigger than this is a bug or an attack, not a weekend in a dead zone. */
+const MAX_MUTATIONS = 200;
+/** Per group, per pull. A client behind by more simply pulls again. */
+const MAX_ROWS_PER_TABLE = 500;
+
+const EXPENSE_SELECT = `
+  id, group_id, deleted_at, created_at, updated_seq,
+  currentVersion:expense_versions!expenses_current_version_id_fkey (
+    id, version_no, description, category, expense_date, currency, amount,
+    split_type, split_params, author_member_id, notes, created_at,
+    payers:expense_payers ( member_id, amount ),
+    shares:expense_shares ( member_id, amount )
+  )
+`;
+
+const SETTLEMENT_SELECT = `
+  id, group_id, from_member_id, to_member_id, currency, amount, method, status, note,
+  initiated_at, confirmed_at, updated_seq,
+  allocations:settlement_allocations ( expense_id, amount )
+`;
+
+Deno.serve(async (request) => {
+  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
+
+  try {
+    if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
+
+    const body = (await request.json()) as SyncRequest;
+    const mutations = body.mutations ?? [];
+    const cursors = body.cursors ?? {};
+
+    if (mutations.length > MAX_MUTATIONS) {
+      throw new HttpError(
+        413,
+        'BATCH_TOO_LARGE',
+        `Send at most ${MAX_MUTATIONS} mutations per request`,
+      );
+    }
+
+    const caller = asCaller(request);
+    const service = asService();
+
+    const { data: user, error: userError } = await caller.auth.getUser();
+    if (userError || !user?.user) {
+      throw new HttpError(401, 'NOT_AUTHENTICATED', 'Sign in first');
+    }
+    const profileId = user.user.id;
+
+    const session = new SyncSession(caller, service, profileId);
+    const outcomes: Outcome[] = [];
+
+    for (const mutation of mutations) {
+      outcomes.push(await session.apply(mutation));
+    }
+
+    // Pull every group the client already knows about, plus any it just
+    // created — otherwise a group made offline would stay invisible until the
+    // next sync.
+    const groupIds = new Set<string>([...Object.keys(cursors), ...session.touchedGroups]);
+    const { changes, cursors: nextCursors } = await pull(caller, groupIds, cursors);
+
+    return json({
+      outcomes,
+      changes,
+      cursors: nextCursors,
+      serverTime: new Date().toISOString(),
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+});
+
+/**
+ * Applies one batch, remembering per-group membership so a hundred mutations in
+ * one group cost one membership lookup rather than a hundred.
+ */
+class SyncSession {
+  readonly touchedGroups = new Set<string>();
+  private readonly memberIds = new Map<string, string | null>();
+
+  constructor(
+    private readonly caller: SupabaseClient,
+    private readonly service: SupabaseClient,
+    private readonly profileId: string,
+  ) {}
+
+  async apply(mutation: MutationEnvelope): Promise<Outcome> {
+    const { clientMutationId } = mutation;
+    if (!clientMutationId) {
+      return {
+        clientMutationId: '',
+        status: 'rejected',
+        code: 'VALIDATION_FAILED',
+        message: 'Every mutation needs a clientMutationId',
+      };
+    }
+
+    // Replay: return exactly what the first attempt produced.
+    const { data: seen } = await this.service
+      .from('sync_mutations')
+      .select('result')
+      .eq('client_mutation_id', clientMutationId)
+      .maybeSingle();
+    if (seen) {
+      this.touchedGroups.add(mutation.groupId);
+      return { clientMutationId, status: 'duplicate', result: seen.result };
+    }
+
+    try {
+      const result = await this.dispatch(mutation);
+      this.touchedGroups.add(mutation.groupId);
+
+      // Recorded after the fact: if the write succeeded but this insert fails,
+      // the mutation's own idempotency key (on expense_versions, settlements,
+      // or the row's primary key) still stops a replay from acting twice.
+      await this.service.from('sync_mutations').insert({
+        client_mutation_id: clientMutationId,
+        profile_id: this.profileId,
+        group_id: mutation.groupId,
+        kind: mutation.kind,
+        result: result ?? {},
+      });
+
+      return { clientMutationId, status: 'applied', result };
+    } catch (error) {
+      const { code, message } = classify(error);
+      return { clientMutationId, status: 'rejected', code, message };
+    }
+  }
+
+  /** Null when the caller is not in the group. RLS is still the real gate. */
+  private async memberId(groupId: string): Promise<string | null> {
+    const cached = this.memberIds.get(groupId);
+    if (cached !== undefined) return cached;
+
+    const { data, error } = await this.caller.rpc('baaki_my_member_id', { p_group_id: groupId });
+    if (error) throw new HttpError(500, 'INTERNAL', error.message);
+    const memberId = (data as string | null) ?? null;
+    this.memberIds.set(groupId, memberId);
+    return memberId;
+  }
+
+  private async requireMemberId(groupId: string): Promise<string> {
+    const memberId = await this.memberId(groupId);
+    if (!memberId) throw new HttpError(403, 'NOT_A_MEMBER', 'You are not a member of this group');
+    return memberId;
+  }
+
+  private async dispatch(mutation: MutationEnvelope): Promise<unknown> {
+    switch (mutation.kind) {
+      case 'expense.create':
+      case 'expense.update':
+        return await this.writeExpense(mutation);
+      case 'expense.delete':
+        return await this.rpcAsCaller('baaki_delete_expense', {
+          p_expense_id: requireString(mutation.payload.expenseId, 'expenseId'),
+        });
+      case 'expense.restore':
+        return await this.rpcAsCaller('baaki_restore_expense', {
+          p_expense_id: requireString(mutation.payload.expenseId, 'expenseId'),
+        });
+      case 'settlement.create':
+        return await this.createSettlement(mutation);
+      case 'settlement.transition':
+        return await this.rpcAsCaller('baaki_confirm_settlement', {
+          p_settlement_id: requireString(mutation.payload.settlementId, 'settlementId'),
+        });
+      case 'member.add_ghost':
+        return await this.rpcAsCaller('baaki_add_ghost_member', {
+          p_group_id: mutation.groupId,
+          p_name: requireString(mutation.payload.name, 'name'),
+          p_member_id: (mutation.payload.memberId as string | undefined) ?? null,
+        });
+      case 'group.create':
+        return await this.rpcAsCaller('baaki_create_group', {
+          p_name: requireString(mutation.payload.name, 'name'),
+          p_type: (mutation.payload.type as string | undefined) ?? 'other',
+          p_currency: (mutation.payload.currency as string | undefined) ?? 'INR',
+          p_emoji: (mutation.payload.emoji as string | undefined) ?? null,
+          p_simplify: mutation.payload.simplify !== false,
+          // The client already chose this id and its queued expenses reference it.
+          p_group_id: mutation.groupId,
+        });
+      case 'group.update': {
+        await this.requireMemberId(mutation.groupId);
+        const { error } = await this.caller
+          .from('groups')
+          .update(mutation.payload)
+          .eq('id', mutation.groupId);
+        if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
+        return { groupId: mutation.groupId };
+      }
+      default:
+        throw new HttpError(
+          400,
+          'VALIDATION_FAILED',
+          `Unknown mutation kind: ${String(mutation.kind)}`,
+        );
+    }
+  }
+
+  private async rpcAsCaller(name: string, args: Record<string, unknown>): Promise<unknown> {
+    const { data, error } = await this.caller.rpc(name, args);
+    if (error) throw error;
+    return data ?? {};
+  }
+
+  private async writeExpense(mutation: MutationEnvelope): Promise<unknown> {
+    const memberId = await this.requireMemberId(mutation.groupId);
+    const payload = mutation.payload as {
+      expenseId?: string;
+      description: string;
+      category?: string | null;
+      expenseDate: string;
+      currency: string;
+      amount: string;
+      splitParams: SplitParams;
+      participants: string[];
+      payers: Record<string, string>;
+      expectedShares?: Record<string, string>;
+      notes?: string | null;
+      receiptId?: string | null;
+      baseVersionNo?: number;
+    };
+
+    const amount = BigInt(payload.amount);
+    if (amount < 0n) throw new HttpError(400, 'INVALID_AMOUNT', 'Amount cannot be negative');
+
+    const payers = Object.entries(payload.payers ?? {}).map(
+      ([id, value]) => [id, BigInt(value)] as const,
+    );
+    const paid = payers.reduce((total, [, value]) => total + value, 0n);
+    if (paid !== amount) {
+      throw new HttpError(
+        400,
+        'PAYER_MISMATCH',
+        `Payers add up to ${paid} but the expense is ${amount}`,
+      );
+    }
+
+    const expenseId = payload.expenseId ?? crypto.randomUUID();
+    const shares = computeShares({
+      amount,
+      currency: payload.currency,
+      params: payload.splitParams,
+      participants: payload.participants,
+      seed: expenseId,
+    });
+
+    // The client computed these too, offline, from the same inputs. If they
+    // differ, one of us is wrong and it is not going in the ledger (TDR §4).
+    if (payload.expectedShares) {
+      for (const [member, share] of shares) {
+        const claimed = payload.expectedShares[member];
+        if (claimed === undefined || BigInt(claimed) !== share) {
+          throw new HttpError(
+            409,
+            'SHARE_MISMATCH',
+            `Server computed ${share} for ${member}, client said ${claimed ?? 'nothing'}`,
+          );
+        }
+      }
+    }
+
+    const { data, error } = await this.service.rpc('baaki_apply_expense', {
+      p_group_id: mutation.groupId,
+      p_expense_id: expenseId,
+      p_author_member_id: memberId,
+      p_description: payload.description,
+      p_category: payload.category ?? null,
+      p_expense_date: payload.expenseDate,
+      p_currency: payload.currency.toUpperCase(),
+      p_amount: amount.toString(),
+      p_split_type: payload.splitParams.kind,
+      p_split_params: payload.splitParams,
+      p_payers: payers.map(([id, value]) => ({ memberId: id, amount: value.toString() })),
+      p_shares: [...shares].map(([id, value]) => ({ memberId: id, amount: value.toString() })),
+      p_client_mutation_id: mutation.clientMutationId,
+      p_notes: payload.notes ?? null,
+      p_receipt_id: payload.receiptId ?? null,
+      // Set only for edits, and only by a client that had actually seen a
+      // version — this is what turns a concurrent edit into a logged conflict
+      // instead of a silent overwrite (TDR §4.4).
+      p_base_version_no: payload.baseVersionNo ?? null,
+    });
+    if (error) throw error;
+    return data;
+  }
+
+  private async createSettlement(mutation: MutationEnvelope): Promise<unknown> {
+    const payload = mutation.payload as {
+      from: string;
+      to: string;
+      amount: string;
+      method: string;
+      currency?: string | null;
+      note?: string | null;
+      allocations?: { expenseId: string; amount: string }[];
+    };
+
+    return await this.rpcAsCaller('baaki_record_settlement', {
+      p_group_id: mutation.groupId,
+      p_from_member_id: payload.from,
+      p_to_member_id: payload.to,
+      p_amount: payload.amount,
+      p_method: payload.method,
+      p_currency: payload.currency ?? null,
+      p_note: payload.note ?? null,
+      p_allocations: payload.allocations ?? [],
+      p_client_mutation_id: mutation.clientMutationId,
+    });
+  }
+}
+
+/**
+ * Everything in these groups since the client's cursor.
+ *
+ * Read as the caller, never as the service role: a client can only ever be sent
+ * rows its own RLS policies already allow, so widening the sync set can never
+ * accidentally widen what it can see (ADR-013).
+ *
+ * The new cursor is the group's own `updated_seq`. That is safe because
+ * `baaki_next_group_seq` takes the sequence by updating the groups row, which
+ * holds a row lock until commit — so within a group, sequence order and commit
+ * order are the same and no lower-numbered row can appear after a higher one.
+ */
+async function pull(
+  caller: SupabaseClient,
+  groupIds: Set<string>,
+  cursors: Record<string, number>,
+): Promise<{ changes: SyncChange[]; cursors: Record<string, number> }> {
+  const changes: SyncChange[] = [];
+  const nextCursors: Record<string, number> = {};
+
+  for (const groupId of groupIds) {
+    const since = cursors[groupId] ?? 0;
+
+    const { data: group, error: groupError } = await caller
+      .from('groups')
+      .select('*')
+      .eq('id', groupId)
+      .maybeSingle();
+    if (groupError) throw new HttpError(500, 'INTERNAL', groupError.message);
+    // Left the group, or never was in it: nothing to say, and no cursor either.
+    if (!group) continue;
+
+    const highWater = Number(group.updated_seq ?? 0);
+    nextCursors[groupId] = highWater;
+
+    if (highWater > since) {
+      changes.push({ table: 'groups', groupId, seq: highWater, row: group });
+    }
+
+    for (const [table, select] of [
+      ['group_members', '*, profile:profiles ( id, display_name, avatar_url, default_vpa )'],
+      ['expenses', EXPENSE_SELECT],
+      ['settlements', SETTLEMENT_SELECT],
+      ['activity_log', '*'],
+    ] as const) {
+      const { data, error } = await caller
+        .from(table)
+        .select(select)
+        .eq('group_id', groupId)
+        .gt('updated_seq', since)
+        .order('updated_seq', { ascending: true })
+        .limit(MAX_ROWS_PER_TABLE);
+
+      // A failed read must never look like "nothing changed" — that is how a
+      // client silently ends up with half a ledger.
+      if (error) throw new HttpError(500, 'PULL_FAILED', `${table}: ${error.message}`);
+
+      for (const row of data ?? []) {
+        const record = row as Record<string, unknown>;
+        changes.push({ table, groupId, seq: Number(record.updated_seq ?? 0), row: record });
+      }
+    }
+  }
+
+  return { changes, cursors: nextCursors };
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new HttpError(400, 'VALIDATION_FAILED', `${field} is required`);
+  }
+  return value;
+}
+
+/** Turn a thrown error into the vocabulary the client's queue understands. */
+function classify(error: unknown): { code: string; message: string } {
+  if (error instanceof HttpError) return { code: error.code, message: error.message };
+
+  const message = error instanceof Error ? error.message : String(error);
+  // The database raises 'UNKNOWN_MEMBER: ...', 'NOT_A_MEMBER: ...' and friends;
+  // keep its own word for what went wrong rather than flattening to INTERNAL.
+  const raised = /^([A-Z_]+):/.exec(message)?.[1];
+  if (raised) return { code: raised, message };
+
+  const wrapped = (error as { code?: string })?.code;
+  if (wrapped === '42501') return { code: 'NOT_A_MEMBER', message };
+
+  return { code: 'VALIDATION_FAILED', message };
+}

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -24,7 +24,7 @@
 
 import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
 
-import { computeShares, type SplitParams } from '../_shared/core.js';
+import { computeShares, verifyClientShares, type SplitParams } from '../_shared/core.js';
 import {
   asCaller,
   asService,
@@ -322,17 +322,10 @@ class SyncSession {
 
     // The client computed these too, offline, from the same inputs. If they
     // differ, one of us is wrong and it is not going in the ledger (TDR §4).
-    if (payload.expectedShares) {
-      for (const [member, share] of shares) {
-        const claimed = payload.expectedShares[member];
-        if (claimed === undefined || BigInt(claimed) !== share) {
-          throw new HttpError(
-            409,
-            'SHARE_MISMATCH',
-            `Server computed ${share} for ${member}, client said ${claimed ?? 'nothing'}`,
-          );
-        }
-      }
+    try {
+      verifyClientShares(shares, payload.expectedShares);
+    } catch (mismatch) {
+      throw new HttpError(409, 'SHARE_MISMATCH', (mismatch as Error).message);
     }
 
     const { data, error } = await this.service.rpc('baaki_apply_expense', {


### PR DESCRIPTION
Baaki now works with no network at all. Expenses are entered, edited and deleted against a local mirror, queued durably, and replayed when a signal comes back — and two people editing from two dead zones both keep their work.

## The rules live in `@baaki/core`

ADR-005 calls sync "the hardest part of the client", so the parts worth being sure about are pure functions with no device in sight.

**`queue.ts`** is FIFO within a group with exponential backoff, and its head-of-line blocking is per-group rather than global — one poisoned expense cannot stop the rest of the app from syncing. Un-sent consecutive edits of the same expense collapse into one; anything the server may already have seen never does, because dropping it would lose a version other people can see.

**`mirror.ts`** keeps the server layer and the pending overlay apart. Optimistic edits are replayed over the mirror at read time rather than written into it, so a pull that lands before our own mutation cannot revert the screen under the user's finger. Pending shares are computed with the same function and the same seed the server uses, so an offline expense shows the numbers it will still have once it syncs.

The TDR states the M2 acceptance criterion as a scenario — *ten expenses on two devices in aeroplane mode, reconnect, identical balances, no duplicates*. That is a property, so it is written as one and run 200 times against a model server, then again for real in `e2e/m2-sync.mjs`.

## The database

- **Groups move their own sync cursor.** A rename changed nothing a client could pull, so a device that was offline during one never learned about it.
- **`sync_mutations`** is the idempotency ledger. Every mutation kind is now replay-safe, not just the two that happened to have a natural key, and a replay returns the original result rather than merely avoiding damage.
- **`baaki_apply_expense` takes the version the client believed it was editing.** A concurrent edit appends, the later receipt wins, and a `superseded` activity entry names whose edit was replaced (TDR §4.4).
- **Groups and ghosts accept a client-chosen id**, so a row created offline keeps the identity the rest of the queue already references.

## The client

`apps/mobile/src/sync/` holds a real SQLite mirror, the mutation queue, and drafts that autosave on every keystroke. Web falls back to AsyncStorage behind the same interface: expo-sqlite's web build needs cross-origin isolation headers a static export cannot send, and a guest opening an invite link should not meet a blank screen over it. The driver is split by *file* rather than by `Platform.OS`, because a static import pulls the WASM build into the bundle either way — which the web export proved.

## A latent M1 bug this surfaced

The add-expense preview seeded the remainder rotation with the literal string `'draft'` while the server seeded it with the real expense id. Any amount that did not divide evenly put the extra paisa on a different person, and the write came back `SHARE_MISMATCH`. Choosing the id on the client — which offline needs regardless — fixes it.

## Verification

124 tests pass, up from 97: 66 in `@baaki/core` and 58 in `@baaki/db`, against real Postgres. Typecheck, lint and format clean; the web bundle exports.

Two bugs of my own were caught by the existing suites before they could go anywhere, which is what they are for: an unassigned plpgsql `RECORD` read on the non-conflict path (this broke *every* expense write, and the M1 RPC tests failed on the first run), and a call to `is_group_member` with the wrong arity, which Postgres only resolves at execution time. Both are fixed forward rather than by editing an applied migration, hence four migration files for one feature.

## Not verified yet

`e2e/m2-sync.mjs` needs the `/sync` edge function deployed, which needs a Supabase access token I deliberately did not reuse — the old one is compromised and awaiting rotation. Everything that does not require deployment is verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6