### PR TITLE
fix: read local-first, and say plainly when a change has not synced

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -46,7 +46,7 @@ export default function AddExpenseScreen() {
   const { group, members, expenses } = useGroup(groupId);
   const { mutate } = useSync();
 
-  const editing = expenses.data?.find((expense) => expense.id === expenseId);
+  const editing = expenses.rows.find((expense) => expense.id === expenseId);
 
   // The id is chosen here, not by the server. It seeds the remainder rotation
   // (ADR-009), so previewing with one id and writing with another would put the

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -50,7 +50,7 @@ export default function ExpenseDetailScreen() {
   const deleteExpense = useDeleteExpense(groupId);
   const restoreExpense = useRestoreExpense(groupId);
 
-  const expense = expenses.data?.find((row) => row.id === expenseId);
+  const expense = expenses.rows.find((row) => row.id === expenseId);
   const version = expense?.currentVersion;
   const lookup = memberLookup(members.data);
   const nameOf = (memberId: string | null): string => {

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -81,9 +81,7 @@ export default function GroupScreen() {
   }
 
   const currency = group.data.default_currency;
-  const visibleExpenses = (expenses.data ?? []).filter(
-    (expense) => showDeleted || !expense.deleted_at,
-  );
+  const visibleExpenses = expenses.rows.filter((expense) => showDeleted || !expense.deleted_at);
   const pendingForMe = (settlements.data ?? []).filter(
     (settlement) =>
       settlement.status === 'initiated' && settlement.to_member_id === ledger.myMemberId,

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -57,7 +57,7 @@ export default function MemberScreen() {
   const balance = ledger.balances.get(member.id) ?? 0n;
 
   // Expenses this person is actually part of.
-  const involved = (expenses.data ?? []).filter((expense) =>
+  const involved = expenses.rows.filter((expense) =>
     expense.currentVersion?.shares.some((share) => share.member_id === member.id),
   );
 

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -75,7 +75,7 @@ export default function SettleScreen() {
     if (!counterparty || !myMemberId) return [];
     const from = iPay ? myMemberId : counterparty.id;
     const to = iPay ? counterparty.id : myMemberId;
-    return (expenses.data ?? [])
+    return expenses.rows
       .map(toSnapshot)
       .filter((snapshot): snapshot is NonNullable<typeof snapshot> => snapshot !== null)
       .map((snapshot) => {
@@ -85,7 +85,7 @@ export default function SettleScreen() {
         return { expenseId: snapshot.id, date: snapshot.date, amount: portion };
       })
       .filter((receivable) => receivable.amount > 0n);
-  }, [expenses.data, counterparty, myMemberId, iPay]);
+  }, [expenses.rows, counterparty, myMemberId, iPay]);
 
   const allocation =
     amount > 0n && receivables.length > 0
@@ -93,7 +93,7 @@ export default function SettleScreen() {
       : { allocations: [], unallocated: amount };
 
   const expenseTitle = (expenseId: string): string =>
-    expenses.data?.find((expense) => expense.id === expenseId)?.currentVersion?.description ??
+    expenses.rows.find((expense) => expense.id === expenseId)?.currentVersion?.description ??
     'Expense';
 
   const record = async (): Promise<void> => {

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -16,7 +16,7 @@ import { useSync } from '@/sync';
 
 export function SyncBanner({ groupId }: { groupId?: string }) {
   const theme = useTheme();
-  const { status, queue, rejected, retry, discard } = useSync();
+  const { status, queue, rejected, retry, discard, lastError } = useSync();
 
   const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
   const refused = groupId ? rejected.filter((item) => item.groupId === groupId) : rejected;
@@ -56,27 +56,44 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
     );
   }
 
-  if (pending.length === 0 && status !== 'offline') return null;
+  if (pending.length === 0 && status !== 'offline' && status !== 'error') return null;
 
-  const offline = status === 'offline';
+  const count = `${pending.length} ${pending.length === 1 ? 'change' : 'changes'}`;
+
+  // Three different truths, and saying the wrong one is worse than saying
+  // nothing: "syncing…" while every request is failing reads as a hang, and
+  // eventually as lost data.
+  const { icon, message } =
+    status === 'offline'
+      ? {
+          icon: 'cloud-offline-outline' as const,
+          message:
+            pending.length > 0
+              ? `Offline — ${count} saved on this phone`
+              : 'Offline — everything here is saved on this phone',
+        }
+      : status === 'error'
+        ? {
+            icon: 'cloud-offline-outline' as const,
+            message: `Can't reach the server — ${count} saved here, waiting to send`,
+          }
+        : { icon: 'sync-outline' as const, message: `Syncing ${count}…` };
+
   return (
-    <Card style={{ backgroundColor: theme.color.brandSoft }}>
+    <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.xs }}>
       <Row style={{ gap: theme.spacing.sm }}>
-        <Ionicons
-          name={offline ? 'cloud-offline-outline' : 'sync-outline'}
-          size={18}
-          color={theme.color.brand}
-        />
+        <Ionicons name={icon} size={18} color={theme.color.brand} />
         <View style={{ flex: 1 }}>
           <Text variant="caption" tone="brand">
-            {offline
-              ? pending.length > 0
-                ? `Offline — ${pending.length} ${pending.length === 1 ? 'change' : 'changes'} saved on this phone`
-                : 'Offline — everything here is saved on this phone'
-              : `Syncing ${pending.length} ${pending.length === 1 ? 'change' : 'changes'}…`}
+            {message}
           </Text>
         </View>
       </Row>
+      {status === 'error' && lastError ? (
+        <Text variant="micro" tone="muted">
+          {lastError}
+        </Text>
+      ) : null}
     </Card>
   );
 }

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -14,14 +14,17 @@ import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tansta
 import {
   computeNetBalances,
   computePairwiseBalances,
+  overlayPending,
   simplify,
   type ExpenseSnapshot,
   type MemberId,
+  type MirrorExpense,
   type SettlementSnapshot,
   type Transfer,
 } from '@baaki/core';
 
 import { supabase } from '@/lib/supabase';
+import { useSync } from '@/sync';
 import {
   addGhostMember,
   confirmSettlement,
@@ -110,6 +113,22 @@ export function useHomeSummary(profileId: string | null) {
   };
 }
 
+/**
+ * ADR-005: what the screen shows is the server's rows with the mutation queue
+ * replayed on top. Without the overlay an expense the user just entered is
+ * invisible until it syncs, which is indistinguishable from losing it.
+ */
+export function usePendingAware(groupId: string, expenses: ExpenseRow[]): ExpenseRow[] {
+  const { queue } = useSync();
+  return useMemo(
+    () =>
+      overlayPending(expenses as unknown as MirrorExpense[], queue, {
+        groupId,
+      }) as unknown as ExpenseRow[],
+    [expenses, queue, groupId],
+  );
+}
+
 export function useGroup(groupId: string) {
   const group = useQuery({
     queryKey: keys.group(groupId),
@@ -142,7 +161,17 @@ export function useGroup(groupId: string) {
     enabled: Boolean(groupId),
   });
 
-  return { group, members, expenses, settlements, activity, balances };
+  const withPending = usePendingAware(groupId, expenses.data ?? []);
+
+  return {
+    group,
+    members,
+    // `expenses.data` is the server's answer; `expenses.rows` is what to render.
+    expenses: { ...expenses, rows: withPending },
+    settlements,
+    activity,
+    balances,
+  };
 }
 
 export function toSnapshot(expense: ExpenseRow): ExpenseSnapshot | null {
@@ -195,7 +224,7 @@ export function useGroupLedger(groupId: string, myProfileId: string | null): Gro
       group.isLoading || members.isLoading || expenses.isLoading || settlements.isLoading;
 
     const currency = group.data?.default_currency ?? 'INR';
-    const snapshots = (expenses.data ?? [])
+    const snapshots = expenses.rows
       .map(toSnapshot)
       .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
     const settlementSnapshots = (settlements.data ?? []).map(toSettlementSnapshot);
@@ -213,9 +242,12 @@ export function useGroupLedger(groupId: string, myProfileId: string | null): Gro
       ? (withPending.get(currency)?.get(myMemberId) ?? 0n) - myBalance
       : 0n;
 
-    // Cross-check against what the database derived independently.
+    // Cross-check against what the database derived independently. Skipped
+    // while anything is still queued: the server has not seen those expenses
+    // yet, so a disagreement is expected rather than a problem to report.
+    const anyPending = expenses.rows.some((expense) => expense.pending === true);
     let mismatch = false;
-    if (balances.data) {
+    if (balances.data && !anyPending) {
       const stored = new Map(
         balances.data
           .filter((row) => row.currency === currency)
@@ -254,7 +286,7 @@ export function useGroupLedger(groupId: string, myProfileId: string | null): Gro
     group.isLoading,
     members.data,
     members.isLoading,
-    expenses.data,
+    expenses.rows,
     expenses.isLoading,
     settlements.data,
     settlements.isLoading,

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -56,6 +56,8 @@ export interface ExpenseRow {
   deleted_at: string | null;
   created_at: string;
   currentVersion: ExpenseVersionRow | null;
+  /** Set while this row exists only in the local mutation queue (ADR-005). */
+  pending?: boolean;
 }
 
 export interface SettlementRow {

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -160,11 +160,27 @@ export function materialiseExpenses(
   queue: readonly QueuedMutation[],
   options: MaterialiseOptions,
 ): MirrorExpense[] {
+  return overlayPending(
+    rowsFor(state, 'expenses', options.groupId) as MirrorExpense[],
+    queue,
+    options,
+  );
+}
+
+/**
+ * The same overlay, over any list of expense rows rather than the mirror.
+ *
+ * The mirror is one source of server rows; a cached network response is
+ * another. Both need the queue replayed on top or the app shows an expense the
+ * user has just entered as missing, which looks exactly like data loss.
+ */
+export function overlayPending(
+  expenses: readonly MirrorExpense[],
+  queue: readonly QueuedMutation[],
+  options: MaterialiseOptions,
+): MirrorExpense[] {
   const byId = new Map<string, MirrorExpense>();
-  for (const row of rowsFor(state, 'expenses', options.groupId)) {
-    const expense = row as MirrorExpense;
-    byId.set(expense.id, expense);
-  }
+  for (const expense of expenses) byId.set(expense.id, expense);
 
   for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
     if (mutation.groupId !== options.groupId) continue;

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -26,9 +26,11 @@ import {
   markFailed,
   materialiseExpenses,
   nextBatch,
+  overlayPending,
   reconcile,
   retryNow,
   toExpenseSnapshot,
+  type MirrorExpense,
   type MirrorState,
   type QueuedMutation,
 } from '../src/sync/index.js';
@@ -547,6 +549,43 @@ describe('the pending overlay', () => {
     expect(Object.fromEntries(shares.map((s) => [s.member_id, s.amount]))).toEqual(
       Object.fromEntries([...server].map(([id, amount]) => [id, amount.toString()])),
     );
+  });
+
+  it('overlays a queue onto rows that did not come from the mirror', () => {
+    // The group screen renders a cached network response, not the mirror, so
+    // the overlay has to work over any list of rows. Without this an expense
+    // the user just entered is invisible until it syncs — which on screen is
+    // indistinguishable from having lost it.
+    const server: MirrorExpense[] = [
+      {
+        id: 'e-server',
+        group_id: GROUP,
+        deleted_at: null,
+        created_at: '2026-03-01T00:00:00Z',
+        currentVersion: null,
+      },
+    ];
+    const queue = enqueue([], {
+      clientMutationId: 'm-1',
+      kind: 'expense.create',
+      groupId: GROUP,
+      clientCreatedAt: '2026-03-02T00:00:00Z',
+      payload: {
+        expenseId: 'e-local',
+        description: 'Entered just now',
+        expenseDate: '2026-03-02',
+        currency: INR,
+        amount: '900',
+        splitParams: { kind: 'equal' },
+        participants: members,
+        payers: { m1: '900' },
+      },
+    });
+
+    const rows = overlayPending(server, queue, { groupId: GROUP });
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.id === 'e-local')?.pending).toBe(true);
+    expect(rows.find((row) => row.id === 'e-server')?.pending).toBeUndefined();
   });
 
   it('stops overlaying once the server confirms the mutation', () => {


### PR DESCRIPTION
Running the app found this, which is the point of running it.

M2 rewired the **write** path into the durable queue but left every screen reading the network response. So an expense the user had just entered was invisible: the banner said *"Syncing 1 change…"* while the list underneath said *"Nothing here yet"* and the balance sat at ₹0. On screen that is indistinguishable from having lost the entry, and it contradicts ADR-005's "UI reads local-first, always".

## The fix

`overlayPending` in `@baaki/core` is `materialiseExpenses` generalised to work over any list of expense rows rather than only the mirror — the mirror is one source of server rows, a cached network response is another, and both need the queue replayed on top.

`useGroup` now returns `expenses.rows`: the server's answer with the queue on top. The group, expense-detail, member, settle and add-expense screens all read that instead of `expenses.data`. Balances come from the same overlaid rows, so an offline expense shows the exact numbers it will still have once it syncs — no correction flicker when the network returns.

Two related corrections:

- **The mismatch warning is suppressed while anything is queued.** The server has not seen those expenses yet, so it disagreeing is expected rather than something to alarm the user about.
- **The banner distinguishes three states it was flattening into one.** "Syncing…" while every request is failing reads as a hang, and eventually as data loss. It now says *"Can't reach the server — 1 change saved here, waiting to send"* and shows the reason underneath.

## Verification

Driven against the real web bundle with the `sync` function deliberately undeployed — the honest worst case. The expense saves, appears at ₹1,500 with a ₹750 balance, and the banner explains itself. Nothing is lost and nothing is claimed that isn't true.

163 tests pass (105 core, 58 db), including a new one covering the overlay over rows that did not come from the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6