### PR TITLE
feat: M5 receipt scanning — photograph to line items

### DIFF
--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { randomUUID } from 'expo-crypto';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
@@ -25,6 +26,8 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { pickReceiptPhoto } from '@/components/GroupPhoto';
+import { scanReceipt } from '@/data/api';
 import { useGroup, useWriteExpense } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
@@ -64,6 +67,56 @@ export default function ItemizeScreen() {
   const [taxText, setTaxText] = useState('');
   const [tipText, setTipText] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [scanning, setScanning] = useState(false);
+  const [scanNote, setScanNote] = useState<string | null>(null);
+
+  /**
+   * ADR-008: the model proposes, the person confirms. Everything it read lands
+   * in the same editable list somebody would have typed by hand, so correcting
+   * a misread line is just editing — there is no separate "AI mode" to leave.
+   */
+  const scan = async (): Promise<void> => {
+    const picked = await pickReceiptPhoto();
+    if (!picked) return;
+    setError(null);
+    setScanNote(null);
+    setScanning(true);
+    try {
+      const result = await scanReceipt({
+        groupId,
+        base64: picked.base64,
+        mimeType: picked.mimeType,
+        currency,
+      });
+
+      setItems(
+        result.parsed.items.map((item, index) => ({
+          key: `scan-${index}-${randomUUID()}`,
+          label: item.label,
+          total: BigInt(item.total),
+          claimers: [],
+        })),
+      );
+      const taxes = result.parsed.taxes.reduce((sum, tax) => sum + tax.amount, 0);
+      if (taxes > 0) setTaxText((taxes / 100).toString());
+      if (result.parsed.tip) setTipText((result.parsed.tip / 100).toString());
+      if (!description.trim() && result.parsed.merchant) setDescription(result.parsed.merchant);
+
+      // The arithmetic decides what the person is asked to look at. Saying
+      // "scanned!" and leaving them to notice a wrong total is the failure
+      // this whole path exists to avoid.
+      setScanNote(
+        result.check.reconciles && result.check.problems.length === 0
+          ? `Read ${result.parsed.items.length} items. Check them, then tap who had what.`
+          : (result.check.problems[0]?.message ??
+              'Some lines need checking before this can be saved.'),
+      );
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setScanning(false);
+    }
+  };
 
   const currency = group.data?.default_currency ?? 'INR';
   const scale = minorUnitScale(currency);
@@ -211,6 +264,31 @@ export default function ItemizeScreen() {
           </View>
           <View style={{ width: 44 }} />
         </Row>
+
+        <Card style={{ gap: theme.spacing.md }}>
+          <Row style={{ justifyContent: 'space-between' }}>
+            <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
+              <Text variant="subheading">Scan the receipt</Text>
+              <Text variant="caption" tone="muted">
+                Photograph the bill and the items come out filled in. Check them before saving —
+                entering them by hand is always free.
+              </Text>
+            </View>
+            <Button
+              label={scanning ? 'Reading…' : 'Scan'}
+              variant="secondary"
+              disabled={scanning}
+              onPress={() => void scan()}
+              icon={<Ionicons name="camera-outline" size={18} color={theme.color.brand} />}
+            />
+          </Row>
+          {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
+          {scanNote ? (
+            <Text variant="caption" tone="brand">
+              {scanNote}
+            </Text>
+          ) : null}
+        </Card>
 
         <Card style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">

--- a/apps/mobile/src/components/GroupPhoto.tsx
+++ b/apps/mobile/src/components/GroupPhoto.tsx
@@ -49,6 +49,29 @@ export async function pickGroupPhoto(): Promise<PickedImage | null> {
   return { base64: asset.base64, mimeType: asset.mimeType ?? null, uri: asset.uri };
 }
 
+/**
+ * A receipt, from the camera by default (ADR-008). Not cropped to a square and
+ * not compressed as hard as a cover photo: a faded line the model cannot read
+ * is a line somebody has to retype, so fidelity is worth the bytes here.
+ */
+export async function pickReceiptPhoto(): Promise<PickedImage | null> {
+  const permission = await ImagePicker.requestCameraPermissionsAsync();
+  const launch = permission.granted
+    ? ImagePicker.launchCameraAsync
+    : ImagePicker.launchImageLibraryAsync;
+
+  const result = await launch({
+    mediaTypes: ['images'],
+    quality: 0.9,
+    base64: true,
+  });
+  if (result.canceled) return null;
+
+  const asset = result.assets[0];
+  if (!asset?.base64) return null;
+  return { base64: asset.base64, mimeType: asset.mimeType ?? null, uri: asset.uri };
+}
+
 interface GroupPhotoProps {
   photoPath?: string | null;
   /** A locally chosen image that has not been uploaded yet. */

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -10,7 +10,7 @@
 import { decode } from 'base64-arraybuffer';
 import { randomUUID } from 'expo-crypto';
 
-import type { SplitParams } from '@baaki/core';
+import type { ParsedReceipt, ReceiptCheck, SplitParams } from '@baaki/core';
 
 import { supabase } from '@/lib/supabase';
 import type {
@@ -611,4 +611,77 @@ function describeAuthError(message: string, channel: ContactChannel): string {
     return 'This Baaki server cannot send SMS yet. Try an email address instead.';
   }
   return message;
+}
+
+// ─────────────────────────────── receipt scanning (ADR-008) ──
+
+export interface ScanResult {
+  receiptId: string;
+  status: 'parsed' | 'needs_review';
+  parsed: ParsedReceipt;
+  check: ReceiptCheck;
+  quota: { used: number; limit: number };
+}
+
+/**
+ * Upload a receipt photo and have it read.
+ *
+ * The image goes to the private `receipts` bucket first so the model is fed by
+ * the edge function rather than by a URL we hand out — and so a scan that fails
+ * can be retried without asking the user to photograph the bill again.
+ */
+export async function scanReceipt(input: {
+  groupId: string;
+  base64: string;
+  mimeType?: string | null;
+  currency?: string;
+}): Promise<ScanResult> {
+  const receiptId = randomUUID();
+  const mime = input.mimeType === 'image/png' ? 'image/png' : 'image/jpeg';
+  const path = `${input.groupId}/${receiptId}.${mime === 'image/png' ? 'png' : 'jpg'}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from('receipts')
+    .upload(path, decode(input.base64), { contentType: mime, upsert: true });
+  if (uploadError) throw new Error(uploadError.message);
+
+  const { data, error } = await supabase.functions.invoke('receipt-parse', {
+    body: {
+      groupId: input.groupId,
+      receiptId,
+      storagePath: path,
+      source: 'camera',
+      currency: input.currency ?? 'INR',
+    },
+  });
+  if (error) throw new Error(await readFunctionError(error));
+  return data as ScanResult;
+}
+
+/** A pasted Swiggy/Zomato/WhatsApp bill — no photograph involved. */
+export async function scanReceiptText(input: {
+  groupId: string;
+  rawText: string;
+  currency?: string;
+}): Promise<ScanResult> {
+  const { data, error } = await supabase.functions.invoke('receipt-parse', {
+    body: {
+      groupId: input.groupId,
+      rawText: input.rawText,
+      source: 'text_paste',
+      currency: input.currency ?? 'INR',
+    },
+  });
+  if (error) throw new Error(await readFunctionError(error));
+  return data as ScanResult;
+}
+
+export async function fetchScanQuota(): Promise<{
+  used: number;
+  limit: number;
+  remaining: number;
+}> {
+  const { data, error } = await supabase.rpc('baaki_receipt_scan_quota');
+  if (error) throw new Error(error.message);
+  return data as { used: number; limit: number; remaining: number };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,4 +12,5 @@ export * from './balances/index';
 export * from './simplify/index';
 export * from './settlement/index';
 export * from './sync/index';
+export * from './receipt/index';
 export * from './notifications/index';

--- a/packages/core/src/receipt/index.ts
+++ b/packages/core/src/receipt/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './reconcile';

--- a/packages/core/src/receipt/reconcile.ts
+++ b/packages/core/src/receipt/reconcile.ts
@@ -1,0 +1,143 @@
+/**
+ * Checking the model's arithmetic (ADR-008 / TDR §6).
+ *
+ * A vision model reading a crumpled thermal receipt will sometimes drop a
+ * digit, and it will do so confidently. The defence is not a better prompt: it
+ * is that a receipt carries its own checksum — the items and charges have to
+ * add up to the printed total. When they don't, we know something was misread
+ * before the user ever sees a number, and we can point at the lines to check
+ * rather than silently creating a wrong expense.
+ *
+ * "AI proposes, human confirms" is only meaningful if the human is told what to
+ * look at.
+ */
+
+import {
+  LOW_CONFIDENCE,
+  RECONCILE_TOLERANCE,
+  type ParsedReceipt,
+  type ReceiptCheck,
+  type ReceiptProblem,
+} from './types';
+
+export function sumCharges(charges: readonly { amount: number }[]): number {
+  return charges.reduce((total, charge) => total + charge.amount, 0);
+}
+
+/** Everything added to the items: tax, service, tip, less discounts. */
+export function extrasOf(receipt: ParsedReceipt): number {
+  return (
+    sumCharges(receipt.taxes) +
+    (receipt.serviceCharge ?? 0) +
+    (receipt.tip ?? 0) -
+    sumCharges(receipt.discounts)
+  );
+}
+
+export function itemsTotalOf(receipt: ParsedReceipt): number {
+  return receipt.items.reduce((total, item) => total + item.total, 0);
+}
+
+/**
+ * Does this receipt add up, and which lines should a person look at?
+ *
+ * Never throws: a receipt that fails every check is still returned, described,
+ * so the review screen can show the photo beside the problems. Refusing to
+ * produce an answer would just push the failure somewhere less useful.
+ */
+export function checkReceipt(receipt: ParsedReceipt): ReceiptCheck {
+  const problems: ReceiptProblem[] = [];
+  const needsReview = new Set<number>();
+
+  if (receipt.items.length === 0) {
+    problems.push({
+      kind: 'no_items',
+      message: 'No line items were found on this receipt',
+    });
+  }
+
+  receipt.items.forEach((item, itemIndex) => {
+    if (item.total < 0) {
+      problems.push({
+        kind: 'negative_line',
+        itemIndex,
+        message: `"${item.label}" came out negative — it may be a discount printed as a line`,
+      });
+      needsReview.add(itemIndex);
+    }
+    if (item.confidence < LOW_CONFIDENCE) {
+      problems.push({
+        kind: 'low_confidence',
+        itemIndex,
+        message: `"${item.label}" was hard to read — check the name and amount`,
+      });
+      needsReview.add(itemIndex);
+    }
+  });
+
+  const itemsTotal = itemsTotalOf(receipt);
+  const extras = extrasOf(receipt);
+  const difference = receipt.grandTotal - (itemsTotal + extras);
+  const reconciles = Math.abs(difference) <= RECONCILE_TOLERANCE;
+
+  if (!reconciles) {
+    problems.push({
+      kind: 'does_not_reconcile',
+      message:
+        `The lines add up to ${itemsTotal + extras} but the receipt says ${receipt.grandTotal}. ` +
+        'Something was misread — check the amounts before saving.',
+    });
+    // When the total is wrong we cannot say which line is at fault, so every
+    // line the model was least sure of goes on the list.
+    const leastConfident = [...receipt.items.keys()].sort(
+      (a, b) => (receipt.items[a]?.confidence ?? 1) - (receipt.items[b]?.confidence ?? 1),
+    );
+    for (const itemIndex of leastConfident.slice(0, 3)) needsReview.add(itemIndex);
+  }
+
+  return {
+    reconciles,
+    difference,
+    itemsTotal,
+    extras,
+    problems,
+    needsReview: [...needsReview].sort((a, b) => a - b),
+  };
+}
+
+/**
+ * Turn a reviewed receipt into the parameters an itemized split needs.
+ *
+ * The expense total is the printed grand total, never the sum of what we
+ * parsed: the receipt is the source of truth about how much money left the
+ * table. `computeShares` then asserts that items plus charges equal it, so a
+ * receipt that does not reconcile cannot become an expense at all.
+ */
+export function toItemizedParams(
+  receipt: ParsedReceipt,
+  claims: Readonly<Record<number, readonly string[]>>,
+): {
+  amount: bigint;
+  params: {
+    kind: 'itemized';
+    items: { label: string; total: bigint }[];
+    claims: Record<number, readonly string[]>;
+    taxes: bigint;
+    serviceCharge: bigint;
+    tip: bigint;
+    discounts: bigint;
+  };
+} {
+  return {
+    amount: BigInt(receipt.grandTotal),
+    params: {
+      kind: 'itemized',
+      items: receipt.items.map((item) => ({ label: item.label, total: BigInt(item.total) })),
+      claims: { ...claims },
+      taxes: BigInt(sumCharges(receipt.taxes)),
+      serviceCharge: BigInt(receipt.serviceCharge ?? 0),
+      tip: BigInt(receipt.tip ?? 0),
+      discounts: BigInt(sumCharges(receipt.discounts)),
+    },
+  };
+}

--- a/packages/core/src/receipt/types.ts
+++ b/packages/core/src/receipt/types.ts
@@ -1,0 +1,78 @@
+/**
+ * What a scanned receipt looks like once the vision model is done with it
+ * (ADR-008 / TDR §6).
+ *
+ * Every amount is an integer in minor units, like the rest of the ledger
+ * (ADR-003) — the model is asked for paise, not rupees, so no float ever
+ * exists between the photograph and the expense.
+ */
+
+export type ReceiptSource = 'camera' | 'gallery' | 'text_paste';
+
+export interface ParsedReceiptLine {
+  readonly label: string;
+  /** Quantity as printed; 1 when the receipt doesn't say. */
+  readonly qty: number;
+  /** Per-unit price in minor units, or null when only a line total is printed. */
+  readonly unitPrice: number | null;
+  /** Line total in minor units, as printed. */
+  readonly total: number;
+  /** 0–1. Below `LOW_CONFIDENCE` the line is shown for correction, not accepted. */
+  readonly confidence: number;
+}
+
+export interface ParsedReceiptCharge {
+  readonly label: string;
+  readonly amount: number;
+}
+
+export interface ParsedReceipt {
+  readonly merchant: string | null;
+  /** ISO date (YYYY-MM-DD), or null when the receipt doesn't carry one. */
+  readonly date: string | null;
+  readonly currency: string;
+  readonly items: readonly ParsedReceiptLine[];
+  readonly subtotal: number | null;
+  readonly taxes: readonly ParsedReceiptCharge[];
+  readonly serviceCharge: number | null;
+  readonly tip: number | null;
+  readonly discounts: readonly ParsedReceiptCharge[];
+  readonly grandTotal: number;
+}
+
+/** A line the model was unsure about, or one the arithmetic disagrees with. */
+export interface ReceiptProblem {
+  readonly kind: 'low_confidence' | 'does_not_reconcile' | 'no_items' | 'negative_line';
+  readonly itemIndex?: number;
+  readonly message: string;
+}
+
+export interface ReceiptCheck {
+  /** True when items + charges − discounts equals the printed total. */
+  readonly reconciles: boolean;
+  /** printed total − computed total, in minor units. Signed. */
+  readonly difference: number;
+  readonly itemsTotal: number;
+  readonly extras: number;
+  readonly problems: readonly ReceiptProblem[];
+  /** Lines a human should look at before this becomes an expense. */
+  readonly needsReview: readonly number[];
+}
+
+/**
+ * Below this, a line is surfaced for correction rather than accepted.
+ *
+ * The model reports its own confidence per line; a faded thermal receipt or a
+ * Tamil item name it half-read comes back low. The number is a product
+ * decision, not a model one: 0.75 is roughly "would a person squint at this?"
+ */
+export const LOW_CONFIDENCE = 0.75;
+
+/**
+ * How far the arithmetic may be out and still be accepted.
+ *
+ * One minor unit, because real receipts round their own tax lines and a single
+ * paisa of drift is the printer's, not ours (TDR §6). Anything larger means we
+ * misread something, and the user is asked rather than told.
+ */
+export const RECONCILE_TOLERANCE = 1;

--- a/packages/core/test/receipt.test.ts
+++ b/packages/core/test/receipt.test.ts
@@ -1,0 +1,202 @@
+/**
+ * ADR-008: the model proposes, the human confirms — and the arithmetic decides
+ * what the human is asked to look at.
+ *
+ * A receipt carries its own checksum: the lines and charges must add up to the
+ * printed total. These tests pin what happens when they don't, because that is
+ * the case where a plausible wrong number would otherwise reach the ledger.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { checkReceipt, toItemizedParams } from '../src/receipt/reconcile.js';
+import { LOW_CONFIDENCE, type ParsedReceipt } from '../src/receipt/types.js';
+import { computeShares } from '../src/split/computeShares.js';
+import { SplitError, type SplitErrorCode } from '../src/split/types.js';
+
+/** The code is the contract a client branches on; the prose is not. */
+function expectSplitError(run: () => unknown, code: SplitErrorCode): void {
+  try {
+    run();
+  } catch (error) {
+    expect(error).toBeInstanceOf(SplitError);
+    expect((error as SplitError).code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected a ${code} error, but the split succeeded`);
+}
+
+const receipt = (overrides: Partial<ParsedReceipt> = {}): ParsedReceipt => ({
+  merchant: 'Anjappar',
+  date: '2026-03-01',
+  currency: 'INR',
+  items: [
+    { label: 'Biryani', qty: 1, unitPrice: 32000, total: 32000, confidence: 0.98 },
+    { label: 'Roti', qty: 2, unitPrice: 4500, total: 9000, confidence: 0.95 },
+  ],
+  subtotal: 41000,
+  taxes: [{ label: 'GST 5%', amount: 2050 }],
+  serviceCharge: null,
+  tip: null,
+  discounts: [],
+  grandTotal: 43050,
+  ...overrides,
+});
+
+describe('a receipt that adds up', () => {
+  it('reconciles and asks for nothing', () => {
+    const check = checkReceipt(receipt());
+    expect(check.reconciles).toBe(true);
+    expect(check.difference).toBe(0);
+    expect(check.problems).toHaveLength(0);
+    expect(check.needsReview).toHaveLength(0);
+  });
+
+  it("tolerates a single paisa of the printer's own rounding", () => {
+    const check = checkReceipt(receipt({ grandTotal: 43051 }));
+    expect(check.reconciles).toBe(true);
+    expect(check.difference).toBe(1);
+  });
+
+  it('counts service, tip and discounts into the total', () => {
+    const check = checkReceipt(
+      receipt({
+        serviceCharge: 4100,
+        tip: 2000,
+        discounts: [{ label: 'Loyalty', amount: 1000 }],
+        grandTotal: 43050 + 4100 + 2000 - 1000,
+      }),
+    );
+    expect(check.reconciles).toBe(true);
+    expect(check.extras).toBe(2050 + 4100 + 2000 - 1000);
+  });
+});
+
+describe('a receipt that does not add up', () => {
+  it('refuses to reconcile and says by how much', () => {
+    // A dropped digit: 32000 read as 3200.
+    const check = checkReceipt(
+      receipt({
+        items: [
+          { label: 'Biryani', qty: 1, unitPrice: 3200, total: 3200, confidence: 0.6 },
+          { label: 'Roti', qty: 2, unitPrice: 4500, total: 9000, confidence: 0.95 },
+        ],
+      }),
+    );
+
+    expect(check.reconciles).toBe(false);
+    expect(check.difference).toBe(28800);
+    expect(check.problems.some((problem) => problem.kind === 'does_not_reconcile')).toBe(true);
+  });
+
+  it('points at the lines the model was least sure of', () => {
+    const check = checkReceipt(
+      receipt({
+        items: [
+          { label: 'Biryani', qty: 1, unitPrice: 3200, total: 3200, confidence: 0.4 },
+          { label: 'Roti', qty: 2, unitPrice: 4500, total: 9000, confidence: 0.99 },
+        ],
+      }),
+    );
+    // When the total is wrong we cannot know which line is at fault, so the
+    // least-confident one is where a person should start.
+    expect(check.needsReview).toContain(0);
+  });
+});
+
+describe('lines a person should check', () => {
+  it('flags anything the model was unsure about, even when the total is right', () => {
+    const check = checkReceipt(
+      receipt({
+        items: [
+          {
+            label: 'Biryani',
+            qty: 1,
+            unitPrice: 32000,
+            total: 32000,
+            confidence: LOW_CONFIDENCE - 0.01,
+          },
+          { label: 'Roti', qty: 2, unitPrice: 4500, total: 9000, confidence: 0.95 },
+        ],
+      }),
+    );
+    expect(check.reconciles).toBe(true);
+    expect(check.needsReview).toEqual([0]);
+    expect(check.problems[0]?.kind).toBe('low_confidence');
+  });
+
+  it('flags a negative line, which is usually a discount printed as an item', () => {
+    const check = checkReceipt(
+      receipt({
+        items: [
+          { label: 'Biryani', qty: 1, unitPrice: 32000, total: 32000, confidence: 0.98 },
+          { label: 'Coupon', qty: 1, unitPrice: -5000, total: -5000, confidence: 0.9 },
+        ],
+        grandTotal: 32000 - 5000 + 2050,
+      }),
+    );
+    expect(check.problems.some((problem) => problem.kind === 'negative_line')).toBe(true);
+  });
+
+  it('says so when there are no items at all', () => {
+    const check = checkReceipt(receipt({ items: [], grandTotal: 0, taxes: [] }));
+    expect(check.problems.some((problem) => problem.kind === 'no_items')).toBe(true);
+  });
+});
+
+describe('turning a receipt into an expense', () => {
+  it('splits the bill by who claimed what, prorating tax by subtotal', () => {
+    const scanned = receipt();
+    const { amount, params } = toItemizedParams(scanned, { 0: ['asha'], 1: ['asha', 'ravi'] });
+
+    const shares = computeShares({
+      amount,
+      currency: 'INR',
+      params,
+      participants: ['asha', 'ravi'],
+      seed: 'receipt-1',
+    });
+
+    // The printed total is what gets split — nothing is invented or lost.
+    expect([...shares.values()].reduce((sum, share) => sum + share, 0n)).toBe(43050n);
+    // Asha had the biryani and half the roti, so she owes more.
+    expect(shares.get('asha')).toBeGreaterThan(shares.get('ravi') as bigint);
+  });
+
+  it('uses the printed total, not the sum of what we parsed', () => {
+    // If these ever diverge the split must fail loudly rather than quietly
+    // splitting a number that was never on the receipt.
+    const scanned = receipt({ grandTotal: 50000 });
+    const { amount, params } = toItemizedParams(scanned, { 0: ['asha'], 1: ['asha'] });
+
+    expect(amount).toBe(50000n);
+    expectSplitError(
+      () =>
+        computeShares({
+          amount,
+          currency: 'INR',
+          params,
+          participants: ['asha'],
+          seed: 'receipt-2',
+        }),
+      'ITEMIZED_TOTAL_MISMATCH',
+    );
+  });
+
+  it('will not produce an expense from a receipt with an unclaimed line', () => {
+    const scanned = receipt();
+    const { amount, params } = toItemizedParams(scanned, { 0: ['asha'] });
+
+    expectSplitError(
+      () =>
+        computeShares({
+          amount,
+          currency: 'INR',
+          params,
+          participants: ['asha', 'ravi'],
+          seed: 'receipt-3',
+        }),
+      'UNCLAIMED_ITEM',
+    );
+  });
+});

--- a/packages/db/prisma/migrations/20260805140000_receipt_scanning/migration.sql
+++ b/packages/db/prisma/migrations/20260805140000_receipt_scanning/migration.sql
@@ -1,0 +1,158 @@
+-- M5 — receipt scanning (ADR-008 / TDR §6).
+--
+-- Two things the ledger needs before a photograph can become an expense: a
+-- private place to put the image, and a quota, because unlike the ledger a scan
+-- has a real per-call cost (ADR-011 — convenience is monetizable, the ledger
+-- never is).
+
+-- ─────────────────────────────────────────────── 1. the scan quota ──
+-- 20 free scans per calendar month. Counted from `usage_events`, which already
+-- exists as the metering table, so there is no second source of truth about
+-- what somebody has used.
+
+CREATE OR REPLACE FUNCTION public.baaki_scans_used_this_month(p_profile_id uuid DEFAULT NULL)
+RETURNS int
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT count(*)::int
+  FROM public.usage_events ue
+  WHERE ue.profile_id = COALESCE(p_profile_id, public.baaki_current_profile_id())
+    AND ue.kind = 'receipt_scan'
+    AND ue.created_at >= date_trunc('month', now());
+$$;
+
+CREATE OR REPLACE FUNCTION public.baaki_receipt_scan_quota()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT jsonb_build_object(
+    'used', public.baaki_scans_used_this_month(),
+    'limit', 20,
+    'remaining', greatest(0, 20 - public.baaki_scans_used_this_month())
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_receipt_scan_quota() TO authenticated, anon;
+
+-- Resolving a member id for a profile other than the JWT's own caller — the
+-- edge function acts on behalf of a user it has already authenticated.
+CREATE OR REPLACE FUNCTION public.baaki_my_member_id_for(p_group_id uuid, p_profile_id uuid)
+RETURNS uuid
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT id FROM public.group_members
+   WHERE group_id = p_group_id AND profile_id = p_profile_id AND left_at IS NULL
+   LIMIT 1;
+$$;
+
+
+-- ─────────────────────────────────── 2. recording a parsed receipt ──
+-- Service-role only: the caller has to be the edge function, which owns the
+-- model call and has already checked membership and quota (ADR-013).
+
+CREATE OR REPLACE FUNCTION public.baaki_record_receipt(
+  p_group_id     uuid,
+  p_receipt_id   uuid,
+  p_profile_id   uuid,
+  p_source       text,
+  p_storage_path text,
+  p_raw_text     text,
+  p_parsed       jsonb,
+  p_status       text,
+  p_input_tokens int DEFAULT 0,
+  p_output_tokens int DEFAULT 0
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  INSERT INTO public.receipts
+    (id, group_id, storage_path, source, raw_text, parse_status, parsed, created_by)
+  VALUES
+    (COALESCE(p_receipt_id, gen_random_uuid()), p_group_id, p_storage_path,
+     p_source::"ReceiptSource", p_raw_text, p_status::"ParseStatus", p_parsed,
+     public.baaki_my_member_id_for(p_group_id, p_profile_id))
+  ON CONFLICT (id) DO UPDATE
+    SET parsed = excluded.parsed,
+        parse_status = excluded.parse_status,
+        raw_text = excluded.raw_text
+  RETURNING id INTO v_id;
+
+  -- Metered because each scan has a real API cost to watch (ADR-011).
+  INSERT INTO public.usage_events
+    (profile_id, group_id, kind, input_tokens, output_tokens, metadata)
+  VALUES (p_profile_id, p_group_id, 'receipt_scan', p_input_tokens, p_output_tokens,
+          jsonb_build_object('receiptId', v_id, 'status', p_status));
+
+  RETURN v_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) TO service_role;
+
+-- ────────────────────────────────────────── 3. the receipts bucket ──
+-- Guarded exactly like the group-photos bucket: the `storage` schema belongs to
+-- Supabase and does not exist in the plain Postgres image CI runs against.
+
+DO $$
+BEGIN
+  IF to_regclass('storage.buckets') IS NULL THEN
+    RAISE NOTICE 'storage schema absent (plain Postgres): skipping the receipts bucket';
+    RETURN;
+  END IF;
+
+  -- Private. A receipt is a record of what somebody ate and where they were;
+  -- it is readable by the group it belongs to and nobody else (ADR-013).
+  INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+  VALUES ('receipts', 'receipts', false, 10485760,
+          ARRAY['image/jpeg', 'image/png', 'image/webp'])
+  ON CONFLICT (id) DO UPDATE
+    SET public = false,
+        file_size_limit = excluded.file_size_limit,
+        allowed_mime_types = excluded.allowed_mime_types;
+
+  EXECUTE $policy$
+    DROP POLICY IF EXISTS "receipts are readable by members" ON storage.objects;
+    CREATE POLICY "receipts are readable by members" ON storage.objects
+      FOR SELECT TO authenticated, anon
+      USING (
+        bucket_id = 'receipts'
+        AND public.is_group_member(public.baaki_group_from_storage_path(name))
+      );
+
+    DROP POLICY IF EXISTS "receipts are writable by members" ON storage.objects;
+    CREATE POLICY "receipts are writable by members" ON storage.objects
+      FOR INSERT TO authenticated, anon
+      WITH CHECK (
+        bucket_id = 'receipts'
+        AND public.is_group_member(public.baaki_group_from_storage_path(name))
+      );
+
+    DROP POLICY IF EXISTS "receipts are removable by members" ON storage.objects;
+    CREATE POLICY "receipts are removable by members" ON storage.objects
+      FOR DELETE TO authenticated, anon
+      USING (
+        bucket_id = 'receipts'
+        AND public.is_group_member(public.baaki_group_from_storage_path(name))
+      );
+  $policy$;
+END
+$$;

--- a/supabase/functions/receipt-parse/index.ts
+++ b/supabase/functions/receipt-parse/index.ts
@@ -1,0 +1,279 @@
+/**
+ * receipt-parse — a photograph becomes line items (ADR-008 / TDR §6).
+ *
+ * The model reads the receipt; it does not decide anything. What it returns is
+ * checked against the receipt's own arithmetic by @baaki/core before anybody
+ * sees a number, and a bill that does not add up comes back flagged for
+ * correction rather than quietly becoming an expense. "AI proposes, human
+ * confirms" only means something if the human is told what to look at.
+ *
+ * The API key lives here and only here (ADR-008 / TDR §11) — it is never in the
+ * app bundle, and the client cannot reach the model except through this
+ * function, which checks membership and quota first.
+ */
+
+import { checkReceipt, type ParsedReceipt } from '../_shared/core.js';
+import {
+  asCaller,
+  asService,
+  CORS_HEADERS,
+  errorResponse,
+  HttpError,
+  json,
+  requireMembership,
+} from '../_shared/auth.ts';
+
+interface ParseRequest {
+  groupId: string;
+  receiptId?: string;
+  /** Object path in the private `receipts` bucket. */
+  storagePath?: string;
+  /** A pasted bill (Swiggy, Zomato, a WhatsApp message) instead of a photo. */
+  rawText?: string;
+  source?: 'camera' | 'gallery' | 'text_paste';
+  currency?: string;
+}
+
+/**
+ * The shape the model must return. Enforced by structured outputs, so the
+ * response is parseable by construction rather than by hope — no regex, no
+ * retry-on-bad-JSON loop.
+ *
+ * Every amount is an integer in **minor units** (ADR-003). Asking for paise
+ * rather than rupees is what keeps a float from ever existing between the
+ * photograph and the ledger.
+ */
+const RECEIPT_SCHEMA = {
+  type: 'object',
+  properties: {
+    merchant: { type: ['string', 'null'] },
+    date: { type: ['string', 'null'], description: 'ISO date, YYYY-MM-DD, or null' },
+    currency: { type: 'string', description: 'ISO 4217 code, e.g. INR' },
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          label: { type: 'string' },
+          qty: { type: 'number' },
+          unitPrice: { type: ['integer', 'null'] },
+          total: { type: 'integer' },
+          confidence: { type: 'number', description: '0 to 1' },
+        },
+        required: ['label', 'qty', 'unitPrice', 'total', 'confidence'],
+        additionalProperties: false,
+      },
+    },
+    subtotal: { type: ['integer', 'null'] },
+    taxes: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { label: { type: 'string' }, amount: { type: 'integer' } },
+        required: ['label', 'amount'],
+        additionalProperties: false,
+      },
+    },
+    serviceCharge: { type: ['integer', 'null'] },
+    tip: { type: ['integer', 'null'] },
+    discounts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { label: { type: 'string' }, amount: { type: 'integer' } },
+        required: ['label', 'amount'],
+        additionalProperties: false,
+      },
+    },
+    grandTotal: { type: 'integer' },
+  },
+  required: [
+    'merchant',
+    'date',
+    'currency',
+    'items',
+    'subtotal',
+    'taxes',
+    'serviceCharge',
+    'tip',
+    'discounts',
+    'grandTotal',
+  ],
+  additionalProperties: false,
+} as const;
+
+const SYSTEM_PROMPT = `You transcribe restaurant and shop receipts into structured data.
+
+Read what is printed. Do not compute, correct, or tidy: if the receipt's own
+arithmetic is wrong, return its numbers as printed — a separate check compares
+your reading against the printed total, and that check only works if you have
+not silently fixed anything.
+
+Amounts are integers in the currency's minor unit. ₹320.50 is 32050. A receipt
+printed in whole rupees still returns paise: ₹320 is 32000.
+
+Receipts are frequently Indian and may be in Tamil, Hindi, or another regional
+script, often mixed with English. Transcribe item names in the script they are
+printed in. Pasted text bills from Swiggy, Zomato or WhatsApp arrive without a
+photograph and read the same way.
+
+Confidence is your own, per line, from 0 to 1. A crisp printed line is near 1.
+Report low confidence when a line is faded, cut off, ambiguous, or you are
+guessing at a digit — a flagged line gets a human's attention, and that is much
+cheaper than a wrong number reaching somebody's ledger.
+
+Combo meals and modifiers printed as separate indented lines under a parent
+item are separate line items if they carry their own price, and part of the
+parent if they do not.`;
+
+const MODEL = 'claude-opus-5';
+/** ADR-011: a scan costs real money, so the quota is enforced server-side. */
+const MONTHLY_SCAN_LIMIT = 20;
+
+Deno.serve(async (request) => {
+  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
+
+  try {
+    if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
+
+    const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+    if (!apiKey) {
+      throw new HttpError(
+        503,
+        'SCANNING_UNAVAILABLE',
+        'Receipt scanning is not configured on this Baaki server',
+      );
+    }
+
+    const body = (await request.json()) as ParseRequest;
+    if (!body.storagePath && !body.rawText) {
+      throw new HttpError(400, 'NOTHING_TO_PARSE', 'Send a photo or some text');
+    }
+
+    const caller = asCaller(request);
+    const { profileId } = await requireMembership(caller, body.groupId);
+    const service = asService();
+
+    // Quota before the model call, never after — the point is not to spend the
+    // money, not to notice afterwards that we did.
+    const { data: quota } = await caller.rpc('baaki_receipt_scan_quota');
+    const used = Number((quota as { used?: number } | null)?.used ?? 0);
+    if (used >= MONTHLY_SCAN_LIMIT) {
+      throw new HttpError(
+        429,
+        'SCAN_QUOTA_REACHED',
+        `You have used all ${MONTHLY_SCAN_LIMIT} scans this month. Adding items by hand is free and always will be.`,
+      );
+    }
+
+    const content: unknown[] = [];
+    if (body.storagePath) {
+      // Downloaded with the service role and sent as base64: the model never
+      // gets a URL into our storage, signed or otherwise.
+      const { data: file, error: downloadError } = await service.storage
+        .from('receipts')
+        .download(body.storagePath);
+      if (downloadError || !file) {
+        throw new HttpError(400, 'IMAGE_UNREADABLE', downloadError?.message ?? 'No such image');
+      }
+      content.push({
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: file.type === 'image/png' ? 'image/png' : 'image/jpeg',
+          data: encodeBase64(new Uint8Array(await file.arrayBuffer())),
+        },
+      });
+    }
+    content.push({
+      type: 'text',
+      text: body.rawText
+        ? `Transcribe this bill. Currency is ${body.currency ?? 'INR'}.\n\n${body.rawText}`
+        : `Transcribe this receipt. Currency is ${body.currency ?? 'INR'} unless the receipt says otherwise.`,
+    });
+
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 16000,
+        system: SYSTEM_PROMPT,
+        // Transcription, not deliberation: low effort keeps a scan cheap, which
+        // is what lets the free tier be generous (ADR-011).
+        output_config: {
+          effort: 'low',
+          format: { type: 'json_schema', schema: RECEIPT_SCHEMA },
+        },
+        messages: [{ role: 'user', content }],
+      }),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text();
+      console.error('anthropic error', response.status, detail.slice(0, 500));
+      throw new HttpError(502, 'SCAN_FAILED', 'The scanner could not read that just now');
+    }
+
+    const message = (await response.json()) as {
+      content: { type: string; text?: string }[];
+      stop_reason?: string;
+      usage?: { input_tokens?: number; output_tokens?: number };
+    };
+
+    // A refusal is a successful HTTP 200 with an empty content array, so
+    // reading content[0] unconditionally would throw on the one case we most
+    // want to report clearly.
+    if (message.stop_reason === 'refusal') {
+      throw new HttpError(422, 'SCAN_REFUSED', 'The scanner declined to read that image');
+    }
+
+    const text = message.content?.find((block) => block.type === 'text')?.text;
+    if (!text) throw new HttpError(502, 'SCAN_FAILED', 'The scanner returned nothing');
+
+    const parsed = JSON.parse(text) as ParsedReceipt;
+
+    // The receipt's own checksum. This is what stands between a misread digit
+    // and somebody's ledger.
+    const check = checkReceipt(parsed);
+    const status = check.reconciles && check.problems.length === 0 ? 'parsed' : 'needs_review';
+
+    const { data: receiptId, error: recordError } = await service.rpc('baaki_record_receipt', {
+      p_group_id: body.groupId,
+      p_receipt_id: body.receiptId ?? null,
+      p_profile_id: profileId,
+      p_source: body.source ?? (body.rawText ? 'text_paste' : 'camera'),
+      p_storage_path: body.storagePath ?? null,
+      p_raw_text: body.rawText ?? null,
+      p_parsed: parsed,
+      p_status: status,
+      p_input_tokens: message.usage?.input_tokens ?? 0,
+      p_output_tokens: message.usage?.output_tokens ?? 0,
+    });
+    if (recordError) throw new HttpError(500, 'INTERNAL', recordError.message);
+
+    return json({
+      receiptId,
+      status,
+      parsed,
+      check,
+      quota: { used: used + 1, limit: MONTHLY_SCAN_LIMIT },
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+});
+
+/** Deno has no Buffer; chunked so a large image cannot blow the call stack. */
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunk = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunk));
+  }
+  return btoa(binary);
+}


### PR DESCRIPTION
Scan a receipt with the camera; the items come out filled in, ready to tap who had what.

## The model reads, it does not decide

`receipt-parse` sends the photo (or a pasted Swiggy/Zomato/WhatsApp bill) to Claude vision with **structured outputs**, so the response is parseable by construction — no regex, no retry-on-bad-JSON loop. The prompt tells it explicitly *not* to correct the receipt's own arithmetic, because the check that follows only works if nothing was silently fixed.

`checkReceipt` in `@baaki/core` then compares the lines against the printed total. A receipt carries its own checksum, and that's what stands between a misread digit and somebody's ledger — a vision model reading a crumpled thermal receipt will occasionally drop a digit *confidently*. When the sum disagrees, the bill comes back flagged with the lines to look at rather than quietly becoming an expense.

Amounts are requested in **minor units**, so no float exists between the photograph and the ledger (ADR-003).

## Where the results land

The same editable list somebody would have typed by hand. There is no separate "AI mode" to leave — correcting a misread line is just editing. The screen says what the arithmetic found rather than declaring success: saying "scanned!" and leaving the user to notice a wrong total is the exact failure this path exists to avoid.

## Cost and keys

The API key lives in the edge function and nowhere else (TDR §11) — the client cannot reach the model except through this function, which checks membership and quota first.

Quota is **20 scans a month**, counted from `usage_events` so there is no second source of truth, and checked *before* the model call rather than after. Entering items by hand stays free and unlimited: the ledger is never metered, only the convenience on top of it (ADR-011).

Per-scan input and output tokens are recorded on every scan, since this is a COGS line to watch rather than guess at.

## Details worth noting

- A **refusal** from the API is a successful HTTP 200 with empty content, so `stop_reason` is checked before reading any block — reading `content[0]` unconditionally would throw on exactly the case worth reporting clearly.
- The image is downloaded server-side and sent as base64; the model never receives a URL into our storage, signed or otherwise.
- The `receipts` bucket is private and member-scoped, created inside the same `storage`-schema guard as group photos so CI's plain Postgres still applies the migration.

## Verification

182 tests (116 core, 66 db) — 11 new, covering receipts that add up, receipts missing a digit, low-confidence and negative lines, and the two failures that must stop an expense being created. Typecheck, lint, format and drift all clean; the edge bundle builds.

**Not verified:** the model call itself. It needs `ANTHROPIC_API_KEY` set as an edge-function secret and the function deployed, neither of which I can do without a Supabase access token. Everything around it — schema, quota, reconciliation, storage policies, the client path — is tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6