### PR TITLE
feat(core): read a bank SMS into a proposed expense

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,3 +14,4 @@ export * from './settlement/index';
 export * from './sync/index';
 export * from './receipt/index';
 export * from './notifications/index';
+export * from './sms/index';

--- a/packages/core/src/sms/index.ts
+++ b/packages/core/src/sms/index.ts
@@ -1,0 +1,1 @@
+export * from './parse';

--- a/packages/core/src/sms/parse.ts
+++ b/packages/core/src/sms/parse.ts
@@ -1,0 +1,317 @@
+/**
+ * Reading a bank SMS into a proposed expense.
+ *
+ * DEVIATION, recorded deliberately: TDR §10 lists SMS auto-import as out of
+ * scope for v1. This module exists because it was asked for directly. It is
+ * additive — nothing else depends on it — and the ledger rules are unchanged: a
+ * parsed message is a *proposal*, never an entry.
+ *
+ * Three things this module will not do, all for the same reason:
+ *
+ *   - it does not touch the network, and nothing here is called from an edge
+ *     function. A bank SMS carries an account tail, a balance, and sometimes a
+ *     one-time password; sending it anywhere to be parsed would be a worse
+ *     privacy trade than the feature is worth (ADR-013);
+ *   - it does not write. `proposeFromSms` returns candidates, and a person
+ *     confirms each one;
+ *   - it does not guess at a split. Who was there is not in the message.
+ *
+ * Everything is parsed as digits and assembled into minor units. No float ever
+ * exists between the text and the amount (ADR-003).
+ */
+
+import { minorUnitExponent, type CurrencyCode } from '../money/currency';
+import { money, type Money } from '../money/money';
+
+export type TransactionDirection = 'debit' | 'credit';
+
+export interface ParsedSms {
+  /** What moved, in minor units. */
+  readonly amount: Money;
+  /** Out of the account, or into it. Only debits can be expenses. */
+  readonly direction: TransactionDirection;
+  /** Best guess at who was paid. Null when the message does not say. */
+  readonly merchant: string | null;
+  /** Last digits of the account or card, when present — for telling cards apart. */
+  readonly accountTail: string | null;
+  /** The bank's own reference, when present. The strongest dedupe key we get. */
+  readonly reference: string | null;
+  /**
+   * When the bank says it happened. Null when the message carries no date, in
+   * which case the caller should fall back to when the message arrived — but
+   * the distinction matters, because a delayed SMS would otherwise land the
+   * expense on the wrong day of a trip.
+   */
+  readonly occurredAt: string | null;
+  /** 0–1. Below `SMS_LOW_CONFIDENCE` the candidate is shown but not pre-selected. */
+  readonly confidence: number;
+}
+
+/** Below this, a person should look before confirming. */
+export const SMS_LOW_CONFIDENCE = 0.7;
+
+/**
+ * Currency markers seen in Indian bank SMS. `Rs` and `INR` are the same thing;
+ * a bank abroad will say `USD` or use a symbol.
+ */
+const CURRENCY_MARKERS: ReadonlyArray<readonly [RegExp, CurrencyCode]> = [
+  [/(?:INR|Rs\.?|₹)/i, 'INR'],
+  [/(?:USD|\$)/, 'USD'],
+  [/(?:EUR|€)/, 'EUR'],
+  [/(?:GBP|£)/, 'GBP'],
+  [/AED/i, 'AED'],
+  [/SGD/i, 'SGD'],
+  [/THB/i, 'THB'],
+];
+
+/**
+ * Words that mean money left the account. Ordered longest-first so that
+ * "debited" is not matched by a looser rule before "credited" is considered.
+ */
+const DEBIT_WORDS = /\b(debited|debit|spent|paid|withdrawn|purchase|sent|deducted)\b/i;
+const CREDIT_WORDS = /\b(credited|credit|received|refund|reversed|cashback)\b/i;
+
+/**
+ * Messages that look like transactions but are not. A one-time password quotes
+ * an amount and would otherwise parse cleanly into an expense somebody never
+ * made — this is the single most dangerous false positive in the set, because
+ * the number is real and the message is from the right sender.
+ */
+const NOT_A_TRANSACTION =
+  /\b(OTP|one[- ]time\s*password|will\s+be\s+debited|request(?:ed)?\s+(?:for|to)|is\s+due|due\s+on|reminder|failed|declined|unsuccessful|balance\s+is|avl\s*bal|available\s+balance\s+is|statement|e-?mandate|auto[- ]?pay\s+scheduled)\b/i;
+
+/**
+ * Amount, as digits: "1,234.56" or "1234" or "1.234,56" is not attempted —
+ * Indian and international banks both write "1,23,456.78" or "1,234.56", and
+ * both use the dot as the decimal separator.
+ */
+const AMOUNT = /(?:INR|Rs\.?|₹|USD|\$|EUR|€|GBP|£|AED|SGD|THB)\s*([\d,]+(?:\.\d{1,2})?)/i;
+
+/** "to AMAZON", "at STARBUCKS", "towards SWIGGY" — whoever was paid. */
+const MERCHANT =
+  /\b(?:to|at|towards|in\s+favour\s+of|VPA)\s+([A-Z0-9][A-Za-z0-9&.'@_-]*(?:\s+[A-Z0-9][A-Za-z0-9&.'@_-]*){0,3})/;
+
+const ACCOUNT_TAIL = /\b(?:a\/c|acct?|account|card|xx+|\*+)\s*(?:no\.?\s*)?[xX*]*(\d{3,6})\b/;
+const REFERENCE =
+  /\b(?:ref(?:erence)?|txn|transaction|UPI\s*Ref|RRN)\s*(?:no\.?|id)?[:\s]\s*([A-Za-z0-9]{6,})/i;
+
+/** "05-08-26", "05/08/2026", "05-Aug-26". Day first, as Indian banks write it. */
+const DATE_NUMERIC = /\b(\d{1,2})[-/](\d{1,2})[-/](\d{2,4})\b/;
+const DATE_NAMED = /\b(\d{1,2})[-\s]([A-Za-z]{3})[-\s](\d{2,4})\b/;
+const TIME = /\b(\d{1,2}):(\d{2})(?::(\d{2}))?\b/;
+
+const MONTHS: Record<string, number> = {
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+};
+
+/**
+ * "1,23,456.78" → 12345678 minor units, by digits.
+ *
+ * A message quoting more precision than the currency has is truncated, not
+ * rounded: banks do not print a third decimal, so seeing one means the parse
+ * went wrong somewhere and inventing a rounding rule would hide that.
+ */
+function toMinor(text: string, currency: CurrencyCode): bigint {
+  const cleaned = text.replace(/,/g, '');
+  const exponent = minorUnitExponent(currency);
+  const [whole = '0', fraction = ''] = cleaned.split('.');
+  const padded = (fraction + '0'.repeat(exponent)).slice(0, exponent);
+  return BigInt(whole + padded);
+}
+
+function detectCurrency(text: string): CurrencyCode {
+  for (const [pattern, code] of CURRENCY_MARKERS) {
+    if (pattern.test(text)) return code;
+  }
+  return 'INR';
+}
+
+function detectDate(text: string): string | null {
+  const time = TIME.exec(text);
+  const clock = time
+    ? `T${(time[1] ?? '0').padStart(2, '0')}:${time[2]}:${(time[3] ?? '00').padStart(2, '0')}.000Z`
+    : 'T00:00:00.000Z';
+
+  const named = DATE_NAMED.exec(text);
+  if (named) {
+    const month = MONTHS[(named[2] ?? '').toLowerCase()];
+    if (month) return `${expandYear(named[3])}-${pad(month)}-${pad(Number(named[1]))}${clock}`;
+  }
+
+  const numeric = DATE_NUMERIC.exec(text);
+  if (numeric) {
+    const day = Number(numeric[1]);
+    const month = Number(numeric[2]);
+    // A day above 12 is unambiguous; otherwise trust the Indian convention.
+    if (day >= 1 && day <= 31 && month >= 1 && month <= 12) {
+      return `${expandYear(numeric[3])}-${pad(month)}-${pad(day)}${clock}`;
+    }
+  }
+  return null;
+}
+
+const pad = (value: number): string => String(value).padStart(2, '0');
+const expandYear = (raw: string | undefined): string =>
+  !raw ? '1970' : raw.length === 4 ? raw : `20${raw.padStart(2, '0')}`;
+
+/**
+ * Read one message. Returns null when it is not a transaction at all — which
+ * is most of them.
+ */
+export function parseSms(text: string): ParsedSms | null {
+  const body = text.replace(/\s+/g, ' ').trim();
+  if (!body) return null;
+
+  // Checked before anything else: an OTP quotes a real amount from a real bank
+  // and is the false positive most likely to be confirmed by accident.
+  if (NOT_A_TRANSACTION.test(body)) return null;
+
+  const amountMatch = AMOUNT.exec(body);
+  if (!amountMatch?.[1]) return null;
+
+  const currency = detectCurrency(body);
+  const minor = toMinor(amountMatch[1], currency);
+  if (minor <= 0n) return null;
+
+  const debit = DEBIT_WORDS.test(body);
+  const credit = CREDIT_WORDS.test(body);
+  // Neither, or both, means we cannot tell which way the money went — and a
+  // credit booked as an expense is worse than no candidate at all.
+  if (debit === credit) return null;
+
+  const merchantMatch = MERCHANT.exec(body);
+  // "at SWIGGY. UPI Ref: …" — a merchant name can contain a dot (AMAZON.IN)
+  // but a dot followed by a space ends the sentence, and everything after it
+  // is the bank talking, not the shop's name.
+  const merchant =
+    merchantMatch?.[1]
+      ?.split(/\.\s/)[0]
+      ?.replace(/[.,;:]+$/, '')
+      .trim() || null;
+  const reference = REFERENCE.exec(body)?.[1] ?? null;
+  const accountTail = ACCOUNT_TAIL.exec(body)?.[1] ?? null;
+  const occurredAt = detectDate(body);
+
+  // Confidence is about how much of the message we actually understood, not
+  // about how plausible the number looks.
+  let confidence = 0.55;
+  if (merchant) confidence += 0.2;
+  if (reference) confidence += 0.15;
+  if (occurredAt) confidence += 0.1;
+  if (accountTail) confidence += 0.05;
+
+  return {
+    amount: money(minor, currency),
+    direction: debit ? 'debit' : 'credit',
+    merchant,
+    accountTail,
+    reference,
+    occurredAt,
+    confidence: Math.min(1, Number(confidence.toFixed(2))),
+  };
+}
+
+export interface SmsMessage {
+  /** The message body. */
+  readonly body: string;
+  /** When it arrived, ISO-8601. Used when the message carries no date itself. */
+  readonly receivedAt: string;
+  /** Sender id, e.g. "AD-HDFCBK". Kept only so a person can recognise it. */
+  readonly sender?: string;
+}
+
+export interface ExpenseCandidate extends ParsedSms {
+  readonly sender: string | null;
+  /** The instant to file it under: the bank's, or the message's. */
+  readonly at: string;
+  /** True when the message itself carried no date and arrival time was used. */
+  readonly dateInferred: boolean;
+  /** Stable across re-scans, so confirming twice cannot double-post. */
+  readonly dedupeKey: string;
+  /** False when something needs a person's eye before confirming. */
+  readonly preselect: boolean;
+}
+
+export interface ProposeOptions {
+  /** Trip window, inclusive. ISO dates or instants. */
+  readonly from: string;
+  readonly to: string;
+  /**
+   * Dedupe keys already on the ledger. A candidate matching one of these is
+   * dropped — re-scanning the inbox must not re-propose what was confirmed.
+   */
+  readonly alreadyImported?: ReadonlySet<string>;
+}
+
+/**
+ * The whole feature, as one pure function: an inbox and a trip window in,
+ * candidates out. Nothing is written and nothing is sent anywhere.
+ */
+export function proposeFromSms(
+  messages: readonly SmsMessage[],
+  options: ProposeOptions,
+): ExpenseCandidate[] {
+  const from = Date.parse(startOfDay(options.from));
+  const to = Date.parse(endOfDay(options.to));
+  const seen = new Set<string>();
+  const candidates: ExpenseCandidate[] = [];
+
+  for (const message of messages) {
+    const parsed = parseSms(message.body);
+    if (!parsed) continue;
+    // Money coming in is not an expense. Refunds are real and worth showing one
+    // day, but as a reversal of a known expense — not as a negative one.
+    if (parsed.direction !== 'debit') continue;
+
+    const at = parsed.occurredAt ?? message.receivedAt;
+    const stamp = Date.parse(at);
+    if (Number.isNaN(stamp) || stamp < from || stamp > to) continue;
+
+    const key = dedupeKey(parsed, at);
+    if (seen.has(key) || options.alreadyImported?.has(key)) continue;
+    seen.add(key);
+
+    candidates.push({
+      ...parsed,
+      sender: message.sender ?? null,
+      at,
+      dateInferred: parsed.occurredAt === null,
+      dedupeKey: key,
+      // Pre-selected only when we understood the message well *and* the bank
+      // told us when it happened. An inferred date on a trip is exactly the
+      // case where an expense silently lands on the wrong day.
+      preselect: parsed.confidence >= SMS_LOW_CONFIDENCE && parsed.occurredAt !== null,
+    });
+  }
+
+  return candidates.sort((a, b) => a.at.localeCompare(b.at));
+}
+
+/**
+ * The bank's reference when there is one — it is unique and survives a reworded
+ * message. Otherwise amount plus the day, which is the most that can be relied
+ * on: the same shop at the same price on the same day is one transaction far
+ * more often than two.
+ */
+export function dedupeKey(parsed: ParsedSms, at: string): string {
+  if (parsed.reference) return `ref:${parsed.reference.toUpperCase()}`;
+  const day = at.slice(0, 10);
+  const merchant = parsed.merchant?.toUpperCase().replace(/\s+/g, '') ?? '?';
+  return `amt:${parsed.amount.currency}:${parsed.amount.minor}:${day}:${merchant}`;
+}
+
+const startOfDay = (value: string): string =>
+  value.length === 10 ? `${value}T00:00:00.000Z` : value;
+const endOfDay = (value: string): string =>
+  value.length === 10 ? `${value}T23:59:59.999Z` : value;

--- a/packages/core/test/sms.test.ts
+++ b/packages/core/test/sms.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Reading a bank SMS into a *proposed* expense.
+ *
+ * The interesting tests here are the refusals. A parser that reads a real debit
+ * correctly is table stakes; one that reads an OTP as a ₹5,000 dinner, or books
+ * a refund as an expense, or re-proposes something already confirmed, produces
+ * wrong money in somebody's ledger from a message they never thought about.
+ *
+ * Every message below is shaped like one an Indian bank actually sends.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { SMS_LOW_CONFIDENCE, parseSms, proposeFromSms, type SmsMessage } from '../src/index.js';
+
+const sms = (body: string, receivedAt = '2026-03-02T10:00:00.000Z'): SmsMessage => ({
+  body,
+  receivedAt,
+  sender: 'AD-HDFCBK',
+});
+
+describe('a real debit', () => {
+  it('reads amount, merchant, reference and date', () => {
+    const parsed = parseSms(
+      'Rs.1,250.00 debited from a/c XX4471 on 02-03-26 at SWIGGY. UPI Ref: 412703998812. Not you? Call 18002586161',
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.amount.minor).toBe(125000n);
+    expect(parsed?.amount.currency).toBe('INR');
+    expect(parsed?.direction).toBe('debit');
+    expect(parsed?.merchant).toBe('SWIGGY');
+    expect(parsed?.accountTail).toBe('4471');
+    expect(parsed?.reference).toBe('412703998812');
+    expect(parsed?.occurredAt?.slice(0, 10)).toBe('2026-03-02');
+    expect(parsed?.confidence).toBeGreaterThanOrEqual(SMS_LOW_CONFIDENCE);
+  });
+
+  it('handles the Indian digit grouping', () => {
+    // 1,23,456.78 — not 123,456.78. Both must land on the same minor units.
+    expect(parseSms('INR 1,23,456.78 debited at HOTEL TAJ')?.amount.minor).toBe(12345678n);
+    expect(parseSms('INR 123,456.78 debited at HOTEL TAJ')?.amount.minor).toBe(12345678n);
+  });
+
+  it('reads a whole-rupee amount', () => {
+    expect(parseSms('Rs 500 spent at CAFE COFFEE DAY')?.amount.minor).toBe(50000n);
+  });
+
+  it('reads a foreign card spend in its own currency', () => {
+    const parsed = parseSms('USD 42.50 spent on card XX1234 at STARBUCKS on 04-Aug-26');
+    expect(parsed?.amount.currency).toBe('USD');
+    expect(parsed?.amount.minor).toBe(4250n);
+    expect(parsed?.occurredAt?.slice(0, 10)).toBe('2026-08-04');
+  });
+
+  it('reads a named-month date with a time', () => {
+    const parsed = parseSms('Rs.900 debited at 05-Aug-2026 14:30 to ANJAPPAR');
+    expect(parsed?.occurredAt).toBe('2026-08-05T14:30:00.000Z');
+  });
+});
+
+describe('messages that must not become expenses', () => {
+  it('refuses an OTP, which quotes a real amount from the real bank', () => {
+    // The most dangerous false positive in the whole set: right sender, right
+    // amount, and a person tapping through would confirm a purchase they were
+    // in the middle of *not* making.
+    expect(
+      parseSms('OTP 448210 for txn of Rs.5,000.00 at AMAZON. Valid 10 min. Do not share.'),
+    ).toBeNull();
+  });
+
+  it('refuses a payment request, which has not happened yet', () => {
+    expect(parseSms('PhonePe: RAVI has requested Rs.800. Approve in the app.')).toBeNull();
+    expect(parseSms('Rs.2,499 will be debited on 10-03-26 towards NETFLIX')).toBeNull();
+  });
+
+  it('refuses a failed or declined transaction', () => {
+    expect(
+      parseSms('Txn of Rs.1,200 at BIGBASKET was declined due to insufficient funds'),
+    ).toBeNull();
+    expect(parseSms('Your payment of Rs.340 to UBER failed. Ref 99182')).toBeNull();
+  });
+
+  it('refuses a balance or statement message', () => {
+    expect(parseSms('Avl Bal in a/c XX4471 is Rs.42,318.55 as on 02-03-26')).toBeNull();
+    expect(parseSms('Your statement for a/c XX4471: total spent Rs.18,200')).toBeNull();
+  });
+
+  it('refuses a bill reminder', () => {
+    expect(parseSms('Reminder: Rs.3,410 is due on 15-03-26 for card XX1234')).toBeNull();
+  });
+
+  it('refuses a message with no amount at all', () => {
+    expect(parseSms('Your card XX4471 has been activated.')).toBeNull();
+  });
+
+  it('refuses a message that does not say which way the money went', () => {
+    // Without a direction word this could be either, and a credit booked as an
+    // expense is worse than proposing nothing.
+    expect(parseSms('Rs.1,000 txn on a/c XX4471 ref 8812')).toBeNull();
+  });
+
+  it('refuses a zero amount', () => {
+    expect(parseSms('Rs.0.00 debited at TEST MERCHANT')).toBeNull();
+  });
+});
+
+describe('money coming in is not an expense', () => {
+  it('reads a credit as a credit', () => {
+    const parsed = parseSms('Rs.2,000 credited to a/c XX4471 from RAVI on 02-03-26');
+    expect(parsed?.direction).toBe('credit');
+  });
+
+  it('and never proposes it', () => {
+    const proposed = proposeFromSms(
+      [
+        sms('Rs.2,000 credited to a/c XX4471 from RAVI on 02-03-26'),
+        sms('Rs.1,500 refund received for order 88123 on 02-03-26'),
+        sms('Rs.750 debited at CAFE on 02-03-26'),
+      ],
+      { from: '2026-03-01', to: '2026-03-05' },
+    );
+    expect(proposed).toHaveLength(1);
+    expect(proposed[0]?.amount.minor).toBe(75000n);
+  });
+});
+
+describe('only what happened during the trip', () => {
+  const inbox = [
+    sms('Rs.400 debited at AIRPORT CAFE on 28-02-26'),
+    sms('Rs.1,250 debited at GOA SHACK on 02-03-26'),
+    sms('Rs.900 debited at BEACH BAR on 04-03-26'),
+    sms('Rs.600 debited at HOME STORE on 09-03-26'),
+  ];
+
+  it('keeps only the messages inside the window', () => {
+    const proposed = proposeFromSms(inbox, { from: '2026-03-01', to: '2026-03-05' });
+    expect(proposed.map((c) => c.merchant)).toEqual(['GOA SHACK', 'BEACH BAR']);
+  });
+
+  it('includes both end days in full', () => {
+    // A trip "1st to 5th" means all of the 1st and all of the 5th. An expense
+    // at 11pm on the last night is not outside the trip.
+    const proposed = proposeFromSms(
+      [
+        sms('Rs.100 debited at LATE BAR on 05-03-26 23:30'),
+        sms('Rs.100 debited at DAWN on 01-03-26 00:15'),
+      ],
+      { from: '2026-03-01', to: '2026-03-05' },
+    );
+    expect(proposed).toHaveLength(2);
+  });
+
+  it('returns them oldest first', () => {
+    const proposed = proposeFromSms(inbox, { from: '2026-02-01', to: '2026-03-31' });
+    expect(proposed.map((c) => c.at)).toEqual([...proposed.map((c) => c.at)].sort());
+  });
+});
+
+describe('confirming twice must not double-post', () => {
+  it('collapses the same message seen twice', () => {
+    const one = sms('Rs.1,250 debited at SWIGGY on 02-03-26. Ref: 412703998812');
+    const proposed = proposeFromSms([one, { ...one }], { from: '2026-03-01', to: '2026-03-05' });
+    expect(proposed).toHaveLength(1);
+  });
+
+  it('drops what was already imported', () => {
+    const inbox = [sms('Rs.1,250 debited at SWIGGY on 02-03-26. Ref: 412703998812')];
+    const first = proposeFromSms(inbox, { from: '2026-03-01', to: '2026-03-05' });
+    expect(first).toHaveLength(1);
+
+    // Re-scanning the inbox after confirming must propose nothing.
+    const again = proposeFromSms(inbox, {
+      from: '2026-03-01',
+      to: '2026-03-05',
+      alreadyImported: new Set(first.map((c) => c.dedupeKey)),
+    });
+    expect(again).toHaveLength(0);
+  });
+
+  it('uses the bank reference when there is one, so rewording does not slip through', () => {
+    const proposed = proposeFromSms(
+      [
+        sms('Rs.1,250 debited at SWIGGY on 02-03-26. Ref: 412703998812'),
+        sms('INR 1250.00 spent at SWIGGY BANGALORE on 02-03-26. UPI Ref: 412703998812'),
+      ],
+      { from: '2026-03-01', to: '2026-03-05' },
+    );
+    expect(proposed).toHaveLength(1);
+  });
+
+  it('still separates two genuinely different amounts on the same day', () => {
+    const proposed = proposeFromSms(
+      [sms('Rs.300 debited at CAFE on 02-03-26'), sms('Rs.700 debited at CAFE on 02-03-26')],
+      { from: '2026-03-01', to: '2026-03-05' },
+    );
+    expect(proposed).toHaveLength(2);
+  });
+});
+
+describe('what a person is asked to look at', () => {
+  it('does not pre-select a message whose date we had to infer', () => {
+    // The bank did not say when, so arrival time was used. On a trip that is
+    // exactly how an expense lands on the wrong day.
+    const proposed = proposeFromSms([sms('Rs.500 debited at CAFE')], {
+      from: '2026-03-01',
+      to: '2026-03-05',
+    });
+    expect(proposed[0]?.dateInferred).toBe(true);
+    expect(proposed[0]?.preselect).toBe(false);
+  });
+
+  it('does not pre-select a message we barely understood', () => {
+    const proposed = proposeFromSms([sms('Rs.500 debited on 02-03-26')], {
+      from: '2026-03-01',
+      to: '2026-03-05',
+    });
+    expect(proposed[0]?.merchant).toBeNull();
+    expect(proposed[0]?.preselect).toBe(false);
+  });
+
+  it('pre-selects only a message that was fully understood', () => {
+    const proposed = proposeFromSms(
+      [sms('Rs.1,250 debited from a/c XX4471 at SWIGGY on 02-03-26. Ref: 412703998812')],
+      { from: '2026-03-01', to: '2026-03-05' },
+    );
+    expect(proposed[0]?.preselect).toBe(true);
+    expect(proposed[0]?.dateInferred).toBe(false);
+  });
+
+  it('keeps the sender so a person can recognise the bank', () => {
+    const proposed = proposeFromSms([sms('Rs.500 debited at CAFE on 02-03-26')], {
+      from: '2026-03-01',
+      to: '2026-03-05',
+    });
+    expect(proposed[0]?.sender).toBe('AD-HDFCBK');
+  });
+});
+
+describe('no float ever exists between the text and the amount (ADR-003)', () => {
+  it('parses amounts that a float would round wrong', () => {
+    for (const [text, minor] of [
+      ['Rs.0.10 debited at X', 10n],
+      ['Rs.0.07 debited at X', 7n],
+      ['Rs.1.15 debited at X', 115n],
+      ['Rs.99,999.99 debited at X', 9999999n],
+      ['Rs.1,00,00,000.01 debited at X', 1000000001n],
+    ] as const) {
+      expect(parseSms(text)?.amount.minor).toBe(minor);
+    }
+  });
+});


### PR DESCRIPTION
## Two constraints, up front

**This deviates from TDR §10**, which lists SMS auto-import as out of scope for v1. Built because it was asked for directly, and recorded in the module header rather than hidden. It is additive — nothing else imports it — and the ledger rules are unchanged: a parsed message is a **proposal**, never an entry.

**iOS cannot do this.** There is no SMS-read API at any permission level. On Android, `READ_SMS` is restricted by Google Play policy to apps that are the *default SMS handler*, which an expense splitter will not qualify for. Shipping paths are: Android dev-build/sideload, or the user sharing a message into the app. That is a policy wall, not an engineering one.

## On-device only

Nothing here is reachable from an edge function and nothing touches the network. A bank SMS carries an account tail, a balance, and sometimes a one-time password — shipping that off to be parsed would be a worse privacy trade than the feature is worth (ADR-013).

## The refusals are the substance

An OTP quotes a real amount from the real bank. It is the false positive most likely to be confirmed by accident, so it is rejected before anything else is attempted — along with payment requests, declines, balance messages, reminders and scheduled mandates.

A message that does not say **which way** the money went is dropped rather than guessed at: a credit booked as an expense is worse than proposing nothing. Refunds parse correctly as credits and are never proposed.

## Getting the day right

Nothing is pre-selected unless the message was fully understood **and** the bank said when it happened. An inferred date is exactly how an expense lands on the wrong day of a trip, so those are shown but left unticked.

Re-scanning an inbox cannot re-propose what was already confirmed — the bank's own reference is the dedupe key when present, so a reworded duplicate still collapses.

## Money

Amounts are assembled from digits; no float exists between the text and the minor units (ADR-003). Indian grouping (`1,23,456.78`) parses identically to `123,456.78`.

## Verification

27 new tests; 159 core tests pass. typecheck, lint, format clean.

## Not in this PR

The Android permission plumbing, the confirm screen, and wiring candidates into the mutation queue. M3 and M4 are also still open — see the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6