### PR TITLE
feat(activity): say who did it, and explain a superseded edit

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -15,11 +15,15 @@ import {
 } from '@baaki/ui';
 
 import { fetchRecentActivity } from '@/data/api';
+import { actorName, type ActivityActor } from '@/data/types';
 import { useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
 
 export default function ActivityScreen() {
   const theme = useTheme();
   const { t, locale } = useStrings();
+  const { session } = useAuth();
+  const myProfileId = session?.user.id ?? null;
 
   const activity = useQuery({
     queryKey: ['activity', 'recent'],
@@ -73,7 +77,7 @@ export default function ActivityScreen() {
                 {dayEntries.map((entry, index) => (
                   <View key={entry.id}>
                     <ListRow
-                      title={describe(entry.verb, entry.object_type, entry.payload)}
+                      title={describe(entry.verb, entry.object_type, entry.payload, entry.actor, myProfileId)}
                       subtitle={`${entry.group?.name ?? 'Group'} · ${new Intl.DateTimeFormat(
                         locale,
                         {
@@ -114,24 +118,51 @@ export default function ActivityScreen() {
   );
 }
 
-function describe(verb: string, objectType: string, payload: Record<string, unknown>): string {
+/**
+ * One line saying who did what.
+ *
+ * The actor is the point. On a shared ledger "Dinner was edited" is not an
+ * answer to anything — "Ravi edited Dinner" is. Written from this reader's
+ * point of view, so their own actions read as "You".
+ */
+function describe(
+  verb: string,
+  objectType: string,
+  payload: Record<string, unknown>,
+  actor: ActivityActor | null | undefined,
+  myProfileId: string | null,
+): string {
   const description = typeof payload.description === 'string' ? payload.description : null;
+  const who = actorName(actor, myProfileId);
+
   switch (verb) {
     case 'added':
-      return description ?? 'New expense';
+      return `${who} added ${description ?? 'an expense'}`;
     case 'edited':
-      return `Edited ${description ?? 'an expense'}`;
+      return `${who} edited ${description ?? 'an expense'}`;
     case 'deleted':
-      return `Deleted ${description ?? 'an expense'}`;
+      return `${who} deleted ${description ?? 'an expense'}`;
     case 'restored':
-      return `Restored ${description ?? 'an expense'}`;
+      return `${who} restored ${description ?? 'an expense'}`;
+    case 'superseded': {
+      // The conflict entry from offline sync (ADR-005). Both edits survive in
+      // expense_versions; this row exists so the person whose edit lost can
+      // find it and put it back. Saying "superseded expense" told them nothing.
+      const replaced =
+        typeof payload.supersededDescription === 'string' ? payload.supersededDescription : null;
+      return replaced
+        ? `${who}'s edit replaced an earlier one — "${replaced}" is still in the history`
+        : `${who}'s edit replaced an earlier one`;
+    }
     case 'settled':
-      return 'Settlement recorded';
+      return `${who} recorded a settlement`;
     case 'confirmed':
-      return 'Settlement confirmed';
+      return `${who} confirmed a settlement`;
+    case 'joined':
+      return `${who} joined`;
     case 'created':
-      return `Group created`;
+      return `${who} created the group`;
     default:
-      return `${verb} ${objectType}`;
+      return `${who} ${verb} ${objectType}`;
   }
 }

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -14,6 +14,7 @@ import type { FxRecord, ParsedReceipt, ReceiptCheck, SplitParams } from '@baaki/
 
 import { supabase } from '@/lib/supabase';
 import type {
+  ActivityGroup,
   ActivityRow,
   BalanceRow,
   ExpenseRow,
@@ -113,31 +114,35 @@ export async function fetchActivity(groupId: string, limit = 50): Promise<Activi
   return unwrap(
     await supabase
       .from('activity_log')
-      .select('id, group_id, actor_member_id, verb, object_type, object_id, payload, created_at')
+      .select(
+        `id, group_id, actor_member_id, verb, object_type, object_id, payload, created_at,
+         actor:group_members!activity_log_actor_member_id_fkey (
+           id, profile_id, ghost_name, profile:profiles ( display_name )
+         )`,
+      )
       .eq('group_id', groupId)
       .order('created_at', { ascending: false })
       .limit(limit),
-  );
+  ) as unknown as ActivityRow[];
 }
 
 /** Activity across every group the user can see — RLS does the filtering. */
 export async function fetchRecentActivity(
   limit = 60,
-): Promise<
-  (ActivityRow & { group: { id: string; name: string; cover_emoji: string | null } | null })[]
-> {
+): Promise<(ActivityRow & { group: ActivityGroup | null })[]> {
   return unwrap(
     await supabase
       .from('activity_log')
       .select(
         `id, group_id, actor_member_id, verb, object_type, object_id, payload, created_at,
-         group:groups ( id, name, cover_emoji )`,
+         group:groups ( id, name, cover_emoji ),
+         actor:group_members!activity_log_actor_member_id_fkey (
+           id, profile_id, ghost_name, profile:profiles ( display_name )
+         )`,
       )
       .order('created_at', { ascending: false })
       .limit(limit),
-  ) as unknown as (ActivityRow & {
-    group: { id: string; name: string; cover_emoji: string | null } | null;
-  })[];
+  ) as unknown as (ActivityRow & { group: ActivityGroup | null })[];
 }
 
 /**

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -78,15 +78,46 @@ export interface SettlementRow {
   allocations?: { expense_id: string; amount: string }[];
 }
 
+/** Who did the thing. Null when the actor has since left the group. */
+export interface ActivityActor {
+  id: MemberId;
+  profile_id: string | null;
+  ghost_name: string | null;
+  profile: { display_name: string | null } | null;
+}
+
+export interface ActivityGroup {
+  id: string;
+  name: string | null;
+  cover_emoji: string | null;
+}
+
 export interface ActivityRow {
   id: string;
   group_id: string;
   actor_member_id: MemberId | null;
+  actor?: ActivityActor | null;
   verb: string;
   object_type: string;
   object_id: string | null;
   payload: Record<string, unknown>;
   created_at: string;
+}
+
+/**
+ * "Ravi", or "You" when it was this person — an activity feed that cannot say
+ * who changed an expense is not answering the question it exists for.
+ *
+ * Matched on profile id rather than member id: the cross-group feed spans
+ * groups, and the same person holds a different member id in each one.
+ */
+export function actorName(
+  actor: ActivityActor | null | undefined,
+  myProfileId: string | null,
+): string {
+  if (!actor) return 'Someone';
+  if (myProfileId && actor.profile_id === myProfileId) return 'You';
+  return actor.profile?.display_name ?? actor.ghost_name ?? 'Someone';
 }
 
 export interface BalanceRow {


### PR DESCRIPTION
The activity feed already existed and worked. It just could not answer the question it exists for.

## It never said who

Every row rendered as `Edited Dinner`. On a shared ledger that is not an answer to anything — `Ravi edited Dinner` is. `actor_member_id` was on every row already and simply never fetched, so the join was the whole fix.

Matched on **profile id, not member id**: the cross-group feed spans groups, and the same person holds a different member id in each one. A member-id comparison would have said "You" in exactly one group and named you in the rest.

## `superseded` rendered as gibberish

That verb had no case and fell through to a default printing `superseded expense`.

It is the conflict entry offline sync writes when someone's edit is replaced by a later one (ADR-005) — and it is the single row a person most needs to understand, because their version is still in `expense_versions` and restoring it is just another edit. Telling them "superseded expense" left them with no way to know that. It now names the description that was replaced and says the history still has it.

`joined` had the same problem and is filled in too.

## Verification

typecheck, lint, format clean. No schema change — the data was always there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6