### PR TITLE
feat: add people by email, or from the phone's contacts

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,6 +15,7 @@
     "expo": "~57.0.10",
     "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.9",
+    "expo-contacts": "~57.0.3",
     "expo-crypto": "~57.0.1",
     "expo-dev-client": "~57.0.10",
     "expo-device": "~57.0.1",

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -17,6 +17,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { ContactPicker } from '@/components/ContactPicker';
 import { useAddGhostMember, useGroup, useGroupLedger } from '@/data/hooks';
 import { displayName, groupLabel, isGhost, vpaOf } from '@/data/types';
 import { useStrings } from '@/i18n';
@@ -34,20 +35,64 @@ export default function MembersScreen() {
   const addGhost = useAddGhostMember(groupId);
 
   const [ghostName, setGhostName] = useState('');
+  const [ghostContact, setGhostContact] = useState('');
+  const [browsing, setBrowsing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const currency = group.data?.default_currency ?? 'INR';
   const ghosts = (members.data ?? []).filter(isGhost);
 
+  /**
+   * One field for the address, whichever kind it is. Asking somebody to first
+   * declare "email or phone?" and then type it is a question the text itself
+   * already answers.
+   */
+  const contactOf = (value: string): { email?: string; phone?: string } => {
+    const trimmed = value.trim();
+    if (!trimmed) return {};
+    return trimmed.includes('@') ? { email: trimmed } : { phone: trimmed };
+  };
+
   const add = (): void => {
     const name = ghostName.trim();
-    if (!name) return;
+    const contact = contactOf(ghostContact);
+    if (!name && !contact.email && !contact.phone) return;
     setError(null);
-    addGhost.mutate(name, {
-      onSuccess: () => setGhostName(''),
-      onError: (caught) => setError(caught instanceof Error ? caught.message : String(caught)),
-    });
+    addGhost.mutate(
+      { name, ...contact },
+      {
+        onSuccess: () => {
+          setGhostName('');
+          setGhostContact('');
+        },
+        onError: (caught) => setError(caught instanceof Error ? caught.message : String(caught)),
+      },
+    );
   };
+
+  const addPicked = (picked: {
+    name: string;
+    email: string | null;
+    phone: string | null;
+  }): void => {
+    setError(null);
+    addGhost.mutate(
+      { name: picked.name, email: picked.email, phone: picked.phone },
+      {
+        onSuccess: () => setBrowsing(false),
+        onError: (caught) => setError(caught instanceof Error ? caught.message : String(caught)),
+      },
+    );
+  };
+
+  // Contacts already used, so the picker can grey them out instead of letting
+  // somebody add the same person twice. The server would collapse it anyway —
+  // this just makes the reason visible.
+  const alreadyAdded = new Set(
+    (members.data ?? []).flatMap((member) =>
+      [member.invite_email, member.invite_phone].filter((value): value is string => Boolean(value)),
+    ),
+  );
 
   return (
     <Screen>
@@ -102,7 +147,7 @@ export default function MembersScreen() {
         {/* ADR-006: a name is enough to start splitting with someone. */}
         <Card style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">
-            Add someone by name
+            Add someone
           </Text>
           <Row>
             <TextInput
@@ -124,12 +169,41 @@ export default function MembersScreen() {
               label="Add"
               size="sm"
               variant="secondary"
-              disabled={!ghostName.trim() || addGhost.isPending}
+              disabled={(!ghostName.trim() && !ghostContact.trim()) || addGhost.isPending}
               onPress={add}
             />
           </Row>
+
+          <TextInput
+            value={ghostContact}
+            onChangeText={setGhostContact}
+            autoCapitalize="none"
+            keyboardType="email-address"
+            placeholder="Email or phone, if you want to send them the link"
+            placeholderTextColor={theme.color.textFaint}
+            accessibilityLabel="Email or phone number"
+            onSubmitEditing={add}
+            style={{
+              fontSize: 15,
+              color: theme.color.text,
+              paddingVertical: theme.spacing.sm,
+            }}
+          />
+
+          <Button
+            label={browsing ? 'Hide contacts' : 'Browse my contacts'}
+            variant="ghost"
+            onPress={() => setBrowsing((open) => !open)}
+          />
+
+          {browsing ? (
+            <View style={{ height: 320 }}>
+              <ContactPicker onPick={addPicked} existing={alreadyAdded} />
+            </View>
+          ) : null}
           <Text variant="micro" tone="faint">
-            They do not need the app to be part of the split. When they join later they can claim
+            A name alone is enough — nobody needs the app, or an email, to be part of the split. An
+            address just means you can send them the link. When they join later they can claim
             everything already recorded under their name.
           </Text>
           {addGhost.isPending ? <ActivityIndicator color={theme.color.brand} /> : null}

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -1,0 +1,186 @@
+/**
+ * Picking somebody out of the phone's contacts.
+ *
+ * The address book never leaves the device. Contacts are read, searched and
+ * displayed locally; only the one person you tap is sent anywhere, and only as
+ * the name and address needed to invite them.
+ *
+ * This is worth being deliberate about, because the usual version of this
+ * feature uploads the whole book to find "who else already uses Baaki". That
+ * turns an address book into a membership oracle — it tells the server, and
+ * anyone who later reaches the server, which of your contacts use the app.
+ * Baaki has no such endpoint and this component does not want one: an invite
+ * link works whether or not the person has ever heard of us (ADR-006).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import * as Contacts from 'expo-contacts';
+import { FlatList, Pressable, TextInput, View } from 'react-native';
+
+import { Avatar, Button, Card, EmptyState, Row, Text, useTheme } from '@baaki/ui';
+
+export interface PickedContact {
+  readonly name: string;
+  readonly email: string | null;
+  readonly phone: string | null;
+}
+
+interface ContactPickerProps {
+  onPick: (contact: PickedContact) => void;
+  /** Already in the group — shown greyed rather than hidden, so it is obvious why. */
+  existing?: ReadonlySet<string>;
+}
+
+type Permission = 'asking' | 'granted' | 'denied';
+
+export function ContactPicker({ onPick, existing }: ContactPickerProps): React.JSX.Element {
+  const theme = useTheme();
+  const [permission, setPermission] = useState<Permission>('asking');
+  const [contacts, setContacts] = useState<PickedContact[]>([]);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const { status } = await Contacts.requestPermissionsAsync();
+      if (cancelled) return;
+      if (status !== 'granted') {
+        setPermission('denied');
+        return;
+      }
+
+      // Only these three fields. Asking for less than the platform offers is
+      // the cheapest privacy measure there is.
+      const { data } = await Contacts.getContactsAsync({
+        fields: [Contacts.Fields.Name, Contacts.Fields.Emails, Contacts.Fields.PhoneNumbers],
+      });
+      if (cancelled) return;
+
+      setContacts(
+        data
+          .map((contact) => ({
+            name: contact.name?.trim() ?? '',
+            email: contact.emails?.[0]?.email?.trim().toLowerCase() ?? null,
+            phone: normalisePhone(contact.phoneNumbers?.[0]?.number ?? null),
+          }))
+          // Somebody with neither an email nor a number cannot be invited, so
+          // showing them would only be an invitation to tap and be refused.
+          .filter((contact) => contact.name && (contact.email || contact.phone))
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      );
+      setPermission('granted');
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const matches = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return contacts;
+    return contacts.filter(
+      (contact) =>
+        contact.name.toLowerCase().includes(needle) ||
+        contact.email?.includes(needle) ||
+        contact.phone?.includes(needle),
+    );
+  }, [contacts, query]);
+
+  if (permission === 'asking') {
+    return (
+      <Card>
+        <Text variant="caption" tone="muted">
+          Looking through your contacts…
+        </Text>
+      </Card>
+    );
+  }
+
+  if (permission === 'denied') {
+    return (
+      <Card style={{ gap: theme.spacing.sm }}>
+        <Text variant="caption" tone="muted">
+          Baaki cannot see your contacts. You can still add people by typing a name, an email or a
+          number — nothing about a group needs your address book.
+        </Text>
+        <Button
+          label="Open settings"
+          variant="ghost"
+          onPress={() => void Contacts.presentFormAsync(null, null)}
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <View style={{ gap: theme.spacing.md, flex: 1 }}>
+      <Card style={{ gap: theme.spacing.xs }}>
+        <TextInput
+          value={query}
+          onChangeText={setQuery}
+          autoCapitalize="none"
+          accessibilityLabel="Search contacts"
+          placeholder="Search contacts"
+          placeholderTextColor={theme.color.textFaint}
+          style={{ fontSize: 16, color: theme.color.text, paddingVertical: theme.spacing.sm }}
+        />
+      </Card>
+
+      <Text variant="micro" tone="faint">
+        Only the person you pick is sent to Baaki. Your contacts stay on this phone.
+      </Text>
+
+      {matches.length === 0 ? (
+        <EmptyState
+          title="Nobody here"
+          body={
+            query ? 'No contact matches that.' : 'None of your contacts has an email or number.'
+          }
+        />
+      ) : (
+        <FlatList
+          data={matches}
+          keyExtractor={(contact, index) => `${contact.email ?? contact.phone}-${index}`}
+          renderItem={({ item }) => {
+            const already = Boolean(
+              (item.email && existing?.has(item.email)) ||
+              (item.phone && existing?.has(item.phone)),
+            );
+            return (
+              <Pressable
+                onPress={() => !already && onPick(item)}
+                accessibilityRole="button"
+                accessibilityLabel={already ? `${item.name}, already added` : `Add ${item.name}`}
+                style={{ opacity: already ? 0.45 : 1, paddingVertical: theme.spacing.sm }}
+              >
+                <Row style={{ gap: theme.spacing.md }}>
+                  <Avatar name={item.name} size={40} />
+                  <View style={{ flex: 1 }}>
+                    <Text variant="body">{item.name}</Text>
+                    <Text variant="micro" tone="faint">
+                      {already ? 'Already in this group' : (item.email ?? item.phone ?? '')}
+                    </Text>
+                  </View>
+                </Row>
+              </Pressable>
+            );
+          }}
+        />
+      )}
+    </View>
+  );
+}
+
+/**
+ * A contact card writes a number however the owner typed it. Keep only digits
+ * and a leading plus; a number with no country code is returned as-is and the
+ * server refuses it, rather than this guessing +91 for somebody's friend
+ * abroad — a trip is exactly when foreign numbers turn up.
+ */
+function normalisePhone(raw: string | null): string | null {
+  if (!raw) return null;
+  const cleaned = raw.replace(/[^0-9+]/g, '');
+  return cleaned.length >= 8 ? cleaned : null;
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -193,7 +193,7 @@ export async function fetchMembersByGroup(): Promise<Map<string, MemberRow[]>> {
     await supabase
       .from('group_members')
       .select(
-        'id, group_id, profile_id, ghost_name, role, vpa, left_at, profile:profiles ( id, display_name, avatar_url, default_vpa )',
+        'id, group_id, profile_id, ghost_name, role, vpa, left_at, invite_email, invite_phone, profile:profiles ( id, display_name, avatar_url, default_vpa )',
       )
       .is('left_at', null)
       .order('created_at', { ascending: true }),
@@ -287,12 +287,39 @@ function normaliseImageMime(mimeType: string | null | undefined): string {
   return 'image/jpeg';
 }
 
-/** ADR-006: a ghost is a real participant who simply hasn't joined yet. */
-export async function addGhostMember(groupId: string, name: string): Promise<void> {
-  const { error } = await supabase
-    .from('group_members')
-    .insert({ group_id: groupId, ghost_name: name.trim(), joined_via: 'ghost' });
-  if (error) throw new Error(error.message);
+/**
+ * ADR-006: a ghost is a real participant who simply hasn't joined yet.
+ *
+ * Goes through an RPC rather than a plain insert so normalisation happens in
+ * one place. The same person typed two ways — `Ravi@Example.com` today,
+ * `ravi@example.com` last week — must not become two members holding two
+ * halves of a balance. The server returns the existing member id when the
+ * contact already matches, so adding twice is harmless.
+ */
+export async function addGhostMember(
+  groupId: string,
+  name: string,
+  contact: { email?: string | null; phone?: string | null } = {},
+): Promise<string> {
+  const { data, error } = await supabase.rpc('baaki_add_ghost_member', {
+    p_group_id: groupId,
+    p_name: name.trim() || null,
+    p_member_id: null,
+    p_email: contact.email?.trim() || null,
+    p_phone: contact.phone?.trim() || null,
+  });
+  if (error) {
+    // The database speaks in codes; surface them rather than a raw SQL string.
+    const code = /^([A-Z_]+):/.exec(error.message)?.[1];
+    throw new Error(
+      code === 'PHONE_NEEDS_COUNTRY_CODE'
+        ? 'That number needs a country code, like +91'
+        : code === 'NOTHING_TO_ADD'
+          ? 'Give a name, an email or a number'
+          : error.message,
+    );
+  }
+  return data as string;
 }
 
 export interface WriteExpenseInput {

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -399,7 +399,10 @@ export function useConfirmSettlement(groupId: string) {
 export function useAddGhostMember(groupId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (name: string) => addGhostMember(groupId, name),
+    mutationFn: (input: string | { name: string; email?: string | null; phone?: string | null }) =>
+      typeof input === 'string'
+        ? addGhostMember(groupId, input)
+        : addGhostMember(groupId, input.name, { email: input.email, phone: input.phone }),
     onSuccess: () => invalidateGroup(queryClient, groupId),
   });
 }

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -21,6 +21,10 @@ export interface GroupRow {
 
 export interface MemberRow {
   id: MemberId;
+  /** Where their invite goes. A hint for one invited person, not a contact book. */
+  invite_email?: string | null;
+  /** E.164. */
+  invite_phone?: string | null;
   group_id: string;
   profile_id: string | null;
   ghost_name: string | null;

--- a/packages/db/prisma/migrations/20260806100000_member_contact_hints/migration.sql
+++ b/packages/db/prisma/migrations/20260806100000_member_contact_hints/migration.sql
@@ -1,0 +1,145 @@
+-- Inviting somebody by email or phone (ADR-006).
+--
+-- A ghost member can now carry the address the invite should go to. This is a
+-- *hint attached to one person you are inviting*, not a contact book: nothing
+-- here stores, uploads or matches against the phone's address book, and there
+-- is deliberately no way to ask this schema "which of these emails already use
+-- Baaki". That question is the one every contacts feature answers by accident,
+-- and answering it turns an address book into a membership oracle.
+--
+-- Normalisation is enforced here rather than trusted from the client, because
+-- the same person typed two ways must not become two ghosts:
+--   asha@Example.COM and asha@example.com are one address;
+--   +91 98765 43210, 09876543210 and +919876543210 are one number.
+-- The client cannot be relied on for that — the offline queue means an old
+-- build's idea of normalisation can arrive months late (ADR-005).
+
+ALTER TABLE public.group_members
+  ADD COLUMN IF NOT EXISTS invite_email text,
+  ADD COLUMN IF NOT EXISTS invite_phone text;
+
+COMMENT ON COLUMN public.group_members.invite_email IS
+  'Where to send this person''s invite. Lowercased. Visible to the group.';
+COMMENT ON COLUMN public.group_members.invite_phone IS
+  'E.164 only, e.g. +919876543210. Visible to the group.';
+
+-- Stored E.164 or not at all. A local-format number is the same person as its
+-- international form, and keeping both would split one human into two members
+-- holding two halves of a balance.
+ALTER TABLE public.group_members
+  DROP CONSTRAINT IF EXISTS group_members_invite_phone_e164;
+ALTER TABLE public.group_members
+  ADD CONSTRAINT group_members_invite_phone_e164
+  CHECK (invite_phone IS NULL OR invite_phone ~ '^\+[1-9][0-9]{7,14}$');
+
+-- Not a full RFC 5322 validation, which is famously not worth attempting in a
+-- CHECK. This rejects the mistakes that matter: whitespace, a missing @, an
+-- uppercase address that would duplicate a lowercase one.
+ALTER TABLE public.group_members
+  DROP CONSTRAINT IF EXISTS group_members_invite_email_shape;
+ALTER TABLE public.group_members
+  ADD CONSTRAINT group_members_invite_email_shape
+  CHECK (invite_email IS NULL OR invite_email ~ '^[^[:space:]@]+@[^[:space:]@]+\.[^[:space:]@]+$');
+
+ALTER TABLE public.group_members
+  DROP CONSTRAINT IF EXISTS group_members_invite_email_lowercase;
+ALTER TABLE public.group_members
+  ADD CONSTRAINT group_members_invite_email_lowercase
+  CHECK (invite_email IS NULL OR invite_email = lower(invite_email));
+
+
+-- ───────────────────────────────────────── adding somebody by contact ──
+-- `baaki_add_ghost_member` already existed as (uuid, text, uuid) — the third
+-- argument is the client-chosen member id that makes a replayed offline
+-- mutation idempotent (ADR-005). Contact details are added to THAT function
+-- rather than declared as a new one.
+--
+-- The overload trap, for the fourth time in this project: CREATE OR REPLACE
+-- with a different argument count creates a SECOND function. Here it was worse
+-- than ambiguity — a 3-argument call `(group, name, member_uuid)` silently
+-- resolved to a new `(group, name, email)` and tried to store a uuid as an
+-- email address. The M2 suite caught it. Adding parameters to an existing
+-- function means editing its real signature, never writing a fresh one.
+
+DROP FUNCTION IF EXISTS public.baaki_add_ghost_member(uuid, text, uuid);
+
+CREATE OR REPLACE FUNCTION public.baaki_add_ghost_member(
+  p_group_id  uuid,
+  p_name      text,
+  p_member_id uuid DEFAULT NULL,
+  p_email     text DEFAULT NULL,
+  p_phone     text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_member_id  uuid;
+  v_email      text := nullif(btrim(lower(coalesce(p_email, ''))), '');
+  v_phone      text := nullif(regexp_replace(coalesce(p_phone, ''), '[^0-9+]', '', 'g'), '');
+  v_name       text := nullif(btrim(coalesce(p_name, '')), '');
+BEGIN
+  IF v_profile_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.group_members gm
+    WHERE gm.group_id = p_group_id AND gm.profile_id = v_profile_id AND gm.left_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- A name is no longer required, because picking an email out of a contact
+  -- card often carries no usable one. Something is still required.
+  IF v_name IS NULL AND v_email IS NULL AND v_phone IS NULL THEN
+    RAISE EXCEPTION 'NOTHING_TO_ADD: give a name, an email or a number'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- A number typed without its country code cannot be assumed Indian just
+  -- because this is an India-first app — somebody on a trip is exactly the
+  -- person whose contacts are foreign. Reject rather than guess wrong.
+  IF v_phone IS NOT NULL AND v_phone !~ '^\+' THEN
+    RAISE EXCEPTION 'PHONE_NEEDS_COUNTRY_CODE: % has no country code', v_phone
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replay of a queued offline mutation returns the same member (ADR-005).
+  IF p_member_id IS NOT NULL THEN
+    SELECT id INTO v_member_id FROM public.group_members
+     WHERE id = p_member_id AND group_id = p_group_id;
+    IF FOUND THEN
+      RETURN v_member_id;
+    END IF;
+  END IF;
+
+  -- Adding the same person twice is the common accident when picking from a
+  -- contact list, and two ghosts for one human split their balance in half.
+  -- Matched on contact rather than name: two people really can be called Ravi.
+  IF v_email IS NOT NULL OR v_phone IS NOT NULL THEN
+    SELECT gm.id INTO v_member_id
+      FROM public.group_members gm
+     WHERE gm.group_id = p_group_id
+       AND gm.left_at IS NULL
+       AND ((v_email IS NOT NULL AND gm.invite_email = v_email)
+         OR (v_phone IS NOT NULL AND gm.invite_phone = v_phone))
+     LIMIT 1;
+    IF v_member_id IS NOT NULL THEN
+      RETURN v_member_id;
+    END IF;
+  END IF;
+
+  INSERT INTO public.group_members
+    (id, group_id, ghost_name, joined_via, invite_email, invite_phone)
+  VALUES
+    (COALESCE(p_member_id, gen_random_uuid()), p_group_id,
+     COALESCE(v_name, v_email, v_phone), 'ghost', v_email, v_phone)
+  RETURNING id INTO v_member_id;
+
+  RETURN v_member_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_add_ghost_member(uuid, text, uuid, text, text)
+  TO authenticated, anon;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -183,6 +183,11 @@ model GroupMember {
   role       MemberRole @default(member)
   /// How they got here: 'creator' | 'invite_link' | 'ghost' | 'import'.
   joinedVia  String?    @map("joined_via")
+  /// Where this person's invite should go. Lowercased. A hint for one invited
+  /// person — never a copy of anybody's address book.
+  inviteEmail String?   @map("invite_email")
+  /// E.164 only, e.g. +919876543210.
+  invitePhone String?   @map("invite_phone")
   /// Per-group override of the profile's default VPA.
   vpa        String?
   leftAt     DateTime?  @map("left_at") @db.Timestamptz(6)

--- a/packages/db/test/contacts.test.ts
+++ b/packages/db/test/contacts.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Adding somebody by email or number (ADR-006).
+ *
+ * The failure worth testing for is not a rejected address — it is the same
+ * human becoming two members. Picking from a contact list makes that easy: the
+ * same person is in there twice, or was added by hand last week and picked from
+ * contacts today. Two ghosts for one person split their balance in half, and
+ * nothing downstream can tell that happened.
+ *
+ * The other half is normalisation. It lives in the database rather than the
+ * client because the offline queue means an old build's idea of what an email
+ * looks like can arrive months late (ADR-005).
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+async function seedGroup(): Promise<string> {
+  const profileId = randomUUID();
+  await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Asha')`, [profileId]);
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  const { rows } = await client.query(
+    `SELECT baaki_create_group('Trip', 'trip', 'INR', NULL, true, NULL, NULL) AS id`,
+  );
+  return String(rows[0].id);
+}
+
+async function reset(): Promise<void> {
+  await client.query(`RESET ROLE`);
+  await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+}
+
+async function add(
+  groupId: string,
+  name: string | null,
+  email: string | null = null,
+  phone: string | null = null,
+): Promise<{ id?: string; error?: string }> {
+  try {
+    const { rows } = await client.query(
+      `SELECT baaki_add_ghost_member($1::uuid, $2::text, NULL::uuid, $3::text, $4::text) AS id`,
+      [groupId, name, email, phone],
+    );
+    return { id: String(rows[0].id) };
+  } catch (error) {
+    return { error: (error as Error).message };
+  }
+}
+
+async function read(memberId: string) {
+  const { rows } = await client.query(
+    `SELECT ghost_name, invite_email, invite_phone, joined_via
+       FROM group_members WHERE id = $1`,
+    [memberId],
+  );
+  return rows[0];
+}
+
+describe('adding somebody by email', () => {
+  it('stores the address, lowercased', async () => {
+    const groupId = await seedGroup();
+    const { id } = await add(groupId, 'Ravi', '  Ravi@Example.COM ');
+    const member = await read(id as string);
+
+    expect(member.invite_email).toBe('ravi@example.com');
+    expect(member.ghost_name).toBe('Ravi');
+    expect(member.joined_via).toBe('ghost');
+    await reset();
+  });
+
+  it('falls back to the address when no name was given', async () => {
+    // Picking an email out of a contact card often carries no usable name.
+    const groupId = await seedGroup();
+    const { id } = await add(groupId, null, 'ravi@example.com');
+    expect((await read(id as string)).ghost_name).toBe('ravi@example.com');
+    await reset();
+  });
+
+  it('refuses something that is not an address', async () => {
+    const groupId = await seedGroup();
+    for (const bad of ['ravi', 'ravi@', '@example.com', 'a b@example.com', 'ravi@example']) {
+      const { error } = await add(groupId, 'Ravi', bad);
+      expect(error).toMatch(/invite_email_shape/);
+    }
+    await reset();
+  });
+});
+
+describe('adding somebody from contacts', () => {
+  it('keeps a number in E.164', async () => {
+    const groupId = await seedGroup();
+    const { id } = await add(groupId, 'Ravi', null, '+91 98765 43210');
+    expect((await read(id as string)).invite_phone).toBe('+919876543210');
+    await reset();
+  });
+
+  it('strips the punctuation a contact card carries', async () => {
+    const groupId = await seedGroup();
+    const { id } = await add(groupId, 'Ravi', null, '+91-98765-43210');
+    expect((await read(id as string)).invite_phone).toBe('+919876543210');
+    await reset();
+  });
+
+  it('refuses a number with no country code rather than assuming India', async () => {
+    // Somebody on a trip is exactly the person whose contacts are foreign, so
+    // defaulting to +91 would silently invite a stranger in another country.
+    const groupId = await seedGroup();
+    const { error } = await add(groupId, 'Ravi', null, '09876543210');
+    expect(error).toMatch(/PHONE_NEEDS_COUNTRY_CODE/);
+    await reset();
+  });
+
+  it('refuses a number that is not a number', async () => {
+    const groupId = await seedGroup();
+    const { error } = await add(groupId, 'Ravi', null, '+12');
+    expect(error).toMatch(/invite_phone_e164/);
+    await reset();
+  });
+});
+
+describe('the same person must not become two members', () => {
+  it('returns the existing member when the email is already there', async () => {
+    const groupId = await seedGroup();
+    const first = await add(groupId, 'Ravi', 'ravi@example.com');
+    const again = await add(groupId, 'Ravi Kumar', 'ravi@example.com');
+
+    expect(again.id).toBe(first.id);
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM group_members WHERE group_id = $1 AND ghost_name IS NOT NULL`,
+      [groupId],
+    );
+    expect(rows[0].n).toBe(1);
+    await reset();
+  });
+
+  it('matches through a differently-typed address', async () => {
+    const groupId = await seedGroup();
+    const first = await add(groupId, 'Ravi', 'ravi@example.com');
+    const again = await add(groupId, 'Ravi', ' RAVI@Example.com ');
+    expect(again.id).toBe(first.id);
+    await reset();
+  });
+
+  it('matches through a differently-typed number', async () => {
+    const groupId = await seedGroup();
+    const first = await add(groupId, 'Ravi', null, '+919876543210');
+    const again = await add(groupId, 'Ravi', null, '+91 98765-43210');
+    expect(again.id).toBe(first.id);
+    await reset();
+  });
+
+  it('still allows two different people with the same name', async () => {
+    // Matched on contact, not name — two people really are called Ravi.
+    const groupId = await seedGroup();
+    const first = await add(groupId, 'Ravi', 'ravi.k@example.com');
+    const second = await add(groupId, 'Ravi', 'ravi.s@example.com');
+    expect(second.id).not.toBe(first.id);
+    await reset();
+  });
+});
+
+describe('who may add', () => {
+  it('refuses somebody who is not in the group', async () => {
+    const groupId = await seedGroup();
+    await reset();
+
+    const outsider = randomUUID();
+    await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Nobody')`, [outsider]);
+    await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+      JSON.stringify({ sub: outsider, role: 'authenticated' }),
+    ]);
+    await client.query(`SET ROLE authenticated`);
+
+    const { error } = await add(groupId, 'Ravi', 'ravi@example.com');
+    expect(error).toMatch(/NOT_A_MEMBER/);
+    await reset();
+  });
+
+  it('refuses an entry with nothing in it at all', async () => {
+    const groupId = await seedGroup();
+    const { error } = await add(groupId, '   ', '', '');
+    expect(error).toMatch(/NOTHING_TO_ADD/);
+    await reset();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       expo-constants:
         specifier: 57.0.9
         version: 57.0.9(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(supports-color@8.1.1)
+      expo-contacts:
+        specifier: ~57.0.3
+        version: 57.0.3(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       expo-crypto:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.10)
@@ -2830,6 +2833,13 @@ packages:
     resolution: {integrity: sha512-Y47sGiF+U8fwicUSPdJPjB27PuU+FgLK4Mpai0ksZF5hv8jNN3HBqKuDNxsiu70uHBKf80TaR4gwMPh0pmETiQ==}
     peerDependencies:
       expo: '*'
+      react-native: '*'
+
+  expo-contacts@57.0.3:
+    resolution: {integrity: sha512-DWxx4XQoT0X+7QvYBaL7js2xcV7nBFoh/ECKVWPoanH82Epyz7dyPFq1Arm4KIHai2SAB6eeiT6z1ivuK7/Ezg==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
       react-native: '*'
 
   expo-crypto@57.0.1:
@@ -8020,6 +8030,12 @@ snapshots:
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  expo-contacts@57.0.3(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+    dependencies:
+      expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
   expo-crypto@57.0.1(expo@57.0.10):
     dependencies:


### PR DESCRIPTION
Two ways to add someone: type an email or number, or pick from the phone's contacts.

## The address book never leaves the device

Contacts are read, searched and displayed locally. Only the person you tap is sent anywhere, and only as the name and address needed to invite them.

That is deliberate. The usual version of this feature uploads the whole book to find *"who else already uses Baaki"* — which turns an address book into a **membership oracle**, telling the server (and anyone who later reaches the server) which of your contacts use the app. There is no such endpoint here, and the schema deliberately cannot answer that question. An invite link works whether or not the person has ever heard of us (ADR-006).

The picker also asks for three fields only — name, first email, first number. Asking for less than the platform offers is the cheapest privacy measure available.

## Normalisation belongs to the database

Not the client: the offline queue means an old build's idea of what an email looks like can arrive months late (ADR-005). The same person typed two ways must not become **two ghosts holding two halves of a balance**, so adding an existing contact returns the member already there — matched on contact, not name, because two people really are called Ravi.

A number with no country code is **refused, not assumed Indian**. Somebody on a trip is exactly the person whose contacts are foreign, and guessing `+91` would silently invite a stranger.

## A regression this introduced, and the fix

The contact parameters were first written as a separate function — which created a **second overload** of `baaki_add_ghost_member`. A three-argument call meaning `(group, name, member_id)` then resolved to `(group, name, email)` and tried to store a uuid as an address.

The M2 suite caught it. This is the **fourth** time this trap has been hit in this project, so it is now written into the migration: parameters go onto the existing signature, never onto a fresh function. Offline replay idempotency is preserved.

## Verification

13 new tests, 91 db tests pass, drift clean, typecheck/lint/format clean, and a full web export — `expo-contacts` is a native module and this project has been bitten by web bundling before.

## Not in this PR

Actually *sending* the invite by email needs Resend, which is M4. Today the address is stored and the existing share sheet sends the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6