### PR TITLE
feat: a People tab — who owes you, and who you owe

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -15,6 +15,11 @@ export default function TabsLayout() {
       icon: (color) => <Ionicons name="home" size={20} color={color} />,
     },
     {
+      key: 'people',
+      label: 'People',
+      icon: (color) => <Ionicons name="people" size={20} color={color} />,
+    },
+    {
       key: 'activity',
       label: t.activity,
       icon: (color) => <Ionicons name="pulse" size={20} color={color} />,
@@ -38,6 +43,7 @@ export default function TabsLayout() {
       )}
     >
       <Tabs.Screen name="index" />
+      <Tabs.Screen name="people" />
       <Tabs.Screen name="activity" />
       <Tabs.Screen name="profile" />
     </Tabs>

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -719,3 +719,32 @@ export async function fetchFxRate(from: string, to: string): Promise<FxRecord> {
   if (error) throw new Error(await readFunctionError(error));
   return data as FxRecord;
 }
+
+// ────────────────────────────────────── people you owe / who owe you ──
+
+export interface PersonBalanceRow {
+  person_key: string;
+  profile_id: string | null;
+  member_id: string;
+  display_name: string;
+  avatar_url: string | null;
+  is_ghost: boolean;
+  currency: string;
+  /** Positive: they owe you. Negative: you owe them. Minor units. */
+  net: string;
+  group_count: number;
+  only_group_id: string | null;
+}
+
+/**
+ * Every person you are not square with, across every group.
+ *
+ * One row per person *per currency* — a single total would need a rate nobody
+ * chose (ADR-003) — and ghosts are never merged across groups, because a name
+ * is not proof that two records are one human.
+ */
+export async function fetchPeopleBalances(): Promise<PersonBalanceRow[]> {
+  const { data, error } = await supabase.rpc('baaki_people_i_owe');
+  if (error) throw new Error(error.message);
+  return (data ?? []) as PersonBalanceRow[];
+}

--- a/packages/db/prisma/migrations/20260806140000_people_you_owe/migration.sql
+++ b/packages/db/prisma/migrations/20260806140000_people_you_owe/migration.sql
@@ -1,0 +1,94 @@
+-- "Who do I owe, and who owes me" — across every group (TDR §5).
+--
+-- Two things this deliberately does not do, both because doing them would
+-- produce a confident wrong number.
+--
+-- It does not sum across currencies. A person can owe you ₹500 and be owed €20;
+-- there is no honest single total without a rate, and inventing one here would
+-- put an unreproducible conversion in front of somebody as if it were a fact
+-- (ADR-003). Each currency is its own row.
+--
+-- It does not merge ghosts across groups. A ghost called "Ravi" in your Goa
+-- group and a ghost called "Ravi" in your flat group are two records with no
+-- evidence they are one human — matching them on name would silently merge two
+-- people's debts, and un-merging afterwards is not possible. Only members with
+-- a profile are identified across groups, because a profile id is proof.
+-- A ghost therefore appears once per group, which is also the truth about what
+-- is known.
+
+CREATE OR REPLACE FUNCTION public.baaki_people_i_owe()
+RETURNS TABLE (
+  /** Stable key: the profile id for a real person, else the member id. */
+  person_key      text,
+  profile_id      uuid,
+  member_id       uuid,
+  display_name    text,
+  avatar_url      text,
+  is_ghost        boolean,
+  currency        char(3),
+  /** Positive: they owe you. Negative: you owe them. */
+  net             bigint,
+  group_count     int,
+  /** Only set when this person is known in exactly one group, so the UI can link there. */
+  only_group_id   uuid
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+  WITH me AS (
+    SELECT gm.id AS member_id, gm.group_id
+      FROM public.group_members gm
+     WHERE gm.profile_id = public.baaki_current_profile_id()
+       AND gm.left_at IS NULL
+  ),
+  -- Both directions, normalised so a row always reads "what this counterparty
+  -- is to me". RLS on pairwise_balances already limits this to my groups.
+  edges AS (
+    SELECT pb.group_id, pb.to_member_id AS other_member_id, pb.currency, -pb.amount AS net
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.from_member_id
+    UNION ALL
+    SELECT pb.group_id, pb.from_member_id, pb.currency, pb.amount
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.to_member_id
+  ),
+  named AS (
+    SELECT
+      e.group_id,
+      e.currency,
+      e.net,
+      gm.id            AS member_id,
+      gm.profile_id,
+      -- A profile id is proof of one human; a ghost name is not, so a ghost
+      -- stays keyed to its own group.
+      COALESCE(gm.profile_id::text, gm.id::text) AS person_key,
+      COALESCE(p.display_name, gm.ghost_name, 'Someone') AS display_name,
+      p.avatar_url,
+      gm.profile_id IS NULL AS is_ghost
+    FROM edges e
+    JOIN public.group_members gm ON gm.id = e.other_member_id
+    LEFT JOIN public.profiles p ON p.id = gm.profile_id
+  )
+  SELECT
+    n.person_key,
+    max(n.profile_id::text)::uuid                       AS profile_id,
+    max(n.member_id::text)::uuid                        AS member_id,
+    max(n.display_name)                                 AS display_name,
+    max(n.avatar_url)                                   AS avatar_url,
+    bool_and(n.is_ghost)                                AS is_ghost,
+    n.currency,
+    sum(n.net)::bigint                                  AS net,
+    count(DISTINCT n.group_id)::int                     AS group_count,
+    CASE WHEN count(DISTINCT n.group_id) = 1
+         THEN max(n.group_id::text)::uuid END           AS only_group_id
+  FROM named n
+  GROUP BY n.person_key, n.currency
+  -- Settled up is not a debt. Showing a row of zero would make a list of
+  -- everybody you have ever split with, which is not the question being asked.
+  HAVING sum(n.net) <> 0
+  ORDER BY abs(sum(n.net)) DESC, max(n.display_name);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_people_i_owe() TO authenticated, anon;

--- a/packages/db/test/people.test.ts
+++ b/packages/db/test/people.test.ts
@@ -1,0 +1,266 @@
+/**
+ * "Who do I owe, and who owes me" across every group.
+ *
+ * The three things worth pinning are all cases where a plausible wrong number
+ * would otherwise reach somebody:
+ *
+ *   - the same person across two groups must add up to one figure;
+ *   - two ghosts with the same name must NOT, because nothing proves they are
+ *     one human and merging debts is not reversible;
+ *   - currencies must never be summed together.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+async function profile(name: string): Promise<string> {
+  const id = randomUUID();
+  await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, $2)`, [id, name]);
+  return id;
+}
+
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+async function makeGroup(owner: string, currency = 'INR'): Promise<string> {
+  return asUser(owner, async () => {
+    const { rows } = await client.query(
+      `SELECT baaki_create_group('Trip', 'trip', $1, NULL, false, NULL, NULL) AS id`,
+      [currency],
+    );
+    return String(rows[0].id);
+  });
+}
+
+async function addGhost(owner: string, groupId: string, name: string): Promise<string> {
+  return asUser(owner, async () => {
+    const { rows } = await client.query(`SELECT baaki_add_ghost_member($1::uuid, $2::text) AS id`, [
+      groupId,
+      name,
+    ]);
+    return String(rows[0].id);
+  });
+}
+
+async function myMember(groupId: string, profileId: string): Promise<string> {
+  const { rows } = await client.query(
+    `SELECT id FROM group_members WHERE group_id = $1 AND profile_id = $2`,
+    [groupId, profileId],
+  );
+  return String(rows[0].id);
+}
+
+/** An expense the caller paid, split equally with one other member. */
+async function expense(
+  owner: string,
+  groupId: string,
+  payer: string,
+  other: string,
+  amount: bigint,
+  currency = 'INR',
+): Promise<void> {
+  const half = amount / 2n;
+  await asUser(owner, () =>
+    client.query(
+      `SELECT baaki_apply_expense($1::uuid, $2::uuid, $3::uuid, 'Dinner', NULL::text,
+                                  '2026-08-06'::date, $4::char(3), $5::bigint,
+                                  'equal'::text, '{"kind":"equal"}'::jsonb,
+                                  $6::jsonb, $7::jsonb, $8::uuid)`,
+      [
+        groupId,
+        randomUUID(),
+        payer,
+        currency,
+        amount.toString(),
+        JSON.stringify([{ memberId: payer, amount: amount.toString() }]),
+        JSON.stringify([
+          { memberId: payer, amount: half.toString() },
+          { memberId: other, amount: (amount - half).toString() },
+        ]),
+        randomUUID(),
+      ],
+    ),
+  );
+}
+
+async function people(profileId: string) {
+  return asUser(profileId, async () => {
+    const { rows } = await client.query(`SELECT * FROM baaki_people_i_owe()`);
+    return rows;
+  });
+}
+
+describe('one person, several groups', () => {
+  it('adds the same person up across groups', async () => {
+    const asha = await profile('Asha');
+    const ravi = await profile('Ravi');
+
+    // Ravi is a real member of both groups, so his profile identifies him.
+    for (const _ of [1, 2]) {
+      void _;
+    }
+    const groupA = await makeGroup(asha);
+    const groupB = await makeGroup(asha);
+    for (const groupId of [groupA, groupB]) {
+      await client.query(
+        `INSERT INTO group_members (group_id, profile_id, joined_via) VALUES ($1, $2, 'invite_link')`,
+        [groupId, ravi],
+      );
+    }
+
+    const ashaA = await myMember(groupA, asha);
+    const raviA = await myMember(groupA, ravi);
+    const ashaB = await myMember(groupB, asha);
+    const raviB = await myMember(groupB, ravi);
+
+    await expense(asha, groupA, ashaA, raviA, 100000n); // Ravi owes 500
+    await expense(asha, groupB, ashaB, raviB, 40000n); //  Ravi owes 200
+
+    const rows = await people(asha);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].display_name).toBe('Ravi');
+    expect(BigInt(rows[0].net)).toBe(70000n);
+    expect(rows[0].group_count).toBe(2);
+    // Two groups, so there is no single group to link to.
+    expect(rows[0].only_group_id).toBeNull();
+  });
+
+  it('says which group when there is only one', async () => {
+    const asha = await profile('Asha');
+    const groupId = await makeGroup(asha);
+    const ghost = await addGhost(asha, groupId, 'Ravi');
+    await expense(asha, groupId, await myMember(groupId, asha), ghost, 100000n);
+
+    const rows = await people(asha);
+    expect(rows[0].group_count).toBe(1);
+    expect(rows[0].only_group_id).toBe(groupId);
+  });
+});
+
+describe('ghosts are not merged across groups', () => {
+  it('keeps two same-named ghosts apart', async () => {
+    // Nothing proves the Ravi in one group is the Ravi in another, and merging
+    // two people's debts cannot be undone afterwards.
+    const asha = await profile('Asha');
+    const groupA = await makeGroup(asha);
+    const groupB = await makeGroup(asha);
+
+    const raviA = await addGhost(asha, groupA, 'Ravi');
+    const raviB = await addGhost(asha, groupB, 'Ravi');
+
+    await expense(asha, groupA, await myMember(groupA, asha), raviA, 100000n);
+    await expense(asha, groupB, await myMember(groupB, asha), raviB, 40000n);
+
+    const rows = await people(asha);
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.is_ghost)).toBe(true);
+    expect(rows.map((row) => BigInt(row.net)).sort()).toEqual([20000n, 50000n]);
+  });
+});
+
+describe('currencies stay apart', () => {
+  it('never sums two currencies into one number', async () => {
+    const asha = await profile('Asha');
+    const ravi = await profile('Ravi');
+    const groupA = await makeGroup(asha, 'INR');
+    const groupB = await makeGroup(asha, 'EUR');
+    for (const groupId of [groupA, groupB]) {
+      await client.query(
+        `INSERT INTO group_members (group_id, profile_id, joined_via) VALUES ($1, $2, 'invite_link')`,
+        [groupId, ravi],
+      );
+    }
+
+    await expense(
+      asha,
+      groupA,
+      await myMember(groupA, asha),
+      await myMember(groupA, ravi),
+      100000n,
+    );
+    await expense(
+      asha,
+      groupB,
+      await myMember(groupB, asha),
+      await myMember(groupB, ravi),
+      4000n,
+      'EUR',
+    );
+
+    const rows = await people(asha);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.currency).sort()).toEqual(['EUR', 'INR']);
+    // One person, two rows — a single total would need a rate that nobody chose.
+    expect(new Set(rows.map((row) => row.person_key)).size).toBe(1);
+  });
+});
+
+describe('what is left out', () => {
+  it('omits anybody who is settled up', async () => {
+    // A row of zero would turn this into a list of everybody you have ever
+    // split with, which is not the question being asked.
+    const asha = await profile('Asha');
+    const groupId = await makeGroup(asha);
+    const ghost = await addGhost(asha, groupId, 'Ravi');
+    const ashaMember = await myMember(groupId, asha);
+
+    await expense(asha, groupId, ashaMember, ghost, 100000n);
+    await expense(asha, groupId, ghost, ashaMember, 100000n);
+
+    expect(await people(asha)).toHaveLength(0);
+  });
+
+  it('shows nothing to somebody in no groups', async () => {
+    const stranger = await profile('Nobody');
+    expect(await people(stranger)).toHaveLength(0);
+  });
+
+  it('never leaks a group the caller is not in', async () => {
+    const asha = await profile('Asha');
+    const stranger = await profile('Nobody');
+    const groupId = await makeGroup(asha);
+    const ghost = await addGhost(asha, groupId, 'Ravi');
+    await expense(asha, groupId, await myMember(groupId, asha), ghost, 100000n);
+
+    expect(await people(stranger)).toHaveLength(0);
+  });
+});
+
+describe('direction', () => {
+  it('reports a debt you owe as negative', async () => {
+    const asha = await profile('Asha');
+    const groupId = await makeGroup(asha);
+    const ghost = await addGhost(asha, groupId, 'Ravi');
+    const ashaMember = await myMember(groupId, asha);
+
+    // Ravi paid; Asha owes half.
+    await expense(asha, groupId, ghost, ashaMember, 100000n);
+
+    const rows = await people(asha);
+    expect(BigInt(rows[0].net)).toBe(-50000n);
+  });
+});


### PR DESCRIPTION
Aggregates pairwise balances across every group into one list per person, split into **Owes you** and **You owe**.

## Two things it deliberately will not do

**It never adds two currencies together.** Somebody can owe you ₹500 and be owed €20. There is no honest single figure without a rate, and inventing one would show an unreproducible conversion as if it were a fact (ADR-003). They appear as two lines.

**It never merges two ghosts with the same name.** Nothing proves the Ravi in your Goa group is the Ravi in your flat group — and merging two people's debts is not something you can undo once done. Only members with a profile are followed across groups, because a profile id is proof and a name is not. A ghost is counted per group, which is also the truth about what is known.

Both are visible in the UI rather than hidden: a ghost carries a "Not joined" badge, and the footnote says amounts are per-currency.

## Smaller decisions

- **Settled-up people are omitted.** A row of zero would turn this into a list of everybody you have ever split with — not the question being asked.
- **A row links to its group only when there is exactly one.** Otherwise the amount is a sum and no single group explains it, so tapping through would show a number that doesn't match.
- Sorted by size of debt, so the ones that matter are at the top.

## Verification

8 new tests, covering both refusals, the direction of a debt (negative = you owe), and that a non-member sees nothing. 182 core + 86 db pass; drift clean; typecheck, lint, format clean; web export includes the route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6