### PR TITLE
Say who did what in a group's activity feed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,22 @@ jobs:
       # every net position, FX is reproducible.
       - run: pnpm test:core
 
+  app:
+    name: what the app tells people
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # The pure modules behind the screens — the activity feed's wording, and
+      # anything else that decides what a person is told about their money.
+      # Rendering is covered by the Maestro flows in e2e/, not here.
+      - run: pnpm test:app
+
   database:
     name: migrations, RLS policies and ledger invariants
     runs-on: ubuntu-latest

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -52,7 +52,8 @@
     "@types/react": "~19.2.2",
     "eslint": "^9.39.5",
     "eslint-config-expo": "~57.0.1",
-    "typescript": "~6.0.3"
+    "typescript": "~6.0.3",
+    "vitest": "^3.2.4"
   },
   "scripts": {
     "start": "expo start",
@@ -65,7 +66,9 @@
     "build:dev": "eas build --profile development --platform android",
     "build:preview": "eas build --profile preview --platform android",
     "build:prod": "eas build --profile production --platform all",
-    "build:local": "eas build --profile preview --platform android --local"
+    "build:local": "eas build --profile preview --platform android --local",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "private": true,
   "expo": {

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -14,8 +14,8 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { describeActivity } from '@/data/activity';
 import { fetchRecentActivity } from '@/data/api';
-import { actorName, type ActivityActor } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
@@ -77,7 +77,7 @@ export default function ActivityScreen() {
                 {dayEntries.map((entry, index) => (
                   <View key={entry.id}>
                     <ListRow
-                      title={describe(entry.verb, entry.object_type, entry.payload, entry.actor, myProfileId)}
+                      title={describeActivity(entry, myProfileId)}
                       subtitle={`${entry.group?.name ?? 'Group'} · ${new Intl.DateTimeFormat(
                         locale,
                         {
@@ -116,53 +116,4 @@ export default function ActivityScreen() {
       </ScrollView>
     </Screen>
   );
-}
-
-/**
- * One line saying who did what.
- *
- * The actor is the point. On a shared ledger "Dinner was edited" is not an
- * answer to anything — "Ravi edited Dinner" is. Written from this reader's
- * point of view, so their own actions read as "You".
- */
-function describe(
-  verb: string,
-  objectType: string,
-  payload: Record<string, unknown>,
-  actor: ActivityActor | null | undefined,
-  myProfileId: string | null,
-): string {
-  const description = typeof payload.description === 'string' ? payload.description : null;
-  const who = actorName(actor, myProfileId);
-
-  switch (verb) {
-    case 'added':
-      return `${who} added ${description ?? 'an expense'}`;
-    case 'edited':
-      return `${who} edited ${description ?? 'an expense'}`;
-    case 'deleted':
-      return `${who} deleted ${description ?? 'an expense'}`;
-    case 'restored':
-      return `${who} restored ${description ?? 'an expense'}`;
-    case 'superseded': {
-      // The conflict entry from offline sync (ADR-005). Both edits survive in
-      // expense_versions; this row exists so the person whose edit lost can
-      // find it and put it back. Saying "superseded expense" told them nothing.
-      const replaced =
-        typeof payload.supersededDescription === 'string' ? payload.supersededDescription : null;
-      return replaced
-        ? `${who}'s edit replaced an earlier one — "${replaced}" is still in the history`
-        : `${who}'s edit replaced an earlier one`;
-    }
-    case 'settled':
-      return `${who} recorded a settlement`;
-    case 'confirmed':
-      return `${who} confirmed a settlement`;
-    case 'joined':
-      return `${who} joined`;
-    case 'created':
-      return `${who} created the group`;
-    default:
-      return `${who} ${verb} ${objectType}`;
-  }
 }

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -27,7 +27,8 @@ import {
   useGroupLedger,
   useGroupRealtime,
 } from '@/data/hooks';
-import { displayName, groupLabel, isGhost } from '@/data/types';
+import { describeActivity, verbEmoji } from '@/data/activity';
+import { actorName, displayName, groupLabel, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { GroupPhoto } from '@/components/GroupPhoto';
@@ -319,14 +320,20 @@ export default function GroupScreen() {
               {(activity.data ?? []).map((entry, index) => (
                 <View key={entry.id}>
                   <ListRow
-                    title={`${nameOf(entry.actor_member_id)} ${entry.verb} ${entry.object_type}`}
+                    title={describeActivity(entry, profile?.id ?? null)}
                     subtitle={new Intl.DateTimeFormat(locale, {
                       day: 'numeric',
                       month: 'short',
                       hour: 'numeric',
                       minute: '2-digit',
                     }).format(new Date(entry.created_at))}
-                    leading={<Avatar name={entry.verb} emoji={verbEmoji(entry.verb)} size={38} />}
+                    leading={
+                      <Avatar
+                        name={actorName(entry.actor, profile?.id ?? null)}
+                        emoji={verbEmoji(entry.verb)}
+                        size={38}
+                      />
+                    }
                     trailing={
                       typeof entry.payload.amount === 'string' ? (
                         <MoneyText
@@ -355,25 +362,4 @@ export default function GroupScreen() {
       />
     </Screen>
   );
-}
-
-function verbEmoji(verb: string): string {
-  switch (verb) {
-    case 'added':
-      return '🧾';
-    case 'edited':
-      return '✏️';
-    case 'deleted':
-      return '🗑️';
-    case 'restored':
-      return '↩️';
-    case 'settled':
-      return '💸';
-    case 'confirmed':
-      return '✅';
-    case 'created':
-      return '✨';
-    default:
-      return '•';
-  }
 }

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -1,0 +1,80 @@
+/**
+ * Turning an activity row into a sentence.
+ *
+ * This lives outside both feed screens because there are two of them — the
+ * cross-group tab and the tab on a group — and a feed that words the same
+ * event two different ways is a feed people stop trusting. It was already
+ * wrong once: the group tab rendered `verb` and `object_type` raw, so an
+ * offline-sync conflict read "Ravi superseded expense_version", which names
+ * a table rather than telling the person their edit was replaced.
+ *
+ * The actor is the point of the whole thing. On a shared ledger "Dinner was
+ * edited" answers nothing — "Ravi edited Dinner" does. Written from the
+ * reader's point of view, so their own actions read as "You".
+ */
+
+import { actorName, type ActivityRow } from './types';
+
+export function describeActivity(entry: ActivityRow, myProfileId: string | null): string {
+  const { payload } = entry;
+  const description = typeof payload.description === 'string' ? payload.description : null;
+  const who = actorName(entry.actor, myProfileId);
+
+  switch (entry.verb) {
+    case 'added':
+      return `${who} added ${description ?? 'an expense'}`;
+    case 'edited':
+      return `${who} edited ${description ?? 'an expense'}`;
+    case 'deleted':
+      return `${who} deleted ${description ?? 'an expense'}`;
+    case 'restored':
+      return `${who} restored ${description ?? 'an expense'}`;
+    case 'superseded': {
+      // The conflict entry from offline sync (ADR-005). Both edits survive in
+      // expense_versions; this row exists so the person whose edit lost can
+      // find it and put it back. Saying "superseded expense" told them nothing.
+      const replaced =
+        typeof payload.supersededDescription === 'string' ? payload.supersededDescription : null;
+      return replaced
+        ? `${who}'s edit replaced an earlier one — "${replaced}" is still in the history`
+        : `${who}'s edit replaced an earlier one`;
+    }
+    case 'settled':
+      return `${who} recorded a settlement`;
+    case 'confirmed':
+      return `${who} confirmed a settlement`;
+    case 'joined':
+      return `${who} joined`;
+    case 'created':
+      return `${who} created the group`;
+    default:
+      // An unknown verb is a row written by a newer build than this one. Say
+      // what is known rather than dropping it — a feed with holes in it is
+      // worse than a feed with one clumsy line.
+      return `${who} ${entry.verb} ${entry.object_type}`;
+  }
+}
+
+export function verbEmoji(verb: string): string {
+  switch (verb) {
+    case 'added':
+      return '🧾';
+    case 'edited':
+    case 'superseded':
+      return '✏️';
+    case 'deleted':
+      return '🗑️';
+    case 'restored':
+      return '↩️';
+    case 'settled':
+      return '💸';
+    case 'confirmed':
+      return '✅';
+    case 'joined':
+      return '👋';
+    case 'created':
+      return '✨';
+    default:
+      return '•';
+  }
+}

--- a/apps/mobile/test/activity.test.ts
+++ b/apps/mobile/test/activity.test.ts
@@ -1,0 +1,160 @@
+/**
+ * The wording of the activity feed.
+ *
+ * This exists because the feed drifted once already: two screens each carried
+ * their own copy of this logic, one was fixed and the other was not, and the
+ * group tab went on rendering "Ravi superseded expense_version" — a table name
+ * shown to somebody whose edit had just been thrown away. There is now one
+ * function, and these tests are what keeps it one.
+ *
+ * The cases worth pinning are the ones where a plausible-looking line tells
+ * the reader something untrue or useless: an unattributed action, somebody
+ * else's name on your own action, and the sync-conflict entry.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { describeActivity, verbEmoji } from '@/data/activity';
+import type { ActivityActor, ActivityRow } from '@/data/types';
+
+const RAVI: ActivityActor = {
+  id: 'member-ravi',
+  profile_id: 'profile-ravi',
+  ghost_name: null,
+  profile: { display_name: 'Ravi' },
+};
+
+const ME: ActivityActor = {
+  id: 'member-asha',
+  profile_id: 'profile-asha',
+  ghost_name: null,
+  profile: { display_name: 'Asha' },
+};
+
+function row(over: Partial<ActivityRow> = {}): ActivityRow {
+  return {
+    id: 'activity-1',
+    group_id: 'group-1',
+    actor_member_id: RAVI.id,
+    actor: RAVI,
+    verb: 'added',
+    object_type: 'expense',
+    object_id: 'expense-1',
+    payload: {},
+    created_at: '2026-08-06T10:00:00.000Z',
+    ...over,
+  };
+}
+
+describe('who did it', () => {
+  it('names the person', () => {
+    expect(describeActivity(row({ payload: { description: 'Dinner' } }), 'profile-asha')).toBe(
+      'Ravi added Dinner',
+    );
+  });
+
+  it('says "You" for the reader, not their own name', () => {
+    expect(
+      describeActivity(row({ actor: ME, payload: { description: 'Dinner' } }), 'profile-asha'),
+    ).toBe('You added Dinner');
+  });
+
+  it('says "You" only to the person who did it', () => {
+    expect(
+      describeActivity(row({ actor: ME, payload: { description: 'Dinner' } }), 'profile-ravi'),
+    ).toBe('Asha added Dinner');
+  });
+
+  it('falls back to a ghost name for somebody without an account', () => {
+    const ghost: ActivityActor = {
+      id: 'member-ghost',
+      profile_id: null,
+      ghost_name: 'Priya',
+      profile: null,
+    };
+    expect(describeActivity(row({ actor: ghost }), 'profile-asha')).toBe('Priya added an expense');
+  });
+
+  it('still says something when the actor cannot be read', () => {
+    // A row whose actor is gone is still an event that happened; dropping it
+    // would leave a hole in a ledger's history.
+    expect(describeActivity(row({ actor: null, actor_member_id: null }), 'profile-asha')).toBe(
+      'Someone added an expense',
+    );
+  });
+
+  it('does not claim an anonymous row is the reader', () => {
+    expect(describeActivity(row({ actor: null }), null)).toBe('Someone added an expense');
+  });
+});
+
+describe('what happened', () => {
+  it.each([
+    ['added', 'Ravi added Dinner'],
+    ['edited', 'Ravi edited Dinner'],
+    ['deleted', 'Ravi deleted Dinner'],
+    ['restored', 'Ravi restored Dinner'],
+  ])('%s', (verb, expected) => {
+    expect(describeActivity(row({ verb, payload: { description: 'Dinner' } }), 'me')).toBe(
+      expected,
+    );
+  });
+
+  it('falls back when the payload carries no description', () => {
+    expect(describeActivity(row({ verb: 'edited' }), 'me')).toBe('Ravi edited an expense');
+  });
+
+  it('explains a sync conflict instead of naming a table', () => {
+    // ADR-005: both edits survive in expense_versions. This line is how the
+    // person whose edit lost finds out it is recoverable.
+    const line = describeActivity(
+      row({ verb: 'superseded', object_type: 'expense_version', payload: {} }),
+      'me',
+    );
+    expect(line).toBe("Ravi's edit replaced an earlier one");
+    expect(line).not.toContain('expense_version');
+  });
+
+  it('names the edit that was replaced when the payload has it', () => {
+    expect(
+      describeActivity(
+        row({ verb: 'superseded', payload: { supersededDescription: 'Dinner' } }),
+        'me',
+      ),
+    ).toBe('Ravi\'s edit replaced an earlier one — "Dinner" is still in the history');
+  });
+
+  it.each([
+    ['settled', 'Ravi recorded a settlement'],
+    ['confirmed', 'Ravi confirmed a settlement'],
+    ['joined', 'Ravi joined'],
+    ['created', 'Ravi created the group'],
+  ])('%s', (verb, expected) => {
+    expect(describeActivity(row({ verb }), 'me')).toBe(expected);
+  });
+
+  it('shows a verb it does not know rather than nothing', () => {
+    // Written by a newer build than this one — an offline queue can replay
+    // months late (ADR-005), so this is reachable in a released app.
+    expect(describeActivity(row({ verb: 'archived', object_type: 'group' }), 'me')).toBe(
+      'Ravi archived group',
+    );
+  });
+
+  it('ignores a description that is not a string', () => {
+    expect(describeActivity(row({ payload: { description: 42 } }), 'me')).toBe(
+      'Ravi added an expense',
+    );
+  });
+});
+
+describe('the icon', () => {
+  it('gives an edit and its conflict the same mark', () => {
+    // A superseded row IS an edit; two icons for one thing reads as two events.
+    expect(verbEmoji('superseded')).toBe(verbEmoji('edited'));
+  });
+
+  it('has something for a verb it has never seen', () => {
+    expect(verbEmoji('archived')).toBe('•');
+  });
+});

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Only the pure modules under src/data are tested here — no React Native, no
+ * Metro, no native modules. Anything that renders belongs in the Maestro flows
+ * under e2e/ instead; standing up a React Native test renderer to assert on a
+ * string would cost more than it caught.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['test/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "pnpm -r --if-present run test",
     "test:core": "pnpm --filter @baaki/core run test",
     "test:db": "pnpm --filter @baaki/db run test",
+    "test:app": "pnpm --filter @baaki/mobile run test",
     "db:generate": "pnpm --filter @baaki/db run generate",
     "db:migrate": "pnpm --filter @baaki/db run migrate:deploy",
     "db:migrate:dev": "pnpm --filter @baaki/db run migrate:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
 
   e2e:
     dependencies:


### PR DESCRIPTION
The activity tab on a group screen rendered `verb` and `object_type` raw. An offline-sync conflict (ADR-005) read:

> Ravi superseded expense_version

which names a table to somebody whose edit was just discarded, and doesn't tell them the earlier version is still in the history and recoverable.

The cross-group Activity tab already worded these properly — it carried its own copy of the logic, which is exactly why fixing one left the other wrong. Both feeds now call a single `describeActivity()` in `src/data/activity.ts`.

## Also fixed

The group tab attributed rows through the member lookup, which returns `Someone` for anybody who has left the group. It now uses the actor join that `fetchActivity` was already selecting, so a departed member's actions keep their name. The row avatar showed the verb string as its fallback initial; it shows the actor.

## Tests

`apps/mobile` had no test runner. It has one now — vitest over the pure modules under `src/data` only, no React Native and no renderer, since standing one up to assert on a string would cost more than it caught. Rendering stays covered by the Maestro flows in `e2e/`.

21 tests: who is named, `You` shown only to the person who acted, ghost fallback, unreadable actor, the sync-conflict line, and an unknown verb from a newer build replaying off a months-old offline queue.

Verified the suite bites: broke the attribution, watched `says "You" for the reader` fail, reverted.

New CI job `app` runs `pnpm test:app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)