### PR TITLE
Import screens: bank messages and Splitwise exports

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "expo-crypto": "~57.0.1",
     "expo-dev-client": "~57.0.10",
     "expo-device": "~57.0.1",
+    "expo-document-picker": "~57.0.1",
     "expo-file-system": "~57.0.1",
     "expo-font": "~57.0.1",
     "expo-glass-effect": "~57.0.1",

--- a/apps/mobile/src/app/group/[id]/import/csv.tsx
+++ b/apps/mobile/src/app/group/[id]/import/csv.tsx
@@ -1,0 +1,343 @@
+/**
+ * A Splitwise export into this group.
+ *
+ * The work here is the mapping, not the parsing. A CSV names people as text;
+ * a group has member ids, and getting that wrong does not fail loudly — it
+ * puts somebody else's share on your name and the numbers still add up. So no
+ * name is matched automatically unless it is exactly a member's name, nothing
+ * is imported until every column has a person against it, and a name with
+ * nobody chosen refuses rather than being dropped.
+ *
+ * The other half is what is *not* imported. `importSplitwiseCsv` names every
+ * row it could not read — a row whose columns do not sum to zero is skipped
+ * rather than adjusted into shape, because adjusting it would silently move
+ * money. Those rows are shown here, by number, so they can be added by hand.
+ */
+
+import { useMemo, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
+import { randomUUID } from 'expo-crypto';
+
+import {
+  Badge,
+  Button,
+  Card,
+  Chip,
+  IconButton,
+  ListRow,
+  MoneyText,
+  Row,
+  Screen,
+  SectionHeader,
+  Text,
+  useTheme,
+} from '@baaki/ui';
+
+import { importSplitwiseCsv, type MemberId, type SplitwiseImport } from '@baaki/core';
+
+import { useGroup } from '@/data/hooks';
+import { planFromCsv, toMutationPayload, UnmappedPersonError } from '@/data/importPlan';
+import { displayName } from '@/data/types';
+import { useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+import { importMutationId } from '@/lib/importId';
+import { useSync } from '@/sync/provider';
+
+/** A new person to create for a CSV column, rather than pointing it at somebody who exists. */
+const NEW_PERSON = '__new__';
+
+export default function ImportCsvScreen() {
+  const theme = useTheme();
+  const { locale } = useStrings();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const groupId = id ?? '';
+  const { profile } = useAuth();
+  const { mutate } = useSync();
+
+  const { group, members } = useGroup(groupId);
+
+  const [file, setFile] = useState<string | null>(null);
+  const [parsed, setParsed] = useState<SplitwiseImport | null>(null);
+  const [mapping, setMapping] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<number | null>(null);
+
+  const groupCurrency = group.data?.default_currency ?? 'INR';
+  const memberRows = members.data ?? [];
+
+  const pick = async (): Promise<void> => {
+    setError(null);
+    setSaved(null);
+    try {
+      const picked = await DocumentPicker.getDocumentAsync({
+        // Some file providers hand a CSV over as text/plain or as an octet
+        // stream. Refusing those would reject files that are perfectly fine.
+        type: ['text/csv', 'text/comma-separated-values', 'text/plain', 'application/octet-stream'],
+        copyToCacheDirectory: true,
+      });
+      if (picked.canceled || !picked.assets[0]) return;
+
+      const asset = picked.assets[0];
+      const contents = new FileSystem.File(asset.uri).textSync();
+      const result = importSplitwiseCsv(contents);
+
+      setFile(asset.name);
+      setParsed(result);
+      // Only an exact name match is pre-filled. A fuzzy guess here would be a
+      // guess about whose money this is.
+      setMapping(
+        Object.fromEntries(
+          result.people.flatMap((person) => {
+            const match = memberRows.find(
+              (member) =>
+                displayName(member, profile?.id).trim().toLowerCase() ===
+                person.trim().toLowerCase(),
+            );
+            return match ? [[person, match.id]] : [];
+          }),
+        ),
+      );
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const unmapped = useMemo(
+    () => (parsed?.people ?? []).filter((person) => !mapping[person]),
+    [parsed, mapping],
+  );
+
+  const currencyMatches = !parsed || parsed.currency === groupCurrency;
+  const canImport =
+    parsed !== null && parsed.expenses.length > 0 && unmapped.length === 0 && currencyMatches;
+
+  const run = async (): Promise<void> => {
+    if (!parsed) return;
+    setError(null);
+    setSaving(true);
+    try {
+      // Anybody the file names who is not in the group yet becomes a member
+      // first, with an id generated here. The id goes into the queue with the
+      // add, so the expenses that follow can name them even offline — the
+      // server keeps the id we chose rather than making its own (ADR-005).
+      const resolved: Record<string, MemberId> = {};
+      for (const person of parsed.people) {
+        const choice = mapping[person];
+        if (choice === NEW_PERSON) {
+          const memberId = randomUUID();
+          await mutate('member.add_ghost', groupId, { name: person, memberId });
+          resolved[person] = memberId;
+        } else if (choice) {
+          resolved[person] = choice;
+        }
+      }
+
+      for (const [index, expense] of parsed.expenses.entries()) {
+        const plan = planFromCsv(expense, resolved, index);
+        const expenseId = await importMutationId(groupId, `expense:${plan.seed}`);
+        const clientMutationId = await importMutationId(groupId, plan.seed);
+        await mutate(
+          'expense.create',
+          groupId,
+          toMutationPayload(plan, { expenseId }),
+          clientMutationId,
+        );
+      }
+
+      setSaved(parsed.expenses.length);
+      setParsed(null);
+      setFile(null);
+      setMapping({});
+    } catch (caught) {
+      setError(
+        caught instanceof UnmappedPersonError
+          ? `Choose who "${caught.person}" is before importing`
+          : caught instanceof Error
+            ? caught.message
+            : String(caught),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (group.isLoading || members.isLoading) {
+    return (
+      <Screen>
+        <View style={{ padding: theme.spacing.xl }}>
+          <ActivityIndicator color={theme.color.brand} />
+        </View>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen edges={['top', 'bottom']}>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label="Close" onPress={() => router.back()}>
+            <Ionicons name="close" size={22} color={theme.color.text} />
+          </IconButton>
+          <Text variant="subheading" style={{ marginLeft: theme.spacing.md }}>
+            Import a Splitwise export
+          </Text>
+        </Row>
+
+        <Card style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            In Splitwise, open the group, choose Export as spreadsheet, and pick the file here.
+          </Text>
+          <Button label={file ? `Chosen: ${file}` : 'Choose a file'} onPress={() => void pick()} />
+        </Card>
+
+        {saved !== null ? (
+          <Card>
+            <Text variant="caption">
+              {saved} expense{saved === 1 ? '' : 's'} imported. They are saved on this phone and
+              will sync when there is a connection.
+            </Text>
+          </Card>
+        ) : null}
+
+        {parsed ? (
+          <>
+            {!currencyMatches ? (
+              <Card>
+                <Text variant="caption" tone="negative">
+                  This file is in {parsed.currency} and this group keeps its money in{' '}
+                  {groupCurrency}. Importing it would need a rate for every row, and the file does
+                  not carry one — start a {parsed.currency} group for it instead.
+                </Text>
+              </Card>
+            ) : null}
+
+            <View style={{ gap: theme.spacing.sm }}>
+              <SectionHeader title="Who is who" />
+              <Card style={{ gap: theme.spacing.lg }}>
+                <Text variant="micro" tone="faint">
+                  The file names people; this group has members. Nothing is imported until every
+                  name has somebody against it.
+                </Text>
+                {parsed.people.map((person) => (
+                  <View key={person} style={{ gap: theme.spacing.xs }}>
+                    <Row style={{ justifyContent: 'space-between' }}>
+                      <Text variant="body">{person}</Text>
+                      <MoneyText
+                        amount={parsed.balances[person] ?? 0n}
+                        currency={parsed.currency}
+                        locale={locale}
+                        variant="caption"
+                        mode="balance"
+                      />
+                    </Row>
+                    <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
+                      {memberRows.map((member) => (
+                        <Chip
+                          key={member.id}
+                          label={displayName(member, profile?.id)}
+                          selected={mapping[person] === member.id}
+                          onPress={() =>
+                            setMapping((current) => ({ ...current, [person]: member.id }))
+                          }
+                        />
+                      ))}
+                      <Chip
+                        label="Add as new"
+                        selected={mapping[person] === NEW_PERSON}
+                        onPress={() =>
+                          setMapping((current) => ({ ...current, [person]: NEW_PERSON }))
+                        }
+                      />
+                    </Row>
+                  </View>
+                ))}
+              </Card>
+            </View>
+
+            <View style={{ gap: theme.spacing.sm }}>
+              <SectionHeader title={`${parsed.expenses.length} expenses`} />
+              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                {parsed.expenses.slice(0, 20).map((expense, index) => (
+                  <View key={`${expense.date}-${expense.description}-${index}`}>
+                    <ListRow
+                      title={expense.description}
+                      subtitle={expense.date}
+                      trailing={
+                        <MoneyText
+                          amount={expense.amount}
+                          currency={expense.currency}
+                          locale={locale}
+                          variant="caption"
+                        />
+                      }
+                    />
+                    {index < Math.min(parsed.expenses.length, 20) - 1 ? (
+                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                    ) : null}
+                  </View>
+                ))}
+              </Card>
+              {parsed.expenses.length > 20 ? (
+                <Text variant="micro" tone="faint">
+                  and {parsed.expenses.length - 20} more
+                </Text>
+              ) : null}
+            </View>
+
+            {parsed.problems.length > 0 ? (
+              <View style={{ gap: theme.spacing.sm }}>
+                <SectionHeader title="Rows left out" />
+                <Card style={{ gap: theme.spacing.sm }}>
+                  <Text variant="micro" tone="faint">
+                    Everything else still imports. These are named so you can add them by hand
+                    rather than discover later that they are missing.
+                  </Text>
+                  {parsed.problems.map((problem, index) => (
+                    <Row key={index} style={{ gap: theme.spacing.sm }}>
+                      <Badge label={problem.row ? `Row ${problem.row}` : 'File'} />
+                      <Text variant="micro" tone="muted" style={{ flex: 1 }}>
+                        {problem.message}
+                      </Text>
+                    </Row>
+                  ))}
+                </Card>
+              </View>
+            ) : null}
+          </>
+        ) : null}
+
+        {error ? (
+          <Text variant="caption" tone="negative">
+            {error}
+          </Text>
+        ) : null}
+
+        {parsed ? (
+          <Button
+            label={
+              saving
+                ? 'Importing…'
+                : unmapped.length > 0
+                  ? `Choose who ${unmapped.length === 1 ? unmapped[0] : `${unmapped.length} people are`}`
+                  : `Import ${parsed.expenses.length} expenses`
+            }
+            onPress={() => void run()}
+            disabled={!canImport || saving}
+          />
+        ) : null}
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/group/[id]/import/sms.tsx
+++ b/apps/mobile/src/app/group/[id]/import/sms.tsx
@@ -1,0 +1,441 @@
+/**
+ * Bank messages into expenses.
+ *
+ * The obvious version of this screen reads the inbox by itself. It cannot:
+ * iOS has no API that lets an app read SMS at all, and on Android `READ_SMS`
+ * is a restricted permission that Google Play grants only to apps that are the
+ * user's default SMS handler. Baaki is not going to be somebody's SMS app, so
+ * the honest design is the one where they hand over the messages.
+ *
+ * What is imported still goes nowhere near a server. Parsing is on-device
+ * (packages/core/src/sms) because a bank message carries an account tail, a
+ * balance, and sometimes a one-time password — sending that anywhere to be
+ * read would be a worse trade than the feature is worth (ADR-013).
+ *
+ * Nothing here writes on its own. Every candidate is confirmed by a person
+ * before it becomes an expense, which is also what makes the parser's refusals
+ * safe: when it cannot tell a payment from a reminder it drops the message,
+ * and a dropped message costs a person one manual entry rather than putting an
+ * expense nobody made into a shared ledger.
+ */
+
+import { useMemo, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+
+import {
+  Badge,
+  Button,
+  Card,
+  Chip,
+  EmptyState,
+  IconButton,
+  ListRow,
+  MoneyText,
+  Row,
+  Screen,
+  SectionHeader,
+  Text,
+  useTheme,
+} from '@baaki/ui';
+
+import { proposeFromSms, type ExpenseCandidate, type MemberId } from '@baaki/core';
+
+import { useGroup, useGroupLedger } from '@/data/hooks';
+import { planFromSms, toMutationPayload } from '@/data/importPlan';
+import { displayName } from '@/data/types';
+import { useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+import { importMutationId } from '@/lib/importId';
+import { useImported } from '@/lib/imported';
+import { useSync } from '@/sync/provider';
+
+/**
+ * Messages are separated by a blank line. A single SMS wraps over several
+ * lines of its own, so splitting on every newline would cut most of them in
+ * half — and half a message parses to either nothing or, worse, a smaller
+ * amount. The count is shown before anything is parsed so a bad paste is
+ * visible rather than silently producing two candidates from six messages.
+ */
+function splitMessages(blob: string): string[] {
+  return blob
+    .split(/\n\s*\n+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+export default function ImportSmsScreen() {
+  const theme = useTheme();
+  const { locale } = useStrings();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const groupId = id ?? '';
+  const { profile } = useAuth();
+  const { mutate } = useSync();
+
+  const { group, members, expenses } = useGroup(groupId);
+  const ledger = useGroupLedger(groupId, profile?.id ?? null);
+  const { keys: alreadyImported, remember } = useImported(groupId);
+
+  const [blob, setBlob] = useState('');
+  const [from, setFrom] = useState(() => defaultFrom(expenses.data));
+  const [to, setTo] = useState(() => today());
+  const [chosen, setChosen] = useState<Record<string, boolean>>({});
+  const [payer, setPayer] = useState<MemberId | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<number | null>(null);
+
+  const groupCurrency = group.data?.default_currency ?? 'INR';
+  const memberRows = useMemo(() => members.data ?? [], [members.data]);
+  const myMemberId = ledger.myMemberId ?? null;
+  const effectivePayer = payer ?? myMemberId;
+  const participants = useMemo(() => memberRows.map((member) => member.id), [memberRows]);
+
+  const messages = useMemo(() => splitMessages(blob), [blob]);
+
+  const candidates = useMemo(
+    () =>
+      proposeFromSms(
+        messages.map((body) => ({ body, receivedAt: new Date().toISOString() })),
+        { from, to, alreadyImported },
+      ),
+    [messages, from, to, alreadyImported],
+  );
+
+  // A message in another currency needs a rate, and the rate is not in the
+  // message. Rather than invent one, these are named and left for the add
+  // screen, which can ask for a rate and record where it came from (ADR-003).
+  const importable = candidates.filter((item) => item.amount.currency === groupCurrency);
+  const otherCurrency = candidates.filter((item) => item.amount.currency !== groupCurrency);
+
+  const selected = importable.filter((item) => chosen[item.dedupeKey] ?? item.preselect);
+
+  const paste = async (): Promise<void> => {
+    const text = await Clipboard.getStringAsync();
+    setBlob((current) => (current ? `${current}\n\n${text}` : text));
+  };
+
+  const confirm = async (): Promise<void> => {
+    if (!effectivePayer) {
+      setError('Choose who paid');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      for (const candidate of selected) {
+        const plan = planFromSms(candidate, {
+          payer: effectivePayer,
+          participants,
+        });
+        // Both ids come from the message itself, so importing the same message
+        // twice produces the same mutation — which the write path answers with
+        // the expense it already wrote, not a second one.
+        const expenseId = await importMutationId(groupId, `expense:${plan.seed}`);
+        const clientMutationId = await importMutationId(groupId, plan.seed);
+        await mutate(
+          'expense.create',
+          groupId,
+          toMutationPayload(plan, { expenseId }),
+          clientMutationId,
+        );
+      }
+      await remember(selected.map((item) => item.dedupeKey));
+      setSaved(selected.length);
+      setBlob('');
+      setChosen({});
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (group.isLoading || members.isLoading) {
+    return (
+      <Screen>
+        <View style={{ padding: theme.spacing.xl }}>
+          <ActivityIndicator color={theme.color.brand} />
+        </View>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen edges={['top', 'bottom']}>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label="Close" onPress={() => router.back()}>
+            <Ionicons name="close" size={22} color={theme.color.text} />
+          </IconButton>
+          <Text variant="subheading" style={{ marginLeft: theme.spacing.md }}>
+            Import from messages
+          </Text>
+        </Row>
+
+        <Card style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            Open your messages app, select the bank messages from this trip, copy them, and paste
+            them here. Baaki reads them on this phone — nothing is sent anywhere until you confirm
+            an expense.
+          </Text>
+          <Text variant="micro" tone="faint">
+            Baaki cannot read your inbox by itself. iPhones give no app that access, and on Android
+            it is reserved for whichever app you use as your messages app.
+          </Text>
+        </Card>
+
+        <View style={{ gap: theme.spacing.sm }}>
+          <SectionHeader title="The messages" />
+          <Card style={{ gap: theme.spacing.sm }}>
+            <TextInput
+              value={blob}
+              onChangeText={setBlob}
+              multiline
+              autoCapitalize="none"
+              accessibilityLabel="Paste bank messages"
+              placeholder={'Paste here.\n\nLeave a blank line between messages.'}
+              placeholderTextColor={theme.color.textFaint}
+              style={{
+                minHeight: 140,
+                fontSize: 15,
+                color: theme.color.text,
+                textAlignVertical: 'top',
+              }}
+            />
+            <Row style={{ justifyContent: 'space-between' }}>
+              <Text variant="micro" tone="faint">
+                {messages.length === 0
+                  ? 'Nothing pasted yet'
+                  : `${messages.length} message${messages.length === 1 ? '' : 's'}`}
+              </Text>
+              <Button label="Paste" variant="ghost" onPress={() => void paste()} />
+            </Row>
+          </Card>
+        </View>
+
+        <View style={{ gap: theme.spacing.sm }}>
+          <SectionHeader title="Between these dates" />
+          <Card style={{ gap: theme.spacing.md }}>
+            <Text variant="micro" tone="faint">
+              Only payments inside this window are proposed, so the rest of your inbox stays out of
+              the group.
+            </Text>
+            <Row style={{ gap: theme.spacing.md }}>
+              <DateField label="From" value={from} onChange={setFrom} />
+              <DateField label="To" value={to} onChange={setTo} />
+            </Row>
+            <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
+              <Chip
+                label="Last 7 days"
+                onPress={() => {
+                  setFrom(daysAgo(7));
+                  setTo(today());
+                }}
+              />
+              <Chip
+                label="Last 30 days"
+                onPress={() => {
+                  setFrom(daysAgo(30));
+                  setTo(today());
+                }}
+              />
+            </Row>
+          </Card>
+        </View>
+
+        {messages.length > 0 ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <SectionHeader title="What was found" />
+            {importable.length === 0 ? (
+              <EmptyState
+                title="Nothing to import"
+                body={
+                  candidates.length === 0
+                    ? 'None of those messages looked like a payment inside these dates. Reminders, one-time passwords and money coming in are all left out on purpose.'
+                    : 'Every payment found was in another currency.'
+                }
+              />
+            ) : (
+              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                {importable.map((candidate, index) => {
+                  const picked = chosen[candidate.dedupeKey] ?? candidate.preselect;
+                  return (
+                    <View key={candidate.dedupeKey}>
+                      <Pressable
+                        onPress={() =>
+                          setChosen((current) => ({
+                            ...current,
+                            [candidate.dedupeKey]: !picked,
+                          }))
+                        }
+                        accessibilityRole="checkbox"
+                        accessibilityState={{ checked: picked }}
+                        accessibilityLabel={`${candidate.merchant ?? 'Card payment'}, ${
+                          picked ? 'selected' : 'not selected'
+                        }`}
+                      >
+                        <ListRow
+                          title={candidate.merchant ?? 'Card payment'}
+                          subtitle={subtitleFor(candidate, locale)}
+                          leading={
+                            <Ionicons
+                              name={picked ? 'checkbox' : 'square-outline'}
+                              size={24}
+                              color={picked ? theme.color.brand : theme.color.textFaint}
+                            />
+                          }
+                          trailing={
+                            <View style={{ alignItems: 'flex-end', gap: 2 }}>
+                              <MoneyText
+                                amount={candidate.amount.minor}
+                                currency={candidate.amount.currency}
+                                locale={locale}
+                                variant="subheading"
+                              />
+                              {candidate.preselect ? null : <Badge label="Check this" />}
+                            </View>
+                          }
+                        />
+                      </Pressable>
+                      {index < importable.length - 1 ? (
+                        <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                      ) : null}
+                    </View>
+                  );
+                })}
+              </Card>
+            )}
+
+            {otherCurrency.length > 0 ? (
+              <Card>
+                <Text variant="caption" tone="muted">
+                  {otherCurrency.length} payment{otherCurrency.length === 1 ? ' was' : 's were'} in
+                  another currency. Add {otherCurrency.length === 1 ? 'it' : 'them'} by hand — the
+                  message does not say what rate you were charged, and this group keeps its money in{' '}
+                  {groupCurrency}.
+                </Text>
+              </Card>
+            ) : null}
+          </View>
+        ) : null}
+
+        {importable.length > 0 ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <SectionHeader title="Who paid" />
+            <Card style={{ gap: theme.spacing.md }}>
+              <Text variant="micro" tone="faint">
+                A bank message says what left your account, not who was there. These are split
+                equally between everyone in the group — change any of them afterwards.
+              </Text>
+              <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
+                {memberRows.map((member) => (
+                  <Chip
+                    key={member.id}
+                    label={displayName(member, profile?.id)}
+                    selected={member.id === effectivePayer}
+                    onPress={() => setPayer(member.id)}
+                  />
+                ))}
+              </Row>
+            </Card>
+          </View>
+        ) : null}
+
+        {error ? (
+          <Text variant="caption" tone="negative">
+            {error}
+          </Text>
+        ) : null}
+
+        {saved !== null ? (
+          <Card>
+            <Text variant="caption">
+              {saved} expense{saved === 1 ? '' : 's'} added. They are saved on this phone and will
+              sync when there is a connection.
+            </Text>
+          </Card>
+        ) : null}
+
+        <Button
+          label={
+            saving
+              ? 'Adding…'
+              : selected.length === 0
+                ? 'Nothing selected'
+                : `Add ${selected.length} expense${selected.length === 1 ? '' : 's'}`
+          }
+          onPress={() => void confirm()}
+          disabled={selected.length === 0 || saving}
+        />
+      </ScrollView>
+    </Screen>
+  );
+}
+
+function DateField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <View style={{ flex: 1, gap: 2 }}>
+      <Text variant="micro" tone="faint">
+        {label}
+      </Text>
+      <TextInput
+        value={value}
+        onChangeText={onChange}
+        autoCapitalize="none"
+        keyboardType="numbers-and-punctuation"
+        accessibilityLabel={`${label} date, year month day`}
+        placeholder="YYYY-MM-DD"
+        placeholderTextColor={theme.color.textFaint}
+        style={{ fontSize: 16, color: theme.color.text, paddingVertical: theme.spacing.xs }}
+      />
+    </View>
+  );
+}
+
+function subtitleFor(candidate: ExpenseCandidate, locale: string): string {
+  const when = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short' }).format(
+    new Date(candidate.at),
+  );
+  const parts = [when];
+  if (candidate.dateInferred) parts.push('date not in the message');
+  if (candidate.accountTail) parts.push(`⋯${candidate.accountTail}`);
+  return parts.join(' · ');
+}
+
+const today = (): string => new Date().toISOString().slice(0, 10);
+
+const daysAgo = (days: number): string =>
+  new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
+
+/**
+ * The group's own history is a better guess at "the trip" than a fixed number
+ * of days: a group made for last month's holiday should not open on a window
+ * that contains none of it.
+ */
+function defaultFrom(expenses: { created_at?: string }[] | undefined): string {
+  const earliest = (expenses ?? [])
+    .map((expense) => String(expense.created_at ?? ''))
+    .filter(Boolean)
+    .sort()[0];
+  return earliest ? earliest.slice(0, 10) : daysAgo(30);
+}

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -261,6 +261,31 @@ export default function GroupSettingsScreen() {
           </Card>
         </View>
 
+        <View>
+          <SectionHeader title="Bring things in" />
+          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            <ListRow
+              title="Import from messages"
+              subtitle="Paste bank messages — read on this phone, confirmed by you"
+              leading={
+                <Ionicons name="chatbox-ellipses-outline" size={22} color={theme.color.textMuted} />
+              }
+              onPress={() => router.push(`/group/${groupId}/import/sms`)}
+              trailing={<Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />}
+            />
+            <View style={{ height: 1, backgroundColor: theme.color.border }} />
+            <ListRow
+              title="Import a Splitwise export"
+              subtitle="Bring an old group's history across"
+              leading={
+                <Ionicons name="document-text-outline" size={22} color={theme.color.textMuted} />
+              }
+              onPress={() => router.push(`/group/${groupId}/import/csv`)}
+              trailing={<Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />}
+            />
+          </Card>
+        </View>
+
         {status ? (
           <Text variant="caption" tone="positive">
             {status}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -10,7 +10,13 @@
 import { decode } from 'base64-arraybuffer';
 import { randomUUID } from 'expo-crypto';
 
-import type { FxRecord, ParsedReceipt, ReceiptCheck, SplitParams } from '@baaki/core';
+import {
+  serialiseSplitParams,
+  type FxRecord,
+  type ParsedReceipt,
+  type ReceiptCheck,
+  type SplitParams,
+} from '@baaki/core';
 
 import { supabase } from '@/lib/supabase';
 import type {
@@ -359,7 +365,10 @@ export async function writeExpense(input: WriteExpenseInput): Promise<WriteExpen
       expenseDate: input.expenseDate,
       currency: input.currency,
       amount: input.amount.toString(),
-      splitParams: input.splitParams,
+      // Exact, adjustment and itemized splits hold minor units, and JSON has
+      // no bigint — stringify throws on one rather than rounding it. Without
+      // this an itemized bill could not be saved at all.
+      splitParams: serialiseSplitParams(input.splitParams),
       participants: input.participants,
       payers: Object.fromEntries(
         Object.entries(input.payers).map(([id, value]) => [id, value.toString()]),

--- a/apps/mobile/src/data/importPlan.ts
+++ b/apps/mobile/src/data/importPlan.ts
@@ -1,0 +1,156 @@
+/**
+ * Turning something imported into the exact payload the write path takes.
+ *
+ * Pure on purpose. Both import screens are mostly picking and confirming, and
+ * the part that can quietly get money wrong — which member ends up on which
+ * share, whose name is on the payment, what the total is — is here where it
+ * can be tested without a phone.
+ *
+ * Nothing in this file writes or enqueues. It produces a plan; the screen
+ * shows it, a person confirms it, and only then does it reach the queue.
+ */
+
+import {
+  serialiseSplitParams,
+  type ExpenseCandidate,
+  type ImportedExpense,
+  type MemberId,
+  type SplitParams,
+} from '@baaki/core';
+
+/** Everything except the ids, which are derived from `seed` (see lib/importId). */
+export interface PlannedExpense {
+  /**
+   * Stable across re-imports of the same thing. The ids both mutation and
+   * expense are derived from, which is what makes a second import a no-op.
+   */
+  readonly seed: string;
+  readonly description: string;
+  readonly category: string | null;
+  readonly expenseDate: string;
+  readonly currency: string;
+  readonly amount: bigint;
+  readonly splitParams: SplitParams;
+  readonly participants: readonly MemberId[];
+  readonly payers: Readonly<Record<MemberId, bigint>>;
+  readonly notes: string | null;
+}
+
+/** A CSV person with no member chosen for them. Refuses rather than guessing. */
+export class UnmappedPersonError extends Error {
+  constructor(readonly person: string) {
+    super(`No one chosen for "${person}"`);
+    this.name = 'UnmappedPersonError';
+  }
+}
+
+/**
+ * One bank message into one expense.
+ *
+ * The message says what left the account and roughly where it went. It does
+ * not say who was there, so the split is whatever the person confirming it
+ * chose — never inferred from the text.
+ */
+export function planFromSms(
+  candidate: ExpenseCandidate,
+  options: {
+    readonly payer: MemberId;
+    readonly participants: readonly MemberId[];
+  },
+): PlannedExpense {
+  if (options.participants.length === 0) {
+    throw new Error('An expense needs at least one person to split between');
+  }
+
+  return {
+    seed: `sms:${candidate.dedupeKey}`,
+    description: candidate.merchant ?? 'Card payment',
+    category: null,
+    expenseDate: candidate.at.slice(0, 10),
+    currency: candidate.amount.currency,
+    amount: candidate.amount.minor,
+    splitParams: { kind: 'equal' },
+    participants: options.participants,
+    payers: { [options.payer]: candidate.amount.minor },
+    // The message is kept verbatim so the expense can be checked against what
+    // the bank actually said, months later, when nobody remembers the trip.
+    notes: noteForSms(candidate),
+  };
+}
+
+function noteForSms(candidate: ExpenseCandidate): string {
+  const parts = ['Imported from an SMS'];
+  if (candidate.sender) parts.push(`from ${candidate.sender}`);
+  if (candidate.accountTail) parts.push(`·⋯${candidate.accountTail}`);
+  if (candidate.reference) parts.push(`· ref ${candidate.reference}`);
+  if (candidate.dateInferred) parts.push('· date taken from when the message arrived');
+  return parts.join(' ');
+}
+
+/**
+ * One CSV row into one expense.
+ *
+ * The file names people; a group has member ids. Every name must have been
+ * given one — an unmapped person raises rather than being dropped, because
+ * dropping them would leave a row whose shares no longer sum to its total and
+ * the write path would reject it with something far less useful to read.
+ */
+export function planFromCsv(
+  expense: ImportedExpense,
+  mapping: Readonly<Record<string, MemberId>>,
+  index: number,
+): PlannedExpense {
+  const remapped = (amounts: Readonly<Record<string, bigint>>): Record<MemberId, bigint> => {
+    const out: Record<MemberId, bigint> = {};
+    for (const [person, value] of Object.entries(amounts)) {
+      const memberId = mapping[person];
+      if (!memberId) throw new UnmappedPersonError(person);
+      // Two CSV columns can be pointed at one member — the same person listed
+      // under two spellings. Add rather than overwrite, or half their money
+      // disappears with nothing to show it happened.
+      out[memberId] = (out[memberId] ?? 0n) + value;
+    }
+    return out;
+  };
+
+  const shares = remapped(expense.shares);
+  const payers = remapped(expense.payers);
+
+  return {
+    // The row's position is part of the seed: a file can legitimately hold two
+    // identical rows (the same coffee, twice, on one day) and both are real.
+    seed: `csv:${index}:${expense.date}:${expense.description}:${expense.currency}:${expense.amount}`,
+    description: expense.description,
+    category: expense.category,
+    expenseDate: expense.date,
+    currency: expense.currency,
+    amount: expense.amount,
+    splitParams: { kind: 'exact', amounts: shares },
+    participants: Object.keys(shares),
+    payers: Object.fromEntries(Object.entries(payers).filter(([, value]) => value !== 0n)),
+    notes: 'Imported from a Splitwise export',
+  };
+}
+
+/** The wire form: bigints as decimal strings, exactly as the queue carries them. */
+export function toMutationPayload(
+  plan: PlannedExpense,
+  ids: { readonly expenseId: string },
+): Record<string, unknown> {
+  return {
+    expenseId: ids.expenseId,
+    description: plan.description,
+    category: plan.category,
+    expenseDate: plan.expenseDate,
+    currency: plan.currency,
+    amount: plan.amount.toString(),
+    // An exact split carries minor units, which JSON cannot hold. One
+    // definition of that conversion, shared with the server (@baaki/core).
+    splitParams: serialiseSplitParams(plan.splitParams),
+    participants: [...plan.participants],
+    payers: Object.fromEntries(
+      Object.entries(plan.payers).map(([id, value]) => [id, value.toString()]),
+    ),
+    notes: plan.notes,
+  };
+}

--- a/apps/mobile/src/lib/importId.ts
+++ b/apps/mobile/src/lib/importId.ts
@@ -1,0 +1,33 @@
+/**
+ * A mutation id that is the same every time for the same imported thing.
+ *
+ * Normal writes get a random `clientMutationId`; the point of it is that a
+ * retry after a flaky network cannot double-post (ADR-005). An import needs
+ * something stronger, because the duplicate does not come from a retry — it
+ * comes from a person. They paste the same messages next week, or pick the
+ * same CSV twice, and the second run has no memory of the first.
+ *
+ * So the id is derived from the thing itself. `expenses.client_mutation_id`
+ * is UNIQUE and the write path already answers a repeat with `replayed`
+ * rather than a second row, which means a re-import is a no-op at the only
+ * layer that actually decides — the database. The screens also keep a local
+ * list of what they have imported (lib/imported), but that is convenience: it
+ * makes the duplicate visible instead of silently doing nothing, and it is
+ * per-device, so it is not what the guarantee rests on.
+ *
+ * The group id is part of the seed on purpose. The same bank message imported
+ * into two different groups is two real expenses, not one.
+ */
+
+import * as Crypto from 'expo-crypto';
+
+import { uuidFromDigest } from './uuid8';
+
+/** The stable id for one imported row, in one group. */
+export async function importMutationId(groupId: string, seed: string): Promise<string> {
+  const digest = await Crypto.digestStringAsync(
+    Crypto.CryptoDigestAlgorithm.SHA256,
+    `baaki:import:${groupId}:${seed}`,
+  );
+  return uuidFromDigest(digest);
+}

--- a/apps/mobile/src/lib/imported.ts
+++ b/apps/mobile/src/lib/imported.ts
@@ -1,0 +1,55 @@
+/**
+ * What this phone has already imported.
+ *
+ * This is not the thing that stops a duplicate — `expenses.client_mutation_id`
+ * is UNIQUE and the ids are derived from the imported row itself (lib/importId),
+ * so a re-import is refused by the database whatever any client believes. This
+ * list exists so the refusal is *visible*: without it, pasting last week's
+ * messages again would show them all as new, the person would confirm them,
+ * and nothing would appear. Silently doing nothing is the worst of the three
+ * possible behaviours.
+ *
+ * It rides on the draft store the sync engine already keeps, so it survives a
+ * restart. It is per-device on purpose — a second phone re-proposing an
+ * expense is a mild annoyance, and the unique constraint still holds the line.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { syncEngine } from '@/sync/engine';
+
+const keyFor = (groupId: string): string => `import:seen:${groupId}`;
+
+/** Grows without bound otherwise; a trip's worth of keys is what is useful. */
+const KEEP = 500;
+
+export interface ImportedKeys {
+  /** Dedupe keys already imported into this group, for `proposeFromSms`. */
+  keys: ReadonlySet<string>;
+  remember: (keys: readonly string[]) => Promise<void>;
+}
+
+export function useImported(groupId: string): ImportedKeys {
+  const [keys, setKeys] = useState<ReadonlySet<string>>(() => new Set());
+
+  useEffect(() => {
+    let active = true;
+    void syncEngine.readDraft<string[]>(keyFor(groupId)).then((stored) => {
+      if (active && stored) setKeys(new Set(stored));
+    });
+    return () => {
+      active = false;
+    };
+  }, [groupId]);
+
+  const remember = useCallback(
+    async (added: readonly string[]): Promise<void> => {
+      const next = [...keys, ...added].slice(-KEEP);
+      setKeys(new Set(next));
+      await syncEngine.saveDraft(keyFor(groupId), next);
+    },
+    [groupId, keys],
+  );
+
+  return { keys, remember };
+}

--- a/apps/mobile/src/lib/uuid8.ts
+++ b/apps/mobile/src/lib/uuid8.ts
@@ -1,0 +1,28 @@
+/**
+ * A hex digest, shaped as a UUID.
+ *
+ * Kept apart from `importId` so it can be tested: the moment a module imports
+ * expo-crypto it drags React Native in with it, and this is the part where
+ * getting it wrong is silent — a malformed id is rejected by Postgres as a
+ * column type, but a *well-formed* id that is not stable stops de-duplicating
+ * anything and nobody finds out until there are two of every expense.
+ */
+
+/**
+ * Version 8 — "custom", which is what this is: a name-based id from our own
+ * hash. Not v4, because nothing here is random; not v5, which would have to
+ * be SHA-1 over a namespace to deserve the name.
+ */
+export function uuidFromDigest(hex: string): string {
+  const clean = hex.toLowerCase().replace(/[^0-9a-f]/g, '');
+  if (clean.length < 32) {
+    // Padding it out would make two different inputs collide, which is the
+    // one failure this whole mechanism exists to prevent.
+    throw new Error(`Digest too short to make a UUID: ${clean.length} hex characters`);
+  }
+  const bytes = clean.slice(0, 32);
+  // Version nibble and variant bits, per RFC 9562 §5.8.
+  const version = `8${bytes.slice(13, 16)}`;
+  const variant = `${'89ab'[parseInt(bytes[16] as string, 16) % 4]}${bytes.slice(17, 20)}`;
+  return [bytes.slice(0, 8), bytes.slice(8, 12), version, variant, bytes.slice(20, 32)].join('-');
+}

--- a/apps/mobile/test/importId.test.ts
+++ b/apps/mobile/test/importId.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The id that makes a second import a no-op.
+ *
+ * `expenses.client_mutation_id` is UNIQUE, so whatever this returns is what
+ * actually decides whether a re-import writes a second expense. Two things
+ * have to hold: it must be shaped like a UUID, or the insert fails on a
+ * column type rather than doing anything useful; and it must be the same
+ * every time for the same input, or the uniqueness buys nothing.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { uuidFromDigest } from '@/lib/uuid8';
+
+const A_DIGEST = '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08';
+
+describe('shaping a digest as a UUID', () => {
+  it('produces something Postgres will take as a uuid', () => {
+    expect(uuidFromDigest(A_DIGEST)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('marks it version 8 — a custom id, which is what it is', () => {
+    // Not v4: nothing here is random. Not v5: that would have to be SHA-1 over
+    // a namespace to deserve the name.
+    expect(uuidFromDigest(A_DIGEST)[14]).toBe('8');
+  });
+
+  it('sets the variant bits', () => {
+    expect('89ab').toContain(uuidFromDigest(A_DIGEST)[19]);
+  });
+
+  it('gives the same answer every time', () => {
+    expect(uuidFromDigest(A_DIGEST)).toBe(uuidFromDigest(A_DIGEST));
+  });
+
+  it('gives different answers to different digests', () => {
+    const other = 'a'.repeat(64);
+    expect(uuidFromDigest(other)).not.toBe(uuidFromDigest(A_DIGEST));
+  });
+
+  it('ignores case and formatting the platform might add', () => {
+    expect(uuidFromDigest(A_DIGEST.toUpperCase())).toBe(uuidFromDigest(A_DIGEST));
+  });
+
+  it('refuses a digest too short to fill a UUID', () => {
+    // Silently padding would make two different inputs collide.
+    expect(() => uuidFromDigest('abc')).toThrow(/too short/);
+  });
+});

--- a/apps/mobile/test/importPlan.test.ts
+++ b/apps/mobile/test/importPlan.test.ts
@@ -109,7 +109,7 @@ describe('one CSV row', () => {
       amounts: { 'm-asha': 30000n, 'm-ravi': 15000n },
     });
     expect(plan.payers).toEqual({ 'm-asha': 45000n });
-    expect(plan.participants.sort()).toEqual(['m-asha', 'm-ravi']);
+    expect([...plan.participants].sort()).toEqual(['m-asha', 'm-ravi']);
   });
 
   it('keeps shares summing to the total', () => {

--- a/apps/mobile/test/importPlan.test.ts
+++ b/apps/mobile/test/importPlan.test.ts
@@ -1,0 +1,190 @@
+/**
+ * What an import turns into before it reaches the queue.
+ *
+ * The failure this guards against is not a crash. It is an import that
+ * succeeds and is wrong: a share landing on the wrong member, a payer that
+ * does not add up to the total, or a second copy of an expense somebody
+ * already has. All three look fine on the screen that produced them.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { ExpenseCandidate, ImportedExpense } from '@baaki/core';
+
+import {
+  planFromCsv,
+  planFromSms,
+  toMutationPayload,
+  UnmappedPersonError,
+} from '@/data/importPlan';
+
+function candidate(over: Partial<ExpenseCandidate> = {}): ExpenseCandidate {
+  return {
+    amount: { minor: 45000n, currency: 'INR' },
+    direction: 'debit',
+    merchant: 'SWIGGY',
+    accountTail: '4821',
+    reference: '412345678901',
+    occurredAt: '2026-08-04T00:00:00.000Z',
+    confidence: 0.9,
+    sender: 'AD-HDFCBK',
+    at: '2026-08-04T00:00:00.000Z',
+    dateInferred: false,
+    dedupeKey: 'ref:412345678901',
+    preselect: true,
+    ...over,
+  };
+}
+
+function imported(over: Partial<ImportedExpense> = {}): ImportedExpense {
+  const shares = { Asha: 30000n, Ravi: 15000n };
+  return {
+    description: 'Dinner',
+    category: 'Food',
+    date: '2026-08-04',
+    currency: 'INR',
+    amount: 45000n,
+    payers: { Asha: 45000n },
+    shares,
+    splitParams: { kind: 'exact', amounts: shares },
+    ...over,
+  };
+}
+
+describe('one bank message', () => {
+  it('becomes an expense the payer covers in full', () => {
+    const plan = planFromSms(candidate(), { payer: 'm-asha', participants: ['m-asha', 'm-ravi'] });
+
+    expect(plan.amount).toBe(45000n);
+    expect(plan.payers).toEqual({ 'm-asha': 45000n });
+    expect(plan.splitParams).toEqual({ kind: 'equal' });
+    expect(plan.participants).toEqual(['m-asha', 'm-ravi']);
+  });
+
+  it('files it on the day the bank said, not the day it was imported', () => {
+    // A message that arrives late would otherwise land the expense on the
+    // wrong day of a trip, which is exactly when the day matters.
+    expect(planFromSms(candidate(), { payer: 'm', participants: ['m'] }).expenseDate).toBe(
+      '2026-08-04',
+    );
+  });
+
+  it('keeps the bank reference so the entry can be checked later', () => {
+    const plan = planFromSms(candidate(), { payer: 'm', participants: ['m'] });
+    expect(plan.notes).toContain('412345678901');
+    expect(plan.notes).toContain('AD-HDFCBK');
+  });
+
+  it('says so when the date came from the message arriving', () => {
+    const plan = planFromSms(candidate({ dateInferred: true }), {
+      payer: 'm',
+      participants: ['m'],
+    });
+    expect(plan.notes).toContain('date taken from when the message arrived');
+  });
+
+  it('falls back to a name when the message does not say where', () => {
+    const plan = planFromSms(candidate({ merchant: null }), { payer: 'm', participants: ['m'] });
+    expect(plan.description).toBe('Card payment');
+  });
+
+  it('refuses an expense with nobody to split it between', () => {
+    expect(() => planFromSms(candidate(), { payer: 'm', participants: [] })).toThrow();
+  });
+
+  it('gives the same seed to the same message every time', () => {
+    // This is what makes a second import a no-op rather than a second expense.
+    const first = planFromSms(candidate(), { payer: 'm', participants: ['m'] });
+    const second = planFromSms(candidate(), { payer: 'other', participants: ['other'] });
+    expect(second.seed).toBe(first.seed);
+  });
+});
+
+describe('one CSV row', () => {
+  it('puts each person’s share on their member id', () => {
+    const plan = planFromCsv(imported(), { Asha: 'm-asha', Ravi: 'm-ravi' }, 0);
+
+    expect(plan.splitParams).toEqual({
+      kind: 'exact',
+      amounts: { 'm-asha': 30000n, 'm-ravi': 15000n },
+    });
+    expect(plan.payers).toEqual({ 'm-asha': 45000n });
+    expect(plan.participants.sort()).toEqual(['m-asha', 'm-ravi']);
+  });
+
+  it('keeps shares summing to the total', () => {
+    const plan = planFromCsv(imported(), { Asha: 'm-asha', Ravi: 'm-ravi' }, 0);
+    const params = plan.splitParams as { kind: 'exact'; amounts: Record<string, bigint> };
+    const total = Object.values(params.amounts).reduce((sum, value) => sum + value, 0n);
+    expect(total).toBe(plan.amount);
+  });
+
+  it('adds two columns together when both point at one person', () => {
+    // The same human listed under two spellings. Overwriting instead of adding
+    // would make half their money vanish with nothing to show it happened.
+    const shares = { Asha: 20000n, 'Asha K': 10000n, Ravi: 15000n };
+    const plan = planFromCsv(
+      imported({ shares, splitParams: { kind: 'exact', amounts: shares } }),
+      { Asha: 'm-asha', 'Asha K': 'm-asha', Ravi: 'm-ravi' },
+      0,
+    );
+    const params = plan.splitParams as { kind: 'exact'; amounts: Record<string, bigint> };
+    expect(params.amounts['m-asha']).toBe(30000n);
+  });
+
+  it('refuses a name nobody was chosen for', () => {
+    // Dropping them would leave a row whose shares no longer sum to its total.
+    expect(() => planFromCsv(imported(), { Asha: 'm-asha' }, 0)).toThrow(UnmappedPersonError);
+    expect(() => planFromCsv(imported(), { Asha: 'm-asha' }, 0)).toThrow(/Ravi/);
+  });
+
+  it('leaves out a payer who paid nothing', () => {
+    const plan = planFromCsv(
+      imported({ payers: { Asha: 45000n, Ravi: 0n } }),
+      { Asha: 'm-asha', Ravi: 'm-ravi' },
+      0,
+    );
+    expect(plan.payers).toEqual({ 'm-asha': 45000n });
+  });
+
+  it('tells two identical rows apart', () => {
+    // The same coffee twice in one day is two expenses, and a file is allowed
+    // to say so. Seeding on content alone would silently collapse them.
+    const first = planFromCsv(imported(), { Asha: 'm-asha', Ravi: 'm-ravi' }, 0);
+    const second = planFromCsv(imported(), { Asha: 'm-asha', Ravi: 'm-ravi' }, 1);
+    expect(second.seed).not.toBe(first.seed);
+  });
+
+  it('gives the same seed to the same row of the same file', () => {
+    const first = planFromCsv(imported(), { Asha: 'm-asha', Ravi: 'm-ravi' }, 3);
+    const second = planFromCsv(imported(), { Asha: 'other', Ravi: 'other2' }, 3);
+    expect(second.seed).toBe(first.seed);
+  });
+});
+
+describe('the payload that goes on the queue', () => {
+  it('survives JSON', () => {
+    // The queue is written to disk as JSON. A bigint anywhere in here throws
+    // on the way out, and the expense is lost rather than saved.
+    const plan = planFromCsv(imported(), { Asha: 'm-asha', Ravi: 'm-ravi' }, 0);
+    const payload = toMutationPayload(plan, { expenseId: 'e-1' });
+    expect(() => JSON.stringify(payload)).not.toThrow();
+  });
+
+  it('carries minor units as strings, never numbers', () => {
+    const plan = planFromCsv(imported(), { Asha: 'm-asha', Ravi: 'm-ravi' }, 0);
+    const payload = toMutationPayload(plan, { expenseId: 'e-1' });
+
+    expect(payload.amount).toBe('45000');
+    expect(payload.payers).toEqual({ 'm-asha': '45000' });
+    expect(payload.splitParams).toEqual({
+      kind: 'exact',
+      amounts: { 'm-asha': '30000', 'm-ravi': '15000' },
+    });
+  });
+
+  it('leaves an equal split alone', () => {
+    const plan = planFromSms(candidate(), { payer: 'm', participants: ['m'] });
+    expect(toMutationPayload(plan, { expenseId: 'e-1' }).splitParams).toEqual({ kind: 'equal' });
+  });
+});

--- a/packages/core/src/split/index.ts
+++ b/packages/core/src/split/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './remainder';
 export * from './computeShares';
 export * from './verify';
+export * from './wire';

--- a/packages/core/src/split/wire.ts
+++ b/packages/core/src/split/wire.ts
@@ -1,0 +1,180 @@
+/**
+ * Split parameters over the wire.
+ *
+ * Three of the six split kinds carry minor units, and minor units are bigints
+ * (ADR-003). JSON has no bigint: `JSON.stringify` throws on one rather than
+ * quietly rounding, which is the right failure but it still means an itemized
+ * bill or an exact split cannot be sent anywhere without passing through here
+ * first.
+ *
+ * They travel as decimal strings, not numbers. A number would survive every
+ * test anybody writes — ₹9,00,000 is nowhere near 2^53 — and then lose a unit
+ * on the one bill big enough to matter. There is no reason to leave that open.
+ *
+ * `parseSplitParams` is deliberately liberal about what it accepts and strict
+ * about what it rejects: a string, a bigint, or an integer number all mean the
+ * same thing and all come back as a bigint, but a fraction does not. A
+ * fractional minor unit means a float got into somebody's money upstream, and
+ * the only useful response is to stop.
+ */
+
+import type { AdjustmentParams, ExactParams, ItemizedParams, MemberId, SplitParams } from './types';
+
+export class SplitWireError extends Error {
+  constructor(
+    readonly code: 'NOT_AN_OBJECT' | 'UNKNOWN_KIND' | 'NOT_AN_INTEGER' | 'BAD_SHAPE',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SplitWireError';
+  }
+}
+
+/** The JSON-safe mirror of `SplitParams`: identical, with minor units as strings. */
+export type WireSplitParams = Record<string, unknown>;
+
+export function serialiseSplitParams(params: SplitParams): WireSplitParams {
+  switch (params.kind) {
+    case 'exact':
+      return { kind: 'exact', amounts: mapValues(params.amounts, String) };
+    case 'adjustment':
+      return { kind: 'adjustment', adjustments: mapValues(params.adjustments, String) };
+    case 'itemized':
+      return {
+        kind: 'itemized',
+        items: params.items.map((item) => ({
+          ...(item.label === undefined ? {} : { label: item.label }),
+          total: item.total.toString(),
+        })),
+        claims: params.claims,
+        ...optionalString('taxes', params.taxes),
+        ...optionalString('serviceCharge', params.serviceCharge),
+        ...optionalString('tip', params.tip),
+        ...optionalString('discounts', params.discounts),
+      };
+    // equal, percent and shares hold nothing that JSON cannot carry.
+    default:
+      return { ...params };
+  }
+}
+
+export function parseSplitParams(raw: unknown): SplitParams {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new SplitWireError('NOT_AN_OBJECT', 'Split parameters must be an object');
+  }
+  const params = raw as Record<string, unknown>;
+
+  switch (params.kind) {
+    case 'equal':
+      return { kind: 'equal' };
+
+    case 'exact':
+      return { kind: 'exact', amounts: minorUnitMap(params.amounts, 'amounts') } as ExactParams;
+
+    case 'adjustment':
+      return {
+        kind: 'adjustment',
+        adjustments: minorUnitMap(params.adjustments, 'adjustments'),
+      } as AdjustmentParams;
+
+    case 'percent': {
+      const basisPoints = params.basisPoints;
+      requireRecord(basisPoints, 'basisPoints');
+      return {
+        kind: 'percent',
+        basisPoints: mapValues(basisPoints, (value) => Number(integer(value, 'basisPoints'))),
+      };
+    }
+
+    case 'shares': {
+      const weights = params.weights;
+      requireRecord(weights, 'weights');
+      return {
+        kind: 'shares',
+        weights: mapValues(weights, (value) => Number(integer(value, 'weights'))),
+      };
+    }
+
+    case 'itemized': {
+      const items = params.items;
+      if (!Array.isArray(items)) {
+        throw new SplitWireError('BAD_SHAPE', 'An itemized split needs a list of items');
+      }
+      requireRecord(params.claims, 'claims');
+      return {
+        kind: 'itemized',
+        items: items.map((item, index) => {
+          if (typeof item !== 'object' || item === null) {
+            throw new SplitWireError('BAD_SHAPE', `Item ${index} is not an object`);
+          }
+          const line = item as Record<string, unknown>;
+          return {
+            ...(typeof line.label === 'string' ? { label: line.label } : {}),
+            total: integer(line.total, `items[${index}].total`),
+          };
+        }),
+        claims: params.claims as ItemizedParams['claims'],
+        ...optionalBig('taxes', maybeInteger(params.taxes, 'taxes')),
+        ...optionalBig('serviceCharge', maybeInteger(params.serviceCharge, 'serviceCharge')),
+        ...optionalBig('tip', maybeInteger(params.tip, 'tip')),
+        ...optionalBig('discounts', maybeInteger(params.discounts, 'discounts')),
+      };
+    }
+
+    default:
+      throw new SplitWireError('UNKNOWN_KIND', `Unknown split kind: ${String(params.kind)}`);
+  }
+}
+
+function minorUnitMap(raw: unknown, field: string): Record<MemberId, bigint> {
+  requireRecord(raw, field);
+  return mapValues(raw, (value) => integer(value, field));
+}
+
+/**
+ * One number, however it arrived. A float is refused rather than rounded: it
+ * cannot have come from a correct client, and rounding it here would put a
+ * number in the ledger that nobody chose.
+ */
+function integer(value: unknown, field: string): bigint {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new SplitWireError('NOT_AN_INTEGER', `${field}: ${value} is not a whole minor unit`);
+    }
+    return BigInt(value);
+  }
+  if (typeof value === 'string' && /^-?\d+$/.test(value.trim())) {
+    return BigInt(value.trim());
+  }
+  throw new SplitWireError('NOT_AN_INTEGER', `${field}: ${String(value)} is not a whole number`);
+}
+
+function maybeInteger(value: unknown, field: string): bigint | undefined {
+  return value === undefined || value === null ? undefined : integer(value, field);
+}
+
+function requireRecord(value: unknown, field: string): asserts value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new SplitWireError('BAD_SHAPE', `${field} must be an object`);
+  }
+}
+
+function mapValues<In, Out>(
+  source: Readonly<Record<string, In>>,
+  transform: (value: In) => Out,
+): Record<string, Out> {
+  return Object.fromEntries(Object.entries(source).map(([key, value]) => [key, transform(value)]));
+}
+
+/** Absent stays absent. `{ tip: null }` would read as "no tip", which is not the same as "no tip line". */
+function optionalString<K extends string>(
+  key: K,
+  value: bigint | undefined,
+): Record<string, string> {
+  return value === undefined ? {} : { [key]: value.toString() };
+}
+
+function optionalBig<K extends string>(key: K, value: bigint | undefined): Record<string, bigint> {
+  return value === undefined ? {} : { [key]: value };
+}

--- a/packages/core/test/wire.test.ts
+++ b/packages/core/test/wire.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Split parameters surviving JSON.
+ *
+ * The thing being pinned is that nothing changes value on the way. Everything
+ * else in the ledger is downstream of these numbers: send an exact split whose
+ * amounts came back one unit light and the shares no longer sum to the total,
+ * which the write path rejects — or worse, they still sum and the wrong person
+ * is short.
+ *
+ * The property is the test that matters: for any split parameters at all,
+ * serialise → JSON → parse gives back exactly what went in.
+ */
+
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseSplitParams,
+  serialiseSplitParams,
+  SplitWireError,
+  type SplitParams,
+} from '../src/index';
+
+const memberId = fc.constantFrom('asha', 'ravi', 'priya', 'dev');
+const minor = fc.bigInt({ min: -(10n ** 15n), max: 10n ** 15n });
+
+const anySplitParams: fc.Arbitrary<SplitParams> = fc.oneof(
+  fc.constant<SplitParams>({ kind: 'equal' }),
+  fc
+    .dictionary(memberId, minor, { minKeys: 1 })
+    .map((amounts) => ({ kind: 'exact', amounts }) as SplitParams),
+  fc
+    .dictionary(memberId, fc.integer({ min: 0, max: 10000 }), { minKeys: 1 })
+    .map((basisPoints) => ({ kind: 'percent', basisPoints }) as SplitParams),
+  fc
+    .dictionary(memberId, fc.integer({ min: 1, max: 100 }), { minKeys: 1 })
+    .map((weights) => ({ kind: 'shares', weights }) as SplitParams),
+  fc
+    .dictionary(memberId, minor, { minKeys: 1 })
+    .map((adjustments) => ({ kind: 'adjustment', adjustments }) as SplitParams),
+  fc
+    .record({
+      items: fc.array(
+        fc.record({ label: fc.string(), total: fc.bigInt({ min: 0n, max: 10n ** 12n }) }),
+        { minLength: 1, maxLength: 6 },
+      ),
+      taxes: fc.option(fc.bigInt({ min: 0n, max: 10n ** 9n }), { nil: undefined }),
+      tip: fc.option(fc.bigInt({ min: 0n, max: 10n ** 9n }), { nil: undefined }),
+    })
+    .map(
+      ({ items, taxes, tip }) =>
+        ({
+          kind: 'itemized',
+          items,
+          claims: Object.fromEntries(items.map((_, index) => [index, ['asha']])),
+          ...(taxes === undefined ? {} : { taxes }),
+          ...(tip === undefined ? {} : { tip }),
+        }) as SplitParams,
+    ),
+);
+
+/** What actually happens to a payload: it goes through JSON, not just a function. */
+const roundTrip = (params: SplitParams): SplitParams =>
+  parseSplitParams(JSON.parse(JSON.stringify(serialiseSplitParams(params))));
+
+describe('a round trip changes nothing', () => {
+  it('holds for every kind of split', () => {
+    fc.assert(
+      fc.property(anySplitParams, (params) => {
+        expect(roundTrip(params)).toEqual(params);
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  it('holds for an amount far past what a double can hold', () => {
+    // 2^53 is where a number silently stops counting. Minor units reach it:
+    // this is ₹90,07,19,92,54,740.99 — absurd for a dinner, ordinary for a
+    // property, and the whole reason these travel as strings.
+    const params: SplitParams = {
+      kind: 'exact',
+      amounts: { asha: 9007199254740993n, ravi: 1n },
+    };
+    expect(roundTrip(params)).toEqual(params);
+    expect((serialiseSplitParams(params).amounts as Record<string, string>).asha).toBe(
+      '9007199254740993',
+    );
+  });
+});
+
+describe('serialising', () => {
+  it('leaves the kinds that hold no money alone', () => {
+    expect(serialiseSplitParams({ kind: 'equal' })).toEqual({ kind: 'equal' });
+    expect(JSON.stringify(serialiseSplitParams({ kind: 'equal' }))).toBe('{"kind":"equal"}');
+  });
+
+  it('produces something JSON can actually take', () => {
+    // The bug this whole module exists for: JSON.stringify throws on a bigint,
+    // so an itemized bill could not be saved at all.
+    const params: SplitParams = {
+      kind: 'itemized',
+      items: [{ label: 'Biryani', total: 45000n }],
+      claims: { 0: ['asha'] },
+      taxes: 2250n,
+    };
+    expect(() => JSON.stringify(params)).toThrow(TypeError);
+    expect(() => JSON.stringify(serialiseSplitParams(params))).not.toThrow();
+  });
+
+  it('keeps an absent optional absent', () => {
+    // `{ tip: null }` reads as "there was no tip"; leaving it out says the bill
+    // had no tip line at all. They are not the same claim about the receipt.
+    const wire = serialiseSplitParams({
+      kind: 'itemized',
+      items: [{ total: 100n }],
+      claims: { 0: ['asha'] },
+    });
+    expect('tip' in wire).toBe(false);
+    expect('taxes' in wire).toBe(false);
+  });
+});
+
+describe('parsing what an older or stranger client sent', () => {
+  it('takes a plain integer as well as a string', () => {
+    // A number is accepted because it is unambiguous, not because it is wanted.
+    expect(parseSplitParams({ kind: 'exact', amounts: { asha: 500 } })).toEqual({
+      kind: 'exact',
+      amounts: { asha: 500n },
+    });
+  });
+
+  it('takes a bigint that never went through JSON', () => {
+    expect(parseSplitParams({ kind: 'exact', amounts: { asha: 500n } })).toEqual({
+      kind: 'exact',
+      amounts: { asha: 500n },
+    });
+  });
+
+  it('refuses a fractional minor unit instead of rounding it', () => {
+    // Half a paisa means a float got into somebody's money upstream. Rounding
+    // here would put a number in the ledger that nobody chose.
+    expect(() => parseSplitParams({ kind: 'exact', amounts: { asha: 500.5 } })).toThrow(
+      SplitWireError,
+    );
+  });
+
+  it('refuses a number dressed as a string', () => {
+    expect(() => parseSplitParams({ kind: 'exact', amounts: { asha: '5.00' } })).toThrow(
+      /not a whole number/,
+    );
+  });
+
+  it('refuses a kind it does not know', () => {
+    expect(() => parseSplitParams({ kind: 'vibes' })).toThrow(/Unknown split kind: vibes/);
+  });
+
+  it('refuses something that is not an object at all', () => {
+    expect(() => parseSplitParams(null)).toThrow(SplitWireError);
+    expect(() => parseSplitParams('equal')).toThrow(SplitWireError);
+  });
+
+  it('refuses a shape that would otherwise parse to nothing', () => {
+    expect(() => parseSplitParams({ kind: 'exact' })).toThrow(/amounts must be an object/);
+    expect(() => parseSplitParams({ kind: 'itemized', items: {} })).toThrow(/list of items/);
+  });
+
+  it('keeps a negative adjustment negative', () => {
+    // Adjustments go both ways: Ravi had the extra beer, Asha skipped dessert.
+    expect(
+      parseSplitParams({ kind: 'adjustment', adjustments: { ravi: '12000', asha: '-4000' } }),
+    ).toEqual({ kind: 'adjustment', adjustments: { ravi: 12000n, asha: -4000n } });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       expo-device:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.10)
+      expo-document-picker:
+        specifier: ~57.0.1
+        version: 57.0.1(expo@57.0.10)
       expo-file-system:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))
@@ -2874,6 +2877,11 @@ packages:
 
   expo-device@57.0.1:
     resolution: {integrity: sha512-jyEMDUticH+dhcL3GHa2aiifOvGXJsmb3oVT2R2q4i8bN7Bddy61+NkpMmuS2VAZrvoLQwf0TJJ/1vi1ukvutA==}
+    peerDependencies:
+      expo: '*'
+
+  expo-document-picker@57.0.1:
+    resolution: {integrity: sha512-qBwM5oxDZ3I9kwFD3pUE1oK/WNv9artoEKO6UpqhQgNRr0XA1ALRVWYjkF4+ge9lUNDRehjTm/jenINkzqg84g==}
     peerDependencies:
       expo: '*'
 
@@ -8077,6 +8085,10 @@ snapshots:
     dependencies:
       expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
       ua-parser-js: 0.7.41
+
+  expo-document-picker@57.0.1(expo@57.0.10):
+    dependencies:
+      expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
 
   expo-file-system@57.0.1(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)):
     dependencies:

--- a/supabase/functions/expense-write/index.ts
+++ b/supabase/functions/expense-write/index.ts
@@ -12,6 +12,8 @@
 
 import {
   computeShares,
+  parseSplitParams,
+  serialiseSplitParams,
   verifyClientShares,
   type FxRecord,
   type SplitParams,
@@ -100,10 +102,19 @@ Deno.serve(async (request) => {
 
     // The authoritative computation.
     const expenseId = body.expenseId ?? crypto.randomUUID();
+    // Minor units arrive as strings, because JSON has no bigint. Parsing here
+    // rather than trusting the shape means a client that sends a fractional
+    // share is refused rather than having it rounded into the ledger.
+    let splitParams: SplitParams;
+    try {
+      splitParams = parseSplitParams(body.splitParams);
+    } catch (bad) {
+      throw new HttpError(400, 'INVALID_SPLIT_PARAMS', (bad as Error).message);
+    }
     const shares = computeShares({
       amount,
       currency: body.currency,
-      params: body.splitParams,
+      params: splitParams,
       participants: body.participants,
       seed: expenseId,
     });
@@ -129,8 +140,10 @@ Deno.serve(async (request) => {
       p_expense_date: body.expenseDate,
       p_currency: body.currency.toUpperCase(),
       p_amount: amount.toString(),
-      p_split_type: body.splitParams.kind,
-      p_split_params: body.splitParams,
+      p_split_type: splitParams.kind,
+      // Stored in the canonical wire form: minor units as strings, whatever
+      // the client happened to send. A number in jsonb is a double.
+      p_split_params: serialiseSplitParams(splitParams),
       p_payers: payers.map(([id, value]) => ({ memberId: id, amount: value.toString() })),
       p_shares: [...shares].map(([id, value]) => ({ memberId: id, amount: value.toString() })),
       p_client_mutation_id: body.clientMutationId,

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -26,6 +26,8 @@ import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
 
 import {
   computeShares,
+  parseSplitParams,
+  serialiseSplitParams,
   verifyClientShares,
   type FxRecord,
   type SplitParams,
@@ -318,10 +320,19 @@ class SyncSession {
     }
 
     const expenseId = payload.expenseId ?? crypto.randomUUID();
+    // Minor units arrive as strings; JSON has no bigint. A queued mutation can
+    // be months old (ADR-005), so this also has to accept what older clients
+    // sent — but never a fractional minor unit, whoever sent it.
+    let splitParams: SplitParams;
+    try {
+      splitParams = parseSplitParams(payload.splitParams);
+    } catch (bad) {
+      throw new HttpError(400, 'VALIDATION_FAILED', (bad as Error).message);
+    }
     const shares = computeShares({
       amount,
       currency: payload.currency,
-      params: payload.splitParams,
+      params: splitParams,
       participants: payload.participants,
       seed: expenseId,
     });
@@ -343,8 +354,8 @@ class SyncSession {
       p_expense_date: payload.expenseDate,
       p_currency: payload.currency.toUpperCase(),
       p_amount: amount.toString(),
-      p_split_type: payload.splitParams.kind,
-      p_split_params: payload.splitParams,
+      p_split_type: splitParams.kind,
+      p_split_params: serialiseSplitParams(splitParams),
       p_payers: payers.map(([id, value]) => ({ memberId: id, amount: value.toString() })),
       p_shares: [...shares].map(([id, value]) => ({ memberId: id, amount: value.toString() })),
       p_client_mutation_id: mutation.clientMutationId,


### PR DESCRIPTION
Both parsers landed earlier with no way to reach them. This wires them to screens and to the offline queue.

## SMS — pasted, not read

Baaki cannot read the inbox. iOS gives no app that access; on Android `READ_SMS` is a Play-restricted permission granted only to the user's default SMS handler. Baaki is not going to be somebody's SMS app, so the design is the one where they hand the messages over.

Parsing stays on-device — a bank message carries an account tail, a balance and sometimes a one-time password (ADR-013). Messages split on blank lines (a single SMS wraps over several lines of its own) and the count is shown **before** parsing, so a bad paste is visible rather than silently producing two candidates from six messages.

Anything not in the group's currency is named and left for the add screen, which can ask for a rate and record where it came from. The message does not carry one.

## CSV — the work is the mapping

A CSV names people as text; a group has member ids. Getting that wrong doesn't fail loudly — it puts someone else's share on your name and the numbers still add up. So: a name is pre-filled only on an exact match, nothing imports until every column has somebody against it, and two columns pointed at one member **add** rather than overwrite. Rows the parser refused are listed by number.

## Re-importing is a no-op

Both the expense id and the `clientMutationId` are derived from the imported row itself, so a second import produces the same mutation and the write path answers with the expense it already wrote. `expenses.client_mutation_id` is UNIQUE — that holds whatever any client believes. The per-device list of imported keys only makes the duplicate *visible* instead of silently doing nothing.

## Live bug fixed on the way

`splitParams` carries minor units, and `JSON.stringify` throws on a bigint. So **saving an itemized bill failed before it reached the network**, and no split kind but `equal` could go through the offline queue at all.

`serialiseSplitParams` / `parseSplitParams` now live in `@baaki/core` and are used by the client and both edge functions. Minor units travel as decimal strings, not numbers — a number survives every test anybody writes and then loses a unit on the one bill big enough to matter. Fractional minor units are refused rather than rounded: that means a float got into somebody's money upstream.

## Tests

13 core tests including a 300-run round-trip property and a case past 2^53. 24 mobile tests for the mapping and the derived ids — shares landing on the right member, payers summing to the total, two identical rows staying two, an unmapped name refusing rather than being dropped.

## ⚠️ Needs a deploy

`expense-write` and `sync` changed. Until `supabase functions deploy expense-write sync` runs, **CSV import and the itemized fix are not live**. SMS import uses equal splits and works against the currently deployed server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)