### PR TITLE
packages/api-client + apps/web-lite — a guest can use a link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
       # anything else that decides what a person is told about their money.
       # Rendering is covered by the Maestro flows in e2e/, not here.
       - run: pnpm test:app
+      # The browser client: turning wire strings into balances. A Number
+      # slipping in here produces figures that look right and quietly differ
+      # from the app's.
+      - run: pnpm test:api
 
   database:
     name: migrations, RLS policies and ledger invariants

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ packages/core/dist/
 {
 {,
 ({
+
+# Next.js
+.next/
+out/
+next-env.d.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@ dist
 packages/db/generated
 packages/db/prisma/migrations
 pnpm-lock.yaml
+.next
+out

--- a/apps/web-lite/.env.example
+++ b/apps/web-lite/.env.example
@@ -1,0 +1,5 @@
+# The anon key is public by design: every table is behind RLS (ADR-013), so it
+# can only ever read rows the signed-in session is entitled to. Service keys
+# belong in edge-function env and nowhere near this file.
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/apps/web-lite/eslint.config.mjs
+++ b/apps/web-lite/eslint.config.mjs
@@ -1,0 +1,3 @@
+import next from 'eslint-config-next';
+
+export default [...next, { ignores: ['.next/**', 'out/**', 'next-env.d.ts'] }];

--- a/apps/web-lite/next.config.ts
+++ b/apps/web-lite/next.config.ts
@@ -1,0 +1,22 @@
+import type { NextConfig } from 'next';
+
+/**
+ * Every page here is a client component, and that is a decision rather than a
+ * default.
+ *
+ * Reads happen in the visitor's browser under their own session, so RLS is
+ * what decides what they see (ADR-013). Rendering a group on the server would
+ * need a key of its own, and the only key able to render somebody else's group
+ * is one that must never leave an edge function (TDR §11). Nothing is gained
+ * by moving the fetch: the page is behind an invite token either way.
+ *
+ * A static export would have been simpler still, but the invite links already
+ * in circulation are `/join/<token>` — a dynamic segment whose values cannot
+ * be known at build time. Changing the link shape to a query string would
+ * break every link already sent.
+ */
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/apps/web-lite/package.json
+++ b/apps/web-lite/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@baaki/web-lite",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint src --max-warnings 0",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@baaki/api-client": "workspace:*",
+    "@baaki/core": "workspace:*",
+    "@supabase/supabase-js": "^2.112.0",
+    "next": "^16.3.0",
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.1.0",
+    "@types/react": "~19.2.2",
+    "@types/react-dom": "~19.2.2",
+    "eslint": "^9.37.0",
+    "eslint-config-next": "^16.3.0",
+    "typescript": "~5.9.2"
+  }
+}

--- a/apps/web-lite/src/app/g/[groupId]/add/page.tsx
+++ b/apps/web-lite/src/app/g/[groupId]/add/page.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+/**
+ * Adding an expense with nothing installed — the point of the whole link.
+ *
+ * Equal splits only. That is not laziness: a guest is adding the auto they
+ * just paid for, and every extra control between them and Save is a chance
+ * they give up and the expense never gets recorded at all. Exact shares,
+ * itemised bills and percentages are in the app, and this screen says so.
+ *
+ * The amount is typed in major units and converted with @baaki/core, so no
+ * float ever exists between the keyboard and the ledger (ADR-003). The server
+ * recomputes every share from the parameters regardless of what is sent — the
+ * numbers below are a claim to be checked, not an instruction (TDR §4).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+
+import { computeShares, parseMajor, serialiseSplitParams, type CurrencyCode } from '@baaki/core';
+import { nameOf, type Group, type Member } from '@baaki/api-client';
+
+import { baaki } from '@/lib/baaki';
+import { money } from '@/lib/money';
+
+export default function AddExpensePage() {
+  const params = useParams<{ groupId: string }>();
+  const router = useRouter();
+  const groupId = params.groupId;
+
+  const [group, setGroup] = useState<Group | null>(null);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [myProfileId, setMyProfileId] = useState<string | null>(null);
+
+  const [description, setDescription] = useState('');
+  const [amountText, setAmountText] = useState('');
+  const [payer, setPayer] = useState<string | null>(null);
+  const [participants, setParticipants] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const [nextGroup, nextMembers, profileId] = await Promise.all([
+        baaki.group(groupId),
+        baaki.members(groupId),
+        baaki.currentProfileId(),
+      ]);
+      if (!active) return;
+      setGroup(nextGroup);
+      setMembers(nextMembers);
+      setMyProfileId(profileId);
+      setParticipants(nextMembers.map((member) => member.id));
+      // Whoever is holding the phone is usually the one who just paid.
+      setPayer(nextMembers.find((member) => member.profile_id === profileId)?.id ?? null);
+    })();
+    return () => {
+      active = false;
+    };
+  }, [groupId]);
+
+  const currency = (group?.default_currency ?? 'INR') as CurrencyCode;
+
+  const amount = useMemo(() => {
+    const trimmed = amountText.trim();
+    if (!trimmed) return null;
+    try {
+      return parseMajor(trimmed, currency).minor;
+    } catch {
+      return null;
+    }
+  }, [amountText, currency]);
+
+  /**
+   * Shown before saving, because "split equally" hides the fact that ₹100
+   * between three people is 33.34 / 33.33 / 33.33 and somebody is a paisa
+   * worse off. Better seen than discovered.
+   */
+  const preview = useMemo(() => {
+    if (!amount || amount <= 0n || participants.length === 0) return null;
+    try {
+      return computeShares({
+        amount,
+        currency,
+        params: { kind: 'equal' },
+        participants,
+        // The server seeds the remainder rotation on the expense id it ends up
+        // writing, so this preview can differ by one minor unit from the final
+        // answer. It is a preview of the shape, not a promise of the cents.
+        seed: 'preview',
+      });
+    } catch {
+      return null;
+    }
+  }, [amount, currency, participants]);
+
+  const toggle = useCallback((memberId: string) => {
+    setParticipants((current) =>
+      current.includes(memberId)
+        ? current.filter((item) => item !== memberId)
+        : [...current, memberId],
+    );
+  }, []);
+
+  const save = useCallback(async () => {
+    if (!amount || amount <= 0n || !payer || participants.length === 0) return;
+    setError(null);
+    setSaving(true);
+    try {
+      await baaki.writeExpense({
+        groupId,
+        description: description.trim() || 'Expense',
+        expenseDate: new Date().toISOString().slice(0, 10),
+        currency,
+        amount,
+        splitParams: serialiseSplitParams({ kind: 'equal' }),
+        participants,
+        payers: { [payer]: amount },
+        // A guest on a phone browser is exactly who taps Save twice on a slow
+        // connection. This is what makes the second tap harmless (ADR-005).
+        clientMutationId: crypto.randomUUID(),
+      });
+      router.replace(`/g/${groupId}`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+      setSaving(false);
+    }
+  }, [amount, payer, participants, groupId, description, currency, router]);
+
+  if (!group) {
+    return (
+      <main>
+        <div className="card">
+          <p className="muted">Loading…</p>
+        </div>
+      </main>
+    );
+  }
+
+  const ready = Boolean(amount && amount > 0n && payer && participants.length > 0);
+
+  return (
+    <main>
+      <div className="card">
+        <h1>Add an expense</h1>
+        <input
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          placeholder="What was it?"
+          aria-label="What was it?"
+        />
+        <input
+          value={amountText}
+          onChange={(event) => setAmountText(event.target.value)}
+          inputMode="decimal"
+          placeholder={`How much? (${currency})`}
+          aria-label={`Amount in ${currency}`}
+        />
+        {amountText.trim() && amount === null ? (
+          <p className="error">That is not an amount.</p>
+        ) : null}
+      </div>
+
+      <div className="card">
+        <h2>Who paid</h2>
+        <div className="people">
+          {members.map((member) => (
+            <button
+              key={member.id}
+              type="button"
+              className="chip"
+              aria-pressed={payer === member.id}
+              onClick={() => setPayer(member.id)}
+            >
+              {member.profile_id === myProfileId ? 'You' : nameOf(member)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="card">
+        <h2>Split between</h2>
+        <div className="people">
+          {members.map((member) => (
+            <button
+              key={member.id}
+              type="button"
+              className="chip"
+              aria-pressed={participants.includes(member.id)}
+              onClick={() => toggle(member.id)}
+            >
+              {member.profile_id === myProfileId ? 'You' : nameOf(member)}
+            </button>
+          ))}
+        </div>
+        {preview ? (
+          <>
+            {[...preview].map(([memberId, share]) => (
+              <div className="row" key={memberId}>
+                <span>{nameOf(members.find((m) => m.id === memberId) ?? members[0]!)}</span>
+                <span className="money">{money(share, currency)}</span>
+              </div>
+            ))}
+            <p className="faint">
+              Split equally. For exact shares or an itemised bill, use the app.
+            </p>
+          </>
+        ) : null}
+      </div>
+
+      {error ? <p className="error">{error}</p> : null}
+
+      <button type="button" onClick={() => void save()} disabled={!ready || saving}>
+        {saving ? 'Saving…' : 'Save'}
+      </button>
+      <button type="button" className="ghost" onClick={() => router.back()}>
+        Cancel
+      </button>
+    </main>
+  );
+}

--- a/apps/web-lite/src/app/g/[groupId]/page.tsx
+++ b/apps/web-lite/src/app/g/[groupId]/page.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+/**
+ * The group, in a browser.
+ *
+ * Deliberately less than the app: balances, who owes whom, the recent
+ * expenses, and one way to add another. Everything a guest needs during the
+ * trip, and nothing that would need explaining.
+ *
+ * The balances are computed by @baaki/core from the same rows the app reads,
+ * so a guest's browser and the payer's phone cannot disagree about who owes
+ * what. If they could, there would be no way to say which one was lying.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+
+import {
+  computeLedger,
+  nameOf,
+  type Expense,
+  type Group,
+  type Member,
+  type Settlement,
+} from '@baaki/api-client';
+
+import { baaki } from '@/lib/baaki';
+import { money } from '@/lib/money';
+
+export default function GroupPage() {
+  const params = useParams<{ groupId: string }>();
+  const groupId = params.groupId;
+
+  const [group, setGroup] = useState<Group | null>(null);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [settlements, setSettlements] = useState<Settlement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Guarded, because navigating away mid-fetch would otherwise write one
+    // group's rows into a screen already showing another's.
+    let active = true;
+    void (async () => {
+      try {
+        const [nextGroup, nextMembers, nextExpenses, nextSettlements] = await Promise.all([
+          baaki.group(groupId),
+          baaki.members(groupId),
+          baaki.expenses(groupId),
+          baaki.settlements(groupId),
+        ]);
+        if (!active) return;
+        setGroup(nextGroup);
+        setMembers(nextMembers);
+        setExpenses(nextExpenses);
+        setSettlements(nextSettlements);
+      } catch (caught) {
+        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [groupId]);
+
+  if (loading) {
+    return (
+      <main>
+        <div className="card">
+          <p className="muted">Loading…</p>
+        </div>
+      </main>
+    );
+  }
+
+  // RLS answers "not yours" with no rows rather than an error, which is the
+  // right behaviour and a confusing screen unless it is said plainly.
+  if (!group) {
+    return (
+      <main>
+        <div className="card">
+          <h1>Not your group</h1>
+          <p>
+            {error ??
+              'This browser is not a member of this group. If somebody sent you a link, open that instead.'}
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const currency = group.default_currency;
+  const ledger = computeLedger(expenses, settlements, currency);
+  const byId = new Map(members.map((member) => [member.id, member]));
+  const live = expenses.filter((expense) => !expense.deleted_at && expense.currentVersion);
+
+  return (
+    <main>
+      <div className="card">
+        <h1>
+          {group.cover_emoji ? `${group.cover_emoji} ` : ''}
+          {group.name?.trim() || 'Your group'}
+        </h1>
+        <p className="faint">
+          {members.length} {members.length === 1 ? 'person' : 'people'} · {live.length}{' '}
+          {live.length === 1 ? 'expense' : 'expenses'}
+        </p>
+      </div>
+
+      <div className="card">
+        <h2>Where everyone stands</h2>
+        {members.map((member) => {
+          const net = ledger.balances.get(member.id) ?? 0n;
+          return (
+            <div className="row" key={member.id}>
+              <span>{nameOf(member)}</span>
+              <span
+                className={`money ${net > 0n ? 'owed' : net < 0n ? 'owe' : ''}`}
+                aria-label={`${nameOf(member)} ${
+                  net === 0n ? 'is settled up' : net > 0n ? 'is owed' : 'owes'
+                } ${money(net < 0n ? -net : net, currency)}`}
+              >
+                {net === 0n ? 'settled up' : money(net < 0n ? -net : net, currency)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {ledger.transfers.length > 0 ? (
+        <div className="card">
+          <h2>Who pays whom</h2>
+          <p className="faint">
+            The fewest payments that settle everybody. Nobody is made to pay somebody they never
+            split anything with.
+          </p>
+          {ledger.transfers.map((transfer, index) => (
+            <div className="row" key={index}>
+              <span>
+                {nameOf(byId.get(transfer.from) ?? fallback(transfer.from))} →{' '}
+                {nameOf(byId.get(transfer.to) ?? fallback(transfer.to))}
+              </span>
+              <span className="money">{money(transfer.amount, transfer.currency)}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {live.length > 0 ? (
+        <div className="card">
+          <h2>Recent</h2>
+          {live.slice(0, 12).map((expense) => {
+            const version = expense.currentVersion;
+            if (!version) return null;
+            return (
+              <div className="row" key={expense.id}>
+                <span>
+                  {version.description}
+                  <br />
+                  <span className="faint">{version.expense_date}</span>
+                </span>
+                <span className="money">{money(BigInt(version.amount), version.currency)}</span>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      <Link className="button" href={`/g/${groupId}/add`}>
+        Add an expense
+      </Link>
+
+      <p className="faint" style={{ textAlign: 'center' }}>
+        Install Baaki to scan receipts, settle over UPI and keep this working without a signal.
+      </p>
+    </main>
+  );
+}
+
+/** A member who has left is still on old expenses; the transfer still names them. */
+function fallback(memberId: string): Member {
+  return {
+    id: memberId,
+    group_id: '',
+    profile_id: null,
+    ghost_name: null,
+    left_at: null,
+    profile: null,
+  };
+}

--- a/apps/web-lite/src/app/globals.css
+++ b/apps/web-lite/src/app/globals.css
@@ -1,0 +1,192 @@
+/*
+ * The same tokens as packages/ui, written out as CSS variables.
+ *
+ * Not imported from there: packages/ui is React Native, and pulling it into a
+ * browser bundle to read six colours would drag the whole primitive library
+ * with it. The values are duplicated deliberately and kept short enough to
+ * check by eye against packages/ui/src/tokens.ts.
+ *
+ * Money colour stays semantic, as it is everywhere else: owed-to-you is always
+ * the green, you-owe is always the red, and nothing decorative uses either.
+ */
+
+:root {
+  --brand: #7a5af8;
+  --brand-600: #6c4ee3;
+  --brand-100: #e9e4ff;
+  --bg: #f3f1fb;
+  --surface: #ffffff;
+  --text: #14142b;
+  --text-muted: #54566b;
+  --text-faint: #7b7b8f;
+  --border: #ededf5;
+  --positive: #0e9f6e;
+  --negative: #e5484d;
+  --radius: 20px;
+  --shadow: 0 8px 24px rgba(30, 20, 80, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 24px 20px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+h1 {
+  font-size: 26px;
+  line-height: 1.2;
+  margin: 0;
+}
+
+h2 {
+  font-size: 17px;
+  margin: 0;
+}
+
+p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.muted {
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.faint {
+  color: var(--text-faint);
+  font-size: 13px;
+}
+
+button,
+.button {
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  background: var(--brand);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+  padding: 14px 20px;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
+  display: block;
+  width: 100%;
+}
+
+button:active {
+  background: var(--brand-600);
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--brand);
+}
+
+input,
+select {
+  width: 100%;
+  font-size: 16px; /* under 16px, iOS Safari zooms the page on focus */
+  padding: 12px 0;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  border-radius: 0;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-bottom-color: var(--brand);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.row + .row {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+/* Tabular figures so a column of amounts lines up on the decimal. */
+.money {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.money.owed {
+  color: var(--positive);
+}
+
+.money.owe {
+  color: var(--negative);
+}
+
+.error {
+  color: var(--negative);
+  font-size: 14px;
+}
+
+.people {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 14px;
+  width: auto;
+  display: inline-block;
+}
+
+.chip[aria-pressed='true'] {
+  background: var(--brand-100);
+  border-color: var(--brand);
+  color: var(--brand-600);
+}

--- a/apps/web-lite/src/app/join/[token]/page.tsx
+++ b/apps/web-lite/src/app/join/[token]/page.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+/**
+ * The link somebody was sent.
+ *
+ * This is the whole growth loop in one screen (ADR-006): a person taps a link
+ * in WhatsApp and is in the group, on a phone with nothing installed. No
+ * account to make, no app store, no password.
+ *
+ * The one thing this screen must get right is the claim. Somebody was probably
+ * already added as a ghost — "Ravi", typed in by whoever started the group —
+ * and the expenses filed against that name are the point of them arriving at
+ * all. Taking that place keeps the history; skipping it makes a second Ravi
+ * and the group now has two people who are one person, which nothing
+ * downstream can undo. So the claim is offered first and by name.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+
+import type { InvitePreview } from '@baaki/api-client';
+
+import { baaki } from '@/lib/baaki';
+
+export default function JoinPage() {
+  const params = useParams<{ token: string }>();
+  const router = useRouter();
+  const token = params.token;
+
+  const [preview, setPreview] = useState<InvitePreview | null>(null);
+  const [claimId, setClaimId] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [joining, setJoining] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void baaki
+      .previewInvite(token)
+      .then((result) => {
+        if (active) setPreview(result);
+      })
+      .catch((caught: unknown) => {
+        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+      });
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  const join = useCallback(async () => {
+    setError(null);
+    setJoining(true);
+    try {
+      // The guest account is made first, then the invite is accepted against
+      // it. Same account when they later add an email, so the group and its
+      // history stay theirs rather than being re-joined as a stranger.
+      await baaki.signInAsGuest();
+      const accepted = await baaki.acceptInvite({
+        token,
+        claimMemberId: claimId,
+        displayName: claimId ? null : name.trim() || null,
+      });
+      router.replace(`/g/${accepted.group.id}`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+      setJoining(false);
+    }
+  }, [token, claimId, name, router]);
+
+  if (error && !preview) {
+    return (
+      <main>
+        <div className="card">
+          <h1>This link does not work</h1>
+          <p>{error}</p>
+          <p className="faint">
+            Links expire, and whoever shared it can turn it off. Ask them for a new one.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (!preview) {
+    return (
+      <main>
+        <div className="card">
+          <p className="muted">Opening the link…</p>
+        </div>
+      </main>
+    );
+  }
+
+  const groupName = preview.group?.name?.trim() || 'a group';
+
+  return (
+    <main>
+      <div className="card">
+        <h1>
+          {preview.group?.cover_emoji ? `${preview.group.cover_emoji} ` : ''}
+          You have been added to {groupName}
+        </h1>
+        <p>
+          {preview.memberCount} {preview.memberCount === 1 ? 'person is' : 'people are'} splitting
+          costs here. You can join and add an expense right now — nothing to install.
+        </p>
+      </div>
+
+      {preview.claimable.length > 0 ? (
+        <div className="card">
+          <h2>Which one are you?</h2>
+          <p className="faint">
+            Somebody already added these names. Picking yours keeps the expenses already filed
+            against it.
+          </p>
+          <div className="people">
+            {preview.claimable.map((person) => (
+              <button
+                key={person.memberId}
+                type="button"
+                className="chip"
+                aria-pressed={claimId === person.memberId}
+                onClick={() => setClaimId(person.memberId)}
+              >
+                {person.name ?? 'Someone'}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="chip"
+              aria-pressed={claimId === null}
+              onClick={() => setClaimId(null)}
+            >
+              None of these
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {claimId === null ? (
+        <div className="card">
+          <h2>Your name</h2>
+          <input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="What should they call you?"
+            aria-label="Your name"
+            autoComplete="name"
+          />
+          <p className="faint">
+            This is the only thing asked of you. No email, no password, no app.
+          </p>
+        </div>
+      ) : null}
+
+      {error ? <p className="error">{error}</p> : null}
+
+      <button type="button" onClick={() => void join()} disabled={joining}>
+        {joining ? 'Joining…' : `Join ${groupName}`}
+      </button>
+    </main>
+  );
+}

--- a/apps/web-lite/src/app/layout.tsx
+++ b/apps/web-lite/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata, Viewport } from 'next';
+
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Baaki',
+  description: 'Split expenses without the argument at the end.',
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: '#7A5AF8',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web-lite/src/app/page.tsx
+++ b/apps/web-lite/src/app/page.tsx
@@ -1,0 +1,18 @@
+/**
+ * There is no web app. This page exists because somebody will type the domain
+ * in, and a blank 404 tells them nothing about what they were sent.
+ */
+export default function Home() {
+  return (
+    <main>
+      <div className="card">
+        <h1>Baaki</h1>
+        <p>
+          Split expenses without the argument at the end. This page is only for opening an invite
+          link — if somebody shared a group with you, open their link rather than this address.
+        </p>
+        <p className="faint">Everything else lives in the app.</p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web-lite/src/lib/baaki.ts
+++ b/apps/web-lite/src/lib/baaki.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { createClient } from '@supabase/supabase-js';
+
+import { createBaakiClient, type BaakiClient } from '@baaki/api-client';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!url || !anonKey) {
+  throw new Error(
+    'NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set. ' +
+      'Copy apps/web-lite/.env.example to .env.local.',
+  );
+}
+
+/**
+ * The anon key ships in the page, the same as it ships in the app binary.
+ * That is what it is for: every table is behind RLS, so this key can only ever
+ * read rows the signed-in session is entitled to (ADR-013).
+ *
+ * The session is stored per browser. A guest who opens a link, joins, and
+ * comes back tomorrow is the same account — which is what makes the later
+ * upgrade to a real login keep their history (ADR-006).
+ */
+export const supabase = createClient(url, anonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: false,
+  },
+});
+
+export const baaki: BaakiClient = createBaakiClient({ supabase });

--- a/apps/web-lite/src/lib/money.ts
+++ b/apps/web-lite/src/lib/money.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { format, type CurrencyCode } from '@baaki/core';
+
+/**
+ * Money is formatted by @baaki/core, not by this app.
+ *
+ * A second formatter is a second set of rounding rules, and the first time
+ * they disagree is a person seeing ₹416.67 on their phone and ₹416.66 in a
+ * browser and deciding one of us is stealing from them (ADR-003).
+ */
+export function money(minor: bigint, currency: string, locale = 'en-IN'): string {
+  return format({ minor, currency: currency as CurrencyCode }, { locale });
+}
+
+/** "you are owed" / "you owe", said out loud for a screen reader (TDR §11). */
+export function balanceLabel(minor: bigint, currency: string, locale = 'en-IN'): string {
+  if (minor === 0n) return 'settled up';
+  const amount = money(minor < 0n ? -minor : minor, currency, locale);
+  return minor > 0n ? `is owed ${amount}` : `owes ${amount}`;
+}

--- a/apps/web-lite/tsconfig.json
+++ b/apps/web-lite/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "jsx": "preserve",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "incremental": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "src", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/e2e/m3-web-lite.mjs
+++ b/e2e/m3-web-lite.mjs
@@ -1,0 +1,335 @@
+/**
+ * M3's acceptance criterion, against the live project:
+ *
+ *   "Guest opens link in browser, adds an expense with no install."
+ *
+ * The point of running this rather than trusting the screens is that the
+ * browser path is a *different client* from the app — its own Supabase session,
+ * its own reads, no offline mirror — and the thing that must hold across both
+ * is that RLS decides what is visible, not the code that happens to be asking.
+ * So this exercises `@baaki/api-client` exactly as `apps/web-lite` does, and
+ * then checks the two things a screen cannot check for itself: that a stranger
+ * with the same anon key sees nothing, and that the guest's account is the
+ * same account after they add credentials to it.
+ *
+ * Run: node e2e/m3-web-lite.mjs   (needs ANON_KEY)
+ */
+import { createClient } from '@supabase/supabase-js';
+
+import { computeNetBalances } from '../supabase/functions/_shared/core.js';
+
+const URL = process.env.SUPABASE_URL ?? 'https://xvjzbpgcmotoahtqcxve.supabase.co';
+const ANON = process.env.ANON_KEY;
+
+if (!ANON) {
+  console.error('Set ANON_KEY.');
+  process.exit(1);
+}
+
+const pass = [];
+const fail = [];
+const check = (label, condition, detail = '') => {
+  (condition ? pass : fail).push(label);
+  console.log(`${condition ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`);
+};
+
+async function describeError(error) {
+  if (!error) return '';
+  const context = error.context;
+  if (context && typeof context.json === 'function') {
+    try {
+      const body = await context.json();
+      return `${body.code ?? '?'}: ${body.message ?? ''}`;
+    } catch {
+      /* not JSON */
+    }
+  }
+  return error.message ?? String(error);
+}
+
+/** A fresh browser: its own session, nothing shared with the last one. */
+const browser = () =>
+  createClient(URL, ANON, { auth: { persistSession: false, autoRefreshToken: false } });
+
+// ── the host: somebody who already has the app ──────────────────────────────
+
+const host = browser();
+{
+  const { error } = await host.auth.signInAnonymously();
+  if (error) {
+    console.error('Could not create the host account:', error.message);
+    process.exit(1);
+  }
+}
+
+const { data: groupId, error: groupError } = await host.rpc('baaki_create_group', {
+  p_name: 'Goa',
+  p_type: 'trip',
+  p_currency: 'INR',
+  p_emoji: '🏖️',
+  p_simplify: true,
+});
+check('host creates a group', !groupError, groupError?.message);
+
+// A ghost, because that is the normal case: the trip is already half planned
+// before the person you are inviting has heard of the app (ADR-006).
+const { data: ghostId, error: ghostError } = await host.rpc('baaki_add_ghost_member', {
+  p_group_id: groupId,
+  p_name: 'Ravi',
+  p_member_id: null,
+});
+check('host adds Ravi as a ghost', !ghostError, ghostError?.message);
+
+const { data: minted, error: mintError } = await host.functions.invoke('invite-mint', {
+  body: { groupId, expiresInDays: 7 },
+});
+check('host mints a link', !mintError && Boolean(minted?.token), await describeError(mintError));
+const token = minted?.token;
+
+// ── the guest: a browser with nothing installed ─────────────────────────────
+
+const guest = browser();
+
+// 1. The link is readable before committing to anything. No account yet.
+const { data: preview, error: previewError } = await guest.functions.invoke('invite-accept', {
+  body: { token, mode: 'preview' },
+});
+check(
+  'link previews with no account at all',
+  !previewError && preview?.group?.id === groupId,
+  await describeError(previewError),
+);
+check(
+  'preview offers Ravi to claim',
+  (preview?.claimable ?? []).some((person) => person.memberId === ghostId),
+  JSON.stringify(preview?.claimable ?? []),
+);
+
+// 2. Joining. Guest account first, then the invite against it — the order the
+//    web-lite join screen uses.
+const { error: guestSignIn } = await guest.auth.signInAnonymously();
+check('guest account is created in the browser', !guestSignIn, guestSignIn?.message);
+
+const {
+  data: { session: guestSession },
+} = await guest.auth.getSession();
+const guestUserId = guestSession?.user?.id;
+check('the guest account is anonymous', guestSession?.user?.is_anonymous === true);
+
+const { data: accepted, error: acceptError } = await guest.functions.invoke('invite-accept', {
+  body: { token, mode: 'join', claimMemberId: ghostId },
+});
+check(
+  'guest joins and claims Ravi',
+  !acceptError && accepted?.claimed === true && accepted?.memberId === ghostId,
+  await describeError(acceptError),
+);
+
+// 3. Reading the group — what apps/web-lite/src/app/g/[groupId] does.
+const { data: readGroup } = await guest
+  .from('groups')
+  .select('id, name, default_currency')
+  .eq('id', groupId);
+check('guest can read the group', (readGroup ?? []).length === 1);
+
+const { data: readMembers } = await guest
+  .from('group_members')
+  .select('id, profile_id, ghost_name, profile:profiles ( display_name )')
+  .eq('group_id', groupId)
+  .is('left_at', null);
+check(
+  'guest can read the members',
+  (readMembers ?? []).length === 2,
+  `${readMembers?.length} rows`,
+);
+
+// 4. Adding an expense with nothing installed. The whole point.
+const hostMemberId = (readMembers ?? []).find((member) => member.id !== ghostId)?.id;
+const { data: written, error: writeError } = await guest.functions.invoke('expense-write', {
+  body: {
+    groupId,
+    description: 'Auto to the beach',
+    expenseDate: new Date().toISOString().slice(0, 10),
+    currency: 'INR',
+    amount: '30000',
+    splitParams: { kind: 'equal' },
+    participants: [ghostId, hostMemberId],
+    payers: { [ghostId]: '30000' },
+    clientMutationId: crypto.randomUUID(),
+  },
+});
+check(
+  'guest adds an expense from the browser',
+  !writeError && Boolean(written?.expenseId),
+  await describeError(writeError),
+);
+
+// 5. The same request twice is one expense. A guest on a slow phone browser is
+//    exactly who taps Save twice.
+const replayId = crypto.randomUUID();
+const body = {
+  groupId,
+  description: 'Chai',
+  expenseDate: new Date().toISOString().slice(0, 10),
+  currency: 'INR',
+  amount: '4000',
+  splitParams: { kind: 'equal' },
+  participants: [ghostId, hostMemberId],
+  payers: { [ghostId]: '4000' },
+  clientMutationId: replayId,
+};
+const first = await guest.functions.invoke('expense-write', { body });
+const second = await guest.functions.invoke('expense-write', { body });
+check(
+  'saving twice writes one expense',
+  second.data?.replayed === true && second.data?.expenseId === first.data?.expenseId,
+  await describeError(second.error),
+);
+
+// 6. The browser and the app agree about the money. Both compute from the same
+//    rows with the same @baaki/core code; if they could differ, there would be
+//    no way to say which was lying.
+const { data: expenses } = await guest
+  .from('expenses')
+  .select(
+    `id, deleted_at,
+     currentVersion:expense_versions!expenses_current_version_id_fkey (
+       currency, amount, expense_date,
+       payers:expense_payers ( member_id, amount ),
+       shares:expense_shares ( member_id, amount )
+     )`,
+  )
+  .eq('group_id', groupId);
+
+const snapshots = (expenses ?? [])
+  .filter((expense) => expense.currentVersion)
+  .map((expense) => ({
+    id: expense.id,
+    currency: expense.currentVersion.currency,
+    amount: BigInt(expense.currentVersion.amount),
+    payers: Object.fromEntries(
+      expense.currentVersion.payers.map((row) => [row.member_id, BigInt(row.amount)]),
+    ),
+    shares: Object.fromEntries(
+      expense.currentVersion.shares.map((row) => [row.member_id, BigInt(row.amount)]),
+    ),
+    date: expense.currentVersion.expense_date,
+    deletedAt: expense.deleted_at,
+  }));
+
+const computed = computeNetBalances(snapshots, []).get('INR') ?? new Map();
+// Read as the guest, not as a service role: the derived table the server
+// maintains has to be visible to a member, and it has to say the same thing.
+const { data: serverBalances } = await guest
+  .from('group_balances')
+  .select('member_id, balance')
+  .eq('group_id', groupId)
+  .eq('currency', 'INR');
+
+const agrees = (serverBalances ?? []).every(
+  (row) => (computed.get(row.member_id) ?? 0n) === BigInt(row.balance),
+);
+check(
+  "the browser's balances match the server's",
+  agrees && (serverBalances ?? []).length > 0,
+  JSON.stringify(
+    (serverBalances ?? []).map((row) => [
+      row.member_id.slice(0, 8),
+      row.balance,
+      String(computed.get(row.member_id)),
+    ]),
+  ),
+);
+
+const sum = [...computed.values()].reduce((total, value) => total + value, 0n);
+check('balances sum to zero', sum === 0n, String(sum));
+
+// 7. A different browser with the same anon key sees none of it. This is the
+//    claim the whole design rests on: the key is public, RLS is the boundary.
+const stranger = browser();
+await stranger.auth.signInAnonymously();
+const { data: strangerGroup } = await stranger.from('groups').select('id').eq('id', groupId);
+const { data: strangerMembers } = await stranger
+  .from('group_members')
+  .select('id')
+  .eq('group_id', groupId);
+const { data: strangerExpenses } = await stranger
+  .from('expenses')
+  .select('id')
+  .eq('group_id', groupId);
+check(
+  'another browser with the same key sees nothing',
+  (strangerGroup ?? []).length === 0 &&
+    (strangerMembers ?? []).length === 0 &&
+    (strangerExpenses ?? []).length === 0,
+  `${strangerGroup?.length}/${strangerMembers?.length}/${strangerExpenses?.length} rows`,
+);
+
+// 8. A stranger cannot write into the group either, token or no token.
+const { error: strangerWrite } = await stranger.functions.invoke('expense-write', {
+  body: {
+    groupId,
+    description: 'Not mine',
+    expenseDate: new Date().toISOString().slice(0, 10),
+    currency: 'INR',
+    amount: '100',
+    splitParams: { kind: 'equal' },
+    participants: [ghostId],
+    payers: { [ghostId]: '100' },
+    clientMutationId: crypto.randomUUID(),
+  },
+});
+check(
+  'another browser cannot write into the group',
+  Boolean(strangerWrite),
+  await describeError(strangerWrite),
+);
+
+// 9. "…later installs, history intact." The half of that this can prove without
+//    an app is that the ghost's place now belongs to the guest's own account —
+//    the claimed member carries their profile id, so the expenses filed against
+//    "Ravi" before they arrived are theirs from here on (ADR-006).
+//
+//    The other half — adding an email or a Google identity to the same
+//    anonymous account rather than making a new one — is auth, which is not
+//    built yet. It cannot be exercised here in any case: the project rate-limits
+//    confirmation emails, so a test that sent one would fail on the second run
+//    for a reason that has nothing to do with the code.
+const {
+  data: { user: stillTheSame },
+} = await guest.auth.getUser();
+check(
+  'the guest is still the same account after all of it',
+  stillTheSame?.id === guestUserId && stillTheSame?.is_anonymous === true,
+  stillTheSame?.id,
+);
+
+const { data: claimedRow } = await guest
+  .from('group_members')
+  .select('id, profile_id, ghost_name')
+  .eq('id', ghostId)
+  .single();
+check(
+  "the ghost's place now belongs to the guest",
+  claimedRow?.profile_id === guestUserId,
+  `${claimedRow?.ghost_name} -> ${claimedRow?.profile_id?.slice(0, 8)}`,
+);
+
+const { data: afterClaim } = await guest.from('expenses').select('id').eq('group_id', groupId);
+check(
+  'the history filed against that name is still there',
+  (afterClaim ?? []).length === (expenses ?? []).length,
+  `${afterClaim?.length} of ${expenses?.length}`,
+);
+
+// ── clean up ────────────────────────────────────────────────────────────────
+
+// Archived rather than deleted: the host is a normal member and a normal
+// member cannot delete a ledger anybody else is in (ADR-004).
+await host.from('groups').update({ archived_at: new Date().toISOString() }).eq('id', groupId);
+
+console.log(`\n${pass.length}/${pass.length + fail.length} passed`);
+if (fail.length > 0) {
+  console.log('Failed:', fail.join(', '));
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test:core": "pnpm --filter @baaki/core run test",
     "test:db": "pnpm --filter @baaki/db run test",
     "test:app": "pnpm --filter @baaki/mobile run test",
+    "test:api": "pnpm --filter @baaki/api-client run test",
+    "web": "pnpm --filter @baaki/web-lite run dev",
     "db:generate": "pnpm --filter @baaki/db run generate",
     "db:migrate": "pnpm --filter @baaki/db run migrate:deploy",
     "db:migrate:dev": "pnpm --filter @baaki/db run migrate:dev",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@baaki/api-client",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@baaki/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@supabase/supabase-js": "*"
+  },
+  "devDependencies": {
+    "@supabase/supabase-js": "^2.112.0",
+    "typescript": "~5.9.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,0 +1,231 @@
+/**
+ * One client for anything that is not the phone.
+ *
+ * Framework-free on purpose: no React, no React Native, no Next. The app has
+ * its own data layer built around an offline mirror and a mutation queue; a
+ * browser opening a link has neither and does not want them. What the two
+ * genuinely share is @baaki/core — the split maths, the balances, the money
+ * types — and that is where sharing stops being a convenience and starts being
+ * a correctness requirement (TDR §1).
+ *
+ * Authorization is not here. Every read goes to PostgREST under the caller's
+ * own session and every RLS policy applies unchanged (ADR-013); a guest who
+ * accepted an invite sees exactly the group they joined, because that is what
+ * the database says, not because this file remembered to filter. The one thing
+ * that carries authority is the invite token, and that is checked server-side
+ * in `invite-accept`.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { AcceptedInvite, Expense, Group, InvitePreview, Member, Settlement } from './types';
+
+const MEMBER_COLUMNS = `
+  id, group_id, profile_id, ghost_name, left_at,
+  profile:profiles ( display_name )
+`;
+
+const EXPENSE_COLUMNS = `
+  id, group_id, deleted_at, created_at,
+  currentVersion:expense_versions!expenses_current_version_id_fkey (
+    id, version_no, description, category, expense_date, currency, amount,
+    split_type, split_params,
+    payers:expense_payers ( member_id, amount ),
+    shares:expense_shares ( member_id, amount )
+  )
+`;
+
+export interface BaakiClientOptions {
+  supabase: SupabaseClient;
+}
+
+export class BaakiApiError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = 'BaakiApiError';
+  }
+}
+
+export function createBaakiClient({ supabase }: BaakiClientOptions) {
+  /**
+   * PostgREST answers "you may not see this" with an empty list, not an error
+   * — that is RLS doing its job. Only a real failure throws.
+   */
+  async function read<T>(query: PromiseLike<{ data: unknown; error: unknown }>): Promise<T[]> {
+    const { data, error } = await query;
+    if (error) throw new BaakiApiError(String((error as { message?: string }).message ?? error));
+    return (data ?? []) as T[];
+  }
+
+  async function callFunction<T>(name: string, body: Record<string, unknown>): Promise<T> {
+    const { data, error } = await supabase.functions.invoke(name, { body });
+    if (error) throw await describeFunctionError(error);
+    return data as T;
+  }
+
+  return {
+    /**
+     * A guest is a real account with no credentials on it yet (ADR-006). It is
+     * created before the invite is accepted so the membership has somebody to
+     * belong to — and it is the *same* account they later add an email to, so
+     * the group does not have to be re-joined and the history stays theirs.
+     */
+    async signInAsGuest(): Promise<void> {
+      const { data } = await supabase.auth.getSession();
+      if (data.session) return;
+      const { error } = await supabase.auth.signInAnonymously();
+      if (error) throw new BaakiApiError(error.message);
+    },
+
+    async currentProfileId(): Promise<string | null> {
+      const { data } = await supabase.auth.getSession();
+      return data.session?.user.id ?? null;
+    },
+
+    /** What is behind the link, without joining anything. */
+    previewInvite(token: string): Promise<InvitePreview> {
+      return callFunction<InvitePreview>('invite-accept', { token, mode: 'preview' });
+    },
+
+    /**
+     * Joining. `claimMemberId` takes over a ghost somebody already added, which
+     * is what keeps the expenses already filed against that name (ADR-006) —
+     * without it the arrival becomes a second person and the group has two of
+     * them.
+     */
+    acceptInvite(input: {
+      token: string;
+      claimMemberId?: string | null;
+      displayName?: string | null;
+    }): Promise<AcceptedInvite> {
+      return callFunction<AcceptedInvite>('invite-accept', { ...input, mode: 'join' });
+    },
+
+    async group(groupId: string): Promise<Group | null> {
+      const rows = await read<Group>(
+        supabase
+          .from('groups')
+          .select('id, name, cover_emoji, default_currency, simplify_debts')
+          .eq('id', groupId)
+          .limit(1),
+      );
+      return rows[0] ?? null;
+    },
+
+    members(groupId: string): Promise<Member[]> {
+      return read<Member>(
+        supabase
+          .from('group_members')
+          .select(MEMBER_COLUMNS)
+          .eq('group_id', groupId)
+          .is('left_at', null)
+          .order('created_at', { ascending: true }),
+      );
+    },
+
+    expenses(groupId: string): Promise<Expense[]> {
+      return read<Expense>(
+        supabase
+          .from('expenses')
+          .select(EXPENSE_COLUMNS)
+          .eq('group_id', groupId)
+          .order('created_at', { ascending: false }),
+      );
+    },
+
+    settlements(groupId: string): Promise<Settlement[]> {
+      return read<Settlement>(
+        supabase
+          .from('settlements')
+          .select(
+            `id, group_id, from_member_id, to_member_id, currency, amount, status,
+             initiated_at, confirmed_at,
+             allocations:settlement_allocations ( expense_id, amount )`,
+          )
+          .eq('group_id', groupId)
+          .order('initiated_at', { ascending: false }),
+      );
+    },
+
+    /**
+     * Writing an expense goes through the edge function, never straight to a
+     * table. The server recomputes every share from the parameters and writes
+     * its own answer; the client's numbers are a claim to be checked, not an
+     * instruction (TDR §4). That rule does not relax because the caller is a
+     * browser.
+     */
+    writeExpense(input: WriteExpenseInput): Promise<WriteExpenseResult> {
+      return callFunction<WriteExpenseResult>('expense-write', {
+        groupId: input.groupId,
+        expenseId: input.expenseId,
+        description: input.description,
+        category: input.category ?? null,
+        expenseDate: input.expenseDate,
+        currency: input.currency,
+        amount: input.amount.toString(),
+        splitParams: input.splitParams,
+        participants: input.participants,
+        payers: Object.fromEntries(
+          Object.entries(input.payers).map(([id, value]) => [id, value.toString()]),
+        ),
+        expectedShares: input.expectedShares
+          ? Object.fromEntries(
+              Object.entries(input.expectedShares).map(([id, value]) => [id, value.toString()]),
+            )
+          : undefined,
+        notes: input.notes ?? null,
+        // The idempotency key. A guest on a flaky phone browser is exactly who
+        // double-taps Save, and this is what makes the second one harmless.
+        clientMutationId: input.clientMutationId,
+      });
+    },
+  };
+}
+
+export type BaakiClient = ReturnType<typeof createBaakiClient>;
+
+export interface WriteExpenseInput {
+  groupId: string;
+  expenseId?: string;
+  description: string;
+  category?: string | null;
+  expenseDate: string;
+  currency: string;
+  amount: bigint;
+  /** Already in wire form — use `serialiseSplitParams` from @baaki/core. */
+  splitParams: unknown;
+  participants: string[];
+  payers: Record<string, bigint>;
+  expectedShares?: Record<string, bigint>;
+  notes?: string | null;
+  clientMutationId: string;
+}
+
+export interface WriteExpenseResult {
+  expenseId: string;
+  versionId: string;
+  versionNo: number;
+  replayed?: boolean;
+}
+
+/**
+ * Supabase wraps a non-2xx response, so the server's own message is one layer
+ * down. Surfacing "This link has expired" instead of "Edge Function returned a
+ * non-2xx status code" is the difference between a person knowing what to do
+ * and filing a bug.
+ */
+async function describeFunctionError(error: unknown): Promise<BaakiApiError> {
+  const context = (error as { context?: Response }).context;
+  if (context && typeof context.json === 'function') {
+    try {
+      const body = (await context.json()) as { code?: string; message?: string };
+      if (body?.message) return new BaakiApiError(body.message, body.code);
+    } catch {
+      /* not JSON; fall through */
+    }
+  }
+  return new BaakiApiError(error instanceof Error ? error.message : String(error));
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,3 @@
+export * from './client';
+export * from './ledger';
+export * from './types';

--- a/packages/api-client/src/ledger.ts
+++ b/packages/api-client/src/ledger.ts
@@ -1,0 +1,83 @@
+/**
+ * Rows into balances.
+ *
+ * Not a second implementation. Every number here comes out of @baaki/core,
+ * which is the same code the app and the edge functions run — the whole reason
+ * `packages/core` is forbidden to depend on React or Supabase (TDR §1). If a
+ * guest's browser and the payer's phone ever disagreed about who owes what,
+ * one of them would be lying to somebody about their money, and there would be
+ * no way to say which.
+ *
+ * What this file does add is the conversion: PostgREST hands back minor units
+ * as decimal strings, and they become bigints here rather than anywhere a
+ * `Number` could get near them (ADR-003).
+ */
+
+import {
+  computeNetBalances,
+  simplify,
+  type CurrencyCode,
+  type ExpenseSnapshot,
+  type MemberId,
+  type SettlementSnapshot,
+  type Transfer,
+} from '@baaki/core';
+
+import type { Expense, Settlement } from './types';
+
+export interface GroupLedger {
+  /** memberId → net position in the group's currency. Positive: they are owed. */
+  balances: Map<MemberId, bigint>;
+  /** Who should pay whom to end up square (ADR-009). */
+  transfers: Transfer[];
+}
+
+export function toExpenseSnapshot(expense: Expense): ExpenseSnapshot | null {
+  const version = expense.currentVersion;
+  if (!version) return null;
+  return {
+    id: expense.id,
+    currency: version.currency as CurrencyCode,
+    amount: BigInt(version.amount),
+    payers: Object.fromEntries(version.payers.map((row) => [row.member_id, BigInt(row.amount)])),
+    shares: Object.fromEntries(version.shares.map((row) => [row.member_id, BigInt(row.amount)])),
+    date: version.expense_date,
+    deletedAt: expense.deleted_at,
+  };
+}
+
+export function toSettlementSnapshot(settlement: Settlement): SettlementSnapshot {
+  return {
+    id: settlement.id,
+    from: settlement.from_member_id,
+    to: settlement.to_member_id,
+    currency: settlement.currency as CurrencyCode,
+    amount: BigInt(settlement.amount),
+    status: settlement.status as SettlementSnapshot['status'],
+    at: settlement.initiated_at,
+    allocations: settlement.allocations?.map((row) => ({
+      expenseId: row.expense_id,
+      amount: BigInt(row.amount),
+    })),
+  };
+}
+
+export function computeLedger(
+  expenses: readonly Expense[],
+  settlements: readonly Settlement[],
+  currency: string,
+): GroupLedger {
+  const snapshots = expenses
+    .map(toExpenseSnapshot)
+    .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
+
+  const balances = computeNetBalances(snapshots, settlements.map(toSettlementSnapshot));
+
+  return {
+    // One currency is shown, because a guest link opens one group and a group
+    // has one default. Anything in another currency still counts in core's
+    // answer; it is simply not this view's job to add them together (ADR-003).
+    balances: balances.get(currency as CurrencyCode) ?? new Map(),
+    transfers: simplify(balances),
+  };
+}

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -1,0 +1,88 @@
+/**
+ * The rows web-lite reads, and nothing more.
+ *
+ * These are deliberately not the app's types. The app reads a full mirror; a
+ * guest on a link reads one group and needs a fraction of it, and asking for
+ * columns nobody renders is asking RLS to prove more than it has to.
+ */
+
+import type { SplitParams } from '@baaki/core';
+
+export type MemberId = string;
+
+export interface Group {
+  id: string;
+  name: string | null;
+  cover_emoji: string | null;
+  default_currency: string;
+  simplify_debts: boolean;
+}
+
+export interface Member {
+  id: MemberId;
+  group_id: string;
+  profile_id: string | null;
+  ghost_name: string | null;
+  left_at: string | null;
+  profile: { display_name: string | null } | null;
+}
+
+export interface ExpenseVersion {
+  id: string;
+  version_no: number;
+  description: string;
+  category: string | null;
+  expense_date: string;
+  currency: string;
+  /** Minor units as a decimal string — the wire never carries a JS number for money. */
+  amount: string;
+  split_type: string;
+  split_params: SplitParams;
+  payers: { member_id: MemberId; amount: string }[];
+  shares: { member_id: MemberId; amount: string }[];
+}
+
+export interface Expense {
+  id: string;
+  group_id: string;
+  deleted_at: string | null;
+  created_at: string;
+  currentVersion: ExpenseVersion | null;
+}
+
+export interface Settlement {
+  id: string;
+  group_id: string;
+  from_member_id: MemberId;
+  to_member_id: MemberId;
+  currency: string;
+  amount: string;
+  status: string;
+  initiated_at: string;
+  confirmed_at: string | null;
+  allocations?: { expense_id: string; amount: string }[];
+}
+
+/** What a link shows before anybody has committed to joining. */
+export interface InvitePreview {
+  group: {
+    id: string;
+    name: string;
+    cover_emoji: string | null;
+    default_currency: string;
+  } | null;
+  memberCount: number;
+  /** Ghost members on the group whose place the arrival can take (ADR-006). */
+  claimable: { memberId: string; name: string | null }[];
+}
+
+export interface AcceptedInvite {
+  group: { id: string; name: string };
+  memberId: MemberId;
+  claimed?: boolean;
+}
+
+/** The name web-lite shows for somebody. */
+export function nameOf(member: Member): string {
+  return member.profile?.display_name ?? member.ghost_name ?? 'Someone';
+}

--- a/packages/api-client/test/ledger.test.ts
+++ b/packages/api-client/test/ledger.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Rows into balances, in a browser.
+ *
+ * The risk this covers is not arithmetic — that is @baaki/core's, and it is
+ * property-tested there. It is the conversion on the way in. PostgREST hands
+ * minor units back as decimal strings, and every one of them has to become a
+ * bigint before anything touches it. A single `Number()` slipping in would
+ * produce balances that look right, agree with themselves, and quietly differ
+ * from the app's by a paisa — which is the version of this bug nobody catches.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { computeLedger, toExpenseSnapshot, type Expense, type Settlement } from '../src/index';
+
+function expense(over: Partial<Expense['currentVersion']> = {}, id = 'e-1'): Expense {
+  return {
+    id,
+    group_id: 'g-1',
+    deleted_at: null,
+    created_at: '2026-08-06T10:00:00.000Z',
+    currentVersion: {
+      id: `${id}-v1`,
+      version_no: 1,
+      description: 'Dinner',
+      category: null,
+      expense_date: '2026-08-04',
+      currency: 'INR',
+      amount: '45000',
+      split_type: 'equal',
+      split_params: { kind: 'equal' },
+      payers: [{ member_id: 'asha', amount: '45000' }],
+      shares: [
+        { member_id: 'asha', amount: '22500' },
+        { member_id: 'ravi', amount: '22500' },
+      ],
+      ...over,
+    } as Expense['currentVersion'],
+  };
+}
+
+describe('reading amounts off the wire', () => {
+  it('turns every string into a bigint', () => {
+    const snapshot = toExpenseSnapshot(expense());
+    expect(snapshot?.amount).toBe(45000n);
+    expect(snapshot?.payers.asha).toBe(22500n * 2n);
+    expect(snapshot?.shares.ravi).toBe(22500n);
+  });
+
+  it('holds an amount a double would round', () => {
+    // 2^53 + 1. A Number here would come back one unit light and every balance
+    // downstream would be quietly wrong.
+    const snapshot = toExpenseSnapshot(
+      expense({
+        amount: '9007199254740993',
+        payers: [{ member_id: 'asha', amount: '9007199254740993' }],
+        shares: [{ member_id: 'asha', amount: '9007199254740993' }],
+      }),
+    );
+    expect(snapshot?.amount).toBe(9007199254740993n);
+  });
+
+  it('has nothing to say about an expense with no version', () => {
+    expect(toExpenseSnapshot({ ...expense(), currentVersion: null })).toBeNull();
+  });
+});
+
+describe('what a guest sees', () => {
+  it('says who is owed and who owes', () => {
+    const ledger = computeLedger([expense()], [], 'INR');
+    expect(ledger.balances.get('asha')).toBe(22500n);
+    expect(ledger.balances.get('ravi')).toBe(-22500n);
+  });
+
+  it('adds up to zero', () => {
+    // Every rupee somebody is owed is a rupee somebody else owes. If this ever
+    // failed, money would have been created.
+    const ledger = computeLedger([expense(), expense({}, 'e-2')], [], 'INR');
+    const total = [...ledger.balances.values()].reduce((sum, value) => sum + value, 0n);
+    expect(total).toBe(0n);
+  });
+
+  it('leaves a deleted expense out', () => {
+    const deleted = { ...expense(), deleted_at: '2026-08-05T00:00:00.000Z' };
+    expect(computeLedger([deleted], [], 'INR').balances.size).toBe(0);
+  });
+
+  it('counts a confirmed settlement and ignores a pending one', () => {
+    // ADR-004: only a confirmed settlement moves the headline balance. Counting
+    // a claim would tell somebody they had been paid when they had not.
+    const settlement = (status: string): Settlement => ({
+      id: `s-${status}`,
+      group_id: 'g-1',
+      from_member_id: 'ravi',
+      to_member_id: 'asha',
+      currency: 'INR',
+      amount: '22500',
+      status,
+      initiated_at: '2026-08-05T00:00:00.000Z',
+      confirmed_at: status === 'confirmed' ? '2026-08-05T01:00:00.000Z' : null,
+    });
+
+    expect(computeLedger([expense()], [settlement('pending')], 'INR').balances.get('ravi')).toBe(
+      -22500n,
+    );
+    expect(computeLedger([expense()], [settlement('confirmed')], 'INR').balances.get('ravi')).toBe(
+      0n,
+    );
+  });
+
+  it('never mixes two currencies into one figure', () => {
+    // A trip abroad has both. Adding them would need a rate nobody chose.
+    const euro = expense(
+      {
+        currency: 'EUR',
+        amount: '4000',
+        payers: [{ member_id: 'ravi', amount: '4000' }],
+        shares: [
+          { member_id: 'asha', amount: '2000' },
+          { member_id: 'ravi', amount: '2000' },
+        ],
+      },
+      'e-eur',
+    );
+    const ledger = computeLedger([expense(), euro], [], 'INR');
+    expect(ledger.balances.get('asha')).toBe(22500n);
+    // The euro side is still in the transfers, in euros, not folded into INR.
+    expect(ledger.transfers.some((transfer) => transfer.currency === 'EUR')).toBe(true);
+  });
+
+  it('has nothing to show a browser that is not a member', () => {
+    // RLS returns no rows rather than an error; that must read as "settled up
+    // with nobody", not as a crash.
+    expect(computeLedger([], [], 'INR').balances.size).toBe(0);
+  });
+});

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: link:../../packages/ui
       '@expo/ui':
         specifier: ~57.0.9
-        version: 57.0.9(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.2.18)(expo@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+        version: 57.0.9(@babel/core@7.29.7(supports-color@8.1.1))(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(expo@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@expo/vector-icons':
         specifier: ^15.1.1
         version: 15.1.1(expo-font@57.0.1)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -100,7 +100,7 @@ importers:
         version: 57.0.1(expo@57.0.10)(react@19.2.3)
       expo-router:
         specifier: ~57.0.10
-        version: 57.0.10(e33838f6b09842139d08e3cb6f1aeab7)
+        version: 57.0.10(b87ba7b276fdb1ace9a6642717514448)
       expo-secure-store:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.10)
@@ -172,11 +172,67 @@ importers:
         specifier: ^3.2.4
         version: 3.2.7(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
 
+  apps/web-lite:
+    dependencies:
+      '@baaki/api-client':
+        specifier: workspace:*
+        version: link:../../packages/api-client
+      '@baaki/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@supabase/supabase-js':
+        specifier: ^2.112.0
+        version: 2.112.0
+      next:
+        specifier: ^16.3.0
+        version: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.1.0
+        version: 24.13.3
+      '@types/react':
+        specifier: ~19.2.2
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ~19.2.2
+        version: 19.2.4(@types/react@19.2.18)
+      eslint:
+        specifier: ^9.37.0
+        version: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-config-next:
+        specifier: ^16.3.0
+        version: 16.3.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.2
+        version: 5.9.3
+
   e2e:
     dependencies:
       '@supabase/supabase-js':
         specifier: ^2.112.0
         version: 2.112.0
+
+  packages/api-client:
+    dependencies:
+      '@baaki/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.112.0
+        version: 2.112.0
+      typescript:
+        specifier: ~5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
 
   packages/core:
     devDependencies:
@@ -646,6 +702,9 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
@@ -967,6 +1026,12 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.2':
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -1214,6 +1279,168 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@isaacs/ttlcache@1.4.1':
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
@@ -1258,6 +1485,76 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
+  '@next/env@16.3.0':
+    resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
+
+  '@next/eslint-plugin-next@16.3.0':
+    resolution: {integrity: sha512-OqgJ8PN0d04KcPhDX/PTY5tJUJZxlbrt7O7FBsm4XE0XW2JDrKnDXsc9uo9WUimJGPoo2j+JRGhyXApC//mvbw==}
+
+  '@next/swc-darwin-arm64@16.3.0':
+    resolution: {integrity: sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.3.0':
+    resolution: {integrity: sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.3.0':
+    resolution: {integrity: sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@16.3.0':
+    resolution: {integrity: sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@16.3.0':
+    resolution: {integrity: sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@16.3.0':
+    resolution: {integrity: sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@16.3.0':
+    resolution: {integrity: sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.3.0':
+    resolution: {integrity: sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
@@ -1787,6 +2084,9 @@ packages:
       '@opentelemetry/api':
         optional: true
 
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
   '@tanstack/query-core@5.101.4':
     resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
 
@@ -1848,6 +2148,11 @@ packages:
   '@types/pg@8.20.3':
     resolution: {integrity: sha512-4Tvg+HO6+oQaAkpT8GTYoSExzpGGZz532GXgbbCElWJQeQdMozBWxEKNBhJJpHFjWXsMxqPbyypvj/89FWNoSQ==}
 
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react-test-renderer@19.1.0':
     resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
 
@@ -1868,8 +2173,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/eslint-plugin@8.66.0':
+    resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.66.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.65.0':
     resolution: {integrity: sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.66.0':
+    resolution: {integrity: sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1881,12 +2201,28 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.66.0':
+    resolution: {integrity: sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.65.0':
     resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.66.0':
+    resolution: {integrity: sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.65.0':
     resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/tsconfig-utils@8.66.0':
+    resolution: {integrity: sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1898,12 +2234,29 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/type-utils@8.66.0':
+    resolution: {integrity: sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.65.0':
     resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.66.0':
+    resolution: {integrity: sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.65.0':
     resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.66.0':
+    resolution: {integrity: sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1915,8 +2268,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.66.0':
+    resolution: {integrity: sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.65.0':
     resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.66.0':
+    resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.3':
@@ -2196,6 +2560,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -2206,6 +2573,14 @@ packages:
 
   await-lock@2.2.2:
     resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   babel-plugin-polyfill-corejs2@0.4.17:
     resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
@@ -2482,6 +2857,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2611,6 +2989,9 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -2695,6 +3076,15 @@ packages:
     peerDependencies:
       eslint: '>=8.10'
 
+  eslint-config-next@16.3.0:
+    resolution: {integrity: sha512-lPrf1kHsMJEZqO0uXkNB400c5MGrhrTk3BNX7P0ol4gt61+iUlQfjy9TyIOEA9eOXrf+5+mYbT/JsY8+zqUByQ==}
+    peerDependencies:
+      eslint: '>=9.0.0'
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   eslint-import-resolver-node@0.3.10:
     resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
 
@@ -2747,6 +3137,12 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
   eslint-plugin-react-hooks@7.1.1:
     resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
@@ -3118,11 +3514,18 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fb-dotslash@0.5.8:
     resolution: {integrity: sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==}
@@ -3245,6 +3648,10 @@ packages:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
 
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -3255,6 +3662,10 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
     engines: {node: '>=18'}
 
   globals@16.5.0:
@@ -3601,6 +4012,13 @@ packages:
     resolution: {integrity: sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==}
     hasBin: true
 
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -3750,6 +4168,10 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   metro-babel-transformer@0.84.4:
     resolution: {integrity: sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
@@ -3893,6 +4315,27 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  next@16.3.0:
+    resolution: {integrity: sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
 
   node-exports-info@1.6.2:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
@@ -4112,6 +4555,10 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4193,6 +4640,9 @@ packages:
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -4412,6 +4862,10 @@ packages:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rollup@4.62.4:
     resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -4419,6 +4873,9 @@ packages:
 
   rtl-detect@1.1.2:
     resolution: {integrity: sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
@@ -4490,6 +4947,15 @@ packages:
 
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
+
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4604,6 +5070,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
+
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
@@ -4648,6 +5118,19 @@ packages:
 
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   styleq@0.1.3:
     resolution: {integrity: sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==}
@@ -4766,6 +5249,13 @@ packages:
   typed-array-length@1.0.8:
     resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
     engines: {node: '>= 0.4'}
+
+  typescript-eslint@8.66.0:
+    resolution: {integrity: sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -5583,6 +6073,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
@@ -5749,6 +6244,11 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))':
+    dependencies:
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.21.2(supports-color@8.1.1)':
@@ -5854,7 +6354,7 @@ snapshots:
       ws: 8.21.1
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.10(e33838f6b09842139d08e3cb6f1aeab7)
+      expo-router: 57.0.10(b87ba7b276fdb1ace9a6642717514448)
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -6131,7 +6631,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 57.0.8(@expo/log-box@57.0.2)(expo@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      expo-router: 57.0.10(e33838f6b09842139d08e3cb6f1aeab7)
+      expo-router: 57.0.10(b87ba7b276fdb1ace9a6642717514448)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -6146,13 +6646,13 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/ui@57.0.9(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.2.18)(expo@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)':
+  '@expo/ui@57.0.9(@babel/core@7.29.7(supports-color@8.1.1))(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(expo@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)':
     dependencies:
       expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
       sf-symbols-typescript: 2.2.0
-      vaul: 1.1.2(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      vaul: 1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       react-dom: 19.2.3(react@19.2.3)
@@ -6192,6 +6692,113 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
+    optional: true
 
   '@isaacs/ttlcache@1.4.1': {}
 
@@ -6242,6 +6849,51 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@next/env@16.3.0': {}
+
+  '@next/eslint-plugin-next@16.3.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      fast-glob: 3.3.1
+    transitivePeerDependencies:
+      - eslint
+
+  '@next/swc-darwin-arm64@16.3.0':
+    optional: true
+
+  '@next/swc-darwin-x64@16.3.0':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.3.0':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.3.0':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.3.0':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.3.0':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.3.0':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.3.0':
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@prisma/client@6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3)':
@@ -6281,16 +6933,17 @@ snapshots:
 
   '@radix-ui/primitive@1.1.7': {}
 
-  '@radix-ui/react-collection@1.1.15(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-collection@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-compose-refs@1.1.5(@types/react@19.2.18)(react@19.2.3)':
     dependencies:
@@ -6304,18 +6957,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-dialog@1.1.23(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-dialog@1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.17(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.3)
@@ -6325,6 +6978,7 @@ snapshots:
       react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-direction@1.1.4(@types/react@19.2.18)(react@19.2.3)':
     dependencies:
@@ -6332,17 +6986,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-dismissable-layer@1.1.19(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.18)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-focus-guards@1.1.6(@types/react@19.2.18)(react@19.2.3)':
     dependencies:
@@ -6350,15 +7005,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-focus-scope@1.1.16(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-focus-scope@1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-id@1.1.4(@types/react@19.2.18)(react@19.2.3)':
     dependencies:
@@ -6367,40 +7023,43 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-portal@1.1.17(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-portal@1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-presence@1.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-presence@1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-primitive@2.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-primitive@2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-roving-focus@1.1.19(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.18)(react@19.2.3)
@@ -6409,6 +7068,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-slot@1.3.3(@types/react@19.2.18)(react@19.2.3)':
     dependencies:
@@ -6417,20 +7077,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-tabs@1.1.21(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-tabs@1.1.21(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.18)(react@19.2.3)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.10(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-use-callback-ref@1.1.4(@types/react@19.2.18)(react@19.2.3)':
     dependencies:
@@ -6735,6 +7396,10 @@ snapshots:
       '@supabase/realtime-js': 2.112.0
       '@supabase/storage-js': 2.112.0
 
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
   '@tanstack/query-core@5.101.4': {}
 
   '@tanstack/react-query@5.101.4(react@19.2.3)':
@@ -6808,6 +7473,10 @@ snapshots:
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
+  '@types/react-dom@19.2.4(@types/react@19.2.18)':
+    dependencies:
+      '@types/react': 19.2.18
+
   '@types/react-test-renderer@19.1.0':
     dependencies:
       '@types/react': 19.2.18
@@ -6838,6 +7507,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/type-utils': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
@@ -6850,6 +7535,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.65.0(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
@@ -6859,14 +7556,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.66.0(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.65.0':
     dependencies:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
 
+  '@typescript-eslint/scope-manager@8.66.0':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
+
   '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.66.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@typescript-eslint/type-utils@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
@@ -6880,7 +7595,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.65.0': {}
+
+  '@typescript-eslint/types@8.66.0': {}
 
   '@typescript-eslint/typescript-estree@8.65.0(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
@@ -6897,6 +7626,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.66.0(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.6
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -6908,9 +7652,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.65.0':
     dependencies:
       '@typescript-eslint/types': 8.65.0
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.66.0':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.3': {}
@@ -7167,6 +7927,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types-flow@0.0.8: {}
+
   async-function@1.0.0: {}
 
   available-typed-arrays@1.0.7:
@@ -7174,6 +7936,10 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   await-lock@2.2.2: {}
+
+  axe-core@4.12.1: {}
+
+  axobject-query@4.1.0: {}
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
@@ -7519,6 +8285,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  damerau-levenshtein@1.0.8: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -7625,6 +8393,8 @@ snapshots:
   electron-to-chromium@1.5.399: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
 
@@ -7832,11 +8602,46 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-config-next@16.3.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      globals: 16.4.0
+      typescript-eslint: 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
   eslint-import-resolver-node@0.3.10(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.16.2
       resolve: 2.0.0-next.7
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      get-tsconfig: 4.14.1
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.17
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7863,6 +8668,17 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      debug: 3.2.7(supports-color@8.1.1)
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7903,6 +8719,54 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7(supports-color@8.1.1)
+      doctrine: 2.1.0
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      hasown: 2.0.4
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.10
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.12.1
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      hasown: 2.0.4
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
@@ -8188,14 +9052,14 @@ snapshots:
       expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
       react: 19.2.3
 
-  expo-router@57.0.10(e33838f6b09842139d08e3cb6f1aeab7):
+  expo-router@57.0.10(b87ba7b276fdb1ace9a6642717514448):
     dependencies:
       '@expo/log-box': 57.0.2(@expo/dom-webview@57.0.1)(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@expo/metro-runtime': 57.0.8(@expo/log-box@57.0.2)(expo@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@expo/schema-utils': 57.0.2
-      '@expo/ui': 57.0.9(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.2.18)(expo@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      '@expo/ui': 57.0.9(@babel/core@7.29.7(supports-color@8.1.1))(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(expo@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-tabs': 1.1.21(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@react-native-masked-view/masked-view': 0.3.2(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
@@ -8224,7 +9088,7 @@ snapshots:
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
       standard-navigation: 0.0.5
-      vaul: 1.1.2(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      vaul: 1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
       react-dom: 19.2.3(react@19.2.3)
       react-native-gesture-handler: 2.32.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -8365,9 +9229,21 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fb-dotslash@0.5.8: {}
 
@@ -8505,6 +9381,10 @@ snapshots:
       nypm: 0.6.9
       pathe: 2.0.3
 
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -8516,6 +9396,8 @@ snapshots:
       path-scurry: 2.0.2
 
   globals@14.0.0: {}
+
+  globals@16.4.0: {}
 
   globals@16.5.0: {}
 
@@ -8849,6 +9731,12 @@ snapshots:
 
   lan-network@0.2.1: {}
 
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -8963,6 +9851,8 @@ snapshots:
       is-plain-obj: 2.1.0
 
   merge-stream@2.0.0: {}
+
+  merge2@1.4.1: {}
 
   metro-babel-transformer@0.84.4(supports-color@8.1.1):
     dependencies:
@@ -9193,6 +10083,32 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@next/env': 16.3.0
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.11.12
+      caniuse-lite: 1.0.30001806
+      postcss: 8.5.23
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.3.0
+      '@next/swc-darwin-x64': 16.3.0
+      '@next/swc-linux-arm64-gnu': 16.3.0
+      '@next/swc-linux-arm64-musl': 16.3.0
+      '@next/swc-linux-x64-gnu': 16.3.0
+      '@next/swc-linux-x64-musl': 16.3.0
+      '@next/swc-win32-arm64-msvc': 16.3.0
+      '@next/swc-win32-x64-msvc': 16.3.0
+      babel-plugin-react-compiler: 1.0.0
+      sharp: 0.35.3(@types/node@24.13.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
+
   node-exports-info@1.6.2:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -9413,6 +10329,12 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
+  postcss@8.5.23:
+    dependencies:
+      nanoid: 3.3.17
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.25:
     dependencies:
       nanoid: 3.3.17
@@ -9489,6 +10411,8 @@ snapshots:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
+
+  queue-microtask@1.2.3: {}
 
   queue@6.0.2:
     dependencies:
@@ -9768,6 +10692,8 @@ snapshots:
       onetime: 2.0.1
       signal-exit: 3.0.7
 
+  reusify@1.1.0: {}
+
   rollup@4.62.4:
     dependencies:
       '@types/estree': 1.0.9
@@ -9801,6 +10727,10 @@ snapshots:
       fsevents: 2.3.3
 
   rtl-detect@1.1.2: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   safe-array-concat@1.1.4:
     dependencies:
@@ -9891,6 +10821,40 @@ snapshots:
   sf-symbols-typescript@2.2.0: {}
 
   shallowequal@1.1.0: {}
+
+  sharp@0.35.3(@types/node@24.13.3):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 24.13.3
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -9994,6 +10958,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.9
@@ -10061,6 +11031,13 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
+  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.3):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+
   styleq@0.1.3: {}
 
   supports-color@5.5.0:
@@ -10125,6 +11102,10 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -10178,6 +11159,17 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript-eslint@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.9.3: {}
 
@@ -10273,9 +11265,9 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vaul@1.1.2(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  vaul@1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@radix-ui/react-dialog': 1.1.23(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:


### PR DESCRIPTION
Closes M3's last acceptance criterion: **"Guest opens link in browser, adds an expense with no install."**

## `packages/api-client`

Framework-free — no React, no React Native, no Next. The app's data layer is built around an offline mirror and a mutation queue; a browser opening a link has neither and does not want them.

What the two share is `@baaki/core`. That is a correctness requirement, not a convenience: if a guest's browser and the payer's phone could disagree about who owes what, there would be no way to say which one was lying.

**Authorization is not in this client.** Every read goes to PostgREST under the caller's own session and every RLS policy applies unchanged. A guest sees the group they joined because the database says so, not because a query remembered to filter.

## `apps/web-lite`

Three screens — the link, the group, add-an-expense.

Equal splits only, and the screen says so. A guest adding the auto they just paid for will abandon the form rather than work through a split editor; exact shares and itemised bills are in the app.

Every page is a client component. Rendering on the server would need a key of its own, and the only key able to render somebody else's group is one that must never leave an edge function.

## Verified against live — 19/19

`e2e/m3-web-lite.mjs`:

- link previews with **no account at all**
- guest joins and claims a ghost, inheriting its history
- guest adds an expense from the browser
- saving twice writes **one** expense (a guest on a slow phone browser is exactly who double-taps Save)
- the browser's computed balances match the server's derived table, and sum to zero
- **another browser holding the same anon key sees zero rows and cannot write** — the claim the whole public-anon-key design rests on

Two things found by running it rather than trusting it:

1. `group_balances` stores `balance`, not `net` — the first version of the check silently compared against an errored query.
2. The project rate-limits confirmation emails. So the credential-upgrade half of "later installs, history intact" is asserted through the claimed member's profile id instead of by sending mail. Auth isn't built yet in any case.

## Tests

9 api-client tests on the wire-string conversion, including an amount past 2^53 — a `Number` slipping in there produces balances that look right and quietly differ from the app's by a paisa. New CI step runs them.

Workspace: 348 tests green, typecheck/lint/format clean, `next build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)