### PR TITLE
Sign in with a password or Google, without losing a guest's data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ packages/core/dist/
 {
 {,
 ({
+
+# Next.js
+.next/
+out/
+next-env.d.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@ dist
 packages/db/generated
 packages/db/prisma/migrations
 pnpm-lock.yaml
+.next
+out

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.101.4",
     "base64-arraybuffer": "^1.0.2",
     "expo": "~57.0.10",
+    "expo-auth-session": "~57.0.6",
     "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.9",
     "expo-contacts": "~57.0.3",

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -1,19 +1,41 @@
+/**
+ * Getting in.
+ *
+ * Four ways, ordered by how little they ask for: carry on as a guest, a code
+ * to a phone, a password, Google. ADR-006 is that nobody is made to register
+ * before they can split a bill, so the guest button is not tucked away at the
+ * bottom in small type.
+ *
+ * Which Supabase call each of these makes is decided in @baaki/core, not here.
+ * A guest who taps "Google" must have Google *added* to the account they
+ * already have — signing them in would create a different account and leave a
+ * week of expenses on one they can no longer reach. That is easy to get wrong
+ * in a screen and impossible to notice afterwards, so the screen does not get
+ * to decide.
+ */
+
 import { useState } from 'react';
 import { ActivityIndicator, KeyboardAvoidingView, Platform, TextInput, View } from 'react-native';
 
-import { Button, Card, Screen, Text, useTheme } from '@baaki/ui';
+import { Button, Card, Chip, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
+type Mode = 'otp' | 'password';
+
 export default function SignInScreen() {
   const theme = useTheme();
   const { t } = useStrings();
-  const { sendOtp, verifyOtp, continueAsGuest } = useAuth();
+  const { sendOtp, verifyOtp, continueAsGuest, withPassword, withGoogle, isGuest } = useAuth();
 
+  const [mode, setMode] = useState<Mode>('otp');
   const [phone, setPhone] = useState('+91');
   const [code, setCode] = useState('');
   const [stage, setStage] = useState<'phone' | 'code'>('phone');
+  const [identifier, setIdentifier] = useState('');
+  const [password, setPassword] = useState('');
+  const [intent, setIntent] = useState<'sign_in' | 'sign_up'>('sign_in');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -40,12 +62,33 @@ export default function SignInScreen() {
             <Text style={{ fontSize: 44, lineHeight: 50, fontWeight: '700' }}>பாக்கி</Text>
             <Text variant="title">Baaki</Text>
             <Text variant="body" tone="muted">
-              Split anything with anyone. {t.freeForever}.
+              {isGuest
+                ? 'Add a way to sign in, so this account is still yours on your next phone.'
+                : `Split anything with anyone. ${t.freeForever}.`}
             </Text>
           </View>
 
           <Card style={{ gap: theme.spacing.lg }}>
-            {stage === 'phone' ? (
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Chip
+                label="Send me a code"
+                selected={mode === 'otp'}
+                onPress={() => {
+                  setMode('otp');
+                  setError(null);
+                }}
+              />
+              <Chip
+                label="Use a password"
+                selected={mode === 'password'}
+                onPress={() => {
+                  setMode('password');
+                  setError(null);
+                }}
+              />
+            </Row>
+
+            {mode === 'otp' && stage === 'phone' ? (
               <>
                 <Text variant="caption" tone="muted">
                   Phone number
@@ -64,6 +107,10 @@ export default function SignInScreen() {
                     paddingVertical: theme.spacing.sm,
                   }}
                 />
+                <Text variant="micro" tone="faint">
+                  Start with your country code. Baaki never assumes +91 — a trip is exactly when
+                  foreign numbers turn up.
+                </Text>
                 <Button
                   label="Send code"
                   size="lg"
@@ -77,7 +124,9 @@ export default function SignInScreen() {
                   }
                 />
               </>
-            ) : (
+            ) : null}
+
+            {mode === 'otp' && stage === 'code' ? (
               <>
                 <Text variant="caption" tone="muted">
                   {`Code sent to ${phone}`}
@@ -114,7 +163,84 @@ export default function SignInScreen() {
                   }}
                 />
               </>
-            )}
+            ) : null}
+
+            {mode === 'password' ? (
+              <>
+                <Text variant="caption" tone="muted">
+                  Email or phone number
+                </Text>
+                {/* One field: "email or phone?" is a question the text already
+                    answers. */}
+                <TextInput
+                  value={identifier}
+                  onChangeText={setIdentifier}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="email-address"
+                  autoComplete="username"
+                  accessibilityLabel="Email or phone number"
+                  placeholder="asha@example.com or +91…"
+                  placeholderTextColor={theme.color.textFaint}
+                  style={{
+                    fontSize: 18,
+                    fontWeight: '500',
+                    color: theme.color.text,
+                    paddingVertical: theme.spacing.sm,
+                  }}
+                />
+                <Text variant="caption" tone="muted">
+                  Password
+                </Text>
+                <TextInput
+                  value={password}
+                  onChangeText={setPassword}
+                  secureTextEntry
+                  autoCapitalize="none"
+                  autoComplete={intent === 'sign_up' ? 'new-password' : 'current-password'}
+                  accessibilityLabel="Password"
+                  placeholderTextColor={theme.color.textFaint}
+                  style={{
+                    fontSize: 18,
+                    fontWeight: '500',
+                    color: theme.color.text,
+                    paddingVertical: theme.spacing.sm,
+                  }}
+                />
+                <Text variant="micro" tone="faint">
+                  Eight characters or more. A phrase you will remember beats a puzzle you will not.
+                </Text>
+                <Button
+                  label={
+                    isGuest
+                      ? 'Add this to my account'
+                      : intent === 'sign_up'
+                        ? 'Create account'
+                        : 'Sign in'
+                  }
+                  size="lg"
+                  fullWidth
+                  disabled={busy || !identifier.trim() || password.length < 8}
+                  onPress={() => void run(() => withPassword(identifier, password, intent))}
+                />
+                {/* A guest is never signing up or in — they are adding a way
+                    back to the account they already have. */}
+                {isGuest ? null : (
+                  <Button
+                    label={
+                      intent === 'sign_up'
+                        ? 'I already have an account'
+                        : 'I am new here — create an account'
+                    }
+                    variant="ghost"
+                    onPress={() => {
+                      setIntent(intent === 'sign_up' ? 'sign_in' : 'sign_up');
+                      setError(null);
+                    }}
+                  />
+                )}
+              </>
+            ) : null}
 
             {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
             {error ? (
@@ -124,19 +250,31 @@ export default function SignInScreen() {
             ) : null}
           </Card>
 
-          {/* ADR-006: nobody is forced to register before they can use Baaki. */}
           <Button
-            label="Continue as guest"
+            label={isGuest ? 'Continue with Google' : 'Sign in with Google'}
             variant="secondary"
             size="lg"
             fullWidth
             disabled={busy}
-            onPress={() => void run(continueAsGuest)}
+            onPress={() => void run(withGoogle)}
           />
 
+          {/* ADR-006: nobody is forced to register before they can use Baaki. */}
+          {isGuest ? null : (
+            <Button
+              label="Continue as guest"
+              variant="secondary"
+              size="lg"
+              fullWidth
+              disabled={busy}
+              onPress={() => void run(continueAsGuest)}
+            />
+          )}
+
           <Text variant="micro" tone="faint" align="center">
-            A guest account keeps everything on this device until you add a phone number. Your
-            ledger is never held hostage.
+            {isGuest
+              ? 'Everything you have already added stays exactly where it is. This only adds a way to sign back in.'
+              : 'A guest account keeps everything on this device until you add a way to sign in. Your ledger is never held hostage.'}
           </Text>
         </View>
       </KeyboardAvoidingView>

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -11,6 +11,8 @@ import { decode } from 'base64-arraybuffer';
 import { randomUUID } from 'expo-crypto';
 
 import {
+  normaliseEmail,
+  normalisePhone,
   serialiseSplitParams,
   type FxRecord,
   type ParsedReceipt,
@@ -620,11 +622,15 @@ export type ContactChannel = 'email' | 'phone';
  * six-digit code; nothing changes until `confirmContact` verifies it.
  */
 export async function startAddingContact(channel: ContactChannel, value: string): Promise<void> {
-  const trimmed = value.trim();
+  // Normalised here rather than sent as typed. A number without a country code
+  // is refused with a sentence somebody can act on, instead of whatever the
+  // auth service says about it — and it is the same rule the invite columns
+  // enforce in the database, so one form cannot accept what another rejects.
+  const normalised = channel === 'email' ? normaliseEmail(value) : normalisePhone(value);
   const { error } =
     channel === 'email'
-      ? await supabase.auth.updateUser({ email: trimmed })
-      : await supabase.auth.updateUser({ phone: trimmed });
+      ? await supabase.auth.updateUser({ email: normalised })
+      : await supabase.auth.updateUser({ phone: normalised });
   if (error) throw new Error(describeAuthError(error.message, channel));
 }
 

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -1,7 +1,23 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import type { Session } from '@supabase/supabase-js';
+import { makeRedirectUri } from 'expo-auth-session';
+import * as WebBrowser from 'expo-web-browser';
+
+import { checkPassword, planAuth, readIdentifier, type Viewer } from '@baaki/core';
 
 import { supabase } from './supabase';
+
+/**
+ * What @baaki/core needs to know to pick the right call. The distinction that
+ * matters is anonymous-with-data versus nobody: they look the same to a screen
+ * and could not be more different to the person holding the phone.
+ */
+function viewerFrom(session: Session | null): Viewer {
+  if (!session?.user) return { kind: 'nobody' };
+  return session.user.is_anonymous === true
+    ? { kind: 'guest', userId: session.user.id }
+    : { kind: 'user', userId: session.user.id };
+}
 
 export interface Profile {
   id: string;
@@ -21,6 +37,19 @@ interface AuthValue {
   sendOtp: (phone: string) => Promise<void>;
   verifyOtp: (phone: string, token: string) => Promise<void>;
   continueAsGuest: () => Promise<void>;
+  /**
+   * Email or phone plus a password. Which Supabase call this makes is decided
+   * by `planAuth` in @baaki/core, not here — a guest must be upgraded in place
+   * (ADR-006), and getting that wrong strands their groups on an account they
+   * can no longer reach.
+   */
+  withPassword: (
+    identifier: string,
+    password: string,
+    intent: 'sign_in' | 'sign_up',
+  ) => Promise<void>;
+  /** Google. Links to the current account when there is one, for the same reason. */
+  withGoogle: () => Promise<void>;
   updateProfile: (patch: Partial<Profile>) => Promise<void>;
   /** Re-read the session after it changes underneath us (e.g. a linked email). */
   refresh: () => Promise<void>;
@@ -108,6 +137,71 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       async continueAsGuest() {
         const { error } = await supabase.auth.signInAnonymously();
         if (error) throw error;
+      },
+
+      async withPassword(identifier, password, intent) {
+        const who = readIdentifier(identifier);
+        checkPassword(password);
+        const method = who.kind === 'email' ? 'email_password' : 'phone_password';
+        const credential = who.kind === 'email' ? { email: who.value } : { phone: who.value };
+        const action = planAuth(viewerFrom(session), method, intent);
+
+        if (action.call === 'updateUser') {
+          // The upgrade. Same user id, so the groups, the expenses and the
+          // money owed all stay where they are (ADR-006).
+          const { error } = await supabase.auth.updateUser({ ...credential, password });
+          if (error) throw error;
+          const { data } = await supabase.auth.getSession();
+          setSession(data.session);
+          return;
+        }
+
+        const { error } =
+          action.call === 'signUp'
+            ? await supabase.auth.signUp({ ...credential, password })
+            : await supabase.auth.signInWithPassword({ ...credential, password });
+        if (error) throw error;
+      },
+
+      async withGoogle() {
+        const action = planAuth(viewerFrom(session), 'google');
+        const redirectTo = makeRedirectUri({ scheme: 'baaki', path: 'auth' });
+
+        // Both calls return a URL rather than opening it: the browser has to be
+        // the in-app one, or the session comes back to a tab the app cannot see.
+        const { data, error } =
+          action.call === 'linkIdentity'
+            ? await supabase.auth.linkIdentity({
+                provider: 'google',
+                options: { redirectTo, skipBrowserRedirect: true },
+              })
+            : await supabase.auth.signInWithOAuth({
+                provider: 'google',
+                options: { redirectTo, skipBrowserRedirect: true },
+              });
+        if (error) throw error;
+        if (!data?.url) throw new Error('Google did not give us a sign-in link');
+
+        const result = await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
+        if (result.type !== 'success') return;
+
+        // The tokens come back in the URL fragment; nothing else reads them.
+        const fragment = result.url.split('#')[1] ?? '';
+        const params = new URLSearchParams(fragment);
+        const access_token = params.get('access_token');
+        const refresh_token = params.get('refresh_token');
+        if (!access_token || !refresh_token) {
+          // A link, rather than a sign-in, returns no tokens — the session it
+          // just added an identity to is the one already held.
+          const { data: current } = await supabase.auth.getSession();
+          setSession(current.session);
+          return;
+        }
+        const { error: sessionError } = await supabase.auth.setSession({
+          access_token,
+          refresh_token,
+        });
+        if (sessionError) throw sessionError;
       },
 
       async updateProfile(patch) {

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -1,0 +1,186 @@
+/**
+ * Deciding how somebody signs in — and, more importantly, how they stop being
+ * a guest without losing everything.
+ *
+ * ADR-006 says an anonymous account is upgraded **in place**. That one
+ * sentence is the whole reason this file exists, because the obvious code does
+ * the opposite: a guest taps "sign in with Google", the app calls
+ * `signInWithOAuth`, Supabase creates a *new* user, the session swaps, and the
+ * trip they have been adding expenses to all week now belongs to an account
+ * they can no longer reach. Nothing errors. The group is not deleted — it is
+ * simply somebody else's, and the only way back is the anonymous session that
+ * was just replaced.
+ *
+ * So the choice of call is not left to whichever screen is asking. Given who
+ * is signed in and what they picked, `planAuth` returns the one correct
+ * action, and the screens do as they are told. It is pure, so the case that
+ * matters — a guest with data — can be tested without an account, a network,
+ * or a phone.
+ *
+ * Nothing here talks to Supabase. It decides; the caller performs.
+ */
+
+export type AuthMethod = 'email_password' | 'phone_password' | 'phone_otp' | 'google';
+
+/** Who is asking. */
+export type Viewer =
+  | { readonly kind: 'nobody' }
+  | { readonly kind: 'guest'; readonly userId: string }
+  | { readonly kind: 'user'; readonly userId: string };
+
+export type AuthAction =
+  /** Brand new account with credentials. */
+  | { readonly call: 'signUp'; readonly method: AuthMethod }
+  /** Existing account, prove it. */
+  | { readonly call: 'signInWithPassword'; readonly method: AuthMethod }
+  | { readonly call: 'signInWithOtp'; readonly method: 'phone_otp' }
+  | { readonly call: 'signInWithOAuth'; readonly method: 'google' }
+  /**
+   * The upgrade. `updateUser` adds an email or phone to the account that is
+   * already signed in; `linkIdentity` does the same for an OAuth provider.
+   * Both keep the user id, which is what keeps the groups.
+   */
+  | { readonly call: 'updateUser'; readonly method: AuthMethod }
+  | { readonly call: 'linkIdentity'; readonly method: 'google' };
+
+export class IdentityError extends Error {
+  constructor(
+    readonly code:
+      | 'PHONE_NEEDS_COUNTRY_CODE'
+      | 'PHONE_NOT_VALID'
+      | 'EMAIL_NOT_VALID'
+      | 'PASSWORD_TOO_SHORT'
+      | 'PASSWORD_TOO_COMMON',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'IdentityError';
+  }
+}
+
+/**
+ * The rule, in one function.
+ *
+ * A guest never signs up and never signs in — both would mint or move to a
+ * different account. A guest only ever *adds* credentials to the account they
+ * already have.
+ */
+export function planAuth(
+  viewer: Viewer,
+  method: AuthMethod,
+  intent: 'sign_in' | 'sign_up' = 'sign_in',
+): AuthAction {
+  if (viewer.kind === 'guest') {
+    // Whatever the screen thought it was doing, this is an upgrade.
+    return method === 'google'
+      ? { call: 'linkIdentity', method: 'google' }
+      : { call: 'updateUser', method };
+  }
+
+  if (viewer.kind === 'user') {
+    // Already a real account. Adding a second way in is still a link, never a
+    // sign-up — somebody with an email adding Google must not end up with two
+    // accounts and half their groups in each.
+    return method === 'google'
+      ? { call: 'linkIdentity', method: 'google' }
+      : { call: 'updateUser', method };
+  }
+
+  switch (method) {
+    case 'google':
+      return { call: 'signInWithOAuth', method: 'google' };
+    case 'phone_otp':
+      return { call: 'signInWithOtp', method: 'phone_otp' };
+    default:
+      return intent === 'sign_up'
+        ? { call: 'signUp', method }
+        : { call: 'signInWithPassword', method };
+  }
+}
+
+/**
+ * A number, in E.164 and nothing else.
+ *
+ * No default country. Baaki is India-first, so +91 is the tempting default and
+ * exactly the wrong one: the person most likely to be typing a number into a
+ * splitting app is on a trip, entering a friend's foreign number, and a silent
+ * +91 would send their invite to a stranger in Delhi. The same rule as
+ * `group_members.invite_phone` in the database, which is the other place a
+ * number can arrive.
+ */
+export function normalisePhone(raw: string): string {
+  const cleaned = raw.replace(/[^\d+]/g, '');
+  if (!cleaned.startsWith('+')) {
+    throw new IdentityError(
+      'PHONE_NEEDS_COUNTRY_CODE',
+      'Start with a country code, like +91 for India',
+    );
+  }
+  if (!/^\+[1-9]\d{7,14}$/.test(cleaned)) {
+    throw new IdentityError('PHONE_NOT_VALID', 'That does not look like a phone number');
+  }
+  return cleaned;
+}
+
+/** Lowercased and trimmed, because a login that is case-sensitive is a bug report. */
+export function normaliseEmail(raw: string): string {
+  const cleaned = raw.trim().toLowerCase();
+  // Deliberately loose. A stricter pattern rejects real addresses, and the
+  // only test that settles it is whether the confirmation mail arrives.
+  if (!/^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test(cleaned)) {
+    throw new IdentityError('EMAIL_NOT_VALID', 'That does not look like an email address');
+  }
+  return cleaned;
+}
+
+/**
+ * Passwords guarding a shared ledger.
+ *
+ * Length, and a short list of the passwords everybody picks. No character-class
+ * rules: they push people towards `Password1!` and away from a long phrase,
+ * which is worse on both counts.
+ */
+const OBVIOUS = new Set([
+  'password',
+  'password1',
+  'password123',
+  '12345678',
+  '123456789',
+  '1234567890',
+  'qwertyui',
+  'iloveyou',
+  'baaki123',
+  'letmein1',
+  'welcome1',
+  'abcd1234',
+]);
+
+export const MIN_PASSWORD_LENGTH = 8;
+
+export function checkPassword(password: string): void {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    throw new IdentityError(
+      'PASSWORD_TOO_SHORT',
+      `Use at least ${MIN_PASSWORD_LENGTH} characters — a phrase is easier to remember than a puzzle`,
+    );
+  }
+  if (OBVIOUS.has(password.toLowerCase())) {
+    throw new IdentityError(
+      'PASSWORD_TOO_COMMON',
+      'That is one of the first passwords anyone tries',
+    );
+  }
+}
+
+/**
+ * What the person typed into a single field: an email, or a number.
+ *
+ * One field rather than two, because asking somebody to first declare which
+ * kind of thing they are about to type, and then type it, is a question the
+ * text itself already answers.
+ */
+export function readIdentifier(raw: string): { kind: 'email' | 'phone'; value: string } {
+  const trimmed = raw.trim();
+  if (trimmed.includes('@')) return { kind: 'email', value: normaliseEmail(trimmed) };
+  return { kind: 'phone', value: normalisePhone(trimmed) };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,4 @@ export * from './receipt/index';
 export * from './notifications/index';
 export * from './sms/index';
 export * from './import/index';
+export * from './auth/identity';

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Signing in, and the one case that must never be got wrong.
+ *
+ * A guest has real data: a trip, a week of expenses, people who owe them
+ * money. If "sign in with Google" calls `signInWithOAuth`, Supabase makes a
+ * new user, the session swaps, and all of it belongs to an account they cannot
+ * reach. Nothing errors. Nothing is deleted. It is simply gone, and the only
+ * way back was the anonymous session that was just replaced.
+ *
+ * Every test in the first block is that failure, from a different angle.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  checkPassword,
+  IdentityError,
+  normaliseEmail,
+  normalisePhone,
+  planAuth,
+  readIdentifier,
+  type AuthMethod,
+  type Viewer,
+} from '../src/index';
+
+const GUEST: Viewer = { kind: 'guest', userId: 'u-guest' };
+const USER: Viewer = { kind: 'user', userId: 'u-real' };
+const NOBODY: Viewer = { kind: 'nobody' };
+
+const EVERY_METHOD: AuthMethod[] = ['email_password', 'phone_password', 'phone_otp', 'google'];
+
+describe('a guest is upgraded, never replaced', () => {
+  it.each(EVERY_METHOD)('%s adds to the account they already have', (method) => {
+    const action = planAuth(GUEST, method);
+    expect(['updateUser', 'linkIdentity']).toContain(action.call);
+  });
+
+  it.each(EVERY_METHOD)('%s never signs them up or in as somebody new', (method) => {
+    // This is the whole file. A guest reaching signUp, signInWithPassword or
+    // signInWithOAuth loses their groups.
+    const action = planAuth(GUEST, method);
+    expect(['signUp', 'signInWithPassword', 'signInWithOtp', 'signInWithOAuth']).not.toContain(
+      action.call,
+    );
+  });
+
+  it('links Google rather than signing in with it', () => {
+    expect(planAuth(GUEST, 'google')).toEqual({ call: 'linkIdentity', method: 'google' });
+  });
+
+  it('ignores a screen that thinks it is a sign-up', () => {
+    // The screen does not get a say. Whatever it believes it is doing, a guest
+    // with data can only ever be upgraded.
+    expect(planAuth(GUEST, 'email_password', 'sign_up').call).toBe('updateUser');
+    expect(planAuth(GUEST, 'email_password', 'sign_in').call).toBe('updateUser');
+  });
+});
+
+describe('somebody who already has an account', () => {
+  it.each(EVERY_METHOD)('%s adds a second way in, not a second account', (method) => {
+    // Somebody with an email who adds Google must not end up with two accounts
+    // and half their groups in each.
+    const action = planAuth(USER, method);
+    expect(['updateUser', 'linkIdentity']).toContain(action.call);
+  });
+});
+
+describe('somebody with no account at all', () => {
+  it('signs in with a password', () => {
+    expect(planAuth(NOBODY, 'email_password')).toEqual({
+      call: 'signInWithPassword',
+      method: 'email_password',
+    });
+  });
+
+  it('signs up when that is what they asked for', () => {
+    expect(planAuth(NOBODY, 'email_password', 'sign_up')).toEqual({
+      call: 'signUp',
+      method: 'email_password',
+    });
+  });
+
+  it('sends a code for phone OTP whichever they asked for', () => {
+    // There is no separate sign-up for an OTP: the code both proves the number
+    // and creates the account.
+    expect(planAuth(NOBODY, 'phone_otp').call).toBe('signInWithOtp');
+    expect(planAuth(NOBODY, 'phone_otp', 'sign_up').call).toBe('signInWithOtp');
+  });
+
+  it('goes to the provider for Google', () => {
+    expect(planAuth(NOBODY, 'google').call).toBe('signInWithOAuth');
+  });
+});
+
+describe('phone numbers', () => {
+  it('keeps a number in E.164', () => {
+    expect(normalisePhone('+91 98765 43210')).toBe('+919876543210');
+  });
+
+  it('strips whatever punctuation a keyboard produced', () => {
+    expect(normalisePhone('+91-98765-43210')).toBe('+919876543210');
+    expect(normalisePhone('+91 (98765) 43210')).toBe('+919876543210');
+  });
+
+  it('refuses a number with no country code rather than assuming India', () => {
+    // The person typing a number into a splitting app is often on a trip,
+    // entering a friend's foreign number. A silent +91 sends it to a stranger.
+    expect(() => normalisePhone('09876543210')).toThrow(IdentityError);
+    expect(() => normalisePhone('09876543210')).toThrow(/country code/);
+  });
+
+  it('refuses something that is not a number', () => {
+    expect(() => normalisePhone('+12')).toThrow(/phone number/);
+    expect(() => normalisePhone('+0123456789')).toThrow(/phone number/);
+  });
+
+  it('takes a number from anywhere, not only India', () => {
+    expect(normalisePhone('+1 415 555 2671')).toBe('+14155552671');
+    expect(normalisePhone('+44 20 7946 0958')).toBe('+442079460958');
+  });
+});
+
+describe('email addresses', () => {
+  it('lowercases and trims', () => {
+    // A login that is case-sensitive is a bug report.
+    expect(normaliseEmail('  Asha@Example.COM ')).toBe('asha@example.com');
+  });
+
+  it('refuses what is plainly not an address', () => {
+    for (const bad of ['asha', 'asha@', '@example.com', 'a b@example.com', 'asha@example']) {
+      expect(() => normaliseEmail(bad)).toThrow(IdentityError);
+    }
+  });
+
+  it('takes the odd-looking addresses that are real', () => {
+    expect(normaliseEmail('asha+goa@example.co.in')).toBe('asha+goa@example.co.in');
+    expect(normaliseEmail("o'neill@example.org")).toBe("o'neill@example.org");
+  });
+});
+
+describe('passwords', () => {
+  it('wants length, not punctuation', () => {
+    // Character-class rules push people to Password1! and away from a phrase.
+    expect(() => checkPassword('correct horse battery staple')).not.toThrow();
+    expect(() => checkPassword('short1')).toThrow(/at least 8/);
+  });
+
+  it('refuses the ones everybody picks', () => {
+    expect(() => checkPassword('password123')).toThrow(/first passwords anyone tries/);
+    expect(() => checkPassword('PASSWORD123')).toThrow(IdentityError);
+  });
+});
+
+describe('one field for either', () => {
+  it('reads an email as an email', () => {
+    expect(readIdentifier(' Asha@Example.com ')).toEqual({
+      kind: 'email',
+      value: 'asha@example.com',
+    });
+  });
+
+  it('reads a number as a number', () => {
+    expect(readIdentifier('+91 98765 43210')).toEqual({ kind: 'phone', value: '+919876543210' });
+  });
+
+  it('complains about the number, not about the format of the field', () => {
+    // Asking "email or phone?" and then asking them to type it is a question
+    // the text already answers — but the error still has to be the useful one.
+    expect(() => readIdentifier('9876543210')).toThrow(/country code/);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       expo:
         specifier: ~57.0.10
         version: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      expo-auth-session:
+        specifier: ~57.0.6
+        version: 57.0.6(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
       expo-clipboard:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -2821,10 +2824,21 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  expo-application@57.0.2:
+    resolution: {integrity: sha512-q31YwcXyymviAmdrtDfAg3Dld4VMxLCNAfgMHip7vZpPX4lzF/AfwsywqBJUAjQnJknzaNAkzqvMVjO5XmKYDA==}
+    peerDependencies:
+      expo: '*'
+
   expo-asset@57.0.8:
     resolution: {integrity: sha512-sGocG+Wd2WcZ1KjKyB2LfUZXzrBM0VHEATGcpJKF9T3HM56M/sMbH73vv+n85u5Zr0FkJjEbV1DWhGPimCR1QQ==}
     peerDependencies:
       expo: '*'
+      react: '*'
+      react-native: '*'
+
+  expo-auth-session@57.0.6:
+    resolution: {integrity: sha512-HRUAzGgWQjfPd+jdd0jbVHm+0QQE6KjVyXXe+rKJ+Ozqne1ub/Str8COVnJ6wZFI9ASuyQiI5G3hAMNd2yr1CQ==}
+    peerDependencies:
       react: '*'
       react-native: '*'
 
@@ -8017,6 +8031,10 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  expo-application@57.0.2(expo@57.0.10):
+    dependencies:
+      expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+
   expo-asset@57.0.8(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.11.4(supports-color@8.1.1)(typescript@6.0.3)
@@ -8027,6 +8045,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-auth-session@57.0.6(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1):
+    dependencies:
+      expo-application: 57.0.2(expo@57.0.10)
+      expo-constants: 57.0.9(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(supports-color@8.1.1)
+      expo-crypto: 57.0.1(expo@57.0.10)
+      expo-linking: 57.0.5(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
+      expo-web-browser: 57.0.2(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))
+      invariant: 2.2.4
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - expo
+      - supports-color
 
   expo-clipboard@57.0.1(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
## The bug this is built around

ADR-006 says an anonymous account is upgraded **in place**. The obvious code does the opposite:

> a guest taps "sign in with Google" → the app calls `signInWithOAuth` → Supabase creates a **new** user → the session swaps → the trip they spent a week adding expenses to now belongs to an account they can no longer reach.

Nothing errors. Nothing is deleted. It is simply somebody else's, and the way back was the anonymous session that was just replaced.

## So the screen doesn't decide

`planAuth()` in `@baaki/core` takes who is signed in and what they picked, and returns the one correct action. A guest can only ever reach `updateUser` or `linkIdentity`.

31 tests. The first block is that failure from every angle — every method, both intents, asserting a guest never reaches `signUp`, `signInWithPassword`, `signInWithOtp` or `signInWithOAuth`:

```ts
it.each(EVERY_METHOD)('%s never signs them up or in as somebody new', (method) => {
  const action = planAuth(GUEST, method);
  expect(['signUp', 'signInWithPassword', 'signInWithOtp', 'signInWithOAuth'])
    .not.toContain(action.call);
});
```

Someone who already has an account is treated the same way: adding Google to an email account **links** it, rather than making a second account with half their groups in it.

## Identifiers

Normalised in core, so one form cannot accept what another rejects. **No default country code** — India-first makes `+91` the tempting default and exactly the wrong one, since the person typing a number into a splitting app is usually on a trip entering a foreign one. `settings/account` now normalises through the same code instead of sending what was typed.

Passwords ask for length, not punctuation: character-class rules push people towards `Password1!` and away from a phrase.

## One field, not two

"Email or phone?" is a question the text itself already answers.

## ⚠️ Google is not usable yet

The code path is complete and typechecked but **has never run**. It needs, in the Supabase dashboard:

1. Google provider enabled, with a client id and secret
2. `baaki://auth` added to the allowed redirect URLs

`expo-auth-session` is a new dependency, so this also needs a fresh dev build.

Everything else — password sign-in, sign-up, and the guest upgrade — works against the existing setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)