### PR TITLE
Trip dates, two reminders a day, the 7-day auto-confirm, and a security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,19 @@ Sign in (phone OTP or guest) · Home · Activity · Account · New group ·
 Group (expenses / balances / activity) · Expense detail with version history ·
 Add or edit expense · Split by item · Settle up · Who pays whom · Members ·
 Member detail · Group settings · Invite · Join from a link ·
-Notification preferences · App lock · Export.
+Notification preferences · Security (app lock, re-ask delay, sign out) ·
+Inbox · Export.
+
+### Scheduled jobs
+
+Both run hourly under `pg_cron`, take their clock as an argument so they can be
+tested without waiting a week, and are idempotent — `notifications.dedupe_key`
+is what makes a retried run a no-op rather than a second buzz.
+
+| Job                                | What it resolves                                                                                                                                                                                             |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `baaki_auto_confirm_settlements()` | A settlement nobody answered for 7 days (ADR-007). A dispute still reopens it.                                                                                                                               |
+| `baaki_trip_nudges()`              | Twice a day during a group's dates: at breakfast about yesterday, at the end of the day about today. Skips anybody who already recorded that day, and asks in the group's timezone rather than the server's. |
 
 ### Edge functions
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -39,7 +39,8 @@
         }
       ],
       "expo-secure-store",
-      "expo-sharing"
+      "expo-sharing",
+      "@react-native-community/datetimepicker"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,6 +8,7 @@
     "@expo/ui": "~57.0.9",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/datetimepicker": "9.1.0",
     "@react-native-ml-kit/text-recognition": "^2.0.0",
     "@sentry/react-native": "~7.11.0",
     "@supabase/supabase-js": "^2.112.0",

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -1,3 +1,4 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useQuery } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { RefreshControl, ScrollView, View } from 'react-native';
@@ -6,8 +7,10 @@ import {
   Avatar,
   Card,
   EmptyState,
+  IconButton,
   ListRow,
   MoneyText,
+  Row,
   Screen,
   SectionHeader,
   Text,
@@ -16,6 +19,7 @@ import {
 
 import { describeActivity } from '@/data/activity';
 import { fetchRecentActivity } from '@/data/api';
+import { useNotifications } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
@@ -30,6 +34,9 @@ export default function ActivityScreen() {
     queryFn: () => fetchRecentActivity(),
   });
   const entries = activity.data ?? [];
+
+  const notifications = useNotifications();
+  const unread = (notifications.data ?? []).filter((row) => row.read_at === null).length;
 
   const byDay = entries.reduce<Record<string, typeof entries>>((groups, entry) => {
     const day = entry.created_at.slice(0, 10);
@@ -54,9 +61,28 @@ export default function ActivityScreen() {
           />
         }
       >
-        <Text variant="title" style={{ paddingTop: theme.spacing.md }}>
-          {t.activity}
-        </Text>
+        <Row style={{ paddingTop: theme.spacing.md, justifyContent: 'space-between' }}>
+          <Text variant="title">{t.activity}</Text>
+          {/* The feed is what happened in the groups; the inbox is what Baaki
+              said to you. Related enough to sit together, different enough not
+              to be interleaved. */}
+          <IconButton label="Inbox" onPress={() => router.push('/inbox' as never)}>
+            <Ionicons name="notifications-outline" size={20} color={theme.color.text} />
+            {unread > 0 ? (
+              <View
+                style={{
+                  position: 'absolute',
+                  top: 6,
+                  right: 6,
+                  width: 9,
+                  height: 9,
+                  borderRadius: 5,
+                  backgroundColor: theme.color.brand,
+                }}
+              />
+            ) : null}
+          </IconButton>
+        </Row>
 
         {entries.length === 0 ? (
           <EmptyState

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { ScrollView, TextInput, View } from 'react-native';
+import { Alert, ScrollView, TextInput, View } from 'react-native';
 
 import { isValidVpa } from '@baaki/core';
 import {
@@ -19,13 +19,68 @@ import {
 
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { describeGrace, useLock } from '@/lib/lock';
 
-const SETTINGS: {
+interface SettingsRow {
   icon: keyof typeof Ionicons.glyphMap;
   label: string;
   hint: string;
   route?: string;
-}[] = [
+  onPress?: () => void;
+}
+
+function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }) {
+  const theme = useTheme();
+  return (
+    <View>
+      <SectionHeader title={title} />
+      <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+        {rows.map((item, index) => {
+          const live = Boolean(item.route ?? item.onPress);
+          return (
+            <View key={item.label}>
+              <ListRow
+                title={item.label}
+                subtitle={item.hint}
+                onPress={
+                  item.onPress ?? (item.route ? () => router.push(item.route as never) : undefined)
+                }
+                leading={
+                  <View
+                    style={{
+                      width: 40,
+                      height: 40,
+                      borderRadius: theme.radius.pill,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: live ? theme.color.brandSoft : theme.color.surfaceMuted,
+                    }}
+                  >
+                    <Ionicons
+                      name={item.icon}
+                      size={18}
+                      color={live ? theme.color.brand : theme.color.textMuted}
+                    />
+                  </View>
+                }
+                trailing={
+                  item.route ? (
+                    <Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />
+                  ) : null
+                }
+              />
+              {index < rows.length - 1 ? (
+                <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              ) : null}
+            </View>
+          );
+        })}
+      </Card>
+    </View>
+  );
+}
+
+const SETTINGS: SettingsRow[] = [
   {
     icon: 'person-circle-outline',
     label: 'Your account',
@@ -44,12 +99,6 @@ const SETTINGS: {
     hint: 'JSON + CSV, lossless, free',
     route: '/settings/export',
   },
-  {
-    icon: 'lock-closed-outline',
-    label: 'App lock',
-    hint: 'Biometrics or passcode',
-    route: '/settings/lock',
-  },
   { icon: 'cloud-upload-outline', label: 'Import from Splitwise', hint: 'Coming in M3' },
 ];
 
@@ -58,9 +107,34 @@ export default function ProfileScreen() {
   const { t, locale } = useStrings();
   const { profile, isGuest, updateProfile, signOut } = useAuth();
 
+  const { enabled: lockEnabled, supported: lockSupported, graceSeconds } = useLock();
+
   const [name, setName] = useState(profile?.display_name ?? '');
   const [vpa, setVpa] = useState(profile?.default_vpa ?? '');
   const [status, setStatus] = useState<string | null>(null);
+
+  const lockSummary = !lockSupported
+    ? 'This device has no biometrics set up'
+    : lockEnabled
+      ? `On · asks ${describeGrace(graceSeconds).toLowerCase()}`
+      : 'Off — anyone holding your phone can read the ledger';
+
+  const signOutHint = isGuest
+    ? 'This guest account lives on this device only'
+    : 'Nothing is deleted; sign back in whenever';
+
+  const confirmSignOut = (): void => {
+    Alert.alert(
+      'Sign out?',
+      isGuest
+        ? 'This is a guest account, so signing out leaves no way back into it. Add an email or phone number first if you want to keep it.'
+        : 'You can sign back in whenever you like. Nothing is deleted.',
+      [
+        { text: 'Stay signed in', style: 'cancel' },
+        { text: 'Sign out', style: 'destructive', onPress: () => void signOut() },
+      ],
+    );
+  };
 
   const vpaValid = vpa.trim() === '' || isValidVpa(vpa.trim());
   const dirty =
@@ -175,50 +249,22 @@ export default function ProfileScreen() {
           </Card>
         ) : null}
 
-        <View>
-          <SectionHeader title="Settings" />
-          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-            {SETTINGS.map((item, index) => (
-              <View key={item.label}>
-                <ListRow
-                  title={item.label}
-                  subtitle={item.hint}
-                  onPress={item.route ? () => router.push(item.route as never) : undefined}
-                  leading={
-                    <View
-                      style={{
-                        width: 40,
-                        height: 40,
-                        borderRadius: theme.radius.pill,
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        backgroundColor: item.route
-                          ? theme.color.brandSoft
-                          : theme.color.surfaceMuted,
-                      }}
-                    >
-                      <Ionicons
-                        name={item.icon}
-                        size={18}
-                        color={item.route ? theme.color.brand : theme.color.textMuted}
-                      />
-                    </View>
-                  }
-                  trailing={
-                    item.route ? (
-                      <Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />
-                    ) : null
-                  }
-                />
-                {index < SETTINGS.length - 1 ? (
-                  <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                ) : null}
-              </View>
-            ))}
-          </Card>
-        </View>
+        <SettingsSection title="Settings" rows={SETTINGS} />
 
-        <Button label="Sign out" variant="ghost" fullWidth onPress={() => void signOut()} />
+        {/* Security is its own section rather than one row among many: it is
+            the only group of settings somebody comes looking for. */}
+        <SettingsSection
+          title="Security"
+          rows={[
+            {
+              icon: 'finger-print-outline',
+              label: 'App lock',
+              hint: lockSummary,
+              route: '/settings/lock',
+            },
+            { icon: 'log-out-outline', label: 'Sign out', hint: signOutHint, onPress: confirmSignOut },
+          ]}
+        />
 
         <Text variant="micro" tone="faint" align="center">
           Baaki · the ledger is free forever. We only ever charge for convenience.

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -150,6 +150,7 @@ function AuthGate() {
       <Stack.Screen name="settings/lock" />
       <Stack.Screen name="settings/account" />
       <Stack.Screen name="join" />
+      <Stack.Screen name="inbox" />
     </Stack>
   );
 }

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -17,6 +17,7 @@ import {
 } from '@baaki/ui';
 
 import { GroupPhoto, pickGroupPhoto } from '@/components/GroupPhoto';
+import { TripDates } from '@/components/TripDates';
 import { removeGroupPhoto, uploadGroupPhoto } from '@/data/api';
 import { useGroup, useGroupLedger, useLeaveGroup, useUpdateGroup } from '@/data/hooks';
 import { useStrings } from '@/i18n';
@@ -27,7 +28,7 @@ const EMOJI = ['🏖️', '🏠', '💜', '🎉', '✈️', '🍽️', '⛰️',
 
 export default function GroupSettingsScreen() {
   const theme = useTheme();
-  const { t } = useStrings();
+  const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
   const { profile } = useAuth();
@@ -219,6 +220,12 @@ export default function GroupSettingsScreen() {
             ))}
           </Row>
         </Card>
+
+        <TripDates
+          group={group.data}
+          locale={locale}
+          onChange={(patch) => updateGroup.mutate(patch, { onSuccess: () => setStatus('Saved') })}
+        />
 
         {/* ADR-009: simplification is presentation only — the pairwise ledger
             underneath is untouched, so this is safe to toggle at any time. */}

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -1,0 +1,183 @@
+/**
+ * The inbox — everything Baaki has told you, whether or not a push arrived.
+ *
+ * TDR §7.1 calls this the ledger of record for what we sent, and that is the
+ * point: a push dropped by the phone, silenced by Do Not Disturb, or sent while
+ * notifications were off is still here. "Your settlement auto-confirmed" is not
+ * something somebody should find out from their balance changing.
+ *
+ * The wording is built here rather than read off the row. The server wrote
+ * `kind` and a payload without knowing who would read it or in which language;
+ * `renderNotification` in @baaki/core turns that into a sentence, with the
+ * stored English as the fallback for a kind this build has never heard of.
+ */
+
+import { useEffect } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { RefreshControl, ScrollView, View } from 'react-native';
+
+import { renderNotification } from '@baaki/core';
+import {
+  Card,
+  EmptyState,
+  IconButton,
+  ListRow,
+  Row,
+  Screen,
+  SectionHeader,
+  Text,
+  useTheme,
+} from '@baaki/ui';
+
+import { useMarkNotificationsRead, useNotifications } from '@/data/hooks';
+import type { NotificationRow } from '@/data/types';
+import { useStrings } from '@/i18n';
+
+const ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {
+  settlement_confirmed: 'checkmark-circle',
+  settlement_initiated: 'arrow-forward-circle',
+  settlement_confirm_request: 'help-circle',
+  trip_nudge_morning: 'sunny',
+  trip_nudge_evening: 'moon',
+  nudge: 'hand-left',
+  expense_added: 'receipt',
+  ghost_claimed: 'person-add',
+  group_invite_accepted: 'person-add',
+};
+
+function factsOf(row: NotificationRow): Record<string, string | undefined> {
+  const payload = row.payload ?? {};
+  const text = (key: string): string | undefined =>
+    typeof payload[key] === 'string' ? (payload[key] as string) : undefined;
+  return {
+    amount: text('amount'),
+    currency: text('currency'),
+    counterparty: text('counterparty'),
+    group: text('group'),
+    description: text('description'),
+    count: text('count'),
+  };
+}
+
+export default function InboxScreen() {
+  const theme = useTheme();
+  const { locale } = useStrings();
+  const notifications = useNotifications();
+  const markRead = useMarkNotificationsRead();
+
+  const rows = notifications.data ?? [];
+  const unread = rows.filter((row) => row.read_at === null);
+
+  // Opening the inbox is reading it. Leaving a badge up after somebody has
+  // looked is how a badge stops meaning anything.
+  useEffect(() => {
+    if (unread.length === 0) return;
+    markRead.mutate(unread.map((row) => row.id));
+    // Only on the ids present when the screen opened; re-running as the list
+    // refetches would fight the user's scroll.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [notifications.isSuccess]);
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={notifications.isFetching && !notifications.isLoading}
+            onRefresh={() => void notifications.refetch()}
+            tintColor={theme.color.brand}
+          />
+        }
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label="Back" onPress={() => router.back()}>
+            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">Inbox</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        {rows.length === 0 ? (
+          <EmptyState
+            title="Nothing yet"
+            body="Reminders, settlement confirmations and anything else Baaki tells you collect here — even when the notification never reached your phone."
+          />
+        ) : (
+          <View>
+            <SectionHeader title="Recent" />
+            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+              {rows.map((row, index) => {
+                const { title, body } = renderNotification(row.kind, factsOf(row), locale, {
+                  title: row.title,
+                  body: row.body,
+                });
+                const unreadRow = row.read_at === null;
+                return (
+                  <View key={row.id}>
+                    <ListRow
+                      title={title}
+                      subtitle={body}
+                      onPress={
+                        row.group_id
+                          ? () => router.push(`/group/${row.group_id}` as never)
+                          : undefined
+                      }
+                      leading={
+                        <View
+                          style={{
+                            width: 40,
+                            height: 40,
+                            borderRadius: theme.radius.pill,
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            backgroundColor: unreadRow
+                              ? theme.color.brandSoft
+                              : theme.color.surfaceMuted,
+                          }}
+                        >
+                          <Ionicons
+                            name={ICONS[row.kind] ?? 'notifications'}
+                            size={18}
+                            color={unreadRow ? theme.color.brand : theme.color.textMuted}
+                          />
+                        </View>
+                      }
+                      trailing={
+                        unreadRow ? (
+                          <View
+                            style={{
+                              width: 8,
+                              height: 8,
+                              borderRadius: 4,
+                              backgroundColor: theme.color.brand,
+                            }}
+                          />
+                        ) : null
+                      }
+                    />
+                    {index < rows.length - 1 ? (
+                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                    ) : null}
+                  </View>
+                );
+              })}
+            </Card>
+          </View>
+        )}
+
+        <Text variant="micro" tone="faint" align="center">
+          Push and email delivery come with M4. Until then this is where everything lands.
+        </Text>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/settings/lock.tsx
+++ b/apps/mobile/src/app/settings/lock.tsx
@@ -1,14 +1,41 @@
+/**
+ * Security.
+ *
+ * Two settings and a way out. The lock guards the screen when the phone is
+ * handed over; the delay decides how often that guard gets in the way of the
+ * person who owns it. Both matter, because a lock that asks too often is a lock
+ * somebody turns off, and a lock nobody turns on protects nothing.
+ */
+
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { ScrollView, Switch, View } from 'react-native';
+import { Alert, ScrollView, Switch, View } from 'react-native';
 
-import { Badge, Card, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import { Badge, Button, Card, Chip, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
 
-import { useLock } from '@/lib/lock';
+import { useAuth } from '@/lib/auth';
+import { describeGrace, GRACE_CHOICES, useLock } from '@/lib/lock';
 
 export default function LockSettingsScreen() {
   const theme = useTheme();
-  const { enabled, supported, setEnabled } = useLock();
+  const { enabled, supported, graceSeconds, setEnabled, setGraceSeconds } = useLock();
+  const { isGuest, signOut } = useAuth();
+
+  const confirmSignOut = (): void => {
+    Alert.alert(
+      'Sign out?',
+      isGuest
+        ? // The one case where signing out is not reversible: a guest session
+          // lives on this device and nowhere else, so there is no credential to
+          // come back with.
+          'This is a guest account, so signing out leaves no way back into it. Add an email or phone number first if you want to keep it.'
+        : 'You can sign back in whenever you like. Nothing is deleted.',
+      [
+        { text: 'Stay signed in', style: 'cancel' },
+        { text: 'Sign out', style: 'destructive', onPress: () => void signOut() },
+      ],
+    );
+  };
 
   return (
     <Screen>
@@ -24,7 +51,7 @@ export default function LockSettingsScreen() {
             <Ionicons name="chevron-back" size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">App lock</Text>
+            <Text variant="heading">Security</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
@@ -34,8 +61,8 @@ export default function LockSettingsScreen() {
             <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
               <Text variant="subheading">Require biometrics or a passcode</Text>
               <Text variant="caption" tone="muted">
-                Baaki locks whenever it goes to the background. Handing someone your phone to show
-                them the split should not show them everything else.
+                Handing someone your phone to show them the split should not show them everything
+                else.
               </Text>
             </View>
             <Switch
@@ -49,6 +76,40 @@ export default function LockSettingsScreen() {
         </Card>
 
         {!supported ? <Badge label="This device has no biometrics or passcode set up" /> : null}
+
+        {enabled ? (
+          <Card style={{ gap: theme.spacing.md }}>
+            <Text variant="subheading">Ask again after</Text>
+            <Text variant="caption" tone="muted">
+              Time in the background before Baaki locks. Settling by UPI sends you to another app
+              and back, so locking the instant you leave means unlocking every time you pay
+              somebody.
+            </Text>
+            <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
+              {GRACE_CHOICES.map((seconds) => (
+                <Chip
+                  key={seconds}
+                  label={describeGrace(seconds)}
+                  selected={graceSeconds === seconds}
+                  onPress={() => void setGraceSeconds(seconds)}
+                />
+              ))}
+            </Row>
+            <Text variant="micro" tone="faint">
+              Reopening Baaki after it has been closed always asks, whatever this says.
+            </Text>
+          </Card>
+        ) : null}
+
+        <Card style={{ gap: theme.spacing.md }}>
+          <Text variant="subheading">Sign out</Text>
+          <Text variant="caption" tone="muted">
+            {isGuest
+              ? 'This account lives on this device only. Signing out ends it.'
+              : 'Your groups and history stay exactly where they are.'}
+          </Text>
+          <Button label="Sign out" variant="secondary" fullWidth onPress={confirmSignOut} />
+        </Card>
 
         <Text variant="micro" tone="faint" align="center">
           This guards the screen, not the data — your ledger is protected by row-level security on

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -1,0 +1,260 @@
+/**
+ * When the trip is, and the two reminders a day that come with it.
+ *
+ * The reason to ask for dates at all is the reminders. Four people go to Goa;
+ * on day one everybody adds everything; by day three nobody has entered
+ * anything since the first lunch, and on the flight home somebody tries to
+ * reconstruct a week of autorickshaws from memory. A shared ledger is only as
+ * good as the habit of adding to it, and the habit needs prompting while the
+ * receipts still exist.
+ *
+ * The times are settable because "breakfast" is not a fixed hour, and a group
+ * asked at the wrong one mutes the app rather than moving the setting. The
+ * timezone is the trip's rather than each reader's for the same reason: a
+ * question about dinner should not arrive at 04:00.
+ */
+
+import { useState } from 'react';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Platform, Pressable, Switch, View } from 'react-native';
+
+import { Button, Card, Row, Text, useTheme } from '@baaki/ui';
+
+import type { GroupRow } from '@/data/types';
+
+type Field = 'start' | 'end' | 'morning' | 'evening';
+
+export interface TripDatesPatch {
+  start_date?: string | null;
+  end_date?: string | null;
+  time_zone?: string;
+  remind_daily?: boolean;
+  remind_morning_at?: string;
+  remind_evening_at?: string;
+}
+
+/**
+ * Parsed as local noon rather than midnight. A date-only string turned into
+ * midnight UTC lands on the previous day for anybody west of Greenwich, which
+ * is how a trip silently starts a day early.
+ */
+function dateFrom(iso: string | null): Date {
+  if (!iso) return new Date();
+  const [year, month, day] = iso.split('-').map(Number);
+  return new Date(year ?? 2026, (month ?? 1) - 1, day ?? 1, 12);
+}
+
+function isoDate(value: Date): string {
+  const month = String(value.getMonth() + 1).padStart(2, '0');
+  const day = String(value.getDate()).padStart(2, '0');
+  return `${value.getFullYear()}-${month}-${day}`;
+}
+
+function timeFrom(value: string): Date {
+  const [hours, minutes] = value.split(':').map(Number);
+  const date = new Date();
+  date.setHours(hours ?? 9, minutes ?? 0, 0, 0);
+  return date;
+}
+
+function isoTime(value: Date): string {
+  return `${String(value.getHours()).padStart(2, '0')}:${String(value.getMinutes()).padStart(2, '0')}:00`;
+}
+
+/** "9:00 am" in whatever the reader's phone calls that. */
+function showTime(value: string, locale: string): string {
+  return timeFrom(value).toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' });
+}
+
+function showDate(iso: string | null, locale: string): string {
+  if (!iso) return 'Not set';
+  return dateFrom(iso).toLocaleDateString(locale, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  });
+}
+
+const deviceZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Kolkata';
+
+/** A tappable label + value that opens the picker for one field. */
+function FieldRow({
+  label,
+  value,
+  onPress,
+}: {
+  label: string;
+  value: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${label}: ${value}`}
+      onPress={onPress}
+      style={{ flex: 1, gap: 2 }}
+    >
+      <Text variant="caption" tone="muted">
+        {label}
+      </Text>
+      <Text variant="subheading">{value}</Text>
+    </Pressable>
+  );
+}
+
+export function TripDates({
+  group,
+  locale,
+  onChange,
+}: {
+  group: GroupRow;
+  locale: string;
+  onChange: (patch: TripDatesPatch) => void;
+}) {
+  const theme = useTheme();
+  const [editing, setEditing] = useState<Field | null>(null);
+
+  const hasDates = Boolean(group.start_date && group.end_date);
+
+  const apply = (field: Field, event: DateTimePickerEvent, picked?: Date): void => {
+    // Android's picker is a modal that reports its own dismissal; iOS's is
+    // inline and reports every scroll.
+    if (Platform.OS === 'android') setEditing(null);
+    if (event.type === 'dismissed' || !picked) return;
+
+    switch (field) {
+      case 'start': {
+        const start = isoDate(picked);
+        // An end date before the start is not a trip. Dragging the start past
+        // the end moves the end rather than refusing the tap.
+        const end = group.end_date && group.end_date < start ? start : group.end_date;
+        onChange({ start_date: start, end_date: end ?? start, time_zone: group.time_zone });
+        return;
+      }
+      case 'end': {
+        const end = isoDate(picked);
+        const start = group.start_date && group.start_date > end ? end : group.start_date;
+        onChange({ end_date: end, start_date: start ?? end });
+        return;
+      }
+      case 'morning':
+        onChange({ remind_morning_at: isoTime(picked) });
+        return;
+      default:
+        onChange({ remind_evening_at: isoTime(picked) });
+    }
+  };
+
+  return (
+    <Card style={{ gap: theme.spacing.lg }}>
+      <View style={{ gap: theme.spacing.xs }}>
+        <Text variant="subheading">Trip dates</Text>
+        <Text variant="caption" tone="muted">
+          While the trip is on, everybody gets a nudge to add what they spent — at breakfast about
+          yesterday, and at the end of the day about today. Nobody is asked about a day they have
+          already added to.
+        </Text>
+      </View>
+
+      <Row style={{ gap: theme.spacing.lg }}>
+        <FieldRow
+          label="Starts"
+          value={showDate(group.start_date, locale)}
+          onPress={() => setEditing('start')}
+        />
+        <FieldRow
+          label="Ends"
+          value={showDate(group.end_date, locale)}
+          onPress={() => setEditing('end')}
+        />
+      </Row>
+
+      {hasDates ? (
+        <>
+          <View style={{ height: 1, backgroundColor: theme.color.border }} />
+
+          <Row style={{ justifyContent: 'space-between' }}>
+            <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
+              <Text variant="subheading">Daily reminders</Text>
+              <Text variant="caption" tone="muted">
+                {`Asked in ${group.time_zone.replace(/_/g, ' ')} — where the trip is, not where each person is.`}
+              </Text>
+            </View>
+            <Switch
+              value={group.remind_daily}
+              onValueChange={(value) => onChange({ remind_daily: value })}
+              trackColor={{ true: theme.color.brand, false: theme.color.border }}
+              accessibilityLabel="Daily reminders"
+            />
+          </Row>
+
+          {group.remind_daily ? (
+            <>
+              <Row style={{ gap: theme.spacing.lg }}>
+                <FieldRow
+                  label="Breakfast"
+                  value={showTime(group.remind_morning_at, locale)}
+                  onPress={() => setEditing('morning')}
+                />
+                <FieldRow
+                  label="End of day"
+                  value={showTime(group.remind_evening_at, locale)}
+                  onPress={() => setEditing('evening')}
+                />
+              </Row>
+
+              {group.time_zone !== deviceZone() ? (
+                <Button
+                  label={`Use my timezone (${deviceZone().split('/').pop()?.replace(/_/g, ' ')})`}
+                  size="sm"
+                  variant="ghost"
+                  onPress={() => onChange({ time_zone: deviceZone() })}
+                />
+              ) : null}
+            </>
+          ) : null}
+        </>
+      ) : (
+        <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+          <Ionicons name="information-circle-outline" size={16} color={theme.color.textFaint} />
+          <Text variant="micro" tone="faint" style={{ flex: 1 }}>
+            A flatshare has no start and no end — leave these empty and nothing is sent.
+          </Text>
+        </Row>
+      )}
+
+      {group.start_date && group.end_date ? (
+        <Button
+          label="Clear dates"
+          size="sm"
+          variant="ghost"
+          onPress={() => onChange({ start_date: null, end_date: null })}
+        />
+      ) : null}
+
+      {editing ? (
+        <DateTimePicker
+          value={
+            editing === 'start'
+              ? dateFrom(group.start_date)
+              : editing === 'end'
+                ? dateFrom(group.end_date)
+                : timeFrom(
+                    editing === 'morning' ? group.remind_morning_at : group.remind_evening_at,
+                  )
+          }
+          mode={editing === 'start' || editing === 'end' ? 'date' : 'time'}
+          // The end of a trip cannot be before its beginning, so the picker
+          // does not offer it.
+          minimumDate={editing === 'end' ? dateFrom(group.start_date) : undefined}
+          onChange={(event, picked) => apply(editing, event, picked)}
+        />
+      ) : null}
+
+      {Platform.OS === 'ios' && editing ? (
+        <Button label="Done" size="sm" variant="secondary" onPress={() => setEditing(null)} />
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -29,9 +29,16 @@ import type {
   GroupRow,
   GroupType,
   MemberRow,
+  NotificationRow,
   SettlementMethod,
   SettlementRow,
 } from './types';
+
+const GROUP_SELECT = `
+  id, name, type, default_currency, simplify_debts, cover_emoji, photo_path,
+  start_date, end_date, time_zone, remind_daily, remind_morning_at, remind_evening_at,
+  archived_at, created_at
+`;
 
 const MEMBER_SELECT = `
   id, group_id, profile_id, ghost_name, role, vpa, left_at,
@@ -60,24 +67,14 @@ export async function fetchGroups(): Promise<GroupRow[]> {
   return unwrap(
     await supabase
       .from('groups')
-      .select(
-        'id, name, type, default_currency, simplify_debts, cover_emoji, photo_path, archived_at, created_at',
-      )
+      .select(GROUP_SELECT)
       .is('archived_at', null)
       .order('created_at', { ascending: false }),
   );
 }
 
 export async function fetchGroup(groupId: string): Promise<GroupRow> {
-  return unwrap(
-    await supabase
-      .from('groups')
-      .select(
-        'id, name, type, default_currency, simplify_debts, cover_emoji, photo_path, archived_at, created_at',
-      )
-      .eq('id', groupId)
-      .single(),
-  );
+  return unwrap(await supabase.from('groups').select(GROUP_SELECT).eq('id', groupId).single());
 }
 
 export async function fetchMembers(groupId: string): Promise<MemberRow[]> {
@@ -475,6 +472,12 @@ export async function updateGroup(
     simplify_debts: boolean;
     default_currency: string;
     archived_at: string | null;
+    start_date: string | null;
+    end_date: string | null;
+    time_zone: string;
+    remind_daily: boolean;
+    remind_morning_at: string;
+    remind_evening_at: string;
   }>,
 ): Promise<void> {
   const { error } = await supabase.from('groups').update(patch).eq('id', groupId);
@@ -597,6 +600,31 @@ export async function fetchNotificationPrefs(profileId: string): Promise<Notific
     .single();
   if (error) throw new Error(error.message);
   return { ...DEFAULT_NOTIFICATION_PREFS, ...((data?.notification_prefs ?? {}) as object) };
+}
+
+// ─────────────────────────────────────────────────────────── the inbox ──
+// Everything Baaki has told this person, whether or not a push ever reached
+// them. TDR §7.1 calls it the ledger of record for what we sent: a push that a
+// phone dropped, or that arrived while notifications were off, is still here.
+
+export async function fetchNotifications(limit = 50): Promise<NotificationRow[]> {
+  // No profile filter: `notifications_select_own` is the only thing that
+  // decides whose inbox this is, and adding a second, weaker check in the
+  // client would only invite disagreement about which one is authoritative.
+  return unwrap(
+    await supabase
+      .from('notifications')
+      .select('id, group_id, kind, title, body, deep_link, payload, read_at, created_at')
+      .order('created_at', { ascending: false })
+      .limit(limit),
+  ) as unknown as NotificationRow[];
+}
+
+export async function markNotificationsRead(ids: string[]): Promise<number> {
+  if (ids.length === 0) return 0;
+  const { data, error } = await supabase.rpc('baaki_mark_notifications_read', { p_ids: ids });
+  if (error) throw new Error(error.message);
+  return Number(data ?? 0);
 }
 
 export async function saveNotificationPrefs(

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -40,8 +40,10 @@ import {
   fetchMembersByGroup,
   fetchMembers,
   fetchMyBalances,
+  fetchNotifications,
   fetchPendingSettlements,
   fetchSettlements,
+  markNotificationsRead,
   recordSettlement,
   leaveGroup,
   restoreExpense,
@@ -61,6 +63,7 @@ export const keys = {
   settlements: (id: string) => ['group', id, 'settlements'] as const,
   activity: (id: string) => ['group', id, 'activity'] as const,
   balances: (id: string) => ['group', id, 'balances'] as const,
+  notifications: ['notifications'] as const,
 };
 
 export function useGroups() {
@@ -393,6 +396,25 @@ export function useConfirmSettlement(groupId: string) {
   return useMutation({
     mutationFn: confirmSettlement,
     onSuccess: () => invalidateGroup(queryClient, groupId),
+  });
+}
+
+/**
+ * The inbox (TDR §7.1).
+ *
+ * Kept short and refetched rather than paginated: this is what Baaki has said
+ * to you lately, not an archive. A read that goes back further than the last
+ * fifty things is a report, not a notification list.
+ */
+export function useNotifications() {
+  return useQuery({ queryKey: keys.notifications, queryFn: () => fetchNotifications() });
+}
+
+export function useMarkNotificationsRead() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: markNotificationsRead,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: keys.notifications }),
   });
 }
 

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -15,6 +15,15 @@ export interface GroupRow {
   cover_emoji: string | null;
   /** Object path in the private `group-photos` bucket, or null. */
   photo_path: string | null;
+  /** ISO dates, both ends inclusive. Null on a group that is not a trip. */
+  start_date: string | null;
+  end_date: string | null;
+  /** IANA zone the daily reminders are scheduled in — the trip's, not the reader's. */
+  time_zone: string;
+  remind_daily: boolean;
+  /** `HH:MM:SS` local to `time_zone`. */
+  remind_morning_at: string;
+  remind_evening_at: string;
   archived_at: string | null;
   created_at: string;
 }
@@ -105,6 +114,25 @@ export interface ActivityRow {
   object_type: string;
   object_id: string | null;
   payload: Record<string, unknown>;
+  created_at: string;
+}
+
+/**
+ * A row in the inbox (TDR §7.1).
+ *
+ * `title` and `body` are English and are a fallback: the server wrote them
+ * without knowing who would read them or in which language. The real wording
+ * comes from `kind` + `payload` through `renderNotification` in @baaki/core.
+ */
+export interface NotificationRow {
+  id: string;
+  group_id: string | null;
+  kind: string;
+  title: string;
+  body: string;
+  deep_link: string | null;
+  payload: Record<string, unknown>;
+  read_at: string | null;
   created_at: string;
 }
 

--- a/apps/mobile/src/lib/lock.tsx
+++ b/apps/mobile/src/lib/lock.tsx
@@ -1,9 +1,29 @@
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
 import { AppState, Platform } from 'react-native';
 
 const KEY = 'baaki.app_lock_enabled';
+const GRACE_KEY = 'baaki.app_lock_grace_seconds';
+
+/**
+ * How long the app may stay open after being backgrounded before it asks again.
+ *
+ * A lock that re-authenticates the instant you glance at a notification is a
+ * lock people turn off, and one that never re-authenticates is decoration. The
+ * default is thirty seconds: long enough to be sent to a UPI app and come back,
+ * short enough that a phone left on a table is not an open ledger.
+ */
+export const GRACE_CHOICES = [0, 15, 30, 60, 300] as const;
+export const DEFAULT_GRACE_SECONDS = 30;
 
 interface LockValue {
   /** Whether the user has turned the lock on. */
@@ -11,7 +31,10 @@ interface LockValue {
   /** Whether the app is currently waiting to be unlocked. */
   locked: boolean;
   supported: boolean;
+  /** Seconds in the background before the lock comes back. */
+  graceSeconds: number;
   setEnabled: (value: boolean) => Promise<void>;
+  setGraceSeconds: (value: number) => Promise<void>;
   unlock: () => Promise<boolean>;
 }
 
@@ -27,6 +50,15 @@ export function LockProvider({ children }: { children: ReactNode }) {
   const [enabled, setEnabledState] = useState(false);
   const [locked, setLocked] = useState(false);
   const [supported, setSupported] = useState(false);
+  const [graceSeconds, setGraceState] = useState(DEFAULT_GRACE_SECONDS);
+
+  /**
+   * When the app was last backgrounded. A ref rather than state because the
+   * listener needs the current value without being torn down and rebuilt as it
+   * changes — a listener that re-subscribes mid-transition misses the
+   * transition.
+   */
+  const leftAt = useRef<number | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -34,26 +66,42 @@ export function LockProvider({ children }: { children: ReactNode }) {
       // SecureStore has no web implementation; the lock is a native feature.
       const hasHardware = Platform.OS !== 'web' && (await LocalAuthentication.hasHardwareAsync());
       const stored = Platform.OS === 'web' ? null : await SecureStore.getItemAsync(KEY);
+      const storedGrace = Platform.OS === 'web' ? null : await SecureStore.getItemAsync(GRACE_KEY);
       if (!active) return;
       setSupported(hasHardware);
       const on = stored === 'true';
       setEnabledState(on);
+      // A cold start is always locked, whatever the grace period says. The
+      // grace is for coming back to a running app, not for reopening a killed
+      // one — and "killed" is indistinguishable from "reinstalled by somebody
+      // else holding the phone".
       setLocked(on);
+      const parsed = Number(storedGrace);
+      if (storedGrace !== null && Number.isFinite(parsed) && parsed >= 0) setGraceState(parsed);
     })();
     return () => {
       active = false;
     };
   }, []);
 
-  // Re-lock when the app goes to the background, which is exactly when the
-  // phone gets handed over.
   useEffect(() => {
     if (!enabled) return;
     const subscription = AppState.addEventListener('change', (state) => {
-      if (state === 'background') setLocked(true);
+      if (state === 'background' || state === 'inactive') {
+        // Only the first departure counts. iOS reports `inactive` on the way to
+        // `background`, and treating the second as a fresh departure would
+        // restart the clock at the moment the phone was put down.
+        leftAt.current ??= Date.now();
+        return;
+      }
+      if (state !== 'active') return;
+      const away = leftAt.current;
+      leftAt.current = null;
+      if (away === null) return;
+      if (Date.now() - away >= graceSeconds * 1000) setLocked(true);
     });
     return () => subscription.remove();
-  }, [enabled]);
+  }, [enabled, graceSeconds]);
 
   const unlock = useCallback(async () => {
     const result = await LocalAuthentication.authenticateAsync({
@@ -77,8 +125,15 @@ export function LockProvider({ children }: { children: ReactNode }) {
     setLocked(false);
   }, []);
 
+  const setGraceSeconds = useCallback(async (value: number) => {
+    await SecureStore.setItemAsync(GRACE_KEY, String(value));
+    setGraceState(value);
+  }, []);
+
   return (
-    <LockContext.Provider value={{ enabled, locked, supported, setEnabled, unlock }}>
+    <LockContext.Provider
+      value={{ enabled, locked, supported, graceSeconds, setEnabled, setGraceSeconds, unlock }}
+    >
       {children}
     </LockContext.Provider>
   );
@@ -88,4 +143,12 @@ export function useLock(): LockValue {
   const value = useContext(LockContext);
   if (!value) throw new Error('useLock must be used inside LockProvider');
   return value;
+}
+
+/** "Straight away", "After 30 seconds" — the words the settings row uses too. */
+export function describeGrace(seconds: number): string {
+  if (seconds <= 0) return 'Straight away';
+  if (seconds < 60) return `After ${seconds} seconds`;
+  if (seconds === 60) return 'After a minute';
+  return `After ${Math.round(seconds / 60)} minutes`;
 }

--- a/packages/core/src/notifications/copy.ts
+++ b/packages/core/src/notifications/copy.ts
@@ -17,7 +17,15 @@ export type NotificationKind =
   | 'nudge'
   | 'ghost_claimed'
   | 'group_invite_accepted'
-  | 'digest_daily';
+  | 'digest_daily'
+  /**
+   * The two reminders that run for the length of a trip. Asked at breakfast
+   * about yesterday and at the end of the day about today, because a ledger is
+   * only as good as the habit of adding to it, and the habit needs prompting
+   * while the receipts still exist.
+   */
+  | 'trip_nudge_morning'
+  | 'trip_nudge_evening';
 
 export interface CopyStrings {
   readonly money: {
@@ -59,6 +67,14 @@ const en: CopyStrings = {
     ghost_claimed: { title: '{actor} joined {group}', body: 'Their past expenses are now linked' },
     group_invite_accepted: { title: '{actor} joined {group}', body: 'Say hello' },
     digest_daily: { title: 'Today in {group}', body: '{count} updates · your baaki is {amount}' },
+    trip_nudge_morning: {
+      title: 'Anything from yesterday?',
+      body: 'Add what you spent on {group} while you still remember it',
+    },
+    trip_nudge_evening: {
+      title: 'Before you forget',
+      body: 'What did you pay for today on {group}?',
+    },
   },
 };
 
@@ -91,6 +107,14 @@ const ta: CopyStrings = {
     ghost_claimed: { title: '{actor} {group} இல் இணைந்தார்', body: 'பழைய செலவுகள் இணைக்கப்பட்டன' },
     group_invite_accepted: { title: '{actor} {group} இல் இணைந்தார்', body: 'வரவேற்கலாம்' },
     digest_daily: { title: 'இன்று {group} இல்', body: '{count} புதுப்பிப்புகள் · பாக்கி {amount}' },
+    trip_nudge_morning: {
+      title: 'நேற்று ஏதாவது இருக்கா?',
+      body: 'நினைவிருக்கும் போதே {group} செலவுகளைச் சேர்க்கவும்',
+    },
+    trip_nudge_evening: {
+      title: 'மறப்பதற்கு முன்',
+      body: 'இன்று {group} இல் என்ன செலவு செய்தீர்கள்?',
+    },
   },
 };
 
@@ -117,6 +141,14 @@ const hi: CopyStrings = {
     ghost_claimed: { title: '{actor} {group} में शामिल हुए', body: 'पुराने खर्च जुड़ गए' },
     group_invite_accepted: { title: '{actor} {group} में शामिल हुए', body: 'नमस्ते कहें' },
     digest_daily: { title: 'आज {group} में', body: '{count} अपडेट · बाकी {amount}' },
+    trip_nudge_morning: {
+      title: 'कल का कुछ बाकी है?',
+      body: 'याद रहते ही {group} के खर्च जोड़ दें',
+    },
+    trip_nudge_evening: {
+      title: 'भूलने से पहले',
+      body: 'आज {group} में आपने किस चीज़ का भुगतान किया?',
+    },
   },
 };
 

--- a/packages/core/src/notifications/index.ts
+++ b/packages/core/src/notifications/index.ts
@@ -1,1 +1,2 @@
 export * from './copy';
+export * from './render';

--- a/packages/core/src/notifications/render.ts
+++ b/packages/core/src/notifications/render.ts
@@ -1,0 +1,79 @@
+/**
+ * Turning a stored notification into a sentence somebody can read.
+ *
+ * The row in `notifications` holds a `kind` and a `payload`, plus an English
+ * `title`/`body` that exist only so a row is never blank. The real wording is
+ * built here, from the copy table, in the reader's language — because Postgres
+ * wrote that row and Postgres has no business holding three translations of
+ * every sentence, nor any idea which of them this particular person reads
+ * (TDR §11: en + ta + hi from day one).
+ *
+ * Amounts are formatted from minor units at the same moment, for the same
+ * reason: `42000` is not `₹420.00` until you know both the currency and the
+ * locale, and neither was known when the row was written.
+ */
+
+import { format, money, type CurrencyCode } from '../money/index';
+import { copyFor, interpolate, type NotificationKind } from './copy';
+
+/**
+ * The facts a notification row carries. Everything is optional because a kind
+ * only uses the ones it names — a missing fact leaves its placeholder visible
+ * rather than printing "undefined" at somebody.
+ */
+export interface NotificationFacts {
+  /** Minor units as a decimal string; bigint, so never a JSON number. */
+  readonly amount?: string;
+  readonly currency?: string;
+  readonly counterparty?: string;
+  readonly group?: string;
+  readonly description?: string;
+  readonly count?: string;
+}
+
+export interface RenderedNotification {
+  readonly title: string;
+  readonly body: string;
+}
+
+/**
+ * @param fallback the English title/body stored on the row, used when the kind
+ * is one this build of the app has never heard of — an older client reading a
+ * newer server's notification still shows something true.
+ */
+export function renderNotification(
+  kind: string,
+  facts: NotificationFacts,
+  locale: string,
+  fallback?: RenderedNotification,
+): RenderedNotification {
+  const copy = copyFor(locale);
+  const template = copy.notifications[kind as NotificationKind];
+  if (!template) return fallback ?? { title: kind, body: '' };
+
+  const values: Record<string, string> = {};
+  if (facts.counterparty) values.actor = facts.counterparty;
+  if (facts.group) values.group = facts.group;
+  if (facts.description) values.description = facts.description;
+  if (facts.count) values.count = facts.count;
+
+  const amount = formatAmount(facts, locale);
+  if (amount) values.amount = amount;
+
+  return {
+    title: interpolate(template.title, values),
+    body: interpolate(template.body, values),
+  };
+}
+
+function formatAmount(facts: NotificationFacts, locale: string): string | null {
+  if (!facts.amount || !facts.currency) return null;
+  try {
+    return format(money(BigInt(facts.amount), facts.currency as CurrencyCode), { locale });
+  } catch {
+    // A currency this build does not know, or an amount that is not a whole
+    // number of minor units. Showing the rest of the sentence beats showing
+    // nothing.
+    return null;
+  }
+}

--- a/packages/core/test/notificationRender.test.ts
+++ b/packages/core/test/notificationRender.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Turning a stored notification into a sentence.
+ *
+ * The row is written by Postgres, which knows what happened and nothing about
+ * who will read it. Language and currency formatting are decided here, at the
+ * moment somebody opens their inbox — which is also the only moment at which
+ * either is knowable.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { renderNotification } from '../src/index';
+
+const TRIP = { group: 'Goa', amount: '42000', currency: 'INR' };
+
+describe('reading a notification', () => {
+  it('fills in the group it is about', () => {
+    const { body } = renderNotification('trip_nudge_evening', TRIP, 'en-IN');
+    expect(body).toContain('Goa');
+    expect(body).not.toContain('{group}');
+  });
+
+  it('formats minor units as money, in the reader’s locale', () => {
+    // 42000 paise is ₹420.00, and the row has no idea of either fact.
+    const { body } = renderNotification('settlement_confirmed', TRIP, 'en-IN');
+    expect(body).toContain('420');
+    expect(body).not.toContain('42000');
+  });
+
+  it('reads in Tamil when that is what the reader uses', () => {
+    const { title } = renderNotification('trip_nudge_morning', TRIP, 'ta-IN');
+    const english = renderNotification('trip_nudge_morning', TRIP, 'en-IN');
+    expect(title).not.toBe(english.title);
+  });
+
+  it('falls back to English for a language nobody has translated yet', () => {
+    const { title } = renderNotification('trip_nudge_morning', TRIP, 'fr-FR');
+    expect(title).toBe(renderNotification('trip_nudge_morning', TRIP, 'en-IN').title);
+  });
+});
+
+describe('an older app reading a newer server', () => {
+  it('shows what the row said rather than a blank line', () => {
+    // The server will grow notification kinds faster than everybody updates.
+    const { title, body } = renderNotification('something_invented_next_year', TRIP, 'en-IN', {
+      title: 'Settled automatically',
+      body: 'Nobody said otherwise for a week',
+    });
+    expect(title).toBe('Settled automatically');
+    expect(body).toBe('Nobody said otherwise for a week');
+  });
+
+  it('never prints the word undefined at somebody', () => {
+    // A kind that names a fact the row did not carry leaves the placeholder
+    // visible, which is odd but honest; `undefined` is neither.
+    const rendered = renderNotification('settlement_confirmed', { group: 'Goa' }, 'en-IN');
+    expect(`${rendered.title} ${rendered.body}`).not.toContain('undefined');
+  });
+});

--- a/packages/db/prisma/migrations/20260806160000_settlement_auto_confirm/migration.sql
+++ b/packages/db/prisma/migrations/20260806160000_settlement_auto_confirm/migration.sql
@@ -1,0 +1,233 @@
+-- Settlement auto-confirm, and the inbox that tells both people (TDR §5, ADR-007).
+--
+-- The settlement state machine has always had a hole at the end of it. A payer
+-- opens their UPI app, pays, comes back and says so; the settlement sits at
+-- `initiated` waiting for the payee to confirm. If the payee never opens the
+-- app again — which is the common case, because from their side nothing is
+-- owed any more — the money stays owed forever in Baaki and the group's
+-- balances are quietly wrong.
+--
+-- ADR-007 answers that with time: after seven days with no response, the
+-- settlement is taken as confirmed and both people are told. Confirmation here
+-- is social rather than cryptographic, so the safety valve is that a dispute
+-- still reopens an auto-confirmed settlement — the status trigger already
+-- permits `auto_confirmed → disputed` and nothing here changes that.
+--
+-- Two things are deliberately *not* done:
+--   * Nothing is auto-confirmed on the payee's behalf while they are still
+--     being asked. The nudge is a notification, not a state change.
+--   * The job never touches `confirmed`, `disputed` or `cancelled` rows. It
+--     only ever resolves the one state that has been left hanging.
+
+-- ─────────────────────────────────────────── 1. an inbox that cannot double-send ──
+-- TDR §7.1 wants no double-send when a fanout is retried. A retry is not an
+-- error condition here — a scheduled job that runs twice, an edge function that
+-- times out after writing — so the guarantee belongs in the table rather than
+-- in whoever is careful enough to check first.
+
+ALTER TABLE public.notifications ADD COLUMN IF NOT EXISTS dedupe_key TEXT;
+
+-- Not partial: Postgres already lets a unique index hold any number of NULLs,
+-- so the rows that opt out of deduplication need no special case.
+CREATE UNIQUE INDEX IF NOT EXISTS "notifications_dedupe_key_key"
+  ON public.notifications (dedupe_key);
+
+COMMENT ON COLUMN public.notifications.dedupe_key IS
+  'Idempotency for fanout: one row per (recipient, event). Retrying a send is a no-op.';
+
+-- ────────────────────────────────────────────────── 2. writing to the inbox ──
+-- `title` and `body` are stored in English and are a fallback, not the product.
+-- The client renders the real thing from `kind` + `payload` through the copy
+-- table in @baaki/core, which is the only place that knows the reader's
+-- language (TDR §11: en + ta + hi from day one). Postgres has no business
+-- holding three translations of every sentence.
+
+CREATE OR REPLACE FUNCTION public.baaki_notify(
+  p_profile_id uuid,
+  p_group_id   uuid,
+  p_kind       text,
+  p_title      text,
+  p_body       text,
+  p_deep_link  text,
+  p_payload    jsonb,
+  p_dedupe_key text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  -- A ghost member has no profile to notify. Silently skipping is right: they
+  -- are a placeholder for somebody who has not joined yet.
+  IF p_profile_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  INSERT INTO public.notifications
+    (profile_id, group_id, kind, title, body, deep_link, payload, channels, dedupe_key)
+  VALUES
+    (p_profile_id, p_group_id, p_kind, p_title, p_body, p_deep_link,
+     COALESCE(p_payload, '{}'::jsonb), ARRAY['in_app']::text[], p_dedupe_key)
+  ON CONFLICT (dedupe_key) DO NOTHING
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;
+
+-- ──────────────────────────────────────────────── 3. the seven-day resolution ──
+-- Takes the cutoff as an argument rather than hard-coding `now()`. A job whose
+-- clock cannot be moved can only be tested by waiting a week, which means it
+-- would not be tested.
+
+CREATE OR REPLACE FUNCTION public.baaki_auto_confirm_settlements(
+  p_now    timestamptz DEFAULT now(),
+  p_window interval    DEFAULT interval '7 days'
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_row     record;
+  v_count   integer := 0;
+  v_amount  text;
+BEGIN
+  FOR v_row IN
+    SELECT s.id,
+           s.group_id,
+           s.amount,
+           s.currency,
+           s.from_member_id,
+           s.to_member_id,
+           g.name                AS group_name,
+           payer.profile_id      AS payer_profile,
+           -- A member is either a real profile or a ghost standing in for
+           -- somebody who has not joined; the name lives in whichever it is.
+           COALESCE(payer_profile.display_name, payer.ghost_name) AS payer_name,
+           payee.profile_id      AS payee_profile,
+           COALESCE(payee_profile.display_name, payee.ghost_name) AS payee_name
+    FROM public.settlements s
+    JOIN public.groups g            ON g.id = s.group_id
+    JOIN public.group_members payer ON payer.id = s.from_member_id
+    JOIN public.group_members payee ON payee.id = s.to_member_id
+    LEFT JOIN public.profiles payer_profile ON payer_profile.id = payer.profile_id
+    LEFT JOIN public.profiles payee_profile ON payee_profile.id = payee.profile_id
+    WHERE s.status = 'initiated'
+      AND s.initiated_at <= p_now - p_window
+    -- Locked so two overlapping runs of the job cannot both claim the same
+    -- settlement; the second simply finds nothing to do.
+    FOR UPDATE OF s SKIP LOCKED
+  LOOP
+    UPDATE public.settlements
+       SET status = 'auto_confirmed'
+     WHERE id = v_row.id;
+
+    INSERT INTO public.activity_log
+      (group_id, actor_member_id, verb, object_type, object_id, payload)
+    VALUES
+      (v_row.group_id, NULL, 'auto_confirmed', 'settlement', v_row.id,
+       jsonb_build_object('amount', v_row.amount::text, 'currency', v_row.currency,
+                          'reason', 'no_response_in_window'));
+
+    v_amount := v_row.amount::text;
+
+    -- Both people are told, and the wording differs because their positions
+    -- do. The payee is the one who might want to dispute it.
+    PERFORM public.baaki_notify(
+      v_row.payee_profile, v_row.group_id, 'settlement_confirmed',
+      'Settled automatically',
+      COALESCE(v_row.payer_name, 'Someone') || ' paid you, and nobody said otherwise for a week',
+      'baaki://group/' || v_row.group_id::text,
+      jsonb_build_object('settlementId', v_row.id, 'amount', v_amount,
+                         'currency', v_row.currency, 'role', 'payee',
+                         'counterparty', v_row.payer_name, 'group', v_row.group_name),
+      'auto_confirm:' || v_row.id::text || ':payee'
+    );
+
+    PERFORM public.baaki_notify(
+      v_row.payer_profile, v_row.group_id, 'settlement_confirmed',
+      'Settled automatically',
+      'Your payment to ' || COALESCE(v_row.payee_name, 'them') || ' was confirmed after a week',
+      'baaki://group/' || v_row.group_id::text,
+      jsonb_build_object('settlementId', v_row.id, 'amount', v_amount,
+                         'currency', v_row.currency, 'role', 'payer',
+                         'counterparty', v_row.payee_name, 'group', v_row.group_name),
+      'auto_confirm:' || v_row.id::text || ':payer'
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END
+$$;
+
+-- ──────────────────────────────────────────────────────── 4. reading the inbox ──
+
+CREATE OR REPLACE FUNCTION public.baaki_mark_notifications_read(p_ids uuid[])
+RETURNS integer
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+  -- SECURITY INVOKER on purpose: `notifications_update_own` is what decides
+  -- whose inbox this is, and it is the same policy a direct PATCH would meet.
+  WITH marked AS (
+    UPDATE public.notifications
+       SET read_at = now()
+     WHERE id = ANY(p_ids) AND read_at IS NULL
+    RETURNING 1
+  )
+  SELECT COUNT(*)::integer FROM marked;
+$$;
+
+-- The job runs as the service role or from cron. Handing it to `authenticated`
+-- would let any signed-in person confirm every pending settlement in the
+-- database on demand.
+REVOKE ALL ON FUNCTION public.baaki_auto_confirm_settlements(timestamptz, interval) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_notify(uuid, uuid, text, text, text, text, jsonb, text) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION
+  public.baaki_mark_notifications_read(uuid[])
+TO authenticated, anon;
+
+-- ───────────────────────────────────────────────────── 5. live inbox + schedule ──
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime')
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_publication_tables
+       WHERE pubname = 'supabase_realtime' AND schemaname = 'public'
+         AND tablename = 'notifications'
+     )
+  THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.notifications;
+  END IF;
+END
+$$;
+
+-- pg_cron exists on Supabase and not in a bare Postgres container, so this is
+-- guarded rather than assumed. Hourly, not daily: the seven-day promise should
+-- not turn into "some time on the eighth day".
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron') THEN
+    CREATE EXTENSION IF NOT EXISTS pg_cron;
+    PERFORM cron.unschedule('baaki-auto-confirm')
+      WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'baaki-auto-confirm');
+    PERFORM cron.schedule(
+      'baaki-auto-confirm', '7 * * * *',
+      'SELECT public.baaki_auto_confirm_settlements()'
+    );
+  END IF;
+EXCEPTION WHEN OTHERS THEN
+  -- A database without permission to create extensions must still migrate.
+  RAISE NOTICE 'pg_cron not scheduled: %', SQLERRM;
+END
+$$;

--- a/packages/db/prisma/migrations/20260806170000_trip_dates_and_nudges/migration.sql
+++ b/packages/db/prisma/migrations/20260806170000_trip_dates_and_nudges/migration.sql
@@ -1,0 +1,179 @@
+-- Trip dates, and the two reminders a day that make a shared ledger work.
+--
+-- The failure this exists for is not technical. Four people go to Goa, and on
+-- day one everybody adds everything. By day three nobody has entered a thing
+-- since the first lunch, and on the flight home somebody tries to reconstruct a
+-- week of autorickshaws from memory. The ledger is only as good as the habit of
+-- adding to it, and the habit needs prompting while the trip is happening —
+-- afterwards is too late, because the receipts are gone and so is the will.
+--
+-- So a group can say when it is happening, and during those dates each member
+-- is asked twice a day:
+--
+--   * at breakfast, about yesterday — the meal where you remember last night
+--   * at the end of the day, about today — while the day is still recoverable
+--
+-- Both are asked in the *group's* timezone, not the server's and not each
+-- reader's. A trip has a place; "breakfast" means breakfast there. Waking
+-- somebody in London at 04:00 to ask about dinner in Goa is worse than not
+-- asking.
+--
+-- Nobody is asked about a day they already recorded. A reminder to do something
+-- already done is how an app teaches people to ignore it.
+
+-- ────────────────────────────────────────────────────── 1. when it happens ──
+
+ALTER TABLE public.groups
+  ADD COLUMN IF NOT EXISTS start_date DATE,
+  ADD COLUMN IF NOT EXISTS end_date   DATE,
+  -- IANA name. Defaulted rather than nullable: every reminder needs one, and a
+  -- group with no answer is India-first Baaki's home timezone.
+  ADD COLUMN IF NOT EXISTS time_zone  TEXT NOT NULL DEFAULT 'Asia/Kolkata',
+  ADD COLUMN IF NOT EXISTS remind_daily BOOLEAN NOT NULL DEFAULT TRUE,
+  -- "Breakfast" is not a fixed hour. A group of students and a group of
+  -- grandparents disagree, and the one that gets it wrong gets muted.
+  ADD COLUMN IF NOT EXISTS remind_morning_at TIME NOT NULL DEFAULT '09:00',
+  ADD COLUMN IF NOT EXISTS remind_evening_at TIME NOT NULL DEFAULT '21:00';
+
+ALTER TABLE public.groups
+  DROP CONSTRAINT IF EXISTS groups_dates_in_order;
+ALTER TABLE public.groups
+  ADD CONSTRAINT groups_dates_in_order
+  CHECK (start_date IS NULL OR end_date IS NULL OR start_date <= end_date);
+
+COMMENT ON COLUMN public.groups.time_zone IS
+  'IANA zone the reminders are scheduled in. A trip has a place; breakfast means breakfast there.';
+
+-- Most groups have no dates at all, so the rows the job cares about are a small
+-- minority and worth an index of their own.
+CREATE INDEX IF NOT EXISTS groups_reminder_window_idx
+  ON public.groups (start_date, end_date);
+
+-- ─────────────────────────────────────────────────────── 2. the two nudges ──
+-- Runs hourly and works out what each group's local time is, rather than being
+-- scheduled per group. `p_now` is an argument so the whole thing can be tested
+-- without waiting for 9am in another country.
+
+CREATE OR REPLACE FUNCTION public.baaki_trip_nudges(p_now timestamptz DEFAULT now())
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group    record;
+  v_member   record;
+  v_local    timestamp;
+  v_today    date;
+  v_slot     text;
+  v_subject  date;
+  v_written  integer := 0;
+  v_id       uuid;
+BEGIN
+  FOR v_group IN
+    SELECT id, name, time_zone, start_date, end_date,
+           remind_morning_at, remind_evening_at
+    FROM public.groups
+    WHERE remind_daily
+      AND archived_at IS NULL
+      AND start_date IS NOT NULL
+      AND end_date   IS NOT NULL
+  LOOP
+    v_local := p_now AT TIME ZONE v_group.time_zone;
+    v_today := v_local::date;
+
+    -- Inclusive of both ends: the last day of a trip is the day with the most
+    -- unrecorded spending on it.
+    CONTINUE WHEN v_today < v_group.start_date OR v_today > v_group.end_date;
+
+    -- Both slots are considered on every run rather than only the latest one.
+    -- If cron is down all morning, the breakfast reminder should still go out
+    -- late rather than not at all, and the dedupe key is what stops it going
+    -- out twice.
+    FOREACH v_slot IN ARRAY ARRAY['morning', 'evening']
+    LOOP
+    IF v_slot = 'morning' THEN
+      CONTINUE WHEN v_local::time < v_group.remind_morning_at;
+      -- At breakfast the interesting day is the one that just ended. On the
+      -- first morning of a trip there is no yesterday worth asking about.
+      v_subject := v_today - 1;
+      CONTINUE WHEN v_subject < v_group.start_date;
+    ELSE
+      CONTINUE WHEN v_local::time < v_group.remind_evening_at;
+      v_subject := v_today;
+    END IF;
+
+    FOR v_member IN
+      SELECT m.id AS member_id, m.profile_id
+      FROM public.group_members m
+      JOIN public.profiles p ON p.id = m.profile_id
+      WHERE m.group_id = v_group.id
+        AND m.profile_id IS NOT NULL
+        AND m.left_at IS NULL
+        -- Somebody who turned nudges off has answered this question already.
+        AND COALESCE((p.notification_prefs ->> 'nudges')::boolean, TRUE)
+    LOOP
+      -- Nobody is asked about a day they already recorded. This is the whole
+      -- difference between a useful reminder and the kind people mute.
+      CONTINUE WHEN EXISTS (
+        SELECT 1
+        FROM public.expenses e
+        JOIN public.expense_versions v ON v.id = e.current_version_id
+        WHERE e.group_id = v_group.id
+          AND e.deleted_at IS NULL
+          AND v.author_member_id = v_member.member_id
+          AND v.expense_date = v_subject
+      );
+
+      v_id := public.baaki_notify(
+        v_member.profile_id,
+        v_group.id,
+        CASE v_slot WHEN 'morning' THEN 'trip_nudge_morning' ELSE 'trip_nudge_evening' END,
+        CASE v_slot
+          WHEN 'morning' THEN 'Anything from yesterday?'
+          ELSE 'Add today before you forget'
+        END,
+        CASE v_slot
+          WHEN 'morning' THEN 'Add what you spent yesterday while you still remember it'
+          ELSE 'What did you pay for today?'
+        END,
+        'baaki://group/' || v_group.id::text || '/add-expense',
+        jsonb_build_object('group', v_group.name, 'date', v_subject::text, 'slot', v_slot),
+        'trip_nudge:' || v_group.id::text || ':' || v_subject::text || ':' || v_slot
+          || ':' || v_member.profile_id::text
+      );
+
+      IF v_id IS NOT NULL THEN
+        v_written := v_written + 1;
+      END IF;
+    END LOOP;
+    END LOOP;
+  END LOOP;
+
+  RETURN v_written;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_trip_nudges(timestamptz) FROM PUBLIC;
+
+-- ───────────────────────────────────────────────────────────── 3. schedule ──
+-- Hourly, because "9am" means a different instant in every timezone and the
+-- job resolves that itself rather than being scheduled per group. A missed run
+-- is not a lost reminder: the next one still finds the slot passed and the
+-- dedupe key absent, so it sends once and late rather than never.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron') THEN
+    CREATE EXTENSION IF NOT EXISTS pg_cron;
+    PERFORM cron.unschedule('baaki-trip-nudges')
+      WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'baaki-trip-nudges');
+    PERFORM cron.schedule(
+      'baaki-trip-nudges', '2 * * * *',
+      'SELECT public.baaki_trip_nudges()'
+    );
+  END IF;
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'pg_cron not scheduled: %', SQLERRM;
+END
+$$;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -148,6 +148,20 @@ model Group {
   /// ADR-009: simplification is a per-group presentation setting.
   simplifyDebts   Boolean   @default(true) @map("simplify_debts")
   coverEmoji      String?   @map("cover_emoji")
+
+  /// When the trip is. Both ends inclusive — the last day of a trip is the one
+  /// with the most unrecorded spending on it.
+  startDate       DateTime? @map("start_date") @db.Date
+  endDate         DateTime? @map("end_date") @db.Date
+  /// IANA zone the daily reminders are scheduled in. A trip has a place, and
+  /// "breakfast" means breakfast there rather than wherever the server is.
+  timeZone        String    @default("Asia/Kolkata") @map("time_zone")
+  remindDaily     Boolean   @default(true) @map("remind_daily")
+  /// "Breakfast" is not a fixed hour, and the group that gets it wrong is the
+  /// one that gets muted.
+  remindMorningAt DateTime  @default(dbgenerated("'09:00:00'::time without time zone")) @map("remind_morning_at") @db.Time(6)
+  remindEveningAt DateTime  @default(dbgenerated("'21:00:00'::time without time zone")) @map("remind_evening_at") @db.Time(6)
+
   archivedAt      DateTime? @map("archived_at") @db.Timestamptz(6)
   createdBy       String?   @map("created_by") @db.Uuid
   /// Monotonic per-group counter driving the sync cursor (TDR §4).
@@ -169,6 +183,9 @@ model Group {
   syncMutations   SyncMutation[]
 
   @@index([archivedAt])
+  /// The nudge job only ever looks at groups that have said when they are
+  /// happening, which is a small minority of them.
+  @@index([startDate, endDate], map: "groups_reminder_window_idx")
   @@map("groups")
   @@schema("public")
 }
@@ -496,6 +513,10 @@ model Notification {
   emailStatus DeliveryStatus? @map("email_status")
   readAt      DateTime?       @map("read_at") @db.Timestamptz(6)
   createdAt   DateTime        @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  /// One row per (recipient, event). Retrying a fanout is a no-op, which is
+  /// what TDR §7.1 means by no double-send.
+  dedupeKey String? @unique @map("dedupe_key")
 
   profile Profile      @relation(fields: [profileId], references: [id], onDelete: Cascade)
   group   Group?       @relation(fields: [groupId], references: [id], onDelete: Cascade)

--- a/packages/db/test/m4-auto-confirm.test.ts
+++ b/packages/db/test/m4-auto-confirm.test.ts
@@ -1,0 +1,240 @@
+/**
+ * The end of the settlement state machine.
+ *
+ * A payer opens their UPI app, pays, comes back and says so. The settlement
+ * sits at `initiated` waiting for the payee to confirm — and from the payee's
+ * side nothing is owed any more, so there is no reason for them to open the app
+ * again. Left alone, that settlement never resolves and the group's balances
+ * are quietly wrong for everybody, forever.
+ *
+ * ADR-007 closes it with time rather than cryptography: seven days of silence
+ * counts as agreement, both people are told, and a dispute still reopens it.
+ * That last part is what makes the first part acceptable, so it is tested here
+ * rather than assumed.
+ *
+ * The clock is an argument to the function. A job whose time cannot be moved
+ * can only be tested by waiting a week, which means it would not be tested.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { big, connect, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+interface Settled {
+  groupId: string;
+  settlementId: string;
+  payerProfile: string;
+  payeeProfile: string;
+}
+
+/** A payment somebody says they made, waiting to be confirmed. */
+async function initiateSettlement(daysAgo: number, ghostPayee = false): Promise<Settled> {
+  const { groupId, profileIds, memberIds } = await seedGroup(client, {
+    memberCount: ghostPayee ? 1 : 2,
+    ghostCount: ghostPayee ? 1 : 0,
+  });
+  const settlementId = randomUUID();
+  await client.query(
+    `INSERT INTO settlements
+       (id, group_id, from_member_id, to_member_id, currency, amount, method, status, initiated_at)
+     VALUES ($1, $2, $3, $4, 'INR', 42000, 'upi', 'initiated', now() - ($5 || ' days')::interval)`,
+    [settlementId, groupId, memberIds[0], memberIds[1], String(daysAgo)],
+  );
+  return {
+    groupId,
+    settlementId,
+    payerProfile: profileIds[0] ?? '',
+    payeeProfile: profileIds[1] ?? '',
+  };
+}
+
+const statusOf = async (settlementId: string): Promise<string> => {
+  const { rows } = await client.query(`SELECT status FROM settlements WHERE id = $1`, [
+    settlementId,
+  ]);
+  return String(rows[0]?.status);
+};
+
+const inboxOf = async (profileId: string): Promise<{ kind: string; body: string }[]> => {
+  const { rows } = await client.query(
+    `SELECT kind, body FROM notifications WHERE profile_id = $1 ORDER BY created_at`,
+    [profileId],
+  );
+  return rows as { kind: string; body: string }[];
+};
+
+const run = async (): Promise<number> => {
+  const { rows } = await client.query(`SELECT baaki_auto_confirm_settlements() AS n`);
+  return Number(rows[0]?.n);
+};
+
+describe('seven days of silence', () => {
+  it('resolves a settlement nobody answered', async () => {
+    const { settlementId } = await initiateSettlement(8);
+    await run();
+    expect(await statusOf(settlementId)).toBe('auto_confirmed');
+  });
+
+  it('leaves one that is only six days old', async () => {
+    // The promise is seven days. Six is still somebody's chance to dispute.
+    const { settlementId } = await initiateSettlement(6);
+    await run();
+    expect(await statusOf(settlementId)).toBe('initiated');
+  });
+
+  it('stamps confirmed_at, so the ledger says when it happened', async () => {
+    const { settlementId } = await initiateSettlement(8);
+    await run();
+    const { rows } = await client.query(`SELECT confirmed_at FROM settlements WHERE id = $1`, [
+      settlementId,
+    ]);
+    expect(rows[0]?.confirmed_at).not.toBeNull();
+  });
+
+  it('counts towards the balances, exactly as a confirmed one does', async () => {
+    const { groupId, settlementId } = await initiateSettlement(8);
+    const before = await client.query(
+      `SELECT COALESCE(SUM(ABS(balance)), 0) AS total FROM group_balances WHERE group_id = $1`,
+      [groupId],
+    );
+    await run();
+    const after = await client.query(
+      `SELECT COALESCE(SUM(ABS(balance)), 0) AS total FROM group_balances WHERE group_id = $1`,
+      [groupId],
+    );
+    // An auto-confirmed settlement that did not move the numbers would be a
+    // status change and nothing more.
+    expect(big(after.rows[0]?.total)).not.toBe(big(before.rows[0]?.total));
+    expect(await statusOf(settlementId)).toBe('auto_confirmed');
+  });
+});
+
+describe('what it never touches', () => {
+  it('leaves a settlement that was already disputed', async () => {
+    const { settlementId } = await initiateSettlement(30);
+    await client.query(`UPDATE settlements SET status = 'disputed' WHERE id = $1`, [settlementId]);
+    await run();
+    expect(await statusOf(settlementId)).toBe('disputed');
+  });
+
+  it('leaves a cancelled one alone however old it is', async () => {
+    const { settlementId } = await initiateSettlement(400);
+    await client.query(`UPDATE settlements SET status = 'cancelled' WHERE id = $1`, [settlementId]);
+    await run();
+    expect(await statusOf(settlementId)).toBe('cancelled');
+  });
+
+  it('does not undo a confirmation somebody actually gave', async () => {
+    const { settlementId } = await initiateSettlement(9);
+    await client.query(`UPDATE settlements SET status = 'confirmed' WHERE id = $1`, [settlementId]);
+    await run();
+    expect(await statusOf(settlementId)).toBe('confirmed');
+  });
+});
+
+describe('a dispute still reopens it', () => {
+  it('because the confirmation was assumed, not given', async () => {
+    // This is the whole reason auto-confirming is defensible. Without it, a
+    // week of not opening the app would be an irreversible admission.
+    const { settlementId } = await initiateSettlement(10);
+    await run();
+    await client.query(`UPDATE settlements SET status = 'disputed' WHERE id = $1`, [settlementId]);
+    expect(await statusOf(settlementId)).toBe('disputed');
+  });
+});
+
+describe('both people are told', () => {
+  it('reaches the payee, who is the one who might dispute it', async () => {
+    const { payeeProfile } = await initiateSettlement(8);
+    await run();
+    const inbox = await inboxOf(payeeProfile);
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0]?.kind).toBe('settlement_confirmed');
+  });
+
+  it('reaches the payer, whose payment stopped being provisional', async () => {
+    const { payerProfile } = await initiateSettlement(8);
+    await run();
+    expect(await inboxOf(payerProfile)).toHaveLength(1);
+  });
+
+  it('says which side of it the reader was on', async () => {
+    const { payerProfile, payeeProfile } = await initiateSettlement(8);
+    await run();
+    const [payer] = await inboxOf(payerProfile);
+    const [payee] = await inboxOf(payeeProfile);
+    // Two people, one event, and the same sentence would be wrong for one of
+    // them.
+    expect(payer?.body).not.toBe(payee?.body);
+  });
+
+  it('skips a ghost, who has no account to be told on', async () => {
+    const { payerProfile } = await initiateSettlement(8, true);
+    const written = await run();
+    expect(written).toBe(1);
+    expect(await inboxOf(payerProfile)).toHaveLength(1);
+  });
+
+  it('writes it to the activity log as well, so the group can see it', async () => {
+    const { groupId } = await initiateSettlement(8);
+    await run();
+    const { rows } = await client.query(
+      `SELECT verb, payload FROM activity_log WHERE group_id = $1 AND object_type = 'settlement'`,
+      [groupId],
+    );
+    expect(rows[0]?.verb).toBe('auto_confirmed');
+    expect(rows[0]?.payload?.reason).toBe('no_response_in_window');
+  });
+});
+
+describe('running the job twice', () => {
+  it('sends nothing a second time', async () => {
+    // A scheduled job runs twice sooner or later — a retry after a timeout, an
+    // overlapping run, a manual invocation. Two identical notifications about
+    // the same settlement is how people learn to ignore the app.
+    const { payeeProfile } = await initiateSettlement(8);
+    await run();
+    await run();
+    expect(await inboxOf(payeeProfile)).toHaveLength(1);
+  });
+
+  it('reports nothing left to do', async () => {
+    await initiateSettlement(8);
+    await run();
+    const second = await run();
+    expect(second).toBe(0);
+  });
+});
+
+describe('who may run it', () => {
+  it('is not something a signed-in person can trigger', async () => {
+    // Otherwise anybody with an account could confirm every pending settlement
+    // in the database, including ones they are not party to.
+    const { profileIds } = await seedGroup(client, { memberCount: 1 });
+    await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+      JSON.stringify({ sub: profileIds[0], role: 'authenticated' }),
+    ]);
+    await client.query(`SET ROLE authenticated`);
+    try {
+      await expect(client.query(`SELECT baaki_auto_confirm_settlements()`)).rejects.toThrow(
+        /permission denied/i,
+      );
+    } finally {
+      await client.query(`RESET ROLE`);
+      await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+    }
+  });
+});

--- a/packages/db/test/m4-trip-nudges.test.ts
+++ b/packages/db/test/m4-trip-nudges.test.ts
@@ -1,0 +1,302 @@
+/**
+ * The two reminders a day that keep a trip ledger honest.
+ *
+ * The failure being prevented is not technical. Four people go to Goa; on day
+ * one everybody adds everything; by day three nobody has entered anything since
+ * the first lunch, and on the flight home somebody tries to reconstruct a week
+ * of autorickshaws from memory. A shared ledger is only as good as the habit of
+ * adding to it, and the habit has to be prompted while the trip is happening —
+ * afterwards the receipts are gone and so is the will.
+ *
+ * Two things decide whether this feature is loved or muted, and both are tested
+ * here rather than assumed:
+ *
+ *   * It asks in the *group's* timezone. A trip has a place, and breakfast
+ *     means breakfast there. Waking somebody at 04:00 to ask about dinner
+ *     somewhere else is worse than not asking.
+ *   * It never asks about a day somebody already recorded. A reminder to do
+ *     something already done is how people learn to ignore an app.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, connect, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+interface Trip {
+  groupId: string;
+  profileIds: string[];
+  memberIds: string[];
+}
+
+async function seedTrip(
+  options: {
+    start?: string;
+    end?: string;
+    timeZone?: string;
+    remind?: boolean;
+    morning?: string;
+    evening?: string;
+  } = {},
+): Promise<Trip> {
+  const {
+    start = '2026-03-10',
+    end = '2026-03-14',
+    timeZone = 'Asia/Kolkata',
+    remind = true,
+    morning = '09:00',
+    evening = '21:00',
+  } = options;
+
+  const seeded = await seedGroup(client, { memberCount: 2, name: 'Goa' });
+  await client.query(
+    `UPDATE groups
+        SET start_date = $2, end_date = $3, time_zone = $4,
+            remind_daily = $5, remind_morning_at = $6, remind_evening_at = $7
+      WHERE id = $1`,
+    [seeded.groupId, start, end, timeZone, remind, morning, evening],
+  );
+  return seeded;
+}
+
+/** Run the job as if it were this instant. */
+const runAt = async (instant: string): Promise<number> => {
+  const { rows } = await client.query(`SELECT baaki_trip_nudges($1::timestamptz) AS n`, [instant]);
+  return Number(rows[0]?.n);
+};
+
+interface NudgeRow {
+  kind: string;
+  payload: { date?: string; slot?: string };
+}
+
+/**
+ * Scoped to one group as well as one person. The job sweeps every trip in the
+ * database, and the other tests in this file have trips of their own.
+ */
+const nudgesFor = async (trip: Trip, memberIndex = 0): Promise<NudgeRow[]> => {
+  const { rows } = await client.query(
+    `SELECT kind, payload FROM notifications
+      WHERE profile_id = $1 AND group_id = $2 AND kind LIKE 'trip_nudge%'
+      ORDER BY kind`,
+    [trip.profileIds[memberIndex], trip.groupId],
+  );
+  return rows as NudgeRow[];
+};
+
+const nudgeOfKind = async (
+  trip: Trip,
+  kind: 'trip_nudge_morning' | 'trip_nudge_evening',
+  memberIndex = 0,
+): Promise<NudgeRow | undefined> =>
+  (await nudgesFor(trip, memberIndex)).find((row) => row.kind === kind);
+
+/** An expense this member entered, dated on a particular day. */
+async function addExpenseAuthoredBy(
+  trip: Trip,
+  memberIndex: number,
+  expenseDate: string,
+): Promise<void> {
+  const author = trip.memberIds[memberIndex] ?? '';
+  await addEqualSplitExpense(client, {
+    groupId: trip.groupId,
+    payers: { [author]: 20000n },
+    // The helper credits the first participant as the author, and who entered
+    // it is exactly what the nudge is looking at.
+    participants: [author, ...trip.memberIds.filter((id) => id !== author)],
+    amount: 20000n,
+    description: 'Lunch',
+    date: expenseDate,
+  });
+}
+
+describe('during the trip', () => {
+  it('asks at the end of the day about today', async () => {
+    const trip = await seedTrip();
+    // 21:30 in Kolkata on the second day.
+    await runAt('2026-03-11T16:00:00Z');
+    expect((await nudgeOfKind(trip, 'trip_nudge_evening'))?.payload?.date).toBe('2026-03-11');
+  });
+
+  it('asks at breakfast about yesterday', async () => {
+    const trip = await seedTrip();
+    // 09:30 in Kolkata — the meal at which you remember last night.
+    await runAt('2026-03-11T04:00:00Z');
+    const nudges = await nudgesFor(trip);
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0]?.kind).toBe('trip_nudge_morning');
+    expect(nudges[0]?.payload?.date).toBe('2026-03-10');
+  });
+
+  it('asks everybody in the group, not only whoever created it', async () => {
+    const trip = await seedTrip();
+    await runAt('2026-03-11T04:00:00Z');
+    expect(await nudgesFor(trip, 0)).toHaveLength(1);
+    expect(await nudgesFor(trip, 1)).toHaveLength(1);
+  });
+
+  it('says nothing before the first slot of the day', async () => {
+    const trip = await seedTrip();
+    // 07:30 local: too early to have anything to say.
+    await runAt('2026-03-11T02:00:00Z');
+    expect(await nudgesFor(trip)).toHaveLength(0);
+  });
+
+  it('does not ask about a yesterday before the trip began', async () => {
+    const trip = await seedTrip();
+    // Breakfast on day one. There is no yesterday worth asking about.
+    await runAt('2026-03-10T04:00:00Z');
+    expect(await nudgesFor(trip)).toHaveLength(0);
+  });
+
+  it('still asks on the last day, which has the most unrecorded spending', async () => {
+    const trip = await seedTrip();
+    await runAt('2026-03-14T16:00:00Z');
+    expect(await nudgeOfKind(trip, 'trip_nudge_evening')).toBeDefined();
+  });
+});
+
+describe('outside the trip', () => {
+  it('says nothing the day before it starts', async () => {
+    const trip = await seedTrip();
+    await runAt('2026-03-09T16:00:00Z');
+    expect(await nudgesFor(trip)).toHaveLength(0);
+  });
+
+  it('says nothing the day after it ends', async () => {
+    const trip = await seedTrip();
+    await runAt('2026-03-15T16:00:00Z');
+    expect(await nudgesFor(trip)).toHaveLength(0);
+  });
+
+  it('says nothing for a group that never gave dates', async () => {
+    // Which is most groups: a flatshare has no start and no end.
+    const seeded = await seedGroup(client, { memberCount: 2, name: 'Flat' });
+    await runAt('2026-03-11T16:00:00Z');
+    expect(await nudgesFor(seeded)).toHaveLength(0);
+  });
+});
+
+describe('the timezone is the group’s, not the server’s', () => {
+  it('waits for evening where the trip is', async () => {
+    // 16:00 UTC is 21:30 in Kolkata but only 17:00 in London. A London trip is
+    // still mid-afternoon: the end-of-day question has not come round there.
+    const london = await seedTrip({ timeZone: 'Europe/London' });
+    await runAt('2026-03-11T16:00:00Z');
+    expect(await nudgeOfKind(london, 'trip_nudge_evening')).toBeUndefined();
+  });
+
+  it('and reaches them when evening actually arrives there', async () => {
+    const london = await seedTrip({ timeZone: 'Europe/London' });
+    await runAt('2026-03-11T21:30:00Z');
+    expect(await nudgeOfKind(london, 'trip_nudge_evening')).toBeDefined();
+  });
+});
+
+describe('not asking for something already done', () => {
+  it('skips somebody who already added an expense for that day', async () => {
+    const trip = await seedTrip();
+    await addExpenseAuthoredBy(trip, 0, '2026-03-11');
+    await runAt('2026-03-11T16:00:00Z');
+    expect(await nudgeOfKind(trip, 'trip_nudge_evening')).toBeUndefined();
+  });
+
+  it('still asks the others, who have not', async () => {
+    const trip = await seedTrip();
+    await addExpenseAuthoredBy(trip, 0, '2026-03-11');
+    await runAt('2026-03-11T16:00:00Z');
+    expect(await nudgeOfKind(trip, 'trip_nudge_evening', 1)).toBeDefined();
+  });
+
+  it('judges by the day in question, not by having ever added anything', async () => {
+    // An expense on Tuesday says nothing about whether Wednesday was recorded.
+    const trip = await seedTrip();
+    await addExpenseAuthoredBy(trip, 0, '2026-03-10');
+    await runAt('2026-03-11T16:00:00Z');
+    expect(await nudgeOfKind(trip, 'trip_nudge_evening')).toBeDefined();
+  });
+});
+
+describe('respecting the answer somebody already gave', () => {
+  it('says nothing to a group that turned reminders off', async () => {
+    const trip = await seedTrip({ remind: false });
+    await runAt('2026-03-11T16:00:00Z');
+    expect(await nudgesFor(trip)).toHaveLength(0);
+  });
+
+  it('says nothing to a person who turned nudges off', async () => {
+    const trip = await seedTrip();
+    await client.query(
+      `UPDATE profiles SET notification_prefs = '{"nudges": false}'::jsonb WHERE id = $1`,
+      [trip.profileIds[0]],
+    );
+    await runAt('2026-03-11T16:00:00Z');
+    expect(await nudgesFor(trip, 0)).toHaveLength(0);
+    expect(await nudgesFor(trip, 1)).not.toHaveLength(0);
+  });
+
+  it('says nothing about an archived trip', async () => {
+    const trip = await seedTrip();
+    await client.query(`UPDATE groups SET archived_at = now() WHERE id = $1`, [trip.groupId]);
+    await runAt('2026-03-11T16:00:00Z');
+    expect(await nudgesFor(trip)).toHaveLength(0);
+  });
+});
+
+describe('running more than once', () => {
+  it('does not ask twice for the same day', async () => {
+    const trip = await seedTrip();
+    await runAt('2026-03-11T16:00:00Z');
+    await runAt('2026-03-11T17:00:00Z');
+    await runAt('2026-03-11T18:00:00Z');
+    // One about yesterday, one about today, and nothing repeated however many
+    // times the job runs.
+    expect(await nudgesFor(trip)).toHaveLength(2);
+  });
+
+  it('sends a missed breakfast reminder late rather than never', async () => {
+    // Cron was down all morning. By evening both slots have passed, and both
+    // are still worth sending — the morning one is about a different day.
+    const trip = await seedTrip();
+    await runAt('2026-03-11T16:00:00Z');
+    const kinds = (await nudgesFor(trip)).map((row) => row.kind);
+    expect(kinds).toContain('trip_nudge_morning');
+    expect(kinds).toContain('trip_nudge_evening');
+  });
+
+  it('asks again the next day, because it is a different day', async () => {
+    const trip = await seedTrip();
+    await runAt('2026-03-11T16:00:00Z');
+    await runAt('2026-03-12T16:00:00Z');
+    const dates = (await nudgesFor(trip)).map((row) => row.payload?.date);
+    expect(new Set(dates).size).toBeGreaterThan(1);
+  });
+});
+
+describe('who may run it', () => {
+  it('is not something a signed-in person can trigger', async () => {
+    const { profileIds } = await seedGroup(client, { memberCount: 1 });
+    await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+      JSON.stringify({ sub: profileIds[0], role: 'authenticated' }),
+    ]);
+    await client.query(`SET ROLE authenticated`);
+    try {
+      await expect(client.query(`SELECT baaki_trip_nudges()`)).rejects.toThrow(
+        /permission denied/i,
+      );
+    } finally {
+      await client.query(`RESET ROLE`);
+      await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
         version: 2.2.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))
+      '@react-native-community/datetimepicker':
+        specifier: 9.1.0
+        version: 9.1.0(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@react-native-ml-kit/text-recognition':
         specifier: ^2.0.0
         version: 2.0.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -1881,6 +1884,19 @@ packages:
     resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
     peerDependencies:
       react-native: ^0.0.0-0 || >=0.65 <1.0
+
+  '@react-native-community/datetimepicker@9.1.0':
+    resolution: {integrity: sha512-eadbnk+I2vxvW30iTAsm/qlCnMMAadkifIMYNEB2lzhxN/SvlKc7S2V4k5DyrwjdCbqdcMk3t9K6fnUMcAV34w==}
+    peerDependencies:
+      expo: '>=52.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      react-native-windows:
+        optional: true
 
   '@react-native-masked-view/masked-view@0.3.2':
     resolution: {integrity: sha512-XwuQoW7/GEgWRMovOQtX3A4PrXhyaZm0lVUiY8qJDvdngjLms9Cpdck6SmGAUNqQwcj2EadHC1HwL0bEyoa/SQ==}
@@ -7777,6 +7793,14 @@ snapshots:
       merge-options: 3.0.4
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
+  '@react-native-community/datetimepicker@9.1.0(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)':
+    dependencies:
+      invariant: 2.2.4
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
+    optionalDependencies:
+      expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+
   '@react-native-masked-view/masked-view@0.3.2(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -9676,7 +9700,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-expo: 1.1.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -9693,7 +9717,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -9716,22 +9740,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
-      get-tsconfig: 4.14.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -9746,6 +9755,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      get-tsconfig: 4.14.1
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.17
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
@@ -9753,7 +9777,7 @@ snapshots:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9764,7 +9788,7 @@ snapshots:
       '@typescript-eslint/parser': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Four things on one thread: a shared ledger is only as good as the habit of adding to it, and nothing was prompting anybody.

## Trip dates + two nudges a day

A group can say when it is happening. For the length of it, everybody is asked twice a day — **at breakfast about yesterday**, **at the end of the day about today**.

Two decisions separate a feature people keep from one they mute, and both are tested rather than assumed:

- **The group's timezone, not the server's or each reader's.** A trip has a place; breakfast means breakfast there. Waking somebody in London at 04:00 to ask about dinner in Goa is worse than not asking.
- **Nobody is asked about a day they already recorded.** A reminder to do something already done is how an app teaches people to ignore it.

Times are settable because "breakfast" is not a fixed hour — a group asked at the wrong one mutes the app rather than moving the setting.

## The seven-day auto-confirm (ADR-007)

The settlement state machine had a hole at the end. A payer pays, comes back, says so — and the settlement waits at `initiated` for a payee who has no reason to open the app again, because from their side nothing is owed any more. Left alone it never resolves and the group's balances are quietly wrong for everybody, forever.

Seven days of silence now counts as agreement, both people are told, and **a dispute still reopens it**. That last part is what makes the first part defensible, so it is a test.

## An inbox

Both jobs write to `notifications`, which the app now reads. Wording is built client-side from `kind` + payload through the copy table in `@baaki/core` — Postgres wrote those rows without knowing who would read them or in which language, and has no business holding three translations of every sentence.

`notifications.dedupe_key` (unique index) is TDR §7.1's no-double-send, enforced by the schema rather than by whoever remembered to check first. A job that runs twice sends once.

## Security section

The app lock existed but re-locked the instant the app backgrounded — unusable in a UPI app, where settling *sends you to another app and back*. Now:

- a configurable delay before it asks again (straight away → 5 minutes, default 30s)
- a Security section on the profile tab that states the current position rather than just "App lock": *"Off — anyone holding your phone can read the ledger"*
- sign-out moved there, with a confirmation that tells a guest what they are about to lose (a guest session has no credential to come back with)

A cold start still always asks, whatever the delay says.

## Testing

Both jobs take their clock as an argument. A job whose time cannot be moved can only be tested by waiting a week, which means it would not be tested.

37 new database tests covering the timezone boundary, the already-recorded skip, both ends of the trip window, per-person and per-group opt-outs, repeated runs, a missed run arriving late, and that neither job can be triggered by a signed-in user.

**454 tests pass** across the workspace.

## Note on scope

The daily reminders are not in the TDR — they were requested directly, like the SMS import before them. §5 and §7 need amending to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6
