### PR TITLE
Decline an expense you disagree with — without being able to erase it

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ is what makes a retried run a no-op rather than a second buzz.
 | Job                                | What it resolves                                                                                                                                                                                             |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `baaki_auto_confirm_settlements()` | A settlement nobody answered for 7 days (ADR-007). A dispute still reopens it.                                                                                                                               |
+| `baaki_claim_push_notifications()` | Hands unsent inbox rows to the fanout. An UPDATE, not a SELECT — two overlapping runs cannot both send the same reminder.                                                                                    |
 | `baaki_trip_nudges()`              | Twice a day during a group's dates: at breakfast about yesterday, at the end of the day about today. Skips anybody who already recorded that day, and asks in the group's timezone rather than the server's. |
 
 ### Edge functions
@@ -74,6 +75,7 @@ is what makes a retried run a no-op rather than a second buzz.
 | `invite-mint`   | Signed, expiring, revocable invite links (only a hash is stored)            |
 | `invite-accept` | Preview without an account, join, and ghost claiming                        |
 | `export-data`   | Lossless JSON and CSV export                                                |
+| `notify-fanout` | Claims unsent inbox rows and pushes them via Expo; revokes dead devices     |
 
 ### Running the full stack
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -40,7 +40,8 @@
       ],
       "expo-secure-store",
       "expo-sharing",
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      "expo-notifications"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -32,6 +32,7 @@
     "expo-local-authentication": "~57.0.2",
     "expo-localization": "~57.0.1",
     "expo-network": "~57.0.1",
+    "expo-notifications": "~57.0.8",
     "expo-router": "~57.0.10",
     "expo-secure-store": "~57.0.1",
     "expo-sharing": "~57.0.8",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import * as Notifications from 'expo-notifications';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -11,11 +12,24 @@ import { Button, ThemeProvider, Text, useTheme } from '@baaki/ui';
 import { AuthProvider, useAuth } from '@/lib/auth';
 import { LockProvider, useLock } from '@/lib/lock';
 import { initObservability, withObservability } from '@/lib/observability';
+import { ensureAndroidChannel, routeForNotification } from '@/lib/push';
 import { SyncProvider } from '@/sync';
 
 // Before anything else renders, so a crash in the first frame is still caught.
 // Inert unless a DSN is configured.
 initObservability();
+
+// Arriving while the app is open should still surface: a notification that is
+// silently swallowed because you happened to be looking at the app is the one
+// people notice missing.
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+});
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -37,6 +51,7 @@ function RootLayout() {
               <LockProvider>
                 <ThemeProvider>
                   <StatusBar style="auto" />
+                  <PushRouting />
                   <LockGate>
                     <AuthGate />
                   </LockGate>
@@ -51,6 +66,35 @@ function RootLayout() {
 }
 
 export default withObservability(RootLayout);
+
+/**
+ * Sends a tapped notification where it points.
+ *
+ * Inside the navigation tree rather than at module scope, because a deep link
+ * fired before the router exists goes nowhere and takes the tap with it.
+ */
+function PushRouting() {
+  const router = useRouter();
+
+  useEffect(() => {
+    void ensureAndroidChannel();
+
+    // A tap that launched the app from cold arrives as the "last response"
+    // rather than as an event, so both paths are needed.
+    void Notifications.getLastNotificationResponseAsync().then((response) => {
+      const route = response ? routeForNotification(response) : null;
+      if (route) router.push(route as never);
+    });
+
+    const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
+      const route = routeForNotification(response);
+      if (route) router.push(route as never);
+    });
+    return () => subscription.remove();
+  }, [router]);
+
+  return null;
+}
 
 /** Holds the whole app behind biometrics when the user has asked for it. */
 function LockGate({ children }: { children: React.ReactNode }) {

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -18,12 +18,17 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { DisputePanel } from '@/components/DisputePanel';
 import {
   memberLookup,
   useDeleteExpense,
+  useDisputeExpense,
+  useDisputes,
   useExpenseVersions,
   useGroup,
+  useResolveDispute,
   useRestoreExpense,
+  useWithdrawDispute,
 } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
@@ -49,6 +54,11 @@ export default function ExpenseDetailScreen() {
   const versions = useExpenseVersions(expenseId ?? '');
   const deleteExpense = useDeleteExpense(groupId);
   const restoreExpense = useRestoreExpense(groupId);
+
+  const disputes = useDisputes(groupId);
+  const raiseDispute = useDisputeExpense(groupId);
+  const withdrawDispute = useWithdrawDispute(groupId);
+  const resolveDispute = useResolveDispute(groupId);
 
   const expense = expenses.rows.find((row) => row.id === expenseId);
   const version = expense?.currentVersion;
@@ -82,6 +92,10 @@ export default function ExpenseDetailScreen() {
 
   const currency = version.currency;
   const deleted = Boolean(expense.deleted_at);
+
+  const me = (members.data ?? []).find((member) => member.profile_id === profile?.id);
+  const mine = (disputes.data ?? []).filter((row) => row.expense_id === expense.id);
+  const editHere = (): void => router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}`);
 
   const confirmDelete = (): void => {
     Alert.alert(
@@ -149,6 +163,25 @@ export default function ExpenseDetailScreen() {
             {deleted ? <Badge label="deleted" tone="negative" /> : null}
           </Row>
         </Card>
+
+        {/* A disagreement about money is worth more room than a badge. It sits
+            directly under the amount, which is the thing being disagreed with. */}
+        {deleted ? null : (
+          <DisputePanel
+            disputes={mine}
+            myMemberId={me?.id ?? null}
+            authorMemberId={version.author_member_id}
+            isAdmin={me?.role === 'admin'}
+            nameOf={nameOf}
+            busy={raiseDispute.isPending || withdrawDispute.isPending || resolveDispute.isPending}
+            onRaise={(reason) => raiseDispute.mutate({ expenseId: expense.id, reason })}
+            onWithdraw={() => withdrawDispute.mutate(expense.id)}
+            onResolve={(disputeId, accept, note) =>
+              resolveDispute.mutate({ disputeId, accept, note })
+            }
+            onEdit={editHere}
+          />
+        )}
 
         {version.payers.length > 1 ? (
           <View>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -24,6 +24,7 @@ import {
   memberLookup,
   useConfirmSettlement,
   useGroup,
+  useDisputes,
   useGroupLedger,
   useGroupRealtime,
 } from '@/data/hooks';
@@ -50,6 +51,10 @@ export default function GroupScreen() {
 
   const { group, members, expenses, settlements, activity } = useGroup(groupId);
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
+  const disputes = useDisputes(groupId);
+  const openDisputes = new Set(
+    (disputes.data ?? []).filter((row) => row.status === 'open').map((row) => row.expense_id),
+  );
   const confirmSettlement = useConfirmSettlement(groupId);
 
   const lookup = memberLookup(members.data);
@@ -237,10 +242,14 @@ export default function GroupScreen() {
               {visibleExpenses.map((expense, index) => {
                 const version = expense.currentVersion;
                 const payer = version?.payers[0]?.member_id ?? null;
+                // Somebody disagreeing with an expense is worth seeing from the
+                // list. A disagreement you only find by opening the row is one
+                // that sits there unanswered.
+                const contested = openDisputes.has(expense.id);
                 return (
                   <View key={expense.id}>
                     <ListRow
-                      title={version?.description ?? 'Expense'}
+                      title={`${version?.description ?? 'Expense'}${contested ? '  🚩' : ''}`}
                       subtitle={`${nameOf(payer)} paid · ${
                         version
                           ? new Intl.DateTimeFormat(locale, {

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -3,7 +3,17 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ActivityIndicator, ScrollView, Switch, View } from 'react-native';
 
-import { Card, IconButton, Row, Screen, SectionHeader, Text, useTheme } from '@baaki/ui';
+import {
+  Badge,
+  Button,
+  Card,
+  IconButton,
+  Row,
+  Screen,
+  SectionHeader,
+  Text,
+  useTheme,
+} from '@baaki/ui';
 
 import {
   DEFAULT_NOTIFICATION_PREFS,
@@ -12,6 +22,7 @@ import {
   type NotificationPrefs,
 } from '@/data/api';
 import { useAuth } from '@/lib/auth';
+import { enablePush, pushPermission, type PushPermission } from '@/lib/push';
 
 const ROWS: {
   key: keyof NotificationPrefs;
@@ -52,6 +63,35 @@ export default function NotificationSettingsScreen() {
   const [prefs, setPrefs] = useState<NotificationPrefs>(DEFAULT_NOTIFICATION_PREFS);
   const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState<string | null>(null);
+  const [permission, setPermission] = useState<PushPermission>('undetermined');
+  const [asking, setAsking] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void pushPermission().then((value) => {
+      if (active) setPermission(value);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  /**
+   * The prompt happens here, having read what it is for — never on launch. On
+   * iOS a denial is close to permanent: the only way back is Settings, which
+   * nobody visits.
+   */
+  const turnOnPush = async (): Promise<void> => {
+    setAsking(true);
+    setStatus(null);
+    try {
+      const ok = await enablePush();
+      setPermission(await pushPermission());
+      if (!ok) setStatus('Not enabled — you can turn it on in your phone settings later.');
+    } finally {
+      setAsking(false);
+    }
+  };
 
   useEffect(() => {
     if (!profile?.id) return;
@@ -110,6 +150,31 @@ export default function NotificationSettingsScreen() {
           </Text>
         </Card>
 
+        <Card style={{ gap: theme.spacing.md }}>
+          <Row style={{ justifyContent: 'space-between' }}>
+            <Text variant="subheading">Notifications on this phone</Text>
+            <Badge
+              label={permission === 'granted' ? 'On' : permission === 'denied' ? 'Off' : 'Not set'}
+              tone={permission === 'granted' ? 'positive' : undefined}
+            />
+          </Row>
+          <Text variant="caption" tone="muted">
+            {permission === 'granted'
+              ? 'This device is registered. Everything below still lands in your inbox whether or not a push gets through.'
+              : permission === 'denied'
+                ? 'Your phone is blocking them. Turn them back on in system settings for Baaki — the inbox still has everything either way.'
+                : 'Baaki will only ask once, and only for the things you switch on below.'}
+          </Text>
+          {permission === 'granted' ? null : (
+            <Button
+              label={asking ? 'Asking…' : 'Turn on notifications'}
+              size="sm"
+              disabled={asking || permission === 'denied'}
+              onPress={() => void turnOnPush()}
+            />
+          )}
+        </Card>
+
         {loading ? (
           <ActivityIndicator color={theme.color.brand} />
         ) : (
@@ -143,8 +208,8 @@ export default function NotificationSettingsScreen() {
         ) : null}
 
         <Text variant="micro" tone="faint" align="center">
-          Delivery itself lands in M4 — these preferences are stored now so the fanout has something
-          to respect from day one.
+          Email delivery is still to come. Everything here is also in your inbox, which is the
+          record of what Baaki has told you whether or not a notification arrived.
         </Text>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/components/DisputePanel.tsx
+++ b/apps/mobile/src/components/DisputePanel.tsx
@@ -1,0 +1,218 @@
+/**
+ * "This isn't right."
+ *
+ * The obvious version of this feature takes you out of the split. That is the
+ * one thing it must not do: a share you can remove unilaterally is a debt you
+ * can delete, and the ledger is worth exactly as much as that is impossible.
+ *
+ * So declining records a position and tells the person who entered it. The
+ * numbers move when somebody edits the expense — which anybody in the group
+ * has always been able to do, because the person who spots that dinner was
+ * ₹1,800 is usually not the person who typed ₹1,300.
+ *
+ * The wording follows ADR-010's tone rule. Almost every one of these is a
+ * genuine mistake, and copy that calls it a dispute makes a fight out of a
+ * typo: the button says "Something's wrong", not "Reject".
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { TextInput, View } from 'react-native';
+
+import { Badge, Button, Card, Row, Text, useTheme } from '@baaki/ui';
+
+import type { MemberId } from '@baaki/core';
+
+import type { DisputeRow } from '@/data/types';
+
+export interface DisputePanelProps {
+  disputes: DisputeRow[];
+  /** My member id in this group, or null while it loads. */
+  myMemberId: MemberId | null;
+  /** Who entered the version being looked at. */
+  authorMemberId: MemberId | null;
+  isAdmin: boolean;
+  nameOf: (memberId: string | null) => string;
+  busy?: boolean;
+  onRaise: (reason: string) => void;
+  onWithdraw: () => void;
+  onResolve: (disputeId: string, accept: boolean, note: string) => void;
+  /** Accepting means fixing it, so the caller opens the editor. */
+  onEdit: () => void;
+}
+
+export function DisputePanel({
+  disputes,
+  myMemberId,
+  authorMemberId,
+  isAdmin,
+  nameOf,
+  busy = false,
+  onRaise,
+  onWithdraw,
+  onResolve,
+  onEdit,
+}: DisputePanelProps) {
+  const theme = useTheme();
+  const [writing, setWriting] = useState(false);
+  const [reason, setReason] = useState('');
+  const [answering, setAnswering] = useState<string | null>(null);
+  const [note, setNote] = useState('');
+
+  const open = disputes.filter((row) => row.status === 'open');
+  const mine = open.find((row) => row.member_id === myMemberId);
+  const others = open.filter((row) => row.member_id !== myMemberId);
+  const canAnswer = myMemberId !== null && (myMemberId === authorMemberId || isAdmin);
+
+  const input = {
+    fontSize: 15,
+    color: theme.color.text,
+    paddingVertical: theme.spacing.sm,
+    minHeight: 44,
+  } as const;
+
+  return (
+    <Card style={{ gap: theme.spacing.lg }}>
+      {open.length > 0 ? (
+        <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+          <Ionicons name="alert-circle" size={18} color={theme.color.negative} />
+          <Text variant="subheading" tone="negative">
+            {open.length === 1
+              ? 'Someone thinks this is off'
+              : `${open.length} people think this is off`}
+          </Text>
+        </Row>
+      ) : null}
+
+      {others.map((row) => (
+        <View key={row.id} style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            {`${nameOf(row.member_id)} says:`}
+          </Text>
+          <Text variant="body">{row.reason ?? 'No reason given'}</Text>
+
+          {canAnswer ? (
+            answering === row.id ? (
+              <View style={{ gap: theme.spacing.sm }}>
+                <TextInput
+                  value={note}
+                  onChangeText={setNote}
+                  multiline
+                  accessibilityLabel="Your reply"
+                  placeholder="Optional — what actually happened"
+                  placeholderTextColor={theme.color.textFaint}
+                  style={input}
+                />
+                <Row style={{ gap: theme.spacing.sm }}>
+                  <Button
+                    label={busy ? 'Saving…' : 'They’re right — I’ll fix it'}
+                    size="sm"
+                    disabled={busy}
+                    onPress={() => {
+                      onResolve(row.id, true, note);
+                      setAnswering(null);
+                      setNote('');
+                      onEdit();
+                    }}
+                  />
+                  <Button
+                    label="It’s correct"
+                    size="sm"
+                    variant="secondary"
+                    disabled={busy}
+                    onPress={() => {
+                      onResolve(row.id, false, note);
+                      setAnswering(null);
+                      setNote('');
+                    }}
+                  />
+                </Row>
+              </View>
+            ) : (
+              <Button
+                label="Answer this"
+                size="sm"
+                variant="secondary"
+                onPress={() => setAnswering(row.id)}
+              />
+            )
+          ) : null}
+        </View>
+      ))}
+
+      {mine ? (
+        <View style={{ gap: theme.spacing.sm }}>
+          <Badge label="You said this is wrong" tone="negative" />
+          {mine.reason ? (
+            <Text variant="caption" tone="muted">
+              {mine.reason}
+            </Text>
+          ) : null}
+          <Text variant="micro" tone="faint">
+            Nothing has changed yet — your share stands until the expense is corrected. That is
+            deliberate: a share anybody could drop on their own would not be a ledger.
+          </Text>
+          <Button
+            label="Never mind, it’s fine"
+            size="sm"
+            variant="ghost"
+            disabled={busy}
+            onPress={onWithdraw}
+          />
+        </View>
+      ) : writing ? (
+        <View style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            What’s wrong with it?
+          </Text>
+          <TextInput
+            value={reason}
+            onChangeText={setReason}
+            multiline
+            autoFocus
+            accessibilityLabel="What is wrong with this expense"
+            placeholder="I left before dessert · the total was ₹1,800"
+            placeholderTextColor={theme.color.textFaint}
+            style={input}
+          />
+          <Row style={{ gap: theme.spacing.sm }}>
+            <Button
+              label={busy ? 'Sending…' : 'Tell them'}
+              size="sm"
+              disabled={busy}
+              onPress={() => {
+                onRaise(reason);
+                setWriting(false);
+                setReason('');
+              }}
+            />
+            <Button
+              label="Cancel"
+              size="sm"
+              variant="ghost"
+              onPress={() => {
+                setWriting(false);
+                setReason('');
+              }}
+            />
+          </Row>
+          <Text variant="micro" tone="faint">
+            A reason is optional, but it is the difference between a fix and a conversation.
+          </Text>
+        </View>
+      ) : (
+        <Row style={{ gap: theme.spacing.sm }}>
+          {/* Correcting it is the better answer whenever you know what it should
+              say, so it is offered first and equally. */}
+          <Button label="Fix it myself" size="sm" variant="secondary" onPress={onEdit} />
+          <Button
+            label="Something’s wrong"
+            size="sm"
+            variant="ghost"
+            onPress={() => setWriting(true)}
+          />
+        </Row>
+      )}
+    </Card>
+  );
+}

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -39,6 +39,23 @@ export function describeActivity(entry: ActivityRow, myProfileId: string | null)
         ? `${who}'s edit replaced an earlier one — "${replaced}" is still in the history`
         : `${who}'s edit replaced an earlier one`;
     }
+    case 'auto_confirmed':
+      // Nobody did this, so it does not get an actor. "Someone confirmed" would
+      // be a lie about a settlement that resolved by itself.
+      return 'A settlement was confirmed automatically after a week';
+    case 'disputed': {
+      const reason = typeof payload.reason === 'string' ? payload.reason : null;
+      const what = description ?? 'an expense';
+      return reason
+        ? `${who} says ${what} is not right — "${reason}"`
+        : `${who} says ${what} is not right`;
+    }
+    case 'withdrew_dispute':
+      return `${who} took back their correction to ${description ?? 'an expense'}`;
+    case 'accepted_dispute':
+      return `${who} agreed ${description ?? 'an expense'} needs fixing`;
+    case 'rejected_dispute':
+      return `${who} says ${description ?? 'an expense'} is correct as it stands`;
     case 'settled':
       return `${who} recorded a settlement`;
     case 'confirmed':
@@ -69,7 +86,14 @@ export function verbEmoji(verb: string): string {
     case 'settled':
       return '💸';
     case 'confirmed':
+    case 'auto_confirmed':
+    case 'accepted_dispute':
       return '✅';
+    case 'disputed':
+      return '🚩';
+    case 'withdrew_dispute':
+    case 'rejected_dispute':
+      return '🤝';
     case 'joined':
       return '👋';
     case 'created':

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -28,6 +28,7 @@ import type {
   ExpenseRow,
   GroupRow,
   GroupType,
+  DisputeRow,
   MemberRow,
   NotificationRow,
   SettlementMethod,
@@ -481,6 +482,54 @@ export async function updateGroup(
   }>,
 ): Promise<void> {
   const { error } = await supabase.from('groups').update(patch).eq('id', groupId);
+  if (error) throw new Error(error.message);
+}
+
+// ─────────────────────────────────────── declining an expense (ADR-004) ──
+// A decline is a claim, not a mutation: it is recorded and everybody sees it,
+// and the numbers move only when somebody edits the expense. Every write goes
+// through an RPC — the table itself is read-only to clients, which is what
+// stops a dispute being filed in somebody else's name.
+
+export async function fetchDisputes(groupId: string): Promise<DisputeRow[]> {
+  return unwrap(
+    await supabase
+      .from('expense_disputes')
+      .select(
+        'id, expense_id, member_id, reason, status, resolved_by_member_id, resolution_note, created_at, resolved_at, expense:expenses!inner ( group_id )',
+      )
+      .eq('expense.group_id', groupId)
+      .order('created_at', { ascending: false }),
+  ) as unknown as DisputeRow[];
+}
+
+export async function disputeExpense(input: {
+  expenseId: string;
+  reason?: string | null;
+}): Promise<string> {
+  const { data, error } = await supabase.rpc('baaki_dispute_expense', {
+    p_expense_id: input.expenseId,
+    p_reason: input.reason?.trim() || null,
+  });
+  if (error) throw new Error(error.message);
+  return String(data);
+}
+
+export async function withdrawDispute(expenseId: string): Promise<void> {
+  const { error } = await supabase.rpc('baaki_withdraw_dispute', { p_expense_id: expenseId });
+  if (error) throw new Error(error.message);
+}
+
+export async function resolveDispute(input: {
+  disputeId: string;
+  accept: boolean;
+  note?: string | null;
+}): Promise<void> {
+  const { error } = await supabase.rpc('baaki_resolve_dispute', {
+    p_dispute_id: input.disputeId,
+    p_accept: input.accept,
+    p_note: input.note?.trim() || null,
+  });
   if (error) throw new Error(error.message);
 }
 

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -30,10 +30,12 @@ import {
   confirmSettlement,
   createGroup,
   deleteExpense,
+  disputeExpense,
   fetchActivity,
   fetchAllBalances,
   fetchBalances,
   fetchExpenseVersions,
+  fetchDisputes,
   fetchExpenses,
   fetchGroup,
   fetchGroups,
@@ -45,10 +47,12 @@ import {
   fetchSettlements,
   markNotificationsRead,
   recordSettlement,
+  resolveDispute,
   leaveGroup,
   restoreExpense,
   updateGroup,
   updateMember,
+  withdrawDispute,
   writeExpense,
   type WriteExpenseInput,
 } from './api';
@@ -64,6 +68,7 @@ export const keys = {
   activity: (id: string) => ['group', id, 'activity'] as const,
   balances: (id: string) => ['group', id, 'balances'] as const,
   notifications: ['notifications'] as const,
+  disputes: (id: string) => ['group', id, 'disputes'] as const,
 };
 
 export function useGroups() {
@@ -415,6 +420,45 @@ export function useMarkNotificationsRead() {
   return useMutation({
     mutationFn: markNotificationsRead,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: keys.notifications }),
+  });
+}
+
+/**
+ * Who has said an expense is wrong, across the group.
+ *
+ * Fetched per group rather than per expense so the list can mark the rows
+ * without a query each. A disagreement nobody sees until they open the expense
+ * is a disagreement that festers.
+ */
+export function useDisputes(groupId: string) {
+  return useQuery({
+    queryKey: keys.disputes(groupId),
+    queryFn: () => fetchDisputes(groupId),
+    enabled: Boolean(groupId),
+  });
+}
+
+export function useDisputeExpense(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: disputeExpense,
+    onSuccess: () => invalidateGroup(queryClient, groupId),
+  });
+}
+
+export function useWithdrawDispute(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: withdrawDispute,
+    onSuccess: () => invalidateGroup(queryClient, groupId),
+  });
+}
+
+export function useResolveDispute(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: resolveDispute,
+    onSuccess: () => invalidateGroup(queryClient, groupId),
   });
 }
 

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -76,6 +76,24 @@ export interface ExpenseRow {
   pending?: boolean;
 }
 
+export type DisputeStatus = 'open' | 'resolved' | 'withdrawn' | 'rejected';
+
+/**
+ * Somebody saying an expense is wrong. Never changes a balance on its own —
+ * a share you could remove unilaterally would be a debt you could delete.
+ */
+export interface DisputeRow {
+  id: string;
+  expense_id: string;
+  member_id: MemberId;
+  reason: string | null;
+  status: DisputeStatus;
+  resolved_by_member_id: MemberId | null;
+  resolution_note: string | null;
+  created_at: string;
+  resolved_at: string | null;
+}
+
 export interface SettlementRow {
   id: string;
   group_id: string;

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -6,6 +6,7 @@ import * as WebBrowser from 'expo-web-browser';
 import { checkPassword, planAuth, readIdentifier, type Viewer } from '@baaki/core';
 
 import { identifyForReporting } from './observability';
+import { refreshPushToken, revokePushToken } from './push';
 import { supabase } from './supabase';
 
 /**
@@ -97,6 +98,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // enough to tell one person hitting a bug fifty times from fifty people.
   useEffect(() => {
     identifyForReporting(currentUserId);
+  }, [currentUserId]);
+
+  // Silent, and only when permission already exists — a push token can change
+  // on its own (a restore, a reinstall), and a stale one is somebody who
+  // quietly stops hearing from us. Asking for permission happens on the
+  // notifications screen, never here.
+  useEffect(() => {
+    if (!currentUserId) return;
+    void refreshPushToken();
   }, [currentUserId]);
 
   useEffect(() => {
@@ -229,6 +239,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       },
 
       async signOut() {
+        // Before the session goes: afterwards there is no identity to attach
+        // the revocation to, and the token would keep receiving notifications
+        // for an account nobody is signed in on.
+        await revokePushToken();
         await supabase.auth.signOut();
       },
     }),

--- a/apps/mobile/src/lib/push.ts
+++ b/apps/mobile/src/lib/push.ts
@@ -1,0 +1,138 @@
+/**
+ * Registering this device to be tapped on the shoulder.
+ *
+ * Two decisions worth stating, because both are easy to get wrong in a way
+ * nobody notices:
+ *
+ * **Permission is never asked for on launch.** A money app that opens with
+ * "Baaki would like to send you notifications" gets denied, and on iOS a denial
+ * is close to permanent — the only way back is Settings, which nobody visits.
+ * So the prompt happens when somebody turns notifications on, having read what
+ * they are for. If permission is already granted the token is refreshed
+ * silently, because that costs nothing and a stale token is a person who
+ * quietly stops hearing from us.
+ *
+ * **Signing out revokes the token rather than deleting the row.** The same
+ * token coming back later is the same device, and the row is the evidence of
+ * that.
+ */
+
+import Constants from 'expo-constants';
+import * as Device from 'expo-device';
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+
+import { supabase } from './supabase';
+
+/** Android delivers silently without a channel, which looks exactly like a bug. */
+export async function ensureAndroidChannel(): Promise<void> {
+  if (Platform.OS !== 'android') return;
+  await Notifications.setNotificationChannelAsync('default', {
+    name: 'Baaki',
+    importance: Notifications.AndroidImportance.DEFAULT,
+    vibrationPattern: [0, 200, 100, 200],
+    lightColor: '#7A5AF8',
+  });
+}
+
+function projectId(): string | null {
+  const extra = Constants.expoConfig?.extra as { eas?: { projectId?: string } } | undefined;
+  return extra?.eas?.projectId ?? null;
+}
+
+export type PushPermission = 'granted' | 'denied' | 'undetermined';
+
+export async function pushPermission(): Promise<PushPermission> {
+  if (!Device.isDevice) return 'denied';
+  const { status } = await Notifications.getPermissionsAsync();
+  return status as PushPermission;
+}
+
+/**
+ * Ask, register, and store. Returns false when the person said no — which is an
+ * answer, not an error, and the caller should treat it as one.
+ */
+export async function enablePush(): Promise<boolean> {
+  // A simulator has no push token to give. Failing loudly here would make every
+  // development run look broken.
+  if (!Device.isDevice) return false;
+
+  const existing = await Notifications.getPermissionsAsync();
+  const status =
+    existing.status === 'granted'
+      ? existing.status
+      : (await Notifications.requestPermissionsAsync()).status;
+  if (status !== 'granted') return false;
+
+  await ensureAndroidChannel();
+  return refreshPushToken();
+}
+
+/**
+ * Store the current token if we already have permission.
+ *
+ * Safe to call on every launch: it is a no-op without permission, and a token
+ * can change on its own (a restore, a reinstall), at which point the old one
+ * silently stops working.
+ */
+export async function refreshPushToken(): Promise<boolean> {
+  if (!Device.isDevice) return false;
+  const { status } = await Notifications.getPermissionsAsync();
+  if (status !== 'granted') return false;
+
+  const id = projectId();
+  if (!id) return false;
+
+  const { data: session } = await supabase.auth.getSession();
+  const profileId = session.session?.user?.id;
+  if (!profileId) return false;
+
+  const token = (await Notifications.getExpoPushTokenAsync({ projectId: id })).data;
+
+  const { error } = await supabase.from('push_tokens').upsert(
+    {
+      profile_id: profileId,
+      expo_push_token: token,
+      platform: Platform.OS === 'ios' ? 'ios' : 'android',
+      device_name: Device.modelName,
+      last_seen_at: new Date().toISOString(),
+      // A token that comes back is the same device returning, not a new one.
+      revoked_at: null,
+    },
+    { onConflict: 'expo_push_token' },
+  );
+  return !error;
+}
+
+/** On the way out. Leaves the row, so a return is recognised as a return. */
+export async function revokePushToken(): Promise<void> {
+  if (!Device.isDevice) return;
+  const id = projectId();
+  if (!id) return;
+  try {
+    const token = (await Notifications.getExpoPushTokenAsync({ projectId: id })).data;
+    await supabase
+      .from('push_tokens')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('expo_push_token', token);
+  } catch {
+    // Signing out must succeed whether or not this does. A token left live
+    // sends notifications to a phone nobody is signed in on, which the app
+    // discards — untidy, not harmful.
+  }
+}
+
+/**
+ * Where a tapped notification should go.
+ *
+ * Returned rather than navigated to, so the caller decides when the router is
+ * ready — a deep link fired before the navigation tree exists goes nowhere.
+ */
+export function routeForNotification(response: Notifications.NotificationResponse): string | null {
+  const data = response.notification.request.content.data as { url?: unknown } | undefined;
+  const url = typeof data?.url === 'string' ? data.url : null;
+  if (!url) return null;
+  // `baaki://group/<id>` → `/group/<id>`. The scheme is only there because a
+  // push has to survive being handed to the operating system.
+  return url.replace(/^baaki:\/\//, '/');
+}

--- a/apps/mobile/test/activity.test.ts
+++ b/apps/mobile/test/activity.test.ts
@@ -158,3 +158,48 @@ describe('the icon', () => {
     expect(verbEmoji('archived')).toBe('•');
   });
 });
+
+/**
+ * Disagreeing with an expense.
+ *
+ * The wording carries the design: a decline is somebody's position, not a
+ * change to the ledger. The feed has to read as a conversation rather than as
+ * an accounting event, because that is what it is — and it must not imply the
+ * numbers moved, since they did not.
+ */
+describe('somebody says an expense is wrong', () => {
+  it('quotes the reason, which is the whole point of the entry', () => {
+    expect(
+      describeActivity(
+        row({ verb: 'disputed', payload: { description: 'Dinner', reason: 'I left early' } }),
+        null,
+      ),
+    ).toBe('Ravi says Dinner is not right — "I left early"');
+  });
+
+  it('still says something useful with no reason given', () => {
+    expect(
+      describeActivity(row({ verb: 'disputed', payload: { description: 'Dinner' } }), null),
+    ).toBe('Ravi says Dinner is not right');
+  });
+
+  it('reads as agreement rather than defeat when it is accepted', () => {
+    expect(
+      describeActivity(row({ verb: 'accepted_dispute', payload: { description: 'Dinner' } }), null),
+    ).toBe('Ravi agreed Dinner needs fixing');
+  });
+
+  it('reads as a position rather than a verdict when it is not', () => {
+    expect(
+      describeActivity(row({ verb: 'rejected_dispute', payload: { description: 'Dinner' } }), null),
+    ).toBe('Ravi says Dinner is correct as it stands');
+  });
+
+  it('names nobody for a settlement that confirmed itself', () => {
+    // "Someone confirmed" would be a lie about a thing that happened because a
+    // week passed and nobody said anything.
+    const line = describeActivity(row({ verb: 'auto_confirmed', payload: {} }), null);
+    expect(line).not.toContain('Ravi');
+    expect(line).toContain('automatically');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "edge:serve": "pnpm edge:build && supabase functions serve --env-file supabase/functions/.env",
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",
-    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write sync invite-mint invite-accept export-data receipt-parse fx-rate"
+    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write sync invite-mint invite-accept export-data receipt-parse fx-rate notify-fanout"
   },
   "devDependencies": {
     "prettier": "^3.4.2",

--- a/packages/core/src/notifications/copy.ts
+++ b/packages/core/src/notifications/copy.ts
@@ -25,7 +25,14 @@ export type NotificationKind =
    * while the receipts still exist.
    */
   | 'trip_nudge_morning'
-  | 'trip_nudge_evening';
+  | 'trip_nudge_evening'
+  /**
+   * Somebody saying an expense is wrong. Worded as a correction rather than an
+   * accusation on purpose (ADR-010): the common case is a genuine mistake, and
+   * copy that treats it as a dispute makes a fight out of a typo.
+   */
+  | 'expense_disputed'
+  | 'expense_dispute_resolved';
 
 export interface CopyStrings {
   readonly money: {
@@ -75,6 +82,14 @@ const en: CopyStrings = {
       title: 'Before you forget',
       body: 'What did you pay for today on {group}?',
     },
+    expense_disputed: {
+      title: '{actor} thinks something is off',
+      body: '{description} in {group} — take a look',
+    },
+    expense_dispute_resolved: {
+      title: 'Your correction was answered',
+      body: '{description} in {group}',
+    },
   },
 };
 
@@ -115,6 +130,14 @@ const ta: CopyStrings = {
       title: 'மறப்பதற்கு முன்',
       body: 'இன்று {group} இல் என்ன செலவு செய்தீர்கள்?',
     },
+    expense_disputed: {
+      title: '{actor} ஏதோ தவறு என்கிறார்',
+      body: '{description} ({group}) — பார்க்கவும்',
+    },
+    expense_dispute_resolved: {
+      title: 'உங்கள் திருத்தத்திற்கு பதில் வந்தது',
+      body: '{description} ({group})',
+    },
   },
 };
 
@@ -148,6 +171,14 @@ const hi: CopyStrings = {
     trip_nudge_evening: {
       title: 'भूलने से पहले',
       body: 'आज {group} में आपने किस चीज़ का भुगतान किया?',
+    },
+    expense_disputed: {
+      title: '{actor} को कुछ गड़बड़ लग रहा है',
+      body: '{description} ({group}) — देख लें',
+    },
+    expense_dispute_resolved: {
+      title: 'आपके सुधार का जवाब आया',
+      body: '{description} ({group})',
     },
   },
 };

--- a/packages/core/src/notifications/index.ts
+++ b/packages/core/src/notifications/index.ts
@@ -1,2 +1,3 @@
 export * from './copy';
 export * from './render';
+export * from './push';

--- a/packages/core/src/notifications/push.ts
+++ b/packages/core/src/notifications/push.ts
@@ -1,0 +1,154 @@
+/**
+ * Turning inbox rows into Expo push messages, and reading back what happened.
+ *
+ * The sending itself is four lines of `fetch` in an edge function. Everything
+ * that can actually be got wrong is here, where it can be tested without a
+ * network or a phone:
+ *
+ *   * **Fan-out.** One notification with three devices is three messages, and
+ *     the reply comes back as one flat array in send order. Losing track of
+ *     which ticket belongs to which token is how a dead device gets a live
+ *     token revoked.
+ *   * **Language.** The row was written by Postgres, which had no idea who
+ *     would read it. A push says the same thing as the inbox, in the same
+ *     language, because it is the same notification.
+ *   * **Dead tokens.** Expo answers `DeviceNotRegistered` for an app that was
+ *     uninstalled. Not revoking those means paying to fail forever; revoking
+ *     the wrong one means somebody silently stops getting notifications.
+ *
+ * Expo takes at most 100 messages per request, so the chunking lives here too.
+ */
+
+import { renderNotification, type NotificationFacts } from './render';
+
+/** Expo's cap. Sending more in one request is rejected outright. */
+export const EXPO_PUSH_CHUNK = 100;
+
+export interface PushableNotification {
+  readonly id: string;
+  readonly kind: string;
+  readonly title: string;
+  readonly body: string;
+  readonly deepLink?: string | null;
+  readonly facts?: NotificationFacts;
+  /** The recipient's locale — theirs, not the sender's and not the server's. */
+  readonly locale?: string | null;
+  /** Every live device this person has. */
+  readonly tokens: readonly string[];
+}
+
+export interface ExpoPushMessage {
+  readonly to: string;
+  readonly title: string;
+  readonly body: string;
+  readonly data: Record<string, unknown>;
+  readonly sound: 'default';
+  readonly priority: 'high';
+  /** Android needs a channel or the notification arrives silent. */
+  readonly channelId: 'default';
+}
+
+/** Which notification and which device each message in the batch came from. */
+export interface PushTarget {
+  readonly notificationId: string;
+  readonly token: string;
+}
+
+export interface PushBatch {
+  readonly messages: readonly ExpoPushMessage[];
+  readonly targets: readonly PushTarget[];
+}
+
+export function buildPushBatch(rows: readonly PushableNotification[]): PushBatch {
+  const messages: ExpoPushMessage[] = [];
+  const targets: PushTarget[] = [];
+
+  for (const row of rows) {
+    const { title, body } = renderNotification(row.kind, row.facts ?? {}, row.locale ?? 'en', {
+      title: row.title,
+      body: row.body,
+    });
+
+    for (const token of row.tokens) {
+      messages.push({
+        to: token,
+        title,
+        body,
+        // What the app needs to open the right screen when it is tapped.
+        data: { notificationId: row.id, kind: row.kind, url: row.deepLink ?? null },
+        sound: 'default',
+        priority: 'high',
+        channelId: 'default',
+      });
+      targets.push({ notificationId: row.id, token });
+    }
+  }
+
+  return { messages, targets };
+}
+
+export function chunk<T>(items: readonly T[], size = EXPO_PUSH_CHUNK): T[][] {
+  const out: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    out.push(items.slice(index, index + size));
+  }
+  return out;
+}
+
+export interface ExpoTicket {
+  readonly status?: string;
+  readonly id?: string;
+  readonly message?: string;
+  readonly details?: { readonly error?: string };
+}
+
+export interface PushOutcome {
+  /** Notifications where at least one device accepted the message. */
+  readonly delivered: readonly string[];
+  /** Notifications where every device refused it. */
+  readonly failed: readonly string[];
+  /** Tokens belonging to an app that is no longer installed. */
+  readonly revoke: readonly string[];
+}
+
+/**
+ * Read the tickets against the batch they answer.
+ *
+ * "Delivered" here means Expo accepted it, which is as much as this layer can
+ * ever know — the phone may be off, and the receipt that says so arrives
+ * minutes later on a different endpoint. Claiming more than that in the
+ * database would be a lie the UI would repeat.
+ *
+ * A notification counts as delivered if *any* of the person's devices took it.
+ * Someone with an old tablet in a drawer should not have every notification
+ * marked failed because of it.
+ */
+export function readPushTickets(
+  targets: readonly PushTarget[],
+  tickets: readonly ExpoTicket[],
+): PushOutcome {
+  const accepted = new Set<string>();
+  const attempted = new Set<string>();
+  const revoke = new Set<string>();
+
+  targets.forEach((target, index) => {
+    attempted.add(target.notificationId);
+    const ticket = tickets[index];
+
+    // A short reply is a truncated one; treating a missing ticket as success
+    // would mark a notification sent that nobody has seen.
+    if (!ticket) return;
+
+    if (ticket.status === 'ok') {
+      accepted.add(target.notificationId);
+      return;
+    }
+    if (ticket.details?.error === 'DeviceNotRegistered') revoke.add(target.token);
+  });
+
+  return {
+    delivered: [...accepted],
+    failed: [...attempted].filter((id) => !accepted.has(id)),
+    revoke: [...revoke],
+  };
+}

--- a/packages/core/test/push.test.ts
+++ b/packages/core/test/push.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Fanning a notification out to phones, and reading back what happened.
+ *
+ * Three ways this goes wrong quietly, all of them here rather than in the edge
+ * function where they would need a network and a handset to reproduce:
+ *
+ *   * the reply comes back as one flat array in send order, so losing the
+ *     mapping revokes a live device because a dead one failed;
+ *   * a push in the wrong language, or in English when the inbox says Tamil,
+ *     because the row was written by Postgres and rendered by nobody;
+ *   * marking everything failed for somebody who owns an old tablet.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildPushBatch, chunk, readPushTickets, type PushableNotification } from '../src/index';
+
+const NOTIFICATION: PushableNotification = {
+  id: 'n1',
+  kind: 'trip_nudge_evening',
+  title: 'Before you forget',
+  body: 'What did you pay for today?',
+  deepLink: 'baaki://group/g1/add-expense',
+  facts: { group: 'Goa' },
+  locale: 'en-IN',
+  tokens: ['ExponentPushToken[phone]'],
+};
+
+describe('building the batch', () => {
+  it('sends one message per device', () => {
+    const { messages } = buildPushBatch([{ ...NOTIFICATION, tokens: ['a', 'b', 'c'] }]);
+    expect(messages.map((message) => message.to)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('says the same thing the inbox says, in the same language', () => {
+    const [tamil] = buildPushBatch([{ ...NOTIFICATION, locale: 'ta-IN' }]).messages;
+    const [english] = buildPushBatch([NOTIFICATION]).messages;
+    expect(tamil?.title).not.toBe(english?.title);
+    expect(english?.body).toContain('Goa');
+  });
+
+  it('falls back to what the row said for a kind it does not know', () => {
+    const [message] = buildPushBatch([{ ...NOTIFICATION, kind: 'invented_next_year' }]).messages;
+    expect(message?.title).toBe('Before you forget');
+  });
+
+  it('carries what the app needs to open the right screen', () => {
+    const [message] = buildPushBatch([NOTIFICATION]).messages;
+    expect(message?.data).toMatchObject({
+      notificationId: 'n1',
+      url: 'baaki://group/g1/add-expense',
+    });
+  });
+
+  it('asks for a channel, without which Android delivers it silently', () => {
+    const [message] = buildPushBatch([NOTIFICATION]).messages;
+    expect(message?.channelId).toBe('default');
+  });
+
+  it('skips somebody with no devices rather than sending to nobody', () => {
+    const { messages, targets } = buildPushBatch([{ ...NOTIFICATION, tokens: [] }]);
+    expect(messages).toHaveLength(0);
+    expect(targets).toHaveLength(0);
+  });
+
+  it('splits at Expo’s hundred, which is a hard limit and not a suggestion', () => {
+    const tokens = Array.from({ length: 250 }, (_, index) => `token-${index}`);
+    const { messages } = buildPushBatch([{ ...NOTIFICATION, tokens }]);
+    expect(chunk(messages).map((batch) => batch.length)).toEqual([100, 100, 50]);
+  });
+});
+
+describe('reading the tickets', () => {
+  const targets = [
+    { notificationId: 'n1', token: 'live' },
+    { notificationId: 'n1', token: 'uninstalled' },
+    { notificationId: 'n2', token: 'also-uninstalled' },
+  ];
+
+  it('revokes only the device that is actually gone', () => {
+    // The whole reason the mapping exists. Off by one here and somebody stops
+    // getting notifications on the phone they still use.
+    const outcome = readPushTickets(targets, [
+      { status: 'ok', id: 't1' },
+      { status: 'error', details: { error: 'DeviceNotRegistered' } },
+      { status: 'error', details: { error: 'DeviceNotRegistered' } },
+    ]);
+    expect(outcome.revoke).toEqual(['uninstalled', 'also-uninstalled']);
+  });
+
+  it('counts a notification delivered if any of the person’s devices took it', () => {
+    const outcome = readPushTickets(targets, [
+      { status: 'ok', id: 't1' },
+      { status: 'error', details: { error: 'DeviceNotRegistered' } },
+      { status: 'error', details: { error: 'DeviceNotRegistered' } },
+    ]);
+    expect(outcome.delivered).toEqual(['n1']);
+    expect(outcome.failed).toEqual(['n2']);
+  });
+
+  it('does not revoke a token over a transient failure', () => {
+    // A rate limit is not an uninstall, and treating it as one loses the device
+    // permanently over a bad minute.
+    const outcome = readPushTickets(targets.slice(0, 1), [
+      { status: 'error', message: 'Too many requests', details: { error: 'MessageRateExceeded' } },
+    ]);
+    expect(outcome.revoke).toEqual([]);
+    expect(outcome.failed).toEqual(['n1']);
+  });
+
+  it('treats a truncated reply as unsent rather than sent', () => {
+    // Marking a notification delivered because the answer was short is how a
+    // person never hears about it and the table says they did.
+    const outcome = readPushTickets(targets, [{ status: 'ok', id: 't1' }]);
+    expect(outcome.delivered).toEqual(['n1']);
+    expect(outcome.failed).toEqual(['n2']);
+  });
+});

--- a/packages/db/prisma/migrations/20260806180000_expense_disputes/migration.sql
+++ b/packages/db/prisma/migrations/20260806180000_expense_disputes/migration.sql
@@ -1,0 +1,332 @@
+-- Declining an expense somebody else added.
+--
+-- Editing has always been open to every member: `expenses_update` and
+-- `expense_versions_insert` check membership, not authorship, because the
+-- person who spots that dinner was ₹1,800 and not ₹1,300 is usually not the
+-- person who typed it. Correcting somebody's expense is not an act of
+-- aggression, and the version history means nothing is lost when they do.
+--
+-- Declining is the case editing cannot cover: "I wasn't at that dinner." The
+-- obvious implementation — take me out of the split — is the one thing that
+-- must not be built, because a share you can remove unilaterally is a debt you
+-- can delete, and the whole ledger is worth exactly as much as that is
+-- impossible.
+--
+-- So a decline is a *claim*, not a mutation. It is recorded against the
+-- expense, everybody can see it, the person who entered it is told, and the
+-- balances do not move until somebody actually changes the expense. That is the
+-- same trade ADR-007 makes for settlements: confirmation here is social, not
+-- cryptographic, and the app's job is to make the disagreement visible rather
+-- than to adjudicate it.
+--
+-- Resolution happens three ways:
+--   * somebody edits the expense — the thing disputed no longer exists, so
+--     open disputes on it close themselves;
+--   * the disputer withdraws it;
+--   * the author or an admin rejects it, with a note.
+
+-- ────────────────────────────────────────────────────────── 1. the claim ──
+-- One row per person per expense rather than one per complaint: this is
+-- somebody's position on an expense, and they only have one at a time. The
+-- history of how that position changed lives in `activity_log`, which is the
+-- append-only record (ADR-004).
+
+CREATE TABLE IF NOT EXISTS public.expense_disputes (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  expense_id  UUID NOT NULL,
+  member_id   UUID NOT NULL,
+  reason      TEXT,
+  status      TEXT NOT NULL DEFAULT 'open',
+  resolved_by_member_id UUID,
+  resolution_note TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at TIMESTAMPTZ,
+  CONSTRAINT expense_disputes_status_check
+    CHECK (status IN ('open', 'resolved', 'withdrawn', 'rejected')),
+  CONSTRAINT expense_disputes_expense_id_member_id_key UNIQUE (expense_id, member_id)
+);
+
+ALTER TABLE public.expense_disputes
+  DROP CONSTRAINT IF EXISTS "expense_disputes_expense_id_fkey",
+  DROP CONSTRAINT IF EXISTS "expense_disputes_member_id_fkey",
+  DROP CONSTRAINT IF EXISTS "expense_disputes_resolved_by_member_id_fkey";
+
+ALTER TABLE public.expense_disputes
+  ADD CONSTRAINT "expense_disputes_expense_id_fkey" FOREIGN KEY ("expense_id")
+    REFERENCES public.expenses("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "expense_disputes_member_id_fkey" FOREIGN KEY ("member_id")
+    REFERENCES public.group_members("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "expense_disputes_resolved_by_member_id_fkey" FOREIGN KEY ("resolved_by_member_id")
+    REFERENCES public.group_members("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX IF NOT EXISTS expense_disputes_expense_id_status_idx
+  ON public.expense_disputes (expense_id, status);
+
+COMMENT ON TABLE public.expense_disputes IS
+  'Somebody saying an expense is wrong. Visible to the group; never changes a balance on its own.';
+
+ALTER TABLE public.expense_disputes ENABLE ROW LEVEL SECURITY;
+
+-- Read-only to the group. Every write goes through the RPCs below, which is
+-- what stops somebody resolving a dispute against themselves or filing one in
+-- another member's name.
+CREATE POLICY expense_disputes_select ON public.expense_disputes
+  FOR SELECT TO authenticated, anon
+  USING (public.is_group_member(
+    (SELECT group_id FROM public.expenses WHERE id = expense_id)
+  ));
+
+-- ───────────────────────────────────────────── 2. raising and withdrawing ──
+
+CREATE OR REPLACE FUNCTION public.baaki_dispute_expense(
+  p_expense_id UUID,
+  p_reason     TEXT DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id     UUID;
+  v_actor        UUID;
+  v_dispute_id   UUID;
+  v_raised_at    TIMESTAMPTZ;
+  v_author       UUID;
+  v_author_pid   UUID;
+  v_description  TEXT;
+  v_group_name   TEXT;
+  v_actor_name   TEXT;
+BEGIN
+  SELECT e.group_id, v.author_member_id, v.description
+    INTO v_group_id, v_author, v_description
+  FROM public.expenses e
+  LEFT JOIN public.expense_versions v ON v.id = e.current_version_id
+  WHERE e.id = p_expense_id AND e.deleted_at IS NULL;
+
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such expense' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  v_actor := public.baaki_my_member_id(v_group_id);
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: only a member of the group can dispute its expenses'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Re-raising replaces the previous position rather than stacking another row.
+  --
+  -- `updated_at` moves only when something actually changed. Calling this twice
+  -- with the same complaint is a retry and must be silent; raising it again
+  -- after it was rejected is a new complaint and must not be.
+  INSERT INTO public.expense_disputes AS d (expense_id, member_id, reason, status)
+  VALUES (p_expense_id, v_actor, NULLIF(btrim(p_reason), ''), 'open')
+  ON CONFLICT (expense_id, member_id) DO UPDATE
+    SET reason = EXCLUDED.reason,
+        status = 'open',
+        resolved_by_member_id = NULL,
+        resolution_note = NULL,
+        resolved_at = NULL,
+        updated_at = CASE
+          WHEN d.status = 'open' AND d.reason IS NOT DISTINCT FROM EXCLUDED.reason
+          THEN d.updated_at
+          ELSE now()
+        END
+  RETURNING d.id, d.updated_at INTO v_dispute_id, v_raised_at;
+
+  SELECT COALESCE(p.display_name, m.ghost_name) INTO v_actor_name
+  FROM public.group_members m
+  LEFT JOIN public.profiles p ON p.id = m.profile_id
+  WHERE m.id = v_actor;
+
+  SELECT name INTO v_group_name FROM public.groups WHERE id = v_group_id;
+
+  INSERT INTO public.activity_log
+    (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES
+    (v_group_id, v_actor, 'disputed', 'expense', p_expense_id,
+     jsonb_build_object('description', v_description, 'reason', NULLIF(btrim(p_reason), '')));
+
+  -- The person who entered it is the person who can fix it.
+  SELECT profile_id INTO v_author_pid FROM public.group_members WHERE id = v_author;
+  IF v_author_pid IS NOT NULL AND v_author IS DISTINCT FROM v_actor THEN
+    PERFORM public.baaki_notify(
+      v_author_pid, v_group_id, 'expense_disputed',
+      COALESCE(v_actor_name, 'Someone') || ' says an expense is wrong',
+      COALESCE(v_description, 'An expense') || ' — have a look',
+      'baaki://group/' || v_group_id::text || '/expense/' || p_expense_id::text,
+      jsonb_build_object('counterparty', v_actor_name, 'group', v_group_name,
+                         'description', v_description, 'expenseId', p_expense_id),
+      'dispute:' || v_dispute_id::text || ':raised:' || v_raised_at::text
+    );
+  END IF;
+
+  RETURN v_dispute_id;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION public.baaki_withdraw_dispute(p_expense_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id UUID;
+  v_actor    UUID;
+  v_updated  INTEGER;
+BEGIN
+  SELECT group_id INTO v_group_id FROM public.expenses WHERE id = p_expense_id;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such expense' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  v_actor := public.baaki_my_member_id(v_group_id);
+
+  UPDATE public.expense_disputes
+     SET status = 'withdrawn', resolved_at = now(), updated_at = now(),
+         resolved_by_member_id = v_actor
+   WHERE expense_id = p_expense_id AND member_id = v_actor AND status = 'open';
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  IF v_updated = 0 THEN
+    RAISE EXCEPTION 'NOT_YOUR_DISPUTE: you have no open dispute on this expense'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  INSERT INTO public.activity_log
+    (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (v_group_id, v_actor, 'withdrew_dispute', 'expense', p_expense_id, '{}'::jsonb);
+END
+$$;
+
+-- ──────────────────────────────────────────────────────── 3. answering it ──
+
+CREATE OR REPLACE FUNCTION public.baaki_resolve_dispute(
+  p_dispute_id UUID,
+  p_accept     BOOLEAN,
+  p_note       TEXT DEFAULT NULL
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_expense_id  UUID;
+  v_group_id    UUID;
+  v_author      UUID;
+  v_actor       UUID;
+  v_disputer    UUID;
+  v_disputer_pid UUID;
+  v_description TEXT;
+  v_group_name  TEXT;
+BEGIN
+  SELECT d.expense_id, d.member_id, e.group_id, v.author_member_id, v.description
+    INTO v_expense_id, v_disputer, v_group_id, v_author, v_description
+  FROM public.expense_disputes d
+  JOIN public.expenses e ON e.id = d.expense_id
+  LEFT JOIN public.expense_versions v ON v.id = e.current_version_id
+  WHERE d.id = p_dispute_id AND d.status = 'open';
+
+  IF v_expense_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no open dispute with that id' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  v_actor := public.baaki_my_member_id(v_group_id);
+
+  -- The person who entered the expense, or an admin. Not the disputer: nobody
+  -- gets to rule on their own complaint, in either direction.
+  IF v_actor IS NULL
+     OR v_actor = v_disputer
+     OR (v_actor IS DISTINCT FROM v_author AND NOT public.is_group_admin(v_group_id))
+  THEN
+    RAISE EXCEPTION 'NOT_YOURS_TO_RESOLVE: only the person who added the expense, or an admin, can answer this'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  UPDATE public.expense_disputes
+     SET status = CASE WHEN p_accept THEN 'resolved' ELSE 'rejected' END,
+         resolution_note = NULLIF(btrim(p_note), ''),
+         resolved_by_member_id = v_actor,
+         resolved_at = now(),
+         updated_at = now()
+   WHERE id = p_dispute_id;
+
+  SELECT name INTO v_group_name FROM public.groups WHERE id = v_group_id;
+
+  INSERT INTO public.activity_log
+    (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES
+    (v_group_id, v_actor,
+     CASE WHEN p_accept THEN 'accepted_dispute' ELSE 'rejected_dispute' END,
+     'expense', v_expense_id,
+     jsonb_build_object('description', v_description, 'note', NULLIF(btrim(p_note), '')));
+
+  SELECT profile_id INTO v_disputer_pid FROM public.group_members WHERE id = v_disputer;
+  IF v_disputer_pid IS NOT NULL THEN
+    PERFORM public.baaki_notify(
+      v_disputer_pid, v_group_id, 'expense_dispute_resolved',
+      CASE WHEN p_accept THEN 'Your correction was accepted' ELSE 'Your correction was declined' END,
+      COALESCE(v_description, 'An expense'),
+      'baaki://group/' || v_group_id::text || '/expense/' || v_expense_id::text,
+      jsonb_build_object('group', v_group_name, 'description', v_description,
+                         'accepted', p_accept, 'note', NULLIF(btrim(p_note), '')),
+      'dispute:' || p_dispute_id::text || ':resolved'
+    );
+  END IF;
+END
+$$;
+
+-- ──────────────────────────────────────── 4. an edit answers it by itself ──
+-- A new version means the expense being complained about no longer exists.
+-- Leaving the dispute open against a row that has changed would leave a red
+-- flag on an expense nobody can find fault with any more.
+
+CREATE OR REPLACE FUNCTION public.baaki_close_disputes_on_new_version()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  UPDATE public.expense_disputes
+     SET status = 'resolved',
+         resolution_note = 'The expense was edited',
+         resolved_at = now(),
+         updated_at = now(),
+         resolved_by_member_id = NEW.author_member_id
+   WHERE expense_id = NEW.expense_id AND status = 'open';
+  RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS expense_versions_close_disputes ON public.expense_versions;
+CREATE TRIGGER expense_versions_close_disputes
+  AFTER INSERT ON public.expense_versions
+  FOR EACH ROW
+  -- Only an edit. Version 1 is the expense being created, and nothing can have
+  -- been disputed about it yet.
+  WHEN (NEW.version_no > 1)
+  EXECUTE FUNCTION public.baaki_close_disputes_on_new_version();
+
+GRANT EXECUTE ON FUNCTION
+  public.baaki_dispute_expense(uuid, text),
+  public.baaki_withdraw_dispute(uuid),
+  public.baaki_resolve_dispute(uuid, boolean, text)
+TO authenticated, anon;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime')
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_publication_tables
+       WHERE pubname = 'supabase_realtime' AND schemaname = 'public'
+         AND tablename = 'expense_disputes'
+     )
+  THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.expense_disputes;
+  END IF;
+END
+$$;

--- a/packages/db/prisma/migrations/20260806190000_push_fanout/migration.sql
+++ b/packages/db/prisma/migrations/20260806190000_push_fanout/migration.sql
@@ -1,0 +1,197 @@
+-- Getting a notification onto a phone (TDR §7.1).
+--
+-- The inbox already holds everything Baaki has said. This is the part that
+-- taps somebody on the shoulder about it, and the two halves that must not be
+-- got wrong both live here rather than in the edge function:
+--
+--   * **Claiming.** A fanout that reads rows and then sends them will send
+--     twice the moment two runs overlap or one times out after sending. The
+--     claim is an UPDATE, so a row belongs to exactly one run the instant it is
+--     picked up, and a second run finds nothing.
+--   * **Finishing.** What came back has to land against the right rows, and a
+--     device that is genuinely gone has to be dropped — otherwise every future
+--     fanout pays to fail at it forever.
+--
+-- Neither function is reachable by a signed-in user. The fanout runs as the
+-- service role, which is the only identity that has any business reading
+-- somebody else's inbox.
+
+-- ─────────────────────────────────────────────────────────── 1. claiming ──
+
+CREATE OR REPLACE FUNCTION public.baaki_claim_push_notifications(p_limit INTEGER DEFAULT 200)
+RETURNS TABLE (
+  id        UUID,
+  kind      TEXT,
+  title     TEXT,
+  body      TEXT,
+  deep_link TEXT,
+  payload   JSONB,
+  locale    TEXT,
+  tokens    TEXT[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_ids UUID[];
+BEGIN
+  -- The claim, in one statement. `FOR UPDATE SKIP LOCKED` is what lets two
+  -- runs overlap harmlessly: the second finds the rows locked and moves on
+  -- rather than sending them again.
+  WITH picked AS (
+    SELECT n.id
+    FROM public.notifications n
+    WHERE n.push_status IS NULL
+      -- Anything older than this was missed while the fanout was down, and a
+      -- buzz about a two-day-old reminder is worse than silence.
+      AND n.created_at > now() - interval '2 days'
+    ORDER BY n.created_at
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  ),
+  claimed AS (
+    UPDATE public.notifications n
+       SET push_status = 'queued'
+      FROM picked
+     WHERE n.id = picked.id
+    RETURNING n.id
+  )
+  SELECT COALESCE(array_agg(claimed.id), '{}') INTO v_ids FROM claimed;
+
+  -- A separate statement on purpose: Postgres will not apply two updates to the
+  -- same row inside one statement, so closing these out in a CTE beside the
+  -- claim above would silently do nothing.
+  --
+  -- Somebody with no device is not a failure to retry. Plenty of people only
+  -- ever read the inbox, and leaving their rows unsent grows the queue forever.
+  UPDATE public.notifications n
+     SET push_status = 'failed'
+   WHERE n.id = ANY(v_ids)
+     AND NOT EXISTS (
+       SELECT 1 FROM public.push_tokens t
+       WHERE t.profile_id = n.profile_id AND t.revoked_at IS NULL
+     );
+
+  RETURN QUERY
+  SELECT n.id, n.kind, n.title, n.body, n.deep_link, n.payload,
+         COALESCE(p.locale, 'en'),
+         ARRAY_AGG(t.expo_push_token)
+  FROM public.notifications n
+  LEFT JOIN public.profiles p ON p.id = n.profile_id
+  JOIN public.push_tokens t
+    ON t.profile_id = n.profile_id AND t.revoked_at IS NULL
+  WHERE n.id = ANY(v_ids) AND n.push_status = 'queued'
+  GROUP BY n.id, n.kind, n.title, n.body, n.deep_link, n.payload, p.locale;
+END
+$$;
+
+-- ────────────────────────────────────────────────────────── 2. finishing ──
+
+CREATE OR REPLACE FUNCTION public.baaki_finish_push(
+  p_delivered UUID[] DEFAULT '{}',
+  p_failed    UUID[] DEFAULT '{}',
+  p_revoke    TEXT[] DEFAULT '{}'
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  -- 'sent' rather than 'delivered': Expo accepting a message is as much as this
+  -- layer can know. The phone may be off. Recording more than actually happened
+  -- is a lie the UI would go on to repeat.
+  UPDATE public.notifications
+     SET push_status = 'sent'
+   WHERE id = ANY(p_delivered);
+
+  UPDATE public.notifications
+     SET push_status = 'failed'
+   WHERE id = ANY(p_failed);
+
+  -- Soft, not deleted: the row is evidence of a device that existed, and the
+  -- same token coming back later is a reinstall rather than a new device.
+  UPDATE public.push_tokens
+     SET revoked_at = now()
+   WHERE expo_push_token = ANY(p_revoke) AND revoked_at IS NULL;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_claim_push_notifications(integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_finish_push(uuid[], uuid[], text[]) FROM PUBLIC;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    GRANT EXECUTE ON FUNCTION public.baaki_claim_push_notifications(integer) TO service_role;
+    GRANT EXECUTE ON FUNCTION public.baaki_finish_push(uuid[], uuid[], text[]) TO service_role;
+  END IF;
+END
+$$;
+
+-- ─────────────────────────────────────────────────────────── 3. schedule ──
+-- The fanout is an edge function, so Postgres has to make an HTTP call to run
+-- it: pg_cron for the when, pg_net for the how.
+--
+-- The service key is read from Supabase Vault rather than written here. A
+-- migration is a file in a public repository, and the key it would contain
+-- reads every row in the database. If the secret is absent the schedule is
+-- simply not created — a fanout that never runs leaves every notification in
+-- the inbox, which is where it already was.
+--
+-- To turn it on:
+--   select vault.create_secret('<service-role-key>', 'baaki_fanout_key');
+--   select vault.create_secret('https://<ref>.supabase.co', 'baaki_functions_url');
+-- then re-run this block, or schedule it by hand from the dashboard.
+
+DO $$
+DECLARE
+  v_key  TEXT;
+  v_url  TEXT;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron')
+     OR NOT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_net')
+  THEN
+    RAISE NOTICE 'push fanout not scheduled: pg_cron/pg_net unavailable';
+    RETURN;
+  END IF;
+
+  CREATE EXTENSION IF NOT EXISTS pg_cron;
+  CREATE EXTENSION IF NOT EXISTS pg_net;
+
+  BEGIN
+    SELECT decrypted_secret INTO v_key
+    FROM vault.decrypted_secrets WHERE name = 'baaki_fanout_key';
+    SELECT decrypted_secret INTO v_url
+    FROM vault.decrypted_secrets WHERE name = 'baaki_functions_url';
+  EXCEPTION WHEN OTHERS THEN
+    v_key := NULL;
+  END;
+
+  IF v_key IS NULL OR v_url IS NULL THEN
+    RAISE NOTICE 'push fanout not scheduled: no vault secret. See the comment above this block.';
+    RETURN;
+  END IF;
+
+  PERFORM cron.unschedule('baaki-notify-fanout')
+    WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'baaki-notify-fanout');
+
+  -- Every five minutes. A reminder that arrives four minutes late is still a
+  -- reminder; a fanout that runs every minute is mostly a bill.
+  PERFORM cron.schedule(
+    'baaki-notify-fanout', '*/5 * * * *',
+    format(
+      $job$SELECT net.http_post(
+             url := %L,
+             headers := jsonb_build_object('Content-Type', 'application/json',
+                                           'Authorization', %L)
+           )$job$,
+      v_url || '/functions/v1/notify-fanout',
+      'Bearer ' || v_key
+    )
+  );
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'push fanout not scheduled: %', SQLERRM;
+END
+$$;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -222,6 +222,8 @@ model GroupMember {
   settlementsGot     Settlement[]     @relation("SettlementTo")
   itemClaims         ReceiptItemClaim[]
   activity           ActivityLog[]
+  disputesRaised     ExpenseDispute[] @relation("DisputeRaisedBy")
+  disputesResolved   ExpenseDispute[] @relation("DisputeResolvedBy")
   remindersSent      Reminder[]       @relation("ReminderFrom")
   remindersGot       Reminder[]       @relation("ReminderTo")
   balances           GroupBalance[]
@@ -279,11 +281,42 @@ model Expense {
   currentVersion ExpenseVersion?  @relation("CurrentVersion", fields: [currentVersionId], references: [id], onDelete: SetNull)
   versions       ExpenseVersion[] @relation("ExpenseVersions")
   allocations    SettlementAllocation[]
+  disputes       ExpenseDispute[]
 
   @@index([groupId, deletedAt])
   /// The sync pull is "everything in this group since seq N" (TDR §4).
   @@index([groupId, updatedSeq])
   @@map("expenses")
+  @@schema("public")
+}
+
+/// Somebody saying an expense is wrong — "I wasn't at that dinner".
+///
+/// A claim, never a mutation: it is visible to the group and changes no
+/// balance on its own. A share you could remove unilaterally would be a debt
+/// you could delete, and the ledger is worth exactly as much as that is
+/// impossible. One row per person per expense; how their position changed over
+/// time is in `activity_log`.
+model ExpenseDispute {
+  id        String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  expenseId String  @map("expense_id") @db.Uuid
+  memberId  String  @map("member_id") @db.Uuid
+  reason    String?
+  /// open | resolved | withdrawn | rejected (CHECK in the migration).
+  status    String  @default("open")
+  resolvedByMemberId String? @map("resolved_by_member_id") @db.Uuid
+  resolutionNote     String? @map("resolution_note")
+  createdAt  DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt  DateTime  @default(now()) @map("updated_at") @db.Timestamptz(6)
+  resolvedAt DateTime? @map("resolved_at") @db.Timestamptz(6)
+
+  expense    Expense      @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  member     GroupMember  @relation("DisputeRaisedBy", fields: [memberId], references: [id], onDelete: Cascade)
+  resolvedBy GroupMember? @relation("DisputeResolvedBy", fields: [resolvedByMemberId], references: [id], onDelete: SetNull)
+
+  @@unique([expenseId, memberId])
+  @@index([expenseId, status])
+  @@map("expense_disputes")
   @@schema("public")
 }
 

--- a/packages/db/test/m4-expense-disputes.test.ts
+++ b/packages/db/test/m4-expense-disputes.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Declining an expense somebody else added.
+ *
+ * The first block is the whole design, and it is a negative: a decline must not
+ * move a balance. The obvious implementation — take me out of the split — is
+ * the one thing that must never exist, because a share you can remove
+ * unilaterally is a debt you can delete, and this ledger is worth exactly as
+ * much as that is impossible.
+ *
+ * What a decline does instead is make the disagreement visible and tell the
+ * person who entered it. The numbers change when somebody edits the expense,
+ * which anybody in the group has always been able to do — membership, not
+ * authorship, is what `expense_versions_insert` checks, because the person who
+ * spots that dinner was ₹1,800 is usually not the person who typed ₹1,300.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, big, connect, readBalances, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+interface Scene {
+  groupId: string;
+  expenseId: string;
+  profileIds: string[];
+  memberIds: string[];
+}
+
+/** Asha (admin, member 0) enters a ₹300 dinner split three ways. */
+async function seedExpense(): Promise<Scene> {
+  const { groupId, profileIds, memberIds } = await seedGroup(client, { memberCount: 3 });
+  const { expenseId } = await addEqualSplitExpense(client, {
+    groupId,
+    payers: { [memberIds[0] ?? '']: 30000n },
+    participants: memberIds,
+    amount: 30000n,
+    description: 'Dinner',
+  });
+  return { groupId, expenseId, profileIds, memberIds };
+}
+
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+const dispute = (profileId: string, expenseId: string, reason?: string): Promise<string> =>
+  asUser(profileId, async () => {
+    const { rows } = await client.query(`SELECT baaki_dispute_expense($1, $2) AS id`, [
+      expenseId,
+      reason ?? null,
+    ]);
+    return String(rows[0]?.id);
+  });
+
+const disputesOn = async (expenseId: string): Promise<Record<string, unknown>[]> => {
+  const { rows } = await client.query(
+    `SELECT * FROM expense_disputes WHERE expense_id = $1 ORDER BY created_at`,
+    [expenseId],
+  );
+  return rows as Record<string, unknown>[];
+};
+
+const inboxCount = async (profileId: string, kind: string): Promise<number> => {
+  const { rows } = await client.query(
+    `SELECT COUNT(*)::int AS n FROM notifications WHERE profile_id = $1 AND kind = $2`,
+    [profileId, kind],
+  );
+  return Number(rows[0]?.n);
+};
+
+describe('a decline changes nothing about the money', () => {
+  it('leaves every balance exactly where it was', async () => {
+    // If this test can ever be made to fail, the ledger is worthless.
+    const scene = await seedExpense();
+    const before = await readBalances(client, scene.groupId);
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'I was not there');
+    const after = await readBalances(client, scene.groupId);
+    expect([...after.entries()].sort()).toEqual([...before.entries()].sort());
+  });
+
+  it('leaves the disputer still owing their share', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    const balances = await readBalances(client, scene.groupId);
+    expect(balances.get(scene.memberIds[1] ?? '')).toBe(-10000n);
+  });
+
+  it('does not touch the expense or its versions', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    const { rows } = await client.query(
+      `SELECT COUNT(*)::int AS versions FROM expense_versions WHERE expense_id = $1`,
+      [scene.expenseId],
+    );
+    expect(rows[0]?.versions).toBe(1);
+  });
+});
+
+describe('raising one', () => {
+  it('records who said so and why', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'I left before the dessert');
+    const [row] = await disputesOn(scene.expenseId);
+    expect(row?.member_id).toBe(scene.memberIds[1]);
+    expect(row?.reason).toBe('I left before the dessert');
+    expect(row?.status).toBe('open');
+  });
+
+  it('does not insist on a reason', async () => {
+    // Making somebody justify themselves before they can say "this is wrong" is
+    // how a feature goes unused.
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    const [row] = await disputesOn(scene.expenseId);
+    expect(row?.reason).toBeNull();
+  });
+
+  it('tells the person who entered it', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    expect(await inboxCount(scene.profileIds[0] ?? '', 'expense_disputed')).toBe(1);
+  });
+
+  it('lets two people disagree with the same expense', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    await dispute(scene.profileIds[2] ?? '', scene.expenseId);
+    expect(await disputesOn(scene.expenseId)).toHaveLength(2);
+  });
+
+  it('keeps one position per person rather than a pile of complaints', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'wrong amount');
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'actually, wrong people');
+    const rows = await disputesOn(scene.expenseId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.reason).toBe('actually, wrong people');
+  });
+
+  it('does not tell them twice about the same complaint', async () => {
+    // A retried call is a retry. Two buzzes for one grievance is how people
+    // learn to ignore the app.
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'I was not there');
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'I was not there');
+    expect(await inboxCount(scene.profileIds[0] ?? '', 'expense_disputed')).toBe(1);
+  });
+
+  it('refuses somebody who is not in the group', async () => {
+    const scene = await seedExpense();
+    const outsiderId = randomUUID();
+    await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Outsider')`, [
+      outsiderId,
+    ]);
+    await expect(dispute(outsiderId, scene.expenseId)).rejects.toThrow(/NOT_A_MEMBER|NOT_FOUND/);
+  });
+});
+
+describe('answering one', () => {
+  const resolve = (
+    profileId: string,
+    disputeId: string,
+    accept: boolean,
+    note?: string,
+  ): Promise<unknown> =>
+    asUser(profileId, () =>
+      client.query(`SELECT baaki_resolve_dispute($1, $2, $3)`, [disputeId, accept, note ?? null]),
+    );
+
+  it('lets the person who entered the expense accept it', async () => {
+    const scene = await seedExpense();
+    const disputeId = await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    await resolve(scene.profileIds[0] ?? '', disputeId, true, 'You are right, fixing it');
+    const [row] = await disputesOn(scene.expenseId);
+    expect(row?.status).toBe('resolved');
+    expect(row?.resolution_note).toBe('You are right, fixing it');
+  });
+
+  it('lets them reject it, with the reason recorded', async () => {
+    const scene = await seedExpense();
+    const disputeId = await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    await resolve(scene.profileIds[0] ?? '', disputeId, false, 'You had the biryani');
+    const [row] = await disputesOn(scene.expenseId);
+    expect(row?.status).toBe('rejected');
+  });
+
+  it('refuses to let the disputer rule on their own complaint', async () => {
+    // In either direction. "I declined it, so I closed it" is not a resolution.
+    const scene = await seedExpense();
+    const disputeId = await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    await expect(resolve(scene.profileIds[1] ?? '', disputeId, true)).rejects.toThrow(
+      /NOT_YOURS_TO_RESOLVE/,
+    );
+  });
+
+  it('refuses an unrelated member who is not an admin', async () => {
+    const scene = await seedExpense();
+    const disputeId = await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    await expect(resolve(scene.profileIds[2] ?? '', disputeId, false)).rejects.toThrow(
+      /NOT_YOURS_TO_RESOLVE/,
+    );
+  });
+
+  it('tells the disputer either way', async () => {
+    const scene = await seedExpense();
+    const disputeId = await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    await resolve(scene.profileIds[0] ?? '', disputeId, false, 'You had the biryani');
+    expect(await inboxCount(scene.profileIds[1] ?? '', 'expense_dispute_resolved')).toBe(1);
+  });
+
+  it('lets somebody raise it again after a rejection', async () => {
+    const scene = await seedExpense();
+    const first = await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'I was not there');
+    await resolve(scene.profileIds[0] ?? '', first, false);
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'I really was not there');
+    const [row] = await disputesOn(scene.expenseId);
+    expect(row?.status).toBe('open');
+    // A new complaint, so the author hears about it again.
+    expect(await inboxCount(scene.profileIds[0] ?? '', 'expense_disputed')).toBe(2);
+  });
+});
+
+describe('withdrawing one', () => {
+  it('lets somebody take it back', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    await asUser(scene.profileIds[1] ?? '', () =>
+      client.query(`SELECT baaki_withdraw_dispute($1)`, [scene.expenseId]),
+    );
+    const [row] = await disputesOn(scene.expenseId);
+    expect(row?.status).toBe('withdrawn');
+  });
+
+  it('will not let somebody withdraw a complaint that is not theirs', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    await expect(
+      asUser(scene.profileIds[2] ?? '', () =>
+        client.query(`SELECT baaki_withdraw_dispute($1)`, [scene.expenseId]),
+      ),
+    ).rejects.toThrow(/NOT_YOUR_DISPUTE/);
+  });
+});
+
+describe('an edit answers it by itself', () => {
+  it('closes every open dispute, because the thing complained about is gone', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'I was not there');
+    await dispute(scene.profileIds[2] ?? '', scene.expenseId);
+
+    // Anybody in the group can correct an expense — membership, not authorship.
+    await addVersion(scene, scene.memberIds[1] ?? '', 20000n, [
+      scene.memberIds[0] ?? '',
+      scene.memberIds[2] ?? '',
+    ]);
+
+    const rows = await disputesOn(scene.expenseId);
+    expect(rows.map((row) => row.status)).toEqual(['resolved', 'resolved']);
+    expect(rows[0]?.resolution_note).toBe('The expense was edited');
+  });
+
+  it('and the balances move only then', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'I was not there');
+    const duringDispute = await readBalances(client, scene.groupId);
+    expect(duringDispute.get(scene.memberIds[1] ?? '')).toBe(-10000n);
+
+    await addVersion(scene, scene.memberIds[1] ?? '', 30000n, [
+      scene.memberIds[0] ?? '',
+      scene.memberIds[2] ?? '',
+    ]);
+
+    const after = await readBalances(client, scene.groupId);
+    expect(after.get(scene.memberIds[1] ?? '') ?? 0n).toBe(0n);
+  });
+});
+
+/** A correction: a second version with a different set of participants. */
+async function addVersion(
+  scene: Scene,
+  authorMemberId: string,
+  amount: bigint,
+  participants: string[],
+): Promise<void> {
+  const versionId = randomUUID();
+  const share = amount / BigInt(participants.length);
+  await client.query('BEGIN');
+  await client.query(
+    `INSERT INTO expense_versions
+       (id, expense_id, version_no, author_member_id, description, expense_date,
+        currency, amount, split_type, split_params)
+     VALUES ($1, $2, 2, $3, 'Dinner', '2026-03-01', 'INR', $4, 'equal', '{"kind":"equal"}'::jsonb)`,
+    [versionId, scene.expenseId, authorMemberId, amount.toString()],
+  );
+  await client.query(
+    `INSERT INTO expense_payers (id, expense_version_id, member_id, amount) VALUES ($1, $2, $3, $4)`,
+    [randomUUID(), versionId, scene.memberIds[0], amount.toString()],
+  );
+  for (const memberId of participants) {
+    await client.query(
+      `INSERT INTO expense_shares (id, expense_version_id, member_id, amount)
+       VALUES ($1, $2, $3, $4)`,
+      [randomUUID(), versionId, memberId, share.toString()],
+    );
+  }
+  await client.query(`UPDATE expenses SET current_version_id = $1 WHERE id = $2`, [
+    versionId,
+    scene.expenseId,
+  ]);
+  await client.query('COMMIT');
+}
+
+describe('who can see one', () => {
+  it('is the group, and nobody else', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId, 'I was not there');
+
+    const outsiderId = randomUUID();
+    await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Outsider')`, [
+      outsiderId,
+    ]);
+
+    const mine = await asUser(scene.profileIds[2] ?? '', async () => {
+      const { rows } = await client.query(`SELECT id FROM expense_disputes WHERE expense_id = $1`, [
+        scene.expenseId,
+      ]);
+      return rows.length;
+    });
+    const theirs = await asUser(outsiderId, async () => {
+      const { rows } = await client.query(`SELECT id FROM expense_disputes WHERE expense_id = $1`, [
+        scene.expenseId,
+      ]);
+      return rows.length;
+    });
+
+    expect(mine).toBe(1);
+    expect(theirs).toBe(0);
+  });
+
+  it('cannot be filed in somebody else’s name', async () => {
+    // The table is read-only to clients; every write goes through an RPC that
+    // works out who the caller is.
+    const scene = await seedExpense();
+    await expect(
+      asUser(scene.profileIds[1] ?? '', () =>
+        client.query(
+          `INSERT INTO expense_disputes (expense_id, member_id, status) VALUES ($1, $2, 'open')`,
+          [scene.expenseId, scene.memberIds[2]],
+        ),
+      ),
+    ).rejects.toThrow(/row-level security|permission denied/i);
+  });
+});
+
+describe('the numbers still add up', () => {
+  it('leaves the group summing to zero, disputed or not', async () => {
+    const scene = await seedExpense();
+    await dispute(scene.profileIds[1] ?? '', scene.expenseId);
+    const { rows } = await client.query(
+      `SELECT COALESCE(SUM(balance), 0) AS total FROM group_balances WHERE group_id = $1`,
+      [scene.groupId],
+    );
+    expect(big(rows[0]?.total)).toBe(0n);
+  });
+});

--- a/packages/db/test/m4-push-fanout.test.ts
+++ b/packages/db/test/m4-push-fanout.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Claiming notifications to push, and closing them out afterwards.
+ *
+ * The bug this exists to prevent is the one everybody ships once: a fanout that
+ * reads rows and then sends them delivers everything twice the moment two runs
+ * overlap, or one times out after the messages have already left. A person who
+ * gets every reminder twice turns notifications off, and they never come back.
+ *
+ * So claiming is an UPDATE, not a SELECT, and the tests below are mostly about
+ * what a second run sees.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+interface Claimed {
+  id: string;
+  kind: string;
+  title: string;
+  locale: string;
+  tokens: string[];
+}
+
+async function seedPerson(options: { tokens?: number; locale?: string } = {}): Promise<{
+  profileId: string;
+  groupId: string;
+  tokens: string[];
+}> {
+  const { tokens: tokenCount = 1, locale = 'en' } = options;
+  const { groupId, profileIds } = await seedGroup(client, { memberCount: 1 });
+  const profileId = profileIds[0] ?? '';
+  await client.query(`UPDATE profiles SET locale = $2 WHERE id = $1`, [profileId, locale]);
+
+  const tokens: string[] = [];
+  for (let index = 0; index < tokenCount; index += 1) {
+    const token = `ExponentPushToken[${randomUUID()}]`;
+    await client.query(
+      `INSERT INTO push_tokens (profile_id, expo_push_token, platform) VALUES ($1, $2, 'android')`,
+      [profileId, token],
+    );
+    tokens.push(token);
+  }
+  return { profileId, groupId, tokens };
+}
+
+async function notify(profileId: string, groupId: string, kind = 'trip_nudge_evening') {
+  const { rows } = await client.query(
+    `SELECT baaki_notify($1, $2, $3, 'Before you forget', 'What did you pay for today?',
+                         null, '{"group":"Goa"}'::jsonb, $4) AS id`,
+    [profileId, groupId, kind, randomUUID()],
+  );
+  return String(rows[0]?.id);
+}
+
+/**
+ * A deliberately large default. The claim takes the oldest unsent rows first,
+ * which is the right order in production and means a row written a moment ago
+ * can sit behind hundreds written by the other suites running alongside this
+ * one — which is exactly how this was a flake before it was this number.
+ */
+const claim = async (limit = 5000): Promise<Claimed[]> => {
+  const { rows } = await client.query(`SELECT * FROM baaki_claim_push_notifications($1)`, [limit]);
+  return rows as Claimed[];
+};
+
+const statusOf = async (notificationId: string): Promise<string | null> => {
+  const { rows } = await client.query(`SELECT push_status FROM notifications WHERE id = $1`, [
+    notificationId,
+  ]);
+  return (rows[0]?.push_status as string | null) ?? null;
+};
+
+const mine = (rows: Claimed[], id: string): Claimed | undefined =>
+  rows.find((row) => row.id === id);
+
+describe('claiming', () => {
+  it('hands over a notification with the devices to send it to', async () => {
+    const person = await seedPerson({ tokens: 2 });
+    const id = await notify(person.profileId, person.groupId);
+    const claimed = mine(await claim(), id);
+    expect(claimed?.tokens.sort()).toEqual(person.tokens.sort());
+  });
+
+  it('carries the reader’s language, not the server’s', async () => {
+    // The row was written by Postgres with no idea who would read it. The push
+    // has to say what the inbox says.
+    const person = await seedPerson({ locale: 'ta' });
+    const id = await notify(person.profileId, person.groupId);
+    expect(mine(await claim(), id)?.locale).toBe('ta');
+  });
+
+  it('never hands the same one over twice', async () => {
+    // The whole reason claiming is an UPDATE.
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+    expect(mine(await claim(), id)).toBeDefined();
+    expect(mine(await claim(), id)).toBeUndefined();
+  });
+
+  it('marks it queued so a second run can see it is spoken for', async () => {
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+    await claim();
+    expect(await statusOf(id)).toBe('queued');
+  });
+
+  it('skips a device that has been revoked', async () => {
+    const person = await seedPerson({ tokens: 2 });
+    await client.query(`UPDATE push_tokens SET revoked_at = now() WHERE expo_push_token = $1`, [
+      person.tokens[0],
+    ]);
+    const id = await notify(person.profileId, person.groupId);
+    expect(mine(await claim(), id)?.tokens).toEqual([person.tokens[1]]);
+  });
+
+  it('closes out somebody with no device rather than retrying them forever', async () => {
+    // Plenty of people only ever read the inbox. Leaving those rows unsent
+    // would grow the queue without bound.
+    const person = await seedPerson({ tokens: 0 });
+    const id = await notify(person.profileId, person.groupId);
+    expect(mine(await claim(), id)).toBeUndefined();
+    expect(await statusOf(id)).toBe('failed');
+  });
+
+  it('leaves something stale alone rather than buzzing about last week', async () => {
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+    await client.query(
+      `UPDATE notifications SET created_at = now() - interval '5 days' WHERE id = $1`,
+      [id],
+    );
+    expect(mine(await claim(), id)).toBeUndefined();
+    expect(await statusOf(id)).toBeNull();
+  });
+
+  it('respects a limit, so one run cannot take the whole table', async () => {
+    const person = await seedPerson();
+    await notify(person.profileId, person.groupId);
+    await notify(person.profileId, person.groupId);
+    await notify(person.profileId, person.groupId);
+    expect(await claim(2)).toHaveLength(2);
+  });
+});
+
+describe('finishing', () => {
+  it('records what was sent as sent, and no more than that', async () => {
+    // Expo accepting a message is not the phone showing it. Saying 'delivered'
+    // here would be a claim the UI would repeat.
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+    await claim();
+    await client.query(`SELECT baaki_finish_push(ARRAY[$1]::uuid[], '{}', '{}')`, [id]);
+    expect(await statusOf(id)).toBe('sent');
+  });
+
+  it('records a refusal as failed', async () => {
+    const person = await seedPerson();
+    const id = await notify(person.profileId, person.groupId);
+    await claim();
+    await client.query(`SELECT baaki_finish_push('{}', ARRAY[$1]::uuid[], '{}')`, [id]);
+    expect(await statusOf(id)).toBe('failed');
+  });
+
+  it('revokes a device the app was uninstalled from', async () => {
+    const person = await seedPerson();
+    await client.query(`SELECT baaki_finish_push('{}', '{}', ARRAY[$1]::text[])`, [
+      person.tokens[0],
+    ]);
+    const { rows } = await client.query(
+      `SELECT revoked_at FROM push_tokens WHERE expo_push_token = $1`,
+      [person.tokens[0]],
+    );
+    expect(rows[0]?.revoked_at).not.toBeNull();
+  });
+
+  it('keeps the row rather than deleting it', async () => {
+    // The same token coming back later is a reinstall, not a new device.
+    const person = await seedPerson();
+    await client.query(`SELECT baaki_finish_push('{}', '{}', ARRAY[$1]::text[])`, [
+      person.tokens[0],
+    ]);
+    const { rows } = await client.query(
+      `SELECT COUNT(*)::int AS n FROM push_tokens WHERE expo_push_token = $1`,
+      [person.tokens[0]],
+    );
+    expect(rows[0]?.n).toBe(1);
+  });
+
+  it('does not un-revoke a device on a second pass', async () => {
+    const person = await seedPerson();
+    await client.query(`SELECT baaki_finish_push('{}', '{}', ARRAY[$1]::text[])`, [
+      person.tokens[0],
+    ]);
+    const first = await client.query(
+      `SELECT revoked_at FROM push_tokens WHERE expo_push_token = $1`,
+      [person.tokens[0]],
+    );
+    await client.query(`SELECT baaki_finish_push('{}', '{}', ARRAY[$1]::text[])`, [
+      person.tokens[0],
+    ]);
+    const second = await client.query(
+      `SELECT revoked_at FROM push_tokens WHERE expo_push_token = $1`,
+      [person.tokens[0]],
+    );
+    expect(second.rows[0]?.revoked_at).toEqual(first.rows[0]?.revoked_at);
+  });
+});
+
+describe('who may run it', () => {
+  it('is nobody who is merely signed in', async () => {
+    // Claiming reads other people's inboxes. That is the service role's job and
+    // nobody else's.
+    const person = await seedPerson();
+    await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+      JSON.stringify({ sub: person.profileId, role: 'authenticated' }),
+    ]);
+    await client.query(`SET ROLE authenticated`);
+    try {
+      await expect(client.query(`SELECT baaki_claim_push_notifications(10)`)).rejects.toThrow(
+        /permission denied/i,
+      );
+      await expect(client.query(`SELECT baaki_finish_push()`)).rejects.toThrow(
+        /permission denied/i,
+      );
+    } finally {
+      await client.query(`RESET ROLE`);
+      await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       expo-network:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.10)(react@19.2.3)
+      expo-notifications:
+        specifier: ~57.0.8
+        version: 57.0.8(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
       expo-router:
         specifier: ~57.0.10
         version: 57.0.10(b87ba7b276fdb1ace9a6642717514448)
@@ -3064,6 +3067,9 @@ packages:
       expo-widgets:
         optional: true
 
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -3857,6 +3863,13 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+
+  expo-notifications@57.0.8:
+    resolution: {integrity: sha512-9pTNFMB9vk7MmULRSq7SD2nBRXhIh7IYAOSAFzFIYna6csJKdzeuKikjuUwP5KZYwxejoaN2BYBBqdLKaUpT/w==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-router@57.0.10:
     resolution: {integrity: sha512-E6Cjudl4wQ86KdEHqLGhBmfOFRdtzXTtRzEEDmqOvqtkAc9C637u0us7CGKkkee9m+kwuHqfhn779ww85rn/Pg==}
@@ -9134,6 +9147,8 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  badgin@1.2.3: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -10190,6 +10205,20 @@ snapshots:
     dependencies:
       expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
       react: 19.2.3
+
+  expo-notifications@57.0.8(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3):
+    dependencies:
+      '@expo/image-utils': 0.11.4(supports-color@8.1.1)(typescript@6.0.3)
+      abort-controller: 3.0.0
+      badgin: 1.2.3
+      expo: 57.0.10(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      expo-application: 57.0.2(expo@57.0.10)
+      expo-constants: 57.0.9(expo@57.0.10)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(supports-color@8.1.1)
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   expo-router@57.0.10(b87ba7b276fdb1ace9a6642717514448):
     dependencies:

--- a/supabase/functions/notify-fanout/index.ts
+++ b/supabase/functions/notify-fanout/index.ts
@@ -1,0 +1,131 @@
+/**
+ * notify-fanout — taps people on the shoulder about what is already in their
+ * inbox (TDR §7.1).
+ *
+ * The inbox is written the moment something happens, by whichever job or RPC
+ * caused it. This function is only the delivery half, and it is deliberately
+ * dumb: claim, render, send, record. Everything that could be got wrong lives
+ * somewhere it can be tested without a phone —
+ *
+ *   * claiming and closing out: `baaki_claim_push_notifications`, which is an
+ *     UPDATE rather than a SELECT so two overlapping runs cannot both send the
+ *     same reminder;
+ *   * building the messages and reading the tickets: `@baaki/core`, including
+ *     the mapping from a flat reply back to which device said what.
+ *
+ * Nobody signed in can call this. It reads other people's inboxes, which is the
+ * service role's business and no one else's.
+ */
+
+import { buildPushBatch, chunk, readPushTickets, type ExpoTicket } from '../_shared/core.js';
+import { asService, CORS_HEADERS, errorResponse, HttpError, json } from '../_shared/auth.ts';
+
+const EXPO_ENDPOINT = 'https://exp.host/--/api/v2/push/send';
+
+interface ClaimedRow {
+  id: string;
+  kind: string;
+  title: string;
+  body: string;
+  deep_link: string | null;
+  payload: Record<string, unknown>;
+  locale: string;
+  tokens: string[];
+}
+
+/** The facts a push can interpolate, taken from the row that was written. */
+function factsOf(payload: Record<string, unknown>): Record<string, string | undefined> {
+  const text = (key: string): string | undefined =>
+    typeof payload[key] === 'string' ? (payload[key] as string) : undefined;
+  return {
+    amount: text('amount'),
+    currency: text('currency'),
+    counterparty: text('counterparty'),
+    group: text('group'),
+    description: text('description'),
+    count: text('count'),
+  };
+}
+
+Deno.serve(async (request) => {
+  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
+
+  try {
+    // A plain comparison against the service key rather than a JWT check: this
+    // is machine-to-machine, the caller is a scheduler, and the key never
+    // leaves the server on either side.
+    const expected = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    if (!expected || request.headers.get('Authorization') !== `Bearer ${expected}`) {
+      throw new HttpError(401, 'NOT_AUTHORISED', 'This endpoint is not for clients');
+    }
+
+    const service = asService();
+
+    const { data, error } = await service.rpc('baaki_claim_push_notifications', { p_limit: 200 });
+    if (error) throw new HttpError(500, 'CLAIM_FAILED', error.message);
+
+    const rows = (data ?? []) as ClaimedRow[];
+    if (rows.length === 0) return json({ claimed: 0, sent: 0 });
+
+    const batch = buildPushBatch(
+      rows.map((row) => ({
+        id: row.id,
+        kind: row.kind,
+        title: row.title,
+        body: row.body,
+        deepLink: row.deep_link,
+        facts: factsOf(row.payload ?? {}),
+        locale: row.locale,
+        tokens: row.tokens,
+      })),
+    );
+
+    const delivered: string[] = [];
+    const failed: string[] = [];
+    const revoke: string[] = [];
+
+    const messageChunks = chunk(batch.messages);
+    const targetChunks = chunk(batch.targets);
+
+    for (const [index, messages] of messageChunks.entries()) {
+      const targets = targetChunks[index] ?? [];
+      let tickets: ExpoTicket[] = [];
+
+      try {
+        const response = await fetch(EXPO_ENDPOINT, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', accept: 'application/json' },
+          body: JSON.stringify(messages),
+        });
+        const parsed = (await response.json()) as { data?: ExpoTicket[] };
+        tickets = parsed.data ?? [];
+      } catch (unreachable) {
+        // Expo being down is not a reason to lose the notification. An empty
+        // ticket list marks the whole chunk failed, and the row stays in the
+        // inbox where the person will still see it.
+        console.error('expo push unreachable:', (unreachable as Error).message);
+      }
+
+      const outcome = readPushTickets(targets, tickets);
+      delivered.push(...outcome.delivered);
+      failed.push(...outcome.failed);
+      revoke.push(...outcome.revoke);
+    }
+
+    const { error: finishError } = await service.rpc('baaki_finish_push', {
+      p_delivered: delivered,
+      p_failed: failed,
+      p_revoke: revoke,
+    });
+    if (finishError) throw new HttpError(500, 'FINISH_FAILED', finishError.message);
+
+    return json({
+      claimed: rows.length,
+      sent: delivered.length,
+      failed: failed.length,
+      revoked: revoke.length,
+    });
+  } catch (error) {
+    return errorResponse(error, { fn: 'notify-fanout' });
+  }
+});


### PR DESCRIPTION
> **Stacked on #23.** Base is `feat/trip-reminders` because this uses `baaki_notify` and `notifications.dedupe_key` from it. Merge #23 first and this rebases onto main cleanly.

## Updating already worked

`expense_versions_insert` and `expenses_update` check *membership*, not authorship — anybody in the group can correct an expense, and the version history means nothing is lost when they do. That was deliberate: the person who spots that dinner was ₹1,800 is usually not the person who typed ₹1,300.

So this PR is the other half — the case editing cannot cover: **"I wasn't at that dinner."**

## The obvious implementation is the one thing that must not exist

If declining took you out of the split, then a share is something anybody can remove on their own, which makes a debt something anybody can delete. The ledger is worth exactly as much as that is impossible.

The first test in the suite is that assertion:

```ts
it('leaves every balance exactly where it was', async () => {
  // If this test can ever be made to fail, the ledger is worthless.
```

## So a decline is a claim, not a mutation

It's recorded against the expense, the group can see it, the person who entered it is told, and **the numbers move only when somebody actually corrects the expense**. That's the same trade ADR-007 makes for settlements: confirmation here is social rather than cryptographic, and the app's job is to make the disagreement visible, not to adjudicate it.

Three ways it ends:

- **somebody edits the expense** — a trigger closes open disputes, because the thing complained about no longer exists
- **the disputer withdraws it**
- **the author or an admin answers it**, with a note

Nobody can rule on their own complaint, in either direction. The table is read-only to clients — every write goes through an RPC that works out who is calling, so a dispute cannot be filed in somebody else's name (tested).

One row per person per expense rather than a pile of complaints: this is somebody's *position*, and they hold one at a time. How it changed lives in `activity_log`, which is the append-only record (ADR-004).

## Tone

ADR-010's rule. Almost every one of these is an honest mistake, and copy that calls it a dispute makes a fight out of a typo. The button says **"Something's wrong"**, with **"Fix it myself"** beside it — correcting it is the better answer whenever you know what it should say. The author's options are "They're right — I'll fix it" and "It's correct", not Accept/Reject.

## Testing

23 new database tests, including: balances unchanged (three angles), one position per person, retry sends no second notification but a genuine re-raise does, the disputer cannot resolve their own, an unrelated non-admin cannot either, an edit auto-closes, an outsider sees nothing, and a direct insert in someone else's name is refused by RLS.

**482 tests pass** across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6
