### PR TITLE
The scheduled jobs were callable by anybody with an account

### DIFF
--- a/e2e/m4-live.mjs
+++ b/e2e/m4-live.mjs
@@ -1,0 +1,199 @@
+/**
+ * The M4 additions, against the deployed project.
+ *
+ * Everything here has passing tests against a local Postgres already. What
+ * those cannot tell you is whether the thing that is *deployed* has them: a
+ * migration applied to the wrong database, an RPC that exists but was never
+ * granted, an RLS policy that reads differently through PostgREST than through
+ * a direct connection. Each of those has happened at least once in this repo,
+ * and each time it was a live run that found it.
+ *
+ * Run: node e2e/m4-live.mjs   (needs ANON_KEY)
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const URL = process.env.SUPABASE_URL ?? 'https://xvjzbpgcmotoahtqcxve.supabase.co';
+const ANON = process.env.ANON_KEY;
+
+if (!ANON) {
+  console.error('Set ANON_KEY.');
+  process.exit(1);
+}
+
+const pass = [];
+const fail = [];
+const check = (label, condition, detail = '') => {
+  (condition ? pass : fail).push(label);
+  console.log(`${condition ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`);
+};
+
+const client = createClient(URL, ANON, { auth: { persistSession: false } });
+await client.auth.signInAnonymously();
+
+const { data: groupId } = await client.rpc('baaki_create_group', {
+  p_name: 'M4 live',
+  p_type: 'trip',
+  p_currency: 'INR',
+  p_emoji: null,
+  p_simplify: true,
+});
+
+const { data: ghostId } = await client.rpc('baaki_add_ghost_member', {
+  p_group_id: groupId,
+  p_name: 'Ravi',
+  p_member_id: null,
+});
+const { data: members } = await client
+  .from('group_members')
+  .select('id, profile_id')
+  .eq('group_id', groupId);
+const me = members.find((member) => member.profile_id).id;
+
+// ── trip dates: columns exist and are writable by a member ──────────────────
+
+const dated = await client
+  .from('groups')
+  .update({
+    start_date: '2026-03-10',
+    end_date: '2026-03-14',
+    time_zone: 'Asia/Kolkata',
+    remind_daily: true,
+    remind_morning_at: '09:00:00',
+    remind_evening_at: '21:00:00',
+  })
+  .eq('id', groupId)
+  .select('start_date, end_date, time_zone, remind_morning_at')
+  .single();
+
+check('a group can say when the trip is', !dated.error, dated.error?.message ?? '');
+check(
+  'and the reminder times come back as they were set',
+  dated.data?.remind_morning_at?.startsWith('09:00'),
+  JSON.stringify(dated.data),
+);
+
+const backwards = await client
+  .from('groups')
+  .update({ start_date: '2026-03-20', end_date: '2026-03-14' })
+  .eq('id', groupId);
+check(
+  'a trip that ends before it starts is refused',
+  Boolean(backwards.error),
+  backwards.error?.message ?? 'accepted',
+);
+
+// ── an expense to disagree with ─────────────────────────────────────────────
+
+const written = await client.functions.invoke('expense-write', {
+  body: {
+    groupId,
+    expenseDate: '2026-03-11',
+    currency: 'INR',
+    description: 'Dinner',
+    amount: '30000',
+    participants: [me, ghostId],
+    splitParams: { kind: 'equal' },
+    payers: { [me]: '30000' },
+    clientMutationId: crypto.randomUUID(),
+  },
+});
+check('an expense still writes after the deploy', !written.error, written.error?.message ?? '');
+
+const expenseId = written.data?.expenseId;
+
+const balancesBefore = await client
+  .from('group_balances')
+  .select('member_id, balance')
+  .eq('group_id', groupId);
+
+// ── declining it ────────────────────────────────────────────────────────────
+
+const raised = await client.rpc('baaki_dispute_expense', {
+  p_expense_id: expenseId,
+  p_reason: 'I was not there',
+});
+check('an expense can be declined', !raised.error, raised.error?.message ?? '');
+
+const { data: disputes } = await client
+  .from('expense_disputes')
+  .select('id, status, reason')
+  .eq('expense_id', expenseId);
+check(
+  'the group can see who disagreed and why',
+  disputes?.[0]?.status === 'open' && disputes?.[0]?.reason === 'I was not there',
+  JSON.stringify(disputes),
+);
+
+const balancesAfter = await client
+  .from('group_balances')
+  .select('member_id, balance')
+  .eq('group_id', groupId);
+check(
+  'and it moves no money at all',
+  // The whole design in one assertion. A share anybody could drop on their own
+  // would be a debt anybody could delete.
+  JSON.stringify(balancesBefore.data) === JSON.stringify(balancesAfter.data),
+  JSON.stringify(balancesAfter.data),
+);
+
+const selfResolve = await client.rpc('baaki_resolve_dispute', {
+  p_dispute_id: disputes?.[0]?.id,
+  p_accept: true,
+  p_note: null,
+});
+check(
+  'nobody rules on their own complaint',
+  // The caller here is both the author and the disputer, and the author check
+  // must not be what lets them through.
+  Boolean(selfResolve.error),
+  selfResolve.error?.message ?? 'allowed',
+);
+
+const withdrawn = await client.rpc('baaki_withdraw_dispute', { p_expense_id: expenseId });
+check('a complaint can be taken back', !withdrawn.error, withdrawn.error?.message ?? '');
+
+// ── the fanout is not for clients ───────────────────────────────────────────
+
+const fanout = await client.functions.invoke('notify-fanout', { body: {} });
+check(
+  'notify-fanout refuses a signed-in caller',
+  // It reads other people's inboxes. Anything but a refusal here is a leak.
+  Boolean(fanout.error),
+  fanout.error?.message ?? 'accepted',
+);
+
+// Each of these was callable by any signed-in person on the deployed project,
+// while the same assertions passed against a local Postgres: Supabase grants
+// EXECUTE to anon and authenticated by default, so revoking from PUBLIC took
+// away a grant that was never what let them in. Claiming leaks other people's
+// notification text and their device tokens; auto-confirm settles strangers'
+// money. This block is the only thing that would have noticed.
+for (const [name, args] of [
+  ['baaki_auto_confirm_settlements', {}],
+  ['baaki_trip_nudges', {}],
+  ['baaki_claim_push_notifications', { p_limit: 1 }],
+  ['baaki_finish_push', {}],
+]) {
+  const attempt = await client.rpc(name, args);
+  check(
+    `${name} is not something a signed-in person can run`,
+    Boolean(attempt.error),
+    attempt.error?.message?.slice(0, 60) ?? 'ALLOWED',
+  );
+}
+
+// ── the inbox ───────────────────────────────────────────────────────────────
+
+const inbox = await client.from('notifications').select('id, kind, dedupe_key').limit(5);
+check('the inbox reads without error', !inbox.error, inbox.error?.message ?? '');
+
+const tokens = await client.from('push_tokens').select('id').limit(1);
+check('push tokens read without error', !tokens.error, tokens.error?.message ?? '');
+
+await client.from('groups').update({ archived_at: new Date().toISOString() }).eq('id', groupId);
+
+console.log(`\n${pass.length}/${pass.length + fail.length} passed`);
+if (fail.length > 0) {
+  console.log('Failed:', fail.join(', '));
+  process.exit(1);
+}

--- a/packages/db/prisma/migrations/20260806200000_job_functions_are_not_public/migration.sql
+++ b/packages/db/prisma/migrations/20260806200000_job_functions_are_not_public/migration.sql
@@ -1,0 +1,78 @@
+-- The scheduled jobs were callable by anybody with an account.
+--
+-- Found by running against the deployed project, and impossible to find any
+-- other way, because local and Supabase disagreed about a default:
+--
+--   Supabase runs `ALTER DEFAULT PRIVILEGES IN SCHEMA public
+--   GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role`.
+--
+-- So every function created there is granted to those roles *directly*, and
+-- `REVOKE ALL ... FROM PUBLIC` — which is what the job migrations did — takes
+-- away a grant that was never what let them in. A bare Postgres has no such
+-- default, so the tests asserting "permission denied" passed locally while the
+-- deployed database allowed all five.
+--
+-- What that meant, live:
+--
+--   * `baaki_auto_confirm_settlements()` — any signed-in person could confirm
+--     every pending settlement in the database, in groups they are not in.
+--   * `baaki_claim_push_notifications()` — returns other people's notification
+--     text and their device push tokens.
+--   * `baaki_finish_push()` — mark somebody else's notifications sent (so they
+--     never arrive) and revoke anybody's device.
+--   * `baaki_trip_nudges()` and `baaki_notify()` — write into other people's
+--     inboxes.
+--
+-- Two fixes, because removing the grant is only half of it:
+--
+--   1. Revoke it, explicitly, from the roles that actually hold it.
+--   2. Make local look like Supabase, so the next function to get this wrong
+--      fails in the test suite instead of in production.
+
+-- ──────────────────────────────── 1. local now has Supabase's default too ──
+-- This is a no-op on Supabase, which already does it. On a plain Postgres it
+-- reproduces the trap: from here on, a new function is granted to anon and
+-- authenticated unless the migration says otherwise, exactly as it would be in
+-- production — and the RLS tests will say so.
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+
+-- ─────────────────────────────────────────── 2. take the grant back again ──
+
+DO $$
+DECLARE
+  v_signature TEXT;
+BEGIN
+  FOREACH v_signature IN ARRAY ARRAY[
+    'public.baaki_auto_confirm_settlements(timestamptz, interval)',
+    'public.baaki_trip_nudges(timestamptz)',
+    'public.baaki_claim_push_notifications(integer)',
+    'public.baaki_finish_push(uuid[], uuid[], text[])',
+    'public.baaki_notify(uuid, uuid, text, text, text, text, jsonb, text)'
+  ]
+  LOOP
+    EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC', v_signature);
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+      EXECUTE format('REVOKE ALL ON FUNCTION %s FROM anon', v_signature);
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+      EXECUTE format('REVOKE ALL ON FUNCTION %s FROM authenticated', v_signature);
+    END IF;
+    -- The jobs run as the service role, and cron runs as the database owner.
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', v_signature);
+    END IF;
+  END LOOP;
+END
+$$;
+
+-- The RPCs that people *are* meant to call keep their grant, stated here so the
+-- two lists sit next to each other and the difference is deliberate rather
+-- than remembered.
+GRANT EXECUTE ON FUNCTION
+  public.baaki_mark_notifications_read(uuid[]),
+  public.baaki_dispute_expense(uuid, text),
+  public.baaki_withdraw_dispute(uuid),
+  public.baaki_resolve_dispute(uuid, boolean, text)
+TO authenticated, anon;


### PR DESCRIPTION
Already applied to the live project — this PR is the code catching up with the fix, not the fix waiting to happen.

## What happened

Found by running `e2e/m4-live.mjs` against the deployed project after this afternoon's deploy. Local Postgres and Supabase disagree about a default:

> Supabase runs `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role`.

So every function created there is granted to those roles **directly**. `REVOKE ALL ... FROM PUBLIC` — which is what the job migrations did, and which is the advice you'll find everywhere — removes a grant that was never what let them in.

A bare Postgres has no such default. The tests asserting "permission denied" passed locally, against a database that was not the one being protected.

## What was reachable by any signed-in person, including an anonymous guest

| Function | What it gave them |
|---|---|
| `baaki_auto_confirm_settlements()` | Confirm every pending settlement in the database, in groups they are not a member of |
| `baaki_claim_push_notifications()` | Other people's notification text, and their device push tokens |
| `baaki_finish_push()` | Mark somebody else's notifications sent so they never arrive; revoke anybody's device |
| `baaki_trip_nudges()`, `baaki_notify()` | Write into other people's inboxes |

Nothing on the project was seven days old, so auto-confirm had nothing to settle. That is luck, not a mitigation.

## The fix, in two parts

**1. Revoke from the roles that actually hold it** — `anon` and `authenticated` — and grant to `service_role`, which is what runs the jobs. The user-facing RPCs (`baaki_dispute_expense`, `baaki_withdraw_dispute`, `baaki_resolve_dispute`, `baaki_mark_notifications_read`) keep their grant, stated in the same migration so the two lists sit next to each other and the difference reads as deliberate.

**2. Give the local database Supabase's default privileges.** Otherwise the next function to get this wrong fails in production again. Local wasn't missing a check — it was a *different database*, and the tests were honest about the wrong one. This is a no-op against Supabase and reproduces the trap everywhere else.

## Verification

Before, against live:

```
ALLOWED  baaki_auto_confirm_settlements
ALLOWED  baaki_trip_nudges
ALLOWED  baaki_claim_push_notifications
ALLOWED  baaki_finish_push
```

After:

```
denied   baaki_auto_confirm_settlements — permission denied for function
denied   baaki_trip_nudges — permission denied for function
denied   baaki_claim_push_notifications — permission denied for function
denied   baaki_finish_push — permission denied for function
```

`e2e/m4-live.mjs` now asserts all four refusals as part of the M4 surface — **16/16 against the deployed project**, along with trip dates, declining an expense, the balances not moving when somebody does, and `notify-fanout` refusing a client. 173 database tests still pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6
