### PR TITLE
feat: screens that move, and a switch for when they should not

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -22,6 +22,7 @@ import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { pickAvatarPhoto } from '@/lib/image';
 import { describeGrace, useLock } from '@/lib/lock';
+import { useMotion } from '@/lib/motion';
 
 interface SettingsRow {
   icon: keyof typeof Ionicons.glyphMap;
@@ -115,6 +116,7 @@ export default function ProfileScreen() {
   const { profile, isGuest, updateProfile, signOut } = useAuth();
 
   const { enabled: lockEnabled, supported: lockSupported, graceSeconds } = useLock();
+  const { animated, overridden: motionOverridden } = useMotion();
 
   const [name, setName] = useState(profile?.display_name ?? '');
   const [vpa, setVpa] = useState(profile?.default_vpa ?? '');
@@ -171,6 +173,12 @@ export default function ProfileScreen() {
       { text: 'Cancel', style: 'cancel' },
     ]);
   };
+
+  const motionSummary = motionOverridden
+    ? animated
+      ? 'Screen animations on'
+      : 'Screen animations off'
+    : `Following your phone — animations ${animated ? 'on' : 'off'}`;
 
   const lockSummary = !lockSupported
     ? 'This device has no biometrics set up'
@@ -314,7 +322,18 @@ export default function ProfileScreen() {
           </Card>
         ) : null}
 
-        <SettingsSection title="Settings" rows={SETTINGS} />
+        <SettingsSection
+          title="Settings"
+          rows={[
+            ...SETTINGS,
+            {
+              icon: 'sparkles-outline',
+              label: 'Motion',
+              hint: motionSummary,
+              route: '/settings/motion',
+            },
+          ]}
+        />
 
         {/* Security is its own section rather than one row among many: it is
             the only group of settings somebody comes looking for. */}

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -11,6 +11,7 @@ import { Button, ThemeProvider, Text, useTheme } from '@baaki/ui';
 
 import { AuthProvider, useAuth } from '@/lib/auth';
 import { LockProvider, useLock } from '@/lib/lock';
+import { MotionProvider, TRANSITION_MS, useMotion } from '@/lib/motion';
 import { initObservability, withObservability } from '@/lib/observability';
 import { ensureAndroidChannel, pushSupported, routeForNotification } from '@/lib/push';
 import { SyncProvider } from '@/sync';
@@ -51,13 +52,15 @@ function RootLayout() {
           <AuthProvider>
             <SyncProvider>
               <LockProvider>
-                <ThemeProvider>
-                  <StatusBar style="auto" />
-                  <PushRouting />
-                  <LockGate>
-                    <AuthGate />
-                  </LockGate>
-                </ThemeProvider>
+                <MotionProvider>
+                  <ThemeProvider>
+                    <StatusBar style="auto" />
+                    <PushRouting />
+                    <LockGate>
+                      <AuthGate />
+                    </LockGate>
+                  </ThemeProvider>
+                </MotionProvider>
               </LockProvider>
             </SyncProvider>
           </AuthProvider>
@@ -140,6 +143,17 @@ function AuthGate() {
   const segments = useSegments();
   const router = useRouter();
   const theme = useTheme();
+  const { animated } = useMotion();
+
+  /**
+   * A push slides in from the right and a modal rises from the bottom, which is
+   * how the screen says whether you have gone somewhere or opened something on
+   * top. With motion off, both become `none` — not a faster slide, because a
+   * shortened animation is still animation to somebody who cannot watch one.
+   */
+  const push = animated ? ('slide_from_right' as const) : ('none' as const);
+  const sheet = animated ? ('slide_from_bottom' as const) : ('none' as const);
+  const modal = { presentation: 'modal' as const, animation: sheet };
 
   useEffect(() => {
     if (loading) return;
@@ -169,36 +183,33 @@ function AuthGate() {
       screenOptions={{
         headerShown: false,
         contentStyle: { backgroundColor: 'transparent' },
+        animation: push,
+        animationDuration: TRANSITION_MS,
+        // Swiping back is the same journey as the animation, so it belongs to
+        // the same switch: with motion off there is nothing to drag.
+        gestureEnabled: animated,
       }}
     >
-      <Stack.Screen name="sign-in" />
-      <Stack.Screen name="(tabs)" />
-      <Stack.Screen name="new-group" options={{ presentation: 'modal' }} />
+      {/* Signing in and out replaces the whole tree; sliding it would suggest a
+          place to go back to, and there is not one. */}
+      <Stack.Screen name="sign-in" options={{ animation: 'none' }} />
+      <Stack.Screen name="(tabs)" options={{ animation: 'none' }} />
+      <Stack.Screen name="new-group" options={modal} />
       <Stack.Screen name="group/[id]/index" />
-      <Stack.Screen
-        name="group/[id]/add-expense"
-        options={{ presentation: 'modal', animation: 'slide_from_bottom' }}
-      />
-      <Stack.Screen
-        name="group/[id]/settle"
-        options={{ presentation: 'modal', animation: 'slide_from_bottom' }}
-      />
+      <Stack.Screen name="group/[id]/add-expense" options={modal} />
+      <Stack.Screen name="group/[id]/settle" options={modal} />
       <Stack.Screen name="group/[id]/simplify" />
       <Stack.Screen name="group/[id]/settings" />
       <Stack.Screen name="group/[id]/members" />
       <Stack.Screen name="group/[id]/member/[memberId]" />
       <Stack.Screen name="group/[id]/expense/[expenseId]" />
-      <Stack.Screen
-        name="group/[id]/invite"
-        options={{ presentation: 'modal', animation: 'slide_from_bottom' }}
-      />
-      <Stack.Screen
-        name="group/[id]/itemize"
-        options={{ presentation: 'modal', animation: 'slide_from_bottom' }}
-      />
+      <Stack.Screen name="group/[id]/invite" options={modal} />
+      <Stack.Screen name="group/[id]/itemize" options={modal} />
       <Stack.Screen name="settings/notifications" />
       <Stack.Screen name="settings/export" />
+      <Stack.Screen name="settings/import" />
       <Stack.Screen name="settings/lock" />
+      <Stack.Screen name="settings/motion" />
       <Stack.Screen name="settings/account" />
       <Stack.Screen name="join" />
       <Stack.Screen name="inbox" />

--- a/apps/mobile/src/app/settings/motion.tsx
+++ b/apps/mobile/src/app/settings/motion.tsx
@@ -1,0 +1,106 @@
+/**
+ * Motion, and the switch for it.
+ *
+ * Three states, not two: on, off, and "whatever the phone says". The third is
+ * the default and matters most — somebody who has already told Android they get
+ * motion sick should not have to tell every app separately, and an app that
+ * makes them is an app they stop using.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { ScrollView, View } from 'react-native';
+
+import {
+  Badge,
+  Button,
+  Card,
+  Divider,
+  IconButton,
+  Row,
+  Screen,
+  Text,
+  Toggle,
+  useTheme,
+} from '@baaki/ui';
+
+import { useMotion } from '@/lib/motion';
+
+export default function MotionSettingsScreen() {
+  const theme = useTheme();
+  const { animated, systemReducesMotion, overridden, setAnimated } = useMotion();
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label="Back" onPress={() => router.back()}>
+            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">Motion</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        <Card style={{ gap: theme.spacing.lg }}>
+          <Row style={{ justifyContent: 'space-between', gap: theme.spacing.lg }}>
+            <View style={{ flex: 1, gap: 2 }}>
+              <Text variant="subheading">Animate between screens</Text>
+              <Text variant="caption" tone="muted">
+                Screens slide in from the right, and sheets rise from the bottom — which is how a
+                screen tells you whether you have gone somewhere or opened something on top of where
+                you were.
+              </Text>
+            </View>
+            <Toggle
+              value={animated}
+              onValueChange={(value) => void setAnimated(value)}
+              accessibilityLabel="Animate between screens"
+            />
+          </Row>
+
+          <Divider />
+
+          <View style={{ gap: theme.spacing.sm }}>
+            <Row style={{ justifyContent: 'space-between' }}>
+              <Text variant="caption" tone="muted">
+                This phone
+              </Text>
+              <Badge
+                label={systemReducesMotion ? 'Reduce motion is on' : 'Reduce motion is off'}
+                tone={systemReducesMotion ? 'brand' : 'neutral'}
+              />
+            </Row>
+            <Text variant="caption" tone="muted">
+              {overridden
+                ? `You have set this yourself, so it stays ${animated ? 'on' : 'off'} whatever the phone says.`
+                : systemReducesMotion
+                  ? 'Following your accessibility settings, which ask for less movement.'
+                  : 'Following your accessibility settings.'}
+            </Text>
+            {overridden ? (
+              <Button
+                label="Follow my phone's setting"
+                variant="ghost"
+                onPress={() => void setAnimated(null)}
+              />
+            ) : null}
+          </View>
+        </Card>
+
+        <Text variant="micro" tone="faint" align="center">
+          Turning motion off does not shorten the animations — it removes them. A faster animation
+          is still an animation to somebody who cannot watch one.
+        </Text>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/lib/motion.tsx
+++ b/apps/mobile/src/lib/motion.tsx
@@ -1,0 +1,106 @@
+/**
+ * Whether screens move.
+ *
+ * Transitions are not decoration: sliding a screen in from the right is what
+ * tells you a push happened and where "back" is, and a modal rising from the
+ * bottom is what says this is a thing you are on top of rather than somewhere
+ * you have gone. Removing them entirely costs that, so the default is on.
+ *
+ * But they are also the first thing to hurt. Motion sickness and vestibular
+ * disorders are real, the phone already has a switch for it, and an app that
+ * ignores that switch is an app somebody has to stop using. So the OS setting
+ * is the default rather than a suggestion, and this preference exists to
+ * override it in either direction — including turning motion off on a phone
+ * that never asked, which is also how you make an old device feel quick.
+ *
+ * TDR §11 treats accessibility settings as inputs, not hints.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AccessibilityInfo } from 'react-native';
+
+const KEY = 'baaki.animations_enabled';
+
+interface MotionValue {
+  /** Whether screen transitions should play. */
+  animated: boolean;
+  /** True while the stored preference is still being read. */
+  loading: boolean;
+  /** What the phone's own accessibility setting says, for explaining the default. */
+  systemReducesMotion: boolean;
+  /** Null puts it back under the system setting's control. */
+  setAnimated: (value: boolean | null) => Promise<void>;
+  /** Whether the person has overridden the system setting. */
+  overridden: boolean;
+}
+
+const MotionContext = createContext<MotionValue | null>(null);
+
+export function MotionProvider({ children }: { children: ReactNode }) {
+  const [stored, setStored] = useState<boolean | null>(null);
+  const [systemReducesMotion, setSystemReducesMotion] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    void (async () => {
+      const [saved, reduce] = await Promise.all([
+        AsyncStorage.getItem(KEY).catch(() => null),
+        AccessibilityInfo.isReduceMotionEnabled().catch(() => false),
+      ]);
+      if (!active) return;
+      setStored(saved === null ? null : saved === 'true');
+      setSystemReducesMotion(reduce);
+      setLoading(false);
+    })();
+
+    // The switch can be flipped while the app is open, and somebody who reaches
+    // for it mid-session is exactly the person who needs it to take effect now.
+    const subscription = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      setSystemReducesMotion,
+    );
+    return () => {
+      active = false;
+      subscription.remove();
+    };
+  }, []);
+
+  const setAnimated = useCallback(async (value: boolean | null) => {
+    setStored(value);
+    if (value === null) await AsyncStorage.removeItem(KEY).catch(() => undefined);
+    else await AsyncStorage.setItem(KEY, String(value)).catch(() => undefined);
+  }, []);
+
+  const value = useMemo<MotionValue>(
+    () => ({
+      animated: stored ?? !systemReducesMotion,
+      loading,
+      systemReducesMotion,
+      setAnimated,
+      overridden: stored !== null,
+    }),
+    [stored, systemReducesMotion, loading, setAnimated],
+  );
+
+  return <MotionContext.Provider value={value}>{children}</MotionContext.Provider>;
+}
+
+export function useMotion(): MotionValue {
+  const value = useContext(MotionContext);
+  if (!value) throw new Error('useMotion must be used inside MotionProvider');
+  return value;
+}
+
+/** How long a transition runs. Short enough to feel like a response, not a scene. */
+export const TRANSITION_MS = 260;


### PR DESCRIPTION
Transitions are not decoration. Sliding in from the right is what tells you a push happened and where "back" is; a sheet rising from the bottom is what says this is something on top of where you were rather than somewhere you have gone. The stack had neither except on four modals, so most of the app cut between screens.

Both now come from one preference, with **three** states rather than two: on, off, and *whatever the phone says*. The third is the default and matters most — somebody who has already told Android they get motion sick should not have to tell every app separately. `reduceMotionChanged` is subscribed to as well as read once, because the person who reaches for that switch mid-session is exactly the one who needs it to take effect now.

Off means `none`, not a shorter duration: a faster animation is still an animation to somebody who cannot watch one. The back gesture goes with it — swiping back is the same journey as the animation.

Sign-in and the tab root stay unanimated in both modes. They replace the whole tree, and sliding that would suggest a place to go back to, which there is not.

Settings → **Motion**, with a live summary on the Settings row ("Following your phone — animations on").

Also registers `settings/import` in the stack, which the Splitwise PR added as a route but never declared.

## Verification

Driven, not just rendered:

- Screen renders; toggle flips
- Flipping it writes `baaki.animations_enabled=false` to storage and the copy changes to "You have set this yourself, so it stays off whatever the phone says"
- Navigation still works with motion off
- "Follow my phone's setting" clears the override and the copy reverts to "Following your accessibility settings"
- The Settings row shows the live state

typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6
