### PR TITLE
fix: the Friends tab was never in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,11 +41,14 @@ packages/core/dist/
 # Shell artefacts: an unquoted JS arrow in a terminal command (`=> row.id`)
 # is parsed as a redirect and silently creates an empty file. These are always
 # accidents, never source.
-*.id
-*)
-{
-{,
-({
+#
+# They are deliberately NOT ignored. The patterns that used to live here (`*)`,
+# `{`, `({`) matched directories as well as files: `*)` swallowed the whole
+# `app/(tabs)/` directory, so `people.tsx` was created, ran locally forever, and
+# was never committed — the tab bar shipped pointing at a route that did not
+# exist in the repo. A stray empty file showing up in `git status` is noise you
+# delete in one command; a source directory silently missing from the repo is a
+# feature that disappears on somebody else's clone.
 
 # Next.js
 .next/

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -15,8 +15,8 @@ export default function TabsLayout() {
       icon: (color) => <Ionicons name="home" size={20} color={color} />,
     },
     {
-      key: 'people',
-      label: 'People',
+      key: 'friends',
+      label: t.friends,
       icon: (color) => <Ionicons name="people" size={20} color={color} />,
     },
     {
@@ -43,7 +43,7 @@ export default function TabsLayout() {
       )}
     >
       <Tabs.Screen name="index" />
-      <Tabs.Screen name="people" />
+      <Tabs.Screen name="friends" />
       <Tabs.Screen name="activity" />
       <Tabs.Screen name="profile" />
     </Tabs>

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -1,0 +1,161 @@
+/**
+ * Everybody you are not square with, across every group.
+ *
+ * Two things this screen refuses to do, because both would put a confident
+ * wrong number in front of somebody:
+ *
+ * It never adds two currencies together. Somebody can owe you ₹500 and be owed
+ * €20, and there is no honest single figure without a rate — so they appear as
+ * two lines rather than one invented total (ADR-003).
+ *
+ * It never merges two ghosts with the same name. Nothing proves the Ravi in
+ * your Goa group is the Ravi in your flat group, and merging two people's
+ * debts is not something you can undo once it is done. Only people with an
+ * account are followed across groups, because a profile id is proof.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { router } from 'expo-router';
+import { RefreshControl, ScrollView, View } from 'react-native';
+
+import {
+  Avatar,
+  Badge,
+  Card,
+  EmptyState,
+  ListRow,
+  MoneyText,
+  Screen,
+  SectionHeader,
+  Text,
+  useTheme,
+} from '@baaki/ui';
+
+import { fetchPeopleBalances, type PersonBalanceRow } from '@/data/api';
+import { useStrings } from '@/i18n';
+
+export default function FriendsScreen() {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+
+  const people = useQuery({
+    queryKey: ['people', 'balances'],
+    queryFn: fetchPeopleBalances,
+  });
+  const rows = people.data ?? [];
+
+  const owedToYou = rows.filter((row) => BigInt(row.net) > 0n);
+  const youOwe = rows.filter((row) => BigInt(row.net) < 0n);
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: 170,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={people.isFetching && !people.isLoading}
+            onRefresh={() => void people.refetch()}
+            tintColor={theme.color.brand}
+          />
+        }
+      >
+        <Text variant="title" style={{ paddingTop: theme.spacing.md }}>
+          {t.friends}
+        </Text>
+
+        {rows.length === 0 ? (
+          <EmptyState
+            title="All square"
+            body="Nobody owes you anything and you owe nobody. Friends you are settling up with will appear here."
+          />
+        ) : (
+          <>
+            <FriendsSection
+              title="Owes you"
+              rows={owedToYou}
+              locale={locale}
+              emptyBody="Nobody owes you anything right now."
+            />
+            <FriendsSection
+              title="You owe"
+              rows={youOwe}
+              locale={locale}
+              emptyBody="You are not behind with anyone."
+            />
+
+            <Text variant="micro" tone="faint" align="center">
+              Amounts are kept per currency, never converted into one total. People without an
+              account are counted per group, because two people can share a name.
+            </Text>
+          </>
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}
+
+function FriendsSection({
+  title,
+  rows,
+  locale,
+  emptyBody,
+}: {
+  title: string;
+  rows: PersonBalanceRow[];
+  locale: string;
+  emptyBody: string;
+}): React.JSX.Element {
+  const theme = useTheme();
+
+  return (
+    <View>
+      <SectionHeader title={title} />
+      {rows.length === 0 ? (
+        <Card>
+          <Text variant="caption" tone="muted">
+            {emptyBody}
+          </Text>
+        </Card>
+      ) : (
+        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+          {rows.map((row, index) => (
+            <View key={`${row.person_key}-${row.currency}`}>
+              <ListRow
+                title={row.display_name}
+                subtitle={
+                  row.group_count === 1 ? 'in one group' : `across ${row.group_count} groups`
+                }
+                leading={<Avatar name={row.display_name} size={40} />}
+                // Only linkable when there is a single group to link to;
+                // otherwise this amount is a sum and no one group explains it.
+                onPress={
+                  row.only_group_id ? () => router.push(`/group/${row.only_group_id}`) : undefined
+                }
+                trailing={
+                  <View style={{ alignItems: 'flex-end', gap: 2 }}>
+                    <MoneyText
+                      amount={BigInt(row.net)}
+                      currency={row.currency}
+                      locale={locale}
+                      variant="subheading"
+                      mode="balance"
+                    />
+                    {row.is_ghost ? <Badge label="Not joined" /> : null}
+                  </View>
+                }
+              />
+              {index < rows.length - 1 ? (
+                <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              ) : null}
+            </View>
+          ))}
+        </Card>
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -346,7 +346,12 @@ export default function ProfileScreen() {
               hint: lockSummary,
               route: '/settings/lock',
             },
-            { icon: 'log-out-outline', label: 'Sign out', hint: signOutHint, onPress: confirmSignOut },
+            {
+              icon: 'log-out-outline',
+              label: 'Sign out',
+              hint: signOutHint,
+              onPress: confirmSignOut,
+            },
           ]}
         />
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -18,6 +18,7 @@ export interface UiStrings {
   yourGroups: string;
   newGroup: string;
   activity: string;
+  friends: string;
   profile: string;
   home: string;
   addExpense: string;
@@ -59,6 +60,7 @@ const en: UiStrings = {
   yourGroups: 'Your groups',
   newGroup: 'New group',
   activity: 'Activity',
+  friends: 'Friends',
   profile: 'Account',
   home: 'Home',
   addExpense: 'Add expense',
@@ -101,6 +103,7 @@ const ta: UiStrings = {
   yourGroups: 'உங்கள் குழுக்கள்',
   newGroup: 'புதிய குழு',
   activity: 'செயல்பாடு',
+  friends: 'நண்பர்கள்',
   profile: 'கணக்கு',
   home: 'முகப்பு',
   addExpense: 'செலவு சேர்',
@@ -128,6 +131,7 @@ const hi: UiStrings = {
   yourGroups: 'आपके समूह',
   newGroup: 'नया समूह',
   activity: 'गतिविधि',
+  friends: 'दोस्त',
   profile: 'खाता',
   home: 'होम',
   addExpense: 'खर्च जोड़ें',


### PR DESCRIPTION
`.gitignore` had `*)` to swallow empty files created by unquoted shell arrows. It also matches the `(tabs)` directory, so `people.tsx` — the whole tab — was never committed. It ran locally forever; any clone, CI checkout, or EAS upload got a tab bar pointing at a route with no screen.

Prettier 3 uses `.gitignore` as a default ignore path, so `(tabs)/profile.tsx` was also unformatted in the repo with `format:check` green. Formatted now.

The patterns are gone and the stray empty files they were hiding are deleted.

Also renames People to Friends across the user-facing surface, with the label going through i18n (en/ta/hi) rather than hardcoded. The data layer keeps its `people` names — that view counts everybody you share a ledger with, including people who never joined.

Verified by driving the running app: `/friends` resolves, the title renders, the tab pill reads Friends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6