### PR TITLE
feat: update prompt, and a wall for builds that must not run

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,54 @@ builds and runs unchanged:
 A DSN is public by design: it can only write events, which is why it ships in
 the binary. `SENTRY_AUTH_TOKEN` is the one that reads, and it stays in CI.
 
+## Releasing, and stopping old builds
+
+The version is compiled into the binary, so a build can only ever describe
+itself — it cannot know something newer exists. The policy lives in
+`public.app_releases`, one row per store, and the app asks on launch and on
+every foreground.
+
+| Column            | Means                                          |
+| ----------------- | ---------------------------------------------- |
+| `latest_version`  | what is published — a dismissible banner       |
+| `minimum_version` | the oldest build allowed to open — a hard wall |
+| `store_url`       | where the Update button goes                   |
+| `message`         | optional, replaces the default wall copy       |
+
+Raising them is one statement, and it takes effect on the next foreground with
+no app release involved:
+
+```sql
+-- a new build is out; nothing is wrong with the old one
+UPDATE app_releases SET latest_version = '0.2.0' WHERE platform = 'android';
+
+-- 0.1.x may no longer run: it computed something wrongly
+UPDATE app_releases
+   SET minimum_version = '0.2.0',
+       message = 'Expenses added on the old version split rupees wrongly.'
+ WHERE platform = 'android';
+```
+
+Only the service role can write it; everybody, including signed-out guests, can
+read it, because the check runs before the sign-in screen.
+
+Three things stop a mistake here from bricking every phone:
+
+- A `CHECK` refuses a `minimum_version` above `latest_version` — that row would
+  block every build in existence, including the one the Update button installs.
+- A `CHECK` refuses a version string the client cannot compare (`v2`, `2.0-rc`),
+  which would otherwise silently switch the policy off.
+- The client fails towards opening: no answer, an unreadable version, or a
+  policy it does not understand all resolve to "carry on". The one exception is
+  a policy it has already fetched, which is cached and honoured offline —
+  "this build computes money wrongly" does not stop being true when the phone
+  loses signal. Every foreground re-checks, so a corrected policy lands as soon
+  as there is a connection.
+
+The comparison itself is `compareVersions` in `packages/core/src/version`,
+mirrored in SQL by `baaki_version_key()` so the database and the app cannot
+disagree about which of two versions is newer.
+
 ## Money rules
 
 - Amounts are **`BIGINT` minor units** plus an ISO-4217 code. No float, no

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -9,9 +9,11 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { Button, ThemeProvider, Text, useTheme } from '@baaki/ui';
 
+import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
 import { LockProvider, useLock } from '@/lib/lock';
 import { MotionProvider, TRANSITION_MS, useMotion } from '@/lib/motion';
+import { UpdateProvider } from '@/lib/update';
 import { initObservability, withObservability } from '@/lib/observability';
 import { ensureAndroidChannel, pushSupported, routeForNotification } from '@/lib/push';
 import { SyncProvider } from '@/sync';
@@ -53,13 +55,23 @@ function RootLayout() {
             <SyncProvider>
               <LockProvider>
                 <MotionProvider>
-                  <ThemeProvider>
-                    <StatusBar style="auto" />
-                    <PushRouting />
-                    <LockGate>
-                      <AuthGate />
-                    </LockGate>
-                  </ThemeProvider>
+                  <UpdateProvider>
+                    <ThemeProvider>
+                      <StatusBar style="auto" />
+                      {/* Outside the lock and the auth gate on purpose: a build
+                          we have stopped trusting should not be unlocking a
+                          ledger or signing anybody in either. */}
+                      <UpdateGate>
+                        <PushRouting />
+                        <LockGate>
+                          <AuthGate />
+                        </LockGate>
+                        {/* Last, so it paints over the screen rather than
+                            under it. */}
+                        <UpdateBanner />
+                      </UpdateGate>
+                    </ThemeProvider>
+                  </UpdateProvider>
                 </MotionProvider>
               </LockProvider>
             </SyncProvider>

--- a/apps/mobile/src/components/UpdateGate.tsx
+++ b/apps/mobile/src/components/UpdateGate.tsx
@@ -1,0 +1,135 @@
+/**
+ * The wall and the nudge.
+ *
+ * `UpdateGate` replaces the whole app when the installed build is no longer
+ * allowed to run. It says what is happening, gives the one button that fixes
+ * it, and — because a wall with no way past it is worse than no wall — a way
+ * to ask again, for the case where the policy itself was the mistake.
+ *
+ * `UpdateBanner` is the other half: a newer build exists, nothing is wrong, so
+ * it sits above the content and can be waved away.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Button, Card, Row, Text, useTheme } from '@baaki/ui';
+
+import { useUpdate } from '@/lib/update';
+
+export function UpdateGate({ children }: { children: React.ReactNode }) {
+  const { decision } = useUpdate();
+  if (decision !== 'required') return <>{children}</>;
+  return <BlockingScreen />;
+}
+
+function BlockingScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const { message, installed, latest, openStore, recheck } = useUpdate();
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: theme.spacing.xl,
+        backgroundColor: theme.color.bg,
+        padding: theme.spacing.xxxl,
+      }}
+    >
+      <View
+        style={{
+          width: 72,
+          height: 72,
+          borderRadius: theme.radius.pill,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: theme.color.brandSoft,
+        }}
+      >
+        <Ionicons name="arrow-up-circle" size={36} color={theme.color.brand} />
+      </View>
+
+      <Text variant="heading" align="center">
+        Baaki needs updating
+      </Text>
+
+      <Text variant="caption" tone="muted" align="center">
+        {message ??
+          'This version can no longer talk to Baaki, so it has been stopped rather than left to show you numbers that might be wrong.'}
+      </Text>
+
+      {/* Said plainly, because "will I lose my data" is the actual worry and
+          nobody is going to install anything until it is answered. */}
+      <Text variant="caption" tone="muted" align="center">
+        Nothing is lost. Every group, expense and settlement is on the server and will be exactly
+        where you left it.
+      </Text>
+
+      <View style={{ alignSelf: 'stretch', gap: theme.spacing.sm }}>
+        <Button label="Update Baaki" size="lg" fullWidth onPress={openStore} />
+        <Button
+          label="I have already updated"
+          variant="ghost"
+          fullWidth
+          onPress={() => void recheck()}
+        />
+      </View>
+
+      <Text variant="micro" tone="faint" align="center">
+        You have {installed}
+        {latest ? ` · ${latest} is available` : ''}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Sits over the top of whatever screen is showing. Absolute rather than in the
+ * layout so that adding it never moves anything: a banner that reflows every
+ * screen underneath it is a banner that gets dismissed for the wrong reason.
+ */
+export function UpdateBanner(): React.JSX.Element | null {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const { decision, dismissed, dismiss, openStore, latest } = useUpdate();
+
+  if (decision !== 'suggested' || dismissed) return null;
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={{
+        position: 'absolute',
+        top: insets.top + theme.spacing.sm,
+        left: theme.spacing.xl,
+        right: theme.spacing.xl,
+        zIndex: 10,
+      }}
+    >
+      <Card style={{ gap: theme.spacing.sm, ...theme.shadow.lifted }}>
+        <Row style={{ gap: theme.spacing.md }}>
+          <Ionicons name="arrow-up-circle-outline" size={22} color={theme.color.brand} />
+          <View style={{ flex: 1 }}>
+            <Text variant="caption">
+              {latest ? `Baaki ${latest} is out` : 'A new Baaki is out'}
+            </Text>
+            <Text variant="micro" tone="faint">
+              Worth a minute when you have one.
+            </Text>
+          </View>
+        </Row>
+        <Row style={{ gap: theme.spacing.sm }}>
+          <View style={{ flex: 1 }}>
+            <Button label="Update" size="sm" fullWidth onPress={openStore} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Button label="Not now" size="sm" variant="ghost" fullWidth onPress={dismiss} />
+          </View>
+        </Row>
+      </Card>
+    </View>
+  );
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1014,3 +1014,29 @@ export async function fetchPeopleBalances(): Promise<PersonBalanceRow[]> {
   if (error) throw new Error(error.message);
   return (data ?? []) as PersonBalanceRow[];
 }
+
+// ────────────────────────────────────────── which builds may still run ──
+
+export interface ReleaseRow {
+  platform: string;
+  latest_version: string;
+  minimum_version: string;
+  store_url: string;
+  message: string | null;
+}
+
+/**
+ * The version policy for one store.
+ *
+ * Readable signed out on purpose: this runs before the sign-in screen, because
+ * a client too old to be trusted with the ledger is too old to sign in to it.
+ */
+export async function fetchReleasePolicy(platform: 'ios' | 'android'): Promise<ReleaseRow | null> {
+  const { data, error } = await supabase
+    .from('app_releases')
+    .select('platform, latest_version, minimum_version, store_url, message')
+    .eq('platform', platform)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data as ReleaseRow | null) ?? null;
+}

--- a/apps/mobile/src/lib/update.tsx
+++ b/apps/mobile/src/lib/update.tsx
@@ -1,0 +1,186 @@
+/**
+ * Whether the build somebody is holding is still allowed to run.
+ *
+ * The version number is compiled into the binary, so a build can only ever
+ * describe itself — it cannot know that something newer exists. The policy
+ * therefore lives on the server (`app_releases`, one row per store) and the app
+ * asks. Two outcomes:
+ *
+ *   suggested — there is a newer build. A banner they can dismiss, and the
+ *   dismissal sticks per version, or the banner becomes the thing they resent
+ *   rather than the thing they act on.
+ *
+ *   required — this build may no longer talk to the server. A wall, because
+ *   letting it through would put wrong numbers into a ledger other people read.
+ *
+ * Everything here fails towards opening the app. No answer, an unreadable
+ * version, a policy that would block every build in existence: all of them come
+ * out as `none`. Locking somebody out of their own ledger because a check
+ * misfired is much worse than a stale client running one more day.
+ *
+ * One deliberate exception to failing open: a policy that *has* been fetched is
+ * cached and honoured offline. "This build computes money wrongly" does not
+ * stop being true because the phone lost signal, and every foreground re-checks
+ * so a corrected policy takes effect as soon as there is a connection.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Constants from 'expo-constants';
+import { AppState, Linking, Platform } from 'react-native';
+
+import { decideUpdate, type UpdateDecision } from '@baaki/core';
+
+import { fetchReleasePolicy } from '@/data/api';
+
+const POLICY_KEY = 'baaki.release_policy';
+const DISMISSED_KEY = 'baaki.update_dismissed';
+
+interface CachedPolicy {
+  latestVersion: string;
+  minimumVersion: string;
+  storeUrl: string;
+  message: string | null;
+}
+
+interface UpdateValue {
+  decision: UpdateDecision;
+  /** The version installed on this phone. */
+  installed: string;
+  /** The newest build in the store, when known. */
+  latest: string | null;
+  /** Whatever the policy wanted said instead of the default copy. */
+  message: string | null;
+  /** Whether the suggestion has been waved away for this version. */
+  dismissed: boolean;
+  dismiss: () => void;
+  /** Opens the store page. No-op when there is nowhere to send anybody. */
+  openStore: () => void;
+  /** Ask the server again — for the "try again" out on the blocking screen. */
+  recheck: () => Promise<void>;
+}
+
+const UpdateContext = createContext<UpdateValue | null>(null);
+
+/**
+ * What this binary calls itself.
+ *
+ * `expo-constants` rather than `expo-application`: without `expo-updates` in
+ * the project the JS bundle cannot be swapped after install, so the version
+ * baked in at build time is the version running. That keeps this check free of
+ * a native module, which matters — a native module missing from a build is how
+ * this app has previously lost a whole screen.
+ */
+const INSTALLED = Constants.expoConfig?.version ?? '0.0.0';
+
+/** Web has no store to send anybody to, so there is nothing to enforce. */
+const STORE: 'ios' | 'android' | null =
+  Platform.OS === 'ios' ? 'ios' : Platform.OS === 'android' ? 'android' : null;
+
+export function UpdateProvider({ children }: { children: ReactNode }) {
+  const [policy, setPolicy] = useState<CachedPolicy | null>(null);
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+  const loaded = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (!STORE) return;
+    try {
+      const row = await fetchReleasePolicy(STORE);
+      if (!row) return;
+      const fresh: CachedPolicy = {
+        latestVersion: row.latest_version,
+        minimumVersion: row.minimum_version,
+        storeUrl: row.store_url,
+        message: row.message,
+      };
+      setPolicy(fresh);
+      await AsyncStorage.setItem(POLICY_KEY, JSON.stringify(fresh)).catch(() => undefined);
+    } catch {
+      // Offline, or the server is having a bad day. Neither is a reason to
+      // change what somebody is allowed to do with their own ledger.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!STORE) return;
+    let active = true;
+
+    void (async () => {
+      // Cache first so a blocked build stays blocked without a round trip,
+      // then the network answer replaces it.
+      const raw = await AsyncStorage.getItem(POLICY_KEY).catch(() => null);
+      const dismissed = await AsyncStorage.getItem(DISMISSED_KEY).catch(() => null);
+      if (!active) return;
+      if (raw) {
+        try {
+          setPolicy(JSON.parse(raw) as CachedPolicy);
+        } catch {
+          // A cache we cannot read is a cache we do not have.
+        }
+      }
+      setDismissedVersion(dismissed);
+      loaded.current = true;
+      await refresh();
+    })();
+
+    // Somebody who leaves the app open for a week should still find out.
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active' && loaded.current) void refresh();
+    });
+
+    return () => {
+      active = false;
+      subscription.remove();
+    };
+  }, [refresh]);
+
+  const decision: UpdateDecision = policy
+    ? decideUpdate(INSTALLED, {
+        latestVersion: policy.latestVersion,
+        minimumVersion: policy.minimumVersion,
+      })
+    : 'none';
+
+  const dismiss = useCallback(() => {
+    const version = policy?.latestVersion;
+    if (!version) return;
+    setDismissedVersion(version);
+    void AsyncStorage.setItem(DISMISSED_KEY, version).catch(() => undefined);
+  }, [policy?.latestVersion]);
+
+  const openStore = useCallback(() => {
+    const url = policy?.storeUrl;
+    if (url) void Linking.openURL(url).catch(() => undefined);
+  }, [policy?.storeUrl]);
+
+  const value = useMemo<UpdateValue>(
+    () => ({
+      decision,
+      installed: INSTALLED,
+      latest: policy?.latestVersion ?? null,
+      message: policy?.message ?? null,
+      dismissed: dismissedVersion !== null && dismissedVersion === policy?.latestVersion,
+      dismiss,
+      openStore,
+      recheck: refresh,
+    }),
+    [decision, policy, dismissedVersion, dismiss, openStore, refresh],
+  );
+
+  return <UpdateContext.Provider value={value}>{children}</UpdateContext.Provider>;
+}
+
+export function useUpdate(): UpdateValue {
+  const value = useContext(UpdateContext);
+  if (!value) throw new Error('useUpdate must be used inside UpdateProvider');
+  return value;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,3 +18,4 @@ export * from './sms/index';
 export * from './import/index';
 export * from './auth/identity';
 export * from './observability/index';
+export * from './version/index';

--- a/packages/core/src/version/index.ts
+++ b/packages/core/src/version/index.ts
@@ -1,0 +1,88 @@
+/**
+ * Deciding whether an installed app is too old.
+ *
+ * Two different judgements, and they are not the same severity:
+ *
+ * A *suggested* update is a new version in the store. Nothing is wrong with
+ * what somebody is holding; there is simply something better. It gets a banner
+ * they can dismiss, and dismissing it must stick, or the banner becomes the
+ * thing they resent rather than the thing they act on.
+ *
+ * A *required* update is a version we can no longer let talk to the server —
+ * a client that computes money wrongly, or one whose sync protocol we have
+ * stopped answering. That gets a wall, because letting it through would put
+ * wrong numbers in a shared ledger that other people are reading.
+ *
+ * Everything here fails towards letting the app open. A version string we
+ * cannot parse, a policy we could not fetch, a comparison we are unsure of —
+ * all of them resolve to `none`. Blocking somebody out of their own ledger
+ * because a check misfired is a far worse outcome than a stale client running
+ * one day longer.
+ */
+
+/** What to do about the installed version. */
+export type UpdateDecision = 'none' | 'suggested' | 'required';
+
+/** What the server says about a platform's builds. */
+export interface ReleasePolicy {
+  /** The newest build in the store. */
+  readonly latestVersion: string;
+  /** The oldest build still allowed to run. */
+  readonly minimumVersion: string;
+}
+
+/**
+ * Parse a dotted version into comparable parts.
+ *
+ * Returns null rather than a guess for anything that is not purely numeric
+ * dotted segments — a build named `1.2.0-beta` is a shape we do not ship, and
+ * inventing an ordering for it would make the answer confident and wrong.
+ */
+export function parseVersion(version: string): readonly number[] | null {
+  const trimmed = version.trim();
+  if (!/^\d+(\.\d+)*$/.test(trimmed)) return null;
+
+  const parts = trimmed.split('.').map((part) => Number(part));
+  return parts.some((part) => !Number.isSafeInteger(part)) ? null : parts;
+}
+
+/**
+ * Compare two dotted versions: negative if `a` is older, positive if newer.
+ *
+ * Missing segments count as zero, so `1.2` and `1.2.0` are the same version —
+ * the store shows one of them and app.json holds the other often enough that
+ * treating them as different would produce an update prompt for no update.
+ *
+ * Returns null when either side is unparseable, so callers have to decide what
+ * an unknown ordering means rather than receiving a silent 0.
+ */
+export function compareVersions(a: string, b: string): number | null {
+  const left = parseVersion(a);
+  const right = parseVersion(b);
+  if (!left || !right) return null;
+
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const difference = (left[index] ?? 0) - (right[index] ?? 0);
+    if (difference !== 0) return difference < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * What the app should do about the version it is running.
+ *
+ * A minimum above the latest is a policy that would block every build in
+ * existence, including the one somebody would be sent to install. It is always
+ * a mistake — a typo, or a minimum bumped before the release it names actually
+ * shipped — so it is treated as one and ignored rather than obeyed.
+ */
+export function decideUpdate(installed: string, policy: ReleasePolicy): UpdateDecision {
+  const belowMinimum = compareVersions(installed, policy.minimumVersion);
+  const minimumIsReal = (compareVersions(policy.minimumVersion, policy.latestVersion) ?? 1) <= 0;
+  if (minimumIsReal && belowMinimum !== null && belowMinimum < 0) return 'required';
+
+  const behindLatest = compareVersions(installed, policy.latestVersion);
+  if (behindLatest !== null && behindLatest < 0) return 'suggested';
+
+  return 'none';
+}

--- a/packages/core/test/version.test.ts
+++ b/packages/core/test/version.test.ts
@@ -1,0 +1,112 @@
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+
+import { compareVersions, decideUpdate, parseVersion } from '../src/version/index';
+
+describe('parseVersion', () => {
+  it('reads dotted numbers', () => {
+    expect(parseVersion('1.2.3')).toEqual([1, 2, 3]);
+    expect(parseVersion(' 0.1.0 ')).toEqual([0, 1, 0]);
+    expect(parseVersion('12')).toEqual([12]);
+  });
+
+  it('refuses anything it would have to guess about', () => {
+    for (const bad of ['', '1.2.3-beta', 'v1.2.3', '1..2', '1.2.', 'latest', '1.2.3.4a']) {
+      expect(parseVersion(bad)).toBeNull();
+    }
+  });
+});
+
+describe('compareVersions', () => {
+  it('orders by segment, not by string', () => {
+    // The string comparison every version check gets wrong once.
+    expect(compareVersions('1.10.0', '1.9.0')).toBe(1);
+    expect(compareVersions('2.0.0', '10.0.0')).toBe(-1);
+  });
+
+  it('treats missing segments as zero', () => {
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+    expect(compareVersions('1.2', '1.2.1')).toBe(-1);
+  });
+
+  it('returns null rather than a made-up ordering', () => {
+    expect(compareVersions('1.2.0-rc1', '1.2.0')).toBeNull();
+    expect(compareVersions('1.2.0', '')).toBeNull();
+  });
+});
+
+describe('decideUpdate', () => {
+  const policy = { latestVersion: '2.0.0', minimumVersion: '1.5.0' };
+
+  it('blocks below the minimum', () => {
+    expect(decideUpdate('1.4.9', policy)).toBe('required');
+  });
+
+  it('suggests between the minimum and the latest', () => {
+    expect(decideUpdate('1.5.0', policy)).toBe('suggested');
+    expect(decideUpdate('1.9.9', policy)).toBe('suggested');
+  });
+
+  it('says nothing at or beyond the latest', () => {
+    expect(decideUpdate('2.0.0', policy)).toBe('none');
+    // A build newer than the store's: every internal build, all the time.
+    expect(decideUpdate('2.1.0', policy)).toBe('none');
+  });
+
+  it('ignores a minimum above the latest instead of blocking everybody', () => {
+    // The typo that would otherwise lock every phone out of its own ledger,
+    // including the one that installs the version it names.
+    const broken = { latestVersion: '2.0.0', minimumVersion: '3.0.0' };
+    expect(decideUpdate('2.0.0', broken)).toBe('none');
+    expect(decideUpdate('1.0.0', broken)).toBe('suggested');
+  });
+
+  it('lets an unreadable version through', () => {
+    expect(decideUpdate('1.2.0-internal', policy)).toBe('none');
+    expect(decideUpdate('1.0.0', { latestVersion: 'unknown', minimumVersion: 'unknown' })).toBe(
+      'none',
+    );
+  });
+});
+
+const version = fc
+  .array(fc.integer({ min: 0, max: 999 }), { minLength: 1, maxLength: 4 })
+  .map((parts) => parts.join('.'));
+
+describe('update decisions, as a property', () => {
+  it('never requires an update from a version at or above the minimum', () => {
+    fc.assert(
+      fc.property(version, version, version, (installed, minimum, latest) => {
+        const decision = decideUpdate(installed, {
+          latestVersion: latest,
+          minimumVersion: minimum,
+        });
+        if (decision !== 'required') return true;
+        return (compareVersions(installed, minimum) ?? 0) < 0;
+      }),
+    );
+  });
+
+  it('never asks somebody to update to a version they already have', () => {
+    fc.assert(
+      fc.property(version, version, (installed, minimum) => {
+        // Latest equal to installed: there is nothing in the store to go to.
+        const decision = decideUpdate(installed, {
+          latestVersion: installed,
+          minimumVersion: minimum,
+        });
+        return decision === 'none';
+      }),
+    );
+  });
+
+  it('is symmetric about ordering', () => {
+    fc.assert(
+      fc.property(version, version, (a, b) => {
+        const forward = compareVersions(a, b);
+        const backward = compareVersions(b, a);
+        return forward !== null && backward !== null && forward === -backward;
+      }),
+    );
+  });
+});

--- a/packages/db/prisma/migrations/20260807000000_app_release_policy/migration.sql
+++ b/packages/db/prisma/migrations/20260807000000_app_release_policy/migration.sql
@@ -1,0 +1,73 @@
+-- What the app is allowed to be running.
+--
+-- One row per store. `latest_version` is what is published; `minimum_version`
+-- is the oldest build still allowed to open. Both are here rather than in the
+-- app because the whole point is to reach a build that has already shipped:
+-- a version number compiled into the binary can only ever describe itself.
+--
+-- Three deliberate constraints, because a bad row in this table is the one
+-- piece of data in the system that can lock every phone out of its own ledger:
+--
+--   1. Versions must be dotted numbers. A row saying `v2` or `2.0-rc` would
+--      compare as unknown, and the client is written to let unknown through —
+--      so a typo here fails open rather than closed, but it also silently
+--      turns the policy off. Rejecting it at write time is better.
+--   2. `minimum_version` may not exceed `latest_version`. That combination
+--      blocks every build in existence, including the one the update button
+--      would send somebody to install. There is no situation where it is
+--      what was meant.
+--   3. `store_url` is required. A wall with no way past it is worse than no
+--      wall, so a forced update cannot be configured without the way out.
+--
+-- Readable by everybody including signed-out guests: the check has to run
+-- before sign-in, since a client too old to be trusted is too old to sync.
+-- Writable by nobody — there are no INSERT/UPDATE/DELETE policies at all, so
+-- only the service role can change it (ADR-013).
+
+CREATE OR REPLACE FUNCTION public.baaki_version_key(p_version text)
+RETURNS int[]
+LANGUAGE sql
+IMMUTABLE
+STRICT
+AS $$
+  -- Padded to four segments so `1.2` and `1.2.0.0` compare equal, matching
+  -- `compareVersions` in @baaki/core. Postgres compares int[] element-wise.
+  SELECT (string_to_array(p_version, '.') || ARRAY['0', '0', '0', '0'])[1:4]::int[]
+$$;
+
+COMMENT ON FUNCTION public.baaki_version_key(text) IS
+  'Dotted version as a comparable int[]. Mirrors compareVersions in @baaki/core.';
+
+CREATE TABLE public.app_releases (
+  platform         text        PRIMARY KEY CHECK (platform IN ('ios', 'android')),
+  latest_version   text        NOT NULL CHECK (latest_version ~ '^[0-9]+(\.[0-9]+){0,3}$'),
+  minimum_version  text        NOT NULL CHECK (minimum_version ~ '^[0-9]+(\.[0-9]+){0,3}$'),
+  store_url        text        NOT NULL CHECK (length(store_url) > 0),
+  -- Optional: shown instead of the default copy, for when the reason matters
+  -- ("expenses added on this version were splitting rupees wrongly").
+  message          text,
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT app_releases_minimum_not_above_latest
+    CHECK (public.baaki_version_key(minimum_version) <= public.baaki_version_key(latest_version))
+);
+
+COMMENT ON TABLE public.app_releases IS
+  'Per-store version policy. Public read, service-role write.';
+
+ALTER TABLE public.app_releases ENABLE ROW LEVEL SECURITY;
+
+-- Signed out on purpose: the version gate runs before the sign-in screen.
+CREATE POLICY "app_releases are readable by everyone"
+  ON public.app_releases
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- Seed both stores at the version that exists today, so switching this on
+-- changes nothing until somebody deliberately raises a number.
+INSERT INTO public.app_releases (platform, latest_version, minimum_version, store_url)
+VALUES
+  ('android', '0.1.0', '0.1.0', 'https://play.google.com/store/apps/details?id=app.baaki.mobile'),
+  ('ios',     '0.1.0', '0.1.0', 'https://apps.apple.com/app/baaki/id0000000000')
+ON CONFLICT (platform) DO NOTHING;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -669,3 +669,19 @@ model SyncMutation {
   @@map("sync_mutations")
   @@schema("public")
 }
+
+/// What the app is allowed to be running, one row per store. Public read so the
+/// version gate can run before sign-in; no write policies, so only the service
+/// role can raise a number. A CHECK stops `minimum_version` from exceeding
+/// `latest_version` — that row would block every build in existence.
+model AppRelease {
+  platform       String   @id
+  latestVersion  String   @map("latest_version")
+  minimumVersion String   @map("minimum_version")
+  storeUrl       String   @map("store_url")
+  message        String?
+  updatedAt      DateTime @default(now()) @map("updated_at") @db.Timestamptz(6)
+
+  @@map("app_releases")
+  @@schema("public")
+}

--- a/packages/db/test/appReleases.test.ts
+++ b/packages/db/test/appReleases.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The version policy is the one table in the database that can lock every
+ * phone out of its own ledger, so what it refuses matters more than what it
+ * stores.
+ *
+ * Two properties, both about the blast radius of a mistake:
+ *
+ *   - anybody can read it, including a signed-out guest, because the gate runs
+ *     before the sign-in screen;
+ *   - nobody can write it, including a signed-in person, because "which builds
+ *     are allowed to open" is not a thing a client gets to decide.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+async function asRole<T>(
+  role: 'anon' | 'authenticated',
+  claims: Record<string, unknown>,
+  run: () => Promise<T>,
+): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify(claims),
+  ]);
+  await client.query(`SET ROLE ${role}`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+describe('app_releases', () => {
+  it('is readable signed out, because the gate runs before sign-in', async () => {
+    const rows = await asRole('anon', { role: 'anon' }, async () => {
+      const result = await client.query(`SELECT platform, store_url FROM app_releases`);
+      return result.rows;
+    });
+
+    expect(rows.map((row) => row.platform).sort()).toEqual(['android', 'ios']);
+    // A forced update with no way past it is worse than no forced update.
+    for (const row of rows) expect(row.store_url).toMatch(/^https:\/\//);
+  });
+
+  it('cannot be written by a signed-in person', async () => {
+    const profileId = randomUUID();
+    await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Someone')`, [
+      profileId,
+    ]);
+
+    await asRole('authenticated', { sub: profileId, role: 'authenticated' }, async () => {
+      // No policy for UPDATE means no rows are visible to update: Postgres
+      // reports success having changed nothing rather than refusing.
+      const updated = await client.query(
+        `UPDATE app_releases SET minimum_version = '99.0.0' WHERE platform = 'android'`,
+      );
+      expect(updated.rowCount).toBe(0);
+
+      await expect(
+        client.query(
+          `INSERT INTO app_releases (platform, latest_version, minimum_version, store_url)
+           VALUES ('android', '99.0.0', '99.0.0', 'https://evil.example')
+           ON CONFLICT (platform) DO UPDATE SET minimum_version = '99.0.0'`,
+        ),
+      ).rejects.toThrow(/row-level security|policy/i);
+    });
+
+    const after = await client.query(
+      `SELECT minimum_version FROM app_releases WHERE platform = 'android'`,
+    );
+    expect(after.rows[0]?.minimum_version).not.toBe('99.0.0');
+  });
+
+  it('refuses a minimum above the latest, which would block every build', async () => {
+    await expect(
+      client.query(`UPDATE app_releases SET minimum_version = '99.0.0' WHERE platform = 'android'`),
+    ).rejects.toThrow(/app_releases_minimum_not_above_latest/);
+  });
+
+  it('refuses a version string the client would not be able to compare', async () => {
+    for (const bad of ['v2', '2.0-rc1', 'latest']) {
+      await expect(
+        client.query(`UPDATE app_releases SET latest_version = $1 WHERE platform = 'android'`, [
+          bad,
+        ]),
+      ).rejects.toThrow(/check constraint/);
+    }
+  });
+
+  it('orders versions by segment, the way the client does', async () => {
+    const { rows } = await client.query(
+      `SELECT baaki_version_key('1.10.0') > baaki_version_key('1.9.0') AS newer,
+              baaki_version_key('1.2')   = baaki_version_key('1.2.0') AS same`,
+    );
+    expect(rows[0]).toEqual({ newer: true, same: true });
+  });
+});


### PR DESCRIPTION
The version is compiled into the binary, so a build can only ever describe itself. The policy lives in `public.app_releases` (one row per store); the app asks on launch and on every foreground.

**Suggested** — a newer build is published. Dismissible banner, and the dismissal sticks per version.

**Required** — this build may no longer talk to the server. A wall, outside the lock screen and the auth gate, because a build we have stopped trusting should not be unlocking a ledger or signing anybody in.

A bad row here can lock every phone out of its own ledger, so:

- a CHECK refuses a minimum above the latest (that row blocks every build in existence, including the one the Update button installs);
- a CHECK refuses a version string the client cannot compare (`v2`, `2.0-rc`), which would otherwise switch the policy off silently;
- the client fails towards opening — no answer, unreadable version, policy it does not understand all resolve to carry on.

The one exception is a policy already fetched: cached and honoured offline, because "this build computes money wrongly" does not stop being true when the phone loses signal. Every foreground re-checks and the wall has an "I have already updated" button, so a corrected policy lands without a reinstall.

`compareVersions` in packages/core is mirrored in SQL by `baaki_version_key()`, so the database and the app cannot disagree about which version is newer.

Read is open to anon (the check runs before sign-in); there are no write policies at all, so only the service role can raise a number.

## Verified

Against the live project: anon read 200, anon INSERT refused with 42501, anon UPDATE matched no rows. Then driven in the running app: banner at 0.2.0, "Not now" survived a reload, raising the minimum replaced the whole app with the wall, and "I have already updated" cleared it without a restart once the policy was relaxed. Live rows restored to 0.1.0.

Migration applied to live. 275 core tests, 178 db tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6