### PR TITLE
feat: browse the phone's contacts from the Friends tab

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -14,6 +14,7 @@
  * account are followed across groups, because a profile id is proof.
  */
 
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useQuery } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { RefreshControl, ScrollView, View } from 'react-native';
@@ -21,10 +22,12 @@ import { RefreshControl, ScrollView, View } from 'react-native';
 import {
   Avatar,
   Badge,
+  Button,
   Card,
   EmptyState,
   ListRow,
   MoneyText,
+  Row,
   Screen,
   SectionHeader,
   Text,
@@ -64,14 +67,21 @@ export default function FriendsScreen() {
           />
         }
       >
-        <Text variant="title" style={{ paddingTop: theme.spacing.md }}>
-          {t.friends}
-        </Text>
+        <Row style={{ justifyContent: 'space-between', paddingTop: theme.spacing.md }}>
+          <Text variant="title">{t.friends}</Text>
+          <Button
+            label="From contacts"
+            variant="secondary"
+            size="sm"
+            icon={<Ionicons name="person-add-outline" size={16} color={theme.color.brand} />}
+            onPress={() => router.push('/friends/contacts')}
+          />
+        </Row>
 
         {rows.length === 0 ? (
           <EmptyState
             title="All square"
-            body="Nobody owes you anything and you owe nobody. Friends you are settling up with will appear here."
+            body="Nobody owes you anything and you owe nobody. Friends you are settling up with will appear here — add somebody from your contacts to get started."
           />
         ) : (
           <>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -217,6 +217,7 @@ function AuthGate() {
       <Stack.Screen name="group/[id]/expense/[expenseId]" />
       <Stack.Screen name="group/[id]/invite" options={modal} />
       <Stack.Screen name="group/[id]/itemize" options={modal} />
+      <Stack.Screen name="friends/contacts" />
       <Stack.Screen name="settings/notifications" />
       <Stack.Screen name="settings/export" />
       <Stack.Screen name="settings/import" />

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -1,0 +1,206 @@
+/**
+ * Browsing the phone's address book to add somebody to a group.
+ *
+ * The address book never leaves the device — `ContactPicker` reads it, searches
+ * it and shows it locally, and only the one person tapped is sent anywhere.
+ * There is deliberately no "which of my contacts already use Baaki" here: that
+ * feature requires uploading the whole book, and it turns an address book into
+ * a membership oracle for anybody who later reaches the server (ADR-006).
+ *
+ * A person in Baaki always belongs to a group, because a debt is between people
+ * *about something*. So picking a contact asks the one question that has to be
+ * answered — which group — rather than inventing a floating "friend" that owes
+ * nobody anything.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { router } from 'expo-router';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
+
+import {
+  Avatar,
+  Button,
+  Card,
+  Divider,
+  IconButton,
+  ListRow,
+  Row,
+  Screen,
+  SectionHeader,
+  Text,
+  useTheme,
+} from '@baaki/ui';
+
+import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
+import { addGhostMember, fetchGroups } from '@/data/api';
+import { groupLabel } from '@/data/types';
+
+export default function ContactsScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const queryClient = useQueryClient();
+
+  const [picked, setPicked] = useState<PickedContact | null>(null);
+  const [added, setAdded] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const groups = useQuery({ queryKey: ['groups'], queryFn: fetchGroups });
+
+  const add = useMutation({
+    mutationFn: async ({ groupId, contact }: { groupId: string; contact: PickedContact }) =>
+      addGhostMember(groupId, contact.name, { email: contact.email, phone: contact.phone }),
+    onSuccess: async (_id, { groupId, contact }) => {
+      setAdded(contact.name);
+      setPicked(null);
+      setError(null);
+      await queryClient.invalidateQueries({ queryKey: ['members', groupId] });
+      await queryClient.invalidateQueries({ queryKey: ['people', 'balances'] });
+    },
+    onError: (caught: unknown) => {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    },
+  });
+
+  return (
+    <Screen>
+      <View
+        style={{
+          flex: 1,
+          paddingHorizontal: theme.spacing.xl,
+          gap: theme.spacing.lg,
+        }}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label="Back" onPress={() => router.back()}>
+            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">From your contacts</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        {picked ? (
+          <ChooseGroup
+            contact={picked}
+            groups={groups.data ?? []}
+            busy={add.isPending}
+            error={error}
+            onCancel={() => {
+              setPicked(null);
+              setError(null);
+            }}
+            onChoose={(groupId) => add.mutate({ groupId, contact: picked })}
+          />
+        ) : (
+          <>
+            {added ? (
+              <Card style={{ backgroundColor: theme.color.brandSoft }}>
+                <Text variant="caption" tone="brand">
+                  {added} added. Pick somebody else, or go back.
+                </Text>
+              </Card>
+            ) : null}
+            <ContactPicker onPick={setPicked} />
+          </>
+        )}
+      </View>
+    </Screen>
+  );
+}
+
+/**
+ * Which group this person joins.
+ *
+ * Groups only — no "add without a group" — because a member with no group has
+ * nothing to owe or be owed, and would sit in the app looking like a mistake.
+ */
+function ChooseGroup({
+  contact,
+  groups,
+  busy,
+  error,
+  onCancel,
+  onChoose,
+}: {
+  contact: PickedContact;
+  groups: readonly { id: string; name: string | null; cover_emoji: string | null }[];
+  busy: boolean;
+  error: string | null;
+  onCancel: () => void;
+  onChoose: (groupId: string) => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+
+  return (
+    <ScrollView
+      contentContainerStyle={{ paddingBottom: theme.spacing.xxxl, gap: theme.spacing.lg }}
+      showsVerticalScrollIndicator={false}
+    >
+      <Card style={{ gap: theme.spacing.xs }}>
+        <Row style={{ gap: theme.spacing.md }}>
+          <Avatar name={contact.name} size={44} />
+          <View style={{ flex: 1 }}>
+            <Text variant="subheading">{contact.name}</Text>
+            <Text variant="micro" tone="faint">
+              {contact.email ?? contact.phone ?? 'No address'}
+            </Text>
+          </View>
+        </Row>
+      </Card>
+
+      <SectionHeader title="Add to which group?" />
+
+      {groups.length === 0 ? (
+        <Card style={{ gap: theme.spacing.md }}>
+          <Text variant="caption" tone="muted">
+            You have no groups yet. A person belongs to a group in Baaki, because a debt is always
+            about something — a trip, a flat, a dinner.
+          </Text>
+          <Button
+            label="Start a group"
+            variant="secondary"
+            onPress={() => router.push('/new-group')}
+          />
+        </Card>
+      ) : (
+        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+          {groups.map((group, index) => (
+            <View key={group.id}>
+              <ListRow
+                title={groupLabel(group)}
+                leading={
+                  <Avatar
+                    name={groupLabel(group)}
+                    emoji={group.cover_emoji ?? undefined}
+                    size={40}
+                  />
+                }
+                onPress={busy ? undefined : () => onChoose(group.id)}
+                trailing={
+                  <Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />
+                }
+              />
+              {index < groups.length - 1 ? <Divider /> : null}
+            </View>
+          ))}
+        </Card>
+      )}
+
+      {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
+      {error ? (
+        <Text variant="caption" tone="negative">
+          {error}
+        </Text>
+      ) : null}
+
+      <Text variant="micro" tone="faint">
+        They do not need the app. Their share is recorded under their name, and if they join later
+        with this email or number they claim everything already sitting there.
+      </Text>
+
+      <Button label="Pick somebody else" variant="ghost" onPress={onCancel} />
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -43,18 +43,27 @@ export function ContactPicker({ onPick, existing }: ContactPickerProps): React.J
     let cancelled = false;
 
     void (async () => {
-      const { status } = await Contacts.requestPermissionsAsync();
-      if (cancelled) return;
-      if (status !== 'granted') {
-        setPermission('denied');
+      // expo-contacts has no web implementation and throws rather than
+      // no-opping there, which would otherwise leave this stuck on "looking
+      // through your contacts…" forever with nothing said about why.
+      let data: Awaited<ReturnType<typeof Contacts.getContactsAsync>>['data'];
+      try {
+        const { status } = await Contacts.requestPermissionsAsync();
+        if (cancelled) return;
+        if (status !== 'granted') {
+          setPermission('denied');
+          return;
+        }
+
+        // Only these three fields. Asking for less than the platform offers is
+        // the cheapest privacy measure there is.
+        ({ data } = await Contacts.getContactsAsync({
+          fields: [Contacts.Fields.Name, Contacts.Fields.Emails, Contacts.Fields.PhoneNumbers],
+        }));
+      } catch {
+        if (!cancelled) setPermission('denied');
         return;
       }
-
-      // Only these three fields. Asking for less than the platform offers is
-      // the cheapest privacy measure there is.
-      const { data } = await Contacts.getContactsAsync({
-        fields: [Contacts.Fields.Name, Contacts.Fields.Emails, Contacts.Fields.PhoneNumbers],
-      });
       if (cancelled) return;
 
       setContacts(
@@ -108,7 +117,7 @@ export function ContactPicker({ onPick, existing }: ContactPickerProps): React.J
         <Button
           label="Open settings"
           variant="ghost"
-          onPress={() => void Contacts.presentFormAsync(null, null)}
+          onPress={() => void Contacts.presentFormAsync(null, null).catch(() => undefined)}
         />
       </Card>
     );


### PR DESCRIPTION
The Friends tab showed balances only, so the address book was reachable only from inside a group, on its members screen. That is backwards — reaching for somebody's name is how adding a person starts.

"From contacts" opens the existing picker; picking somebody asks the one question that has to be answered — which group. No group-less "friend": a member with no group has nothing to owe or be owed and would look like a bug.

Still no "which of my contacts already use Baaki". That needs the whole address book uploaded and turns a contact list into a membership oracle (ADR-006).

Also fixes the picker hanging forever on web — expo-contacts has no web implementation and throws rather than no-opping, and the rejection escaped the effect uncaught, leaving "Looking through your contacts…" on screen permanently. It now falls into the same honest denied state.

## Verified

Driven in the running app: picker lists contacts, tapping one shows the group chooser, choosing a group wrote a real ghost member to the live database, confirmation returned to the list. The test ghost was removed from the live group afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6