### PR TITLE
fix: register the contacts config plugin, and send "Open settings" to settings

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -38,6 +38,12 @@
           "imageWidth": 76
         }
       ],
+      [
+        "expo-contacts",
+        {
+          "contactsPermission": "Baaki uses your contacts so you can pick who was there instead of typing their name. Your contacts stay on this phone — only the person you tap is sent."
+        }
+      ],
       "expo-secure-store",
       "expo-sharing",
       "@react-native-community/datetimepicker",

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -15,7 +15,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import * as Contacts from 'expo-contacts';
-import { FlatList, Pressable, TextInput, View } from 'react-native';
+import { FlatList, Linking, Pressable, TextInput, View } from 'react-native';
 
 import { Avatar, Button, Card, EmptyState, Row, Text, useTheme } from '@baaki/ui';
 
@@ -114,10 +114,13 @@ export function ContactPicker({ onPick, existing }: ContactPickerProps): React.J
           Baaki cannot see your contacts. You can still add people by typing a name, an email or a
           number — nothing about a group needs your address book.
         </Text>
+        {/* `Contacts.presentFormAsync` used to be here, which opens a form for
+            creating a *new* contact — not the permission screen the label
+            promises. This is the one that goes where it says. */}
         <Button
           label="Open settings"
           variant="ghost"
-          onPress={() => void Contacts.presentFormAsync(null, null).catch(() => undefined)}
+          onPress={() => void Linking.openSettings().catch(() => undefined)}
         />
       </Card>
     );


### PR DESCRIPTION
Two things wrong with the contact picker's edges, both invisible until somebody is standing at them.

`expo-contacts` ships a config plugin that was never listed in `app.json`. Android worked anyway — the library's own manifest gets merged — but iOS takes `NSContactsUsageDescription` from that plugin and nowhere else, and iOS terminates an app that asks for contacts without one. The picker would have killed the app on first tap, and review rejects the binary before that. Registering it also replaces the generic default string with what is actually true: contacts stay on the phone, only the person tapped is sent.

"Open settings" called `Contacts.presentFormAsync`, which opens a *new contact* form. Somebody who had just refused permission and wanted to change their mind got a blank contact card, with the screen they wanted still two apps away. Now `Linking.openSettings()`.

Verified the plugin resolves — READ_CONTACTS/WRITE_CONTACTS appear in the prebuild config's Android permissions, and the plugin source sets `NSContactsUsageDescription` from `contactsPermission`.

Needs a native rebuild to reach iOS. Android already had the permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6