### PR TITLE
feat: give the welcome and lock screens a curved brand panel

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,11 +45,25 @@ of clipping.
 
 ## Shape and depth
 
-Radii: `sm 12 · md 16 · lg 20 · xl 24 · xxl 32 · pill 999`. Cards are `xl`,
-anything interactive and small is a pill.
+Radii: `sm 12 · md 16 · lg 20 · xl 24 · xxl 32 · pill 999`. Cards are `md`,
+anything interactive and small is a pill. The reference boards are drawn at
+tablet width, where `xl` reads as a gentle curve; on a phone the same radius eats
+into a card only a few hundred points wide and the panel starts to look like a
+pill, and pills are for things you tap.
 
 Exactly two shadows: `soft` for resting cards, `lifted` for the floating tab bar
 and the FAB. Depth means "this floats above the page", never "this is pretty".
+
+The doorway screens — the welcome and the lock screen — open with a brand-purple
+panel whose bottom edge sweeps rather than cuts (`CurvedPanel`). It is the one
+place the app is allowed a flourish, because it is the one place with nothing to
+read: no balance, no list, no decision. Everywhere past it is somebody's money,
+and a shape that draws the eye there is a shape competing with a number.
+
+The arc is an over-wide box with a large bottom radius, not an SVG path — the
+screen only ever sees the flat middle of a much wider ellipse. That keeps
+`react-native-svg` out of the dependency list, which matters for a screen that
+has to render before anything else in the app does.
 
 ## Spacing
 
@@ -59,9 +73,9 @@ floating tab bar never covers the last row.
 
 ## Components
 
-`Screen · Card · TintCard · Text · Button · IconButton · Fab · Chip · ChipRow ·
-Badge · Avatar · AvatarStack · ListRow · EmptyState · MoneyText · PillTabBar ·
-AmountKeypad`
+`Screen · Card · TintCard · CurvedPanel · Text · Button · IconButton · Fab ·
+Chip · ChipRow · Badge · Avatar · AvatarStack · ListRow · EmptyState ·
+MoneyText · Toggle · PillTabBar · AmountKeypad`
 
 Two carry product decisions rather than styling:
 

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,13 +1,15 @@
 import { useEffect } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import Constants from 'expo-constants';
 import * as Notifications from 'expo-notifications';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, useWindowDimensions, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
-import { Button, ThemeProvider, Text, useTheme } from '@baaki/ui';
+import { Button, CurvedPanel, ThemeProvider, Text, useTheme } from '@baaki/ui';
 
 import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
@@ -118,10 +120,18 @@ function PushRouting() {
   return null;
 }
 
-/** Holds the whole app behind biometrics when the user has asked for it. */
+/**
+ * Holds the whole app behind biometrics when the user has asked for it.
+ *
+ * Deliberately the same shape as the welcome — coloured sweep, wordmark, one
+ * button, version at the foot. Somebody meeting this screen is looking at a
+ * phone that will not open, and the fastest way to say "this is still your app,
+ * nothing has gone wrong" is for it to look like the app.
+ */
 function LockGate({ children }: { children: React.ReactNode }) {
   const { locked, unlock } = useLock();
   const theme = useTheme();
+  const { height: screenHeight } = useWindowDimensions();
 
   useEffect(() => {
     if (locked) void unlock();
@@ -130,21 +140,52 @@ function LockGate({ children }: { children: React.ReactNode }) {
   if (!locked) return <>{children}</>;
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: theme.spacing.xl,
-        backgroundColor: theme.color.bg,
-        padding: theme.spacing.xxxl,
-      }}
-    >
-      <Text style={{ fontSize: 44, lineHeight: 50, fontWeight: '700' }}>பாக்கி</Text>
-      <Text variant="caption" tone="muted" align="center">
-        Baaki is locked.
+    <View style={{ flex: 1, backgroundColor: theme.color.bg }}>
+      <CurvedPanel height={Math.min(screenHeight * 0.46, 420)}>
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: theme.spacing.sm,
+          }}
+        >
+          <Text
+            style={{ fontSize: 56, lineHeight: 72, fontWeight: '700', color: theme.color.onBrand }}
+          >
+            பாக்கி
+          </Text>
+          <Ionicons name="lock-closed" size={22} color={theme.color.onBrand} />
+        </View>
+      </CurvedPanel>
+
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          paddingHorizontal: theme.spacing.xxxl,
+          gap: theme.spacing.lg,
+        }}
+      >
+        <Text variant="display" align="center">
+          Baaki is locked
+        </Text>
+        <Text variant="body" tone="muted" align="center">
+          Unlock with the same face or fingerprint that opens this phone.
+        </Text>
+        <View style={{ paddingTop: theme.spacing.md }}>
+          <Button label="Unlock" size="lg" fullWidth onPress={() => void unlock()} />
+        </View>
+      </View>
+
+      <Text
+        variant="micro"
+        tone="faint"
+        align="center"
+        style={{ paddingBottom: theme.spacing.xxxl }}
+      >
+        Baaki {Constants.expoConfig?.version ?? ''}
       </Text>
-      <Button label="Unlock" size="lg" onPress={() => void unlock()} />
     </View>
   );
 }

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -15,9 +15,18 @@
  */
 
 import { useState } from 'react';
-import { ActivityIndicator, KeyboardAvoidingView, Platform, TextInput, View } from 'react-native';
+import Constants from 'expo-constants';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  TextInput,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 
-import { Button, Card, Chip, Row, Screen, Text, useTheme } from '@baaki/ui';
+import { Button, Card, Chip, CurvedPanel, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -28,7 +37,14 @@ export default function SignInScreen() {
   const theme = useTheme();
   const { t } = useStrings();
   const { sendOtp, verifyOtp, continueAsGuest, withPassword, withGoogle, isGuest } = useAuth();
+  const { height: screenHeight } = useWindowDimensions();
 
+  /**
+   * A guest arriving here is not choosing how to start — they already have an
+   * account and are adding a way back into it. Showing them the welcome would
+   * be asking a question they answered a week ago.
+   */
+  const [showOptions, setShowOptions] = useState(isGuest);
   const [mode, setMode] = useState<Mode>('otp');
   const [phone, setPhone] = useState('+91');
   const [code, setCode] = useState('');
@@ -51,232 +67,348 @@ export default function SignInScreen() {
     }
   };
 
-  return (
-    <Screen edges={['top', 'bottom']}>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        style={{ flex: 1, justifyContent: 'center', paddingHorizontal: theme.spacing.xl }}
-      >
-        <View style={{ gap: theme.spacing.xxl }}>
-          <View style={{ gap: theme.spacing.sm }}>
-            <Text style={{ fontSize: 44, lineHeight: 50, fontWeight: '700' }}>பாக்கி</Text>
-            <Text variant="title">Baaki</Text>
-            <Text variant="body" tone="muted">
-              {isGuest
-                ? 'Add a way to sign in, so this account is still yours on your next phone.'
-                : `Split anything with anyone. ${t.freeForever}.`}
+  /**
+   * The welcome: the wordmark on a coloured sweep, one sentence, and the button
+   * that gets somebody straight into a ledger. ADR-006 says nobody registers
+   * before they can split a bill, so "carry on as a guest" *is* the primary
+   * action here rather than the small print under a sign-up form.
+   */
+  if (!showOptions) {
+    return (
+      <View style={{ flex: 1, backgroundColor: theme.color.bg }}>
+        <CurvedPanel height={Math.min(screenHeight * 0.46, 420)}>
+          <View
+            style={{
+              flex: 1,
+              alignItems: 'center',
+              justifyContent: 'center',
+              paddingHorizontal: theme.spacing.xxxl,
+              gap: theme.spacing.sm,
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 56,
+                lineHeight: 72,
+                fontWeight: '700',
+                color: theme.color.onBrand,
+              }}
+            >
+              பாக்கி
+            </Text>
+            <Text variant="caption" tone="onBrand" align="center">
+              baaki · what is left over
             </Text>
           </View>
+        </CurvedPanel>
 
-          <Card style={{ gap: theme.spacing.lg }}>
-            <Row style={{ gap: theme.spacing.sm }}>
-              <Chip
-                label="Send me a code"
-                selected={mode === 'otp'}
-                onPress={() => {
-                  setMode('otp');
-                  setError(null);
-                }}
-              />
-              <Chip
-                label="Use a password"
-                selected={mode === 'password'}
-                onPress={() => {
-                  setMode('password');
-                  setError(null);
-                }}
-              />
-            </Row>
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            paddingHorizontal: theme.spacing.xxxl,
+            gap: theme.spacing.lg,
+          }}
+        >
+          <Text variant="display" align="center">
+            Split anything{'\n'}with anyone
+          </Text>
+          <Text variant="body" tone="muted" align="center">
+            {`${t.freeForever}. No account needed to start — add one later and everything you have entered comes with you.`}
+          </Text>
 
-            {mode === 'otp' && stage === 'phone' ? (
-              <>
-                <Text variant="caption" tone="muted">
-                  Phone number
-                </Text>
-                <TextInput
-                  value={phone}
-                  onChangeText={setPhone}
-                  keyboardType="phone-pad"
-                  autoComplete="tel"
-                  accessibilityLabel="Phone number"
-                  placeholderTextColor={theme.color.textFaint}
-                  style={{
-                    fontSize: 22,
-                    fontWeight: '600',
-                    color: theme.color.text,
-                    paddingVertical: theme.spacing.sm,
-                  }}
-                />
-                <Text variant="micro" tone="faint">
-                  Start with your country code. Baaki never assumes +91 — a trip is exactly when
-                  foreign numbers turn up.
-                </Text>
-                <Button
-                  label="Send code"
-                  size="lg"
-                  fullWidth
-                  disabled={busy || phone.trim().length < 8}
-                  onPress={() =>
-                    void run(async () => {
-                      await sendOtp(phone.trim());
-                      setStage('code');
-                    })
-                  }
-                />
-              </>
-            ) : null}
-
-            {mode === 'otp' && stage === 'code' ? (
-              <>
-                <Text variant="caption" tone="muted">
-                  {`Code sent to ${phone}`}
-                </Text>
-                <TextInput
-                  value={code}
-                  onChangeText={setCode}
-                  keyboardType="number-pad"
-                  autoComplete="sms-otp"
-                  accessibilityLabel="Verification code"
-                  placeholder="123456"
-                  placeholderTextColor={theme.color.textFaint}
-                  style={{
-                    fontSize: 28,
-                    fontWeight: '700',
-                    letterSpacing: 8,
-                    color: theme.color.text,
-                    paddingVertical: theme.spacing.sm,
-                  }}
-                />
-                <Button
-                  label="Verify"
-                  size="lg"
-                  fullWidth
-                  disabled={busy || code.trim().length < 4}
-                  onPress={() => void run(() => verifyOtp(phone.trim(), code.trim()))}
-                />
-                <Button
-                  label="Use a different number"
-                  variant="ghost"
-                  onPress={() => {
-                    setStage('phone');
-                    setCode('');
-                  }}
-                />
-              </>
-            ) : null}
-
-            {mode === 'password' ? (
-              <>
-                <Text variant="caption" tone="muted">
-                  Email or phone number
-                </Text>
-                {/* One field: "email or phone?" is a question the text already
-                    answers. */}
-                <TextInput
-                  value={identifier}
-                  onChangeText={setIdentifier}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  keyboardType="email-address"
-                  autoComplete="username"
-                  accessibilityLabel="Email or phone number"
-                  placeholder="asha@example.com or +91…"
-                  placeholderTextColor={theme.color.textFaint}
-                  style={{
-                    fontSize: 18,
-                    fontWeight: '500',
-                    color: theme.color.text,
-                    paddingVertical: theme.spacing.sm,
-                  }}
-                />
-                <Text variant="caption" tone="muted">
-                  Password
-                </Text>
-                <TextInput
-                  value={password}
-                  onChangeText={setPassword}
-                  secureTextEntry
-                  autoCapitalize="none"
-                  autoComplete={intent === 'sign_up' ? 'new-password' : 'current-password'}
-                  accessibilityLabel="Password"
-                  placeholderTextColor={theme.color.textFaint}
-                  style={{
-                    fontSize: 18,
-                    fontWeight: '500',
-                    color: theme.color.text,
-                    paddingVertical: theme.spacing.sm,
-                  }}
-                />
-                <Text variant="micro" tone="faint">
-                  Eight characters or more. A phrase you will remember beats a puzzle you will not.
-                </Text>
-                <Button
-                  label={
-                    isGuest
-                      ? 'Add this to my account'
-                      : intent === 'sign_up'
-                        ? 'Create account'
-                        : 'Sign in'
-                  }
-                  size="lg"
-                  fullWidth
-                  disabled={busy || !identifier.trim() || password.length < 8}
-                  onPress={() => void run(() => withPassword(identifier, password, intent))}
-                />
-                {/* A guest is never signing up or in — they are adding a way
-                    back to the account they already have. */}
-                {isGuest ? null : (
-                  <Button
-                    label={
-                      intent === 'sign_up'
-                        ? 'I already have an account'
-                        : 'I am new here — create an account'
-                    }
-                    variant="ghost"
-                    onPress={() => {
-                      setIntent(intent === 'sign_up' ? 'sign_in' : 'sign_up');
-                      setError(null);
-                    }}
-                  />
-                )}
-              </>
-            ) : null}
-
-            {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
-            {error ? (
-              <Text variant="caption" tone="negative">
-                {error}
-              </Text>
-            ) : null}
-          </Card>
-
-          <Button
-            label={isGuest ? 'Continue with Google' : 'Sign in with Google'}
-            variant="secondary"
-            size="lg"
-            fullWidth
-            disabled={busy}
-            onPress={() => void run(withGoogle)}
-          />
-
-          {/* ADR-006: nobody is forced to register before they can use Baaki. */}
-          {isGuest ? null : (
+          <View style={{ gap: theme.spacing.sm, paddingTop: theme.spacing.md }}>
             <Button
-              label="Continue as guest"
-              variant="secondary"
+              label="Start now"
               size="lg"
               fullWidth
               disabled={busy}
               onPress={() => void run(continueAsGuest)}
             />
-          )}
+            <Button
+              label="I already have an account"
+              variant="ghost"
+              fullWidth
+              onPress={() => setShowOptions(true)}
+            />
+          </View>
 
-          <Text variant="micro" tone="faint" align="center">
-            {isGuest
-              ? 'Everything you have already added stays exactly where it is. This only adds a way to sign back in.'
-              : 'A guest account keeps everything on this device until you add a way to sign in. Your ledger is never held hostage.'}
-          </Text>
+          {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
+          {error ? (
+            <Text variant="caption" tone="negative" align="center">
+              {error}
+            </Text>
+          ) : null}
         </View>
+
+        <Text
+          variant="micro"
+          tone="faint"
+          align="center"
+          style={{ paddingBottom: theme.spacing.xxxl }}
+        >
+          Baaki {Constants.expoConfig?.version ?? ''}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <Screen edges={['bottom']}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={{ flex: 1 }}
+      >
+        <ScrollView
+          contentContainerStyle={{ paddingBottom: theme.spacing.xxxl }}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <CurvedPanel height={180} curve={0.7}>
+            <View
+              style={{
+                flex: 1,
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: theme.spacing.xs,
+              }}
+            >
+              <Text
+                style={{
+                  fontSize: 34,
+                  lineHeight: 46,
+                  fontWeight: '700',
+                  color: theme.color.onBrand,
+                }}
+              >
+                பாக்கி
+              </Text>
+              <Text variant="caption" tone="onBrand" align="center">
+                {isGuest ? 'Keep this account on your next phone' : 'Welcome back'}
+              </Text>
+            </View>
+          </CurvedPanel>
+
+          <View style={{ gap: theme.spacing.xxl, paddingHorizontal: theme.spacing.xl }}>
+            <Text variant="body" tone="muted" align="center">
+              {isGuest
+                ? 'Add a way to sign in, so this account is still yours on your next phone.'
+                : 'Sign in however you set it up.'}
+            </Text>
+
+            <Card style={{ gap: theme.spacing.lg }}>
+              <Row style={{ gap: theme.spacing.sm }}>
+                <Chip
+                  label="Send me a code"
+                  selected={mode === 'otp'}
+                  onPress={() => {
+                    setMode('otp');
+                    setError(null);
+                  }}
+                />
+                <Chip
+                  label="Use a password"
+                  selected={mode === 'password'}
+                  onPress={() => {
+                    setMode('password');
+                    setError(null);
+                  }}
+                />
+              </Row>
+
+              {mode === 'otp' && stage === 'phone' ? (
+                <>
+                  <Text variant="caption" tone="muted">
+                    Phone number
+                  </Text>
+                  <TextInput
+                    value={phone}
+                    onChangeText={setPhone}
+                    keyboardType="phone-pad"
+                    autoComplete="tel"
+                    accessibilityLabel="Phone number"
+                    placeholderTextColor={theme.color.textFaint}
+                    style={{
+                      fontSize: 22,
+                      fontWeight: '600',
+                      color: theme.color.text,
+                      paddingVertical: theme.spacing.sm,
+                    }}
+                  />
+                  <Text variant="micro" tone="faint">
+                    Start with your country code. Baaki never assumes +91 — a trip is exactly when
+                    foreign numbers turn up.
+                  </Text>
+                  <Button
+                    label="Send code"
+                    size="lg"
+                    fullWidth
+                    disabled={busy || phone.trim().length < 8}
+                    onPress={() =>
+                      void run(async () => {
+                        await sendOtp(phone.trim());
+                        setStage('code');
+                      })
+                    }
+                  />
+                </>
+              ) : null}
+
+              {mode === 'otp' && stage === 'code' ? (
+                <>
+                  <Text variant="caption" tone="muted">
+                    {`Code sent to ${phone}`}
+                  </Text>
+                  <TextInput
+                    value={code}
+                    onChangeText={setCode}
+                    keyboardType="number-pad"
+                    autoComplete="sms-otp"
+                    accessibilityLabel="Verification code"
+                    placeholder="123456"
+                    placeholderTextColor={theme.color.textFaint}
+                    style={{
+                      fontSize: 28,
+                      fontWeight: '700',
+                      letterSpacing: 8,
+                      color: theme.color.text,
+                      paddingVertical: theme.spacing.sm,
+                    }}
+                  />
+                  <Button
+                    label="Verify"
+                    size="lg"
+                    fullWidth
+                    disabled={busy || code.trim().length < 4}
+                    onPress={() => void run(() => verifyOtp(phone.trim(), code.trim()))}
+                  />
+                  <Button
+                    label="Use a different number"
+                    variant="ghost"
+                    onPress={() => {
+                      setStage('phone');
+                      setCode('');
+                    }}
+                  />
+                </>
+              ) : null}
+
+              {mode === 'password' ? (
+                <>
+                  <Text variant="caption" tone="muted">
+                    Email or phone number
+                  </Text>
+                  {/* One field: "email or phone?" is a question the text already
+                    answers. */}
+                  <TextInput
+                    value={identifier}
+                    onChangeText={setIdentifier}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    keyboardType="email-address"
+                    autoComplete="username"
+                    accessibilityLabel="Email or phone number"
+                    placeholder="asha@example.com or +91…"
+                    placeholderTextColor={theme.color.textFaint}
+                    style={{
+                      fontSize: 18,
+                      fontWeight: '500',
+                      color: theme.color.text,
+                      paddingVertical: theme.spacing.sm,
+                    }}
+                  />
+                  <Text variant="caption" tone="muted">
+                    Password
+                  </Text>
+                  <TextInput
+                    value={password}
+                    onChangeText={setPassword}
+                    secureTextEntry
+                    autoCapitalize="none"
+                    autoComplete={intent === 'sign_up' ? 'new-password' : 'current-password'}
+                    accessibilityLabel="Password"
+                    placeholderTextColor={theme.color.textFaint}
+                    style={{
+                      fontSize: 18,
+                      fontWeight: '500',
+                      color: theme.color.text,
+                      paddingVertical: theme.spacing.sm,
+                    }}
+                  />
+                  <Text variant="micro" tone="faint">
+                    Eight characters or more. A phrase you will remember beats a puzzle you will
+                    not.
+                  </Text>
+                  <Button
+                    label={
+                      isGuest
+                        ? 'Add this to my account'
+                        : intent === 'sign_up'
+                          ? 'Create account'
+                          : 'Sign in'
+                    }
+                    size="lg"
+                    fullWidth
+                    disabled={busy || !identifier.trim() || password.length < 8}
+                    onPress={() => void run(() => withPassword(identifier, password, intent))}
+                  />
+                  {/* A guest is never signing up or in — they are adding a way
+                    back to the account they already have. */}
+                  {isGuest ? null : (
+                    <Button
+                      label={
+                        intent === 'sign_up'
+                          ? 'I already have an account'
+                          : 'I am new here — create an account'
+                      }
+                      variant="ghost"
+                      onPress={() => {
+                        setIntent(intent === 'sign_up' ? 'sign_in' : 'sign_up');
+                        setError(null);
+                      }}
+                    />
+                  )}
+                </>
+              ) : null}
+
+              {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
+              {error ? (
+                <Text variant="caption" tone="negative">
+                  {error}
+                </Text>
+              ) : null}
+            </Card>
+
+            <Button
+              label={isGuest ? 'Continue with Google' : 'Sign in with Google'}
+              variant="secondary"
+              size="lg"
+              fullWidth
+              disabled={busy}
+              onPress={() => void run(withGoogle)}
+            />
+
+            {/* ADR-006: nobody is forced to register before they can use Baaki.
+              Still here, one step back from the welcome, for somebody who came
+              looking for their account and decided not to bother. */}
+            {isGuest ? null : (
+              <Button
+                label="Continue as guest"
+                variant="ghost"
+                size="lg"
+                fullWidth
+                disabled={busy}
+                onPress={() => void run(continueAsGuest)}
+              />
+            )}
+
+            <Text variant="micro" tone="faint" align="center">
+              {isGuest
+                ? 'Everything you have already added stays exactly where it is. This only adds a way to sign back in.'
+                : 'A guest account keeps everything on this device until you add a way to sign in. Your ledger is never held hostage.'}
+            </Text>
+          </View>
+        </ScrollView>
       </KeyboardAvoidingView>
     </Screen>
   );

--- a/packages/ui/src/components/CurvedPanel.tsx
+++ b/packages/ui/src/components/CurvedPanel.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from 'react';
+import { useWindowDimensions, View, type ViewStyle } from 'react-native';
+
+import { useTheme } from '../theme';
+
+export interface CurvedPanelProps {
+  children?: ReactNode;
+  /** How tall the coloured area is. */
+  height: number;
+  /** Brand purple, or the soft tint for a lighter first impression. */
+  tone?: 'brand' | 'soft';
+  /**
+   * How deep the sweep is, 0–1 of the panel height. Higher curves harder;
+   * 0 is a straight edge.
+   */
+  curve?: number;
+  style?: ViewStyle;
+}
+
+/**
+ * A coloured panel whose bottom edge sweeps rather than cuts.
+ *
+ * Drawn with an over-wide box and a large bottom radius rather than an SVG
+ * path: the arc is the middle of a much wider ellipse, which is why it reads as
+ * a gentle sweep instead of two corners that have been rounded. It also keeps
+ * this out of react-native-svg — a native module that would have to be in every
+ * build before the sign-in screen could render, and a native module missing
+ * from a build is how this app has previously lost a whole screen.
+ *
+ * Children sit above the curve at true screen width; the widening is only ever
+ * the background's problem.
+ */
+export function CurvedPanel({
+  children,
+  height,
+  tone = 'brand',
+  curve = 0.55,
+  style,
+}: CurvedPanelProps) {
+  const theme = useTheme();
+  const { width } = useWindowDimensions();
+
+  // Wide enough that the screen only ever sees the flat middle of the arc.
+  const overhang = width * 0.45;
+  const drawnWidth = width + overhang * 2;
+
+  // React Native clamps a corner radius to what the box can hold, so the two
+  // bottom radii together may not exceed the width. Doing that arithmetic here
+  // means the shape is the one asked for rather than whatever survived.
+  const radius = Math.min(height * curve * 2, drawnWidth / 2);
+
+  return (
+    <View style={[{ height }, style]}>
+      <View
+        pointerEvents="none"
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: -overhang,
+          width: drawnWidth,
+          height,
+          backgroundColor: tone === 'brand' ? theme.color.brand : theme.color.brandSoft,
+          borderBottomLeftRadius: radius,
+          borderBottomRightRadius: radius,
+        }}
+      />
+      <View style={{ flex: 1 }}>{children}</View>
+    </View>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,6 +10,7 @@ export * from './tokens';
 export * from './theme';
 export * from './components/Text';
 export * from './components/Surfaces';
+export * from './components/CurvedPanel';
 export * from './components/Button';
 export * from './components/Chip';
 export * from './components/Avatar';


### PR DESCRIPTION
Both doorway screens were a centred column on a flat background — correct, and saying nothing. The welcome in particular was a wall of four sign-in methods before anybody had been told what the app is for.

The welcome now opens on a brand-purple panel whose bottom edge sweeps rather than cuts, with the wordmark on it, one line of what Baaki does, and a single primary button. That button is **Start now**, which continues as a guest — ADR-006 says nobody registers before they can split a bill, so the guest path is the primary action, not small print under a sign-up form. Everything that was there before (code to a phone, password, Google, sign-up/sign-in switching) is one tap behind "I already have an account", unchanged. A guest arriving to add credentials skips the welcome — they are not choosing how to start.

The lock screen takes the same shape deliberately: somebody meeting it is looking at a phone that will not open, and the quickest way to say "this is still your app" is for it to look like the app.

The arc is an over-wide box with a large bottom radius, not an SVG path, so the screen sees only the flat middle of a much wider ellipse. That keeps `react-native-svg` out of the dependency list — which matters for a component that renders before anything else in the app.

The version now sits at the foot of both. People get asked for it when something breaks and it was previously findable nowhere.

DESIGN.md gains the component and a correction: it still said cards are `xl`, which stopped being true when they moved to `md`.

## Verified

Both screens driven in the running app. The welcome could not be reached by signing out — this is a guest account and signing out of one is irreversible — so the redirect was bypassed temporarily for the screenshot and put back. No session was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6