### PR TITLE
feat: show a first-time user what Baaki is, before asking anything

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,10 @@
 node_modules
 dist
 .expo
+# Written by expo start, ignored by apps/mobile/.gitignore — but Prettier only
+# reads the .gitignore next to where it runs, so it would otherwise report a
+# generated file as a style violation nobody can fix for good.
+apps/mobile/expo-env.d.ts
 packages/db/generated
 packages/db/prisma/migrations
 pnpm-lock.yaml

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -61,9 +61,28 @@ read: no balance, no list, no decision. Everywhere past it is somebody's money,
 and a shape that draws the eye there is a shape competing with a number.
 
 The arc is an over-wide box with a large bottom radius, not an SVG path — the
-screen only ever sees the flat middle of a much wider ellipse. That keeps
+screen only ever sees the middle of a much wider circle. That keeps
 `react-native-svg` out of the dependency list, which matters for a screen that
 has to render before anything else in the app does.
+
+The overhang has to scale with the radius, not with the screen. It did not once,
+and the sign-in header shipped as a plain rectangle: the panel was short, so the
+radius was small, so the whole arc sat off the sides of the screen and the flat
+middle was all that showed. The arithmetic and its three caps now live in
+`packages/ui/src/curve.ts`, on their own and tested, because nothing about that
+failure looked like a failure.
+
+## Meeting Baaki for the first time
+
+Three full-bleed pastel cards before the welcome — what you get for free, that
+the people you split with need no account, and that settling hands the amount to
+UPI. Swipeable, skippable from the first frame, shown once and never again.
+
+It is emoji rather than illustration, at the same size art would be. Art means a
+binary asset in every build, and these are the frames that render before the app
+has proved anything about itself; the group covers are emoji for the same reason,
+so the tour looks like the product rather than a brochure stapled to the front of
+it.
 
 ## Spacing
 

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -14,7 +14,8 @@
  * to decide.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
 import {
   ActivityIndicator,
@@ -28,10 +29,13 @@ import {
 
 import { Button, Card, Chip, CurvedPanel, Row, Screen, Text, useTheme } from '@baaki/ui';
 
+import { Onboarding } from '@/components/Onboarding';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
 type Mode = 'otp' | 'password';
+
+const TOUR_KEY = 'baaki.onboarding_seen';
 
 export default function SignInScreen() {
   const theme = useTheme();
@@ -45,6 +49,34 @@ export default function SignInScreen() {
    * be asking a question they answered a week ago.
    */
   const [showOptions, setShowOptions] = useState(isGuest);
+
+  /**
+   * `null` until storage answers. Rendering the welcome while we find out would
+   * show it for one frame and then yank it away, which reads as a glitch on the
+   * very first screen of the app.
+   *
+   * A guest is not a first-time user — they have been using Baaki and have come
+   * here to add a way back in — so the tour is never their problem.
+   */
+  const [tourSeen, setTourSeen] = useState<boolean | null>(isGuest ? true : null);
+
+  useEffect(() => {
+    if (tourSeen !== null) return;
+    let cancelled = false;
+    void AsyncStorage.getItem(TOUR_KEY)
+      .then((value) => {
+        if (!cancelled) setTourSeen(value === 'yes');
+      })
+      // Storage failing is not a reason to hold somebody at a blank screen.
+      // Worst case they see the tour once more than they should.
+      .catch(() => {
+        if (!cancelled) setTourSeen(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tourSeen]);
+
   const [mode, setMode] = useState<Mode>('otp');
   const [phone, setPhone] = useState('+91');
   const [code, setCode] = useState('');
@@ -66,6 +98,23 @@ export default function SignInScreen() {
       setBusy(false);
     }
   };
+
+  if (tourSeen === null) {
+    return <View style={{ flex: 1, backgroundColor: theme.color.bg }} />;
+  }
+
+  if (!tourSeen) {
+    return (
+      <Onboarding
+        onDone={() => {
+          setTourSeen(true);
+          // Not awaited: the tour is over the moment they say so, and a write
+          // that fails costs them one repeat, not a stuck screen.
+          void AsyncStorage.setItem(TOUR_KEY, 'yes').catch(() => {});
+        }}
+      />
+    );
+  }
 
   /**
    * The welcome: the wordmark on a coloured sweep, one sentence, and the button

--- a/apps/mobile/src/components/Onboarding.tsx
+++ b/apps/mobile/src/components/Onboarding.tsx
@@ -1,0 +1,211 @@
+/**
+ * The three cards a first-time user meets, before the welcome.
+ *
+ * A tour is a tax on somebody who wants to split a bill, so it is paid exactly
+ * once and it is always skippable from the first frame. What it buys is the
+ * three things about Baaki that are not guessable from a ledger screen: that
+ * nothing is behind a sign-up, that the people you split with do not need the
+ * app, and that settling hands the amount to UPI rather than leaving you to
+ * type it. Somebody who never reads this loses nothing they cannot find later.
+ *
+ * Full-bleed tint per card rather than one background: the colour changing
+ * under your thumb is the progress indicator that needs no explanation, and the
+ * dots are there for anyone who wants to count.
+ */
+
+import { useRef, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import {
+  Pressable,
+  ScrollView,
+  useWindowDimensions,
+  View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Text, useTheme, type TintName } from '@baaki/ui';
+
+import { useMotion } from '@/lib/motion';
+
+interface Slide {
+  readonly tint: TintName;
+  readonly emoji: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+/**
+ * Emoji rather than illustration. Not for want of an artist: art has to ship as
+ * a binary asset in every build, and this screen is the one that renders before
+ * the app has proved anything about itself. The group covers are emoji for the
+ * same reason, so the tour looks like the product rather than like a brochure
+ * bolted to the front of it.
+ */
+const SLIDES: readonly Slide[] = [
+  {
+    tint: 'lilac',
+    emoji: '🧾',
+    // Not "split anything with anyone" — that is the welcome's line, and the
+    // welcome is the very next screen. Two cards saying the same sentence in
+    // sequence reads as a page that failed to advance.
+    title: 'Dinner, rent,\na whole trip',
+    body: 'Baaki keeps who paid and who owes, down to the last rupee — free, and with no account to make first.',
+  },
+  {
+    tint: 'mint',
+    emoji: '🔗',
+    title: 'Send a link,\nthey are in',
+    body: 'The people you split with do not need to install anything. They open a link and see the same numbers you do.',
+  },
+  {
+    tint: 'peach',
+    emoji: '⚡',
+    title: 'Settle it\nin one tap',
+    body: 'Baaki hands the exact amount to your UPI app, so nobody does the arithmetic twice and nobody is owed a rounding error.',
+  },
+];
+
+export function Onboarding({ onDone }: { onDone: () => void }) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const { animated } = useMotion();
+  const { width, height } = useWindowDimensions();
+  const scroller = useRef<ScrollView>(null);
+  const [index, setIndex] = useState(0);
+
+  const goTo = (next: number) => {
+    if (next >= SLIDES.length) {
+      onDone();
+      return;
+    }
+    setIndex(next);
+    scroller.current?.scrollTo({ x: next * width, animated });
+  };
+
+  // The page under the thumb decides the index, so a drag and a tap on the
+  // arrow cannot disagree about which card is showing.
+  //
+  // Driven by scroll position rather than by the momentum-end event: a slow
+  // drag that is released without a flick never produces momentum, and the
+  // dots would sit under the wrong card until the next tap.
+  const onScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const page = Math.round(event.nativeEvent.contentOffset.x / width);
+    if (page !== index) setIndex(page);
+  };
+
+  return (
+    <ScrollView
+      ref={scroller}
+      horizontal
+      pagingEnabled
+      showsHorizontalScrollIndicator={false}
+      onScroll={onScroll}
+      scrollEventThrottle={16}
+      style={{ flex: 1 }}
+    >
+      {SLIDES.map((slide, slideIndex) => {
+        const { bg, ink } = theme.tint[slide.tint];
+        const last = slideIndex === SLIDES.length - 1;
+
+        return (
+          <View
+            key={slide.tint}
+            style={{
+              width,
+              // Stated rather than stretched: a horizontal ScrollView sizes
+              // itself to its content, so a card left to find its own height
+              // is only as tall as its paragraph and the colour stops in the
+              // middle of the screen.
+              height,
+              backgroundColor: bg,
+              paddingTop: insets.top + theme.spacing.md,
+              paddingBottom: insets.bottom + theme.spacing.xxl,
+              paddingHorizontal: theme.spacing.xxxl,
+            }}
+          >
+            <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+              <Text style={{ fontSize: 20, fontWeight: '700', color: ink }}>பாக்கி</Text>
+              <Pressable
+                onPress={onDone}
+                accessibilityRole="button"
+                accessibilityLabel="Skip the introduction"
+                hitSlop={12}
+              >
+                <Text variant="caption" style={{ color: ink, opacity: 0.7 }}>
+                  Skip
+                </Text>
+              </Pressable>
+            </View>
+
+            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+              {/* Decorative: the sentence below says the same thing, and a
+                  screen reader announcing "receipt" adds nothing. */}
+              <Text
+                accessibilityElementsHidden
+                importantForAccessibility="no"
+                style={{ fontSize: 120 }}
+              >
+                {slide.emoji}
+              </Text>
+            </View>
+
+            <View style={{ gap: theme.spacing.md }}>
+              <Text style={{ fontSize: 36, fontWeight: '700', color: ink }}>{slide.title}</Text>
+              <Text variant="body" style={{ color: ink, opacity: 0.75 }}>
+                {slide.body}
+              </Text>
+            </View>
+
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingTop: theme.spacing.xxl,
+              }}
+            >
+              <View style={{ flexDirection: 'row', gap: theme.spacing.sm }}>
+                {SLIDES.map((dot, dotIndex) => (
+                  <View
+                    key={dot.tint}
+                    style={{
+                      height: 8,
+                      width: dotIndex === index ? 24 : 8,
+                      borderRadius: theme.radius.pill,
+                      backgroundColor: ink,
+                      opacity: dotIndex === index ? 1 : 0.3,
+                    }}
+                  />
+                ))}
+              </View>
+
+              <Pressable
+                onPress={() => goTo(slideIndex + 1)}
+                accessibilityRole="button"
+                accessibilityLabel={last ? 'Get started' : 'Next'}
+                style={({ pressed }) => ({
+                  height: 56,
+                  width: 56,
+                  borderRadius: theme.radius.pill,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: theme.color.surface,
+                  opacity: pressed ? 0.85 : 1,
+                  ...theme.shadow.soft,
+                })}
+              >
+                <Ionicons
+                  name={last ? 'checkmark' : 'arrow-forward'}
+                  size={24}
+                  color={theme.color.text}
+                />
+              </Pressable>
+            </View>
+          </View>
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/apps/mobile/test/curve.test.ts
+++ b/apps/mobile/test/curve.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The doorway screens' sweep.
+ *
+ * This exists because the sign-in header shipped as a flat rectangle. The
+ * component was right, the colours were right, the panel was there — the arc
+ * had simply been pushed off the sides of the screen by an overhang that did
+ * not scale with the radius, and a shorter panel made the radius small. Nothing
+ * failed; it just stopped being a curve.
+ *
+ * So the thing pinned here is not "the numbers are these numbers", it is "at
+ * every panel height the app actually uses, the curve is still visible".
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { curveGeometry } from '@baaki/ui/curve';
+
+// A narrow phone, a normal one, and a tablet-ish width.
+const WIDTHS = [320, 390, 768];
+
+describe('curveGeometry', () => {
+  it('drops the edge visibly on a tall panel', () => {
+    // The welcome and lock screens: 46% of the screen, capped at 420.
+    const { edgeDip } = curveGeometry(390, 420, 0.55);
+    expect(edgeDip).toBeGreaterThan(20);
+  });
+
+  it('drops the edge visibly on a short panel too', () => {
+    // The sign-in header. This is the case that shipped flat: the requested
+    // radius (252) was taller than the panel (180), so it was scaled away.
+    const { edgeDip } = curveGeometry(390, 180, 0.7);
+    expect(edgeDip).toBeGreaterThan(10);
+  });
+
+  it('never asks for a radius the renderer would silently rescale', () => {
+    for (const width of WIDTHS) {
+      for (const height of [120, 180, 260, 420]) {
+        for (const curve of [0.2, 0.55, 0.7, 1]) {
+          const { radius, drawnWidth } = curveGeometry(width, height, curve);
+          // A corner cannot be taller than its box…
+          expect(radius).toBeLessThanOrEqual(height);
+          // …and two bottom corners cannot be wider than one.
+          expect(radius * 2).toBeLessThanOrEqual(drawnWidth);
+        }
+      }
+    }
+  });
+
+  it('keeps the arc reaching into the visible width', () => {
+    // The overhang must stay inside the arc. Once it passes the radius, the
+    // screen sees only the flat middle — which is what "flat" looked like.
+    for (const width of WIDTHS) {
+      for (const height of [120, 180, 260, 420]) {
+        const { overhang, radius, edgeDip } = curveGeometry(width, height, 0.55);
+        expect(overhang).toBeLessThan(radius);
+        expect(edgeDip).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('draws nothing at all rather than half a shape when asked for no curve', () => {
+    const { radius, edgeDip, drawnWidth } = curveGeometry(390, 200, 0);
+    expect(radius).toBe(0);
+    expect(edgeDip).toBe(0);
+    expect(drawnWidth).toBe(390);
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./curve": "./src/curve.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/ui/src/components/CurvedPanel.tsx
+++ b/packages/ui/src/components/CurvedPanel.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { useWindowDimensions, View, type ViewStyle } from 'react-native';
 
+import { curveGeometry } from '../curve';
 import { useTheme } from '../theme';
 
 export interface CurvedPanelProps {
@@ -40,14 +41,9 @@ export function CurvedPanel({
   const theme = useTheme();
   const { width } = useWindowDimensions();
 
-  // Wide enough that the screen only ever sees the flat middle of the arc.
-  const overhang = width * 0.45;
-  const drawnWidth = width + overhang * 2;
-
-  // React Native clamps a corner radius to what the box can hold, so the two
-  // bottom radii together may not exceed the width. Doing that arithmetic here
-  // means the shape is the one asked for rather than whatever survived.
-  const radius = Math.min(height * curve * 2, drawnWidth / 2);
+  // Wide enough that the screen only ever sees the middle of the arc, and no
+  // wider — see curve.ts, where the arithmetic and its three caps live.
+  const { overhang, drawnWidth, radius } = curveGeometry(width, height, curve);
 
   return (
     <View style={[{ height }, style]}>

--- a/packages/ui/src/curve.ts
+++ b/packages/ui/src/curve.ts
@@ -1,0 +1,56 @@
+/**
+ * Where to draw a `CurvedPanel`'s background so its bottom edge sweeps.
+ *
+ * Separate from the component, and free of React Native, because this is the
+ * part that can be wrong without looking wrong: the panel still renders, still
+ * fills, still has the right colour — it is just flat. That shipped once
+ * already (the sign-in header), and a screenshot is the only thing that caught
+ * it.
+ */
+
+export interface CurveGeometry {
+  /** How far past each screen edge the coloured box is drawn. */
+  readonly overhang: number;
+  /** Total width of the drawn box: the screen plus both overhangs. */
+  readonly drawnWidth: number;
+  /** The bottom corner radius to apply. */
+  readonly radius: number;
+  /** How far the sweep drops below the panel's bottom, at the screen edge. */
+  readonly edgeDip: number;
+}
+
+/**
+ * The screen's edge sits this far into the corner arc, as a fraction of the
+ * radius. It has to scale *with* the radius rather than with the screen: an
+ * overhang wider than the arc puts the whole curve off-screen and leaves the
+ * flat middle showing, which is exactly how a curve goes missing.
+ *
+ * At this value the visible drop is about 15% of the radius — enough to read as
+ * a sweep, little enough that there is still a straight run of colour to put a
+ * wordmark on.
+ */
+const EDGE_INSET = 0.474;
+
+export function curveGeometry(width: number, height: number, curve: number): CurveGeometry {
+  // Three caps, and each one belongs here rather than left to the renderer.
+  // CSS scales *every* radius on a box down together when any pair overruns a
+  // side, so a radius 40px too tall does not come back 40px shorter — it comes
+  // back a different shape, in this case a rectangle. Clamping in code means
+  // what is asked for is what is drawn.
+  //
+  //   height * curve * 2 — what the caller asked for
+  //   height            — a corner cannot be taller than its box
+  //   width * 0.95      — the two bottom corners together cannot exceed the
+  //                       drawn width, and the drawn width depends on the
+  //                       radius, which settles at width / 1.052
+  const radius = Math.max(0, Math.min(height * curve * 2, height, width * 0.95));
+  const overhang = radius * EDGE_INSET;
+  const inset = radius - overhang;
+
+  return {
+    overhang,
+    drawnWidth: width + overhang * 2,
+    radius,
+    edgeDip: radius - Math.sqrt(Math.max(0, radius * radius - inset * inset)),
+  };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -8,6 +8,7 @@
 
 export * from './tokens';
 export * from './theme';
+export * from './curve';
 export * from './components/Text';
 export * from './components/Surfaces';
 export * from './components/CurvedPanel';


### PR DESCRIPTION
Three swipeable cards ahead of the welcome — what is free, that the people you split with need no account, and that settling hands the amount to a UPI app. Skippable from the first frame, shown exactly once (`baaki.onboarding_seen`), and never shown to a guest, who has been using Baaki for a week and has come to the sign-in screen to add a way back in.

Full-bleed tint per card: the colour changing under your thumb is a progress indicator nobody has to be taught. Dots are there for anyone who wants to count.

Emoji rather than illustration — art has to ship as a binary asset in every build, and these are the frames that render before the app has proved anything about itself.

## Also: the curved panel was not curved

The sign-in header shipped as a plain rectangle. The overhang was a fraction of the screen width while the radius came from the panel height, so on a short panel the whole arc sat off both sides and only its flat middle was on screen. CSS makes this silent: when any radius overruns its box, *every* radius on that box is scaled down together, so an over-tall corner does not come back shorter — it comes back straight.

The arithmetic and its three caps now live in `packages/ui/src/curve.ts`, and `apps/mobile/test/curve.test.ts` pins the property that matters: at every panel height the app uses, the arc still reaches into the visible width. The welcome and lock screens are pixel-identical; only the short panel changes.

Also adds `apps/mobile/expo-env.d.ts` to `.prettierignore` — it is generated by `expo start` and ignored by `apps/mobile/.gitignore`, but Prettier only reads the `.gitignore` beside where it runs, so it was reported as a style violation nobody could fix for good.

## Driven, not just built

Run against the live project on the web build, in a fresh browser context so the existing guest was never signed out:

- first card, both light and dark
- swipe to the third; the dots follow (they did not, at first — the index came from the momentum-end event, which a slow drag never fires)
- **Skip** and the tick on the last card both land on the welcome
- reload afterwards: the tour stays gone

`pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean; `test:app` 55 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6