### PR TITLE
feat: say what the expense was for, instead of typing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,30 @@ builds and runs unchanged:
 A DSN is public by design: it can only write events, which is why it ships in
 the binary. `SENTRY_AUTH_TOKEN` is the one that reads, and it stays in CI.
 
+## Saying the note instead of typing it
+
+The mic beside "What was it for?" is the platform's own recogniser —
+`SFSpeechRecognizer` on iOS, `SpeechRecognizer` on Android, via
+`expo-speech-recognition`. On-device whenever the phone has a model for the
+language, so what somebody says across a restaurant table is not sent anywhere;
+where it has none, the OS falls back to the same network recogniser its own
+keyboard mic uses.
+
+Three decisions worth knowing:
+
+- **It recognises in the language the app is showing**, and keeps the phone's
+  own region when the two agree — `en-GB` stays `en-GB`, a bare `ta` becomes
+  `ta-IN`. `speechLocale` in `apps/mobile/src/lib/dictation.ts`.
+- **Member names are passed as `contextualStrings`.** A general model guesses at
+  Indian names and gets them wrong, and the note is where they turn up.
+- **Dictation adds to the field, never replaces it.** Interim results arrive in
+  full each time, so the text is recomputed from what was there when the mic was
+  tapped rather than appended — `mergeTranscript`, and the test that pins it.
+
+Native module, so it needs a new dev build or store build: `npx expo prebuild`
+then `eas build`. The mic does not render on web, and an existing binary will
+not grow it from an over-the-air change.
+
 ## Releasing, and stopping old builds
 
 The version is compiled into the binary, so a build can only ever describe

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -44,6 +44,14 @@
           "contactsPermission": "Baaki uses your contacts so you can pick who was there instead of typing their name. Your contacts stay on this phone — only the person you tap is sent."
         }
       ],
+      [
+        "expo-speech-recognition",
+        {
+          "microphonePermission": "Baaki uses the microphone only while you hold the mic button, to write down what you say.",
+          "speechRecognitionPermission": "Baaki turns what you say into the note on an expense, so you can add one without typing at the table.",
+          "androidSpeechServicePackages": ["com.google.android.googlequicksearchbox"]
+        }
+      ],
       "expo-secure-store",
       "expo-sharing",
       "@react-native-community/datetimepicker",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,6 +37,7 @@
     "expo-router": "~57.0.11",
     "expo-secure-store": "~57.0.1",
     "expo-sharing": "~57.0.8",
+    "expo-speech-recognition": "^56.0.1",
     "expo-splash-screen": "~57.0.5",
     "expo-sqlite": "~57.0.1",
     "expo-status-bar": "~57.0.1",

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -21,6 +21,7 @@ import {
 } from '@baaki/ui';
 
 import { CurrencyRate } from '@/components/CurrencyRate';
+import { DictateButton } from '@/components/DictateButton';
 import { useGroup } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
@@ -66,6 +67,19 @@ export default function AddExpenseScreen() {
   const [splitKind, setSplitKind] = useState<SplitKind>('equal');
   const [payer, setPayer] = useState<MemberId | null>(null);
   const [participants, setParticipants] = useState<MemberId[]>([]);
+  /**
+   * Names to bias the recogniser towards. "You" and "Someone" are placeholders
+   * this screen prints, not things anybody says out loud, so they would only
+   * teach it to hear the wrong word.
+   */
+  const nameHints = useMemo(
+    () =>
+      (members.data ?? [])
+        .map((member) => displayName(member, profile?.id))
+        .filter((name) => name !== 'You' && name !== 'Someone'),
+    [members.data, profile?.id],
+  );
+
   const [expenseCurrency, setExpenseCurrency] = useState<string | null>(null);
   const [fx, setFx] = useState<FxRecord | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -278,19 +292,26 @@ export default function AddExpenseScreen() {
           <Text variant="caption" tone="muted">
             {t.description}
           </Text>
-          <TextInput
-            value={description}
-            onChangeText={setDescription}
-            placeholder="Beach shack dinner"
-            placeholderTextColor={theme.color.textFaint}
-            accessibilityLabel={t.description}
-            style={{
-              fontSize: 17,
-              fontWeight: '600',
-              color: theme.color.text,
-              paddingVertical: theme.spacing.sm,
-            }}
-          />
+          <Row style={{ gap: theme.spacing.md, alignItems: 'flex-start' }}>
+            <TextInput
+              value={description}
+              onChangeText={setDescription}
+              placeholder="Beach shack dinner"
+              placeholderTextColor={theme.color.textFaint}
+              accessibilityLabel={t.description}
+              style={{
+                flex: 1,
+                fontSize: 17,
+                fontWeight: '600',
+                color: theme.color.text,
+                paddingVertical: theme.spacing.sm,
+              }}
+            />
+            {/* The member names are handed to the recogniser as hints. A
+                general model guesses at Indian names and gets them wrong, and
+                the note is exactly where they turn up. */}
+            <DictateButton value={description} onChange={setDescription} hints={nameHints} />
+          </Row>
         </Card>
 
         <View style={{ gap: theme.spacing.md }}>

--- a/apps/mobile/src/components/DictateButton.tsx
+++ b/apps/mobile/src/components/DictateButton.tsx
@@ -1,0 +1,178 @@
+/**
+ * A microphone beside a text field.
+ *
+ * Speech recognition is the platform's own — `SFSpeechRecognizer` on iOS,
+ * `SpeechRecognizer` on Android — and on-device whenever the phone can manage
+ * it, so what somebody says at a restaurant table is not shipped to a server to
+ * be turned into "Beach shack dinner". Where the phone has no on-device model
+ * the OS falls back to its network recogniser, which is the same recogniser the
+ * keyboard's own mic key uses.
+ *
+ * Web renders nothing. Browsers do have a speech API, but it is Google's
+ * servers behind it, and this repo uses the web build to check screens rather
+ * than to ship them.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { ExpoSpeechRecognitionModule, useSpeechRecognitionEvent } from 'expo-speech-recognition';
+import { Linking, Platform, Pressable, View } from 'react-native';
+
+import { Text, useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+import { dictationError, mergeTranscript, speechLocale } from '@/lib/dictation';
+
+export interface DictateButtonProps {
+  /** What is in the field now. Dictation adds to it, never replaces it. */
+  value: string;
+  onChange: (next: string) => void;
+  /**
+   * Words the recogniser should expect — member names, usually. Indian names
+   * are exactly what a general model gets wrong, and this is the one lever the
+   * platform gives us over that.
+   */
+  hints?: readonly string[];
+}
+
+const SUPPORTED = Platform.OS === 'ios' || Platform.OS === 'android';
+
+/** Whether this phone has a recogniser at all. A phone without one gets no mic. */
+function recognitionAvailable(): boolean {
+  if (!SUPPORTED) return false;
+  try {
+    return ExpoSpeechRecognitionModule.isRecognitionAvailable();
+  } catch {
+    return false;
+  }
+}
+
+export function DictateButton({ value, onChange, hints }: DictateButtonProps) {
+  const theme = useTheme();
+  const { language, locale } = useStrings();
+
+  // Asked once, on the first render: this is a property of the phone, not
+  // something that changes while somebody is looking at an expense.
+  const [available] = useState(recognitionAvailable);
+  const [listening, setListening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // What the field held when the mic was tapped. Interim results are re-issued
+  // in full, so every one of them is merged onto this rather than onto the
+  // field's current contents.
+  const before = useRef(value);
+
+  useSpeechRecognitionEvent('result', (event) => {
+    const transcript = event.results[0]?.transcript ?? '';
+    onChange(mergeTranscript(before.current, transcript));
+  });
+
+  useSpeechRecognitionEvent('error', (event) => {
+    const message = dictationError(event.error);
+    if (message) setError(message);
+  });
+
+  useSpeechRecognitionEvent('end', () => setListening(false));
+
+  const stop = useCallback(() => {
+    ExpoSpeechRecognitionModule.stop();
+    setListening(false);
+  }, []);
+
+  const start = useCallback(async () => {
+    setError(null);
+
+    const permission = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
+    if (!permission.granted) {
+      setError(
+        permission.canAskAgain
+          ? 'Baaki needs permission to use the microphone.'
+          : 'Microphone access is off for Baaki. You can turn it on in Settings.',
+      );
+      return;
+    }
+
+    // Best effort, not a requirement: asking for on-device recognition on a
+    // phone that has no model for this language would fail outright, and a
+    // failed note is worse than a note the OS transcribed over the network.
+    let onDevice = false;
+    try {
+      onDevice = ExpoSpeechRecognitionModule.supportsOnDeviceRecognition();
+    } catch {
+      onDevice = false;
+    }
+
+    before.current = value;
+    setListening(true);
+
+    try {
+      ExpoSpeechRecognitionModule.start({
+        lang: speechLocale(language, locale),
+        interimResults: true,
+        maxAlternatives: 1,
+        // A note is one short utterance. Continuous listening would leave the
+        // mic open on a table full of other people talking.
+        continuous: false,
+        requiresOnDeviceRecognition: onDevice,
+        // Android only honours this with on-device recognition; iOS punctuates
+        // either way.
+        addsPunctuation: onDevice,
+        contextualStrings: hints && hints.length > 0 ? [...hints] : undefined,
+        iosTaskHint: 'dictation',
+      });
+    } catch {
+      setListening(false);
+      setError('Dictation could not start. Type the note instead.');
+    }
+  }, [hints, language, locale, value]);
+
+  // Leaving the screen mid-sentence must not leave the microphone open.
+  useEffect(() => {
+    return () => {
+      if (SUPPORTED) ExpoSpeechRecognitionModule.abort();
+    };
+  }, []);
+
+  if (!SUPPORTED || !available) return null;
+
+  return (
+    <View style={{ alignItems: 'flex-end', gap: theme.spacing.xs }}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={listening ? 'Stop dictating' : 'Dictate the note'}
+        accessibilityState={{ busy: listening }}
+        onPress={() => (listening ? stop() : void start())}
+        hitSlop={8}
+        style={({ pressed }) => ({
+          width: 44,
+          height: 44,
+          borderRadius: theme.radius.pill,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: listening ? theme.color.brand : theme.color.brandSoft,
+          opacity: pressed ? 0.85 : 1,
+        })}
+      >
+        <Ionicons
+          name={listening ? 'stop' : 'mic-outline'}
+          size={20}
+          color={listening ? theme.color.onBrand : theme.color.brand}
+        />
+      </Pressable>
+
+      {listening ? (
+        <Text variant="micro" tone="brand">
+          Listening…
+        </Text>
+      ) : null}
+
+      {error ? (
+        <Pressable onPress={() => void Linking.openSettings()} accessibilityRole="button">
+          <Text variant="micro" tone="negative" style={{ textAlign: 'right' }}>
+            {error}
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -1,0 +1,71 @@
+/**
+ * The parts of dictation that are not the microphone.
+ *
+ * Kept free of React and of the native module so they can be tested without a
+ * device: which language to recognise in, how a transcript joins whatever is
+ * already in the field, and what to tell somebody when it fails. All three have
+ * been quietly wrong in other apps — recognising English while somebody speaks
+ * Tamil, replacing what they typed instead of adding to it, and showing
+ * "error 7".
+ */
+
+import type { Language } from '@/i18n';
+
+/**
+ * The BCP-47 tag to recognise in.
+ *
+ * The device's own tag wins when it agrees with the language the app is showing
+ * — somebody on `en-GB` should be recognised as `en-GB`, not corrected to
+ * Indian English. When it disagrees, or carries no region, India is the
+ * fallback: Baaki is India-first, and `ta`/`hi` with no region is a recogniser
+ * lottery on Android.
+ */
+export function speechLocale(language: Language, deviceLocale: string): string {
+  const [tag, region] = deviceLocale.trim().split(/[-_]/);
+  if (tag?.toLowerCase() === language && region) return `${language}-${region.toUpperCase()}`;
+  return `${language}-IN`;
+}
+
+/**
+ * What the field should read while somebody is speaking.
+ *
+ * `before` is whatever was in the field when the mic was tapped, and it is
+ * never thrown away: dictation adds to a note, it does not replace one. The
+ * transcript is recomputed from `before` on every interim result rather than
+ * appended, because interim results are re-issued in full — appending them
+ * gives you "dinner dinner at dinner at the".
+ */
+export function mergeTranscript(before: string, transcript: string): string {
+  const spoken = transcript.trim();
+  if (!spoken) return before;
+  const kept = before.trimEnd();
+  return kept ? `${kept} ${spoken}` : spoken;
+}
+
+/**
+ * Every error this can end on, in words.
+ *
+ * The codes are the Web Speech API's, which both native implementations are
+ * mapped onto. Anything unrecognised gets a sentence that is still true, so a
+ * new code in a future version is a vague message rather than a blank one.
+ */
+export function dictationError(code: string): string {
+  switch (code) {
+    case 'not-allowed':
+    case 'service-not-allowed':
+      return 'Baaki needs permission to use the microphone. You can turn it on in Settings.';
+    case 'no-speech':
+      return 'Did not catch anything. Tap the mic and speak again.';
+    case 'audio-capture':
+      return 'The microphone is busy. Close anything else that is recording and try again.';
+    case 'network':
+      return 'Speech recognition needs a connection on this phone. Type the note instead.';
+    case 'language-not-supported':
+      return 'This phone cannot recognise that language yet. Type the note instead.';
+    // Not an error anybody needs telling about: it is what stopping produces.
+    case 'aborted':
+      return '';
+    default:
+      return 'Dictation stopped. Type the note instead.';
+  }
+}

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Dictation, minus the microphone.
+ *
+ * The three things that can be wrong without anybody noticing on the device
+ * they happen to be holding: recognising the wrong language, eating what was
+ * already typed, and turning a platform error code into a blank screen.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { dictationError, mergeTranscript, speechLocale } from '@/lib/dictation';
+
+describe('speechLocale', () => {
+  it('keeps the phone’s own region when it agrees with the app language', () => {
+    // Somebody in London is recognised as British English, not corrected to
+    // Indian English because the app happens to be India-first.
+    expect(speechLocale('en', 'en-GB')).toBe('en-GB');
+    expect(speechLocale('ta', 'ta-LK')).toBe('ta-LK');
+  });
+
+  it('falls back to India when the tag carries no region', () => {
+    // Bare "ta" is a lottery on Android — some recognisers take it, some
+    // return language-not-supported.
+    expect(speechLocale('ta', 'ta')).toBe('ta-IN');
+    expect(speechLocale('hi', 'hi')).toBe('hi-IN');
+  });
+
+  it('follows the app language, not the phone, when they disagree', () => {
+    // The app is showing Tamil, so Tamil is what the user is about to speak.
+    expect(speechLocale('ta', 'en-US')).toBe('ta-IN');
+  });
+
+  it('survives the shapes a locale tag actually arrives in', () => {
+    expect(speechLocale('en', 'en_IN')).toBe('en-IN');
+    expect(speechLocale('en', 'en-in')).toBe('en-IN');
+    expect(speechLocale('en', '')).toBe('en-IN');
+  });
+});
+
+describe('mergeTranscript', () => {
+  it('adds to what was already typed', () => {
+    expect(mergeTranscript('Dinner', 'at the beach shack')).toBe('Dinner at the beach shack');
+  });
+
+  it('does not double the space at the join', () => {
+    expect(mergeTranscript('Dinner ', 'at the shack')).toBe('Dinner at the shack');
+    expect(mergeTranscript('Dinner', '  at the shack ')).toBe('Dinner at the shack');
+  });
+
+  it('is the transcript alone when the field was empty', () => {
+    expect(mergeTranscript('', 'Auto to the airport')).toBe('Auto to the airport');
+  });
+
+  it('leaves the field alone when nothing was heard', () => {
+    expect(mergeTranscript('Dinner', '')).toBe('Dinner');
+    expect(mergeTranscript('Dinner', '   ')).toBe('Dinner');
+  });
+
+  it('is stable across interim results, which arrive in full each time', () => {
+    // This is the property that matters: interim results are re-issued whole,
+    // so merging must be recomputed from the same starting text rather than
+    // appended, or the note reads "Dinner dinner at dinner at the".
+    const before = 'Dinner';
+    const interim = ['at', 'at the', 'at the beach shack'];
+    const rendered = interim.map((text) => mergeTranscript(before, text));
+    expect(rendered.at(-1)).toBe('Dinner at the beach shack');
+    expect(new Set(rendered).size).toBe(interim.length);
+  });
+});
+
+describe('dictationError', () => {
+  it('says what to do about a refused microphone', () => {
+    expect(dictationError('not-allowed')).toMatch(/Settings/);
+    expect(dictationError('service-not-allowed')).toMatch(/Settings/);
+  });
+
+  it('stays quiet when the user stopped it themselves', () => {
+    // Stopping emits `aborted`. Telling somebody their own tap was an error is
+    // how an app teaches people to ignore its messages.
+    expect(dictationError('aborted')).toBe('');
+  });
+
+  it('still says something useful for a code it has never seen', () => {
+    expect(dictationError('some-future-code')).not.toBe('');
+  });
+
+  it('never leaves somebody without a way forward', () => {
+    const codes = ['no-speech', 'audio-capture', 'network', 'language-not-supported', 'client'];
+    for (const code of codes) {
+      expect(dictationError(code)).toMatch(/try again|Type the note|speak again/i);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       expo-sharing:
         specifier: ~57.0.8
         version: 57.0.8(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      expo-speech-recognition:
+        specifier: ^56.0.1
+        version: 56.0.1(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       expo-splash-screen:
         specifier: ~57.0.5
         version: 57.0.5(expo@57.0.11)(supports-color@8.1.1)(typescript@6.0.3)
@@ -3925,6 +3928,13 @@ packages:
 
   expo-sharing@57.0.8:
     resolution: {integrity: sha512-ZjiA09iJjzveachyBlbIijSH++fiacdvuenxb/gsdW21V3SUSxMQd+krPmafnhnMus5aBqpP0TXCBfBJN+0Bfg==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+
+  expo-speech-recognition@56.0.1:
+    resolution: {integrity: sha512-TpP1KCiq3vYfSQF0XpUkWLXp4mTw6MLuyMGPzVVKwqzs7oiKlJ/e0q3PNNjfqs058X47ftqT+31lTaWRWRbmPg==}
     peerDependencies:
       expo: '*'
       react: '*'
@@ -10323,6 +10333,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-speech-recognition@56.0.1(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+    dependencies:
+      expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
   expo-splash-screen@57.0.5(expo@57.0.11)(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
A mic beside **"What was it for?"** on the add-expense screen. Native recognisers only — `SFSpeechRecognizer` on iOS, `SpeechRecognizer` on Android, via `expo-speech-recognition` — and on-device whenever the phone has a model for the language, so a note spoken across a restaurant table is not sent anywhere. Where the phone has no model, the OS falls back to the same network recogniser its own keyboard mic key uses.

## The three things that are easy to get wrong

**Language.** It recognises in the language the app is showing, keeping the phone's own region when the two agree — `en-GB` stays `en-GB` rather than being corrected to Indian English. A region-less `ta`/`hi` becomes `ta-IN`/`hi-IN`, because a bare tag is a lottery across Android recognisers.

**Names.** Member names go over as `contextualStrings`. A general model guesses at Indian names and gets them wrong, and the note is exactly where they turn up. `You` and `Someone` are filtered out — they are labels this screen prints, not words anybody says.

**What was already typed.** Dictation adds to the field, never replaces it. Interim results are re-issued *in full*, so the text is recomputed from what the field held when the mic was tapped; appending them gives you "dinner dinner at dinner at the".

Those three plus the error-code wording are pure and live in `src/lib/dictation.ts` with 13 tests. The component holds only the microphone, and aborts it on unmount so leaving the screen mid-sentence cannot leave the mic open.

## What is verified, and what is not

Verified: the web bundle builds with the module in it, the app boots and the add-expense screen renders unchanged (the mic is native-only, so web shows none), `expo-doctor` 19/20 — the one failure is the pre-existing `app.json` + `app.config.ts` warning, `typecheck`/`lint`/`format:check` clean, `test:app` 68 passed.

**Not verified: the microphone itself.** This box has no Android SDK and no Mac, so no native build was possible. It needs `npx expo prebuild` + a dev build on a real device, and an existing binary will not grow a mic from an over-the-air change.

One version note: `expo-speech-recognition@56.0.1` is the latest published and there is no SDK 57 tag yet. It inherits the project's `compileSdkVersion`/`minSdkVersion` and depends on `ExpoModulesCore` unpinned, and `expo-doctor`'s dependency check passes — but the first native build is the real test.

Not in the TDR — this is an addition, and §9 should be amended to cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6