### PR TITLE
fix: let people actually type the shares and percentages

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -26,6 +26,14 @@ import { useGroup } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import {
+  entryValues,
+  fillEntries,
+  formatEntry,
+  splitProblem,
+  type SplitEntries,
+  type SplitKind,
+} from '@/lib/split';
 import { clearDraft, useDraft, useRestoredDraft, useSync } from '@/sync';
 
 interface ExpenseDraft {
@@ -34,9 +42,20 @@ interface ExpenseDraft {
   splitKind: SplitKind;
   payer: MemberId | null;
   participants: MemberId[];
+  /** Kept apart, because a weight of 1 is not one percent. */
+  weights: SplitEntries;
+  percents: SplitEntries;
 }
 
-type SplitKind = 'equal' | 'shares' | 'percent';
+/** A saved split's integers, back as the text somebody would have typed. */
+function textEntries(
+  values: Readonly<Record<string, number>>,
+  kind: 'shares' | 'percent',
+): SplitEntries {
+  return Object.fromEntries(
+    Object.entries(values).map(([memberId, value]) => [memberId, formatEntry(kind, value)]),
+  );
+}
 
 export default function AddExpenseScreen() {
   const theme = useTheme();
@@ -67,6 +86,11 @@ export default function AddExpenseScreen() {
   const [splitKind, setSplitKind] = useState<SplitKind>('equal');
   const [payer, setPayer] = useState<MemberId | null>(null);
   const [participants, setParticipants] = useState<MemberId[]>([]);
+  // What was typed into each member's field, as text. Two maps, not one: the
+  // same person is "2 shares" and "40%", and switching between the two must not
+  // reinterpret one number as the other.
+  const [weights, setWeights] = useState<SplitEntries>({});
+  const [percents, setPercents] = useState<SplitEntries>({});
   /**
    * Names to bias the recogniser towards. "You" and "Someone" are placeholders
    * this screen prints, not things anybody says out loud, so they would only
@@ -109,6 +133,8 @@ export default function AddExpenseScreen() {
       setSplitKind(draft.splitKind);
       setPayer(draft.payer ?? myMemberId);
       setParticipants(draft.participants);
+      setWeights(draft.weights ?? {});
+      setPercents(draft.percents ?? {});
     } else if (version) {
       setAmount(BigInt(version.amount));
       setDescription(version.description);
@@ -121,11 +147,39 @@ export default function AddExpenseScreen() {
             ? 'shares'
             : 'equal',
       );
+      // The numbers somebody chose the first time, back in the fields they were
+      // typed into — an edit that silently re-divided them equally would be a
+      // worse lie than refusing to open.
+      const params = version.split_params;
+      if (params.kind === 'shares') {
+        setWeights(textEntries(params.weights, 'shares'));
+      } else if (params.kind === 'percent') {
+        setPercents(textEntries(params.basisPoints, 'percent'));
+      }
     } else {
       setParticipants((members.data ?? []).map((member) => member.id));
       setPayer(myMemberId);
     }
   }
+
+  // Everybody in a weighted split needs a number to start from, and the set
+  // changes as people are ticked on and off. `fillEntries` returns null once
+  // there is nothing left to fill, which is what stops this looping.
+  if (splitKind === 'shares') {
+    const filled = fillEntries('shares', weights, participants);
+    if (filled) setWeights(filled);
+  } else if (splitKind === 'percent') {
+    const filled = fillEntries('percent', percents, participants);
+    if (filled) setPercents(filled);
+  }
+
+  const entries = splitKind === 'shares' ? weights : percents;
+  const setEntry = (memberId: MemberId, text: string): void => {
+    const update = (current: SplitEntries): SplitEntries => ({ ...current, [memberId]: text });
+    if (splitKind === 'shares') setWeights(update);
+    else setPercents(update);
+  };
+  const splitIssue = splitProblem(splitKind, entries, participants);
 
   const groupCurrency = group.data?.default_currency ?? 'INR';
   // The expense keeps the currency it was paid in; the group's is only the
@@ -135,26 +189,19 @@ export default function AddExpenseScreen() {
   // Every keystroke, debounced just enough to avoid one write per character.
   useDraft<ExpenseDraft>(
     draftKey,
-    { amount: amount.toString(), description, splitKind, payer, participants },
+    { amount: amount.toString(), description, splitKind, payer, participants, weights, percents },
     { enabled: seededFor !== null },
   );
 
   const splitParams: SplitParams = useMemo(() => {
     if (splitKind === 'shares') {
-      return { kind: 'shares', weights: Object.fromEntries(participants.map((id) => [id, 1])) };
+      return { kind: 'shares', weights: entryValues('shares', weights, participants) };
     }
     if (splitKind === 'percent') {
-      const each = Math.floor(10000 / Math.max(participants.length, 1));
-      const basisPoints: Record<string, number> = {};
-      participants.forEach((id) => {
-        basisPoints[id] = each;
-      });
-      const first = participants[0];
-      if (first) basisPoints[first] = each + (10000 - each * participants.length);
-      return { kind: 'percent', basisPoints };
+      return { kind: 'percent', basisPoints: entryValues('percent', percents, participants) };
     }
     return { kind: 'equal' };
-  }, [splitKind, participants]);
+  }, [splitKind, weights, percents, participants]);
 
   // Preview with the same engine the server uses; if they ever disagree the
   // server wins and tells us why (SHARE_MISMATCH).
@@ -364,13 +411,10 @@ export default function AddExpenseScreen() {
 
           {(members.data ?? []).map((member) => {
             const selected = participants.includes(member.id);
+            const name = displayName(member, profile?.id);
             return (
-              <Pressable
+              <View
                 key={member.id}
-                accessibilityRole="checkbox"
-                accessibilityState={{ checked: selected }}
-                accessibilityLabel={displayName(member, profile?.id)}
-                onPress={() => toggleParticipant(member.id)}
                 style={{
                   flexDirection: 'row',
                   alignItems: 'center',
@@ -378,26 +422,86 @@ export default function AddExpenseScreen() {
                   paddingVertical: theme.spacing.sm,
                 }}
               >
-                <Avatar name={displayName(member)} ghost={isGhost(member)} size={38} />
-                <Text variant="subheading" style={{ flex: 1 }}>
-                  {displayName(member, profile?.id)}
-                </Text>
-                {preview && selected ? (
-                  <MoneyText
-                    amount={preview.get(member.id) ?? 0n}
-                    currency={currency}
-                    locale={locale}
-                    variant="caption"
-                  />
+                {/* The name toggles; the field beside it must not, or nobody
+                    could tap into it without dropping the person. */}
+                <Pressable
+                  accessibilityRole="checkbox"
+                  accessibilityState={{ checked: selected }}
+                  accessibilityLabel={name}
+                  onPress={() => toggleParticipant(member.id)}
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: theme.spacing.md,
+                    flex: 1,
+                  }}
+                >
+                  <Avatar name={displayName(member)} ghost={isGhost(member)} size={38} />
+                  <View style={{ flex: 1, minWidth: 0 }}>
+                    <Text variant="subheading" numberOfLines={1}>
+                      {name}
+                    </Text>
+                    {preview && selected ? (
+                      <MoneyText
+                        amount={preview.get(member.id) ?? 0n}
+                        currency={currency}
+                        locale={locale}
+                        variant="micro"
+                      />
+                    ) : null}
+                  </View>
+                </Pressable>
+
+                {splitKind !== 'equal' && selected ? (
+                  <Row style={{ gap: 2, alignItems: 'center', flexGrow: 0, flexShrink: 0 }}>
+                    <TextInput
+                      value={entries[member.id] ?? ''}
+                      onChangeText={(text) => setEntry(member.id, text)}
+                      keyboardType={splitKind === 'percent' ? 'decimal-pad' : 'number-pad'}
+                      selectTextOnFocus
+                      placeholder={splitKind === 'percent' ? '0' : '1'}
+                      placeholderTextColor={theme.color.textFaint}
+                      accessibilityLabel={
+                        splitKind === 'percent' ? `${name}'s percentage` : `${name}'s shares`
+                      }
+                      style={{
+                        width: 72,
+                        fontSize: 16,
+                        fontWeight: '700',
+                        textAlign: 'right',
+                        color: theme.color.text,
+                        backgroundColor: theme.color.bg,
+                        borderRadius: theme.radius.sm,
+                        paddingVertical: theme.spacing.sm,
+                        paddingHorizontal: theme.spacing.sm,
+                      }}
+                    />
+                    <Text variant="micro" tone="muted">
+                      {splitKind === 'percent' ? '%' : '×'}
+                    </Text>
+                  </Row>
                 ) : null}
-                <Ionicons
-                  name={selected ? 'checkmark-circle' : 'ellipse-outline'}
-                  size={22}
-                  color={selected ? theme.color.brand : theme.color.textFaint}
-                />
-              </Pressable>
+
+                <Pressable
+                  accessible={false}
+                  onPress={() => toggleParticipant(member.id)}
+                  hitSlop={8}
+                >
+                  <Ionicons
+                    name={selected ? 'checkmark-circle' : 'ellipse-outline'}
+                    size={22}
+                    color={selected ? theme.color.brand : theme.color.textFaint}
+                  />
+                </Pressable>
+              </View>
             );
           })}
+
+          {splitIssue ? (
+            <Text variant="micro" tone="negative">
+              {splitIssue}
+            </Text>
+          ) : null}
         </Card>
 
         {error ? (
@@ -410,7 +514,7 @@ export default function AddExpenseScreen() {
           label={editing ? 'Save changes' : t.save}
           size="lg"
           fullWidth
-          disabled={amount === 0n || participants.length === 0 || saving}
+          disabled={amount === 0n || participants.length === 0 || splitIssue !== null || saving}
           onPress={() => void submit()}
         />
 

--- a/apps/mobile/src/lib/split.ts
+++ b/apps/mobile/src/lib/split.ts
@@ -1,0 +1,153 @@
+/**
+ * The numbers somebody types into a shares or percent split.
+ *
+ * `@baaki/core` takes integers — whole weights, and basis points that sum to
+ * exactly 10000. A person types text, and text is where the gap is: "33.33" is
+ * 3333 basis points, "" is a field they have not reached yet, and "1.5" is a
+ * share count that does not exist. Keeping the parsing here means the screen
+ * holds what was typed and nothing else, and that the rules can be tested
+ * without a keyboard.
+ *
+ * Nothing here rounds silently. A percentage with three decimal places is
+ * refused rather than trimmed, because trimming it would put a number in the
+ * ledger that nobody chose.
+ */
+
+export type SplitKind = 'equal' | 'shares' | 'percent';
+
+/** What a weighted split kind holds: one line of text per member. */
+export type SplitEntries = Record<string, string>;
+
+const TOTAL_BASIS_POINTS = 10000;
+
+/** Up to three digits, then at most two decimal places. */
+const PERCENT = /^\d{0,3}(\.\d{0,2})?$/;
+
+/** Whole numbers only, and not so many digits that the field stops being one. */
+const WEIGHT = /^\d{1,9}$/;
+
+/**
+ * One typed entry as a number — basis points for percent, a weight for shares.
+ *
+ * An empty field is 0, not an error: it is somebody mid-way through filling the
+ * form, and the totals below will say what is still missing. Anything actually
+ * malformed comes back as `null`.
+ */
+export function parseEntry(kind: 'shares' | 'percent', text: string): number | null {
+  const value = text.trim();
+  if (value === '' || value === '.') return 0;
+
+  if (kind === 'shares') {
+    return WEIGHT.test(value) ? Number(value) : null;
+  }
+
+  if (!PERCENT.test(value)) return null;
+  const percent = Number(value);
+  if (!Number.isFinite(percent) || percent > 100) return null;
+  // × 100 in decimal, not in floating point: 0.29 * 10000 is 2899.9999999999995.
+  const [whole = '0', fraction = ''] = value.split('.');
+  return Number(whole) * 100 + Number(fraction.padEnd(2, '0'));
+}
+
+/** Basis points back into a field: 3333 reads "33.33", 2500 reads "25". */
+export function formatEntry(kind: 'shares' | 'percent', value: number): string {
+  if (kind === 'shares') return String(value);
+  const whole = Math.trunc(value / 100);
+  const fraction = value % 100;
+  if (fraction === 0) return String(whole);
+  return `${whole}.${String(fraction).padStart(2, '0')}`.replace(/0$/, '');
+}
+
+/**
+ * The integers `computeShares` wants, for the people actually in the split.
+ *
+ * Members who were unchecked keep their text — unchecking somebody should not
+ * throw away what was typed for them — but they are not passed on, because a
+ * weight for a non-participant is rejected downstream.
+ */
+export function entryValues(
+  kind: 'shares' | 'percent',
+  entries: SplitEntries,
+  participants: readonly string[],
+): Record<string, number> {
+  const values: Record<string, number> = {};
+  for (const id of participants) {
+    values[id] = parseEntry(kind, entries[id] ?? '') ?? 0;
+  }
+  return values;
+}
+
+/**
+ * What is wrong with these entries, in words somebody can act on — or `null`
+ * when the split is ready to save.
+ *
+ * The percent case is the one that matters: `computeShares` throws unless the
+ * basis points sum to exactly 10000, and a thrown preview looks to the user
+ * like the screen simply stopped working. Saying "3.5% left" instead is the
+ * whole point of this function.
+ */
+export function splitProblem(
+  kind: SplitKind,
+  entries: SplitEntries,
+  participants: readonly string[],
+): string | null {
+  if (kind === 'equal') return null;
+  if (participants.length === 0) return null;
+
+  for (const id of participants) {
+    if (parseEntry(kind, entries[id] ?? '') === null) {
+      return kind === 'shares'
+        ? 'Shares must be whole numbers.'
+        : 'Percentages can have at most two decimal places.';
+    }
+  }
+
+  const values = entryValues(kind, entries, participants);
+  const total = Object.values(values).reduce((sum, value) => sum + value, 0);
+
+  if (kind === 'shares') {
+    return total > 0 ? null : 'Give at least one person a share.';
+  }
+
+  if (total === TOTAL_BASIS_POINTS) return null;
+  const off = formatEntry('percent', Math.abs(total - TOTAL_BASIS_POINTS));
+  return total < TOTAL_BASIS_POINTS
+    ? `That is ${formatEntry('percent', total)}% — ${off}% left to give out.`
+    : `That is ${formatEntry('percent', total)}% — ${off}% too much.`;
+}
+
+/**
+ * Entries for anybody who has none yet, or `null` when everyone already has
+ * one. Returning `null` rather than an equal object is what lets the caller
+ * set this during render without looping.
+ *
+ * A fresh percent split is divided evenly with the odd basis point on the first
+ * person, so the form opens on something valid. Somebody added to a split that
+ * is already filled in starts at 0 instead — quietly rebalancing would rewrite
+ * numbers the user chose deliberately.
+ */
+export function fillEntries(
+  kind: 'shares' | 'percent',
+  entries: SplitEntries,
+  participants: readonly string[],
+): SplitEntries | null {
+  const missing = participants.filter((id) => entries[id] === undefined);
+  if (missing.length === 0) return null;
+
+  if (kind === 'shares') {
+    return { ...entries, ...Object.fromEntries(missing.map((id) => [id, '1'])) };
+  }
+
+  const untouched = missing.length === participants.length;
+  if (!untouched) {
+    return { ...entries, ...Object.fromEntries(missing.map((id) => [id, '0'])) };
+  }
+
+  const each = Math.floor(TOTAL_BASIS_POINTS / participants.length);
+  const filled: SplitEntries = { ...entries };
+  participants.forEach((id, index) => {
+    const basisPoints = index === 0 ? TOTAL_BASIS_POINTS - each * (participants.length - 1) : each;
+    filled[id] = formatEntry('percent', basisPoints);
+  });
+  return filled;
+}

--- a/apps/mobile/test/split.test.ts
+++ b/apps/mobile/test/split.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeShares } from '@baaki/core';
+
+import { entryValues, fillEntries, formatEntry, parseEntry, splitProblem } from '../src/lib/split';
+
+describe('parseEntry', () => {
+  it('reads whole shares', () => {
+    expect(parseEntry('shares', '3')).toBe(3);
+    expect(parseEntry('shares', ' 12 ')).toBe(12);
+  });
+
+  it('refuses a fractional share rather than rounding it', () => {
+    expect(parseEntry('shares', '1.5')).toBeNull();
+    expect(parseEntry('shares', '-1')).toBeNull();
+    expect(parseEntry('shares', 'two')).toBeNull();
+  });
+
+  it('reads percentages as basis points', () => {
+    expect(parseEntry('percent', '25')).toBe(2500);
+    expect(parseEntry('percent', '33.33')).toBe(3333);
+    expect(parseEntry('percent', '33.3')).toBe(3330);
+    expect(parseEntry('percent', '100')).toBe(10000);
+  });
+
+  it('converts in decimal, not in floating point', () => {
+    // 0.29 * 10000 is 2899.9999999999995 — one paisa off, silently.
+    expect(parseEntry('percent', '0.29')).toBe(29);
+    expect(parseEntry('percent', '8.11')).toBe(811);
+  });
+
+  it('refuses a third decimal place and anything over 100', () => {
+    expect(parseEntry('percent', '33.333')).toBeNull();
+    expect(parseEntry('percent', '101')).toBeNull();
+  });
+
+  it('treats a field nobody has typed in yet as zero, not as an error', () => {
+    expect(parseEntry('percent', '')).toBe(0);
+    expect(parseEntry('percent', '.')).toBe(0);
+    expect(parseEntry('shares', '')).toBe(0);
+  });
+});
+
+describe('formatEntry', () => {
+  it('round-trips a percentage back into the field it came from', () => {
+    for (const text of ['25', '33.33', '33.3', '0.29', '100', '12.05']) {
+      expect(formatEntry('percent', parseEntry('percent', text) ?? -1)).toBe(text);
+    }
+  });
+});
+
+describe('splitProblem', () => {
+  const people = ['a', 'b', 'c'];
+
+  it('says nothing about an equal split', () => {
+    expect(splitProblem('equal', {}, people)).toBeNull();
+  });
+
+  it('accepts shares with at least one positive weight', () => {
+    expect(splitProblem('shares', { a: '2', b: '1', c: '0' }, people)).toBeNull();
+  });
+
+  it('refuses shares that are all zero', () => {
+    expect(splitProblem('shares', { a: '0', b: '0', c: '0' }, people)).toMatch(/at least one/);
+  });
+
+  it('says how much percentage is left, and how much is too much', () => {
+    expect(splitProblem('percent', { a: '30', b: '30', c: '30' }, people)).toBe(
+      'That is 90% — 10% left to give out.',
+    );
+    expect(splitProblem('percent', { a: '50', b: '30', c: '30' }, people)).toBe(
+      'That is 110% — 10% too much.',
+    );
+  });
+
+  it('accepts percentages that sum to exactly 100', () => {
+    expect(splitProblem('percent', { a: '33.34', b: '33.33', c: '33.33' }, people)).toBeNull();
+  });
+
+  it('ignores members who are not in the split', () => {
+    expect(splitProblem('percent', { a: '50', b: '50', c: '80' }, ['a', 'b'])).toBeNull();
+  });
+});
+
+describe('fillEntries', () => {
+  const people = ['a', 'b', 'c'];
+
+  it('opens a fresh percent split on something valid', () => {
+    const filled = fillEntries('percent', {}, people);
+    expect(splitProblem('percent', filled ?? {}, people)).toBeNull();
+  });
+
+  it('starts somebody added later at zero rather than rewriting the others', () => {
+    const filled = fillEntries('percent', { a: '60', b: '40' }, people);
+    expect(filled).toEqual({ a: '60', b: '40', c: '0' });
+  });
+
+  it('gives a new member of a shares split one share', () => {
+    expect(fillEntries('shares', { a: '2' }, people)).toEqual({ a: '2', b: '1', c: '1' });
+  });
+
+  it('returns null when there is nothing to fill, so render does not loop', () => {
+    expect(fillEntries('shares', { a: '1', b: '1', c: '1' }, people)).toBeNull();
+  });
+});
+
+describe('what the screen hands to the money engine', () => {
+  const people = ['a', 'b', 'c'];
+
+  it('splits by weight', () => {
+    const shares = computeShares({
+      amount: 6000n,
+      currency: 'INR',
+      params: {
+        kind: 'shares',
+        weights: entryValues('shares', { a: '3', b: '2', c: '1' }, people),
+      },
+      participants: people,
+      seed: 'expense-1',
+    });
+    expect(shares.get('a')).toBe(3000n);
+    expect(shares.get('b')).toBe(2000n);
+    expect(shares.get('c')).toBe(1000n);
+  });
+
+  it('splits by percentage without losing a paisa', () => {
+    const entries = fillEntries('percent', {}, people) ?? {};
+    const shares = computeShares({
+      amount: 10000n,
+      currency: 'INR',
+      params: { kind: 'percent', basisPoints: entryValues('percent', entries, people) },
+      participants: people,
+      seed: 'expense-1',
+    });
+    expect([...shares.values()].reduce((sum, share) => sum + share, 0n)).toBe(10000n);
+  });
+
+  it('never reaches the engine while the problem message is showing', () => {
+    const entries = { a: '30', b: '30', c: '30' };
+    expect(splitProblem('percent', entries, people)).not.toBeNull();
+    expect(() =>
+      computeShares({
+        amount: 10000n,
+        currency: 'INR',
+        params: { kind: 'percent', basisPoints: entryValues('percent', entries, people) },
+        participants: people,
+        seed: 'expense-1',
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
The **Shares** and **Percent** chips have been on the add-expense screen since M0 with nothing behind them: `splitParams` handed every participant a weight of 1, or an evenly divided slice of 10000 basis points. Both chips computed exactly what *Equally* computed, and there was no field anywhere to say otherwise.

Each participant now gets a number beside their name, and the split is computed from what was typed.

## Where the care went

Parsing lives in `apps/mobile/src/lib/split.ts`, away from React, because it is where the wrong thing is easy to do quietly:

- A percentage is converted in decimal, not by multiplying a float — `0.29 * 10000` is `2899.9999999999995`, one paisa on somebody's dinner.
- A third decimal place is refused rather than trimmed; a fractional share is refused rather than rounded.
- Percentages must sum to exactly 10000 basis points or `computeShares` throws, and a thrown preview reads as a broken screen. The card says *"That is 86.67% — 13.33% left to give out"* and holds the save button instead.
- An empty field is 0, not an error: it is somebody mid-way through the form.

Shares and percentages are held in separate maps — the same person is "2 shares" and "40%" — so switching chips cannot reinterpret one as the other. Both persist into the draft, and an edit reopens on the numbers that were saved.

## Verified

- 20 new tests (88 total in `test:app`), typecheck, lint and format clean.
- Driven on the web build against the live project: 1:3:2 of ₹300 gives ₹50/₹150/₹100; 25/50/25 gives ₹75/₹150/₹75, stored by the server as "By percentage" with no `SHARE_MISMATCH`, and reopening the edit screen shows 25/50/25 again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6