### PR TITLE
feat: scan the bill from the add-expense screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,40 @@ opened. The import therefore lives in `DictateVoice.tsx` and is reached from
 added from here on wants the same treatment**, unless every binary that will
 ever run the bundle is guaranteed to contain it.
 
+## Scanning the bill instead of typing it
+
+The camera on the add-expense screen is the platform's document scanner —
+`VNDocumentCameraViewController` on iOS, ML Kit's document scanner on Android,
+via `react-native-document-scanner-plugin`. It finds the page edges and
+corrects the perspective, which matters more than it sounds: what follows is
+OCR, and OCR reads characters without knowing which ones are on the receipt. A
+flat crop of the bill is a different proposition from a photograph of a table.
+
+Capture is one function, `captureReceipt` in `apps/mobile/src/lib/image.ts`,
+used by both the add-expense screen and Split by item. It falls back to the
+plain camera on a build with no scanner, so the screen asking for a receipt
+never has to know which one it got.
+
+What a scan does depends on where it was started:
+
+- **Add expense** takes the grand total and the merchant's name, and leaves the
+  splitting alone. Most bills are split some way that has nothing to do with
+  what each line cost, and dropping somebody into claiming items because they
+  photographed a bill would be worse than letting them type a total.
+- **Split by item** fills the lines, as it always has.
+
+A scan started on one and finished on the other is not re-taken. The parsed
+receipt is handed over through the draft store — `apps/mobile/src/lib/handover.ts`
+— keyed per group, consumed once, cleared immediately, and ignored after ten
+minutes. A scan costs the group one of its free scans (ADR-011), so asking for
+the same bill twice is a real cost; a receipt left lying in the store to
+pre-fill somebody's screen days later is a real bug.
+
+Native module, so it needs `npx expo prebuild` and a new build, and it gets the
+lazy-require treatment described above — `TurboModuleRegistry.get` answers
+"is it in this binary" without throwing, and the package is only required once
+the answer is yes.
+
 ## Releasing, and stopping old builds
 
 The version is compiled into the binary, so a build can only ever describe

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -52,6 +52,12 @@
           "androidSpeechServicePackages": ["com.google.android.googlequicksearchbox"]
         }
       ],
+      [
+        "react-native-document-scanner-plugin",
+        {
+          "cameraPermission": "Baaki uses the camera to scan a bill, so the total and the items come out filled in instead of typed. The photograph stays on this phone whenever it can be read here."
+        }
+      ],
       "expo-secure-store",
       "expo-sharing",
       "@react-native-community/datetimepicker",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -47,6 +47,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.2",
+    "react-native-document-scanner-plugin": "^2.0.4",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "~5.7.0",

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -22,10 +22,14 @@ import {
 
 import { CurrencyRate } from '@/components/CurrencyRate';
 import { DictateButton } from '@/components/DictateButton';
+import { scanReceipt, scanReceiptText } from '@/data/api';
 import { useGroup } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { handoverKey } from '@/lib/handover';
+import { captureReceipt } from '@/lib/image';
+import { recogniseReceipt } from '@/lib/ocr';
 import {
   entryValues,
   fillEntries,
@@ -35,7 +39,7 @@ import {
   type SplitEntries,
   type SplitKind,
 } from '@/lib/split';
-import { clearDraft, useDraft, useRestoredDraft, useSync } from '@/sync';
+import { clearDraft, syncEngine, useDraft, useRestoredDraft, useSync } from '@/sync';
 
 interface ExpenseDraft {
   amount: string;
@@ -109,6 +113,10 @@ export default function AddExpenseScreen() {
   const [fx, setFx] = useState<FxRecord | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [scanning, setScanning] = useState(false);
+  const [scanNote, setScanNote] = useState<string | null>(null);
+  /** Set once a scan has read line items, so the offer to itemize is real. */
+  const [scannedItems, setScannedItems] = useState(0);
 
   const myMemberId = useMemo(
     () => (members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ?? null,
@@ -294,6 +302,63 @@ export default function AddExpenseScreen() {
     return (amount * BigInt(basisPoints)) / 10000n;
   };
 
+  /**
+   * Photograph the bill, fill in the two fields somebody was about to type.
+   *
+   * This screen deliberately does not become an itemizing screen. Most bills
+   * are split some way that has nothing to do with what each line cost, and a
+   * scan that dragged everybody into claiming items would be worse than typing
+   * a total. What it takes is the grand total and the merchant's name; the
+   * lines it read are handed to the itemize screen, which is one tap away for
+   * the times that matters.
+   *
+   * ADR-008 still holds: the model proposes and the person confirms. Nothing
+   * saves itself, and the amount lands in the same field, editable.
+   */
+  const scan = async (): Promise<void> => {
+    const picked = await captureReceipt();
+    if (!picked) return;
+    setError(null);
+    setScanNote(null);
+    setScanning(true);
+    try {
+      // Read the text on the phone first: the photograph never leaves the
+      // device when it works, and it costs about a tenth as much. A dark or
+      // blurred bill falls back to sending the image, which reads it better.
+      const recognised = await recogniseReceipt(picked.uri);
+      const result = recognised
+        ? await scanReceiptText({ groupId, rawText: recognised.text, currency, source: 'camera' })
+        : await scanReceipt({
+            groupId,
+            base64: picked.base64,
+            mimeType: picked.mimeType,
+            currency,
+          });
+
+      if (result.parsed.grandTotal > 0) setAmount(BigInt(result.parsed.grandTotal));
+      if (result.parsed.merchant && !description.trim()) setDescription(result.parsed.merchant);
+      setScannedItems(result.parsed.items.length);
+
+      // Kept for the itemize screen in case they want it. Nobody should have to
+      // photograph the same bill twice, and a scan is metered (ADR-011).
+      void syncEngine.saveDraft(handoverKey(groupId), {
+        parsed: result.parsed,
+        at: Date.now(),
+      });
+
+      setScanNote(
+        result.check.reconciles && result.check.problems.length === 0
+          ? 'Read the total off the bill. Check it, then split it however you like.'
+          : (result.check.problems[0]?.message ??
+              'Check the total against the bill before saving.'),
+      );
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setScanning(false);
+    }
+  };
+
   const toggleParticipant = (memberId: MemberId): void => {
     setParticipants((current) =>
       current.includes(memberId)
@@ -345,6 +410,44 @@ export default function AddExpenseScreen() {
 
         <Card>
           <AmountKeypad currency={currency} value={amount} onChange={setAmount} />
+        </Card>
+
+        {/* Below the keypad, not above it. Typing a number is the fast path and
+            stays the first thing on the screen; the camera is for the bill that
+            is easier to point at than to read. */}
+        <Card style={{ gap: theme.spacing.md }}>
+          <Row style={{ justifyContent: 'space-between' }}>
+            <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
+              <Text variant="subheading">Scan the bill</Text>
+              <Text variant="caption" tone="muted">
+                The total and the name of the place come out filled in. Check them — entering them
+                by hand is always free.
+              </Text>
+            </View>
+            <Button
+              label={scanning ? 'Reading…' : 'Scan'}
+              variant="secondary"
+              disabled={scanning || saving}
+              onPress={() => void scan()}
+              icon={<Ionicons name="camera-outline" size={18} color={theme.color.brand} />}
+            />
+          </Row>
+          {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
+          {scanNote ? (
+            <Text variant="caption" tone="brand">
+              {scanNote}
+            </Text>
+          ) : null}
+          {scannedItems > 0 && !editing ? (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => router.replace(`/group/${groupId}/itemize`)}
+            >
+              <Text variant="caption" tone="brand" style={{ fontWeight: '700' }}>
+                {`It read ${scannedItems} items — split by item instead →`}
+              </Text>
+            </Pressable>
+          ) : null}
         </Card>
 
         <CurrencyRate

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -11,6 +11,7 @@ import {
   minorUnitScale,
   type ItemizedParams,
   type MemberId,
+  type ParsedReceipt,
 } from '@baaki/core';
 import {
   Avatar,
@@ -26,13 +27,15 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { pickReceiptPhoto } from '@/lib/image';
+import { captureReceipt } from '@/lib/image';
 import { scanReceipt, scanReceiptText } from '@/data/api';
 import { recogniseReceipt } from '@/lib/ocr';
 import { useGroup, useWriteExpense } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { handoverIsFresh, handoverKey, type ReceiptHandover } from '@/lib/handover';
+import { clearDraft, useRestoredDraft } from '@/sync';
 
 interface DraftItem {
   key: string;
@@ -76,8 +79,39 @@ export default function ItemizeScreen() {
    * in the same editable list somebody would have typed by hand, so correcting
    * a misread line is just editing — there is no separate "AI mode" to leave.
    */
+  const fillFromReceipt = (parsed: ParsedReceipt): void => {
+    setItems(
+      parsed.items.map((item, index) => ({
+        key: `scan-${index}-${randomUUID()}`,
+        label: item.label,
+        total: BigInt(item.total),
+        claimers: [],
+      })),
+    );
+    const taxes = parsed.taxes.reduce((sum, tax) => sum + tax.amount, 0);
+    if (taxes > 0) setTaxText((taxes / 100).toString());
+    if (parsed.tip) setTipText((parsed.tip / 100).toString());
+    if (parsed.merchant) {
+      setDescription((current) => (current.trim() ? current : (parsed.merchant ?? '')));
+    }
+  };
+
+  // A bill scanned on the add-expense screen, followed here. Taken once and
+  // cleared: nobody should be asked to photograph the same receipt twice, and
+  // nobody who came here to type should find last week's dinner waiting.
+  const handover = useRestoredDraft<ReceiptHandover>(handoverKey(groupId));
+  const [tookHandover, setTookHandover] = useState(false);
+  if (!handover.loading && handover.draft && !tookHandover) {
+    setTookHandover(true);
+    void clearDraft(handoverKey(groupId));
+    if (handoverIsFresh(handover.draft)) {
+      fillFromReceipt(handover.draft.parsed);
+      setScanNote('Carried over from the scan. Check the lines, then tap who had what.');
+    }
+  }
+
   const scan = async (): Promise<void> => {
-    const picked = await pickReceiptPhoto();
+    const picked = await captureReceipt();
     if (!picked) return;
     setError(null);
     setScanNote(null);
@@ -103,18 +137,7 @@ export default function ItemizeScreen() {
             currency,
           });
 
-      setItems(
-        result.parsed.items.map((item, index) => ({
-          key: `scan-${index}-${randomUUID()}`,
-          label: item.label,
-          total: BigInt(item.total),
-          claimers: [],
-        })),
-      );
-      const taxes = result.parsed.taxes.reduce((sum, tax) => sum + tax.amount, 0);
-      if (taxes > 0) setTaxText((taxes / 100).toString());
-      if (result.parsed.tip) setTipText((result.parsed.tip / 100).toString());
-      if (!description.trim() && result.parsed.merchant) setDescription(result.parsed.merchant);
+      fillFromReceipt(result.parsed);
 
       // The arithmetic decides what the person is asked to look at. Saying
       // "scanned!" and leaving them to notice a wrong total is the failure
@@ -284,8 +307,8 @@ export default function ItemizeScreen() {
             <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
               <Text variant="subheading">Scan the receipt</Text>
               <Text variant="caption" tone="muted">
-                Photograph the bill and the items come out filled in. Check them before saving —
-                entering them by hand is always free.
+                Scan the bill and the items come out filled in. Check them before saving — entering
+                them by hand is always free.
               </Text>
             </View>
             <Button

--- a/apps/mobile/src/lib/handover.ts
+++ b/apps/mobile/src/lib/handover.ts
@@ -1,0 +1,40 @@
+/**
+ * Passing a scanned receipt from one screen to the next.
+ *
+ * Somebody who scans a bill on the add-expense screen and then decides to split
+ * it by item should not be asked to photograph it a second time — the scan cost
+ * them a moment, cost the group one of its free scans (ADR-011), and the answer
+ * is already sitting in memory.
+ *
+ * The route params cannot carry it: a parsed receipt is a nested object, and a
+ * URL is a bad place for one. It goes through the draft store instead, which is
+ * already the thing that survives the screen going away (ADR-005), keyed per
+ * group so two groups open at once cannot swap bills.
+ *
+ * It is consumed once and cleared. A receipt left lying in the store would
+ * pre-fill the itemize screen days later for somebody who came to type a bill
+ * in by hand, which is worse than making them scan again.
+ */
+
+import type { ParsedReceipt } from '@baaki/core';
+
+export interface ReceiptHandover {
+  readonly parsed: ParsedReceipt;
+  /** Epoch milliseconds. A scan nobody followed up on goes stale (see `HANDOVER_TTL_MS`). */
+  readonly at: number;
+}
+
+/**
+ * How long a scan stays worth handing over. Long enough to cover somebody
+ * reading the total, changing their mind and tapping through; short enough that
+ * an abandoned scan is not still waiting after lunch.
+ */
+export const HANDOVER_TTL_MS = 10 * 60 * 1000;
+
+export function handoverKey(groupId: string): string {
+  return `receipt-handover:${groupId}`;
+}
+
+export function handoverIsFresh(handover: ReceiptHandover, now = Date.now()): boolean {
+  return now - handover.at < HANDOVER_TTL_MS && now >= handover.at;
+}

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -19,7 +19,9 @@
 
 import * as FileSystem from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
-import { Platform } from 'react-native';
+import { Image, Platform } from 'react-native';
+
+import { scanDocument } from './scanner';
 
 /**
  * Loaded on demand, and only once the native side is known to be there.
@@ -208,4 +210,48 @@ export async function pickReceiptPhoto(): Promise<PickedImage | null> {
       compress: 0.9,
     })) ?? (await readUnshrunk(asset.uri));
   return { base64: shrunk.base64, mimeType: 'image/jpeg', uri: shrunk.uri };
+}
+
+/**
+ * A receipt, however this phone can best get one.
+ *
+ * The document scanner is tried first: it finds the page edges and flattens the
+ * perspective, and OCR on a flat crop of the bill is a different proposition
+ * from OCR on a photograph of a table. Where the build has no scanner — web, or
+ * a binary from before it was installed — this falls through to the plain
+ * camera, which is what every scan used until now.
+ *
+ * The two are deliberately one function. Two capture paths would drift, and the
+ * screen asking for a receipt has no business knowing which one it got.
+ */
+export async function captureReceipt(): Promise<PickedImage | null> {
+  const scanned = await scanDocument();
+  if (!scanned) return pickReceiptPhoto();
+
+  // The scanner reports no dimensions, and `shrink` caps whichever edge is
+  // longer. Asking the file is cheap; failing to ask would send a 4000px scan
+  // up whole, so an unreadable size is a reason to skip the resize rather than
+  // to abandon the scan.
+  const size = await imageSize(scanned);
+  const shrunk =
+    (size
+      ? await shrink({
+          uri: scanned,
+          width: size.width,
+          height: size.height,
+          maxEdge: RECEIPT_MAX_EDGE,
+          compress: 0.9,
+        })
+      : null) ?? (await readUnshrunk(scanned));
+  return { base64: shrunk.base64, mimeType: 'image/jpeg', uri: shrunk.uri };
+}
+
+function imageSize(uri: string): Promise<{ width: number; height: number } | null> {
+  return new Promise((resolve) => {
+    Image.getSize(
+      uri,
+      (width, height) => resolve({ width, height }),
+      () => resolve(null),
+    );
+  });
 }

--- a/apps/mobile/src/lib/scanner.ts
+++ b/apps/mobile/src/lib/scanner.ts
@@ -1,0 +1,82 @@
+/**
+ * The camera that knows it is looking at a piece of paper.
+ *
+ * A photograph of a bill taken at a table is at an angle, on a patterned cloth,
+ * with half a plate in frame. The OCR that follows reads characters; it has no
+ * idea which of those characters are on the receipt. The platforms both ship a
+ * scanner that solves exactly this — `VNDocumentCameraViewController` on iOS,
+ * ML Kit's document scanner on Android — which finds the page edges, corrects
+ * the perspective and hands back a flat, cropped image. The same receipt reads
+ * far better afterwards, and nobody had to line the shot up.
+ *
+ * **Nothing is imported at the top of this file that can fail.**
+ * `react-native-document-scanner-plugin` calls
+ * `TurboModuleRegistry.getEnforcing('DocumentScanner')` while its own module is
+ * being evaluated, which throws on any binary built before it was installed.
+ * That is not a missing button — expo-router loads every route file to build
+ * the route tree, so it is the app failing to launch. `TurboModuleRegistry.get`
+ * answers the same question and returns null instead of throwing, so the
+ * package is only ever required once it is known to be there.
+ */
+
+import { Platform, TurboModuleRegistry } from 'react-native';
+
+interface DocumentScanner {
+  scanDocument(options: {
+    croppedImageQuality?: number;
+    maxNumDocuments?: number;
+  }): Promise<{ scannedImages?: string[]; status?: string }>;
+}
+
+/** Whether this build contains the scanner. False on web, and on older binaries. */
+export function scannerAvailable(): boolean {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') return false;
+  try {
+    return TurboModuleRegistry.get('DocumentScanner') != null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Open the scanner and return the cropped page as a local file URI.
+ *
+ * Null covers every ordinary way this ends without an image: no scanner in
+ * this build, and the person backing out of the camera. Neither is an error to
+ * report — the caller falls back to the plain camera, or does nothing.
+ *
+ * One page only. A restaurant bill is one page, and a second image would have
+ * to be reconciled against the first before either could become an expense —
+ * work with no home in ADR-008's "the model proposes, the person confirms".
+ */
+export async function scanDocument(): Promise<string | null> {
+  if (!scannerAvailable()) return null;
+
+  let scanner: DocumentScanner;
+  try {
+    // Required, not imported: an import is hoisted and would be evaluated at
+    // module load, which is the thing the check above exists to avoid.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const loaded = require('react-native-document-scanner-plugin') as {
+      default: DocumentScanner;
+    };
+    scanner = loaded.default;
+  } catch {
+    return null;
+  }
+
+  try {
+    const { scannedImages } = await scanner.scanDocument({
+      maxNumDocuments: 1,
+      // A receipt is read by a model, not looked at. Faded thermal print is
+      // the whole difficulty, and compression artefacts land on exactly the
+      // strokes that were already marginal.
+      croppedImageQuality: 100,
+    });
+    return scannedImages?.[0] ?? null;
+  } catch {
+    // A camera that will not open is a reason to fall back to the picker, not
+    // a reason to put an error in front of somebody holding a bill.
+    return null;
+  }
+}

--- a/apps/mobile/test/handover.test.ts
+++ b/apps/mobile/test/handover.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { handoverIsFresh, handoverKey, HANDOVER_TTL_MS } from '../src/lib/handover';
+
+const receipt = {
+  merchant: 'Anjappar',
+  date: null,
+  currency: 'INR',
+  items: [],
+  subtotal: null,
+  taxes: [],
+  serviceCharge: null,
+  tip: null,
+  discounts: [],
+  grandTotal: 32000,
+};
+
+describe('handoverKey', () => {
+  it('keys per group, so two open groups cannot swap bills', () => {
+    expect(handoverKey('a')).not.toBe(handoverKey('b'));
+  });
+});
+
+describe('handoverIsFresh', () => {
+  const now = 1_700_000_000_000;
+
+  it('carries a scan somebody has just taken', () => {
+    expect(handoverIsFresh({ parsed: receipt, at: now - 1000 }, now)).toBe(true);
+  });
+
+  it('drops one nobody followed up on', () => {
+    expect(handoverIsFresh({ parsed: receipt, at: now - HANDOVER_TTL_MS - 1 }, now)).toBe(false);
+  });
+
+  it('drops one stamped in the future rather than trusting it forever', () => {
+    // A phone whose clock was corrected between the scan and the tap. Refusing
+    // it costs one re-scan; trusting it means a bill that never goes stale.
+    expect(handoverIsFresh({ parsed: receipt, at: now + 60_000 }, now)).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       react-native:
         specifier: 0.86.2
         version: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
+      react-native-document-scanner-plugin:
+        specifier: ^2.0.4
+        version: 2.0.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-gesture-handler:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -5273,6 +5276,12 @@ packages:
 
   react-is@19.2.8:
     resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
+
+  react-native-document-scanner-plugin@2.0.4:
+    resolution: {integrity: sha512-Y+tEP8qqgIseYw2T9NisT7+vaXJCM1QMj6KUqplNBQ3C+XivDwtyzp2vg03kH6Bjhg+ZxHzuEyu96ltBOax0iw==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   react-native-drawer-layout@4.2.9:
     resolution: {integrity: sha512-ETOxvlhhb4LmuuG3RN7A3qwt9jr9AZ2it+1G2kNE4g2fTyxxay7QQkPm1HfKi/JzmMSWC5+YTepGSgZNpJIDGg==}
@@ -11718,6 +11727,11 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.8: {}
+
+  react-native-document-scanner-plugin@2.0.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
   react-native-drawer-layout@4.2.9(e4920abfc9e65318671d090248ed021b):
     dependencies:


### PR DESCRIPTION
Adds `react-native-document-scanner-plugin` and puts a camera on the add-expense screen itself, rather than only behind *Split by item*.

## Why the platform scanner and not the plain camera

VisionKit on iOS, ML Kit's document scanner on Android. It finds the page edges and corrects the perspective, which matters more than it sounds: what follows is OCR, and OCR reads characters without knowing which of them are on the receipt. A flat crop of the bill is a different proposition from a photograph of a table — and nobody had to line the shot up.

Capture is **one** function, `captureReceipt`, used by both screens and falling back to the plain camera where the build has no scanner. Two capture paths would drift, and the screen asking for a receipt has no business knowing which one it got. *Split by item* gets the better crop for free.

## What a scan does here

It takes the **grand total** and the **merchant's name**, and leaves the splitting alone. Most bills are split some way that has nothing to do with what each line cost, and dropping somebody into claiming items because they photographed a bill would be worse than letting them type a total.

The lines it read are offered, not imposed — *"It read 7 items — split by item instead →"*.

That handover goes through the draft store rather than route params (a parsed receipt is a nested object; a URL is a bad place for one), keyed per group, consumed once, cleared immediately, ignored after ten minutes. A scan costs the group one of its free scans (ADR-011), so asking for the same bill twice is a real cost; a receipt left in the store to pre-fill somebody's screen days later is a real bug.

## The native-module rule, again

Reached the way the speech recogniser is: `TurboModuleRegistry.get` answers "is this in the binary" without throwing, so the package is only `require`d once the answer is yes. Being wrong about that is not a missing camera — it is the app failing to launch, because expo-router loads every route file to build the route tree.

## Verified

- typecheck, lint, format clean; `test:app` 92 passed (4 new).
- `expo config --type introspect` confirms the config plugin lands `NSCameraUsageDescription`; `expo-doctor` 19/20 (the remaining one is the known `app.json`/`app.config.ts` false positive).
- Both screens driven on the web build with no errors in the Metro log.

**Not verified: the scanner itself.** No Android SDK and no Mac here, so the camera fell back to the picker throughout. It needs `npx expo prebuild` and a dev build to be real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6