### PR TITLE
fix: make the Android build work from a pnpm checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,34 @@ lazy-require treatment described above — `TurboModuleRegistry.get` answers
 "is it in this binary" without throwing, and the package is only required once
 the answer is yes.
 
+### Building it natively
+
+```bash
+cd apps/mobile
+npx expo prebuild --platform android    # ios needs macOS; Expo refuses on Windows
+cd android && ./gradlew assembleDebug -PreactNativeArchitectures=arm64-v8a
+```
+
+Needs JDK 17, and an Android SDK with `platform-tools`, `platforms;android-36`
+and `build-tools;36.0.0`. The APK lands in
+`android/app/build/outputs/apk/debug/`.
+
+Two things in this repo exist only because of pnpm, and both fail in ways that
+name a file nobody here wrote:
+
+- **`plugins/withShortNativeBuildPath.js`** moves the CMake staging directory to
+  `C:\cxx\<module>` on Windows. Five dependencies compile C++, and CMake refuses
+  an object path over 250 characters — pnpm's store spends 192 of them before
+  the object is named. What you see is not a path error: ninja regenerates its
+  manifest in a loop and dies with `manifest 'build.ninja' still dirty after 100
+tries`, ten minutes in, blaming `react-native-screens`. Windows long paths do
+  not help; the limit is CMake's.
+- **`packageExtensions`** in `pnpm-workspace.yaml` declares
+  `@expo/config-plugins` for `react-native-document-scanner-plugin`, whose
+  config plugin requires it without depending on it. Always present under npm's
+  flat layout; absent under pnpm's, where the build dies in
+  `expo-constants:createExpoConfig`.
+
 ## Releasing, and stopping old builds
 
 The version is compiled into the binary, so a build can only ever describe

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -58,6 +58,7 @@
           "cameraPermission": "Baaki uses the camera to scan a bill, so the total and the items come out filled in instead of typed. The photograph stays on this phone whenever it can be read here."
         }
       ],
+      "./plugins/withShortNativeBuildPath",
       "expo-secure-store",
       "expo-sharing",
       "@react-native-community/datetimepicker",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -57,6 +57,7 @@
     "react-native-worklets": "0.10.1"
   },
   "devDependencies": {
+    "@expo/config-plugins": "^57.0.7",
     "@types/react": "~19.2.2",
     "eslint": "^9.39.5",
     "eslint-config-expo": "~57.0.1",

--- a/apps/mobile/plugins/withShortNativeBuildPath.js
+++ b/apps/mobile/plugins/withShortNativeBuildPath.js
@@ -1,0 +1,59 @@
+/**
+ * Keep CMake's object paths under its own limit, on Windows.
+ *
+ * Five of this app's dependencies compile C++ — reanimated, worklets, screens,
+ * gesture-handler, expo-modules-core. CMake refuses an object file whose full
+ * path exceeds 250 characters (`CMAKE_OBJECT_PATH_MAX`), and pnpm's store
+ * spends 192 of them before the object is even named:
+ *
+ *   node_modules/.pnpm/react-native-screens@4.26.2_2e35a…/node_modules/
+ *     react-native-screens/android/.cxx/Debug/4p3m6i70/arm64-v8a/
+ *     CMakeFiles/rnscreens.dir/
+ *
+ * What that produces is not a clear error about path length. CMake logs a
+ * warning nobody reads, then ninja regenerates its manifest in a loop and dies
+ * with `manifest 'build.ninja' still dirty after 100 tries`, ten minutes into
+ * the build, naming a dependency the author never touched. Enabling Windows
+ * long paths does not help: the 250 is CMake's, not the filesystem's.
+ *
+ * So the native staging directory moves to the root of a drive, which gives the
+ * object names the room they need.
+ *
+ * **This has to go in `settings.gradle`.** AGP reads `buildStagingDirectory`
+ * while each subproject configures itself, so the root build script is already
+ * too late — it fails with "it is too late to set buildStagingDirectory, it has
+ * already been read". `gradle.beforeProject` is the hook that is guaranteed to
+ * run first.
+ *
+ * macOS and Linux are untouched. They have no such problem, and a build output
+ * outside the project is a surprise worth avoiding where it buys nothing.
+ */
+
+const { withSettingsGradle } = require('@expo/config-plugins');
+
+const MARKER = 'baaki:short-native-build-path';
+
+/** Where the native build goes. Short by definition — that is the entire point. */
+const STAGING_ROOT = 'C:/cxx';
+
+const SNIPPET = `
+// ${MARKER} — see apps/mobile/plugins/withShortNativeBuildPath.js
+if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+  gradle.beforeProject { project ->
+    ["com.android.library", "com.android.application"].each { pluginId ->
+      project.plugins.withId(pluginId) {
+        project.android.externalNativeBuild.cmake.buildStagingDirectory =
+          new File("${STAGING_ROOT}/" + project.name)
+      }
+    }
+  }
+}
+`;
+
+module.exports = function withShortNativeBuildPath(config) {
+  return withSettingsGradle(config, (gradleConfig) => {
+    if (gradleConfig.modResults.contents.includes(MARKER)) return gradleConfig;
+    gradleConfig.modResults.contents += SNIPPET;
+    return gradleConfig;
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   expo-constants: 57.0.9
 
+packageExtensionsChecksum: sha256-JdGVH/MPbTDqIS2VCmpiXKZw1GpAMl9t/i4VsL8gZoU=
+
 importers:
 
   .:
@@ -154,7 +156,7 @@ importers:
         version: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
       react-native-document-scanner-plugin:
         specifier: ^2.0.4
-        version: 2.0.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+        version: 2.0.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
       react-native-gesture-handler:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -177,6 +179,9 @@ importers:
         specifier: 0.10.1
         version: 0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
     devDependencies:
+      '@expo/config-plugins':
+        specifier: ^57.0.7
+        version: 57.0.7(supports-color@8.1.1)(typescript@6.0.3)
       '@types/react':
         specifier: ~19.2.2
         version: 19.2.18
@@ -1123,9 +1128,6 @@ packages:
 
   '@expo/code-signing-certificates@0.0.6':
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
-
-  '@expo/config-plugins@57.0.6':
-    resolution: {integrity: sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==}
 
   '@expo/config-plugins@57.0.7':
     resolution: {integrity: sha512-jvXMiNuH8W7fmU9yCk4/jVwDX2G/5rWUg5PZ22mriccEeQVS9HJjQiUHivMaK6MxEG5L9f0RPScxe/nQfnpQvg==}
@@ -7034,25 +7036,6 @@ snapshots:
     dependencies:
       node-forge: 1.4.0
 
-  '@expo/config-plugins@57.0.6(supports-color@8.1.1)(typescript@6.0.3)':
-    dependencies:
-      '@expo/config-types': 57.0.2
-      '@expo/json-file': 11.0.1
-      '@expo/plist': 0.8.1
-      '@expo/require-utils': 57.0.4(supports-color@8.1.1)(typescript@6.0.3)
-      '@expo/sdk-runtime-versions': 1.0.0
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      getenv: 2.0.0
-      glob: 13.0.6
-      semver: 7.8.5
-      slugify: 1.6.9
-      xcode: 3.0.1
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@expo/config-plugins@57.0.7(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@expo/config-types': 57.0.2
@@ -7076,7 +7059,7 @@ snapshots:
 
   '@expo/config@57.0.6(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
-      '@expo/config-plugins': 57.0.6(supports-color@8.1.1)(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.7(supports-color@8.1.1)(typescript@6.0.3)
       '@expo/config-types': 57.0.2
       '@expo/json-file': 11.0.1
       '@expo/require-utils': 57.0.4(supports-color@8.1.1)(typescript@6.0.3)
@@ -7151,7 +7134,7 @@ snapshots:
 
   '@expo/inline-modules@0.1.4(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
-      '@expo/config-plugins': 57.0.6(supports-color@8.1.1)(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.7(supports-color@8.1.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7278,7 +7261,7 @@ snapshots:
   '@expo/prebuild-config@57.0.10(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@expo/config': 57.0.6(supports-color@8.1.1)(typescript@6.0.3)
-      '@expo/config-plugins': 57.0.6(supports-color@8.1.1)(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.7(supports-color@8.1.1)(typescript@6.0.3)
       '@expo/config-types': 57.0.2
       '@expo/image-utils': 0.11.4(supports-color@8.1.1)(typescript@6.0.3)
       '@expo/json-file': 11.0.1
@@ -10333,7 +10316,7 @@ snapshots:
 
   expo-sharing@57.0.8(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
-      '@expo/config-plugins': 57.0.6(supports-color@8.1.1)(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.7(supports-color@8.1.1)(typescript@6.0.3)
       '@expo/config-types': 57.0.2
       '@expo/plist': 0.8.1
       expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
@@ -10351,7 +10334,7 @@ snapshots:
 
   expo-splash-screen@57.0.5(expo@57.0.11)(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
-      '@expo/config-plugins': 57.0.6(supports-color@8.1.1)(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.7(supports-color@8.1.1)(typescript@6.0.3)
       '@expo/image-utils': 0.11.4(supports-color@8.1.1)(typescript@6.0.3)
       expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
       xml2js: 0.6.0
@@ -11728,10 +11711,14 @@ snapshots:
 
   react-is@19.2.8: {}
 
-  react-native-document-scanner-plugin@2.0.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+  react-native-document-scanner-plugin@2.0.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
+      '@expo/config-plugins': 57.0.7(supports-color@8.1.1)(typescript@6.0.3)
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   react-native-drawer-layout@4.2.9(e4920abfc9e65318671d090248ed021b):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,3 +37,14 @@ minimumReleaseAgeExclude:
 # the app already depends on.
 overrides:
   expo-constants: 57.0.9
+
+# Expo loads a package's config plugin from inside that package, and several of
+# them require `@expo/config-plugins` without declaring it — it is always
+# present under npm's flat layout, so nobody notices. Under pnpm's strict one
+# the Android build dies in `expo-constants:createExpoConfig` with "Cannot find
+# module '@expo/config-plugins'", naming a file nobody in this repo wrote.
+# Declaring the dependency on the package's behalf is narrower than hoisting.
+packageExtensions:
+  react-native-document-scanner-plugin:
+    dependencies:
+      '@expo/config-plugins': '^57.0.7'


### PR DESCRIPTION
`npx expo prebuild` then `gradlew assembleDebug` failed twice on this repo, and neither failure named anything anybody here wrote.

## CMake object paths

Five dependencies compile C++. CMake refuses an object file whose full path exceeds 250 characters (`CMAKE_OBJECT_PATH_MAX`), and pnpm's store spends 192 of them before the object is named:

```
node_modules/.pnpm/react-native-screens@4.26.2_2e35a…/node_modules/
  react-native-screens/android/.cxx/Debug/4p3m6i70/arm64-v8a/CMakeFiles/rnscreens.dir/
```

CMake logs a warning nobody reads; ninja then regenerates its manifest in a loop and dies with `manifest 'build.ninja' still dirty after 100 tries` — ten minutes into the build, blaming `react-native-screens`. Windows long paths are already enabled here and do not help: the 250 is CMake's, not the filesystem's.

`plugins/withShortNativeBuildPath.js` moves the staging directory to `C:\cxx\<module>`.

It has to go in `settings.gradle`. AGP reads `buildStagingDirectory` while each subproject configures, so the root build script is too late (*"it is too late to set buildStagingDirectory, it has already been read"*), and appending an `afterEvaluate` there fails outright because some subprojects have already been evaluated. `gradle.beforeProject` is the hook that runs first.

## A dependency a package forgot to declare

`react-native-document-scanner-plugin`'s config plugin requires `@expo/config-plugins` without depending on it — always present under npm's flat layout, absent under pnpm's, where the build dies in `expo-constants:createExpoConfig` with "Cannot find module".

`packageExtensions` in `pnpm-workspace.yaml` declares it on the package's behalf, which is narrower than hoisting. Note pnpm 11 no longer reads the `pnpm` field in `package.json` — these settings live in the workspace file now.

## Verified

`rm -rf android` → `expo prebuild --platform android` → `gradlew assembleDebug -PreactNativeArchitectures=arm64-v8a`:

- **BUILD SUCCESSFUL in 3m 26s**, 108 MB APK
- `DocumentScannerModule` and `expo/modules/speechrecognition/ExpoSpeechRecognitionModule` both confirmed in the dex
- ML Kit's OCR pipeline shipped too, with Devanagari and Bengali models

The whole chain reproduces from a clean prebuild, which is the point — the fix is in the repo, not in a hand-edited generated file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6