### PR TITLE
feat: put a category on an expense without anybody having to choose one

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -4,7 +4,14 @@ import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
-import { computeShares, type FxRecord, type MemberId, type SplitParams } from '@baaki/core';
+import {
+  computeShares,
+  guessCategory,
+  type CategoryId,
+  type FxRecord,
+  type MemberId,
+  type SplitParams,
+} from '@baaki/core';
 import {
   AmountKeypad,
   Avatar,
@@ -20,6 +27,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { CategoryPicker } from '@/components/Category';
 import { CurrencyRate } from '@/components/CurrencyRate';
 import { DictateButton } from '@/components/DictateButton';
 import { scanReceipt, scanReceiptText } from '@/data/api';
@@ -50,6 +58,9 @@ interface ExpenseDraft {
   /** Kept apart, because a weight of 1 is not one percent. */
   weights: SplitEntries;
   percents: SplitEntries;
+  category: CategoryId | null;
+  /** Whether the category above was chosen, rather than guessed. */
+  categoryChosen: boolean;
 }
 
 /** A saved split's integers, back as the text somebody would have typed. */
@@ -96,6 +107,10 @@ export default function AddExpenseScreen() {
   // reinterpret one number as the other.
   const [weights, setWeights] = useState<SplitEntries>({});
   const [percents, setPercents] = useState<SplitEntries>({});
+  // Guessed from the description until somebody picks one themselves, at which
+  // point the guess must stop moving it — see `categoryChosen`.
+  const [category, setCategory] = useState<CategoryId | null>(null);
+  const [categoryChosen, setCategoryChosen] = useState(false);
   /**
    * Names to bias the recogniser towards. "You" and "Someone" are placeholders
    * this screen prints, not things anybody says out loud, so they would only
@@ -144,9 +159,15 @@ export default function AddExpenseScreen() {
       setParticipants(draft.participants);
       setWeights(draft.weights ?? {});
       setPercents(draft.percents ?? {});
+      setCategory(draft.category ?? null);
+      setCategoryChosen(draft.categoryChosen ?? false);
     } else if (version) {
       setAmount(BigInt(version.amount));
       setDescription(version.description);
+      // A saved category is a decision somebody already made. Re-guessing it on
+      // open would quietly rewrite their answer.
+      setCategory((version.category as CategoryId | null) ?? null);
+      setCategoryChosen(version.category !== null);
       setPayer(version.payers[0]?.member_id ?? myMemberId);
       setParticipants(version.shares.map((share) => share.member_id));
       setSplitKind(
@@ -169,6 +190,15 @@ export default function AddExpenseScreen() {
       setParticipants((members.data ?? []).map((member) => member.id));
       setPayer(myMemberId);
     }
+  }
+
+  // The guess follows the description while it is being typed, and stops the
+  // moment a chip is tapped. Keyed by the text it was made from so it runs once
+  // per description rather than once per render.
+  const [guessedFrom, setGuessedFrom] = useState<string | null>(null);
+  if (seededFor !== null && !categoryChosen && description !== guessedFrom) {
+    setGuessedFrom(description);
+    setCategory(guessCategory(description));
   }
 
   // Everybody in a weighted split needs a number to start from, and the set
@@ -198,7 +228,17 @@ export default function AddExpenseScreen() {
   // Every keystroke, debounced just enough to avoid one write per character.
   useDraft<ExpenseDraft>(
     draftKey,
-    { amount: amount.toString(), description, splitKind, payer, participants, weights, percents },
+    {
+      amount: amount.toString(),
+      description,
+      splitKind,
+      payer,
+      participants,
+      weights,
+      percents,
+      category,
+      categoryChosen,
+    },
     { enabled: seededFor !== null },
   );
 
@@ -260,6 +300,7 @@ export default function AddExpenseScreen() {
       await mutate(expenseId ? 'expense.update' : 'expense.create', groupId, {
         expenseId: targetExpenseId,
         description: description.trim() || 'Expense',
+        category,
         expenseDate: new Date().toISOString().slice(0, 10),
         currency,
         amount: amount.toString(),
@@ -484,6 +525,22 @@ export default function AddExpenseScreen() {
             <DictateButton value={description} onChange={setDescription} hints={nameHints} />
           </Row>
         </Card>
+
+        {/* Pre-picked from the description, because a menu between somebody and
+            saving a dinner is how a column ends up empty — and an empty column
+            is a spending chart nobody can draw (TDR §8). */}
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="caption" tone="muted">
+            {t.whatFor}
+          </Text>
+          <CategoryPicker
+            value={category}
+            onChange={(picked) => {
+              setCategory(picked);
+              setCategoryChosen(true);
+            }}
+          />
+        </View>
 
         <View style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -18,6 +18,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { CategoryBadge } from '@/components/Category';
 import { DisputePanel } from '@/components/DisputePanel';
 import {
   memberLookup,
@@ -145,6 +146,7 @@ export default function ExpenseDetailScreen() {
         </Row>
 
         <Card style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+          <CategoryBadge category={version.category} size={48} />
           <MoneyText
             amount={BigInt(version.amount)}
             currency={currency}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -32,6 +32,7 @@ import { describeActivity, verbEmoji } from '@/data/activity';
 import { actorName, displayName, groupLabel, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { CategoryBadge } from '@/components/Category';
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { SyncBanner } from '@/components/SyncBanner';
 
@@ -262,12 +263,7 @@ export default function GroupScreen() {
                           ? ` · edited ×${version!.version_no - 1}`
                           : ''
                       }`}
-                      leading={
-                        <Avatar
-                          name={version?.category ?? version?.description ?? 'Expense'}
-                          size={42}
-                        />
-                      }
+                      leading={<CategoryBadge category={version?.category} size={42} />}
                       onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
                       trailing={
                         version ? (

--- a/apps/mobile/src/components/Category.tsx
+++ b/apps/mobile/src/components/Category.tsx
@@ -1,0 +1,107 @@
+/**
+ * The category, as a thing you can see and change.
+ *
+ * `CategoryBadge` is the tinted circle that stands in for an expense in a list
+ * — a fork for dinner, an auto for the ride — which is worth more than the two
+ * initials of a description at a glance.
+ *
+ * `CategoryPicker` is the row of chips under the description on the
+ * add-expense screen. It is pre-selected from what was typed
+ * (`guessCategory`), and the moment somebody taps a chip themselves the guess
+ * stops overriding them: a field that keeps changing under your finger is
+ * worse than no field.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, ScrollView, View } from 'react-native';
+
+import { CATEGORIES, categoryOf, type CategoryId } from '@baaki/core';
+import { Text, useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+
+export function CategoryBadge({
+  category,
+  size = 42,
+}: {
+  category: string | null | undefined;
+  size?: number;
+}) {
+  const theme = useTheme();
+  const resolved = categoryOf(category);
+  const tint = theme.tint[resolved.tint];
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: tint.bg,
+      }}
+    >
+      <Ionicons
+        name={resolved.icon as keyof typeof Ionicons.glyphMap}
+        size={Math.round(size * 0.5)}
+        color={tint.ink}
+      />
+    </View>
+  );
+}
+
+export function CategoryPicker({
+  value,
+  onChange,
+}: {
+  value: CategoryId | null;
+  onChange: (value: CategoryId) => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={{ gap: theme.spacing.sm, paddingRight: theme.spacing.xl }}
+    >
+      {CATEGORIES.map((category) => {
+        const selected = category.id === value;
+        const tint = theme.tint[category.tint];
+        const label = t.categories[category.id];
+        return (
+          <Pressable
+            key={category.id}
+            accessibilityRole="radio"
+            accessibilityState={{ selected }}
+            accessibilityLabel={label}
+            onPress={() => onChange(category.id)}
+            style={({ pressed }) => ({
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+              height: 36,
+              paddingHorizontal: theme.spacing.md,
+              borderRadius: theme.radius.pill,
+              backgroundColor: selected ? tint.bg : theme.color.surface,
+              borderWidth: 1,
+              borderColor: selected ? tint.ink : 'transparent',
+              opacity: pressed ? 0.85 : 1,
+            })}
+          >
+            <Ionicons
+              name={category.icon as keyof typeof Ionicons.glyphMap}
+              size={15}
+              color={selected ? tint.ink : theme.color.textMuted}
+            />
+            <Text variant="caption" style={{ color: selected ? tint.ink : theme.color.textMuted }}>
+              {label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -6,6 +6,8 @@
 
 import { getLocales } from 'expo-localization';
 
+import type { CategoryId } from '@baaki/core';
+
 export type Language = 'en' | 'ta' | 'hi';
 
 export interface UiStrings {
@@ -48,6 +50,13 @@ export interface UiStrings {
   freeForever: string;
   nothingYet: string;
   nothingYetBody: string;
+  whatFor: string;
+  spending: string;
+  byCategory: string;
+  byMonth: string;
+  nothingToChart: string;
+  /** The ten categories of TDR §8, in the language the phone is set to. */
+  categories: Record<CategoryId, string>;
 }
 
 const en: UiStrings = {
@@ -90,6 +99,23 @@ const en: UiStrings = {
   freeForever: 'Unlimited and free, forever',
   nothingYet: 'Nothing here yet',
   nothingYetBody: 'Add your first expense and the maths takes care of itself.',
+  whatFor: 'What kind of expense',
+  spending: 'Spending',
+  byCategory: 'Where it went',
+  byMonth: 'Month by month',
+  nothingToChart: 'Add a few expenses and this fills in.',
+  categories: {
+    food: 'Food & drink',
+    groceries: 'Groceries',
+    travel: 'Travel',
+    stay: 'Stay',
+    shopping: 'Shopping',
+    entertainment: 'Fun',
+    home: 'Home & bills',
+    health: 'Health',
+    gifts: 'Gifts',
+    other: 'Other',
+  },
 };
 
 const ta: UiStrings = {
@@ -118,6 +144,23 @@ const ta: UiStrings = {
   description: 'எதற்காக?',
   save: 'செலவைச் சேமி',
   freeForever: 'எப்போதும் இலவசம்',
+  whatFor: 'எந்த வகைச் செலவு',
+  spending: 'செலவு',
+  byCategory: 'எதற்குச் சென்றது',
+  byMonth: 'மாதம் வாரியாக',
+  nothingToChart: 'சில செலவுகளைச் சேர்த்தால் இது நிரம்பும்.',
+  categories: {
+    food: 'உணவு',
+    groceries: 'மளிகை',
+    travel: 'பயணம்',
+    stay: 'தங்குமிடம்',
+    shopping: 'ஷாப்பிங்',
+    entertainment: 'பொழுதுபோக்கு',
+    home: 'வீடு & பில்',
+    health: 'உடல்நலம்',
+    gifts: 'பரிசு',
+    other: 'மற்றவை',
+  },
 };
 
 const hi: UiStrings = {
@@ -146,6 +189,23 @@ const hi: UiStrings = {
   description: 'किस लिए?',
   save: 'खर्च सेव करें',
   freeForever: 'हमेशा मुफ़्त',
+  whatFor: 'किस तरह का खर्च',
+  spending: 'खर्च',
+  byCategory: 'कहाँ गया',
+  byMonth: 'महीने के हिसाब से',
+  nothingToChart: 'कुछ खर्च जोड़ें, यह अपने आप भर जाएगा।',
+  categories: {
+    food: 'खाना-पीना',
+    groceries: 'किराना',
+    travel: 'सफ़र',
+    stay: 'ठहरना',
+    shopping: 'शॉपिंग',
+    entertainment: 'मनोरंजन',
+    home: 'घर व बिल',
+    health: 'सेहत',
+    gifts: 'तोहफ़े',
+    other: 'अन्य',
+  },
 };
 
 const STRINGS: Record<Language, UiStrings> = { en, ta, hi };

--- a/packages/core/src/category/categories.ts
+++ b/packages/core/src/category/categories.ts
@@ -1,0 +1,378 @@
+/**
+ * What an expense was for.
+ *
+ * The category exists for one reason: TDR §8's charts. A chart drawn over a
+ * column nobody fills is an empty screen, and asking somebody to choose from a
+ * menu before they can save a dinner is the sort of friction that makes people
+ * stop entering expenses at all. So the category is **guessed from what they
+ * already typed** and shown as a chip they can change — the same bargain as
+ * ADR-008's receipts: the machine proposes, the person confirms.
+ *
+ * The keyword table is deliberately Indian. A general categoriser trained
+ * elsewhere files an auto ride under "other" and biryani under "groceries";
+ * here the ordinary vocabulary of splitting a bill in India — auto, chai,
+ * Swiggy, Zepto, IRCTC, kirana — is what it knows first. Every list here is
+ * lowercase and matched against whole tokens, never substrings: `ola` is a cab
+ * company and also the middle of "chocolate".
+ *
+ * Ten categories, not fifty. A chart with fifty slices tells nobody anything,
+ * and every category added is another thing to scroll past on the way to
+ * saving. "Other" is a real answer and stays.
+ */
+
+export type CategoryId =
+  | 'food'
+  | 'groceries'
+  | 'travel'
+  | 'stay'
+  | 'shopping'
+  | 'entertainment'
+  | 'home'
+  | 'health'
+  | 'gifts'
+  | 'other';
+
+export interface Category {
+  readonly id: CategoryId;
+  /** English. The app translates through its own string table (TDR §11). */
+  readonly label: string;
+  /** An Ionicons name. A string here keeps this package free of React. */
+  readonly icon: string;
+  /** Which pastel from the design system's tint family this draws in. */
+  readonly tint: 'lilac' | 'pink' | 'mint' | 'peach' | 'sky' | 'coral';
+  /** Lowercase whole words that mean this category. */
+  readonly keywords: readonly string[];
+}
+
+export const CATEGORIES: readonly Category[] = [
+  {
+    id: 'food',
+    label: 'Food & drink',
+    icon: 'restaurant-outline',
+    tint: 'peach',
+    keywords: [
+      'food',
+      'lunch',
+      'dinner',
+      'breakfast',
+      'brunch',
+      'snacks',
+      'restaurant',
+      'hotel',
+      'mess',
+      'canteen',
+      'cafe',
+      'coffee',
+      'chai',
+      'tea',
+      'juice',
+      'biryani',
+      'dosa',
+      'idli',
+      'thali',
+      'pizza',
+      'burger',
+      'shawarma',
+      'meals',
+      'tiffin',
+      'swiggy',
+      'zomato',
+      'eatsure',
+      'dominos',
+      'kfc',
+      'mcdonalds',
+      'starbucks',
+      'bar',
+      'beer',
+      'drinks',
+      'pub',
+      'cake',
+      'dessert',
+      'icecream',
+    ],
+  },
+  {
+    id: 'groceries',
+    label: 'Groceries',
+    icon: 'basket-outline',
+    tint: 'mint',
+    keywords: [
+      'groceries',
+      'grocery',
+      'kirana',
+      'provisions',
+      'sabzi',
+      'vegetables',
+      'fruits',
+      'milk',
+      'curd',
+      'eggs',
+      'rice',
+      'atta',
+      'oil',
+      'bigbasket',
+      'dmart',
+      'blinkit',
+      'zepto',
+      'instamart',
+      'jiomart',
+      'supermarket',
+      'market',
+    ],
+  },
+  {
+    id: 'travel',
+    label: 'Travel',
+    icon: 'car-outline',
+    tint: 'sky',
+    keywords: [
+      'travel',
+      'auto',
+      'rickshaw',
+      'cab',
+      'taxi',
+      'uber',
+      'ola',
+      'rapido',
+      'namma',
+      'yatri',
+      'bus',
+      'metro',
+      'train',
+      'irctc',
+      'railway',
+      'flight',
+      'indigo',
+      'vistara',
+      'akasa',
+      'airport',
+      'petrol',
+      'diesel',
+      'fuel',
+      'toll',
+      'fastag',
+      'parking',
+      'ferry',
+      'bike',
+      'scooter',
+      'rental',
+    ],
+  },
+  {
+    id: 'stay',
+    label: 'Stay',
+    icon: 'bed-outline',
+    tint: 'lilac',
+    keywords: [
+      'stay',
+      'room',
+      'rooms',
+      'lodge',
+      'resort',
+      'homestay',
+      'guesthouse',
+      'hostel',
+      'dorm',
+      'airbnb',
+      'oyo',
+      'treebo',
+      'villa',
+      'cottage',
+      'checkin',
+      'accommodation',
+    ],
+  },
+  {
+    id: 'shopping',
+    label: 'Shopping',
+    icon: 'bag-handle-outline',
+    tint: 'pink',
+    keywords: [
+      'shopping',
+      'clothes',
+      'shirt',
+      'saree',
+      'kurta',
+      'shoes',
+      'chappal',
+      'bag',
+      'amazon',
+      'flipkart',
+      'myntra',
+      'ajio',
+      'meesho',
+      'nykaa',
+      'decathlon',
+      'ikea',
+      'mall',
+    ],
+  },
+  {
+    id: 'entertainment',
+    label: 'Fun',
+    icon: 'game-controller-outline',
+    tint: 'coral',
+    keywords: [
+      'movie',
+      'movies',
+      'cinema',
+      'pvr',
+      'inox',
+      'bookmyshow',
+      'ticket',
+      'tickets',
+      'concert',
+      'show',
+      'netflix',
+      'spotify',
+      'hotstar',
+      'prime',
+      'game',
+      'gaming',
+      'bowling',
+      'arcade',
+      'club',
+      'party',
+      'trek',
+      'museum',
+      'zoo',
+      'beach',
+    ],
+  },
+  {
+    id: 'home',
+    label: 'Home & bills',
+    icon: 'home-outline',
+    tint: 'lilac',
+    keywords: [
+      'rent',
+      'maintenance',
+      'deposit',
+      'electricity',
+      'current',
+      'eb',
+      'water',
+      'gas',
+      'cylinder',
+      'wifi',
+      'broadband',
+      'internet',
+      'airtel',
+      'jio',
+      'bsnl',
+      'dth',
+      'recharge',
+      'maid',
+      'cook',
+      'cleaning',
+      'laundry',
+      'repair',
+      'plumber',
+      'electrician',
+      'furniture',
+      'utensils',
+    ],
+  },
+  {
+    id: 'health',
+    label: 'Health',
+    icon: 'medkit-outline',
+    tint: 'mint',
+    keywords: [
+      'medicine',
+      'medicines',
+      'pharmacy',
+      'chemist',
+      'apollo',
+      'pharmeasy',
+      'doctor',
+      'clinic',
+      'hospital',
+      'scan',
+      'lab',
+      'test',
+      'dentist',
+      'gym',
+      'yoga',
+      'insurance',
+    ],
+  },
+  {
+    id: 'gifts',
+    label: 'Gifts',
+    icon: 'gift-outline',
+    tint: 'pink',
+    keywords: [
+      'gift',
+      'gifts',
+      'birthday',
+      'anniversary',
+      'wedding',
+      'flowers',
+      'chocolates',
+      'donation',
+      'tip',
+      'shagun',
+    ],
+  },
+  {
+    id: 'other',
+    label: 'Other',
+    icon: 'ellipsis-horizontal-circle-outline',
+    tint: 'sky',
+    keywords: [],
+  },
+];
+
+const BY_ID = new Map<string, Category>(CATEGORIES.map((category) => [category.id, category]));
+
+/** The fallback, and the one every unknown string resolves to. */
+export const OTHER: Category = BY_ID.get('other')!;
+
+/**
+ * The category for a stored value.
+ *
+ * Anything unrecognised becomes "Other" rather than throwing: the column is a
+ * free-text `String?` in the schema, an import can put anything in it, and a
+ * chart is not worth crashing a screen over.
+ */
+export function categoryOf(id: string | null | undefined): Category {
+  if (!id) return OTHER;
+  return BY_ID.get(id.trim().toLowerCase()) ?? OTHER;
+}
+
+/** Lowercased whole words, Unicode-aware so Tamil and Hindi survive intact. */
+function tokenise(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter((token) => token.length > 0);
+}
+
+/**
+ * Guess from what somebody typed, or null when nothing matches.
+ *
+ * Null is not "other" — it means the guess has nothing to say, and the caller
+ * should leave the field alone rather than assert a category the person never
+ * chose. Ties go to the category listed first, which keeps the same words
+ * producing the same answer on every device (the same determinism ADR-009 asks
+ * of the money).
+ */
+export function guessCategory(description: string): CategoryId | null {
+  const tokens = new Set(tokenise(description));
+  if (tokens.size === 0) return null;
+
+  let best: CategoryId | null = null;
+  let bestHits = 0;
+  for (const category of CATEGORIES) {
+    let hits = 0;
+    for (const keyword of category.keywords) {
+      if (tokens.has(keyword)) hits += 1;
+    }
+    if (hits > bestHits) {
+      best = category.id;
+      bestHits = hits;
+    }
+  }
+  return best;
+}

--- a/packages/core/src/category/index.ts
+++ b/packages/core/src/category/index.ts
@@ -1,0 +1,1 @@
+export * from './categories';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './simplify/index';
 export * from './settlement/index';
 export * from './sync/index';
 export * from './receipt/index';
+export * from './category/index';
 export * from './notifications/index';
 export * from './sms/index';
 export * from './import/index';

--- a/packages/core/test/category.test.ts
+++ b/packages/core/test/category.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The guess is allowed to be wrong. It is not allowed to be wrong *silently* in
+ * the ways that matter: matching inside another word, disagreeing with itself
+ * between two devices, or claiming a category for a description that says
+ * nothing.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { CATEGORIES, categoryOf, guessCategory, OTHER } from '../src/category/categories.js';
+
+describe('guessCategory', () => {
+  it('reads the ordinary vocabulary of an Indian bill', () => {
+    expect(guessCategory('Auto to the station')).toBe('travel');
+    expect(guessCategory('Biryani at Anjappar')).toBe('food');
+    expect(guessCategory('Blinkit order')).toBe('groceries');
+    expect(guessCategory('OYO for two nights')).toBe('stay');
+    expect(guessCategory('BookMyShow tickets')).toBe('entertainment');
+    expect(guessCategory('Electricity bill')).toBe('home');
+    expect(guessCategory('Pharmacy run')).toBe('health');
+    expect(guessCategory("Ananya's birthday gift")).toBe('gifts');
+  });
+
+  it('matches whole words, never substrings', () => {
+    // 'ola' is a cab company and also the middle of chocolate; 'eb' is the
+    // electricity board and also the middle of everything.
+    expect(guessCategory('Chocolates')).not.toBe('travel');
+    expect(guessCategory('Webcam')).not.toBe('home');
+  });
+
+  it('says nothing rather than guessing "other"', () => {
+    expect(guessCategory('')).toBeNull();
+    expect(guessCategory('   ')).toBeNull();
+    expect(guessCategory('Saturday')).toBeNull();
+  });
+
+  it('is deterministic when two categories both match', () => {
+    // 'hotel' is food (the Tamil sense) and 'room' is stay. Whichever wins, it
+    // wins the same way on every device — an unstable guess would rewrite
+    // somebody's category the next time the screen re-rendered.
+    const mixed = 'Hotel room and dinner';
+    const first = guessCategory(mixed);
+    expect(guessCategory(mixed)).toBe(first);
+    expect(first).toBe('food');
+  });
+
+  it('ignores case and punctuation', () => {
+    expect(guessCategory('UBER — airport')).toBe('travel');
+    expect(guessCategory('swiggy!!')).toBe('food');
+  });
+});
+
+describe('categoryOf', () => {
+  it('resolves every known id', () => {
+    for (const category of CATEGORIES) {
+      expect(categoryOf(category.id)).toBe(category);
+    }
+  });
+
+  it('falls back to Other for anything a stored row might hold', () => {
+    // The column is free text: an import, an older build, or a typo can put
+    // anything there, and a chart is not worth crashing a screen over.
+    expect(categoryOf(null)).toBe(OTHER);
+    expect(categoryOf(undefined)).toBe(OTHER);
+    expect(categoryOf('')).toBe(OTHER);
+    expect(categoryOf('Entertainment ')).toBe(categoryOf('entertainment'));
+    expect(categoryOf('vacation')).toBe(OTHER);
+  });
+});
+
+describe('the category list itself', () => {
+  it('has unique ids and no keyword claimed twice', () => {
+    const ids = CATEGORIES.map((category) => category.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    const seen = new Map<string, string>();
+    for (const category of CATEGORIES) {
+      for (const keyword of category.keywords) {
+        expect(keyword).toBe(keyword.toLowerCase());
+        const owner = seen.get(keyword);
+        expect(owner, `"${keyword}" is claimed by both ${owner} and ${category.id}`).toBeUndefined();
+        seen.set(keyword, category.id);
+      }
+    }
+  });
+});


### PR DESCRIPTION
M5 wants charts of where the money went. Nothing in the app was filling the column they would be drawn from — `expense_versions.category` has existed since M0, but only the Splitwise importer ever wrote to it.

Asking outright is the obvious fix and the wrong one: a menu between somebody and saving a dinner is the friction that stops people entering expenses at all. So the category is **guessed from the description** and shown as a chip they can change — the same bargain ADR-008 makes for receipts.

## What is here

- `packages/core/src/category` — ten categories with an Indian keyword table (auto, chai, Swiggy, Zepto, IRCTC, kirana), `guessCategory`, `categoryOf`.
- `CategoryPicker` and `CategoryBadge` in the app; the tinted circle replaces the two-initial avatar in the expense list and on the detail screen.
- Labels translated to ta and hi (TDR §11).

## Decisions

- **Whole tokens, never substrings.** `ola` is a cab company and also the middle of "chocolate". Tokenising is Unicode-aware so Tamil and Hindi text survives.
- **The guess stops when a chip is tapped.** A field that moves under your finger is worse than no field.
- **Opening an old expense never re-guesses** — that column holds a decision somebody already made.
- **No match returns null, not "other."** Having nothing to say is not the same as choosing the last option.

## Verification

`pnpm typecheck`, `pnpm lint` clean. Core 283 tests pass (8 new), mobile 92. `packages/db` tests need local Postgres and were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6