### PR TITLE
feat: read a Baaki export back in, balance for balance

### DIFF
--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -1,17 +1,21 @@
 /**
- * Bringing a Splitwise group across (ADR-012, TDR §10).
+ * Bringing a ledger in — from Splitwise, or from Baaki itself (ADR-012).
  *
- * The parsing is the easy half and has been in `packages/core` since M0. This
- * screen is the other half: deciding which column of the file is which person
- * here, and being straight about what the file does and does not contain.
+ * The parsing is the easy half and lives in `packages/core`. This screen is the
+ * other half: deciding which name in the file is which person here, and being
+ * straight about what each kind of file does and does not contain.
  *
- * What it contains is each person's **net** for every row. What it does not
- * contain is who paid — many (paid, owed) pairs produce the same net, and the
- * export keeps none of them. So the balances that come out of this are exact to
- * the paisa and the payer on each row is a deterministic reconstruction. The
- * preview says so in those words, because somebody who later opens a row and
- * finds they apparently paid for a dinner they did not pay for deserves to have
- * been told first.
+ * A **Splitwise** export holds each person's *net* for every row. It does not
+ * hold who paid — many (paid, owed) pairs produce the same net, and the file
+ * keeps none of them. Balances come across to the paisa; the payer on each row
+ * is a deterministic reconstruction, and the preview says so in those words,
+ * because somebody who later opens a row and finds they apparently paid for a
+ * dinner they did not pay for deserves to have been told first.
+ *
+ * A **Baaki** export holds the real (paid, owed) pair and the settlements
+ * besides, so nothing is reconstructed. What still does not survive is stated
+ * in ./import's own words on screen: ids, edit history and settlement
+ * allocations are new, and that is what "lossless" honestly covers (M5).
  */
 
 import { useState } from 'react';
@@ -22,11 +26,19 @@ import * as FileSystem from 'expo-file-system';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
 
-import { importSplitwiseCsv, type SplitwiseImport } from '@baaki/core';
+import {
+  importSplitwiseCsv,
+  isBaakiExport,
+  parseBaakiExport,
+  type BaakiImportGroup,
+  type BaakiImportSettlement,
+  type ImportProblem,
+} from '@baaki/core';
 import {
   Badge,
   Button,
   Card,
+  ChipRow,
   Divider,
   IconButton,
   MoneyText,
@@ -37,7 +49,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { createGroup, fetchMembers, importSplitwise, type ImportPerson } from '@/data/api';
+import { createGroup, fetchMembers, importLedger, type ImportPerson } from '@/data/api';
 import { useGroups } from '@/data/hooks';
 import { displayName, groupLabel, type MemberRow } from '@/data/types';
 import { useAuth } from '@/lib/auth';
@@ -47,13 +59,65 @@ type Mapping = { kind: 'me' } | { kind: 'member'; memberId: string } | { kind: '
 
 const NEW_GROUP = 'new';
 
+/**
+ * The two file formats, flattened to what this screen needs.
+ *
+ * They differ in exactly two ways that matter here — whether the payer is real
+ * or reconstructed, and whether settlements came along — so one shape with two
+ * origins beats two screens that drift apart.
+ */
+interface Loaded {
+  origin: 'splitwise' | 'baaki';
+  /** What to call the group if a new one is made. */
+  suggestedName: string;
+  people: readonly string[];
+  currency: string;
+  expenses: readonly {
+    description: string;
+    category: string | null;
+    date: string;
+    currency: string;
+    amount: bigint;
+    payers: Readonly<Record<string, bigint>>;
+    shares: Readonly<Record<string, bigint>>;
+  }[];
+  settlements: readonly BaakiImportSettlement[];
+  /** Net per person in `currency`. Other currencies are counted but not shown. */
+  balances: Readonly<Record<string, bigint>>;
+  /** Currencies in the file beyond the main one, so the preview can say so. */
+  otherCurrencies: readonly string[];
+  problems: readonly ImportProblem[];
+}
+
+function fromBaaki(group: BaakiImportGroup, fallbackName: string): Loaded {
+  const currencies = [...new Set(group.expenses.map((expense) => expense.currency))];
+  return {
+    origin: 'baaki',
+    suggestedName: group.name ?? fallbackName,
+    people: group.people,
+    currency: group.currency,
+    expenses: group.expenses,
+    settlements: group.settlements,
+    balances: group.balances[group.currency] ?? {},
+    otherCurrencies: currencies.filter((currency) => currency !== group.currency),
+    problems: group.problems,
+  };
+}
+
 export default function ImportScreen() {
   const theme = useTheme();
   const groups = useGroups();
   const { profile } = useAuth();
 
   const [file, setFile] = useState<string | null>(null);
-  const [parsed, setParsed] = useState<SplitwiseImport | null>(null);
+  const [parsed, setParsed] = useState<Loaded | null>(null);
+  /**
+   * A Baaki export can hold every group somebody is in. Importing them all in
+   * one go would need one who-is-who mapping per group on one screen, which is
+   * how somebody puts a stranger's history into the wrong ledger. One at a
+   * time, chosen deliberately.
+   */
+  const [fileGroups, setFileGroups] = useState<readonly BaakiImportGroup[]>([]);
   const [target, setTarget] = useState<string>(NEW_GROUP);
   const [members, setMembers] = useState<MemberRow[]>([]);
   const [mapping, setMapping] = useState<Record<string, Mapping>>({});
@@ -66,9 +130,23 @@ export default function ImportScreen() {
 
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [done, setDone] = useState<{ groupId: string; expenses: number; ghosts: number } | null>(
-    null,
-  );
+  const [done, setDone] = useState<{
+    groupId: string;
+    expenses: number;
+    ghosts: number;
+    settlements: number;
+  } | null>(null);
+
+  /** Everyone starts as somebody new — see `load`. */
+  const load = (loaded: Loaded): void => {
+    setParsed(loaded);
+    setMutationIds([...loaded.expenses, ...loaded.settlements].map(() => randomUUID()));
+    // Claiming a name as yourself is a deliberate act. Guessing by name would
+    // silently merge your ledger with a stranger who shares your first name.
+    setMapping(Object.fromEntries(loaded.people.map((person) => [person, { kind: 'ghost' }])));
+    setTarget(NEW_GROUP);
+    setMembers([]);
+  };
 
   const choose = async (): Promise<void> => {
     setError(null);
@@ -78,7 +156,13 @@ export default function ImportScreen() {
       // Some Android file providers hand back `application/octet-stream` for a
       // .csv, so text/* is allowed too rather than hiding the file the person
       // came here to select.
-      type: ['text/csv', 'text/comma-separated-values', 'text/plain', 'application/octet-stream'],
+      type: [
+        'text/csv',
+        'text/comma-separated-values',
+        'text/plain',
+        'application/json',
+        'application/octet-stream',
+      ],
       copyToCacheDirectory: true,
     });
     if (picked.canceled) return;
@@ -87,16 +171,38 @@ export default function ImportScreen() {
     if (!asset) return;
 
     setBusy(true);
+    setFileGroups([]);
+    setParsed(null);
     try {
-      const csv = new FileSystem.File(asset.uri).textSync();
-      const result = importSplitwiseCsv(csv);
+      const text = new FileSystem.File(asset.uri).textSync();
       setFile(asset.name);
-      setParsed(result);
-      setMutationIds(result.expenses.map(() => randomUUID()));
-      // Everyone starts as somebody new. Claiming one of them as yourself is a
-      // deliberate act — guessing by name would silently merge your ledger with
-      // a stranger who happens to share your first name.
-      setMapping(Object.fromEntries(result.people.map((person) => [person, { kind: 'ghost' }])));
+
+      // Asked of the contents, not the extension: a file saved from a browser
+      // or shared through a chat app arrives named all sorts of things.
+      if (isBaakiExport(text)) {
+        const result = parseBaakiExport(text);
+        if (result.problems.length > 0) {
+          setError(result.problems[0]!.message);
+          return;
+        }
+        const fallback = asset.name.replace(/\.json$/i, '');
+        setFileGroups(result.groups);
+        if (result.groups[0]) load(fromBaaki(result.groups[0], fallback));
+        return;
+      }
+
+      const result = importSplitwiseCsv(text);
+      load({
+        origin: 'splitwise',
+        suggestedName: asset.name.replace(/\.csv$/i, '') || 'Imported group',
+        people: result.people,
+        currency: result.currency,
+        expenses: result.expenses,
+        settlements: [],
+        balances: result.balances,
+        otherCurrencies: [],
+        problems: result.problems,
+      });
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
     } finally {
@@ -160,7 +266,7 @@ export default function ImportScreen() {
       let groupId = target;
       if (groupId === NEW_GROUP) {
         groupId = await createGroup({
-          name: file?.replace(/\.csv$/i, '') || 'Imported group',
+          name: parsed.suggestedName || 'Imported group',
           type: 'other',
           currency: parsed.currency,
         });
@@ -179,9 +285,10 @@ export default function ImportScreen() {
         return { name: person, memberId: null };
       });
 
-      const result = await importSplitwise({
+      const result = await importLedger({
         groupId,
         people,
+        origin: parsed.origin,
         expenses: parsed.expenses.map((expense, index) => ({
           clientMutationId: mutationIds[index] ?? randomUUID(),
           description: expense.description,
@@ -192,9 +299,25 @@ export default function ImportScreen() {
           payers: expense.payers,
           shares: expense.shares,
         })),
+        settlements: parsed.settlements.map((settlement, index) => ({
+          clientMutationId: mutationIds[parsed.expenses.length + index] ?? randomUUID(),
+          from: settlement.from,
+          to: settlement.to,
+          currency: settlement.currency,
+          amount: settlement.amount,
+          method: settlement.method,
+          status: settlement.status,
+          note: settlement.note,
+          at: settlement.at,
+        })),
       });
 
-      setDone({ groupId, expenses: result.expenses, ghosts: result.ghosts });
+      setDone({
+        groupId,
+        expenses: result.expenses,
+        ghosts: result.ghosts,
+        settlements: result.settlements ?? 0,
+      });
       void groups.refetch();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
@@ -218,7 +341,7 @@ export default function ImportScreen() {
             <Ionicons name="chevron-back" size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Import from Splitwise</Text>
+            <Text variant="heading">Import a ledger</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
@@ -229,14 +352,15 @@ export default function ImportScreen() {
             <Badge label="free" tone="positive" />
           </Row>
           <Text variant="caption" tone="muted">
-            In Splitwise, open a group → the ⚙ menu → Export as spreadsheet. Choose that CSV here.
-            Everyone in it becomes a member of the group — they do not need the app, and they can
-            claim their history whenever they join.
+            From Splitwise: open a group → the ⚙ menu → Export as spreadsheet, and choose that CSV
+            here. From Baaki: choose a JSON file you exported from Settings. Everyone named in it
+            becomes a member of the group — they do not need the app, and they can claim their
+            history whenever they join.
           </Text>
         </Card>
 
         <Button
-          label={file ? 'Choose a different file' : 'Choose a CSV file'}
+          label={file ? 'Choose a different file' : 'Choose a file'}
           size="lg"
           fullWidth
           variant={file ? 'secondary' : 'primary'}
@@ -253,22 +377,51 @@ export default function ImportScreen() {
 
         {busy && !parsed ? <ActivityIndicator color={theme.color.brand} /> : null}
 
+        {/* A file holding several groups: one at a time, chosen here. */}
+        {fileGroups.length > 1 && !done ? (
+          <View style={{ gap: theme.spacing.md }}>
+            <SectionHeader title="Which group" />
+            <ChipRow<string>
+              value={parsed?.suggestedName ?? ''}
+              onChange={(name) => {
+                const chosen = fileGroups.find(
+                  (group, index) => (group.name ?? `Group ${index + 1}`) === name,
+                );
+                if (chosen) load(fromBaaki(chosen, name));
+              }}
+              options={fileGroups.map((group, index) => ({
+                value: group.name ?? `Group ${index + 1}`,
+                label: `${group.name ?? `Group ${index + 1}`} · ${group.expenses.length}`,
+              }))}
+            />
+          </View>
+        ) : null}
+
         {parsed && !done ? (
           <>
             <Card style={{ gap: theme.spacing.sm }}>
               <Text variant="subheading">{file}</Text>
               <Text variant="caption" tone="muted">
-                {parsed.expenses.length} expense{parsed.expenses.length === 1 ? '' : 's'} ·{' '}
-                {parsed.people.length} people · {parsed.currency}
+                {parsed.expenses.length} expense{parsed.expenses.length === 1 ? '' : 's'}
+                {parsed.settlements.length > 0
+                  ? ` · ${parsed.settlements.length} settlement${parsed.settlements.length === 1 ? '' : 's'}`
+                  : ''}{' '}
+                · {parsed.people.length} people · {parsed.currency}
               </Text>
 
               <Divider />
 
               <Text variant="caption" tone="muted">
-                Balances come across exactly. Who paid does not: a Splitwise export records only
-                what each person came out up or down on a row, and many different payers produce the
-                same result. Every imported expense is marked, and you can correct any of them.
+                {parsed.origin === 'baaki'
+                  ? 'Every balance comes across to the paisa, settlements included. What does not come across: the edit history of each expense, and which expenses a past payment was applied against. Neither changes what anybody owes.'
+                  : 'Balances come across exactly. Who paid does not: a Splitwise export records only what each person came out up or down on a row, and many different payers produce the same result. Every imported expense is marked, and you can correct any of them.'}
               </Text>
+
+              {parsed.otherCurrencies.length > 0 ? (
+                <Text variant="micro" tone="faint">
+                  {`The amounts below are the ${parsed.currency} ones. ${parsed.otherCurrencies.join(', ')} come across too, and are never converted.`}
+                </Text>
+              ) : null}
             </Card>
 
             {parsed.problems.length > 0 ? (
@@ -384,6 +537,9 @@ export default function ImportScreen() {
             </Text>
             <Text variant="caption" tone="muted">
               {done.expenses} expense{done.expenses === 1 ? '' : 's'}
+              {done.settlements > 0
+                ? ` · ${done.settlements} settlement${done.settlements === 1 ? '' : 's'}`
+                : ''}
               {done.ghosts > 0
                 ? ` · ${done.ghosts} ${done.ghosts === 1 ? 'person' : 'people'} added, waiting to be claimed`
                 : ''}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -712,15 +712,30 @@ export interface ImportExpense {
   shares: Record<string, bigint>;
 }
 
+export interface ImportSettlement {
+  clientMutationId: string;
+  /** Display names, resolved to member ids server-side. */
+  from: string;
+  to: string;
+  currency: string;
+  amount: bigint;
+  method: string;
+  status: string;
+  note?: string | null;
+  /** ISO timestamp. */
+  at: string;
+}
+
 export interface ImportResult {
   groupId: string;
   expenses: number;
   ghosts: number;
+  settlements?: number;
   members: Record<string, string>;
 }
 
 /**
- * Write a parsed Splitwise export into a group.
+ * Write a parsed file — a Splitwise export or one of ours — into a group.
  *
  * One RPC, so one transaction: a person moving four years of history cannot
  * tell a half-finished import from a complete one, because the balances add up
@@ -730,14 +745,29 @@ export interface ImportResult {
  * `clientMutationId` per row makes a second tap on Import a replay rather than
  * a second copy (ADR-005), so generate them once and reuse them on retry.
  */
-export async function importSplitwise(input: {
+export async function importLedger(input: {
   groupId: string;
   people: ImportPerson[];
   expenses: ImportExpense[];
+  /** Only a Baaki export has these; a Splitwise file has no notion of them. */
+  settlements?: ImportSettlement[];
+  origin?: 'splitwise' | 'baaki';
 }): Promise<ImportResult> {
-  const { data, error } = await supabase.rpc('baaki_import_splitwise', {
+  const { data, error } = await supabase.rpc('baaki_import_ledger', {
     p_group_id: input.groupId,
     p_people: input.people,
+    p_origin: input.origin ?? 'splitwise',
+    p_settlements: (input.settlements ?? []).map((settlement) => ({
+      clientMutationId: settlement.clientMutationId,
+      from: settlement.from,
+      to: settlement.to,
+      currency: settlement.currency,
+      amount: settlement.amount.toString(),
+      method: settlement.method,
+      status: settlement.status,
+      note: settlement.note ?? null,
+      at: settlement.at,
+    })),
     // Minor units as strings all the way down: a number in JSON is a double,
     // and a double is how a paisa goes missing from a four-year history.
     p_expenses: input.expenses.map((expense) => ({

--- a/packages/core/src/import/baaki.ts
+++ b/packages/core/src/import/baaki.ts
@@ -1,0 +1,373 @@
+/**
+ * Reading Baaki's own export back in (M5, ADR-012).
+ *
+ * The M5 acceptance line is "export re-imports losslessly". Unlike a Splitwise
+ * file — where each person's column is a *net* and the payer has to be
+ * reconstructed (see ./splitwise.ts) — our own export carries the real (paid,
+ * owed) pair for every expense and the settlements besides. So the balances
+ * that come out are not merely correct in aggregate: every row is the row that
+ * left.
+ *
+ * What *cannot* survive the trip is worth stating plainly, because an export
+ * that claimed more than it delivers is the failure this file exists to avoid:
+ *
+ *   - **Ids change.** Every member, expense and settlement is new in the new
+ *     group. Nothing else would be safe: a file could otherwise be made to
+ *     overwrite rows in a group it was never part of.
+ *   - **Edit history does not come.** The export holds every version (ADR-004);
+ *     what returns is what each expense currently says. Those edits were made
+ *     by people who are not members of the new group, and attributing them to
+ *     whoever pressed Import would be a fiction. Balances are computed from
+ *     current versions only, so nothing the acceptance criterion measures is
+ *     lost.
+ *   - **Settlement allocations do not come.** They name expense ids, and those
+ *     ids are new. Allocations decide which expenses a payment is applied
+ *     against, never how much anybody owes in total.
+ *
+ * Everything here is parsed from strings. The export writes minor units as
+ * strings precisely so a JSON number — which is a double — never gets near
+ * somebody's money (ADR-003).
+ */
+
+import type { CurrencyCode } from '../money/currency';
+import type { ImportProblem } from './splitwise';
+
+/** Statuses that move a balance (TDR §3.3). The rest are carried as history. */
+const SETTLING = new Set(['confirmed', 'auto_confirmed']);
+
+export interface BaakiImportExpense {
+  readonly description: string;
+  readonly category: string | null;
+  /** ISO date, YYYY-MM-DD. */
+  readonly date: string;
+  readonly currency: CurrencyCode;
+  readonly amount: bigint;
+  /** Keyed by the display name this file uses for each person. */
+  readonly payers: Readonly<Record<string, bigint>>;
+  readonly shares: Readonly<Record<string, bigint>>;
+}
+
+export interface BaakiImportSettlement {
+  readonly from: string;
+  readonly to: string;
+  readonly currency: CurrencyCode;
+  readonly amount: bigint;
+  readonly method: string;
+  readonly status: string;
+  readonly note: string | null;
+  /** ISO timestamp. */
+  readonly at: string;
+}
+
+export interface BaakiImportGroup {
+  /** The group's name in the file, or null for a nameless group. */
+  readonly name: string | null;
+  readonly currency: CurrencyCode;
+  /** Everybody the file names, in the order it named them. */
+  readonly people: readonly string[];
+  readonly expenses: readonly BaakiImportExpense[];
+  readonly settlements: readonly BaakiImportSettlement[];
+  /** Net per person, minor units, per currency. Sums to zero in each currency. */
+  readonly balances: Readonly<Record<string, Readonly<Record<string, bigint>>>>;
+  readonly problems: readonly ImportProblem[];
+}
+
+export interface BaakiImport {
+  readonly exportedAt: string | null;
+  readonly schemaVersion: number;
+  readonly groups: readonly BaakiImportGroup[];
+  readonly problems: readonly ImportProblem[];
+}
+
+/** The only schema this build knows how to read. */
+export const SUPPORTED_SCHEMA_VERSION = 1;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/**
+ * Minor units from whatever the file holds.
+ *
+ * Strings are the contract, but a hand-edited file or an older export can
+ * carry an integer, and refusing to read a whole ledger over that would be
+ * pedantry. A fractional number is refused: it means somebody has already lost
+ * precision upstream, and quietly rounding it here would bury that.
+ */
+function minor(value: unknown): bigint | null {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return Number.isSafeInteger(value) ? BigInt(value) : null;
+  if (typeof value !== 'string') return null;
+  const text = value.trim();
+  return /^-?\d+$/.test(text) ? BigInt(text) : null;
+}
+
+/** The name this file uses for a member — what payers and shares are keyed by. */
+function memberName(member: Record<string, unknown>, index: number): string {
+  const profile = asRecord(member.profile);
+  const display = typeof profile?.display_name === 'string' ? profile.display_name.trim() : '';
+  const ghost = typeof member.ghost_name === 'string' ? member.ghost_name.trim() : '';
+  return display || ghost || `Member ${index + 1}`;
+}
+
+/**
+ * Parse an export file.
+ *
+ * Never throws. A file this size is somebody's whole history and it can be
+ * damaged in a dozen ways; each is reported as a problem against the row it
+ * came from, and everything readable is still read. The caller decides whether
+ * a partial import is worth offering — and the screen shows the problems
+ * before anybody taps Import.
+ */
+export function parseBaakiExport(text: string): BaakiImport {
+  const problems: ImportProblem[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return {
+      exportedAt: null,
+      schemaVersion: 0,
+      groups: [],
+      problems: [
+        { kind: 'unparseable_row', row: null, message: 'That file is not a Baaki export.' },
+      ],
+    };
+  }
+
+  const root = asRecord(parsed);
+  const groupsRaw = asArray(root?.groups);
+  const schemaVersion = typeof root?.schemaVersion === 'number' ? root.schemaVersion : 0;
+
+  if (!root || groupsRaw.length === 0) {
+    problems.push({
+      kind: 'no_rows',
+      row: null,
+      message: 'That file has no groups in it.',
+    });
+  } else if (schemaVersion > SUPPORTED_SCHEMA_VERSION) {
+    // Forwards, not backwards: a newer file may hold fields this build would
+    // silently drop, and dropping half of somebody's ledger without saying so
+    // is exactly what this whole module exists to avoid.
+    problems.push({
+      kind: 'unparseable_row',
+      row: null,
+      message: `That file was written by a newer version of Baaki (format ${schemaVersion}). Update the app and try again.`,
+    });
+  }
+
+  const groups = groupsRaw.map((entry) => parseGroup(entry));
+
+  return {
+    exportedAt: typeof root?.exportedAt === 'string' ? root.exportedAt : null,
+    schemaVersion,
+    groups: schemaVersion > SUPPORTED_SCHEMA_VERSION ? [] : groups,
+    problems,
+  };
+}
+
+function parseGroup(entry: unknown): BaakiImportGroup {
+  const problems: ImportProblem[] = [];
+  const record = asRecord(entry) ?? {};
+  const group = asRecord(record.group) ?? {};
+  const currency = (
+    typeof group.default_currency === 'string' ? group.default_currency : 'INR'
+  ).toUpperCase() as CurrencyCode;
+
+  // Members first: everything else refers to them by id, and this is the only
+  // place their names are known.
+  const namesById = new Map<string, string>();
+  const people: string[] = [];
+  const taken = new Set<string>();
+  for (const [index, member] of asArray(record.members).entries()) {
+    const memberRecord = asRecord(member);
+    if (!memberRecord || typeof memberRecord.id !== 'string') continue;
+    let name = memberName(memberRecord, index);
+    // Two people can share a name; the map that carries an expense to the
+    // right person cannot. Disambiguate rather than merging two ledgers.
+    if (taken.has(name)) {
+      let suffix = 2;
+      while (taken.has(`${name} (${suffix})`)) suffix += 1;
+      name = `${name} (${suffix})`;
+    }
+    taken.add(name);
+    namesById.set(memberRecord.id, name);
+    people.push(name);
+  }
+
+  if (people.length === 0) {
+    problems.push({
+      kind: 'no_people',
+      row: null,
+      message: 'That group has nobody in it.',
+    });
+  }
+
+  const expenses: BaakiImportExpense[] = [];
+  for (const [index, entryValue] of asArray(record.expenses).entries()) {
+    const expense = asRecord(entryValue);
+    if (!expense) continue;
+    // A deleted expense is history, not spending, and re-importing one would
+    // put money back into the new group's balances that nobody owes.
+    if (expense.deleted_at) continue;
+
+    const versions = asArray(expense.versions).map(asRecord);
+    const current =
+      versions.find((version) => version?.id === expense.current_version_id) ??
+      versions[versions.length - 1];
+    if (!current) continue;
+
+    const amount = minor(current.amount);
+    const payers = amounts(current.payers, namesById);
+    const shares = amounts(current.shares, namesById);
+    const row = index + 1;
+
+    if (amount === null || payers === null || shares === null) {
+      problems.push({
+        kind: 'unparseable_row',
+        row,
+        message: `"${String(current.description ?? 'An expense')}" holds an amount that could not be read.`,
+      });
+      continue;
+    }
+
+    const paid = sum(payers);
+    const owed = sum(shares);
+    if (paid !== amount || owed !== amount) {
+      // The same invariant the database enforces on every write. A file that
+      // breaks it would be rejected server-side anyway; saying so here names
+      // the row instead of failing the whole import with a constraint error.
+      problems.push({
+        kind: 'row_does_not_balance',
+        row,
+        message: `"${String(current.description ?? 'An expense')}" does not add up: paid ${paid}, owed ${owed}, total ${amount}.`,
+      });
+      continue;
+    }
+
+    expenses.push({
+      description: typeof current.description === 'string' ? current.description : 'Expense',
+      category: typeof current.category === 'string' ? current.category : null,
+      date: String(current.expense_date ?? '').slice(0, 10),
+      currency: String(current.currency ?? currency).toUpperCase() as CurrencyCode,
+      amount,
+      payers,
+      shares,
+    });
+  }
+
+  const settlements: BaakiImportSettlement[] = [];
+  for (const [index, entryValue] of asArray(record.settlements).entries()) {
+    const settlement = asRecord(entryValue);
+    if (!settlement) continue;
+    const from = namesById.get(String(settlement.from_member_id));
+    const to = namesById.get(String(settlement.to_member_id));
+    const amount = minor(settlement.amount);
+    if (!from || !to || amount === null) {
+      problems.push({
+        kind: 'unparseable_row',
+        row: index + 1,
+        message: 'A settlement names somebody who is not in the file.',
+      });
+      continue;
+    }
+    settlements.push({
+      from,
+      to,
+      currency: String(settlement.currency ?? currency).toUpperCase() as CurrencyCode,
+      amount,
+      method: typeof settlement.method === 'string' ? settlement.method : 'other',
+      status: typeof settlement.status === 'string' ? settlement.status : 'confirmed',
+      note: typeof settlement.note === 'string' ? settlement.note : null,
+      at:
+        typeof settlement.initiated_at === 'string'
+          ? settlement.initiated_at
+          : new Date(0).toISOString(),
+    });
+  }
+
+  return {
+    name: typeof group.name === 'string' && group.name.trim() !== '' ? group.name : null,
+    currency,
+    people,
+    expenses,
+    settlements,
+    balances: balancesOf(expenses, settlements),
+    problems,
+  };
+}
+
+function amounts(
+  rows: unknown,
+  namesById: Map<string, string>,
+): Record<string, bigint> | null {
+  const result: Record<string, bigint> = {};
+  for (const entry of asArray(rows)) {
+    const record = asRecord(entry);
+    const name = namesById.get(String(record?.member_id));
+    const value = minor(record?.amount);
+    if (!name || value === null) return null;
+    result[name] = (result[name] ?? 0n) + value;
+  }
+  return result;
+}
+
+function sum(values: Readonly<Record<string, bigint>>): bigint {
+  return Object.values(values).reduce((total, value) => total + value, 0n);
+}
+
+/**
+ * What each person's balance will be once this file has been imported.
+ *
+ * Computed here, from the parsed rows, so the preview can be checked against
+ * the group it came from *before* anything is written — which is the whole
+ * proof that the round trip is lossless.
+ */
+export function balancesOf(
+  expenses: readonly BaakiImportExpense[],
+  settlements: readonly BaakiImportSettlement[],
+): Record<string, Record<string, bigint>> {
+  const byCurrency: Record<string, Record<string, bigint>> = {};
+  const add = (currency: string, person: string, delta: bigint): void => {
+    const bucket = (byCurrency[currency] ??= {});
+    bucket[person] = (bucket[person] ?? 0n) + delta;
+  };
+
+  for (const expense of expenses) {
+    for (const [person, paid] of Object.entries(expense.payers)) {
+      add(expense.currency, person, paid);
+    }
+    for (const [person, owed] of Object.entries(expense.shares)) {
+      add(expense.currency, person, -owed);
+    }
+  }
+  for (const settlement of settlements) {
+    if (!SETTLING.has(settlement.status)) continue;
+    add(settlement.currency, settlement.from, settlement.amount);
+    add(settlement.currency, settlement.to, -settlement.amount);
+  }
+
+  for (const bucket of Object.values(byCurrency)) {
+    for (const [person, value] of Object.entries(bucket)) {
+      if (value === 0n) delete bucket[person];
+    }
+  }
+  return byCurrency;
+}
+
+/** Whether this is our file at all — asked before a CSV parser is reached for. */
+export function isBaakiExport(text: string): boolean {
+  try {
+    const root = asRecord(JSON.parse(text));
+    return Array.isArray(root?.groups) && typeof root?.schemaVersion === 'number';
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/import/index.ts
+++ b/packages/core/src/import/index.ts
@@ -1,1 +1,2 @@
 export * from './splitwise';
+export * from './baaki';

--- a/packages/core/test/baakiImport.test.ts
+++ b/packages/core/test/baakiImport.test.ts
@@ -1,0 +1,400 @@
+/**
+ * "export re-imports losslessly" — the last line of M5's acceptance criteria.
+ *
+ * The test builds an export the way `supabase/functions/export-data` builds
+ * one, reads it back, and asserts that every person's balance in every
+ * currency is bit-for-bit what it was. That is what "lossless" is allowed to
+ * mean here, and the rest of these tests pin the places where a file could
+ * plausibly say something the ledger never did.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  balancesOf,
+  isBaakiExport,
+  parseBaakiExport,
+  type BaakiImportGroup,
+} from '../src/import/baaki.js';
+
+interface Member {
+  id: string;
+  name: string;
+  ghost?: boolean;
+}
+
+/** The shape `export-data` writes, at the size a test can read. */
+function exportFile(options: {
+  members: Member[];
+  expenses: {
+    id: string;
+    description: string;
+    category?: string | null;
+    date?: string;
+    currency?: string;
+    amount: string;
+    payers: Record<string, string>;
+    shares: Record<string, string>;
+    deleted?: boolean;
+    /** An older version, kept by ADR-004 and not to be re-imported. */
+    previous?: { amount: string; payers: Record<string, string>; shares: Record<string, string> };
+  }[];
+  settlements?: {
+    from: string;
+    to: string;
+    amount: string;
+    currency?: string;
+    status?: string;
+  }[];
+  schemaVersion?: number;
+}): string {
+  const rows = (values: Record<string, string>): { member_id: string; amount: string }[] =>
+    Object.entries(values).map(([member_id, amount]) => ({ member_id, amount }));
+
+  return JSON.stringify({
+    exportedAt: '2026-08-07T10:00:00.000Z',
+    schemaVersion: options.schemaVersion ?? 1,
+    amountUnit: 'minor',
+    groups: [
+      {
+        group: { id: 'g1', name: 'Goa trip', default_currency: 'INR' },
+        members: options.members.map((member) => ({
+          id: member.id,
+          ghost_name: member.ghost ? member.name : null,
+          profile: member.ghost ? null : { display_name: member.name },
+        })),
+        expenses: options.expenses.map((expense) => ({
+          id: expense.id,
+          current_version_id: `${expense.id}v2`,
+          deleted_at: expense.deleted ? '2026-08-01T00:00:00.000Z' : null,
+          versions: [
+            ...(expense.previous
+              ? [
+                  {
+                    id: `${expense.id}v1`,
+                    version_no: 1,
+                    description: expense.description,
+                    category: expense.category ?? null,
+                    expense_date: expense.date ?? '2026-03-01',
+                    currency: expense.currency ?? 'INR',
+                    amount: expense.previous.amount,
+                    payers: rows(expense.previous.payers),
+                    shares: rows(expense.previous.shares),
+                  },
+                ]
+              : []),
+            {
+              id: `${expense.id}v2`,
+              version_no: expense.previous ? 2 : 1,
+              description: expense.description,
+              category: expense.category ?? null,
+              expense_date: expense.date ?? '2026-03-01',
+              currency: expense.currency ?? 'INR',
+              amount: expense.amount,
+              payers: rows(expense.payers),
+              shares: rows(expense.shares),
+            },
+          ],
+        })),
+        settlements: (options.settlements ?? []).map((settlement, index) => ({
+          id: `s${index}`,
+          from_member_id: settlement.from,
+          to_member_id: settlement.to,
+          currency: settlement.currency ?? 'INR',
+          amount: settlement.amount,
+          method: 'upi',
+          status: settlement.status ?? 'confirmed',
+          note: null,
+          initiated_at: '2026-04-01T00:00:00.000Z',
+          allocations: [],
+        })),
+        activity: [],
+      },
+    ],
+  });
+}
+
+const asha: Member = { id: 'm1', name: 'Asha' };
+const ravi: Member = { id: 'm2', name: 'Ravi' };
+const priya: Member = { id: 'm3', name: 'Priya', ghost: true };
+
+function only(text: string): BaakiImportGroup {
+  const parsed = parseBaakiExport(text);
+  expect(parsed.problems).toEqual([]);
+  expect(parsed.groups).toHaveLength(1);
+  return parsed.groups[0]!;
+}
+
+describe('a Baaki export, read back', () => {
+  it('reproduces every balance exactly — expenses and settlements together', () => {
+    const file = exportFile({
+      members: [asha, ravi, priya],
+      expenses: [
+        {
+          id: 'e1',
+          description: 'Beach shack dinner',
+          category: 'food',
+          amount: '100000',
+          payers: { m1: '100000' },
+          // 100000 / 3 with the odd paisa on the first person — exactly what
+          // the ledger stored, and not something to be divided again here.
+          shares: { m1: '33334', m2: '33333', m3: '33333' },
+        },
+        {
+          id: 'e2',
+          description: 'Scooter hire',
+          category: 'travel',
+          amount: '60000',
+          payers: { m2: '40000', m3: '20000' },
+          shares: { m1: '20000', m2: '20000', m3: '20000' },
+        },
+      ],
+      settlements: [{ from: 'm2', to: 'm1', amount: '5000' }],
+    });
+
+    const group = only(file);
+    expect(group.expenses).toHaveLength(2);
+    expect(group.settlements).toHaveLength(1);
+    expect(group.people).toEqual(['Asha', 'Ravi', 'Priya']);
+
+    // Worked out by hand from the rows above, which is the point: nothing in
+    // the pipeline gets to decide these. A settlement moves the *payer's*
+    // balance up and the payee's down — paying off a debt is what makes a
+    // negative balance rise (TDR §3.3).
+    expect(group.balances.INR).toEqual({
+      Asha: 100000n - 33334n - 20000n - 5000n, //  41666
+      Ravi: 40000n - 33333n - 20000n + 5000n, //   -8333
+      Priya: 20000n - 33333n - 20000n, //         -33333
+    });
+
+    // The invariant every group has: what is owed is owed to somebody.
+    const total = Object.values(group.balances.INR!).reduce((sum, value) => sum + value, 0n);
+    expect(total).toBe(0n);
+  });
+
+  it('imports what an expense now says, not what it used to say', () => {
+    const group = only(
+      exportFile({
+        members: [asha, ravi],
+        expenses: [
+          {
+            id: 'e1',
+            description: 'Dinner',
+            amount: '80000',
+            payers: { m1: '80000' },
+            shares: { m1: '40000', m2: '40000' },
+            previous: {
+              amount: '20000',
+              payers: { m1: '20000' },
+              shares: { m1: '10000', m2: '10000' },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(group.expenses).toHaveLength(1);
+    expect(group.expenses[0]!.amount).toBe(80000n);
+    expect(group.balances.INR).toEqual({ Asha: 40000n, Ravi: -40000n });
+  });
+
+  it('leaves a deleted expense out', () => {
+    const group = only(
+      exportFile({
+        members: [asha, ravi],
+        expenses: [
+          {
+            id: 'e1',
+            description: 'Dinner',
+            amount: '80000',
+            payers: { m1: '80000' },
+            shares: { m1: '40000', m2: '40000' },
+          },
+          {
+            id: 'e2',
+            description: 'Cancelled booking',
+            amount: '50000',
+            payers: { m2: '50000' },
+            shares: { m1: '25000', m2: '25000' },
+            deleted: true,
+          },
+        ],
+      }),
+    );
+
+    expect(group.expenses).toHaveLength(1);
+    expect(group.balances.INR).toEqual({ Asha: 40000n, Ravi: -40000n });
+  });
+
+  it('counts only the settlements that settle', () => {
+    const group = only(
+      exportFile({
+        members: [asha, ravi],
+        expenses: [
+          {
+            id: 'e1',
+            description: 'Dinner',
+            amount: '80000',
+            payers: { m1: '80000' },
+            shares: { m1: '40000', m2: '40000' },
+          },
+        ],
+        settlements: [
+          { from: 'm2', to: 'm1', amount: '10000', status: 'initiated' },
+          { from: 'm2', to: 'm1', amount: '5000', status: 'auto_confirmed' },
+          { from: 'm2', to: 'm1', amount: '9999', status: 'cancelled' },
+        ],
+      }),
+    );
+
+    // All three are carried across as history; only the auto-confirmed one
+    // moves a balance (TDR §3.3).
+    expect(group.settlements).toHaveLength(3);
+    expect(group.balances.INR).toEqual({ Asha: 35000n, Ravi: -35000n });
+  });
+
+  it('keeps currencies apart', () => {
+    const group = only(
+      exportFile({
+        members: [asha, ravi],
+        expenses: [
+          {
+            id: 'e1',
+            description: 'Dinner',
+            amount: '80000',
+            payers: { m1: '80000' },
+            shares: { m1: '40000', m2: '40000' },
+          },
+          {
+            id: 'e2',
+            description: 'Hostel',
+            currency: 'EUR',
+            amount: '4000',
+            payers: { m2: '4000' },
+            shares: { m1: '2000', m2: '2000' },
+          },
+        ],
+      }),
+    );
+
+    expect(group.balances.INR).toEqual({ Asha: 40000n, Ravi: -40000n });
+    expect(group.balances.EUR).toEqual({ Asha: -2000n, Ravi: 2000n });
+  });
+
+  it('tells two people with the same name apart instead of merging them', () => {
+    // Merging them would silently combine two people's debts, and there is no
+    // un-merging afterwards.
+    const group = only(
+      exportFile({
+        members: [
+          { id: 'm1', name: 'Ravi' },
+          { id: 'm2', name: 'Ravi', ghost: true },
+        ],
+        expenses: [
+          {
+            id: 'e1',
+            description: 'Dinner',
+            amount: '60000',
+            payers: { m1: '60000' },
+            shares: { m1: '30000', m2: '30000' },
+          },
+        ],
+      }),
+    );
+
+    expect(group.people).toEqual(['Ravi', 'Ravi (2)']);
+    expect(group.balances.INR).toEqual({ Ravi: 30000n, 'Ravi (2)': -30000n });
+  });
+
+  it('names the row that does not add up and imports the rest', () => {
+    const parsed = parseBaakiExport(
+      exportFile({
+        members: [asha, ravi],
+        expenses: [
+          {
+            id: 'e1',
+            description: 'Dinner',
+            amount: '80000',
+            payers: { m1: '80000' },
+            shares: { m1: '40000', m2: '40000' },
+          },
+          {
+            id: 'e2',
+            description: 'Tampered',
+            amount: '50000',
+            payers: { m1: '50000' },
+            shares: { m1: '25000', m2: '20000' },
+          },
+        ],
+      }),
+    );
+
+    const group = parsed.groups[0]!;
+    expect(group.expenses.map((expense) => expense.description)).toEqual(['Dinner']);
+    expect(group.problems).toHaveLength(1);
+    expect(group.problems[0]!.kind).toBe('row_does_not_balance');
+    expect(group.problems[0]!.message).toContain('Tampered');
+  });
+
+  it('refuses a file from a newer version rather than dropping half of it', () => {
+    const parsed = parseBaakiExport(
+      exportFile({
+        members: [asha, ravi],
+        expenses: [],
+        schemaVersion: 2,
+      }),
+    );
+    expect(parsed.groups).toEqual([]);
+    expect(parsed.problems[0]!.message).toContain('newer version');
+  });
+
+  it('says what a file is not', () => {
+    expect(isBaakiExport('date,description,cost\n2026-01-01,Dinner,300')).toBe(false);
+    expect(isBaakiExport('{')).toBe(false);
+    expect(parseBaakiExport('not json at all').problems[0]!.kind).toBe('unparseable_row');
+    expect(isBaakiExport(exportFile({ members: [asha], expenses: [] }))).toBe(true);
+  });
+
+  it('refuses a fractional amount instead of rounding somebody’s money', () => {
+    const file = JSON.parse(
+      exportFile({
+        members: [asha, ravi],
+        expenses: [
+          {
+            id: 'e1',
+            description: 'Dinner',
+            amount: '80000',
+            payers: { m1: '80000' },
+            shares: { m1: '40000', m2: '40000' },
+          },
+        ],
+      }),
+    ) as { groups: { expenses: { versions: { amount: unknown }[] }[] }[] };
+    file.groups[0]!.expenses[0]!.versions[0]!.amount = 800.5;
+
+    const group = parseBaakiExport(JSON.stringify(file)).groups[0]!;
+    expect(group.expenses).toEqual([]);
+    expect(group.problems[0]!.kind).toBe('unparseable_row');
+  });
+});
+
+describe('balancesOf', () => {
+  it('leaves out anybody who is square', () => {
+    expect(
+      balancesOf(
+        [
+          {
+            description: 'Dinner',
+            category: null,
+            date: '2026-03-01',
+            currency: 'INR',
+            amount: 20000n,
+            payers: { Asha: 10000n, Ravi: 10000n },
+            shares: { Asha: 10000n, Ravi: 10000n },
+          },
+        ],
+        [],
+      ),
+    ).toEqual({ INR: {} });
+  });
+});

--- a/packages/db/prisma/migrations/20260807070000_m5_import_a_baaki_export/migration.sql
+++ b/packages/db/prisma/migrations/20260807070000_m5_import_a_baaki_export/migration.sql
@@ -1,0 +1,255 @@
+-- Reading a Baaki export back in (M5, ADR-012).
+--
+-- The M5 acceptance line is "export re-imports losslessly", and the word doing
+-- the work is *losslessly*: the balances that come out of the new group must be
+-- the balances that went into the file, to the paisa, for every person and
+-- every currency.
+--
+-- That rules out routing this through `baaki_import_splitwise`. A Splitwise
+-- file carries each person's net and the payer is reconstructed; a Baaki export
+-- carries the real (paid, owed) pair, and throwing it away on the way back in
+-- would be a strange thing for an app to do to its own file. It also carries
+-- settlements, which that function has no notion of and which move every
+-- balance they touch.
+--
+-- So: one function, one transaction, the same shape of arguments, plus
+-- settlements. `baaki_import_splitwise` becomes a thin call into it, so there
+-- is one import path to reason about rather than two that drift.
+--
+-- What is deliberately NOT carried across:
+--
+--   * **Old ids.** Every expense, member and settlement is new here. Importing
+--     ids would let a file overwrite rows in a group it was never part of.
+--   * **Version history.** The export holds every version of every expense
+--     (ADR-004); what is re-imported is what each expense currently says. The
+--     old history describes edits made by people who are not members of this
+--     new group, and re-attributing them would be a fiction. Balances are
+--     computed from current versions only, so nothing is lost that the
+--     acceptance criterion measures.
+--   * **Settlement allocations.** They name expense ids, and those ids are new.
+--     Allocations decide which expenses a payment is applied against, never how
+--     much anybody owes in total, so the balances are unaffected — the payment
+--     lands as an unallocated settlement, oldest-first, exactly as one recorded
+--     by hand would.
+--
+-- All of that is what "lossless" honestly means here, and the import screen
+-- says the same thing in words before anybody taps it.
+
+-- ─────────────────────────────────────────────── 1. the general import ──
+
+CREATE OR REPLACE FUNCTION public.baaki_import_ledger(
+  p_group_id uuid,
+  -- [{ "name": "Asha", "memberId": "<uuid>" | null }] — null means "new here":
+  -- create a ghost they can claim later (ADR-006).
+  p_people   jsonb,
+  -- [{ "clientMutationId", "description", "category", "date", "currency",
+  --    "amount", "payers": { "Asha": "120000" }, "shares": { ... } }]
+  -- Minor units as strings: a number in jsonb is a double, and a double is how
+  -- a paisa goes missing from four years of history (ADR-003).
+  p_expenses jsonb,
+  -- [{ "clientMutationId", "from": "Asha", "to": "Ravi", "currency", "amount",
+  --    "method", "status", "note", "at" }] — only confirmed and auto_confirmed
+  -- settlements move a balance, but the rest are carried so the history reads
+  -- the way it did in the file.
+  p_settlements jsonb DEFAULT '[]'::jsonb,
+  /** Recorded in the activity entry, so the feed can say where this came from. */
+  p_origin   text DEFAULT 'splitwise'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id  uuid := public.baaki_current_profile_id();
+  v_author      uuid;
+  v_person      jsonb;
+  v_expense     jsonb;
+  v_settlement  jsonb;
+  v_name        text;
+  v_member      uuid;
+  v_names       jsonb := '{}'::jsonb;   -- name -> member id, as text
+  v_payers      jsonb;
+  v_shares      jsonb;
+  v_entry       record;
+  v_created     int := 0;
+  v_ghosts      int := 0;
+  v_settled     int := 0;
+  v_mutation    uuid;
+  v_result      jsonb;
+BEGIN
+  IF v_profile_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.group_members gm
+    WHERE gm.group_id = p_group_id AND gm.profile_id = v_profile_id AND gm.left_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_author := public.baaki_my_member_id_for(p_group_id, v_profile_id);
+
+  IF jsonb_typeof(p_people) <> 'array' OR jsonb_array_length(p_people) = 0 THEN
+    RAISE EXCEPTION 'NO_PEOPLE: the import named nobody' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Resolve every name to a member of this group up front, so an unmappable
+  -- one fails before a single row is written.
+  FOR v_person IN SELECT * FROM jsonb_array_elements(p_people) LOOP
+    v_name := btrim(COALESCE(v_person ->> 'name', ''));
+    IF v_name = '' THEN
+      RAISE EXCEPTION 'NO_PEOPLE: somebody in the file has no name'
+        USING ERRCODE = 'check_violation';
+    END IF;
+
+    IF (v_person ->> 'memberId') IS NOT NULL THEN
+      SELECT gm.id INTO v_member
+        FROM public.group_members gm
+       WHERE gm.id = (v_person ->> 'memberId')::uuid AND gm.group_id = p_group_id;
+      IF v_member IS NULL THEN
+        RAISE EXCEPTION 'UNKNOWN_MEMBER: % is not in this group', v_name
+          USING ERRCODE = 'foreign_key_violation';
+      END IF;
+    ELSE
+      INSERT INTO public.group_members (group_id, ghost_name, joined_via)
+      VALUES (p_group_id, v_name, 'ghost')
+      RETURNING id INTO v_member;
+      v_ghosts := v_ghosts + 1;
+    END IF;
+
+    v_names := v_names || jsonb_build_object(v_name, v_member::text);
+  END LOOP;
+
+  FOR v_expense IN SELECT * FROM jsonb_array_elements(p_expenses) LOOP
+    -- Names become member ids here rather than on the client, so the client
+    -- never gets to choose which member a row lands on.
+    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+             'memberId', v_names ->> entry.key,
+             'amount',   entry.value #>> '{}'
+           )), '[]'::jsonb)
+      INTO v_payers
+      FROM jsonb_each(v_expense -> 'payers') AS entry;
+
+    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+             'memberId', v_names ->> entry.key,
+             'amount',   entry.value #>> '{}'
+           )), '[]'::jsonb)
+      INTO v_shares
+      FROM jsonb_each(v_expense -> 'shares') AS entry;
+
+    FOR v_entry IN
+      SELECT key FROM jsonb_each(v_expense -> 'shares')
+      UNION
+      SELECT key FROM jsonb_each(v_expense -> 'payers')
+    LOOP
+      IF (v_names ->> v_entry.key) IS NULL THEN
+        RAISE EXCEPTION 'UNKNOWN_MEMBER: "%" appears in an expense but not in the people list',
+          v_entry.key USING ERRCODE = 'foreign_key_violation';
+      END IF;
+    END LOOP;
+
+    v_result := public.baaki_apply_expense(
+      p_group_id           => p_group_id,
+      p_expense_id         => NULL,
+      p_author_member_id   => v_author,
+      p_description        => COALESCE(v_expense ->> 'description', 'Imported expense'),
+      p_category           => v_expense ->> 'category',
+      p_expense_date       => (v_expense ->> 'date')::date,
+      p_currency           => upper(COALESCE(v_expense ->> 'currency', 'INR'))::char(3),
+      p_amount             => (v_expense ->> 'amount')::bigint,
+      -- 'exact' regardless of how the split was originally expressed: the
+      -- participants are new members with new ids, so a percentage or a set of
+      -- weights would have to be re-divided and could land a paisa somewhere
+      -- the file did not. The amounts are the amounts.
+      p_split_type         => 'exact',
+      p_split_params       => jsonb_build_object('kind', 'exact', 'amounts', (
+        SELECT COALESCE(jsonb_object_agg(v_names ->> entry.key, entry.value), '{}'::jsonb)
+          FROM jsonb_each(v_expense -> 'shares') AS entry
+      )),
+      p_payers             => v_payers,
+      p_shares             => v_shares,
+      p_client_mutation_id => (v_expense ->> 'clientMutationId')::uuid,
+      p_source             => 'imported'
+    );
+
+    -- A replayed row is one this import already wrote — a second tap, or a lost
+    -- response. Not an error, and not a second copy either (ADR-005).
+    IF COALESCE((v_result ->> 'replayed')::boolean, false) = false THEN
+      v_created := v_created + 1;
+    END IF;
+  END LOOP;
+
+  FOR v_settlement IN SELECT * FROM jsonb_array_elements(p_settlements) LOOP
+    IF (v_names ->> (v_settlement ->> 'from')) IS NULL
+       OR (v_names ->> (v_settlement ->> 'to')) IS NULL THEN
+      RAISE EXCEPTION 'UNKNOWN_MEMBER: a settlement names somebody who is not in the people list'
+        USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    v_mutation := (v_settlement ->> 'clientMutationId')::uuid;
+    -- Same idempotency rule as the expenses: a replayed import must not pay
+    -- somebody twice.
+    CONTINUE WHEN v_mutation IS NOT NULL AND EXISTS (
+      SELECT 1 FROM public.settlements s WHERE s.client_mutation_id = v_mutation
+    );
+
+    INSERT INTO public.settlements
+      (group_id, from_member_id, to_member_id, currency, amount, method, status, note,
+       initiated_at, confirmed_at, client_mutation_id)
+    VALUES (
+      p_group_id,
+      (v_names ->> (v_settlement ->> 'from'))::uuid,
+      (v_names ->> (v_settlement ->> 'to'))::uuid,
+      upper(COALESCE(v_settlement ->> 'currency', 'INR'))::char(3),
+      (v_settlement ->> 'amount')::bigint,
+      COALESCE(v_settlement ->> 'method', 'other')::"SettlementMethod",
+      COALESCE(v_settlement ->> 'status', 'confirmed')::"SettlementStatus",
+      v_settlement ->> 'note',
+      COALESCE((v_settlement ->> 'at')::timestamptz, now()),
+      CASE
+        WHEN COALESCE(v_settlement ->> 'status', 'confirmed') IN ('confirmed', 'auto_confirmed')
+        THEN COALESCE((v_settlement ->> 'at')::timestamptz, now())
+      END,
+      v_mutation
+    );
+    v_settled := v_settled + 1;
+  END LOOP;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (
+    p_group_id, v_author, 'imported', 'group', p_group_id,
+    jsonb_build_object(
+      'expenses', v_created, 'ghosts', v_ghosts, 'settlements', v_settled, 'from', p_origin
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'groupId', p_group_id,
+    'expenses', v_created,
+    'ghosts', v_ghosts,
+    'settlements', v_settled,
+    'members', v_names
+  );
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_import_ledger(uuid, jsonb, jsonb, jsonb, text)
+  TO authenticated, anon;
+
+
+-- ──────────────────────────────── 2. the Splitwise path, now a wrapper ──
+-- Same signature it has always had, so nothing that calls it changes.
+
+CREATE OR REPLACE FUNCTION public.baaki_import_splitwise(
+  p_group_id uuid,
+  p_people   jsonb,
+  p_expenses jsonb
+)
+RETURNS jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT public.baaki_import_ledger(p_group_id, p_people, p_expenses, '[]'::jsonb, 'splitwise');
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_import_splitwise(uuid, jsonb, jsonb) TO authenticated, anon;

--- a/packages/db/test/m5-import-export.test.ts
+++ b/packages/db/test/m5-import-export.test.ts
@@ -1,0 +1,381 @@
+/**
+ * "export re-imports losslessly" — M5's last acceptance line, proved against
+ * the database rather than in the abstract.
+ *
+ * A group is built, settled against, exported the way `export-data` exports
+ * it, and read back into a brand-new group by `baaki_import_ledger`. The
+ * assertion is the only one that matters: every person's balance in the new
+ * group equals their balance in the old one, to the paisa.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { parseBaakiExport } from '@baaki/core';
+
+import { addEqualSplitExpense, big, connect, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+/** Balances keyed by the name each member goes by, so two groups can be compared. */
+async function balancesByName(groupId: string): Promise<Record<string, bigint>> {
+  const result = await client.query(
+    `SELECT COALESCE(p.display_name, gm.ghost_name) AS name, b.currency, b.balance
+       FROM baaki_group_balances_truth($1) b
+       JOIN group_members gm ON gm.id = b.member_id
+       LEFT JOIN profiles p ON p.id = gm.profile_id`,
+    [groupId],
+  );
+  return Object.fromEntries(
+    result.rows.map((row) => [`${String(row.name)}:${String(row.currency)}`, big(row.balance)]),
+  );
+}
+
+/** Exactly the JSON `supabase/functions/export-data` writes, read from the database. */
+async function exportGroup(groupId: string): Promise<string> {
+  // One at a time: a single pg client cannot run these in parallel, and
+  // `Promise.all` over it only earns a deprecation warning.
+  const group = await client.query(`SELECT * FROM groups WHERE id = $1`, [groupId]);
+  const members = await client.query(
+      `SELECT gm.*, CASE WHEN p.id IS NULL THEN NULL
+                         ELSE jsonb_build_object('display_name', p.display_name) END AS profile
+         FROM group_members gm LEFT JOIN profiles p ON p.id = gm.profile_id
+        WHERE gm.group_id = $1 ORDER BY gm.created_at`,
+    [groupId],
+  );
+  const expenses = await client.query(
+    `SELECT e.*, (
+         SELECT jsonb_agg(jsonb_build_object(
+           'id', ev.id, 'version_no', ev.version_no, 'description', ev.description,
+           'category', ev.category, 'expense_date', ev.expense_date, 'currency', ev.currency,
+           'amount', ev.amount::text,
+           'payers', (SELECT COALESCE(jsonb_agg(jsonb_build_object(
+                        'member_id', ep.member_id, 'amount', ep.amount::text)), '[]'::jsonb)
+                        FROM expense_payers ep WHERE ep.expense_version_id = ev.id),
+           'shares', (SELECT COALESCE(jsonb_agg(jsonb_build_object(
+                        'member_id', es.member_id, 'amount', es.amount::text)), '[]'::jsonb)
+                        FROM expense_shares es WHERE es.expense_version_id = ev.id)))
+         FROM expense_versions ev WHERE ev.expense_id = e.id) AS versions
+         FROM expenses e WHERE e.group_id = $1`,
+    [groupId],
+  );
+  const settlements = await client.query(
+    `SELECT id, from_member_id, to_member_id, currency, amount::text, method, status, note,
+            initiated_at
+       FROM settlements WHERE group_id = $1`,
+    [groupId],
+  );
+
+  return JSON.stringify({
+    exportedAt: new Date().toISOString(),
+    schemaVersion: 1,
+    amountUnit: 'minor',
+    groups: [
+      {
+        group: group.rows[0],
+        members: members.rows,
+        expenses: expenses.rows,
+        settlements: settlements.rows,
+        activity: [],
+      },
+    ],
+  });
+}
+
+describe('a Baaki export, imported back', () => {
+  it('reproduces every balance exactly, in a group that never existed before', async () => {
+    const seeded = await seedGroup(client, { memberCount: 3, ghostCount: 1 });
+    const [asha, ravi, priya, ghost] = seeded.memberIds as [string, string, string, string];
+
+    // A three-way split with an odd paisa, a multi-payer expense, and a ghost
+    // who owes — the three shapes that a lossy import would round away.
+    await addEqualSplitExpense(client, {
+      groupId: seeded.groupId,
+      amount: 100000n,
+      payers: { [asha]: 100000n },
+      participants: [asha, ravi, priya],
+      category: 'food',
+    });
+    await addEqualSplitExpense(client, {
+      groupId: seeded.groupId,
+      amount: 60000n,
+      payers: { [ravi]: 40000n, [priya]: 20000n },
+      participants: [asha, ravi, priya, ghost],
+      category: 'travel',
+    });
+    await addEqualSplitExpense(client, {
+      groupId: seeded.groupId,
+      amount: 4000n,
+      payers: { [asha]: 4000n },
+      participants: [asha, ravi],
+      currency: 'EUR',
+      category: 'stay',
+    });
+
+    await client.query(
+      `INSERT INTO settlements
+         (group_id, from_member_id, to_member_id, currency, amount, method, status, confirmed_at)
+       VALUES ($1, $2, $3, 'INR', 5000, 'upi', 'confirmed', now())`,
+      [seeded.groupId, ravi, asha],
+    );
+    // An unconfirmed one, which must be carried across as history without
+    // moving a single balance (TDR §3.3).
+    await client.query(
+      `INSERT INTO settlements
+         (group_id, from_member_id, to_member_id, currency, amount, method, status)
+       VALUES ($1, $2, $3, 'INR', 9999, 'cash', 'initiated')`,
+      [seeded.groupId, priya, asha],
+    );
+
+    const before = await balancesByName(seeded.groupId);
+    expect(Object.keys(before).length).toBeGreaterThan(0);
+
+    const parsed = parseBaakiExport(await exportGroup(seeded.groupId));
+    expect(parsed.problems).toEqual([]);
+    const exported = parsed.groups[0]!;
+    expect(exported.expenses).toHaveLength(3);
+    expect(exported.settlements).toHaveLength(2);
+
+    // The importer is somebody with no history at all, which is the real case:
+    // a new phone, a new account, a file.
+    const importer = randomUUID();
+    await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Importer')`, [
+      importer,
+    ]);
+
+    const newGroupId = await asUser(importer, async () => {
+      const created = await client.query(
+        `SELECT baaki_create_group('Imported trip', 'trip', 'INR', NULL, true) AS id`,
+      );
+      const groupId = String(created.rows[0]!.id);
+
+      await client.query(
+        `SELECT baaki_import_ledger($1, $2::jsonb, $3::jsonb, $4::jsonb, 'baaki')`,
+        [
+          groupId,
+          JSON.stringify(exported.people.map((name) => ({ name, memberId: null }))),
+          JSON.stringify(
+            exported.expenses.map((expense) => ({
+              clientMutationId: randomUUID(),
+              description: expense.description,
+              category: expense.category,
+              date: expense.date,
+              currency: expense.currency,
+              amount: expense.amount.toString(),
+              payers: asStrings(expense.payers),
+              shares: asStrings(expense.shares),
+            })),
+          ),
+          JSON.stringify(
+            exported.settlements.map((settlement) => ({
+              clientMutationId: randomUUID(),
+              from: settlement.from,
+              to: settlement.to,
+              currency: settlement.currency,
+              amount: settlement.amount.toString(),
+              method: settlement.method,
+              status: settlement.status,
+              note: settlement.note,
+              at: settlement.at,
+            })),
+          ),
+        ],
+      );
+      return groupId;
+    });
+
+    const after = await balancesByName(newGroupId);
+    expect(after).toEqual(before);
+
+    // And the file's own arithmetic agreed with the database's all along —
+    // which is what lets the import screen show a preview that can be trusted.
+    const fromFile = Object.fromEntries(
+      Object.entries(exported.balances).flatMap(([currency, people]) =>
+        Object.entries(people).map(([name, value]) => [`${name}:${currency}`, value]),
+      ),
+    );
+    expect(fromFile).toEqual(before);
+  });
+
+  it('does not pay anybody twice when an import is replayed', async () => {
+    const seeded = await seedGroup(client, { memberCount: 2 });
+    const [asha, ravi] = seeded.memberIds as [string, string];
+    await addEqualSplitExpense(client, {
+      groupId: seeded.groupId,
+      amount: 20000n,
+      payers: { [asha]: 20000n },
+      participants: [asha, ravi],
+    });
+    await client.query(
+      `INSERT INTO settlements
+         (group_id, from_member_id, to_member_id, currency, amount, method, status, confirmed_at)
+       VALUES ($1, $2, $3, 'INR', 1000, 'cash', 'confirmed', now())`,
+      [seeded.groupId, ravi, asha],
+    );
+
+    const exported = parseBaakiExport(await exportGroup(seeded.groupId)).groups[0]!;
+    const importer = randomUUID();
+    await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Twice')`, [importer]);
+
+    // The same mutation ids both times: a lost response and a second tap look
+    // identical from here, and neither may double the ledger (ADR-005).
+    const expenseIds = exported.expenses.map(() => randomUUID());
+    const settlementIds = exported.settlements.map(() => randomUUID());
+
+    const run = async (groupId: string): Promise<void> => {
+      await client.query(
+        `SELECT baaki_import_ledger($1, $2::jsonb, $3::jsonb, $4::jsonb, 'baaki')`,
+        [
+          groupId,
+          JSON.stringify(exported.people.map((name) => ({ name, memberId: null }))),
+          JSON.stringify(
+            exported.expenses.map((expense, index) => ({
+              clientMutationId: expenseIds[index],
+              description: expense.description,
+              category: expense.category,
+              date: expense.date,
+              currency: expense.currency,
+              amount: expense.amount.toString(),
+              payers: asStrings(expense.payers),
+              shares: asStrings(expense.shares),
+            })),
+          ),
+          JSON.stringify(
+            exported.settlements.map((settlement, index) => ({
+              clientMutationId: settlementIds[index],
+              from: settlement.from,
+              to: settlement.to,
+              currency: settlement.currency,
+              amount: settlement.amount.toString(),
+              method: settlement.method,
+              status: settlement.status,
+              at: settlement.at,
+            })),
+          ),
+        ],
+      );
+    };
+
+    const newGroupId = await asUser(importer, async () => {
+      const created = await client.query(
+        `SELECT baaki_create_group('Twice over', 'trip', 'INR', NULL, true) AS id`,
+      );
+      const groupId = String(created.rows[0]!.id);
+      await run(groupId);
+      await run(groupId);
+      return groupId;
+    });
+
+    const settlements = await client.query(
+      `SELECT count(*)::int AS n FROM settlements WHERE group_id = $1`,
+      [newGroupId],
+    );
+    const expenses = await client.query(
+      `SELECT count(*)::int AS n FROM expenses WHERE group_id = $1`,
+      [newGroupId],
+    );
+    expect(settlements.rows[0]!.n).toBe(1);
+    expect(expenses.rows[0]!.n).toBe(1);
+  });
+
+  it('refuses a file naming somebody who is not in the people list', async () => {
+    const importer = randomUUID();
+    await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Careful')`, [
+      importer,
+    ]);
+
+    await expect(
+      asUser(importer, async () => {
+        const created = await client.query(
+          `SELECT baaki_create_group('Broken', 'trip', 'INR', NULL, true) AS id`,
+        );
+        await client.query(
+          `SELECT baaki_import_ledger($1, $2::jsonb, $3::jsonb, '[]'::jsonb, 'baaki')`,
+          [
+            String(created.rows[0]!.id),
+            JSON.stringify([{ name: 'Asha', memberId: null }]),
+            JSON.stringify([
+              {
+                clientMutationId: randomUUID(),
+                description: 'Dinner',
+                category: null,
+                date: '2026-03-01',
+                currency: 'INR',
+                amount: '20000',
+                payers: { Asha: '20000' },
+                shares: { Asha: '10000', Nobody: '10000' },
+              },
+            ]),
+          ],
+        );
+      }),
+    ).rejects.toThrow(/UNKNOWN_MEMBER/);
+  });
+
+  it('still imports a Splitwise file through the same path', async () => {
+    const importer = randomUUID();
+    await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Switcher')`, [
+      importer,
+    ]);
+
+    const result = await asUser(importer, async () => {
+      const created = await client.query(
+        `SELECT baaki_create_group('From Splitwise', 'trip', 'INR', NULL, true) AS id`,
+      );
+      const groupId = String(created.rows[0]!.id);
+      const imported = await client.query(
+        `SELECT baaki_import_splitwise($1, $2::jsonb, $3::jsonb) AS result`,
+        [
+          groupId,
+          JSON.stringify([
+            { name: 'Asha', memberId: null },
+            { name: 'Ravi', memberId: null },
+          ]),
+          JSON.stringify([
+            {
+              clientMutationId: randomUUID(),
+              description: 'Dinner',
+              category: 'food',
+              date: '2026-03-01',
+              currency: 'INR',
+              amount: '20000',
+              payers: { Asha: '20000' },
+              shares: { Asha: '10000', Ravi: '10000' },
+            },
+          ]),
+        ],
+      );
+      return imported.rows[0]!.result as { expenses: number; ghosts: number };
+    });
+
+    expect(result.expenses).toBe(1);
+    expect(result.ghosts).toBe(2);
+  });
+});
+
+function asStrings(values: Readonly<Record<string, bigint>>): Record<string, string> {
+  return Object.fromEntries(Object.entries(values).map(([name, value]) => [name, value.toString()]));
+}


### PR DESCRIPTION
M5's last acceptance line is "export re-imports losslessly". Until now the import screen could read Splitwise's file but not our own.

A Splitwise export holds each person's *net* per row, so the payer has to be reconstructed. Ours holds the real (paid, owed) pair and the settlements besides — throwing that away on the way back in would be a strange thing for an app to do to its own file. So `baaki_import_ledger` takes settlements as well as expenses, and `baaki_import_splitwise` becomes a thin call into it: one import path instead of two that drift.

## What "lossless" honestly covers

| Comes across | Does not |
|---|---|
| Every balance, to the paisa, in every currency | Ids — every row is new in the new group. Importing ids would let a file overwrite rows in a group it was never part of. |
| Settlements, confirmed and not | Edit history. The file holds every version (ADR-004); what returns is what each expense currently says. |
| Categories, dates, currencies | Settlement allocations. They name expense ids, and those ids are new — and they never change what anybody owes. |

The same three sentences appear in the migration, in the parser, and on the screen before anybody taps Import.

## The parser refuses rather than guesses

- A fractional amount is a paisa somebody already lost upstream — refused, not rounded.
- A row whose payers and shares disagree with its total is named and skipped; the rest still imports.
- A file from a newer version of the app is refused outright rather than read with half its fields silently dropped.
- Two people called Ravi stay two people.

## Verification

A db test builds a group with an odd-paisa three-way split, a multi-payer expense, a ghost, a second currency, and both a confirmed and an unconfirmed settlement; exports it exactly as `export-data` would; imports it as a stranger with no history; and asserts the balances are identical. A replayed import writes nothing twice.

187 db tests pass against a fresh Postgres 17 (4 new), no Prisma drift. Core 294 (11 new). `pnpm typecheck` and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6