### PR TITLE
feat: markets beyond India — payment rails, country, and local vocabulary

### DIFF
--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -5,7 +5,10 @@ import { ActivityIndicator, Alert, Linking, Pressable, ScrollView, View } from '
 
 import {
   allocateSettlement,
-  buildUpiIntentUri,
+  buildPaymentUri,
+  defaultRailFor,
+  railById,
+  railsFor,
   toMajorString,
   type MemberId,
   type Receivable,
@@ -26,11 +29,10 @@ import {
 } from '@baaki/ui';
 
 import { toSnapshot, useGroup, useGroupLedger, useRecordSettlement } from '@/data/hooks';
-import { displayName, isGhost, vpaOf, type MemberRow } from '@/data/types';
+import { displayName, isGhost, payableAt, type MemberRow } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
-type Method = 'upi' | 'cash' | 'bank';
 
 export default function SettleScreen() {
   const theme = useTheme();
@@ -44,10 +46,19 @@ export default function SettleScreen() {
   const recordSettlement = useRecordSettlement(groupId);
 
   const [selected, setSelected] = useState<MemberId | null>(null);
-  const [method, setMethod] = useState<Method>('upi');
   const [error, setError] = useState<string | null>(null);
 
   const currency = group.data?.default_currency ?? 'INR';
+  /**
+   * Where this group settles decides what it can settle with. A group that
+   * never said still gets bank, cash and the cross-border wallets — never an
+   * empty list, because a group that cannot record a payment is not a group
+   * anybody can use.
+   */
+  const country = group.data?.country_code ?? null;
+  const rails = useMemo(() => railsFor(country), [country]);
+  const [rail, setRail] = useState<string | null>(null);
+  const method = rail ?? defaultRailFor(country);
   const myMemberId = ledger.myMemberId;
 
   const counterparties = useMemo(
@@ -96,6 +107,21 @@ export default function SettleScreen() {
     expenses.rows.find((expense) => expense.id === expenseId)?.currentVersion?.description ??
     'Expense';
 
+  /**
+   * Whether the button hands off to something before recording.
+   *
+   * Only when I am the one paying, and only on a rail that has somewhere to
+   * send me — either an app to open or a handle to copy. Recording that
+   * somebody *else* paid me never opens anything.
+   */
+  const handsOff = iPay && (railById(method)?.handle ?? 'none') !== 'none';
+
+  const settleLabel = handsOff
+    ? `Pay via ${railById(method)?.label ?? ''}`.trim()
+    : method === 'cash'
+      ? t.paidInCash
+      : t.bankOther;
+
   const record = async (): Promise<void> => {
     if (!counterparty || !myMemberId || amount === 0n) return;
     setError(null);
@@ -105,7 +131,7 @@ export default function SettleScreen() {
         fromMemberId: iPay ? myMemberId : counterparty.id,
         toMemberId: iPay ? counterparty.id : myMemberId,
         amount,
-        method,
+        rail: method,
         currency,
         allocations: allocation.allocations,
       });
@@ -115,19 +141,34 @@ export default function SettleScreen() {
     }
   };
 
-  const payViaUpi = async (): Promise<void> => {
+  /**
+   * Hand off to their payment app if this rail has one, and otherwise show the
+   * handle to copy.
+   *
+   * The second half is not a degraded case — it is the ordinary one. UPI is the
+   * only rail with a scheme we can stand behind, so everywhere except India
+   * this shows a Pix key or a mobile number and the person finishes in their
+   * own bank app. Either way Baaki never moves the money (ADR-007); it records
+   * that somebody says they did, and the person paid confirms it.
+   */
+  const payThen = async (): Promise<void> => {
     if (!counterparty) return;
-    const vpa = vpaOf(counterparty);
-    if (!vpa) {
+
+    const payable = payableAt(counterparty);
+    const railInfo = railById(method);
+
+    if (!payable) {
       Alert.alert(
-        'No UPI ID yet',
-        `${displayName(counterparty)} hasn't added a UPI ID. Settle in cash, or ask them to add one.`,
+        `No ${railInfo?.label ?? 'payment'} details yet`,
+        `${displayName(counterparty)} hasn't added how they're paid. Settle in cash, or ask them to add it.`,
       );
       return;
     }
-    const uri = buildUpiIntentUri(
+
+    const uri = buildPaymentUri(
       {
-        vpa,
+        railId: payable.rail,
+        handle: payable.handle,
         payeeName: displayName(counterparty),
         amount,
         currency,
@@ -136,20 +177,24 @@ export default function SettleScreen() {
       (value, code) => toMajorString({ minor: value, currency: code }),
     );
 
-    // Baaki never moves the money: the payer's own UPI app does (ADR-007).
-    const canOpen = await Linking.canOpenURL(uri).catch(() => false);
-    if (canOpen) {
+    const canOpen = uri ? await Linking.canOpenURL(uri).catch(() => false) : false;
+    if (uri && canOpen) {
       await Linking.openURL(uri);
       Alert.alert('Did the payment go through?', 'Only record it if it actually completed.', [
         { text: 'No', style: 'cancel' },
         { text: 'Yes, record it', onPress: () => void record() },
       ]);
-    } else {
-      Alert.alert('Pay to', `${vpa}\n\nThen come back and record it.`, [
+      return;
+    }
+
+    Alert.alert(
+      `Pay ${displayName(counterparty)}`,
+      `${railById(payable.rail)?.label ?? 'Send to'}\n${payable.handle}\n\nThen come back and record it.`,
+      [
         { text: 'Cancel', style: 'cancel' },
         { text: 'Record it', onPress: () => void record() },
-      ]);
-    }
+      ],
+    );
   };
 
   if (group.isLoading || members.isLoading) {
@@ -226,14 +271,13 @@ export default function SettleScreen() {
               <Badge label="Recorded, not moved by Baaki" />
             </Card>
 
-            <ChipRow<Method>
+            {/* Whatever this country pays with, best first. In India that is
+                still UPI, cash, bank; in the UAE it is Aani, Wise, Revolut,
+                bank, cash — the screen does not know the difference. */}
+            <ChipRow<string>
               value={method}
-              onChange={setMethod}
-              options={[
-                { value: 'upi', label: t.payViaUpi },
-                { value: 'cash', label: t.paidInCash },
-                { value: 'bank', label: t.bankOther },
-              ]}
+              onChange={setRail}
+              options={rails.map((entry) => ({ value: entry.id, label: entry.label }))}
             />
 
             {allocation.allocations.length > 0 ? (
@@ -269,15 +313,13 @@ export default function SettleScreen() {
             ) : null}
 
             <Button
-              label={
-                method === 'upi' ? t.payViaUpi : method === 'cash' ? t.paidInCash : t.bankOther
-              }
+              label={settleLabel}
               size="lg"
               fullWidth
               disabled={amount === 0n || recordSettlement.isPending}
-              onPress={() => (method === 'upi' && iPay ? void payViaUpi() : void record())}
+              onPress={() => (handsOff ? void payThen() : void record())}
               icon={
-                method === 'upi' ? (
+                handsOff ? (
                   <Ionicons name="open-outline" size={18} color={theme.color.onBrand} />
                 ) : undefined
               }

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -36,14 +36,14 @@ import type {
 } from './types';
 
 const GROUP_SELECT = `
-  id, name, type, default_currency, simplify_debts, cover_emoji, photo_path,
+  id, name, type, country_code, default_currency, simplify_debts, cover_emoji, photo_path,
   start_date, end_date, time_zone, remind_daily, remind_morning_at, remind_evening_at,
   archived_at, created_at
 `;
 
 const MEMBER_SELECT = `
-  id, group_id, profile_id, ghost_name, role, vpa, left_at,
-  profile:profiles ( id, display_name, avatar_url, default_vpa )
+  id, group_id, profile_id, ghost_name, role, vpa, payment_rail, payment_handle, left_at,
+  profile:profiles ( id, display_name, avatar_url, default_vpa, payment_rail, payment_handle )
 `;
 
 const EXPENSE_SELECT = `
@@ -502,7 +502,12 @@ export async function recordSettlement(input: {
   fromMemberId: string;
   toMemberId: string;
   amount: bigint;
-  method: SettlementMethod;
+  /**
+   * Which rail the money moved on — a `RailId` from `@baaki/core`. The coarse
+   * `method` enum is derived from it server-side, so a rail the enum has never
+   * heard of (Pix, Aani) still records rather than being rejected.
+   */
+  rail: string;
   currency?: string;
   note?: string | null;
   allocations?: { expenseId: string; amount: bigint }[];
@@ -513,7 +518,14 @@ export async function recordSettlement(input: {
     p_from_member_id: input.fromMemberId,
     p_to_member_id: input.toMemberId,
     p_amount: input.amount.toString(),
-    p_method: input.method,
+    // The enum only knows these four. Everything else is `other` there and
+    // itself in `p_rail`.
+    p_method: (['upi', 'cash', 'bank', 'other'] as const).includes(
+      input.rail as SettlementMethod,
+    )
+      ? (input.rail as SettlementMethod)
+      : 'other',
+    p_rail: input.rail,
     p_currency: input.currency ?? null,
     p_note: input.note ?? null,
     p_allocations: (input.allocations ?? []).map((allocation) => ({

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -10,6 +10,12 @@ export interface GroupRow {
   /** Optional — an unnamed group is labelled by who is in it (see groupLabel). */
   name: string | null;
   type: GroupType;
+  /**
+   * ISO-3166 alpha-2 — where this group settles, which decides which payment
+   * rails it is offered. Null is a supported state: it falls back to bank,
+   * cash and the cross-border wallets.
+   */
+  country_code: string | null;
   default_currency: string;
   simplify_debts: boolean;
   cover_emoji: string | null;
@@ -38,13 +44,19 @@ export interface MemberRow {
   profile_id: string | null;
   ghost_name: string | null;
   role: 'admin' | 'member';
+  /** The UPI-shaped fields. Superseded by the rail pair; still read as a fallback. */
   vpa: string | null;
+  /** Which rail this person is paid on here — a `RailId` from `@baaki/core`. */
+  payment_rail?: string | null;
+  payment_handle?: string | null;
   left_at: string | null;
   profile?: {
     id: string;
     display_name: string;
     avatar_url: string | null;
     default_vpa: string | null;
+    payment_rail?: string | null;
+    payment_handle?: string | null;
   } | null;
 }
 
@@ -215,4 +227,28 @@ export function isGhost(member: MemberRow): boolean {
 
 export function vpaOf(member: MemberRow): string | null {
   return member.vpa ?? member.profile?.default_vpa ?? null;
+}
+
+/**
+ * How this person is paid: the rail, and the handle on it.
+ *
+ * Per-group first, then their profile default — the same precedence `vpaOf`
+ * has always used, because one person can be paid over UPI in one group and
+ * over Wise in another. The `vpa` columns are the last fallback: everything
+ * written before rails existed is a UPI ID, and the person who typed it should
+ * not have to type it again.
+ */
+export function payableAt(member: MemberRow): { rail: string; handle: string } | null {
+  const handle =
+    member.payment_handle ?? member.profile?.payment_handle ?? vpaOf(member) ?? null;
+  if (!handle) return null;
+
+  const rail =
+    member.payment_rail ??
+    member.profile?.payment_rail ??
+    // A handle from before rails existed can only have been a UPI ID.
+    (vpaOf(member) ? 'upi' : null);
+  if (!rail) return null;
+
+  return { rail, handle };
 }

--- a/packages/core/src/category/categories.ts
+++ b/packages/core/src/category/categories.ts
@@ -20,6 +20,8 @@
  * saving. "Other" is a real answer and stays.
  */
 
+import { keywordsForMarket } from './markets';
+
 export type CategoryId =
   | 'food'
   | 'groceries'
@@ -357,16 +359,30 @@ function tokenise(text: string): string[] {
  * chose. Ties go to the category listed first, which keeps the same words
  * producing the same answer on every device (the same determinism ADR-009 asks
  * of the money).
+ *
+ * `countryCode` adds that market's vocabulary on top of the shared list — the
+ * chains and words in `markets.ts`. Leave it off and the behaviour is what it
+ * always was, which is what every caller written before markets existed
+ * expects. A country nobody has written keywords for is not an error either: it
+ * gets the shared list, same as before.
  */
-export function guessCategory(description: string): CategoryId | null {
+export function guessCategory(
+  description: string,
+  countryCode?: string | null,
+): CategoryId | null {
   const tokens = new Set(tokenise(description));
   if (tokens.size === 0) return null;
+
+  const market = keywordsForMarket(countryCode);
 
   let best: CategoryId | null = null;
   let bestHits = 0;
   for (const category of CATEGORIES) {
     let hits = 0;
     for (const keyword of category.keywords) {
+      if (tokens.has(keyword)) hits += 1;
+    }
+    for (const keyword of market[category.id] ?? []) {
       if (tokens.has(keyword)) hits += 1;
     }
     if (hits > bestHits) {

--- a/packages/core/src/category/index.ts
+++ b/packages/core/src/category/index.ts
@@ -1,1 +1,2 @@
 export * from './categories';
+export * from './markets';

--- a/packages/core/src/category/markets.ts
+++ b/packages/core/src/category/markets.ts
@@ -1,0 +1,142 @@
+/**
+ * The shops people actually name, per country.
+ *
+ * `categories.ts` knows Swiggy, Zepto, IRCTC and kirana, which is right for the
+ * market Baaki was built for and useless in Dubai — where the same expense is
+ * Talabat, Careem, Lulu and Salik. Every one of those lands in "Other", and
+ * "Other" is not a chart. The Spending screen does not look empty when this is
+ * missing; it looks *broken*, which is worse, because a person cannot tell the
+ * difference between an app that has no data and one that does not understand
+ * their receipts.
+ *
+ * This is a layer, not a replacement. The shared list in `categories.ts` still
+ * carries the ordinary English words — lunch, taxi, hotel, groceries — and a
+ * market adds its own vocabulary on top. Which means a market is a few lines
+ * here rather than a fork of the categoriser, and an unknown country still
+ * categorises as well as it did before.
+ *
+ * Same rules as the shared list: lowercase, whole tokens, never substrings.
+ * Brand names get their bare form (`careem`, not `careem ride`) because
+ * tokenising splits the description anyway.
+ */
+
+import type { CategoryId } from './categories';
+
+/**
+ * ISO-3166 alpha-2. A market is a country because that is what payment rails,
+ * currencies and shops are keyed by — not a language, which several of these
+ * share.
+ */
+export type MarketId = 'IN' | 'AE' | 'SA' | 'QA' | 'KW' | 'BH' | 'OM' | 'BR' | 'SG' | 'ID';
+
+type Keywords = Partial<Record<CategoryId, readonly string[]>>;
+
+/** Shared across the Gulf: the same chains trade in all six countries. */
+const GULF: Keywords = {
+  food: [
+    'talabat',
+    'deliveroo',
+    'zomato',
+    'careemfood',
+    'shawarma',
+    'karak',
+    'machboos',
+    'kabsa',
+    'manakish',
+    'iftar',
+    'suhoor',
+    'brunch',
+  ],
+  groceries: [
+    'lulu',
+    'carrefour',
+    'spinneys',
+    'union',
+    'choithrams',
+    'instashop',
+    'kibsons',
+    'noon',
+    'baqala',
+    'tamimi',
+    'othaim',
+    'danube',
+  ],
+  travel: [
+    'careem',
+    'uber',
+    'salik',
+    'darb',
+    'nol',
+    'adnoc',
+    'enoc',
+    'eppco',
+    'petrol',
+    'metro',
+    'emirates',
+    'flydubai',
+    'etihad',
+    'rta',
+    'parking',
+  ],
+  stay: ['hotel', 'airbnb', 'resort', 'chalet'],
+  entertainment: ['vox', 'reel', 'novo', 'cinema', 'yas', 'ferrari', 'globalvillage', 'desert'],
+  home: ['dewa', 'sewa', 'addc', 'etisalat', 'du', 'ejari', 'chiller', 'rent'],
+  health: ['aster', 'medcare', 'nmc', 'burjeel', 'pharmacy', 'clinic'],
+  shopping: ['namshi', 'sharaf', 'jumbo', 'centrepoint', 'mall'],
+  gifts: ['eidiya', 'eid', 'gift'],
+};
+
+export const MARKET_KEYWORDS: Readonly<Record<MarketId, Keywords>> = {
+  // India's vocabulary already lives in the shared list, where it was the
+  // starting point. Nothing to add here; the entry exists so the type is
+  // complete and so it is obvious the omission is deliberate.
+  IN: {},
+
+  AE: GULF,
+  SA: GULF,
+  QA: GULF,
+  KW: GULF,
+  BH: GULF,
+  OM: GULF,
+
+  BR: {
+    food: ['ifood', 'rappi', 'padaria', 'churrasco', 'lanche', 'almoco', 'jantar', 'cafe'],
+    groceries: ['mercado', 'supermercado', 'carrefour', 'assai', 'atacadao', 'feira', 'hortifruti'],
+    travel: ['uber', 'noventa', 'metro', 'onibus', 'gasolina', 'posto', 'pedagio', 'latam', 'gol'],
+    stay: ['hotel', 'pousada', 'airbnb'],
+    entertainment: ['cinema', 'ingresso', 'balada', 'show'],
+    home: ['aluguel', 'condominio', 'luz', 'agua', 'internet'],
+    health: ['farmacia', 'drogaria', 'medico'],
+    shopping: ['shopping', 'americanas', 'magalu'],
+  },
+
+  SG: {
+    food: ['grabfood', 'foodpanda', 'hawker', 'kopitiam', 'zichar', 'chicken', 'laksa'],
+    groceries: ['ntuc', 'fairprice', 'coldstorage', 'sheng', 'giant', 'redmart'],
+    travel: ['grab', 'gojek', 'mrt', 'ez-link', 'ezlink', 'comfort', 'erp'],
+    entertainment: ['golden', 'cathay', 'shaw', 'sentosa'],
+    home: ['sp', 'singtel', 'starhub', 'conservancy'],
+  },
+
+  ID: {
+    food: ['gofood', 'grabfood', 'warung', 'padang', 'bakso', 'nasi', 'sate', 'kopi'],
+    groceries: ['indomaret', 'alfamart', 'hypermart', 'superindo', 'pasar'],
+    travel: ['gojek', 'grab', 'transjakarta', 'krl', 'pertamina', 'bensin', 'tol', 'garuda'],
+    stay: ['hotel', 'villa', 'homestay'],
+    home: ['pln', 'listrik', 'indihome', 'kost'],
+  },
+};
+
+/**
+ * The extra vocabulary for a country, or nothing.
+ *
+ * An unrecognised country is not an error — it means the shared English list is
+ * all there is, which is exactly what every market had before this file.
+ */
+export function keywordsForMarket(countryCode: string | null | undefined): Keywords {
+  const country = (countryCode ?? '').trim().toUpperCase();
+  return MARKET_KEYWORDS[country as MarketId] ?? {};
+}
+
+/** Every country this file knows something about. */
+export const KNOWN_MARKETS: readonly MarketId[] = Object.keys(MARKET_KEYWORDS) as MarketId[];

--- a/packages/core/src/settlement/index.ts
+++ b/packages/core/src/settlement/index.ts
@@ -1,1 +1,2 @@
 export * from './apply';
+export * from './rails';

--- a/packages/core/src/settlement/rails.ts
+++ b/packages/core/src/settlement/rails.ts
@@ -1,0 +1,365 @@
+/**
+ * How money actually moves, per country.
+ *
+ * Baaki was built UPI-first, and `settle.tsx` said so: `'upi' | 'cash' |
+ * 'bank'`, a union of three, one of which does not exist outside India. That is
+ * fine for one market and a rewrite for every other one, so the rails are data
+ * here instead — a list keyed by country, which makes Brazil a new entry rather
+ * than a new screen.
+ *
+ * **Only UPI has a deep link, and that is deliberate.**
+ *
+ * `upi://pay` is a published Android intent that every Indian bank app
+ * implements, and it is the reason settling in Baaki takes one tap. Almost
+ * nothing else works that way. Pix is a copy-and-paste key or a scanned EMV
+ * code, not a URL. Zelle and Venmo have app links that are neither documented
+ * nor stable, and guessing at one produces a button that silently fails on
+ * somebody's phone while they believe they have paid. So a rail either has a
+ * scheme we can stand behind, or it shows the payee's handle to copy and the
+ * person finishes in their own bank app. A rail that admits it cannot hand off
+ * is more useful than one that pretends it can.
+ *
+ * Recording the settlement is separate from performing it either way — the
+ * ledger has always tracked what people say they paid, confirmed by whoever was
+ * paid (ADR-007), and that part is identical in every country.
+ */
+
+import type { CurrencyCode } from '../money/currency';
+
+export type RailId =
+  // Instant, national, free at the point of use.
+  | 'upi' // India
+  | 'pix' // Brazil
+  | 'paynow' // Singapore
+  | 'promptpay' // Thailand
+  | 'qris' // Indonesia
+  | 'aani' // United Arab Emirates
+  // Consumer apps.
+  | 'zelle'
+  | 'venmo'
+  | 'cashapp'
+  | 'interac'
+  | 'wise'
+  | 'revolut'
+  // Always available, everywhere.
+  | 'bank'
+  | 'cash'
+  | 'other';
+
+/** What you need from the person being paid before anything can happen. */
+export type HandleKind =
+  /** UPI ID — `name@bank`. */
+  | 'vpa'
+  /** A Pix key: CPF, phone, email or a random UUID. Anything goes. */
+  | 'pix_key'
+  /** A mobile number, usually with country code. */
+  | 'phone'
+  | 'email'
+  /** `$cashtag`, `@venmo-handle`. */
+  | 'tag'
+  /** IBAN, or an account and sort code, or whatever the country uses. */
+  | 'account'
+  /** Nothing to collect — cash changed hands. */
+  | 'none';
+
+export interface PaymentRail {
+  readonly id: RailId;
+  /** English. The app translates through its own string table (TDR §11). */
+  readonly label: string;
+  /** An Ionicons name, as with categories — keeps this package free of React. */
+  readonly icon: string;
+  /**
+   * ISO-3166 alpha-2 codes this rail serves, or `'any'` for the ones that work
+   * wherever there is a bank or a wallet.
+   */
+  readonly countries: readonly string[] | 'any';
+  readonly handle: HandleKind;
+  /** Shown under the field, in the local vocabulary. */
+  readonly handleHint: string;
+  /**
+   * True only where a deep link is published, implemented by the banks, and
+   * has been seen to work. Everything else is copy-the-handle.
+   */
+  readonly deepLink: boolean;
+}
+
+/**
+ * Ordered by how directly each one moves money, so a country's best option is
+ * first. `cash`, `bank` and `other` sort last in `railsFor` regardless.
+ */
+export const PAYMENT_RAILS: readonly PaymentRail[] = [
+  {
+    id: 'upi',
+    label: 'UPI',
+    icon: 'flash-outline',
+    countries: ['IN'],
+    handle: 'vpa',
+    handleHint: 'Their UPI ID, like ravi@okhdfcbank',
+    deepLink: true,
+  },
+  {
+    id: 'pix',
+    label: 'Pix',
+    icon: 'flash-outline',
+    countries: ['BR'],
+    handle: 'pix_key',
+    // A Pix key is whatever the person registered — that is the whole design of
+    // it, and pretending it is one shape rejects valid keys.
+    handleHint: 'Their Pix key — CPF, phone, email or random key',
+    deepLink: false,
+  },
+  {
+    id: 'paynow',
+    label: 'PayNow',
+    icon: 'flash-outline',
+    countries: ['SG'],
+    handle: 'phone',
+    handleHint: 'Their mobile number or NRIC',
+    deepLink: false,
+  },
+  {
+    id: 'promptpay',
+    label: 'PromptPay',
+    icon: 'flash-outline',
+    countries: ['TH'],
+    handle: 'phone',
+    handleHint: 'Their mobile number or national ID',
+    deepLink: false,
+  },
+  {
+    id: 'qris',
+    label: 'QRIS',
+    icon: 'qr-code-outline',
+    countries: ['ID'],
+    handle: 'phone',
+    handleHint: 'Their registered mobile number',
+    deepLink: false,
+  },
+  {
+    id: 'aani',
+    label: 'Aani',
+    icon: 'flash-outline',
+    // The UAE's instant payment service. Transfers settle by mobile number
+    // inside the bank apps; there is no public intent to hand off to.
+    countries: ['AE'],
+    handle: 'phone',
+    handleHint: 'Their mobile number, like +971 50 123 4567',
+    deepLink: false,
+  },
+  {
+    id: 'zelle',
+    label: 'Zelle',
+    icon: 'send-outline',
+    countries: ['US'],
+    handle: 'phone',
+    handleHint: 'The mobile number or email on their Zelle',
+    deepLink: false,
+  },
+  {
+    id: 'venmo',
+    label: 'Venmo',
+    icon: 'send-outline',
+    countries: ['US'],
+    handle: 'tag',
+    handleHint: 'Their Venmo handle, like @ravi-kumar',
+    deepLink: false,
+  },
+  {
+    id: 'cashapp',
+    label: 'Cash App',
+    icon: 'send-outline',
+    countries: ['US', 'GB'],
+    handle: 'tag',
+    handleHint: 'Their $cashtag',
+    deepLink: false,
+  },
+  {
+    id: 'interac',
+    label: 'Interac e-Transfer',
+    icon: 'send-outline',
+    countries: ['CA'],
+    handle: 'email',
+    handleHint: 'The email on their Interac',
+    deepLink: false,
+  },
+  {
+    id: 'wise',
+    label: 'Wise',
+    icon: 'globe-outline',
+    // The one that matters for a group split across countries, which is most
+    // trips: everybody can receive into it.
+    countries: 'any',
+    handle: 'email',
+    handleHint: 'The email on their Wise account',
+    deepLink: false,
+  },
+  {
+    id: 'revolut',
+    label: 'Revolut',
+    icon: 'globe-outline',
+    countries: 'any',
+    handle: 'tag',
+    handleHint: 'Their @revtag',
+    deepLink: false,
+  },
+  {
+    id: 'bank',
+    label: 'Bank transfer',
+    icon: 'business-outline',
+    countries: 'any',
+    handle: 'account',
+    handleHint: 'Their IBAN or account number',
+    deepLink: false,
+  },
+  {
+    id: 'cash',
+    label: 'Cash',
+    icon: 'cash-outline',
+    countries: 'any',
+    handle: 'none',
+    handleHint: '',
+    deepLink: false,
+  },
+  {
+    id: 'other',
+    label: 'Something else',
+    icon: 'ellipsis-horizontal-outline',
+    countries: 'any',
+    handle: 'none',
+    handleHint: '',
+    deepLink: false,
+  },
+];
+
+const BY_ID = new Map<RailId, PaymentRail>(PAYMENT_RAILS.map((rail) => [rail.id, rail]));
+
+export function railById(id: string): PaymentRail | null {
+  return BY_ID.get(id as RailId) ?? null;
+}
+
+/** Rails that always appear, wherever somebody is. Cash is never not an option. */
+const UNIVERSAL_LAST: readonly RailId[] = ['bank', 'cash', 'other'];
+
+/**
+ * What this country can pay with, best first.
+ *
+ * An unknown or missing country still gets a usable list rather than an empty
+ * one — somebody who never set a country can still record that they paid in
+ * cash, and a group settling in a country nobody configured is not a group that
+ * should be told it cannot settle.
+ */
+export function railsFor(countryCode: string | null | undefined): readonly PaymentRail[] {
+  const country = (countryCode ?? '').trim().toUpperCase();
+
+  const national = PAYMENT_RAILS.filter(
+    (rail) =>
+      rail.countries !== 'any' &&
+      country !== '' &&
+      rail.countries.includes(country) &&
+      !UNIVERSAL_LAST.includes(rail.id),
+  );
+
+  const global = PAYMENT_RAILS.filter(
+    (rail) => rail.countries === 'any' && !UNIVERSAL_LAST.includes(rail.id),
+  );
+
+  const last = UNIVERSAL_LAST.map((id) => BY_ID.get(id)).filter(
+    (rail): rail is PaymentRail => rail !== undefined,
+  );
+
+  return [...national, ...global, ...last];
+}
+
+/** The rail a country leads with — what the settle screen selects by default. */
+export function defaultRailFor(countryCode: string | null | undefined): RailId {
+  return railsFor(countryCode)[0]?.id ?? 'cash';
+}
+
+// ─────────────────────────────────────────────────── handles ──
+
+const VPA_RE = /^[a-zA-Z0-9.\-_]{2,256}@[a-zA-Z]{2,64}$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+/** Digits, with optional `+` and the spaces, dashes and brackets people type. */
+const PHONE_RE = /^\+?[\d\s\-()]{6,20}$/;
+const TAG_RE = /^[@$]?[a-zA-Z0-9._-]{2,64}$/;
+const ACCOUNT_RE = /^[a-zA-Z0-9\s-]{4,40}$/;
+
+/**
+ * Whether this is plausibly the handle the rail asked for.
+ *
+ * Plausibly, not certainly. The only thing that truly validates a payment
+ * handle is a payment, and a validator strict enough to be sure would reject
+ * somebody's real account and leave them unable to record a debt they owe.
+ * Wrong here means one confused tap; wrong the other way means the app is
+ * broken for them.
+ */
+export function isValidHandle(railId: string, handle: string): boolean {
+  const rail = railById(railId);
+  if (!rail) return false;
+
+  const value = handle.trim();
+  if (rail.handle === 'none') return true;
+  if (value === '') return false;
+
+  switch (rail.handle) {
+    case 'vpa':
+      return VPA_RE.test(value);
+    case 'email':
+      return EMAIL_RE.test(value);
+    case 'phone':
+      return PHONE_RE.test(value);
+    case 'tag':
+      return TAG_RE.test(value);
+    case 'account':
+      return ACCOUNT_RE.test(value);
+    case 'pix_key':
+      // Deliberately permissive: a Pix key is a CPF, a phone, an email or a
+      // UUID, and the person registering it chose which.
+      return value.length >= 4 && value.length <= 77;
+    default:
+      return false;
+  }
+}
+
+export interface PaymentLinkInput {
+  readonly railId: string;
+  readonly handle: string;
+  readonly payeeName: string;
+  /** Minor units. */
+  readonly amount: bigint;
+  readonly currency: CurrencyCode;
+  readonly note?: string;
+}
+
+/**
+ * A URI that hands off to a payment app, or `null` when this rail has none.
+ *
+ * `null` is the ordinary answer, not a failure — the caller shows the handle to
+ * copy instead. See the note at the top about why we do not guess at schemes.
+ */
+export function buildPaymentUri(
+  input: PaymentLinkInput,
+  formatMajor: (amount: bigint, currency: CurrencyCode) => string,
+): string | null {
+  const rail = railById(input.railId);
+  if (!rail?.deepLink) return null;
+  if (!isValidHandle(input.railId, input.handle)) return null;
+
+  if (rail.id === 'upi') {
+    // Built by hand rather than with URLSearchParams: this package has to
+    // compile unchanged for React Native, Deno and the browser.
+    const params: [string, string][] = [
+      ['pa', input.handle.trim()],
+      ['pn', input.payeeName],
+      ['am', formatMajor(input.amount, input.currency)],
+      ['cu', input.currency],
+    ];
+    if (input.note) params.push(['tn', input.note.slice(0, 50)]);
+    const query = params
+      .map(([key, value]) => `${key}=${encodeURIComponent(value).replace(/%20/g, '+')}`)
+      .join('&');
+    return `upi://pay?${query}`;
+  }
+
+  return null;
+}

--- a/packages/core/test/category.test.ts
+++ b/packages/core/test/category.test.ts
@@ -84,3 +84,55 @@ describe('the category list itself', () => {
     }
   });
 });
+
+describe('a market adds its own vocabulary', () => {
+  it('reads a Gulf receipt that used to land in Other', () => {
+    // Every one of these is a normal Dubai expense and every one of them
+    // guessed nothing before markets existed — which made the Spending screen
+    // look broken rather than empty.
+    expect(guessCategory('Talabat dinner', 'AE')).toBe('food');
+    expect(guessCategory('Careem to the airport', 'AE')).toBe('travel');
+    expect(guessCategory('Lulu run', 'AE')).toBe('groceries');
+    expect(guessCategory('Salik toll', 'AE')).toBe('travel');
+    expect(guessCategory('DEWA bill', 'AE')).toBe('home');
+  });
+
+  it('shares the Gulf list across all six countries', () => {
+    for (const country of ['AE', 'SA', 'QA', 'KW', 'BH', 'OM']) {
+      expect(guessCategory('Talabat', country), country).toBe('food');
+    }
+  });
+
+  it('knows Brazil and Southeast Asia too', () => {
+    expect(guessCategory('iFood almoco', 'BR')).toBe('food');
+    expect(guessCategory('Uber pro aeroporto', 'BR')).toBe('travel');
+    expect(guessCategory('Grab to work', 'SG')).toBe('travel');
+    expect(guessCategory('NTUC groceries', 'SG')).toBe('groceries');
+    expect(guessCategory('Gojek', 'ID')).toBe('travel');
+  });
+
+  it('leaves the shared list working with no market at all', () => {
+    // Every caller written before markets existed passes one argument.
+    expect(guessCategory('Swiggy dinner')).toBe('food');
+    expect(guessCategory('Auto to the station')).toBe('travel');
+    expect(guessCategory('Swiggy dinner', undefined)).toBe('food');
+  });
+
+  it('treats a country nobody has written keywords for as no worse than before', () => {
+    for (const country of ['ZZ', '', null, 'DE']) {
+      expect(guessCategory('Dinner at the restaurant', country), String(country)).toBe('food');
+      expect(guessCategory('Talabat', country), String(country)).toBeNull();
+    }
+  });
+
+  it('still keeps India working when a market is named', () => {
+    expect(guessCategory('Swiggy dinner', 'IN')).toBe('food');
+    expect(guessCategory('Auto to the station', 'IN')).toBe('travel');
+  });
+
+  it('matches whole tokens in a market list too', () => {
+    // 'du' is a UAE telecom and also the start of plenty of words.
+    expect(guessCategory('Duplicate charge', 'AE')).not.toBe('home');
+    expect(guessCategory('du bill', 'AE')).toBe('home');
+  });
+});

--- a/packages/core/test/rails.test.ts
+++ b/packages/core/test/rails.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Payment rails, per country.
+ *
+ * The settle screen used to be `'upi' | 'cash' | 'bank'` — three options, one
+ * of which exists in one country. These tests pin the two things that make the
+ * replacement worth having: a country gets its own rails first, and a rail
+ * never claims a deep link it does not have.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { toMajorString } from '../src/money/money.js';
+import {
+  buildPaymentUri,
+  defaultRailFor,
+  isValidHandle,
+  PAYMENT_RAILS,
+  railById,
+  railsFor,
+} from '../src/settlement/rails';
+
+const major = (amount: bigint, currency: string): string =>
+  toMajorString({ minor: amount, currency });
+
+describe('what a country can pay with', () => {
+  it('leads with the rail that country actually uses', () => {
+    expect(defaultRailFor('IN')).toBe('upi');
+    expect(defaultRailFor('BR')).toBe('pix');
+    expect(defaultRailFor('AE')).toBe('aani');
+    expect(defaultRailFor('SG')).toBe('paynow');
+    expect(defaultRailFor('TH')).toBe('promptpay');
+    expect(defaultRailFor('ID')).toBe('qris');
+  });
+
+  it('does not offer one country’s rail to another', () => {
+    const gulf = railsFor('AE').map((rail) => rail.id);
+    expect(gulf).not.toContain('upi');
+    expect(gulf).not.toContain('pix');
+
+    const india = railsFor('IN').map((rail) => rail.id);
+    expect(india).not.toContain('aani');
+    expect(india).toContain('upi');
+  });
+
+  it('always ends with bank, cash and something else', () => {
+    // Cash is never not an option, and a list that cannot express "I handed
+    // them a note" is a list somebody has to lie to.
+    for (const country of ['IN', 'AE', 'BR', 'US', 'ZZ', '']) {
+      const ids = railsFor(country).map((rail) => rail.id);
+      expect(ids.slice(-3), `for ${country || '(none)'}`).toEqual(['bank', 'cash', 'other']);
+    }
+  });
+
+  it('gives an unknown or missing country a usable list rather than an empty one', () => {
+    // Somebody who never set a country must still be able to record a debt.
+    for (const country of [null, undefined, '', 'ZZ', '  ']) {
+      const rails = railsFor(country);
+      expect(rails.length).toBeGreaterThan(0);
+      expect(rails.map((rail) => rail.id)).toContain('cash');
+    }
+    expect(defaultRailFor(null)).toBeTruthy();
+  });
+
+  it('offers the cross-border ones everywhere, because a trip is not one country', () => {
+    for (const country of ['IN', 'AE', 'BR', 'DE']) {
+      const ids = railsFor(country).map((rail) => rail.id);
+      expect(ids).toContain('wise');
+      expect(ids).toContain('revolut');
+    }
+  });
+
+  it('reads a country case- and space-insensitively', () => {
+    expect(defaultRailFor(' ae ')).toBe('aani');
+    expect(defaultRailFor('ae')).toBe('aani');
+  });
+});
+
+describe('a rail never claims a hand-off it does not have', () => {
+  it('marks only UPI as deep-linkable', () => {
+    // Guessing at a scheme produces a button that silently fails on somebody's
+    // phone while they believe they have paid. If this list ever grows, it
+    // grows because somebody watched the link open a real bank app.
+    const linkable = PAYMENT_RAILS.filter((rail) => rail.deepLink).map((rail) => rail.id);
+    expect(linkable).toEqual(['upi']);
+  });
+
+  it('returns null for every rail that cannot hand off', () => {
+    for (const rail of PAYMENT_RAILS.filter((entry) => !entry.deepLink)) {
+      const uri = buildPaymentUri(
+        {
+          railId: rail.id,
+          handle: 'ravi@example.com',
+          payeeName: 'Ravi',
+          amount: 50000n,
+          currency: 'AED',
+        },
+        major,
+      );
+      expect(uri, `${rail.id} must not invent a scheme`).toBeNull();
+    }
+  });
+
+  it('builds the UPI intent it always built', () => {
+    const uri = buildPaymentUri(
+      {
+        railId: 'upi',
+        handle: 'ravi@okhdfcbank',
+        payeeName: 'Ravi Kumar',
+        amount: 45050n,
+        currency: 'INR',
+        note: 'Goa trip',
+      },
+      major,
+    );
+    expect(uri).toContain('upi://pay?');
+    expect(uri).toContain('pa=ravi%40okhdfcbank');
+    expect(uri).toContain('cu=INR');
+    expect(uri).toContain('pn=Ravi+Kumar');
+  });
+
+  it('refuses to build a link from a handle that is not one', () => {
+    expect(
+      buildPaymentUri(
+        { railId: 'upi', handle: 'not a upi id', payeeName: 'R', amount: 1n, currency: 'INR' },
+        major,
+      ),
+    ).toBeNull();
+  });
+
+  it('says nothing at all about a rail it has never heard of', () => {
+    expect(railById('bitcoin')).toBeNull();
+    expect(isValidHandle('bitcoin', 'anything')).toBe(false);
+  });
+});
+
+describe('handles', () => {
+  it('accepts what each rail actually asks for', () => {
+    expect(isValidHandle('upi', 'ravi@okhdfcbank')).toBe(true);
+    expect(isValidHandle('aani', '+971 50 123 4567')).toBe(true);
+    expect(isValidHandle('paynow', '+65 8123 4567')).toBe(true);
+    expect(isValidHandle('venmo', '@ravi-kumar')).toBe(true);
+    expect(isValidHandle('cashapp', '$ravi')).toBe(true);
+    expect(isValidHandle('interac', 'ravi@example.com')).toBe(true);
+    expect(isValidHandle('bank', 'AE07 0331 2345 6789 0123 456')).toBe(true);
+  });
+
+  it('takes a Pix key in any of its four shapes', () => {
+    // The whole design of Pix is that the key is whatever the person
+    // registered. A validator with an opinion here rejects real accounts.
+    for (const key of [
+      '12345678901',
+      '+5511987654321',
+      'ravi@example.com',
+      '123e4567-e89b-12d3-a456-426614174000',
+    ]) {
+      expect(isValidHandle('pix', key), key).toBe(true);
+    }
+  });
+
+  it('rejects an empty handle where one is needed, and asks for none where it is not', () => {
+    expect(isValidHandle('upi', '   ')).toBe(false);
+    expect(isValidHandle('aani', '')).toBe(false);
+    expect(isValidHandle('cash', '')).toBe(true);
+    expect(isValidHandle('other', '')).toBe(true);
+  });
+
+  it('does not take a UPI ID for a phone number', () => {
+    expect(isValidHandle('upi', '+971501234567')).toBe(false);
+    expect(isValidHandle('aani', 'ravi@okhdfcbank')).toBe(false);
+  });
+});
+
+describe('the list itself', () => {
+  it('has no duplicate ids', () => {
+    const ids = PAYMENT_RAILS.map((rail) => rail.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('gives every rail that needs a handle something to say about it', () => {
+    for (const rail of PAYMENT_RAILS) {
+      if (rail.handle === 'none') continue;
+      expect(rail.handleHint, `${rail.id} needs a hint`).not.toBe('');
+    }
+  });
+});

--- a/packages/db/prisma/migrations/20260807110000_payment_rails_and_country/migration.sql
+++ b/packages/db/prisma/migrations/20260807110000_payment_rails_and_country/migration.sql
@@ -1,0 +1,210 @@
+-- A country, and the rail money moves on in it.
+--
+-- The schema said UPI in three places without saying "UPI": `settlements.method`
+-- is an enum whose interesting value is `upi`, and the handle a person is paid
+-- at is called `vpa` — a UPI ID — on both `profiles` and `group_members`. That
+-- is honest for one market and wrong for the next one, where the same field
+-- holds a Pix key, an IBAN or a phone number.
+--
+-- Three additions, no removals:
+--
+--   * **`country_code`** on `profiles` and `groups`. A group is where it
+--     settles, not where its members live — a Goa trip run from Dubai settles
+--     in rupees over UPI, and the group is the thing that knows that. Nullable,
+--     because a group that never says stays exactly as it is today.
+--   * **`payment_rail` + `payment_handle`** alongside the `vpa` columns, and
+--     backfilled from them. A handle without the rail it belongs to is
+--     unusable outside India: `+971 50 123 4567` is an Aani number, a PayNow
+--     number or a Zelle number, and only the rail says which.
+--   * **`settlements.rail`** — which rail was actually used, backfilled from
+--     `method`. `method` stays: it is on every existing row, the app reads it,
+--     and an enum is a poor place to add fifteen values (`ALTER TYPE ... ADD
+--     VALUE` does not compose with a migration that runs in a transaction).
+--     `rail` is the truth going forward; `method` is the coarse legacy shape.
+--
+-- `vpa` and `default_vpa` are left in place and left alone. They are read by
+-- five screens, and a rename is a change to all of them plus every RPC that
+-- touches one — worth doing, not worth doing in the same change as the thing
+-- that makes the rename meaningful.
+
+-- ───────────────────────────────────────────────────── where people are ──
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS country_code char(2),
+  ADD COLUMN IF NOT EXISTS payment_rail text,
+  ADD COLUMN IF NOT EXISTS payment_handle text;
+
+ALTER TABLE public.groups
+  ADD COLUMN IF NOT EXISTS country_code char(2);
+
+ALTER TABLE public.group_members
+  ADD COLUMN IF NOT EXISTS payment_rail text,
+  ADD COLUMN IF NOT EXISTS payment_handle text;
+
+ALTER TABLE public.settlements
+  ADD COLUMN IF NOT EXISTS rail text;
+
+-- ─────────────────────────────────────────────── what a rail may be ──
+--
+-- Kept in step with `RailId` in `packages/core/src/settlement/rails.ts`. A
+-- constraint rather than an enum so that adding Brazil is one migration and no
+-- type surgery — the reason `method` is not being extended.
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_payment_rail_known;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_payment_rail_known CHECK (
+    payment_rail IS NULL OR payment_rail IN (
+      'upi','pix','paynow','promptpay','qris','aani',
+      'zelle','venmo','cashapp','interac','wise','revolut',
+      'bank','cash','other'
+    )
+  );
+
+ALTER TABLE public.group_members
+  DROP CONSTRAINT IF EXISTS group_members_payment_rail_known;
+ALTER TABLE public.group_members
+  ADD CONSTRAINT group_members_payment_rail_known CHECK (
+    payment_rail IS NULL OR payment_rail IN (
+      'upi','pix','paynow','promptpay','qris','aani',
+      'zelle','venmo','cashapp','interac','wise','revolut',
+      'bank','cash','other'
+    )
+  );
+
+ALTER TABLE public.settlements
+  DROP CONSTRAINT IF EXISTS settlements_rail_known;
+ALTER TABLE public.settlements
+  ADD CONSTRAINT settlements_rail_known CHECK (
+    rail IS NULL OR rail IN (
+      'upi','pix','paynow','promptpay','qris','aani',
+      'zelle','venmo','cashapp','interac','wise','revolut',
+      'bank','cash','other'
+    )
+  );
+
+-- ────────────────────────────────────────────────────────── backfill ──
+--
+-- Everything already in this database is Indian, and every handle in it is a
+-- UPI ID, because until now there was nothing else it could be.
+
+UPDATE public.profiles
+   SET payment_rail = 'upi', payment_handle = default_vpa
+ WHERE default_vpa IS NOT NULL AND payment_handle IS NULL;
+
+UPDATE public.group_members
+   SET payment_rail = 'upi', payment_handle = vpa
+ WHERE vpa IS NOT NULL AND payment_handle IS NULL;
+
+-- `method` and `rail` share their four historical values exactly, so this is a
+-- copy rather than a mapping.
+UPDATE public.settlements
+   SET rail = method::text
+ WHERE rail IS NULL;
+
+-- Existing groups are Indian groups. A group created from here on gets its
+-- country from whoever created it, and a group with no country still works —
+-- `railsFor(null)` returns bank, cash and the cross-border wallets.
+UPDATE public.groups SET country_code = 'IN' WHERE country_code IS NULL;
+UPDATE public.profiles SET country_code = 'IN' WHERE country_code IS NULL;
+
+-- ──────────────────────────────────── recording which rail was used ──
+--
+-- One function, not two: the old nine-argument signature is dropped rather
+-- than left beside a ten-argument one, because two functions that differ by a
+-- default are two functions to keep in step. Every caller passes named
+-- parameters (`p_group_id => ...`), so a new parameter with a default is
+-- invisible to all of them.
+
+DROP FUNCTION IF EXISTS public.baaki_record_settlement(
+  uuid, uuid, uuid, bigint, text, character, text, jsonb, uuid
+);
+
+-- The body below is the M1 function unchanged, with `rail` added. Nothing else
+-- about it moves: the currency still falls back to the group's, the client
+-- mutation id is still stored (without it a retried settlement pays somebody
+-- twice, ADR-005), allocations still accumulate on conflict, and the activity
+-- entry is still written.
+
+CREATE OR REPLACE FUNCTION public.baaki_record_settlement(
+  p_group_id           uuid,
+  p_from_member_id     uuid,
+  p_to_member_id       uuid,
+  p_amount             bigint,
+  p_method             text,
+  p_currency           char(3) DEFAULT NULL,
+  p_note               text DEFAULT NULL,
+  p_allocations        jsonb DEFAULT '[]'::jsonb,
+  p_client_mutation_id uuid DEFAULT NULL,
+  /** Which rail, specifically. Falls back to `p_method` for older clients. */
+  p_rail               text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_settlement_id uuid;
+  v_currency      char(3);
+  v_actor         uuid;
+  v_allocation    jsonb;
+  v_rail          text := COALESCE(NULLIF(btrim(p_rail), ''), p_method);
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in this group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: settle a positive amount' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying the same mutation must not create a second settlement (ADR-005).
+  IF p_client_mutation_id IS NOT NULL THEN
+    SELECT id INTO v_settlement_id
+    FROM public.settlements WHERE client_mutation_id = p_client_mutation_id;
+    IF v_settlement_id IS NOT NULL THEN
+      RETURN v_settlement_id;
+    END IF;
+  END IF;
+
+  SELECT COALESCE(p_currency, default_currency) INTO v_currency
+  FROM public.groups WHERE id = p_group_id;
+
+  INSERT INTO public.settlements
+    (group_id, from_member_id, to_member_id, currency, amount, method, rail, status, note,
+     client_mutation_id)
+  VALUES
+    (p_group_id, p_from_member_id, p_to_member_id, upper(v_currency), p_amount,
+     -- A rail the old enum has never heard of still records as a settlement:
+     -- it lands as `other` in the legacy column and as itself in `rail`.
+     CASE WHEN p_method IN ('upi', 'cash', 'bank', 'other') THEN p_method ELSE 'other' END
+       ::"SettlementMethod",
+     v_rail, 'initiated', p_note, p_client_mutation_id)
+  RETURNING id INTO v_settlement_id;
+
+  FOR v_allocation IN SELECT * FROM jsonb_array_elements(COALESCE(p_allocations, '[]'::jsonb))
+  LOOP
+    INSERT INTO public.settlement_allocations (settlement_id, expense_id, amount)
+    VALUES (
+      v_settlement_id,
+      (v_allocation ->> 'expenseId')::uuid,
+      (v_allocation ->> 'amount')::bigint
+    )
+    ON CONFLICT (settlement_id, expense_id)
+    DO UPDATE SET amount = public.settlement_allocations.amount + EXCLUDED.amount;
+  END LOOP;
+
+  v_actor := public.baaki_my_member_id(p_group_id);
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (p_group_id, v_actor, 'settled', 'settlement', v_settlement_id,
+          jsonb_build_object('amount', p_amount, 'currency', v_currency,
+                             'method', p_method, 'rail', v_rail));
+
+  RETURN v_settlement_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_record_settlement(
+  uuid, uuid, uuid, bigint, text, character, text, jsonb, uuid, text
+) TO authenticated, anon;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -124,8 +124,17 @@ model Profile {
   id                String   @id @db.Uuid
   displayName       String   @map("display_name")
   avatarUrl         String?  @map("avatar_url")
-  /// Optional UPI ID used to build settlement intents (ADR-007).
+  /// Optional UPI ID used to build settlement intents (ADR-007). Superseded by
+  /// `paymentRail` + `paymentHandle`, which say the same thing for a country
+  /// that does not have UPI. Kept until the screens reading it move over.
   defaultVpa        String?  @map("default_vpa")
+  /// Which rail they are paid on — see `RailId` in `@baaki/core`. A handle
+  /// without it is unusable abroad: a phone number is an Aani number, a PayNow
+  /// number or a Zelle number, and only the rail says which.
+  paymentRail       String?  @map("payment_rail")
+  paymentHandle     String?  @map("payment_handle")
+  /// ISO-3166 alpha-2. Decides which rails they are offered.
+  countryCode       String?  @map("country_code") @db.Char(2)
   defaultCurrency   String   @default("INR") @map("default_currency") @db.Char(3)
   locale            String   @default("en")
   notificationPrefs Json     @default("{}") @map("notification_prefs")
@@ -154,6 +163,11 @@ model Group {
   /// Object path in the private `group-photos` bucket, read via a signed URL.
   photoPath       String?   @map("photo_path")
   type            GroupType @default(other)
+  /// ISO-3166 alpha-2 — where this group settles, which is not always where its
+  /// members live. A Goa trip run from Dubai settles in rupees over UPI, and
+  /// the group is the thing that knows that. NULL still works: it falls back to
+  /// bank, cash and the cross-border wallets.
+  countryCode     String?   @map("country_code") @db.Char(2)
   defaultCurrency String    @default("INR") @map("default_currency") @db.Char(3)
   /// ADR-009: simplification is a per-group presentation setting.
   simplifyDebts   Boolean   @default(true) @map("simplify_debts")
@@ -215,8 +229,14 @@ model GroupMember {
   inviteEmail String?   @map("invite_email")
   /// E.164 only, e.g. +919876543210.
   invitePhone String?   @map("invite_phone")
-  /// Per-group override of the profile's default VPA.
+  /// Per-group override of the profile's default VPA. Superseded by
+  /// `paymentRail` + `paymentHandle`; kept until the screens move over.
   vpa        String?
+  /// Per-group override of how this person is paid — the same pair as on the
+  /// profile. One group settles over UPI and another over Wise, and the person
+  /// is the same person.
+  paymentRail   String? @map("payment_rail")
+  paymentHandle String? @map("payment_handle")
   leftAt     DateTime?  @map("left_at") @db.Timestamptz(6)
   updatedSeq BigInt     @default(0) @map("updated_seq")
   createdAt  DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
@@ -448,7 +468,11 @@ model Settlement {
   toMemberId       String           @map("to_member_id") @db.Uuid
   currency         String           @db.Char(3)
   amount           BigInt
+  /// The coarse, historical shape. `rail` is the truth going forward — an enum
+  /// is a poor place to add fifteen values, and every existing row has this.
   method           SettlementMethod
+  /// Which rail the money actually moved on — see `RailId` in `@baaki/core`.
+  rail             String?
   status           SettlementStatus @default(initiated)
   note             String?
   initiatedAt      DateTime         @default(now()) @map("initiated_at") @db.Timestamptz(6)

--- a/packages/db/test/payment-rails.test.ts
+++ b/packages/db/test/payment-rails.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Which rail the money moved on.
+ *
+ * `settlements.method` is an enum with four values, one of which is `upi`.
+ * Adding Pix, PayNow, Aani and the rest to it would mean `ALTER TYPE ... ADD
+ * VALUE`, which does not compose with a migration running in a transaction —
+ * so `rail` is a text column beside it, and `method` keeps holding the coarse
+ * shape every existing row already has.
+ *
+ * The thing worth testing is that the two never disagree in a way that loses
+ * information: a rail the enum has never heard of still records, and it records
+ * as itself.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, seedGroup, type SeededGroup } from './helpers';
+
+let client: Client;
+let group: SeededGroup;
+
+beforeAll(async () => {
+  client = await connect();
+  group = await seedGroup(client, { memberCount: 2, name: 'Dubai' });
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+async function record(
+  method: string,
+  rail: string | null,
+  mutationId: string | null = randomUUID(),
+): Promise<{ id: string; method: string; rail: string | null }> {
+  // Session-level, not transaction-local: these statements do not run inside a
+  // transaction, and `is_local = true` would discard the claim before the RPC
+  // ever read it.
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: group.profileIds[0], role: 'authenticated' }),
+  ]);
+  const { rows } = await client.query(
+    `SELECT baaki_record_settlement($1, $2, $3, 5000, $4, 'AED', NULL, '[]'::jsonb, $5, $6) AS id`,
+    [group.groupId, group.memberIds[0], group.memberIds[1], method, mutationId, rail],
+  );
+  const id = String(rows[0].id);
+  const { rows: stored } = await client.query(
+    `SELECT method::text AS method, rail FROM settlements WHERE id = $1`,
+    [id],
+  );
+  return { id, method: String(stored[0].method), rail: stored[0].rail };
+}
+
+describe('recording which rail was used', () => {
+  it('stores a rail the enum has never heard of, as itself', () => {
+    // The whole point. Before this, an Aani transfer had nowhere to go: the
+    // enum would have rejected it and the settlement would have failed.
+    return record('other', 'aani').then((row) => {
+      expect(row.rail).toBe('aani');
+      expect(row.method).toBe('other');
+    });
+  });
+
+  it('keeps method and rail agreeing for the four that always existed', async () => {
+    for (const value of ['upi', 'cash', 'bank', 'other']) {
+      const row = await record(value, value);
+      expect(row.method, value).toBe(value);
+      expect(row.rail, value).toBe(value);
+    }
+  });
+
+  it('falls back to the method when a client does not send a rail', async () => {
+    // An app build from before this migration sends nine arguments. It must
+    // keep working, and what it recorded must still be readable as a rail.
+    const row = await record('cash', null);
+    expect(row.rail).toBe('cash');
+    expect(row.method).toBe('cash');
+  });
+
+  it('refuses a rail that is not a rail', async () => {
+    await expect(record('other', 'bitcoin')).rejects.toThrow(/settlements_rail_known|violates/i);
+  });
+
+  it('still records nothing twice', async () => {
+    // Adding a parameter to this function is exactly how idempotency gets lost
+    // — the client mutation id has to survive the rewrite, or a retried
+    // settlement pays somebody a second time (ADR-005).
+    const mutationId = randomUUID();
+    const first = await record('cash', 'cash', mutationId);
+    const second = await record('cash', 'cash', mutationId);
+    expect(second.id).toBe(first.id);
+
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM settlements WHERE client_mutation_id = $1`,
+      [mutationId],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+
+  it('still writes the activity entry, now naming the rail', async () => {
+    const row = await record('other', 'aani');
+    const { rows } = await client.query(
+      `SELECT payload FROM activity_log WHERE object_id = $1 AND verb = 'settled'`,
+      [row.id],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].payload.rail).toBe('aani');
+  });
+});
+
+describe('where a group settles', () => {
+  it('accepts a group that never says where it is', async () => {
+    // The migration backfilled the rows that existed when it ran — everything
+    // in this database was Indian, because until now there was nothing else it
+    // could be. It did not add a default, and it should not have: 'IN' is the
+    // wrong guess for an app that is going elsewhere. A group with no country
+    // is a supported state, and `railsFor(null)` answers with bank, cash and
+    // the cross-border wallets.
+    const id = randomUUID();
+    await client.query(
+      `INSERT INTO groups (id, name, type, default_currency, created_by)
+       VALUES ($1, 'Nowhere', 'other', 'AED', $2)`,
+      [id, group.profileIds[0]],
+    );
+    const { rows } = await client.query(`SELECT country_code FROM groups WHERE id = $1`, [id]);
+    expect(rows[0].country_code).toBeNull();
+  });
+
+  it('lets a group settle somewhere other than where it was made', async () => {
+    await client.query(`UPDATE groups SET country_code = 'AE' WHERE id = $1`, [group.groupId]);
+    const { rows } = await client.query(`SELECT country_code FROM groups WHERE id = $1`, [
+      group.groupId,
+    ]);
+    expect(rows[0].country_code).toBe('AE');
+  });
+
+  it('carries a handle with the rail it belongs to', async () => {
+    // A phone number on its own is an Aani number, a PayNow number or a Zelle
+    // number. Storing one without the other is storing something unusable.
+    await client.query(
+      `UPDATE group_members SET payment_rail = 'aani', payment_handle = '+971501234567' WHERE id = $1`,
+      [group.memberIds[0]],
+    );
+    const { rows } = await client.query(
+      `SELECT payment_rail, payment_handle FROM group_members WHERE id = $1`,
+      [group.memberIds[0]],
+    );
+    expect(rows[0].payment_rail).toBe('aani');
+    expect(rows[0].payment_handle).toBe('+971501234567');
+  });
+
+  it('refuses a rail that is not a rail there too', async () => {
+    await expect(
+      client.query(`UPDATE group_members SET payment_rail = 'bitcoin' WHERE id = $1`, [
+        group.memberIds[0],
+      ]),
+    ).rejects.toThrow(/group_members_payment_rail_known|violates/i);
+  });
+});


### PR DESCRIPTION
Groundwork for going international. Two commits: the core layer, then the schema and the screen.

## The problem

Three things assumed one country, and all three were the kind of assumption that becomes a rewrite rather than a setting:

- `settle.tsx` offered `'upi' | 'cash' | 'bank'` — a union of three, one of which does not exist outside India.
- The handle somebody is paid at is called `vpa` on `profiles` and `group_members`. A UPI ID. Abroad that field holds a Pix key, an IBAN or a phone number.
- Category keywords knew Swiggy, Zepto, IRCTC and kirana. In Dubai every expense lands in "Other" — which doesn't make the Spending screen look empty, it makes it look **broken**.

## Payment rails are data now

A rail per country with the handle it needs: UPI, Pix, PayNow, PromptPay, QRIS, Aani, Zelle, Venmo, Cash App, Interac, plus Wise and Revolut everywhere because a trip is rarely one country. Bank, cash and something else always come last — a list that cannot say "I handed them a note" is a list somebody has to lie to.

**Only UPI is marked deep-linkable, and a test pins that.** `upi://pay` is a published intent every Indian bank app implements. Pix is a copied key, not a URL; Zelle and Venmo have app links that are neither documented nor stable. Guessing at a scheme produces a button that silently fails on somebody's phone while they believe they have paid. So a rail either has a scheme we can stand behind, or it shows the handle to copy and the person finishes in their own bank app.

Handle validation is deliberately permissive. The only thing that truly validates a payment handle is a payment; a validator strict enough to be certain would reject somebody's real account and leave them unable to record a debt they owe. A Pix key in particular is a CPF, a phone, an email or a UUID — the person registering it chose which.

## Schema

`rail` is a text column beside `method`, not fifteen new enum values: `ALTER TYPE ... ADD VALUE` does not compose with a migration running in a transaction, and `method` is on every existing row and read by the app. A rail the enum has never heard of lands as `other` there and as itself in `rail`, so an Aani transfer records instead of being rejected.

`payment_rail` + `payment_handle` sit beside the `vpa` columns, backfilled from them. `payableAt()` falls back per-group → profile → old `vpa`, because anything written before rails existed can only have been a UPI ID.

Groups get a `country_code`. Existing rows are stamped `IN` — everything in the database was Indian because there was nothing else it could be — but **no default was added**: `'IN'` is the wrong guess for an app going elsewhere, and a group with no country is a supported state.

## One thing worth calling out

I rewrote `baaki_record_settlement` from the shape I remembered and it dropped the client mutation id, the activity entry and the currency fallback. That would have meant **a retried settlement paying somebody twice** (ADR-005). Caught by diffing against the M1 original before applying. What is in the migration is that original body, verbatim, plus the rail.

## Markets

Category keywords are a layer over the shared English words, not a fork of the categoriser. The Gulf's six countries share one set (Talabat, Careem, Lulu, Salik, DEWA); Brazil, Singapore and Indonesia are there so "Brazil is configuration" is a claim with code behind it. `guessCategory` takes an optional country and behaves exactly as before without one, so every existing caller is untouched.

## Verification

- **core 323** (24 new), **db 215** (10 new), **mobile 92**. Typecheck, lint and `expo export --platform web` all clean; no Prisma drift.
- Migration deployed: 3/3 settlements backfilled, 44 groups stamped `IN`.
- `ChipRow` was already a horizontal `ScrollView`, so six chips where there were three still scroll — checked rather than assumed.
- Not driven on a device. The settle screen renders from a group's country, and no group in the live project has one other than `IN` yet.

## Not in this PR

Arabic and RTL, regional price tiers, and the entitlement model. Those come next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6