### PR TITLE
feat: let a group say where it is, and a person say how they are paid

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -3,11 +3,12 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { Alert, ScrollView, TextInput, View } from 'react-native';
 
-import { isValidVpa } from '@baaki/core';
+import { defaultRailFor, isValidHandle, railById, railsFor } from '@baaki/core';
 import {
   Badge,
   Button,
   Card,
+  ChipRow,
   ListRow,
   Row,
   Screen,
@@ -18,7 +19,7 @@ import {
 
 import { ProfileAvatar } from '@/components/ProfileAvatar';
 import { removeAvatar, uploadAvatar } from '@/data/api';
-import { useStrings } from '@/i18n';
+import { deviceCountry, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { pickAvatarPhoto } from '@/lib/image';
 import { describeGrace, useLock } from '@/lib/lock';
@@ -119,7 +120,16 @@ export default function ProfileScreen() {
   const { animated, overridden: motionOverridden } = useMotion();
 
   const [name, setName] = useState(profile?.display_name ?? '');
-  const [vpa, setVpa] = useState(profile?.default_vpa ?? '');
+  /**
+   * How this person is paid. Falls back through the rail pair, then the old
+   * `default_vpa` — anything written before rails existed can only have been a
+   * UPI ID, and nobody should have to type theirs again.
+   */
+  const country = profile?.country_code ?? deviceCountry();
+  const [rail, setRail] = useState(
+    profile?.payment_rail ?? (profile?.default_vpa ? 'upi' : defaultRailFor(country)),
+  );
+  const [handle, setHandle] = useState(profile?.payment_handle ?? profile?.default_vpa ?? '');
   const [status, setStatus] = useState<string | null>(null);
   const [photoBusy, setPhotoBusy] = useState(false);
 
@@ -203,16 +213,24 @@ export default function ProfileScreen() {
     );
   };
 
-  const vpaValid = vpa.trim() === '' || isValidVpa(vpa.trim());
+  const railInfo = railById(rail);
+  const handleValid = handle.trim() === '' || isValidHandle(rail, handle.trim());
   const dirty =
-    name.trim() !== (profile?.display_name ?? '') || vpa.trim() !== (profile?.default_vpa ?? '');
+    name.trim() !== (profile?.display_name ?? '') ||
+    handle.trim() !== (profile?.payment_handle ?? profile?.default_vpa ?? '') ||
+    rail !== (profile?.payment_rail ?? (profile?.default_vpa ? 'upi' : rail));
 
   const save = async (): Promise<void> => {
     setStatus(null);
+    const trimmed = handle.trim();
     try {
       await updateProfile({
         display_name: name.trim() || 'You',
-        default_vpa: vpa.trim() === '' ? null : vpa.trim(),
+        payment_rail: trimmed === '' ? null : rail,
+        payment_handle: trimmed === '' ? null : trimmed,
+        // Kept in step while the older screens still read it. A handle on any
+        // other rail is not a UPI ID and must not masquerade as one.
+        default_vpa: rail === 'upi' && trimmed !== '' ? trimmed : null,
       });
       setStatus('Saved');
     } catch (caught) {
@@ -270,32 +288,52 @@ export default function ProfileScreen() {
             />
           </View>
 
-          <View style={{ gap: theme.spacing.xs }}>
+          <View style={{ gap: theme.spacing.sm }}>
             <Text variant="caption" tone="muted">
-              UPI ID
+              How people pay you
             </Text>
-            <TextInput
-              value={vpa}
-              onChangeText={setVpa}
-              autoCapitalize="none"
-              accessibilityLabel="UPI ID"
-              placeholder="you@bank"
-              placeholderTextColor={theme.color.textFaint}
-              style={{
-                fontSize: 18,
-                fontWeight: '600',
-                color: vpaValid ? theme.color.text : theme.color.negative,
-                paddingVertical: theme.spacing.sm,
-              }}
+            {/* Whatever this person's country uses. In India that still starts
+                on UPI; in the UAE it starts on Aani. */}
+            <ChipRow<string>
+              value={rail}
+              onChange={setRail}
+              options={railsFor(country).map((entry) => ({
+                value: entry.id,
+                label: entry.label,
+              }))}
             />
-            <Text variant="micro" tone={vpaValid ? 'faint' : 'negative'}>
-              {vpaValid
-                ? 'People settling with you get a one-tap UPI intent. Baaki never handles the money.'
-                : 'That does not look like a UPI ID (name@bank).'}
-            </Text>
+            {railInfo && railInfo.handle !== 'none' ? (
+              <>
+                <TextInput
+                  value={handle}
+                  onChangeText={setHandle}
+                  autoCapitalize="none"
+                  accessibilityLabel={`Your ${railInfo.label} details`}
+                  placeholder={railInfo.handleHint}
+                  placeholderTextColor={theme.color.textFaint}
+                  style={{
+                    fontSize: 18,
+                    fontWeight: '600',
+                    color: handleValid ? theme.color.text : theme.color.negative,
+                    paddingVertical: theme.spacing.sm,
+                  }}
+                />
+                <Text variant="micro" tone={handleValid ? 'faint' : 'negative'}>
+                  {!handleValid
+                    ? `That does not look like ${railInfo.handleHint.toLowerCase()}.`
+                    : railInfo.deepLink
+                      ? 'People settling with you get a one-tap payment. Baaki never handles the money.'
+                      : 'People settling with you see this to pay you from their own bank app. Baaki never handles the money.'}
+                </Text>
+              </>
+            ) : (
+              <Text variant="micro" tone="faint">
+                Nothing to add — people will record what they paid you by hand.
+              </Text>
+            )}
           </View>
 
-          <Button label="Save" disabled={!dirty || !vpaValid} onPress={() => void save()} />
+          <Button label="Save" disabled={!dirty || !handleValid} onPress={() => void save()} />
           {status ? (
             <Text variant="caption" tone={status === 'Saved' ? 'positive' : 'negative'}>
               {status}

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -19,6 +19,7 @@ import {
 
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { pickGroupPhoto } from '@/lib/image';
+import { CountryRow } from '@/components/CountryPicker';
 import { TripDates } from '@/components/TripDates';
 import { removeGroupPhoto, uploadGroupPhoto } from '@/data/api';
 import { useGroup, useGroupLedger, useLeaveGroup, useUpdateGroup } from '@/data/hooks';
@@ -222,6 +223,15 @@ export default function GroupSettingsScreen() {
             ))}
           </Row>
         </Card>
+
+        {/* Decides which payment rails the settle screen offers, and what a new
+            expense starts in. Nothing already recorded changes. */}
+        <CountryRow
+          countryCode={group.data.country_code}
+          onChange={(country_code) =>
+            updateGroup.mutate({ country_code }, { onSuccess: () => setStatus('Saved') })
+          }
+        />
 
         <TripDates
           group={group.data}

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -3,6 +3,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
+import { currencyForCountry } from '@baaki/core';
 import { Button, Card, ChipRow, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
@@ -10,7 +11,7 @@ import { pickGroupPhoto, type PickedImage } from '@/lib/image';
 import { addGhostMember, uploadGroupPhoto } from '@/data/api';
 import { useCreateGroup } from '@/data/hooks';
 import type { GroupType } from '@/data/types';
-import { useStrings } from '@/i18n';
+import { deviceCountry, useStrings } from '@/i18n';
 
 const EMOJI = ['🏖️', '🏠', '💜', '🎉', '✈️', '🍽️', '⛰️', '🎓'];
 
@@ -27,6 +28,9 @@ export default function NewGroupScreen() {
   const [ghostName, setGhostName] = useState('');
   const [ghosts, setGhosts] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  // Read once, not on every render: a phone does not change country mid-form,
+  // and re-reading it would be a new value every time for `useMemo` to chase.
+  const [country] = useState(() => deviceCountry());
 
   const submit = async (): Promise<void> => {
     setError(null);
@@ -35,7 +39,11 @@ export default function NewGroupScreen() {
         // Blank is fine — the group gets labelled by who is in it instead.
         name: name.trim() || null,
         type,
-        currency: 'INR',
+        // Where the phone is, and what that country counts in. A group made in
+        // Dubai defaulting to rupees is the small wrongness that makes an app
+        // feel written for somewhere else.
+        country,
+        currency: currencyForCountry(country) ?? 'INR',
         emoji,
         // Trips benefit most from simplification; a two-person group does not.
         simplify: type === 'trip' || type === 'event',

--- a/apps/mobile/src/components/CountryPicker.tsx
+++ b/apps/mobile/src/components/CountryPicker.tsx
@@ -1,0 +1,151 @@
+/**
+ * Where a group settles.
+ *
+ * Not a flag-and-dial-code control — this only decides two things, and saying
+ * which is more useful than a pretty list: **which payment rails the settle
+ * screen offers**, and what currency a new group starts in. A group in the UAE
+ * gets Aani and dirhams; the same group set to India gets UPI and rupees.
+ *
+ * The list is deliberately short and ordered by market rather than
+ * alphabetically (see `COUNTRIES` in `@baaki/core`), because somebody in the
+ * Gulf should not scroll past forty countries to find theirs. "Not set" is a
+ * real, supported answer and stays first: a group with no country falls back to
+ * bank, cash and the cross-border wallets, which is the right behaviour for a
+ * group whose members are in four places.
+ */
+
+import { useState } from 'react';
+import { Modal, Pressable, ScrollView, View } from 'react-native';
+
+import { COUNTRIES, countryName, railsFor } from '@baaki/core';
+import { Button, Card, ListRow, Row, Screen, Text, useTheme } from '@baaki/ui';
+
+export function CountryRow({
+  countryCode,
+  onChange,
+}: {
+  countryCode: string | null;
+  onChange: (countryCode: string | null) => void;
+}) {
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
+
+  // What this choice actually buys, said in the row rather than in a help page.
+  const rails = railsFor(countryCode)
+    .slice(0, 3)
+    .map((rail) => rail.label)
+    .join(', ');
+
+  return (
+    <>
+      <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+        <ListRow
+          title="Country"
+          subtitle={
+            countryCode
+              ? `${countryName(countryCode) ?? countryCode} · settles with ${rails}`
+              : `Not set · settles with ${rails}`
+          }
+          onPress={() => setOpen(true)}
+        />
+      </Card>
+
+      <Modal visible={open} animationType="slide" onRequestClose={() => setOpen(false)}>
+        <Screen edges={['top', 'bottom']}>
+          <View
+            style={{
+              paddingHorizontal: theme.spacing.xl,
+              paddingBottom: theme.spacing.lg,
+              gap: theme.spacing.xs,
+            }}
+          >
+            <Text variant="heading">Where does this group settle?</Text>
+            <Text variant="caption" tone="muted">
+              This decides how you can pay each other, and what currency a new expense starts in.
+              Nothing already recorded changes.
+            </Text>
+          </View>
+
+          <ScrollView
+            contentContainerStyle={{
+              paddingHorizontal: theme.spacing.xl,
+              paddingBottom: theme.spacing.xxxl,
+              gap: theme.spacing.sm,
+            }}
+            showsVerticalScrollIndicator={false}
+          >
+            <Choice
+              label="Not set"
+              hint="Bank transfer, cash, Wise and Revolut"
+              selected={countryCode === null}
+              onPress={() => {
+                onChange(null);
+                setOpen(false);
+              }}
+            />
+            {COUNTRIES.map((country) => (
+              <Choice
+                key={country.code}
+                label={country.name}
+                hint={railsFor(country.code)
+                  .slice(0, 3)
+                  .map((rail) => rail.label)
+                  .join(', ')}
+                selected={countryCode === country.code}
+                onPress={() => {
+                  onChange(country.code);
+                  setOpen(false);
+                }}
+              />
+            ))}
+          </ScrollView>
+
+          <View style={{ paddingHorizontal: theme.spacing.xl, paddingBottom: theme.spacing.lg }}>
+            <Button label="Close" variant="ghost" fullWidth onPress={() => setOpen(false)} />
+          </View>
+        </Screen>
+      </Modal>
+    </>
+  );
+}
+
+function Choice({
+  label,
+  hint,
+  selected,
+  onPress,
+}: {
+  label: string;
+  hint: string;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="radio"
+      accessibilityState={{ selected }}
+      style={{
+        paddingVertical: theme.spacing.md,
+        paddingHorizontal: theme.spacing.lg,
+        borderRadius: theme.radius.md,
+        backgroundColor: selected ? theme.color.brandSoft : theme.color.surface,
+      }}
+    >
+      <Row style={{ justifyContent: 'space-between' }}>
+        <View style={{ flex: 1, paddingRight: theme.spacing.md }}>
+          <Text variant="subheading">{label}</Text>
+          <Text variant="micro" tone="muted">
+            {hint}
+          </Text>
+        </View>
+        {selected ? (
+          <Text variant="subheading" tone="brand">
+            ✓
+          </Text>
+        ) : null}
+      </Row>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -225,6 +225,12 @@ export async function createGroup(input: {
   simplify?: boolean;
   groupId?: string;
   photoPath?: string | null;
+  /**
+   * ISO-3166 alpha-2. Decides which payment rails the group is offered. Null
+   * falls back to the creator's own country server-side, and then to nothing —
+   * which is a supported state, not a broken one.
+   */
+  country?: string | null;
 }): Promise<string> {
   const { data, error } = await supabase.rpc('baaki_create_group', {
     p_name: input.name?.trim() || null,
@@ -234,6 +240,7 @@ export async function createGroup(input: {
     p_simplify: input.simplify ?? true,
     p_group_id: input.groupId ?? null,
     p_photo_path: input.photoPath ?? null,
+    p_country: input.country ?? null,
   });
   if (error) throw new Error(error.message);
   return data as string;
@@ -553,6 +560,8 @@ export async function updateGroup(
     photo_path: string | null;
     simplify_debts: boolean;
     default_currency: string;
+    /** ISO-3166 alpha-2 — decides which payment rails the group is offered. */
+    country_code: string | null;
     archived_at: string | null;
     start_date: string | null;
     end_date: string | null;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -219,6 +219,21 @@ export function deviceLocale(): string {
   return getLocales()[0]?.languageTag ?? 'en-IN';
 }
 
+/**
+ * Which country this phone thinks it is in, as ISO-3166 alpha-2, or null.
+ *
+ * Used to start a new group on the right payment rails and currency. It is the
+ * *region* of the locale, not the language: somebody in Dubai reading the app
+ * in Hindi is in AE, and guessing IN from `hi` would put them on UPI.
+ *
+ * Null rather than a fallback. A group with no country still works, and a
+ * confident wrong answer is worse than no answer — it gets missed.
+ */
+export function deviceCountry(): string | null {
+  const region = getLocales()[0]?.regionCode ?? null;
+  return region && /^[A-Za-z]{2}$/.test(region) ? region.toUpperCase() : null;
+}
+
 export function useStrings(): { t: UiStrings; locale: string; language: Language } {
   const language = deviceLanguage();
   return { t: STRINGS[language], locale: deviceLocale(), language };

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -25,7 +25,13 @@ export interface Profile {
   id: string;
   display_name: string;
   avatar_url: string | null;
+  /** The UPI-shaped field. Superseded by the rail pair; still read as a fallback. */
   default_vpa: string | null;
+  /** How this person is paid: a `RailId` from `@baaki/core`, and a handle on it. */
+  payment_rail: string | null;
+  payment_handle: string | null;
+  /** ISO-3166 alpha-2 — seeds a new group's country when they make one. */
+  country_code: string | null;
   default_currency: string;
   locale: string;
 }
@@ -118,7 +124,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       for (let attempt = 0; attempt < 5; attempt += 1) {
         const { data } = await supabase
           .from('profiles')
-          .select('id, display_name, avatar_url, default_vpa, default_currency, locale')
+          .select(
+            'id, display_name, avatar_url, default_vpa, payment_rail, payment_handle, country_code, default_currency, locale',
+          )
           .eq('id', session.user.id)
           .maybeSingle();
         if (!active) return;
@@ -227,7 +235,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           .from('profiles')
           .update(patch)
           .eq('id', session.user.id)
-          .select('id, display_name, avatar_url, default_vpa, default_currency, locale')
+          .select(
+            'id, display_name, avatar_url, default_vpa, payment_rail, payment_handle, country_code, default_currency, locale',
+          )
           .single();
         if (error) throw error;
         setProfile(data as Profile);

--- a/packages/core/src/money/index.ts
+++ b/packages/core/src/money/index.ts
@@ -2,3 +2,4 @@ export * from './currency';
 export * from './money';
 export * from './format';
 export * from './fx';
+export * from './region';

--- a/packages/core/src/money/region.ts
+++ b/packages/core/src/money/region.ts
@@ -1,0 +1,128 @@
+/**
+ * What a country spends.
+ *
+ * A group created in Dubai defaulting to rupees is the sort of small wrongness
+ * that makes an app feel like it was written for somewhere else — which, until
+ * now, it was. The currency is only ever a *default*: every group can change
+ * it, every expense can override it, and nothing here decides what anything is
+ * worth. It decides what the picker starts on.
+ *
+ * Not a complete list of the world. It covers the markets Baaki is going to and
+ * the ones its users travel between, and everything else falls back to the
+ * caller's own default rather than to a guess. A wrong currency is worse than
+ * no opinion: `INR` on a group in Berlin gets typed over once, but a plausible
+ * wrong guess gets missed.
+ */
+
+import type { CurrencyCode } from './currency';
+
+const CURRENCY_BY_COUNTRY: Readonly<Record<string, CurrencyCode>> = {
+  // India, and the markets it exports people to.
+  IN: 'INR',
+  AE: 'AED',
+  SA: 'SAR',
+  QA: 'QAR',
+  KW: 'KWD',
+  BH: 'BHD',
+  OM: 'OMR',
+
+  // Where the rails already fit.
+  BR: 'BRL',
+  SG: 'SGD',
+  ID: 'IDR',
+  TH: 'THB',
+  MY: 'MYR',
+  PH: 'PHP',
+  VN: 'VND',
+
+  // Where people travel from and to.
+  US: 'USD',
+  CA: 'CAD',
+  GB: 'GBP',
+  AU: 'AUD',
+  NZ: 'NZD',
+  JP: 'JPY',
+  CH: 'CHF',
+  LK: 'LKR',
+  NP: 'NPR',
+  BD: 'BDT',
+  PK: 'PKR',
+
+  // The euro, spelled out per country rather than inferred — there is no rule
+  // that maps a country to a currency, only a list, and pretending otherwise
+  // puts euros in Poland.
+  DE: 'EUR',
+  FR: 'EUR',
+  ES: 'EUR',
+  IT: 'EUR',
+  NL: 'EUR',
+  PT: 'EUR',
+  IE: 'EUR',
+  AT: 'EUR',
+  BE: 'EUR',
+  GR: 'EUR',
+  FI: 'EUR',
+};
+
+/**
+ * The currency a group in this country most likely counts in, or null.
+ *
+ * Null means "no opinion" and the caller should keep whatever default it
+ * already had. It is deliberately not a fallback to USD: an unrecognised
+ * country is not an American one.
+ */
+export function currencyForCountry(countryCode: string | null | undefined): CurrencyCode | null {
+  const country = (countryCode ?? '').trim().toUpperCase();
+  return CURRENCY_BY_COUNTRY[country] ?? null;
+}
+
+/** Whether this looks like an ISO-3166 alpha-2 code at all. */
+export function isCountryCode(value: string | null | undefined): boolean {
+  return /^[A-Za-z]{2}$/.test((value ?? '').trim());
+}
+
+/**
+ * The countries worth showing in a picker, most relevant first.
+ *
+ * Ordered rather than alphabetical: somebody in the Gulf should not scroll past
+ * forty countries to find theirs, and the app knows which markets it is for.
+ */
+export const COUNTRIES: readonly { code: string; name: string }[] = [
+  { code: 'IN', name: 'India' },
+  { code: 'AE', name: 'United Arab Emirates' },
+  { code: 'SA', name: 'Saudi Arabia' },
+  { code: 'QA', name: 'Qatar' },
+  { code: 'KW', name: 'Kuwait' },
+  { code: 'BH', name: 'Bahrain' },
+  { code: 'OM', name: 'Oman' },
+  { code: 'SG', name: 'Singapore' },
+  { code: 'MY', name: 'Malaysia' },
+  { code: 'ID', name: 'Indonesia' },
+  { code: 'TH', name: 'Thailand' },
+  { code: 'PH', name: 'Philippines' },
+  { code: 'VN', name: 'Vietnam' },
+  { code: 'LK', name: 'Sri Lanka' },
+  { code: 'NP', name: 'Nepal' },
+  { code: 'BD', name: 'Bangladesh' },
+  { code: 'PK', name: 'Pakistan' },
+  { code: 'BR', name: 'Brazil' },
+  { code: 'GB', name: 'United Kingdom' },
+  { code: 'US', name: 'United States' },
+  { code: 'CA', name: 'Canada' },
+  { code: 'AU', name: 'Australia' },
+  { code: 'NZ', name: 'New Zealand' },
+  { code: 'DE', name: 'Germany' },
+  { code: 'FR', name: 'France' },
+  { code: 'ES', name: 'Spain' },
+  { code: 'IT', name: 'Italy' },
+  { code: 'NL', name: 'Netherlands' },
+  { code: 'PT', name: 'Portugal' },
+  { code: 'IE', name: 'Ireland' },
+  { code: 'CH', name: 'Switzerland' },
+  { code: 'JP', name: 'Japan' },
+];
+
+export function countryName(countryCode: string | null | undefined): string | null {
+  const country = (countryCode ?? '').trim().toUpperCase();
+  return COUNTRIES.find((entry) => entry.code === country)?.name ?? null;
+}

--- a/packages/core/test/region.test.ts
+++ b/packages/core/test/region.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { COUNTRIES, countryName, currencyForCountry, isCountryCode } from '../src/money/region';
+import { isCurrencyCode, minorUnitExponent } from '../src/money/currency';
+
+describe('what a country counts in', () => {
+  it('knows the markets Baaki is going to', () => {
+    expect(currencyForCountry('IN')).toBe('INR');
+    expect(currencyForCountry('AE')).toBe('AED');
+    expect(currencyForCountry('SA')).toBe('SAR');
+    expect(currencyForCountry('BR')).toBe('BRL');
+    expect(currencyForCountry('SG')).toBe('SGD');
+  });
+
+  it('says nothing rather than guessing', () => {
+    // A wrong currency is worse than no opinion: INR on a group in Berlin gets
+    // typed over once, but a plausible wrong guess gets missed. And an
+    // unrecognised country is not an American one.
+    expect(currencyForCountry('ZZ')).toBeNull();
+    expect(currencyForCountry('')).toBeNull();
+    expect(currencyForCountry(null)).toBeNull();
+    expect(currencyForCountry(undefined)).toBeNull();
+  });
+
+  it('reads a code case- and space-insensitively', () => {
+    expect(currencyForCountry(' ae ')).toBe('AED');
+    expect(currencyForCountry('ae')).toBe('AED');
+  });
+
+  it('spells the euro out per country instead of inferring it', () => {
+    for (const country of ['DE', 'FR', 'ES', 'IT', 'NL', 'PT', 'IE', 'AT', 'BE', 'GR', 'FI']) {
+      expect(currencyForCountry(country), country).toBe('EUR');
+    }
+    // There is no rule that maps a country to a currency, only a list —
+    // inferring one puts euros in Poland.
+    expect(currencyForCountry('PL')).not.toBe('EUR');
+  });
+
+  it('only names currencies the money layer will accept', () => {
+    // Catches a typo — 'AEDD' would sail through everything else and only
+    // surface as a wrong amount on somebody's screen.
+    for (const country of COUNTRIES) {
+      const currency = currencyForCountry(country.code);
+      if (!currency) continue;
+      expect(isCurrencyCode(currency), `${country.code} → ${currency}`).toBe(true);
+    }
+  });
+
+  it('gets the three-decimal Gulf currencies right', () => {
+    // The one this list could quietly break. `minorUnitExponent` defaults to 2
+    // for anything it does not know, so a missing entry does not throw — it
+    // divides a Kuwaiti dinar by 100 instead of 1000 and loses a factor of ten
+    // on every amount.
+    expect(minorUnitExponent('KWD')).toBe(3);
+    expect(minorUnitExponent('BHD')).toBe(3);
+    expect(minorUnitExponent('OMR')).toBe(3);
+    expect(minorUnitExponent('AED')).toBe(2);
+    expect(minorUnitExponent('INR')).toBe(2);
+  });
+});
+
+describe('the country list', () => {
+  it('leads with the markets this app is for', () => {
+    // Ordered by market, not alphabetically: somebody in the Gulf should not
+    // scroll past forty countries to find theirs.
+    expect(COUNTRIES[0]?.code).toBe('IN');
+    expect(COUNTRIES.slice(0, 7).map((entry) => entry.code)).toEqual([
+      'IN',
+      'AE',
+      'SA',
+      'QA',
+      'KW',
+      'BH',
+      'OM',
+    ]);
+  });
+
+  it('has no duplicates and names everything it lists', () => {
+    const codes = COUNTRIES.map((entry) => entry.code);
+    expect(new Set(codes).size).toBe(codes.length);
+    for (const entry of COUNTRIES) {
+      expect(entry.name, entry.code).not.toBe('');
+      expect(countryName(entry.code)).toBe(entry.name);
+    }
+  });
+
+  it('does not name a country it has never heard of', () => {
+    expect(countryName('ZZ')).toBeNull();
+    expect(countryName(null)).toBeNull();
+  });
+
+  it('recognises the shape of a country code', () => {
+    expect(isCountryCode('AE')).toBe(true);
+    expect(isCountryCode('ae')).toBe(true);
+    expect(isCountryCode('en-AE')).toBe(false);
+    expect(isCountryCode('UAE')).toBe(false);
+    expect(isCountryCode('')).toBe(false);
+    expect(isCountryCode(null)).toBe(false);
+  });
+});

--- a/packages/db/prisma/migrations/20260807120000_group_country/migration.sql
+++ b/packages/db/prisma/migrations/20260807120000_group_country/migration.sql
@@ -1,0 +1,119 @@
+-- Letting a group say where it is.
+--
+-- The previous migration gave `groups` a `country_code` and the settle screen
+-- reads it, but nothing could ever write one: `baaki_create_group` had no
+-- parameter for it and every group came out NULL. Plumbing without a tap.
+--
+-- The body below is the deployed function verbatim — read back out of the live
+-- database with `pg_get_functiondef` rather than reconstructed from an earlier
+-- migration, because this function has been replaced twice and the version in
+-- `20260805050000_m2_offline_sync` is two revisions stale. (Rebuilding
+-- `baaki_record_settlement` from memory a migration ago dropped its client
+-- mutation id, which would have let a retried settlement pay somebody twice.
+-- Reading the real one first is cheap; the alternative is not.)
+--
+-- One parameter added, with a default, so every existing caller is unaffected.
+--
+-- The DROP first is not optional. `CREATE OR REPLACE` only replaces a function
+-- of the *same* arity — add a parameter and Postgres keeps both, and then a
+-- seven-argument call matches neither uniquely: `function baaki_create_group(
+-- unknown, unknown, unknown, unknown, boolean, unknown, unknown) is not
+-- unique`. Every existing caller breaks, having changed nothing.
+
+DROP FUNCTION IF EXISTS public.baaki_create_group(
+  text, text, character, text, boolean, uuid, text
+);
+
+CREATE OR REPLACE FUNCTION public.baaki_create_group(
+  p_name       text DEFAULT NULL::text,
+  p_type       text DEFAULT 'other'::text,
+  p_currency   character DEFAULT 'INR'::bpchar,
+  p_emoji      text DEFAULT NULL::text,
+  p_simplify   boolean DEFAULT true,
+  p_group_id   uuid DEFAULT NULL::uuid,
+  p_photo_path text DEFAULT NULL::text,
+  /**
+   * ISO-3166 alpha-2 — where this group settles, which decides which payment
+   * rails it is offered. NULL is a supported answer: a group that never says
+   * falls back to bank, cash and the cross-border wallets, which is what
+   * `railsFor(null)` returns.
+   */
+  p_country    char(2) DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_group_id   uuid;
+  v_member_id  uuid;
+  v_name       text := nullif(btrim(coalesce(p_name, '')), '');
+  v_country    char(2) := nullif(btrim(upper(coalesce(p_country, ''))), '');
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED: a group needs an owner'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id = v_profile_id) THEN
+    RAISE EXCEPTION 'NO_PROFILE: profile % does not exist', v_profile_id
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  -- Replaying the create half of a queue must return the same group, not a
+  -- second one — and must not let somebody else's id be hijacked (ADR-005).
+  IF p_group_id IS NOT NULL AND EXISTS (SELECT 1 FROM public.groups WHERE id = p_group_id) THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = p_group_id AND gm.profile_id = v_profile_id AND gm.left_at IS NULL
+    ) THEN
+      RAISE EXCEPTION 'GROUP_EXISTS: that group id is already taken'
+        USING ERRCODE = 'unique_violation';
+    END IF;
+    RETURN p_group_id;
+  END IF;
+
+  INSERT INTO public.groups
+    (id, name, type, default_currency, cover_emoji, simplify_debts, created_by, photo_path,
+     country_code)
+  VALUES
+    (COALESCE(p_group_id, gen_random_uuid()), v_name, p_type::"GroupType",
+     upper(p_currency), p_emoji, p_simplify, v_profile_id, p_photo_path,
+     -- Falls back to the creator's own country, because a person making a
+     -- group is almost always making it where they are. Still NULL if they
+     -- have never said either.
+     COALESCE(v_country, (SELECT country_code FROM public.profiles WHERE id = v_profile_id)))
+  RETURNING id INTO v_group_id;
+
+  INSERT INTO public.group_members (group_id, profile_id, role, joined_via)
+  VALUES (v_group_id, v_profile_id, 'admin', 'creator')
+  RETURNING id INTO v_member_id;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (v_group_id, v_member_id, 'created', 'group', v_group_id,
+          jsonb_build_object('name', v_name));
+
+  RETURN v_group_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_create_group(
+  text, text, character, text, boolean, uuid, text, char
+) TO authenticated, anon;
+
+-- A country is two letters or it is nothing. Cheap, and it stops a locale tag
+-- ('en-AE') or a full country name being written where a code belongs.
+ALTER TABLE public.groups
+  DROP CONSTRAINT IF EXISTS groups_country_code_shape;
+ALTER TABLE public.groups
+  ADD CONSTRAINT groups_country_code_shape CHECK (
+    country_code IS NULL OR country_code ~ '^[A-Z]{2}$'
+  );
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_country_code_shape;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_country_code_shape CHECK (
+    country_code IS NULL OR country_code ~ '^[A-Z]{2}$'
+  );

--- a/packages/db/test/payment-rails.test.ts
+++ b/packages/db/test/payment-rails.test.ts
@@ -160,3 +160,74 @@ describe('where a group settles', () => {
     ).rejects.toThrow(/group_members_payment_rail_known|violates/i);
   });
 });
+
+describe('creating a group somewhere', () => {
+  async function create(country: string | null, profileId: string): Promise<string> {
+    await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+      JSON.stringify({ sub: profileId, role: 'authenticated' }),
+    ]);
+    const { rows } = await client.query(
+      `SELECT baaki_create_group('Trip', 'trip', 'AED', NULL, true, NULL, NULL, $1) AS id`,
+      [country],
+    );
+    return String(rows[0].id);
+  }
+
+  it('stores the country it was told', async () => {
+    const id = await create('AE', group.profileIds[0] as string);
+    const { rows } = await client.query(`SELECT country_code FROM groups WHERE id = $1`, [id]);
+    expect(rows[0].country_code).toBe('AE');
+  });
+
+  it('falls back to the creator’s own country', async () => {
+    // Somebody making a group is almost always making it where they are, and
+    // the old client that sends seven arguments should still land somewhere
+    // sensible rather than nowhere.
+    await client.query(`UPDATE profiles SET country_code = 'SA' WHERE id = $1`, [
+      group.profileIds[0],
+    ]);
+    const id = await create(null, group.profileIds[0] as string);
+    const { rows } = await client.query(`SELECT country_code FROM groups WHERE id = $1`, [id]);
+    expect(rows[0].country_code).toBe('SA');
+  });
+
+  it('leaves it unset when nobody has ever said', async () => {
+    await client.query(`UPDATE profiles SET country_code = NULL WHERE id = $1`, [
+      group.profileIds[0],
+    ]);
+    const id = await create(null, group.profileIds[0] as string);
+    const { rows } = await client.query(`SELECT country_code FROM groups WHERE id = $1`, [id]);
+    expect(rows[0].country_code).toBeNull();
+  });
+
+  it('upper-cases a lowercase country', async () => {
+    const id = await create('ae', group.profileIds[0] as string);
+    const { rows } = await client.query(`SELECT country_code FROM groups WHERE id = $1`, [id]);
+    expect(rows[0].country_code).toBe('AE');
+  });
+
+  it('refuses a locale tag where a country code belongs', async () => {
+    // 'en-AE' is the shape most likely to arrive by accident, and char(2)
+    // would silently truncate it to 'en' — a country that does not exist.
+    await expect(
+      client.query(`UPDATE groups SET country_code = 'en' WHERE id = $1`, [group.groupId]),
+    ).rejects.toThrow(/groups_country_code_shape|violates/i);
+  });
+
+  it('still returns the same group when a create is replayed', async () => {
+    // Adding a parameter to this function is how idempotency gets lost.
+    const groupId = randomUUID();
+    await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+      JSON.stringify({ sub: group.profileIds[0], role: 'authenticated' }),
+    ]);
+    const call = `SELECT baaki_create_group('Replayed', 'trip', 'AED', NULL, true, $1, NULL, 'AE') AS id`;
+    const first = await client.query(call, [groupId]);
+    const second = await client.query(call, [groupId]);
+    expect(String(second.rows[0].id)).toBe(String(first.rows[0].id));
+
+    const { rows } = await client.query(`SELECT count(*)::int AS n FROM groups WHERE id = $1`, [
+      groupId,
+    ]);
+    expect(rows[0].n).toBe(1);
+  });
+});


### PR DESCRIPTION
#52 gave `groups` a country and taught the settle screen to read it — but nothing could ever write one. `baaki_create_group` had no parameter for it, so every group came out NULL. Plumbing with no tap. Same for the rail pair on `profiles`: `payableAt()` looked for it and no screen could set it, so **outside India nobody could be paid at all**.

Three taps.

### A new group starts where the phone is

`deviceCountry()` reads the locale's **region**, not its language. Somebody in Dubai reading the app in Hindi is in `AE` — guessing `IN` from `hi` would put them on UPI. The currency follows: a group made in the UAE starts in dirhams.

### A country picker in group settings

Each option shows the rails it brings, so the choice says what it buys rather than just listing flags. **"Not set" stays first and is a real answer** — a group whose members are in four places should settle over bank, cash, Wise and Revolut, which is exactly what `railsFor(null)` returns.

### The profile's UPI field is now a rail and a handle

Chips are whatever that person's country uses; the placeholder and the validation follow the rail, so Aani asks for a mobile number and says so. `default_vpa` is kept in step **only while the rail is UPI** — a Pix key must not masquerade as a UPI ID to the five screens still reading that column.

### `currencyForCountry` says nothing rather than guessing

A wrong currency is worse than no opinion: `INR` on a group in Berlin gets typed over once, but a plausible wrong guess gets missed. The euro is spelled out per country because there is no rule mapping a country to a currency, only a list — inferring one puts euros in Poland. A test pins the three-decimal Gulf currencies (KWD, BHD, OMR): `minorUnitExponent` defaults to 2 for anything it doesn't know, so a missing entry wouldn't throw, it would divide a Kuwaiti dinar by 100 instead of 1000.

## Two things this cost me

**`CREATE OR REPLACE` only replaces a function of the same arity.** Adding a parameter kept *both*, and every seven-argument call started failing with `function baaki_create_group(...) is not unique`. Four existing tests caught it. The `DROP` has to come first — the same trap I'd avoided on `baaki_record_settlement` one PR earlier and walked straight into here.

**The function body was read out of the live database** with `pg_get_functiondef`, not copied from a migration — this function has been replaced twice and the copy in `m2_offline_sync` is two revisions stale.

## Verification

- **core 333** (10 new), **db 221** (6 new), **mobile 92**. Typecheck, lint, `expo export --platform web` clean; no Prisma drift.
- Migration deployed; confirmed exactly one `baaki_create_group` overload live.
- New db tests cover the country falling back to the creator's own, staying NULL when nobody has said, upper-casing, rejecting a locale tag where `char(2)` would silently truncate `en-AE` to `en`, and a replayed create still returning the same group.
- Not driven on a device — the Gulf path still has no real data behind it.

## Next

Arabic and RTL, then entitlements and regional pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6