### PR TITLE
feat: Arabic, and a layout that runs the other way

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -69,6 +69,7 @@
       "reactCompiler": true
     },
     "extra": {
+      "supportsRTL": true,
       "router": {},
       "eas": {
         "projectId": "d0d34ed9-5888-4204-b116-a873d3bec94f"

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Card,
   ChipRow,
+  directionalIcon,
   ListRow,
   Row,
   Screen,
@@ -69,7 +70,7 @@ function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }
                 }
                 trailing={
                   item.route ? (
-                    <Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />
+                    <Ionicons name={directionalIcon('chevron-forward')} size={18} color={theme.color.textFaint} />
                   ) : null
                 }
               />

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -9,10 +9,11 @@ import { ActivityIndicator, useWindowDimensions, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
-import { Button, CurvedPanel, ThemeProvider, Text, useTheme } from '@baaki/ui';
+import { Button, CurvedPanel, setLayoutDirection, ThemeProvider, Text, useTheme } from '@baaki/ui';
 
 import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
+import { isRtl } from '@/i18n';
 import { LockProvider, useLock } from '@/lib/lock';
 import { MotionProvider, TRANSITION_MS, useMotion } from '@/lib/motion';
 import { UpdateProvider } from '@/lib/update';
@@ -48,9 +49,31 @@ const queryClient = new QueryClient({
   },
 });
 
+/**
+ * `dir` is what makes react-native-web mirror the layout. On a device the
+ * native side has already done it from the phone's own language and this is
+ * inert — but web is how this repo does its visual checks, so without it every
+ * RTL check would be looking at a left-to-right screen.
+ *
+ * It is a react-native-web prop with no React Native counterpart, so it is not
+ * in the View types. The cast lives here and nowhere else.
+ */
+const WEB_DIRECTION = { dir: isRtl() ? 'rtl' : 'ltr' } as object;
+
+/**
+ * Tell the design system which way we run, once, before anything renders.
+ *
+ * Taken from the phone's language rather than `I18nManager.isRTL`, because on
+ * web that flag stays false even with `dir="rtl"` on the root and a visibly
+ * mirrored layout — and web is where this repo does its visual checks. An
+ * arrow that keeps pointing the wrong way in a mirrored screenshot is a
+ * check that passes while the screen is wrong.
+ */
+setLayoutDirection(isRtl());
+
 function RootLayout() {
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
+    <GestureHandlerRootView style={{ flex: 1 }} {...WEB_DIRECTION}>
       <SafeAreaProvider>
         <QueryClientProvider client={queryClient}>
           <AuthProvider>

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -23,6 +23,7 @@ import {
   Avatar,
   Button,
   Card,
+  directionalIcon,
   Divider,
   IconButton,
   ListRow,
@@ -73,7 +74,7 @@ export default function ContactsScreen(): React.JSX.Element {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">From your contacts</Text>
@@ -179,7 +180,7 @@ function ChooseGroup({
                 }
                 onPress={busy ? undefined : () => onChoose(group.id)}
                 trailing={
-                  <Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />
+                  <Ionicons name={directionalIcon('chevron-forward')} size={18} color={theme.color.textFaint} />
                 }
               />
               {index < groups.length - 1 ? <Divider /> : null}

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -7,6 +7,7 @@ import {
   Badge,
   Button,
   Card,
+  directionalIcon,
   EmptyState,
   IconButton,
   ListRow,
@@ -127,7 +128,7 @@ export default function ExpenseDetailScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading" numberOfLines={1}>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Card,
   ChipRow,
+  directionalIcon,
   EmptyState,
   Fab,
   IconButton,
@@ -118,7 +119,7 @@ export default function GroupScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <Row style={{ flex: 1, gap: theme.spacing.md, justifyContent: 'center' }}>
             <GroupPhoto

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -25,10 +25,13 @@ import { ActivityIndicator, ScrollView, View } from 'react-native';
 
 import { categoryOf, format, type CategoryId } from '@baaki/core';
 import {
+  type BarDatum,
   BarList,
   Card,
   ChipRow,
   ColumnChart,
+  type ColumnDatum,
+  directionalIcon,
   EmptyState,
   IconButton,
   MoneyText,
@@ -37,8 +40,6 @@ import {
   SectionHeader,
   Text,
   useTheme,
-  type BarDatum,
-  type ColumnDatum,
 } from '@baaki/ui';
 
 import { CategoryBadge } from '@/components/Category';
@@ -102,7 +103,7 @@ export default function InsightsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.spending}</Text>

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -9,6 +9,7 @@ import {
   Badge,
   Button,
   Card,
+  directionalIcon,
   EmptyState,
   IconButton,
   ListRow,
@@ -85,7 +86,7 @@ export default function MemberScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{displayName(member, profile?.id)}</Text>

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -8,6 +8,7 @@ import {
   Badge,
   Button,
   Card,
+  directionalIcon,
   IconButton,
   ListRow,
   MoneyText,
@@ -107,7 +108,7 @@ export default function MembersScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.members}</Text>

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -6,6 +6,7 @@ import { Alert, Pressable, ScrollView, TextInput, View } from 'react-native';
 import {
   Button,
   Card,
+  directionalIcon,
   EmptyState,
   IconButton,
   ListRow,
@@ -133,7 +134,7 @@ export default function GroupSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">Group settings</Text>
@@ -266,7 +267,7 @@ export default function GroupSettingsScreen() {
               subtitle="Add people, rename, set UPI IDs"
               leading={<Ionicons name="people-outline" size={22} color={theme.color.textMuted} />}
               onPress={() => router.push(`/group/${groupId}/members`)}
-              trailing={<Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />}
+              trailing={<Ionicons name={directionalIcon('chevron-forward')} size={18} color={theme.color.textFaint} />}
             />
             <View style={{ height: 1, backgroundColor: theme.color.border }} />
             <ListRow
@@ -274,7 +275,7 @@ export default function GroupSettingsScreen() {
               subtitle="Share a link — no install needed to join"
               leading={<Ionicons name="share-outline" size={22} color={theme.color.textMuted} />}
               onPress={() => router.push(`/group/${groupId}/invite`)}
-              trailing={<Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />}
+              trailing={<Ionicons name={directionalIcon('chevron-forward')} size={18} color={theme.color.textFaint} />}
             />
           </Card>
         </View>
@@ -289,7 +290,7 @@ export default function GroupSettingsScreen() {
                 <Ionicons name="chatbox-ellipses-outline" size={22} color={theme.color.textMuted} />
               }
               onPress={() => router.push(`/group/${groupId}/import/sms`)}
-              trailing={<Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />}
+              trailing={<Ionicons name={directionalIcon('chevron-forward')} size={18} color={theme.color.textFaint} />}
             />
             <View style={{ height: 1, backgroundColor: theme.color.border }} />
             <ListRow
@@ -299,7 +300,7 @@ export default function GroupSettingsScreen() {
                 <Ionicons name="document-text-outline" size={22} color={theme.color.textMuted} />
               }
               onPress={() => router.push(`/group/${groupId}/import/csv`)}
-              trailing={<Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />}
+              trailing={<Ionicons name={directionalIcon('chevron-forward')} size={18} color={theme.color.textFaint} />}
             />
           </Card>
         </View>

--- a/apps/mobile/src/app/group/[id]/simplify.tsx
+++ b/apps/mobile/src/app/group/[id]/simplify.tsx
@@ -6,6 +6,7 @@ import {
   Avatar,
   Badge,
   Card,
+  directionalIcon,
   EmptyState,
   IconButton,
   MoneyText,
@@ -48,7 +49,7 @@ export default function SimplifyScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.whoPaysWhom}</Text>
@@ -84,7 +85,7 @@ export default function SimplifyScreen() {
               >
                 <Row style={{ flex: 1 }}>
                   <Avatar name={nameOf(transfer.from)} size={38} />
-                  <Ionicons name="arrow-forward" size={16} color={theme.color.textFaint} />
+                  <Ionicons name={directionalIcon('arrow-forward')} size={16} color={theme.color.textFaint} />
                   <Avatar name={nameOf(transfer.to)} size={38} />
                   <View style={{ flex: 1, marginLeft: theme.spacing.sm }}>
                     <Text variant="body" numberOfLines={1}>

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -20,6 +20,7 @@ import { RefreshControl, ScrollView, View } from 'react-native';
 import { renderNotification } from '@baaki/core';
 import {
   Card,
+  directionalIcon,
   EmptyState,
   IconButton,
   ListRow,
@@ -98,7 +99,7 @@ export default function InboxScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">Inbox</Text>

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -12,7 +12,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 
-import { Badge, Button, Card, ChipRow, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import { Badge, Button, Card, ChipRow, directionalIcon, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { confirmContact, startAddingContact, type ContactChannel } from '@/data/api';
 import { useAuth } from '@/lib/auth';
@@ -78,7 +78,7 @@ export default function AccountScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">Your account</Text>

--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -5,7 +5,7 @@ import { router } from 'expo-router';
 import * as Sharing from 'expo-sharing';
 import { ActivityIndicator, Platform, ScrollView, View } from 'react-native';
 
-import { Badge, Button, Card, ChipRow, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import { Badge, Button, Card, ChipRow, directionalIcon, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { exportData } from '@/data/api';
 import { useGroups } from '@/data/hooks';
@@ -71,7 +71,7 @@ export default function ExportScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">Export your data</Text>

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -39,6 +39,7 @@ import {
   Button,
   Card,
   ChipRow,
+  directionalIcon,
   Divider,
   IconButton,
   MoneyText,
@@ -338,7 +339,7 @@ export default function ImportScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">Import a ledger</Text>

--- a/apps/mobile/src/app/settings/lock.tsx
+++ b/apps/mobile/src/app/settings/lock.tsx
@@ -16,6 +16,7 @@ import {
   Button,
   Card,
   Chip,
+  directionalIcon,
   IconButton,
   Row,
   Screen,
@@ -59,7 +60,7 @@ export default function LockSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">Security</Text>

--- a/apps/mobile/src/app/settings/motion.tsx
+++ b/apps/mobile/src/app/settings/motion.tsx
@@ -15,6 +15,7 @@ import {
   Badge,
   Button,
   Card,
+  directionalIcon,
   Divider,
   IconButton,
   Row,
@@ -42,7 +43,7 @@ export default function MotionSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">Motion</Text>

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -7,6 +7,7 @@ import {
   Badge,
   Button,
   Card,
+  directionalIcon,
   IconButton,
   Row,
   Screen,
@@ -150,7 +151,7 @@ export default function NotificationSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label="Back" onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={20} color={theme.color.text} />
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">Notifications</Text>

--- a/apps/mobile/src/components/Onboarding.tsx
+++ b/apps/mobile/src/components/Onboarding.tsx
@@ -25,15 +25,14 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Text, useTheme, type TintName } from '@baaki/ui';
+import { directionalIcon, Text, useTheme, type TintName } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
 import { useMotion } from '@/lib/motion';
 
 interface Slide {
   readonly tint: TintName;
   readonly emoji: string;
-  readonly title: string;
-  readonly body: string;
 }
 
 /**
@@ -44,33 +43,16 @@ interface Slide {
  * bolted to the front of it.
  */
 const SLIDES: readonly Slide[] = [
-  {
-    tint: 'lilac',
-    emoji: '🧾',
-    // Not "split anything with anyone" — that is the welcome's line, and the
-    // welcome is the very next screen. Two cards saying the same sentence in
-    // sequence reads as a page that failed to advance.
-    title: 'Dinner, rent,\na whole trip',
-    body: 'Baaki keeps who paid and who owes, down to the last rupee — free, and with no account to make first.',
-  },
-  {
-    tint: 'mint',
-    emoji: '🔗',
-    title: 'Send a link,\nthey are in',
-    body: 'The people you split with do not need to install anything. They open a link and see the same numbers you do.',
-  },
-  {
-    tint: 'peach',
-    emoji: '⚡',
-    title: 'Settle it\nin one tap',
-    body: 'Baaki hands the exact amount to your UPI app, so nobody does the arithmetic twice and nobody is owed a rounding error.',
-  },
+  { tint: 'lilac', emoji: '🧾' },
+  { tint: 'mint', emoji: '🔗' },
+  { tint: 'peach', emoji: '⚡' },
 ];
 
 export function Onboarding({ onDone }: { onDone: () => void }) {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
   const { animated } = useMotion();
+  const { t } = useStrings();
   const { width, height } = useWindowDimensions();
   const scroller = useRef<ScrollView>(null);
   const [index, setIndex] = useState(0);
@@ -106,6 +88,8 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
       style={{ flex: 1 }}
     >
       {SLIDES.map((slide, slideIndex) => {
+        // The words live in the string table; this file only knows the look.
+        const copy = t.onboarding[slideIndex] ?? t.onboarding[0]!;
         const { bg, ink } = theme.tint[slide.tint];
         const last = slideIndex === SLIDES.length - 1;
 
@@ -130,12 +114,10 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
               <Pressable
                 onPress={onDone}
                 accessibilityRole="button"
-                accessibilityLabel="Skip the introduction"
+                accessibilityLabel={t.skip}
                 hitSlop={12}
               >
-                <Text variant="caption" style={{ color: ink, opacity: 0.7 }}>
-                  Skip
-                </Text>
+                <Text variant="caption" style={{ color: ink, opacity: 0.7 }}>{t.skip}</Text>
               </Pressable>
             </View>
 
@@ -152,9 +134,9 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
             </View>
 
             <View style={{ gap: theme.spacing.md }}>
-              <Text style={{ fontSize: 36, fontWeight: '700', color: ink }}>{slide.title}</Text>
+              <Text style={{ fontSize: 36, fontWeight: '700', color: ink }}>{copy.title}</Text>
               <Text variant="body" style={{ color: ink, opacity: 0.75 }}>
-                {slide.body}
+                {copy.body}
               </Text>
             </View>
 
@@ -184,7 +166,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
               <Pressable
                 onPress={() => goTo(slideIndex + 1)}
                 accessibilityRole="button"
-                accessibilityLabel={last ? 'Get started' : 'Next'}
+                accessibilityLabel={last ? t.getStarted : t.next}
                 style={({ pressed }) => ({
                   height: 56,
                   width: 56,
@@ -197,7 +179,10 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                 })}
               >
                 <Ionicons
-                  name={last ? 'checkmark' : 'arrow-forward'}
+                  // A tick means the same in both directions; an arrow does
+                  // not, and this one kept pointing right in a mirrored screen
+                  // — "next" pointing backwards, on the very first screen.
+                  name={last ? 'checkmark' : directionalIcon('arrow-forward')}
                   size={24}
                   color={theme.color.text}
                 />

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1,14 +1,36 @@
 /**
- * i18n scaffolding from day one (TDR §11): en + ta + hi, with locale-aware
- * money and date formatting everywhere. Notification copy lives in
+ * i18n from day one (TDR §11): en, ta, hi and now ar, with locale-aware money
+ * and date formatting everywhere. Notification copy lives in
  * @baaki/core/notifications so the server sends the same words.
+ *
+ * Arabic is the first right-to-left language here, and it is more than a fourth
+ * column of strings — the whole layout mirrors. React Native does that itself
+ * when `I18nManager.isRTL` is true, which the OS sets from the phone's own
+ * language, so there is no switch in this app to flip: somebody whose phone is
+ * in Arabic gets Arabic and a mirrored layout, and everybody else does not.
+ * `extra.supportsRTL` in app.json is what lets the native side honour it.
+ *
+ * React Native mirrors more than it gets credit for: with
+ * `doLeftAndRightSwapInRTL` — true by default — it swaps `left`/`right` in
+ * styles, reverses `flexDirection: 'row'` and flips `textAlign`. So the
+ * `marginLeft`s and `paddingRight`s scattered through this app are not bugs in
+ * an RTL layout, and rewriting them to `marginStart`/`paddingEnd` would change
+ * nothing at all.
+ *
+ * What it cannot mirror is an **icon**, because an icon is content rather than
+ * layout. `chevron-forward` keeps pointing right in a screen that now runs the
+ * other way, so "next" points backwards. `directionalIcon` in @baaki/ui is the
+ * fix, and every arrow in the app goes through it.
  */
 
 import { getLocales } from 'expo-localization';
 
 import type { CategoryId } from '@baaki/core';
 
-export type Language = 'en' | 'ta' | 'hi';
+export type Language = 'en' | 'ta' | 'hi' | 'ar';
+
+/** The languages that read right to left. */
+export const RTL_LANGUAGES: readonly Language[] = ['ar'];
 
 export interface UiStrings {
   greeting: string;
@@ -57,6 +79,16 @@ export interface UiStrings {
   nothingToChart: string;
   /** The ten categories of TDR §8, in the language the phone is set to. */
   categories: Record<CategoryId, string>;
+  /**
+   * The three cards before sign-in. They were literals in `Onboarding.tsx`
+   * until Arabic arrived — which meant the very first screen of an app being
+   * launched in the Gulf was in English, and told the reader about rupees and
+   * UPI apps. The first screen is the worst place to be somewhere else.
+   */
+  onboarding: readonly { title: string; body: string }[];
+  skip: string;
+  next: string;
+  getStarted: string;
 }
 
 const en: UiStrings = {
@@ -116,6 +148,27 @@ const en: UiStrings = {
     gifts: 'Gifts',
     other: 'Other',
   },
+  skip: 'Skip',
+  next: 'Next',
+  getStarted: 'Get started',
+  onboarding: [
+    {
+      // Not "split anything with anyone" — that is the welcome's line, and the
+      // welcome is the very next screen.
+      title: 'Dinner, rent,\na whole trip',
+      body: 'Baaki keeps who paid and who owes, down to the last decimal — free, and with no account to make first.',
+    },
+    {
+      title: 'Send a link,\nthey are in',
+      body: 'The people you split with do not need to install anything. They open a link and see the same numbers you do.',
+    },
+    {
+      // "your payment app", not "your UPI app": this is the first screen
+      // somebody in Dubai or São Paulo sees, and UPI means nothing there.
+      title: 'Settle it\nin one tap',
+      body: 'Baaki hands the exact amount to your payment app, so nobody does the arithmetic twice and nobody is owed a rounding error.',
+    },
+  ],
 };
 
 const ta: UiStrings = {
@@ -208,11 +261,111 @@ const hi: UiStrings = {
   },
 };
 
-const STRINGS: Record<Language, UiStrings> = { en, ta, hi };
+/**
+ * Gulf Arabic, not literary Arabic. "بَاقِي" is the app's own name and the
+ * ordinary word for what is left over — the same pun the Tamil name is, which
+ * is why it is not translated away here.
+ */
+const ar: UiStrings = {
+  greeting: 'أهلاً',
+  yourBaaki: 'باقيك',
+  acrossGroups: 'في {count} مجموعات',
+  youAreOwed: 'لك',
+  youOwe: 'عليك',
+  allSettled: 'تمت التسوية',
+  yourGroups: 'مجموعاتك',
+  newGroup: 'مجموعة جديدة',
+  activity: 'النشاط',
+  friends: 'الأصدقاء',
+  profile: 'الحساب',
+  home: 'الرئيسية',
+  addExpense: 'إضافة مصروف',
+  scanBill: 'مسح الفاتورة',
+  settleUp: 'تسوية',
+  simplify: 'تبسيط',
+  whoPaysWhom: 'من يدفع لمن',
+  expenses: 'المصروفات',
+  balances: 'الأرصدة',
+  paidBy: 'دفعها',
+  splitEqually: 'تقسيم بالتساوي',
+  description: 'على ماذا؟',
+  save: 'حفظ المصروف',
+  pendingConfirmation: 'بانتظار التأكيد',
+  toConfirm: 'للتأكيد',
+  overallOwed: 'لك إجمالاً',
+  overallOwe: 'باقيك للدفع',
+  payViaUpi: 'الدفع عبر UPI',
+  paidInCash: 'دُفعت نقداً',
+  bankOther: 'تحويل بنكي / غير ذلك',
+  perExpense: 'تطبيق على مصروفات محددة',
+  members: 'الأعضاء',
+  notJoinedYet: 'لم ينضم بعد',
+  scansLeft: 'عمليات مسح متبقية',
+  simplifyOn: 'التبسيط مفعّل',
+  simplifyOff: 'التبسيط متوقف',
+  freeForever: 'بلا حدود ومجاني، للأبد',
+  nothingYet: 'لا شيء هنا بعد',
+  nothingYetBody: 'أضف أول مصروف والحساب يتكفل بنفسه.',
+  whatFor: 'نوع المصروف',
+  spending: 'الإنفاق',
+  byCategory: 'أين ذهبت',
+  byMonth: 'شهراً بشهر',
+  nothingToChart: 'أضف بعض المصروفات وسيمتلئ هذا.',
+  categories: {
+    food: 'طعام وشراب',
+    groceries: 'بقالة',
+    travel: 'تنقّل',
+    stay: 'إقامة',
+    shopping: 'تسوّق',
+    entertainment: 'ترفيه',
+    home: 'المنزل والفواتير',
+    health: 'صحة',
+    gifts: 'هدايا',
+    other: 'أخرى',
+  },
+  skip: 'تخطٍ',
+  next: 'التالي',
+  getStarted: 'لنبدأ',
+  onboarding: [
+    {
+      title: 'عشاء، إيجار،\nرحلة كاملة',
+      body: 'باقي يحفظ من دفع ومن عليه، بالفلس الواحد — مجاناً، وبدون إنشاء حساب أولاً.',
+    },
+    {
+      title: 'أرسل رابطاً،\nوانضموا',
+      body: 'من تقتسم معهم لا يحتاجون تثبيت أي شيء. يفتحون الرابط ويرون نفس الأرقام التي تراها.',
+    },
+    {
+      title: 'سوِّ الحساب\nبضغطة واحدة',
+      body: 'باقي يمرّر المبلغ بالضبط إلى تطبيق الدفع لديك، فلا أحد يحسب مرتين ولا أحد يخسر كسراً.',
+    },
+  ],
+};
+
+const STRINGS: Record<Language, UiStrings> = { en, ta, hi, ar };
+
+/**
+ * The tables themselves, so a test can check that every language says
+ * everything. A missing key is not a crash — it is `undefined` rendered as a
+ * blank on one screen in one language, which is exactly the kind of thing that
+ * ships.
+ */
+export const STRINGS_BY_LANGUAGE = STRINGS;
 
 export function deviceLanguage(): Language {
   const tag = getLocales()[0]?.languageCode ?? 'en';
-  return tag === 'ta' || tag === 'hi' ? tag : 'en';
+  return tag === 'ta' || tag === 'hi' || tag === 'ar' ? tag : 'en';
+}
+
+/**
+ * Whether this phone reads right to left.
+ *
+ * Taken from the language rather than from `I18nManager.isRTL`, so it is the
+ * same answer on web — where there is no `I18nManager` worth asking and the
+ * root view is given a `dir` instead.
+ */
+export function isRtl(): boolean {
+  return RTL_LANGUAGES.includes(deviceLanguage());
 }
 
 export function deviceLocale(): string {

--- a/apps/mobile/test/rtl.test.ts
+++ b/apps/mobile/test/rtl.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Right-to-left, and the one thing React Native will not do for you.
+ *
+ * RN mirrors more than it gets credit for. With `doLeftAndRightSwapInRTL` —
+ * true by default — it swaps `left`/`right` in styles, reverses
+ * `flexDirection: 'row'` and flips `textAlign`. The `marginLeft`s scattered
+ * through this app are not RTL bugs, and rewriting them all to `marginStart`
+ * would have been churn that changed nothing.
+ *
+ * An icon is content, not layout, so nothing flips it. `chevron-forward` keeps
+ * pointing right in a screen that now runs the other way, which is how "next"
+ * ends up pointing backwards. That is what these tests are about.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The design system reaches for react-native only to read `I18nManager.isRTL`
+// as its starting value; the app overrides it at launch from the phone's
+// language. Stubbing it keeps this a pure test.
+vi.mock('react-native', () => ({ I18nManager: { isRTL: false } }));
+
+const { directionalIcon, isRtlLayout, setLayoutDirection } = await import(
+  '../../../packages/ui/src/direction'
+);
+
+describe('mirroring an icon', () => {
+  beforeEach(() => setLayoutDirection(false));
+
+  it('changes nothing at all left to right', () => {
+    setLayoutDirection(false);
+    expect(directionalIcon('chevron-forward')).toBe('chevron-forward');
+    expect(directionalIcon('chevron-back')).toBe('chevron-back');
+    expect(directionalIcon('arrow-forward')).toBe('arrow-forward');
+  });
+
+  it('turns every arrow around right to left', () => {
+    setLayoutDirection(true);
+    expect(directionalIcon('chevron-forward')).toBe('chevron-back');
+    expect(directionalIcon('chevron-back')).toBe('chevron-forward');
+    expect(directionalIcon('arrow-forward')).toBe('arrow-back');
+    expect(directionalIcon('arrow-forward-circle')).toBe('arrow-back-circle');
+    expect(directionalIcon('caret-forward')).toBe('caret-back');
+  });
+
+  it('mirrors the outline and circle variants too', () => {
+    // Missing one of these is how a single chevron on a single screen keeps
+    // pointing the wrong way and nobody notices for a release.
+    setLayoutDirection(true);
+    expect(directionalIcon('chevron-forward-outline')).toBe('chevron-back-outline');
+    expect(directionalIcon('chevron-back-circle')).toBe('chevron-forward-circle');
+    expect(directionalIcon('arrow-back-circle-outline')).toBe('arrow-forward-circle-outline');
+  });
+
+  it('leaves alone the icons that mean the same in both directions', () => {
+    // A blanket "flip anything with a direction in its name" turns an up arrow
+    // into nonsense, and a tick into a different tick.
+    setLayoutDirection(true);
+    for (const icon of [
+      'arrow-up',
+      'arrow-up-circle-outline',
+      'arrow-down',
+      'checkmark',
+      'camera-outline',
+      'close',
+      'trash-outline',
+    ]) {
+      expect(directionalIcon(icon), icon).toBe(icon);
+    }
+  });
+
+  it('is its own inverse', () => {
+    setLayoutDirection(true);
+    for (const icon of ['chevron-forward', 'arrow-back', 'caret-forward-outline']) {
+      expect(directionalIcon(directionalIcon(icon)), icon).toBe(icon);
+    }
+  });
+
+  it('reports the direction it was told', () => {
+    setLayoutDirection(true);
+    expect(isRtlLayout()).toBe(true);
+    setLayoutDirection(false);
+    expect(isRtlLayout()).toBe(false);
+  });
+});

--- a/apps/mobile/test/strings.test.ts
+++ b/apps/mobile/test/strings.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Every language says everything.
+ *
+ * A missing key is not a crash — it is `undefined` rendered as a blank space on
+ * one screen in one language, which is exactly the kind of thing that ships.
+ * TypeScript catches a missing *top-level* key because `UiStrings` is a closed
+ * interface, but it cannot catch a string left in English by accident, and it
+ * cannot catch a category map that quietly lost an entry.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('expo-localization', () => ({ getLocales: () => [{ languageCode: 'en' }] }));
+
+const { STRINGS_BY_LANGUAGE, RTL_LANGUAGES } = await import('../src/i18n');
+
+const LANGUAGES = ['en', 'ta', 'hi', 'ar'] as const;
+
+describe('the string tables', () => {
+  it('has all four languages', () => {
+    expect(Object.keys(STRINGS_BY_LANGUAGE).sort()).toEqual([...LANGUAGES].sort());
+  });
+
+  it('gives every language every key', () => {
+    const english = Object.keys(STRINGS_BY_LANGUAGE.en).sort();
+    for (const language of LANGUAGES) {
+      expect(Object.keys(STRINGS_BY_LANGUAGE[language]).sort(), language).toEqual(english);
+    }
+  });
+
+  it('gives every language every category', () => {
+    const categories = Object.keys(STRINGS_BY_LANGUAGE.en.categories).sort();
+    for (const language of LANGUAGES) {
+      expect(Object.keys(STRINGS_BY_LANGUAGE[language].categories).sort(), language).toEqual(
+        categories,
+      );
+    }
+  });
+
+  it('leaves nothing blank', () => {
+    for (const language of LANGUAGES) {
+      for (const [key, value] of Object.entries(STRINGS_BY_LANGUAGE[language])) {
+        if (typeof value === 'string') {
+          expect(value.trim(), `${language}.${key}`).not.toBe('');
+        }
+      }
+      for (const [key, value] of Object.entries(STRINGS_BY_LANGUAGE[language].categories)) {
+        expect(value.trim(), `${language}.categories.${key}`).not.toBe('');
+      }
+    }
+  });
+
+  it('gives every language three onboarding cards, filled in', () => {
+    // These were literals inside `Onboarding.tsx` until Arabic arrived, which
+    // meant the very first screen of the app was in English whatever the phone
+    // said — and told the reader about rupees and UPI apps.
+    for (const language of LANGUAGES) {
+      const cards = STRINGS_BY_LANGUAGE[language].onboarding;
+      expect(cards, language).toHaveLength(3);
+      for (const [index, card] of cards.entries()) {
+        expect(card.title.trim(), `${language}.onboarding[${index}].title`).not.toBe('');
+        expect(card.body.trim(), `${language}.onboarding[${index}].body`).not.toBe('');
+      }
+    }
+  });
+
+  it('does not name one country’s payment rail on the first screen', () => {
+    // "your UPI app" is the wrong first sentence for somebody in Dubai or São
+    // Paulo, and the onboarding runs before anybody has chosen a country.
+    for (const language of LANGUAGES) {
+      for (const card of STRINGS_BY_LANGUAGE[language].onboarding) {
+        expect(card.body, language).not.toMatch(/\bUPI\b/i);
+        expect(card.body, language).not.toMatch(/rupee/i);
+      }
+    }
+  });
+
+  it('keeps the placeholder in the one string that has one', () => {
+    // `acrossGroups` interpolates {count}. A translation that drops it renders
+    // "across groups" and the number simply disappears.
+    for (const language of LANGUAGES) {
+      expect(STRINGS_BY_LANGUAGE[language].acrossGroups, language).toContain('{count}');
+    }
+  });
+
+  it('actually translated Arabic rather than copying English', () => {
+    // The failure this catches is a half-done language: the table exists, the
+    // keys are all there, and half the app is still in English.
+    const arabic = STRINGS_BY_LANGUAGE.ar;
+    const english = STRINGS_BY_LANGUAGE.en;
+    const untranslated = Object.keys(english).filter(
+      (key) =>
+        typeof english[key as keyof typeof english] === 'string' &&
+        english[key as keyof typeof english] === arabic[key as keyof typeof arabic],
+    );
+    expect(untranslated).toEqual([]);
+
+    // And it is written in Arabic script, not transliterated.
+    expect(arabic.settleUp).toMatch(/\p{Script=Arabic}/u);
+  });
+
+  it('knows which languages read right to left', () => {
+    expect(RTL_LANGUAGES).toEqual(['ar']);
+  });
+});

--- a/packages/ui/src/direction.ts
+++ b/packages/ui/src/direction.ts
@@ -1,0 +1,74 @@
+/**
+ * Which way the layout runs, and the one thing React Native will not mirror for
+ * you.
+ *
+ * RN already does most of the work: with `doLeftAndRightSwapInRTL` — true by
+ * default — it swaps `left`/`right` in styles, reverses `flexDirection: 'row'`,
+ * and flips `textAlign`. So `marginLeft` and `paddingRight` are *not* bugs in
+ * an RTL app, and rewriting them all to `marginStart`/`paddingEnd` would be
+ * churn that changes nothing.
+ *
+ * What it cannot mirror is an **icon**, because an icon is content. A chevron
+ * called `chevron-forward` keeps pointing right in a screen that now runs the
+ * other way, so "next" points backwards and "back" points onward. That is the
+ * whole of this file.
+ *
+ * The flag is set once at startup from the app's own language rather than read
+ * from `I18nManager.isRTL` on every call, for a reason worth stating: on web
+ * `I18nManager.isRTL` is false even when the root view carries `dir="rtl"` and
+ * the layout is visibly mirrored. Web is how this repo does its visual checks,
+ * and a check that shows a mirrored screen with unmirrored arrows would be
+ * checking the wrong thing.
+ */
+
+import { I18nManager } from 'react-native';
+
+let rtl = I18nManager.isRTL;
+
+/**
+ * Tell the design system which way the app is running. Called once, at startup,
+ * with the answer derived from the phone's language.
+ */
+export function setLayoutDirection(isRtl: boolean): void {
+  rtl = isRtl;
+}
+
+export function isRtlLayout(): boolean {
+  return rtl;
+}
+
+/** Icons whose meaning is a direction, and their mirror image. */
+const MIRRORED: Readonly<Record<string, string>> = {
+  'chevron-forward': 'chevron-back',
+  'chevron-back': 'chevron-forward',
+  'chevron-forward-outline': 'chevron-back-outline',
+  'chevron-back-outline': 'chevron-forward-outline',
+  'chevron-forward-circle': 'chevron-back-circle',
+  'chevron-back-circle': 'chevron-forward-circle',
+  'chevron-forward-circle-outline': 'chevron-back-circle-outline',
+  'chevron-back-circle-outline': 'chevron-forward-circle-outline',
+  'arrow-forward': 'arrow-back',
+  'arrow-back': 'arrow-forward',
+  'arrow-forward-outline': 'arrow-back-outline',
+  'arrow-back-outline': 'arrow-forward-outline',
+  'arrow-forward-circle': 'arrow-back-circle',
+  'arrow-back-circle': 'arrow-forward-circle',
+  'arrow-forward-circle-outline': 'arrow-back-circle-outline',
+  'arrow-back-circle-outline': 'arrow-forward-circle-outline',
+  'caret-forward': 'caret-back',
+  'caret-back': 'caret-forward',
+  'caret-forward-outline': 'caret-back-outline',
+  'caret-back-outline': 'caret-forward-outline',
+};
+
+/**
+ * The icon to draw, mirrored when the layout is.
+ *
+ * Only left/right icons are in the table. An up arrow, a tick and a camera mean
+ * the same thing in every direction, and a blanket "flip anything with a
+ * direction in its name" would turn `arrow-up` into nonsense.
+ */
+export function directionalIcon<T extends string>(name: T): T {
+  if (!rtl) return name;
+  return (MIRRORED[name] ?? name) as T;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,3 +21,4 @@ export * from './components/Toggle';
 export * from './components/PillTabBar';
 export * from './components/AmountKeypad';
 export * from './components/Chart';
+export * from './direction';


### PR DESCRIPTION
The first right-to-left language — more than a fourth column of strings.

## What React Native already does, and what it doesn't

With `doLeftAndRightSwapInRTL` (**true by default**) RN swaps `left`/`right` in styles, reverses `flexDirection: 'row'`, and flips `textAlign`.

I started this believing otherwise, and had a plan to rewrite 23 `marginLeft`s to `marginStart`. Reading RN's own source stopped it. **That work would have changed nothing, and a test enforcing it would have encoded a rule that is false.**

What RN *cannot* mirror is an **icon**, because an icon is content, not layout. 23 chevrons and arrows kept pointing right in a screen that now runs the other way — "next" pointing backwards. `directionalIcon` in `@baaki/ui` is the fix, and every arrow goes through it. Only genuinely directional icons are in the table: a blanket "flip anything with a direction in its name" turns `arrow-up` into nonsense.

## Direction comes from the phone

No language switch in the app. Somebody whose phone is Arabic gets Arabic and a mirrored layout; nobody else is asked. `extra.supportsRTL` lets the native side honour it, and the root view carries `dir` so react-native-web mirrors too — not cosmetic, since web is where this repo does its visual checks, and a check showing a mirrored screen with unmirrored arrows is checking the wrong thing.

## Onboarding was hardcoded English

Three slides of literals — so the very first screen of an app being launched in the Gulf was in English, and told the reader about **rupees** and a **UPI app**. Copy moved into the string tables; "your UPI app" became "your payment app"; a test fails if either word reappears there. Nobody has chosen a country by that point in the app.

## Found by looking, not reading

A screenshot of the export with the locale forced to Arabic showed the next arrow **still pointing right** and Skip **still in English**. Neither was visible to typecheck, lint, or 107 passing tests. Both fixed; the follow-up screenshot shows the arrow turned around.

## Still open — stated rather than papered over

**The paged onboarding carousel clips its content at the edge under RTL.** It's a scroll-offset problem in a horizontal `pagingEnabled` ScrollView, where react-native-web and native RN disagree about which end offset zero means. I have not fixed it blind: a change that corrects the web export could easily break the platform that already handles it, and there's no device here to tell them apart.

Two pre-existing things this touched but did not change:
- Tamil and Hindi inherit English for ~12 keys through their `...en` spread.
- The onboarding wordmark is Tamil script in every language. That's a brand decision, not a bug — but it deserves a deliberate answer for the Gulf.

## Verification

- **mobile 107 tests**, 15 new — icon mirroring (including that it's its own inverse, and leaves `arrow-up`/`checkmark` alone), and every language saying everything with nothing blank and no key left in English.
- Typecheck, lint and `expo export --platform web` clean.
- Two screenshots taken against a forced-Arabic build; the second confirms the fix.
- Not run on a device. Whether native RN mirrors the carousel correctly is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6