### PR TITLE
feat: cover the United States, Canada and Australia

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -322,7 +322,7 @@ export default function ProfileScreen() {
                 <Text variant="micro" tone={handleValid ? 'faint' : 'negative'}>
                   {!handleValid
                     ? `That does not look like ${railInfo.handleHint.toLowerCase()}.`
-                    : railInfo.deepLink
+                    : railInfo.link
                       ? 'People settling with you get a one-tap payment. Baaki never handles the money.'
                       : 'People settling with you see this to pay you from their own bank app. Baaki never handles the money.'}
                 </Text>

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -177,9 +177,13 @@ export default function SettleScreen() {
       (value, code) => toMajorString({ minor: value, currency: code }),
     );
 
-    const canOpen = uri ? await Linking.canOpenURL(uri).catch(() => false) : false;
+    // An 'app' scheme is asked about first: a custom scheme with nothing
+    // installed to answer it fails silently, and a tap that looks like it
+    // worked while no money moved is the worst outcome here. An https link
+    // always opens — worst case a web page — so it needs no permission.
+    const canOpen = uri ? uri.kind === 'web' || (await Linking.canOpenURL(uri.uri).catch(() => false)) : false;
     if (uri && canOpen) {
-      await Linking.openURL(uri);
+      await Linking.openURL(uri.uri);
       Alert.alert('Did the payment go through?', 'Only record it if it actually completed.', [
         { text: 'No', style: 'cancel' },
         { text: 'Yes, record it', onPress: () => void record() },

--- a/packages/core/src/category/markets.ts
+++ b/packages/core/src/category/markets.ts
@@ -27,7 +27,20 @@ import type { CategoryId } from './categories';
  * currencies and shops are keyed by — not a language, which several of these
  * share.
  */
-export type MarketId = 'IN' | 'AE' | 'SA' | 'QA' | 'KW' | 'BH' | 'OM' | 'BR' | 'SG' | 'ID';
+export type MarketId =
+  | 'IN'
+  | 'AE'
+  | 'SA'
+  | 'QA'
+  | 'KW'
+  | 'BH'
+  | 'OM'
+  | 'BR'
+  | 'SG'
+  | 'ID'
+  | 'US'
+  | 'CA'
+  | 'AU';
 
 type Keywords = Partial<Record<CategoryId, readonly string[]>>;
 
@@ -86,6 +99,35 @@ const GULF: Keywords = {
   gifts: ['eidiya', 'eid', 'gift'],
 };
 
+/**
+ * North America and Australia share most of their chains, and the ones that
+ * differ are the ones worth naming — Tim Hortons and Presto in Canada,
+ * Woolworths and Opal in Australia. Delivery is the same three names
+ * everywhere, which is why they sit in the shared set.
+ */
+const ANGLOSPHERE: Keywords = {
+  food: [
+    'doordash',
+    'ubereats',
+    'grubhub',
+    'starbucks',
+    'chipotle',
+    'mcdonalds',
+    'subway',
+    'dominos',
+    'takeaway',
+    'takeout',
+    'coffee',
+  ],
+  groceries: ['costco', 'walmart', 'target', 'aldi', 'groceries'],
+  travel: ['uber', 'lyft', 'gas', 'petrol', 'parking', 'toll', 'flight', 'rental'],
+  stay: ['airbnb', 'hotel', 'motel', 'hostel'],
+  entertainment: ['netflix', 'spotify', 'cinema', 'movies', 'tickets', 'concert'],
+  home: ['rent', 'electricity', 'internet', 'wifi', 'utilities'],
+  health: ['pharmacy', 'dentist', 'doctor', 'gym'],
+  shopping: ['amazon', 'ikea'],
+};
+
 export const MARKET_KEYWORDS: Readonly<Record<MarketId, Keywords>> = {
   // India's vocabulary already lives in the shared list, where it was the
   // starting point. Nothing to add here; the entry exists so the type is
@@ -108,6 +150,50 @@ export const MARKET_KEYWORDS: Readonly<Record<MarketId, Keywords>> = {
     home: ['aluguel', 'condominio', 'luz', 'agua', 'internet'],
     health: ['farmacia', 'drogaria', 'medico'],
     shopping: ['shopping', 'americanas', 'magalu'],
+  },
+
+  US: {
+    ...ANGLOSPHERE,
+    groceries: [
+      ...(ANGLOSPHERE.groceries ?? []),
+      'safeway',
+      'kroger',
+      'publix',
+      'wegmans',
+      'trader',
+      'instacart',
+      'wholefoods',
+    ],
+    travel: [...(ANGLOSPHERE.travel ?? []), 'amtrak', 'metrocard', 'clipper', 'shell', 'chevron'],
+    health: [...(ANGLOSPHERE.health ?? []), 'cvs', 'walgreens'],
+  },
+
+  CA: {
+    ...ANGLOSPHERE,
+    food: [...(ANGLOSPHERE.food ?? []), 'tims', 'timhortons', 'skipthedishes', 'poutine'],
+    groceries: [
+      ...(ANGLOSPHERE.groceries ?? []),
+      'loblaws',
+      'sobeys',
+      'metro',
+      'superstore',
+      'nofrills',
+    ],
+    travel: [...(ANGLOSPHERE.travel ?? []), 'presto', 'ttc', 'via', 'petrocanada', 'esso'],
+    health: [...(ANGLOSPHERE.health ?? []), 'shoppers'],
+    // Canadians call the power bill hydro, and it is the one word here that
+    // categorises wrongly everywhere else — which is why markets are a layer.
+    home: [...(ANGLOSPHERE.home ?? []), 'hydro', 'rogers', 'telus', 'bell'],
+  },
+
+  AU: {
+    ...ANGLOSPHERE,
+    food: [...(ANGLOSPHERE.food ?? []), 'menulog', 'deliveroo', 'maccas', 'brekkie'],
+    groceries: [...(ANGLOSPHERE.groceries ?? []), 'woolworths', 'woolies', 'coles', 'iga'],
+    travel: [...(ANGLOSPHERE.travel ?? []), 'opal', 'myki', 'gocard', 'ampol', 'qantas', 'jetstar'],
+    entertainment: [...(ANGLOSPHERE.entertainment ?? []), 'hoyts', 'palace'],
+    home: [...(ANGLOSPHERE.home ?? []), 'telstra', 'optus', 'agl', 'origin'],
+    shopping: [...(ANGLOSPHERE.shopping ?? []), 'bunnings', 'kmart', 'bigw'],
   },
 
   SG: {

--- a/packages/core/src/settlement/rails.ts
+++ b/packages/core/src/settlement/rails.ts
@@ -7,17 +7,23 @@
  * here instead — a list keyed by country, which makes Brazil a new entry rather
  * than a new screen.
  *
- * **Only UPI has a deep link, and that is deliberate.**
+ * **A rail links only where somebody has published a link.**
  *
  * `upi://pay` is a published Android intent that every Indian bank app
- * implements, and it is the reason settling in Baaki takes one tap. Almost
- * nothing else works that way. Pix is a copy-and-paste key or a scanned EMV
- * code, not a URL. Zelle and Venmo have app links that are neither documented
- * nor stable, and guessing at one produces a button that silently fails on
- * somebody's phone while they believe they have paid. So a rail either has a
- * scheme we can stand behind, or it shows the payee's handle to copy and the
- * person finishes in their own bank app. A rail that admits it cannot hand off
- * is more useful than one that pretends it can.
+ * implements, and it is the reason settling in Baaki takes one tap. The danger
+ * with a custom scheme is that it fails *silently* when nothing is installed to
+ * answer it — a tap that appears to work while no money moves — so `'app'`
+ * links are checked with `canOpenURL` before they are offered.
+ *
+ * An https link is a different thing and is treated differently. `cash.app/
+ * $tag/25` and `paypal.me/user/25USD` are public, long-standing URLs whose
+ * worst case is a web page, not a lie. Those are `'web'`.
+ *
+ * Everything else shows the payee's handle to copy, and that is the ordinary
+ * case rather than a failure: Pix is a key or a scanned EMV code, not a URL;
+ * Zelle and PayID live inside each bank's own app; Venmo's app links are
+ * neither documented nor stable. A rail that admits it cannot hand off is more
+ * useful than one that pretends it can.
  *
  * Recording the settlement is separate from performing it either way — the
  * ledger has always tracked what people say they paid, confirmed by whoever was
@@ -34,6 +40,7 @@ export type RailId =
   | 'promptpay' // Thailand
   | 'qris' // Indonesia
   | 'aani' // United Arab Emirates
+  | 'payid' // Australia
   // Consumer apps.
   | 'zelle'
   | 'venmo'
@@ -41,6 +48,7 @@ export type RailId =
   | 'interac'
   | 'wise'
   | 'revolut'
+  | 'paypal'
   // Always available, everywhere.
   | 'bank'
   | 'cash'
@@ -77,10 +85,19 @@ export interface PaymentRail {
   /** Shown under the field, in the local vocabulary. */
   readonly handleHint: string;
   /**
-   * True only where a deep link is published, implemented by the banks, and
-   * has been seen to work. Everything else is copy-the-handle.
+   * How, if at all, this rail can be handed off to.
+   *
+   *   * `'app'` — a custom scheme like `upi://pay`, published and implemented
+   *     by the banks. The risk of one of these is that it fails **silently**
+   *     when nothing is installed to answer it, so the caller checks first and
+   *     falls back to showing the handle.
+   *   * `'web'` — a plain https URL such as `cash.app/$tag/25`. Different in
+   *     kind, not degree: the worst case is a web page rather than a tap that
+   *     appears to work and does not. Safe to offer without a check.
+   *   * `null` — no link anybody has published. Show the handle to copy, which
+   *     is the ordinary case and not a failure.
    */
-  readonly deepLink: boolean;
+  readonly link: 'app' | 'web' | null;
 }
 
 /**
@@ -95,7 +112,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: ['IN'],
     handle: 'vpa',
     handleHint: 'Their UPI ID, like ravi@okhdfcbank',
-    deepLink: true,
+    link: 'app',
   },
   {
     id: 'pix',
@@ -106,7 +123,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     // A Pix key is whatever the person registered — that is the whole design of
     // it, and pretending it is one shape rejects valid keys.
     handleHint: 'Their Pix key — CPF, phone, email or random key',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'paynow',
@@ -115,7 +132,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: ['SG'],
     handle: 'phone',
     handleHint: 'Their mobile number or NRIC',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'promptpay',
@@ -124,7 +141,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: ['TH'],
     handle: 'phone',
     handleHint: 'Their mobile number or national ID',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'qris',
@@ -133,7 +150,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: ['ID'],
     handle: 'phone',
     handleHint: 'Their registered mobile number',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'aani',
@@ -144,7 +161,18 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: ['AE'],
     handle: 'phone',
     handleHint: 'Their mobile number, like +971 50 123 4567',
-    deepLink: false,
+    link: null,
+  },
+  {
+    id: 'payid',
+    label: 'PayID',
+    icon: 'flash-outline',
+    // Australia's instant rail over the NPP. Like Aani and PayNow, it settles
+    // inside the bank apps by mobile number or email, with no public intent.
+    countries: ['AU'],
+    handle: 'phone',
+    handleHint: 'Their PayID — mobile number or email',
+    link: null,
   },
   {
     id: 'zelle',
@@ -153,7 +181,8 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: ['US'],
     handle: 'phone',
     handleHint: 'The mobile number or email on their Zelle',
-    deepLink: false,
+    // Zelle lives inside each bank's own app and publishes nothing to link to.
+    link: null,
   },
   {
     id: 'venmo',
@@ -162,7 +191,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: ['US'],
     handle: 'tag',
     handleHint: 'Their Venmo handle, like @ravi-kumar',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'cashapp',
@@ -171,7 +200,21 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: ['US', 'GB'],
     handle: 'tag',
     handleHint: 'Their $cashtag',
-    deepLink: false,
+    // `cash.app/$tag/25` is a public, long-standing URL: it opens the app when
+    // it is installed and a web page when it is not, so there is no silent
+    // failure to protect anybody from. Dollars only — see `buildPaymentUri`.
+    link: 'web',
+  },
+  {
+    id: 'paypal',
+    label: 'PayPal',
+    icon: 'globe-outline',
+    // PayPal.me works in every market Baaki is going to, and is the one link
+    // somebody in the US, Canada or Australia can send to somebody in India.
+    countries: 'any',
+    handle: 'tag',
+    handleHint: 'Their PayPal.me name',
+    link: 'web',
   },
   {
     id: 'interac',
@@ -180,7 +223,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: ['CA'],
     handle: 'email',
     handleHint: 'The email on their Interac',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'wise',
@@ -191,7 +234,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: 'any',
     handle: 'email',
     handleHint: 'The email on their Wise account',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'revolut',
@@ -200,7 +243,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: 'any',
     handle: 'tag',
     handleHint: 'Their @revtag',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'bank',
@@ -209,7 +252,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: 'any',
     handle: 'account',
     handleHint: 'Their IBAN or account number',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'cash',
@@ -218,7 +261,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: 'any',
     handle: 'none',
     handleHint: '',
-    deepLink: false,
+    link: null,
   },
   {
     id: 'other',
@@ -227,7 +270,7 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     countries: 'any',
     handle: 'none',
     handleHint: '',
-    deepLink: false,
+    link: null,
   },
 ];
 
@@ -321,6 +364,18 @@ export function isValidHandle(railId: string, handle: string): boolean {
   }
 }
 
+/**
+ * Where a link leads, and how much to trust it.
+ *
+ * The caller needs the difference: an `'app'` URI has to be offered to
+ * `canOpenURL` first, because a custom scheme with nothing installed to answer
+ * it fails silently. A `'web'` one can be opened as it is.
+ */
+export interface PaymentLink {
+  readonly kind: 'app' | 'web';
+  readonly uri: string;
+}
+
 export interface PaymentLinkInput {
   readonly railId: string;
   readonly handle: string;
@@ -340,26 +395,53 @@ export interface PaymentLinkInput {
 export function buildPaymentUri(
   input: PaymentLinkInput,
   formatMajor: (amount: bigint, currency: CurrencyCode) => string,
-): string | null {
+): PaymentLink | null {
   const rail = railById(input.railId);
-  if (!rail?.deepLink) return null;
+  if (!rail?.link) return null;
   if (!isValidHandle(input.railId, input.handle)) return null;
+
+  const handle = input.handle.trim();
+  const major = formatMajor(input.amount, input.currency);
 
   if (rail.id === 'upi') {
     // Built by hand rather than with URLSearchParams: this package has to
     // compile unchanged for React Native, Deno and the browser.
     const params: [string, string][] = [
-      ['pa', input.handle.trim()],
+      ['pa', handle],
       ['pn', input.payeeName],
-      ['am', formatMajor(input.amount, input.currency)],
+      ['am', major],
       ['cu', input.currency],
     ];
     if (input.note) params.push(['tn', input.note.slice(0, 50)]);
     const query = params
       .map(([key, value]) => `${key}=${encodeURIComponent(value).replace(/%20/g, '+')}`)
       .join('&');
-    return `upi://pay?${query}`;
+    return { kind: 'app', uri: `upi://pay?${query}` };
+  }
+
+  if (rail.id === 'cashapp') {
+    // Cash App settles in dollars. A link carrying "25" for an amount that is
+    // 25 pounds would open a request for 25 of something else, which is worse
+    // than no link — so anything but USD copies the handle instead.
+    if (input.currency !== 'USD') return null;
+    return { kind: 'web', uri: `https://cash.app/${encodeURIComponent(cashtag(handle))}/${major}` };
+  }
+
+  if (rail.id === 'paypal') {
+    // PayPal.me takes the currency in the path, so unlike Cash App it is safe
+    // in any of them.
+    const name = handle.replace(/^@/, '');
+    return {
+      kind: 'web',
+      uri: `https://paypal.me/${encodeURIComponent(name)}/${major}${input.currency}`,
+    };
   }
 
   return null;
+}
+
+/** `$ravi` from `ravi`, `$ravi` or `@ravi` — Cash App's URLs want the dollar. */
+function cashtag(handle: string): string {
+  const bare = handle.replace(/^[@$]/, '');
+  return `$${bare}`;
 }

--- a/packages/core/test/category.test.ts
+++ b/packages/core/test/category.test.ts
@@ -136,3 +136,58 @@ describe('a market adds its own vocabulary', () => {
     expect(guessCategory('du bill', 'AE')).toBe('home');
   });
 });
+
+describe('North America and Australia', () => {
+  it('reads an ordinary American expense', () => {
+    expect(guessCategory('DoorDash dinner', 'US')).toBe('food');
+    expect(guessCategory('Lyft home', 'US')).toBe('travel');
+    expect(guessCategory('Trader Joes run', 'US')).toBe('groceries');
+    expect(guessCategory('CVS pharmacy', 'US')).toBe('health');
+  });
+
+  it('reads a Canadian one', () => {
+    expect(guessCategory('Tims coffee', 'CA')).toBe('food');
+    expect(guessCategory('Loblaws shop', 'CA')).toBe('groceries');
+    expect(guessCategory('Presto top up', 'CA')).toBe('travel');
+  });
+
+  it('reads an Australian one', () => {
+    expect(guessCategory('Woolies shop', 'AU')).toBe('groceries');
+    expect(guessCategory('Opal card', 'AU')).toBe('travel');
+    expect(guessCategory('Menulog dinner', 'AU')).toBe('food');
+    expect(guessCategory('Bunnings trip', 'AU')).toBe('shopping');
+  });
+
+  it('shares the chains the three of them actually share', () => {
+    for (const country of ['US', 'CA', 'AU']) {
+      expect(guessCategory('Uber to the airport', country), country).toBe('travel');
+      expect(guessCategory('Airbnb for the weekend', country), country).toBe('stay');
+      expect(guessCategory('Costco haul', country), country).toBe('groceries');
+    }
+  });
+
+  it('keeps a word that means different things in different places local', () => {
+    // 'hydro' is the power bill in Canada and nothing at all elsewhere.
+    expect(guessCategory('Hydro bill', 'CA')).toBe('home');
+    expect(guessCategory('Hydro bill', 'US')).toBeNull();
+    expect(guessCategory('Hydro bill', 'IN')).toBeNull();
+  });
+
+  it('does not leak one market’s vocabulary into another', () => {
+    expect(guessCategory('Woolies', 'US')).toBeNull();
+    expect(guessCategory('Talabat', 'CA')).toBeNull();
+    expect(guessCategory('Menulog', 'US')).toBeNull();
+    expect(guessCategory('Presto', 'AU')).toBeNull();
+  });
+
+  it('still knows the shared list everywhere, India’s brands included', () => {
+    // Worth stating rather than discovering: the base list in categories.ts is
+    // India-flavoured — swiggy, zomato, irctc, kirana — and it applies in every
+    // market, not just IN. Harmless (nobody in Sydney types "Swiggy") and
+    // deliberate: a group that has never set a country would otherwise lose
+    // the categorisation it has today.
+    for (const country of ['US', 'CA', 'AU', null]) {
+      expect(guessCategory('Swiggy', country), String(country)).toBe('food');
+    }
+  });
+});

--- a/packages/core/test/rails.test.ts
+++ b/packages/core/test/rails.test.ts
@@ -76,16 +76,23 @@ describe('what a country can pay with', () => {
 });
 
 describe('a rail never claims a hand-off it does not have', () => {
-  it('marks only UPI as deep-linkable', () => {
-    // Guessing at a scheme produces a button that silently fails on somebody's
-    // phone while they believe they have paid. If this list ever grows, it
-    // grows because somebody watched the link open a real bank app.
-    const linkable = PAYMENT_RAILS.filter((rail) => rail.deepLink).map((rail) => rail.id);
-    expect(linkable).toEqual(['upi']);
+  it('keeps custom schemes to the one that is published', () => {
+    // An 'app' scheme is the dangerous kind: it fails silently when nothing is
+    // installed to answer it. If this list ever grows, it grows because
+    // somebody watched the link open a real bank app.
+    const schemes = PAYMENT_RAILS.filter((rail) => rail.link === 'app').map((rail) => rail.id);
+    expect(schemes).toEqual(['upi']);
+  });
+
+  it('allows an https link only where the URL is public and stable', () => {
+    // These are a different risk: the worst case is a web page, not a tap that
+    // appears to work while no money moves.
+    const web = PAYMENT_RAILS.filter((rail) => rail.link === 'web').map((rail) => rail.id);
+    expect(web).toEqual(['cashapp', 'paypal']);
   });
 
   it('returns null for every rail that cannot hand off', () => {
-    for (const rail of PAYMENT_RAILS.filter((entry) => !entry.deepLink)) {
+    for (const rail of PAYMENT_RAILS.filter((entry) => entry.link === null)) {
       const uri = buildPaymentUri(
         {
           railId: rail.id,
@@ -112,10 +119,11 @@ describe('a rail never claims a hand-off it does not have', () => {
       },
       major,
     );
-    expect(uri).toContain('upi://pay?');
-    expect(uri).toContain('pa=ravi%40okhdfcbank');
-    expect(uri).toContain('cu=INR');
-    expect(uri).toContain('pn=Ravi+Kumar');
+    expect(uri?.kind).toBe('app');
+    expect(uri?.uri).toContain('upi://pay?');
+    expect(uri?.uri).toContain('pa=ravi%40okhdfcbank');
+    expect(uri?.uri).toContain('cu=INR');
+    expect(uri?.uri).toContain('pn=Ravi+Kumar');
   });
 
   it('refuses to build a link from a handle that is not one', () => {
@@ -180,6 +188,88 @@ describe('the list itself', () => {
     for (const rail of PAYMENT_RAILS) {
       if (rail.handle === 'none') continue;
       expect(rail.handleHint, `${rail.id} needs a hint`).not.toBe('');
+    }
+  });
+});
+
+describe('the markets Baaki is going to next', () => {
+  it('gives Australia its own instant rail', () => {
+    // PayID settles over the NPP by mobile number or email. Without it an
+    // Australian group fell straight through to bank and cash.
+    expect(defaultRailFor('AU')).toBe('payid');
+    expect(railsFor('AU').map((rail) => rail.id)).toContain('payid');
+  });
+
+  it('gives the United States and Canada theirs', () => {
+    expect(railsFor('US').map((rail) => rail.id).slice(0, 3)).toEqual([
+      'zelle',
+      'venmo',
+      'cashapp',
+    ]);
+    expect(defaultRailFor('CA')).toBe('interac');
+  });
+
+  it('offers PayPal everywhere, because it is the one link that crosses', () => {
+    // Somebody in Sydney paying somebody in Chennai has no shared rail. This
+    // is the answer, and it is why PayPal is 'any' rather than a US entry.
+    for (const country of ['US', 'CA', 'AU', 'IN', 'AE', 'BR']) {
+      expect(railsFor(country).map((rail) => rail.id), country).toContain('paypal');
+    }
+  });
+
+  it('builds a Cash App link that opens with the amount filled in', () => {
+    const link = buildPaymentUri(
+      { railId: 'cashapp', handle: 'ravi', payeeName: 'Ravi', amount: 2500n, currency: 'USD' },
+      major,
+    );
+    expect(link?.kind).toBe('web');
+    expect(link?.uri).toBe('https://cash.app/%24ravi/25.00');
+  });
+
+  it('accepts a $cashtag with or without its dollar', () => {
+    for (const handle of ['ravi', '$ravi', '@ravi']) {
+      const link = buildPaymentUri(
+        { railId: 'cashapp', handle, payeeName: 'Ravi', amount: 2500n, currency: 'USD' },
+        major,
+      );
+      expect(link?.uri, handle).toBe('https://cash.app/%24ravi/25.00');
+    }
+  });
+
+  it('refuses a Cash App link in anything but dollars', () => {
+    // A link carrying "25" for 25 Australian dollars would open a request for
+    // 25 US dollars — worse than no link, because it looks right.
+    const link = buildPaymentUri(
+      { railId: 'cashapp', handle: '$ravi', payeeName: 'Ravi', amount: 2500n, currency: 'AUD' },
+      major,
+    );
+    expect(link).toBeNull();
+  });
+
+  it('puts the currency in a PayPal link, so it is safe in any of them', () => {
+    for (const [currency, expected] of [
+      ['USD', 'https://paypal.me/ravi/25.00USD'],
+      ['AUD', 'https://paypal.me/ravi/25.00AUD'],
+      ['CAD', 'https://paypal.me/ravi/25.00CAD'],
+    ] as const) {
+      const link = buildPaymentUri(
+        { railId: 'paypal', handle: '@ravi', payeeName: 'Ravi', amount: 2500n, currency },
+        major,
+      );
+      expect(link?.uri, currency).toBe(expected);
+    }
+  });
+
+  it('still refuses to invent a link for Zelle, Venmo or PayID', () => {
+    // All three live inside somebody else's app and publish nothing stable.
+    for (const railId of ['zelle', 'venmo', 'payid', 'interac']) {
+      expect(
+        buildPaymentUri(
+          { railId, handle: '+61 400 123 456', payeeName: 'Ravi', amount: 2500n, currency: 'AUD' },
+          major,
+        ),
+        railId,
+      ).toBeNull();
     }
   });
 });

--- a/packages/db/prisma/migrations/20260807130000_rails_for_the_anglosphere/migration.sql
+++ b/packages/db/prisma/migrations/20260807130000_rails_for_the_anglosphere/migration.sql
@@ -1,0 +1,49 @@
+-- Two more rails: PayID and PayPal.
+--
+-- The CHECK constraints added in `20260807110000_payment_rails_and_country`
+-- name every rail by hand, deliberately — a constraint rather than an enum, so
+-- that adding a country is one migration and no type surgery. This is that
+-- migration, and it is the whole cost of opening three markets at the database
+-- level.
+--
+--   * **PayID** — Australia's instant rail over the NPP. Without it an
+--     Australian group fell straight through to bank and cash, because
+--     `railsFor('AU')` had nothing national to offer.
+--   * **PayPal** — everywhere. It is the one link somebody in Sydney can send
+--     somebody in Chennai, which is the case Wise and Revolut only half cover.
+--
+-- Nothing else moves: no column, no default, no backfill. A settlement already
+-- recorded keeps the rail it was recorded with.
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_payment_rail_known;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_payment_rail_known CHECK (
+    payment_rail IS NULL OR payment_rail IN (
+      'upi','pix','paynow','promptpay','qris','aani','payid',
+      'zelle','venmo','cashapp','interac','wise','revolut','paypal',
+      'bank','cash','other'
+    )
+  );
+
+ALTER TABLE public.group_members
+  DROP CONSTRAINT IF EXISTS group_members_payment_rail_known;
+ALTER TABLE public.group_members
+  ADD CONSTRAINT group_members_payment_rail_known CHECK (
+    payment_rail IS NULL OR payment_rail IN (
+      'upi','pix','paynow','promptpay','qris','aani','payid',
+      'zelle','venmo','cashapp','interac','wise','revolut','paypal',
+      'bank','cash','other'
+    )
+  );
+
+ALTER TABLE public.settlements
+  DROP CONSTRAINT IF EXISTS settlements_rail_known;
+ALTER TABLE public.settlements
+  ADD CONSTRAINT settlements_rail_known CHECK (
+    rail IS NULL OR rail IN (
+      'upi','pix','paynow','promptpay','qris','aani','payid',
+      'zelle','venmo','cashapp','interac','wise','revolut','paypal',
+      'bank','cash','other'
+    )
+  );

--- a/packages/db/test/payment-rails.test.ts
+++ b/packages/db/test/payment-rails.test.ts
@@ -231,3 +231,29 @@ describe('creating a group somewhere', () => {
     expect(rows[0].n).toBe(1);
   });
 });
+
+describe('the rails added for the anglosphere', () => {
+  it('accepts PayID and PayPal, which the first constraint did not know', async () => {
+    for (const rail of ['payid', 'paypal']) {
+      await client.query(
+        `UPDATE group_members SET payment_rail = $2, payment_handle = '+61400123456' WHERE id = $1`,
+        [group.memberIds[0], rail],
+      );
+      const { rows } = await client.query(
+        `SELECT payment_rail FROM group_members WHERE id = $1`,
+        [group.memberIds[0]],
+      );
+      expect(rows[0].payment_rail, rail).toBe(rail);
+    }
+  });
+
+  it('records a settlement on one of them', async () => {
+    const row = await record('other', 'payid');
+    expect(row.rail).toBe('payid');
+    expect(row.method).toBe('other');
+  });
+
+  it('still refuses a rail that is not a rail', async () => {
+    await expect(record('other', 'bitcoin')).rejects.toThrow(/settlements_rail_known|violates/i);
+  });
+});


### PR DESCRIPTION
Three markets. The gaps were not where the country list suggested.

## Australia had no rail at all

The US had Zelle, Venmo and Cash App, and Canada had Interac, from the original table. **AU fell straight through to bank and cash** — `railsFor('AU')` had nothing national to offer. PayID settles over the NPP by mobile number or email, the same shape as Aani and PayNow, and is now Australia's default.

**PayPal, everywhere.** It's the one link somebody in Sydney can send somebody in Chennai — the case Wise and Revolut only half cover, since both need the payee signed up for the same thing.

## None of the three had category keywords

The same bug already fixed once for the Gulf: every expense lands in "Other", and Spending doesn't look empty, it looks **broken**. DoorDash, Lyft, Trader Joe's, Tim Hortons, Presto, Woolies, Opal, Bunnings. The three share most of their chains, so they share a set; only what actually differs is per-country.

## `deepLink: boolean` → `link: 'app' | 'web' | null`

The substantive change. My original rule — *only UPI, because a guessed scheme fails silently* — was right about custom schemes and wrong to lump https links in with them.

`cash.app/$tag/25` and `paypal.me/user/25USD` are public, long-standing URLs whose worst case is **a web page**, not a tap that looks like it worked while no money moved. Those are offered without a `canOpenURL` check; `upi://` still gets one.

**Cash App links are refused in anything but dollars.** A link carrying `25` for twenty-five Australian dollars opens a request for twenty-five US ones — worse than no link, because it looks right.

Zelle, Venmo, PayID and Interac still have no link and still say so. All four live inside somebody else's app and publish nothing stable.

## Two things the tests corrected rather than confirmed

- **`hydro`** is the power bill in Canada and nothing anywhere else. I'd put it in the shared set; the test that caught it was expressing the right intent, so **the word moved, not the assertion**.
- The base keyword list in `categories.ts` is India-flavoured (`swiggy`, `zomato`, `irctc`) and applies in **every** market, not just `IN`. That's deliberate — a group that never set a country would otherwise lose the categorisation it has today — so it's now written down and asserted instead of being a surprise to whoever next reads it.

## Verification

- **core 349** (26 new), **db 224** (3 new), **mobile 107**. Typecheck and lint clean; no Prisma drift.
- Migration deployed; the live constraint verified to accept both new rails.
- Not run on a device. No group in the live project has `country_code` outside `IN`, so none of these rails has rendered with real data.

## What this does not do

Spanish for the US Hispanic market, and the entitlement/regional-pricing work. The US and Australia are also where Splitwise is strongest — the wedge there is the unlimited free ledger ADR-011 already commits to, not the settlement rails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6