### PR TITLE
feat: a trip plan, day by day, next to what it actually cost

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -136,6 +136,13 @@ export default function GroupScreen() {
               </Text>
             </View>
           </Row>
+          {/* Only where there is a trip to plan. A planner on a flatshare
+              group is a tab nobody opens twice. */}
+          {group.data.type === 'trip' ? (
+            <IconButton label={t.plan} onPress={() => router.push(`/group/${groupId}/plan`)}>
+              <Ionicons name="map-outline" size={19} color={theme.color.text} />
+            </IconButton>
+          ) : null}
           <IconButton
             label={t.spending}
             onPress={() => router.push(`/group/${groupId}/insights`)}

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -1,0 +1,367 @@
+/**
+ * The trip, day by day: what was planned, and what it actually cost.
+ *
+ * The reason this lives in Baaki rather than in a notes app is the second half.
+ * Anything can hold "Dudhsagar falls" under Saturday. Only the app that already
+ * has the ledger can put ₹2,000 planned beside ₹3,150 spent, and say the trip
+ * is ₹4,000 over on day four.
+ *
+ * Planned and spent sit next to each other and are never added together, and
+ * neither is ever converted into the other's currency (ADR-003). A plan item is
+ * not money: it moves nobody's balance, it never reaches the export, and
+ * ticking it off is somebody saying they did the thing — not that they paid for
+ * it.
+ */
+
+import { useMemo, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
+
+import {
+  budgetVariance,
+  buildTimeline,
+  dayNumber,
+  type PlanItem,
+  type TimelineExpense,
+} from '@baaki/core';
+import {
+  Button,
+  Card,
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  MoneyText,
+  Row,
+  Screen,
+  Text,
+  useTheme,
+} from '@baaki/ui';
+
+import { addPlanItem, removePlanItem, setPlanItemDone } from '@/data/api';
+import { usePlanItems, useGroup } from '@/data/hooks';
+import { useStrings } from '@/i18n';
+
+/** Today where the trip is, not where the server is. */
+function todayIn(timeZone: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-CA', { timeZone }).format(new Date());
+  } catch {
+    return new Date().toISOString().slice(0, 10);
+  }
+}
+
+/** 'Sat 14 Mar' from '2026-03-14', without letting a timezone move it. */
+function dayLabel(day: string, locale: string): string {
+  const [year, month, date] = day.split('-').map(Number);
+  const moment = new Date(Date.UTC(year ?? 1970, (month ?? 1) - 1, date ?? 1));
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    timeZone: 'UTC',
+  }).format(moment);
+}
+
+export default function PlanScreen() {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const groupId = id ?? '';
+
+  const { group, expenses } = useGroup(groupId);
+  const plan = usePlanItems(groupId);
+
+  const [addingTo, setAddingTo] = useState<string | null>(null);
+  const [title, setTitle] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const currency = group.data?.default_currency ?? 'INR';
+  const timeZone = group.data?.time_zone ?? 'Asia/Kolkata';
+  const today = todayIn(timeZone);
+
+  const items: PlanItem[] = useMemo(
+    () =>
+      (plan.data ?? []).map((row) => ({
+        id: row.id,
+        day: row.day.slice(0, 10),
+        startsAt: row.starts_at ? row.starts_at.slice(0, 5) : null,
+        title: row.title,
+        note: row.note,
+        category: row.category,
+        plannedMinor: row.planned_minor === null ? null : BigInt(row.planned_minor),
+        currency: row.currency,
+        done: row.done_at !== null,
+        expenseId: row.expense_id,
+        position: row.position,
+      })),
+    [plan.data],
+  );
+
+  const spend: TimelineExpense[] = useMemo(
+    () =>
+      expenses.rows
+        .filter((expense) => expense.currentVersion && !expense.deleted_at)
+        .map((expense) => ({
+          id: expense.id,
+          date: expense.currentVersion!.expense_date.slice(0, 10),
+          description: expense.currentVersion!.description,
+          category: expense.currentVersion!.category,
+          amountMinor: BigInt(expense.currentVersion!.amount),
+          currency: expense.currentVersion!.currency,
+        })),
+    [expenses.rows],
+  );
+
+  const timeline = useMemo(
+    () =>
+      buildTimeline({
+        items,
+        expenses: spend,
+        startDate: group.data?.start_date?.slice(0, 10) ?? null,
+        endDate: group.data?.end_date?.slice(0, 10) ?? null,
+      }),
+    [items, spend, group.data?.start_date, group.data?.end_date],
+  );
+
+  const variance = useMemo(() => budgetVariance(timeline), [timeline]);
+  const currentDay = dayNumber(
+    today,
+    group.data?.start_date?.slice(0, 10) ?? null,
+    group.data?.end_date?.slice(0, 10) ?? null,
+  );
+
+  const submit = async (day: string): Promise<void> => {
+    if (!title.trim()) return;
+    setBusy(true);
+    try {
+      await addPlanItem({ groupId, day, title: title.trim(), currency });
+      setTitle('');
+      setAddingTo(null);
+      await plan.refetch();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggle = async (item: PlanItem): Promise<void> => {
+    await setPlanItemDone(item.id, !item.done);
+    await plan.refetch();
+  };
+
+  const remove = async (item: PlanItem): Promise<void> => {
+    await removePlanItem(item.id);
+    await plan.refetch();
+  };
+
+  if (group.isLoading || plan.isLoading) {
+    return (
+      <Screen>
+        <View style={{ padding: theme.spacing.xl }}>
+          <ActivityIndicator color={theme.color.brand} />
+        </View>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen edges={['top', 'bottom']}>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.lg,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md, gap: theme.spacing.sm }}>
+          <IconButton label="Back" onPress={() => router.back()}>
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+          </IconButton>
+          <Text variant="heading">{t.plan}</Text>
+        </Row>
+
+        {/* Planned against actual, per currency and never added together. */}
+        <Card style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            {currentDay ? `${t.plan} · day ${currentDay}` : t.plan}
+          </Text>
+          {Object.keys(variance).length === 0 ? (
+            <Text variant="caption" tone="faint">
+              {t.nothingPlannedYet}
+            </Text>
+          ) : (
+            Object.entries(variance).map(([code, over]) => (
+              <Row key={code} style={{ justifyContent: 'space-between' }}>
+                <View>
+                  <Text variant="caption" tone="muted">
+                    {t.planned}
+                  </Text>
+                  <MoneyText
+                    amount={timeline.plannedByCurrency[code] ?? 0n}
+                    currency={code}
+                    locale={locale}
+                    variant="subheading"
+                  />
+                </View>
+                <View>
+                  <Text variant="caption" tone="muted">
+                    {t.spent}
+                  </Text>
+                  <MoneyText
+                    amount={timeline.spentByCurrency[code] ?? 0n}
+                    currency={code}
+                    locale={locale}
+                    variant="subheading"
+                  />
+                </View>
+                <View>
+                  <Text variant="caption" tone="muted">
+                    {over > 0n ? t.overBudget : t.underBudget}
+                  </Text>
+                  <MoneyText
+                    amount={over < 0n ? -over : over}
+                    currency={code}
+                    locale={locale}
+                    variant="subheading"
+                    mode="plain"
+                  />
+                </View>
+              </Row>
+            ))
+          )}
+        </Card>
+
+        {timeline.days.length === 0 ? (
+          <EmptyState title={t.nothingPlannedYet} body={t.planEmptyBody} />
+        ) : null}
+
+        {timeline.days.map((day) => (
+          <View key={day.day} style={{ gap: theme.spacing.sm }}>
+            <Row style={{ justifyContent: 'space-between' }}>
+              <Text variant="subheading" tone={day.day === today ? 'brand' : 'default'}>
+                {dayLabel(day.day, locale)}
+              </Text>
+              {Object.entries(day.spentByCurrency).map(([code, amount]) => (
+                <MoneyText
+                  key={code}
+                  amount={amount}
+                  currency={code}
+                  locale={locale}
+                  variant="caption"
+                />
+              ))}
+            </Row>
+
+            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+              {day.items.map((item) => (
+                <Row key={item.id} style={{ paddingVertical: theme.spacing.md, gap: theme.spacing.md }}>
+                  <Pressable
+                    onPress={() => void toggle(item)}
+                    accessibilityRole="checkbox"
+                    accessibilityState={{ checked: item.done }}
+                    accessibilityLabel={item.title}
+                    hitSlop={10}
+                  >
+                    <Ionicons
+                      name={item.done ? 'checkmark-circle' : 'ellipse-outline'}
+                      size={22}
+                      color={item.done ? theme.color.positive : theme.color.textFaint}
+                    />
+                  </Pressable>
+                  <View style={{ flex: 1 }}>
+                    <Text variant="body" tone={item.done ? 'faint' : 'default'}>
+                      {item.startsAt ? `${item.startsAt}  ` : ''}
+                      {item.title}
+                    </Text>
+                    {item.note ? (
+                      <Text variant="micro" tone="muted">
+                        {item.note}
+                      </Text>
+                    ) : null}
+                  </View>
+                  {item.plannedMinor !== null ? (
+                    <MoneyText
+                      amount={item.plannedMinor}
+                      currency={item.currency}
+                      locale={locale}
+                      variant="caption"
+                    />
+                  ) : null}
+                  <Pressable
+                    onPress={() => void remove(item)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Remove ${item.title}`}
+                    hitSlop={10}
+                  >
+                    <Ionicons name="close" size={18} color={theme.color.textFaint} />
+                  </Pressable>
+                </Row>
+              ))}
+
+              {/* What was actually spent that day, so the plan and the ledger
+                  are read in one place rather than two screens apart. */}
+              {day.expenses.map((expense) => (
+                <Row
+                  key={expense.id}
+                  style={{ paddingVertical: theme.spacing.sm, gap: theme.spacing.md }}
+                >
+                  <Ionicons name="receipt-outline" size={18} color={theme.color.textFaint} />
+                  <Text variant="caption" tone="muted" style={{ flex: 1 }} numberOfLines={1}>
+                    {expense.description}
+                  </Text>
+                  <MoneyText
+                    amount={expense.amountMinor}
+                    currency={expense.currency}
+                    locale={locale}
+                    variant="caption"
+                  />
+                </Row>
+              ))}
+
+              {addingTo === day.day ? (
+                <View style={{ paddingVertical: theme.spacing.md, gap: theme.spacing.sm }}>
+                  <TextInput
+                    value={title}
+                    onChangeText={setTitle}
+                    placeholder={t.whatIsPlanned}
+                    placeholderTextColor={theme.color.textFaint}
+                    autoFocus
+                    onSubmitEditing={() => void submit(day.day)}
+                    style={{ fontSize: 16, color: theme.color.text, paddingVertical: 4 }}
+                  />
+                  <Row style={{ gap: theme.spacing.sm }}>
+                    <Button label={t.add} size="sm" disabled={busy} onPress={() => void submit(day.day)} />
+                    <Button
+                      label={t.cancel}
+                      size="sm"
+                      variant="ghost"
+                      onPress={() => {
+                        setAddingTo(null);
+                        setTitle('');
+                      }}
+                    />
+                  </Row>
+                </View>
+              ) : (
+                <Pressable
+                  onPress={() => {
+                    setAddingTo(day.day);
+                    setTitle('');
+                  }}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${t.add} — ${dayLabel(day.day, locale)}`}
+                  style={{ paddingVertical: theme.spacing.md }}
+                >
+                  <Text variant="caption" tone="brand">
+                    + {t.add}
+                  </Text>
+                </Pressable>
+              )}
+            </Card>
+          </View>
+        ))}
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1118,3 +1118,72 @@ export async function fetchReleasePolicy(platform: 'ios' | 'android'): Promise<R
   if (error) throw new Error(error.message);
   return (data as ReleaseRow | null) ?? null;
 }
+
+// ───────────────────────────────────────────── the trip plan (timeline) ──
+
+export interface PlanItemRow {
+  id: string;
+  group_id: string;
+  day: string;
+  starts_at: string | null;
+  title: string;
+  note: string | null;
+  category: string | null;
+  planned_minor: string | null;
+  currency: string;
+  done_at: string | null;
+  expense_id: string | null;
+  position: number;
+}
+
+export async function fetchPlanItems(groupId: string): Promise<PlanItemRow[]> {
+  const { data, error } = await supabase
+    .from('trip_plan_items')
+    .select(
+      'id, group_id, day, starts_at, title, note, category, planned_minor, currency, done_at, expense_id, position',
+    )
+    .eq('group_id', groupId)
+    .order('day', { ascending: true })
+    .order('position', { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as PlanItemRow[];
+}
+
+export async function addPlanItem(input: {
+  groupId: string;
+  day: string;
+  title: string;
+  startsAt?: string | null;
+  note?: string | null;
+  plannedMinor?: bigint | null;
+  currency?: string | null;
+  /** Chosen here so a retry after a dropped connection replays (ADR-005). */
+  itemId?: string;
+}): Promise<string> {
+  const { data, error } = await supabase.rpc('baaki_add_plan_item', {
+    p_group_id: input.groupId,
+    p_day: input.day,
+    p_title: input.title,
+    p_starts_at: input.startsAt ?? null,
+    p_note: input.note ?? null,
+    p_category: null,
+    p_planned_minor: input.plannedMinor?.toString() ?? null,
+    p_currency: input.currency ?? null,
+    p_item_id: input.itemId ?? randomUUID(),
+  });
+  if (error) throw new Error(error.message);
+  return data as string;
+}
+
+export async function setPlanItemDone(itemId: string, done: boolean): Promise<void> {
+  const { error } = await supabase.rpc('baaki_update_plan_item', {
+    p_item_id: itemId,
+    p_done: done,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function removePlanItem(itemId: string): Promise<void> {
+  const { error } = await supabase.rpc('baaki_remove_plan_item', { p_item_id: itemId });
+  if (error) throw new Error(error.message);
+}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -45,6 +45,7 @@ import {
   fetchMyBalances,
   fetchNotifications,
   fetchPendingSettlements,
+  fetchPlanItems,
   fetchSettlements,
   markNotificationsRead,
   recordSettlement,
@@ -524,5 +525,14 @@ export function useLeaveGroup(groupId: string) {
   return useMutation({
     mutationFn: leaveGroup,
     onSuccess: () => invalidateGroup(queryClient, groupId),
+  });
+}
+
+/** The trip's plan. Read-only here; writes go through the RPCs in api.ts. */
+export function usePlanItems(groupId: string) {
+  return useQuery({
+    queryKey: ['plan', groupId],
+    queryFn: () => fetchPlanItems(groupId),
+    enabled: groupId !== '',
   });
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -86,6 +86,16 @@ export interface UiStrings {
    * UPI apps. The first screen is the worst place to be somewhere else.
    */
   onboarding: readonly { title: string; body: string }[];
+  plan: string;
+  planned: string;
+  spent: string;
+  overBudget: string;
+  underBudget: string;
+  nothingPlannedYet: string;
+  planEmptyBody: string;
+  whatIsPlanned: string;
+  add: string;
+  cancel: string;
   skip: string;
   next: string;
   getStarted: string;
@@ -148,6 +158,16 @@ const en: UiStrings = {
     gifts: 'Gifts',
     other: 'Other',
   },
+  plan: 'Plan',
+  planned: 'Planned',
+  spent: 'Spent',
+  overBudget: 'over',
+  underBudget: 'under',
+  nothingPlannedYet: 'Nothing planned yet',
+  planEmptyBody: 'Add the days and what you mean to do. What it actually costs fills itself in.',
+  whatIsPlanned: 'What are you doing?',
+  add: 'Add',
+  cancel: 'Cancel',
   skip: 'Skip',
   next: 'Next',
   getStarted: 'Get started',
@@ -323,6 +343,16 @@ const ar: UiStrings = {
     gifts: 'هدايا',
     other: 'أخرى',
   },
+  plan: 'الخطة',
+  planned: 'المخطط',
+  spent: 'المصروف',
+  overBudget: 'زيادة',
+  underBudget: 'أقل',
+  nothingPlannedYet: 'لا خطة بعد',
+  planEmptyBody: 'أضف الأيام وما تنوي فعله. أما التكلفة الفعلية فتُملأ من تلقاء نفسها.',
+  whatIsPlanned: 'ماذا ستفعل؟',
+  add: 'إضافة',
+  cancel: 'إلغاء',
   skip: 'تخطٍ',
   next: 'التالي',
   getStarted: 'لنبدأ',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,3 +21,4 @@ export * from './auth/identity';
 export * from './observability/index';
 export * from './version/index';
 export * from './billing/index';
+export * from './trip/index';

--- a/packages/core/src/trip/index.ts
+++ b/packages/core/src/trip/index.ts
@@ -1,0 +1,1 @@
+export * from './timeline';

--- a/packages/core/src/trip/timeline.ts
+++ b/packages/core/src/trip/timeline.ts
@@ -1,0 +1,200 @@
+/**
+ * A trip, day by day: what was planned, and what it actually cost.
+ *
+ * The reason this is worth building inside Baaki rather than reaching for an
+ * itinerary app is the second half of that sentence. Anything can hold a list
+ * of days with "Dudhsagar falls" on one of them. Only the app that already has
+ * the ledger can say the falls were budgeted at ₹2,000 and came to ₹3,150, and
+ * that the trip is ₹4,000 over four days in.
+ *
+ * Three rules the maths follows, all of them the same rules the ledger already
+ * has:
+ *
+ *   * **Currencies never mix.** A day with a hotel in euros and lunch in rupees
+ *     has two totals, not one made up by an exchange rate nobody agreed
+ *     (ADR-003). `plannedByCurrency` and `spentByCurrency` are maps for that
+ *     reason, and the screen shows each on its own line.
+ *   * **Minor units and bigint throughout.** No Number touches an amount here.
+ *   * **A day is a date string, never a Date.** `'2026-03-14'` compared as
+ *     text. Building a `Date` to group by day is how a trip that starts on the
+ *     14th shows its first expense on the 13th for everybody east of UTC — the
+ *     same bug the spending chart had.
+ */
+
+import type { CurrencyCode } from '../money/currency';
+
+/** A plan item: something somebody intends to do, and what they think it costs. */
+export interface PlanItem {
+  readonly id: string;
+  /** `YYYY-MM-DD`, in the trip's own timezone. */
+  readonly day: string;
+  /** `HH:MM` or null for "sometime that day". Sorts before untimed items. */
+  readonly startsAt: string | null;
+  readonly title: string;
+  readonly note: string | null;
+  readonly category: string | null;
+  /** What it was budgeted at, in minor units, or null for "no idea yet". */
+  readonly plannedMinor: bigint | null;
+  readonly currency: CurrencyCode;
+  /** Ticked off. A plan item is done when somebody says it is, not when it is paid. */
+  readonly done: boolean;
+  /** The expense that turned out to be this, once somebody links them. */
+  readonly expenseId: string | null;
+  readonly position: number;
+}
+
+/** An expense, reduced to what a timeline needs of it. */
+export interface TimelineExpense {
+  readonly id: string;
+  /** `YYYY-MM-DD`. */
+  readonly date: string;
+  readonly description: string;
+  readonly category: string | null;
+  readonly amountMinor: bigint;
+  readonly currency: CurrencyCode;
+}
+
+export interface TimelineDay {
+  readonly day: string;
+  readonly items: readonly PlanItem[];
+  readonly expenses: readonly TimelineExpense[];
+  readonly plannedByCurrency: Readonly<Record<string, bigint>>;
+  readonly spentByCurrency: Readonly<Record<string, bigint>>;
+}
+
+export interface Timeline {
+  readonly days: readonly TimelineDay[];
+  readonly plannedByCurrency: Readonly<Record<string, bigint>>;
+  readonly spentByCurrency: Readonly<Record<string, bigint>>;
+}
+
+/** `'2026-03-14'` + n days, as text. No Date, no timezone, no drift. */
+export function addDays(day: string, count: number): string {
+  const [year, month, date] = day.split('-').map(Number);
+  // UTC deliberately: this is date arithmetic on a label, not a moment in time.
+  const moment = new Date(Date.UTC(year ?? 1970, (month ?? 1) - 1, (date ?? 1) + count));
+  return moment.toISOString().slice(0, 10);
+}
+
+/** Every day from start to end inclusive, or an empty list if the range is nonsense. */
+export function daysBetween(start: string, end: string, limit = 400): string[] {
+  if (!start || !end || end < start) return [];
+  const days: string[] = [];
+  let day = start;
+  while (day <= end && days.length < limit) {
+    days.push(day);
+    day = addDays(day, 1);
+  }
+  return days;
+}
+
+function add(into: Record<string, bigint>, currency: string, amount: bigint): void {
+  into[currency] = (into[currency] ?? 0n) + amount;
+}
+
+/**
+ * Merge a plan and a ledger into one list of days.
+ *
+ * Days come from the trip's own dates when it has them, so an empty Tuesday in
+ * the middle still appears — a planner that hides the days with nothing on them
+ * is a planner nobody can plan *into*. Anything dated outside that range still
+ * shows up rather than being dropped: an expense on the way home is a real
+ * expense, and silently omitting it would make the totals disagree with the
+ * group's own balances.
+ */
+export function buildTimeline(input: {
+  readonly items: readonly PlanItem[];
+  readonly expenses: readonly TimelineExpense[];
+  /** The trip's dates, if it has any. */
+  readonly startDate?: string | null;
+  readonly endDate?: string | null;
+}): Timeline {
+  const dayKeys = new Set<string>();
+
+  if (input.startDate && input.endDate) {
+    for (const day of daysBetween(input.startDate, input.endDate)) dayKeys.add(day);
+  }
+  for (const item of input.items) dayKeys.add(item.day);
+  for (const expense of input.expenses) dayKeys.add(expense.date);
+
+  const plannedTotal: Record<string, bigint> = {};
+  const spentTotal: Record<string, bigint> = {};
+
+  const days = [...dayKeys]
+    .sort()
+    .map((day) => {
+      const items = input.items
+        .filter((item) => item.day === day)
+        .sort(
+          (a, b) =>
+            // Timed things first and in order; then whatever order somebody
+            // dragged them into. Two untimed items keep their position rather
+            // than shuffling on every render.
+            Number(a.startsAt === null) - Number(b.startsAt === null) ||
+            (a.startsAt ?? '').localeCompare(b.startsAt ?? '') ||
+            a.position - b.position ||
+            a.id.localeCompare(b.id),
+        );
+
+      const expenses = input.expenses
+        .filter((expense) => expense.date === day)
+        .sort((a, b) => a.description.localeCompare(b.description) || a.id.localeCompare(b.id));
+
+      const planned: Record<string, bigint> = {};
+      const spent: Record<string, bigint> = {};
+
+      for (const item of items) {
+        if (item.plannedMinor === null) continue;
+        add(planned, item.currency, item.plannedMinor);
+        add(plannedTotal, item.currency, item.plannedMinor);
+      }
+      for (const expense of expenses) {
+        add(spent, expense.currency, expense.amountMinor);
+        add(spentTotal, expense.currency, expense.amountMinor);
+      }
+
+      return { day, items, expenses, plannedByCurrency: planned, spentByCurrency: spent };
+    });
+
+  return { days, plannedByCurrency: plannedTotal, spentByCurrency: spentTotal };
+}
+
+/**
+ * Planned against actual, per currency.
+ *
+ * Positive is over budget, because that is the number somebody is looking for.
+ * A currency that was planned and never spent, or spent and never planned,
+ * appears in both maps — leaving one out would make a trip look on budget
+ * because nobody budgeted.
+ */
+export function budgetVariance(timeline: {
+  readonly plannedByCurrency: Readonly<Record<string, bigint>>;
+  readonly spentByCurrency: Readonly<Record<string, bigint>>;
+}): Record<string, bigint> {
+  const variance: Record<string, bigint> = {};
+  for (const currency of new Set([
+    ...Object.keys(timeline.plannedByCurrency),
+    ...Object.keys(timeline.spentByCurrency),
+  ])) {
+    variance[currency] =
+      (timeline.spentByCurrency[currency] ?? 0n) - (timeline.plannedByCurrency[currency] ?? 0n);
+  }
+  return variance;
+}
+
+/**
+ * Which day a trip is on, or null when it is not running.
+ *
+ * `today` is passed in rather than read from the clock: the answer depends on
+ * the trip's timezone, and this package has no business knowing what time it is
+ * in Goa.
+ */
+export function dayNumber(
+  today: string,
+  startDate: string | null | undefined,
+  endDate: string | null | undefined,
+): number | null {
+  if (!startDate || !endDate) return null;
+  if (today < startDate || today > endDate) return null;
+  return daysBetween(startDate, today).length;
+}

--- a/packages/core/test/timeline.test.ts
+++ b/packages/core/test/timeline.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The trip timeline: days, plans, and what they actually cost.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  addDays,
+  budgetVariance,
+  buildTimeline,
+  dayNumber,
+  daysBetween,
+  type PlanItem,
+  type TimelineExpense,
+} from '../src/trip/timeline';
+
+const item = (over: Partial<PlanItem> & { id: string; day: string }): PlanItem => ({
+  startsAt: null,
+  title: 'Something',
+  note: null,
+  category: null,
+  plannedMinor: null,
+  currency: 'INR',
+  done: false,
+  expenseId: null,
+  position: 0,
+  ...over,
+});
+
+const spend = (
+  over: Partial<TimelineExpense> & { id: string; date: string; amountMinor: bigint },
+): TimelineExpense => ({
+  description: 'Something',
+  category: null,
+  currency: 'INR',
+  ...over,
+});
+
+describe('walking the days', () => {
+  it('counts across a month end without a timezone touching it', () => {
+    // Building a Date to add a day is how a trip starting on the 14th shows
+    // its first expense on the 13th for everybody east of UTC.
+    expect(addDays('2026-02-28', 1)).toBe('2026-03-01');
+    expect(addDays('2026-03-01', -1)).toBe('2026-02-28');
+    expect(addDays('2026-12-31', 1)).toBe('2027-01-01');
+  });
+
+  it('includes both ends of a range', () => {
+    expect(daysBetween('2026-03-14', '2026-03-17')).toEqual([
+      '2026-03-14',
+      '2026-03-15',
+      '2026-03-16',
+      '2026-03-17',
+    ]);
+    expect(daysBetween('2026-03-14', '2026-03-14')).toEqual(['2026-03-14']);
+  });
+
+  it('says nothing rather than looping on a backwards range', () => {
+    expect(daysBetween('2026-03-17', '2026-03-14')).toEqual([]);
+    expect(daysBetween('', '2026-03-14')).toEqual([]);
+  });
+
+  it('knows which day of the trip it is', () => {
+    expect(dayNumber('2026-03-14', '2026-03-14', '2026-03-17')).toBe(1);
+    expect(dayNumber('2026-03-16', '2026-03-14', '2026-03-17')).toBe(3);
+    expect(dayNumber('2026-03-18', '2026-03-14', '2026-03-17')).toBeNull();
+    expect(dayNumber('2026-03-14', null, null)).toBeNull();
+  });
+});
+
+describe('the timeline', () => {
+  it('keeps an empty day in the middle', () => {
+    // A planner that hides the days with nothing on them is a planner nobody
+    // can plan into.
+    const timeline = buildTimeline({
+      items: [item({ id: 'a', day: '2026-03-14' })],
+      expenses: [],
+      startDate: '2026-03-14',
+      endDate: '2026-03-16',
+    });
+    expect(timeline.days.map((day) => day.day)).toEqual(['2026-03-14', '2026-03-15', '2026-03-16']);
+    expect(timeline.days[1]!.items).toEqual([]);
+  });
+
+  it('keeps an expense from outside the trip dates rather than dropping it', () => {
+    // An expense on the way home is a real expense, and hiding it would make
+    // these totals disagree with the group's own balances.
+    const timeline = buildTimeline({
+      items: [],
+      expenses: [spend({ id: 'e', date: '2026-03-18', amountMinor: 5000n })],
+      startDate: '2026-03-14',
+      endDate: '2026-03-16',
+    });
+    expect(timeline.days.map((day) => day.day)).toContain('2026-03-18');
+    expect(timeline.spentByCurrency).toEqual({ INR: 5000n });
+  });
+
+  it('works for a group with no dates at all', () => {
+    const timeline = buildTimeline({
+      items: [item({ id: 'a', day: '2026-03-14' })],
+      expenses: [spend({ id: 'e', date: '2026-03-15', amountMinor: 100n })],
+    });
+    expect(timeline.days.map((day) => day.day)).toEqual(['2026-03-14', '2026-03-15']);
+  });
+
+  it('puts timed things first, in order, and leaves the rest where they were put', () => {
+    const timeline = buildTimeline({
+      items: [
+        item({ id: 'c', day: 'd', position: 2 }),
+        item({ id: 'b', day: 'd', startsAt: '14:00' }),
+        item({ id: 'a', day: 'd', startsAt: '09:30' }),
+        item({ id: 'd', day: 'd', position: 1 }),
+      ],
+      expenses: [],
+    });
+    expect(timeline.days[0]!.items.map((entry) => entry.id)).toEqual(['a', 'b', 'd', 'c']);
+  });
+
+  it('adds up planned and spent per day and over the trip', () => {
+    const timeline = buildTimeline({
+      items: [
+        item({ id: 'a', day: '2026-03-14', plannedMinor: 200000n }),
+        item({ id: 'b', day: '2026-03-15', plannedMinor: 50000n }),
+        // No estimate yet — counted as nothing, not as budgeted-at-zero.
+        item({ id: 'c', day: '2026-03-15' }),
+      ],
+      expenses: [
+        spend({ id: 'e1', date: '2026-03-14', amountMinor: 315000n }),
+        spend({ id: 'e2', date: '2026-03-15', amountMinor: 40000n }),
+      ],
+      startDate: '2026-03-14',
+      endDate: '2026-03-15',
+    });
+
+    expect(timeline.days[0]!.plannedByCurrency).toEqual({ INR: 200000n });
+    expect(timeline.days[0]!.spentByCurrency).toEqual({ INR: 315000n });
+    expect(timeline.plannedByCurrency).toEqual({ INR: 250000n });
+    expect(timeline.spentByCurrency).toEqual({ INR: 355000n });
+  });
+
+  it('never mixes two currencies into one number', () => {
+    // A day with a hotel in euros and lunch in rupees has two totals, not one
+    // made up by a rate nobody agreed (ADR-003).
+    const timeline = buildTimeline({
+      items: [
+        item({ id: 'a', day: 'd', plannedMinor: 12000n, currency: 'EUR' }),
+        item({ id: 'b', day: 'd', plannedMinor: 80000n, currency: 'INR' }),
+      ],
+      expenses: [
+        spend({ id: 'e1', date: 'd', amountMinor: 15000n, currency: 'EUR' }),
+        spend({ id: 'e2', date: 'd', amountMinor: 60000n, currency: 'INR' }),
+      ],
+    });
+    expect(timeline.plannedByCurrency).toEqual({ EUR: 12000n, INR: 80000n });
+    expect(timeline.spentByCurrency).toEqual({ EUR: 15000n, INR: 60000n });
+  });
+});
+
+describe('planned against actual', () => {
+  it('reports over budget as positive, because that is the number people look for', () => {
+    expect(
+      budgetVariance({ plannedByCurrency: { INR: 250000n }, spentByCurrency: { INR: 355000n } }),
+    ).toEqual({ INR: 105000n });
+  });
+
+  it('reports under budget as negative', () => {
+    expect(
+      budgetVariance({ plannedByCurrency: { INR: 250000n }, spentByCurrency: { INR: 100000n } }),
+    ).toEqual({ INR: -150000n });
+  });
+
+  it('does not let a trip look on budget because nobody budgeted', () => {
+    expect(budgetVariance({ plannedByCurrency: {}, spentByCurrency: { INR: 90000n } })).toEqual({
+      INR: 90000n,
+    });
+    expect(budgetVariance({ plannedByCurrency: { EUR: 5000n }, spentByCurrency: {} })).toEqual({
+      EUR: -5000n,
+    });
+  });
+
+  it('keeps each currency’s answer separate', () => {
+    expect(
+      budgetVariance({
+        plannedByCurrency: { INR: 100n, EUR: 100n },
+        spentByCurrency: { INR: 150n, EUR: 50n },
+      }),
+    ).toEqual({ INR: 50n, EUR: -50n });
+  });
+});

--- a/packages/db/prisma/migrations/20260807160000_trip_plan/migration.sql
+++ b/packages/db/prisma/migrations/20260807160000_trip_plan/migration.sql
@@ -1,0 +1,223 @@
+-- A trip's plan, day by day.
+--
+-- Baaki already knows when a trip runs (`start_date`, `end_date`, `time_zone`)
+-- and what it cost. What it has never held is what anybody *meant* to do — and
+-- that is the half that makes a planner here worth more than a planner
+-- anywhere else. Any notes app can hold "Dudhsagar falls" under Saturday. Only
+-- the app that already has the ledger can say the falls were budgeted at ₹2,000
+-- and came to ₹3,150, and that the trip is ₹4,000 over on day four.
+--
+-- A plan item is **not** money. It is an intention, it moves nobody's balance,
+-- and it is deliberately not an expense with a flag: an expense that has not
+-- happened would show up in balances, in exports and in simplification, and
+-- every one of those would be wrong. The link between the two is one nullable
+-- column, set when somebody says "this is what that was".
+
+CREATE TABLE IF NOT EXISTS public.trip_plan_items (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id      uuid NOT NULL REFERENCES public.groups(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  /** The day it is planned for, in the trip's own timezone. A date, never a timestamp. */
+  day           date NOT NULL,
+  /** Time of day, or NULL for "sometime that day". */
+  starts_at     time,
+  title         text NOT NULL,
+  note          text,
+  category      text,
+  /**
+   * What somebody thinks it will cost, in minor units. NULL is "no idea yet",
+   * which is a different thing from zero and must not be counted as budgeted.
+   */
+  planned_minor bigint,
+  currency      char(3) NOT NULL DEFAULT 'INR',
+  /** Ticked off. A plan item is done when somebody says so, not when it is paid. */
+  done_at       timestamptz,
+  /** What it turned out to be, once somebody links them. */
+  expense_id    uuid REFERENCES public.expenses(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  /** Hand-ordering within a day, for the things that have no time. */
+  position      int NOT NULL DEFAULT 0,
+  created_by    uuid REFERENCES public.group_members(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT trip_plan_items_title_present CHECK (btrim(title) <> ''),
+  -- A negative budget is not a budget. Zero is allowed: "the beach is free" is
+  -- a real thing to plan.
+  CONSTRAINT trip_plan_items_planned_sane CHECK (planned_minor IS NULL OR planned_minor >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS trip_plan_items_group_day_idx
+  ON public.trip_plan_items (group_id, day, position);
+
+ALTER TABLE public.trip_plan_items ENABLE ROW LEVEL SECURITY;
+
+-- Everybody in the group sees the plan; that is the point of a shared one.
+CREATE POLICY trip_plan_items_select ON public.trip_plan_items
+  FOR SELECT TO anon, authenticated
+  USING (public.is_group_member(group_id));
+
+-- No INSERT, UPDATE or DELETE policy, and no privilege either. The RPCs below
+-- are the only way in, for the reason the security audit left behind: a client
+-- that writes the table directly gets to choose `created_by`, and "who added
+-- this" is not a question a client answers about itself.
+REVOKE ALL ON public.trip_plan_items FROM anon, authenticated;
+GRANT SELECT ON public.trip_plan_items TO anon, authenticated;
+
+-- ────────────────────────────────────────────────────────────── writing ──
+
+CREATE OR REPLACE FUNCTION public.baaki_add_plan_item(
+  p_group_id      uuid,
+  p_day           date,
+  p_title         text,
+  p_starts_at     time DEFAULT NULL,
+  p_note          text DEFAULT NULL,
+  p_category      text DEFAULT NULL,
+  p_planned_minor bigint DEFAULT NULL,
+  p_currency      char(3) DEFAULT NULL,
+  p_item_id       uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id       uuid;
+  v_position int;
+  v_currency char(3);
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF coalesce(btrim(p_title), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_TITLE: a plan item needs a name' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying a create must return the same item, not a second one (ADR-005) —
+  -- a planner is used on a phone with one bar of signal by definition.
+  IF p_item_id IS NOT NULL THEN
+    SELECT id INTO v_id FROM public.trip_plan_items WHERE id = p_item_id;
+    IF v_id IS NOT NULL THEN
+      RETURN v_id;
+    END IF;
+  END IF;
+
+  SELECT COALESCE(p_currency, default_currency) INTO v_currency
+  FROM public.groups WHERE id = p_group_id;
+
+  SELECT COALESCE(max(position), -1) + 1 INTO v_position
+  FROM public.trip_plan_items WHERE group_id = p_group_id AND day = p_day;
+
+  INSERT INTO public.trip_plan_items
+    (id, group_id, day, starts_at, title, note, category, planned_minor, currency,
+     position, created_by)
+  VALUES
+    (COALESCE(p_item_id, gen_random_uuid()), p_group_id, p_day, p_starts_at, btrim(p_title),
+     p_note, p_category, p_planned_minor, upper(v_currency), v_position,
+     public.baaki_my_member_id(p_group_id))
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_add_plan_item(
+  uuid, date, text, time, text, text, bigint, character, uuid
+) TO authenticated, anon;
+
+/**
+ * Change one. Anybody in the group may — a shared plan that only its author can
+ * edit is a plan that goes stale the moment they put their phone down.
+ *
+ * NULL means "leave alone" for every field, so a caller changing the time does
+ * not have to resend the note. Clearing a budget or a time is done with
+ * `p_clear`, because NULL cannot mean both "unchanged" and "empty".
+ */
+CREATE OR REPLACE FUNCTION public.baaki_update_plan_item(
+  p_item_id       uuid,
+  p_day           date DEFAULT NULL,
+  p_starts_at     time DEFAULT NULL,
+  p_title         text DEFAULT NULL,
+  p_note          text DEFAULT NULL,
+  p_category      text DEFAULT NULL,
+  p_planned_minor bigint DEFAULT NULL,
+  p_done          boolean DEFAULT NULL,
+  p_expense_id    uuid DEFAULT NULL,
+  p_clear         text[] DEFAULT '{}'
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+BEGIN
+  SELECT group_id INTO v_group_id FROM public.trip_plan_items WHERE id = p_item_id;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such plan item' USING ERRCODE = 'no_data_found';
+  END IF;
+  IF NOT public.is_group_member(v_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- An expense can only ever be one from this same group. Otherwise a plan item
+  -- could point at a stranger's expense and leak its description through the
+  -- join the app makes.
+  IF p_expense_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.expenses WHERE id = p_expense_id AND group_id = v_group_id
+  ) THEN
+    RAISE EXCEPTION 'UNKNOWN_EXPENSE: that expense is not in this group'
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  UPDATE public.trip_plan_items SET
+    day           = COALESCE(p_day, day),
+    starts_at     = CASE WHEN 'starts_at' = ANY(p_clear) THEN NULL
+                         ELSE COALESCE(p_starts_at, starts_at) END,
+    title         = COALESCE(NULLIF(btrim(COALESCE(p_title, '')), ''), title),
+    note          = CASE WHEN 'note' = ANY(p_clear) THEN NULL ELSE COALESCE(p_note, note) END,
+    category      = CASE WHEN 'category' = ANY(p_clear) THEN NULL
+                         ELSE COALESCE(p_category, category) END,
+    planned_minor = CASE WHEN 'planned_minor' = ANY(p_clear) THEN NULL
+                         ELSE COALESCE(p_planned_minor, planned_minor) END,
+    done_at       = CASE WHEN p_done IS NULL THEN done_at
+                         WHEN p_done THEN COALESCE(done_at, now())
+                         ELSE NULL END,
+    expense_id    = CASE WHEN 'expense_id' = ANY(p_clear) THEN NULL
+                         ELSE COALESCE(p_expense_id, expense_id) END,
+    updated_at    = now()
+  WHERE id = p_item_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_update_plan_item(
+  uuid, date, time, text, text, text, bigint, boolean, uuid, text[]
+) TO authenticated, anon;
+
+/** Remove one. A plan is not a ledger — this is a real delete, not a tombstone. */
+CREATE OR REPLACE FUNCTION public.baaki_remove_plan_item(p_item_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+BEGIN
+  SELECT group_id INTO v_group_id FROM public.trip_plan_items WHERE id = p_item_id;
+  IF v_group_id IS NULL THEN
+    RETURN; -- Already gone. Deleting twice is not an error.
+  END IF;
+  IF NOT public.is_group_member(v_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  DELETE FROM public.trip_plan_items WHERE id = p_item_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_remove_plan_item(uuid) TO authenticated, anon;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -207,6 +207,7 @@ model Group {
   notifications   Notification[]
   usageEvents     UsageEvent[]
   passes          GroupPass[]
+  planItems       TripPlanItem[]
   syncMutations   SyncMutation[]
 
   @@index([archivedAt])
@@ -254,6 +255,7 @@ model GroupMember {
   settlementsSent    Settlement[]     @relation("SettlementFrom")
   settlementsGot     Settlement[]     @relation("SettlementTo")
   itemClaims         ReceiptItemClaim[]
+  planItems          TripPlanItem[]
   activity           ActivityLog[]
   disputesRaised     ExpenseDispute[] @relation("DisputeRaisedBy")
   disputesResolved   ExpenseDispute[] @relation("DisputeResolvedBy")
@@ -315,6 +317,7 @@ model Expense {
   versions       ExpenseVersion[] @relation("ExpenseVersions")
   allocations    SettlementAllocation[]
   disputes       ExpenseDispute[]
+  planItems      TripPlanItem[]
 
   @@index([groupId, deletedAt])
   /// The sync pull is "everything in this group since seq N" (TDR §4).
@@ -767,5 +770,39 @@ model GroupPass {
 
   @@index([groupId, expiresAt], map: "group_passes_group_idx")
   @@map("group_passes")
+  @@schema("public")
+}
+
+/// What a trip means to do, day by day. Not money: a plan item moves nobody's
+/// balance, and is deliberately not an expense with a flag — an expense that
+/// has not happened would show up in balances, exports and simplification.
+model TripPlanItem {
+  id           String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  groupId      String    @map("group_id") @db.Uuid
+  /// The day it is planned for, in the trip's own timezone.
+  day          DateTime  @db.Date
+  /// NULL for "sometime that day".
+  startsAt     DateTime? @map("starts_at") @db.Time(6)
+  title        String
+  note         String?
+  category     String?
+  /// NULL is "no idea yet" — a different thing from zero, and not counted as
+  /// budgeted.
+  plannedMinor BigInt?   @map("planned_minor")
+  currency     String    @default("INR") @db.Char(3)
+  doneAt       DateTime? @map("done_at") @db.Timestamptz(6)
+  /// What it turned out to be, once somebody links them.
+  expenseId    String?   @map("expense_id") @db.Uuid
+  position     Int       @default(0)
+  createdBy    String?   @map("created_by") @db.Uuid
+  createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  group   Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  expense Expense?     @relation(fields: [expenseId], references: [id], onDelete: SetNull)
+  author  GroupMember? @relation(fields: [createdBy], references: [id], onDelete: SetNull)
+
+  @@index([groupId, day, position], map: "trip_plan_items_group_day_idx")
+  @@map("trip_plan_items")
   @@schema("public")
 }

--- a/packages/db/test/trip-plan.test.ts
+++ b/packages/db/test/trip-plan.test.ts
@@ -1,0 +1,328 @@
+/**
+ * The trip plan: shared, editable by anybody in the group, and never money.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, expectDenied, seedGroup, type SeededGroup } from './helpers';
+
+let client: Client;
+let group: SeededGroup;
+
+beforeAll(async () => {
+  client = await connect();
+  group = await seedGroup(client, { memberCount: 2, name: 'Goa' });
+  await client.query(
+    `UPDATE groups SET start_date = '2026-03-14', end_date = '2026-03-17' WHERE id = $1`,
+    [group.groupId],
+  );
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+beforeEach(async () => {
+  await client.query(`DELETE FROM trip_plan_items WHERE group_id = $1`, [group.groupId]);
+});
+
+/**
+ * Run as somebody, and **commit**. Not wrapped in a rolled-back transaction:
+ * half these tests assert on what is still there afterwards, and a rollback
+ * would make every one of them pass against an empty table.
+ */
+async function as<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query('SET ROLE authenticated');
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+/** starts_at, note, category, planned_minor, currency, item_id — all optional. */
+const add = (title: string, day = '2026-03-14') =>
+  client.query(
+    `SELECT baaki_add_plan_item($1, $2, $3, NULL, NULL, NULL, NULL, NULL, NULL) AS id`,
+    [group.groupId, day, title],
+  );
+
+describe('adding to the plan', () => {
+  it('records who added it, from the session rather than the argument', async () => {
+    // "Who added this" is not a question a client answers about itself — the
+    // same rule as actor_member_id on the activity log.
+    const id = await as(group.profileIds[0] as string, async () => {
+      const { rows } = await add('Dudhsagar falls');
+      return String(rows[0].id);
+    });
+    const { rows } = await client.query(
+      `SELECT created_by, title, currency FROM trip_plan_items WHERE id = $1`,
+      [id],
+    );
+    expect(rows[0].created_by).toBe(group.memberIds[0]);
+    expect(rows[0].title).toBe('Dudhsagar falls');
+    // Falls back to the group's currency rather than a hardcoded rupee.
+    expect(rows[0].currency).toBe('INR');
+  });
+
+  it('refuses an item with no name', async () => {
+    await as(group.profileIds[0] as string, async () => {
+      const message = await expectDenied(add('   '));
+      expect(message).toMatch(/INVALID_TITLE/);
+    });
+  });
+
+  it('refuses somebody who is not in the group', async () => {
+    const outsider = randomUUID();
+    await client.query(
+      `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Mallory', 'INR')`,
+      [outsider],
+    );
+    await as(outsider, async () => {
+      const message = await expectDenied(add('Sneak in'));
+      expect(message).toMatch(/NOT_A_MEMBER/);
+    });
+  });
+
+  it('returns the same item when a create is replayed', async () => {
+    // A planner is used on a phone with one bar of signal by definition.
+    const itemId = randomUUID();
+    const call = `SELECT baaki_add_plan_item($1, $2, 'Beach', NULL, NULL, NULL, NULL, NULL, $3) AS id`;
+    await as(group.profileIds[0] as string, async () => {
+      const first = await client.query(call, [group.groupId, '2026-03-15', itemId]);
+      const second = await client.query(call, [group.groupId, '2026-03-15', itemId]);
+      expect(String(second.rows[0].id)).toBe(String(first.rows[0].id));
+    });
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM trip_plan_items WHERE id = $1`,
+      [itemId],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+
+  it('numbers each day’s items from zero independently', async () => {
+    await as(group.profileIds[0] as string, async () => {
+      await add('One', '2026-03-14');
+      await add('Two', '2026-03-14');
+      await add('Other day', '2026-03-15');
+    });
+    const { rows } = await client.query(
+      `SELECT day::text, position FROM trip_plan_items WHERE group_id = $1 ORDER BY day, position`,
+      [group.groupId],
+    );
+    expect(rows.map((row) => row.position)).toEqual([0, 1, 0]);
+  });
+
+  it('refuses a negative budget but allows a free one', async () => {
+    await as(group.profileIds[0] as string, async () => {
+      const message = await expectDenied(
+        client.query(
+          `SELECT baaki_add_plan_item($1, '2026-03-14', 'Bad', NULL, NULL, NULL, -100, NULL, NULL)`,
+          [group.groupId],
+        ),
+      );
+      expect(message).toMatch(/trip_plan_items_planned_sane|violates/i);
+
+      // "The beach is free" is a real thing to plan.
+      await client.query(
+        `SELECT baaki_add_plan_item($1, '2026-03-14', 'Beach', NULL, NULL, NULL, 0, NULL, NULL)`,
+        [group.groupId],
+      );
+    });
+  });
+});
+
+describe('changing the plan', () => {
+  async function seedItem(): Promise<string> {
+    const { rows } = await client.query(
+      `SELECT baaki_add_plan_item($1, '2026-03-14', 'Falls', NULL, 'take cash', NULL, 200000, NULL, NULL) AS id`,
+      [group.groupId],
+    );
+    return String(rows[0].id);
+  }
+
+  it('lets anybody in the group edit, not only whoever added it', async () => {
+    // A shared plan only its author can edit goes stale the moment they put
+    // their phone down.
+    const id = await as(group.profileIds[0] as string, seedItem);
+    await as(group.profileIds[1] as string, async () => {
+      await client.query(`SELECT baaki_update_plan_item($1, NULL, NULL, 'Dudhsagar falls')`, [id]);
+    });
+    const { rows } = await client.query(`SELECT title FROM trip_plan_items WHERE id = $1`, [id]);
+    expect(rows[0].title).toBe('Dudhsagar falls');
+  });
+
+  it('leaves untouched fields alone', async () => {
+    const id = await as(group.profileIds[0] as string, seedItem);
+    await as(group.profileIds[0] as string, async () => {
+      await client.query(`SELECT baaki_update_plan_item($1, '2026-03-16')`, [id]);
+    });
+    const { rows } = await client.query(
+      `SELECT day::text AS day, note, planned_minor FROM trip_plan_items WHERE id = $1`,
+      [id],
+    );
+    expect(rows[0].day).toBe('2026-03-16');
+    expect(rows[0].note).toBe('take cash');
+    expect(String(rows[0].planned_minor)).toBe('200000');
+  });
+
+  it('clears a field only when asked to, because NULL cannot mean two things', async () => {
+    const id = await as(group.profileIds[0] as string, seedItem);
+    await as(group.profileIds[0] as string, async () => {
+      await client.query(
+        `SELECT baaki_update_plan_item($1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                                       ARRAY['note','planned_minor'])`,
+        [id],
+      );
+    });
+    const { rows } = await client.query(
+      `SELECT note, planned_minor FROM trip_plan_items WHERE id = $1`,
+      [id],
+    );
+    expect(rows[0].note).toBeNull();
+    expect(rows[0].planned_minor).toBeNull();
+  });
+
+  it('ticks off and un-ticks', async () => {
+    const id = await as(group.profileIds[0] as string, seedItem);
+    await as(group.profileIds[0] as string, async () => {
+      await client.query(
+        `SELECT baaki_update_plan_item($1, NULL, NULL, NULL, NULL, NULL, NULL, true)`,
+        [id],
+      );
+    });
+    let { rows } = await client.query(`SELECT done_at FROM trip_plan_items WHERE id = $1`, [id]);
+    expect(rows[0].done_at).not.toBeNull();
+
+    await as(group.profileIds[0] as string, async () => {
+      await client.query(
+        `SELECT baaki_update_plan_item($1, NULL, NULL, NULL, NULL, NULL, NULL, false)`,
+        [id],
+      );
+    });
+    ({ rows } = await client.query(`SELECT done_at FROM trip_plan_items WHERE id = $1`, [id]));
+    expect(rows[0].done_at).toBeNull();
+  });
+
+  it('refuses to link an expense from another group', async () => {
+    // Otherwise a plan item could point at a stranger's expense and leak its
+    // description through the join the app makes.
+    const id = await as(group.profileIds[0] as string, seedItem);
+
+    // `RESET ROLE` puts the role back but leaves the JWT claim set, and
+    // `baaki_apply_expense` now checks its caller — so seeding another group's
+    // expense while still "logged in" as somebody outside it is refused.
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+    const other = await seedGroup(client, { memberCount: 1, name: 'Elsewhere' });
+    const { rows: made } = await client.query(
+      `SELECT baaki_apply_expense($1, NULL, $2, 'Theirs', NULL, current_date, 'INR', 1000,
+        'equal', '{"kind":"equal"}'::jsonb, $3::jsonb, $4::jsonb, $5) AS out`,
+      [
+        other.groupId,
+        other.memberIds[0],
+        JSON.stringify([{ memberId: other.memberIds[0], amount: '1000' }]),
+        JSON.stringify([{ memberId: other.memberIds[0], amount: '1000' }]),
+        randomUUID(),
+      ],
+    );
+    const foreignExpense = (made[0].out as { expenseId: string }).expenseId;
+
+    await as(group.profileIds[0] as string, async () => {
+      const message = await expectDenied(
+        client.query(
+          `SELECT baaki_update_plan_item($1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, $2)`,
+          [id, foreignExpense],
+        ),
+      );
+      expect(message).toMatch(/UNKNOWN_EXPENSE/);
+    });
+  });
+
+  it('refuses an outsider editing or removing', async () => {
+    const id = await as(group.profileIds[0] as string, seedItem);
+    const outsider = randomUUID();
+    await client.query(
+      `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Mallory', 'INR')`,
+      [outsider],
+    );
+    await as(outsider, async () => {
+      expect(
+        await expectDenied(
+          client.query(`SELECT baaki_update_plan_item($1, NULL, NULL, 'Mine now')`, [id]),
+        ),
+      ).toMatch(/NOT_A_MEMBER/);
+      expect(await expectDenied(client.query(`SELECT baaki_remove_plan_item($1)`, [id]))).toMatch(
+        /NOT_A_MEMBER/,
+      );
+    });
+  });
+
+  it('removes, and removing twice is not an error', async () => {
+    const id = await as(group.profileIds[0] as string, seedItem);
+    await as(group.profileIds[0] as string, async () => {
+      await client.query(`SELECT baaki_remove_plan_item($1)`, [id]);
+      await client.query(`SELECT baaki_remove_plan_item($1)`, [id]);
+    });
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM trip_plan_items WHERE id = $1`,
+      [id],
+    );
+    expect(rows[0].n).toBe(0);
+  });
+});
+
+describe('a plan is not a ledger', () => {
+  it('changes nobody’s balance', async () => {
+    // The reason a plan item is its own table rather than an expense with a
+    // flag: an expense that has not happened would show up in balances, in
+    // exports and in simplification, and all three would be wrong.
+    const before = await client.query(
+      `SELECT coalesce(sum(balance), 0)::text AS total FROM group_balances WHERE group_id = $1`,
+      [group.groupId],
+    );
+    await as(group.profileIds[0] as string, async () => {
+      await client.query(
+        `SELECT baaki_add_plan_item($1, '2026-03-14', 'Hotel', NULL, NULL, NULL, 900000, NULL, NULL)`,
+        [group.groupId],
+      );
+    });
+    const after = await client.query(
+      `SELECT coalesce(sum(balance), 0)::text AS total FROM group_balances WHERE group_id = $1`,
+      [group.groupId],
+    );
+    expect(after.rows[0].total).toBe(before.rows[0].total);
+  });
+
+  it('is not writable directly, so created_by cannot be forged', async () => {
+    await as(group.profileIds[1] as string, async () => {
+      const message = await expectDenied(
+        client.query(
+          `INSERT INTO trip_plan_items (group_id, day, title, created_by)
+           VALUES ($1, '2026-03-14', 'Forged', $2)`,
+          [group.groupId, group.memberIds[0]],
+        ),
+      );
+      expect(message).toMatch(/permission denied/i);
+    });
+  });
+
+  it('is readable by everybody in the group', async () => {
+    await as(group.profileIds[0] as string, async () => {
+      await add('Shared');
+    });
+    const seen = await as(group.profileIds[1] as string, async () => {
+      const { rows } = await client.query(
+        `SELECT count(*)::int AS n FROM trip_plan_items WHERE group_id = $1`,
+        [group.groupId],
+      );
+      return rows[0].n as number;
+    });
+    expect(seen).toBe(1);
+  });
+});


### PR DESCRIPTION
A planner in an expense app is only worth building if it touches the money. Anything holds "Dudhsagar falls" under Saturday; only the app that already has the ledger can put **₹2,000 planned beside ₹3,150 spent** and say the trip is ₹4,000 over on day four. That comparison is the feature — the list of days is the part everybody else already has.

## A plan item is not money

And deliberately not an expense with a flag. An expense that hasn't happened would appear in balances, in exports and in simplification, and all three would be wrong. It's its own table, it moves nobody's balance — there's a test that says exactly that — and the link between an intention and what it turned out to cost is one nullable column somebody sets when they say "this was that".

## What the maths inherits from the ledger

- **Currencies never mix.** A day with a hotel in euros and lunch in rupees has two totals, not one invented by a rate nobody agreed (ADR-003).
- **bigint minor units throughout.** No Number touches an amount.
- **A day is a `'2026-03-14'` string compared as text.** Building a `Date` to group by day is how a trip starting on the 14th shows its first expense on the 13th for everybody east of UTC — the bug the spending chart already had once.

Two smaller calls: an empty Tuesday in the middle still appears, because a planner that hides the days with nothing on them is a planner nobody can plan *into*. And an expense dated outside the trip is still shown — one on the way home is a real expense, and dropping it would make these totals disagree with the group's own balances.

## Writes

RPCs, not the table. `created_by` comes from the session — "who added this" isn't a question a client answers about itself, the same rule as `actor_member_id` — and the INSERT/UPDATE/DELETE privileges are revoked so that stays true.

Anybody in the group can edit any item: a shared plan only its author can change goes stale the moment they put their phone down. A budget of zero is allowed and a negative one isn't, because "the beach is free" is a real thing to plan. `NULL` planned means *no idea yet*, which is not the same as budgeted-at-zero and isn't counted as budgeted.

## Reachable

From the group header, and only for `type = 'trip'` — a planner on a flatshare group is a tab nobody opens twice. Deliberately not another `country_code`: shipping the table without a way in would repeat that.

## Verification

- **core 373** (16 new), **db 270** (16 new), **mobile 107**. Typecheck, lint, `expo export --platform web` clean; no Prisma drift.
- Deployed; live grants verified down to `SELECT`.
- **Not driven on a device**, and no dated trip exists in the live project to render it against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6