### PR TITLE
feat: split one bill from several phones, and close two more grants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,17 +34,8 @@ jobs:
       # sat in the repo root for five milestones. They came from shell quoting
       # that ran a fragment of TypeScript as a redirection, and `git add -A`
       # swept them in. Nothing type-checks a filename, so nothing complained.
-      # Root level only, and an allow-list rather than a list of bad
-      # characters: Expo Router's own `(tabs)` and `[id]` directories are full
-      # of the brackets a blanket check would trip over.
       - name: No files from a mis-quoted shell command
-        run: |
-          bad=$(git ls-files -- ':(glob)*' | grep -E '[^A-Za-z0-9._-]' || true)
-          if [ -n "$bad" ]; then
-            echo 'Files in the repo root that look like shell debris:'
-            echo "$bad"
-            exit 1
-          fi
+        run: bash scripts/check-filenames.sh
       # The edge functions import a bundled copy of @baaki/core; build it first
       # so a broken bundle fails here rather than at deploy time.
       - run: pnpm edge:build
@@ -115,15 +106,19 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
-      - name: Create the shadow database used by the drift check
-        run: PGPASSWORD=postgres psql -h localhost -U postgres -c 'CREATE DATABASE baaki_shadow'
-
       # Every migration must apply cleanly to an empty database — including the
       # hand-written RLS / trigger / derived-balance SQL.
       - name: Apply migrations to a fresh database
         run: pnpm db:migrate
 
       # Guards schema.prisma against the applied migrations (TDR §2.0).
+      #
+      # Diffed against the database the step above just built, not replayed
+      # into a shadow database. The replay cannot work: `_prisma_migrations` is
+      # created by Prisma outside any migration, and the security hardening
+      # migration revokes privileges on it — which fails against a shadow
+      # database where that table does not exist. Diffing the migrated database
+      # asks the same question and is the one CI can answer.
       - name: Prisma drift check
         run: pnpm db:drift
 

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -384,6 +384,7 @@ export default function AddExpenseScreen() {
       // photograph the same bill twice, and a scan is metered (ADR-011).
       void syncEngine.saveDraft(handoverKey(groupId), {
         parsed: result.parsed,
+        receiptId: result.receiptId,
         at: Date.now(),
       });
 

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { RefreshControl, ScrollView, View } from 'react-native';
+import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
 
 import {
   Avatar,
@@ -28,6 +28,7 @@ import {
   useDisputes,
   useGroupLedger,
   useGroupRealtime,
+  useOpenReceipts,
 } from '@/data/hooks';
 import { describeActivity, verbEmoji } from '@/data/activity';
 import { actorName, displayName, groupLabel, isGhost } from '@/data/types';
@@ -54,6 +55,7 @@ export default function GroupScreen() {
   const { group, members, expenses, settlements, activity } = useGroup(groupId);
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
   const disputes = useDisputes(groupId);
+  const openReceipts = useOpenReceipts(groupId);
   const openDisputes = new Set(
     (disputes.data ?? []).filter((row) => row.status === 'open').map((row) => row.expense_id),
   );
@@ -169,6 +171,37 @@ export default function GroupScreen() {
             </Text>
           </Card>
         ) : null}
+
+        {/* A bill somebody at this table scanned and shared. Without this the
+            second person has no way to reach it, and the claims CRDT is
+            plumbing with no tap. */}
+        {(openReceipts.data ?? []).map((receipt) => (
+          <Pressable
+            key={receipt.id}
+            accessibilityRole="button"
+            accessibilityLabel={`Split ${receipt.parsed?.merchant ?? 'the bill'} by item`}
+            onPress={() => router.push(`/group/${groupId}/itemize?receipt=${receipt.id}`)}
+          >
+            <Card style={{ gap: theme.spacing.sm }}>
+              <Row style={{ gap: theme.spacing.sm }}>
+                <Ionicons name="receipt-outline" size={18} color={theme.color.brand} />
+                <Text variant="subheading" style={{ flex: 1 }} numberOfLines={1}>
+                  {receipt.parsed?.merchant ?? 'A bill'}
+                </Text>
+                <Ionicons
+                  name={directionalIcon('chevron-forward')}
+                  size={18}
+                  color={theme.color.textFaint}
+                />
+              </Row>
+              <Text variant="caption" tone="muted">
+                {receipt.claimed === 0
+                  ? `${receipt.items} lines, nobody has claimed one yet. Tap what you had.`
+                  : `${receipt.claimed} of ${receipt.items} lines claimed. Tap what you had.`}
+              </Text>
+            </Card>
+          </Pressable>
+        ))}
 
         <Card style={{ gap: theme.spacing.lg }}>
           <Row style={{ justifyContent: 'space-between' }}>

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -28,9 +28,9 @@ import {
 } from '@baaki/ui';
 
 import { captureReceipt } from '@/lib/image';
-import { scanReceipt, scanReceiptText } from '@/data/api';
+import { publishReceiptItems, scanReceipt, scanReceiptText, setItemClaim } from '@/data/api';
 import { recogniseReceipt } from '@/lib/ocr';
-import { useGroup, useWriteExpense } from '@/data/hooks';
+import { useGroup, useItemClaims, useReceipt, useWriteExpense } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -53,16 +53,41 @@ interface DraftItem {
  *
  * This is the screen the AI receipt scan fills in for you in M5; today you type
  * the lines, and the maths is already exact.
+ *
+ * **Two modes, and the difference is who is holding a phone.**
+ *
+ * On your own, this is a list in React state: you type the lines, tap who had
+ * what, save. Nothing is shared and nothing needs to be.
+ *
+ * Round a table it is a shared document. Whoever scanned the bill checks the
+ * lines the model read — ADR-008 is that the model proposes and a person
+ * confirms — and then hands them over with one button. From that moment the
+ * lines are fixed and everybody claims their own, live, on their own phone.
+ * The lines freeze because a claim is stored against a line's *index*: deleting
+ * the second of six afterwards would move four people's dinners onto somebody
+ * else's bill.
+ *
+ * Claims go through `baaki_set_item_claim`, which resolves who you are from
+ * your session and refuses to take a member as an argument — the same rule as
+ * `actor_member_id`. The single exception is a ghost member, who has no phone
+ * to tap with, and whom therefore anybody may claim for.
  */
 export default function ItemizeScreen() {
   const theme = useTheme();
   const { t, locale } = useStrings();
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id, receipt: receiptParam } = useLocalSearchParams<{ id: string; receipt?: string }>();
   const groupId = id ?? '';
   const { profile } = useAuth();
 
   const { group, members } = useGroup(groupId);
   const writeExpense = useWriteExpense(groupId);
+
+  // Arriving with `?receipt=` means somebody else scanned this and shared it;
+  // there is nothing to correct and nothing to publish, only lines to claim.
+  const [sharedId, setSharedId] = useState<string | null>(receiptParam ?? null);
+  const shared = useReceipt(sharedId);
+  const claims = useItemClaims(sharedId);
+  const [publishing, setPublishing] = useState(false);
 
   const [description, setDescription] = useState('');
   const [items, setItems] = useState<DraftItem[]>([]);
@@ -73,6 +98,8 @@ export default function ItemizeScreen() {
   const [error, setError] = useState<string | null>(null);
   const [scanning, setScanning] = useState(false);
   const [scanNote, setScanNote] = useState<string | null>(null);
+  /** A bill that has been scanned but not yet handed to the table. */
+  const [scanId, setScanId] = useState<string | null>(null);
 
   /**
    * ADR-008: the model proposes, the person confirms. Everything it read lands
@@ -106,6 +133,7 @@ export default function ItemizeScreen() {
     void clearDraft(handoverKey(groupId));
     if (handoverIsFresh(handover.draft)) {
       fillFromReceipt(handover.draft.parsed);
+      if (handover.draft.receiptId) setScanId(handover.draft.receiptId);
       setScanNote('Carried over from the scan. Check the lines, then tap who had what.');
     }
   }
@@ -138,6 +166,7 @@ export default function ItemizeScreen() {
           });
 
       fillFromReceipt(result.parsed);
+      setScanId(result.receiptId);
 
       // The arithmetic decides what the person is asked to look at. Saying
       // "scanned!" and leaving them to notice a wrong total is the failure
@@ -165,33 +194,62 @@ export default function ItemizeScreen() {
     return BigInt(whole) * scale + BigInt(fraction.padEnd(2, '0') || '0');
   };
 
-  const taxes = toMinor(taxText);
-  const tip = toMinor(tipText);
-  const itemsTotal = items.reduce((total, item) => total + item.total, 0n);
-  const grandTotal = itemsTotal + taxes + tip;
-
   const myMemberId = useMemo(
     () => (members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ?? null,
     [members.data, profile?.id],
   );
 
-  const unclaimed = items.filter((item) => item.claimers.length === 0);
+  const isShared = sharedId !== null;
+
+  const ghostIds = useMemo(
+    () => new Set((members.data ?? []).filter(isGhost).map((member) => member.id)),
+    [members.data],
+  );
+
+  /**
+   * The shared bill: lines from the receipt everybody is looking at, claimers
+   * from the CRDT. Nothing here comes from local state — a line list that
+   * differed between two phones would put the same claim on two different
+   * dishes.
+   */
+  const sharedItems: DraftItem[] = useMemo(() => {
+    const lines = shared.data?.parsed?.items ?? [];
+    const byIndex = new Map<number, MemberId[]>();
+    for (const row of claims.data ?? []) {
+      byIndex.set(row.item_index, [...(byIndex.get(row.item_index) ?? []), row.member_id]);
+    }
+    return lines.map((line, index) => ({
+      key: `shared-${index}`,
+      label: line.label,
+      total: BigInt(line.total),
+      claimers: byIndex.get(index) ?? [],
+    }));
+  }, [shared.data, claims.data]);
+
+  const shown = isShared ? sharedItems : items;
+
+  const taxes = toMinor(taxText);
+  const tip = toMinor(tipText);
+  const itemsTotal = shown.reduce((total, item) => total + item.total, 0n);
+  const grandTotal = itemsTotal + taxes + tip;
+
+  const unclaimed = shown.filter((item) => item.claimers.length === 0);
   // Memoised: a fresh array each render would re-run the split preview forever.
-  const participants = useMemo(() => [...new Set(items.flatMap((item) => item.claimers))], [items]);
+  const participants = useMemo(() => [...new Set(shown.flatMap((item) => item.claimers))], [shown]);
 
   const splitParams: ItemizedParams = useMemo(
     () => ({
       kind: 'itemized',
-      items: items.map((item) => ({ label: item.label, total: item.total })),
-      claims: Object.fromEntries(items.map((item, index) => [index, item.claimers])),
+      items: shown.map((item) => ({ label: item.label, total: item.total })),
+      claims: Object.fromEntries(shown.map((item, index) => [index, item.claimers])),
       taxes,
       tip,
     }),
-    [items, taxes, tip],
+    [shown, taxes, tip],
   );
 
   const preview = useMemo(() => {
-    if (items.length === 0 || unclaimed.length > 0 || participants.length === 0) return null;
+    if (shown.length === 0 || unclaimed.length > 0 || participants.length === 0) return null;
     try {
       return computeShares({
         amount: grandTotal,
@@ -203,7 +261,7 @@ export default function ItemizeScreen() {
     } catch {
       return null;
     }
-  }, [items, unclaimed.length, participants, grandTotal, currency, splitParams]);
+  }, [shown, unclaimed.length, participants, grandTotal, currency, splitParams]);
 
   if (group.isLoading || members.isLoading) {
     return (
@@ -240,19 +298,79 @@ export default function ItemizeScreen() {
     setAmountText('');
   };
 
-  const toggleClaim = (itemKey: string, memberId: MemberId): void => {
-    setItems((current) =>
-      current.map((item) =>
-        item.key === itemKey
-          ? {
-              ...item,
-              claimers: item.claimers.includes(memberId)
-                ? item.claimers.filter((claimer) => claimer !== memberId)
-                : [...item.claimers, memberId],
-            }
-          : item,
-      ),
-    );
+  /**
+   * Whether this phone may speak for that person.
+   *
+   * Yourself, always. A ghost, because they have no phone and somebody has to.
+   * Anybody else with the app, never — the server refuses it too, and the
+   * refusal is the point: a claim is a fact its owner asserted, not a guess
+   * somebody else made on their behalf.
+   */
+  const mayClaimFor = (memberId: MemberId): boolean =>
+    !isShared || memberId === myMemberId || ghostIds.has(memberId);
+
+  const toggleClaim = async (itemKey: string, memberId: MemberId): Promise<void> => {
+    if (!isShared) {
+      setItems((current) =>
+        current.map((item) =>
+          item.key === itemKey
+            ? {
+                ...item,
+                claimers: item.claimers.includes(memberId)
+                  ? item.claimers.filter((claimer) => claimer !== memberId)
+                  : [...item.claimers, memberId],
+              }
+            : item,
+        ),
+      );
+      return;
+    }
+
+    const index = shown.findIndex((item) => item.key === itemKey);
+    const item = shown[index];
+    if (index < 0 || !item) return;
+    if (!mayClaimFor(memberId)) {
+      setError('They are on Baaki — they tap their own lines.');
+      return;
+    }
+
+    setError(null);
+    try {
+      await setItemClaim({
+        receiptId: sharedId,
+        itemIndex: index,
+        claimed: !item.claimers.includes(memberId),
+        forMemberId: memberId === myMemberId ? null : memberId,
+      });
+      await claims.refetch();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  /**
+   * Hand the lines to the table.
+   *
+   * This is the moment the bill stops being one person's list and becomes a
+   * shared document. It is also the last moment a misread line can be fixed,
+   * which is why the button says what it does.
+   */
+  const publish = async (): Promise<void> => {
+    if (!scanId || items.length === 0) return;
+    setError(null);
+    setPublishing(true);
+    try {
+      await publishReceiptItems(
+        scanId,
+        items.map((item) => ({ label: item.label, total: Number(item.total) })),
+      );
+      setSharedId(scanId);
+      setScanNote('Everybody in the group can see this bill now. Tap the lines you had.');
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setPublishing(false);
+    }
   };
 
   const save = async (): Promise<void> => {
@@ -302,30 +420,67 @@ export default function ItemizeScreen() {
           <View style={{ width: 44 }} />
         </Row>
 
-        <Card style={{ gap: theme.spacing.md }}>
-          <Row style={{ justifyContent: 'space-between' }}>
-            <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-              <Text variant="subheading">Scan the receipt</Text>
-              <Text variant="caption" tone="muted">
-                Scan the bill and the items come out filled in. Check them before saving — entering
-                them by hand is always free.
+        {isShared ? (
+          /* A shared bill: the lines are settled, and the only thing left to do
+             is say who had what. Everybody sees everybody else's taps. */
+          <Card style={{ gap: theme.spacing.sm }}>
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Ionicons name="people-outline" size={18} color={theme.color.brand} />
+              <Text variant="subheading" style={{ flex: 1 }}>
+                Splitting together
               </Text>
-            </View>
-            <Button
-              label={scanning ? 'Reading…' : 'Scan'}
-              variant="secondary"
-              disabled={scanning}
-              onPress={() => void scan()}
-              icon={<Ionicons name="camera-outline" size={18} color={theme.color.brand} />}
-            />
-          </Row>
-          {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
-          {scanNote ? (
-            <Text variant="caption" tone="brand">
-              {scanNote}
+              {claims.isFetching ? <ActivityIndicator color={theme.color.brand} /> : null}
+            </Row>
+            <Text variant="caption" tone="muted">
+              Everybody in the group is looking at these lines. Tap the ones you had — they see it
+              as you do it. The lines cannot change now, because a claim is pinned to its line.
             </Text>
-          ) : null}
-        </Card>
+          </Card>
+        ) : (
+          <Card style={{ gap: theme.spacing.md }}>
+            <Row style={{ justifyContent: 'space-between' }}>
+              <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
+                <Text variant="subheading">Scan the receipt</Text>
+                <Text variant="caption" tone="muted">
+                  Scan the bill and the items come out filled in. Check them before saving —
+                  entering them by hand is always free.
+                </Text>
+              </View>
+              <Button
+                label={scanning ? 'Reading…' : 'Scan'}
+                variant="secondary"
+                disabled={scanning}
+                onPress={() => void scan()}
+                icon={<Ionicons name="camera-outline" size={18} color={theme.color.brand} />}
+              />
+            </Row>
+            {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
+            {scanNote ? (
+              <Text variant="caption" tone="brand">
+                {scanNote}
+              </Text>
+            ) : null}
+          </Card>
+        )}
+
+        {/* The one-way door: correcting a misread line is a before-sharing job,
+            so the button says what it costs as well as what it does. */}
+        {!isShared && scanId && items.length > 0 ? (
+          <Card style={{ gap: theme.spacing.md }}>
+            <Text variant="subheading">Everyone at the table has a phone?</Text>
+            <Text variant="caption" tone="muted">
+              Hand these lines to the group and they each tap what they had, on their own phone.
+              Check the lines first — once anybody has claimed one, the list is fixed.
+            </Text>
+            <Button
+              label={publishing ? 'Sharing…' : 'Split together'}
+              variant="secondary"
+              disabled={publishing}
+              onPress={() => void publish()}
+              icon={<Ionicons name="people-outline" size={18} color={theme.color.brand} />}
+            />
+          </Card>
+        ) : null}
 
         <Card style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">
@@ -346,79 +501,95 @@ export default function ItemizeScreen() {
           />
         </Card>
 
-        <Card style={{ gap: theme.spacing.md }}>
-          <Text variant="caption" tone="muted">
-            Add a line
-          </Text>
-          <Row>
-            <TextInput
-              value={label}
-              onChangeText={setLabel}
-              placeholder="Biryani"
-              placeholderTextColor={theme.color.textFaint}
-              accessibilityLabel="Item name"
-              style={{
-                flex: 1,
-                fontSize: 16,
-                fontWeight: '600',
-                color: theme.color.text,
-                paddingVertical: theme.spacing.sm,
-              }}
-            />
-            <TextInput
-              value={amountText}
-              onChangeText={setAmountText}
-              placeholder="320"
-              keyboardType="decimal-pad"
-              placeholderTextColor={theme.color.textFaint}
-              accessibilityLabel="Item amount"
-              onSubmitEditing={addItem}
-              style={{
-                width: 90,
-                fontSize: 16,
-                fontWeight: '700',
-                textAlign: 'right',
-                color: theme.color.text,
-                paddingVertical: theme.spacing.sm,
-              }}
-            />
-            <Button
-              label="Add"
-              size="sm"
-              variant="secondary"
-              disabled={toMinor(amountText) <= 0n}
-              onPress={addItem}
-            />
-          </Row>
-        </Card>
+        {/* Adding a line renumbers nothing, but removing one would — and the
+            two belong together, so both wait until the bill is shared. */}
+        {isShared ? null : (
+          <Card style={{ gap: theme.spacing.md }}>
+            <Text variant="caption" tone="muted">
+              Add a line
+            </Text>
+            <Row>
+              <TextInput
+                value={label}
+                onChangeText={setLabel}
+                placeholder="Biryani"
+                placeholderTextColor={theme.color.textFaint}
+                accessibilityLabel="Item name"
+                style={{
+                  flex: 1,
+                  fontSize: 16,
+                  fontWeight: '600',
+                  color: theme.color.text,
+                  paddingVertical: theme.spacing.sm,
+                }}
+              />
+              <TextInput
+                value={amountText}
+                onChangeText={setAmountText}
+                placeholder="320"
+                keyboardType="decimal-pad"
+                placeholderTextColor={theme.color.textFaint}
+                accessibilityLabel="Item amount"
+                onSubmitEditing={addItem}
+                style={{
+                  width: 90,
+                  fontSize: 16,
+                  fontWeight: '700',
+                  textAlign: 'right',
+                  color: theme.color.text,
+                  paddingVertical: theme.spacing.sm,
+                }}
+              />
+              <Button
+                label="Add"
+                size="sm"
+                variant="secondary"
+                disabled={toMinor(amountText) <= 0n}
+                onPress={addItem}
+              />
+            </Row>
+          </Card>
+        )}
 
-        {items.map((item) => (
+        {shown.map((item) => (
           <Card key={item.key} style={{ gap: theme.spacing.md }}>
             <Row style={{ justifyContent: 'space-between' }}>
               <Text variant="subheading" style={{ flex: 1 }} numberOfLines={1}>
                 {item.label}
               </Text>
               <MoneyText amount={item.total} currency={currency} locale={locale} />
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={`Remove ${item.label}`}
-                onPress={() => setItems((current) => current.filter((row) => row.key !== item.key))}
-              >
-                <Ionicons name="trash-outline" size={18} color={theme.color.textFaint} />
-              </Pressable>
+              {isShared ? null : (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Remove ${item.label}`}
+                  onPress={() =>
+                    setItems((current) => current.filter((row) => row.key !== item.key))
+                  }
+                >
+                  <Ionicons name="trash-outline" size={18} color={theme.color.textFaint} />
+                </Pressable>
+              )}
             </Row>
 
             <Row style={{ flexWrap: 'wrap', gap: theme.spacing.md }}>
               {(members.data ?? []).map((member) => {
                 const claimed = item.claimers.includes(member.id);
+                const mine = mayClaimFor(member.id);
                 return (
                   <Pressable
                     key={member.id}
                     accessibilityRole="checkbox"
-                    accessibilityState={{ checked: claimed }}
+                    accessibilityState={{ checked: claimed, disabled: !mine }}
                     accessibilityLabel={`${displayName(member, profile?.id)} had ${item.label}`}
-                    onPress={() => toggleClaim(item.key, member.id)}
-                    style={{ alignItems: 'center', gap: 4, opacity: claimed ? 1 : 0.35 }}
+                    disabled={!mine}
+                    onPress={() => void toggleClaim(item.key, member.id)}
+                    style={{
+                      alignItems: 'center',
+                      gap: 4,
+                      // Somebody else's claim still shows — that is the point of
+                      // doing this together — it just is not yours to change.
+                      opacity: claimed ? 1 : mine ? 0.35 : 0.2,
+                    }}
                   >
                     <Avatar name={displayName(member)} ghost={isGhost(member)} size={38} />
                     <Text variant="micro" tone={claimed ? 'brand' : 'muted'}>
@@ -520,8 +691,10 @@ export default function ItemizeScreen() {
             })
           ) : (
             <Text variant="caption" tone="muted">
-              {items.length === 0
-                ? 'Add the lines from the bill and tap who had what.'
+              {shown.length === 0
+                ? isShared
+                  ? 'Waiting for the lines from this bill.'
+                  : 'Add the lines from the bill and tap who had what.'
                 : unclaimed.length > 0
                   ? `${unclaimed.length} line${unclaimed.length === 1 ? '' : 's'} still unclaimed — nobody pays for a dish nobody ordered.`
                   : 'Tap who had each line to see the split.'}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1185,3 +1185,91 @@ export async function removePlanItem(itemId: string): Promise<void> {
   const { error } = await supabase.rpc('baaki_remove_plan_item', { p_item_id: itemId });
   if (error) throw new Error(error.message);
 }
+
+// ──────────────────────────────── splitting one bill from several phones ──
+
+export interface ItemClaimRow {
+  item_index: number;
+  member_id: string;
+  revision: number;
+}
+
+/**
+ * Who has claimed what on a scanned bill, right now.
+ *
+ * Released claims are left out: a tombstone is evidence that somebody let a
+ * line go, which is not the same as never having taken it, and the CRDT needs
+ * the difference even though the screen does not.
+ */
+export async function fetchItemClaims(receiptId: string): Promise<ItemClaimRow[]> {
+  const { data, error } = await supabase.rpc('baaki_item_claims', { p_receipt_id: receiptId });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as ItemClaimRow[];
+}
+
+/**
+ * Claim or release one line.
+ *
+ * `forMemberId` is left out for your own lines — the server resolves who you
+ * are and will not take it as an argument. It is only ever sent for a ghost
+ * member, who has no phone to tap with and no other way onto the bill.
+ */
+export async function setItemClaim(input: {
+  receiptId: string;
+  itemIndex: number;
+  claimed: boolean;
+  forMemberId?: string | null;
+}): Promise<void> {
+  const { error } = await supabase.rpc('baaki_set_item_claim', {
+    p_receipt_id: input.receiptId,
+    p_item_index: input.itemIndex,
+    p_claimed: input.claimed,
+    p_for_member_id: input.forMemberId ?? null,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export interface OpenReceiptRow {
+  id: string;
+  created_at: string;
+  parsed: ParsedReceipt | null;
+  claimed: number;
+  items: number;
+}
+
+/** The bills scanned in this group that nobody has turned into an expense yet. */
+export async function fetchOpenReceipts(groupId: string): Promise<OpenReceiptRow[]> {
+  const { data, error } = await supabase.rpc('baaki_open_receipts', { p_group_id: groupId });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as OpenReceiptRow[];
+}
+
+/** One scanned bill, for the person who did not scan it. */
+export async function fetchReceipt(
+  receiptId: string,
+): Promise<{ id: string; group_id: string; parsed: ParsedReceipt | null } | null> {
+  const { data, error } = await supabase
+    .from('receipts')
+    .select('id, group_id, parsed')
+    .eq('id', receiptId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data ?? null) as { id: string; group_id: string; parsed: ParsedReceipt | null } | null;
+}
+
+/**
+ * Hand the corrected lines to everybody else and open the bill for claiming.
+ *
+ * Refused once anybody has claimed, because a claim is stored against a line's
+ * index — renumbering afterwards would move somebody else's dinner.
+ */
+export async function publishReceiptItems(
+  receiptId: string,
+  items: { label: string; total: number }[],
+): Promise<void> {
+  const { error } = await supabase.rpc('baaki_publish_receipt_items', {
+    p_receipt_id: receiptId,
+    p_items: items,
+  });
+  if (error) throw new Error(error.message);
+}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -37,6 +37,9 @@ import {
   fetchExpenseVersions,
   fetchDisputes,
   fetchExpenses,
+  fetchItemClaims,
+  fetchOpenReceipts,
+  fetchReceipt,
   fetchGroup,
   fetchGroups,
   fetchGroupSpending,
@@ -533,6 +536,65 @@ export function usePlanItems(groupId: string) {
   return useQuery({
     queryKey: ['plan', groupId],
     queryFn: () => fetchPlanItems(groupId),
+    enabled: groupId !== '',
+  });
+}
+
+// ──────────────────────────────── splitting one bill from several phones ──
+
+/**
+ * Who has claimed which line, kept live.
+ *
+ * Realtime rather than polling, because the whole point is four people round a
+ * table watching each other's taps appear. `receipt_item_claims` has no
+ * `group_id` to filter on, so the filter is the receipt — which is narrower
+ * anyway: nobody needs to hear about a bill they are not looking at.
+ */
+export function useItemClaims(receiptId: string | null) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!receiptId) return;
+    const channel = supabase
+      .channel(`receipt:${receiptId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'receipt_item_claims',
+          filter: `receipt_id=eq.${receiptId}`,
+        },
+        () => void queryClient.invalidateQueries({ queryKey: ['claims', receiptId] }),
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [receiptId, queryClient]);
+
+  return useQuery({
+    queryKey: ['claims', receiptId],
+    queryFn: () => fetchItemClaims(receiptId!),
+    enabled: Boolean(receiptId),
+  });
+}
+
+/** One scanned bill, for whoever did not scan it. */
+export function useReceipt(receiptId: string | null) {
+  return useQuery({
+    queryKey: ['receipt', receiptId],
+    queryFn: () => fetchReceipt(receiptId!),
+    enabled: Boolean(receiptId),
+  });
+}
+
+/** The bills in this group that are scanned but not yet split. */
+export function useOpenReceipts(groupId: string) {
+  return useQuery({
+    queryKey: ['open-receipts', groupId],
+    queryFn: () => fetchOpenReceipts(groupId),
     enabled: groupId !== '',
   });
 }

--- a/apps/mobile/src/lib/handover.ts
+++ b/apps/mobile/src/lib/handover.ts
@@ -20,6 +20,13 @@ import type { ParsedReceipt } from '@baaki/core';
 
 export interface ReceiptHandover {
   readonly parsed: ParsedReceipt;
+  /**
+   * The receipt row the scan was recorded against. Carried across so a bill
+   * scanned on the add-expense screen can still be shared with the table from
+   * the itemize screen — without it, following the handover meant losing the
+   * only thing that makes the lines shareable.
+   */
+  readonly receiptId?: string;
   /** Epoch milliseconds. A scan nobody followed up on goes stale (see `HANDOVER_TTL_MS`). */
   readonly at: number;
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,7 @@
     "migrate:create": "prisma migrate dev --create-only",
     "migrate:deploy": "prisma migrate deploy",
     "migrate:reset": "prisma migrate reset --force",
-    "drift": "prisma migrate diff --from-migrations ./prisma/migrations --to-schema-datamodel ./prisma/schema.prisma --shadow-database-url \"$SHADOW_DATABASE_URL\" --exit-code",
+    "drift": "prisma migrate diff --from-schema-datasource ./prisma/schema.prisma --to-schema-datamodel ./prisma/schema.prisma --exit-code",
     "studio": "prisma studio",
     "typecheck": "prisma generate --no-hints && tsc --noEmit",
     "test": "vitest run"

--- a/packages/db/prisma/migrations/20260807170000_shared_itemizing/migration.sql
+++ b/packages/db/prisma/migrations/20260807170000_shared_itemizing/migration.sql
@@ -1,0 +1,233 @@
+-- Splitting one bill from four phones.
+--
+-- The claims CRDT has existed since the last milestone and nothing has ever
+-- called it: the itemize screen kept its lines and its claims in React state,
+-- so "who had what" was one person's opinion typed into one device. This is
+-- the migration that gives the screen something to talk to.
+--
+-- Two things are needed beyond what is already there.
+--
+-- **Somebody has to speak for the people without the app.** A group has ghost
+-- members — a name and nothing else, no profile, no phone, no way to tap. The
+-- existing `baaki_set_item_claim` resolves the member from the caller and
+-- refuses to take one as an argument, which is exactly right for anybody who
+-- can answer for themselves and impossible for anybody who cannot. So the
+-- argument exists now, and is accepted for precisely one kind of member: one
+-- with no profile attached. Claiming a line for a real person who is sitting
+-- at the same table with the app open is still not something a client gets to
+-- do.
+--
+-- **The parsed receipt has to be trustworthy.** It was writable by any member
+-- of the group, which mattered little while it was read once and forgotten.
+-- Now it is the shared list of lines everybody claims against, so a member who
+-- can rewrite it can change what everybody else is agreeing to. The edge
+-- function that reads receipts writes them through `baaki_record_receipt` with
+-- the service role; no client has ever written this table directly, so taking
+-- the privilege away breaks nothing and closes the door.
+
+-- ─────────────────────────────────────────── claiming, for somebody else ──
+
+-- `CREATE OR REPLACE` with a new argument does not replace anything: it leaves
+-- the old three-argument function in place beside the new one, and every
+-- existing call fails with "function ... is not unique". Drop it first.
+DROP FUNCTION IF EXISTS public.baaki_set_item_claim(uuid, int, boolean);
+
+CREATE FUNCTION public.baaki_set_item_claim(
+  p_receipt_id    uuid,
+  p_item_index    int,
+  p_claimed       boolean,
+  /**
+   * Whose claim this is, or NULL for the caller's own — which is what the app
+   * sends for everybody who has the app. A member id is only accepted here for
+   * a ghost: somebody has to tap for the friend who is not on Baaki, and there
+   * is nobody else who can.
+   */
+  p_for_member_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+  v_member   uuid;
+  v_revision int;
+  v_ghost    boolean;
+BEGIN
+  SELECT group_id INTO v_group_id FROM public.receipts WHERE id = p_receipt_id;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such receipt' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF NOT public.is_group_member(v_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_item_index < 0 THEN
+    RAISE EXCEPTION 'INVALID_ITEM: an item index is not negative'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF p_for_member_id IS NULL THEN
+    v_member := public.baaki_my_member_id(v_group_id);
+    IF v_member IS NULL THEN
+      RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  ELSE
+    SELECT (profile_id IS NULL) INTO v_ghost
+    FROM public.group_members
+    WHERE id = p_for_member_id AND group_id = v_group_id AND left_at IS NULL;
+
+    IF v_ghost IS NULL THEN
+      RAISE EXCEPTION 'UNKNOWN_MEMBER: that person is not in this group'
+        USING ERRCODE = 'foreign_key_violation';
+    END IF;
+    IF NOT v_ghost THEN
+      -- The whole point of the CRDT is that everybody claims their own lines.
+      -- Letting one phone claim for another is how a set of facts turns back
+      -- into one person's opinion, and it is the `actor_member_id` bug wearing
+      -- a different hat.
+      RAISE EXCEPTION 'NOT_YOURS: they are on Baaki — they claim their own lines'
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    v_member := p_for_member_id;
+  END IF;
+
+  -- One statement, so two devices racing on the same row serialise in the
+  -- database rather than in whichever of them read first.
+  INSERT INTO public.receipt_item_claims (receipt_id, item_index, member_id, released_at, revision)
+  VALUES (
+    p_receipt_id, p_item_index, v_member,
+    CASE WHEN p_claimed THEN NULL ELSE now() END,
+    1
+  )
+  ON CONFLICT (receipt_id, item_index, member_id) DO UPDATE
+    SET released_at = CASE WHEN p_claimed THEN NULL ELSE now() END,
+        revision    = public.receipt_item_claims.revision + 1,
+        updated_at  = now()
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object(
+    'receiptId', p_receipt_id,
+    'itemIndex', p_item_index,
+    'memberId', v_member,
+    'claimed', p_claimed,
+    'revision', v_revision
+  );
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_set_item_claim(uuid, int, boolean, uuid)
+  TO authenticated, anon;
+
+-- ─────────────────────────────────────────────────── publishing the lines ──
+
+/**
+ * Hand the corrected lines to everybody else, and open the bill for claiming.
+ *
+ * ADR-008 is that the model proposes and a person confirms, so the scan lands
+ * in an editable list and whoever scanned it fixes what was misread. That step
+ * has to happen *before* anybody claims, because a claim is stored against a
+ * line's index: deleting the second of six lines afterwards would silently move
+ * four people's dinners onto somebody else's. So this refuses once a single
+ * claim exists, and from that moment the list is what everybody agreed to look
+ * at.
+ *
+ * It writes `parsed`, which no client may write directly — that is the point of
+ * routing it through here.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_publish_receipt_items(
+  p_receipt_id uuid,
+  p_items      jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+BEGIN
+  SELECT group_id INTO v_group_id FROM public.receipts WHERE id = p_receipt_id;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such receipt' USING ERRCODE = 'no_data_found';
+  END IF;
+  IF NOT public.is_group_member(v_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF jsonb_typeof(p_items) IS DISTINCT FROM 'array' OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'INVALID_ITEMS: a bill needs lines' USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.receipt_item_claims WHERE receipt_id = p_receipt_id) THEN
+    RAISE EXCEPTION 'ALREADY_CLAIMING: somebody has started claiming these lines'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  UPDATE public.receipts
+     SET parsed = jsonb_set(COALESCE(parsed, '{}'::jsonb), '{items}', p_items, true),
+         updated_at = now()
+   WHERE id = p_receipt_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_publish_receipt_items(uuid, jsonb)
+  TO authenticated, anon;
+
+-- ──────────────────────────────────────────── the bills still being split ──
+
+/**
+ * The receipts in a group that nobody has turned into an expense yet.
+ *
+ * This is what makes the shared screen reachable. Without it the second person
+ * at the table has no way to arrive at the bill the first person scanned, and
+ * the CRDT is plumbing with no tap — which is the thing I criticised about the
+ * country column and then very nearly did again.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_open_receipts(p_group_id uuid)
+RETURNS TABLE (
+  id         uuid,
+  created_at timestamptz,
+  parsed     jsonb,
+  claimed    int,
+  items      int
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    r.id,
+    r.created_at,
+    r.parsed,
+    (
+      SELECT count(DISTINCT c.item_index)::int
+      FROM public.receipt_item_claims c
+      WHERE c.receipt_id = r.id AND c.released_at IS NULL
+    ),
+    COALESCE(jsonb_array_length(r.parsed -> 'items'), 0)
+  FROM public.receipts r
+  WHERE r.group_id = p_group_id
+    AND r.parse_status IN ('parsed', 'needs_review')
+    AND r.parsed IS NOT NULL
+    -- Once a version points at the receipt the bill has been split and the
+    -- screen is history, not work in progress.
+    AND NOT EXISTS (
+      SELECT 1 FROM public.expense_versions v WHERE v.receipt_id = r.id
+    )
+  ORDER BY r.created_at DESC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_open_receipts(uuid) TO authenticated, anon;
+
+-- ──────────────────────────────────────── nobody rewrites a shared receipt ──
+
+DROP POLICY IF EXISTS receipts_insert ON public.receipts;
+DROP POLICY IF EXISTS receipts_update ON public.receipts;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.receipts FROM anon, authenticated;

--- a/packages/db/prisma/migrations/20260807180000_revoke_trigger_and_references/migration.sql
+++ b/packages/db/prisma/migrations/20260807180000_revoke_trigger_and_references/migration.sql
@@ -1,0 +1,33 @@
+-- The two privileges the audit missed.
+--
+-- Supabase grants `ALL` on every table in `public` to `anon` and
+-- `authenticated`. The security hardening migration went through that grant
+-- verb by verb — SELECT, INSERT, UPDATE, DELETE, and later TRUNCATE, which RLS
+-- does not govern — and left two behind because they read as harmless:
+-- TRIGGER and REFERENCES. Twenty-three tables, ninety-two grants.
+--
+-- **TRIGGER is not harmless.** `CREATE TRIGGER` needs the TRIGGER privilege on
+-- the table and EXECUTE on the function, and nothing else — in particular it
+-- does not need CREATE on the schema, which `anon` and `authenticated` do not
+-- have. So a signed-in member cannot write their own trigger function, but they
+-- can attach one of Baaki's. Hanging the balance-maintenance trigger on
+-- `expense_shares` a second time makes every share count twice, and the derived
+-- balances stop matching the ledger they are derived from — which is the one
+-- thing this app promises. The client-side recomputation would catch it and
+-- say the balances disagree, which is the right failure and still a failure.
+--
+-- **REFERENCES is smaller and still wrong.** It lets somebody point a foreign
+-- key at a table they can only read, which pins rows against deletion and
+-- turns a constraint violation into a probe for which ids exist.
+--
+-- Neither is used by anything. Prisma runs migrations as the table owner, which
+-- needs no grant, and every trigger in this schema is created by a migration.
+
+REVOKE TRIGGER, REFERENCES ON ALL TABLES IN SCHEMA public FROM anon, authenticated;
+
+-- And for the next table somebody adds. Default privileges apply to objects
+-- created by the role that sets them, which is the role Prisma migrates as —
+-- so a table created by a future migration starts without these too, rather
+-- than waiting for the next audit.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  REVOKE TRIGGER, REFERENCES ON TABLES FROM anon, authenticated;

--- a/packages/db/test/helpers.ts
+++ b/packages/db/test/helpers.ts
@@ -86,6 +86,12 @@ export interface AddExpenseOptions {
   description?: string;
   date?: string;
   category?: string | null;
+  /**
+   * The scanned bill this expense came out of. Set here rather than afterwards
+   * because `expense_versions` is append-only (ADR-004) — an UPDATE is refused
+   * by the trigger.
+   */
+  receiptId?: string | null;
 }
 
 /**
@@ -105,6 +111,7 @@ export async function addEqualSplitExpense(
     description = 'Dinner',
     date = '2026-03-01',
     category = null,
+    receiptId = null,
   } = options;
 
   const expenseId = randomUUID();
@@ -126,8 +133,8 @@ export async function addEqualSplitExpense(
   await client.query(
     `INSERT INTO expense_versions
        (id, expense_id, version_no, author_member_id, description, category, expense_date,
-        currency, amount, split_type, split_params)
-     VALUES ($1, $2, 1, $3, $4, $5, $6, $7, $8, 'equal', '{"kind":"equal"}'::jsonb)`,
+        currency, amount, split_type, split_params, receipt_id)
+     VALUES ($1, $2, 1, $3, $4, $5, $6, $7, $8, 'equal', '{"kind":"equal"}'::jsonb, $9)`,
     [
       versionId,
       expenseId,
@@ -137,6 +144,7 @@ export async function addEqualSplitExpense(
       date,
       currency,
       amount.toString(),
+      receiptId,
     ],
   );
   for (const [memberId, paid] of Object.entries(payers)) {

--- a/packages/db/test/item-claims.test.ts
+++ b/packages/db/test/item-claims.test.ts
@@ -16,7 +16,14 @@ import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { Client } from 'pg';
 
-import { CONNECTION_STRING, connect, expectDenied, seedGroup, type SeededGroup } from './helpers';
+import {
+  addEqualSplitExpense,
+  CONNECTION_STRING,
+  connect,
+  expectDenied,
+  seedGroup,
+  type SeededGroup,
+} from './helpers';
 
 let admin: Client;
 let group: SeededGroup;
@@ -196,5 +203,235 @@ describe('a claim is always about the person making it', () => {
       clients[0]!.query(`SELECT baaki_set_item_claim($1, 0, true)`, [randomUUID()]),
     );
     expect(message).toMatch(/NOT_FOUND/);
+  });
+});
+
+describe('claiming for the friend who is not on Baaki', () => {
+  let ghostId: string;
+
+  beforeAll(async () => {
+    ghostId = randomUUID();
+    await admin.query(
+      `INSERT INTO group_members (id, group_id, ghost_name, joined_via)
+       VALUES ($1, $2, 'Ravi', 'ghost')`,
+      [ghostId, group.groupId],
+    );
+  });
+
+  it('lets anybody in the group tap for a ghost, because nobody else can', async () => {
+    // A ghost is a name and nothing else — no profile, no phone, no way to
+    // claim a line. Refusing on their behalf would mean the bill can never be
+    // finished, which is a worse answer than the small forgery risk.
+    await clients[1]!.query(`SELECT baaki_set_item_claim($1, 4, true, $2)`, [receiptId, ghostId]);
+    expect(await liveClaims()).toEqual([{ item: 4, member: ghostId }]);
+  });
+
+  it('releases a ghost’s claim the same way', async () => {
+    await clients[1]!.query(`SELECT baaki_set_item_claim($1, 4, true, $2)`, [receiptId, ghostId]);
+    await clients[2]!.query(`SELECT baaki_set_item_claim($1, 4, false, $2)`, [receiptId, ghostId]);
+    expect(await liveClaims()).toEqual([]);
+  });
+
+  it('still refuses to claim for somebody who has the app', async () => {
+    // This is the whole point of the CRDT: a set of facts each owned by the
+    // person who added it. One phone claiming for another turns it back into
+    // one person's opinion.
+    const message = await expectDenied(
+      clients[0]!.query(`SELECT baaki_set_item_claim($1, 5, true, $2)`, [
+        receiptId,
+        group.memberIds[1],
+      ]),
+    );
+    expect(message).toMatch(/NOT_YOURS/);
+  });
+
+  it('refuses a member id from another group entirely', async () => {
+    const other = await seedGroup(admin, { memberCount: 1, ghostCount: 1, name: 'Elsewhere' });
+    const message = await expectDenied(
+      clients[0]!.query(`SELECT baaki_set_item_claim($1, 6, true, $2)`, [
+        receiptId,
+        other.memberIds[1],
+      ]),
+    );
+    expect(message).toMatch(/UNKNOWN_MEMBER/);
+  });
+});
+
+describe('finding the bill somebody else scanned', () => {
+  beforeEach(async () => {
+    await admin.query(`DELETE FROM receipt_item_claims WHERE receipt_id = $1`, [receiptId]);
+    await admin.query(`UPDATE receipts SET parsed = $2 WHERE id = $1`, [
+      receiptId,
+      JSON.stringify({
+        merchant: 'Anjappar',
+        items: [
+          { label: 'Biryani', total: 32000 },
+          { label: 'Naan', total: 6000 },
+        ],
+        taxes: [],
+        tip: null,
+      }),
+    ]);
+  });
+
+  it('lists a scanned bill nobody has split yet, with how far along it is', async () => {
+    // Without this the second person at the table has no way to reach the bill
+    // the first person scanned, and the whole CRDT is plumbing with no tap.
+    await clients[0]!.query(`SELECT baaki_set_item_claim($1, 0, true)`, [receiptId]);
+    await clients[1]!.query(`SELECT baaki_set_item_claim($1, 0, true)`, [receiptId]);
+
+    const { rows } = await clients[2]!.query(
+      `SELECT id, claimed, items FROM baaki_open_receipts($1)`,
+      [group.groupId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(receiptId);
+    // Two people on one line is one line claimed, not two.
+    expect(rows[0].claimed).toBe(1);
+    expect(rows[0].items).toBe(2);
+  });
+
+  it('drops it from the list once it has become an expense', async () => {
+    const { rows: before } = await clients[0]!.query(`SELECT id FROM baaki_open_receipts($1)`, [
+      group.groupId,
+    ]);
+    expect(before).toHaveLength(1);
+
+    await addEqualSplitExpense(admin, {
+      groupId: group.groupId,
+      payers: { [group.memberIds[0]!]: 38000n },
+      participants: [group.memberIds[0]!, group.memberIds[1]!],
+      amount: 38000n,
+      description: 'Anjappar',
+      receiptId,
+    });
+
+    const { rows: after } = await clients[0]!.query(`SELECT id FROM baaki_open_receipts($1)`, [
+      group.groupId,
+    ]);
+    expect(after).toHaveLength(0);
+  });
+
+  it('shows a stranger nothing', async () => {
+    const other = await seedGroup(admin, { memberCount: 1, name: 'Elsewhere' });
+    const { rows } = await clients[0]!.query(`SELECT id FROM baaki_open_receipts($1)`, [
+      other.groupId,
+    ]);
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe('publishing the corrected lines', () => {
+  const lines = JSON.stringify([
+    { label: 'Biryani', total: 32000 },
+    { label: 'Naan', total: 6000 },
+  ]);
+
+  beforeEach(async () => {
+    await admin.query(`DELETE FROM receipt_item_claims WHERE receipt_id = $1`, [receiptId]);
+    await admin.query(`UPDATE receipts SET parsed = NULL WHERE id = $1`, [receiptId]);
+  });
+
+  it('lets a member hand the lines to everybody else', async () => {
+    await clients[0]!.query(`SELECT baaki_publish_receipt_items($1, $2::jsonb)`, [
+      receiptId,
+      lines,
+    ]);
+    const { rows } = await clients[2]!.query(
+      `SELECT jsonb_array_length(parsed -> 'items') AS n FROM receipts WHERE id = $1`,
+      [receiptId],
+    );
+    expect(Number(rows[0].n)).toBe(2);
+  });
+
+  it('refuses once somebody has started claiming', async () => {
+    // A claim is stored against a line's index. Deleting the second of six
+    // lines afterwards would move four people's dinners onto somebody else.
+    await clients[0]!.query(`SELECT baaki_publish_receipt_items($1, $2::jsonb)`, [
+      receiptId,
+      lines,
+    ]);
+    await clients[1]!.query(`SELECT baaki_set_item_claim($1, 0, true)`, [receiptId]);
+
+    const message = await expectDenied(
+      clients[0]!.query(
+        `SELECT baaki_publish_receipt_items($1, '[{"label":"x","total":1}]'::jsonb)`,
+        [receiptId],
+      ),
+    );
+    expect(message).toMatch(/ALREADY_CLAIMING/);
+  });
+
+  it('refuses a released claim too, because the index still means something', async () => {
+    await clients[0]!.query(`SELECT baaki_publish_receipt_items($1, $2::jsonb)`, [
+      receiptId,
+      lines,
+    ]);
+    await clients[1]!.query(`SELECT baaki_set_item_claim($1, 0, true)`, [receiptId]);
+    await clients[1]!.query(`SELECT baaki_set_item_claim($1, 0, false)`, [receiptId]);
+
+    const message = await expectDenied(
+      clients[0]!.query(`SELECT baaki_publish_receipt_items($1, $2::jsonb)`, [receiptId, lines]),
+    );
+    expect(message).toMatch(/ALREADY_CLAIMING/);
+  });
+
+  it('refuses an empty bill', async () => {
+    const message = await expectDenied(
+      clients[0]!.query(`SELECT baaki_publish_receipt_items($1, '[]'::jsonb)`, [receiptId]),
+    );
+    expect(message).toMatch(/INVALID_ITEMS/);
+  });
+
+  it('refuses somebody outside the group', async () => {
+    const outsider = randomUUID();
+    await admin.query(
+      `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Mallory', 'INR')`,
+      [outsider],
+    );
+    const stranger = new Client({ connectionString: CONNECTION_STRING });
+    await stranger.connect();
+    try {
+      await stranger.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+        JSON.stringify({ sub: outsider, role: 'authenticated' }),
+      ]);
+      await stranger.query('SET ROLE authenticated');
+      const message = await expectDenied(
+        stranger.query(`SELECT baaki_publish_receipt_items($1, $2::jsonb)`, [receiptId, lines]),
+      );
+      expect(message).toMatch(/NOT_A_MEMBER/);
+    } finally {
+      await stranger.end();
+    }
+  });
+});
+
+describe('the parsed receipt is not a client’s to rewrite', () => {
+  it('refuses a member editing the lines everybody is claiming against', async () => {
+    // It mattered little while `parsed` was read once and forgotten. Now it is
+    // the shared list of lines, so a member who can rewrite it can change what
+    // everybody else is agreeing to.
+    const message = await expectDenied(
+      clients[0]!.query(`UPDATE receipts SET parsed = '{"items":[]}'::jsonb WHERE id = $1`, [
+        receiptId,
+      ]),
+    );
+    expect(message).toMatch(/permission denied/i);
+  });
+
+  it('refuses a member inventing a receipt in somebody else’s name', async () => {
+    const message = await expectDenied(
+      clients[0]!.query(
+        `INSERT INTO receipts (group_id, created_by, source, parse_status)
+         VALUES ($1, $2, 'camera', 'parsed')`,
+        [group.groupId, group.memberIds[3]],
+      ),
+    );
+    expect(message).toMatch(/permission denied/i);
+  });
+
+  it('still lets everybody in the group read it', async () => {
+    const { rows } = await clients[3]!.query(`SELECT id FROM receipts WHERE id = $1`, [receiptId]);
+    expect(rows).toHaveLength(1);
   });
 });

--- a/packages/db/test/security-hardening.test.ts
+++ b/packages/db/test/security-hardening.test.ts
@@ -374,6 +374,60 @@ describe('the parts of the database that are nobody’s business', () => {
     expect(allowed, 'these tables can be emptied by any signed-in user').toEqual([]);
   });
 
+  /**
+   * The two the first pass missed, for the same reason and on the same
+   * twenty-three tables: `GRANT ALL` was unpicked verb by verb, and these two
+   * read as harmless.
+   *
+   * TRIGGER is not. `CREATE TRIGGER` needs the privilege on the table and
+   * EXECUTE on the function and nothing else — no CREATE on the schema, which
+   * these roles do not have anyway. So a member cannot write a trigger
+   * function, but can attach one of Baaki's: hang the balance-maintenance
+   * trigger on `expense_shares` a second time and every share counts twice.
+   */
+  it('lets no client attach a trigger or a foreign key to any table', async () => {
+    const { rows } = await client.query(
+      `SELECT c.relname
+         FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relkind = 'r'
+        ORDER BY c.relname`,
+    );
+
+    const allowed: string[] = [];
+    for (const row of rows) {
+      const table = `public.${String(row.relname)}`;
+      const { rows: grant } = await client.query(
+        `SELECT has_table_privilege('anon', $1, 'TRIGGER') AS at,
+                has_table_privilege('authenticated', $1, 'TRIGGER') AS bt,
+                has_table_privilege('anon', $1, 'REFERENCES') AS ar,
+                has_table_privilege('authenticated', $1, 'REFERENCES') AS br`,
+        [table],
+      );
+      const [held] = grant;
+      if (held.at || held.bt) allowed.push(`${row.relname} TRIGGER`);
+      if (held.ar || held.br) allowed.push(`${row.relname} REFERENCES`);
+    }
+
+    expect(allowed, 'a member could attach these').toEqual([]);
+  });
+
+  it('starts a table added tomorrow without them either', async () => {
+    // `ALTER DEFAULT PRIVILEGES` is what stops this being rediscovered by the
+    // next audit instead of prevented by this one. It applies to objects
+    // created by the role that set it, which is the role Prisma migrates as.
+    await client.query('CREATE TABLE public.baaki_default_privilege_probe (id int)');
+    try {
+      const { rows } = await client.query(
+        `SELECT has_table_privilege('authenticated', 'public.baaki_default_privilege_probe', 'TRIGGER') AS t,
+                has_table_privilege('authenticated', 'public.baaki_default_privilege_probe', 'REFERENCES') AS r`,
+      );
+      expect(rows[0].t, 'TRIGGER on a new table').toBe(false);
+      expect(rows[0].r, 'REFERENCES on a new table').toBe(false);
+    } finally {
+      await client.query('DROP TABLE public.baaki_default_privilege_probe');
+    }
+  });
+
   it('gives a JWT claim naming a group no power at all', async () => {
     // `is_group_member` used to accept any group id in
     // `app_metadata.baaki_groups`. Nothing ever wrote that claim, and it had

--- a/scripts/check-filenames.sh
+++ b/scripts/check-filenames.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Files that came from a mis-quoted shell command, rather than from anybody.
+#
+# Seven of them sat in the repo root for five milestones — `(value.length`,
+# `b.currency`, `convert(money(100n` and friends, all empty, all swept in by
+# `git add -A` after a heredoc or a `>` landed somewhere it should not have.
+# Six more appeared in `packages/db` the day the first seven were removed.
+# Nothing type-checks a filename, so nothing ever complained.
+#
+# Two rules, both about the *last* segment of the path:
+#
+#   1. It must end in an extension this repo actually uses. That is what
+#      catches `b.currency` and `item.claimers))]`, which otherwise look like
+#      ordinary dotted names.
+#   2. Apart from the extension it must be ordinary — letters, digits, dot,
+#      dash, underscore. Expo Router's `(tabs)` and `[id].tsx` are the
+#      deliberate exceptions, and are spelled out rather than exempted by
+#      loosening the character class for everybody.
+#
+# Adding a genuinely new kind of file means adding its extension here, which is
+# the intended cost: it is one line, and it is a decision worth making once.
+
+set -euo pipefail
+
+EXTENSIONS='ts|tsx|js|jsx|mjs|cjs|json|md|sql|prisma|ya?ml|toml|css|html|svg|png|jpg|jpeg|webp|ico|ttf|otf|sh|txt|example|gitignore|gitattributes|npmrc|nvmrc|prettierrc|prettierignore|editorconfig|lock'
+
+bad=""
+while IFS= read -r path; do
+  name=${path##*/}
+
+  # Assets come out of design tools and Expo's icon generator with spaces and
+  # copy-numbers in their names — `expo-symbol 2.svg`. Nobody types those, so
+  # they are not the failure this is looking for.
+  case $path in apps/*/assets/*) continue ;; esac
+
+  # Expo Router names a route group `(tabs)` and a dynamic segment `[id]` or
+  # `[...rest]`. Both are directories or files the framework requires.
+  if [[ $name =~ ^\(.+\)$ ]]; then continue; fi
+  if [[ $name =~ ^\[\.{0,3}[A-Za-z0-9_-]+\](\.[A-Za-z0-9]+)?$ ]]; then continue; fi
+
+  if [[ ! $name =~ ^[A-Za-z0-9._-]+$ ]] || [[ ! $name =~ \.($EXTENSIONS)$ ]]; then
+    bad+="  $path"$'\n'
+  fi
+done < <(git ls-files)
+
+if [[ -n $bad ]]; then
+  echo 'Tracked files that look like shell debris, or use an unknown extension:'
+  printf '%s' "$bad"
+  echo
+  echo 'If one of these is a real file, add its extension to scripts/check-filenames.sh.'
+  exit 1
+fi


### PR DESCRIPTION
The claims CRDT has existed since the last milestone and nothing has
ever called it. `receipt_item_claims` had a unique constraint, an
observed-remove set, tombstones and a revision counter, and the itemize
screen kept its lines and its claims in React state — so "who had what"
was one person's opinion typed into one device. This wires it up.

**Two modes, and the difference is who is holding a phone.** On your own
the screen is what it was: type the lines, tap who had what, save. Round
a table, whoever scanned the bill checks the lines the model read —
ADR-008 is that the model proposes and a person confirms — and hands them
over with one button. From then on everybody claims their own lines on
their own phone and sees each other's taps arrive.

The lines freeze at that moment, and `baaki_publish_receipt_items`
refuses once a single claim exists. A claim is stored against a line's
*index*: deleting the second of six afterwards would move four people's
dinners onto somebody else's bill.

`baaki_set_item_claim` still resolves who you are from your session. The
one thing it now takes is a member id, accepted for exactly one kind of
member: a ghost, who has no phone to tap with and no other way onto the
bill. Claiming for somebody who has the app is refused by the server and
not offered by the screen.

There is a way in, too — the group screen lists bills that are scanned
but not yet split, with how far along they are. Shipping the table
without that would repeat the country-column mistake I criticised in #52.

**Two grants the security audit missed**, on all twenty-three tables.
`GRANT ALL` was unpicked verb by verb and TRIGGER and REFERENCES read as
harmless. TRIGGER is not: `CREATE TRIGGER` needs the privilege on the
table and EXECUTE on the function and nothing else — no CREATE on the
schema, which these roles do not have. So a member cannot write a trigger
function but can attach one of Baaki's, and hanging the balance
maintenance trigger on `expense_shares` twice makes every share count
twice. Revoked, with `ALTER DEFAULT PRIVILEGES` so the next table starts
without them. `receipts` also loses INSERT and UPDATE: `parsed` is now
the shared list of lines everybody claims against, and a member who can
rewrite it can change what everybody else is agreeing to.

Two CI gates that main has been failing, found by running them:
`db:drift` has been broken since the security migration — the shadow
replay cannot work, because `_prisma_migrations` is created by Prisma
outside any migration and that migration revokes privileges on it. It now
diffs the database the previous step just built, which asks the same
question. And the filename check from #59 is now a script covering every
directory, not just the root, because six more pieces of shell debris
appeared in `packages/db` the same day.

Verified: 287 db tests against a throwaway Postgres, every migration
applied to an empty database, no drift, and the live grants asserted down
to SELECT. The trigger guard was checked by re-granting it and watching
the test fail.

Not verified: never driven end to end on two devices. The server side is
covered by tests; the two-phone experience is not.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6