### PR TITLE
fix: four things two phones found that no test could

### DIFF
--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -579,9 +579,14 @@ export default function ItemizeScreen() {
                   <Pressable
                     key={member.id}
                     accessibilityRole="checkbox"
-                    accessibilityState={{ checked: claimed, disabled: !mine }}
+                    accessibilityState={{ checked: claimed }}
                     accessibilityLabel={`${displayName(member, profile?.id)} had ${item.label}`}
-                    disabled={!mine}
+                    // Deliberately still tappable when it is not yours to
+                    // change. `disabled` made it a silent no-op: tapping a
+                    // friend's face on a shared bill did nothing at all and
+                    // never reached the sentence explaining why — which, on
+                    // two phones round a table, reads as the app being broken
+                    // rather than as a rule.
                     onPress={() => void toggleClaim(item.key, member.id)}
                     style={{
                       alignItems: 'center',

--- a/apps/mobile/src/app/join.tsx
+++ b/apps/mobile/src/app/join.tsx
@@ -25,12 +25,28 @@ export default function JoinScreen() {
 
   const [preview, setPreview] = useState<InvitePreview | null>(null);
   const [claimId, setClaimId] = useState<string | null>(null);
-  // A link with no token can be judged during render; no effect needed.
   const [busy, setBusy] = useState(Boolean(token));
   const [joining, setJoining] = useState(false);
-  const [error, setError] = useState<string | null>(
-    token ? null : 'This link is missing its invite code',
-  );
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * Whether the route parameters have had a chance to arrive.
+   *
+   * A link with no token looked like something that could be judged during the
+   * first render. It cannot: a deep link is parsed a frame later, so on a real
+   * invite opened on a real phone the screen said "This link is missing its
+   * invite code" and then went on saying it while the group name, the member
+   * list and a working Join button loaded underneath. Waiting a tick before
+   * calling a link broken is the whole fix.
+   */
+  const [settled, setSettled] = useState(Boolean(token));
+  useEffect(() => {
+    if (settled) return;
+    const timer = setTimeout(() => setSettled(true), 0);
+    return () => clearTimeout(timer);
+  }, [settled]);
+
+  const shown = error ?? (!token && settled ? 'This link is missing its invite code' : null);
 
   useEffect(() => {
     let active = true;
@@ -83,7 +99,7 @@ export default function JoinScreen() {
         <EmptyState
           title="This link has expired"
           body={
-            error ??
+            shown ??
             'Ask whoever sent it for a fresh one — links expire so they cannot be passed around forever.'
           }
           action={<Button label="Go to Baaki" onPress={() => router.replace('/')} />}
@@ -156,9 +172,9 @@ export default function JoinScreen() {
           </Card>
         ) : null}
 
-        {error ? (
+        {shown ? (
           <Text variant="caption" tone="negative" align="center">
-            {error}
+            {shown}
           </Text>
         ) : null}
 

--- a/packages/db/prisma/migrations/20260807190000_publish_receipt_claims/migration.sql
+++ b/packages/db/prisma/migrations/20260807190000_publish_receipt_claims/migration.sql
@@ -1,0 +1,41 @@
+-- The claims nobody could see arrive.
+--
+-- `useItemClaims` subscribes to `receipt_item_claims` so four people round a
+-- table watch each other's taps appear. It subscribed to a table Postgres was
+-- not publishing: `supabase_realtime` was given its list in M1 and nothing has
+-- added to it since, so every claim written after that landed in the database
+-- and reached nobody.
+--
+-- Found by running two phones against one bill. One claimed a line, the row was
+-- there a second later with revision 1, and the other phone went on saying
+-- "nobody has claimed this" — which no test in this repo could have caught,
+-- because every one of them reads the table directly.
+--
+-- `receipts` joins it for the same reason one step earlier: publishing the
+-- lines is what turns a private list into a shared one, and the other phone
+-- should not have to be told to pull down and refresh to find out.
+
+DO $$
+DECLARE
+  v_table text;
+BEGIN
+  -- Guarded: CI runs against plain Postgres, which has no `supabase_realtime`.
+  IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+    FOREACH v_table IN ARRAY ARRAY['receipt_item_claims', 'receipts', 'trip_plan_items']
+    LOOP
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_publication_tables
+        WHERE pubname = 'supabase_realtime' AND schemaname = 'public' AND tablename = v_table
+      ) THEN
+        EXECUTE format('ALTER PUBLICATION supabase_realtime ADD TABLE public.%I', v_table);
+      END IF;
+    END LOOP;
+  END IF;
+END
+$$;
+
+-- A claim is resolved by its revision, so a subscriber that receives only the
+-- changed columns cannot tell which of two updates is newer. REPLICA IDENTITY
+-- FULL sends the whole row, which is what the other tables in this publication
+-- already do and what the CRDT needs.
+ALTER TABLE public.receipt_item_claims REPLICA IDENTITY FULL;

--- a/supabase/functions/receipt-parse/index.ts
+++ b/supabase/functions/receipt-parse/index.ts
@@ -227,7 +227,25 @@ Deno.serve(async (request) => {
     if (!response.ok) {
       const detail = await response.text();
       console.error('anthropic error', response.status, detail.slice(0, 500));
-      throw new HttpError(502, 'SCAN_FAILED', 'The scanner could not read that just now');
+
+      // Say *why*, not just that it failed. "The scanner could not read that
+      // just now" told the person nothing and told whoever had to debug it
+      // less — the only copy of the reason was in a log nobody watching a
+      // phone can reach. The upstream type and message are the model's
+      // complaint about the request, never about the key, so they are safe to
+      // pass on.
+      let reason = '';
+      try {
+        const upstream = JSON.parse(detail) as { error?: { type?: string; message?: string } };
+        reason = [upstream.error?.type, upstream.error?.message].filter(Boolean).join(': ');
+      } catch {
+        reason = detail.slice(0, 200);
+      }
+      throw new HttpError(
+        502,
+        'SCAN_FAILED',
+        `The scanner could not read that just now (${response.status}${reason ? ` ${reason}` : ''})`,
+      );
     }
 
     const message = (await response.json()) as {


### PR DESCRIPTION
Ran the shared-bill flow on two Android emulators against the live
project. Everything below was invisible to 287 database tests, 373 core
tests and 115 app tests, because every one of them reads the database
directly and none of them is a second phone.

**Live claiming never worked.** `useItemClaims` subscribes to
`receipt_item_claims`, and Postgres was not publishing it: the
`supabase_realtime` publication was given its list in M1 and nothing has
added to it since. One phone claimed a line, the row was there a second
later with revision 1, and the other phone went on saying "nobody has
claimed this". The migration adds `receipt_item_claims`, `receipts` — so
a bill somebody publishes appears without a pull-to-refresh — and
`trip_plan_items`, which has the same hole. `REPLICA IDENTITY FULL` too:
a claim is resolved by its revision, and a subscriber sent only the
changed columns cannot tell which of two updates is newer.

**Tapping a friend's face did nothing at all.** The avatars for people
who claim their own lines were `disabled`, so the tap never reached the
sentence explaining why — on two phones round a table that reads as the
app being broken rather than as a rule. Now tappable, and it says
"They are on Baaki — they tap their own lines."

**The join screen called a good link broken.** `token` is not in the
route params on the first render — a deep link is parsed a frame later —
so "This link is missing its invite code" was already on screen when the
real invite arrived, and nothing cleared it. The group name, the member
list and a working Join button all loaded underneath the error. Now the
message is derived rather than stored, and waits a tick before calling a
link broken.

**A failed scan told nobody anything.** "The scanner could not read that
just now" was the whole message, and the reason existed only in an edge
function log that nobody holding a phone can reach. It now carries the
upstream status and the model's own complaint — which is how the actual
cause of today's failure was found in one retry: HTTP 400,
`invalid_request_error: Your credit balance is too low to access the
Anthropic API`. Not a bug in this repo, and not something the app could
previously have said.

Verified on device after each fix: two phones in one group, a claim on
one appearing on the other untouched, a ghost member claimed by somebody
else's phone, and a forged claim for a real member refused server-side
with nothing written. Every migration still applies to an empty database,
287 db tests pass against a throwaway Postgres, and there is no drift.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6