### PR TITLE
fix: the contacts screen blamed the wrong thing, and money reads better

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -98,6 +98,25 @@ has proved anything about itself; the group covers are emoji for the same reason
 so the tour looks like the product rather than a brochure stapled to the front of
 it.
 
+## Lists somebody has to aim at
+
+The contact picker is the one screen where the data is not ours and can be
+enormous — a phone with nine hundred names in it. It borrows the shape of the
+phone's own contacts app rather than inventing one: the count in the search
+field, letter headings that stick as you scroll, and an index rail down the
+right side. Nobody has to learn it, and a thousand rows stops being something
+you scroll and becomes something you aim at.
+
+The rail's letters come from the contacts rather than a hard-coded A–Z, so an
+address book of Tamil or Devanagari names gets a rail that matches it instead of
+filing everyone under `#`. When there are more letters than fit, it shows every
+nth: a squashed complete alphabet is worse at aiming than a sparse one.
+
+`@shopify/flash-list` does the recycling — sections are one flat array of
+headings and people, with `getItemType` telling it the two are different shapes.
+The rail is ours, forty lines, because every published React Native
+alphabet-index component was abandoned years ago.
+
 ## Spacing
 
 4px base: `xs 4 · sm 8 · md 12 · lg 16 · xl 20 · xxl 24 · xxxl 32`. Screens use

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,6 +24,13 @@ file explains the _why_, the tokens are the source of truth.
 Dark mode keeps the same hues at lower luminance (`theme.tsx`), so a group's
 colour identity survives the switch.
 
+**The brand wash** (`theme.gradient.brand`) is three stops off that same purple
+ramp, dark corner to light, and it is the only gradient in the app. It is a way
+of drawing the brand, not a second brand: every stop is dark enough to carry
+white text, because the balance and its labels sit on all of them. `Gradient`
+paints it, and falls back to flat brand if `expo-linear-gradient` is missing
+from a build — a decoration may never be the reason a screen fails to render.
+
 ### The one rule that is not decorative
 
 **Money colour is semantic and global.** Owed-to-you is always the
@@ -32,6 +39,13 @@ the app may use those two colours, because in a ledger app colour is data:
 a user should be able to answer "am I up or down?" without reading a digit.
 
 `MoneyText` enforces it — components pass an amount and a mode, never a colour.
+
+It also renders the minor units fainter than the major ones (`₹1,517`**`.53`**),
+in the amount's own colour rather than grey, so the fade works on the brand
+panel, on green and on red alike. Where the split falls is the locale's
+business, not ours: `formatParts` in `@baaki/core` cuts the string at the
+separator `Intl` actually used, because `de-DE` writes `1.517,53 €` and
+searching for a `.` would take the wrong one.
 
 ## Type
 
@@ -92,7 +106,7 @@ floating tab bar never covers the last row.
 
 ## Components
 
-`Screen · Card · TintCard · CurvedPanel · Text · Button · IconButton · Fab ·
+`Screen · Card · TintCard · CurvedPanel · Gradient · Text · Button · IconButton · Fab ·
 Chip · ChipRow · Badge · Avatar · AvatarStack · ListRow · EmptyState ·
 MoneyText · Toggle · PillTabBar · AmountKeypad`
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,6 +11,7 @@
     "@react-native-community/datetimepicker": "9.1.0",
     "@react-native-ml-kit/text-recognition": "^2.0.0",
     "@sentry/react-native": "~7.11.0",
+    "@shopify/flash-list": "2.0.2",
     "@supabase/supabase-js": "^2.112.0",
     "@tanstack/react-query": "^5.101.4",
     "base64-arraybuffer": "^1.0.2",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -29,6 +29,7 @@
     "expo-image": "~57.0.2",
     "expo-image-manipulator": "~57.0.8",
     "expo-image-picker": "~57.0.8",
+    "expo-linear-gradient": "~57.0.1",
     "expo-linking": "~57.0.5",
     "expo-local-authentication": "~57.0.2",
     "expo-localization": "~57.0.1",

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1,14 +1,15 @@
+import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { RefreshControl, ScrollView, View } from 'react-native';
 
-import { format } from '@baaki/core';
 import {
   Avatar,
   Badge,
   Button,
   Card,
   EmptyState,
+  Gradient,
   IconButton,
   ListRow,
   MoneyText,
@@ -36,6 +37,23 @@ export default function HomeScreen() {
 
   const list = groups.data ?? [];
   const loading = groups.isLoading || summary.isLoading;
+
+  /**
+   * Which action is waiting to be told a group.
+   *
+   * Both headline actions need one, and guessing is worse than asking: an
+   * expense filed against the wrong trip is a debt somebody has to notice and
+   * unpick. With no groups the question is "start one"; with exactly one there
+   * is nothing to ask.
+   */
+  const [pending, setPending] = useState<'add-expense' | 'settle' | null>(null);
+
+  const start = (action: 'add-expense' | 'settle'): void => {
+    const only = list.length === 1 ? list[0] : undefined;
+    if (list.length === 0) router.push('/new-group');
+    else if (only) router.push(`/group/${only.id}/${action}`);
+    else setPending(action);
+  };
 
   return (
     <Screen>
@@ -93,7 +111,10 @@ export default function HomeScreen() {
         ) : null}
 
         {/* Headline: one glance answers "am I up or down?" */}
-        <Card style={{ backgroundColor: theme.color.brand, gap: theme.spacing.lg }}>
+        <Gradient
+          radius={theme.radius.md}
+          style={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
+        >
           <Row style={{ justifyContent: 'space-between' }}>
             <Text variant="caption" tone="onBrand" style={{ opacity: 0.8 }}>
               {t.yourBaaki}
@@ -104,19 +125,13 @@ export default function HomeScreen() {
           </Row>
 
           <View>
-            <Text
+            <MoneyText
+              amount={summary.totals.net < 0n ? -summary.totals.net : summary.totals.net}
+              currency="INR"
+              locale={locale}
               tone="onBrand"
-              tabular
               style={{ fontSize: 40, lineHeight: 46, fontWeight: '700' }}
-            >
-              {format(
-                {
-                  minor: summary.totals.net < 0n ? -summary.totals.net : summary.totals.net,
-                  currency: 'INR',
-                },
-                { locale, compactFraction: true },
-              )}
-            </Text>
+            />
             <Text variant="caption" tone="onBrand" style={{ opacity: 0.85 }}>
               {summary.totals.net === 0n
                 ? t.allSettled
@@ -131,26 +146,82 @@ export default function HomeScreen() {
               <Text variant="micro" tone="onBrand" style={{ opacity: 0.75 }}>
                 {t.youAreOwed}
               </Text>
-              <Text variant="subheading" tone="onBrand" tabular>
-                {format(
-                  { minor: summary.totals.owed, currency: 'INR' },
-                  { locale, compactFraction: true },
-                )}
-              </Text>
+              <MoneyText
+                amount={summary.totals.owed}
+                currency="INR"
+                locale={locale}
+                tone="onBrand"
+              />
             </View>
             <View>
               <Text variant="micro" tone="onBrand" style={{ opacity: 0.75 }}>
                 {t.youOwe}
               </Text>
-              <Text variant="subheading" tone="onBrand" tabular>
-                {format(
-                  { minor: summary.totals.owing, currency: 'INR' },
-                  { locale, compactFraction: true },
-                )}
-              </Text>
+              <MoneyText
+                amount={summary.totals.owing}
+                currency="INR"
+                locale={locale}
+                tone="onBrand"
+              />
             </View>
           </Row>
-        </Card>
+
+          {/* The two things anybody opens Baaki to do, where the balance they
+              just read is still on screen. Which group they mean is asked
+              below only when there is more than one answer. */}
+          <Row style={{ gap: theme.spacing.md }}>
+            <Button
+              label={t.addExpense}
+              variant="onBrand"
+              style={{ flex: 1 }}
+              icon={<Ionicons name="add-circle-outline" size={18} color={theme.color.brand} />}
+              onPress={() => start('add-expense')}
+            />
+            <Button
+              label={t.settleUp}
+              variant="onBrandOutline"
+              style={{ flex: 1 }}
+              icon={
+                <Ionicons name="swap-horizontal-outline" size={18} color={theme.color.onBrand} />
+              }
+              onPress={() => start('settle')}
+            />
+          </Row>
+        </Gradient>
+
+        {pending ? (
+          <Card style={{ gap: theme.spacing.sm }}>
+            <Row style={{ justifyContent: 'space-between' }}>
+              <Text variant="subheading">
+                {pending === 'add-expense' ? t.addExpense : t.settleUp}
+              </Text>
+              <Text variant="caption" tone="brand" onPress={() => setPending(null)}>
+                {t.cancel}
+              </Text>
+            </Row>
+            <Text variant="caption" tone="muted">
+              {t.whichGroup}
+            </Text>
+            {list.map((group) => (
+              <ListRow
+                key={group.id}
+                title={groupLabel(group, summary.membersFor(group.id), profile?.id)}
+                leading={
+                  <Avatar
+                    name={groupLabel(group, summary.membersFor(group.id), profile?.id)}
+                    emoji={group.cover_emoji ?? undefined}
+                    tint={tintForKey(group.id)}
+                    size={36}
+                  />
+                }
+                onPress={() => {
+                  setPending(null);
+                  router.push(`/group/${group.id}/${pending}`);
+                }}
+              />
+            ))}
+          </Card>
+        ) : null}
 
         {loading ? (
           <Card>

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -2,15 +2,17 @@
  * Browsing the phone's address book to add somebody to a group.
  *
  * The address book never leaves the device — `ContactPicker` reads it, searches
- * it and shows it locally, and only the one person tapped is sent anywhere.
+ * it and shows it locally, and only the people ticked are sent anywhere.
  * There is deliberately no "which of my contacts already use Baaki" here: that
  * feature requires uploading the whole book, and it turns an address book into
  * a membership oracle for anybody who later reaches the server (ADR-006).
  *
  * A person in Baaki always belongs to a group, because a debt is between people
- * *about something*. So picking a contact asks the one question that has to be
- * answered — which group — rather than inventing a floating "friend" that owes
- * nobody anything.
+ * *about something*. So picking contacts asks the one question that has to be
+ * answered — which group — rather than inventing floating "friends" that owe
+ * nobody anything. The whole lot goes into one group: picking six people for a
+ * trip and then answering "which group?" six times is the same answer six
+ * times.
  */
 
 import { useState } from 'react';
@@ -21,6 +23,7 @@ import { ActivityIndicator, ScrollView, View } from 'react-native';
 
 import {
   Avatar,
+  AvatarStack,
   Button,
   Card,
   directionalIcon,
@@ -42,18 +45,47 @@ export default function ContactsScreen(): React.JSX.Element {
   const theme = useTheme();
   const queryClient = useQueryClient();
 
-  const [picked, setPicked] = useState<PickedContact | null>(null);
+  const [picked, setPicked] = useState<readonly PickedContact[]>([]);
   const [added, setAdded] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const groups = useQuery({ queryKey: ['groups'], queryFn: fetchGroups });
 
+  /**
+   * Everybody picked, into the one group, one call each.
+   *
+   * A failure part-way leaves the earlier ones added, and says whose name did
+   * not make it. Adding five people is five separate acts, not a transaction:
+   * throwing away four good ones because the fifth had a number the server
+   * would not take is a worse answer than telling you about the fifth.
+   */
   const add = useMutation({
-    mutationFn: async ({ groupId, contact }: { groupId: string; contact: PickedContact }) =>
-      addGhostMember(groupId, contact.name, { email: contact.email, phone: contact.phone }),
-    onSuccess: async (_id, { groupId, contact }) => {
-      setAdded(contact.name);
-      setPicked(null);
+    mutationFn: async ({
+      groupId,
+      contacts,
+    }: {
+      groupId: string;
+      contacts: readonly PickedContact[];
+    }) => {
+      const failed: string[] = [];
+      let last = '';
+      for (const contact of contacts) {
+        try {
+          await addGhostMember(groupId, contact.name, {
+            email: contact.email,
+            phone: contact.phone,
+          });
+        } catch (caught) {
+          failed.push(contact.name);
+          last = caught instanceof Error ? caught.message : String(caught);
+        }
+      }
+      if (failed.length > 0) throw new Error(`Could not add ${failed.join(', ')}: ${last}`);
+      return contacts.length;
+    },
+    onSuccess: async (count, { groupId }) => {
+      setAdded(`${count} ${count === 1 ? 'person' : 'people'}`);
+      setPicked([]);
       setError(null);
       await queryClient.invalidateQueries({ queryKey: ['members', groupId] });
       await queryClient.invalidateQueries({ queryKey: ['people', 'balances'] });
@@ -64,11 +96,16 @@ export default function ContactsScreen(): React.JSX.Element {
   });
 
   return (
-    <Screen>
+    // The picker anchors a button to the bottom of the screen, so this one has
+    // to hold the bottom inset too. Without it the button lands under the
+    // navigation bar — invisible on a phone with three buttons rather than a
+    // gesture pill, which is the case an emulator does not show you.
+    <Screen edges={['top', 'bottom']}>
       <View
         style={{
           flex: 1,
           paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.md,
           gap: theme.spacing.lg,
         }}
       >
@@ -82,17 +119,17 @@ export default function ContactsScreen(): React.JSX.Element {
           <View style={{ width: 44 }} />
         </Row>
 
-        {picked ? (
+        {picked.length > 0 ? (
           <ChooseGroup
-            contact={picked}
+            contacts={picked}
             groups={groups.data ?? []}
             busy={add.isPending}
             error={error}
             onCancel={() => {
-              setPicked(null);
+              setPicked([]);
               setError(null);
             }}
-            onChoose={(groupId) => add.mutate({ groupId, contact: picked })}
+            onChoose={(groupId) => add.mutate({ groupId, contacts: picked })}
           />
         ) : (
           <>
@@ -103,7 +140,7 @@ export default function ContactsScreen(): React.JSX.Element {
                 </Text>
               </Card>
             ) : null}
-            <ContactPicker onPick={setPicked} />
+            <ContactPicker onConfirm={setPicked} confirmVerb="Continue with" />
           </>
         )}
       </View>
@@ -118,14 +155,14 @@ export default function ContactsScreen(): React.JSX.Element {
  * nothing to owe or be owed, and would sit in the app looking like a mistake.
  */
 function ChooseGroup({
-  contact,
+  contacts,
   groups,
   busy,
   error,
   onCancel,
   onChoose,
 }: {
-  contact: PickedContact;
+  contacts: readonly PickedContact[];
   groups: readonly { id: string; name: string | null; cover_emoji: string | null }[];
   busy: boolean;
   error: string | null;
@@ -133,6 +170,7 @@ function ChooseGroup({
   onChoose: (groupId: string) => void;
 }): React.JSX.Element {
   const theme = useTheme();
+  const only = contacts.length === 1 ? contacts[0] : undefined;
 
   return (
     <ScrollView
@@ -141,17 +179,25 @@ function ChooseGroup({
     >
       <Card style={{ gap: theme.spacing.xs }}>
         <Row style={{ gap: theme.spacing.md }}>
-          <Avatar name={contact.name} size={44} />
+          {only ? (
+            <Avatar name={only.name} size={44} />
+          ) : (
+            <AvatarStack names={contacts.map((contact) => contact.name)} size={36} />
+          )}
           <View style={{ flex: 1 }}>
-            <Text variant="subheading">{contact.name}</Text>
-            <Text variant="micro" tone="faint">
-              {contact.email ?? contact.phone ?? 'No address'}
+            <Text variant="subheading" numberOfLines={1}>
+              {only ? only.name : `${contacts.length} people`}
+            </Text>
+            <Text variant="micro" tone="faint" numberOfLines={2}>
+              {only
+                ? (only.email ?? only.phone ?? 'No address')
+                : contacts.map((contact) => contact.name).join(', ')}
             </Text>
           </View>
         </Row>
       </Card>
 
-      <SectionHeader title="Add to which group?" />
+      <SectionHeader title={only ? 'Add to which group?' : 'Add them all to which group?'} />
 
       {groups.length === 0 ? (
         <Card style={{ gap: theme.spacing.md }}>
@@ -205,7 +251,7 @@ function ChooseGroup({
         with this email or number they claim everything already sitting there.
       </Text>
 
-      <Button label="Pick somebody else" variant="ghost" onPress={onCancel} />
+      <Button label="Pick different people" variant="ghost" onPress={onCancel} />
     </ScrollView>
   );
 }

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -18,7 +18,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { ContactPicker } from '@/components/ContactPicker';
+import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
 import { useAddGhostMember, useGroup, useGroupLedger } from '@/data/hooks';
 import { displayName, groupLabel, isGhost, vpaOf } from '@/data/types';
 import { useStrings } from '@/i18n';
@@ -38,6 +38,7 @@ export default function MembersScreen() {
   const [ghostName, setGhostName] = useState('');
   const [ghostContact, setGhostContact] = useState('');
   const [browsing, setBrowsing] = useState(false);
+  const [adding, setAdding] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const currency = group.data?.default_currency ?? 'INR';
@@ -71,19 +72,41 @@ export default function MembersScreen() {
     );
   };
 
-  const addPicked = (picked: {
-    name: string;
-    email: string | null;
-    phone: string | null;
-  }): void => {
+  /**
+   * Several people at once, one call each — the server takes one member per
+   * request and batching them here would only hide which of them failed.
+   *
+   * They are added in sequence rather than in parallel because a batch of
+   * simultaneous writes to the same group races the balance triggers for no
+   * benefit; nobody picks contacts fast enough for the wait to show.
+   *
+   * A failure part-way does not undo the ones already in. Adding somebody is
+   * not a transaction — it is five separate acts — so the honest report is
+   * which names did not make it, not a rollback nobody asked for.
+   */
+  const addPicked = async (people: readonly PickedContact[]): Promise<void> => {
     setError(null);
-    addGhost.mutate(
-      { name: picked.name, email: picked.email, phone: picked.phone },
-      {
-        onSuccess: () => setBrowsing(false),
-        onError: (caught) => setError(caught instanceof Error ? caught.message : String(caught)),
-      },
-    );
+    setAdding(true);
+    const failed: string[] = [];
+    let last = '';
+    for (const person of people) {
+      try {
+        await addGhost.mutateAsync({
+          name: person.name,
+          email: person.email,
+          phone: person.phone,
+        });
+      } catch (caught) {
+        failed.push(person.name);
+        last = caught instanceof Error ? caught.message : String(caught);
+      }
+    }
+    setAdding(false);
+    if (failed.length === 0) {
+      setBrowsing(false);
+      return;
+    }
+    setError(`Could not add ${failed.join(', ')}: ${last}`);
   };
 
   // Contacts already used, so the picker can grey them out instead of letting
@@ -198,8 +221,14 @@ export default function MembersScreen() {
           />
 
           {browsing ? (
-            <View style={{ height: 320 }}>
-              <ContactPicker onPick={addPicked} existing={alreadyAdded} />
+            // Tall enough that the letter rail has something to aim at — a
+            // 320pt window turns a thousand contacts back into a peephole.
+            <View style={{ height: 480 }}>
+              <ContactPicker
+                onConfirm={(people) => void addPicked(people)}
+                existing={alreadyAdded}
+                busy={adding}
+              />
             </View>
           ) : null}
           <Text variant="micro" tone="faint">
@@ -207,7 +236,7 @@ export default function MembersScreen() {
             address just means you can send them the link. When they join later they can claim
             everything already recorded under their name.
           </Text>
-          {addGhost.isPending ? <ActivityIndicator color={theme.color.brand} /> : null}
+          {addGhost.isPending || adding ? <ActivityIndicator color={theme.color.brand} /> : null}
           {error ? (
             <Text variant="caption" tone="negative">
               {error}

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -1,8 +1,8 @@
 /**
- * Picking somebody out of the phone's contacts.
+ * Picking people out of the phone's contacts.
  *
  * The address book never leaves the device. Contacts are read, searched and
- * displayed locally; only the one person you tap is sent anywhere, and only as
+ * displayed locally; only the people you tick are sent anywhere, and only as
  * the name and address needed to invite them.
  *
  * This is worth being deliberate about, because the usual version of this
@@ -11,11 +11,27 @@
  * anyone who later reaches the server, which of your contacts use the app.
  * Baaki has no such endpoint and this component does not want one: an invite
  * link works whether or not the person has ever heard of us (ADR-006).
+ *
+ * The shape is the phone's own contacts app, because that is the list everyone
+ * here has already learned: a search field that says how many there are,
+ * letter sections that stick to the top as you scroll, and an index rail down
+ * the side to throw yourself at a letter. A thousand contacts is not a list you
+ * scroll — it is a list you aim at.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { Contact, ContactField, getPermissionsAsync, requestPermissionsAsync } from 'expo-contacts';
-import { AppState, FlatList, Linking, Pressable, TextInput, View } from 'react-native';
+import {
+  AppState,
+  Linking,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+  type LayoutChangeEvent,
+} from 'react-native';
 
 import { Avatar, Button, Card, EmptyState, Row, Text, useTheme } from '@baaki/ui';
 
@@ -26,9 +42,14 @@ export interface PickedContact {
 }
 
 interface ContactPickerProps {
-  onPick: (contact: PickedContact) => void;
+  /** Called with everyone ticked, once, when the confirm button is pressed. */
+  onConfirm: (contacts: readonly PickedContact[]) => void;
   /** Already in the group — shown greyed rather than hidden, so it is obvious why. */
   existing?: ReadonlySet<string>;
+  /** The verb on the confirm button. The count and noun are added here. */
+  confirmVerb?: string;
+  /** Disables confirming while the caller is still writing the last lot away. */
+  busy?: boolean;
 }
 
 /**
@@ -56,11 +77,28 @@ const FIELDS = [
   ContactField.PHONES,
 ] as const;
 
-export function ContactPicker({ onPick, existing }: ContactPickerProps): React.JSX.Element {
+/** A letter heading, or somebody. One flat array so the list can recycle both. */
+type Entry = { readonly letter: string } | PickedContact;
+
+const isHeading = (entry: Entry): entry is { readonly letter: string } => 'letter' in entry;
+
+const ROW_HEIGHT = 64;
+const HEADING_HEIGHT = 38;
+const RAIL_WIDTH = 24;
+const RAIL_LETTER_HEIGHT = 15;
+const STRIP_HEIGHT = 62;
+
+export function ContactPicker({
+  onConfirm,
+  existing,
+  confirmVerb = 'Add',
+  busy = false,
+}: ContactPickerProps): React.JSX.Element {
   const theme = useTheme();
   const [access, setAccess] = useState<Access>('asking');
   const [contacts, setContacts] = useState<PickedContact[]>([]);
   const [query, setQuery] = useState('');
+  const [picked, setPicked] = useState<ReadonlyMap<string, PickedContact>>(new Map());
   const cancelled = useRef(false);
 
   const load = useCallback(async (): Promise<void> => {
@@ -140,6 +178,55 @@ export function ContactPicker({ onPick, existing }: ContactPickerProps): React.J
     );
   }, [contacts, query]);
 
+  /**
+   * The flat list, the indices that stick, and where each letter starts.
+   *
+   * All three come out of one pass because they have to agree: a rail that
+   * jumps to a stale index scrolls to the wrong person, and that is the kind of
+   * wrong that only shows up on somebody else's address book.
+   */
+  const sections = useMemo(() => {
+    const entries: Entry[] = [];
+    const sticky: number[] = [];
+    const starts = new Map<string, number>();
+    let current: string | null = null;
+
+    for (const contact of matches) {
+      const letter = bucketOf(contact.name);
+      if (letter !== current) {
+        current = letter;
+        starts.set(letter, entries.length);
+        sticky.push(entries.length);
+        entries.push({ letter });
+      }
+      entries.push(contact);
+    }
+    return { entries, sticky, starts, letters: [...starts.keys()] };
+  }, [matches]);
+
+  const listRef = useRef<FlashListRef<Entry>>(null);
+
+  /**
+   * Back to the top whenever the search changes. Without this the list keeps
+   * the offset it had before, so typing two letters leaves you looking at the
+   * middle of four results with the first one scrolled off — it reads as
+   * "nothing matched" when in fact the match is above you.
+   */
+  useEffect(() => {
+    if (sections.entries.length > 0) {
+      void listRef.current?.scrollToIndex({ index: 0, animated: false });
+    }
+  }, [query, sections.entries.length]);
+
+  const toggle = useCallback((key: string, contact: PickedContact) => {
+    setPicked((previous) => {
+      const next = new Map(previous);
+      if (next.has(key)) next.delete(key);
+      else next.set(key, contact);
+      return next;
+    });
+  }, []);
+
   if (access === 'asking') {
     return (
       <Card>
@@ -181,23 +268,47 @@ export function ContactPicker({ onPick, existing }: ContactPickerProps): React.J
     );
   }
 
+  const chosen = [...picked.values()];
+
   return (
     <View style={{ gap: theme.spacing.md, flex: 1 }}>
-      <Card style={{ gap: theme.spacing.xs }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: theme.spacing.sm,
+          height: 44,
+          paddingHorizontal: theme.spacing.lg,
+          borderRadius: theme.radius.pill,
+          backgroundColor: theme.color.surfaceMuted,
+        }}
+      >
+        <Ionicons name="search" size={18} color={theme.color.textFaint} />
         <TextInput
           value={query}
           onChangeText={setQuery}
           autoCapitalize="none"
           accessibilityLabel="Search contacts"
-          placeholder="Search contacts"
+          // The phone's own contacts app puts the count here rather than the
+          // word "search", and it answers the first question somebody has when
+          // they open a list this long: is it all of them?
+          placeholder={`${contacts.length} contacts`}
           placeholderTextColor={theme.color.textFaint}
-          style={{ fontSize: 16, color: theme.color.text, paddingVertical: theme.spacing.sm }}
+          style={{ flex: 1, fontSize: 16, color: theme.color.text, paddingVertical: 0 }}
         />
-      </Card>
+        {query ? (
+          <Pressable
+            onPress={() => setQuery('')}
+            accessibilityRole="button"
+            accessibilityLabel="Clear search"
+            hitSlop={8}
+          >
+            <Ionicons name="close-circle" size={18} color={theme.color.textFaint} />
+          </Pressable>
+        ) : null}
+      </View>
 
-      <Text variant="micro" tone="faint">
-        Only the person you pick is sent to Baaki. Your contacts stay on this phone.
-      </Text>
+      {chosen.length > 0 ? <PickedStrip chosen={chosen} onRemove={toggle} /> : null}
 
       {matches.length === 0 ? (
         <EmptyState
@@ -207,37 +318,356 @@ export function ContactPicker({ onPick, existing }: ContactPickerProps): React.J
           }
         />
       ) : (
-        <FlatList
-          data={matches}
-          keyExtractor={(contact, index) => `${contact.email ?? contact.phone}-${index}`}
-          renderItem={({ item }) => {
-            const already = Boolean(
-              (item.email && existing?.has(item.email)) ||
-              (item.phone && existing?.has(item.phone)),
-            );
-            return (
-              <Pressable
-                onPress={() => !already && onPick(item)}
-                accessibilityRole="button"
-                accessibilityLabel={already ? `${item.name}, already added` : `Add ${item.name}`}
-                style={{ opacity: already ? 0.45 : 1, paddingVertical: theme.spacing.sm }}
-              >
-                <Row style={{ gap: theme.spacing.md }}>
-                  <Avatar name={item.name} size={40} />
-                  <View style={{ flex: 1 }}>
-                    <Text variant="body">{item.name}</Text>
-                    <Text variant="micro" tone="faint">
-                      {already ? 'Already in this group' : (item.email ?? item.phone ?? '')}
-                    </Text>
-                  </View>
-                </Row>
-              </Pressable>
-            );
-          }}
-        />
+        <View style={{ flex: 1, flexDirection: 'row' }}>
+          <View
+            style={{
+              flex: 1,
+              borderRadius: theme.radius.md,
+              backgroundColor: theme.color.surface,
+              overflow: 'hidden',
+            }}
+          >
+            <FlashList
+              ref={listRef}
+              data={sections.entries}
+              extraData={picked}
+              stickyHeaderIndices={sections.sticky}
+              // Headings and people are different shapes; telling the list so
+              // lets it recycle each against its own kind instead of throwing
+              // away a row every time a letter goes by.
+              getItemType={(entry) => (isHeading(entry) ? 'heading' : 'person')}
+              keyExtractor={(entry, index) =>
+                isHeading(entry) ? `letter-${entry.letter}` : `${keyOf(entry)}-${index}`
+              }
+              keyboardShouldPersistTaps="handled"
+              renderItem={({ item }) => {
+                if (isHeading(item)) return <Heading letter={item.letter} />;
+                const key = keyOf(item);
+                const already = Boolean(
+                  (item.email && existing?.has(item.email)) ||
+                    (item.phone && existing?.has(item.phone)),
+                );
+                return (
+                  <ContactRow
+                    contact={item}
+                    already={already}
+                    selected={picked.has(key)}
+                    onPress={() => toggle(key, item)}
+                  />
+                );
+              }}
+            />
+          </View>
+
+          {/* Only worth a rail when there is more than one letter to aim at. */}
+          {sections.letters.length > 1 ? (
+            <IndexRail
+              letters={sections.letters}
+              onSeek={(letter) => {
+                const index = sections.starts.get(letter);
+                if (index !== undefined) {
+                  void listRef.current?.scrollToIndex({ index, animated: false });
+                }
+              }}
+            />
+          ) : null}
+        </View>
       )}
+
+      <Text variant="micro" tone="faint">
+        Only the people you pick are sent to Baaki. Your contacts stay on this phone.
+      </Text>
+
+      <Button
+        label={
+          chosen.length === 0
+            ? 'Nobody picked yet'
+            : `${confirmVerb} ${chosen.length} ${chosen.length === 1 ? 'person' : 'people'}`
+        }
+        fullWidth
+        disabled={chosen.length === 0 || busy}
+        onPress={() => onConfirm(chosen)}
+      />
     </View>
   );
+}
+
+/**
+ * The letter heading. A filled square rather than the app's usual pill, because
+ * a pill in this design system means "you can tap this" and a heading is not
+ * something you tap — you tap the rail on the right.
+ */
+function Heading({ letter }: { letter: string }): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <View
+      style={{
+        height: HEADING_HEIGHT,
+        justifyContent: 'center',
+        paddingHorizontal: theme.spacing.lg,
+        // Opaque: a sticky heading floats over the rows sliding under it.
+        backgroundColor: theme.color.surface,
+      }}
+    >
+      <View
+        style={{
+          width: 26,
+          height: 26,
+          borderRadius: theme.radius.sm,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: theme.color.brand,
+        }}
+      >
+        <Text variant="caption" tone="onBrand">
+          {letter}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function ContactRow({
+  contact,
+  already,
+  selected,
+  onPress,
+}: {
+  contact: PickedContact;
+  already: boolean;
+  selected: boolean;
+  onPress: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const inset = theme.spacing.lg + 40 + theme.spacing.md;
+
+  return (
+    <Pressable
+      onPress={already ? undefined : onPress}
+      disabled={already}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: selected, disabled: already }}
+      accessibilityLabel={already ? `${contact.name}, already added` : contact.name}
+      style={({ pressed }) => ({
+        opacity: already ? 0.45 : 1,
+        backgroundColor: pressed ? theme.color.surfaceMuted : theme.color.surface,
+      })}
+    >
+      <Row
+        style={{
+          height: ROW_HEIGHT,
+          paddingHorizontal: theme.spacing.lg,
+          gap: theme.spacing.md,
+        }}
+      >
+        <Avatar name={contact.name} size={40} />
+        <View style={{ flex: 1 }}>
+          <Text variant="body" numberOfLines={1}>
+            {contact.name}
+          </Text>
+          <Text variant="micro" tone="faint" numberOfLines={1}>
+            {already ? 'Already in this group' : (contact.email ?? contact.phone ?? '')}
+          </Text>
+        </View>
+        <Ionicons
+          name={selected ? 'checkmark-circle' : 'ellipse-outline'}
+          size={24}
+          color={selected ? theme.color.brand : theme.color.border}
+        />
+      </Row>
+      {/* Inset past the avatar, so the rule reads as separating names rather
+          than boxing every row. */}
+      <View style={{ height: 1, marginLeft: inset, backgroundColor: theme.color.border }} />
+    </Pressable>
+  );
+}
+
+/**
+ * Who is ticked, at the top, as faces.
+ *
+ * The count on the button says how many; this says who. Without it, ticking
+ * somebody four hundred rows ago is an act of faith — you cannot scroll back to
+ * check without losing your place.
+ */
+function PickedStrip({
+  chosen,
+  onRemove,
+}: {
+  chosen: readonly PickedContact[];
+  onRemove: (key: string, contact: PickedContact) => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      // A horizontal ScrollView is still a flex child of the column above it,
+      // and without this it takes every spare pixel and pushes the list off the
+      // bottom of the screen. It grew to half the screen for two faces.
+      style={{ height: STRIP_HEIGHT, flexGrow: 0, flexShrink: 0 }}
+      contentContainerStyle={{ gap: theme.spacing.md, paddingRight: theme.spacing.lg }}
+    >
+      {chosen.map((contact) => (
+        <Pressable
+          key={keyOf(contact)}
+          onPress={() => onRemove(keyOf(contact), contact)}
+          accessibilityRole="button"
+          accessibilityLabel={`Remove ${contact.name}`}
+          style={{ width: 56, alignItems: 'center', gap: 2 }}
+        >
+          <View>
+            <Avatar name={contact.name} size={40} />
+            <View
+              style={{
+                position: 'absolute',
+                right: -2,
+                top: -2,
+                width: 18,
+                height: 18,
+                borderRadius: 9,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.color.text,
+                borderWidth: 1.5,
+                borderColor: theme.color.bg,
+              }}
+            >
+              <Ionicons name="close" size={10} color={theme.color.surface} />
+            </View>
+          </View>
+          {/* Full width and centred, or Android measures the label against the
+              text rather than the tile and clips it mid-word with no ellipsis
+              to say it did. */}
+          <Text
+            variant="micro"
+            tone="muted"
+            numberOfLines={1}
+            style={{ width: '100%', textAlign: 'center' }}
+          >
+            {contact.name.split(/\s+/)[0]}
+          </Text>
+        </Pressable>
+      ))}
+    </ScrollView>
+  );
+}
+
+/**
+ * The index rail.
+ *
+ * Hand-written, because every published React Native alphabet-index component
+ * stopped being maintained years ago and would have to be patched onto a modern
+ * list anyway. It is forty lines: letters laid out in a column, a drag mapped
+ * back to whichever one it is over.
+ *
+ * The letters come from the data rather than a hard-coded A–Z, so a book full
+ * of Tamil or Devanagari names gets a rail that matches it. When there are more
+ * letters than fit, it takes every nth — the rail is for aiming, not for
+ * reading, and a squashed complete alphabet is worse at aiming than a sparse
+ * one.
+ */
+function IndexRail({
+  letters,
+  onSeek,
+}: {
+  letters: readonly string[];
+  onSeek: (letter: string) => void;
+}): React.JSX.Element {
+  const [height, setHeight] = useState(0);
+  const [active, setActive] = useState<string | null>(null);
+
+  const shown = useMemo(() => {
+    const room = Math.max(1, Math.floor(height / RAIL_LETTER_HEIGHT));
+    if (height === 0 || letters.length <= room) return letters;
+    const stride = Math.ceil(letters.length / room);
+    return letters.filter((_, index) => index % stride === 0);
+  }, [letters, height]);
+
+  /**
+   * Which letter the finger is over.
+   *
+   * Measured against the block of letters, not the rail: the letters are
+   * centred in a rail as tall as the list, so dividing the rail's height by the
+   * letter count would put every hit target somewhere the letter is not.
+   */
+  const seekAt = (y: number): void => {
+    if (shown.length === 0) return;
+    const top = Math.max(0, (height - shown.length * RAIL_LETTER_HEIGHT) / 2);
+    const index = Math.min(
+      shown.length - 1,
+      Math.max(0, Math.floor((y - top) / RAIL_LETTER_HEIGHT)),
+    );
+    const letter = shown[index];
+    if (letter === undefined || letter === active) return;
+    setActive(letter);
+    onSeek(letter);
+  };
+
+  return (
+    <View
+      onLayout={(event: LayoutChangeEvent) => setHeight(event.nativeEvent.layout.height)}
+      // The rail is one control, not a column of buttons: a finger dragged down
+      // it should sweep through letters the way it does on the phone's own
+      // contacts app, so it claims the gesture rather than passing taps down.
+      onStartShouldSetResponder={() => true}
+      onMoveShouldSetResponder={() => true}
+      onResponderGrant={(event) => seekAt(event.nativeEvent.locationY)}
+      onResponderMove={(event) => seekAt(event.nativeEvent.locationY)}
+      onResponderRelease={() => setActive(null)}
+      onResponderTerminate={() => setActive(null)}
+      accessible
+      accessibilityRole="adjustable"
+      accessibilityLabel="Jump to a letter"
+      style={{
+        width: RAIL_WIDTH,
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      {/* The letters take no touches of their own. A touch reports `locationY`
+          against whatever element it landed on, so while each glyph was its own
+          target every drag read as a few points from the top of a 15pt letter —
+          the rail answered "#" wherever you put your finger. */}
+      <View pointerEvents="none" style={{ alignItems: 'center' }}>
+        {shown.map((letter) => (
+          <Text
+            key={letter}
+            variant="micro"
+            tone={letter === active ? 'brand' : 'faint'}
+            style={{ height: RAIL_LETTER_HEIGHT, lineHeight: RAIL_LETTER_HEIGHT }}
+          >
+            {letter}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Which heading somebody files under.
+ *
+ * Anything that is not a letter — a number, an emoji, a name starting with a
+ * bracket — goes under `#`, the way every address book does it. Scripts without
+ * upper case simply come back unchanged, which is the right answer: Tamil sorts
+ * under Tamil.
+ */
+function bucketOf(name: string): string {
+  const first = name.trim().charAt(0);
+  if (!first) return '#';
+  const upper = first.toLocaleUpperCase();
+  return /\p{Letter}/u.test(upper) ? upper : '#';
+}
+
+/**
+ * Identity for selection. The address first, because that is what actually
+ * distinguishes two people called Amma in a family's address book; the name
+ * only carries the difference when neither has one, which the loader has
+ * already ruled out.
+ */
+function keyOf(contact: PickedContact): string {
+  return `${contact.email ?? ''}|${contact.phone ?? ''}|${contact.name}`;
 }
 
 /**

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -13,9 +13,9 @@
  * link works whether or not the person has ever heard of us (ADR-006).
  */
 
-import { useEffect, useMemo, useState } from 'react';
-import * as Contacts from 'expo-contacts';
-import { FlatList, Linking, Pressable, TextInput, View } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Contact, ContactField, getPermissionsAsync, requestPermissionsAsync } from 'expo-contacts';
+import { AppState, FlatList, Linking, Pressable, TextInput, View } from 'react-native';
 
 import { Avatar, Button, Card, EmptyState, Row, Text, useTheme } from '@baaki/ui';
 
@@ -31,60 +31,103 @@ interface ContactPickerProps {
   existing?: ReadonlySet<string>;
 }
 
-type Permission = 'asking' | 'granted' | 'denied';
+/**
+ * `denied` is the person's answer. `unavailable` is ours — the address book
+ * could not be read for a reason that has nothing to do with them.
+ *
+ * These used to be one state, and the whole feature died of it: in SDK 57 the
+ * old `Contacts.getContactsAsync` throws on every call, so a phone that had
+ * just granted permission was told "Baaki cannot see your contacts" and offered
+ * a settings screen where the switch was already on. A catch that turns every
+ * failure into the same sentence does not just lose the reason — it prints a
+ * confident lie.
+ */
+type Access = 'asking' | 'granted' | 'denied' | 'unavailable';
+
+/**
+ * Only these. Asking for less than the platform offers is the cheapest privacy
+ * measure there is — the name to show, and the one address needed to invite.
+ */
+const FIELDS = [
+  ContactField.FULL_NAME,
+  ContactField.GIVEN_NAME,
+  ContactField.FAMILY_NAME,
+  ContactField.EMAILS,
+  ContactField.PHONES,
+] as const;
 
 export function ContactPicker({ onPick, existing }: ContactPickerProps): React.JSX.Element {
   const theme = useTheme();
-  const [permission, setPermission] = useState<Permission>('asking');
+  const [access, setAccess] = useState<Access>('asking');
   const [contacts, setContacts] = useState<PickedContact[]>([]);
   const [query, setQuery] = useState('');
+  const cancelled = useRef(false);
 
-  useEffect(() => {
-    let cancelled = false;
+  const load = useCallback(async (): Promise<void> => {
+    let granted: boolean;
+    try {
+      const current = await getPermissionsAsync();
+      granted =
+        current.granted || (current.canAskAgain && (await requestPermissionsAsync()).granted);
+    } catch {
+      // Permission itself could not be asked: no contacts module on this
+      // platform (web) or an OS that refused the question.
+      if (!cancelled.current) setAccess('unavailable');
+      return;
+    }
+    if (cancelled.current) return;
+    if (!granted) {
+      setAccess('denied');
+      return;
+    }
 
-    void (async () => {
-      // expo-contacts has no web implementation and throws rather than
-      // no-opping there, which would otherwise leave this stuck on "looking
-      // through your contacts…" forever with nothing said about why.
-      let data: Awaited<ReturnType<typeof Contacts.getContactsAsync>>['data'];
-      try {
-        const { status } = await Contacts.requestPermissionsAsync();
-        if (cancelled) return;
-        if (status !== 'granted') {
-          setPermission('denied');
-          return;
-        }
+    let rows: Awaited<ReturnType<typeof Contact.getAllDetails<typeof FIELDS>>>;
+    try {
+      rows = await Contact.getAllDetails(FIELDS);
+    } catch {
+      if (!cancelled.current) setAccess('unavailable');
+      return;
+    }
+    if (cancelled.current) return;
 
-        // Only these three fields. Asking for less than the platform offers is
-        // the cheapest privacy measure there is.
-        ({ data } = await Contacts.getContactsAsync({
-          fields: [Contacts.Fields.Name, Contacts.Fields.Emails, Contacts.Fields.PhoneNumbers],
-        }));
-      } catch {
-        if (!cancelled) setPermission('denied');
-        return;
-      }
-      if (cancelled) return;
-
-      setContacts(
-        data
-          .map((contact) => ({
-            name: contact.name?.trim() ?? '',
-            email: contact.emails?.[0]?.email?.trim().toLowerCase() ?? null,
-            phone: normalisePhone(contact.phoneNumbers?.[0]?.number ?? null),
-          }))
-          // Somebody with neither an email nor a number cannot be invited, so
-          // showing them would only be an invitation to tap and be refused.
-          .filter((contact) => contact.name && (contact.email || contact.phone))
-          .sort((a, b) => a.name.localeCompare(b.name)),
-      );
-      setPermission('granted');
-    })();
-
-    return () => {
-      cancelled = true;
-    };
+    setContacts(
+      rows
+        .map((row) => ({
+          name: (row.fullName ?? [row.givenName, row.familyName].filter(Boolean).join(' ')).trim(),
+          email: row.emails?.[0]?.address?.trim().toLowerCase() ?? null,
+          phone: normalisePhone(row.phones?.[0]?.number ?? null),
+        }))
+        // Somebody with neither an email nor a number cannot be invited, so
+        // showing them would only be an invitation to tap and be refused.
+        .filter((contact) => contact.name && (contact.email || contact.phone))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    );
+    setAccess('granted');
   }, []);
+
+  // Read on a tick rather than in the effect body: the React Compiler counts a
+  // synchronous call that can setState as a cascading render, and reading an
+  // address book is exactly the "talk to a platform API" case a timer suits.
+  useEffect(() => {
+    cancelled.current = false;
+    const timer = setTimeout(() => void load(), 0);
+    return () => {
+      clearTimeout(timer);
+      cancelled.current = true;
+    };
+  }, [load]);
+
+  /**
+   * "Open settings" sends somebody out of the app to grant access. Without
+   * this, they came back to the same refusal and had to guess that killing
+   * Baaki and starting it again was the missing step.
+   */
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active' && access === 'denied') void load();
+    });
+    return () => subscription.remove();
+  }, [access, load]);
 
   const matches = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -97,7 +140,7 @@ export function ContactPicker({ onPick, existing }: ContactPickerProps): React.J
     );
   }, [contacts, query]);
 
-  if (permission === 'asking') {
+  if (access === 'asking') {
     return (
       <Card>
         <Text variant="caption" tone="muted">
@@ -107,7 +150,7 @@ export function ContactPicker({ onPick, existing }: ContactPickerProps): React.J
     );
   }
 
-  if (permission === 'denied') {
+  if (access === 'denied') {
     return (
       <Card style={{ gap: theme.spacing.sm }}>
         <Text variant="caption" tone="muted">
@@ -122,6 +165,18 @@ export function ContactPicker({ onPick, existing }: ContactPickerProps): React.J
           variant="ghost"
           onPress={() => void Linking.openSettings().catch(() => undefined)}
         />
+      </Card>
+    );
+  }
+
+  if (access === 'unavailable') {
+    return (
+      <Card style={{ gap: theme.spacing.sm }}>
+        <Text variant="caption" tone="muted">
+          Baaki could not read the address book on this phone. Nothing is wrong with your
+          permissions — add people by typing a name, an email or a number instead.
+        </Text>
+        <Button label="Try again" variant="ghost" onPress={() => void load()} />
       </Card>
     );
   }

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -345,7 +345,7 @@ export function ContactPicker({
                 const key = keyOf(item);
                 const already = Boolean(
                   (item.email && existing?.has(item.email)) ||
-                    (item.phone && existing?.has(item.phone)),
+                  (item.phone && existing?.has(item.phone)),
                 );
                 return (
                   <ContactRow

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -96,6 +96,7 @@ export interface UiStrings {
   whatIsPlanned: string;
   add: string;
   cancel: string;
+  whichGroup: string;
   skip: string;
   next: string;
   getStarted: string;
@@ -168,6 +169,7 @@ const en: UiStrings = {
   whatIsPlanned: 'What are you doing?',
   add: 'Add',
   cancel: 'Cancel',
+  whichGroup: 'Which group is this for?',
   skip: 'Skip',
   next: 'Next',
   getStarted: 'Get started',
@@ -268,6 +270,7 @@ const ta: UiStrings = {
   whatIsPlanned: 'என்ன செய்யப் போகிறீர்கள்?',
   add: 'சேர்',
   cancel: 'ரத்து',
+  whichGroup: 'எந்தக் குழுவுக்கு?',
   skip: 'தவிர்',
   next: 'அடுத்து',
   getStarted: 'தொடங்கலாம்',
@@ -354,6 +357,7 @@ const hi: UiStrings = {
   whatIsPlanned: 'क्या करना है?',
   add: 'जोड़ें',
   cancel: 'रद्द',
+  whichGroup: 'किस समूह के लिए?',
   skip: 'छोड़ें',
   next: 'आगे',
   getStarted: 'शुरू करें',
@@ -445,6 +449,7 @@ const ar: UiStrings = {
   whatIsPlanned: 'ماذا ستفعل؟',
   add: 'إضافة',
   cancel: 'إلغاء',
+  whichGroup: 'لأي مجموعة؟',
   skip: 'تخطٍ',
   next: 'التالي',
   getStarted: 'لنبدأ',

--- a/packages/core/src/money/format.ts
+++ b/packages/core/src/money/format.ts
@@ -20,6 +20,51 @@ export interface FormatOptions {
 const DEFAULT_LOCALE: Locale = 'en-IN';
 
 export function format(amount: Money, options: FormatOptions = {}): string {
+  return parts(amount, options)
+    .map((part) => part.value)
+    .join('');
+}
+
+/**
+ * A formatted amount split at the decimal point.
+ *
+ * The paise are worth less than the rupees and should not shout as loudly, so
+ * the display renders them fainter — but only the locale knows where the split
+ * falls. `₹1,517.53`, `$1,517.53` and `1 517,53 €` disagree about the
+ * separator and about which side the symbol sits on, and searching the string
+ * for a '.' gets two of those three wrong.
+ */
+export interface MoneyParts {
+  /** Sign, symbol and whole units — everything before the decimal separator. */
+  readonly lead: string;
+  /** The separator and the minor units (`.53`), or `''` when none are shown. */
+  readonly fraction: string;
+  /** Whatever the locale prints after them, such as a trailing `€`. */
+  readonly trail: string;
+  /** The three joined — identical to `format()` on the same arguments. */
+  readonly text: string;
+}
+
+export function formatParts(amount: Money, options: FormatOptions = {}): MoneyParts {
+  const lead: string[] = [];
+  const fraction: string[] = [];
+  const trail: string[] = [];
+
+  // Everything from the decimal separator onwards is the fraction, until
+  // something that is plainly not part of the number turns up again.
+  let seen: 'lead' | 'fraction' | 'trail' = 'lead';
+  for (const part of parts(amount, options)) {
+    if (part.type === 'decimal') seen = 'fraction';
+    else if (seen === 'fraction' && part.type !== 'fraction') seen = 'trail';
+
+    (seen === 'lead' ? lead : seen === 'fraction' ? fraction : trail).push(part.value);
+  }
+
+  const joined = [lead.join(''), fraction.join(''), trail.join('')] as const;
+  return { lead: joined[0], fraction: joined[1], trail: joined[2], text: joined.join('') };
+}
+
+function parts(amount: Money, options: FormatOptions): Intl.NumberFormatPart[] {
   const { locale = DEFAULT_LOCALE, compactFraction = false, signDisplay = 'auto' } = options;
   const exponent = minorUnitExponent(amount.currency);
   const isWhole = amount.minor % minorUnitScale(amount.currency) === 0n;
@@ -37,7 +82,7 @@ export function format(amount: Money, options: FormatOptions = {}): string {
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
     signDisplay: signDisplay === 'never' ? 'auto' : signDisplay,
-  }).format(asNumber);
+  }).formatToParts(asNumber);
 }
 
 /** Just the currency symbol for the locale ("₹", "$"). */

--- a/packages/core/test/money.test.ts
+++ b/packages/core/test/money.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import fc from 'fast-check';
 
 import { minorUnitExponent, MoneyError } from '../src/money/currency.js';
-import { format, balanceDirection, moneyAccessibilityLabel } from '../src/money/format.js';
+import {
+  format,
+  formatParts,
+  balanceDirection,
+  moneyAccessibilityLabel,
+} from '../src/money/format.js';
 import { convert, fxRate, fromFxRecord, invertRate, toFxRecord } from '../src/money/fx.js';
 import {
   add,
@@ -53,6 +58,42 @@ describe('parse and render', () => {
     expect(formatted).toContain('420.50');
     expect(format(money(42000n, 'INR'), { locale: 'en-IN', compactFraction: true })).not.toContain(
       '.00',
+    );
+  });
+
+  it('splits an amount at the decimal point the locale actually uses', () => {
+    const rupees = formatParts(money(151753n, 'INR'), { locale: 'en-IN' });
+    expect(rupees.lead).toBe('₹1,517');
+    expect(rupees.fraction).toBe('.53');
+    expect(rupees.trail).toBe('');
+
+    // A locale that puts the symbol last and separates with a comma: splitting
+    // the rendered string on '.' would hand back the whole thing.
+    const euros = formatParts(money(151753n, 'EUR'), { locale: 'de-DE' });
+    expect(euros.fraction).toBe(',53');
+    expect(euros.trail).toContain('€');
+  });
+
+  it('leaves nothing to fade when the amount is whole or the currency has no minor unit', () => {
+    expect(
+      formatParts(money(42000n, 'INR'), { locale: 'en-IN', compactFraction: true }).fraction,
+    ).toBe('');
+    expect(formatParts(money(4200n, 'JPY'), { locale: 'en-IN' }).fraction).toBe('');
+  });
+
+  it('always joins back to exactly what format() renders', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: -(10n ** 10n), max: 10n ** 10n }),
+        fc.constantFrom('en-IN', 'ta-IN', 'de-DE'),
+        fc.constantFrom('INR', 'USD', 'JPY', 'KWD' as const),
+        fc.boolean(),
+        (minor, locale, currency, compactFraction) => {
+          const amount = money(minor, currency as 'INR');
+          const options = { locale, compactFraction };
+          expect(formatParts(amount, options).text).toBe(format(amount, options));
+        },
+      ),
     );
   });
 

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -4,7 +4,12 @@ import { Pressable, View, type PressableProps, type ViewStyle } from 'react-nati
 import { useTheme } from '../theme';
 import { Text } from './Text';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+/**
+ * `onBrand` and `onBrandOutline` are the pair that sits on the brand panel:
+ * purple-on-purple is invisible there, so the filled one inverts to white with
+ * a purple label and its partner is an outline in the panel's own white.
+ */
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'onBrand' | 'onBrandOutline';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 export interface ButtonProps extends Omit<PressableProps, 'style' | 'children'> {
@@ -46,7 +51,6 @@ export function Button({
           justifyContent: 'center',
           gap: theme.spacing.sm,
           alignSelf: fullWidth ? 'stretch' : 'flex-start',
-          opacity: disabled ? 0.45 : 1,
           backgroundColor:
             variant === 'primary'
               ? pressed
@@ -54,7 +58,16 @@ export function Button({
                 : theme.color.brand
               : variant === 'secondary'
                 ? theme.color.brandSoft
-                : 'transparent',
+                : variant === 'onBrand'
+                  ? theme.color.onBrand
+                  : variant === 'onBrandOutline'
+                    ? pressed
+                      ? '#FFFFFF29'
+                      : '#FFFFFF1F'
+                    : 'transparent',
+          borderWidth: variant === 'onBrandOutline' ? 1 : 0,
+          borderColor: variant === 'onBrandOutline' ? '#FFFFFF5C' : undefined,
+          opacity: disabled ? 0.45 : variant === 'onBrand' && pressed ? 0.9 : 1,
         },
         variant === 'primary' && !disabled && theme.shadow.soft,
         style,
@@ -64,7 +77,9 @@ export function Button({
       {icon}
       <Text
         variant={size === 'sm' ? 'caption' : 'subheading'}
-        tone={variant === 'primary' ? 'onBrand' : 'brand'}
+        tone={
+          variant === 'primary' ? 'onBrand' : variant === 'onBrandOutline' ? 'onBrand' : 'brand'
+        }
       >
         {label}
       </Text>

--- a/packages/ui/src/components/Gradient.tsx
+++ b/packages/ui/src/components/Gradient.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+import { View, type ViewStyle } from 'react-native';
+
+import { useTheme } from '../theme';
+
+export interface GradientProps {
+  children?: ReactNode;
+  /** Corner radius; defaults to the card radius so it drops into a layout. */
+  radius?: number;
+  style?: ViewStyle;
+}
+
+/**
+ * The brand wash: one purple sliding into a lighter one, corner to corner.
+ *
+ * Flat brand is fine and was what Baaki shipped; a wash gives the balance the
+ * depth the reference boards get from theirs, and costs nothing at rest. The
+ * colours are the brand ramp rather than anything new, so a gradient can never
+ * disagree with the rest of the app about what purple is.
+ *
+ * `expo-linear-gradient` is a native module, and a native module missing from
+ * a build is how this app has previously lost a whole screen. So it is
+ * required lazily behind a check that cannot throw, and a build without it
+ * paints the flat brand colour and carries on — the balance is still legible,
+ * still white on purple, and nobody sees a crash because a decoration was
+ * unavailable.
+ */
+export function Gradient({ children, radius, style }: GradientProps) {
+  const theme = useTheme();
+  const LinearGradient = loadLinearGradient();
+  const borderRadius = radius ?? theme.radius.md;
+
+  if (!LinearGradient) {
+    return (
+      <View style={[{ backgroundColor: theme.color.brand, borderRadius }, style]}>{children}</View>
+    );
+  }
+
+  return (
+    <LinearGradient
+      colors={theme.gradient.brand}
+      // Top-left to bottom-right: the reference sweeps diagonally, and a
+      // vertical wash on a short card reads as a printing error.
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={[{ borderRadius }, style]}
+    >
+      {children}
+    </LinearGradient>
+  );
+}
+
+type LinearGradientComponent = (props: {
+  colors: readonly string[];
+  start?: { x: number; y: number };
+  end?: { x: number; y: number };
+  style?: unknown;
+  children?: ReactNode;
+}) => React.JSX.Element;
+
+let resolved: LinearGradientComponent | null | undefined;
+
+function loadLinearGradient(): LinearGradientComponent | null {
+  if (resolved !== undefined) return resolved;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const module = require('expo-linear-gradient') as { LinearGradient?: LinearGradientComponent };
+    resolved = module.LinearGradient ?? null;
+  } catch {
+    resolved = null;
+  }
+  return resolved;
+}

--- a/packages/ui/src/components/MoneyText.tsx
+++ b/packages/ui/src/components/MoneyText.tsx
@@ -1,14 +1,17 @@
+import { StyleSheet, Text as RNText, type TextStyle } from 'react-native';
+
 import {
   balanceDirection,
   copyFor,
-  format,
+  formatParts,
   moneyAccessibilityLabel,
   type BalanceDirection,
   type CurrencyCode,
   type Money,
 } from '@baaki/core';
 
-import { Text, type TextProps, type TextVariant } from './Text';
+import { useTheme } from '../theme';
+import { Text, toneColor, type TextProps, type TextTone, type TextVariant } from './Text';
 
 export interface MoneyTextProps extends Omit<TextProps, 'children' | 'tone'> {
   amount: bigint;
@@ -25,7 +28,30 @@ export interface MoneyTextProps extends Omit<TextProps, 'children' | 'tone'> {
   direction?: BalanceDirection;
   compactFraction?: boolean;
   showSign?: boolean;
+  /**
+   * Override the colour the mode would choose. Only for surfaces that own
+   * their own contrast, such as white money on the brand panel — never to
+   * paint a balance a colour that disagrees with its sign.
+   */
+  tone?: TextTone;
+  /**
+   * Render the paise fainter than the rupees. On by default: the minor units
+   * are the least important digits on the screen and reading them at full
+   * weight is what makes a large balance hard to take in at a glance.
+   *
+   * Faded, not recoloured — the fraction stays whatever colour the amount is,
+   * so this works on the brand panel, on green and on red without a table of
+   * exceptions.
+   */
+  fadeFraction?: boolean;
 }
+
+/**
+ * Enough to read the paise as secondary, not so little they look disabled.
+ * Written as an alpha suffix on the tone's own colour, so a faded fraction is
+ * the same hue as the amount it belongs to on every surface.
+ */
+const FRACTION_ALPHA = '8C';
 
 /**
  * Money is never rendered as a bare number: it carries its own colour semantics
@@ -40,31 +66,44 @@ export function MoneyText({
   direction,
   compactFraction = true,
   showSign = false,
+  tone,
+  fadeFraction = true,
   ...rest
 }: MoneyTextProps) {
+  const theme = useTheme();
   const money: Money = { minor: amount, currency };
   const resolvedDirection = direction ?? balanceDirection(amount);
   const strings = copyFor(locale).money;
 
-  const rendered = format(mode === 'balance' ? { ...money, minor: abs(amount) } : money, {
+  const shown = mode === 'balance' ? { ...money, minor: abs(amount) } : money;
+  const options = {
     locale,
     compactFraction,
-    signDisplay: showSign ? 'always' : 'auto',
-  });
+    signDisplay: (showSign ? 'always' : 'auto') as 'always' | 'auto',
+  };
+  const parts = formatParts(shown, options);
 
-  const tone =
-    mode === 'balance'
+  const resolvedTone =
+    tone ??
+    (mode === 'balance'
       ? resolvedDirection === 'owed_to_you'
         ? 'positive'
         : resolvedDirection === 'you_owe'
           ? 'negative'
           : 'muted'
-      : 'default';
+      : 'default');
+
+  // The caller may have overridden the colour outright (white money on the
+  // brand panel); fade that, not the tone's.
+  const flattened = StyleSheet.flatten(rest.style) as TextStyle | undefined;
+  const base =
+    typeof flattened?.color === 'string' ? flattened.color : toneColor(theme, resolvedTone);
+  const fadedColor = base.length === 7 && base.startsWith('#') ? `${base}${FRACTION_ALPHA}` : base;
 
   return (
     <Text
       variant={variant}
-      tone={tone}
+      tone={resolvedTone}
       tabular
       accessibilityLabel={
         mode === 'balance'
@@ -72,11 +111,23 @@ export function MoneyText({
               locale,
               compactFraction,
             })
-          : rendered
+          : parts.text
       }
       {...rest}
     >
-      {rendered}
+      {fadeFraction && parts.fraction ? (
+        <>
+          {parts.lead}
+          {/* A bare RNText so it inherits the caller's size and weight — a
+              nested `<Text>` of ours would reset them to its variant's, and a
+              40pt balance would print its paise at 15pt. Colour, not opacity:
+              a nested span's opacity is unreliable on Android. */}
+          <RNText style={{ color: fadedColor }}>{parts.fraction}</RNText>
+          {parts.trail}
+        </>
+      ) : (
+        parts.text
+      )}
     </Text>
   );
 }

--- a/packages/ui/src/components/Text.tsx
+++ b/packages/ui/src/components/Text.tsx
@@ -5,12 +5,38 @@ import {
   type TextStyle,
 } from 'react-native';
 
-import { useTheme } from '../theme';
+import { useTheme, type Theme } from '../theme';
 import type { typography } from '../tokens';
 
 export type TextVariant = keyof typeof typography;
 export type TextTone =
   'default' | 'muted' | 'faint' | 'brand' | 'positive' | 'negative' | 'onBrand';
+
+/**
+ * The colour a tone resolves to.
+ *
+ * Exported because a caller sometimes needs the colour rather than a `<Text>`
+ * — a nested span that must inherit its parent's size but not its opacity, for
+ * one. Anything that recomputes this mapping locally will drift from it.
+ */
+export function toneColor(theme: Theme, tone: TextTone): string {
+  switch (tone) {
+    case 'muted':
+      return theme.color.textMuted;
+    case 'faint':
+      return theme.color.textFaint;
+    case 'brand':
+      return theme.color.brand;
+    case 'positive':
+      return theme.color.positive;
+    case 'negative':
+      return theme.color.negative;
+    case 'onBrand':
+      return theme.color.onBrand;
+    default:
+      return theme.color.text;
+  }
+}
 
 export interface TextProps extends RNTextProps {
   variant?: TextVariant;
@@ -41,20 +67,7 @@ export function Text({
       ? Math.round(override.fontSize * (scale.lineHeight / scale.fontSize))
       : scale.lineHeight;
 
-  const color =
-    tone === 'muted'
-      ? theme.color.textMuted
-      : tone === 'faint'
-        ? theme.color.textFaint
-        : tone === 'brand'
-          ? theme.color.brand
-          : tone === 'positive'
-            ? theme.color.positive
-            : tone === 'negative'
-              ? theme.color.negative
-              : tone === 'onBrand'
-                ? theme.color.onBrand
-                : theme.color.text;
+  const color = toneColor(theme, tone);
 
   return (
     <RNText

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,7 @@ export * from './curve';
 export * from './components/Text';
 export * from './components/Surfaces';
 export * from './components/CurvedPanel';
+export * from './components/Gradient';
 export * from './components/Button';
 export * from './components/Chip';
 export * from './components/Avatar';

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { useColorScheme } from 'react-native';
 
-import { palette, radius, shadow, spacing, typography, type TintName } from './tokens';
+import { gradients, palette, radius, shadow, spacing, typography, type TintName } from './tokens';
 
 export interface TintPair {
   readonly bg: string;
@@ -27,6 +27,10 @@ export interface Theme {
     readonly positiveSoft: string;
     readonly negative: string;
     readonly negativeSoft: string;
+  };
+  readonly gradient: {
+    /** Stops for the brand wash, in paint order. */
+    readonly brand: readonly string[];
   };
   readonly tint: Readonly<Record<TintName, TintPair>>;
   readonly radius: typeof radius;
@@ -73,6 +77,7 @@ const lightTheme: Theme = {
     negative: palette.negative,
     negativeSoft: palette.pink,
   },
+  gradient: { brand: gradients.light },
   tint: lightTints,
   radius,
   spacing,
@@ -100,6 +105,7 @@ const darkTheme: Theme = {
     negative: '#FF7B72',
     negativeSoft: '#4A2A31',
   },
+  gradient: { brand: gradients.dark },
   tint: darkTints,
 };
 

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -60,6 +60,18 @@ export const palette = {
   night600: '#2A2A47',
 } as const;
 
+/**
+ * The brand wash, dark corner to light.
+ *
+ * Three stops off the existing brand ramp rather than new colours: a gradient
+ * is a way of drawing the brand, not a second brand. Every stop is dark enough
+ * to hold white text, because the balance and its labels sit on all of them.
+ */
+export const gradients = {
+  light: [palette.brand700, palette.brand500, '#A472F0'],
+  dark: ['#3A2585', '#5B41C9', '#7E52C9'],
+} as const;
+
 /** The pastel family, in the order groups cycle through it. */
 export const tints = ['lilac', 'pink', 'mint', 'peach', 'sky', 'coral'] as const;
 export type TintName = (typeof tints)[number];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       expo-image-picker:
         specifier: ~57.0.8
         version: 57.0.8(expo@57.0.11)
+      expo-linear-gradient:
+        specifier: ~57.0.1
+        version: 57.0.1(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       expo-linking:
         specifier: ~57.0.5
         version: 57.0.5(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
@@ -3835,6 +3838,13 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+
+  expo-linear-gradient@57.0.1:
+    resolution: {integrity: sha512-CpS8eMqoIWcHVGKV66zbDvzotCw9qYp3f8CuI9N+h1LaO0tMLUzBpkhAKePUsXlpN3yolYlHFSPkfVZ/uSh+iA==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-linking@57.0.5:
     resolution: {integrity: sha512-SmJI3wr0EVfeKPGf+Qgr9gUbrXk8mM0ATqYLvAX/EAzawDjohPzMJ5pTt7TYMX0Wknj4XCtyCQrGhnERMXT6cQ==}
@@ -10187,6 +10197,12 @@ snapshots:
     dependencies:
       expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
       react: 19.2.3
+
+  expo-linear-gradient@57.0.1(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+    dependencies:
+      expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
   expo-linking@57.0.5(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       '@sentry/react-native':
         specifier: ~7.11.0
         version: 7.11.0(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
+      '@shopify/flash-list':
+        specifier: 2.0.2
+        version: 2.0.2(@babel/runtime@7.29.7)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@supabase/supabase-js':
         specifier: ^2.112.0
         version: 2.112.0(@opentelemetry/api@1.9.1)
@@ -2427,6 +2430,13 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       webpack: '>=5.0.0'
+
+  '@shopify/flash-list@2.0.2':
+    resolution: {integrity: sha512-zhlrhA9eiuEzja4wxVvotgXHtqd3qsYbXkQ3rsBfOgbFA9BVeErpDE/yEwtlIviRGEqpuFj/oU5owD6ByaNX+w==}
+    peerDependencies:
+      '@babel/runtime': '*'
+      react: '*'
+      react-native: '*'
 
   '@sinclair/typebox@0.27.12':
     resolution: {integrity: sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==}
@@ -8405,6 +8415,13 @@ snapshots:
       - encoding
       - rollup
       - supports-color
+
+  '@shopify/flash-list@2.0.2(@babel/runtime@7.29.7)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
+      tslib: 2.8.1
 
   '@sinclair/typebox@0.27.12': {}
 


### PR DESCRIPTION
Two things a phone found, in one branch because they touch the same app on the same afternoon.

## Browsing contacts was dead, and blamed the person for it

`expo-contacts` 57 did not deprecate the old API. It replaced it with a stub that throws:

```ts
export async function getContactsAsync(...) {
  throw errorOnLegacyMethodUse('getContactsAsync');
}
```

`ContactPicker` caught that and set its state to `denied` — so a phone that had *just* granted permission was told **"Baaki cannot see your contacts"** and offered a settings screen where the switch was already on. Confirmed on a device: `READ_CONTACTS: granted=true` while the screen said the opposite.

- The read moves to the class API: `Contact.getAllDetails` with the same five fields, so the address book still never leaves the phone and there is still no "which of my contacts use Baaki" endpoint (ADR-006).
- `denied` (their answer) is now separate from `unavailable` (ours). One catch for both is what turned a broken dependency into a confident lie about permissions.
- The picker re-reads on foreground. "Open settings" used to send somebody out to grant access and back to the same refusal, with killing the app as the undocumented last step.

## Money reads better, on a wash

- **`formatParts`** (`@baaki/core`) splits an amount at the decimal separator `Intl` actually used — the only way to fade minor units without getting `de-DE`'s `1.517,53 €` backwards. A property test asserts the parts always rejoin to exactly what `format()` returns.
- **`MoneyText`** renders the fraction in the amount's own colour at 55% alpha, not grey, so one rule covers the brand panel, owed-green and owe-red alike.
- **The brand wash** (`theme.gradient.brand`): three stops off the existing purple ramp, dark corner to light, every one dark enough to carry white text. A way of drawing the brand, not a second brand. `expo-linear-gradient` is a native module and a missing native module has cost this app a whole screen before, so `Gradient` requires it lazily and paints flat brand if it is absent.
- **Two actions under the balance.** Both need a group, and guessing is worse than asking: no groups starts one, one group goes straight in, more asks which.

## Verified

On a Pixel 9 emulator, release build, light and dark:

- contacts list renders; denial shows the denial copy; granting while backgrounded and returning fills the list with no restart
- gradient stops sampled per theme — light `(88,57,198)→(162,113,240)`, dark `(59,38,136)→(124,81,200)`
- `₹1,234.56` entered through the keypad; balance rendered `$823.04` with the cents faded; test expense deleted afterwards

376 core + 115 mobile tests, typecheck, lint and format all green.

## Not covered

The other legacy-API natives — `expo-speech-recognition` and the document scanner — have the same shape of trap and have not been swept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6
