### PR TITLE
feat: the account screen gets a face, and one number worth showing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,6 +117,26 @@ headings and people, with `getItemType` telling it the two are different shapes.
 The rail is ours, forty lines, because every published React Native
 alphabet-index component was abandoned years ago.
 
+## A screen with three faces
+
+The account screen opens with a hero rather than a title: the avatar, the name,
+and one number in a pill under it. Below that, `SegmentedTabs` splits what used
+to be a single long scroll into **You · Paying · Settings**.
+
+`SegmentedTabs` is not `PillTabBar`. The pill bar floats above everything and
+moves you between destinations; this sits in the page, under a rule, because the
+page you are on has three faces and this chooses which one. Two floating pills on
+one screen would be two things claiming to be the navigation.
+
+The pill under the name is **what has actually changed hands through you** —
+settled settlements only, per currency, in both directions. The board this was
+drawn from puts a points total there, and Baaki has none: a score next to
+somebody's money is a number that means nothing sitting among numbers that mean
+everything. It is deliberately _not_ coloured like a balance, because paying and
+being paid are the same fact here — a debt closed. Currencies are counted rather
+than added; no rate turns rupees into euros, and this would be the only place in
+the app that guessed at money.
+
 ## Spacing
 
 4px base: `xs 4 · sm 8 · md 12 · lg 16 · xl 20 · xxl 24 · xxxl 32`. Screens use
@@ -127,7 +147,7 @@ floating tab bar never covers the last row.
 
 `Screen · Card · TintCard · CurvedPanel · Gradient · Text · Button · IconButton · Fab ·
 Chip · ChipRow · Badge · Avatar · AvatarStack · ListRow · EmptyState ·
-MoneyText · Toggle · PillTabBar · AmountKeypad`
+MoneyText · Toggle · PillTabBar · SegmentedTabs · AmountKeypad`
 
 Two carry product decisions rather than styling:
 

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -11,15 +11,18 @@ import {
   ChipRow,
   directionalIcon,
   ListRow,
+  MoneyText,
   Row,
   Screen,
   SectionHeader,
+  SegmentedTabs,
   Text,
   useTheme,
 } from '@baaki/ui';
 
 import { ProfileAvatar } from '@/components/ProfileAvatar';
 import { removeAvatar, uploadAvatar } from '@/data/api';
+import { useSettledTotals } from '@/data/hooks';
 import { deviceCountry, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { pickAvatarPhoto } from '@/lib/image';
@@ -116,6 +119,101 @@ const SETTINGS: SettingsRow[] = [
   },
 ];
 
+/** The three faces of this screen. */
+type Face = 'you' | 'paying' | 'settings';
+
+/**
+ * One Save, shown on whichever face you are looking at.
+ *
+ * It writes the whole profile, not the tab: a name typed on one face and a UPI
+ * ID typed on another are one edit to one row, and asking somebody to go back
+ * and save each face separately would invent a rule the data does not have.
+ */
+function SaveRow({
+  dirty,
+  valid,
+  status,
+  onSave,
+}: {
+  dirty: boolean;
+  valid: boolean;
+  status: string | null;
+  onSave: () => void;
+}) {
+  return (
+    <>
+      <Button label="Save" fullWidth disabled={!dirty || !valid} onPress={onSave} />
+      {status ? (
+        <Text variant="caption" tone={status === 'Saved' ? 'positive' : 'negative'}>
+          {status}
+        </Text>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * What has actually changed hands through you.
+ *
+ * The board this is drawn from puts a points total here. Baaki has no points
+ * and should not invent any: a score next to somebody's money is a number that
+ * means nothing pretending to sit with numbers that mean everything. This is
+ * the true version of the same idea — one figure, earned, that appears nowhere
+ * else in the app.
+ *
+ * It is not a balance and is deliberately not coloured like one. Paying and
+ * being paid are the same fact here: a debt closed.
+ */
+function SettledPill({ profileId, locale }: { profileId: string | null; locale: string }) {
+  const theme = useTheme();
+  const totals = useSettledTotals(profileId);
+
+  const entries = [...(totals.data ?? new Map<string, bigint>())].sort((a, b) =>
+    b[1] === a[1] ? 0 : b[1] > a[1] ? 1 : -1,
+  );
+  const top = entries[0];
+
+  return (
+    <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+      <Row
+        style={{
+          gap: theme.spacing.sm,
+          paddingHorizontal: theme.spacing.lg,
+          paddingVertical: theme.spacing.sm,
+          borderRadius: theme.radius.pill,
+          backgroundColor: theme.color.brandSoft,
+        }}
+      >
+        <Ionicons name="checkmark-done" size={16} color={theme.color.brand} />
+        {top ? (
+          <Row style={{ gap: 4 }}>
+            <MoneyText
+              amount={top[1]}
+              currency={top[0] as never}
+              locale={locale}
+              variant="subheading"
+              tone="brand"
+            />
+            <Text variant="caption" tone="brand">
+              settled
+            </Text>
+          </Row>
+        ) : (
+          <Text variant="caption" tone="brand">
+            Nothing settled yet
+          </Text>
+        )}
+      </Row>
+      {/* No rate turns rupees into euros, so the rest are counted, not added. */}
+      {entries.length > 1 ? (
+        <Text variant="micro" tone="faint">
+          {`and ${entries.length - 1} other ${entries.length === 2 ? 'currency' : 'currencies'}`}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
 export default function ProfileScreen() {
   const theme = useTheme();
   const { t, locale } = useStrings();
@@ -137,6 +235,7 @@ export default function ProfileScreen() {
   const [handle, setHandle] = useState(profile?.payment_handle ?? profile?.default_vpa ?? '');
   const [status, setStatus] = useState<string | null>(null);
   const [photoBusy, setPhotoBusy] = useState(false);
+  const [face, setFace] = useState<Face>('you');
 
   /**
    * Pick, shrink, upload, then tell the profile where it landed. The upload
@@ -254,149 +353,181 @@ export default function ProfileScreen() {
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
-        <Text variant="title" style={{ paddingTop: theme.spacing.md }}>
-          {t.profile}
-        </Text>
-
-        <Card style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+        {/* The hero. No card behind it: the avatar, the name and the one number
+            are the page's title, and a title does not sit in a box. */}
+        <View style={{ alignItems: 'center', gap: theme.spacing.md, paddingTop: theme.spacing.lg }}>
           <ProfileAvatar
             name={profile?.display_name ?? 'You'}
             avatarUrl={profile?.avatar_url}
-            size={78}
+            size={92}
             onPress={profile ? photoOptions : undefined}
             busy={photoBusy}
           />
-          <Row style={{ gap: theme.spacing.sm }}>
-            <Badge label={t.freeForever} tone="positive" />
-            <Badge label={locale} tone="brand" />
-            {isGuest ? <Badge label="Guest" /> : null}
-          </Row>
-        </Card>
-
-        <Card style={{ gap: theme.spacing.lg }}>
-          <View style={{ gap: theme.spacing.xs }}>
-            <Text variant="caption" tone="muted">
-              Display name
-            </Text>
-            <TextInput
-              value={name}
-              onChangeText={setName}
-              accessibilityLabel="Display name"
-              placeholder="Your name"
-              placeholderTextColor={theme.color.textFaint}
-              style={{
-                fontSize: 18,
-                fontWeight: '600',
-                color: theme.color.text,
-                paddingVertical: theme.spacing.sm,
-              }}
-            />
+          <View style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Text variant="title">{profile?.display_name ?? 'You'}</Text>
+              {/* The badge says the account has no email or phone on it. When
+                  somebody has not renamed themselves it repeats the name they
+                  were given, which reads as a bug rather than a fact. */}
+              {isGuest && profile?.display_name !== 'Guest' ? <Badge label="Guest" /> : null}
+            </Row>
+            <SettledPill profileId={profile?.id ?? null} locale={locale} />
           </View>
+        </View>
 
-          <View style={{ gap: theme.spacing.sm }}>
-            <Text variant="caption" tone="muted">
-              How people pay you
-            </Text>
-            {/* Whatever this person's country uses. In India that still starts
-                on UPI; in the UAE it starts on Aani. */}
-            <ChipRow<string>
-              value={rail}
-              onChange={setRail}
-              options={railsFor(country).map((entry) => ({
-                value: entry.id,
-                label: entry.label,
-              }))}
-            />
-            {railInfo && railInfo.handle !== 'none' ? (
-              <>
+        <SegmentedTabs<Face>
+          value={face}
+          onChange={setFace}
+          tabs={[
+            // Not `t.profile` — that reads "Account", which is the whole
+            // screen. A tab has to name the part, not the page.
+            { value: 'you', label: 'You' },
+            { value: 'paying', label: 'Paying' },
+            { value: 'settings', label: 'Settings' },
+          ]}
+        />
+
+        {face === 'you' ? (
+          <>
+            <Card style={{ gap: theme.spacing.lg }}>
+              <View style={{ gap: theme.spacing.xs }}>
+                <Text variant="caption" tone="muted">
+                  Display name
+                </Text>
                 <TextInput
-                  value={handle}
-                  onChangeText={setHandle}
-                  autoCapitalize="none"
-                  accessibilityLabel={`Your ${railInfo.label} details`}
-                  placeholder={railInfo.handleHint}
+                  value={name}
+                  onChangeText={setName}
+                  accessibilityLabel="Display name"
+                  placeholder="Your name"
                   placeholderTextColor={theme.color.textFaint}
                   style={{
                     fontSize: 18,
                     fontWeight: '600',
-                    color: handleValid ? theme.color.text : theme.color.negative,
+                    color: theme.color.text,
                     paddingVertical: theme.spacing.sm,
                   }}
                 />
-                <Text variant="micro" tone={handleValid ? 'faint' : 'negative'}>
-                  {!handleValid
-                    ? `That does not look like ${railInfo.handleHint.toLowerCase()}.`
-                    : railInfo.link
-                      ? 'People settling with you get a one-tap payment. Baaki never handles the money.'
-                      : 'People settling with you see this to pay you from their own bank app. Baaki never handles the money.'}
+              </View>
+              <SaveRow
+                dirty={dirty}
+                valid={handleValid}
+                status={status}
+                onSave={() => void save()}
+              />
+            </Card>
+
+            {isGuest ? (
+              <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.md }}>
+                <Text variant="subheading" tone="brand">
+                  Guest account
                 </Text>
-              </>
-            ) : (
-              <Text variant="micro" tone="faint">
-                Nothing to add — people will record what they paid you by hand.
+                <Text variant="caption" tone="muted">
+                  Everything you have entered is already saved and yours. Add an email or phone
+                  number whenever you want to reach it from another phone — it keeps this account
+                  rather than starting a new one.
+                </Text>
+                <Button
+                  label="Add your details"
+                  variant="secondary"
+                  size="sm"
+                  onPress={() => router.push('/settings/account')}
+                />
+              </Card>
+            ) : null}
+
+            <Row style={{ gap: theme.spacing.sm, justifyContent: 'center' }}>
+              <Badge label={t.freeForever} tone="positive" />
+              <Badge label={locale} tone="brand" />
+            </Row>
+          </>
+        ) : null}
+
+        {face === 'paying' ? (
+          <Card style={{ gap: theme.spacing.lg }}>
+            <View style={{ gap: theme.spacing.sm }}>
+              <Text variant="caption" tone="muted">
+                How people pay you
               </Text>
-            )}
-          </View>
-
-          <Button label="Save" disabled={!dirty || !handleValid} onPress={() => void save()} />
-          {status ? (
-            <Text variant="caption" tone={status === 'Saved' ? 'positive' : 'negative'}>
-              {status}
-            </Text>
-          ) : null}
-        </Card>
-
-        {isGuest ? (
-          <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.md }}>
-            <Text variant="subheading" tone="brand">
-              Guest account
-            </Text>
-            <Text variant="caption" tone="muted">
-              Everything you have entered is already saved and yours. Add an email or phone number
-              whenever you want to reach it from another phone — it keeps this account rather than
-              starting a new one.
-            </Text>
-            <Button
-              label="Add your details"
-              variant="secondary"
-              size="sm"
-              onPress={() => router.push('/settings/account')}
-            />
+              {/* Whatever this person's country uses. In India that still starts
+                  on UPI; in the UAE it starts on Aani. */}
+              <ChipRow<string>
+                value={rail}
+                onChange={setRail}
+                options={railsFor(country).map((entry) => ({
+                  value: entry.id,
+                  label: entry.label,
+                }))}
+              />
+              {railInfo && railInfo.handle !== 'none' ? (
+                <>
+                  <TextInput
+                    value={handle}
+                    onChangeText={setHandle}
+                    autoCapitalize="none"
+                    accessibilityLabel={`Your ${railInfo.label} details`}
+                    placeholder={railInfo.handleHint}
+                    placeholderTextColor={theme.color.textFaint}
+                    style={{
+                      fontSize: 18,
+                      fontWeight: '600',
+                      color: handleValid ? theme.color.text : theme.color.negative,
+                      paddingVertical: theme.spacing.sm,
+                    }}
+                  />
+                  <Text variant="micro" tone={handleValid ? 'faint' : 'negative'}>
+                    {!handleValid
+                      ? `That does not look like ${railInfo.handleHint.toLowerCase()}.`
+                      : railInfo.link
+                        ? 'People settling with you get a one-tap payment. Baaki never handles the money.'
+                        : 'People settling with you see this to pay you from their own bank app. Baaki never handles the money.'}
+                  </Text>
+                </>
+              ) : (
+                <Text variant="micro" tone="faint">
+                  Nothing to add — people will record what they paid you by hand.
+                </Text>
+              )}
+            </View>
+            <SaveRow dirty={dirty} valid={handleValid} status={status} onSave={() => void save()} />
           </Card>
         ) : null}
 
-        <SettingsSection
-          title="Settings"
-          rows={[
-            ...SETTINGS,
-            {
-              icon: 'sparkles-outline',
-              label: 'Motion',
-              hint: motionSummary,
-              route: '/settings/motion',
-            },
-          ]}
-        />
+        {face !== 'settings' ? null : (
+          <>
+            <SettingsSection
+              title="Settings"
+              rows={[
+                ...SETTINGS,
+                {
+                  icon: 'sparkles-outline',
+                  label: 'Motion',
+                  hint: motionSummary,
+                  route: '/settings/motion',
+                },
+              ]}
+            />
 
-        {/* Security is its own section rather than one row among many: it is
+            {/* Security is its own section rather than one row among many: it is
             the only group of settings somebody comes looking for. */}
-        <SettingsSection
-          title="Security"
-          rows={[
-            {
-              icon: 'finger-print-outline',
-              label: 'App lock',
-              hint: lockSummary,
-              route: '/settings/lock',
-            },
-            {
-              icon: 'log-out-outline',
-              label: 'Sign out',
-              hint: signOutHint,
-              onPress: confirmSignOut,
-            },
-          ]}
-        />
+            <SettingsSection
+              title="Security"
+              rows={[
+                {
+                  icon: 'finger-print-outline',
+                  label: 'App lock',
+                  hint: lockSummary,
+                  route: '/settings/lock',
+                },
+                {
+                  icon: 'log-out-outline',
+                  label: 'Sign out',
+                  hint: signOutHint,
+                  onPress: confirmSignOut,
+                },
+              ]}
+            />
+          </>
+        )}
 
         <Text variant="micro" tone="faint" align="center">
           Baaki · the ledger is free forever. We only ever charge for convenience.

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -14,6 +14,7 @@ import {
   normaliseEmail,
   normalisePhone,
   serialiseSplitParams,
+  type CurrencyCode,
   type FxRecord,
   type ParsedReceipt,
   type ReceiptCheck,
@@ -187,6 +188,48 @@ export async function fetchPendingSettlements(): Promise<{ group_id: string; id:
   return unwrap(
     await supabase.from('settlements').select('id, group_id').eq('status', 'initiated'),
   );
+}
+
+/**
+ * How much has actually changed hands through this person, per currency.
+ *
+ * Both directions count. This is not a balance and must never be shown as one:
+ * money paid and money received are the same fact here — that a debt was
+ * closed — so it carries no sign and no owed/owe colour.
+ *
+ * Only settled settlements count. `initiated` means somebody says they paid and
+ * nobody has agreed yet (ADR-007), and a number that goes up the moment you
+ * claim something is a number that flatters rather than reports.
+ *
+ * Kept per currency because there is no rate that makes rupees and euros one
+ * total, and inventing one here would be the only place in Baaki that guesses
+ * at money.
+ */
+export async function fetchSettledTotals(profileId: string): Promise<Map<CurrencyCode, bigint>> {
+  const rows = unwrap(
+    await supabase
+      .from('settlements')
+      .select(
+        `currency, amount,
+         from:group_members!settlements_from_member_id_fkey ( profile_id ),
+         to:group_members!settlements_to_member_id_fkey ( profile_id )`,
+      )
+      .in('status', ['confirmed', 'auto_confirmed']),
+  ) as unknown as {
+    currency: CurrencyCode;
+    amount: string | number;
+    from: { profile_id: string | null } | null;
+    to: { profile_id: string | null } | null;
+  }[];
+
+  const totals = new Map<CurrencyCode, bigint>();
+  for (const row of rows) {
+    // Row-level security already limits this to groups I am in; it does not
+    // limit it to settlements I am *part of*, and the two are not the same.
+    if (row.from?.profile_id !== profileId && row.to?.profile_id !== profileId) continue;
+    totals.set(row.currency, (totals.get(row.currency) ?? 0n) + BigInt(row.amount));
+  }
+  return totals;
 }
 
 /**

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -48,6 +48,7 @@ import {
   fetchMyBalances,
   fetchNotifications,
   fetchPendingSettlements,
+  fetchSettledTotals,
   fetchPlanItems,
   fetchSettlements,
   markNotificationsRead,
@@ -83,6 +84,18 @@ export function useGroups() {
 
 export function useAllBalances() {
   return useQuery({ queryKey: keys.allBalances, queryFn: fetchAllBalances });
+}
+
+/**
+ * How much has changed hands through this person, per currency. Not a balance
+ * — see `fetchSettledTotals`.
+ */
+export function useSettledTotals(profileId: string | null) {
+  return useQuery({
+    queryKey: ['settlements', 'settled', profileId],
+    queryFn: () => fetchSettledTotals(profileId as string),
+    enabled: Boolean(profileId),
+  });
 }
 
 /** Home-screen data: my balance per group, member counts, pending confirmations. */
@@ -356,6 +369,11 @@ export function invalidateGroup(queryClient: QueryClient, groupId: string): void
   void queryClient.invalidateQueries({ queryKey: ['group', groupId] });
   void queryClient.invalidateQueries({ queryKey: keys.groups });
   void queryClient.invalidateQueries({ queryKey: keys.allBalances });
+  // The lifetime settled total is not scoped to a group, so nothing above
+  // reaches it. Confirming a settlement in one group left the figure on the
+  // account screen showing the old number until the app was restarted — a
+  // total that only updates when you kill the app is worse than no total.
+  void queryClient.invalidateQueries({ queryKey: ['settlements', 'settled'] });
 }
 
 // ─────────────────────────────────────────────────────────── mutations ──

--- a/packages/ui/src/components/SegmentedTabs.tsx
+++ b/packages/ui/src/components/SegmentedTabs.tsx
@@ -1,0 +1,85 @@
+import { Pressable, View } from 'react-native';
+
+import { useTheme } from '../theme';
+import { Text } from './Text';
+
+export interface SegmentedTab<T extends string> {
+  readonly value: T;
+  readonly label: string;
+}
+
+/**
+ * Tabs that divide one screen, not the app.
+ *
+ * `PillTabBar` moves you between destinations and floats above everything to
+ * say so. This is the other kind: the page you are on has three faces and this
+ * chooses which one. It reads as part of the page — a rule underneath, a mark
+ * under the live one — because a second floating pill on the same screen would
+ * be two things claiming to be the navigation.
+ *
+ * Small caps and letterspacing are the one place the app raises its voice like
+ * this. It works here because the row is a label for what follows rather than
+ * something to read, and because this screen has a single number on it.
+ */
+export function SegmentedTabs<T extends string>({
+  value,
+  onChange,
+  tabs,
+}: {
+  value: T;
+  onChange: (value: T) => void;
+  tabs: readonly SegmentedTab<T>[];
+}) {
+  const theme = useTheme();
+
+  return (
+    <View
+      accessibilityRole="tablist"
+      style={{
+        flexDirection: 'row',
+        borderBottomWidth: 1,
+        borderBottomColor: theme.color.border,
+      }}
+    >
+      {tabs.map((tab) => {
+        const live = tab.value === value;
+        return (
+          <Pressable
+            key={tab.value}
+            onPress={() => onChange(tab.value)}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: live }}
+            accessibilityLabel={tab.label}
+            style={({ pressed }) => ({
+              flex: 1,
+              alignItems: 'center',
+              paddingVertical: theme.spacing.md,
+              opacity: pressed ? 0.6 : 1,
+            })}
+          >
+            <Text
+              variant="caption"
+              tone={live ? 'brand' : 'faint'}
+              style={{ letterSpacing: 0.8, fontWeight: live ? '700' : '600' }}
+            >
+              {tab.label.toUpperCase()}
+            </Text>
+            {/* Drawn whether or not it is live, so the label does not shift by
+                two points as you move between tabs. */}
+            <View
+              style={{
+                position: 'absolute',
+                left: theme.spacing.lg,
+                right: theme.spacing.lg,
+                bottom: -1,
+                height: 2,
+                borderRadius: 1,
+                backgroundColor: live ? theme.color.brand : 'transparent',
+              }}
+            />
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -20,6 +20,7 @@ export * from './components/MoneyText';
 export * from './components/ListRow';
 export * from './components/Toggle';
 export * from './components/PillTabBar';
+export * from './components/SegmentedTabs';
 export * from './components/AmountKeypad';
 export * from './components/Chart';
 export * from './direction';


### PR DESCRIPTION
The account screen was a title and one long column. It now opens with a hero — avatar, name, one figure in a pill — and splits the rest across **You / Paying / Settings**.

Adapted from a rewards-app reference. The *shape* transfers; the content does not. That reference puts "5000 pts" under the name, and Baaki has no points — a score next to somebody's money is a number that means nothing sitting among numbers that mean everything.

## The pill

It shows **what has actually changed hands through you**: settled settlements, both directions, per currency.

- **Not a balance, not coloured like one.** Paying and being paid are the same fact here — a debt closed — so it carries no sign and none of the owed/owe semantics.
- **Only `confirmed` and `auto_confirmed`.** `initiated` means somebody says they paid and nobody has agreed yet (ADR-007). A total that rises the moment you claim something flatters rather than reports.
- **Currencies counted, not added.** No rate turns rupees into euros, and this would otherwise be the only place in Baaki that guessed at money.

RLS limits the query to groups you are in, which is *not* the same as settlements you are part of, so rows are filtered against your profile before anything is summed.

## `SegmentedTabs`

New in `@baaki/ui`, and deliberately not `PillTabBar`. The pill bar floats above the app and moves you between destinations; this sits in the page under a rule and chooses which face of one screen you are on. Two floating pills would be two things claiming to be the navigation.

## Fixed while driving it

The total is not scoped to a group, so nothing in `invalidateGroup` reached it. Confirming a settlement left the old number on screen until the app was restarted.

## Verified on a device

Emulator, dev client, three-button navigation. All three tabs render and switch. The pill was driven end-to-end with real data: group → \$200 expense → settle → confirm, pill reads **\$100 settled**; a second round takes it to **\$200 live, without a restart**, which is the invalidation fix.

## Not covered

- Only exercised with **one currency**. The `+ n other currencies` line has not been seen on a device.
- An unrelated `NativeDatabase.prepareAsync has been rejected` error toast appears on cold start (expo-sqlite, the offline queue). Not touched by this change and not investigated.
- The test data lives in a throwaway guest account on the emulator, not in any real user's ledger, but there is no hard-delete for a group so it remains in the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6