### PR TITLE
feat: pick the language, at the front door and in the settings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -137,6 +137,49 @@ being paid are the same fact here — a debt closed. Currencies are counted rath
 than added; no rate turns rupees into euros, and this would be the only place in
 the app that guessed at money.
 
+## Choosing a language, and the restart it sometimes costs
+
+The phone's language is the default and stays the default. A picker exists on
+top of it because a phone is one setting for one person and the two do not
+always agree: somebody in Chennai with an English phone still reads Tamil
+faster, and a visitor's phone is in Arabic while their group is not.
+
+Each language is listed in its own script first, with the English name under it.
+Somebody who has opened the app in a language they cannot read is scanning for
+the **shape** of their own writing, and "Tamil" spelled in Latin letters is not
+that shape. The two words the picker is reached by — Language and Upgrade —
+are the only settings labels that are translated, for the same reason: a row
+labelled in the language you are trying to escape is no help at all.
+
+Words change instantly. **Direction does not.** React Native decides
+right-to-left natively, before any JavaScript runs, and `forceRTL` says so
+itself — _changes take full effect on the next application start_. There is no
+reload to call. So the screen says "close and open Baaki again" in a banner that
+stays until it is true, rather than half-mirroring a screen and calling it done.
+
+Two consequences worth stating, because both are the kind of thing that looks
+like a bug when it is right:
+
+- **The icons follow the screen, not the choice.** `setLayoutDirection` is given
+  the direction the app actually launched in, so between choosing Arabic and
+  restarting the arrows keep pointing the way the layout still runs. Mirroring
+  them on the choice would put backwards chevrons on an unmirrored screen.
+- **A choice changes the language, not the country.** The locale keeps the
+  phone's region and swaps only the language subtag, so reading the app in Hindi
+  in Dubai formats money and dates as `hi-AE`. Where somebody is decides what
+  their currency and calendar look like; what they read does not.
+
+## A door with no shop behind it
+
+The Upgrade row leads to a screen that says there is nothing to buy, and says
+what would ever cost money: scanning bills, which costs real money per scan, and
+outsized exports. The ledger — groups, expenses, splits, balances, settling up,
+and getting all of it back out — is free forever and is not on that list.
+
+It sits in its own section above Settings rather than among them. Paying for
+something is not a preference, and a row that sells you something between
+Notifications and Export is a row dressed up as a setting.
+
 ## Spacing
 
 4px base: `xs 4 · sm 8 · md 12 · lg 16 · xl 20 · xxl 24 · xxxl 32`. Screens use

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -157,6 +157,16 @@ itself — _changes take full effect on the next application start_. There is no
 reload to call. So the screen says "close and open Baaki again" in a banner that
 stays until it is true, rather than half-mirroring a screen and calling it done.
 
+The choice is offered twice, and the second time is the important one. A
+settings row is the right home for it once somebody is inside the app; it is the
+wrong home for somebody standing at the front door who cannot read the door.
+So the four scripts also sit flat on the sign-in screen, under the buttons —
+four chips, endonyms only, no "follow my phone" among them, because following
+the phone is what the app is already doing and a row of five where one is an
+English sentence has stopped being scannable. In the settings list Language
+leads rather than sits fifth, for the same reason: a row you can only reach by
+reading past rows you cannot read is a row that is not there.
+
 Two consequences worth stating, because both are the kind of thing that looks
 like a bug when it is right:
 

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -523,16 +523,20 @@ export default function ProfileScreen() {
               ]}
             />
 
+            {/* Language leads. It was fifth, under Import, and it is the one
+                setting somebody may have to reach *before* they can read the
+                four above it — a row you can only find by reading past rows you
+                cannot read is a row that is not there. */}
             <SettingsSection
               title="Settings"
               rows={[
-                ...SETTINGS,
                 {
                   icon: 'language-outline',
                   label: t.language,
                   hint: languageSummary,
                   route: '/settings/language',
                 },
+                ...SETTINGS,
                 {
                   icon: 'sparkles-outline',
                   label: 'Motion',

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -23,7 +23,8 @@ import {
 import { ProfileAvatar } from '@/components/ProfileAvatar';
 import { removeAvatar, uploadAvatar } from '@/data/api';
 import { useSettledTotals } from '@/data/hooks';
-import { deviceCountry, useStrings } from '@/i18n';
+import { deviceCountry, LANGUAGE_NAMES, useStrings } from '@/i18n';
+import { useLanguage } from '@/i18n/language';
 import { useAuth } from '@/lib/auth';
 import { pickAvatarPhoto } from '@/lib/image';
 import { describeGrace, useLock } from '@/lib/lock';
@@ -221,6 +222,7 @@ export default function ProfileScreen() {
 
   const { enabled: lockEnabled, supported: lockSupported, graceSeconds } = useLock();
   const { animated, overridden: motionOverridden } = useMotion();
+  const { language, stored: languageChosen, restartNeeded } = useLanguage();
 
   const [name, setName] = useState(profile?.display_name ?? '');
   /**
@@ -287,6 +289,17 @@ export default function ProfileScreen() {
       { text: 'Cancel', style: 'cancel' },
     ]);
   };
+
+  /**
+   * The row says the language in its own script. It is the one settings row
+   * whose subtitle has to be legible to somebody who cannot read the rest of
+   * the screen — which is exactly the person going looking for it.
+   */
+  const languageSummary = restartNeeded
+    ? `${LANGUAGE_NAMES[language].own} · reopen Baaki to mirror it`
+    : languageChosen === null
+      ? `Following your phone — ${LANGUAGE_NAMES[language].own}`
+      : `${LANGUAGE_NAMES[language].own} · ${LANGUAGE_NAMES[language].english}`;
 
   const motionSummary = motionOverridden
     ? animated
@@ -494,10 +507,32 @@ export default function ProfileScreen() {
 
         {face !== 'settings' ? null : (
           <>
+            {/* Its own section, above the settings rather than among them.
+                Paying for something is not a preference, and a row that sells
+                you something sitting between Notifications and Export is a row
+                dressed up as a setting. */}
+            <SettingsSection
+              title="Baaki"
+              rows={[
+                {
+                  icon: 'rocket-outline',
+                  label: t.upgrade,
+                  hint: 'Nothing to buy yet — the ledger stays free',
+                  route: '/settings/upgrade',
+                },
+              ]}
+            />
+
             <SettingsSection
               title="Settings"
               rows={[
                 ...SETTINGS,
+                {
+                  icon: 'language-outline',
+                  label: t.language,
+                  hint: languageSummary,
+                  route: '/settings/language',
+                },
                 {
                   icon: 'sparkles-outline',
                   label: 'Motion',

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -13,7 +13,8 @@ import { Button, CurvedPanel, setLayoutDirection, ThemeProvider, Text, useTheme 
 
 import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
-import { isRtl } from '@/i18n';
+import { isRtl, isRtlLanguage } from '@/i18n';
+import { LanguageProvider, useLanguage } from '@/i18n/language';
 import { LockProvider, useLock } from '@/lib/lock';
 import { MotionProvider, TRANSITION_MS, useMotion } from '@/lib/motion';
 import { UpdateProvider } from '@/lib/update';
@@ -50,60 +51,80 @@ const queryClient = new QueryClient({
 });
 
 /**
- * `dir` is what makes react-native-web mirror the layout. On a device the
- * native side has already done it from the phone's own language and this is
- * inert — but web is how this repo does its visual checks, so without it every
- * RTL check would be looking at a left-to-right screen.
+ * Tell the design system which way we run, before anything renders.
  *
- * It is a react-native-web prop with no React Native counterpart, so it is not
- * in the View types. The cast lives here and nowhere else.
- */
-const WEB_DIRECTION = { dir: isRtl() ? 'rtl' : 'ltr' } as object;
-
-/**
- * Tell the design system which way we run, once, before anything renders.
+ * The phone's language is the starting guess, and `LanguageProvider` corrects
+ * it on mount — to the direction the app actually launched in on a device, and
+ * to the chosen language on web, where the mirroring follows `dir` live.
  *
- * Taken from the phone's language rather than `I18nManager.isRTL`, because on
- * web that flag stays false even with `dir="rtl"` on the root and a visibly
- * mirrored layout — and web is where this repo does its visual checks. An
- * arrow that keeps pointing the wrong way in a mirrored screenshot is a
- * check that passes while the screen is wrong.
+ * Taken from the language rather than `I18nManager.isRTL`, because on web that
+ * flag stays false even with `dir="rtl"` on the root and a visibly mirrored
+ * layout — and web is where this repo does its visual checks. An arrow that
+ * keeps pointing the wrong way in a mirrored screenshot is a check that passes
+ * while the screen is wrong.
  */
 setLayoutDirection(isRtl());
 
+/**
+ * `dir` is what makes react-native-web mirror the layout. On a device the
+ * native side has already decided at launch and this is inert — but web is how
+ * this repo does its visual checks, so without it every RTL check would be
+ * looking at a left-to-right screen.
+ *
+ * It is a react-native-web prop with no React Native counterpart, so it is not
+ * in the View types. The cast lives here and nowhere else.
+ *
+ * Inside a component rather than at module scope now, because the language is
+ * something somebody can change while the app is open.
+ */
+function DirectionRoot({ children }: { children: React.ReactNode }) {
+  const { language } = useLanguage();
+  const webDirection = { dir: isRtlLanguage(language) ? 'rtl' : 'ltr' } as object;
+
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }} {...webDirection}>
+      {children}
+    </GestureHandlerRootView>
+  );
+}
+
 function RootLayout() {
   return (
-    <GestureHandlerRootView style={{ flex: 1 }} {...WEB_DIRECTION}>
-      <SafeAreaProvider>
-        <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <SyncProvider>
-              <LockProvider>
-                <MotionProvider>
-                  <UpdateProvider>
-                    <ThemeProvider>
-                      <StatusBar style="auto" />
-                      {/* Outside the lock and the auth gate on purpose: a build
-                          we have stopped trusting should not be unlocking a
-                          ledger or signing anybody in either. */}
-                      <UpdateGate>
-                        <PushRouting />
-                        <LockGate>
-                          <AuthGate />
-                        </LockGate>
-                        {/* Last, so it paints over the screen rather than
-                            under it. */}
-                        <UpdateBanner />
-                      </UpdateGate>
-                    </ThemeProvider>
-                  </UpdateProvider>
-                </MotionProvider>
-              </LockProvider>
-            </SyncProvider>
-          </AuthProvider>
-        </QueryClientProvider>
-      </SafeAreaProvider>
-    </GestureHandlerRootView>
+    // Outermost, above even the gesture root: every string in the app below it
+    // reads from here, and the root view's own direction is one of them.
+    <LanguageProvider>
+      <DirectionRoot>
+        <SafeAreaProvider>
+          <QueryClientProvider client={queryClient}>
+            <AuthProvider>
+              <SyncProvider>
+                <LockProvider>
+                  <MotionProvider>
+                    <UpdateProvider>
+                      <ThemeProvider>
+                        <StatusBar style="auto" />
+                        {/* Outside the lock and the auth gate on purpose: a build
+                            we have stopped trusting should not be unlocking a
+                            ledger or signing anybody in either. */}
+                        <UpdateGate>
+                          <PushRouting />
+                          <LockGate>
+                            <AuthGate />
+                          </LockGate>
+                          {/* Last, so it paints over the screen rather than
+                              under it. */}
+                          <UpdateBanner />
+                        </UpdateGate>
+                      </ThemeProvider>
+                    </UpdateProvider>
+                  </MotionProvider>
+                </LockProvider>
+              </SyncProvider>
+            </AuthProvider>
+          </QueryClientProvider>
+        </SafeAreaProvider>
+      </DirectionRoot>
+    </LanguageProvider>
   );
 }
 
@@ -287,6 +308,8 @@ function AuthGate() {
       <Stack.Screen name="settings/import" />
       <Stack.Screen name="settings/lock" />
       <Stack.Screen name="settings/motion" />
+      <Stack.Screen name="settings/language" />
+      <Stack.Screen name="settings/upgrade" />
       <Stack.Screen name="settings/account" />
       <Stack.Screen name="join" />
       <Stack.Screen name="inbox" />

--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -1,0 +1,117 @@
+/**
+ * The language, and the restart that a mirrored layout costs.
+ *
+ * Four languages and "follow my phone", which is the default and stays first.
+ * Each one is written in its own script, because somebody who has opened the
+ * app in a language they cannot read is scanning for the *shape* of their own
+ * writing — "Tamil" spelled in Latin letters is not that shape.
+ *
+ * Choosing Arabic changes the words at once and the direction only after the
+ * app is opened again. React Native decides right-to-left natively, before any
+ * JavaScript runs, and there is no reload to call. So the screen says so, in a
+ * banner that stays until it is true.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { ScrollView, View } from 'react-native';
+
+import { Card, directionalIcon, IconButton, ListRow, Row, Screen, Text, useTheme } from '@baaki/ui';
+
+import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES, useStrings, type Language } from '@/i18n';
+import { useLanguage } from '@/i18n/language';
+
+export default function LanguageSettingsScreen() {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const { stored, language, phoneLanguage, setLanguage, restartNeeded } = useLanguage();
+
+  const rows: { key: string; title: string; subtitle: string; value: Language | null }[] = [
+    {
+      key: 'phone',
+      title: 'Follow my phone',
+      subtitle: `Currently ${LANGUAGE_NAMES[phoneLanguage].english}`,
+      value: null,
+    },
+    ...LANGUAGES.map((entry) => ({
+      key: entry,
+      title: LANGUAGE_NAMES[entry].own,
+      subtitle: isRtlLanguage(entry)
+        ? `${LANGUAGE_NAMES[entry].english} · right to left`
+        : LANGUAGE_NAMES[entry].english,
+      value: entry as Language | null,
+    })),
+  ];
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label="Back" onPress={() => router.back()}>
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.language}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        {/* Above the list, not below it: somebody who has just chosen Arabic and
+            is looking at a screen that did not mirror needs the explanation
+            where their eyes already are. */}
+        {restartNeeded ? (
+          <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.sm }}>
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Ionicons name="refresh" size={18} color={theme.color.brand} />
+              <Text variant="subheading" tone="brand">
+                Close and open Baaki again
+              </Text>
+            </Row>
+            <Text variant="caption" tone="muted">
+              {isRtlLanguage(language)
+                ? 'The words have changed already. Mirroring the layout — the arrows, the sides everything sits on — is something the phone decides when the app starts, so it takes effect next time you open it.'
+                : 'The words have changed already. Turning the mirrored layout back the other way is something the phone decides when the app starts, so it takes effect next time you open it.'}
+            </Text>
+          </Card>
+        ) : null}
+
+        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+          {rows.map((row, index) => {
+            const chosen = stored === row.value;
+            return (
+              <View key={row.key}>
+                <ListRow
+                  title={row.title}
+                  subtitle={row.subtitle}
+                  onPress={() => void setLanguage(row.value)}
+                  accessibilityLabel={`${row.title}${chosen ? ', selected' : ''}`}
+                  trailing={
+                    chosen ? (
+                      <Ionicons name="checkmark" size={20} color={theme.color.brand} />
+                    ) : null
+                  }
+                />
+                {index < rows.length - 1 ? (
+                  <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                ) : null}
+              </View>
+            );
+          })}
+        </Card>
+
+        <Text variant="micro" tone="faint" align="center">
+          Your phone&apos;s language is the default, and choosing one here only changes Baaki.
+          Amounts and dates still follow where you are — reading the app in Hindi in Dubai does not
+          move you to India.
+        </Text>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/settings/upgrade.tsx
+++ b/apps/mobile/src/app/settings/upgrade.tsx
@@ -1,0 +1,106 @@
+/**
+ * The entry, and nothing behind it yet.
+ *
+ * There is no paid tier to sell today — no store products, no prices, no
+ * receipts. What there is, is a decision worth writing down before anything is
+ * built on top of it: the ledger is free forever, and the only thing Baaki
+ * would ever charge for is convenience. Splitting a bill, settling it, seeing
+ * what you owe and being owed are not features to be taken away and sold back.
+ *
+ * So this screen says the boundary out loud and admits there is nothing to buy.
+ * A row that leads nowhere would be worse than no row: somebody who taps
+ * "Upgrade" and lands on a dead screen learns that the app is broken, and
+ * somebody who finds a price list here learns something that is not true yet.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { ScrollView, View } from 'react-native';
+
+import { Card, directionalIcon, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+
+/** What a paid tier would be for, and what it would never touch. */
+const CONVENIENCES: { icon: keyof typeof Ionicons.glyphMap; title: string; body: string }[] = [
+  {
+    icon: 'scan-outline',
+    title: 'More scanned bills',
+    body: 'Photograph a receipt and have the lines read off it. Every scan costs real money to run, which is the honest reason it is the thing with a limit.',
+  },
+  {
+    icon: 'cloud-download-outline',
+    title: 'Bigger exports and imports',
+    body: 'Your data is yours and leaves in full for free. Larger jobs and scheduled backups are the convenience.',
+  },
+];
+
+export default function UpgradeScreen() {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label="Back" onPress={() => router.back()}>
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.upgrade}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.md }}>
+          {/* No badge saying "coming later". A brand badge on a brand-soft card
+              is text with an invisible pill behind it, and the heading is
+              already the whole announcement. */}
+          <Text variant="subheading" tone="brand">
+            Nothing to buy yet
+          </Text>
+          <Text variant="caption" tone="muted">
+            This is the door, not the shop. When there is something worth paying for it will be
+            here, with the price on it and no surprises.
+          </Text>
+        </Card>
+
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="caption" tone="muted">
+            What would ever cost money
+          </Text>
+          {CONVENIENCES.map((item) => (
+            <Card key={item.title} style={{ gap: theme.spacing.sm }}>
+              <Row style={{ gap: theme.spacing.sm }}>
+                <Ionicons name={item.icon} size={18} color={theme.color.brand} />
+                <Text variant="subheading">{item.title}</Text>
+              </Row>
+              <Text variant="caption" tone="muted">
+                {item.body}
+              </Text>
+            </Card>
+          ))}
+        </View>
+
+        <Card style={{ gap: theme.spacing.sm }}>
+          <Row style={{ gap: theme.spacing.sm }}>
+            <Ionicons name="lock-open-outline" size={18} color={theme.color.positive} />
+            <Text variant="subheading">What never will</Text>
+          </Row>
+          <Text variant="caption" tone="muted">
+            The ledger. Groups, expenses, splits, balances, settling up, and getting all of it back
+            out again — {t.freeForever.toLowerCase()}. A ledger you can only half read is not a
+            ledger.
+          </Text>
+        </Card>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -12,6 +12,13 @@
  * week of expenses on one they can no longer reach. That is easy to get wrong
  * in a screen and impossible to notice afterwards, so the screen does not get
  * to decide.
+ *
+ * The language chips are here for the same reason the guest button is: this is
+ * the first screen, and the first screen has to work for somebody it opened
+ * wrong. Baaki follows the phone by default, and a phone is one setting for one
+ * person — a shared handset, a borrowed one, or simply a person who reads Tamil
+ * and set their phone up in English. Making them sign in first, to reach a
+ * settings row they cannot read, is a door that only opens from the inside.
  */
 
 import { useEffect, useState } from 'react';
@@ -29,6 +36,7 @@ import {
 
 import { Button, Card, Chip, CurvedPanel, Row, Screen, Text, useTheme } from '@baaki/ui';
 
+import { LanguagePicker } from '@/components/LanguagePicker';
 import { Onboarding } from '@/components/Onboarding';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -190,14 +198,22 @@ export default function SignInScreen() {
           ) : null}
         </View>
 
-        <Text
-          variant="micro"
-          tone="faint"
-          align="center"
-          style={{ paddingBottom: theme.spacing.xxxl }}
+        {/* Under the buttons, not above them. The decision this screen exists
+            to get is "start now"; the language is the one thing somebody might
+            have to fix before they can read it, which earns a place on the
+            screen but not the top of it. */}
+        <View
+          style={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: theme.spacing.xxxl,
+            gap: theme.spacing.md,
+          }}
         >
-          Baaki {Constants.expoConfig?.version ?? ''}
-        </Text>
+          <LanguagePicker />
+          <Text variant="micro" tone="faint" align="center">
+            Baaki {Constants.expoConfig?.version ?? ''}
+          </Text>
+        </View>
       </View>
     );
   }
@@ -244,6 +260,11 @@ export default function SignInScreen() {
                 ? 'Add a way to sign in, so this account is still yours on your next phone.'
                 : 'Sign in however you set it up.'}
             </Text>
+
+            {/* Above the form rather than below it. A guest arrives straight
+                here without passing the welcome, so this is their only sight of
+                the chips before they are asked to read a form. */}
+            <LanguagePicker />
 
             <Card style={{ gap: theme.spacing.lg }}>
               <Row style={{ gap: theme.spacing.sm }}>

--- a/apps/mobile/src/components/LanguagePicker.tsx
+++ b/apps/mobile/src/components/LanguagePicker.tsx
@@ -1,0 +1,62 @@
+/**
+ * The language, offered before there is anywhere to put a setting.
+ *
+ * The settings row is the right home for this once somebody is inside the app.
+ * It is the wrong home for somebody standing at the front door who cannot read
+ * the door — they would have to sign in, find the account tab, find the third
+ * face of it, and scroll, all in a language they opened by accident. So the
+ * choice is also offered flat, on the way in.
+ *
+ * Four chips, each written in its own script and nothing else. No "follow my
+ * phone" option here: following the phone is what the app is already doing, and
+ * a row of five where one of them is a sentence in English is a row that has
+ * stopped being scannable. Tapping a script is the whole interaction.
+ *
+ * Choosing Arabic changes the words at once and the *direction* only after the
+ * app is opened again — `@/i18n/language` explains why at length. Here that
+ * costs one line of small print, and only while it is true.
+ */
+
+import { View } from 'react-native';
+
+import { Chip, Row, Text, useTheme } from '@baaki/ui';
+
+import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES } from '@/i18n';
+import { useLanguage } from '@/i18n/language';
+
+export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-start' }) {
+  const theme = useTheme();
+  const { language, setLanguage, restartNeeded } = useLanguage();
+
+  return (
+    <View style={{ gap: theme.spacing.sm }}>
+      {/* Wrapping rather than scrolling. Four is few enough to show all four,
+          and a language hidden off the edge of a rail is a language somebody
+          who cannot read the screen will never find. */}
+      <Row
+        gap={theme.spacing.sm}
+        style={{ justifyContent: align, flexWrap: 'wrap' }}
+        accessibilityRole="radiogroup"
+      >
+        {LANGUAGES.map((entry) => (
+          <Chip
+            key={entry}
+            // The endonym alone. Somebody hunting for their own language is
+            // matching the shape of their script, not reading a label.
+            label={LANGUAGE_NAMES[entry].own}
+            selected={entry === language}
+            onPress={() => void setLanguage(entry)}
+          />
+        ))}
+      </Row>
+
+      {restartNeeded ? (
+        <Text variant="micro" tone="faint" align={align === 'center' ? 'center' : 'left'}>
+          {isRtlLanguage(language)
+            ? 'Close and open Baaki once to mirror the layout.'
+            : 'Close and open Baaki once to turn the layout back.'}
+        </Text>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -3,12 +3,18 @@
  * and date formatting everywhere. Notification copy lives in
  * @baaki/core/notifications so the server sends the same words.
  *
+ * The phone's own language is the default and always will be. What sits on top
+ * of it now is a choice — `LanguageProvider` in `./language` — because the
+ * phone is one setting for one person and this app is used by people who read
+ * one language and set their phone to another. Somebody in Chennai with an
+ * English phone reads Tamil faster than they read English.
+ *
  * Arabic is the first right-to-left language here, and it is more than a fourth
  * column of strings — the whole layout mirrors. React Native does that itself
- * when `I18nManager.isRTL` is true, which the OS sets from the phone's own
- * language, so there is no switch in this app to flip: somebody whose phone is
- * in Arabic gets Arabic and a mirrored layout, and everybody else does not.
- * `extra.supportsRTL` in app.json is what lets the native side honour it.
+ * when `I18nManager.isRTL` is true, and it decides that once, natively, at
+ * launch. `extra.supportsRTL` in app.json is what lets the native side honour
+ * it; `./language` is where the restart that a direction change needs is
+ * explained rather than hidden.
  *
  * React Native mirrors more than it gets credit for: with
  * `doLeftAndRightSwapInRTL` — true by default — it swaps `left`/`right` in
@@ -23,14 +29,37 @@
  * fix, and every arrow in the app goes through it.
  */
 
+import { createContext, useContext } from 'react';
 import { getLocales } from 'expo-localization';
 
 import type { CategoryId } from '@baaki/core';
 
 export type Language = 'en' | 'ta' | 'hi' | 'ar';
 
+/** Every language this app speaks, in the order the picker lists them. */
+export const LANGUAGES: readonly Language[] = ['en', 'ta', 'hi', 'ar'];
+
 /** The languages that read right to left. */
 export const RTL_LANGUAGES: readonly Language[] = ['ar'];
+
+/**
+ * What each language calls itself, and what English calls it.
+ *
+ * The endonym leads. Somebody looking for their own language is scanning for
+ * the shape of their own script, and "Tamil" written in Latin letters is not
+ * that shape — it is the name of their language in a language they may not
+ * read. The English gloss follows for everyone else.
+ */
+export const LANGUAGE_NAMES: Readonly<Record<Language, { own: string; english: string }>> = {
+  en: { own: 'English', english: 'English' },
+  ta: { own: 'தமிழ்', english: 'Tamil' },
+  hi: { own: 'हिन्दी', english: 'Hindi' },
+  ar: { own: 'العربية', english: 'Arabic' },
+};
+
+export function isRtlLanguage(language: Language): boolean {
+  return RTL_LANGUAGES.includes(language);
+}
 
 export interface UiStrings {
   greeting: string;
@@ -100,6 +129,14 @@ export interface UiStrings {
   skip: string;
   next: string;
   getStarted: string;
+  /**
+   * The two words on the account screen that have to be in the reader's own
+   * language even when the app is in the wrong one — because "Language" is what
+   * somebody who has opened the app in a language they cannot read is hunting
+   * for, and a row labelled in that same unreadable language is no help at all.
+   */
+  language: string;
+  upgrade: string;
 }
 
 const en: UiStrings = {
@@ -173,6 +210,8 @@ const en: UiStrings = {
   skip: 'Skip',
   next: 'Next',
   getStarted: 'Get started',
+  language: 'Language',
+  upgrade: 'Upgrade',
   onboarding: [
     {
       // Not "split anything with anyone" — that is the welcome's line, and the
@@ -274,6 +313,8 @@ const ta: UiStrings = {
   skip: 'தவிர்',
   next: 'அடுத்து',
   getStarted: 'தொடங்கலாம்',
+  language: 'மொழி',
+  upgrade: 'மேம்படுத்தல்',
   onboarding: [
     {
       title: 'இரவு உணவு, வாடகை,\nஒரு முழுப் பயணம்',
@@ -361,6 +402,8 @@ const hi: UiStrings = {
   skip: 'छोड़ें',
   next: 'आगे',
   getStarted: 'शुरू करें',
+  language: 'भाषा',
+  upgrade: 'अपग्रेड',
   onboarding: [
     {
       title: 'खाना, किराया,\nपूरी यात्रा',
@@ -453,6 +496,8 @@ const ar: UiStrings = {
   skip: 'تخطٍ',
   next: 'التالي',
   getStarted: 'لنبدأ',
+  language: 'اللغة',
+  upgrade: 'الترقية',
   onboarding: [
     {
       title: 'عشاء، إيجار،\nرحلة كاملة',
@@ -514,9 +559,37 @@ export function deviceCountry(): string | null {
   return region && /^[A-Za-z]{2}$/.test(region) ? region.toUpperCase() : null;
 }
 
+/**
+ * The locale to format money and dates in, once somebody has chosen a language
+ * their phone is not set to.
+ *
+ * The language changes; the region does not. Somebody in Dubai reading the app
+ * in Hindi is still in the UAE — dates and currency belong to where they are,
+ * not to what they read. So this swaps the language subtag and keeps the rest,
+ * which is exactly what `hi-AE` means.
+ *
+ * Not called at all when the language is following the phone: there the phone's
+ * own locale tag is richer than anything reassembled here, and reassembling it
+ * would throw away a calendar or numbering system somebody had chosen.
+ */
+export function localeFor(language: Language): string {
+  const region = deviceCountry();
+  return region ? `${language}-${region}` : language;
+}
+
+/**
+ * The chosen language, or null while nothing has provided one.
+ *
+ * Null is not a bug: `useStrings` is called from screens that render before the
+ * provider is mounted and from tests that never mount it, and both should get
+ * the phone's language rather than an exception.
+ */
+export const LanguageContext = createContext<{ language: Language; locale: string } | null>(null);
+
 export function useStrings(): { t: UiStrings; locale: string; language: Language } {
-  const language = deviceLanguage();
-  return { t: STRINGS[language], locale: deviceLocale(), language };
+  const chosen = useContext(LanguageContext);
+  const language = chosen?.language ?? deviceLanguage();
+  return { t: STRINGS[language], locale: chosen?.locale ?? deviceLocale(), language };
 }
 
 export function fill(template: string, values: Record<string, string | number>): string {

--- a/apps/mobile/src/i18n/language.tsx
+++ b/apps/mobile/src/i18n/language.tsx
@@ -1,0 +1,175 @@
+/**
+ * Which language the app is in, and which way it runs.
+ *
+ * The phone's language is the default and stays the default. This exists
+ * because a phone is one setting for one person, and the two do not always
+ * agree: somebody in Chennai whose phone is in English still reads Tamil
+ * faster, and somebody visiting from Dubai has a phone in Arabic and a group
+ * full of people who do not read it.
+ *
+ * ## The restart, and why it is not hidden
+ *
+ * Strings change instantly — they are React state and nothing else. Direction
+ * does not. React Native decides right-to-left once, natively, before any
+ * JavaScript runs, and `I18nManager.forceRTL` says so itself: *changes take
+ * full effect on the next application start*. There is no reload to call — this
+ * app does not carry `expo-updates` — so the honest thing is to say the words
+ * "close and open Baaki again" rather than write half a mirrored screen.
+ *
+ * `allowRTL` and `forceRTL` are both set, in step, because they answer
+ * different halves of the question. Android computes RTL as
+ * `forced || (allowed && the device is RTL)`, so `forceRTL(false)` alone would
+ * not give an English reader on an Arabic phone a left-to-right app — it only
+ * stops *forcing*, and the device pref would win. Setting both makes the choice
+ * mean what it says in both directions.
+ *
+ * ## Icons follow the screen, not the choice
+ *
+ * `setLayoutDirection` takes the direction the app is *actually laid out in*,
+ * which between choosing Arabic and restarting is still the old one. Mirroring
+ * the arrows the moment the language changes would put backwards chevrons on an
+ * unmirrored screen — a bug that looks exactly like the one it is trying to
+ * prevent.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { I18nManager, Platform } from 'react-native';
+
+import { setLayoutDirection } from '@baaki/ui';
+
+import {
+  deviceLanguage,
+  deviceLocale,
+  isRtlLanguage,
+  LanguageContext,
+  localeFor,
+  type Language,
+} from '@/i18n';
+
+const KEY = 'baaki.language';
+
+/**
+ * The direction the app actually launched in.
+ *
+ * Read once, at module scope, because that is when it was true. `isRTL` comes
+ * from native constants captured at startup and does not move when `forceRTL`
+ * is called, which is precisely what makes it the right thing to compare a new
+ * choice against.
+ *
+ * Web has no `I18nManager` worth asking — the root view carries a `dir` instead
+ * and CSS honours it the moment it changes, so there is nothing to restart and
+ * nothing to compare.
+ */
+const LAUNCHED_RTL = Platform.OS === 'web' ? null : I18nManager.isRTL;
+
+interface LanguageValue {
+  /** The language the app is speaking. */
+  language: Language;
+  /** The explicit choice, or null when it is following the phone. */
+  stored: Language | null;
+  /** The locale money and dates are formatted in. */
+  locale: string;
+  /** True while the stored choice is still being read. */
+  loading: boolean;
+  /** Null puts it back under the phone's control. */
+  setLanguage: (value: Language | null) => Promise<void>;
+  /** What the phone itself is set to, for explaining the default. */
+  phoneLanguage: Language;
+  /**
+   * True when the chosen language reads the other way from the layout on
+   * screen. Only ever true on a device, and only until the app is opened again.
+   */
+  restartNeeded: boolean;
+}
+
+/**
+ * The whole value, for the two screens that change it.
+ *
+ * Separate from `LanguageContext` in `./index` on purpose, and holding the very
+ * same object. That one carries the two fields every screen in the app reads
+ * through `useStrings`, and it lives beside the string tables — where a setter
+ * and a restart flag have no business being, and would drag React Native and
+ * AsyncStorage into a module the tests import for its data.
+ */
+const LanguageValueContext = createContext<LanguageValue | null>(null);
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [stored, setStored] = useState<Language | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const phoneLanguage = deviceLanguage();
+  const language = stored ?? phoneLanguage;
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const saved = await AsyncStorage.getItem(KEY).catch(() => null);
+      if (!active) return;
+      setStored(isLanguage(saved) ? saved : null);
+      setLoading(false);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // On web the layout mirrors the moment `dir` changes, so the icons have to
+  // keep up with the choice. On a device they have to keep up with the launch.
+  useEffect(() => {
+    setLayoutDirection(LAUNCHED_RTL ?? isRtlLanguage(language));
+  }, [language]);
+
+  const setLanguage = useCallback(async (value: Language | null) => {
+    setStored(value);
+    if (value === null) await AsyncStorage.removeItem(KEY).catch(() => undefined);
+    else await AsyncStorage.setItem(KEY, value).catch(() => undefined);
+
+    // Persisted natively and read before any JavaScript next time the app
+    // opens. Nothing about the current session changes.
+    if (Platform.OS !== 'web') {
+      const rtl = isRtlLanguage(value ?? deviceLanguage());
+      I18nManager.allowRTL(rtl);
+      I18nManager.forceRTL(rtl);
+    }
+  }, []);
+
+  const value = useMemo<LanguageValue>(
+    () => ({
+      language,
+      stored,
+      // Following the phone keeps the phone's own tag, which is richer than
+      // anything reassembled from a language and a country.
+      locale: stored === null ? deviceLocale() : localeFor(stored),
+      loading,
+      setLanguage,
+      phoneLanguage,
+      restartNeeded: LAUNCHED_RTL !== null && LAUNCHED_RTL !== isRtlLanguage(language),
+    }),
+    [language, stored, loading, setLanguage, phoneLanguage],
+  );
+
+  return (
+    <LanguageContext.Provider value={value}>
+      <LanguageValueContext.Provider value={value}>{children}</LanguageValueContext.Provider>
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage(): LanguageValue {
+  const value = useContext(LanguageValueContext);
+  if (!value) throw new Error('useLanguage must be used inside LanguageProvider');
+  return value;
+}
+
+function isLanguage(value: string | null): value is Language {
+  return value === 'en' || value === 'ta' || value === 'hi' || value === 'ar';
+}

--- a/apps/mobile/test/language.test.ts
+++ b/apps/mobile/test/language.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Choosing a language, and what a choice does not change.
+ *
+ * The provider itself needs React and AsyncStorage and is checked on a device.
+ * What is checked here is the arithmetic under it: which languages read the
+ * other way, what each one calls itself, and the locale a chosen language is
+ * formatted in — which is the one that can quietly move somebody's money to a
+ * different country.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface FakeLocale {
+  languageCode?: string;
+  regionCode?: string;
+  languageTag?: string;
+}
+
+let locales: FakeLocale[] = [];
+
+vi.mock('expo-localization', () => ({ getLocales: () => locales }));
+
+const {
+  deviceLanguage,
+  isRtlLanguage,
+  LANGUAGE_NAMES,
+  LANGUAGES,
+  localeFor,
+  RTL_LANGUAGES,
+  STRINGS_BY_LANGUAGE,
+} = await import('../src/i18n');
+
+beforeEach(() => {
+  locales = [{ languageCode: 'en', regionCode: 'IN', languageTag: 'en-IN' }];
+});
+
+describe('the languages on offer', () => {
+  it('offers exactly the languages there are string tables for', () => {
+    expect([...LANGUAGES].sort()).toEqual(Object.keys(STRINGS_BY_LANGUAGE).sort());
+  });
+
+  it('names every one of them', () => {
+    for (const language of LANGUAGES) {
+      expect(LANGUAGE_NAMES[language].own.trim(), language).not.toBe('');
+      expect(LANGUAGE_NAMES[language].english.trim(), language).not.toBe('');
+    }
+  });
+
+  it('writes each name in its own script', () => {
+    // The whole point of the endonym. Somebody who has opened the app in a
+    // language they cannot read is scanning for the shape of their own
+    // writing, and "Tamil" in Latin letters is not that shape.
+    expect(LANGUAGE_NAMES.ta.own).toMatch(/\p{Script=Tamil}/u);
+    expect(LANGUAGE_NAMES.hi.own).toMatch(/\p{Script=Devanagari}/u);
+    expect(LANGUAGE_NAMES.ar.own).toMatch(/\p{Script=Arabic}/u);
+  });
+
+  it('agrees with RTL_LANGUAGES about which way each one reads', () => {
+    for (const language of LANGUAGES) {
+      expect(isRtlLanguage(language), language).toBe(RTL_LANGUAGES.includes(language));
+    }
+    expect(isRtlLanguage('ar')).toBe(true);
+    expect(isRtlLanguage('en')).toBe(false);
+  });
+});
+
+describe('the locale a chosen language is formatted in', () => {
+  it('keeps the country and swaps only the language', () => {
+    // Reading the app in Hindi in Dubai does not move you to India. Dates and
+    // currency belong to where somebody is, not to what they read.
+    locales = [{ languageCode: 'ar', regionCode: 'AE', languageTag: 'ar-AE' }];
+    expect(localeFor('hi')).toBe('hi-AE');
+    expect(localeFor('en')).toBe('en-AE');
+  });
+
+  it('falls back to the bare language when the phone will not say where it is', () => {
+    locales = [{ languageCode: 'en' }];
+    expect(localeFor('ta')).toBe('ta');
+  });
+
+  it('ignores a region the phone reports as nonsense', () => {
+    locales = [{ languageCode: 'en', regionCode: '419' }];
+    expect(localeFor('en')).toBe('en');
+  });
+
+  it('produces a tag Intl will actually take', () => {
+    // A tag assembled by hand is a tag that can be malformed, and the first
+    // thing it touches is money.
+    locales = [{ languageCode: 'en', regionCode: 'ae' }];
+    for (const language of LANGUAGES) {
+      const tag = localeFor(language);
+      expect(() => new Intl.NumberFormat(tag), tag).not.toThrow();
+      expect(new Intl.NumberFormat(tag).resolvedOptions().locale, tag).toContain(language);
+    }
+  });
+});
+
+describe('falling back to the phone', () => {
+  it('takes a language it speaks', () => {
+    locales = [{ languageCode: 'ta', regionCode: 'IN' }];
+    expect(deviceLanguage()).toBe('ta');
+  });
+
+  it('answers English for one it does not', () => {
+    locales = [{ languageCode: 'fr', regionCode: 'FR' }];
+    expect(deviceLanguage()).toBe('en');
+  });
+});


### PR DESCRIPTION
Reopens #64, which GitHub closed automatically when its base branch `feat/account-hero` was deleted on merging #63. Same work, rebased onto `main`.

## Choosing a language

Five choices behind the settings row — "Follow my phone", which stays the default, plus the four the app speaks. Each listed in its own script first: somebody who has opened Baaki in a language they cannot read is scanning for the *shape* of their writing, and "Tamil" in Latin letters is not that shape. `Language` and `Upgrade` are the only two settings labels translated into all four, for the same reason.

The same four scripts also sit flat on the **sign-in screen**, as chips — under the buttons on the welcome, above the form on the sign-in options, where a guest arrives without ever passing the welcome. A settings row is the right home for this once somebody is inside the app and the wrong home for somebody at the front door: reaching it otherwise means signing in, finding the account tab, finding its third face, and scrolling, all in the language they are trying to escape. In the settings list Language leads rather than sits fifth for the same reason.

## The restart, and why it is not hidden

Words change instantly. **Direction does not.** React Native decides right-to-left natively, before any JavaScript runs, and `forceRTL` says so itself — *changes take full effect on the next application start*. There is no `expo-updates` here, so there is no reload to call. The screen says "close and open Baaki again" in a banner that stays until it is true, rather than half-mirroring a screen.

Two consequences that look like bugs and are not:

- **Icons follow the screen, not the choice.** `setLayoutDirection` gets the direction the app actually launched in, so between choosing Arabic and restarting the arrows keep pointing the way the layout still runs.
- **A choice changes the language, not the country.** The locale keeps the phone's region and swaps only the language subtag — Hindi in Dubai formats as `hi-AE`.

Forcing LTR needs `allowRTL(false)` as well as `forceRTL(false)`. Android computes RTL as `forced || (allowed && device is RTL)`, so `forceRTL(false)` alone leaves an English reader on an Arabic phone with a mirrored app.

## Upgrade

An entry point and an honest empty room: it says there is nothing to buy, and says what would ever cost money (scanned bills, which cost real money per scan; outsized exports) against what never will (the ledger). Its own section above Settings rather than among them — paying for something is not a preference.

## Checked

Driven on two emulators. The settings picker: English→Tamil live with no restart, Tamil→Arabic showing the banner on a still-unmirrored screen, a cold start returning fully mirrored with the choice kept, and the whole way back to LTR — which is the only thing that exercises the `allowRTL(false)` branch. The sign-in picker from a clean install on a second device, through the same four transitions, including the sign-in options face in RTL.

Repo-wide typecheck, `expo lint`, prettier, and 125 tests (10 new) pass.

## Not covered

iOS is untested — needs a Mac. And the picker changes the words that go through `useStrings`; roughly 260 strings across the app are still English literals, which is visible the moment you pick Tamil on the welcome screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6