### PR TITLE
i18n: make the language picker actually change the language

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -157,6 +157,17 @@ itself — _changes take full effect on the next application start_. There is no
 reload to call. So the screen says "close and open Baaki again" in a banner that
 stays until it is true, rather than half-mirroring a screen and calling it done.
 
+The banner alone was not enough, twice over. A banner lives on one screen, and
+somebody who taps a language and walks away never reads it — they come back to a
+mirrored app in a language that is no longer Arabic and report it as broken. So
+the words are also said in an alert, at the moment of the choice, in the
+language just chosen, and only when the direction actually turns: going Arabic →
+English → Arabic in one sitting ends where the app launched and has nothing left
+to restart for. The sentence has **two directions** and they are not
+interchangeable — telling somebody who has just chosen English that reopening
+will "mirror it" describes the opposite of what will happen, on the one screen
+they are reading to find out why it has not turned back.
+
 The choice is offered twice, and the second time is the important one. A
 settings row is the right home for it once somebody is inside the app; it is the
 wrong home for somebody standing at the front door who cannot read the door.

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -66,7 +66,7 @@ export default function ActivityScreen() {
           {/* The feed is what happened in the groups; the inbox is what Baaki
               said to you. Related enough to sit together, different enough not
               to be interleaved. */}
-          <IconButton label="Inbox" onPress={() => router.push('/inbox' as never)}>
+          <IconButton label={t.tabs.inbox} onPress={() => router.push('/inbox' as never)}>
             <Ionicons name="notifications-outline" size={20} color={theme.color.text} />
             {unread > 0 ? (
               <View
@@ -85,10 +85,7 @@ export default function ActivityScreen() {
         </Row>
 
         {entries.length === 0 ? (
-          <EmptyState
-            title={t.nothingYet}
-            body="Every expense, edit, deletion and settlement lands here — for everyone in the group."
-          />
+          <EmptyState title={t.nothingYet} body={t.tabs.activityEmptyBody} />
         ) : (
           Object.entries(byDay).map(([day, dayEntries]) => (
             <View key={day}>
@@ -104,7 +101,7 @@ export default function ActivityScreen() {
                   <View key={entry.id}>
                     <ListRow
                       title={describeActivity(entry, myProfileId)}
-                      subtitle={`${entry.group?.name ?? 'Group'} · ${new Intl.DateTimeFormat(
+                      subtitle={`${entry.group?.name ?? t.tabs.group} · ${new Intl.DateTimeFormat(
                         locale,
                         {
                           hour: 'numeric',
@@ -113,7 +110,7 @@ export default function ActivityScreen() {
                       ).format(new Date(entry.created_at))}`}
                       leading={
                         <Avatar
-                          name={entry.group?.name ?? 'Group'}
+                          name={entry.group?.name ?? t.tabs.group}
                           emoji={entry.group?.cover_emoji ?? undefined}
                           size={40}
                         />

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -35,7 +35,7 @@ import {
 } from '@baaki/ui';
 
 import { fetchPeopleBalances, type PersonBalanceRow } from '@/data/api';
-import { useStrings } from '@/i18n';
+import { plural, useStrings } from '@/i18n';
 
 export default function FriendsScreen() {
   const theme = useTheme();
@@ -70,7 +70,7 @@ export default function FriendsScreen() {
         <Row style={{ justifyContent: 'space-between', paddingTop: theme.spacing.md }}>
           <Text variant="title">{t.friends}</Text>
           <Button
-            label="From contacts"
+            label={t.tabs.fromContacts}
             variant="secondary"
             size="sm"
             icon={<Ionicons name="person-add-outline" size={16} color={theme.color.brand} />}
@@ -79,23 +79,20 @@ export default function FriendsScreen() {
         </Row>
 
         {rows.length === 0 ? (
-          <EmptyState
-            title="All square"
-            body="Nobody owes you anything and you owe nobody. Friends you are settling up with will appear here — add somebody from your contacts to get started."
-          />
+          <EmptyState title={t.tabs.allSquare} body={t.tabs.allSquareBody} />
         ) : (
           <>
             <FriendsSection
-              title="Owes you"
+              title={t.tabs.owesYou}
               rows={owedToYou}
               locale={locale}
-              emptyBody="Nobody owes you anything right now."
+              emptyBody={t.tabs.nobodyOwesYou}
             />
             <FriendsSection
-              title="You owe"
+              title={t.tabs.youOweThem}
               rows={youOwe}
               locale={locale}
-              emptyBody="You are not behind with anyone."
+              emptyBody={t.tabs.youAreNotBehind}
             />
 
             <Text variant="micro" tone="faint" align="center">
@@ -121,6 +118,7 @@ function FriendsSection({
   emptyBody: string;
 }): React.JSX.Element {
   const theme = useTheme();
+  const { t } = useStrings();
 
   return (
     <View>
@@ -138,7 +136,9 @@ function FriendsSection({
               <ListRow
                 title={row.display_name}
                 subtitle={
-                  row.group_count === 1 ? 'in one group' : `across ${row.group_count} groups`
+                  row.group_count === 1
+                    ? t.tabs.inOneGroup
+                    : plural(locale, row.group_count, t.tabs.acrossGroups)
                 }
                 leading={<Avatar name={row.display_name} size={40} />}
                 // Only linkable when there is a single group to link to;
@@ -155,7 +155,7 @@ function FriendsSection({
                       variant="subheading"
                       mode="balance"
                     />
-                    {row.is_ghost ? <Badge label="Not joined" /> : null}
+                    {row.is_ghost ? <Badge label={t.tabs.notJoined} /> : null}
                   </View>
                 }
               />

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -95,14 +95,13 @@ export default function HomeScreen() {
         {isGuest ? (
           <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.sm }}>
             <Text variant="subheading" tone="brand">
-              You are using Baaki as a guest
+              {t.tabs.guestBanner}
             </Text>
             <Text variant="caption" tone="muted">
-              Nothing is missing — everything you enter is saved and yours. Add an email or phone
-              number whenever you want to reach it from another phone.
+              {t.tabs.guestBannerBody}
             </Text>
             <Button
-              label="Add your details"
+              label={t.tabs.addYourDetails}
               variant="secondary"
               size="sm"
               onPress={() => router.push('/settings/account')}
@@ -226,13 +225,13 @@ export default function HomeScreen() {
         {loading ? (
           <Card>
             <Text variant="caption" tone="muted">
-              Loading your groups…
+              {t.tabs.loadingGroups}
             </Text>
           </Card>
         ) : list.length === 0 ? (
           <EmptyState
-            title="No groups yet"
-            body="Start one for a trip, a flat, or the two of you. Adding expenses is free and unlimited, forever."
+            title={t.tabs.noGroups}
+            body={t.tabs.noGroupsBody}
             action={<Button label={t.newGroup} onPress={() => router.push('/new-group')} />}
           />
         ) : (

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -23,7 +23,14 @@ import {
 import { ProfileAvatar } from '@/components/ProfileAvatar';
 import { removeAvatar, uploadAvatar } from '@/data/api';
 import { useSettledTotals } from '@/data/hooks';
-import { deviceCountry, LANGUAGE_NAMES, plural, useStrings, type UiStrings } from '@/i18n';
+import {
+  deviceCountry,
+  isRtlLanguage,
+  LANGUAGE_NAMES,
+  plural,
+  useStrings,
+  type UiStrings,
+} from '@/i18n';
 import { useLanguage } from '@/i18n/language';
 import { useAuth } from '@/lib/auth';
 import { pickAvatarPhoto } from '@/lib/image';
@@ -303,9 +310,17 @@ export default function ProfileScreen() {
    * The row says the language in its own script. It is the one settings row
    * whose subtitle has to be legible to somebody who cannot read the rest of
    * the screen — which is exactly the person going looking for it.
+   *
+   * The restart hint has two directions and they are not interchangeable.
+   * Telling somebody who has just chosen English that reopening will "mirror
+   * it" describes the opposite of what will happen, on the one screen they are
+   * looking at to find out why it has not.
    */
   const languageSummary = restartNeeded
-    ? t.account.languageRestartHint.replace('{language}', LANGUAGE_NAMES[language].own)
+    ? (isRtlLanguage(language)
+        ? t.account.languageRestartHint
+        : t.account.languageRestartHintBack
+      ).replace('{language}', LANGUAGE_NAMES[language].own)
     : languageChosen === null
       ? t.account.languageFollowingPhone.replace('{language}', LANGUAGE_NAMES[language].own)
       : `${LANGUAGE_NAMES[language].own} · ${LANGUAGE_NAMES[language].english}`;

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -23,7 +23,7 @@ import {
 import { ProfileAvatar } from '@/components/ProfileAvatar';
 import { removeAvatar, uploadAvatar } from '@/data/api';
 import { useSettledTotals } from '@/data/hooks';
-import { deviceCountry, LANGUAGE_NAMES, useStrings } from '@/i18n';
+import { deviceCountry, LANGUAGE_NAMES, plural, useStrings, type UiStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
 import { useAuth } from '@/lib/auth';
 import { pickAvatarPhoto } from '@/lib/image';
@@ -93,32 +93,39 @@ function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }
   );
 }
 
-const SETTINGS: SettingsRow[] = [
-  {
-    icon: 'person-circle-outline',
-    label: 'Your account',
-    hint: 'Add an email or phone, or carry on as a guest',
-    route: '/settings/account',
-  },
-  {
-    icon: 'notifications-outline',
-    label: 'Notifications',
-    hint: 'Only what involves me',
-    route: '/settings/notifications',
-  },
-  {
-    icon: 'download-outline',
-    label: 'Export data',
-    hint: 'JSON + CSV, lossless, free',
-    route: '/settings/export',
-  },
-  {
-    icon: 'cloud-upload-outline',
-    label: 'Import from Splitwise',
-    hint: 'Bring a group across from a CSV export',
-    route: '/settings/import',
-  },
-];
+/**
+ * A function of the strings rather than a constant, because the labels are no
+ * longer knowable at module load — they depend on which language the reader
+ * has chosen, and that can change while the app is open.
+ */
+function settingsRows(t: UiStrings): SettingsRow[] {
+  return [
+    {
+      icon: 'person-circle-outline',
+      label: t.account.yourAccount,
+      hint: t.account.yourAccountHint,
+      route: '/settings/account',
+    },
+    {
+      icon: 'notifications-outline',
+      label: t.account.notifications,
+      hint: t.account.notificationsHint,
+      route: '/settings/notifications',
+    },
+    {
+      icon: 'download-outline',
+      label: t.account.exportDataRow,
+      hint: t.account.exportHint,
+      route: '/settings/export',
+    },
+    {
+      icon: 'cloud-upload-outline',
+      label: t.account.importSplitwise,
+      hint: t.account.importHint,
+      route: '/settings/import',
+    },
+  ];
+}
 
 /** The three faces of this screen. */
 type Face = 'you' | 'paying' | 'settings';
@@ -141,11 +148,12 @@ function SaveRow({
   status: string | null;
   onSave: () => void;
 }) {
+  const { t } = useStrings();
   return (
     <>
-      <Button label="Save" fullWidth disabled={!dirty || !valid} onPress={onSave} />
+      <Button label={t.common.save} fullWidth disabled={!dirty || !valid} onPress={onSave} />
       {status ? (
-        <Text variant="caption" tone={status === 'Saved' ? 'positive' : 'negative'}>
+        <Text variant="caption" tone={status === t.account.saved ? 'positive' : 'negative'}>
           {status}
         </Text>
       ) : null}
@@ -167,6 +175,7 @@ function SaveRow({
  */
 function SettledPill({ profileId, locale }: { profileId: string | null; locale: string }) {
   const theme = useTheme();
+  const { t } = useStrings();
   const totals = useSettledTotals(profileId);
 
   const entries = [...(totals.data ?? new Map<string, bigint>())].sort((a, b) =>
@@ -196,19 +205,19 @@ function SettledPill({ profileId, locale }: { profileId: string | null; locale: 
               tone="brand"
             />
             <Text variant="caption" tone="brand">
-              settled
+              {t.account.settled}
             </Text>
           </Row>
         ) : (
           <Text variant="caption" tone="brand">
-            Nothing settled yet
+            {t.account.nothingSettledYet}
           </Text>
         )}
       </Row>
       {/* No rate turns rupees into euros, so the rest are counted, not added. */}
       {entries.length > 1 ? (
         <Text variant="micro" tone="faint">
-          {`and ${entries.length - 1} other ${entries.length === 2 ? 'currency' : 'currencies'}`}
+          {plural(locale, entries.length - 1, t.account.otherCurrencies)}
         </Text>
       ) : null}
     </View>
@@ -283,10 +292,10 @@ export default function ProfileScreen() {
       void choosePhoto();
       return;
     }
-    Alert.alert('Your photo', undefined, [
-      { text: 'Choose a new one', onPress: () => void choosePhoto() },
-      { text: 'Remove', style: 'destructive', onPress: () => void clearPhoto() },
-      { text: 'Cancel', style: 'cancel' },
+    Alert.alert(t.account.yourPhoto, undefined, [
+      { text: t.account.chooseNewPhoto, onPress: () => void choosePhoto() },
+      { text: t.common.remove, style: 'destructive', onPress: () => void clearPhoto() },
+      { text: t.common.cancel, style: 'cancel' },
     ]);
   };
 
@@ -296,36 +305,34 @@ export default function ProfileScreen() {
    * the screen — which is exactly the person going looking for it.
    */
   const languageSummary = restartNeeded
-    ? `${LANGUAGE_NAMES[language].own} · reopen Baaki to mirror it`
+    ? t.account.languageRestartHint.replace('{language}', LANGUAGE_NAMES[language].own)
     : languageChosen === null
-      ? `Following your phone — ${LANGUAGE_NAMES[language].own}`
+      ? t.account.languageFollowingPhone.replace('{language}', LANGUAGE_NAMES[language].own)
       : `${LANGUAGE_NAMES[language].own} · ${LANGUAGE_NAMES[language].english}`;
 
   const motionSummary = motionOverridden
     ? animated
-      ? 'Screen animations on'
-      : 'Screen animations off'
-    : `Following your phone — animations ${animated ? 'on' : 'off'}`;
+      ? t.account.motionOn
+      : t.account.motionOff
+    : animated
+      ? t.account.motionFollowingOn
+      : t.account.motionFollowingOff;
 
   const lockSummary = !lockSupported
-    ? 'This device has no biometrics set up'
+    ? t.account.lockNoBiometrics
     : lockEnabled
-      ? `On · asks ${describeGrace(graceSeconds).toLowerCase()}`
-      : 'Off — anyone holding your phone can read the ledger';
+      ? t.account.lockOn.replace('{when}', describeGrace(graceSeconds, t, locale).toLowerCase())
+      : t.account.lockOff;
 
-  const signOutHint = isGuest
-    ? 'This guest account lives on this device only'
-    : 'Nothing is deleted; sign back in whenever';
+  const signOutHint = isGuest ? t.account.signOutGuestHint : t.account.signOutHint;
 
   const confirmSignOut = (): void => {
     Alert.alert(
-      'Sign out?',
-      isGuest
-        ? 'This is a guest account, so signing out leaves no way back into it. Add an email or phone number first if you want to keep it.'
-        : 'You can sign back in whenever you like. Nothing is deleted.',
+      t.lock.signOutQuestion,
+      isGuest ? t.lock.signOutGuestWarning : t.lock.signOutReassure,
       [
-        { text: 'Stay signed in', style: 'cancel' },
-        { text: 'Sign out', style: 'destructive', onPress: () => void signOut() },
+        { text: t.lock.staySignedIn, style: 'cancel' },
+        { text: t.lock.signOut, style: 'destructive', onPress: () => void signOut() },
       ],
     );
   };
@@ -342,14 +349,14 @@ export default function ProfileScreen() {
     const trimmed = handle.trim();
     try {
       await updateProfile({
-        display_name: name.trim() || 'You',
+        display_name: name.trim() || t.account.you,
         payment_rail: trimmed === '' ? null : rail,
         payment_handle: trimmed === '' ? null : trimmed,
         // Kept in step while the older screens still read it. A handle on any
         // other rail is not a UPI ID and must not masquerade as one.
         default_vpa: rail === 'upi' && trimmed !== '' ? trimmed : null,
       });
-      setStatus('Saved');
+      setStatus(t.account.saved);
     } catch (caught) {
       setStatus(caught instanceof Error ? caught.message : String(caught));
     }
@@ -370,7 +377,7 @@ export default function ProfileScreen() {
             are the page's title, and a title does not sit in a box. */}
         <View style={{ alignItems: 'center', gap: theme.spacing.md, paddingTop: theme.spacing.lg }}>
           <ProfileAvatar
-            name={profile?.display_name ?? 'You'}
+            name={profile?.display_name ?? t.account.you}
             avatarUrl={profile?.avatar_url}
             size={92}
             onPress={profile ? photoOptions : undefined}
@@ -378,11 +385,13 @@ export default function ProfileScreen() {
           />
           <View style={{ alignItems: 'center', gap: theme.spacing.sm }}>
             <Row style={{ gap: theme.spacing.sm }}>
-              <Text variant="title">{profile?.display_name ?? 'You'}</Text>
+              <Text variant="title">{profile?.display_name ?? t.account.you}</Text>
               {/* The badge says the account has no email or phone on it. When
                   somebody has not renamed themselves it repeats the name they
                   were given, which reads as a bug rather than a fact. */}
-              {isGuest && profile?.display_name !== 'Guest' ? <Badge label="Guest" /> : null}
+              {isGuest && profile?.display_name !== 'Guest' ? (
+                <Badge label={t.common.guest} />
+              ) : null}
             </Row>
             <SettledPill profileId={profile?.id ?? null} locale={locale} />
           </View>
@@ -394,9 +403,9 @@ export default function ProfileScreen() {
           tabs={[
             // Not `t.profile` — that reads "Account", which is the whole
             // screen. A tab has to name the part, not the page.
-            { value: 'you', label: 'You' },
-            { value: 'paying', label: 'Paying' },
-            { value: 'settings', label: 'Settings' },
+            { value: 'you', label: t.account.faceYou },
+            { value: 'paying', label: t.account.facePaying },
+            { value: 'settings', label: t.account.faceSettings },
           ]}
         />
 
@@ -405,13 +414,13 @@ export default function ProfileScreen() {
             <Card style={{ gap: theme.spacing.lg }}>
               <View style={{ gap: theme.spacing.xs }}>
                 <Text variant="caption" tone="muted">
-                  Display name
+                  {t.account.displayName}
                 </Text>
                 <TextInput
                   value={name}
                   onChangeText={setName}
-                  accessibilityLabel="Display name"
-                  placeholder="Your name"
+                  accessibilityLabel={t.account.displayName}
+                  placeholder={t.common.yourName}
                   placeholderTextColor={theme.color.textFaint}
                   style={{
                     fontSize: 18,
@@ -432,15 +441,13 @@ export default function ProfileScreen() {
             {isGuest ? (
               <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.md }}>
                 <Text variant="subheading" tone="brand">
-                  Guest account
+                  {t.account.guestAccount}
                 </Text>
                 <Text variant="caption" tone="muted">
-                  Everything you have entered is already saved and yours. Add an email or phone
-                  number whenever you want to reach it from another phone — it keeps this account
-                  rather than starting a new one.
+                  {t.account.guestAccountBody}
                 </Text>
                 <Button
-                  label="Add your details"
+                  label={t.account.addYourDetails}
                   variant="secondary"
                   size="sm"
                   onPress={() => router.push('/settings/account')}
@@ -459,7 +466,7 @@ export default function ProfileScreen() {
           <Card style={{ gap: theme.spacing.lg }}>
             <View style={{ gap: theme.spacing.sm }}>
               <Text variant="caption" tone="muted">
-                How people pay you
+                {t.account.howPeoplePayYou}
               </Text>
               {/* Whatever this person's country uses. In India that still starts
                   on UPI; in the UAE it starts on Aani. */}
@@ -477,7 +484,7 @@ export default function ProfileScreen() {
                     value={handle}
                     onChangeText={setHandle}
                     autoCapitalize="none"
-                    accessibilityLabel={`Your ${railInfo.label} details`}
+                    accessibilityLabel={t.account.yourRailDetails.replace('{rail}', railInfo.label)}
                     placeholder={railInfo.handleHint}
                     placeholderTextColor={theme.color.textFaint}
                     style={{
@@ -489,15 +496,15 @@ export default function ProfileScreen() {
                   />
                   <Text variant="micro" tone={handleValid ? 'faint' : 'negative'}>
                     {!handleValid
-                      ? `That does not look like ${railInfo.handleHint.toLowerCase()}.`
+                      ? t.account.handleWrong.replace('{hint}', railInfo.handleHint.toLowerCase())
                       : railInfo.link
-                        ? 'People settling with you get a one-tap payment. Baaki never handles the money.'
-                        : 'People settling with you see this to pay you from their own bank app. Baaki never handles the money.'}
+                        ? t.account.railLinkNote
+                        : t.account.railManualNote}
                   </Text>
                 </>
               ) : (
                 <Text variant="micro" tone="faint">
-                  Nothing to add — people will record what they paid you by hand.
+                  {t.account.nothingToAdd}
                 </Text>
               )}
             </View>
@@ -512,12 +519,12 @@ export default function ProfileScreen() {
                 you something sitting between Notifications and Export is a row
                 dressed up as a setting. */}
             <SettingsSection
-              title="Baaki"
+              title={t.account.sectionBaaki}
               rows={[
                 {
                   icon: 'rocket-outline',
                   label: t.upgrade,
-                  hint: 'Nothing to buy yet — the ledger stays free',
+                  hint: t.account.upgradeHint,
                   route: '/settings/upgrade',
                 },
               ]}
@@ -528,7 +535,7 @@ export default function ProfileScreen() {
                 four above it — a row you can only find by reading past rows you
                 cannot read is a row that is not there. */}
             <SettingsSection
-              title="Settings"
+              title={t.account.sectionSettings}
               rows={[
                 {
                   icon: 'language-outline',
@@ -536,10 +543,10 @@ export default function ProfileScreen() {
                   hint: languageSummary,
                   route: '/settings/language',
                 },
-                ...SETTINGS,
+                ...settingsRows(t),
                 {
                   icon: 'sparkles-outline',
-                  label: 'Motion',
+                  label: t.account.motionRow,
                   hint: motionSummary,
                   route: '/settings/motion',
                 },
@@ -549,17 +556,17 @@ export default function ProfileScreen() {
             {/* Security is its own section rather than one row among many: it is
             the only group of settings somebody comes looking for. */}
             <SettingsSection
-              title="Security"
+              title={t.account.sectionSecurity}
               rows={[
                 {
                   icon: 'finger-print-outline',
-                  label: 'App lock',
+                  label: t.lock.appLock,
                   hint: lockSummary,
                   route: '/settings/lock',
                 },
                 {
                   icon: 'log-out-outline',
-                  label: 'Sign out',
+                  label: t.lock.signOut,
                   hint: signOutHint,
                   onPress: confirmSignOut,
                 },
@@ -569,7 +576,7 @@ export default function ProfileScreen() {
         )}
 
         <Text variant="micro" tone="faint" align="center">
-          Baaki · the ledger is free forever. We only ever charge for convenience.
+          {t.account.footnote}
         </Text>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -15,6 +15,7 @@ import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
 import { isRtl, isRtlLanguage } from '@/i18n';
 import { LanguageProvider, useLanguage } from '@/i18n/language';
+import { LocaleSync } from '@/i18n/localeSync';
 import { LockProvider, useLock } from '@/lib/lock';
 import { MotionProvider, TRANSITION_MS, useMotion } from '@/lib/motion';
 import { UpdateProvider } from '@/lib/update';
@@ -97,6 +98,10 @@ function RootLayout() {
         <SafeAreaProvider>
           <QueryClientProvider client={queryClient}>
             <AuthProvider>
+              {/* Directly under the auth tree and outside every gate: which
+                  language somebody is notified in should not depend on whether
+                  the app is locked or the build is current. */}
+              <LocaleSync />
               <SyncProvider>
                 <LockProvider>
                   <MotionProvider>

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -37,12 +37,15 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
+
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
 import { addGhostMember, fetchGroups } from '@/data/api';
 import { groupLabel } from '@/data/types';
 
 export default function ContactsScreen(): React.JSX.Element {
   const theme = useTheme();
+  const { t } = useStrings();
   const queryClient = useQueryClient();
 
   const [picked, setPicked] = useState<readonly PickedContact[]>([]);
@@ -110,11 +113,11 @@ export default function ContactsScreen(): React.JSX.Element {
         }}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">From your contacts</Text>
+            <Text variant="heading">{t.misc.fromYourContacts}</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
@@ -140,7 +143,7 @@ export default function ContactsScreen(): React.JSX.Element {
                 </Text>
               </Card>
             ) : null}
-            <ContactPicker onConfirm={setPicked} confirmVerb="Continue with" />
+            <ContactPicker onConfirm={setPicked} confirmVerb={t.misc.continueWith} />
           </>
         )}
       </View>
@@ -170,6 +173,7 @@ function ChooseGroup({
   onChoose: (groupId: string) => void;
 }): React.JSX.Element {
   const theme = useTheme();
+  const { t } = useStrings();
   const only = contacts.length === 1 ? contacts[0] : undefined;
 
   return (
@@ -190,14 +194,14 @@ function ChooseGroup({
             </Text>
             <Text variant="micro" tone="faint" numberOfLines={2}>
               {only
-                ? (only.email ?? only.phone ?? 'No address')
+                ? (only.email ?? only.phone ?? t.misc.noAddress)
                 : contacts.map((contact) => contact.name).join(', ')}
             </Text>
           </View>
         </Row>
       </Card>
 
-      <SectionHeader title={only ? 'Add to which group?' : 'Add them all to which group?'} />
+      <SectionHeader title={only ? t.misc.addToWhichGroup : t.misc.addThemAllToWhichGroup} />
 
       {groups.length === 0 ? (
         <Card style={{ gap: theme.spacing.md }}>
@@ -206,7 +210,7 @@ function ChooseGroup({
             about something — a trip, a flat, a dinner.
           </Text>
           <Button
-            label="Start a group"
+            label={t.misc.startAGroup}
             variant="secondary"
             onPress={() => router.push('/new-group')}
           />
@@ -251,7 +255,7 @@ function ChooseGroup({
         with this email or number they claim everything already sitting there.
       </Text>
 
-      <Button label="Pick different people" variant="ghost" onPress={onCancel} />
+      <Button label={t.misc.pickDifferentPeople} variant="ghost" onPress={onCancel} />
     </ScrollView>
   );
 }

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -282,7 +282,7 @@ export default function AddExpenseScreen() {
   if (!group.data) {
     return (
       <Screen>
-        <EmptyState title="Group not found" body="It may have been archived." />
+        <EmptyState title={t.group.notFound} body={t.group.notFoundArchived} />
       </Screen>
     );
   }
@@ -290,7 +290,7 @@ export default function AddExpenseScreen() {
   const submit = async (): Promise<void> => {
     setError(null);
     if (!payer) {
-      setError('Choose who paid');
+      setError(t.expense.chooseWhoPaid);
       return;
     }
     setSaving(true);
@@ -390,9 +390,8 @@ export default function AddExpenseScreen() {
 
       setScanNote(
         result.check.reconciles && result.check.problems.length === 0
-          ? 'Read the total off the bill. Check it, then split it however you like.'
-          : (result.check.problems[0]?.message ??
-              'Check the total against the bill before saving.'),
+          ? t.expense.scanReconciles
+          : (result.check.problems[0]?.message ?? t.expense.scanCheckTotal),
       );
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
@@ -421,11 +420,11 @@ export default function AddExpenseScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Close" onPress={() => router.back()}>
+          <IconButton label={t.common.close} onPress={() => router.back()}>
             <Ionicons name="close" size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{editing ? 'Edit expense' : t.addExpense}</Text>
+            <Text variant="heading">{editing ? t.expense.edit : t.addExpense}</Text>
             <Text variant="micro" tone="muted">
               {groupLabel(group.data, members.data ?? [], profile?.id)}
             </Text>
@@ -434,7 +433,7 @@ export default function AddExpenseScreen() {
             <View style={{ width: 44 }} />
           ) : (
             <IconButton
-              label="Split by item"
+              label={t.expense.splitByItem}
               onPress={() => router.replace(`/group/${groupId}/itemize`)}
             >
               <Ionicons name="list-outline" size={20} color={theme.color.brand} />
@@ -445,7 +444,7 @@ export default function AddExpenseScreen() {
         {editing ? (
           <Card style={{ backgroundColor: theme.color.brandSoft }}>
             <Text variant="caption" tone="brand">
-              Editing keeps the old version. Everyone can see what changed, and it can be restored.
+              {t.expense.editingKeepsVersion}
             </Text>
           </Card>
         ) : null}
@@ -460,14 +459,13 @@ export default function AddExpenseScreen() {
         <Card style={{ gap: theme.spacing.md }}>
           <Row style={{ justifyContent: 'space-between' }}>
             <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-              <Text variant="subheading">Scan the bill</Text>
+              <Text variant="subheading">{t.expense.scanBillTitle}</Text>
               <Text variant="caption" tone="muted">
-                The total and the name of the place come out filled in. Check them — entering them
-                by hand is always free.
+                {t.expense.scanBillBody}
               </Text>
             </View>
             <Button
-              label={scanning ? 'Reading…' : 'Scan'}
+              label={scanning ? t.expense.reading : t.expense.scan}
               variant="secondary"
               disabled={scanning || saving}
               onPress={() => void scan()}
@@ -509,7 +507,7 @@ export default function AddExpenseScreen() {
             <TextInput
               value={description}
               onChangeText={setDescription}
-              placeholder="Beach shack dinner"
+              placeholder={t.expense.descriptionPlaceholder}
               placeholderTextColor={theme.color.textFaint}
               accessibilityLabel={t.description}
               style={{
@@ -545,15 +543,15 @@ export default function AddExpenseScreen() {
 
         <View style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">
-            How to split
+            {t.expense.howToSplit}
           </Text>
           <ChipRow<SplitKind>
             value={splitKind}
             onChange={setSplitKind}
             options={[
-              { value: 'equal', label: 'Equally' },
-              { value: 'shares', label: 'Shares' },
-              { value: 'percent', label: 'Percent' },
+              { value: 'equal', label: t.expense.equally },
+              { value: 'shares', label: t.expense.shares },
+              { value: 'percent', label: t.expense.percent },
             ]}
           />
         </View>
@@ -584,10 +582,12 @@ export default function AddExpenseScreen() {
         <Card style={{ gap: theme.spacing.md }}>
           <Row style={{ justifyContent: 'space-between' }}>
             <Text variant="caption" tone="muted">
-              Split between
+              {t.expense.splitBetween}
             </Text>
             <Text variant="micro" tone="muted">
-              {`${participants.length} of ${members.data?.length ?? 0}`}
+              {t.expense.ofCount
+                .replace('{chosen}', String(participants.length))
+                .replace('{total}', String(members.data?.length ?? 0))}
             </Text>
           </Row>
 
@@ -693,7 +693,7 @@ export default function AddExpenseScreen() {
         ) : null}
 
         <Button
-          label={editing ? 'Save changes' : t.save}
+          label={editing ? t.expense.saveChanges : t.save}
           size="lg"
           fullWidth
           disabled={amount === 0n || participants.length === 0 || splitIssue !== null || saving}

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -33,21 +33,23 @@ import {
   useWithdrawDispute,
 } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
-import { useStrings } from '@/i18n';
+import { useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
-const SPLIT_LABELS: Record<string, string> = {
-  equal: 'Split equally',
-  exact: 'Exact amounts',
-  percent: 'By percentage',
-  shares: 'By shares',
-  adjustment: 'With adjustments',
-  itemized: 'Itemized',
-};
+function splitLabels(t: UiStrings): Record<string, string> {
+  return {
+    equal: t.expense.splitEqually,
+    exact: t.expense.exactAmounts,
+    percent: t.expense.byPercentage,
+    shares: t.expense.byShares,
+    adjustment: t.expense.withAdjustments,
+    itemized: t.expense.itemized,
+  };
+}
 
 export default function ExpenseDetailScreen() {
   const theme = useTheme();
-  const { locale } = useStrings();
+  const { t, locale } = useStrings();
   const { id, expenseId } = useLocalSearchParams<{ id: string; expenseId: string }>();
   const groupId = id ?? '';
   const { profile } = useAuth();
@@ -84,9 +86,9 @@ export default function ExpenseDetailScreen() {
     return (
       <Screen>
         <EmptyState
-          title="Expense not found"
-          body="It may have been deleted more than 30 days ago."
-          action={<Button label="Back" onPress={() => router.back()} />}
+          title={t.expense.notFound}
+          body={t.expense.notFoundBody}
+          action={<Button label={t.common.back} onPress={() => router.back()} />}
         />
       </Screen>
     );
@@ -100,20 +102,16 @@ export default function ExpenseDetailScreen() {
   const editHere = (): void => router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}`);
 
   const confirmDelete = (): void => {
-    Alert.alert(
-      'Delete this expense?',
-      'It stops counting towards balances but stays in the activity feed, and anyone in the group can restore it for 30 days.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Delete',
-          style: 'destructive',
-          onPress: () => {
-            deleteExpense.mutate(expense.id, { onSuccess: () => router.back() });
-          },
+    Alert.alert(t.expense.deleteQuestion, t.expense.deleteBody, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.common.delete,
+        style: 'destructive',
+        onPress: () => {
+          deleteExpense.mutate(expense.id, { onSuccess: () => router.back() });
         },
-      ],
-    );
+      },
+    ]);
   };
 
   return (
@@ -127,7 +125,7 @@ export default function ExpenseDetailScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
@@ -139,7 +137,7 @@ export default function ExpenseDetailScreen() {
             </Text>
           </View>
           <IconButton
-            label="Edit"
+            label={t.common.edit}
             onPress={() => router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}`)}
           >
             <Ionicons name="create-outline" size={18} color={theme.color.text} />
@@ -161,9 +159,9 @@ export default function ExpenseDetailScreen() {
             ).format(new Date(version.expense_date))}`}
           </Text>
           <Row style={{ gap: theme.spacing.sm }}>
-            <Badge label={SPLIT_LABELS[version.split_type] ?? version.split_type} tone="brand" />
+            <Badge label={splitLabels(t)[version.split_type] ?? version.split_type} tone="brand" />
             {version.version_no > 1 ? <Badge label={`edited ${version.version_no - 1}×`} /> : null}
-            {deleted ? <Badge label="deleted" tone="negative" /> : null}
+            {deleted ? <Badge label={t.expense.deleted} tone="negative" /> : null}
           </Row>
         </Card>
 
@@ -188,7 +186,7 @@ export default function ExpenseDetailScreen() {
 
         {version.payers.length > 1 ? (
           <View>
-            <SectionHeader title="Paid by" />
+            <SectionHeader title={t.paidBy} />
             <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
               {version.payers.map((payer, index) => (
                 <View key={payer.member_id}>
@@ -214,7 +212,7 @@ export default function ExpenseDetailScreen() {
         ) : null}
 
         <View>
-          <SectionHeader title="Who owes what" />
+          <SectionHeader title={t.expense.whoOwesWhat} />
           <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
             {version.shares.map((share, index) => {
               const member = lookup.get(share.member_id);
@@ -250,7 +248,7 @@ export default function ExpenseDetailScreen() {
 
         {/* ADR-004: every edit is kept, and the group can see what changed. */}
         <View>
-          <SectionHeader title="History" />
+          <SectionHeader title={t.expense.history} />
           <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
             {(versions.data ?? []).map((entry, index) => (
               <View key={entry.id}>
@@ -286,7 +284,7 @@ export default function ExpenseDetailScreen() {
 
         {deleted ? (
           <Button
-            label="Restore this expense"
+            label={t.expense.restore}
             size="lg"
             fullWidth
             disabled={restoreExpense.isPending}
@@ -294,7 +292,7 @@ export default function ExpenseDetailScreen() {
           />
         ) : (
           <Button
-            label="Delete expense"
+            label={t.expense.deleteAction}
             variant="ghost"
             size="lg"
             fullWidth

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -72,7 +72,7 @@ export default function GroupScreen() {
       <Screen>
         <View style={{ padding: theme.spacing.xl }}>
           <Text variant="caption" tone="muted">
-            Loading…
+            {t.group.loading}
           </Text>
         </View>
       </Screen>
@@ -83,9 +83,9 @@ export default function GroupScreen() {
     return (
       <Screen>
         <EmptyState
-          title="Group not found"
-          body="It may have been archived, or you are no longer a member."
-          action={<Button label="Back" onPress={() => router.back()} />}
+          title={t.group.notFound}
+          body={t.group.notFoundBody}
+          action={<Button label={t.common.back} onPress={() => router.back()} />}
         />
       </Screen>
     );
@@ -120,7 +120,7 @@ export default function GroupScreen() {
         }
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <Row style={{ flex: 1, gap: theme.spacing.md, justifyContent: 'center' }}>
@@ -149,7 +149,7 @@ export default function GroupScreen() {
             <Ionicons name="pie-chart-outline" size={19} color={theme.color.text} />
           </IconButton>
           <IconButton
-            label="Group settings"
+            label={t.group.settings}
             onPress={() => router.push(`/group/${groupId}/settings`)}
           >
             <Ionicons name="ellipsis-horizontal" size={20} color={theme.color.text} />
@@ -163,11 +163,10 @@ export default function GroupScreen() {
         {ledger.mismatch ? (
           <Card style={{ backgroundColor: theme.color.negativeSoft, gap: theme.spacing.sm }}>
             <Text variant="subheading" tone="negative">
-              Balances need a refresh
+              {t.group.mismatch}
             </Text>
             <Text variant="caption" tone="muted">
-              This device and the server disagree about this group&apos;s balances. Pull to refresh;
-              if it persists, the ledger below is the source of truth.
+              {t.group.mismatchBody}
             </Text>
           </Card>
         ) : null}
@@ -246,12 +245,12 @@ export default function GroupScreen() {
             />
             <Row style={{ gap: theme.spacing.md }}>
               <Button
-                label="Confirm received"
+                label={t.group.confirmReceived}
                 onPress={() => confirmSettlement.mutate(settlement.id)}
                 disabled={confirmSettlement.isPending}
               />
               <Text variant="micro" tone="faint" style={{ flex: 1 }}>
-                Auto-confirms in 7 days if nobody responds.
+                {t.group.autoConfirms}
               </Text>
             </Row>
           </Card>
@@ -274,7 +273,7 @@ export default function GroupScreen() {
               tone="muted"
               onPress={() => setShowDeleted((current) => !current)}
             >
-              {showDeleted ? 'Hide deleted' : 'Show deleted'}
+              {showDeleted ? t.group.hideDeleted : t.group.showDeleted}
             </Text>
           </Row>
         ) : null}
@@ -360,10 +359,7 @@ export default function GroupScreen() {
 
         {tab === 'activity' ? (
           (activity.data ?? []).length === 0 ? (
-            <EmptyState
-              title={t.nothingYet}
-              body="Everything that happens here shows up in this feed."
-            />
+            <EmptyState title={t.nothingYet} body={t.group.activityEmptyBody} />
           ) : (
             <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
               {(activity.data ?? []).map((entry, index) => (

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -102,7 +102,7 @@ export default function InsightsScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -20,7 +20,7 @@ const INVITE_BASE = 'https://baaki.app/join';
 
 export default function InviteScreen() {
   const theme = useTheme();
-  const { locale } = useStrings();
+  const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
 
@@ -96,11 +96,11 @@ export default function InviteScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Close" onPress={() => router.back()}>
+          <IconButton label={t.common.close} onPress={() => router.back()}>
             <Ionicons name="close" size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Invite people</Text>
+            <Text variant="heading">{t.people.inviteTitle}</Text>
             <Text variant="micro" tone="muted">
               {label}
             </Text>
@@ -109,11 +109,9 @@ export default function InviteScreen() {
         </Row>
 
         <Card style={{ gap: theme.spacing.md }}>
-          <Text variant="subheading">Anyone with the link can join</Text>
+          <Text variant="subheading">{t.people.anyoneWithLink}</Text>
           <Text variant="caption" tone="muted">
-            They do not need to install anything or make an account to see the group and add
-            expenses. If they were already in it as a name, they can claim that history when they
-            join.
+            {t.people.anyoneWithLinkBody}
           </Text>
         </Card>
 
@@ -121,17 +119,20 @@ export default function InviteScreen() {
           <>
             <Card style={{ gap: theme.spacing.md }}>
               <Text variant="caption" tone="muted">
-                Invite link
+                {t.people.inviteLink}
               </Text>
               <Text variant="body" style={{ color: theme.color.brand }} selectable>
                 {link}
               </Text>
               <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
                 <Badge
-                  label={`expires ${new Intl.DateTimeFormat(locale, {
-                    day: 'numeric',
-                    month: 'short',
-                  }).format(new Date(invite.expiresAt))}`}
+                  label={t.people.expires.replace(
+                    '{when}',
+                    new Intl.DateTimeFormat(locale, {
+                      day: 'numeric',
+                      month: 'short',
+                    }).format(new Date(invite.expiresAt)),
+                  )}
                 />
                 <Badge label={`${invite.maxUses} uses`} />
               </Row>
@@ -140,7 +141,7 @@ export default function InviteScreen() {
             <Row style={{ gap: theme.spacing.md, flexWrap: 'wrap' }}>
               {(
                 [
-                  { channel: 'whatsapp', label: 'WhatsApp', icon: 'logo-whatsapp' },
+                  { channel: 'whatsapp', label: t.people.whatsapp, icon: 'logo-whatsapp' },
                   { channel: 'sms', label: 'SMS', icon: 'chatbubble-outline' },
                   { channel: 'email', label: 'Email', icon: 'mail-outline' },
                 ] as const
@@ -157,13 +158,13 @@ export default function InviteScreen() {
 
             <Row style={{ gap: theme.spacing.md }}>
               <Button
-                label="Share another way"
+                label={t.people.shareAnotherWay}
                 size="lg"
                 onPress={() => void share()}
                 icon={<Ionicons name="share-outline" size={18} color={theme.color.onBrand} />}
               />
               <Button
-                label={copied ? 'Copied' : 'Copy link'}
+                label={copied ? t.people.linkCopied : t.people.copyLink}
                 variant="secondary"
                 size="lg"
                 onPress={() => void copy()}
@@ -177,7 +178,7 @@ export default function InviteScreen() {
           </>
         ) : (
           <Button
-            label="Create an invite link"
+            label={t.people.createLink}
             size="lg"
             fullWidth
             disabled={busy}

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -48,7 +48,7 @@ export default function MemberScreen() {
   if (!member) {
     return (
       <Screen>
-        <EmptyState title="Member not found" body="They may have left the group." />
+        <EmptyState title={t.people.memberNotFound} body={t.people.memberNotFoundBody} />
       </Screen>
     );
   }
@@ -67,7 +67,7 @@ export default function MemberScreen() {
     updateMember.mutate(
       { memberId: member.id, patch },
       {
-        onSuccess: () => setStatus('Saved'),
+        onSuccess: () => setStatus(t.account.saved),
         onError: (caught) => setStatus(caught instanceof Error ? caught.message : String(caught)),
       },
     );
@@ -85,7 +85,7 @@ export default function MemberScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
@@ -108,8 +108,8 @@ export default function MemberScreen() {
           />
           <Row style={{ gap: theme.spacing.sm }}>
             {ghost ? <Badge label={t.notJoinedYet} /> : null}
-            {member.role === 'admin' ? <Badge label="admin" tone="brand" /> : null}
-            {isMe ? <Badge label="you" tone="positive" /> : null}
+            {member.role === 'admin' ? <Badge label={t.people.admin} tone="brand" /> : null}
+            {isMe ? <Badge label={t.people.you} tone="positive" /> : null}
           </Row>
           {balance !== 0n && !isMe ? (
             <Button label={t.settleUp} onPress={() => router.push(`/group/${groupId}/settle`)} />
@@ -119,13 +119,13 @@ export default function MemberScreen() {
         {ghost ? (
           <Card style={{ gap: theme.spacing.md }}>
             <Text variant="caption" tone="muted">
-              Name
+              {t.common.name}
             </Text>
             <Row>
               <TextInput
                 value={name}
                 onChangeText={setName}
-                accessibilityLabel="Member name"
+                accessibilityLabel={t.people.memberName}
                 placeholderTextColor={theme.color.textFaint}
                 style={{
                   flex: 1,
@@ -136,7 +136,7 @@ export default function MemberScreen() {
                 }}
               />
               <Button
-                label="Save"
+                label={t.common.save}
                 size="sm"
                 variant="secondary"
                 disabled={!name.trim() || name.trim() === member.ghost_name}
@@ -144,7 +144,7 @@ export default function MemberScreen() {
               />
             </Row>
             <Text variant="micro" tone="faint">
-              This person holds real balances. When they join, they can claim this history.
+              {t.people.ghostNote}
             </Text>
           </Card>
         ) : null}
@@ -152,14 +152,14 @@ export default function MemberScreen() {
         {isMe ? (
           <Card style={{ gap: theme.spacing.md }}>
             <Text variant="caption" tone="muted">
-              UPI ID for this group
+              {t.people.upiForGroup}
             </Text>
             <Row>
               <TextInput
                 value={vpa}
                 onChangeText={setVpa}
                 autoCapitalize="none"
-                accessibilityLabel="UPI ID for this group"
+                accessibilityLabel={t.people.upiForGroup}
                 placeholder={profile?.default_vpa ?? 'you@bank'}
                 placeholderTextColor={theme.color.textFaint}
                 style={{
@@ -171,7 +171,7 @@ export default function MemberScreen() {
                 }}
               />
               <Button
-                label="Save"
+                label={t.common.save}
                 size="sm"
                 variant="secondary"
                 disabled={!vpaValid || vpa.trim() === (member.vpa ?? '')}
@@ -179,14 +179,13 @@ export default function MemberScreen() {
               />
             </Row>
             <Text variant="micro" tone="faint">
-              Overrides your account UPI ID here only — useful when one group settles to a different
-              account.
+              {t.people.upiForGroupNote}
             </Text>
           </Card>
         ) : null}
 
         {status ? (
-          <Text variant="caption" tone={status === 'Saved' ? 'positive' : 'negative'}>
+          <Text variant="caption" tone={status === t.account.saved ? 'positive' : 'negative'}>
             {status}
           </Text>
         ) : null}

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -21,7 +21,7 @@ import {
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
 import { useAddGhostMember, useGroup, useGroupLedger } from '@/data/hooks';
 import { displayName, groupLabel, isGhost, vpaOf } from '@/data/types';
-import { useStrings } from '@/i18n';
+import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
 export default function MembersScreen() {
@@ -130,7 +130,7 @@ export default function MembersScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
@@ -139,7 +139,10 @@ export default function MembersScreen() {
               {groupLabel(group.data, members.data ?? [])}
             </Text>
           </View>
-          <IconButton label="Invite" onPress={() => router.push(`/group/${groupId}/invite`)}>
+          <IconButton
+            label={t.people.invite}
+            onPress={() => router.push(`/group/${groupId}/invite`)}
+          >
             <Ionicons name="share-outline" size={18} color={theme.color.brand} />
           </IconButton>
         </Row>
@@ -171,15 +174,15 @@ export default function MembersScreen() {
         {/* ADR-006: a name is enough to start splitting with someone. */}
         <Card style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">
-            Add someone
+            {t.people.addSomeone}
           </Text>
           <Row>
             <TextInput
               value={ghostName}
               onChangeText={setGhostName}
-              placeholder="Rahul"
+              placeholder={t.people.namePlaceholder}
               placeholderTextColor={theme.color.textFaint}
-              accessibilityLabel="Name"
+              accessibilityLabel={t.common.name}
               onSubmitEditing={add}
               style={{
                 flex: 1,
@@ -190,7 +193,7 @@ export default function MembersScreen() {
               }}
             />
             <Button
-              label="Add"
+              label={t.add}
               size="sm"
               variant="secondary"
               disabled={(!ghostName.trim() && !ghostContact.trim()) || addGhost.isPending}
@@ -203,9 +206,9 @@ export default function MembersScreen() {
             onChangeText={setGhostContact}
             autoCapitalize="none"
             keyboardType="email-address"
-            placeholder="Email or phone, if you want to send them the link"
+            placeholder={t.people.contactPlaceholder}
             placeholderTextColor={theme.color.textFaint}
-            accessibilityLabel="Email or phone number"
+            accessibilityLabel={t.common.emailOrPhone}
             onSubmitEditing={add}
             style={{
               fontSize: 15,
@@ -215,7 +218,7 @@ export default function MembersScreen() {
           />
 
           <Button
-            label={browsing ? 'Hide contacts' : 'Browse my contacts'}
+            label={browsing ? t.people.hideContacts : t.people.browseContacts}
             variant="ghost"
             onPress={() => setBrowsing((open) => !open)}
           />
@@ -246,13 +249,13 @@ export default function MembersScreen() {
 
         {ghosts.length > 0 ? (
           <Row style={{ justifyContent: 'space-between' }}>
-            <Badge label={`${ghosts.length} yet to join`} />
+            <Badge label={plural(locale, ghosts.length, t.people.yetToJoin)} />
             <Text
               variant="caption"
               tone="brand"
               onPress={() => router.push(`/group/${groupId}/invite`)}
             >
-              Send an invite link
+              {t.people.sendInviteLink}
             </Text>
           </Row>
         ) : null}

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -175,7 +175,7 @@ export default function PlanScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md, gap: theme.spacing.sm }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <Text variant="heading">{t.plan}</Text>

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -54,7 +54,7 @@ export default function GroupSettingsScreen() {
     try {
       await uploadGroupPhoto({ groupId, base64: picked.base64, mimeType: picked.mimeType });
       await group.refetch();
-      setStatus('Photo updated');
+      setStatus(t.group.photoUpdated);
     } catch (caught) {
       setStatus(caught instanceof Error ? caught.message : String(caught));
     } finally {
@@ -75,7 +75,7 @@ export default function GroupSettingsScreen() {
   if (!group.data) {
     return (
       <Screen>
-        <EmptyState title="Group not found" body="It may have been archived." />
+        <EmptyState title={t.group.notFound} body={t.group.notFoundArchived} />
       </Screen>
     );
   }
@@ -84,16 +84,13 @@ export default function GroupSettingsScreen() {
 
   const leave = (): void => {
     if (!settled) {
-      Alert.alert(
-        'Settle up first',
-        'You still have a balance in this group. Leaving now would strand it — settle up, then leave.',
-      );
+      Alert.alert(t.group.settleFirst, t.group.settleFirstBody);
       return;
     }
-    Alert.alert('Leave this group?', 'Your past expenses stay in the group history.', [
-      { text: 'Cancel', style: 'cancel' },
+    Alert.alert(t.group.leaveQuestion, t.group.leaveBody, [
+      { text: t.common.cancel, style: 'cancel' },
       {
-        text: 'Leave',
+        text: t.group.leave,
         style: 'destructive',
         onPress: () => {
           if (!ledger.myMemberId) return;
@@ -104,21 +101,17 @@ export default function GroupSettingsScreen() {
   };
 
   const archive = (): void => {
-    Alert.alert(
-      'Archive this group?',
-      'It disappears from your list but nothing is deleted, and anyone can unarchive it.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Archive',
-          onPress: () =>
-            updateGroup.mutate(
-              { archived_at: new Date().toISOString() },
-              { onSuccess: () => router.replace('/') },
-            ),
-        },
-      ],
-    );
+    Alert.alert(t.group.archiveQuestion, t.group.archiveBody, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.group.archive,
+        onPress: () =>
+          updateGroup.mutate(
+            { archived_at: new Date().toISOString() },
+            { onSuccess: () => router.replace('/') },
+          ),
+      },
+    ]);
   };
 
   return (
@@ -133,11 +126,11 @@ export default function GroupSettingsScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Group settings</Text>
+            <Text variant="heading">{t.group.settings}</Text>
             <Text variant="micro" tone="muted">
               {groupLabel(group.data, members.data ?? [])}
             </Text>
@@ -156,12 +149,12 @@ export default function GroupSettingsScreen() {
             />
             <View style={{ flex: 1, gap: theme.spacing.xs }}>
               <Text variant="caption" tone="muted">
-                Name (optional)
+                {t.group.nameOptional}
               </Text>
               <TextInput
                 value={name}
                 onChangeText={setName}
-                accessibilityLabel="Group name"
+                accessibilityLabel={t.group.groupName}
                 placeholder={groupLabel(null, members.data ?? [], profile?.id)}
                 placeholderTextColor={theme.color.textFaint}
                 style={{
@@ -176,7 +169,7 @@ export default function GroupSettingsScreen() {
 
           <Row style={{ gap: theme.spacing.sm }}>
             <Button
-              label="Save name"
+              label={t.group.saveName}
               size="sm"
               variant="secondary"
               // Clearing the field is a real choice: the group goes back to
@@ -185,13 +178,13 @@ export default function GroupSettingsScreen() {
               onPress={() =>
                 updateGroup.mutate(
                   { name: name.trim() || null },
-                  { onSuccess: () => setStatus('Saved') },
+                  { onSuccess: () => setStatus(t.account.saved) },
                 )
               }
             />
             {group.data.photo_path ? (
               <Button
-                label="Remove photo"
+                label={t.group.removePhoto}
                 size="sm"
                 variant="ghost"
                 onPress={() => void dropPhoto()}
@@ -230,14 +223,16 @@ export default function GroupSettingsScreen() {
         <CountryRow
           countryCode={group.data.country_code}
           onChange={(country_code) =>
-            updateGroup.mutate({ country_code }, { onSuccess: () => setStatus('Saved') })
+            updateGroup.mutate({ country_code }, { onSuccess: () => setStatus(t.account.saved) })
           }
         />
 
         <TripDates
           group={group.data}
           locale={locale}
-          onChange={(patch) => updateGroup.mutate(patch, { onSuccess: () => setStatus('Saved') })}
+          onChange={(patch) =>
+            updateGroup.mutate(patch, { onSuccess: () => setStatus(t.account.saved) })
+          }
         />
 
         {/* ADR-009: simplification is presentation only — the pairwise ledger
@@ -245,16 +240,15 @@ export default function GroupSettingsScreen() {
         <Card>
           <Row style={{ justifyContent: 'space-between' }}>
             <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-              <Text variant="subheading">Simplify debts</Text>
+              <Text variant="subheading">{t.group.simplifyDebts}</Text>
               <Text variant="caption" tone="muted">
-                Suggest the fewest payments that settle the group. The real who-owes-whom ledger is
-                never rewritten.
+                {t.group.simplifyDebtsBody}
               </Text>
             </View>
             <Toggle
               value={group.data.simplify_debts}
               onValueChange={(value) => updateGroup.mutate({ simplify_debts: value })}
-              accessibilityLabel="Simplify debts"
+              accessibilityLabel={t.group.simplifyDebts}
             />
           </Row>
         </Card>
@@ -264,7 +258,7 @@ export default function GroupSettingsScreen() {
           <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
             <ListRow
               title={`${members.data?.length ?? 0} ${t.members}`}
-              subtitle="Add people, rename, set UPI IDs"
+              subtitle={t.group.membersHint}
               leading={<Ionicons name="people-outline" size={22} color={theme.color.textMuted} />}
               onPress={() => router.push(`/group/${groupId}/members`)}
               trailing={
@@ -277,8 +271,8 @@ export default function GroupSettingsScreen() {
             />
             <View style={{ height: 1, backgroundColor: theme.color.border }} />
             <ListRow
-              title="Invite people"
-              subtitle="Share a link — no install needed to join"
+              title={t.group.invitePeople}
+              subtitle={t.group.invitePeopleHint}
               leading={<Ionicons name="share-outline" size={22} color={theme.color.textMuted} />}
               onPress={() => router.push(`/group/${groupId}/invite`)}
               trailing={
@@ -293,11 +287,11 @@ export default function GroupSettingsScreen() {
         </View>
 
         <View>
-          <SectionHeader title="Bring things in" />
+          <SectionHeader title={t.group.bringThingsIn} />
           <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
             <ListRow
-              title="Import from messages"
-              subtitle="Paste bank messages — read on this phone, confirmed by you"
+              title={t.group.importMessages}
+              subtitle={t.group.importMessagesHint}
               leading={
                 <Ionicons name="chatbox-ellipses-outline" size={22} color={theme.color.textMuted} />
               }
@@ -312,8 +306,8 @@ export default function GroupSettingsScreen() {
             />
             <View style={{ height: 1, backgroundColor: theme.color.border }} />
             <ListRow
-              title="Import a Splitwise export"
-              subtitle="Bring an old group's history across"
+              title={t.group.importSplitwise}
+              subtitle={t.group.importSplitwiseHint}
               leading={
                 <Ionicons name="document-text-outline" size={22} color={theme.color.textMuted} />
               }
@@ -336,11 +330,11 @@ export default function GroupSettingsScreen() {
         ) : null}
 
         <View style={{ gap: theme.spacing.md }}>
-          <Button label="Archive group" variant="ghost" fullWidth onPress={archive} />
-          <Button label="Leave group" variant="ghost" fullWidth onPress={leave} />
+          <Button label={t.group.archiveGroup} variant="ghost" fullWidth onPress={archive} />
+          <Button label={t.group.leaveGroup} variant="ghost" fullWidth onPress={leave} />
           {!settled ? (
             <Text variant="micro" tone="faint" align="center">
-              You can leave once your balance here is zero.
+              {t.group.leaveWhenZero}
             </Text>
           ) : null}
         </View>

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -223,7 +223,7 @@ export default function SettleScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Close" onPress={() => router.back()}>
+          <IconButton label={t.common.close} onPress={() => router.back()}>
             <Ionicons name="close" size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
@@ -236,7 +236,7 @@ export default function SettleScreen() {
         </Row>
 
         {counterparties.length === 0 || !counterparty ? (
-          <EmptyState title={t.allSettled} body="Nobody owes anybody in this group." />
+          <EmptyState title={t.allSettled} body={t.group.nobodyOwes} />
         ) : (
           <>
             <Card style={{ gap: theme.spacing.md }}>
@@ -273,7 +273,7 @@ export default function SettleScreen() {
                   : `${displayName(counterparty)} pays you`}
               </Text>
               <MoneyText amount={amount} currency={currency} locale={locale} variant="display" />
-              <Badge label="Recorded, not moved by Baaki" />
+              <Badge label={t.group.recordedNotMoved} />
             </Card>
 
             {/* Whatever this country pays with, best first. In India that is

--- a/apps/mobile/src/app/group/[id]/simplify.tsx
+++ b/apps/mobile/src/app/group/[id]/simplify.tsx
@@ -48,7 +48,7 @@ export default function SimplifyScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
@@ -75,7 +75,7 @@ export default function SimplifyScreen() {
         </Card>
 
         {ledger.transfers.length === 0 ? (
-          <EmptyState title={t.allSettled} body="Nobody owes anybody in this group." />
+          <EmptyState title={t.allSettled} body={t.group.nobodyOwes} />
         ) : (
           <Card padded={false} style={{ padding: theme.spacing.lg, gap: theme.spacing.lg }}>
             {ledger.transfers.map((transfer) => (

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -63,7 +63,7 @@ function factsOf(row: NotificationRow): Record<string, string | undefined> {
 
 export default function InboxScreen() {
   const theme = useTheme();
-  const { locale } = useStrings();
+  const { t, locale } = useStrings();
   const notifications = useNotifications();
   const markRead = useMarkNotificationsRead();
 
@@ -98,23 +98,20 @@ export default function InboxScreen() {
         }
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Inbox</Text>
+            <Text variant="heading">{t.inbox.title}</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
 
         {rows.length === 0 ? (
-          <EmptyState
-            title="Nothing yet"
-            body="Reminders, settlement confirmations and anything else Baaki tells you collect here — even when the notification never reached your phone."
-          />
+          <EmptyState title={t.nothingYet} body={t.inbox.nothingYetBody} />
         ) : (
           <View>
-            <SectionHeader title="Recent" />
+            <SectionHeader title={t.inbox.recent} />
             <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
               {rows.map((row, index) => {
                 const { title, body } = renderNotification(row.kind, factsOf(row), locale, {

--- a/apps/mobile/src/app/join.tsx
+++ b/apps/mobile/src/app/join.tsx
@@ -6,6 +6,8 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { Avatar, Badge, Button, Card, EmptyState, Row, Screen, Text, useTheme } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
+
 import { acceptInvite, previewInvite, type InvitePreview } from '@/data/api';
 import { keys } from '@/data/hooks';
 import { useAuth } from '@/lib/auth';
@@ -19,6 +21,7 @@ import { useAuth } from '@/lib/auth';
  */
 export default function JoinScreen() {
   const theme = useTheme();
+  const { t } = useStrings();
   const { token } = useLocalSearchParams<{ token?: string }>();
   const { session, continueAsGuest } = useAuth();
   const queryClient = useQueryClient();
@@ -46,7 +49,7 @@ export default function JoinScreen() {
     return () => clearTimeout(timer);
   }, [settled]);
 
-  const shown = error ?? (!token && settled ? 'This link is missing its invite code' : null);
+  const shown = error ?? (!token && settled ? t.misc.linkMissingCode : null);
 
   useEffect(() => {
     let active = true;
@@ -97,12 +100,9 @@ export default function JoinScreen() {
     return (
       <Screen>
         <EmptyState
-          title="This link has expired"
-          body={
-            shown ??
-            'Ask whoever sent it for a fresh one — links expire so they cannot be passed around forever.'
-          }
-          action={<Button label="Go to Baaki" onPress={() => router.replace('/')} />}
+          title={t.misc.linkExpired}
+          body={shown ?? t.misc.linkExpiredBody}
+          action={<Button label={t.misc.goToBaaki} onPress={() => router.replace('/')} />}
         />
       </Screen>
     );
@@ -127,12 +127,12 @@ export default function JoinScreen() {
           <Text variant="caption" tone="muted" align="center">
             {`${preview.memberCount} people are splitting expenses here`}
           </Text>
-          <Badge label="Free forever, no account needed" tone="positive" />
+          <Badge label={t.misc.freeNoAccount} tone="positive" />
         </Card>
 
         {preview.claimable.length > 0 ? (
           <Card style={{ gap: theme.spacing.md }}>
-            <Text variant="subheading">Is one of these you?</Text>
+            <Text variant="subheading">{t.misc.isOneOfTheseYou}</Text>
             <Text variant="caption" tone="muted">
               Pick your name and everything already recorded for you comes with you.
             </Text>
@@ -142,7 +142,7 @@ export default function JoinScreen() {
                   key={candidate.memberId}
                   accessibilityRole="radio"
                   accessibilityState={{ selected: claimId === candidate.memberId }}
-                  accessibilityLabel={candidate.name ?? 'Unnamed'}
+                  accessibilityLabel={candidate.name ?? t.misc.unnamed}
                   onPress={() =>
                     setClaimId((current) =>
                       current === candidate.memberId ? null : candidate.memberId,
@@ -156,7 +156,7 @@ export default function JoinScreen() {
                 >
                   <Avatar name={candidate.name ?? '?'} ghost size={52} />
                   <Text variant="micro" tone={claimId === candidate.memberId ? 'brand' : 'muted'}>
-                    {candidate.name ?? 'Unnamed'}
+                    {candidate.name ?? t.misc.unnamed}
                   </Text>
                 </Pressable>
               ))}
@@ -179,7 +179,7 @@ export default function JoinScreen() {
         ) : null}
 
         <Button
-          label={claimId ? 'Join and claim my history' : 'Join this group'}
+          label={claimId ? t.misc.joinAndClaim : t.misc.joinGroup}
           size="lg"
           fullWidth
           disabled={joining}

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -82,7 +82,7 @@ export default function NewGroupScreen() {
         keyboardShouldPersistTaps="handled"
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Close" onPress={() => router.back()}>
+          <IconButton label={t.common.close} onPress={() => router.back()}>
             <Ionicons name="close" size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
@@ -107,9 +107,9 @@ export default function NewGroupScreen() {
               <TextInput
                 value={name}
                 onChangeText={setName}
-                placeholder="Goa trip"
+                placeholder={t.misc.newGroupPlaceholder}
                 placeholderTextColor={theme.color.textFaint}
-                accessibilityLabel="Group name"
+                accessibilityLabel={t.group.groupName}
                 autoFocus
                 style={{
                   fontSize: 22,
@@ -176,9 +176,9 @@ export default function NewGroupScreen() {
             <TextInput
               value={ghostName}
               onChangeText={setGhostName}
-              placeholder="Rahul"
+              placeholder={t.people.namePlaceholder}
               placeholderTextColor={theme.color.textFaint}
-              accessibilityLabel="Person's name"
+              accessibilityLabel={t.misc.personName}
               onSubmitEditing={() => {
                 if (ghostName.trim()) {
                   setGhosts((current) => [...current, ghostName.trim()]);
@@ -194,7 +194,7 @@ export default function NewGroupScreen() {
               }}
             />
             <Button
-              label="Add"
+              label={t.add}
               size="sm"
               variant="secondary"
               disabled={!ghostName.trim()}
@@ -241,7 +241,7 @@ export default function NewGroupScreen() {
         ) : null}
 
         <Button
-          label="Create group"
+          label={t.misc.createGroup}
           size="lg"
           fullWidth
           disabled={createGroup.isPending || uploading}

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -26,10 +26,12 @@ import {
 } from '@baaki/ui';
 
 import { confirmContact, startAddingContact, type ContactChannel } from '@/data/api';
+import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
 export default function AccountScreen() {
   const theme = useTheme();
+  const { t } = useStrings();
   const { session, isGuest, refresh } = useAuth();
 
   const [channel, setChannel] = useState<ContactChannel>('email');
@@ -88,23 +90,25 @@ export default function AccountScreen() {
         keyboardShouldPersistTaps="handled"
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Your account</Text>
+            <Text variant="heading">{t.contact.title}</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
 
         <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.sm }}>
           <Row style={{ gap: theme.spacing.sm }}>
-            {isGuest ? <Badge label="Guest" /> : <Badge label="Signed in" tone="positive" />}
+            {isGuest ? (
+              <Badge label={t.common.guest} />
+            ) : (
+              <Badge label={t.contact.signedIn} tone="positive" />
+            )}
           </Row>
           <Text variant="caption" tone="muted">
-            {isGuest
-              ? 'Everything you have entered is already saved and yours. Adding an email or phone number is only so you can get back to it from another phone.'
-              : 'This account is reachable from any device you sign in on.'}
+            {isGuest ? t.contact.guestBody : t.contact.memberBody}
           </Text>
         </Card>
 
@@ -119,20 +123,20 @@ export default function AccountScreen() {
               setValue('');
             }}
             options={[
-              { value: 'email', label: 'Email' },
-              { value: 'phone', label: 'Phone' },
+              { value: 'email', label: t.contact.email },
+              { value: 'phone', label: t.contact.phone },
             ]}
           />
 
           {existing ? (
             <Text variant="caption" tone="positive">
-              {`Already added: ${existing}`}
+              {t.contact.alreadyAdded.replace('{value}', existing)}
             </Text>
           ) : null}
 
           <View style={{ gap: theme.spacing.xs }}>
             <Text variant="caption" tone="muted">
-              {channel === 'email' ? 'Email address' : 'Phone number'}
+              {channel === 'email' ? t.contact.emailAddress : t.contact.phoneNumber}
             </Text>
             <TextInput
               value={value}
@@ -145,8 +149,12 @@ export default function AccountScreen() {
               autoCapitalize="none"
               autoComplete={channel === 'email' ? 'email' : 'tel'}
               keyboardType={channel === 'email' ? 'email-address' : 'phone-pad'}
-              accessibilityLabel={channel === 'email' ? 'Email address' : 'Phone number'}
-              placeholder={channel === 'email' ? 'you@example.com' : '+91 98765 43210'}
+              accessibilityLabel={
+                channel === 'email' ? t.contact.emailAddress : t.contact.phoneNumber
+              }
+              placeholder={
+                channel === 'email' ? t.contact.emailPlaceholder : t.contact.phonePlaceholder
+              }
               placeholderTextColor={theme.color.textFaint}
               style={{
                 fontSize: 18,
@@ -160,9 +168,7 @@ export default function AccountScreen() {
           {sent ? (
             <View style={{ gap: theme.spacing.xs }}>
               <Text variant="caption" tone="muted">
-                {channel === 'email'
-                  ? 'Enter the six-digit code we emailed you'
-                  : 'Enter the six-digit code we texted you'}
+                {channel === 'email' ? t.contact.codeEmailed : t.contact.codeTexted}
               </Text>
               <TextInput
                 value={code}
@@ -170,7 +176,7 @@ export default function AccountScreen() {
                 editable={!busy}
                 keyboardType="number-pad"
                 maxLength={6}
-                accessibilityLabel="Verification code"
+                accessibilityLabel={t.contact.verificationCode}
                 placeholder="123456"
                 placeholderTextColor={theme.color.textFaint}
                 style={{
@@ -187,7 +193,13 @@ export default function AccountScreen() {
           {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
 
           <Button
-            label={sent ? 'Confirm' : channel === 'email' ? 'Send me a code' : 'Text me a code'}
+            label={
+              sent
+                ? t.contact.confirm
+                : channel === 'email'
+                  ? t.contact.sendCodeEmail
+                  : t.contact.sendCodePhone
+            }
             size="lg"
             fullWidth
             disabled={busy || (sent ? code.trim().length < 6 : !looksValid)}
@@ -195,12 +207,12 @@ export default function AccountScreen() {
           />
 
           {sent ? (
-            <Button label="Use a different one" variant="ghost" onPress={() => setSent(false)} />
+            <Button label={t.contact.useDifferent} variant="ghost" onPress={() => setSent(false)} />
           ) : null}
 
           {done ? (
             <Text variant="caption" tone="positive">
-              Added. You can sign in with it on another phone now.
+              {t.contact.added}
             </Text>
           ) : null}
           {error ? (
@@ -211,8 +223,7 @@ export default function AccountScreen() {
         </Card>
 
         <Text variant="micro" tone="faint" align="center">
-          Baaki never asks for this to let you in, and never shares it with anyone in your groups.
-          People see the name you choose, nothing else.
+          {t.contact.footnote}
         </Text>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -21,6 +21,7 @@ import {
 import { exportData } from '@/data/api';
 import { useGroups } from '@/data/hooks';
 import { groupLabel } from '@/data/types';
+import { useStrings } from '@/i18n';
 
 type Format = 'json' | 'csv';
 
@@ -32,6 +33,7 @@ type Format = 'json' | 'csv';
 export default function ExportScreen() {
   const theme = useTheme();
   const groups = useGroups();
+  const { t } = useStrings();
 
   const [format, setFormat] = useState<Format>('json');
   const [scope, setScope] = useState<string>('all');
@@ -58,7 +60,7 @@ export default function ExportScreen() {
       if (await Sharing.isAvailableAsync()) {
         await Sharing.shareAsync(file.uri, {
           mimeType: result.contentType,
-          dialogTitle: 'Your Baaki export',
+          dialogTitle: t.exportData.shareTitle,
           UTI: format === 'json' ? 'public.json' : 'public.comma-separated-values-text',
         });
       }
@@ -81,50 +83,48 @@ export default function ExportScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Export your data</Text>
+            <Text variant="heading">{t.exportData.title}</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
 
         <Card style={{ gap: theme.spacing.sm }}>
           <Row style={{ justifyContent: 'space-between' }}>
-            <Text variant="subheading">Everything, always free</Text>
-            <Badge label="no paywall" tone="positive" />
+            <Text variant="subheading">{t.exportData.everythingFree}</Text>
+            <Badge label={t.exportData.noPaywall} tone="positive" />
           </Row>
           <Text variant="caption" tone="muted">
-            JSON includes every version of every expense, who paid, who owed, settlements with their
-            per-expense allocations, and the activity trail — enough to rebuild your ledger exactly.
-            CSV is the spreadsheet view, including per-person settlement detail.
+            {t.exportData.explain}
           </Text>
         </Card>
 
         <View style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">
-            Format
+            {t.exportData.format}
           </Text>
           <ChipRow<Format>
             value={format}
             onChange={setFormat}
             options={[
-              { value: 'json', label: 'JSON (lossless)' },
-              { value: 'csv', label: 'CSV (spreadsheet)' },
+              { value: 'json', label: t.exportData.json },
+              { value: 'csv', label: t.exportData.csv },
             ]}
           />
         </View>
 
         <View style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">
-            What to export
+            {t.exportData.whatToExport}
           </Text>
           <ChipRow<string>
             value={scope}
             onChange={setScope}
             options={[
-              { value: 'all', label: 'All my groups' },
+              { value: 'all', label: t.exportData.allMyGroups },
               ...(groups.data ?? []).map((group) => ({
                 value: group.id,
                 label: groupLabel(group),
@@ -134,7 +134,7 @@ export default function ExportScreen() {
         </View>
 
         <Button
-          label={busy ? 'Preparing…' : 'Export'}
+          label={busy ? t.exportData.preparing : t.exportData.action}
           size="lg"
           fullWidth
           disabled={busy}
@@ -146,14 +146,14 @@ export default function ExportScreen() {
         {done ? (
           <Card style={{ gap: theme.spacing.sm }}>
             <Text variant="subheading" tone="positive">
-              Export ready
+              {t.exportData.ready}
             </Text>
             <Text variant="caption" tone="muted">
               {done}
             </Text>
             {Platform.OS === 'web' ? (
               <Text variant="micro" tone="faint">
-                On web the file is written to the app cache; use a device to share it onward.
+                {t.exportData.webNote}
               </Text>
             ) : null}
           </Card>
@@ -166,7 +166,7 @@ export default function ExportScreen() {
         ) : null}
 
         <Button
-          label="Import from Splitwise"
+          label={t.exportData.importInstead}
           variant="ghost"
           fullWidth
           onPress={() => router.push('/settings/import')}

--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -71,13 +71,13 @@ export default function LanguageSettingsScreen() {
             <Row style={{ gap: theme.spacing.sm }}>
               <Ionicons name="refresh" size={18} color={theme.color.brand} />
               <Text variant="subheading" tone="brand">
-                Close and open Baaki again
+                {t.account.restartTitle}
               </Text>
             </Row>
             <Text variant="caption" tone="muted">
               {isRtlLanguage(language)
-                ? 'The words have changed already. Mirroring the layout — the arrows, the sides everything sits on — is something the phone decides when the app starts, so it takes effect next time you open it.'
-                : 'The words have changed already. Turning the mirrored layout back the other way is something the phone decides when the app starts, so it takes effect next time you open it.'}
+                ? t.account.restartBannerMirror
+                : t.account.restartBannerUnmirror}
             </Text>
           </Card>
         ) : null}
@@ -107,9 +107,7 @@ export default function LanguageSettingsScreen() {
         </Card>
 
         <Text variant="micro" tone="faint" align="center">
-          Your phone&apos;s language is the default, and choosing one here only changes Baaki.
-          Amounts and dates still follow where you are — reading the app in Hindi in Dubai does not
-          move you to India.
+          {t.account.languageFooterNote}
         </Text>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -29,15 +29,15 @@ export default function LanguageSettingsScreen() {
   const rows: { key: string; title: string; subtitle: string; value: Language | null }[] = [
     {
       key: 'phone',
-      title: 'Follow my phone',
-      subtitle: `Currently ${LANGUAGE_NAMES[phoneLanguage].english}`,
+      title: t.misc.followMyPhone,
+      subtitle: t.misc.currentlyLanguage.replace('{language}', LANGUAGE_NAMES[phoneLanguage].own),
       value: null,
     },
     ...LANGUAGES.map((entry) => ({
       key: entry,
       title: LANGUAGE_NAMES[entry].own,
       subtitle: isRtlLanguage(entry)
-        ? `${LANGUAGE_NAMES[entry].english} · right to left`
+        ? `${LANGUAGE_NAMES[entry].english} · ${t.misc.rightToLeft}`
         : LANGUAGE_NAMES[entry].english,
       value: entry as Language | null,
     })),
@@ -54,7 +54,7 @@ export default function LanguageSettingsScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>

--- a/apps/mobile/src/app/settings/lock.tsx
+++ b/apps/mobile/src/app/settings/lock.tsx
@@ -25,26 +25,28 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { describeGrace, GRACE_CHOICES, useLock } from '@/lib/lock';
 
 export default function LockSettingsScreen() {
   const theme = useTheme();
+  const { t, locale } = useStrings();
   const { enabled, supported, graceSeconds, setEnabled, setGraceSeconds } = useLock();
   const { isGuest, signOut } = useAuth();
 
   const confirmSignOut = (): void => {
     Alert.alert(
-      'Sign out?',
+      t.lock.signOutQuestion,
       isGuest
         ? // The one case where signing out is not reversible: a guest session
           // lives on this device and nowhere else, so there is no credential to
           // come back with.
-          'This is a guest account, so signing out leaves no way back into it. Add an email or phone number first if you want to keep it.'
-        : 'You can sign back in whenever you like. Nothing is deleted.',
+          t.lock.signOutGuestWarning
+        : t.lock.signOutReassure,
       [
-        { text: 'Stay signed in', style: 'cancel' },
-        { text: 'Sign out', style: 'destructive', onPress: () => void signOut() },
+        { text: t.lock.staySignedIn, style: 'cancel' },
+        { text: t.lock.signOut, style: 'destructive', onPress: () => void signOut() },
       ],
     );
   };
@@ -59,11 +61,11 @@ export default function LockSettingsScreen() {
         }}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Security</Text>
+            <Text variant="heading">{t.lock.title}</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
@@ -71,60 +73,54 @@ export default function LockSettingsScreen() {
         <Card>
           <Row style={{ justifyContent: 'space-between' }}>
             <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-              <Text variant="subheading">Require biometrics or a passcode</Text>
+              <Text variant="subheading">{t.lock.requireBiometrics}</Text>
               <Text variant="caption" tone="muted">
-                Handing someone your phone to show them the split should not show them everything
-                else.
+                {t.lock.requireExplain}
               </Text>
             </View>
             <Toggle
               value={enabled}
               disabled={!supported}
               onValueChange={(value) => void setEnabled(value)}
-              accessibilityLabel="App lock"
+              accessibilityLabel={t.lock.appLock}
             />
           </Row>
         </Card>
 
-        {!supported ? <Badge label="This device has no biometrics or passcode set up" /> : null}
+        {!supported ? <Badge label={t.lock.unsupported} /> : null}
 
         {enabled ? (
           <Card style={{ gap: theme.spacing.md }}>
-            <Text variant="subheading">Ask again after</Text>
+            <Text variant="subheading">{t.lock.askAgainAfter}</Text>
             <Text variant="caption" tone="muted">
-              Time in the background before Baaki locks. Settling by UPI sends you to another app
-              and back, so locking the instant you leave means unlocking every time you pay
-              somebody.
+              {t.lock.askAgainExplain}
             </Text>
             <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
               {GRACE_CHOICES.map((seconds) => (
                 <Chip
                   key={seconds}
-                  label={describeGrace(seconds)}
+                  label={describeGrace(seconds, t, locale)}
                   selected={graceSeconds === seconds}
                   onPress={() => void setGraceSeconds(seconds)}
                 />
               ))}
             </Row>
             <Text variant="micro" tone="faint">
-              Reopening Baaki after it has been closed always asks, whatever this says.
+              {t.lock.reopenAlwaysAsks}
             </Text>
           </Card>
         ) : null}
 
         <Card style={{ gap: theme.spacing.md }}>
-          <Text variant="subheading">Sign out</Text>
+          <Text variant="subheading">{t.lock.signOut}</Text>
           <Text variant="caption" tone="muted">
-            {isGuest
-              ? 'This account lives on this device only. Signing out ends it.'
-              : 'Your groups and history stay exactly where they are.'}
+            {isGuest ? t.lock.signOutGuest : t.lock.signOutMember}
           </Text>
-          <Button label="Sign out" variant="secondary" fullWidth onPress={confirmSignOut} />
+          <Button label={t.lock.signOut} variant="secondary" fullWidth onPress={confirmSignOut} />
         </Card>
 
         <Text variant="micro" tone="faint" align="center">
-          This guards the screen, not the data — your ledger is protected by row-level security on
-          the server whether the lock is on or not.
+          {t.lock.footnote}
         </Text>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/settings/motion.tsx
+++ b/apps/mobile/src/app/settings/motion.tsx
@@ -25,10 +25,12 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
 import { useMotion } from '@/lib/motion';
 
 export default function MotionSettingsScreen() {
   const theme = useTheme();
+  const { t } = useStrings();
   const { animated, systemReducesMotion, overridden, setAnimated } = useMotion();
 
   return (
@@ -42,11 +44,11 @@ export default function MotionSettingsScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Motion</Text>
+            <Text variant="heading">{t.motion.title}</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
@@ -54,17 +56,15 @@ export default function MotionSettingsScreen() {
         <Card style={{ gap: theme.spacing.lg }}>
           <Row style={{ justifyContent: 'space-between', gap: theme.spacing.lg }}>
             <View style={{ flex: 1, gap: 2 }}>
-              <Text variant="subheading">Animate between screens</Text>
+              <Text variant="subheading">{t.motion.animateBetweenScreens}</Text>
               <Text variant="caption" tone="muted">
-                Screens slide in from the right, and sheets rise from the bottom — which is how a
-                screen tells you whether you have gone somewhere or opened something on top of where
-                you were.
+                {t.motion.animateExplain}
               </Text>
             </View>
             <Toggle
               value={animated}
               onValueChange={(value) => void setAnimated(value)}
-              accessibilityLabel="Animate between screens"
+              accessibilityLabel={t.motion.animateBetweenScreens}
             />
           </Row>
 
@@ -73,23 +73,25 @@ export default function MotionSettingsScreen() {
           <View style={{ gap: theme.spacing.sm }}>
             <Row style={{ justifyContent: 'space-between' }}>
               <Text variant="caption" tone="muted">
-                This phone
+                {t.motion.thisPhone}
               </Text>
               <Badge
-                label={systemReducesMotion ? 'Reduce motion is on' : 'Reduce motion is off'}
+                label={systemReducesMotion ? t.motion.reduceMotionOn : t.motion.reduceMotionOff}
                 tone={systemReducesMotion ? 'brand' : 'neutral'}
               />
             </Row>
             <Text variant="caption" tone="muted">
               {overridden
-                ? `You have set this yourself, so it stays ${animated ? 'on' : 'off'} whatever the phone says.`
+                ? animated
+                  ? t.motion.setYourselfOn
+                  : t.motion.setYourselfOff
                 : systemReducesMotion
-                  ? 'Following your accessibility settings, which ask for less movement.'
-                  : 'Following your accessibility settings.'}
+                  ? t.motion.followingReduced
+                  : t.motion.following}
             </Text>
             {overridden ? (
               <Button
-                label="Follow my phone's setting"
+                label={t.motion.followPhone}
                 variant="ghost"
                 onPress={() => void setAnimated(null)}
               />
@@ -98,8 +100,7 @@ export default function MotionSettingsScreen() {
         </Card>
 
         <Text variant="micro" tone="faint" align="center">
-          Turning motion off does not shorten the animations — it removes them. A faster animation
-          is still an animation to somebody who cannot watch one.
+          {t.motion.footnote}
         </Text>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -23,40 +23,35 @@ import {
   saveNotificationPrefs,
   type NotificationPrefs,
 } from '@/data/api';
+import { useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { enablePush, pushPermission, type PushFailure, type PushPermission } from '@/lib/push';
 
-const ROWS: {
-  key: keyof NotificationPrefs;
-  title: string;
-  body: string;
-}[] = [
-  {
-    key: 'involvesMe',
-    title: 'Only what involves me',
-    body: 'Push when you owe, are owed, or are mentioned — not for every expense in every group.',
-  },
-  {
-    key: 'settlementRequests',
-    title: 'Settlement confirmations',
-    body: 'When someone says they paid you, so your baaki stays right.',
-  },
-  {
-    key: 'nudges',
-    title: 'Reminders',
-    body: 'A friendly nudge about money owed. Limited to one per person per day, in the database.',
-  },
-  {
-    key: 'groupActivityDigest',
-    title: 'Daily group summary',
-    body: 'Everything else, batched into one notification a day instead of a stream.',
-  },
-  {
-    key: 'weeklyEmail',
-    title: 'Weekly email digest',
-    body: 'Your net baaki and pending confirmations, once a week. Off by default.',
-  },
-];
+function rows(t: UiStrings): { key: keyof NotificationPrefs; title: string; body: string }[] {
+  return [
+    {
+      key: 'involvesMe',
+      title: t.notifications.involvesMe,
+      body: t.notifications.involvesMeBody,
+    },
+    {
+      key: 'settlementRequests',
+      title: t.notifications.settlementRequests,
+      body: t.notifications.settlementRequestsBody,
+    },
+    { key: 'nudges', title: t.notifications.nudges, body: t.notifications.nudgesBody },
+    {
+      key: 'groupActivityDigest',
+      title: t.notifications.digest,
+      body: t.notifications.digestBody,
+    },
+    {
+      key: 'weeklyEmail',
+      title: t.notifications.weeklyEmail,
+      body: t.notifications.weeklyEmailBody,
+    },
+  ];
+}
 
 /**
  * What went wrong, said to the person it happened to.
@@ -65,17 +60,19 @@ const ROWS: {
  * settings. Telling somebody to check their settings when the real problem is
  * that this build has no Firebase key sends them somewhere that cannot help.
  */
-const PUSH_FAILURE_COPY: Record<PushFailure, string> = {
-  denied: 'Not enabled — you can turn it on in your phone settings later.',
-  unsupported: 'This device cannot receive push notifications. Everything still lands in Activity.',
-  not_signed_in: 'Sign in first, so we know which phone is yours.',
-  not_configured:
-    'Push is not set up in this build of Baaki. Nothing you did — everything still lands in Activity.',
-  save_failed: 'Could not save this phone. Check your connection and try again.',
-};
+function pushFailureCopy(t: UiStrings): Record<PushFailure, string> {
+  return {
+    denied: t.notifications.failDenied,
+    unsupported: t.notifications.failUnsupported,
+    not_signed_in: t.notifications.failNotSignedIn,
+    not_configured: t.notifications.failNotConfigured,
+    save_failed: t.notifications.failSaveFailed,
+  };
+}
 
 export default function NotificationSettingsScreen() {
   const theme = useTheme();
+  const { t } = useStrings();
   const { profile } = useAuth();
 
   const [prefs, setPrefs] = useState<NotificationPrefs>(DEFAULT_NOTIFICATION_PREFS);
@@ -105,7 +102,7 @@ export default function NotificationSettingsScreen() {
     try {
       const result = await enablePush();
       setPermission(await pushPermission());
-      if (!result.ok) setStatus(PUSH_FAILURE_COPY[result.why]);
+      if (!result.ok) setStatus(pushFailureCopy(t)[result.why]);
     } finally {
       setAsking(false);
     }
@@ -133,7 +130,7 @@ export default function NotificationSettingsScreen() {
     if (!profile?.id) return;
     setStatus(null);
     void saveNotificationPrefs(profile.id, next)
-      .then(() => setStatus('Saved'))
+      .then(() => setStatus(t.account.saved))
       .catch((caught: unknown) =>
         setStatus(caught instanceof Error ? caught.message : String(caught)),
       );
@@ -150,11 +147,11 @@ export default function NotificationSettingsScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Notifications</Text>
+            <Text variant="heading">{t.notifications.title}</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
@@ -163,29 +160,34 @@ export default function NotificationSettingsScreen() {
             defaults are the fix, and they are all off-switchable. */}
         <Card style={{ backgroundColor: theme.color.brandSoft }}>
           <Text variant="caption" tone="brand">
-            Baaki never emails you about routine expense activity. Only the six things you would
-            actually want in your inbox, each unsubscribable on its own.
+            {t.notifications.neverSpam}
           </Text>
         </Card>
 
         <Card style={{ gap: theme.spacing.md }}>
           <Row style={{ justifyContent: 'space-between' }}>
-            <Text variant="subheading">Notifications on this phone</Text>
+            <Text variant="subheading">{t.notifications.onThisPhone}</Text>
             <Badge
-              label={permission === 'granted' ? 'On' : permission === 'denied' ? 'Off' : 'Not set'}
+              label={
+                permission === 'granted'
+                  ? t.notifications.granted
+                  : permission === 'denied'
+                    ? t.notifications.denied
+                    : t.notifications.undetermined
+              }
               tone={permission === 'granted' ? 'positive' : undefined}
             />
           </Row>
           <Text variant="caption" tone="muted">
             {permission === 'granted'
-              ? 'This device is registered. Everything below still lands in your inbox whether or not a push gets through.'
+              ? t.notifications.permissionOn
               : permission === 'denied'
-                ? 'Your phone is blocking them. Turn them back on in system settings for Baaki — the inbox still has everything either way.'
-                : 'Baaki will only ask once, and only for the things you switch on below.'}
+                ? t.notifications.permissionOff
+                : t.notifications.permissionUnset}
           </Text>
           {permission === 'granted' ? null : (
             <Button
-              label={asking ? 'Asking…' : 'Turn on notifications'}
+              label={asking ? t.notifications.asking : t.notifications.turnOn}
               size="sm"
               disabled={asking || permission === 'denied'}
               onPress={() => void turnOnPush()}
@@ -197,9 +199,9 @@ export default function NotificationSettingsScreen() {
           <ActivityIndicator color={theme.color.brand} />
         ) : (
           <View>
-            <SectionHeader title="Push" />
+            <SectionHeader title={t.notifications.pushSection} />
             <Card style={{ gap: theme.spacing.xl }}>
-              {ROWS.map((row) => (
+              {rows(t).map((row) => (
                 <Row key={row.key} style={{ justifyContent: 'space-between' }}>
                   <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
                     <Text variant="subheading">{row.title}</Text>
@@ -219,14 +221,13 @@ export default function NotificationSettingsScreen() {
         )}
 
         {status ? (
-          <Text variant="caption" tone={status === 'Saved' ? 'positive' : 'negative'}>
+          <Text variant="caption" tone={status === t.account.saved ? 'positive' : 'negative'}>
             {status}
           </Text>
         ) : null}
 
         <Text variant="micro" tone="faint" align="center">
-          Email delivery is still to come. Everything here is also in your inbox, which is the
-          record of what Baaki has told you whether or not a notification arrived.
+          {t.notifications.footnote}
         </Text>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/settings/upgrade.tsx
+++ b/apps/mobile/src/app/settings/upgrade.tsx
@@ -50,7 +50,7 @@ export default function UpgradeScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label="Back" onPress={() => router.back()}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -154,7 +154,7 @@ export default function SignInScreen() {
               பாக்கி
             </Text>
             <Text variant="caption" tone="onBrand" align="center">
-              baaki · what is left over
+              {t.signIn.tagline}
             </Text>
           </View>
         </CurvedPanel>
@@ -168,22 +168,22 @@ export default function SignInScreen() {
           }}
         >
           <Text variant="display" align="center">
-            Split anything{'\n'}with anyone
+            {t.signIn.splitAnything}
           </Text>
           <Text variant="body" tone="muted" align="center">
-            {`${t.freeForever}. No account needed to start — add one later and everything you have entered comes with you.`}
+            {`${t.freeForever}. ${t.signIn.welcomeBody}`}
           </Text>
 
           <View style={{ gap: theme.spacing.sm, paddingTop: theme.spacing.md }}>
             <Button
-              label="Start now"
+              label={t.signIn.startNow}
               size="lg"
               fullWidth
               disabled={busy}
               onPress={() => void run(continueAsGuest)}
             />
             <Button
-              label="I already have an account"
+              label={t.signIn.haveAccount}
               variant="ghost"
               fullWidth
               onPress={() => setShowOptions(true)}
@@ -249,16 +249,14 @@ export default function SignInScreen() {
                 பாக்கி
               </Text>
               <Text variant="caption" tone="onBrand" align="center">
-                {isGuest ? 'Keep this account on your next phone' : 'Welcome back'}
+                {isGuest ? t.signIn.keepOnNextPhone : t.signIn.welcomeBack}
               </Text>
             </View>
           </CurvedPanel>
 
           <View style={{ gap: theme.spacing.xxl, paddingHorizontal: theme.spacing.xl }}>
             <Text variant="body" tone="muted" align="center">
-              {isGuest
-                ? 'Add a way to sign in, so this account is still yours on your next phone.'
-                : 'Sign in however you set it up.'}
+              {isGuest ? t.signIn.guestAddWay : t.signIn.signInHowever}
             </Text>
 
             {/* Above the form rather than below it. A guest arrives straight
@@ -269,7 +267,7 @@ export default function SignInScreen() {
             <Card style={{ gap: theme.spacing.lg }}>
               <Row style={{ gap: theme.spacing.sm }}>
                 <Chip
-                  label="Send me a code"
+                  label={t.signIn.sendMeACode}
                   selected={mode === 'otp'}
                   onPress={() => {
                     setMode('otp');
@@ -277,7 +275,7 @@ export default function SignInScreen() {
                   }}
                 />
                 <Chip
-                  label="Use a password"
+                  label={t.signIn.useAPassword}
                   selected={mode === 'password'}
                   onPress={() => {
                     setMode('password');
@@ -289,14 +287,14 @@ export default function SignInScreen() {
               {mode === 'otp' && stage === 'phone' ? (
                 <>
                   <Text variant="caption" tone="muted">
-                    Phone number
+                    {t.signIn.phoneNumber}
                   </Text>
                   <TextInput
                     value={phone}
                     onChangeText={setPhone}
                     keyboardType="phone-pad"
                     autoComplete="tel"
-                    accessibilityLabel="Phone number"
+                    accessibilityLabel={t.signIn.phoneNumber}
                     placeholderTextColor={theme.color.textFaint}
                     style={{
                       fontSize: 22,
@@ -306,11 +304,10 @@ export default function SignInScreen() {
                     }}
                   />
                   <Text variant="micro" tone="faint">
-                    Start with your country code. Baaki never assumes +91 — a trip is exactly when
-                    foreign numbers turn up.
+                    {t.signIn.countryCodeHint}
                   </Text>
                   <Button
-                    label="Send code"
+                    label={t.signIn.sendCode}
                     size="lg"
                     fullWidth
                     disabled={busy || phone.trim().length < 8}
@@ -327,14 +324,14 @@ export default function SignInScreen() {
               {mode === 'otp' && stage === 'code' ? (
                 <>
                   <Text variant="caption" tone="muted">
-                    {`Code sent to ${phone}`}
+                    {t.signIn.codeSentTo.replace('{value}', phone)}
                   </Text>
                   <TextInput
                     value={code}
                     onChangeText={setCode}
                     keyboardType="number-pad"
                     autoComplete="sms-otp"
-                    accessibilityLabel="Verification code"
+                    accessibilityLabel={t.contact.verificationCode}
                     placeholder="123456"
                     placeholderTextColor={theme.color.textFaint}
                     style={{
@@ -346,14 +343,14 @@ export default function SignInScreen() {
                     }}
                   />
                   <Button
-                    label="Verify"
+                    label={t.signIn.verify}
                     size="lg"
                     fullWidth
                     disabled={busy || code.trim().length < 4}
                     onPress={() => void run(() => verifyOtp(phone.trim(), code.trim()))}
                   />
                   <Button
-                    label="Use a different number"
+                    label={t.signIn.differentNumber}
                     variant="ghost"
                     onPress={() => {
                       setStage('phone');
@@ -366,7 +363,7 @@ export default function SignInScreen() {
               {mode === 'password' ? (
                 <>
                   <Text variant="caption" tone="muted">
-                    Email or phone number
+                    {t.signIn.identifier}
                   </Text>
                   {/* One field: "email or phone?" is a question the text already
                     answers. */}
@@ -377,8 +374,8 @@ export default function SignInScreen() {
                     autoCorrect={false}
                     keyboardType="email-address"
                     autoComplete="username"
-                    accessibilityLabel="Email or phone number"
-                    placeholder="asha@example.com or +91…"
+                    accessibilityLabel={t.signIn.identifier}
+                    placeholder={t.signIn.identifierPlaceholder}
                     placeholderTextColor={theme.color.textFaint}
                     style={{
                       fontSize: 18,
@@ -388,7 +385,7 @@ export default function SignInScreen() {
                     }}
                   />
                   <Text variant="caption" tone="muted">
-                    Password
+                    {t.signIn.password}
                   </Text>
                   <TextInput
                     value={password}
@@ -396,7 +393,7 @@ export default function SignInScreen() {
                     secureTextEntry
                     autoCapitalize="none"
                     autoComplete={intent === 'sign_up' ? 'new-password' : 'current-password'}
-                    accessibilityLabel="Password"
+                    accessibilityLabel={t.signIn.password}
                     placeholderTextColor={theme.color.textFaint}
                     style={{
                       fontSize: 18,
@@ -406,16 +403,15 @@ export default function SignInScreen() {
                     }}
                   />
                   <Text variant="micro" tone="faint">
-                    Eight characters or more. A phrase you will remember beats a puzzle you will
-                    not.
+                    {t.signIn.passwordHint}
                   </Text>
                   <Button
                     label={
                       isGuest
-                        ? 'Add this to my account'
+                        ? t.signIn.addToAccount
                         : intent === 'sign_up'
-                          ? 'Create account'
-                          : 'Sign in'
+                          ? t.signIn.createAccount
+                          : t.signIn.signInAction
                     }
                     size="lg"
                     fullWidth
@@ -427,9 +423,7 @@ export default function SignInScreen() {
                   {isGuest ? null : (
                     <Button
                       label={
-                        intent === 'sign_up'
-                          ? 'I already have an account'
-                          : 'I am new here — create an account'
+                        intent === 'sign_up' ? t.signIn.switchToSignIn : t.signIn.switchToSignUp
                       }
                       variant="ghost"
                       onPress={() => {
@@ -450,7 +444,7 @@ export default function SignInScreen() {
             </Card>
 
             <Button
-              label={isGuest ? 'Continue with Google' : 'Sign in with Google'}
+              label={isGuest ? t.signIn.continueGoogle : t.signIn.signInGoogle}
               variant="secondary"
               size="lg"
               fullWidth
@@ -463,7 +457,7 @@ export default function SignInScreen() {
               looking for their account and decided not to bother. */}
             {isGuest ? null : (
               <Button
-                label="Continue as guest"
+                label={t.signIn.continueGuest}
                 variant="ghost"
                 size="lg"
                 fullWidth
@@ -473,9 +467,7 @@ export default function SignInScreen() {
             )}
 
             <Text variant="micro" tone="faint" align="center">
-              {isGuest
-                ? 'Everything you have already added stays exactly where it is. This only adds a way to sign back in.'
-                : 'A guest account keeps everything on this device until you add a way to sign in. Your ledger is never held hostage.'}
+              {isGuest ? t.signIn.guestFootnote : t.signIn.memberFootnote}
             </Text>
           </View>
         </ScrollView>

--- a/apps/mobile/src/components/CurrencyRate.tsx
+++ b/apps/mobile/src/components/CurrencyRate.tsx
@@ -34,6 +34,8 @@ import {
 } from '@baaki/core';
 import { Button, Card, ChipRow, Text, useTheme } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
+
 import { fetchFxRate } from '@/data/api';
 
 /** Enough for the currencies an India-first app actually sees. */
@@ -62,6 +64,7 @@ export function CurrencyRate({
   onFxChange,
 }: CurrencyRateProps): React.JSX.Element {
   const theme = useTheme();
+  const { t } = useStrings();
   const [open, setOpen] = useState(false);
   const [method, setMethod] = useState<Method>('charged');
   const [chargedText, setChargedText] = useState('');
@@ -93,7 +96,7 @@ export function CurrencyRate({
       onFxChange(toFxRecord(rateFromAmounts(money(amount, currency), charged)));
     } catch {
       onFxChange(null);
-      setError('That does not look like an amount');
+      setError(t.misc.notAnAmount);
     }
   };
 
@@ -108,7 +111,7 @@ export function CurrencyRate({
       onFxChange(toFxRecord(rateFromDecimal(text.trim(), currency, groupCurrency)));
     } catch {
       onFxChange(null);
-      setError('That does not look like a rate');
+      setError(t.misc.notARate);
     }
   };
 
@@ -134,7 +137,7 @@ export function CurrencyRate({
   if (!open && !foreign) {
     return (
       <Button
-        label="Paid in another currency"
+        label={t.misc.paidAnotherCurrency}
         variant="ghost"
         onPress={() => setOpen(true)}
         accessibilityHint={`This group settles in ${groupCurrency}`}
@@ -165,7 +168,7 @@ export function CurrencyRate({
               setError(null);
             }}
             options={[
-              { value: 'charged', label: 'What I was charged' },
+              { value: 'charged', label: t.misc.whatIWasCharged },
               { value: 'typed', label: 'I know the rate' },
               { value: 'fetched', label: "Today's rate" },
             ]}
@@ -210,7 +213,11 @@ export function CurrencyRate({
 
           {method === 'fetched' ? (
             <Button
-              label={busy ? 'Asking…' : `Get today's ${currency}→${groupCurrency} rate`}
+              label={
+                busy
+                  ? t.misc.askingRate
+                  : t.misc.getTodaysRate.replace('{from}', currency).replace('{to}', groupCurrency)
+              }
               variant="secondary"
               disabled={busy}
               onPress={() => void fetchToday()}

--- a/apps/mobile/src/components/DictateVoice.tsx
+++ b/apps/mobile/src/components/DictateVoice.tsx
@@ -47,7 +47,7 @@ function recognitionAvailable(): boolean {
 
 export function DictateVoice({ value, onChange, hints }: DictateProps) {
   const theme = useTheme();
-  const { language, locale } = useStrings();
+  const { t, language, locale } = useStrings();
 
   // Asked once, on the first render: this is a property of the phone, not
   // something that changes while somebody is looking at an expense.
@@ -82,11 +82,7 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
 
     const permission = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
     if (!permission.granted) {
-      setError(
-        permission.canAskAgain
-          ? 'Baaki needs permission to use the microphone.'
-          : 'Microphone access is off for Baaki. You can turn it on in Settings.',
-      );
+      setError(permission.canAskAgain ? t.misc.micPermission : t.misc.micBlocked);
       return;
     }
 
@@ -120,9 +116,9 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
       });
     } catch {
       setListening(false);
-      setError('Dictation could not start. Type the note instead.');
+      setError(t.misc.dictationFailed);
     }
-  }, [hints, language, locale, value]);
+  }, [hints, language, locale, value, t]);
 
   // Leaving the screen mid-sentence must not leave the microphone open.
   useEffect(() => {
@@ -137,7 +133,7 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
     <View style={{ alignItems: 'flex-end', gap: theme.spacing.xs }}>
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel={listening ? 'Stop dictating' : 'Dictate the note'}
+        accessibilityLabel={listening ? t.misc.stopDictating : t.misc.dictateNote}
         accessibilityState={{ busy: listening }}
         onPress={() => (listening ? stop() : void start())}
         hitSlop={8}

--- a/apps/mobile/src/components/GroupPhoto.tsx
+++ b/apps/mobile/src/components/GroupPhoto.tsx
@@ -18,6 +18,8 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 
 import { Text, useTheme } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
+
 import { groupPhotoUrl } from '@/data/api';
 
 interface GroupPhotoProps {
@@ -39,6 +41,7 @@ export function GroupPhoto({
   busy = false,
 }: GroupPhotoProps) {
   const theme = useTheme();
+  const { t } = useStrings();
   const url = useGroupPhotoUrl(photoPath);
   const source = localUri ?? url;
 
@@ -92,7 +95,7 @@ export function GroupPhoto({
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={source ? 'Change group photo' : 'Add a group photo'}
+      accessibilityLabel={source ? t.misc.changeGroupPhoto : t.misc.addGroupPhoto}
     >
       {body}
     </Pressable>

--- a/apps/mobile/src/components/LanguagePicker.tsx
+++ b/apps/mobile/src/components/LanguagePicker.tsx
@@ -21,11 +21,12 @@ import { View } from 'react-native';
 
 import { Chip, Row, Text, useTheme } from '@baaki/ui';
 
-import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES } from '@/i18n';
+import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES, useStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
 
 export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-start' }) {
   const theme = useTheme();
+  const { t } = useStrings();
   const { language, setLanguage, restartNeeded } = useLanguage();
 
   return (
@@ -52,9 +53,7 @@ export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-
 
       {restartNeeded ? (
         <Text variant="micro" tone="faint" align={align === 'center' ? 'center' : 'left'}>
-          {isRtlLanguage(language)
-            ? 'Close and open Baaki once to mirror the layout.'
-            : 'Close and open Baaki once to turn the layout back.'}
+          {isRtlLanguage(language) ? t.signIn.restartToMirror : t.signIn.restartToUnmirror}
         </Text>
       ) : null}
     </View>

--- a/apps/mobile/src/components/ProfileAvatar.tsx
+++ b/apps/mobile/src/components/ProfileAvatar.tsx
@@ -13,6 +13,8 @@ import { ActivityIndicator, Pressable, View } from 'react-native';
 
 import { Avatar, useTheme } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
+
 import { avatarPhotoUrl } from '@/data/api';
 
 /** Resolves whatever is in `avatar_url` to a displayable URL, and re-resolves on change. */
@@ -56,6 +58,7 @@ export function ProfileAvatar({
   busy?: boolean;
 }) {
   const theme = useTheme();
+  const { t } = useStrings();
   const url = useAvatarUrl(avatarUrl);
 
   const body = (
@@ -104,7 +107,7 @@ export function ProfileAvatar({
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={url ? 'Change your photo' : 'Add a photo'}
+      accessibilityLabel={url ? t.misc.changeYourPhoto : t.misc.addYourPhoto}
     >
       {body}
     </Pressable>

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -12,10 +12,13 @@ import { Pressable, View } from 'react-native';
 
 import { Card, Row, Text, useTheme } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
+
 import { useSync } from '@/sync';
 
 export function SyncBanner({ groupId }: { groupId?: string }) {
   const theme = useTheme();
+  const { t } = useStrings();
   const { status, queue, rejected, retry, discard, lastError } = useSync();
 
   const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
@@ -32,7 +35,7 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
           </Text>
         </Row>
         <Text variant="caption" tone="muted">
-          {first?.message ?? 'The server refused this change.'}
+          {first?.message ?? t.misc.serverRefused}
         </Text>
         <Row style={{ gap: theme.spacing.lg }}>
           <Pressable
@@ -68,9 +71,7 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
       ? {
           icon: 'cloud-offline-outline' as const,
           message:
-            pending.length > 0
-              ? `Offline — ${count} saved on this phone`
-              : 'Offline — everything here is saved on this phone',
+            pending.length > 0 ? `Offline — ${count} saved on this phone` : t.misc.offlineSaved,
         }
       : status === 'error'
         ? {

--- a/apps/mobile/src/components/UpdateGate.tsx
+++ b/apps/mobile/src/components/UpdateGate.tsx
@@ -16,6 +16,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Button, Card, Row, Text, useTheme } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
+
 import { useUpdate } from '@/lib/update';
 
 export function UpdateGate({ children }: { children: React.ReactNode }) {
@@ -26,6 +28,7 @@ export function UpdateGate({ children }: { children: React.ReactNode }) {
 
 function BlockingScreen(): React.JSX.Element {
   const theme = useTheme();
+  const { t } = useStrings();
   const { message, installed, latest, openStore, recheck } = useUpdate();
 
   return (
@@ -69,9 +72,9 @@ function BlockingScreen(): React.JSX.Element {
       </Text>
 
       <View style={{ alignSelf: 'stretch', gap: theme.spacing.sm }}>
-        <Button label="Update Baaki" size="lg" fullWidth onPress={openStore} />
+        <Button label={t.misc.updateBaaki} size="lg" fullWidth onPress={openStore} />
         <Button
-          label="I have already updated"
+          label={t.misc.alreadyUpdated}
           variant="ghost"
           fullWidth
           onPress={() => void recheck()}
@@ -93,6 +96,7 @@ function BlockingScreen(): React.JSX.Element {
  */
 export function UpdateBanner(): React.JSX.Element | null {
   const theme = useTheme();
+  const { t } = useStrings();
   const insets = useSafeAreaInsets();
   const { decision, dismissed, dismiss, openStore, latest } = useUpdate();
 
@@ -123,10 +127,10 @@ export function UpdateBanner(): React.JSX.Element | null {
         </Row>
         <Row style={{ gap: theme.spacing.sm }}>
           <View style={{ flex: 1 }}>
-            <Button label="Update" size="sm" fullWidth onPress={openStore} />
+            <Button label={t.misc.update} size="sm" fullWidth onPress={openStore} />
           </View>
           <View style={{ flex: 1 }}>
-            <Button label="Not now" size="sm" variant="ghost" fullWidth onPress={dismiss} />
+            <Button label={t.misc.notNow} size="sm" variant="ghost" fullWidth onPress={dismiss} />
           </View>
         </Row>
       </Card>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -537,6 +537,53 @@ export interface UiStrings {
     withAdjustments: string;
     itemized: string;
   };
+  /** Starting a group, joining one by link, and the odds and ends around both. */
+  misc: {
+    newGroupPlaceholder: string;
+    personName: string;
+    createGroup: string;
+    linkExpired: string;
+    linkExpiredBody: string;
+    linkMissingCode: string;
+    goToBaaki: string;
+    freeNoAccount: string;
+    isOneOfTheseYou: string;
+    unnamed: string;
+    joinAndClaim: string;
+    joinGroup: string;
+    fromYourContacts: string;
+    continueWith: string;
+    noAddress: string;
+    addToWhichGroup: string;
+    addThemAllToWhichGroup: string;
+    startAGroup: string;
+    pickDifferentPeople: string;
+    someone: string;
+    serverRefused: string;
+    offlineSaved: string;
+    notAnAmount: string;
+    notARate: string;
+    paidAnotherCurrency: string;
+    whatIWasCharged: string;
+    askingRate: string;
+    getTodaysRate: string;
+    micPermission: string;
+    micBlocked: string;
+    dictationFailed: string;
+    stopDictating: string;
+    dictateNote: string;
+    updateBaaki: string;
+    alreadyUpdated: string;
+    update: string;
+    notNow: string;
+    changeGroupPhoto: string;
+    addGroupPhoto: string;
+    changeYourPhoto: string;
+    addYourPhoto: string;
+    followMyPhone: string;
+    currentlyLanguage: string;
+    rightToLeft: string;
+  };
 }
 
 const en: UiStrings = {
@@ -1001,6 +1048,53 @@ const en: UiStrings = {
     byShares: 'By shares',
     withAdjustments: 'With adjustments',
     itemized: 'Itemized',
+  },
+  misc: {
+    newGroupPlaceholder: 'Goa trip',
+    personName: "Person's name",
+    createGroup: 'Create group',
+    linkExpired: 'This link has expired',
+    linkExpiredBody:
+      'Ask whoever sent it for a fresh one — links expire so they cannot be passed around forever.',
+    linkMissingCode: 'This link is missing its invite code',
+    goToBaaki: 'Go to Baaki',
+    freeNoAccount: 'Free forever, no account needed',
+    isOneOfTheseYou: 'Is one of these you?',
+    unnamed: 'Unnamed',
+    joinAndClaim: 'Join and claim my history',
+    joinGroup: 'Join this group',
+    fromYourContacts: 'From your contacts',
+    continueWith: 'Continue with',
+    noAddress: 'No address',
+    addToWhichGroup: 'Add to which group?',
+    addThemAllToWhichGroup: 'Add them all to which group?',
+    startAGroup: 'Start a group',
+    pickDifferentPeople: 'Pick different people',
+    someone: 'Someone',
+    serverRefused: 'The server refused this change.',
+    offlineSaved: 'Offline — everything here is saved on this phone',
+    notAnAmount: 'That does not look like an amount',
+    notARate: 'That does not look like a rate',
+    paidAnotherCurrency: 'Paid in another currency',
+    whatIWasCharged: 'What I was charged',
+    askingRate: 'Asking…',
+    getTodaysRate: 'Get today’s {from}→{to} rate',
+    micPermission: 'Baaki needs permission to use the microphone.',
+    micBlocked: 'Microphone access is off for Baaki. You can turn it on in Settings.',
+    dictationFailed: 'Dictation could not start. Type the note instead.',
+    stopDictating: 'Stop dictating',
+    dictateNote: 'Dictate the note',
+    updateBaaki: 'Update Baaki',
+    alreadyUpdated: 'I have already updated',
+    update: 'Update',
+    notNow: 'Not now',
+    changeGroupPhoto: 'Change group photo',
+    addGroupPhoto: 'Add a group photo',
+    changeYourPhoto: 'Change your photo',
+    addYourPhoto: 'Add a photo',
+    followMyPhone: 'Follow my phone',
+    currentlyLanguage: 'Currently {language}',
+    rightToLeft: 'right to left',
   },
 };
 
@@ -1485,6 +1579,53 @@ const ta: UiStrings = {
     withAdjustments: 'சரிசெய்தலுடன்',
     itemized: 'பொருள் வாரியாக',
   },
+  misc: {
+    newGroupPlaceholder: 'கோவா பயணம்',
+    personName: 'நபரின் பெயர்',
+    createGroup: 'குழுவை உருவாக்கு',
+    linkExpired: 'இந்த இணைப்பு காலாவதியாகிவிட்டது',
+    linkExpiredBody:
+      'அனுப்பியவரிடம் புதிய ஒன்றைக் கேளுங்கள் — இணைப்புகள் காலாவதியாவதால்தான் அவை என்றென்றும் கைமாறுவதில்லை.',
+    linkMissingCode: 'இந்த இணைப்பில் அழைப்புக் குறியீடு இல்லை',
+    goToBaaki: 'பாக்கிக்குச் செல்',
+    freeNoAccount: 'எப்போதும் இலவசம், கணக்கு தேவையில்லை',
+    isOneOfTheseYou: 'இவர்களில் ஒருவர் நீங்களா?',
+    unnamed: 'பெயரிடப்படாதவர்',
+    joinAndClaim: 'சேர்ந்து என் வரலாற்றை உரிமை கொள்',
+    joinGroup: 'இந்தக் குழுவில் சேர்',
+    fromYourContacts: 'உங்கள் தொடர்புகளிலிருந்து',
+    continueWith: 'இவர்களுடன் தொடர்',
+    noAddress: 'முகவரி இல்லை',
+    addToWhichGroup: 'எந்தக் குழுவில் சேர்ப்பது?',
+    addThemAllToWhichGroup: 'அனைவரையும் எந்தக் குழுவில் சேர்ப்பது?',
+    startAGroup: 'ஒரு குழுவைத் தொடங்கு',
+    pickDifferentPeople: 'வேறு ஆட்களைத் தேர்ந்தெடு',
+    someone: 'யாரோ',
+    serverRefused: 'இந்த மாற்றத்தை சர்வர் ஏற்கவில்லை.',
+    offlineSaved: 'இணைப்பு இல்லை — இங்குள்ள அனைத்தும் இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளது',
+    notAnAmount: 'இது ஒரு தொகை போல் தெரியவில்லை',
+    notARate: 'இது ஒரு மாற்று விகிதம் போல் தெரியவில்லை',
+    paidAnotherCurrency: 'வேறு நாணயத்தில் கொடுத்தது',
+    whatIWasCharged: 'என்னிடம் வசூலிக்கப்பட்டது',
+    askingRate: 'கேட்கிறது…',
+    getTodaysRate: 'இன்றைய {from}→{to} விகிதத்தைப் பெறு',
+    micPermission: 'ஒலிவாங்கியைப் பயன்படுத்த பாக்கிக்கு அனுமதி தேவை.',
+    micBlocked: 'பாக்கிக்கு ஒலிவாங்கி அணுகல் நிறுத்தப்பட்டுள்ளது. அமைப்புகளில் இயக்கலாம்.',
+    dictationFailed: 'சொல்வதைப் பதிவு செய்ய முடியவில்லை. குறிப்பைத் தட்டச்சு செய்யுங்கள்.',
+    stopDictating: 'சொல்வதை நிறுத்து',
+    dictateNote: 'குறிப்பைச் சொல்',
+    updateBaaki: 'பாக்கியைப் புதுப்பி',
+    alreadyUpdated: 'நான் ஏற்கனவே புதுப்பித்துவிட்டேன்',
+    update: 'புதுப்பி',
+    notNow: 'இப்போது வேண்டாம்',
+    changeGroupPhoto: 'குழுப் புகைப்படத்தை மாற்று',
+    addGroupPhoto: 'குழுப் புகைப்படத்தைச் சேர்',
+    changeYourPhoto: 'உங்கள் புகைப்படத்தை மாற்று',
+    addYourPhoto: 'ஒரு புகைப்படத்தைச் சேர்',
+    followMyPhone: 'என் ஃபோனைப் பின்பற்று',
+    currentlyLanguage: 'தற்போது {language}',
+    rightToLeft: 'வலமிருந்து இடம்',
+  },
 };
 
 const hi: UiStrings = {
@@ -1941,6 +2082,53 @@ const hi: UiStrings = {
     byShares: 'हिस्सों से',
     withAdjustments: 'समायोजन के साथ',
     itemized: 'चीज़-वार',
+  },
+  misc: {
+    newGroupPlaceholder: 'गोवा ट्रिप',
+    personName: 'व्यक्ति का नाम',
+    createGroup: 'समूह बनाएँ',
+    linkExpired: 'यह लिंक खत्म हो चुका है',
+    linkExpiredBody:
+      'जिसने भेजा था उससे नया माँग लें — लिंक इसीलिए खत्म होते हैं ताकि वे हमेशा घूमते न रहें।',
+    linkMissingCode: 'इस लिंक में निमंत्रण कोड नहीं है',
+    goToBaaki: 'बाकी पर जाएँ',
+    freeNoAccount: 'हमेशा मुफ़्त, खाता ज़रूरी नहीं',
+    isOneOfTheseYou: 'क्या इनमें से कोई आप हैं?',
+    unnamed: 'बिना नाम',
+    joinAndClaim: 'जुड़ें और अपना इतिहास लें',
+    joinGroup: 'इस समूह में जुड़ें',
+    fromYourContacts: 'आपके संपर्कों से',
+    continueWith: 'इनके साथ जारी रखें',
+    noAddress: 'कोई पता नहीं',
+    addToWhichGroup: 'किस समूह में जोड़ें?',
+    addThemAllToWhichGroup: 'इन सबको किस समूह में जोड़ें?',
+    startAGroup: 'समूह शुरू करें',
+    pickDifferentPeople: 'दूसरे लोग चुनें',
+    someone: 'कोई',
+    serverRefused: 'सर्वर ने यह बदलाव नहीं माना।',
+    offlineSaved: 'ऑफ़लाइन — यहाँ का सब कुछ इसी फ़ोन पर सेव है',
+    notAnAmount: 'यह रकम जैसा नहीं लगता',
+    notARate: 'यह दर जैसा नहीं लगता',
+    paidAnotherCurrency: 'दूसरी मुद्रा में चुकाया',
+    whatIWasCharged: 'मुझसे जो लिया गया',
+    askingRate: 'पूछ रहे हैं…',
+    getTodaysRate: 'आज की {from}→{to} दर लाएँ',
+    micPermission: 'माइक्रोफ़ोन इस्तेमाल करने के लिए बाकी को अनुमति चाहिए।',
+    micBlocked: 'बाकी के लिए माइक्रोफ़ोन बंद है। आप इसे सेटिंग्स में चालू कर सकते हैं।',
+    dictationFailed: 'बोलकर लिखना शुरू नहीं हो सका। नोट टाइप कर लें।',
+    stopDictating: 'बोलना बंद करें',
+    dictateNote: 'नोट बोलें',
+    updateBaaki: 'बाकी अपडेट करें',
+    alreadyUpdated: 'मैंने पहले ही अपडेट कर लिया',
+    update: 'अपडेट',
+    notNow: 'अभी नहीं',
+    changeGroupPhoto: 'समूह की फ़ोटो बदलें',
+    addGroupPhoto: 'समूह की फ़ोटो जोड़ें',
+    changeYourPhoto: 'अपनी फ़ोटो बदलें',
+    addYourPhoto: 'फ़ोटो जोड़ें',
+    followMyPhone: 'मेरे फ़ोन के अनुसार',
+    currentlyLanguage: 'अभी {language}',
+    rightToLeft: 'दाएँ से बाएँ',
   },
 };
 
@@ -2427,6 +2615,52 @@ const ar: UiStrings = {
     byShares: 'بالحصص',
     withAdjustments: 'مع تعديلات',
     itemized: 'حسب الأصناف',
+  },
+  misc: {
+    newGroupPlaceholder: 'رحلة دبي',
+    personName: 'اسم الشخص',
+    createGroup: 'إنشاء مجموعة',
+    linkExpired: 'انتهت صلاحية هذا الرابط',
+    linkExpiredBody: 'اطلب رابطًا جديدًا ممن أرسله — الروابط تنتهي كي لا تتداول إلى الأبد.',
+    linkMissingCode: 'هذا الرابط ينقصه رمز الدعوة',
+    goToBaaki: 'اذهب إلى باقي',
+    freeNoAccount: 'مجاني دائمًا، بلا حاجة إلى حساب',
+    isOneOfTheseYou: 'هل أحد هؤلاء أنت؟',
+    unnamed: 'بلا اسم',
+    joinAndClaim: 'انضم وطالب بسجلي',
+    joinGroup: 'انضم إلى هذه المجموعة',
+    fromYourContacts: 'من جهات اتصالك',
+    continueWith: 'المتابعة مع',
+    noAddress: 'لا يوجد عنوان',
+    addToWhichGroup: 'إلى أي مجموعة نضيفه؟',
+    addThemAllToWhichGroup: 'إلى أي مجموعة نضيفهم جميعًا؟',
+    startAGroup: 'ابدأ مجموعة',
+    pickDifferentPeople: 'اختر أشخاصًا آخرين',
+    someone: 'أحدهم',
+    serverRefused: 'رفض الخادم هذا التغيير.',
+    offlineSaved: 'دون اتصال — كل ما هنا محفوظ على هذا الهاتف',
+    notAnAmount: 'هذا لا يبدو مبلغًا',
+    notARate: 'هذا لا يبدو سعر صرف',
+    paidAnotherCurrency: 'دُفع بعملة أخرى',
+    whatIWasCharged: 'ما خُصم مني',
+    askingRate: 'جارٍ السؤال…',
+    getTodaysRate: 'اجلب سعر {from}→{to} اليوم',
+    micPermission: 'يحتاج باقي إلى إذن لاستخدام الميكروفون.',
+    micBlocked: 'الوصول إلى الميكروفون معطّل لباقي. يمكنك تفعيله من الإعدادات.',
+    dictationFailed: 'تعذّر بدء الإملاء. اكتب الملاحظة بدلًا من ذلك.',
+    stopDictating: 'إيقاف الإملاء',
+    dictateNote: 'أملِ الملاحظة',
+    updateBaaki: 'حدّث باقي',
+    alreadyUpdated: 'لقد حدّثت بالفعل',
+    update: 'تحديث',
+    notNow: 'ليس الآن',
+    changeGroupPhoto: 'تغيير صورة المجموعة',
+    addGroupPhoto: 'أضف صورة للمجموعة',
+    changeYourPhoto: 'تغيير صورتك',
+    addYourPhoto: 'أضف صورة',
+    followMyPhone: 'اتبع هاتفي',
+    currentlyLanguage: 'حاليًا {language}',
+    rightToLeft: 'من اليمين إلى اليسار',
   },
 };
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -472,6 +472,71 @@ export interface UiStrings {
     nobodyOwes: string;
     recordedNotMoved: string;
   };
+  /** The people in a group, and the link that brings more in. */
+  people: {
+    invite: string;
+    addSomeone: string;
+    namePlaceholder: string;
+    contactPlaceholder: string;
+    yetToJoin: PluralForms;
+    sendInviteLink: string;
+    memberNotFound: string;
+    memberNotFoundBody: string;
+    admin: string;
+    you: string;
+    memberName: string;
+    ghostNote: string;
+    upiForGroup: string;
+    upiForGroupNote: string;
+    inviteTitle: string;
+    anyoneWithLink: string;
+    anyoneWithLinkBody: string;
+    inviteLink: string;
+    whatsapp: string;
+    shareAnotherWay: string;
+    copyLink: string;
+    createLink: string;
+    linkCopied: string;
+    expires: string;
+    hideContacts: string;
+    browseContacts: string;
+  };
+  /** Adding and editing an expense, and reading one off a bill. */
+  expense: {
+    edit: string;
+    chooseWhoPaid: string;
+    editingKeepsVersion: string;
+    splitByItem: string;
+    scanBillTitle: string;
+    scanBillBody: string;
+    scan: string;
+    reading: string;
+    scanReconciles: string;
+    scanCheckTotal: string;
+    descriptionPlaceholder: string;
+    howToSplit: string;
+    equally: string;
+    shares: string;
+    percent: string;
+    splitBetween: string;
+    ofCount: string;
+    saveChanges: string;
+    notFound: string;
+    notFoundBody: string;
+    deleteQuestion: string;
+    deleteBody: string;
+    deleted: string;
+    whoOwesWhat: string;
+    history: string;
+    restore: string;
+    deleteAction: string;
+    splitEqually: string;
+    exactAmounts: string;
+    byPercentage: string;
+    byShares: string;
+    withAdjustments: string;
+    itemized: string;
+  };
 }
 
 const en: UiStrings = {
@@ -868,6 +933,74 @@ const en: UiStrings = {
     archive: 'Archive',
     nobodyOwes: 'Nobody owes anybody in this group.',
     recordedNotMoved: 'Recorded, not moved by Baaki',
+  },
+  people: {
+    invite: 'Invite',
+    addSomeone: 'Add someone',
+    namePlaceholder: 'Rahul',
+    contactPlaceholder: 'Email or phone, if you want to send them the link',
+    yetToJoin: { one: '{n} yet to join', other: '{n} yet to join' },
+    sendInviteLink: 'Send an invite link',
+    memberNotFound: 'Member not found',
+    memberNotFoundBody: 'They may have left the group.',
+    admin: 'admin',
+    you: 'you',
+    memberName: 'Member name',
+    ghostNote: 'This person holds real balances. When they join, they can claim this history.',
+    upiForGroup: 'UPI ID for this group',
+    upiForGroupNote:
+      'Overrides your account UPI ID here only — useful when one group settles to a different account.',
+    inviteTitle: 'Invite people',
+    anyoneWithLink: 'Anyone with the link can join',
+    anyoneWithLinkBody:
+      'They do not need to install anything or make an account to see the group and add expenses.',
+    inviteLink: 'Invite link',
+    whatsapp: 'WhatsApp',
+    shareAnotherWay: 'Share another way',
+    copyLink: 'Copy link',
+    createLink: 'Create an invite link',
+    linkCopied: 'Link copied',
+    expires: 'expires {when}',
+    hideContacts: 'Hide contacts',
+    browseContacts: 'Browse my contacts',
+  },
+  expense: {
+    edit: 'Edit expense',
+    chooseWhoPaid: 'Choose who paid',
+    editingKeepsVersion:
+      'Editing keeps the old version. Everyone can see what changed, and it can be restored.',
+    splitByItem: 'Split by item',
+    scanBillTitle: 'Scan the bill',
+    scanBillBody:
+      'The total and the name of the place come out filled in. Check them — entering them by hand is always free.',
+    scan: 'Scan',
+    reading: 'Reading…',
+    scanReconciles: 'Read the total off the bill. Check it, then split it however you like.',
+    scanCheckTotal: 'Check the total against the bill before saving.',
+    descriptionPlaceholder: 'Beach shack dinner',
+    howToSplit: 'How to split',
+    equally: 'Equally',
+    shares: 'Shares',
+    percent: 'Percent',
+    splitBetween: 'Split between',
+    ofCount: '{chosen} of {total}',
+    saveChanges: 'Save changes',
+    notFound: 'Expense not found',
+    notFoundBody: 'It may have been deleted more than 30 days ago.',
+    deleteQuestion: 'Delete this expense?',
+    deleteBody:
+      'It stops counting towards balances but stays in the activity feed, and anyone in the group can restore it for 30 days.',
+    deleted: 'deleted',
+    whoOwesWhat: 'Who owes what',
+    history: 'History',
+    restore: 'Restore this expense',
+    deleteAction: 'Delete expense',
+    splitEqually: 'Split equally',
+    exactAmounts: 'Exact amounts',
+    byPercentage: 'By percentage',
+    byShares: 'By shares',
+    withAdjustments: 'With adjustments',
+    itemized: 'Itemized',
   },
 };
 
@@ -1282,6 +1415,76 @@ const ta: UiStrings = {
     nobodyOwes: 'இந்தக் குழுவில் யாரும் யாருக்கும் தர வேண்டியதில்லை.',
     recordedNotMoved: 'பதிவு செய்யப்பட்டது, பாக்கி பணத்தை அனுப்பவில்லை',
   },
+  people: {
+    invite: 'அழை',
+    addSomeone: 'ஒருவரைச் சேர்',
+    namePlaceholder: 'ராகுல்',
+    contactPlaceholder: 'இணைப்பை அனுப்ப விரும்பினால் மின்னஞ்சல் அல்லது தொலைபேசி',
+    yetToJoin: { one: '{n} பேர் இன்னும் சேரவில்லை', other: '{n} பேர் இன்னும் சேரவில்லை' },
+    sendInviteLink: 'அழைப்பு இணைப்பை அனுப்பு',
+    memberNotFound: 'உறுப்பினர் கிடைக்கவில்லை',
+    memberNotFoundBody: 'அவர்கள் குழுவிலிருந்து விலகியிருக்கலாம்.',
+    admin: 'நிர்வாகி',
+    you: 'நீங்கள்',
+    memberName: 'உறுப்பினர் பெயர்',
+    ghostNote:
+      'இவருக்கு உண்மையான இருப்புகள் உள்ளன. அவர்கள் சேரும்போது இந்த வரலாற்றைத் தங்களுடையதாக்கிக் கொள்ளலாம்.',
+    upiForGroup: 'இந்தக் குழுவுக்கான UPI ID',
+    upiForGroupNote:
+      'இங்கே மட்டும் உங்கள் கணக்கின் UPI ID ஐ மேலெழுதும் — ஒரு குழு வேறு கணக்குக்குத் தீர்க்கும்போது பயனுள்ளது.',
+    inviteTitle: 'ஆட்களை அழை',
+    anyoneWithLink: 'இணைப்பு உள்ள யாரும் சேரலாம்',
+    anyoneWithLinkBody:
+      'குழுவைப் பார்க்கவும் செலவுகளைச் சேர்க்கவும் அவர்கள் எதையும் நிறுவவோ கணக்கு உருவாக்கவோ தேவையில்லை.',
+    inviteLink: 'அழைப்பு இணைப்பு',
+    whatsapp: 'WhatsApp',
+    shareAnotherWay: 'வேறு வழியில் பகிர்',
+    copyLink: 'இணைப்பை நகலெடு',
+    createLink: 'அழைப்பு இணைப்பை உருவாக்கு',
+    linkCopied: 'இணைப்பு நகலெடுக்கப்பட்டது',
+    expires: '{when} க்கு காலாவதி',
+    hideContacts: 'தொடர்புகளை மறை',
+    browseContacts: 'என் தொடர்புகளைப் பார்',
+  },
+  expense: {
+    edit: 'செலவைத் திருத்து',
+    chooseWhoPaid: 'யார் கொடுத்தார்கள் என்று தேர்ந்தெடுக்கவும்',
+    editingKeepsVersion:
+      'திருத்தினாலும் பழைய பதிப்பு இருக்கும். என்ன மாறியது என்பதை அனைவரும் பார்க்கலாம், மீட்கவும் முடியும்.',
+    splitByItem: 'பொருள் வாரியாகப் பிரி',
+    scanBillTitle: 'ரசீதை ஸ்கேன் செய்',
+    scanBillBody:
+      'மொத்தமும் இடத்தின் பெயரும் தானாக நிரப்பப்படும். சரிபாருங்கள் — கையால் உள்ளிடுவது எப்போதும் இலவசம்.',
+    scan: 'ஸ்கேன்',
+    reading: 'படிக்கிறது…',
+    scanReconciles:
+      'ரசீதிலிருந்து மொத்தம் படிக்கப்பட்டது. சரிபார்த்து, உங்களுக்கு ஏற்றபடி பிரியுங்கள்.',
+    scanCheckTotal: 'சேமிப்பதற்கு முன் ரசீதுடன் மொத்தத்தைச் சரிபாருங்கள்.',
+    descriptionPlaceholder: 'கடற்கரை உணவகச் சாப்பாடு',
+    howToSplit: 'எப்படிப் பிரிப்பது',
+    equally: 'சமமாக',
+    shares: 'பங்குகள்',
+    percent: 'சதவீதம்',
+    splitBetween: 'யாருக்கிடையே',
+    ofCount: '{total} இல் {chosen}',
+    saveChanges: 'மாற்றங்களைச் சேமி',
+    notFound: 'செலவு கிடைக்கவில்லை',
+    notFoundBody: '30 நாட்களுக்கு முன்பே அது நீக்கப்பட்டிருக்கலாம்.',
+    deleteQuestion: 'இந்தச் செலவை நீக்கவா?',
+    deleteBody:
+      'இது இருப்புக் கணக்கில் சேராது, ஆனால் செயல்பாட்டுப் பட்டியலில் இருக்கும், 30 நாட்களுக்குள் குழுவில் யார் வேண்டுமானாலும் மீட்கலாம்.',
+    deleted: 'நீக்கப்பட்டது',
+    whoOwesWhat: 'யார் என்ன தர வேண்டும்',
+    history: 'வரலாறு',
+    restore: 'இந்தச் செலவை மீட்டெடு',
+    deleteAction: 'செலவை நீக்கு',
+    splitEqually: 'சமமாகப் பிரி',
+    exactAmounts: 'சரியான தொகைகள்',
+    byPercentage: 'சதவீதப்படி',
+    byShares: 'பங்குகளின்படி',
+    withAdjustments: 'சரிசெய்தலுடன்',
+    itemized: 'பொருள் வாரியாக',
+  },
 };
 
 const hi: UiStrings = {
@@ -1670,6 +1873,74 @@ const hi: UiStrings = {
     archive: 'संग्रहित करें',
     nobodyOwes: 'इस समूह में किसी पर किसी का कुछ बाकी नहीं है।',
     recordedNotMoved: 'दर्ज किया गया, बाकी ने पैसा नहीं भेजा',
+  },
+  people: {
+    invite: 'बुलाएँ',
+    addSomeone: 'किसी को जोड़ें',
+    namePlaceholder: 'राहुल',
+    contactPlaceholder: 'ईमेल या फ़ोन, अगर उन्हें लिंक भेजना हो',
+    yetToJoin: { one: '{n} अभी जुड़ना बाकी', other: '{n} अभी जुड़ना बाकी' },
+    sendInviteLink: 'निमंत्रण लिंक भेजें',
+    memberNotFound: 'सदस्य नहीं मिला',
+    memberNotFoundBody: 'हो सकता है उन्होंने समूह छोड़ दिया हो।',
+    admin: 'एडमिन',
+    you: 'आप',
+    memberName: 'सदस्य का नाम',
+    ghostNote: 'इस व्यक्ति का असली हिसाब है। जुड़ने पर वे यह इतिहास अपने नाम कर सकते हैं।',
+    upiForGroup: 'इस समूह के लिए UPI ID',
+    upiForGroupNote:
+      'सिर्फ़ यहाँ आपके खाते की UPI ID की जगह लेता है — जब कोई समूह किसी दूसरे खाते में निपटता हो तो काम आता है।',
+    inviteTitle: 'लोगों को बुलाएँ',
+    anyoneWithLink: 'जिसके पास लिंक हो वह जुड़ सकता है',
+    anyoneWithLinkBody:
+      'समूह देखने और खर्च जोड़ने के लिए उन्हें कुछ इंस्टॉल करने या खाता बनाने की ज़रूरत नहीं।',
+    inviteLink: 'निमंत्रण लिंक',
+    whatsapp: 'WhatsApp',
+    shareAnotherWay: 'किसी और तरीके से साझा करें',
+    copyLink: 'लिंक कॉपी करें',
+    createLink: 'निमंत्रण लिंक बनाएँ',
+    linkCopied: 'लिंक कॉपी हो गया',
+    expires: '{when} को खत्म',
+    hideContacts: 'संपर्क छिपाएँ',
+    browseContacts: 'मेरे संपर्क देखें',
+  },
+  expense: {
+    edit: 'खर्च बदलें',
+    chooseWhoPaid: 'चुनें किसने दिया',
+    editingKeepsVersion:
+      'बदलने पर पुराना संस्करण बना रहता है। सब देख सकते हैं क्या बदला, और उसे वापस भी लाया जा सकता है।',
+    splitByItem: 'चीज़-वार बाँटें',
+    scanBillTitle: 'बिल स्कैन करें',
+    scanBillBody:
+      'कुल रकम और जगह का नाम अपने आप भर जाते हैं। जाँच लें — हाथ से डालना हमेशा मुफ़्त है।',
+    scan: 'स्कैन',
+    reading: 'पढ़ रहे हैं…',
+    scanReconciles: 'बिल से कुल रकम पढ़ ली। जाँच लें, फिर जैसे चाहें बाँटें।',
+    scanCheckTotal: 'सेव करने से पहले कुल रकम बिल से मिला लें।',
+    descriptionPlaceholder: 'बीच शैक का खाना',
+    howToSplit: 'कैसे बाँटें',
+    equally: 'बराबर',
+    shares: 'हिस्से',
+    percent: 'प्रतिशत',
+    splitBetween: 'किनके बीच',
+    ofCount: '{total} में से {chosen}',
+    saveChanges: 'बदलाव सेव करें',
+    notFound: 'खर्च नहीं मिला',
+    notFoundBody: 'हो सकता है इसे 30 दिन से पहले हटा दिया गया हो।',
+    deleteQuestion: 'यह खर्च मिटाएँ?',
+    deleteBody:
+      'यह हिसाब में गिनना बंद कर देगा पर गतिविधि में बना रहेगा, और समूह का कोई भी 30 दिन तक इसे वापस ला सकता है।',
+    deleted: 'हटाया गया',
+    whoOwesWhat: 'किस पर क्या बाकी',
+    history: 'इतिहास',
+    restore: 'यह खर्च वापस लाएँ',
+    deleteAction: 'खर्च मिटाएँ',
+    splitEqually: 'बराबर बाँटें',
+    exactAmounts: 'सटीक रकम',
+    byPercentage: 'प्रतिशत से',
+    byShares: 'हिस्सों से',
+    withAdjustments: 'समायोजन के साथ',
+    itemized: 'चीज़-वार',
   },
 };
 
@@ -2085,6 +2356,77 @@ const ar: UiStrings = {
     archive: 'أرشفة',
     nobodyOwes: 'لا أحد يدين لأحد في هذه المجموعة.',
     recordedNotMoved: 'مسجَّل، ولم يحوّل باقي المال',
+  },
+  people: {
+    invite: 'دعوة',
+    addSomeone: 'أضف شخصًا',
+    namePlaceholder: 'راكيش',
+    contactPlaceholder: 'بريد أو هاتف، إن أردت إرسال الرابط إليه',
+    yetToJoin: {
+      zero: '{n} لم ينضموا بعد',
+      one: 'واحد لم ينضم بعد',
+      two: 'اثنان لم ينضما بعد',
+      few: '{n} لم ينضموا بعد',
+      many: '{n} لم ينضموا بعد',
+      other: '{n} لم ينضموا بعد',
+    },
+    sendInviteLink: 'أرسل رابط دعوة',
+    memberNotFound: 'العضو غير موجود',
+    memberNotFoundBody: 'ربما غادر المجموعة.',
+    admin: 'مشرف',
+    you: 'أنت',
+    memberName: 'اسم العضو',
+    ghostNote: 'لهذا الشخص أرصدة حقيقية. حين ينضم يمكنه أن يطالب بهذا السجل.',
+    upiForGroup: 'معرّف الدفع لهذه المجموعة',
+    upiForGroupNote: 'يتجاوز معرّف حسابك هنا فقط — مفيد حين تُسوّى مجموعة إلى حساب مختلف.',
+    inviteTitle: 'ادعُ أشخاصًا',
+    anyoneWithLink: 'يستطيع أي شخص لديه الرابط الانضمام',
+    anyoneWithLinkBody: 'لا يحتاجون إلى تثبيت شيء أو إنشاء حساب لرؤية المجموعة وإضافة المصروفات.',
+    inviteLink: 'رابط الدعوة',
+    whatsapp: 'واتساب',
+    shareAnotherWay: 'شارك بطريقة أخرى',
+    copyLink: 'نسخ الرابط',
+    createLink: 'أنشئ رابط دعوة',
+    linkCopied: 'تم نسخ الرابط',
+    expires: 'ينتهي {when}',
+    hideContacts: 'إخفاء جهات الاتصال',
+    browseContacts: 'تصفّح جهات اتصالي',
+  },
+  expense: {
+    edit: 'تعديل المصروف',
+    chooseWhoPaid: 'اختر من دفع',
+    editingKeepsVersion: 'التعديل يحتفظ بالنسخة القديمة. يرى الجميع ما تغيّر، ويمكن استرجاعها.',
+    splitByItem: 'التقسيم حسب الصنف',
+    scanBillTitle: 'امسح الفاتورة',
+    scanBillBody: 'يُملأ المجموع واسم المكان تلقائيًا. تحقّق منهما — والإدخال اليدوي مجاني دائمًا.',
+    scan: 'مسح',
+    reading: 'جارٍ القراءة…',
+    scanReconciles: 'قرأنا المجموع من الفاتورة. تحقّق منه ثم قسّمه كما تشاء.',
+    scanCheckTotal: 'قارن المجموع بالفاتورة قبل الحفظ.',
+    descriptionPlaceholder: 'عشاء على الشاطئ',
+    howToSplit: 'طريقة التقسيم',
+    equally: 'بالتساوي',
+    shares: 'حصص',
+    percent: 'نسبة مئوية',
+    splitBetween: 'التقسيم بين',
+    ofCount: '{chosen} من {total}',
+    saveChanges: 'حفظ التغييرات',
+    notFound: 'المصروف غير موجود',
+    notFoundBody: 'ربما حُذف قبل أكثر من 30 يومًا.',
+    deleteQuestion: 'حذف هذا المصروف؟',
+    deleteBody:
+      'سيتوقف احتسابه في الأرصدة لكنه يبقى في سجل النشاط، ويمكن لأي عضو استرجاعه خلال 30 يومًا.',
+    deleted: 'محذوف',
+    whoOwesWhat: 'من عليه ماذا',
+    history: 'السجل',
+    restore: 'استرجاع هذا المصروف',
+    deleteAction: 'حذف المصروف',
+    splitEqually: 'تقسيم بالتساوي',
+    exactAmounts: 'مبالغ محددة',
+    byPercentage: 'بالنسبة المئوية',
+    byShares: 'بالحصص',
+    withAdjustments: 'مع تعديلات',
+    itemized: 'حسب الأصناف',
   },
 };
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -311,6 +311,96 @@ export interface UiStrings {
     motionFollowingOff: string;
     footnote: string;
   };
+  /** Notification preferences, and what the phone will and will not allow. */
+  notifications: {
+    title: string;
+    neverSpam: string;
+    onThisPhone: string;
+    permissionOn: string;
+    permissionOff: string;
+    permissionUnset: string;
+    granted: string;
+    denied: string;
+    undetermined: string;
+    asking: string;
+    turnOn: string;
+    pushSection: string;
+    involvesMe: string;
+    involvesMeBody: string;
+    settlementRequests: string;
+    settlementRequestsBody: string;
+    nudges: string;
+    nudgesBody: string;
+    digest: string;
+    digestBody: string;
+    weeklyEmail: string;
+    weeklyEmailBody: string;
+    failDenied: string;
+    failUnsupported: string;
+    failNotSignedIn: string;
+    failNotConfigured: string;
+    failSaveFailed: string;
+    footnote: string;
+  };
+  /** Attaching an email or phone to the account you already have (ADR-006). */
+  contact: {
+    title: string;
+    signedIn: string;
+    guestBody: string;
+    memberBody: string;
+    email: string;
+    phone: string;
+    alreadyAdded: string;
+    emailAddress: string;
+    phoneNumber: string;
+    emailPlaceholder: string;
+    phonePlaceholder: string;
+    codeEmailed: string;
+    codeTexted: string;
+    verificationCode: string;
+    confirm: string;
+    sendCodeEmail: string;
+    sendCodePhone: string;
+    useDifferent: string;
+    added: string;
+    footnote: string;
+  };
+  /** The welcome and the ways in (ADR-006: nobody registers to split a bill). */
+  signIn: {
+    tagline: string;
+    splitAnything: string;
+    welcomeBody: string;
+    startNow: string;
+    haveAccount: string;
+    welcomeBack: string;
+    keepOnNextPhone: string;
+    guestAddWay: string;
+    signInHowever: string;
+    sendMeACode: string;
+    useAPassword: string;
+    phoneNumber: string;
+    countryCodeHint: string;
+    sendCode: string;
+    codeSentTo: string;
+    verify: string;
+    differentNumber: string;
+    identifier: string;
+    identifierPlaceholder: string;
+    password: string;
+    passwordHint: string;
+    addToAccount: string;
+    createAccount: string;
+    signInAction: string;
+    switchToSignIn: string;
+    switchToSignUp: string;
+    continueGoogle: string;
+    signInGoogle: string;
+    continueGuest: string;
+    guestFootnote: string;
+    memberFootnote: string;
+    restartToMirror: string;
+    restartToUnmirror: string;
+  };
 }
 
 const en: UiStrings = {
@@ -528,6 +618,108 @@ const en: UiStrings = {
     motionFollowingOn: 'Following your phone — animations on',
     motionFollowingOff: 'Following your phone — animations off',
     footnote: 'Baaki · the ledger is free forever. We only ever charge for convenience.',
+  },
+  notifications: {
+    title: 'Notifications',
+    neverSpam:
+      'Baaki never emails you about routine expense activity. Only the six things you would actually want in your inbox, each unsubscribable on its own.',
+    onThisPhone: 'Notifications on this phone',
+    permissionOn:
+      'This device is registered. Everything below still lands in your inbox whether or not a push gets through.',
+    permissionOff:
+      'Your phone is blocking them. Turn them back on in system settings for Baaki — the inbox still has everything either way.',
+    permissionUnset: 'Baaki will only ask once, and only for the things you switch on below.',
+    granted: 'On',
+    denied: 'Off',
+    undetermined: 'Not set',
+    asking: 'Asking…',
+    turnOn: 'Turn on notifications',
+    pushSection: 'Push',
+    involvesMe: 'Only what involves me',
+    involvesMeBody:
+      'Push when you owe, are owed, or are mentioned — not for every expense in every group.',
+    settlementRequests: 'Settlement confirmations',
+    settlementRequestsBody: 'When someone says they paid you, so your baaki stays right.',
+    nudges: 'Reminders',
+    nudgesBody:
+      'A friendly nudge about money owed. Limited to one per person per day, in the database.',
+    digest: 'Daily group summary',
+    digestBody: 'Everything else, batched into one notification a day instead of a stream.',
+    weeklyEmail: 'Weekly email digest',
+    weeklyEmailBody: 'Your net baaki and pending confirmations, once a week. Off by default.',
+    failDenied: 'Not enabled — you can turn it on in your phone settings later.',
+    failUnsupported:
+      'This device cannot receive push notifications. Everything still lands in Activity.',
+    failNotSignedIn: 'Sign in first, so we know which phone is yours.',
+    failNotConfigured:
+      'Push is not set up in this build of Baaki. Nothing you did — everything still lands in Activity.',
+    failSaveFailed: 'Could not save this phone. Check your connection and try again.',
+    footnote:
+      'Email delivery is still to come. Everything here is also in your inbox, which is the record of what Baaki has told you whether or not a notification arrived.',
+  },
+  contact: {
+    title: 'Your account',
+    signedIn: 'Signed in',
+    guestBody:
+      'Everything you have entered is already saved and yours. Adding an email or phone number is only so you can get back to it from another phone.',
+    memberBody: 'This account is reachable from any device you sign in on.',
+    email: 'Email',
+    phone: 'Phone',
+    alreadyAdded: 'Already added: {value}',
+    emailAddress: 'Email address',
+    phoneNumber: 'Phone number',
+    emailPlaceholder: 'you@example.com',
+    phonePlaceholder: '+91 98765 43210',
+    codeEmailed: 'Enter the six-digit code we emailed you',
+    codeTexted: 'Enter the six-digit code we texted you',
+    verificationCode: 'Verification code',
+    confirm: 'Confirm',
+    sendCodeEmail: 'Send me a code',
+    sendCodePhone: 'Text me a code',
+    useDifferent: 'Use a different one',
+    added: 'Added. You can sign in with it on another phone now.',
+    footnote:
+      'Baaki never asks for this to let you in, and never shares it with anyone in your groups. People see the name you choose, nothing else.',
+  },
+  signIn: {
+    tagline: 'baaki · what is left over',
+    splitAnything: 'Split anything\nwith anyone',
+    welcomeBody:
+      'No account needed to start — add one later and everything you have entered comes with you.',
+    startNow: 'Start now',
+    haveAccount: 'I already have an account',
+    welcomeBack: 'Welcome back',
+    keepOnNextPhone: 'Keep this account on your next phone',
+    guestAddWay: 'Add a way to sign in, so this account is still yours on your next phone.',
+    signInHowever: 'Sign in however you set it up.',
+    sendMeACode: 'Send me a code',
+    useAPassword: 'Use a password',
+    phoneNumber: 'Phone number',
+    countryCodeHint:
+      'Start with your country code. Baaki never assumes +91 — a trip is exactly when foreign numbers turn up.',
+    sendCode: 'Send code',
+    codeSentTo: 'Code sent to {value}',
+    verify: 'Verify',
+    differentNumber: 'Use a different number',
+    identifier: 'Email or phone number',
+    identifierPlaceholder: 'asha@example.com or +91…',
+    password: 'Password',
+    passwordHint:
+      'Eight characters or more. A phrase you will remember beats a puzzle you will not.',
+    addToAccount: 'Add this to my account',
+    createAccount: 'Create account',
+    signInAction: 'Sign in',
+    switchToSignIn: 'I already have an account',
+    switchToSignUp: 'I am new here — create an account',
+    continueGoogle: 'Continue with Google',
+    signInGoogle: 'Sign in with Google',
+    continueGuest: 'Continue as guest',
+    guestFootnote:
+      'Everything you have already added stays exactly where it is. This only adds a way to sign back in.',
+    memberFootnote:
+      'A guest account keeps everything on this device until you add a way to sign in. Your ledger is never held hostage.',
+    restartToMirror: 'Close and open Baaki once to mirror the layout.',
+    restartToUnmirror: 'Close and open Baaki once to turn the layout back.',
   },
 };
 
@@ -758,6 +950,112 @@ const ta: UiStrings = {
     motionFollowingOff: 'உங்கள் ஃபோனைப் பின்பற்றுகிறது — அசைவுகள் நிறுத்தத்தில்',
     footnote: 'பாக்கி · கணக்கு எப்போதும் இலவசம். வசதிக்கு மட்டுமே நாங்கள் கட்டணம் வாங்குவோம்.',
   },
+  notifications: {
+    title: 'அறிவிப்புகள்',
+    neverSpam:
+      'வழக்கமான செலவுச் செயல்பாடுகள் குறித்து பாக்கி உங்களுக்கு மின்னஞ்சல் அனுப்புவதே இல்லை. உங்கள் அஞ்சல் பெட்டியில் நீங்கள் உண்மையிலேயே விரும்பும் ஆறு விஷயங்கள் மட்டுமே, ஒவ்வொன்றையும் தனித்தனியே நிறுத்தலாம்.',
+    onThisPhone: 'இந்த ஃபோனில் அறிவிப்புகள்',
+    permissionOn:
+      'இந்தச் சாதனம் பதிவு செய்யப்பட்டுள்ளது. அறிவிப்பு வந்தாலும் வராவிட்டாலும் கீழே உள்ள அனைத்தும் உங்கள் அஞ்சல் பெட்டியில் வந்து சேரும்.',
+    permissionOff:
+      'உங்கள் ஃபோன் அவற்றைத் தடுக்கிறது. பாக்கிக்கான சாதன அமைப்புகளில் மீண்டும் இயக்கவும் — எப்படியிருந்தாலும் அஞ்சல் பெட்டியில் எல்லாம் இருக்கும்.',
+    permissionUnset:
+      'பாக்கி ஒரே ஒரு முறை மட்டுமே கேட்கும், அதுவும் நீங்கள் கீழே இயக்கியவற்றுக்கு மட்டும்.',
+    granted: 'இயக்கத்தில்',
+    denied: 'நிறுத்தத்தில்',
+    undetermined: 'அமைக்கப்படவில்லை',
+    asking: 'கேட்கிறது…',
+    turnOn: 'அறிவிப்புகளை இயக்கு',
+    pushSection: 'அறிவிப்பு',
+    involvesMe: 'என்னைச் சார்ந்தவை மட்டும்',
+    involvesMeBody:
+      'நீங்கள் தர வேண்டியபோதோ, வர வேண்டியபோதோ, குறிப்பிடப்படும்போதோ அறிவிப்பு — ஒவ்வொரு குழுவின் ஒவ்வொரு செலவுக்கும் அல்ல.',
+    settlementRequests: 'தீர்வு உறுதிப்படுத்தல்கள்',
+    settlementRequestsBody:
+      'உங்களுக்குப் பணம் கொடுத்ததாக யாராவது சொல்லும்போது, உங்கள் பாக்கி சரியாக இருக்க.',
+    nudges: 'நினைவூட்டல்கள்',
+    nudgesBody:
+      'தர வேண்டிய பணம் குறித்த மென்மையான நினைவூட்டல். ஒரு நாளைக்கு ஒருவருக்கு ஒன்று மட்டுமே, தரவுத்தளத்திலேயே வரையறுக்கப்பட்டது.',
+    digest: 'நாள்தோறும் குழுச் சுருக்கம்',
+    digestBody: 'மற்ற அனைத்தும், தொடர்ச்சியாக அல்லாமல் நாளுக்கு ஒரு அறிவிப்பாகத் தொகுத்து.',
+    weeklyEmail: 'வாராந்திர மின்னஞ்சல் சுருக்கம்',
+    weeklyEmailBody:
+      'உங்கள் நிகர பாக்கியும் நிலுவையிலுள்ள உறுதிப்படுத்தல்களும், வாரம் ஒருமுறை. இயல்பாக நிறுத்தத்தில்.',
+    failDenied: 'இயக்கப்படவில்லை — பின்னர் ஃபோன் அமைப்புகளில் இயக்கிக்கொள்ளலாம்.',
+    failUnsupported:
+      'இந்தச் சாதனத்தால் அறிவிப்புகளைப் பெற முடியாது. எல்லாம் செயல்பாட்டுப் பக்கத்தில் வந்து சேரும்.',
+    failNotSignedIn: 'முதலில் உள்நுழையவும், எந்த ஃபோன் உங்களுடையது என்று தெரிய.',
+    failNotConfigured:
+      'பாக்கியின் இந்தப் பதிப்பில் அறிவிப்பு அமைக்கப்படவில்லை. நீங்கள் செய்த தவறு ஒன்றுமில்லை — எல்லாம் செயல்பாட்டுப் பக்கத்தில் வந்து சேரும்.',
+    failSaveFailed: 'இந்த ஃபோனைச் சேமிக்க முடியவில்லை. இணைப்பைச் சரிபார்த்து மீண்டும் முயலவும்.',
+    footnote:
+      'மின்னஞ்சல் இன்னும் வரவில்லை. இங்குள்ள அனைத்தும் உங்கள் அஞ்சல் பெட்டியிலும் இருக்கும் — அறிவிப்பு வந்ததா இல்லையா என்பதைப் பொருட்படுத்தாமல் பாக்கி உங்களிடம் சொன்னதற்கான பதிவு அதுவே.',
+  },
+  contact: {
+    title: 'உங்கள் கணக்கு',
+    signedIn: 'உள்நுழைந்துள்ளீர்கள்',
+    guestBody:
+      'நீங்கள் சேர்த்தவை அனைத்தும் ஏற்கனவே சேமிக்கப்பட்டு உங்களுடையவை. மின்னஞ்சலோ தொலைபேசி எண்ணோ சேர்ப்பது வேறு ஃபோனிலிருந்து இதை அணுகுவதற்காக மட்டுமே.',
+    memberBody: 'நீங்கள் உள்நுழையும் எந்தச் சாதனத்திலிருந்தும் இந்தக் கணக்கை அணுகலாம்.',
+    email: 'மின்னஞ்சல்',
+    phone: 'தொலைபேசி',
+    alreadyAdded: 'ஏற்கனவே சேர்க்கப்பட்டது: {value}',
+    emailAddress: 'மின்னஞ்சல் முகவரி',
+    phoneNumber: 'தொலைபேசி எண்',
+    emailPlaceholder: 'you@example.com',
+    phonePlaceholder: '+91 98765 43210',
+    codeEmailed: 'மின்னஞ்சலில் அனுப்பிய ஆறு இலக்கக் குறியீட்டை உள்ளிடவும்',
+    codeTexted: 'குறுஞ்செய்தியில் அனுப்பிய ஆறு இலக்கக் குறியீட்டை உள்ளிடவும்',
+    verificationCode: 'சரிபார்ப்புக் குறியீடு',
+    confirm: 'உறுதிப்படுத்து',
+    sendCodeEmail: 'எனக்கு ஒரு குறியீடு அனுப்பு',
+    sendCodePhone: 'குறுஞ்செய்தியில் குறியீடு அனுப்பு',
+    useDifferent: 'வேறொன்றைப் பயன்படுத்து',
+    added: 'சேர்க்கப்பட்டது. இப்போது வேறு ஃபோனிலும் இதைக் கொண்டு உள்நுழையலாம்.',
+    footnote:
+      'உள்ளே விடுவதற்கு பாக்கி இதை ஒருபோதும் கேட்பதில்லை, உங்கள் குழுக்களில் உள்ள யாருடனும் இதைப் பகிர்வதும் இல்லை. நீங்கள் தேர்ந்தெடுத்த பெயரை மட்டுமே மற்றவர்கள் பார்ப்பார்கள்.',
+  },
+  signIn: {
+    tagline: 'பாக்கி · மீதம் இருப்பது',
+    splitAnything: 'எதையும் பிரி\nயாருடனும்',
+    welcomeBody:
+      'தொடங்க கணக்கு தேவையில்லை — பின்னர் ஒன்றைச் சேர்த்தால் நீங்கள் சேர்த்த அனைத்தும் உங்களுடன் வரும்.',
+    startNow: 'இப்போதே தொடங்கு',
+    haveAccount: 'என்னிடம் ஏற்கனவே கணக்கு உள்ளது',
+    welcomeBack: 'மீண்டும் வரவேற்கிறோம்',
+    keepOnNextPhone: 'அடுத்த ஃபோனிலும் இந்தக் கணக்கை வைத்திருங்கள்',
+    guestAddWay:
+      'உள்நுழைய ஒரு வழியைச் சேர்க்கவும், அடுத்த ஃபோனிலும் இந்தக் கணக்கு உங்களுடையதாக இருக்கும்.',
+    signInHowever: 'நீங்கள் அமைத்த முறையில் உள்நுழையவும்.',
+    sendMeACode: 'எனக்கு ஒரு குறியீடு அனுப்பு',
+    useAPassword: 'கடவுச்சொல்லைப் பயன்படுத்து',
+    phoneNumber: 'தொலைபேசி எண்',
+    countryCodeHint:
+      'நாட்டுக் குறியீட்டுடன் தொடங்குங்கள். பாக்கி +91 என்று ஊகிப்பதே இல்லை — வெளிநாட்டு எண்கள் வருவது பயணத்தின்போதுதான்.',
+    sendCode: 'குறியீடு அனுப்பு',
+    codeSentTo: '{value} க்கு குறியீடு அனுப்பப்பட்டது',
+    verify: 'சரிபார்',
+    differentNumber: 'வேறு எண்ணைப் பயன்படுத்து',
+    identifier: 'மின்னஞ்சல் அல்லது தொலைபேசி எண்',
+    identifierPlaceholder: 'asha@example.com அல்லது +91…',
+    password: 'கடவுச்சொல்',
+    passwordHint:
+      'எட்டு எழுத்துகள் அல்லது அதற்கு மேல். நினைவில் நிற்கும் சொற்றொடர், நினைவில் நிற்காத புதிரை விட மேல்.',
+    addToAccount: 'இதை என் கணக்கில் சேர்',
+    createAccount: 'கணக்கை உருவாக்கு',
+    signInAction: 'உள்நுழை',
+    switchToSignIn: 'என்னிடம் ஏற்கனவே கணக்கு உள்ளது',
+    switchToSignUp: 'நான் புதியவர் — கணக்கை உருவாக்கு',
+    continueGoogle: 'Google மூலம் தொடர்',
+    signInGoogle: 'Google மூலம் உள்நுழை',
+    continueGuest: 'விருந்தினராகத் தொடர்',
+    guestFootnote:
+      'நீங்கள் ஏற்கனவே சேர்த்த அனைத்தும் அப்படியே இருக்கும். இது மீண்டும் உள்நுழைய ஒரு வழியை மட்டுமே சேர்க்கிறது.',
+    memberFootnote:
+      'உள்நுழைய ஒரு வழியைச் சேர்க்கும் வரை விருந்தினர் கணக்கு அனைத்தையும் இந்தச் சாதனத்திலேயே வைத்திருக்கும். உங்கள் கணக்கு எப்போதும் பணயம் வைக்கப்படுவதில்லை.',
+    restartToMirror: 'தளவமைப்பைப் பிரதிபலிக்க பாக்கியை ஒருமுறை மூடித் திறக்கவும்.',
+    restartToUnmirror: 'தளவமைப்பை மீண்டும் மாற்ற பாக்கியை ஒருமுறை மூடித் திறக்கவும்.',
+  },
 };
 
 const hi: UiStrings = {
@@ -971,6 +1269,106 @@ const hi: UiStrings = {
     motionFollowingOn: 'आपके फ़ोन के अनुसार — एनिमेशन चालू',
     motionFollowingOff: 'आपके फ़ोन के अनुसार — एनिमेशन बंद',
     footnote: 'बाकी · हिसाब हमेशा मुफ़्त है। हम सिर्फ़ सुविधा के पैसे लेते हैं।',
+  },
+  notifications: {
+    title: 'सूचनाएँ',
+    neverSpam:
+      'रोज़मर्रा की खर्च गतिविधि के लिए बाकी कभी ईमेल नहीं करता। सिर्फ़ वे छह चीज़ें जो आप वाकई इनबॉक्स में चाहेंगे, और हर एक अलग से बंद की जा सकती है।',
+    onThisPhone: 'इस फ़ोन पर सूचनाएँ',
+    permissionOn:
+      'यह डिवाइस पंजीकृत है। सूचना पहुँचे या न पहुँचे, नीचे का सब कुछ आपके इनबॉक्स में आता ही है।',
+    permissionOff:
+      'आपका फ़ोन इन्हें रोक रहा है। बाकी के लिए सिस्टम सेटिंग्स में इन्हें दोबारा चालू करें — इनबॉक्स में सब कुछ वैसे भी रहेगा।',
+    permissionUnset:
+      'बाकी सिर्फ़ एक बार पूछेगा, और सिर्फ़ उन्हीं चीज़ों के लिए जो आप नीचे चालू करें।',
+    granted: 'चालू',
+    denied: 'बंद',
+    undetermined: 'तय नहीं',
+    asking: 'पूछ रहे हैं…',
+    turnOn: 'सूचनाएँ चालू करें',
+    pushSection: 'पुश',
+    involvesMe: 'सिर्फ़ वही जिनसे मेरा वास्ता है',
+    involvesMeBody:
+      'जब आप पर बाकी हो, आपको मिलना हो, या आपका ज़िक्र हो तब सूचना — हर समूह के हर खर्च पर नहीं।',
+    settlementRequests: 'निपटान की पुष्टि',
+    settlementRequestsBody: 'जब कोई कहे कि उसने आपको भुगतान किया, ताकि आपकी बाकी सही रहे।',
+    nudges: 'याद दिलाना',
+    nudgesBody: 'बाकी पैसे की एक विनम्र याद। डेटाबेस में ही सीमित — एक व्यक्ति को दिन में एक बार।',
+    digest: 'दैनिक समूह सारांश',
+    digestBody: 'बाकी सब कुछ, लगातार की जगह दिन में एक सूचना में इकट्ठा।',
+    weeklyEmail: 'साप्ताहिक ईमेल सारांश',
+    weeklyEmailBody: 'आपकी कुल बाकी और लंबित पुष्टियाँ, हफ़्ते में एक बार। डिफ़ॉल्ट रूप से बंद।',
+    failDenied: 'चालू नहीं हुआ — आप बाद में फ़ोन सेटिंग्स में इसे चालू कर सकते हैं।',
+    failUnsupported: 'यह डिवाइस पुश सूचनाएँ नहीं ले सकता। सब कुछ गतिविधि में आता ही रहेगा।',
+    failNotSignedIn: 'पहले साइन इन करें, ताकि पता चले कौन सा फ़ोन आपका है।',
+    failNotConfigured:
+      'बाकी के इस बिल्ड में पुश सेट नहीं है। आपकी कोई गलती नहीं — सब कुछ गतिविधि में आता रहेगा।',
+    failSaveFailed: 'यह फ़ोन सेव नहीं हो सका। कनेक्शन जाँचकर दोबारा कोशिश करें।',
+    footnote:
+      'ईमेल अभी आना बाकी है। यहाँ का सब कुछ आपके इनबॉक्स में भी है, और सूचना पहुँची या नहीं, बाकी ने आपसे क्या कहा उसका रिकॉर्ड वही है।',
+  },
+  contact: {
+    title: 'आपका खाता',
+    signedIn: 'साइन इन हैं',
+    guestBody:
+      'आपने जो कुछ जोड़ा है वह पहले ही सेव है और आपका है। ईमेल या फ़ोन नंबर जोड़ना सिर्फ़ इसलिए है कि आप इसे किसी दूसरे फ़ोन से भी पा सकें।',
+    memberBody: 'जिस भी डिवाइस पर साइन इन करें, यह खाता वहाँ मिल जाएगा।',
+    email: 'ईमेल',
+    phone: 'फ़ोन',
+    alreadyAdded: 'पहले से जुड़ा है: {value}',
+    emailAddress: 'ईमेल पता',
+    phoneNumber: 'फ़ोन नंबर',
+    emailPlaceholder: 'you@example.com',
+    phonePlaceholder: '+91 98765 43210',
+    codeEmailed: 'ईमेल पर भेजा गया छह अंकों का कोड डालें',
+    codeTexted: 'मैसेज पर भेजा गया छह अंकों का कोड डालें',
+    verificationCode: 'सत्यापन कोड',
+    confirm: 'पुष्टि करें',
+    sendCodeEmail: 'मुझे कोड भेजें',
+    sendCodePhone: 'मैसेज पर कोड भेजें',
+    useDifferent: 'कोई दूसरा इस्तेमाल करें',
+    added: 'जुड़ गया। अब आप इससे किसी दूसरे फ़ोन पर साइन इन कर सकते हैं।',
+    footnote:
+      'अंदर आने देने के लिए बाकी यह कभी नहीं माँगता, और आपके समूह में किसी के साथ इसे साझा नहीं करता। लोग सिर्फ़ वही नाम देखते हैं जो आप चुनते हैं।',
+  },
+  signIn: {
+    tagline: 'बाकी · जो बच रहता है',
+    splitAnything: 'कुछ भी बाँटें\nकिसी के साथ भी',
+    welcomeBody:
+      'शुरू करने के लिए खाता ज़रूरी नहीं — बाद में जोड़ लें, आपका जोड़ा हुआ सब कुछ साथ आ जाएगा।',
+    startNow: 'अभी शुरू करें',
+    haveAccount: 'मेरा खाता पहले से है',
+    welcomeBack: 'वापस स्वागत है',
+    keepOnNextPhone: 'इस खाते को अगले फ़ोन पर भी रखें',
+    guestAddWay: 'साइन इन का कोई तरीका जोड़ें, ताकि अगले फ़ोन पर भी यह खाता आपका ही रहे।',
+    signInHowever: 'जैसे सेट किया था वैसे साइन इन करें।',
+    sendMeACode: 'मुझे कोड भेजें',
+    useAPassword: 'पासवर्ड इस्तेमाल करें',
+    phoneNumber: 'फ़ोन नंबर',
+    countryCodeHint:
+      'देश कोड से शुरू करें। बाकी +91 कभी नहीं मान लेता — विदेशी नंबर सफ़र में ही तो आते हैं।',
+    sendCode: 'कोड भेजें',
+    codeSentTo: '{value} पर कोड भेजा गया',
+    verify: 'सत्यापित करें',
+    differentNumber: 'कोई दूसरा नंबर इस्तेमाल करें',
+    identifier: 'ईमेल या फ़ोन नंबर',
+    identifierPlaceholder: 'asha@example.com या +91…',
+    password: 'पासवर्ड',
+    passwordHint: 'आठ या ज़्यादा अक्षर। याद रहने वाला वाक्यांश, न याद रहने वाली पहेली से बेहतर है।',
+    addToAccount: 'इसे मेरे खाते में जोड़ें',
+    createAccount: 'खाता बनाएँ',
+    signInAction: 'साइन इन',
+    switchToSignIn: 'मेरा खाता पहले से है',
+    switchToSignUp: 'मैं नया हूँ — खाता बनाएँ',
+    continueGoogle: 'Google से जारी रखें',
+    signInGoogle: 'Google से साइन इन करें',
+    continueGuest: 'मेहमान के तौर पर जारी रखें',
+    guestFootnote:
+      'आपने जो जोड़ा है वह जहाँ है वहीं रहेगा। इससे सिर्फ़ दोबारा साइन इन करने का रास्ता जुड़ता है।',
+    memberFootnote:
+      'जब तक आप साइन इन का कोई तरीका न जोड़ें, मेहमान खाता सब कुछ इसी डिवाइस पर रखता है। आपका हिसाब कभी बंधक नहीं बनाया जाता।',
+    restartToMirror: 'लेआउट की दिशा बदलने के लिए बाकी को एक बार बंद करके खोलें।',
+    restartToUnmirror: 'लेआउट वापस पलटने के लिए बाकी को एक बार बंद करके खोलें।',
   },
 };
 
@@ -1209,6 +1607,101 @@ const ar: UiStrings = {
     motionFollowingOn: 'يتبع هاتفك — الحركات مفعّلة',
     motionFollowingOff: 'يتبع هاتفك — الحركات متوقفة',
     footnote: 'باقي · الدفتر مجاني إلى الأبد. لا نتقاضى إلا مقابل الراحة.',
+  },
+  notifications: {
+    title: 'الإشعارات',
+    neverSpam:
+      'لا يرسل باقي بريدًا عن نشاط المصروفات المعتاد. ستة أشياء فقط قد ترغب فعلًا في وصولها إلى بريدك، ويمكن إيقاف كل منها وحده.',
+    onThisPhone: 'الإشعارات على هذا الهاتف',
+    permissionOn: 'هذا الجهاز مسجَّل. كل ما في الأسفل يصل إلى صندوقك سواء وصل الإشعار أم لا.',
+    permissionOff:
+      'هاتفك يحجبها. أعد تفعيلها من إعدادات النظام لباقي — وصندوق الوارد يحتفظ بكل شيء في الحالتين.',
+    permissionUnset: 'سيسأل باقي مرة واحدة فقط، وللأشياء التي تفعّلها في الأسفل فقط.',
+    granted: 'مفعّلة',
+    denied: 'متوقفة',
+    undetermined: 'غير محددة',
+    asking: 'جارٍ السؤال…',
+    turnOn: 'تفعيل الإشعارات',
+    pushSection: 'الإشعارات الفورية',
+    involvesMe: 'ما يخصّني فقط',
+    involvesMeBody: 'إشعار حين يكون عليك أو لك أو حين تُذكر — لا لكل مصروف في كل مجموعة.',
+    settlementRequests: 'تأكيدات التسوية',
+    settlementRequestsBody: 'حين يقول أحدهم إنه دفع لك، كي يبقى باقيك صحيحًا.',
+    nudges: 'التذكيرات',
+    nudgesBody: 'تذكير لطيف بالمال المستحق. مرة واحدة لكل شخص يوميًا، بحدٍّ في قاعدة البيانات.',
+    digest: 'ملخص المجموعة اليومي',
+    digestBody: 'كل ما تبقّى، مجمّعًا في إشعار واحد يوميًا بدل تدفق مستمر.',
+    weeklyEmail: 'ملخص أسبوعي بالبريد',
+    weeklyEmailBody: 'صافي باقيك والتأكيدات المعلّقة، مرة كل أسبوع. متوقف افتراضيًا.',
+    failDenied: 'لم يُفعَّل — يمكنك تفعيله لاحقًا من إعدادات هاتفك.',
+    failUnsupported: 'لا يستطيع هذا الجهاز استقبال الإشعارات. كل شيء يصل إلى النشاط رغم ذلك.',
+    failNotSignedIn: 'سجّل الدخول أولًا، كي نعرف أي هاتف هو هاتفك.',
+    failNotConfigured:
+      'الإشعارات غير مهيأة في هذه النسخة من باقي. لا ذنب لك — كل شيء يصل إلى النشاط رغم ذلك.',
+    failSaveFailed: 'تعذّر حفظ هذا الهاتف. تحقق من اتصالك وحاول مرة أخرى.',
+    footnote:
+      'البريد لم يصل بعد. كل ما هنا موجود أيضًا في صندوقك، وهو سجل ما أخبرك به باقي سواء وصل إشعار أم لا.',
+  },
+  contact: {
+    title: 'حسابك',
+    signedIn: 'مسجّل الدخول',
+    guestBody:
+      'كل ما أدخلته محفوظ بالفعل وهو ملكك. إضافة بريد إلكتروني أو رقم هاتف هي فقط كي تصل إليه من هاتف آخر.',
+    memberBody: 'يمكن الوصول إلى هذا الحساب من أي جهاز تسجّل الدخول عليه.',
+    email: 'بريد إلكتروني',
+    phone: 'هاتف',
+    alreadyAdded: 'مضاف بالفعل: {value}',
+    emailAddress: 'البريد الإلكتروني',
+    phoneNumber: 'رقم الهاتف',
+    emailPlaceholder: 'you@example.com',
+    phonePlaceholder: '+971 50 123 4567',
+    codeEmailed: 'أدخل الرمز المكوّن من ستة أرقام الذي أرسلناه إلى بريدك',
+    codeTexted: 'أدخل الرمز المكوّن من ستة أرقام الذي أرسلناه برسالة نصية',
+    verificationCode: 'رمز التحقق',
+    confirm: 'تأكيد',
+    sendCodeEmail: 'أرسل لي رمزًا',
+    sendCodePhone: 'أرسل الرمز برسالة',
+    useDifferent: 'استخدم غيره',
+    added: 'تمت الإضافة. يمكنك الآن تسجيل الدخول به على هاتف آخر.',
+    footnote:
+      'لا يطلب باقي هذا ليسمح لك بالدخول، ولا يشاركه مع أحد في مجموعاتك. يرى الناس الاسم الذي تختاره، لا غير.',
+  },
+  signIn: {
+    tagline: 'باقي · ما يتبقّى',
+    splitAnything: 'قسّم أي شيء\nمع أي أحد',
+    welcomeBody: 'لا حاجة لحساب للبدء — أضف واحدًا لاحقًا وسيأتي معك كل ما أدخلته.',
+    startNow: 'ابدأ الآن',
+    haveAccount: 'لديّ حساب بالفعل',
+    welcomeBack: 'أهلًا بعودتك',
+    keepOnNextPhone: 'احتفظ بهذا الحساب على هاتفك التالي',
+    guestAddWay: 'أضف طريقة لتسجيل الدخول، ليبقى هذا الحساب لك على هاتفك التالي.',
+    signInHowever: 'سجّل الدخول بالطريقة التي أعددتها.',
+    sendMeACode: 'أرسل لي رمزًا',
+    useAPassword: 'استخدم كلمة مرور',
+    phoneNumber: 'رقم الهاتف',
+    countryCodeHint:
+      'ابدأ برمز بلدك. لا يفترض باقي أبدًا رمزًا بعينه — فالأرقام الأجنبية تظهر في السفر تحديدًا.',
+    sendCode: 'أرسل الرمز',
+    codeSentTo: 'أُرسل الرمز إلى {value}',
+    verify: 'تحقّق',
+    differentNumber: 'استخدم رقمًا آخر',
+    identifier: 'البريد الإلكتروني أو رقم الهاتف',
+    identifierPlaceholder: 'asha@example.com أو ‎+971…',
+    password: 'كلمة المرور',
+    passwordHint: 'ثمانية أحرف أو أكثر. عبارة تتذكّرها خير من لغز لن تتذكّره.',
+    addToAccount: 'أضف هذا إلى حسابي',
+    createAccount: 'إنشاء حساب',
+    signInAction: 'تسجيل الدخول',
+    switchToSignIn: 'لديّ حساب بالفعل',
+    switchToSignUp: 'أنا جديد هنا — أنشئ حسابًا',
+    continueGoogle: 'المتابعة عبر Google',
+    signInGoogle: 'تسجيل الدخول عبر Google',
+    continueGuest: 'المتابعة كضيف',
+    guestFootnote: 'كل ما أضفته يبقى كما هو تمامًا. هذا يضيف فقط طريقة للعودة وتسجيل الدخول.',
+    memberFootnote:
+      'يحتفظ حساب الضيف بكل شيء على هذا الجهاز حتى تضيف طريقة لتسجيل الدخول. دفترك ليس رهينة أبدًا.',
+    restartToMirror: 'أغلق باقي وافتحه مرة واحدة لعكس اتجاه الواجهة.',
+    restartToUnmirror: 'أغلق باقي وافتحه مرة واحدة لإعادة اتجاه الواجهة.',
   },
 };
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -207,6 +207,7 @@ export interface UiStrings {
     emailOrPhone: string;
     notFound: string;
     goBack: string;
+    ok: string;
   };
   /** Getting the whole ledger out, in full and for free (ADR-012). */
   exportData: {
@@ -300,6 +301,11 @@ export interface UiStrings {
     motionRow: string;
     languageFollowingPhone: string;
     languageRestartHint: string;
+    languageRestartHintBack: string;
+    restartTitle: string;
+    restartBannerMirror: string;
+    restartBannerUnmirror: string;
+    languageFooterNote: string;
     lockNoBiometrics: string;
     lockOn: string;
     lockOff: string;
@@ -675,6 +681,7 @@ const en: UiStrings = {
     emailOrPhone: 'Email or phone number',
     notFound: 'Not found',
     goBack: 'Go back',
+    ok: 'OK',
   },
   onboarding: [
     {
@@ -791,6 +798,14 @@ const en: UiStrings = {
     motionRow: 'Motion',
     languageFollowingPhone: 'Following your phone — {language}',
     languageRestartHint: '{language} · reopen Baaki to mirror it',
+    languageRestartHintBack: '{language} · reopen Baaki to turn the layout back',
+    restartTitle: 'Close and open Baaki again',
+    restartBannerMirror:
+      'The words have changed already. Mirroring the layout — the arrows, the sides everything sits on — is something the phone decides when the app starts, so it takes effect next time you open it.',
+    restartBannerUnmirror:
+      'The words have changed already. Turning the mirrored layout back the other way is something the phone decides when the app starts, so it takes effect next time you open it.',
+    languageFooterNote:
+      "Your phone's language is the default, and choosing one here only changes Baaki. Amounts and dates still follow where you are — reading the app in Hindi in Dubai does not move you to India.",
     lockNoBiometrics: 'This device has no biometrics set up',
     lockOn: 'On · asks {when}',
     lockOff: 'Off — anyone holding your phone can read the ledger',
@@ -1197,6 +1212,7 @@ const ta: UiStrings = {
     emailOrPhone: 'மின்னஞ்சல் அல்லது தொலைபேசி எண்',
     notFound: 'கிடைக்கவில்லை',
     goBack: 'திரும்பிச் செல்',
+    ok: 'சரி',
   },
   onboarding: [
     {
@@ -1314,6 +1330,14 @@ const ta: UiStrings = {
     motionRow: 'அசைவு',
     languageFollowingPhone: 'உங்கள் ஃபோனைப் பின்பற்றுகிறது — {language}',
     languageRestartHint: '{language} · பிரதிபலிக்க பாக்கியை மீண்டும் திற',
+    languageRestartHintBack: '{language} · தளவமைப்பை மீட்க பாக்கியை மீண்டும் திற',
+    restartTitle: 'பாக்கியை மூடித் திறக்கவும்',
+    restartBannerMirror:
+      'சொற்கள் ஏற்கெனவே மாறிவிட்டன. தளவமைப்பைப் பிரதிபலிப்பது — அம்புக்குறிகள், எல்லாம் அமரும் பக்கம் — செயலி தொடங்கும்போது ஃபோன் முடிவு செய்வது. எனவே அடுத்த முறை திறக்கும்போதுதான் அது நடக்கும்.',
+    restartBannerUnmirror:
+      'சொற்கள் ஏற்கெனவே மாறிவிட்டன. பிரதிபலித்த தளவமைப்பை மீண்டும் மாற்றுவதும் செயலி தொடங்கும்போது ஃபோன் முடிவு செய்வது. எனவே அடுத்த முறை திறக்கும்போதுதான் அது நடக்கும்.',
+    languageFooterNote:
+      'உங்கள் ஃபோனின் மொழியே இயல்புநிலை; இங்கே தேர்ந்தெடுப்பது பாக்கியை மட்டுமே மாற்றும். தொகைகளும் தேதிகளும் நீங்கள் இருக்கும் இடத்தையே பின்பற்றும் — துபாயில் இந்தியில் படிப்பது உங்களை இந்தியாவுக்கு நகர்த்தாது.',
     lockNoBiometrics: 'இந்தச் சாதனத்தில் கைரேகை அமைக்கப்படவில்லை',
     lockOn: 'இயக்கத்தில் · {when} கேட்கும்',
     lockOff: 'நிறுத்தத்தில் — உங்கள் ஃபோனை வைத்திருப்பவர் யாரும் கணக்கைப் படிக்கலாம்',
@@ -1717,6 +1741,7 @@ const hi: UiStrings = {
     emailOrPhone: 'ईमेल या फ़ोन नंबर',
     notFound: 'नहीं मिला',
     goBack: 'वापस जाएँ',
+    ok: 'ठीक है',
   },
   onboarding: [
     {
@@ -1829,6 +1854,14 @@ const hi: UiStrings = {
     motionRow: 'गति',
     languageFollowingPhone: 'आपके फ़ोन के अनुसार — {language}',
     languageRestartHint: '{language} · दिशा बदलने के लिए बाकी दोबारा खोलें',
+    languageRestartHintBack: '{language} · दिशा वापस लाने के लिए बाकी दोबारा खोलें',
+    restartTitle: 'बाकी को बंद करके दोबारा खोलें',
+    restartBannerMirror:
+      'शब्द तो पहले ही बदल गए हैं। लेआउट को पलटना — तीर, और हर चीज़ किस तरफ़ बैठती है — यह फ़ोन ऐप शुरू होते समय तय करता है, इसलिए यह अगली बार खोलने पर लागू होगा।',
+    restartBannerUnmirror:
+      'शब्द तो पहले ही बदल गए हैं। पलटे हुए लेआउट को वापस सीधा करना भी फ़ोन ऐप शुरू होते समय तय करता है, इसलिए यह अगली बार खोलने पर लागू होगा।',
+    languageFooterNote:
+      'आपके फ़ोन की भाषा ही डिफ़ॉल्ट है, और यहाँ चुनने से सिर्फ़ बाकी बदलता है। रकम और तारीखें वहीं के हिसाब से चलती रहेंगी जहाँ आप हैं — दुबई में हिंदी में पढ़ने से आप भारत नहीं पहुँच जाते।',
     lockNoBiometrics: 'इस डिवाइस पर बायोमेट्रिक सेट नहीं है',
     lockOn: 'चालू · {when} पूछता है',
     lockOff: 'बंद — आपका फ़ोन पकड़े कोई भी हिसाब पढ़ सकता है',
@@ -2226,6 +2259,7 @@ const ar: UiStrings = {
     emailOrPhone: 'البريد الإلكتروني أو رقم الهاتف',
     notFound: 'غير موجود',
     goBack: 'العودة',
+    ok: 'حسنًا',
   },
   onboarding: [
     {
@@ -2357,6 +2391,14 @@ const ar: UiStrings = {
     motionRow: 'الحركة',
     languageFollowingPhone: 'يتبع هاتفك — {language}',
     languageRestartHint: '{language} · أعد فتح باقي لعكس الاتجاه',
+    languageRestartHintBack: '{language} · أعد فتح باقي لإعادة الاتجاه',
+    restartTitle: 'أغلق باقي وافتحه من جديد',
+    restartBannerMirror:
+      'تغيّرت الكلمات بالفعل. أما عكس اتجاه الواجهة — الأسهم والجهة التي يجلس عليها كل شيء — فيقرره الهاتف عند بدء التطبيق، لذا يسري في المرة القادمة التي تفتحه فيها.',
+    restartBannerUnmirror:
+      'تغيّرت الكلمات بالفعل. أما إعادة الواجهة المعكوسة إلى اتجاهها فيقرره الهاتف عند بدء التطبيق، لذا يسري في المرة القادمة التي تفتحه فيها.',
+    languageFooterNote:
+      'لغة هاتفك هي الافتراضية، والاختيار هنا يغيّر باقي وحده. تبقى المبالغ والتواريخ تابعة لمكانك — قراءة التطبيق بالهندية في دبي لا تنقلك إلى الهند.',
     lockNoBiometrics: 'لا توجد بصمة مضبوطة على هذا الجهاز',
     lockOn: 'مفعّل · يسأل {when}',
     lockOff: 'متوقف — أي شخص يمسك هاتفك يمكنه قراءة الدفتر',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -61,6 +61,50 @@ export function isRtlLanguage(language: Language): boolean {
   return RTL_LANGUAGES.includes(language);
 }
 
+/**
+ * The forms a phrase takes as its number changes.
+ *
+ * English has two and the app was written as though every language does:
+ * `${n} expense${n === 1 ? '' : 's'}` appeared in nine files. That is not a
+ * shortcut, it is a claim — that "one" and "not one" is the whole of it — and
+ * it is false in three of the four languages here. Arabic has six categories
+ * and treats 2, 11 and 100 differently; Tamil and Hindi do not build plurals by
+ * suffix at all, so the English trick produces a word that does not exist.
+ *
+ * `other` is the only required form because it is the only one every language
+ * uses. `Intl.PluralRules` decides which of the rest apply, so a table that
+ * fills in `one` and `other` is correct English and correct Tamil, and a table
+ * that fills in all six is correct Arabic.
+ */
+export interface PluralForms {
+  readonly zero?: string;
+  readonly one?: string;
+  readonly two?: string;
+  readonly few?: string;
+  readonly many?: string;
+  readonly other: string;
+}
+
+/**
+ * Picks the form and puts the number in it.
+ *
+ * `{n}` is replaced with the count formatted for the locale, not with
+ * `String(count)` — an Egyptian Arabic locale writes ١٢ and a phrase that says
+ * "12" beside Arabic words is a phrase in two number systems.
+ */
+export function plural(locale: string, count: number, forms: PluralForms): string {
+  let rule: Intl.LDMLPluralRule = 'other';
+  let shown = String(count);
+  try {
+    rule = new Intl.PluralRules(locale).select(count);
+    shown = new Intl.NumberFormat(locale).format(count);
+  } catch {
+    // A locale Intl will not take is not a reason to render nothing. The
+    // English-shaped `other` form with a plain number beats an empty row.
+  }
+  return (forms[rule] ?? forms.other).replaceAll('{n}', shown);
+}
+
 export interface UiStrings {
   greeting: string;
   yourBaaki: string;
@@ -137,6 +181,136 @@ export interface UiStrings {
    */
   language: string;
   upgrade: string;
+  /**
+   * The words that are on almost every screen.
+   *
+   * "Back" appeared as an English literal in nineteen files, "Close" in seven.
+   * Translating each one where it stood would have meant nineteen chances to
+   * write a different word for the same button, so they live here once. Nothing
+   * belongs in this group unless it is genuinely the same word everywhere —
+   * a label that means something slightly different on two screens is two
+   * labels, and sharing it is how translations go subtly wrong.
+   */
+  common: {
+    back: string;
+    close: string;
+    cancel: string;
+    save: string;
+    edit: string;
+    remove: string;
+    delete: string;
+    share: string;
+    done: string;
+    guest: string;
+    name: string;
+    yourName: string;
+    emailOrPhone: string;
+    notFound: string;
+    goBack: string;
+  };
+  /** Getting the whole ledger out, in full and for free (ADR-012). */
+  exportData: {
+    title: string;
+    everythingFree: string;
+    noPaywall: string;
+    explain: string;
+    format: string;
+    json: string;
+    csv: string;
+    whatToExport: string;
+    allMyGroups: string;
+    preparing: string;
+    action: string;
+    ready: string;
+    webNote: string;
+    shareTitle: string;
+    importInstead: string;
+  };
+  /** The motion switch, and the phone setting it defers to. */
+  motion: {
+    title: string;
+    animateBetweenScreens: string;
+    animateExplain: string;
+    thisPhone: string;
+    reduceMotionOn: string;
+    reduceMotionOff: string;
+    setYourselfOn: string;
+    setYourselfOff: string;
+    followingReduced: string;
+    following: string;
+    followPhone: string;
+    footnote: string;
+  };
+  /** The app lock, the delay before it asks again, and the way out. */
+  lock: {
+    title: string;
+    requireBiometrics: string;
+    requireExplain: string;
+    appLock: string;
+    unsupported: string;
+    askAgainAfter: string;
+    askAgainExplain: string;
+    graceImmediate: string;
+    graceSeconds: PluralForms;
+    graceMinutes: PluralForms;
+    reopenAlwaysAsks: string;
+    signOut: string;
+    signOutGuest: string;
+    signOutMember: string;
+    signOutQuestion: string;
+    signOutGuestWarning: string;
+    signOutReassure: string;
+    staySignedIn: string;
+    footnote: string;
+  };
+  /** The account screen and its three faces. */
+  account: {
+    faceYou: string;
+    facePaying: string;
+    faceSettings: string;
+    settled: string;
+    nothingSettledYet: string;
+    otherCurrencies: PluralForms;
+    saved: string;
+    displayName: string;
+    you: string;
+    guestAccount: string;
+    guestAccountBody: string;
+    addYourDetails: string;
+    yourPhoto: string;
+    chooseNewPhoto: string;
+    howPeoplePayYou: string;
+    yourRailDetails: string;
+    handleWrong: string;
+    railLinkNote: string;
+    railManualNote: string;
+    nothingToAdd: string;
+    sectionBaaki: string;
+    sectionSettings: string;
+    sectionSecurity: string;
+    upgradeHint: string;
+    yourAccount: string;
+    yourAccountHint: string;
+    notifications: string;
+    notificationsHint: string;
+    exportDataRow: string;
+    exportHint: string;
+    importSplitwise: string;
+    importHint: string;
+    motionRow: string;
+    languageFollowingPhone: string;
+    languageRestartHint: string;
+    lockNoBiometrics: string;
+    lockOn: string;
+    lockOff: string;
+    signOutGuestHint: string;
+    signOutHint: string;
+    motionOn: string;
+    motionOff: string;
+    motionFollowingOn: string;
+    motionFollowingOff: string;
+    footnote: string;
+  };
 }
 
 const en: UiStrings = {
@@ -212,6 +386,23 @@ const en: UiStrings = {
   getStarted: 'Get started',
   language: 'Language',
   upgrade: 'Upgrade',
+  common: {
+    back: 'Back',
+    close: 'Close',
+    cancel: 'Cancel',
+    save: 'Save',
+    edit: 'Edit',
+    remove: 'Remove',
+    delete: 'Delete',
+    share: 'Share',
+    done: 'Done',
+    guest: 'Guest',
+    name: 'Name',
+    yourName: 'Your name',
+    emailOrPhone: 'Email or phone number',
+    notFound: 'Not found',
+    goBack: 'Go back',
+  },
   onboarding: [
     {
       // Not "split anything with anyone" — that is the welcome's line, and the
@@ -230,6 +421,114 @@ const en: UiStrings = {
       body: 'Baaki hands the exact amount to your payment app, so nobody does the arithmetic twice and nobody is owed a rounding error.',
     },
   ],
+  exportData: {
+    title: 'Export your data',
+    everythingFree: 'Everything, always free',
+    noPaywall: 'no paywall',
+    explain:
+      'JSON includes every version of every expense, who paid, who owed, settlements with their per-expense allocations, and the activity trail — enough to rebuild your ledger exactly. CSV is the spreadsheet view, including per-person settlement detail.',
+    format: 'Format',
+    json: 'JSON (lossless)',
+    csv: 'CSV (spreadsheet)',
+    whatToExport: 'What to export',
+    allMyGroups: 'All my groups',
+    preparing: 'Preparing…',
+    action: 'Export',
+    ready: 'Export ready',
+    webNote: 'On web the file is written to the app cache; use a device to share it onward.',
+    shareTitle: 'Your Baaki export',
+    importInstead: 'Import from Splitwise',
+  },
+  motion: {
+    title: 'Motion',
+    animateBetweenScreens: 'Animate between screens',
+    animateExplain:
+      'Screens slide in from the right, and sheets rise from the bottom — which is how a screen tells you whether you have gone somewhere or opened something on top of where you were.',
+    thisPhone: 'This phone',
+    reduceMotionOn: 'Reduce motion is on',
+    reduceMotionOff: 'Reduce motion is off',
+    setYourselfOn: 'You have set this yourself, so it stays on whatever the phone says.',
+    setYourselfOff: 'You have set this yourself, so it stays off whatever the phone says.',
+    followingReduced: 'Following your accessibility settings, which ask for less movement.',
+    following: 'Following your accessibility settings.',
+    followPhone: "Follow my phone's setting",
+    footnote:
+      'Turning motion off does not shorten the animations — it removes them. A faster animation is still an animation to somebody who cannot watch one.',
+  },
+  lock: {
+    title: 'Security',
+    requireBiometrics: 'Require biometrics or a passcode',
+    requireExplain:
+      'Handing someone your phone to show them the split should not show them everything else.',
+    appLock: 'App lock',
+    unsupported: 'This device has no biometrics or passcode set up',
+    askAgainAfter: 'Ask again after',
+    askAgainExplain:
+      'Time in the background before Baaki locks. Settling by UPI sends you to another app and back, so locking the instant you leave means unlocking every time you pay somebody.',
+    graceImmediate: 'Straight away',
+    graceSeconds: { one: 'After {n} second', other: 'After {n} seconds' },
+    graceMinutes: { one: 'After a minute', other: 'After {n} minutes' },
+    reopenAlwaysAsks: 'Reopening Baaki after it has been closed always asks, whatever this says.',
+    signOut: 'Sign out',
+    signOutGuest: 'This account lives on this device only. Signing out ends it.',
+    signOutMember: 'Your groups and history stay exactly where they are.',
+    signOutQuestion: 'Sign out?',
+    signOutGuestWarning:
+      'This is a guest account, so signing out leaves no way back into it. Add an email or phone number first if you want to keep it.',
+    signOutReassure: 'You can sign back in whenever you like. Nothing is deleted.',
+    staySignedIn: 'Stay signed in',
+    footnote:
+      'This guards the screen, not the data — your ledger is protected by row-level security on the server whether the lock is on or not.',
+  },
+  account: {
+    faceYou: 'You',
+    facePaying: 'Paying',
+    faceSettings: 'Settings',
+    settled: 'settled',
+    nothingSettledYet: 'Nothing settled yet',
+    otherCurrencies: { one: 'and {n} other currency', other: 'and {n} other currencies' },
+    saved: 'Saved',
+    displayName: 'Display name',
+    you: 'You',
+    guestAccount: 'Guest account',
+    guestAccountBody:
+      'Everything you have entered is already saved and yours. Add an email or phone number whenever you want to reach it from another phone — it keeps this account rather than starting a new one.',
+    addYourDetails: 'Add your details',
+    yourPhoto: 'Your photo',
+    chooseNewPhoto: 'Choose a new one',
+    howPeoplePayYou: 'How people pay you',
+    yourRailDetails: 'Your {rail} details',
+    handleWrong: 'That does not look like {hint}.',
+    railLinkNote: 'People settling with you get a one-tap payment. Baaki never handles the money.',
+    railManualNote:
+      'People settling with you see this to pay you from their own bank app. Baaki never handles the money.',
+    nothingToAdd: 'Nothing to add — people will record what they paid you by hand.',
+    sectionBaaki: 'Baaki',
+    sectionSettings: 'Settings',
+    sectionSecurity: 'Security',
+    upgradeHint: 'Nothing to buy yet — the ledger stays free',
+    yourAccount: 'Your account',
+    yourAccountHint: 'Add an email or phone, or carry on as a guest',
+    notifications: 'Notifications',
+    notificationsHint: 'Only what involves me',
+    exportDataRow: 'Export data',
+    exportHint: 'JSON + CSV, lossless, free',
+    importSplitwise: 'Import from Splitwise',
+    importHint: 'Bring a group across from a CSV export',
+    motionRow: 'Motion',
+    languageFollowingPhone: 'Following your phone — {language}',
+    languageRestartHint: '{language} · reopen Baaki to mirror it',
+    lockNoBiometrics: 'This device has no biometrics set up',
+    lockOn: 'On · asks {when}',
+    lockOff: 'Off — anyone holding your phone can read the ledger',
+    signOutGuestHint: 'This guest account lives on this device only',
+    signOutHint: 'Nothing is deleted; sign back in whenever',
+    motionOn: 'Screen animations on',
+    motionOff: 'Screen animations off',
+    motionFollowingOn: 'Following your phone — animations on',
+    motionFollowingOff: 'Following your phone — animations off',
+    footnote: 'Baaki · the ledger is free forever. We only ever charge for convenience.',
+  },
 };
 
 /**
@@ -315,6 +614,23 @@ const ta: UiStrings = {
   getStarted: 'தொடங்கலாம்',
   language: 'மொழி',
   upgrade: 'மேம்படுத்தல்',
+  common: {
+    back: 'பின்',
+    close: 'மூடு',
+    cancel: 'ரத்து',
+    save: 'சேமி',
+    edit: 'திருத்து',
+    remove: 'நீக்கு',
+    delete: 'அழி',
+    share: 'பகிர்',
+    done: 'முடிந்தது',
+    guest: 'விருந்தினர்',
+    name: 'பெயர்',
+    yourName: 'உங்கள் பெயர்',
+    emailOrPhone: 'மின்னஞ்சல் அல்லது தொலைபேசி எண்',
+    notFound: 'கிடைக்கவில்லை',
+    goBack: 'திரும்பிச் செல்',
+  },
   onboarding: [
     {
       title: 'இரவு உணவு, வாடகை,\nஒரு முழுப் பயணம்',
@@ -329,6 +645,119 @@ const ta: UiStrings = {
       body: 'சரியான தொகையை பாக்கி உங்கள் பணச் செயலிக்கே கொடுக்கும் — யாரும் இரண்டு முறை கணக்குப் போட வேண்டாம், யாருக்கும் சில்லறை பாக்கி நிற்காது.',
     },
   ],
+  exportData: {
+    title: 'உங்கள் தரவை ஏற்றுமதி செய்',
+    everythingFree: 'எல்லாமே, எப்போதும் இலவசம்',
+    noPaywall: 'கட்டணச் சுவர் இல்லை',
+    explain:
+      'JSON இல் ஒவ்வொரு செலவின் ஒவ்வொரு பதிப்பும், யார் கொடுத்தார்கள், யார் தர வேண்டும், தீர்வுகளும் அவற்றின் செலவு வாரியான பங்கீடும், செயல்பாட்டுப் பதிவும் இருக்கும் — உங்கள் கணக்கை அப்படியே மீண்டும் கட்ட இது போதும். CSV என்பது விரிதாள் பார்வை, ஆள் வாரியான தீர்வு விவரங்களுடன்.',
+    format: 'வடிவம்',
+    json: 'JSON (முழுமையானது)',
+    csv: 'CSV (விரிதாள்)',
+    whatToExport: 'எதை ஏற்றுமதி செய்ய',
+    allMyGroups: 'என் குழுக்கள் அனைத்தும்',
+    preparing: 'தயாராகிறது…',
+    action: 'ஏற்றுமதி',
+    ready: 'ஏற்றுமதி தயார்',
+    webNote:
+      'வலையில் கோப்பு ஆப்பின் தற்காலிக இடத்தில் எழுதப்படுகிறது; மேலும் பகிர ஒரு சாதனத்தைப் பயன்படுத்துங்கள்.',
+    shareTitle: 'உங்கள் பாக்கி ஏற்றுமதி',
+    importInstead: 'Splitwise இலிருந்து இறக்குமதி',
+  },
+  motion: {
+    title: 'அசைவு',
+    animateBetweenScreens: 'திரைகளுக்கு இடையே அசைவு',
+    animateExplain:
+      'திரைகள் வலமிருந்து நுழையும், தாள்கள் கீழிருந்து எழும் — நீங்கள் வேறு இடத்திற்குச் சென்றீர்களா அல்லது இருந்த இடத்தின் மேல் ஒன்றைத் திறந்தீர்களா என்பதை திரை இப்படித்தான் சொல்கிறது.',
+    thisPhone: 'இந்த ஃபோன்',
+    reduceMotionOn: 'அசைவைக் குறை இயக்கத்தில்',
+    reduceMotionOff: 'அசைவைக் குறை நிறுத்தத்தில்',
+    setYourselfOn:
+      'இதை நீங்களே அமைத்துள்ளீர்கள், எனவே ஃபோன் என்ன சொன்னாலும் இயக்கத்திலேயே இருக்கும்.',
+    setYourselfOff:
+      'இதை நீங்களே அமைத்துள்ளீர்கள், எனவே ஃபோன் என்ன சொன்னாலும் நிறுத்தத்திலேயே இருக்கும்.',
+    followingReduced: 'குறைவான அசைவைக் கேட்கும் உங்கள் அணுகல் அமைப்புகளைப் பின்பற்றுகிறது.',
+    following: 'உங்கள் அணுகல் அமைப்புகளைப் பின்பற்றுகிறது.',
+    followPhone: 'என் ஃபோனின் அமைப்பைப் பின்பற்று',
+    footnote:
+      'அசைவை நிறுத்துவது அசைவுகளைக் குறைப்பதில்லை — அவற்றை நீக்குகிறது. பார்க்க முடியாதவருக்கு வேகமான அசைவும் அசைவுதான்.',
+  },
+  lock: {
+    title: 'பாதுகாப்பு',
+    requireBiometrics: 'கைரேகை அல்லது கடவுக்குறியீடு கேட்கவும்',
+    requireExplain:
+      'பங்கீட்டைக் காட்ட ஃபோனைக் கொடுப்பது மற்ற எல்லாவற்றையும் காட்டுவதாக இருக்கக் கூடாது.',
+    appLock: 'ஆப் பூட்டு',
+    unsupported: 'இந்தச் சாதனத்தில் கைரேகையோ கடவுக்குறியீடோ அமைக்கப்படவில்லை',
+    askAgainAfter: 'மீண்டும் கேட்க',
+    askAgainExplain:
+      'பாக்கி பூட்டப்படுவதற்கு முன் பின்னணியில் இருக்கும் நேரம். UPI மூலம் தீர்ப்பது உங்களை வேறு ஆப்புக்கு அனுப்பி மீண்டும் கொண்டுவரும், எனவே வெளியேறியதுமே பூட்டினால் ஒவ்வொரு முறை பணம் கொடுக்கும்போதும் திறக்க வேண்டியிருக்கும்.',
+    graceImmediate: 'உடனடியாக',
+    graceSeconds: { one: '{n} வினாடி கழித்து', other: '{n} வினாடிகள் கழித்து' },
+    graceMinutes: { one: 'ஒரு நிமிடம் கழித்து', other: '{n} நிமிடங்கள் கழித்து' },
+    reopenAlwaysAsks: 'பாக்கியை மூடிவிட்டுத் திறந்தால் இது என்னவாக இருந்தாலும் எப்போதும் கேட்கும்.',
+    signOut: 'வெளியேறு',
+    signOutGuest:
+      'இந்தக் கணக்கு இந்தச் சாதனத்தில் மட்டுமே உள்ளது. வெளியேறினால் அது முடிந்துவிடும்.',
+    signOutMember: 'உங்கள் குழுக்களும் வரலாறும் அப்படியே இருக்கும்.',
+    signOutQuestion: 'வெளியேறவா?',
+    signOutGuestWarning:
+      'இது விருந்தினர் கணக்கு, வெளியேறினால் திரும்ப வர வழி இல்லை. வைத்திருக்க விரும்பினால் முதலில் மின்னஞ்சல் அல்லது தொலைபேசி எண்ணைச் சேர்க்கவும்.',
+    signOutReassure: 'எப்போது வேண்டுமானாலும் மீண்டும் உள்நுழையலாம். எதுவும் அழிக்கப்படவில்லை.',
+    staySignedIn: 'உள்ளேயே இரு',
+    footnote:
+      'இது திரையைக் காக்கிறது, தரவை அல்ல — பூட்டு இருந்தாலும் இல்லாவிட்டாலும் உங்கள் கணக்கு சர்வரில் வரிசை அளவிலான பாதுகாப்பால் காக்கப்படுகிறது.',
+  },
+  account: {
+    faceYou: 'நீங்கள்',
+    facePaying: 'பணம் பெற',
+    faceSettings: 'அமைப்புகள்',
+    settled: 'தீர்ந்தது',
+    nothingSettledYet: 'இன்னும் எதுவும் தீரவில்லை',
+    otherCurrencies: { one: 'மேலும் {n} நாணயம்', other: 'மேலும் {n} நாணயங்கள்' },
+    saved: 'சேமிக்கப்பட்டது',
+    displayName: 'காட்டப்படும் பெயர்',
+    you: 'நீங்கள்',
+    guestAccount: 'விருந்தினர் கணக்கு',
+    guestAccountBody:
+      'நீங்கள் சேர்த்தவை அனைத்தும் ஏற்கனவே சேமிக்கப்பட்டு உங்களுடையவை. வேறு ஃபோனிலிருந்து அணுக விரும்பும்போது மின்னஞ்சலையோ தொலைபேசி எண்ணையோ சேர்க்கவும் — புதிய கணக்கு தொடங்காமல் இதே கணக்கு தொடரும்.',
+    addYourDetails: 'உங்கள் விவரங்களைச் சேர்',
+    yourPhoto: 'உங்கள் புகைப்படம்',
+    chooseNewPhoto: 'புதிதாக ஒன்றைத் தேர்ந்தெடு',
+    howPeoplePayYou: 'உங்களுக்கு எப்படிப் பணம் தருவது',
+    yourRailDetails: 'உங்கள் {rail} விவரங்கள்',
+    handleWrong: 'இது {hint} போல் தெரியவில்லை.',
+    railLinkNote:
+      'உங்களுடன் தீர்ப்பவர்களுக்கு ஒரே தட்டில் பணம் அனுப்ப முடியும். பாக்கி பணத்தைக் கையாள்வதே இல்லை.',
+    railManualNote:
+      'உங்களுடன் தீர்ப்பவர்கள் இதைப் பார்த்து தங்கள் வங்கி ஆப்பிலிருந்து பணம் அனுப்புவார்கள். பாக்கி பணத்தைக் கையாள்வதே இல்லை.',
+    nothingToAdd: 'சேர்க்க ஒன்றுமில்லை — கொடுத்ததை மற்றவர்கள் கையால் பதிவு செய்வார்கள்.',
+    sectionBaaki: 'பாக்கி',
+    sectionSettings: 'அமைப்புகள்',
+    sectionSecurity: 'பாதுகாப்பு',
+    upgradeHint: 'வாங்க இன்னும் ஒன்றுமில்லை — கணக்கு இலவசமாகவே இருக்கும்',
+    yourAccount: 'உங்கள் கணக்கு',
+    yourAccountHint: 'மின்னஞ்சல் அல்லது தொலைபேசியைச் சேர், அல்லது விருந்தினராகவே தொடர்',
+    notifications: 'அறிவிப்புகள்',
+    notificationsHint: 'என்னைச் சார்ந்தவை மட்டும்',
+    exportDataRow: 'தரவை ஏற்றுமதி செய்',
+    exportHint: 'JSON + CSV, முழுமையானது, இலவசம்',
+    importSplitwise: 'Splitwise இலிருந்து இறக்குமதி',
+    importHint: 'CSV ஏற்றுமதியிலிருந்து ஒரு குழுவைக் கொண்டுவா',
+    motionRow: 'அசைவு',
+    languageFollowingPhone: 'உங்கள் ஃபோனைப் பின்பற்றுகிறது — {language}',
+    languageRestartHint: '{language} · பிரதிபலிக்க பாக்கியை மீண்டும் திற',
+    lockNoBiometrics: 'இந்தச் சாதனத்தில் கைரேகை அமைக்கப்படவில்லை',
+    lockOn: 'இயக்கத்தில் · {when} கேட்கும்',
+    lockOff: 'நிறுத்தத்தில் — உங்கள் ஃபோனை வைத்திருப்பவர் யாரும் கணக்கைப் படிக்கலாம்',
+    signOutGuestHint: 'இந்த விருந்தினர் கணக்கு இந்தச் சாதனத்தில் மட்டுமே உள்ளது',
+    signOutHint: 'எதுவும் அழிக்கப்படாது; எப்போது வேண்டுமானாலும் மீண்டும் உள்நுழையலாம்',
+    motionOn: 'திரை அசைவுகள் இயக்கத்தில்',
+    motionOff: 'திரை அசைவுகள் நிறுத்தத்தில்',
+    motionFollowingOn: 'உங்கள் ஃபோனைப் பின்பற்றுகிறது — அசைவுகள் இயக்கத்தில்',
+    motionFollowingOff: 'உங்கள் ஃபோனைப் பின்பற்றுகிறது — அசைவுகள் நிறுத்தத்தில்',
+    footnote: 'பாக்கி · கணக்கு எப்போதும் இலவசம். வசதிக்கு மட்டுமே நாங்கள் கட்டணம் வாங்குவோம்.',
+  },
 };
 
 const hi: UiStrings = {
@@ -404,6 +833,23 @@ const hi: UiStrings = {
   getStarted: 'शुरू करें',
   language: 'भाषा',
   upgrade: 'अपग्रेड',
+  common: {
+    back: 'वापस',
+    close: 'बंद करें',
+    cancel: 'रद्द करें',
+    save: 'सेव करें',
+    edit: 'बदलें',
+    remove: 'हटाएँ',
+    delete: 'मिटाएँ',
+    share: 'साझा करें',
+    done: 'हो गया',
+    guest: 'मेहमान',
+    name: 'नाम',
+    yourName: 'आपका नाम',
+    emailOrPhone: 'ईमेल या फ़ोन नंबर',
+    notFound: 'नहीं मिला',
+    goBack: 'वापस जाएँ',
+  },
   onboarding: [
     {
       title: 'खाना, किराया,\nपूरी यात्रा',
@@ -418,6 +864,114 @@ const hi: UiStrings = {
       body: 'बाकी ठीक उतनी रकम आपके पेमेंट ऐप को दे देता है, ताकि कोई दोबारा जोड़-घटाव न करे और किसी का चिल्लर न रह जाए।',
     },
   ],
+  exportData: {
+    title: 'अपना डेटा निर्यात करें',
+    everythingFree: 'सब कुछ, हमेशा मुफ़्त',
+    noPaywall: 'कोई पेवॉल नहीं',
+    explain:
+      'JSON में हर खर्च का हर संस्करण, किसने दिया, किस पर बाकी था, निपटान और उनका खर्च-वार बँटवारा, और गतिविधि का पूरा ब्योरा होता है — आपका पूरा हिसाब हूबहू दोबारा बनाने के लिए काफ़ी। CSV स्प्रेडशीट वाला रूप है, जिसमें व्यक्ति-वार निपटान का ब्योरा भी है।',
+    format: 'प्रारूप',
+    json: 'JSON (कुछ छूटता नहीं)',
+    csv: 'CSV (स्प्रेडशीट)',
+    whatToExport: 'क्या निर्यात करें',
+    allMyGroups: 'मेरे सभी समूह',
+    preparing: 'तैयार हो रहा है…',
+    action: 'निर्यात',
+    ready: 'निर्यात तैयार है',
+    webNote:
+      'वेब पर फ़ाइल ऐप के कैश में लिखी जाती है; आगे साझा करने के लिए किसी डिवाइस का उपयोग करें।',
+    shareTitle: 'आपका बाकी निर्यात',
+    importInstead: 'Splitwise से आयात करें',
+  },
+  motion: {
+    title: 'गति',
+    animateBetweenScreens: 'स्क्रीनों के बीच एनिमेशन',
+    animateExplain:
+      'स्क्रीन दाईं ओर से आती हैं और शीट नीचे से उठती हैं — स्क्रीन इसी तरह बताती है कि आप कहीं गए हैं या जहाँ थे उसी के ऊपर कुछ खोला है।',
+    thisPhone: 'यह फ़ोन',
+    reduceMotionOn: 'गति कम करना चालू है',
+    reduceMotionOff: 'गति कम करना बंद है',
+    setYourselfOn: 'यह आपने खुद तय किया है, इसलिए फ़ोन कुछ भी कहे यह चालू ही रहेगा।',
+    setYourselfOff: 'यह आपने खुद तय किया है, इसलिए फ़ोन कुछ भी कहे यह बंद ही रहेगा।',
+    followingReduced: 'आपकी सुगम्यता सेटिंग्स के अनुसार, जो कम हलचल माँगती हैं।',
+    following: 'आपकी सुगम्यता सेटिंग्स के अनुसार।',
+    followPhone: 'मेरे फ़ोन की सेटिंग मानें',
+    footnote:
+      'गति बंद करने से एनिमेशन छोटे नहीं होते — वे हट जाते हैं। जो उन्हें देख नहीं सकता, उसके लिए तेज़ एनिमेशन भी एनिमेशन ही है।',
+  },
+  lock: {
+    title: 'सुरक्षा',
+    requireBiometrics: 'बायोमेट्रिक या पासकोड माँगें',
+    requireExplain: 'हिसाब दिखाने के लिए फ़ोन थमाना बाकी सब कुछ दिखाना नहीं होना चाहिए।',
+    appLock: 'ऐप लॉक',
+    unsupported: 'इस डिवाइस पर बायोमेट्रिक या पासकोड सेट नहीं है',
+    askAgainAfter: 'दोबारा पूछें',
+    askAgainExplain:
+      'बाकी के लॉक होने से पहले बैकग्राउंड में बीता समय। UPI से निपटाने पर आप दूसरे ऐप में जाकर लौटते हैं, इसलिए निकलते ही लॉक करने का मतलब है हर भुगतान पर दोबारा खोलना।',
+    graceImmediate: 'तुरंत',
+    graceSeconds: { one: '{n} सेकंड बाद', other: '{n} सेकंड बाद' },
+    graceMinutes: { one: 'एक मिनट बाद', other: '{n} मिनट बाद' },
+    reopenAlwaysAsks: 'बाकी को बंद करके दोबारा खोलने पर हमेशा पूछा जाएगा, यहाँ कुछ भी लिखा हो।',
+    signOut: 'साइन आउट',
+    signOutGuest: 'यह खाता सिर्फ़ इसी डिवाइस पर है। साइन आउट करने से यह खत्म हो जाएगा।',
+    signOutMember: 'आपके समूह और इतिहास जहाँ हैं वहीं रहेंगे।',
+    signOutQuestion: 'साइन आउट करें?',
+    signOutGuestWarning:
+      'यह मेहमान खाता है, साइन आउट करने पर वापस आने का कोई रास्ता नहीं बचेगा। इसे रखना है तो पहले ईमेल या फ़ोन नंबर जोड़ें।',
+    signOutReassure: 'आप जब चाहें दोबारा साइन इन कर सकते हैं। कुछ भी मिटता नहीं।',
+    staySignedIn: 'साइन इन रहें',
+    footnote:
+      'यह स्क्रीन की रक्षा करता है, डेटा की नहीं — लॉक चालू हो या बंद, आपका हिसाब सर्वर पर रो-लेवल सुरक्षा से सुरक्षित है।',
+  },
+  account: {
+    faceYou: 'आप',
+    facePaying: 'भुगतान',
+    faceSettings: 'सेटिंग्स',
+    settled: 'निपटा',
+    nothingSettledYet: 'अभी कुछ नहीं निपटा',
+    otherCurrencies: { one: 'और {n} अन्य मुद्रा', other: 'और {n} अन्य मुद्राएँ' },
+    saved: 'सेव हो गया',
+    displayName: 'दिखने वाला नाम',
+    you: 'आप',
+    guestAccount: 'मेहमान खाता',
+    guestAccountBody:
+      'आपने जो कुछ जोड़ा है वह पहले ही सेव है और आपका है। जब भी किसी दूसरे फ़ोन से पहुँचना हो, ईमेल या फ़ोन नंबर जोड़ लें — इससे नया खाता नहीं बनता, यही खाता बना रहता है।',
+    addYourDetails: 'अपनी जानकारी जोड़ें',
+    yourPhoto: 'आपकी फ़ोटो',
+    chooseNewPhoto: 'नई चुनें',
+    howPeoplePayYou: 'लोग आपको कैसे भुगतान करें',
+    yourRailDetails: 'आपकी {rail} जानकारी',
+    handleWrong: 'यह {hint} जैसा नहीं लगता।',
+    railLinkNote: 'आपसे हिसाब करने वालों को एक टैप में भुगतान मिलता है। बाकी पैसा कभी नहीं छूता।',
+    railManualNote:
+      'आपसे हिसाब करने वाले इसे देखकर अपने बैंक ऐप से भुगतान करते हैं। बाकी पैसा कभी नहीं छूता।',
+    nothingToAdd: 'जोड़ने को कुछ नहीं — लोग जो चुकाया है उसे खुद दर्ज करेंगे।',
+    sectionBaaki: 'बाकी',
+    sectionSettings: 'सेटिंग्स',
+    sectionSecurity: 'सुरक्षा',
+    upgradeHint: 'अभी खरीदने को कुछ नहीं — हिसाब मुफ़्त ही रहेगा',
+    yourAccount: 'आपका खाता',
+    yourAccountHint: 'ईमेल या फ़ोन जोड़ें, या मेहमान बने रहें',
+    notifications: 'सूचनाएँ',
+    notificationsHint: 'सिर्फ़ वही जिनसे मेरा वास्ता है',
+    exportDataRow: 'डेटा निर्यात',
+    exportHint: 'JSON + CSV, कुछ छूटता नहीं, मुफ़्त',
+    importSplitwise: 'Splitwise से आयात',
+    importHint: 'CSV निर्यात से कोई समूह ले आएँ',
+    motionRow: 'गति',
+    languageFollowingPhone: 'आपके फ़ोन के अनुसार — {language}',
+    languageRestartHint: '{language} · दिशा बदलने के लिए बाकी दोबारा खोलें',
+    lockNoBiometrics: 'इस डिवाइस पर बायोमेट्रिक सेट नहीं है',
+    lockOn: 'चालू · {when} पूछता है',
+    lockOff: 'बंद — आपका फ़ोन पकड़े कोई भी हिसाब पढ़ सकता है',
+    signOutGuestHint: 'यह मेहमान खाता सिर्फ़ इसी डिवाइस पर है',
+    signOutHint: 'कुछ मिटता नहीं; जब चाहें दोबारा साइन इन करें',
+    motionOn: 'स्क्रीन एनिमेशन चालू',
+    motionOff: 'स्क्रीन एनिमेशन बंद',
+    motionFollowingOn: 'आपके फ़ोन के अनुसार — एनिमेशन चालू',
+    motionFollowingOff: 'आपके फ़ोन के अनुसार — एनिमेशन बंद',
+    footnote: 'बाकी · हिसाब हमेशा मुफ़्त है। हम सिर्फ़ सुविधा के पैसे लेते हैं।',
+  },
 };
 
 /**
@@ -498,6 +1052,23 @@ const ar: UiStrings = {
   getStarted: 'لنبدأ',
   language: 'اللغة',
   upgrade: 'الترقية',
+  common: {
+    back: 'رجوع',
+    close: 'إغلاق',
+    cancel: 'إلغاء',
+    save: 'حفظ',
+    edit: 'تعديل',
+    remove: 'إزالة',
+    delete: 'حذف',
+    share: 'مشاركة',
+    done: 'تم',
+    guest: 'ضيف',
+    name: 'الاسم',
+    yourName: 'اسمك',
+    emailOrPhone: 'البريد الإلكتروني أو رقم الهاتف',
+    notFound: 'غير موجود',
+    goBack: 'العودة',
+  },
   onboarding: [
     {
       title: 'عشاء، إيجار،\nرحلة كاملة',
@@ -512,6 +1083,133 @@ const ar: UiStrings = {
       body: 'باقي يمرّر المبلغ بالضبط إلى تطبيق الدفع لديك، فلا أحد يحسب مرتين ولا أحد يخسر كسراً.',
     },
   ],
+  exportData: {
+    title: 'تصدير بياناتك',
+    everythingFree: 'كل شيء، مجانًا دائمًا',
+    noPaywall: 'بلا جدار دفع',
+    explain:
+      'يتضمن JSON كل نسخة من كل مصروف، ومن دفع، ومن عليه، والتسويات مع توزيعها على كل مصروف، وسجل النشاط — بما يكفي لإعادة بناء دفترك تمامًا. أما CSV فهو العرض الجدولي، ويشمل تفاصيل التسوية لكل شخص.',
+    format: 'الصيغة',
+    json: 'JSON (بلا فقدان)',
+    csv: 'CSV (جدول بيانات)',
+    whatToExport: 'ما الذي تريد تصديره',
+    allMyGroups: 'كل مجموعاتي',
+    preparing: 'جارٍ التحضير…',
+    action: 'تصدير',
+    ready: 'التصدير جاهز',
+    webNote: 'على الويب يُكتب الملف في ذاكرة التطبيق المؤقتة؛ استخدم جهازًا لمشاركته.',
+    shareTitle: 'تصدير باقي الخاص بك',
+    importInstead: 'استيراد من Splitwise',
+  },
+  motion: {
+    title: 'الحركة',
+    animateBetweenScreens: 'حركة بين الشاشات',
+    animateExplain:
+      'تنزلق الشاشات من الجانب، وترتفع الأوراق من الأسفل — وهكذا تخبرك الشاشة إن كنت قد انتقلت إلى مكان آخر أم فتحت شيئًا فوق ما كنت فيه.',
+    thisPhone: 'هذا الهاتف',
+    reduceMotionOn: 'تقليل الحركة مفعّل',
+    reduceMotionOff: 'تقليل الحركة غير مفعّل',
+    setYourselfOn: 'لقد ضبطت هذا بنفسك، فسيبقى مفعّلًا مهما قال الهاتف.',
+    setYourselfOff: 'لقد ضبطت هذا بنفسك، فسيبقى متوقفًا مهما قال الهاتف.',
+    followingReduced: 'يتبع إعدادات تسهيل الوصول لديك، وهي تطلب حركة أقل.',
+    following: 'يتبع إعدادات تسهيل الوصول لديك.',
+    followPhone: 'اتبع إعداد هاتفي',
+    footnote:
+      'إيقاف الحركة لا يجعل الحركات أقصر — بل يزيلها. الحركة السريعة تظل حركة لمن لا يستطيع مشاهدتها.',
+  },
+  lock: {
+    title: 'الأمان',
+    requireBiometrics: 'اطلب البصمة أو رمز المرور',
+    requireExplain: 'إعطاء هاتفك لأحد كي يرى التقسيم لا ينبغي أن يريه كل شيء آخر.',
+    appLock: 'قفل التطبيق',
+    unsupported: 'لا توجد بصمة أو رمز مرور مضبوط على هذا الجهاز',
+    askAgainAfter: 'اسأل مرة أخرى بعد',
+    askAgainExplain:
+      'المدة في الخلفية قبل أن يُقفل باقي. التسوية عبر UPI تنقلك إلى تطبيق آخر ثم تعيدك، فالقفل لحظة الخروج يعني فتح القفل مع كل دفعة.',
+    graceImmediate: 'فورًا',
+    graceSeconds: {
+      zero: 'بعد {n} ثانية',
+      one: 'بعد ثانية',
+      two: 'بعد ثانيتين',
+      few: 'بعد {n} ثوانٍ',
+      many: 'بعد {n} ثانية',
+      other: 'بعد {n} ثانية',
+    },
+    graceMinutes: {
+      zero: 'بعد {n} دقيقة',
+      one: 'بعد دقيقة',
+      two: 'بعد دقيقتين',
+      few: 'بعد {n} دقائق',
+      many: 'بعد {n} دقيقة',
+      other: 'بعد {n} دقيقة',
+    },
+    reopenAlwaysAsks: 'إعادة فتح باقي بعد إغلاقه تطلب التحقق دائمًا، مهما كان هذا الإعداد.',
+    signOut: 'تسجيل الخروج',
+    signOutGuest: 'هذا الحساب موجود على هذا الجهاز فقط. تسجيل الخروج ينهيه.',
+    signOutMember: 'مجموعاتك وسجلك يبقيان كما هما تمامًا.',
+    signOutQuestion: 'تسجيل الخروج؟',
+    signOutGuestWarning:
+      'هذا حساب ضيف، وتسجيل الخروج لا يترك طريقًا للعودة إليه. أضف بريدًا إلكترونيًا أو رقم هاتف أولًا إن أردت الاحتفاظ به.',
+    signOutReassure: 'يمكنك تسجيل الدخول متى شئت. لا يُحذف شيء.',
+    staySignedIn: 'ابقَ مسجّل الدخول',
+    footnote:
+      'هذا يحمي الشاشة لا البيانات — دفترك محمي على الخادم بأمان على مستوى الصفوف سواء كان القفل مفعّلًا أم لا.',
+  },
+  account: {
+    faceYou: 'أنت',
+    facePaying: 'الدفع',
+    faceSettings: 'الإعدادات',
+    settled: 'تمت تسويته',
+    nothingSettledYet: 'لم تتم تسوية شيء بعد',
+    otherCurrencies: {
+      zero: 'و{n} عملة أخرى',
+      one: 'وعملة أخرى',
+      two: 'وعملتان أخريان',
+      few: 'و{n} عملات أخرى',
+      many: 'و{n} عملة أخرى',
+      other: 'و{n} عملة أخرى',
+    },
+    saved: 'تم الحفظ',
+    displayName: 'الاسم الظاهر',
+    you: 'أنت',
+    guestAccount: 'حساب ضيف',
+    guestAccountBody:
+      'كل ما أدخلته محفوظ بالفعل وهو ملكك. أضف بريدًا إلكترونيًا أو رقم هاتف متى أردت الوصول إليه من هاتف آخر — سيحتفظ بهذا الحساب بدل أن يبدأ حسابًا جديدًا.',
+    addYourDetails: 'أضف بياناتك',
+    yourPhoto: 'صورتك',
+    chooseNewPhoto: 'اختر صورة جديدة',
+    howPeoplePayYou: 'كيف يدفع لك الناس',
+    yourRailDetails: 'بيانات {rail} الخاصة بك',
+    handleWrong: 'هذا لا يبدو مثل {hint}.',
+    railLinkNote: 'من يسوّي معك يدفع بضغطة واحدة. باقي لا يلمس المال أبدًا.',
+    railManualNote: 'من يسوّي معك يرى هذا ليدفع لك من تطبيق مصرفه. باقي لا يلمس المال أبدًا.',
+    nothingToAdd: 'لا شيء تضيفه — سيسجّل الناس ما دفعوه لك يدويًا.',
+    sectionBaaki: 'باقي',
+    sectionSettings: 'الإعدادات',
+    sectionSecurity: 'الأمان',
+    upgradeHint: 'لا شيء للشراء بعد — الدفتر يبقى مجانيًا',
+    yourAccount: 'حسابك',
+    yourAccountHint: 'أضف بريدًا أو هاتفًا، أو تابع كضيف',
+    notifications: 'الإشعارات',
+    notificationsHint: 'ما يخصّني فقط',
+    exportDataRow: 'تصدير البيانات',
+    exportHint: 'JSON + CSV، بلا فقدان، مجانًا',
+    importSplitwise: 'استيراد من Splitwise',
+    importHint: 'أحضر مجموعة من ملف CSV مُصدَّر',
+    motionRow: 'الحركة',
+    languageFollowingPhone: 'يتبع هاتفك — {language}',
+    languageRestartHint: '{language} · أعد فتح باقي لعكس الاتجاه',
+    lockNoBiometrics: 'لا توجد بصمة مضبوطة على هذا الجهاز',
+    lockOn: 'مفعّل · يسأل {when}',
+    lockOff: 'متوقف — أي شخص يمسك هاتفك يمكنه قراءة الدفتر',
+    signOutGuestHint: 'حساب الضيف هذا موجود على هذا الجهاز فقط',
+    signOutHint: 'لا يُحذف شيء؛ سجّل الدخول متى شئت',
+    motionOn: 'حركات الشاشة مفعّلة',
+    motionOff: 'حركات الشاشة متوقفة',
+    motionFollowingOn: 'يتبع هاتفك — الحركات مفعّلة',
+    motionFollowingOff: 'يتبع هاتفك — الحركات متوقفة',
+    footnote: 'باقي · الدفتر مجاني إلى الأبد. لا نتقاضى إلا مقابل الراحة.',
+  },
 };
 
 const STRINGS: Record<Language, UiStrings> = { en, ta, hi, ar };

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -401,6 +401,77 @@ export interface UiStrings {
     restartToMirror: string;
     restartToUnmirror: string;
   };
+  /** The three tabs, and the inbox behind the bell. */
+  tabs: {
+    guestBanner: string;
+    guestBannerBody: string;
+    addYourDetails: string;
+    loadingGroups: string;
+    noGroups: string;
+    noGroupsBody: string;
+    activityEmptyBody: string;
+    inbox: string;
+    fromContacts: string;
+    allSquare: string;
+    allSquareBody: string;
+    owesYou: string;
+    youOweThem: string;
+    nobodyOwesYou: string;
+    youAreNotBehind: string;
+    inOneGroup: string;
+    acrossGroups: PluralForms;
+    notJoined: string;
+    group: string;
+  };
+  /** The inbox — the record of what Baaki said, whether or not push arrived. */
+  inbox: {
+    title: string;
+    nothingYetBody: string;
+    recent: string;
+  };
+  /** A group: its screen, its settings, and the ways out of it. */
+  group: {
+    notFound: string;
+    notFoundBody: string;
+    notFoundArchived: string;
+    loading: string;
+    settings: string;
+    mismatch: string;
+    mismatchBody: string;
+    confirmReceived: string;
+    autoConfirms: string;
+    hideDeleted: string;
+    showDeleted: string;
+    activityEmptyBody: string;
+    photoUpdated: string;
+    nameOptional: string;
+    groupName: string;
+    saveName: string;
+    removePhoto: string;
+    simplifyDebts: string;
+    simplifyDebtsBody: string;
+    membersHint: string;
+    invitePeople: string;
+    invitePeopleHint: string;
+    bringThingsIn: string;
+    importMessages: string;
+    importMessagesHint: string;
+    importSplitwise: string;
+    importSplitwiseHint: string;
+    archiveGroup: string;
+    leaveGroup: string;
+    leaveWhenZero: string;
+    settleFirst: string;
+    settleFirstBody: string;
+    leaveQuestion: string;
+    leaveBody: string;
+    leave: string;
+    archiveQuestion: string;
+    archiveBody: string;
+    archive: string;
+    nobodyOwes: string;
+    recordedNotMoved: string;
+  };
 }
 
 const en: UiStrings = {
@@ -720,6 +791,83 @@ const en: UiStrings = {
       'A guest account keeps everything on this device until you add a way to sign in. Your ledger is never held hostage.',
     restartToMirror: 'Close and open Baaki once to mirror the layout.',
     restartToUnmirror: 'Close and open Baaki once to turn the layout back.',
+  },
+  tabs: {
+    guestBanner: 'You are using Baaki as a guest',
+    guestBannerBody:
+      'Nothing is missing — everything you enter is saved and yours. Add an email or phone number whenever you want to reach it from another phone.',
+    addYourDetails: 'Add your details',
+    loadingGroups: 'Loading your groups…',
+    noGroups: 'No groups yet',
+    noGroupsBody:
+      'Start one for a trip, a flat, or the two of you. Adding expenses is free and unlimited, forever.',
+    activityEmptyBody:
+      'Every expense, edit, deletion and settlement lands here — for everyone in the group.',
+    inbox: 'Inbox',
+    fromContacts: 'From contacts',
+    allSquare: 'All square',
+    allSquareBody:
+      'Nobody owes you anything and you owe nobody. Friends you are settling up with will appear here — add somebody from your contacts to get started.',
+    owesYou: 'Owes you',
+    youOweThem: 'You owe',
+    nobodyOwesYou: 'Nobody owes you anything right now.',
+    youAreNotBehind: 'You are not behind with anyone.',
+    inOneGroup: 'in one group',
+    acrossGroups: { one: 'across {n} group', other: 'across {n} groups' },
+    notJoined: 'Not joined',
+    group: 'Group',
+  },
+  inbox: {
+    title: 'Inbox',
+    nothingYetBody:
+      'Reminders, settlement confirmations and anything else Baaki tells you collect here — even when the notification never reached your phone.',
+    recent: 'Recent',
+  },
+  group: {
+    notFound: 'Group not found',
+    notFoundBody: 'It may have been archived, or you are no longer a member.',
+    notFoundArchived: 'It may have been archived.',
+    loading: 'Loading…',
+    settings: 'Group settings',
+    mismatch: 'Balances need a refresh',
+    mismatchBody:
+      'This device and the server disagree about this group’s balances. Pull to refresh; if it persists, the ledger below is the source of truth.',
+    confirmReceived: 'Confirm received',
+    autoConfirms: 'Auto-confirms in 7 days if nobody responds.',
+    hideDeleted: 'Hide deleted',
+    showDeleted: 'Show deleted',
+    activityEmptyBody: 'Everything that happens here shows up in this feed.',
+    photoUpdated: 'Photo updated',
+    nameOptional: 'Name (optional)',
+    groupName: 'Group name',
+    saveName: 'Save name',
+    removePhoto: 'Remove photo',
+    simplifyDebts: 'Simplify debts',
+    simplifyDebtsBody:
+      'Suggest the fewest payments that settle the group. The real who-owes-whom ledger is never rewritten.',
+    membersHint: 'Add people, rename, set UPI IDs',
+    invitePeople: 'Invite people',
+    invitePeopleHint: 'Share a link — no install needed to join',
+    bringThingsIn: 'Bring things in',
+    importMessages: 'Import from messages',
+    importMessagesHint: 'Paste bank messages — read on this phone, confirmed by you',
+    importSplitwise: 'Import a Splitwise export',
+    importSplitwiseHint: 'Bring an old group’s history across',
+    archiveGroup: 'Archive group',
+    leaveGroup: 'Leave group',
+    leaveWhenZero: 'You can leave once your balance here is zero.',
+    settleFirst: 'Settle up first',
+    settleFirstBody:
+      'You still have a balance in this group. Leaving now would strand it — settle up, then leave.',
+    leaveQuestion: 'Leave this group?',
+    leaveBody: 'Your past expenses stay in the group history.',
+    leave: 'Leave',
+    archiveQuestion: 'Archive this group?',
+    archiveBody:
+      'It disappears from your list but nothing is deleted, and anyone can unarchive it.',
+    archive: 'Archive',
+    nobodyOwes: 'Nobody owes anybody in this group.',
+    recordedNotMoved: 'Recorded, not moved by Baaki',
   },
 };
 
@@ -1056,6 +1204,84 @@ const ta: UiStrings = {
     restartToMirror: 'தளவமைப்பைப் பிரதிபலிக்க பாக்கியை ஒருமுறை மூடித் திறக்கவும்.',
     restartToUnmirror: 'தளவமைப்பை மீண்டும் மாற்ற பாக்கியை ஒருமுறை மூடித் திறக்கவும்.',
   },
+  tabs: {
+    guestBanner: 'நீங்கள் பாக்கியை விருந்தினராகப் பயன்படுத்துகிறீர்கள்',
+    guestBannerBody:
+      'எதுவும் விடுபடவில்லை — நீங்கள் சேர்ப்பவை அனைத்தும் சேமிக்கப்பட்டு உங்களுடையவை. வேறு ஃபோனிலிருந்து அணுக விரும்பும்போது மின்னஞ்சலையோ தொலைபேசி எண்ணையோ சேர்க்கவும்.',
+    addYourDetails: 'உங்கள் விவரங்களைச் சேர்',
+    loadingGroups: 'உங்கள் குழுக்கள் ஏற்றப்படுகின்றன…',
+    noGroups: 'இன்னும் குழுக்கள் இல்லை',
+    noGroupsBody:
+      'ஒரு பயணத்துக்கோ, வீட்டுக்கோ, இருவருக்கோ ஒன்றைத் தொடங்குங்கள். செலவுகளைச் சேர்ப்பது எப்போதும் இலவசம், வரம்பில்லாதது.',
+    activityEmptyBody:
+      'ஒவ்வொரு செலவும், திருத்தமும், நீக்கமும், தீர்வும் இங்கே வந்து சேரும் — குழுவில் உள்ள அனைவருக்கும்.',
+    inbox: 'அஞ்சல் பெட்டி',
+    fromContacts: 'தொடர்புகளிலிருந்து',
+    allSquare: 'எல்லாம் சரி',
+    allSquareBody:
+      'உங்களுக்கு யாரும் தர வேண்டியதில்லை, நீங்களும் யாருக்கும் தர வேண்டியதில்லை. நீங்கள் தீர்த்துக்கொள்ளும் நண்பர்கள் இங்கே தோன்றுவார்கள் — தொடங்க உங்கள் தொடர்புகளிலிருந்து யாரையாவது சேருங்கள்.',
+    owesYou: 'உங்களுக்குத் தர வேண்டியவர்கள்',
+    youOweThem: 'நீங்கள் தர வேண்டியவர்கள்',
+    nobodyOwesYou: 'இப்போது உங்களுக்கு யாரும் தர வேண்டியதில்லை.',
+    youAreNotBehind: 'நீங்கள் யாருக்கும் பாக்கி வைத்திருக்கவில்லை.',
+    inOneGroup: 'ஒரு குழுவில்',
+    acrossGroups: { one: '{n} குழுவில்', other: '{n} குழுக்களில்' },
+    notJoined: 'சேரவில்லை',
+    group: 'குழு',
+  },
+  inbox: {
+    title: 'அஞ்சல் பெட்டி',
+    nothingYetBody:
+      'நினைவூட்டல்கள், தீர்வு உறுதிப்படுத்தல்கள், பாக்கி உங்களிடம் சொல்லும் மற்ற அனைத்தும் இங்கே சேரும் — அறிவிப்பு உங்கள் ஃபோனுக்கு வராவிட்டாலும் கூட.',
+    recent: 'சமீபத்தியவை',
+  },
+  group: {
+    notFound: 'குழு கிடைக்கவில்லை',
+    notFoundBody: 'அது காப்பகப்படுத்தப்பட்டிருக்கலாம், அல்லது நீங்கள் இனி உறுப்பினர் இல்லை.',
+    notFoundArchived: 'அது காப்பகப்படுத்தப்பட்டிருக்கலாம்.',
+    loading: 'ஏற்றப்படுகிறது…',
+    settings: 'குழு அமைப்புகள்',
+    mismatch: 'இருப்புகளைப் புதுப்பிக்க வேண்டும்',
+    mismatchBody:
+      'இந்தக் குழுவின் இருப்புகள் குறித்து இந்தச் சாதனமும் சர்வரும் ஒத்துப்போகவில்லை. இழுத்துப் புதுப்பிக்கவும்; தொடர்ந்தால் கீழே உள்ள கணக்கே சரியானது.',
+    confirmReceived: 'கிடைத்தது என்று உறுதிப்படுத்து',
+    autoConfirms: 'யாரும் பதிலளிக்காவிட்டால் 7 நாட்களில் தானாகவே உறுதியாகும்.',
+    hideDeleted: 'நீக்கியவற்றை மறை',
+    showDeleted: 'நீக்கியவற்றைக் காட்டு',
+    activityEmptyBody: 'இங்கே நடக்கும் அனைத்தும் இந்தப் பட்டியலில் தோன்றும்.',
+    photoUpdated: 'புகைப்படம் புதுப்பிக்கப்பட்டது',
+    nameOptional: 'பெயர் (விருப்பம்)',
+    groupName: 'குழுவின் பெயர்',
+    saveName: 'பெயரைச் சேமி',
+    removePhoto: 'புகைப்படத்தை நீக்கு',
+    simplifyDebts: 'கடன்களை எளிமையாக்கு',
+    simplifyDebtsBody:
+      'குழுவைத் தீர்க்கும் மிகக் குறைந்த பணப்பரிமாற்றங்களைப் பரிந்துரைக்கும். யார் யாருக்குத் தர வேண்டும் என்ற உண்மையான கணக்கு மாற்றப்படுவதே இல்லை.',
+    membersHint: 'ஆட்களைச் சேர், பெயர் மாற்று, UPI ID அமை',
+    invitePeople: 'ஆட்களை அழை',
+    invitePeopleHint: 'ஒரு இணைப்பைப் பகிருங்கள் — சேர ஆப் நிறுவத் தேவையில்லை',
+    bringThingsIn: 'கொண்டுவருதல்',
+    importMessages: 'செய்திகளிலிருந்து இறக்குமதி',
+    importMessagesHint:
+      'வங்கிச் செய்திகளை ஒட்டுங்கள் — இந்த ஃபோனிலேயே படிக்கப்படும், நீங்கள் உறுதிப்படுத்துவீர்கள்',
+    importSplitwise: 'Splitwise ஏற்றுமதியை இறக்குமதி செய்',
+    importSplitwiseHint: 'பழைய குழுவின் வரலாற்றைக் கொண்டுவா',
+    archiveGroup: 'குழுவைக் காப்பகப்படுத்து',
+    leaveGroup: 'குழுவிலிருந்து விலகு',
+    leaveWhenZero: 'இங்கே உங்கள் இருப்பு பூஜ்ஜியமானதும் விலகலாம்.',
+    settleFirst: 'முதலில் தீர்த்துக்கொள்ளுங்கள்',
+    settleFirstBody:
+      'இந்தக் குழுவில் உங்களுக்கு இன்னும் இருப்பு உள்ளது. இப்போது விலகினால் அது தொங்கிவிடும் — தீர்த்துவிட்டு விலகுங்கள்.',
+    leaveQuestion: 'இந்தக் குழுவிலிருந்து விலகவா?',
+    leaveBody: 'உங்கள் பழைய செலவுகள் குழு வரலாற்றில் இருக்கும்.',
+    leave: 'விலகு',
+    archiveQuestion: 'இந்தக் குழுவைக் காப்பகப்படுத்தவா?',
+    archiveBody:
+      'இது உங்கள் பட்டியலிலிருந்து மறையும், ஆனால் எதுவும் அழிக்கப்படாது, யார் வேண்டுமானாலும் மீண்டும் கொண்டுவரலாம்.',
+    archive: 'காப்பகப்படுத்து',
+    nobodyOwes: 'இந்தக் குழுவில் யாரும் யாருக்கும் தர வேண்டியதில்லை.',
+    recordedNotMoved: 'பதிவு செய்யப்பட்டது, பாக்கி பணத்தை அனுப்பவில்லை',
+  },
 };
 
 const hi: UiStrings = {
@@ -1369,6 +1595,81 @@ const hi: UiStrings = {
       'जब तक आप साइन इन का कोई तरीका न जोड़ें, मेहमान खाता सब कुछ इसी डिवाइस पर रखता है। आपका हिसाब कभी बंधक नहीं बनाया जाता।',
     restartToMirror: 'लेआउट की दिशा बदलने के लिए बाकी को एक बार बंद करके खोलें।',
     restartToUnmirror: 'लेआउट वापस पलटने के लिए बाकी को एक बार बंद करके खोलें।',
+  },
+  tabs: {
+    guestBanner: 'आप बाकी को मेहमान के तौर पर इस्तेमाल कर रहे हैं',
+    guestBannerBody:
+      'कुछ छूट नहीं रहा — आप जो भी डालते हैं वह सेव है और आपका है। जब भी किसी दूसरे फ़ोन से पहुँचना हो, ईमेल या फ़ोन नंबर जोड़ लें।',
+    addYourDetails: 'अपनी जानकारी जोड़ें',
+    loadingGroups: 'आपके समूह आ रहे हैं…',
+    noGroups: 'अभी कोई समूह नहीं',
+    noGroupsBody:
+      'किसी सफ़र, फ़्लैट, या बस आप दोनों के लिए एक शुरू करें। खर्च जोड़ना हमेशा मुफ़्त और असीमित है।',
+    activityEmptyBody: 'हर खर्च, बदलाव, हटाना और निपटान यहीं आता है — समूह के हर व्यक्ति के लिए।',
+    inbox: 'इनबॉक्स',
+    fromContacts: 'संपर्कों से',
+    allSquare: 'सब बराबर',
+    allSquareBody:
+      'न किसी पर आपका बाकी है, न आप पर किसी का। जिनसे आप हिसाब करेंगे वे यहाँ दिखेंगे — शुरू करने के लिए संपर्कों से किसी को जोड़ें।',
+    owesYou: 'आपको देने हैं',
+    youOweThem: 'आपको देने हैं जिन्हें',
+    nobodyOwesYou: 'अभी किसी पर आपका कुछ बाकी नहीं है।',
+    youAreNotBehind: 'आप पर किसी का कुछ बाकी नहीं है।',
+    inOneGroup: 'एक समूह में',
+    acrossGroups: { one: '{n} समूह में', other: '{n} समूहों में' },
+    notJoined: 'शामिल नहीं',
+    group: 'समूह',
+  },
+  inbox: {
+    title: 'इनबॉक्स',
+    nothingYetBody:
+      'याद दिलाना, निपटान की पुष्टि और बाकी जो कुछ भी आपसे कहता है, सब यहाँ जमा होता है — भले ही सूचना आपके फ़ोन तक कभी न पहुँची हो।',
+    recent: 'हाल के',
+  },
+  group: {
+    notFound: 'समूह नहीं मिला',
+    notFoundBody: 'हो सकता है यह संग्रहित कर दिया गया हो, या आप अब सदस्य न हों।',
+    notFoundArchived: 'हो सकता है यह संग्रहित कर दिया गया हो।',
+    loading: 'आ रहा है…',
+    settings: 'समूह सेटिंग्स',
+    mismatch: 'बाकी को ताज़ा करना होगा',
+    mismatchBody:
+      'इस समूह के हिसाब पर यह डिवाइस और सर्वर सहमत नहीं हैं। खींचकर ताज़ा करें; फिर भी बना रहे तो नीचे का हिसाब ही सही है।',
+    confirmReceived: 'मिलने की पुष्टि करें',
+    autoConfirms: 'कोई जवाब न दे तो 7 दिन में अपने आप पुष्ट हो जाएगा।',
+    hideDeleted: 'हटाए हुए छिपाएँ',
+    showDeleted: 'हटाए हुए दिखाएँ',
+    activityEmptyBody: 'यहाँ जो कुछ होगा वह इसी फ़ीड में दिखेगा।',
+    photoUpdated: 'फ़ोटो बदल गई',
+    nameOptional: 'नाम (वैकल्पिक)',
+    groupName: 'समूह का नाम',
+    saveName: 'नाम सेव करें',
+    removePhoto: 'फ़ोटो हटाएँ',
+    simplifyDebts: 'हिसाब सरल करें',
+    simplifyDebtsBody:
+      'समूह को निपटाने के सबसे कम भुगतान सुझाता है। किस पर किसका बाकी है, वह असली हिसाब कभी नहीं बदला जाता।',
+    membersHint: 'लोग जोड़ें, नाम बदलें, UPI ID सेट करें',
+    invitePeople: 'लोगों को बुलाएँ',
+    invitePeopleHint: 'एक लिंक साझा करें — जुड़ने के लिए कुछ इंस्टॉल करने की ज़रूरत नहीं',
+    bringThingsIn: 'बाहर से लाएँ',
+    importMessages: 'मैसेज से आयात',
+    importMessagesHint: 'बैंक मैसेज पेस्ट करें — इसी फ़ोन पर पढ़े जाते हैं, पुष्टि आप करते हैं',
+    importSplitwise: 'Splitwise निर्यात आयात करें',
+    importSplitwiseHint: 'पुराने समूह का इतिहास ले आएँ',
+    archiveGroup: 'समूह संग्रहित करें',
+    leaveGroup: 'समूह छोड़ें',
+    leaveWhenZero: 'यहाँ आपका हिसाब शून्य होते ही आप छोड़ सकते हैं।',
+    settleFirst: 'पहले हिसाब चुकाएँ',
+    settleFirstBody:
+      'इस समूह में अभी आपका हिसाब बाकी है। अभी छोड़ने पर वह अधर में रह जाएगा — पहले चुकाएँ, फिर छोड़ें।',
+    leaveQuestion: 'यह समूह छोड़ें?',
+    leaveBody: 'आपके पुराने खर्च समूह के इतिहास में बने रहेंगे।',
+    leave: 'छोड़ें',
+    archiveQuestion: 'यह समूह संग्रहित करें?',
+    archiveBody: 'यह आपकी सूची से हट जाएगा पर मिटेगा कुछ नहीं, और कोई भी इसे वापस ला सकता है।',
+    archive: 'संग्रहित करें',
+    nobodyOwes: 'इस समूह में किसी पर किसी का कुछ बाकी नहीं है।',
+    recordedNotMoved: 'दर्ज किया गया, बाकी ने पैसा नहीं भेजा',
   },
 };
 
@@ -1702,6 +2003,88 @@ const ar: UiStrings = {
       'يحتفظ حساب الضيف بكل شيء على هذا الجهاز حتى تضيف طريقة لتسجيل الدخول. دفترك ليس رهينة أبدًا.',
     restartToMirror: 'أغلق باقي وافتحه مرة واحدة لعكس اتجاه الواجهة.',
     restartToUnmirror: 'أغلق باقي وافتحه مرة واحدة لإعادة اتجاه الواجهة.',
+  },
+  tabs: {
+    guestBanner: 'أنت تستخدم باقي كضيف',
+    guestBannerBody:
+      'لا شيء ناقص — كل ما تدخله محفوظ وهو ملكك. أضف بريدًا إلكترونيًا أو رقم هاتف متى أردت الوصول إليه من هاتف آخر.',
+    addYourDetails: 'أضف بياناتك',
+    loadingGroups: 'جارٍ تحميل مجموعاتك…',
+    noGroups: 'لا مجموعات بعد',
+    noGroupsBody:
+      'ابدأ واحدة لرحلة أو لشقة أو لكما أنتما. إضافة المصروفات مجانية وبلا حدود، دائمًا.',
+    activityEmptyBody: 'كل مصروف وتعديل وحذف وتسوية يصل إلى هنا — لكل من في المجموعة.',
+    inbox: 'صندوق الوارد',
+    fromContacts: 'من جهات الاتصال',
+    allSquare: 'كل شيء متساوٍ',
+    allSquareBody:
+      'لا أحد يدين لك ولا أنت تدين لأحد. سيظهر هنا من تسوّي معهم — أضف شخصًا من جهات اتصالك للبدء.',
+    owesYou: 'لك عندهم',
+    youOweThem: 'عليك لهم',
+    nobodyOwesYou: 'لا أحد يدين لك بشيء الآن.',
+    youAreNotBehind: 'لست متأخرًا مع أحد.',
+    inOneGroup: 'في مجموعة واحدة',
+    acrossGroups: {
+      zero: 'في {n} مجموعة',
+      one: 'في مجموعة واحدة',
+      two: 'في مجموعتين',
+      few: 'في {n} مجموعات',
+      many: 'في {n} مجموعة',
+      other: 'في {n} مجموعة',
+    },
+    notJoined: 'لم ينضم',
+    group: 'مجموعة',
+  },
+  inbox: {
+    title: 'صندوق الوارد',
+    nothingYetBody:
+      'التذكيرات وتأكيدات التسوية وكل ما يخبرك به باقي يتجمّع هنا — حتى حين لا يصل الإشعار إلى هاتفك.',
+    recent: 'الأحدث',
+  },
+  group: {
+    notFound: 'المجموعة غير موجودة',
+    notFoundBody: 'ربما أُرشفت، أو لم تعد عضوًا فيها.',
+    notFoundArchived: 'ربما أُرشفت.',
+    loading: 'جارٍ التحميل…',
+    settings: 'إعدادات المجموعة',
+    mismatch: 'الأرصدة بحاجة إلى تحديث',
+    mismatchBody:
+      'هذا الجهاز والخادم لا يتفقان على أرصدة هذه المجموعة. اسحب للتحديث؛ وإن استمر الأمر فالدفتر بالأسفل هو المرجع.',
+    confirmReceived: 'أكّد الاستلام',
+    autoConfirms: 'يتأكد تلقائيًا خلال 7 أيام إن لم يردّ أحد.',
+    hideDeleted: 'إخفاء المحذوف',
+    showDeleted: 'إظهار المحذوف',
+    activityEmptyBody: 'كل ما يحدث هنا يظهر في هذا السجل.',
+    photoUpdated: 'تم تحديث الصورة',
+    nameOptional: 'الاسم (اختياري)',
+    groupName: 'اسم المجموعة',
+    saveName: 'حفظ الاسم',
+    removePhoto: 'إزالة الصورة',
+    simplifyDebts: 'تبسيط الديون',
+    simplifyDebtsBody:
+      'يقترح أقل عدد من الدفعات لتسوية المجموعة. أما دفتر من يدين لمن فلا يُعاد كتابته أبدًا.',
+    membersHint: 'أضف أشخاصًا، غيّر الأسماء، اضبط معرّفات الدفع',
+    invitePeople: 'ادعُ أشخاصًا',
+    invitePeopleHint: 'شارك رابطًا — لا حاجة لتثبيت شيء للانضمام',
+    bringThingsIn: 'استيراد',
+    importMessages: 'استيراد من الرسائل',
+    importMessagesHint: 'ألصق رسائل المصرف — تُقرأ على هذا الهاتف وتؤكدها أنت',
+    importSplitwise: 'استيراد ملف Splitwise',
+    importSplitwiseHint: 'أحضر سجل مجموعة قديمة',
+    archiveGroup: 'أرشفة المجموعة',
+    leaveGroup: 'مغادرة المجموعة',
+    leaveWhenZero: 'يمكنك المغادرة حين يصبح رصيدك هنا صفرًا.',
+    settleFirst: 'سوِّ حسابك أولًا',
+    settleFirstBody:
+      'ما زال لك رصيد في هذه المجموعة. المغادرة الآن تتركه معلّقًا — سوِّ الحساب ثم غادر.',
+    leaveQuestion: 'مغادرة هذه المجموعة؟',
+    leaveBody: 'تبقى مصروفاتك السابقة في سجل المجموعة.',
+    leave: 'مغادرة',
+    archiveQuestion: 'أرشفة هذه المجموعة؟',
+    archiveBody: 'تختفي من قائمتك دون حذف أي شيء، ويمكن لأي أحد إعادتها.',
+    archive: 'أرشفة',
+    nobodyOwes: 'لا أحد يدين لأحد في هذه المجموعة.',
+    recordedNotMoved: 'مسجَّل، ولم يحوّل باقي المال',
   },
 };
 

--- a/apps/mobile/src/i18n/language.tsx
+++ b/apps/mobile/src/i18n/language.tsx
@@ -16,6 +16,11 @@
  * app does not carry `expo-updates` — so the honest thing is to say the words
  * "close and open Baaki again" rather than write half a mirrored screen.
  *
+ * Said in an alert, at the moment of the choice, and not only in a banner. A
+ * banner lives on one screen; somebody who taps a language and walks away never
+ * reads it, comes back to a mirrored English app and reports it as broken. It
+ * is worth interrupting for, once, and only when the direction actually turns.
+ *
  * `allowRTL` and `forceRTL` are both set, in step, because they answer
  * different halves of the question. Android computes RTL as
  * `forced || (allowed && the device is RTL)`, so `forceRTL(false)` alone would
@@ -42,7 +47,7 @@ import {
   type ReactNode,
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { I18nManager, Platform } from 'react-native';
+import { Alert, I18nManager, Platform } from 'react-native';
 
 import { setLayoutDirection } from '@baaki/ui';
 
@@ -52,6 +57,7 @@ import {
   isRtlLanguage,
   LanguageContext,
   localeFor,
+  STRINGS_BY_LANGUAGE,
   type Language,
 } from '@/i18n';
 
@@ -136,9 +142,28 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     // Persisted natively and read before any JavaScript next time the app
     // opens. Nothing about the current session changes.
     if (Platform.OS !== 'web') {
-      const rtl = isRtlLanguage(value ?? deviceLanguage());
+      const chosen = value ?? deviceLanguage();
+      const rtl = isRtlLanguage(chosen);
       I18nManager.allowRTL(rtl);
       I18nManager.forceRTL(rtl);
+
+      // Said at the moment of the choice, and said in a way that has to be
+      // dismissed, because the alternative has already failed twice: a banner
+      // lives on one screen, and somebody who taps a language and walks away
+      // never reads it. The words are in the language just chosen — that is the
+      // one they have said they read.
+      //
+      // Compared against the direction the app *launched* in rather than the
+      // language being replaced. Going Arabic → English → Arabic in one sitting
+      // ends where it started, and there is nothing left to restart for.
+      if (rtl !== LAUNCHED_RTL) {
+        const words = STRINGS_BY_LANGUAGE[chosen];
+        Alert.alert(
+          words.account.restartTitle,
+          rtl ? words.signIn.restartToMirror : words.signIn.restartToUnmirror,
+          [{ text: words.common.ok }],
+        );
+      }
     }
   }, []);
 

--- a/apps/mobile/src/i18n/localeSync.tsx
+++ b/apps/mobile/src/i18n/localeSync.tsx
@@ -1,0 +1,43 @@
+/**
+ * Telling the server which language to write to somebody in.
+ *
+ * The language picker is a device setting — AsyncStorage, instant, offline.
+ * Notifications are not: they are written by Postgres and rendered by an edge
+ * function, neither of which can see a phone's storage. What they read is
+ * `profiles.locale`, which until now was set once from the sign-up metadata and
+ * never touched again. So somebody could put the entire app into Tamil and go
+ * on receiving push in English forever, with nothing on any screen to explain
+ * it.
+ *
+ * This is the one line between the two. It lives in its own component rather
+ * than inside `LanguageProvider` because that provider sits above the auth
+ * tree — deliberately, so the sign-in screen has strings — and cannot reach a
+ * session from up there.
+ *
+ * Failure is silent on purpose. A locale that did not reach the server means
+ * the next notification arrives in the previous language; holding a toast in
+ * front of somebody who has just changed a setting, over a row they cannot fix
+ * and did not ask about, is worse than the wrong language on one notification.
+ * The effect runs again on the next change and on every fresh session.
+ */
+
+import { useEffect } from 'react';
+
+import { useAuth } from '@/lib/auth';
+import { useLanguage } from '@/i18n/language';
+
+export function LocaleSync() {
+  const { locale, loading } = useLanguage();
+  const { session, profile, updateProfile } = useAuth();
+
+  useEffect(() => {
+    // `loading` matters: the stored choice arrives a tick after mount, and
+    // writing the phone's locale in that tick would overwrite a real choice
+    // with the default every single launch.
+    if (loading || !session || !profile) return;
+    if (profile.locale === locale) return;
+    void updateProfile({ locale }).catch(() => undefined);
+  }, [loading, session, profile, locale, updateProfile]);
+
+  return null;
+}

--- a/apps/mobile/src/lib/lock.tsx
+++ b/apps/mobile/src/lib/lock.tsx
@@ -11,6 +11,8 @@ import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
 import { AppState, Platform } from 'react-native';
 
+import { plural, type UiStrings } from '@/i18n';
+
 const KEY = 'baaki.app_lock_enabled';
 const GRACE_KEY = 'baaki.app_lock_grace_seconds';
 
@@ -146,9 +148,8 @@ export function useLock(): LockValue {
 }
 
 /** "Straight away", "After 30 seconds" — the words the settings row uses too. */
-export function describeGrace(seconds: number): string {
-  if (seconds <= 0) return 'Straight away';
-  if (seconds < 60) return `After ${seconds} seconds`;
-  if (seconds === 60) return 'After a minute';
-  return `After ${Math.round(seconds / 60)} minutes`;
+export function describeGrace(seconds: number, t: UiStrings, locale: string): string {
+  if (seconds <= 0) return t.lock.graceImmediate;
+  if (seconds < 60) return plural(locale, seconds, t.lock.graceSeconds);
+  return plural(locale, Math.round(seconds / 60), t.lock.graceMinutes);
 }

--- a/apps/mobile/test/language.test.ts
+++ b/apps/mobile/test/language.test.ts
@@ -106,3 +106,61 @@ describe('falling back to the phone', () => {
     expect(deviceLanguage()).toBe('en');
   });
 });
+
+describe('what every table owes the others', () => {
+  /**
+   * TypeScript guarantees the four tables have the same *shape*. It cannot
+   * check what is inside a string, and two things inside these strings matter:
+   * that somebody actually wrote words, and that the `{placeholders}` survived
+   * translation. A dropped `{n}` is a sentence that silently loses its number.
+   */
+  const leaves = (value: unknown, path = ''): [string, string][] => {
+    if (typeof value === 'string') return [[path, value]];
+    if (Array.isArray(value)) return value.flatMap((item, i) => leaves(item, `${path}[${i}]`));
+    if (value && typeof value === 'object') {
+      return Object.entries(value).flatMap(([key, inner]) => leaves(inner, `${path}.${key}`));
+    }
+    return [];
+  };
+
+  const placeholders = (text: string): string[] =>
+    [...text.matchAll(/\{(\w+)\}/g)].map((m) => m[1]).sort();
+
+  it('never leaves a string blank', () => {
+    for (const language of LANGUAGES) {
+      for (const [path, text] of leaves(STRINGS_BY_LANGUAGE[language])) {
+        expect(text.trim(), `${language}${path}`).not.toBe('');
+      }
+    }
+  });
+
+  /**
+   * A singular or dual form is allowed to say the number in words rather than
+   * print it — Arabic's "بعد ثانيتين" is "after two seconds" with no numeral in it, and
+   * demanding a `{n}` there would force a translation nobody says aloud. The
+   * `other` form is the one that must carry it.
+   */
+  const mayOmitTheNumber = (path: string): boolean => /\.(zero|one|two|few|many)$/.test(path);
+
+  it('keeps every placeholder the English says', () => {
+    const english = new Map(leaves(STRINGS_BY_LANGUAGE.en));
+    for (const language of LANGUAGES) {
+      if (language === 'en') continue;
+      for (const [path, text] of leaves(STRINGS_BY_LANGUAGE[language])) {
+        const source = english.get(path);
+        // Plural tables legitimately have forms English does not (Arabic's
+        // `two`, `few`, `many`), so a path English lacks is not a fault.
+        if (source === undefined) continue;
+        const here = placeholders(text);
+        const there = placeholders(source);
+
+        // Never invent one: `{amount}` where English said `{value}` renders the
+        // token itself at somebody, which is worse than the wrong language.
+        for (const name of here) expect(there, `${language}${path}`).toContain(name);
+        if (!mayOmitTheNumber(path)) {
+          expect(here, `${language}${path}`).toEqual(there);
+        }
+      }
+    }
+  });
+});

--- a/apps/mobile/test/language.test.ts
+++ b/apps/mobile/test/language.test.ts
@@ -164,3 +164,38 @@ describe('what every table owes the others', () => {
     }
   });
 });
+
+/**
+ * The restart is described twice, once for each direction, and the two are not
+ * interchangeable. Telling somebody who has just chosen English that reopening
+ * will "mirror it" describes the opposite of what will happen — on the one
+ * screen they are reading to find out why it has not turned back.
+ */
+describe('the two directions of the restart', () => {
+  const PAIRS: readonly [string, string][] = [
+    ['account.languageRestartHint', 'account.languageRestartHintBack'],
+    ['account.restartBannerMirror', 'account.restartBannerUnmirror'],
+    ['signIn.restartToMirror', 'signIn.restartToUnmirror'],
+  ];
+
+  const at = (table: object, path: string): string =>
+    path.split('.').reduce<never>((node, key) => (node as never)[key], table as never);
+
+  it('says something different about each direction, in every language', () => {
+    for (const language of LANGUAGES) {
+      const table = STRINGS_BY_LANGUAGE[language];
+      for (const [mirror, unmirror] of PAIRS) {
+        expect(at(table, mirror).trim(), `${language}.${mirror}`).not.toBe('');
+        expect(at(table, unmirror), `${language}.${unmirror}`).not.toBe(at(table, mirror));
+      }
+    }
+  });
+
+  it('names the language in the settings row either way', () => {
+    for (const language of LANGUAGES) {
+      const table = STRINGS_BY_LANGUAGE[language];
+      expect(at(table, 'account.languageRestartHint'), language).toContain('{language}');
+      expect(at(table, 'account.languageRestartHintBack'), language).toContain('{language}');
+    }
+  });
+});

--- a/packages/core/src/notifications/copy.ts
+++ b/packages/core/src/notifications/copy.ts
@@ -1,10 +1,17 @@
 /**
- * Centralised notification + money copy (TDR §7.1), en / ta / hi.
+ * Centralised notification + money copy (TDR §7.1), en / ta / hi / ar.
  * Tone rule from ADR-010: friendly vasool, never collection-agency.
  * `{placeholders}` are substituted by the caller.
+ *
+ * Arabic arrived in the app four screens before it arrived here, and the gap
+ * was silent: `copyFor('ar')` fell through `?? en` and sent English to somebody
+ * whose whole app was in Arabic. A fallback that cannot be seen from the call
+ * site is a fallback that ships. The four tables are now the same four the app
+ * speaks, and `LanguageCode` is what makes adding a fifth a compile error here
+ * rather than a surprise on somebody's lock screen.
  */
 
-export type LanguageCode = 'en' | 'ta' | 'hi';
+export type LanguageCode = 'en' | 'ta' | 'hi' | 'ar';
 
 export type NotificationKind =
   | 'expense_added'
@@ -183,7 +190,55 @@ const hi: CopyStrings = {
   },
 };
 
-export const COPY: Readonly<Record<LanguageCode, CopyStrings>> = { en, ta, hi };
+const ar: CopyStrings = {
+  money: {
+    owedToYou: 'لك {amount}',
+    youOwe: 'عليك {amount}',
+    settled: 'تمت التسوية',
+    netPositive: 'لك {amount} في المجمل',
+    netNegative: 'باقيك {amount}',
+  },
+  notifications: {
+    expense_added: {
+      title: 'أضاف {actor} مصروفًا',
+      body: '{description} · {amount} في {group}',
+    },
+    expense_edited: { title: 'عدّل {actor} مصروفًا', body: '{description} في {group}' },
+    expense_deleted: { title: 'حذف {actor} مصروفًا', body: '{description} في {group}' },
+    you_owe: { title: 'عليك {amount}', body: '{description} في {group}' },
+    settlement_initiated: {
+      title: 'دفع لك {actor} مبلغ {amount}',
+      body: 'اضغط لتأكيد استلامه',
+    },
+    settlement_confirm_request: {
+      title: 'يقول {actor} إنه دفع لك {amount}',
+      body: 'أكّد حتى يبقى باقيك صحيحًا',
+    },
+    settlement_confirmed: { title: 'تمت التسوية مع {actor}', body: '{amount} في {group}' },
+    nudge: { title: 'تذكير لطيف من {actor}', body: '{amount} معلّقة في {group}' },
+    ghost_claimed: { title: 'انضم {actor} إلى {group}', body: 'رُبطت مصروفاته السابقة' },
+    group_invite_accepted: { title: 'انضم {actor} إلى {group}', body: 'ألقِ التحية' },
+    digest_daily: { title: 'اليوم في {group}', body: '{count} تحديثات · باقيك {amount}' },
+    trip_nudge_morning: {
+      title: 'هل بقي شيء من الأمس؟',
+      body: 'أضف ما أنفقته على {group} ما دمت تتذكره',
+    },
+    trip_nudge_evening: {
+      title: 'قبل أن تنسى',
+      body: 'ماذا دفعت اليوم في {group}؟',
+    },
+    expense_disputed: {
+      title: 'يرى {actor} أن هناك خطأً',
+      body: '{description} في {group} — ألقِ نظرة',
+    },
+    expense_dispute_resolved: {
+      title: 'وصل ردّ على تصحيحك',
+      body: '{description} في {group}',
+    },
+  },
+};
+
+export const COPY: Readonly<Record<LanguageCode, CopyStrings>> = { en, ta, hi, ar };
 
 export function copyFor(language: string): CopyStrings {
   const base = language.slice(0, 2).toLowerCase() as LanguageCode;

--- a/packages/core/src/notifications/render.ts
+++ b/packages/core/src/notifications/render.ts
@@ -6,7 +6,8 @@
  * built here, from the copy table, in the reader's language — because Postgres
  * wrote that row and Postgres has no business holding three translations of
  * every sentence, nor any idea which of them this particular person reads
- * (TDR §11: en + ta + hi from day one).
+ * (TDR §11: en + ta + hi from day one, and ar since the layout learned to
+ * mirror).
  *
  * Amounts are formatted from minor units at the same moment, for the same
  * reason: `42000` is not `₹420.00` until you know both the currency and the

--- a/packages/core/test/notificationRender.test.ts
+++ b/packages/core/test/notificationRender.test.ts
@@ -9,9 +9,12 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { renderNotification } from '../src/index';
+import { COPY, renderNotification } from '../src/index';
 
 const TRIP = { group: 'Goa', amount: '42000', currency: 'INR' };
+
+/** Every language the app offers a picker for. */
+const SPOKEN = ['en', 'ta', 'hi', 'ar'] as const;
 
 describe('reading a notification', () => {
   it('fills in the group it is about', () => {
@@ -33,9 +36,49 @@ describe('reading a notification', () => {
     expect(title).not.toBe(english.title);
   });
 
+  it('reads in Arabic when that is what the reader uses', () => {
+    // Arabic shipped in the app four screens before it shipped here, and the
+    // gap was invisible: `copyFor` fell through to English and sent it to
+    // somebody whose entire app was in Arabic.
+    const { title } = renderNotification('trip_nudge_morning', TRIP, 'ar-AE');
+    const english = renderNotification('trip_nudge_morning', TRIP, 'en-IN');
+    expect(title).not.toBe(english.title);
+    expect(title).toMatch(/\p{Script=Arabic}/u);
+  });
+
   it('falls back to English for a language nobody has translated yet', () => {
     const { title } = renderNotification('trip_nudge_morning', TRIP, 'fr-FR');
     expect(title).toBe(renderNotification('trip_nudge_morning', TRIP, 'en-IN').title);
+  });
+});
+
+describe('what every language owes', () => {
+  /**
+   * The fallback in `copyFor` is a kindness to a language nobody has started,
+   * and a trap for one somebody has. These two tests are the difference: they
+   * fail when a language the picker offers has no table, and when a table has
+   * a kind missing rather than quietly borrowing the English one.
+   */
+  it('has a table for every language the app offers', () => {
+    for (const language of SPOKEN) {
+      expect(COPY[language], language).toBeDefined();
+    }
+  });
+
+  it('says every kind, in every language, without leaving it English', () => {
+    const kinds = Object.keys(COPY.en.notifications);
+    for (const language of SPOKEN) {
+      for (const kind of kinds) {
+        const entry = COPY[language].notifications[kind as keyof typeof COPY.en.notifications];
+        expect(entry?.title.trim(), `${language}.${kind}`).toBeTruthy();
+        expect(entry?.body.trim(), `${language}.${kind}`).toBeTruthy();
+        if (language !== 'en') {
+          expect(entry?.title, `${language}.${kind}`).not.toBe(
+            COPY.en.notifications[kind as keyof typeof COPY.en.notifications].title,
+          );
+        }
+      }
+    }
   });
 });
 


### PR DESCRIPTION
The picker shipped working and the app stayed English. This closes most of that gap and fixes three things underneath it that no screen showed.

## Three that were invisible

**Arabic push copy.** `LanguageCode` in `@baaki/core` was `'en' | 'ta' | 'hi'` four screens after the app learned Arabic, so `copyFor('ar')` fell through `?? en` and sent English to somebody whose whole app was in Arabic. A fallback you cannot see from the call site is a fallback that ships. Two tests now fail if a language the picker offers has no table, or has one with a kind quietly borrowed from English.

**The chosen language now reaches the server.** `profiles.locale` was set once from sign-up metadata and never touched again — the picker wrote AsyncStorage and nothing else. `LocaleSync` is the one line between them. It cannot live in `LanguageProvider`, which sits above the auth tree so the sign-in screen has strings, so it is its own component under `AuthProvider`, outside every gate: which language you are notified in should not depend on whether the app is locked.

**Plurals.** `${n} expense${n === 1 ? '' : 's'}` appeared in nine files. That is not a shortcut but a claim — that "one" and "not one" is the whole of it — and it is false in three of the four languages here. `plural()` uses `Intl.PluralRules` and formats the number for the locale too, because a phrase reading "12" beside Arabic words is a phrase in two number systems.

## The screens

Roughly 170 of ~267 English literals moved into `UiStrings`, in all four languages: the welcome and sign-in, the account screen and every settings screen, Home, Activity, Friends, the inbox, the group screen and its settings, members, the member sheet, invites, adding and editing an expense, joining by link, the contact flow, and the shared components — including the avatar pickers whose only strings were accessibility labels, exactly the kind that stays English for years.

Tables that were module constants are now functions of the strings. A label is no longer knowable at module load: it depends on a choice somebody can change while the app is open.

`common` holds the words that are on every screen. "Back" was an English literal in nineteen files and "Close" in seven — nineteen chances to write a different word for the same button is how translations go subtly wrong.

## Two guards

TypeScript guarantees the four tables share a shape; it cannot see inside a string. So: no leaf may be blank, and no translation may lose or invent a `{placeholder}` — a dropped `{n}` is a sentence that silently stops saying its number.

The placeholder rule has one deliberate exemption, and the test found it rather than the other way round: a singular or dual form may say the number in words instead of printing it. Arabic's "بعد ثانيتين" is "after two seconds" with no numeral, and demanding `{n}` there would force a phrase nobody says aloud. `other` must still carry it.

## Not covered

**97 literal sites remain**, concentrated in seven files: the SMS importer, the itemize screen, the dispute panel, the Splitwise importer, the trip-date picker, the contact and country pickers, and the auth error strings. All are reachable, none are on the first-run path, and every one of them is a screen somebody can hit — this is a real remainder, not a rounding error.

Also untouched: `apps/web-lite` has no i18n at all, and it is what people without the app land on. And the Arabic-Indic digit case (`ar-EG` formats `١٢٣`) still has no test.

## Checked

Repo-wide `tsc`, `expo lint` clean, prettier, and 127 mobile + 379 core tests. Not yet re-driven on a device — the previous RTL round trip was verified before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6