### PR TITLE
fix: stop two callers sharing one SQLite connection

### DIFF
--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -2,12 +2,18 @@
  * The native store: real SQLite, as ADR-005 asks for.
  *
  * Metro resolves this file everywhere except web, where `driver.web.ts` wins.
+ *
+ * Every public method goes through `Serial`. See that file for why: expo-sqlite
+ * runs `withTransactionAsync` as a plain `BEGIN`/`COMMIT` pair on the shared
+ * connection, so overlapping callers nest transactions, and the loser's
+ * rollback discards the winner's work.
  */
 
 import * as SQLite from 'expo-sqlite';
 
 import type { MirrorRow, QueuedMutation, SyncTable } from '@baaki/core';
 
+import { Serial } from './serial';
 import type { LocalStore, StoredRow } from './store';
 
 const SCHEMA = `
@@ -43,147 +49,184 @@ CREATE TABLE IF NOT EXISTS drafts (
 
 class SqliteStore implements LocalStore {
   private database: SQLite.SQLiteDatabase | null = null;
-  private opening: Promise<void> | null = null;
+  private opening: Promise<SQLite.SQLiteDatabase> | null = null;
+  private readonly serial = new Serial();
 
   async ready(): Promise<void> {
-    if (this.database) return;
+    await this.db();
+  }
+
+  /**
+   * The open connection, opening it once if need be.
+   *
+   * The failure is remembered only for as long as it is in flight. A rejected
+   * promise left in `opening` would be handed to every later caller for the
+   * life of the process, so one unlucky moment at launch — the previous
+   * process still holding the file, a phone busy enough to time out — would
+   * turn into an app that has permanently stopped saving anything.
+   */
+  private async db(): Promise<SQLite.SQLiteDatabase> {
+    if (this.database) return this.database;
     this.opening ??= (async () => {
       const database = await SQLite.openDatabaseAsync('baaki.db');
       await database.execAsync(SCHEMA);
       this.database = database;
+      return database;
     })();
-    await this.opening;
-  }
-
-  private async db(): Promise<SQLite.SQLiteDatabase> {
-    await this.ready();
-    if (!this.database) throw new Error('The local database failed to open');
-    return this.database;
+    try {
+      return await this.opening;
+    } catch (error) {
+      this.opening = null;
+      throw error;
+    }
   }
 
   async putRows(rows: readonly StoredRow[]): Promise<void> {
     if (rows.length === 0) return;
-    const database = await this.db();
-    // One transaction: a pull is one fact, and half of it landing after a kill
-    // would leave the mirror ahead of its own cursor.
-    await database.withTransactionAsync(async () => {
-      for (const row of rows) {
-        await database.runAsync(
-          `INSERT INTO mirror_rows (table_name, id, group_id, seq, json)
-           VALUES (?, ?, ?, ?, ?)
-           ON CONFLICT (table_name, id) DO UPDATE SET
-             group_id = excluded.group_id, seq = excluded.seq, json = excluded.json`,
-          [row.table, row.id, row.groupId, row.seq, JSON.stringify(row.row)],
-        );
-      }
+    await this.serial.run(async () => {
+      const database = await this.db();
+      // One transaction: a pull is one fact, and half of it landing after a kill
+      // would leave the mirror ahead of its own cursor.
+      await database.withTransactionAsync(async () => {
+        for (const row of rows) {
+          await database.runAsync(
+            `INSERT INTO mirror_rows (table_name, id, group_id, seq, json)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT (table_name, id) DO UPDATE SET
+               group_id = excluded.group_id, seq = excluded.seq, json = excluded.json`,
+            [row.table, row.id, row.groupId, row.seq, JSON.stringify(row.row)],
+          );
+        }
+      });
     });
   }
 
-  async readRows(): Promise<StoredRow[]> {
-    const database = await this.db();
-    const rows = await database.getAllAsync<{
-      table_name: string;
-      id: string;
-      group_id: string;
-      seq: number;
-      json: string;
-    }>(`SELECT table_name, id, group_id, seq, json FROM mirror_rows`);
-    return rows.map((row) => ({
-      table: row.table_name as SyncTable,
-      id: row.id,
-      groupId: row.group_id,
-      seq: row.seq,
-      row: JSON.parse(row.json) as MirrorRow,
-    }));
-  }
-
-  async readCursors(): Promise<Record<string, number>> {
-    const database = await this.db();
-    const rows = await database.getAllAsync<{ group_id: string; seq: number }>(
-      `SELECT group_id, seq FROM sync_cursors`,
-    );
-    return Object.fromEntries(rows.map((row) => [row.group_id, row.seq]));
-  }
-
-  async writeCursors(cursors: Record<string, number>): Promise<void> {
-    const database = await this.db();
-    await database.withTransactionAsync(async () => {
-      for (const [groupId, seq] of Object.entries(cursors)) {
-        await database.runAsync(
-          `INSERT INTO sync_cursors (group_id, seq) VALUES (?, ?)
-           ON CONFLICT (group_id) DO UPDATE SET seq = excluded.seq`,
-          [groupId, seq],
-        );
-      }
+  readRows(): Promise<StoredRow[]> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      const rows = await database.getAllAsync<{
+        table_name: string;
+        id: string;
+        group_id: string;
+        seq: number;
+        json: string;
+      }>(`SELECT table_name, id, group_id, seq, json FROM mirror_rows`);
+      return rows.map((row) => ({
+        table: row.table_name as SyncTable,
+        id: row.id,
+        groupId: row.group_id,
+        seq: row.seq,
+        row: JSON.parse(row.json) as MirrorRow,
+      }));
     });
   }
 
-  async readQueue(): Promise<QueuedMutation[]> {
-    const database = await this.db();
-    const rows = await database.getAllAsync<{ json: string }>(
-      `SELECT json FROM pending_mutations ORDER BY seq ASC`,
-    );
-    return rows.map((row) => JSON.parse(row.json) as QueuedMutation);
-  }
-
-  async writeQueue(queue: readonly QueuedMutation[]): Promise<void> {
-    const database = await this.db();
-    await database.withTransactionAsync(async () => {
-      // `WHERE 1 = 1` for the same reason the server needs it: a bare DELETE is
-      // the kind of statement that is one typo away from deleting everything.
-      await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
-      for (const mutation of queue) {
-        await database.runAsync(
-          `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
-          [mutation.clientMutationId, mutation.seq, JSON.stringify(mutation)],
-        );
-      }
+  readCursors(): Promise<Record<string, number>> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      const rows = await database.getAllAsync<{ group_id: string; seq: number }>(
+        `SELECT group_id, seq FROM sync_cursors`,
+      );
+      return Object.fromEntries(rows.map((row) => [row.group_id, row.seq]));
     });
   }
 
-  async readDraft<T>(key: string): Promise<T | null> {
-    const database = await this.db();
-    const row = await database.getFirstAsync<{ json: string }>(
-      `SELECT json FROM drafts WHERE key = ?`,
-      [key],
-    );
-    return row ? (JSON.parse(row.json) as T) : null;
+  writeCursors(cursors: Record<string, number>): Promise<void> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      await database.withTransactionAsync(async () => {
+        for (const [groupId, seq] of Object.entries(cursors)) {
+          await database.runAsync(
+            `INSERT INTO sync_cursors (group_id, seq) VALUES (?, ?)
+             ON CONFLICT (group_id) DO UPDATE SET seq = excluded.seq`,
+            [groupId, seq],
+          );
+        }
+      });
+    });
   }
 
-  async writeDraft(key: string, value: unknown): Promise<void> {
-    const database = await this.db();
-    await database.runAsync(
-      `INSERT INTO drafts (key, json, saved_at) VALUES (?, ?, ?)
-       ON CONFLICT (key) DO UPDATE SET json = excluded.json, saved_at = excluded.saved_at`,
-      [key, JSON.stringify(value), new Date().toISOString()],
-    );
+  readQueue(): Promise<QueuedMutation[]> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      const rows = await database.getAllAsync<{ json: string }>(
+        `SELECT json FROM pending_mutations ORDER BY seq ASC`,
+      );
+      return rows.map((row) => JSON.parse(row.json) as QueuedMutation);
+    });
   }
 
-  async clearDraft(key: string): Promise<void> {
-    const database = await this.db();
-    await database.runAsync(`DELETE FROM drafts WHERE key = ?`, [key]);
+  writeQueue(queue: readonly QueuedMutation[]): Promise<void> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      await database.withTransactionAsync(async () => {
+        // `WHERE 1 = 1` for the same reason the server needs it: a bare DELETE
+        // is the kind of statement that is one typo away from deleting
+        // everything.
+        await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
+        for (const mutation of queue) {
+          await database.runAsync(
+            `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
+            [mutation.clientMutationId, mutation.seq, JSON.stringify(mutation)],
+          );
+        }
+      });
+    });
   }
 
-  async listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]> {
-    const database = await this.db();
-    const rows = await database.getAllAsync<{ key: string; json: string; saved_at: string }>(
-      `SELECT key, json, saved_at FROM drafts ORDER BY saved_at DESC`,
-    );
-    return rows.map((row) => ({
-      key: row.key,
-      value: JSON.parse(row.json) as unknown,
-      savedAt: row.saved_at,
-    }));
+  readDraft<T>(key: string): Promise<T | null> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      const row = await database.getFirstAsync<{ json: string }>(
+        `SELECT json FROM drafts WHERE key = ?`,
+        [key],
+      );
+      return row ? (JSON.parse(row.json) as T) : null;
+    });
   }
 
-  async reset(): Promise<void> {
-    const database = await this.db();
-    await database.execAsync(`
-      DELETE FROM mirror_rows WHERE 1 = 1;
-      DELETE FROM pending_mutations WHERE 1 = 1;
-      DELETE FROM sync_cursors WHERE 1 = 1;
-      DELETE FROM drafts WHERE 1 = 1;
-    `);
+  writeDraft(key: string, value: unknown): Promise<void> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      await database.runAsync(
+        `INSERT INTO drafts (key, json, saved_at) VALUES (?, ?, ?)
+         ON CONFLICT (key) DO UPDATE SET json = excluded.json, saved_at = excluded.saved_at`,
+        [key, JSON.stringify(value), new Date().toISOString()],
+      );
+    });
+  }
+
+  clearDraft(key: string): Promise<void> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      await database.runAsync(`DELETE FROM drafts WHERE key = ?`, [key]);
+    });
+  }
+
+  listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      const rows = await database.getAllAsync<{ key: string; json: string; saved_at: string }>(
+        `SELECT key, json, saved_at FROM drafts ORDER BY saved_at DESC`,
+      );
+      return rows.map((row) => ({
+        key: row.key,
+        value: JSON.parse(row.json) as unknown,
+        savedAt: row.saved_at,
+      }));
+    });
+  }
+
+  reset(): Promise<void> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      await database.execAsync(`
+        DELETE FROM mirror_rows WHERE 1 = 1;
+        DELETE FROM pending_mutations WHERE 1 = 1;
+        DELETE FROM sync_cursors WHERE 1 = 1;
+        DELETE FROM drafts WHERE 1 = 1;
+      `);
+    });
   }
 }
 

--- a/apps/mobile/src/sync/driver.web.ts
+++ b/apps/mobile/src/sync/driver.web.ts
@@ -12,6 +12,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import type { QueuedMutation } from '@baaki/core';
 
+import { Serial } from './serial';
 import type { LocalStore, StoredRow } from './store';
 
 const WEB_KEYS = {
@@ -22,6 +23,10 @@ const WEB_KEYS = {
 } as const;
 
 class AsyncStorageStore implements LocalStore {
+  // Every entry point below is read-modify-write, so two overlapping callers
+  // lose one of the two writes. Same lock as native, for a plainer reason.
+  private readonly serial = new Serial();
+
   async ready(): Promise<void> {}
 
   private async read<T>(key: string, fallback: T): Promise<T> {
@@ -35,64 +40,75 @@ class AsyncStorageStore implements LocalStore {
     }
   }
 
-  async putRows(rows: readonly StoredRow[]): Promise<void> {
-    if (rows.length === 0) return;
-    const existing = await this.readRows();
-    const byKey = new Map(existing.map((row) => [`${row.table}:${row.id}`, row]));
-    for (const row of rows) byKey.set(`${row.table}:${row.id}`, row);
-    await AsyncStorage.setItem(WEB_KEYS.rows, JSON.stringify([...byKey.values()]));
+  putRows(rows: readonly StoredRow[]): Promise<void> {
+    if (rows.length === 0) return Promise.resolve();
+    return this.serial.run(async () => {
+      const existing = await this.read<StoredRow[]>(WEB_KEYS.rows, []);
+      const byKey = new Map(existing.map((row) => [`${row.table}:${row.id}`, row]));
+      for (const row of rows) byKey.set(`${row.table}:${row.id}`, row);
+      await AsyncStorage.setItem(WEB_KEYS.rows, JSON.stringify([...byKey.values()]));
+    });
   }
 
   readRows(): Promise<StoredRow[]> {
-    return this.read<StoredRow[]>(WEB_KEYS.rows, []);
+    return this.serial.run(() => this.read<StoredRow[]>(WEB_KEYS.rows, []));
   }
 
   readCursors(): Promise<Record<string, number>> {
-    return this.read<Record<string, number>>(WEB_KEYS.cursors, {});
+    return this.serial.run(() => this.read<Record<string, number>>(WEB_KEYS.cursors, {}));
   }
 
-  async writeCursors(cursors: Record<string, number>): Promise<void> {
-    await AsyncStorage.setItem(WEB_KEYS.cursors, JSON.stringify(cursors));
+  writeCursors(cursors: Record<string, number>): Promise<void> {
+    return this.serial.run(() => AsyncStorage.setItem(WEB_KEYS.cursors, JSON.stringify(cursors)));
   }
 
   readQueue(): Promise<QueuedMutation[]> {
-    return this.read<QueuedMutation[]>(WEB_KEYS.queue, []);
+    return this.serial.run(() => this.read<QueuedMutation[]>(WEB_KEYS.queue, []));
   }
 
-  async writeQueue(queue: readonly QueuedMutation[]): Promise<void> {
-    await AsyncStorage.setItem(WEB_KEYS.queue, JSON.stringify(queue));
+  writeQueue(queue: readonly QueuedMutation[]): Promise<void> {
+    return this.serial.run(() => AsyncStorage.setItem(WEB_KEYS.queue, JSON.stringify(queue)));
   }
 
+  /** Unlocked on purpose: every caller already holds the lock. */
   private drafts(): Promise<Record<string, { value: unknown; savedAt: string }>> {
     return this.read<Record<string, { value: unknown; savedAt: string }>>(WEB_KEYS.drafts, {});
   }
 
-  async readDraft<T>(key: string): Promise<T | null> {
-    const drafts = await this.drafts();
-    return (drafts[key]?.value as T | undefined) ?? null;
+  readDraft<T>(key: string): Promise<T | null> {
+    return this.serial.run(async () => {
+      const drafts = await this.drafts();
+      return (drafts[key]?.value as T | undefined) ?? null;
+    });
   }
 
-  async writeDraft(key: string, value: unknown): Promise<void> {
-    const drafts = await this.drafts();
-    drafts[key] = { value, savedAt: new Date().toISOString() };
-    await AsyncStorage.setItem(WEB_KEYS.drafts, JSON.stringify(drafts));
+  writeDraft(key: string, value: unknown): Promise<void> {
+    return this.serial.run(async () => {
+      const drafts = await this.drafts();
+      drafts[key] = { value, savedAt: new Date().toISOString() };
+      await AsyncStorage.setItem(WEB_KEYS.drafts, JSON.stringify(drafts));
+    });
   }
 
-  async clearDraft(key: string): Promise<void> {
-    const drafts = await this.drafts();
-    delete drafts[key];
-    await AsyncStorage.setItem(WEB_KEYS.drafts, JSON.stringify(drafts));
+  clearDraft(key: string): Promise<void> {
+    return this.serial.run(async () => {
+      const drafts = await this.drafts();
+      delete drafts[key];
+      await AsyncStorage.setItem(WEB_KEYS.drafts, JSON.stringify(drafts));
+    });
   }
 
-  async listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]> {
-    const drafts = await this.drafts();
-    return Object.entries(drafts)
-      .map(([key, entry]) => ({ key, value: entry.value, savedAt: entry.savedAt }))
-      .sort((a, b) => b.savedAt.localeCompare(a.savedAt));
+  listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]> {
+    return this.serial.run(async () => {
+      const drafts = await this.drafts();
+      return Object.entries(drafts)
+        .map(([key, entry]) => ({ key, value: entry.value, savedAt: entry.savedAt }))
+        .sort((a, b) => b.savedAt.localeCompare(a.savedAt));
+    });
   }
 
-  async reset(): Promise<void> {
-    await AsyncStorage.multiRemove(Object.values(WEB_KEYS));
+  reset(): Promise<void> {
+    return this.serial.run(() => AsyncStorage.multiRemove(Object.values(WEB_KEYS)));
   }
 }
 

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -29,6 +29,7 @@ import {
   type SyncTable,
 } from '@baaki/core';
 
+import { reportHandled } from '@/lib/observability';
 import { supabase } from '@/lib/supabase';
 
 import { createLocalStore, type LocalStore, type StoredRow } from './store';
@@ -183,9 +184,19 @@ export class SyncEngine {
     // One in flight at a time: two concurrent flushes would send the same batch
     // twice. Harmless thanks to idempotency, but it wastes a round trip and
     // makes the outcome bookkeeping race.
-    this.flushing ??= this.runFlush(options).finally(() => {
-      this.flushing = null;
-    });
+    this.flushing ??= this.runFlush(options)
+      .catch((error: unknown) => {
+        // Hydration and disk failures arrive here. Flush is fired and forgotten
+        // from four places — a timer, foreground, reconnect and every enqueue —
+        // so a rejection has nobody waiting on it and lands on the screen as an
+        // uncaught promise rejection instead. The banner is where this belongs.
+        const message = error instanceof Error ? error.message : String(error);
+        reportHandled(error, 'sync.flush');
+        this.set({ status: 'error', lastError: message });
+      })
+      .finally(() => {
+        this.flushing = null;
+      });
     return this.flushing;
   }
 
@@ -274,8 +285,13 @@ export class SyncEngine {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const queue = markFailed(this.state.queue, batch, message, now);
-      await this.store.writeQueue(queue);
       this.set({ status: 'error', queue, lastError: message });
+      // Writing down *why* the sync failed must not itself become a louder
+      // failure that replaces the reason. The attempt counts are already in
+      // memory and the next flush writes them again.
+      await this.store.writeQueue(queue).catch((writeError: unknown) => {
+        reportHandled(writeError, 'sync.markFailed');
+      });
     }
   }
 

--- a/apps/mobile/src/sync/provider.tsx
+++ b/apps/mobile/src/sync/provider.tsx
@@ -23,6 +23,7 @@ import { randomUUID } from 'expo-crypto';
 import type { MutationEnvelope, MutationKind } from '@baaki/core';
 
 import { useAuth } from '@/lib/auth';
+import { reportHandled } from '@/lib/observability';
 
 import { syncEngine, type SyncState } from './engine';
 
@@ -54,8 +55,12 @@ export function SyncProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!signedIn) {
       // Signing out wipes the mirror: the next person to use this phone must
-      // not find the previous account's ledger in it.
-      if (wasSignedIn.current) void syncEngine.clear();
+      // not find the previous account's ledger in it. Worth reporting rather
+      // than swallowing — a wipe that failed is a privacy problem, not a
+      // cosmetic one — but not worth throwing at a screen mid-sign-out.
+      if (wasSignedIn.current) {
+        void syncEngine.clear().catch((error: unknown) => reportHandled(error, 'sync.clear'));
+      }
       wasSignedIn.current = false;
       syncEngine.stop();
       return;
@@ -64,7 +69,13 @@ export function SyncProvider({ children }: { children: ReactNode }) {
     wasSignedIn.current = true;
     let cancelled = false;
     void (async () => {
-      await syncEngine.hydrate();
+      // Nothing awaits this, so anything thrown here would surface as an
+      // uncaught promise rejection over whatever screen happens to be up.
+      // `flush` hydrates too, and records the failure where the banner can
+      // read it.
+      await syncEngine.hydrate().catch((error: unknown) => {
+        reportHandled(error, 'sync.hydrate');
+      });
       if (cancelled) return;
       syncEngine.start();
       void syncEngine.flush();
@@ -151,7 +162,11 @@ export function useDraft<T>(key: string, value: T, options: { enabled?: boolean 
   useEffect(() => {
     if (!enabled) return;
     const timer = setTimeout(() => {
-      void syncEngine.saveDraft(key, JSON.parse(serialised) as T);
+      // A draft is a convenience. Losing one to a busy disk is a shame; showing
+      // somebody a crash dialog in the middle of typing an expense is worse.
+      void syncEngine
+        .saveDraft(key, JSON.parse(serialised) as T)
+        .catch((error: unknown) => reportHandled(error, 'sync.saveDraft'));
     }, 300);
     return () => clearTimeout(timer);
   }, [key, serialised, enabled]);
@@ -169,6 +184,7 @@ export function useRestoredDraft<T>(key: string): { draft: T | null; loading: bo
       .then((value) => {
         if (active) setDraft(value);
       })
+      .catch((error: unknown) => reportHandled(error, 'sync.readDraft'))
       .finally(() => {
         if (active) setLoading(false);
       });

--- a/apps/mobile/src/sync/serial.ts
+++ b/apps/mobile/src/sync/serial.ts
@@ -1,0 +1,44 @@
+/**
+ * One at a time, please.
+ *
+ * Both local stores are shared by callers that do not know about each other:
+ * a flush persisting a server answer, a keystroke saving a draft, and a tap
+ * queueing a mutation can all be in flight in the same tick. Neither store
+ * survives that on its own.
+ *
+ * On native it is worse than a lost write. `withTransactionAsync` is, in
+ * expo-sqlite's own source, `execAsync('BEGIN')` … `execAsync('COMMIT')` on the
+ * *shared* connection — so a second caller's `BEGIN` lands inside the first
+ * one's transaction and SQLite refuses it. The failure then rolls back work
+ * that belonged to somebody else, which for the mutation queue means quietly
+ * dropping something the person was told had been saved.
+ *
+ * On web the store is read-modify-write over AsyncStorage, so two overlapping
+ * `putRows` calls simply lose one of them.
+ *
+ * The fix for both is the same and belongs in one place: a promise chain that
+ * every public store method passes through, so the disk sees one operation at
+ * a time in the order it was asked for.
+ */
+
+/** A queue of one. Tasks run in the order they were handed over. */
+export class Serial {
+  private tail: Promise<unknown> = Promise.resolve();
+
+  run<T>(task: () => Promise<T>): Promise<T> {
+    // The same `task` on both arms: a failure ahead of us in the queue is that
+    // caller's problem, not a reason to refuse to run. Without this a single
+    // rejected write would wedge the store for the life of the process.
+    const result = this.tail.then(task, task);
+
+    // The chain remembers only that the slot is free, never why it freed up.
+    // Keeping the rejection here instead would surface it a second time, with
+    // nobody waiting on it, as an unhandled promise rejection.
+    this.tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return result;
+  }
+}

--- a/apps/mobile/test/localStore.test.ts
+++ b/apps/mobile/test/localStore.test.ts
@@ -1,0 +1,205 @@
+/**
+ * The local store under two callers at once.
+ *
+ * This is the shape of the bug that produced `Call to function
+ * 'NativeDatabase.prepareAsync' has been rejected.` on cold start. Nothing in
+ * the app calls the store from one place: a flush persisting a server answer,
+ * a keystroke saving a draft and a tap queueing a mutation are all in flight
+ * within the same second of launch.
+ *
+ * expo-sqlite's `withTransactionAsync` is — in its own source — `BEGIN`,
+ * the task, `COMMIT`, run on the *shared* connection. So a second caller's
+ * `BEGIN` arrives inside the first one's transaction, SQLite refuses it, and
+ * the rollback that follows throws away work that belonged to somebody else.
+ * The fake below is faithful about exactly that and nothing else.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { QueuedMutation } from '@baaki/core';
+
+/** A pause long enough for another caller to interleave, if it can. */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+class FakeDatabase {
+  inTransaction = false;
+  /** Statements that actually ran, in order. */
+  readonly statements: string[] = [];
+  /** How deep the nesting got. More than one means the lock is not working. */
+  concurrent = 0;
+  private live = 0;
+
+  private async enter<T>(run: () => Promise<T>): Promise<T> {
+    this.live += 1;
+    this.concurrent = Math.max(this.concurrent, this.live);
+    try {
+      return await run();
+    } finally {
+      this.live -= 1;
+    }
+  }
+
+  async execAsync(source: string): Promise<void> {
+    await this.enter(async () => {
+      await tick();
+      const command = source.trim().split(/\s+/)[0]?.toUpperCase();
+      if (command === 'BEGIN') {
+        if (this.inTransaction) {
+          throw new Error('cannot start a transaction within a transaction');
+        }
+        this.inTransaction = true;
+      } else if (command === 'COMMIT' || command === 'ROLLBACK') {
+        if (!this.inTransaction) {
+          throw new Error(`cannot ${command.toLowerCase()} - no transaction is active`);
+        }
+        this.inTransaction = false;
+      }
+      this.statements.push(source.trim());
+    });
+  }
+
+  async runAsync(source: string): Promise<void> {
+    await this.enter(async () => {
+      await tick();
+      // Three tokens, so `INSERT INTO drafts` and `INSERT INTO
+      // pending_mutations` stay tellable apart — the whole point of one test.
+      this.statements.push(source.trim().split(/\s+/).slice(0, 3).join(' '));
+    });
+  }
+
+  async getAllAsync<T>(): Promise<T[]> {
+    return this.enter(async () => {
+      await tick();
+      return [];
+    });
+  }
+
+  async getFirstAsync<T>(): Promise<T | null> {
+    return this.enter(async () => {
+      await tick();
+      return null;
+    });
+  }
+
+  // Copied in shape from expo-sqlite's own implementation, which is the whole
+  // point: it is not atomic against anything else using this connection.
+  async withTransactionAsync(task: () => Promise<void>): Promise<void> {
+    try {
+      await this.execAsync('BEGIN');
+      await task();
+      await this.execAsync('COMMIT');
+    } catch (error) {
+      await this.execAsync('ROLLBACK');
+      throw error;
+    }
+  }
+}
+
+let database: FakeDatabase;
+let openCalls = 0;
+let failNextOpen = false;
+
+vi.mock('expo-sqlite', () => ({
+  openDatabaseAsync: async () => {
+    openCalls += 1;
+    await tick();
+    if (failNextOpen) {
+      failNextOpen = false;
+      throw new Error('unable to open database file');
+    }
+    return database;
+  },
+}));
+
+const { createLocalStore } = await import('../src/sync/driver');
+
+const mutation = (id: string): QueuedMutation =>
+  ({
+    clientMutationId: id,
+    seq: 1,
+    kind: 'expense.create',
+    groupId: 'g1',
+    clientCreatedAt: '2026-01-01T00:00:00.000Z',
+    payload: {},
+    attempts: 0,
+    nextAttemptAt: 0,
+    lastError: null,
+  }) as unknown as QueuedMutation;
+
+beforeEach(() => {
+  database = new FakeDatabase();
+  openCalls = 0;
+  failNextOpen = false;
+});
+
+describe('two callers, one connection', () => {
+  it('does not nest one transaction inside another', async () => {
+    const store = createLocalStore();
+
+    // The cold-start shape: the queue being written while a pull is persisting
+    // rows, which is what a tap during the first flush actually looks like.
+    await Promise.all([
+      store.writeQueue([mutation('a')]),
+      store.putRows([
+        { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
+      ] as never),
+      store.writeCursors({ g1: 1 }),
+    ]);
+
+    expect(database.concurrent).toBe(1);
+    expect(database.inTransaction).toBe(false);
+    expect(database.statements.filter((s) => s === 'ROLLBACK')).toEqual([]);
+  });
+
+  it('keeps a bare write out of somebody else’s transaction', async () => {
+    const store = createLocalStore();
+
+    // A draft save is a single statement with no transaction of its own, so
+    // without the lock it lands between another caller's BEGIN and COMMIT.
+    await Promise.all([
+      store.writeQueue([mutation('a')]),
+      store.writeDraft('expense:new', { a: 1 }),
+    ]);
+
+    const begin = database.statements.indexOf('BEGIN');
+    const commit = database.statements.indexOf('COMMIT');
+    const draft = database.statements.indexOf('INSERT INTO drafts');
+    expect(begin).toBeGreaterThanOrEqual(0);
+    expect(commit).toBeGreaterThan(begin);
+    // Either wholly before the transaction or wholly after it, never inside.
+    expect(draft < begin || draft > commit).toBe(true);
+  });
+
+  it('runs the work in the order it was asked for', async () => {
+    const store = createLocalStore();
+    const order: string[] = [];
+
+    await Promise.all([
+      store.writeQueue([mutation('a')]).then(() => order.push('queue')),
+      store.writeDraft('k', 1).then(() => order.push('draft')),
+      store.clearDraft('k').then(() => order.push('clear')),
+    ]);
+
+    expect(order).toEqual(['queue', 'draft', 'clear']);
+  });
+});
+
+describe('an open that fails', () => {
+  it('lets the next call try again instead of failing forever', async () => {
+    const store = createLocalStore();
+    failNextOpen = true;
+
+    await expect(store.readQueue()).rejects.toThrow('unable to open database file');
+
+    // The whole point: one bad moment at launch must not leave an app that has
+    // permanently stopped saving anything until it is killed and reopened.
+    await expect(store.readQueue()).resolves.toEqual([]);
+    expect(openCalls).toBe(2);
+  });
+
+  it('opens once and once only when it works', async () => {
+    const store = createLocalStore();
+    await Promise.all([store.readQueue(), store.readRows(), store.readCursors()]);
+    expect(openCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
`Call to function 'NativeDatabase.prepareAsync' has been rejected.` on cold start was never investigated. It is two callers writing through the same connection at once, and it was costing more than a toast.

## What was happening

expo-sqlite's `withTransactionAsync` is — in [its own source](https://github.com/expo/expo/blob/main/packages/expo-sqlite/src/SQLiteDatabase.ts) — `execAsync('BEGIN')`, the task, `execAsync('COMMIT')`, run on the **shared** connection. It is not isolated from anything else using that connection.

Nothing in this app calls the store from one place. Within the first second of launch:

- `runFlush` persists a server answer as `putRows` → `writeCursors` → `writeQueue`, three transactions back to back
- `useDraft` autosaves as a bare `INSERT`, on a 300 ms debounce, with no transaction of its own
- any tap calls `enqueue`, which writes the queue in a fourth

When two of those overlap, SQLite refuses the nested `BEGIN`, and the `catch` in `withTransactionAsync` issues a `ROLLBACK` that **discards work belonging to the other caller**. For the mutation queue that means dropping something the person was already told had been saved — the one thing ADR-005 promises will survive a force-kill.

## The fix

`Serial` — a one-deep promise chain that every public store method passes through, so the disk sees one operation at a time in the order it was asked for. The web store gets the same lock for a plainer reason: it is read-modify-write over AsyncStorage, so two overlapping `putRows` simply lose one.

## Two more things this turned up

**A failed open poisoned the store for the life of the process.** `this.opening ??= …` is never reassigned once it holds a rejected promise, so every later call awaited the same failure. One unlucky moment at launch — the previous process still holding the file after a fast relaunch — left an app that had permanently stopped saving anything until it was killed and reopened. The failure is now remembered only while it is in flight.

**The error had nowhere to land, which is why it reached the screen.** `flush` is fired and forgotten from four places (timer, foreground, reconnect, every enqueue), and the `catch` inside `runFlush` awaited *another* queue write that could throw in turn. So a disk failure became an uncaught promise rejection over whatever screen was up. Storage failures now land in `lastError` for the sync banner and in `reportHandled`; the four fire-and-forget call sites in the provider each catch their own.

## Verification

`test/localStore.test.ts` fakes a connection that is faithful about exactly one thing — refusing a nested `BEGIN` — and drives the cold-start shape through it. **All three concurrency tests fail if `Serial` is removed** and pass with it; the two open-failure tests hold either way.

On an emulator: six cold starts with zero rejections in logcat, an expense saved and synced, and still there after a force-stop and relaunch.

134 mobile tests, repo `tsc`, `expo lint` and prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6