### PR TITLE
feat: let the app restart itself, and turn on EAS Update

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -168,6 +168,17 @@ interchangeable — telling somebody who has just chosen English that reopening
 will "mirror it" describes the opposite of what will happen, on the one screen
 they are reading to find out why it has not turned back.
 
+Since `expo-updates` was added, the app can restart itself, so the alert
+**offers** rather than instructs. It still asks: throwing somebody out of the
+screen they are standing on is not a thing to do without permission, and the
+banner keeps a Restart button for whoever says "not now" and changes their mind.
+Builds that cannot do it — anything older than the binary that added the module,
+and any reload the platform refuses — fall back to the sentence that was always
+true. That check has to be `requireOptionalNativeModule('ExpoUpdates')` rather
+than a `try`/`catch` around the import: `expo-updates` calls
+`requireNativeModule` at its own module scope, and that throw reaches the global
+error handler on the way past, so the red box appears even though the catch runs.
+
 The choice is offered twice, and the second time is the important one. A
 settings row is the right home for it once somebody is inside the app; it is the
 wrong home for somebody standing at the front door who cannot read the door.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -8,6 +8,13 @@
     "scheme": "baaki",
     "userInterfaceStyle": "automatic",
     "backgroundColor": "#F3F1FB",
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/d0d34ed9-5888-4204-b116-a873d3bec94f",
+      "fallbackToCacheTimeout": 0
+    },
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "app.baaki.mobile"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -45,6 +45,7 @@
     "expo-status-bar": "~57.0.1",
     "expo-symbols": "~57.0.2",
     "expo-system-ui": "~57.0.2",
+    "expo-updates": "~57.0.12",
     "expo-web-browser": "~57.0.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -16,10 +16,21 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ScrollView, View } from 'react-native';
 
-import { Card, directionalIcon, IconButton, ListRow, Row, Screen, Text, useTheme } from '@baaki/ui';
+import {
+  Button,
+  Card,
+  directionalIcon,
+  IconButton,
+  ListRow,
+  Row,
+  Screen,
+  Text,
+  useTheme,
+} from '@baaki/ui';
 
 import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES, useStrings, type Language } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
+import { canRestart, restartApp } from '@/lib/restart';
 
 export default function LanguageSettingsScreen() {
   const theme = useTheme();
@@ -79,6 +90,16 @@ export default function LanguageSettingsScreen() {
                 ? t.account.restartBannerMirror
                 : t.account.restartBannerUnmirror}
             </Text>
+            {/* The alert at the moment of the choice can be dismissed, and this
+                is where somebody comes back to when they change their mind. */}
+            {canRestart() ? (
+              <Button
+                label={t.account.restartNow}
+                size="sm"
+                variant="secondary"
+                onPress={() => void restartApp()}
+              />
+            ) : null}
           </Card>
         ) : null}
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -303,7 +303,10 @@ export interface UiStrings {
     languageRestartHint: string;
     languageRestartHintBack: string;
     restartTitle: string;
+    restartNow: string;
     restartBannerMirror: string;
+    restartNowMirror: string;
+    restartNowUnmirror: string;
     restartBannerUnmirror: string;
     languageFooterNote: string;
     lockNoBiometrics: string;
@@ -800,6 +803,9 @@ const en: UiStrings = {
     languageRestartHint: '{language} · reopen Baaki to mirror it',
     languageRestartHintBack: '{language} · reopen Baaki to turn the layout back',
     restartTitle: 'Close and open Baaki again',
+    restartNow: 'Restart Baaki',
+    restartNowMirror: 'Restart Baaki now to mirror the layout?',
+    restartNowUnmirror: 'Restart Baaki now to turn the layout back?',
     restartBannerMirror:
       'The words have changed already. Mirroring the layout — the arrows, the sides everything sits on — is something the phone decides when the app starts, so it takes effect next time you open it.',
     restartBannerUnmirror:
@@ -1332,6 +1338,9 @@ const ta: UiStrings = {
     languageRestartHint: '{language} · பிரதிபலிக்க பாக்கியை மீண்டும் திற',
     languageRestartHintBack: '{language} · தளவமைப்பை மீட்க பாக்கியை மீண்டும் திற',
     restartTitle: 'பாக்கியை மூடித் திறக்கவும்',
+    restartNow: 'பாக்கியை மறுதொடக்கம் செய்',
+    restartNowMirror: 'தளவமைப்பைப் பிரதிபலிக்க பாக்கியை இப்போதே மறுதொடக்கம் செய்யவா?',
+    restartNowUnmirror: 'தளவமைப்பை மீண்டும் மாற்ற பாக்கியை இப்போதே மறுதொடக்கம் செய்யவா?',
     restartBannerMirror:
       'சொற்கள் ஏற்கெனவே மாறிவிட்டன. தளவமைப்பைப் பிரதிபலிப்பது — அம்புக்குறிகள், எல்லாம் அமரும் பக்கம் — செயலி தொடங்கும்போது ஃபோன் முடிவு செய்வது. எனவே அடுத்த முறை திறக்கும்போதுதான் அது நடக்கும்.',
     restartBannerUnmirror:
@@ -1856,6 +1865,9 @@ const hi: UiStrings = {
     languageRestartHint: '{language} · दिशा बदलने के लिए बाकी दोबारा खोलें',
     languageRestartHintBack: '{language} · दिशा वापस लाने के लिए बाकी दोबारा खोलें',
     restartTitle: 'बाकी को बंद करके दोबारा खोलें',
+    restartNow: 'बाकी दोबारा शुरू करें',
+    restartNowMirror: 'दिशा बदलने के लिए बाकी अभी दोबारा शुरू करें?',
+    restartNowUnmirror: 'दिशा वापस लाने के लिए बाकी अभी दोबारा शुरू करें?',
     restartBannerMirror:
       'शब्द तो पहले ही बदल गए हैं। लेआउट को पलटना — तीर, और हर चीज़ किस तरफ़ बैठती है — यह फ़ोन ऐप शुरू होते समय तय करता है, इसलिए यह अगली बार खोलने पर लागू होगा।',
     restartBannerUnmirror:
@@ -2393,6 +2405,9 @@ const ar: UiStrings = {
     languageRestartHint: '{language} · أعد فتح باقي لعكس الاتجاه',
     languageRestartHintBack: '{language} · أعد فتح باقي لإعادة الاتجاه',
     restartTitle: 'أغلق باقي وافتحه من جديد',
+    restartNow: 'أعد تشغيل باقي',
+    restartNowMirror: 'هل نعيد تشغيل باقي الآن لعكس اتجاه الواجهة؟',
+    restartNowUnmirror: 'هل نعيد تشغيل باقي الآن لإعادة الاتجاه؟',
     restartBannerMirror:
       'تغيّرت الكلمات بالفعل. أما عكس اتجاه الواجهة — الأسهم والجهة التي يجلس عليها كل شيء — فيقرره الهاتف عند بدء التطبيق، لذا يسري في المرة القادمة التي تفتحه فيها.',
     restartBannerUnmirror:

--- a/apps/mobile/src/i18n/language.tsx
+++ b/apps/mobile/src/i18n/language.tsx
@@ -12,9 +12,13 @@
  * Strings change instantly — they are React state and nothing else. Direction
  * does not. React Native decides right-to-left once, natively, before any
  * JavaScript runs, and `I18nManager.forceRTL` says so itself: *changes take
- * full effect on the next application start*. There is no reload to call — this
- * app does not carry `expo-updates` — so the honest thing is to say the words
- * "close and open Baaki again" rather than write half a mirrored screen.
+ * full effect on the next application start*. So the app restarts itself, via
+ * `@/lib/restart` — and asks first, because throwing somebody out of the screen
+ * they are standing on is not something to do without permission.
+ *
+ * A build that cannot restart itself — anything older than the one that added
+ * `expo-updates`, and any reload the platform refuses — still gets the sentence
+ * that was always true: close and open Baaki again.
  *
  * Said in an alert, at the moment of the choice, and not only in a banner. A
  * banner lives on one screen; somebody who taps a language and walks away never
@@ -50,6 +54,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Alert, I18nManager, Platform } from 'react-native';
 
 import { setLayoutDirection } from '@baaki/ui';
+
+import { canRestart, restartApp } from '@/lib/restart';
 
 import {
   deviceLanguage,
@@ -158,11 +164,26 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
       // ends where it started, and there is nothing left to restart for.
       if (rtl !== LAUNCHED_RTL) {
         const words = STRINGS_BY_LANGUAGE[chosen];
-        Alert.alert(
-          words.account.restartTitle,
-          rtl ? words.signIn.restartToMirror : words.signIn.restartToUnmirror,
-          [{ text: words.common.ok }],
-        );
+
+        // Builds carrying `expo-updates` can do it themselves, so they offer
+        // rather than instruct. Older binaries — and any build that refuses the
+        // reload — still get the sentence that was always true.
+        if (canRestart()) {
+          Alert.alert(
+            words.account.restartTitle,
+            rtl ? words.account.restartNowMirror : words.account.restartNowUnmirror,
+            [
+              { text: words.misc.notNow, style: 'cancel' },
+              { text: words.account.restartNow, onPress: () => void restartApp() },
+            ],
+          );
+        } else {
+          Alert.alert(
+            words.account.restartTitle,
+            rtl ? words.signIn.restartToMirror : words.signIn.restartToUnmirror,
+            [{ text: words.common.ok }],
+          );
+        }
       }
     }
   }, []);

--- a/apps/mobile/src/lib/restart.ts
+++ b/apps/mobile/src/lib/restart.ts
@@ -1,0 +1,83 @@
+/**
+ * Restarting the app from inside it.
+ *
+ * There is exactly one thing in Baaki that cannot take effect while the app is
+ * running: the direction the layout runs in. React Native reads that from
+ * native constants before any JavaScript, so `I18nManager.forceRTL` says of
+ * itself that changes *take full effect on the next application start*. Until
+ * this file existed the only honest answer was to ask the person to close and
+ * open Baaki, which two people in a row read as a broken app.
+ *
+ * `expo-updates` owns the only supported way to restart the JavaScript runtime
+ * in a release build. It is here for that, and the fact that it also brings OTA
+ * updates is a separate decision recorded in `app.json`.
+ *
+ * ## Why it is asked for twice, and required rather than imported
+ *
+ * Every build older than the one that added `expo-updates` — including the
+ * development client on somebody's phone right now — has no such native module,
+ * and a static import is hoisted and evaluated at module load. That is how a
+ * missing native module stops being a failed feature and becomes an app that
+ * dies at launch. Nothing in the type checker, the linter or the test suite
+ * catches it, because all three run against the JavaScript.
+ *
+ * A `try`/`catch` around the require is *not* enough, which cost a round trip
+ * on a device to learn. `expo-updates` calls `requireNativeModule('ExpoUpdates')`
+ * at its own module scope, and that throw is reported to the global error
+ * handler on the way past — so the red box appears even though the catch runs
+ * and returns null. `requireOptionalNativeModule` is the same lookup with the
+ * throw replaced by a null, so asking it first means nothing is ever thrown.
+ */
+
+// Via `expo` rather than `expo-modules-core`, which is a transitive dependency
+// this app does not declare and has no business importing directly.
+import { requireOptionalNativeModule } from 'expo';
+import { Platform } from 'react-native';
+
+interface UpdatesModule {
+  reloadAsync: () => Promise<void>;
+}
+
+function loadUpdates(): UpdatesModule | null {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') return null;
+  if (requireOptionalNativeModule('ExpoUpdates') == null) return null;
+  try {
+    // Required, not imported: an import is hoisted and evaluated at module
+    // load, which is the thing the check above exists to avoid.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const loaded = require('expo-updates') as Partial<UpdatesModule>;
+    return typeof loaded?.reloadAsync === 'function' ? (loaded as UpdatesModule) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether this build can restart itself.
+ *
+ * False on web, where there is nothing to restart — the layout mirrors the
+ * moment `dir` changes — and false on any binary built before `expo-updates`
+ * was added. Callers use it to decide *what to offer*, not what to say
+ * afterwards: a screen that offers a button it cannot honour is worse than one
+ * that asks plainly.
+ */
+export function canRestart(): boolean {
+  return loadUpdates() !== null;
+}
+
+/**
+ * Restart now. Resolves `false` if it could not, and does not resolve at all in
+ * the ordinary case — the runtime is gone before the promise settles.
+ */
+export async function restartApp(): Promise<boolean> {
+  const updates = loadUpdates();
+  if (!updates) return false;
+  try {
+    await updates.reloadAsync();
+    return true;
+  } catch {
+    // A refused reload leaves the app running and perfectly usable, just still
+    // the old way round. The words about closing it by hand are still true.
+    return false;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       expo-system-ui:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.11)(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(supports-color@8.1.1)
+      expo-updates:
+        specifier: ~57.0.12
+        version: 57.0.12(expo-dev-client@57.0.10(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)))(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
       expo-web-browser:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))
@@ -2967,6 +2970,9 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -3794,6 +3800,9 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-eas-client@57.0.1:
+    resolution: {integrity: sha512-4w51+zsl/ziUHQMJgLgUdgsNhRPAwHBfySpPB1hpWU21X74QS9T4SqDftaRnrDagn/DfcrXUMJvHbDQUxLPJNA==}
+
   expo-file-system@57.0.2:
     resolution: {integrity: sha512-bPgzpaOJ3NWHZxV++Osj/1QoFzFe/QOo1jBF4EODJdiZgrrxyi2dv+7PLhKuut5QqPBuihUOITRh3s5jhRtA5A==}
     peerDependencies:
@@ -3984,6 +3993,9 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-structured-headers@57.0.0:
+    resolution: {integrity: sha512-//t9UNPbJSEysc2x4VKJG/u7Osvv5DYJWsET5bqt/B+qcD1by/JXvSQzX3Q/YAgA96xFPontrz6OAPLbO4JKEA==}
+
   expo-symbols@57.0.2:
     resolution: {integrity: sha512-qZ0iqOflm5lZGwRsQ5Y8sDksw3GAUKwHSX1bJBoocXf7gu14vafIXXYWte+JT9VfXAUGyKodJhLHP/GoOrcNWg==}
     peerDependencies:
@@ -4006,6 +4018,18 @@ packages:
     resolution: {integrity: sha512-+LUWwJ0gf/TEKMVdQAw/Gjih4dvrk+URgy24X9qEGKuuMDZqjBRm9T4yQyBVALGL5TTdPUaB6ILxx3lshm3pwQ==}
     peerDependencies:
       expo: '*'
+
+  expo-updates@57.0.12:
+    resolution: {integrity: sha512-ZFsW8Mi9qFrrYPSXF++1FXejjflRdgbVPzaSJJATuHelVmIIb3D98gCO9sIsaLPHO1RCQVj1ltkj51VnwVL+4g==}
+    hasBin: true
+    peerDependencies:
+      expo: '*'
+      expo-dev-client: '*'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      expo-dev-client:
+        optional: true
 
   expo-web-browser@57.0.2:
     resolution: {integrity: sha512-3vl5kvd7PB48ub6PpNIJUuPxO8xVa6D8RnIgNba6SXRwqFprOfeEZgwTgtm41kz0AAtvMOztUVNEUkwrHKjqMQ==}
@@ -9009,6 +9033,8 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  arg@4.1.3: {}
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -10167,6 +10193,8 @@ snapshots:
     dependencies:
       expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
 
+  expo-eas-client@57.0.1: {}
+
   expo-file-system@57.0.2(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)):
     dependencies:
       expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
@@ -10388,6 +10416,8 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
+  expo-structured-headers@57.0.0: {}
+
   expo-symbols@57.0.2(expo-font@57.0.1)(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.42
@@ -10411,6 +10441,31 @@ snapshots:
   expo-updates-interface@57.0.1(expo@57.0.11):
     dependencies:
       expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+
+  expo-updates@57.0.12(expo-dev-client@57.0.10(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)))(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1):
+    dependencies:
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/plist': 0.8.1
+      '@expo/spawn-async': 1.8.0
+      arg: 4.1.3
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      expo-eas-client: 57.0.1
+      expo-manifests: 57.0.1(expo@57.0.11)
+      expo-structured-headers: 57.0.0
+      expo-updates-interface: 57.0.1(expo@57.0.11)
+      getenv: 2.0.0
+      glob: 13.0.6
+      ignore: 5.3.2
+      nullthrows: 1.1.1
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
+      resolve-from: 5.0.0
+    optionalDependencies:
+      expo-dev-client: 57.0.10(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))
+    transitivePeerDependencies:
+      - supports-color
 
   expo-web-browser@57.0.2(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)):
     dependencies:


### PR DESCRIPTION
The layout direction is the one thing in Baaki that cannot take effect while the app is running. React Native reads it from native constants before any JavaScript, and `I18nManager.forceRTL` says of itself that changes *take full effect on the next application start*. Until now the only honest answer was to ask somebody to close and open Baaki — which two people in a row read as a broken app.

`expo-updates` owns the only supported way to restart the JavaScript runtime in a release build. It is here for that.

## This is a release-process change, not a side effect

Adding the module turns on EAS Update. That was the explicit choice, and it is worth being plain about what it brings:

- `eas update` can now ship JS-only fixes without a store release
- `runtimeVersion` follows `appVersion`
- the `development` / `preview` / `production` channels already declared in `eas.json` become live
- the app checks for an update on cold start (`fallbackToCacheTimeout: 0`, so it never blocks launch)

**The discipline `appVersion` asks for**: an update is only delivered to binaries whose runtime version matches, so any change touching native code — a new Expo module, a config plugin, a native dependency bump — needs `version` in `app.json` bumped **and a fresh build**, or the OTA lands on a binary that lacks the native module. The `fingerprint` policy computes this automatically and is the upgrade path if that discipline slips; Expo's docs still call it experimental, so this takes the recommended default.

## The interaction

The alert now **offers** rather than instructs, with a Restart button, and the banner on the language screen keeps one for whoever says "not now" and changes their mind. It asks first — throwing somebody out of the screen they are standing on is not a thing to do without permission. Six new strings, all four languages.

## One thing that cost a device round trip

The availability check is `requireOptionalNativeModule('ExpoUpdates')`, **not** a `try`/`catch` around the import. `expo-updates` calls `requireNativeModule` at its own module scope, and that throw reaches the global error handler on the way past — so the red box appears even though the catch runs and returns null. First attempt did exactly that:

> `Uncaught Error — Cannot find native module 'ExpoUpdates'` at `restart.ts:35:27`, inside the `try`.

## Verification, and its limit

Verified on the installed dev build, which has **no** `expo-updates` native module — the case every existing binary is in:

- cold start, no red box, no crash
- choosing Arabic and choosing English back both fall through to the plain "close and open Baaki again" alert
- no Restart button on the banner

**The restart path itself is not verified.** It cannot be until a native build carrying `expo-updates` exists, and the same is true of the first `eas update` publish. Both are the next thing to do with this branch, not something this PR can claim.

134 mobile tests, repo `tsc`, `expo lint` and prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6