### PR TITLE
i18n: web-lite speaks the same four languages

### DIFF
--- a/apps/web-lite/next.config.ts
+++ b/apps/web-lite/next.config.ts
@@ -2,14 +2,19 @@ import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 
 /**
- * Every page here is a client component, and that is a decision rather than a
- * default.
+ * Every page that reads data is a client component, and that is a decision
+ * rather than a default.
  *
  * Reads happen in the visitor's browser under their own session, so RLS is
  * what decides what they see (ADR-013). Rendering a group on the server would
  * need a key of its own, and the only key able to render somebody else's group
  * is one that must never leave an edge function (TDR §11). Nothing is gained
  * by moving the fetch: the page is behind an invite token either way.
+ *
+ * The layout and the home page are the exception, and read nothing: they are
+ * server components solely so `Accept-Language` can decide `lang` and `dir`
+ * before the first paint. A language guessed twice — once on the server and
+ * again from `navigator.language` — is a page that visibly changes its mind.
  *
  * A static export would have been simpler still, but the invite links already
  * in circulation are `/join/<token>` — a dynamic segment whose values cannot

--- a/apps/web-lite/src/app/g/[groupId]/add/page.tsx
+++ b/apps/web-lite/src/app/g/[groupId]/add/page.tsx
@@ -22,11 +22,14 @@ import { nameOf, type Group, type Member } from '@baaki/api-client';
 
 import { baaki } from '@/lib/baaki';
 import { money } from '@/lib/money';
+import { fill } from '@/i18n';
+import { useStrings } from '@/i18n-context';
 
 export default function AddExpensePage() {
   const params = useParams<{ groupId: string }>();
   const router = useRouter();
   const groupId = params.groupId;
+  const { t } = useStrings();
 
   const [group, setGroup] = useState<Group | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
@@ -110,7 +113,7 @@ export default function AddExpensePage() {
     try {
       await baaki.writeExpense({
         groupId,
-        description: description.trim() || 'Expense',
+        description: description.trim() || t.add.defaultDescription,
         expenseDate: new Date().toISOString().slice(0, 10),
         currency,
         amount,
@@ -126,13 +129,22 @@ export default function AddExpensePage() {
       setError(caught instanceof Error ? caught.message : String(caught));
       setSaving(false);
     }
-  }, [amount, payer, participants, groupId, description, currency, router]);
+  }, [
+    amount,
+    payer,
+    participants,
+    groupId,
+    description,
+    currency,
+    router,
+    t.add.defaultDescription,
+  ]);
 
   if (!group) {
     return (
       <main>
         <div className="card">
-          <p className="muted">Loading…</p>
+          <p className="muted">{t.group.loading}</p>
         </div>
       </main>
     );
@@ -143,27 +155,25 @@ export default function AddExpensePage() {
   return (
     <main>
       <div className="card">
-        <h1>Add an expense</h1>
+        <h1>{t.add.title}</h1>
         <input
           value={description}
           onChange={(event) => setDescription(event.target.value)}
-          placeholder="What was it?"
-          aria-label="What was it?"
+          placeholder={t.add.whatWasIt}
+          aria-label={t.add.whatWasIt}
         />
         <input
           value={amountText}
           onChange={(event) => setAmountText(event.target.value)}
           inputMode="decimal"
-          placeholder={`How much? (${currency})`}
-          aria-label={`Amount in ${currency}`}
+          placeholder={fill(t.add.howMuch, { currency })}
+          aria-label={fill(t.add.amountIn, { currency })}
         />
-        {amountText.trim() && amount === null ? (
-          <p className="error">That is not an amount.</p>
-        ) : null}
+        {amountText.trim() && amount === null ? <p className="error">{t.add.notAnAmount}</p> : null}
       </div>
 
       <div className="card">
-        <h2>Who paid</h2>
+        <h2>{t.add.whoPaid}</h2>
         <div className="people">
           {members.map((member) => (
             <button
@@ -173,14 +183,14 @@ export default function AddExpensePage() {
               aria-pressed={payer === member.id}
               onClick={() => setPayer(member.id)}
             >
-              {member.profile_id === myProfileId ? 'You' : nameOf(member)}
+              {member.profile_id === myProfileId ? t.add.you : nameOf(member)}
             </button>
           ))}
         </div>
       </div>
 
       <div className="card">
-        <h2>Split between</h2>
+        <h2>{t.add.splitBetween}</h2>
         <div className="people">
           {members.map((member) => (
             <button
@@ -190,7 +200,7 @@ export default function AddExpensePage() {
               aria-pressed={participants.includes(member.id)}
               onClick={() => toggle(member.id)}
             >
-              {member.profile_id === myProfileId ? 'You' : nameOf(member)}
+              {member.profile_id === myProfileId ? t.add.you : nameOf(member)}
             </button>
           ))}
         </div>
@@ -202,9 +212,7 @@ export default function AddExpensePage() {
                 <span className="money">{money(share, currency)}</span>
               </div>
             ))}
-            <p className="faint">
-              Split equally. For exact shares or an itemised bill, use the app.
-            </p>
+            <p className="faint">{t.add.splitEquallyNote}</p>
           </>
         ) : null}
       </div>
@@ -212,10 +220,10 @@ export default function AddExpensePage() {
       {error ? <p className="error">{error}</p> : null}
 
       <button type="button" onClick={() => void save()} disabled={!ready || saving}>
-        {saving ? 'Saving…' : 'Save'}
+        {saving ? t.add.saving : t.add.save}
       </button>
       <button type="button" className="ghost" onClick={() => router.back()}>
-        Cancel
+        {t.add.cancel}
       </button>
     </main>
   );

--- a/apps/web-lite/src/app/g/[groupId]/page.tsx
+++ b/apps/web-lite/src/app/g/[groupId]/page.tsx
@@ -27,10 +27,13 @@ import {
 
 import { baaki } from '@/lib/baaki';
 import { money } from '@/lib/money';
+import { plural } from '@/i18n';
+import { useStrings } from '@/i18n-context';
 
 export default function GroupPage() {
   const params = useParams<{ groupId: string }>();
   const groupId = params.groupId;
+  const { t, locale } = useStrings();
 
   const [group, setGroup] = useState<Group | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
@@ -71,7 +74,7 @@ export default function GroupPage() {
     return (
       <main>
         <div className="card">
-          <p className="muted">Loading…</p>
+          <p className="muted">{t.group.loading}</p>
         </div>
       </main>
     );
@@ -83,11 +86,8 @@ export default function GroupPage() {
     return (
       <main>
         <div className="card">
-          <h1>Not your group</h1>
-          <p>
-            {error ??
-              'This browser is not a member of this group. If somebody sent you a link, open that instead.'}
-          </p>
+          <h1>{t.group.notYours}</h1>
+          <p>{error ?? t.group.notYoursBody}</p>
         </div>
       </main>
     );
@@ -103,16 +103,16 @@ export default function GroupPage() {
       <div className="card">
         <h1>
           {group.cover_emoji ? `${group.cover_emoji} ` : ''}
-          {group.name?.trim() || 'Your group'}
+          {group.name?.trim() || t.group.yourGroup}
         </h1>
         <p className="faint">
-          {members.length} {members.length === 1 ? 'person' : 'people'} · {live.length}{' '}
-          {live.length === 1 ? 'expense' : 'expenses'}
+          {plural(locale, members.length, t.group.peopleCount)} ·{' '}
+          {plural(locale, live.length, t.group.expenseCount)}
         </p>
       </div>
 
       <div className="card">
-        <h2>Where everyone stands</h2>
+        <h2>{t.group.whereEveryoneStands}</h2>
         {members.map((member) => {
           const net = ledger.balances.get(member.id) ?? 0n;
           return (
@@ -121,10 +121,10 @@ export default function GroupPage() {
               <span
                 className={`money ${net > 0n ? 'owed' : net < 0n ? 'owe' : ''}`}
                 aria-label={`${nameOf(member)} ${
-                  net === 0n ? 'is settled up' : net > 0n ? 'is owed' : 'owes'
+                  net === 0n ? t.group.isSettledUp : net > 0n ? t.group.isOwed : t.group.owes
                 } ${money(net < 0n ? -net : net, currency)}`}
               >
-                {net === 0n ? 'settled up' : money(net < 0n ? -net : net, currency)}
+                {net === 0n ? t.group.settledUp : money(net < 0n ? -net : net, currency)}
               </span>
             </div>
           );
@@ -133,11 +133,8 @@ export default function GroupPage() {
 
       {ledger.transfers.length > 0 ? (
         <div className="card">
-          <h2>Who pays whom</h2>
-          <p className="faint">
-            The fewest payments that settle everybody. Nobody is made to pay somebody they never
-            split anything with.
-          </p>
+          <h2>{t.group.whoPaysWhom}</h2>
+          <p className="faint">{t.group.whoPaysWhomNote}</p>
           {ledger.transfers.map((transfer, index) => (
             <div className="row" key={index}>
               <span>
@@ -152,7 +149,7 @@ export default function GroupPage() {
 
       {live.length > 0 ? (
         <div className="card">
-          <h2>Recent</h2>
+          <h2>{t.group.recent}</h2>
           {live.slice(0, 12).map((expense) => {
             const version = expense.currentVersion;
             if (!version) return null;
@@ -171,11 +168,11 @@ export default function GroupPage() {
       ) : null}
 
       <Link className="button" href={`/g/${groupId}/add`}>
-        Add an expense
+        {t.group.addAnExpense}
       </Link>
 
       <p className="faint" style={{ textAlign: 'center' }}>
-        Install Baaki to scan receipts, settle over UPI and keep this working without a signal.
+        {t.group.installNote}
       </p>
     </main>
   );

--- a/apps/web-lite/src/app/join/[token]/page.tsx
+++ b/apps/web-lite/src/app/join/[token]/page.tsx
@@ -21,11 +21,14 @@ import { useParams, useRouter } from 'next/navigation';
 import type { InvitePreview } from '@baaki/api-client';
 
 import { baaki } from '@/lib/baaki';
+import { fill, plural } from '@/i18n';
+import { useStrings } from '@/i18n-context';
 
 export default function JoinPage() {
   const params = useParams<{ token: string }>();
   const router = useRouter();
   const token = params.token;
+  const { t, locale } = useStrings();
 
   const [preview, setPreview] = useState<InvitePreview | null>(null);
   const [claimId, setClaimId] = useState<string | null>(null);
@@ -72,11 +75,9 @@ export default function JoinPage() {
     return (
       <main>
         <div className="card">
-          <h1>This link does not work</h1>
+          <h1>{t.join.linkBroken}</h1>
           <p>{error}</p>
-          <p className="faint">
-            Links expire, and whoever shared it can turn it off. Ask them for a new one.
-          </p>
+          <p className="faint">{t.join.linkBrokenBody}</p>
         </div>
       </main>
     );
@@ -86,34 +87,28 @@ export default function JoinPage() {
     return (
       <main>
         <div className="card">
-          <p className="muted">Opening the link…</p>
+          <p className="muted">{t.join.opening}</p>
         </div>
       </main>
     );
   }
 
-  const groupName = preview.group?.name?.trim() || 'a group';
+  const groupName = preview.group?.name?.trim() || t.join.aGroup;
 
   return (
     <main>
       <div className="card">
         <h1>
           {preview.group?.cover_emoji ? `${preview.group.cover_emoji} ` : ''}
-          You have been added to {groupName}
+          {fill(t.join.addedTo, { group: groupName })}
         </h1>
-        <p>
-          {preview.memberCount} {preview.memberCount === 1 ? 'person is' : 'people are'} splitting
-          costs here. You can join and add an expense right now — nothing to install.
-        </p>
+        <p>{plural(locale, preview.memberCount, t.join.splittingHere)}</p>
       </div>
 
       {preview.claimable.length > 0 ? (
         <div className="card">
-          <h2>Which one are you?</h2>
-          <p className="faint">
-            Somebody already added these names. Picking yours keeps the expenses already filed
-            against it.
-          </p>
+          <h2>{t.join.whichOneAreYou}</h2>
+          <p className="faint">{t.join.claimNote}</p>
           <div className="people">
             {preview.claimable.map((person) => (
               <button
@@ -123,7 +118,7 @@ export default function JoinPage() {
                 aria-pressed={claimId === person.memberId}
                 onClick={() => setClaimId(person.memberId)}
               >
-                {person.name ?? 'Someone'}
+                {person.name ?? t.join.someone}
               </button>
             ))}
             <button
@@ -132,7 +127,7 @@ export default function JoinPage() {
               aria-pressed={claimId === null}
               onClick={() => setClaimId(null)}
             >
-              None of these
+              {t.join.noneOfThese}
             </button>
           </div>
         </div>
@@ -140,24 +135,22 @@ export default function JoinPage() {
 
       {claimId === null ? (
         <div className="card">
-          <h2>Your name</h2>
+          <h2>{t.join.yourName}</h2>
           <input
             value={name}
             onChange={(event) => setName(event.target.value)}
-            placeholder="What should they call you?"
-            aria-label="Your name"
+            placeholder={t.join.namePlaceholder}
+            aria-label={t.join.yourName}
             autoComplete="name"
           />
-          <p className="faint">
-            This is the only thing asked of you. No email, no password, no app.
-          </p>
+          <p className="faint">{t.join.onlyThingAsked}</p>
         </div>
       ) : null}
 
       {error ? <p className="error">{error}</p> : null}
 
       <button type="button" onClick={() => void join()} disabled={joining}>
-        {joining ? 'Joining…' : `Join ${groupName}`}
+        {joining ? t.join.joining : fill(t.join.joinGroup, { group: groupName })}
       </button>
     </main>
   );

--- a/apps/web-lite/src/app/layout.tsx
+++ b/apps/web-lite/src/app/layout.tsx
@@ -1,4 +1,8 @@
 import type { Metadata, Viewport } from 'next';
+import { headers } from 'next/headers';
+
+import { StringsProvider } from '@/i18n-context';
+import { isRtlLanguage, localeFor, pickLanguage, stringsFor } from '@/i18n';
 
 import './globals.css';
 
@@ -13,10 +17,31 @@ export const viewport: Viewport = {
   themeColor: '#7A5AF8',
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+/**
+ * The language is read from `Accept-Language` here and nowhere else.
+ *
+ * Doing it on the server is what lets `lang` and `dir` be right in the first
+ * paint. A guest opening an invite on an Arabic phone should find the page
+ * already the right way round, not watch it turn around after hydration —
+ * and unlike the app, the web has no restart problem: `dir` on `<html>` is
+ * honoured by CSS the moment it is set.
+ */
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const accept = (await headers()).get('accept-language');
+  const language = pickLanguage(accept);
+  const locale = localeFor(language, accept);
+  const t = stringsFor(language);
+
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang={language} dir={isRtlLanguage(language) ? 'rtl' : 'ltr'}>
+      <head>
+        <title>{t.home.title}</title>
+      </head>
+      <body>
+        <StringsProvider language={language} locale={locale}>
+          {children}
+        </StringsProvider>
+      </body>
     </html>
   );
 }

--- a/apps/web-lite/src/app/page.tsx
+++ b/apps/web-lite/src/app/page.tsx
@@ -2,16 +2,20 @@
  * There is no web app. This page exists because somebody will type the domain
  * in, and a blank 404 tells them nothing about what they were sent.
  */
-export default function Home() {
+
+import { headers } from 'next/headers';
+
+import { pickLanguage, stringsFor } from '@/i18n';
+
+export default async function Home() {
+  const t = stringsFor(pickLanguage((await headers()).get('accept-language')));
+
   return (
     <main>
       <div className="card">
-        <h1>Baaki</h1>
-        <p>
-          Split expenses without the argument at the end. This page is only for opening an invite
-          link — if somebody shared a group with you, open their link rather than this address.
-        </p>
-        <p className="faint">Everything else lives in the app.</p>
+        <h1>{t.home.title}</h1>
+        <p>{t.home.description}</p>
+        <p className="faint">{t.home.elsewhere}</p>
       </div>
     </main>
   );

--- a/apps/web-lite/src/i18n-context.tsx
+++ b/apps/web-lite/src/i18n-context.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+/**
+ * Handing the server's answer down to the client pages.
+ *
+ * The language is decided once, on the server, from `Accept-Language` — see
+ * `layout.tsx`. Three of the four pages are client components and cannot read
+ * a request header, so the resolved language and locale come down through this
+ * provider rather than being guessed a second time from `navigator.language`.
+ *
+ * Guessing twice is the bug this avoids: the server would render Arabic and the
+ * client would re-render English on a phone whose browser UI language differs
+ * from what it sends, and the page would visibly change its mind.
+ */
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import { stringsFor, type Language, type WebStrings } from '@/i18n';
+
+interface Value {
+  language: Language;
+  locale: string;
+  t: WebStrings;
+}
+
+const StringsContext = createContext<Value | null>(null);
+
+export function StringsProvider({
+  language,
+  locale,
+  children,
+}: {
+  language: Language;
+  locale: string;
+  children: ReactNode;
+}) {
+  const value = useMemo<Value>(
+    () => ({ language, locale, t: stringsFor(language) }),
+    [language, locale],
+  );
+  return <StringsContext.Provider value={value}>{children}</StringsContext.Provider>;
+}
+
+export function useStrings(): Value {
+  const value = useContext(StringsContext);
+  if (!value) throw new Error('useStrings must be used inside StringsProvider');
+  return value;
+}

--- a/apps/web-lite/src/i18n.ts
+++ b/apps/web-lite/src/i18n.ts
@@ -1,0 +1,443 @@
+/**
+ * The words on the four pages a guest sees, in the four languages the app
+ * speaks.
+ *
+ * Separate from `apps/mobile/src/i18n` on purpose and not shared through a
+ * package: that module imports `react-native` and `expo-localization` at the
+ * top, and this is a Next app. What is shared is the *shape* — a closed
+ * `WebStrings` interface with no spread of English underneath it, so adding a
+ * key is a compile error in all four languages until somebody writes the words.
+ *
+ * The language is decided on the server from `Accept-Language`, which is what
+ * lets `<html lang>` and `dir` be right in the first paint rather than
+ * corrected a frame later. A guest arriving on an Arabic phone should not watch
+ * the page turn around.
+ */
+
+export type Language = 'en' | 'ta' | 'hi' | 'ar';
+
+export const LANGUAGES: readonly Language[] = ['en', 'ta', 'hi', 'ar'];
+
+export function isRtlLanguage(language: Language): boolean {
+  return language === 'ar';
+}
+
+/**
+ * The best of the languages the browser asked for.
+ *
+ * `Accept-Language` is already in preference order and carries quality values
+ * we do not need to weigh: the first tag whose language subtag is one of ours
+ * is the answer, and English is the answer when none of them is.
+ */
+export function pickLanguage(acceptLanguage: string | null | undefined): Language {
+  if (!acceptLanguage) return 'en';
+  for (const part of acceptLanguage.split(',')) {
+    const tag = part.split(';')[0]?.trim().toLowerCase();
+    const subtag = tag?.split('-')[0];
+    if (subtag && (LANGUAGES as readonly string[]).includes(subtag)) {
+      return subtag as Language;
+    }
+  }
+  return 'en';
+}
+
+/**
+ * The locale money and dates are formatted in.
+ *
+ * The region is kept from whatever the browser asked for, so somebody reading
+ * in Hindi from Dubai still sees `hi-AE` money. Choosing a language is not
+ * choosing a country.
+ */
+export function localeFor(language: Language, acceptLanguage: string | null | undefined): string {
+  if (!acceptLanguage) return language;
+  for (const part of acceptLanguage.split(',')) {
+    const tag = part.split(';')[0]?.trim();
+    if (tag?.toLowerCase().startsWith(language + '-')) return tag;
+  }
+  return language;
+}
+
+export interface PluralForms {
+  zero?: string;
+  one?: string;
+  two?: string;
+  few?: string;
+  many?: string;
+  other: string;
+}
+
+/** The right form for `count`, with the number formatted for the locale. */
+export function plural(locale: string, count: number, forms: PluralForms): string {
+  let rule: Intl.LDMLPluralRule = 'other';
+  let shown = String(count);
+  try {
+    rule = new Intl.PluralRules(locale).select(count);
+    shown = new Intl.NumberFormat(locale).format(count);
+  } catch {
+    // A locale Intl will not take is not a reason to render nothing.
+  }
+  return (forms[rule] ?? forms.other).replaceAll('{n}', shown);
+}
+
+export interface WebStrings {
+  /** The page somebody reaches by typing the domain in. */
+  home: {
+    title: string;
+    description: string;
+    elsewhere: string;
+  };
+  /** The invite link, which is the whole growth loop (ADR-006). */
+  join: {
+    linkBroken: string;
+    linkBrokenBody: string;
+    opening: string;
+    aGroup: string;
+    addedTo: string;
+    splittingHere: PluralForms;
+    whichOneAreYou: string;
+    claimNote: string;
+    someone: string;
+    noneOfThese: string;
+    yourName: string;
+    namePlaceholder: string;
+    onlyThingAsked: string;
+    joining: string;
+    joinGroup: string;
+  };
+  /** The group, in a browser: less than the app, and enough for a trip. */
+  group: {
+    loading: string;
+    notYours: string;
+    notYoursBody: string;
+    yourGroup: string;
+    peopleCount: PluralForms;
+    expenseCount: PluralForms;
+    whereEveryoneStands: string;
+    settledUp: string;
+    isSettledUp: string;
+    isOwed: string;
+    owes: string;
+    whoPaysWhom: string;
+    whoPaysWhomNote: string;
+    recent: string;
+    addAnExpense: string;
+    installNote: string;
+  };
+  /** Adding one expense, equally split, and nothing cleverer. */
+  add: {
+    title: string;
+    defaultDescription: string;
+    whatWasIt: string;
+    howMuch: string;
+    amountIn: string;
+    notAnAmount: string;
+    whoPaid: string;
+    you: string;
+    splitBetween: string;
+    splitEquallyNote: string;
+    saving: string;
+    save: string;
+    cancel: string;
+  };
+}
+
+const en: WebStrings = {
+  home: {
+    title: 'Baaki',
+    description:
+      'Split expenses without the argument at the end. This page is only for opening an invite link — if somebody shared a group with you, open their link rather than this address.',
+    elsewhere: 'Everything else lives in the app.',
+  },
+  join: {
+    linkBroken: 'This link does not work',
+    linkBrokenBody: 'Links expire, and whoever shared it can turn it off. Ask them for a new one.',
+    opening: 'Opening the link…',
+    aGroup: 'a group',
+    addedTo: 'You have been added to {group}',
+    splittingHere: {
+      one: '{n} person is splitting costs here. You can join and add an expense right now — nothing to install.',
+      other:
+        '{n} people are splitting costs here. You can join and add an expense right now — nothing to install.',
+    },
+    whichOneAreYou: 'Which one are you?',
+    claimNote:
+      'Somebody already added these names. Picking yours keeps the expenses already filed against it.',
+    someone: 'Someone',
+    noneOfThese: 'None of these',
+    yourName: 'Your name',
+    namePlaceholder: 'What should they call you?',
+    onlyThingAsked: 'This is the only thing asked of you. No email, no password, no app.',
+    joining: 'Joining…',
+    joinGroup: 'Join {group}',
+  },
+  group: {
+    loading: 'Loading…',
+    notYours: 'Not your group',
+    notYoursBody:
+      'This browser is not a member of this group. If somebody sent you a link, open that instead.',
+    yourGroup: 'Your group',
+    peopleCount: { one: '{n} person', other: '{n} people' },
+    expenseCount: { one: '{n} expense', other: '{n} expenses' },
+    whereEveryoneStands: 'Where everyone stands',
+    settledUp: 'settled up',
+    isSettledUp: 'is settled up',
+    isOwed: 'is owed',
+    owes: 'owes',
+    whoPaysWhom: 'Who pays whom',
+    whoPaysWhomNote:
+      'The fewest payments that settle everybody. Nobody is made to pay somebody they never split anything with.',
+    recent: 'Recent',
+    addAnExpense: 'Add an expense',
+    installNote:
+      'Install Baaki to scan receipts, settle over UPI and keep this working without a signal.',
+  },
+  add: {
+    title: 'Add an expense',
+    defaultDescription: 'Expense',
+    whatWasIt: 'What was it?',
+    howMuch: 'How much? ({currency})',
+    amountIn: 'Amount in {currency}',
+    notAnAmount: 'That is not an amount.',
+    whoPaid: 'Who paid',
+    you: 'You',
+    splitBetween: 'Split between',
+    splitEquallyNote: 'Split equally. For exact shares or an itemised bill, use the app.',
+    saving: 'Saving…',
+    save: 'Save',
+    cancel: 'Cancel',
+  },
+};
+
+const ta: WebStrings = {
+  home: {
+    title: 'பாக்கி',
+    description:
+      'கடைசியில் வாக்குவாதம் இல்லாமல் செலவுகளைப் பிரியுங்கள். இந்தப் பக்கம் அழைப்புச் சுட்டியைத் திறக்க மட்டுமே — யாராவது ஒரு குழுவை உங்களுடன் பகிர்ந்திருந்தால், இந்த முகவரிக்குப் பதிலாக அவர்களின் சுட்டியைத் திறக்கவும்.',
+    elsewhere: 'மற்ற அனைத்தும் செயலியில் உள்ளது.',
+  },
+  join: {
+    linkBroken: 'இந்தச் சுட்டி வேலை செய்யவில்லை',
+    linkBrokenBody:
+      'சுட்டிகள் காலாவதியாகும், பகிர்ந்தவர் அதை நிறுத்தவும் முடியும். புதிய ஒன்றைக் கேளுங்கள்.',
+    opening: 'சுட்டியைத் திறக்கிறது…',
+    aGroup: 'ஒரு குழு',
+    addedTo: '{group} இல் நீங்கள் சேர்க்கப்பட்டுள்ளீர்கள்',
+    splittingHere: {
+      one: '{n} நபர் இங்கே செலவுகளைப் பிரிக்கிறார். இப்போதே சேர்ந்து ஒரு செலவைச் சேர்க்கலாம் — எதுவும் நிறுவ வேண்டாம்.',
+      other:
+        '{n} பேர் இங்கே செலவுகளைப் பிரிக்கிறார்கள். இப்போதே சேர்ந்து ஒரு செலவைச் சேர்க்கலாம் — எதுவும் நிறுவ வேண்டாம்.',
+    },
+    whichOneAreYou: 'நீங்கள் யார்?',
+    claimNote:
+      'இந்தப் பெயர்களை ஏற்கெனவே யாரோ சேர்த்துவிட்டார்கள். உங்களுடையதைத் தேர்ந்தெடுத்தால், அதற்கு எதிராக ஏற்கெனவே பதிவான செலவுகள் உங்களுடன் இருக்கும்.',
+    someone: 'யாரோ',
+    noneOfThese: 'இவை எதுவும் இல்லை',
+    yourName: 'உங்கள் பெயர்',
+    namePlaceholder: 'உங்களை என்ன அழைக்க வேண்டும்?',
+    onlyThingAsked:
+      'உங்களிடம் கேட்கப்படுவது இது ஒன்றுதான். மின்னஞ்சல் இல்லை, கடவுச்சொல் இல்லை, செயலி இல்லை.',
+    joining: 'சேர்கிறது…',
+    joinGroup: '{group} இல் சேர்',
+  },
+  group: {
+    loading: 'ஏற்றுகிறது…',
+    notYours: 'உங்கள் குழு அல்ல',
+    notYoursBody:
+      'இந்த உலாவி இந்தக் குழுவின் உறுப்பினர் அல்ல. யாராவது உங்களுக்கு ஒரு சுட்டி அனுப்பியிருந்தால், அதைத் திறக்கவும்.',
+    yourGroup: 'உங்கள் குழு',
+    peopleCount: { one: '{n} நபர்', other: '{n} நபர்கள்' },
+    expenseCount: { one: '{n} செலவு', other: '{n} செலவுகள்' },
+    whereEveryoneStands: 'யார் எங்கே நிற்கிறார்கள்',
+    settledUp: 'தீர்ந்தது',
+    isSettledUp: 'கணக்கு தீர்ந்தது',
+    isOwed: 'பெற வேண்டியது',
+    owes: 'தர வேண்டியது',
+    whoPaysWhom: 'யார் யாருக்குத் தருவது',
+    whoPaysWhomNote:
+      'அனைவரையும் தீர்க்கும் மிகக் குறைந்த கொடுப்பனவுகள். எதையும் சேர்ந்து பிரிக்காத ஒருவருக்கு யாரும் பணம் தர வேண்டியதில்லை.',
+    recent: 'சமீபத்தியவை',
+    addAnExpense: 'ஒரு செலவைச் சேர்',
+    installNote:
+      'ரசீதுகளை ஸ்கேன் செய்ய, UPI மூலம் தீர்க்க, சிக்னல் இல்லாமலும் இது வேலை செய்ய — பாக்கியை நிறுவுங்கள்.',
+  },
+  add: {
+    title: 'ஒரு செலவைச் சேர்',
+    defaultDescription: 'செலவு',
+    whatWasIt: 'எதற்காக?',
+    howMuch: 'எவ்வளவு? ({currency})',
+    amountIn: '{currency} இல் தொகை',
+    notAnAmount: 'அது ஒரு தொகை அல்ல.',
+    whoPaid: 'யார் கொடுத்தார்கள்',
+    you: 'நீங்கள்',
+    splitBetween: 'யாருக்கிடையே',
+    splitEquallyNote:
+      'சமமாகப் பிரிக்கப்பட்டது. சரியான பங்குகளுக்கோ பொருள் வாரியான ரசீதுக்கோ செயலியைப் பயன்படுத்துங்கள்.',
+    saving: 'சேமிக்கிறது…',
+    save: 'சேமி',
+    cancel: 'ரத்து',
+  },
+};
+
+const hi: WebStrings = {
+  home: {
+    title: 'बाकी',
+    description:
+      'आख़िर में बहस किए बिना खर्च बाँटें। यह पेज सिर्फ़ न्योते का लिंक खोलने के लिए है — अगर किसी ने आपके साथ कोई समूह साझा किया है, तो इस पते के बजाय उनका लिंक खोलें।',
+    elsewhere: 'बाकी सब कुछ ऐप में है।',
+  },
+  join: {
+    linkBroken: 'यह लिंक काम नहीं करता',
+    linkBrokenBody:
+      'लिंक की मियाद ख़त्म हो जाती है, और जिसने साझा किया वह उसे बंद भी कर सकता है। उनसे नया माँगें।',
+    opening: 'लिंक खुल रहा है…',
+    aGroup: 'एक समूह',
+    addedTo: 'आपको {group} में जोड़ा गया है',
+    splittingHere: {
+      one: '{n} व्यक्ति यहाँ खर्च बाँट रहा है। आप अभी जुड़कर खर्च जोड़ सकते हैं — कुछ भी इंस्टॉल नहीं करना।',
+      other:
+        '{n} लोग यहाँ खर्च बाँट रहे हैं। आप अभी जुड़कर खर्च जोड़ सकते हैं — कुछ भी इंस्टॉल नहीं करना।',
+    },
+    whichOneAreYou: 'इनमें आप कौन हैं?',
+    claimNote:
+      'ये नाम पहले ही किसी ने जोड़ दिए हैं। अपना चुनने से उस नाम पर पहले से दर्ज खर्च आपके साथ रहते हैं।',
+    someone: 'कोई',
+    noneOfThese: 'इनमें से कोई नहीं',
+    yourName: 'आपका नाम',
+    namePlaceholder: 'वे आपको क्या कहकर बुलाएँ?',
+    onlyThingAsked: 'आपसे बस यही पूछा जाता है। न ईमेल, न पासवर्ड, न ऐप।',
+    joining: 'जुड़ रहे हैं…',
+    joinGroup: '{group} में जुड़ें',
+  },
+  group: {
+    loading: 'लोड हो रहा है…',
+    notYours: 'यह आपका समूह नहीं',
+    notYoursBody:
+      'यह ब्राउज़र इस समूह का सदस्य नहीं है। अगर किसी ने आपको लिंक भेजा है, तो उसे खोलें।',
+    yourGroup: 'आपका समूह',
+    peopleCount: { one: '{n} व्यक्ति', other: '{n} लोग' },
+    expenseCount: { one: '{n} खर्च', other: '{n} खर्च' },
+    whereEveryoneStands: 'किसका क्या हिसाब है',
+    settledUp: 'हिसाब बराबर',
+    isSettledUp: 'का हिसाब बराबर है',
+    isOwed: 'को मिलने हैं',
+    owes: 'को देने हैं',
+    whoPaysWhom: 'कौन किसे देगा',
+    whoPaysWhomNote:
+      'सबका हिसाब बराबर करने वाले सबसे कम भुगतान। किसी को ऐसे व्यक्ति को पैसे देने के लिए नहीं कहा जाता जिसके साथ उसने कभी कुछ बाँटा ही नहीं।',
+    recent: 'हाल के',
+    addAnExpense: 'खर्च जोड़ें',
+    installNote:
+      'रसीदें स्कैन करने, UPI से निपटाने और बिना सिग्नल भी यह चलाने के लिए बाकी इंस्टॉल करें।',
+  },
+  add: {
+    title: 'खर्च जोड़ें',
+    defaultDescription: 'खर्च',
+    whatWasIt: 'किस चीज़ का था?',
+    howMuch: 'कितना? ({currency})',
+    amountIn: '{currency} में रकम',
+    notAnAmount: 'यह रकम नहीं है।',
+    whoPaid: 'किसने दिया',
+    you: 'आप',
+    splitBetween: 'किनके बीच',
+    splitEquallyNote: 'बराबर बाँटा गया। सटीक हिस्सों या चीज़-वार बिल के लिए ऐप इस्तेमाल करें।',
+    saving: 'सेव हो रहा है…',
+    save: 'सेव करें',
+    cancel: 'रद्द करें',
+  },
+};
+
+const ar: WebStrings = {
+  home: {
+    title: 'باقي',
+    description:
+      'قسّموا المصاريف دون خلاف في النهاية. هذه الصفحة لفتح رابط دعوة فقط — إن شاركك أحدهم مجموعة، فافتح رابطه بدل هذا العنوان.',
+    elsewhere: 'كل ما عدا ذلك في التطبيق.',
+  },
+  join: {
+    linkBroken: 'هذا الرابط لا يعمل',
+    linkBrokenBody: 'تنتهي صلاحية الروابط، ويمكن لمن شاركها أن يوقفها. اطلب منه رابطًا جديدًا.',
+    opening: 'جارٍ فتح الرابط…',
+    aGroup: 'مجموعة',
+    addedTo: 'تمت إضافتك إلى {group}',
+    splittingHere: {
+      zero: 'لا أحد يقسّم التكاليف هنا بعد. يمكنك الانضمام وإضافة مصروف الآن — دون تثبيت شيء.',
+      one: 'شخص واحد يقسّم التكاليف هنا. يمكنك الانضمام وإضافة مصروف الآن — دون تثبيت شيء.',
+      two: 'شخصان يقسّمان التكاليف هنا. يمكنك الانضمام وإضافة مصروف الآن — دون تثبيت شيء.',
+      few: '{n} أشخاص يقسّمون التكاليف هنا. يمكنك الانضمام وإضافة مصروف الآن — دون تثبيت شيء.',
+      many: '{n} شخصًا يقسّمون التكاليف هنا. يمكنك الانضمام وإضافة مصروف الآن — دون تثبيت شيء.',
+      other: '{n} شخص يقسّمون التكاليف هنا. يمكنك الانضمام وإضافة مصروف الآن — دون تثبيت شيء.',
+    },
+    whichOneAreYou: 'أيّهم أنت؟',
+    claimNote: 'أضاف أحدهم هذه الأسماء من قبل. اختيار اسمك يبقي المصاريف المسجّلة عليه معك.',
+    someone: 'أحدهم',
+    noneOfThese: 'لا أحد منهم',
+    yourName: 'اسمك',
+    namePlaceholder: 'بماذا ينادونك؟',
+    onlyThingAsked: 'هذا كل ما يُطلب منك. لا بريد، ولا كلمة مرور، ولا تطبيق.',
+    joining: 'جارٍ الانضمام…',
+    joinGroup: 'انضم إلى {group}',
+  },
+  group: {
+    loading: 'جارٍ التحميل…',
+    notYours: 'ليست مجموعتك',
+    notYoursBody:
+      'هذا المتصفح ليس عضوًا في هذه المجموعة. إن أرسل إليك أحدهم رابطًا، فافتحه بدلًا من ذلك.',
+    yourGroup: 'مجموعتك',
+    peopleCount: {
+      zero: 'لا أشخاص',
+      one: 'شخص واحد',
+      two: 'شخصان',
+      few: '{n} أشخاص',
+      many: '{n} شخصًا',
+      other: '{n} شخص',
+    },
+    expenseCount: {
+      zero: 'لا مصاريف',
+      one: 'مصروف واحد',
+      two: 'مصروفان',
+      few: '{n} مصاريف',
+      many: '{n} مصروفًا',
+      other: '{n} مصروف',
+    },
+    whereEveryoneStands: 'أين يقف كل واحد',
+    settledUp: 'مسوّى',
+    isSettledUp: 'حسابه مسوّى',
+    isOwed: 'له',
+    owes: 'عليه',
+    whoPaysWhom: 'من يدفع لمن',
+    whoPaysWhomNote:
+      'أقل عدد من الدفعات يسوّي حساب الجميع. ولا يُطلب من أحد أن يدفع لشخص لم يقسّم معه شيئًا قط.',
+    recent: 'الأحدث',
+    addAnExpense: 'أضف مصروفًا',
+    installNote: 'ثبّت باقي لمسح الإيصالات والتسوية عبر UPI ولكي يعمل هذا دون اتصال.',
+  },
+  add: {
+    title: 'أضف مصروفًا',
+    defaultDescription: 'مصروف',
+    whatWasIt: 'على ماذا؟',
+    howMuch: 'كم؟ ({currency})',
+    amountIn: 'المبلغ بـ {currency}',
+    notAnAmount: 'هذا ليس مبلغًا.',
+    whoPaid: 'من دفع',
+    you: 'أنت',
+    splitBetween: 'التقسيم بين',
+    splitEquallyNote: 'قُسّم بالتساوي. للحصص المحددة أو فاتورة بالأصناف، استخدم التطبيق.',
+    saving: 'جارٍ الحفظ…',
+    save: 'حفظ',
+    cancel: 'إلغاء',
+  },
+};
+
+export const STRINGS_BY_LANGUAGE: Record<Language, WebStrings> = { en, ta, hi, ar };
+
+export function stringsFor(language: Language): WebStrings {
+  return STRINGS_BY_LANGUAGE[language];
+}
+
+/** Substitute `{name}` placeholders. */
+export function fill(template: string, values: Record<string, string | number>): string {
+  return Object.entries(values).reduce(
+    (text, [key, value]) => text.replaceAll(`{${key}}`, String(value)),
+    template,
+  );
+}

--- a/apps/web-lite/test/i18n.test.ts
+++ b/apps/web-lite/test/i18n.test.ts
@@ -1,0 +1,134 @@
+/**
+ * What the four pages owe every language.
+ *
+ * The same rule as the app's own table test, for the same reason: a key added
+ * in English and forgotten everywhere else is a screen that silently reverts
+ * to a language the reader came here to escape. `WebStrings` is a closed
+ * interface with no spread of English underneath it, so the type checker
+ * catches a *missing* key — what it cannot catch is an empty one, a lost
+ * placeholder, or a translation that quietly kept the English.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  LANGUAGES,
+  STRINGS_BY_LANGUAGE,
+  fill,
+  isRtlLanguage,
+  localeFor,
+  pickLanguage,
+  plural,
+} from '../src/i18n';
+
+type Leaf = [path: string, text: string];
+
+function leaves(node: unknown, path = ''): Leaf[] {
+  if (typeof node === 'string') return [[path, node]];
+  if (node && typeof node === 'object') {
+    return Object.entries(node).flatMap(([key, value]) => leaves(value, `${path}.${key}`));
+  }
+  return [];
+}
+
+const placeholders = (text: string): string[] =>
+  [...text.matchAll(/\{(\w+)\}/g)].map((match) => match[1]).sort();
+
+describe('the language the browser asked for', () => {
+  it('takes the first tag it recognises, in order', () => {
+    expect(pickLanguage('ta-IN,ta;q=0.9,en;q=0.8')).toBe('ta');
+    expect(pickLanguage('fr-FR,fr;q=0.9,hi;q=0.5')).toBe('hi');
+    expect(pickLanguage('ar')).toBe('ar');
+  });
+
+  it('falls back to English rather than guessing', () => {
+    expect(pickLanguage(null)).toBe('en');
+    expect(pickLanguage('')).toBe('en');
+    expect(pickLanguage('fr-FR,de;q=0.8')).toBe('en');
+  });
+
+  it('keeps the region, because a language is not a country', () => {
+    // Reading in Hindi from Dubai still formats money as `hi-AE`.
+    expect(localeFor('hi', 'hi-AE,hi;q=0.9,en;q=0.8')).toBe('hi-AE');
+    expect(localeFor('ar', 'ar-EG,ar;q=0.9')).toBe('ar-EG');
+    expect(localeFor('ta', 'en-GB,ta;q=0.7')).toBe('ta');
+  });
+
+  it('knows which way each one reads', () => {
+    expect(LANGUAGES.filter(isRtlLanguage)).toEqual(['ar']);
+  });
+});
+
+describe('what every table owes the others', () => {
+  it('has a table for every language on offer', () => {
+    expect([...LANGUAGES].sort()).toEqual(Object.keys(STRINGS_BY_LANGUAGE).sort());
+  });
+
+  it('never leaves a string blank', () => {
+    for (const language of LANGUAGES) {
+      for (const [path, text] of leaves(STRINGS_BY_LANGUAGE[language])) {
+        expect(text.trim(), `${language}${path}`).not.toBe('');
+      }
+    }
+  });
+
+  /**
+   * A singular, dual or paucal form may say the number in words instead of
+   * printing it. The `other` form is the one that must carry the placeholder.
+   */
+  const mayOmitTheNumber = (path: string): boolean => /\.(zero|one|two|few|many)$/.test(path);
+
+  it('keeps every placeholder the English says', () => {
+    const english = new Map(leaves(STRINGS_BY_LANGUAGE.en));
+    for (const language of LANGUAGES) {
+      if (language === 'en') continue;
+      for (const [path, text] of leaves(STRINGS_BY_LANGUAGE[language])) {
+        const source = english.get(path);
+        // Arabic has plural forms English does not, so a path English lacks is
+        // not a fault.
+        if (source === undefined) continue;
+        const here = placeholders(text);
+        const there = placeholders(source);
+        // Never invent one: `{amount}` where English said `{value}` renders the
+        // token itself at somebody, which is worse than the wrong language.
+        for (const name of here) expect(there, `${language}${path}`).toContain(name);
+        if (!mayOmitTheNumber(path)) expect(here, `${language}${path}`).toEqual(there);
+      }
+    }
+  });
+
+  it('says something different from English in every language', () => {
+    const english = new Map(leaves(STRINGS_BY_LANGUAGE.en));
+    for (const language of LANGUAGES) {
+      if (language === 'en') continue;
+      const table = leaves(STRINGS_BY_LANGUAGE[language]);
+      // Not every string can differ — 'Baaki' is a name, and a currency code is
+      // a currency code — so this is a proportion, not a rule per string.
+      const translated = table.filter(([path, text]) => english.get(path) !== text);
+      expect(translated.length / table.length, language).toBeGreaterThan(0.9);
+    }
+  });
+});
+
+describe('counting people', () => {
+  it('uses the language’s own plural categories', () => {
+    const { splittingHere } = STRINGS_BY_LANGUAGE.ar.join;
+    // Arabic has six; two of them are not "one or many".
+    expect(plural('ar', 1, splittingHere)).toBe(splittingHere.one);
+    expect(plural('ar', 2, splittingHere)).toBe(splittingHere.two);
+    expect(plural('ar', 3, splittingHere)).not.toBe(splittingHere.other);
+  });
+
+  it('formats the number for the locale', () => {
+    expect(plural('en-IN', 4, STRINGS_BY_LANGUAGE.en.group.peopleCount)).toBe('4 people');
+    // Arabic-Indic digits where the locale asks for them.
+    expect(plural('ar-EG', 8, STRINGS_BY_LANGUAGE.ar.group.peopleCount)).toContain('٨');
+  });
+});
+
+describe('filling in a name', () => {
+  it('substitutes every placeholder it is given', () => {
+    expect(fill(STRINGS_BY_LANGUAGE.en.join.joinGroup, { group: 'Goa' })).toBe('Join Goa');
+    expect(fill('{a} and {a}', { a: 'x' })).toBe('x and x');
+  });
+});


### PR DESCRIPTION
The last gap from the audit. The four pages a guest **without the app** lands on were English only — which is the wrong way round, because that guest is the person least likely to have chosen this app or its language.

## Where the language comes from

`Accept-Language`, read on the server in the layout, and handed to the three client pages through a provider.

That is what lets `lang` and `dir` be right in the **first paint**: a guest opening an invite on an Arabic phone finds the page already the right way round. Unlike the app there is no restart to wait for — CSS honours `dir` the moment it is set.

**Guessing twice is the bug this avoids.** Detecting again from `navigator.language` on the client would have the server render Arabic and the client re-render English on any phone whose browser UI language differs from what it sends, and the page would visibly change its mind mid-load.

The region is kept when the locale is built, so reading in Hindi from Dubai still formats money as `hi-AE`. Choosing a language is not choosing a country.

## Why the strings are not shared with the app

`apps/mobile/src/i18n` imports `react-native` and `expo-localization` at module scope. This is a Next app. What *is* shared is the shape: a closed `WebStrings` interface with no `...en` spread underneath it, so adding a key is a compile error in all four languages until somebody writes the words — the same mechanism the app relies on.

## Verified against a running server

```
$ curl -H "Accept-Language: ar-EG,ar;q=0.9,en;q=0.5" localhost:3131/
<html lang="ar" dir="rtl">
<h1>باقي</h1>
```

and `ta-IN` → `lang="ta"`, `hi-IN` → `lang="hi"`, `fr-FR,de` → `lang="en"`. `next build` passes; all routes are now dynamic, which is correct for pages whose content depends on the request.

## Tests

Eleven, mirroring the app's own table test — no blank strings, no lost or invented placeholders, and a check that each language actually differs from English rather than having been copied. Plus **the Arabic-Indic digit case the app's suite has never covered**: `plural('ar-EG', 8, …)` must contain ٨.

## One honest note

The home page and the layout become server components. `next.config.ts` asserted that *every* page here is a client component; it now says every page that **reads data** is, and explains why these two are not. Nothing about the RLS reasoning changes — neither of them reads anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6