### PR TITLE
i18n: the sync banner counts changes in the reader's language

### DIFF
--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -12,13 +12,13 @@ import { Pressable, View } from 'react-native';
 
 import { Card, Row, Text, useTheme } from '@baaki/ui';
 
-import { useStrings } from '@/i18n';
+import { plural, useStrings } from '@/i18n';
 
 import { useSync } from '@/sync';
 
 export function SyncBanner({ groupId }: { groupId?: string }) {
   const theme = useTheme();
-  const { t } = useStrings();
+  const { t, locale } = useStrings();
   const { status, queue, rejected, retry, discard, lastError } = useSync();
 
   const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
@@ -61,24 +61,32 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
 
   if (pending.length === 0 && status !== 'offline' && status !== 'error') return null;
 
-  const count = `${pending.length} ${pending.length === 1 ? 'change' : 'changes'}`;
-
   // Three different truths, and saying the wrong one is worse than saying
   // nothing: "syncing…" while every request is failing reads as a hang, and
   // eventually as lost data.
+  //
+  // The count is pluralised rather than glued together from a number and a
+  // word. These four sentences were the last English left in the app after the
+  // i18n sweep, and "3 changes" cannot be built by suffixing anything in Tamil,
+  // Hindi or Arabic.
   const { icon, message } =
     status === 'offline'
       ? {
           icon: 'cloud-offline-outline' as const,
           message:
-            pending.length > 0 ? `Offline — ${count} saved on this phone` : t.misc.offlineSaved,
+            pending.length > 0
+              ? plural(locale, pending.length, t.misc.offlineWithCount)
+              : t.misc.offlineSaved,
         }
       : status === 'error'
         ? {
             icon: 'cloud-offline-outline' as const,
-            message: `Can't reach the server — ${count} saved here, waiting to send`,
+            message: plural(locale, pending.length, t.misc.cantReachServer),
           }
-        : { icon: 'sync-outline' as const, message: `Syncing ${count}…` };
+        : {
+            icon: 'sync-outline' as const,
+            message: plural(locale, pending.length, t.misc.syncingCount),
+          };
 
   return (
     <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.xs }}>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -570,6 +570,9 @@ export interface UiStrings {
     someone: string;
     serverRefused: string;
     offlineSaved: string;
+    offlineWithCount: PluralForms;
+    cantReachServer: PluralForms;
+    syncingCount: PluralForms;
     notAnAmount: string;
     notARate: string;
     paidAnotherCurrency: string;
@@ -1301,6 +1304,15 @@ const en: UiStrings = {
     pickDifferentPeople: 'Pick different people',
     someone: 'Someone',
     serverRefused: 'The server refused this change.',
+    offlineWithCount: {
+      one: 'Offline — {n} change saved on this phone',
+      other: 'Offline — {n} changes saved on this phone',
+    },
+    cantReachServer: {
+      one: "Can't reach the server — {n} change saved here, waiting to send",
+      other: "Can't reach the server — {n} changes saved here, waiting to send",
+    },
+    syncingCount: { one: 'Sending {n} change…', other: 'Sending {n} changes…' },
     offlineSaved: 'Offline — everything here is saved on this phone',
     notAnAmount: 'That does not look like an amount',
     notARate: 'That does not look like a rate',
@@ -2094,6 +2106,18 @@ const ta: UiStrings = {
     pickDifferentPeople: 'வேறு ஆட்களைத் தேர்ந்தெடு',
     someone: 'யாரோ',
     serverRefused: 'இந்த மாற்றத்தை சர்வர் ஏற்கவில்லை.',
+    offlineWithCount: {
+      one: 'இணைப்பு இல்லை — {n} மாற்றம் இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளது',
+      other: 'இணைப்பு இல்லை — {n} மாற்றங்கள் இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளன',
+    },
+    cantReachServer: {
+      one: 'சர்வரை அடைய முடியவில்லை — {n} மாற்றம் இங்கே சேமிக்கப்பட்டு காத்திருக்கிறது',
+      other: 'சர்வரை அடைய முடியவில்லை — {n} மாற்றங்கள் இங்கே சேமிக்கப்பட்டு காத்திருக்கின்றன',
+    },
+    syncingCount: {
+      one: '{n} மாற்றம் அனுப்பப்படுகிறது…',
+      other: '{n} மாற்றங்கள் அனுப்பப்படுகின்றன…',
+    },
     offlineSaved: 'இணைப்பு இல்லை — இங்குள்ள அனைத்தும் இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளது',
     notAnAmount: 'இது ஒரு தொகை போல் தெரியவில்லை',
     notARate: 'இது ஒரு மாற்று விகிதம் போல் தெரியவில்லை',
@@ -2870,6 +2894,15 @@ const hi: UiStrings = {
     pickDifferentPeople: 'दूसरे लोग चुनें',
     someone: 'कोई',
     serverRefused: 'सर्वर ने यह बदलाव नहीं माना।',
+    offlineWithCount: {
+      one: 'ऑफ़लाइन — {n} बदलाव इसी फ़ोन पर सेव है',
+      other: 'ऑफ़लाइन — {n} बदलाव इसी फ़ोन पर सेव हैं',
+    },
+    cantReachServer: {
+      one: 'सर्वर तक नहीं पहुँच पा रहे — {n} बदलाव यहीं सेव है, भेजने का इंतज़ार',
+      other: 'सर्वर तक नहीं पहुँच पा रहे — {n} बदलाव यहीं सेव हैं, भेजने का इंतज़ार',
+    },
+    syncingCount: { one: '{n} बदलाव भेजा जा रहा है…', other: '{n} बदलाव भेजे जा रहे हैं…' },
     offlineSaved: 'ऑफ़लाइन — यहाँ का सब कुछ इसी फ़ोन पर सेव है',
     notAnAmount: 'यह रकम जैसा नहीं लगता',
     notARate: 'यह दर जैसा नहीं लगता',
@@ -3664,6 +3697,30 @@ const ar: UiStrings = {
     pickDifferentPeople: 'اختر أشخاصًا آخرين',
     someone: 'أحدهم',
     serverRefused: 'رفض الخادم هذا التغيير.',
+    offlineWithCount: {
+      zero: 'دون اتصال — لا تغييرات',
+      one: 'دون اتصال — تغيير واحد محفوظ على هذا الهاتف',
+      two: 'دون اتصال — تغييران محفوظان على هذا الهاتف',
+      few: 'دون اتصال — {n} تغييرات محفوظة على هذا الهاتف',
+      many: 'دون اتصال — {n} تغييرًا محفوظًا على هذا الهاتف',
+      other: 'دون اتصال — {n} تغيير محفوظ على هذا الهاتف',
+    },
+    cantReachServer: {
+      zero: 'تعذّر الوصول إلى الخادم',
+      one: 'تعذّر الوصول إلى الخادم — تغيير واحد محفوظ هنا في انتظار الإرسال',
+      two: 'تعذّر الوصول إلى الخادم — تغييران محفوظان هنا في انتظار الإرسال',
+      few: 'تعذّر الوصول إلى الخادم — {n} تغييرات محفوظة هنا في انتظار الإرسال',
+      many: 'تعذّر الوصول إلى الخادم — {n} تغييرًا محفوظًا هنا في انتظار الإرسال',
+      other: 'تعذّر الوصول إلى الخادم — {n} تغيير محفوظ هنا في انتظار الإرسال',
+    },
+    syncingCount: {
+      zero: 'جارٍ الإرسال…',
+      one: 'جارٍ إرسال تغيير واحد…',
+      two: 'جارٍ إرسال تغييرين…',
+      few: 'جارٍ إرسال {n} تغييرات…',
+      many: 'جارٍ إرسال {n} تغييرًا…',
+      other: 'جارٍ إرسال {n} تغيير…',
+    },
     offlineSaved: 'دون اتصال — كل ما هنا محفوظ على هذا الهاتف',
     notAnAmount: 'هذا لا يبدو مبلغًا',
     notARate: 'هذا لا يبدو سعر صرف',


### PR DESCRIPTION
The four sentences on the sync banner were still English on `main`, and I said otherwise in #69. Correcting that here.

They were built by gluing a number to an English word:

```ts
const count = `${pending.length} ${pending.length === 1 ? 'change' : 'changes'}`;
```

and then embedded in three more English sentences — `Offline — ${count} saved on this phone`, `Can't reach the server — ${count} saved here, waiting to send`, `Syncing ${count}…`.

Suffixing cannot produce these in the other three languages. Tamil and Hindi inflect the noun with the count, and Arabic has six plural categories where English has two, so the number and the sentence have to be one string per plural form rather than a number concatenated to a word. `plural()` already existed for exactly this; the banner now uses it, and takes `locale` from `useStrings()` so the numeral is formatted too — Arabic-Indic digits where the locale asks for them.

These are worth more than their line count suggests: they are what somebody reads at the moment the network has gone and they are wondering whether their expense survived. Being told that in a language they did not choose is the worst possible time for it.

**Scope.** Three new `PluralForms` keys in `misc`, their translations in all four tables, and the banner rewritten to use them. Nothing else.

**Gates.** `tsc` clean, `expo lint` clean, prettier clean, 134 tests passing. Not exercised on a device — the banner only appears offline or mid-flush, and the string-table test already covers the part that can silently rot (a missing form, a dropped `{n}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s2F6X3sQ8hSuGtPGReez6
