### PR TITLE
feat: make the app work with no signal, and say what has not been sent

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -36,6 +36,7 @@ import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { CategoryBadge } from '@/components/Category';
 import { GroupPhoto } from '@/components/GroupPhoto';
+import { PendingMark } from '@/components/PendingMark';
 import { SyncBanner } from '@/components/SyncBanner';
 
 type Tab = 'expenses' | 'balances' | 'activity';
@@ -237,12 +238,15 @@ export default function GroupScreen() {
             <Text variant="subheading">
               {`${nameOf(settlement.from_member_id)} says they paid you`}
             </Text>
-            <MoneyText
-              amount={BigInt(settlement.amount)}
-              currency={settlement.currency}
-              locale={locale}
-              variant="title"
-            />
+            <Row style={{ gap: theme.spacing.sm }}>
+              <MoneyText
+                amount={BigInt(settlement.amount)}
+                currency={settlement.currency}
+                locale={locale}
+                variant="title"
+              />
+              {settlement.pending ? <PendingMark size={16} /> : null}
+            </Row>
             <Row style={{ gap: theme.spacing.md }}>
               <Button
                 label={t.group.confirmReceived}
@@ -310,11 +314,14 @@ export default function GroupScreen() {
                       onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
                       trailing={
                         version ? (
-                          <MoneyText
-                            amount={BigInt(version.amount)}
-                            currency={version.currency}
-                            locale={locale}
-                          />
+                          <Row style={{ gap: theme.spacing.sm }}>
+                            <MoneyText
+                              amount={BigInt(version.amount)}
+                              currency={version.currency}
+                              locale={locale}
+                            />
+                            {expense.pending ? <PendingMark /> : null}
+                          </Row>
                         ) : null
                       }
                     />
@@ -341,12 +348,15 @@ export default function GroupScreen() {
                   }
                   leading={<Avatar name={displayName(member)} ghost={isGhost(member)} />}
                   trailing={
-                    <MoneyText
-                      amount={ledger.balances.get(member.id) ?? 0n}
-                      currency={currency}
-                      locale={locale}
-                      mode="balance"
-                    />
+                    <Row style={{ gap: theme.spacing.sm }}>
+                      <MoneyText
+                        amount={ledger.balances.get(member.id) ?? 0n}
+                        currency={currency}
+                        locale={locale}
+                        mode="balance"
+                      />
+                      {member.pending ? <PendingMark /> : null}
+                    </Row>
                   }
                 />
                 {index < (members.data?.length ?? 0) - 1 ? (

--- a/apps/mobile/src/components/PendingMark.tsx
+++ b/apps/mobile/src/components/PendingMark.tsx
@@ -1,0 +1,35 @@
+/**
+ * "This one hasn't left the phone yet."
+ *
+ * Offline is a normal state in Baaki (ADR-005), not an error, so this is a mark
+ * rather than a warning: a small outline cloud beside the amount, gone the
+ * moment the row syncs.
+ *
+ * It is deliberately not a colour. Green and red are the ledger's own
+ * vocabulary — owed to you, and you owe — and a third colour on the same row
+ * would be a second thing to decode on a screen whose whole job is one number.
+ * The row is real either way: an unsent expense already counts toward the
+ * balance, because the arithmetic is the same on both sides of the wire.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { View } from 'react-native';
+
+import { useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+
+export function PendingMark({ size = 14 }: { size?: number }) {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  return (
+    <View
+      accessible
+      accessibilityLabel={t.misc.notSentYet}
+      style={{ alignItems: 'center', justifyContent: 'center' }}
+    >
+      <Ionicons name="cloud-upload-outline" size={size} color={theme.color.textFaint} />
+    </View>
+  );
+}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -10,11 +10,17 @@
 
 import { useEffect, useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { randomUUID } from 'expo-crypto';
 
 import {
   computeNetBalances,
   computePairwiseBalances,
+  materialiseExpenses,
+  materialiseGroups,
+  materialiseMembers,
+  materialiseSettlements,
   overlayPending,
+  rowsFor,
   simplify,
   type ExpenseSnapshot,
   type MemberId,
@@ -24,45 +30,30 @@ import {
 } from '@baaki/core';
 
 import { supabase } from '@/lib/supabase';
-import { useSync } from '@/sync';
+import { syncEngine, useSync } from '@/sync';
 import {
-  addGhostMember,
-  confirmSettlement,
   createGroup,
-  deleteExpense,
   disputeExpense,
-  fetchActivity,
   fetchAllBalances,
   fetchBalances,
   fetchExpenseVersions,
   fetchDisputes,
-  fetchExpenses,
   fetchItemClaims,
   fetchOpenReceipts,
   fetchReceipt,
-  fetchGroup,
-  fetchGroups,
   fetchGroupSpending,
-  fetchMembersByGroup,
-  fetchMembers,
-  fetchMyBalances,
   fetchNotifications,
-  fetchPendingSettlements,
-  fetchSettledTotals,
   fetchPlanItems,
-  fetchSettlements,
   markNotificationsRead,
   recordSettlement,
   resolveDispute,
   leaveGroup,
-  restoreExpense,
   updateGroup,
   updateMember,
   withdrawDispute,
-  writeExpense,
   type WriteExpenseInput,
 } from './api';
-import type { ExpenseRow, MemberRow, SettlementRow } from './types';
+import type { ActivityRow, ExpenseRow, GroupRow, MemberRow, SettlementRow } from './types';
 
 export const keys = {
   groups: ['groups'] as const,
@@ -78,10 +69,58 @@ export const keys = {
   spending: (id: string) => ['group', id, 'spending'] as const,
 };
 
-export function useGroups() {
-  return useQuery({ queryKey: keys.groups, queryFn: fetchGroups });
+/**
+ * A mirror read, wearing the shape of a query.
+ *
+ * The screens were written against React Query objects, and there is no reason
+ * for every one of them to learn a second vocabulary just because the rows now
+ * come off the disk instead of the wire. `isLoading` means "the mirror has not
+ * been read from SQLite yet" — a few milliseconds at launch — and never "we are
+ * waiting for the network", because nothing here waits for the network.
+ */
+export interface LocalRead<T> {
+  data: T;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: false;
+  refetch: () => void;
 }
 
+function useLocalRead<T>(data: T): LocalRead<T> {
+  const { hydrated, status, flush } = useSync();
+  return {
+    data,
+    isLoading: !hydrated,
+    isFetching: status === 'syncing',
+    isError: false,
+    refetch: () => void flush(),
+  };
+}
+
+/**
+ * ADR-005: the UI reads local-first, always.
+ *
+ * These used to be network queries, and the app was offline-first in name only
+ * — the queue and the mirror were built and nothing read from them, so a phone
+ * with no signal opened on an empty ledger. Rows now come from the mirror the
+ * sync engine maintains; the network's only job is to fill it.
+ */
+export function useGroups(): LocalRead<GroupRow[]> {
+  const { mirror, queue } = useSync();
+  const groups = useMemo(
+    () => materialiseGroups(mirror, queue) as unknown as GroupRow[],
+    [mirror, queue],
+  );
+  return useLocalRead(groups);
+}
+
+/**
+ * The server's own derived balances. Deliberately still a network read and
+ * deliberately never rendered: this is the independent second opinion that
+ * `useGroupLedger` checks its arithmetic against (ADR-004). Reading it from the
+ * mirror would make it agree with the local computation by construction, which
+ * is the one thing a cross-check must not do.
+ */
 export function useAllBalances() {
   return useQuery({ queryKey: keys.allBalances, queryFn: fetchAllBalances });
 }
@@ -90,54 +129,88 @@ export function useAllBalances() {
  * How much has changed hands through this person, per currency. Not a balance
  * — see `fetchSettledTotals`.
  */
-export function useSettledTotals(profileId: string | null) {
-  return useQuery({
-    queryKey: ['settlements', 'settled', profileId],
-    queryFn: () => fetchSettledTotals(profileId as string),
-    enabled: Boolean(profileId),
-  });
+export function useSettledTotals(profileId: string | null): LocalRead<Map<string, bigint>> {
+  const { mirror } = useSync();
+
+  const totals = useMemo(() => {
+    const mine = new Set(
+      (rowsFor(mirror, 'group_members') as unknown as MemberRow[])
+        .filter((member) => member.profile_id === profileId)
+        .map((member) => member.id),
+    );
+
+    const out = new Map<string, bigint>();
+    for (const row of rowsFor(mirror, 'settlements') as unknown as SettlementRow[]) {
+      if (row.status !== 'confirmed' && row.status !== 'auto_confirmed') continue;
+      if (!mine.has(row.from_member_id) && !mine.has(row.to_member_id)) continue;
+      out.set(row.currency, (out.get(row.currency) ?? 0n) + BigInt(row.amount));
+    }
+    return out;
+  }, [mirror, profileId]);
+
+  return useLocalRead(totals);
 }
 
-/** Home-screen data: my balance per group, member counts, pending confirmations. */
+/**
+ * Home-screen data: my balance per group, member counts, pending confirmations.
+ *
+ * Every figure is computed here from mirrored rows rather than read from the
+ * server's `group_balances`, so the home screen shows the same numbers with the
+ * radio off as with it on — and an expense still sitting in the queue is
+ * already in them, because `materialiseExpenses` replays the queue on top.
+ */
 export function useHomeSummary(profileId: string | null) {
-  const balances = useQuery({
-    queryKey: ['balances', 'mine', profileId],
-    queryFn: () => fetchMyBalances(profileId as string),
-    enabled: Boolean(profileId),
-  });
-  const members = useQuery({ queryKey: ['members', 'byGroup'], queryFn: fetchMembersByGroup });
-  const pending = useQuery({
-    queryKey: ['settlements', 'pending'],
-    queryFn: fetchPendingSettlements,
-  });
+  const { mirror, queue, hydrated, status, flush } = useSync();
 
-  const byGroup = new Map<string, bigint>();
-  for (const row of balances.data ?? []) {
-    byGroup.set(row.group_id, (byGroup.get(row.group_id) ?? 0n) + BigInt(row.balance));
-  }
+  const summary = useMemo(() => {
+    const membersByGroup = new Map<string, MemberRow[]>();
+    const byGroup = new Map<string, bigint>();
+    const awaiting = new Set<string>();
 
-  let owed = 0n;
-  let owing = 0n;
-  for (const balance of byGroup.values()) {
-    if (balance > 0n) owed += balance;
-    else owing += -balance;
-  }
+    for (const group of materialiseGroups(mirror, queue) as unknown as GroupRow[]) {
+      const currency = group.default_currency ?? 'INR';
+      membersByGroup.set(
+        group.id,
+        materialiseMembers(mirror, queue, { groupId: group.id }) as unknown as MemberRow[],
+      );
+      const settlements = materialiseSettlements(mirror, queue, {
+        groupId: group.id,
+      }) as unknown as SettlementRow[];
 
-  const pendingByGroup = new Set((pending.data ?? []).map((row) => row.group_id));
+      const snapshots = materialiseExpenses(mirror, queue, { groupId: group.id })
+        .map((expense) => toSnapshot(expense as unknown as ExpenseRow))
+        .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
+
+      const net = computeNetBalances(snapshots, settlements.map(toSettlementSnapshot));
+      const mine = (membersByGroup.get(group.id) ?? []).find(
+        (member) => member.profile_id === profileId,
+      );
+      if (mine) byGroup.set(group.id, net.get(currency)?.get(mine.id) ?? 0n);
+
+      if (settlements.some((settlement) => settlement.status === 'initiated')) {
+        awaiting.add(group.id);
+      }
+    }
+
+    let owed = 0n;
+    let owing = 0n;
+    for (const balance of byGroup.values()) {
+      if (balance > 0n) owed += balance;
+      else owing += -balance;
+    }
+
+    return { byGroup, membersByGroup, awaiting, totals: { net: owed - owing, owed, owing } };
+  }, [mirror, queue, profileId]);
 
   return {
-    balanceFor: (groupId: string) => byGroup.get(groupId) ?? 0n,
-    membersFor: (groupId: string) => members.data?.get(groupId) ?? [],
-    memberCountFor: (groupId: string) => members.data?.get(groupId)?.length ?? 0,
-    hasPending: (groupId: string) => pendingByGroup.has(groupId),
-    totals: { net: owed - owing, owed, owing },
-    isLoading: balances.isLoading || members.isLoading,
-    isFetching: balances.isFetching || members.isFetching || pending.isFetching,
-    refetch: () => {
-      void balances.refetch();
-      void members.refetch();
-      void pending.refetch();
-    },
+    balanceFor: (groupId: string) => summary.byGroup.get(groupId) ?? 0n,
+    membersFor: (groupId: string) => summary.membersByGroup.get(groupId) ?? [],
+    memberCountFor: (groupId: string) => summary.membersByGroup.get(groupId)?.length ?? 0,
+    hasPending: (groupId: string) => summary.awaiting.has(groupId),
+    totals: summary.totals,
+    isLoading: !hydrated,
+    isFetching: status === 'syncing',
+    refetch: () => void flush(),
   };
 }
 
@@ -157,45 +230,59 @@ export function usePendingAware(groupId: string, expenses: ExpenseRow[]): Expens
   );
 }
 
+/**
+ * One group, entirely from the mirror.
+ *
+ * `balances` is the exception and stays a network read — it is the server's
+ * independently derived answer, kept only so `useGroupLedger` can notice if the
+ * two ever disagree. It is allowed to be absent; a group opens without it.
+ */
 export function useGroup(groupId: string) {
-  const group = useQuery({
-    queryKey: keys.group(groupId),
-    queryFn: () => fetchGroup(groupId),
-    enabled: Boolean(groupId),
-  });
-  const members = useQuery({
-    queryKey: keys.members(groupId),
-    queryFn: () => fetchMembers(groupId),
-    enabled: Boolean(groupId),
-  });
-  const expenses = useQuery({
-    queryKey: keys.expenses(groupId),
-    queryFn: () => fetchExpenses(groupId),
-    enabled: Boolean(groupId),
-  });
-  const settlements = useQuery({
-    queryKey: keys.settlements(groupId),
-    queryFn: () => fetchSettlements(groupId),
-    enabled: Boolean(groupId),
-  });
-  const activity = useQuery({
-    queryKey: keys.activity(groupId),
-    queryFn: () => fetchActivity(groupId),
-    enabled: Boolean(groupId),
-  });
+  const { mirror, queue } = useSync();
+
+  const rows = useMemo(() => {
+    const group =
+      (materialiseGroups(mirror, queue).find((row) => row.id === groupId) as unknown as
+        GroupRow | undefined) ?? null;
+    const members = materialiseMembers(mirror, queue, { groupId }) as unknown as MemberRow[];
+    const settlements = materialiseSettlements(mirror, queue, {
+      groupId,
+    }) as unknown as SettlementRow[];
+    const activity = (rowsFor(mirror, 'activity_log', groupId) as unknown as ActivityRow[]).sort(
+      (a, b) => String(b.created_at).localeCompare(String(a.created_at)),
+    );
+
+    // Server rows, and server rows with the queue replayed on top. Screens want
+    // the second; anything checking what the server actually knows wants the
+    // first, and conflating them is how a queued expense starts looking real
+    // enough to reconcile against.
+    const stored = (rowsFor(mirror, 'expenses', groupId) as unknown as ExpenseRow[]).sort((a, b) =>
+      String(b.created_at).localeCompare(String(a.created_at)),
+    );
+    const withPending = materialiseExpenses(mirror, queue, {
+      groupId,
+    }) as unknown as ExpenseRow[];
+
+    return { group, members, settlements, activity, stored, withPending };
+  }, [mirror, queue, groupId]);
+
+  const group = useLocalRead(rows.group);
+  const members = useLocalRead(rows.members);
+  const settlements = useLocalRead(rows.settlements);
+  const activity = useLocalRead(rows.activity);
+  const expenses = useLocalRead(rows.stored);
+
   const balances = useQuery({
     queryKey: keys.balances(groupId),
     queryFn: () => fetchBalances(groupId),
     enabled: Boolean(groupId),
   });
 
-  const withPending = usePendingAware(groupId, expenses.data ?? []);
-
   return {
     group,
     members,
-    // `expenses.data` is the server's answer; `expenses.rows` is what to render.
-    expenses: { ...expenses, rows: withPending },
+    // `expenses.data` is what the server has; `expenses.rows` is what to render.
+    expenses: { ...expenses, rows: rows.withPending },
     settlements,
     activity,
     balances,
@@ -324,8 +411,13 @@ export function useGroupLedger(groupId: string, myProfileId: string | null): Gro
 }
 
 /**
- * Live group channel (TDR §1). Any change to the group's rows invalidates the
- * affected queries, so a second device sees an expense without a manual pull.
+ * Live group channel (TDR §1). Any change to the group's rows pulls the group,
+ * so a second device sees an expense without a manual refresh.
+ *
+ * It syncs rather than invalidates: the screen reads the mirror, so a query
+ * marked stale would change nothing on it. Realtime's job here is to say "there
+ * is something new", not to carry it — the row still arrives through sync,
+ * which is the one path that also writes it to disk.
  */
 export function useGroupRealtime(groupId: string): void {
   const queryClient = useQueryClient();
@@ -365,66 +457,145 @@ export function useGroupRealtime(groupId: string): void {
   }, [groupId, queryClient]);
 }
 
+/**
+ * Pull the group, and mark stale the few things still read over the network.
+ *
+ * Most of what a group screen shows now comes from the mirror, so the sync is
+ * the part that matters; the invalidations cover what sync does not carry —
+ * the server's cross-check balances, receipts, disputes and spending.
+ */
 export function invalidateGroup(queryClient: QueryClient, groupId: string): void {
+  void syncEngine.flush({ groupIds: [groupId] });
   void queryClient.invalidateQueries({ queryKey: ['group', groupId] });
-  void queryClient.invalidateQueries({ queryKey: keys.groups });
   void queryClient.invalidateQueries({ queryKey: keys.allBalances });
-  // The lifetime settled total is not scoped to a group, so nothing above
-  // reaches it. Confirming a settlement in one group left the figure on the
-  // account screen showing the old number until the app was restarted — a
-  // total that only updates when you kill the app is worse than no total.
-  void queryClient.invalidateQueries({ queryKey: ['settlements', 'settled'] });
 }
 
 // ─────────────────────────────────────────────────────────── mutations ──
 
+/**
+ * bigint does not survive JSON, and the queue is JSON on disk. Amounts go as
+ * decimal strings and come back exact — the one thing money may never do here
+ * is round-trip through a float.
+ */
+function serialiseExpense(input: Omit<WriteExpenseInput, 'groupId'>): Record<string, unknown> {
+  return {
+    description: input.description.trim() || 'Expense',
+    category: input.category ?? null,
+    expenseDate: input.expenseDate,
+    currency: input.currency,
+    amount: input.amount.toString(),
+    fx: input.fx ?? null,
+    splitParams: input.splitParams,
+    participants: input.participants,
+    payers: Object.fromEntries(
+      Object.entries(input.payers).map(([member, amount]) => [member, amount.toString()]),
+    ),
+    expectedShares: input.expectedShares
+      ? Object.fromEntries(
+          Object.entries(input.expectedShares).map(([member, share]) => [member, share.toString()]),
+        )
+      : undefined,
+    notes: input.notes ?? null,
+  };
+}
+
+/**
+ * Every write below queues rather than calls.
+ *
+ * `mutate` persists the envelope to SQLite before it resolves and returns as
+ * soon as it is on disk, so the screen can move on at the speed of the phone
+ * and a force-kill on the next line still syncs. They used to call the RPCs
+ * directly, which meant every one of them simply failed with no signal —
+ * offline the app could read nothing and write nothing.
+ *
+ * The ids are generated here rather than by the database. A group has to have
+ * an id the moment it exists, because the expenses queued behind it reference
+ * it, and the server is told to use the one the client already chose.
+ */
 export function useCreateGroup() {
-  const queryClient = useQueryClient();
+  const { mutate } = useSync();
   return useMutation({
-    mutationFn: createGroup,
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: keys.groups });
+    mutationFn: async (input: Parameters<typeof createGroup>[0]) => {
+      const groupId = input.groupId ?? randomUUID();
+      await mutate('group.create', groupId, {
+        name: input.name?.trim() || null,
+        type: input.type,
+        currency: input.currency,
+        emoji: input.emoji ?? null,
+        simplify: input.simplify ?? true,
+        photoPath: input.photoPath ?? null,
+        country: input.country ?? null,
+      });
+      return groupId;
     },
   });
 }
 
 export function useWriteExpense(groupId: string) {
-  const queryClient = useQueryClient();
+  const { mutate } = useSync();
   return useMutation({
-    mutationFn: (input: Omit<WriteExpenseInput, 'groupId'>) => writeExpense({ ...input, groupId }),
-    onSuccess: () => invalidateGroup(queryClient, groupId),
+    mutationFn: async (input: Omit<WriteExpenseInput, 'groupId'>) => {
+      const expenseId = input.expenseId ?? randomUUID();
+      await mutate(input.expenseId ? 'expense.update' : 'expense.create', groupId, {
+        ...serialiseExpense(input),
+        expenseId,
+      });
+      return expenseId;
+    },
   });
 }
 
 export function useDeleteExpense(groupId: string) {
-  const queryClient = useQueryClient();
+  const { mutate } = useSync();
   return useMutation({
-    mutationFn: deleteExpense,
-    onSuccess: () => invalidateGroup(queryClient, groupId),
+    mutationFn: (expenseId: string) => mutate('expense.delete', groupId, { expenseId }),
   });
 }
 
 export function useRestoreExpense(groupId: string) {
-  const queryClient = useQueryClient();
+  const { mutate } = useSync();
   return useMutation({
-    mutationFn: restoreExpense,
-    onSuccess: () => invalidateGroup(queryClient, groupId),
+    mutationFn: (expenseId: string) => mutate('expense.restore', groupId, { expenseId }),
   });
 }
 
 export function useRecordSettlement(groupId: string) {
-  const queryClient = useQueryClient();
+  const { mutate } = useSync();
   return useMutation({
-    mutationFn: (input: Parameters<typeof recordSettlement>[0]) => recordSettlement(input),
-    onSuccess: () => invalidateGroup(queryClient, groupId),
+    mutationFn: (input: Parameters<typeof recordSettlement>[0]) =>
+      mutate(
+        'settlement.create',
+        input.groupId,
+        {
+          // Chosen here so the overlay has a stable row to show while it waits.
+          settlementId: randomUUID(),
+          from: input.fromMemberId,
+          to: input.toMemberId,
+          amount: input.amount.toString(),
+          // The enum only knows these four; `rail` carries the truth.
+          method: (['upi', 'cash', 'bank', 'other'] as const).includes(
+            input.rail as 'upi' | 'cash' | 'bank' | 'other',
+          )
+            ? input.rail
+            : 'other',
+          rail: input.rail,
+          currency: input.currency ?? null,
+          note: input.note ?? null,
+          allocations: (input.allocations ?? []).map((allocation) => ({
+            expenseId: allocation.expenseId,
+            amount: allocation.amount.toString(),
+          })),
+        },
+        input.clientMutationId,
+      ),
   });
 }
 
 export function useConfirmSettlement(groupId: string) {
-  const queryClient = useQueryClient();
+  const { mutate } = useSync();
   return useMutation({
-    mutationFn: confirmSettlement,
-    onSuccess: () => invalidateGroup(queryClient, groupId),
+    mutationFn: (settlementId: string) =>
+      mutate('settlement.transition', groupId, { settlementId }),
   });
 }
 
@@ -496,13 +667,24 @@ export function useResolveDispute(groupId: string) {
 }
 
 export function useAddGhostMember(groupId: string) {
-  const queryClient = useQueryClient();
+  const { mutate } = useSync();
   return useMutation({
-    mutationFn: (input: string | { name: string; email?: string | null; phone?: string | null }) =>
-      typeof input === 'string'
-        ? addGhostMember(groupId, input)
-        : addGhostMember(groupId, input.name, { email: input.email, phone: input.phone }),
-    onSuccess: () => invalidateGroup(queryClient, groupId),
+    mutationFn: async (
+      input: string | { name: string; email?: string | null; phone?: string | null },
+    ) => {
+      const person = typeof input === 'string' ? { name: input } : input;
+      // Chosen here so the expenses queued behind this member can already name
+      // them. Adding somebody and immediately splitting a bill with them is one
+      // action to a person, and offline it has to work like one.
+      const memberId = randomUUID();
+      await mutate('member.add_ghost', groupId, {
+        memberId,
+        name: person.name,
+        email: 'email' in person ? (person.email ?? null) : null,
+        phone: 'phone' in person ? (person.phone ?? null) : null,
+      });
+      return memberId;
+    },
   });
 }
 
@@ -520,10 +702,10 @@ export function useExpenseVersions(expenseId: string) {
 }
 
 export function useUpdateGroup(groupId: string) {
-  const queryClient = useQueryClient();
+  const { mutate } = useSync();
   return useMutation({
-    mutationFn: (patch: Parameters<typeof updateGroup>[1]) => updateGroup(groupId, patch),
-    onSuccess: () => invalidateGroup(queryClient, groupId),
+    mutationFn: (patch: Parameters<typeof updateGroup>[1]) =>
+      mutate('group.update', groupId, patch as Record<string, unknown>),
   });
 }
 

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -32,6 +32,8 @@ export interface GroupRow {
   remind_evening_at: string;
   archived_at: string | null;
   created_at: string;
+  /** True while this row exists only in the local queue (ADR-005). */
+  pending?: boolean;
 }
 
 export interface MemberRow {
@@ -58,6 +60,8 @@ export interface MemberRow {
     payment_rail?: string | null;
     payment_handle?: string | null;
   } | null;
+  /** True while this row exists only in the local queue (ADR-005). */
+  pending?: boolean;
 }
 
 export interface ExpenseVersionRow {
@@ -119,6 +123,8 @@ export interface SettlementRow {
   initiated_at: string;
   confirmed_at: string | null;
   allocations?: { expense_id: string; amount: string }[];
+  /** True while this row exists only in the local queue (ADR-005). */
+  pending?: boolean;
 }
 
 /** Who did the thing. Null when the actor has since left the group. */

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -86,6 +86,41 @@ export interface PluralForms {
 }
 
 /**
+ * The plural rules for the four languages Baaki speaks, written out.
+ *
+ * `Intl.PluralRules` is not in the Hermes build this app ships on. It is not
+ * merely inaccurate there — the constructor throws, so every plural in the app
+ * silently fell through to the `other` form and the home screen read "across 1
+ * groups". A `catch` that turns a missing API into the wrong word is worse than
+ * no plural support at all, because nothing about it looks broken in a test.
+ *
+ * These are CLDR's rules for the cardinal case, which is all this is used for.
+ * A language Baaki does not speak still gets the one/other rule, which is right
+ * for most European languages and no worse than the old behaviour anywhere.
+ */
+function selectRule(locale: string, count: number): Intl.LDMLPluralRule | null {
+  const language = locale.toLowerCase().split(/[-_]/)[0];
+
+  if (language === 'ar') {
+    const mod100 = count % 100;
+    if (count === 0) return 'zero';
+    if (count === 1) return 'one';
+    if (count === 2) return 'two';
+    if (mod100 >= 3 && mod100 <= 10) return 'few';
+    if (mod100 >= 11 && mod100 <= 99) return 'many';
+    return 'other';
+  }
+
+  // Tamil and Hindi both take `one` for exactly one. Hindi also takes it for 0,
+  // which English does not — "0 बदलाव है" is right and "0 changes" is too.
+  if (language === 'hi') return count === 0 || count === 1 ? 'one' : 'other';
+  if (language === 'en' || language === 'ta') return count === 1 ? 'one' : 'other';
+
+  // A language Baaki does not speak. Let Intl answer if it can.
+  return null;
+}
+
+/**
  * Picks the form and puts the number in it.
  *
  * `{n}` is replaced with the count formatted for the locale, not with
@@ -93,15 +128,25 @@ export interface PluralForms {
  * "12" beside Arabic words is a phrase in two number systems.
  */
 export function plural(locale: string, count: number, forms: PluralForms): string {
-  let rule: Intl.LDMLPluralRule = 'other';
+  // Our own rules first, Intl only for a language we do not ship. Asking the
+  // platform about the four languages we already know the answer for makes the
+  // wording depend on which Android build somebody happens to be holding.
+  let rule = selectRule(locale, count);
+  if (rule === null) {
+    try {
+      rule = new Intl.PluralRules(locale).select(count);
+    } catch {
+      rule = count === 1 ? 'one' : 'other';
+    }
+  }
+
   let shown = String(count);
   try {
-    rule = new Intl.PluralRules(locale).select(count);
     shown = new Intl.NumberFormat(locale).format(count);
   } catch {
-    // A locale Intl will not take is not a reason to render nothing. The
-    // English-shaped `other` form with a plain number beats an empty row.
+    // A locale Intl will not take is not a reason to render nothing.
   }
+
   return (forms[rule] ?? forms.other).replaceAll('{n}', shown);
 }
 
@@ -570,6 +615,8 @@ export interface UiStrings {
     someone: string;
     serverRefused: string;
     offlineSaved: string;
+    /** The mark on a row that is saved here but has not reached the server. */
+    notSentYet: string;
     offlineWithCount: PluralForms;
     cantReachServer: PluralForms;
     syncingCount: PluralForms;
@@ -1304,6 +1351,7 @@ const en: UiStrings = {
     pickDifferentPeople: 'Pick different people',
     someone: 'Someone',
     serverRefused: 'The server refused this change.',
+    notSentYet: 'Not sent yet',
     offlineWithCount: {
       one: 'Offline — {n} change saved on this phone',
       other: 'Offline — {n} changes saved on this phone',
@@ -2106,6 +2154,7 @@ const ta: UiStrings = {
     pickDifferentPeople: 'வேறு ஆட்களைத் தேர்ந்தெடு',
     someone: 'யாரோ',
     serverRefused: 'இந்த மாற்றத்தை சர்வர் ஏற்கவில்லை.',
+    notSentYet: 'இன்னும் அனுப்பப்படவில்லை',
     offlineWithCount: {
       one: 'இணைப்பு இல்லை — {n} மாற்றம் இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளது',
       other: 'இணைப்பு இல்லை — {n} மாற்றங்கள் இந்த ஃபோனில் சேமிக்கப்பட்டுள்ளன',
@@ -2894,6 +2943,7 @@ const hi: UiStrings = {
     pickDifferentPeople: 'दूसरे लोग चुनें',
     someone: 'कोई',
     serverRefused: 'सर्वर ने यह बदलाव नहीं माना।',
+    notSentYet: 'अभी भेजा नहीं गया',
     offlineWithCount: {
       one: 'ऑफ़लाइन — {n} बदलाव इसी फ़ोन पर सेव है',
       other: 'ऑफ़लाइन — {n} बदलाव इसी फ़ोन पर सेव हैं',
@@ -3697,6 +3747,7 @@ const ar: UiStrings = {
     pickDifferentPeople: 'اختر أشخاصًا آخرين',
     someone: 'أحدهم',
     serverRefused: 'رفض الخادم هذا التغيير.',
+    notSentYet: 'لم يُرسل بعد',
     offlineWithCount: {
       zero: 'دون اتصال — لا تغييرات',
       one: 'دون اتصال — تغيير واحد محفوظ على هذا الهاتف',

--- a/apps/mobile/test/strings.test.ts
+++ b/apps/mobile/test/strings.test.ts
@@ -127,3 +127,72 @@ describe('the string tables', () => {
     expect(RTL_LANGUAGES).toEqual(['ar']);
   });
 });
+
+/**
+ * The plural rules are ours, not the platform's.
+ *
+ * `Intl.PluralRules` is absent from the Hermes build this app ships on: the
+ * constructor throws, the old helper caught it, and every plural in the app
+ * quietly rendered its `other` form. The home screen read "across 1 groups" and
+ * nothing in CI could see it, because Node has full ICU and always answered
+ * correctly. These run against the rules directly for that reason.
+ */
+describe('plural rules', () => {
+  it('picks singular for one, in every language that has one', async () => {
+    const { plural } = await import('../src/i18n');
+    expect(plural('en', 1, { one: '{n} change', other: '{n} changes' })).toBe('1 change');
+    expect(plural('en-US', 1, { one: '{n} change', other: '{n} changes' })).toBe('1 change');
+    expect(plural('ta', 1, { one: 'one', other: 'many' })).toBe('one');
+    expect(plural('hi', 1, { one: 'one', other: 'many' })).toBe('one');
+    expect(plural('ar', 1, { one: 'one', other: 'many' })).toBe('one');
+  });
+
+  it('picks the plural for everything else', async () => {
+    const { plural } = await import('../src/i18n');
+    for (const count of [0, 2, 5, 21, 100]) {
+      expect(plural('en', count, { one: 'one', other: 'many' })).toBe('many');
+    }
+  });
+
+  it('follows Hindi in treating zero as singular', async () => {
+    const { plural } = await import('../src/i18n');
+    expect(plural('hi', 0, { one: 'one', other: 'many' })).toBe('one');
+    expect(plural('en', 0, { one: 'one', other: 'many' })).toBe('many');
+  });
+
+  it('walks all six Arabic categories', async () => {
+    const { plural } = await import('../src/i18n');
+    const forms = {
+      zero: 'zero',
+      one: 'one',
+      two: 'two',
+      few: 'few',
+      many: 'many',
+      other: 'other',
+    };
+    expect(plural('ar', 0, forms)).toBe('zero');
+    expect(plural('ar', 1, forms)).toBe('one');
+    expect(plural('ar', 2, forms)).toBe('two');
+    expect(plural('ar', 3, forms)).toBe('few');
+    expect(plural('ar', 10, forms)).toBe('few');
+    expect(plural('ar', 11, forms)).toBe('many');
+    expect(plural('ar', 99, forms)).toBe('many');
+    expect(plural('ar', 100, forms)).toBe('other');
+  });
+
+  it('still renders a sentence when the platform has no Intl at all', async () => {
+    const { plural } = await import('../src/i18n');
+    // Hermes does not merely get this wrong — it does not define it, and the
+    // constructor throws. Standing that up here is the only way CI can see what
+    // a phone sees, because Node ships full ICU and always answers.
+    const intl = Intl as unknown as Record<string, unknown>;
+    const original = intl.PluralRules;
+    delete intl.PluralRules;
+    try {
+      expect(plural('en', 1, { one: '{n} change', other: '{n} changes' })).toBe('1 change');
+      expect(plural('ar', 2, { one: 'one', two: 'two', other: 'other' })).toBe('two');
+    } finally {
+      intl.PluralRules = original;
+    }
+  });
+});

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -245,8 +245,8 @@ function applyPending(
       return;
     }
     default:
-      // Members, groups and settlements are mirrored but not overlaid: none of
-      // them can be created offline in a way that changes an expense row.
+      // Members, groups and settlements do not change an expense row. They have
+      // their own overlays below, because they can all be created offline now.
       return;
   }
 }
@@ -284,4 +284,204 @@ export function toExpenseSnapshot(expense: MirrorExpense): ExpenseSnapshot | nul
     date: version.expense_date,
     deletedAt: expense.deleted_at,
   };
+}
+
+// ─────────────────────────────── settlements, members and groups ──
+//
+// Expenses were the only thing the app could create offline, so they were the
+// only thing overlaid. Now that every mutation queues, the rest need the same
+// treatment: a settlement recorded in a basement, a friend added on a plane and
+// a group started in a tunnel all have to appear the moment they are made.
+// Without this they sit in the queue, invisible, and the app looks like it
+// dropped them — the failure ADR-005 exists to prevent.
+//
+// All three mark `pending` so a screen can say the row has not left the phone.
+
+export interface MirrorSettlement extends MirrorRow {
+  readonly id: string;
+  readonly group_id: string;
+  readonly from_member_id: string;
+  readonly to_member_id: string;
+  readonly currency: string;
+  readonly amount: string;
+  readonly status: string;
+  readonly initiated_at: string;
+  readonly confirmed_at: string | null;
+  readonly allocations?: readonly { expense_id: string; amount: string }[];
+  readonly pending?: boolean;
+}
+
+export function materialiseSettlements(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: { readonly groupId: string },
+): MirrorSettlement[] {
+  const byId = new Map<string, MirrorSettlement>();
+  for (const row of rowsFor(state, 'settlements', options.groupId) as MirrorSettlement[]) {
+    byId.set(row.id, row);
+  }
+
+  for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (mutation.groupId !== options.groupId) continue;
+
+    if (mutation.kind === 'settlement.create') {
+      const payload = mutation.payload as {
+        settlementId?: string;
+        from: string;
+        to: string;
+        currency?: string | null;
+        amount: string;
+        note?: string | null;
+        allocations?: readonly { expenseId: string; amount: string }[];
+      };
+      // Falling back to the mutation id keeps the row addressable even for a
+      // client that did not choose an id — two different queued settlements can
+      // never collide, because the mutation id is the idempotency key.
+      const id = payload.settlementId ?? `pending:${mutation.clientMutationId}`;
+      byId.set(id, {
+        id,
+        group_id: mutation.groupId,
+        from_member_id: payload.from,
+        to_member_id: payload.to,
+        currency: payload.currency ?? 'INR',
+        amount: payload.amount,
+        // `initiated`, not `confirmed`: the other person has still not agreed,
+        // and a settlement that counts itself confirmed on the way out would
+        // clear a debt nobody acknowledged.
+        status: 'initiated',
+        initiated_at: mutation.clientCreatedAt,
+        confirmed_at: null,
+        note: payload.note ?? null,
+        allocations: (payload.allocations ?? []).map((allocation) => ({
+          expense_id: allocation.expenseId,
+          amount: allocation.amount,
+        })),
+        pending: true,
+      });
+      continue;
+    }
+
+    if (mutation.kind === 'settlement.transition') {
+      const { settlementId } = mutation.payload as { settlementId: string };
+      const existing = byId.get(settlementId);
+      if (existing) {
+        byId.set(settlementId, {
+          ...existing,
+          status: 'confirmed',
+          confirmed_at: mutation.clientCreatedAt,
+          pending: true,
+        });
+      }
+    }
+  }
+
+  return [...byId.values()].sort((a, b) =>
+    String(b.initiated_at).localeCompare(String(a.initiated_at)),
+  );
+}
+
+export interface MirrorMember extends MirrorRow {
+  readonly id: string;
+  readonly group_id: string;
+  readonly profile_id: string | null;
+  readonly ghost_name: string | null;
+  readonly left_at: string | null;
+  readonly pending?: boolean;
+}
+
+export function materialiseMembers(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: { readonly groupId: string },
+): MirrorMember[] {
+  const byId = new Map<string, MirrorMember>();
+  for (const row of rowsFor(state, 'group_members', options.groupId) as MirrorMember[]) {
+    byId.set(row.id, row);
+  }
+
+  for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (mutation.groupId !== options.groupId || mutation.kind !== 'member.add_ghost') continue;
+    const payload = mutation.payload as {
+      memberId?: string;
+      name: string;
+      email?: string | null;
+      phone?: string | null;
+    };
+    const id = payload.memberId ?? `pending:${mutation.clientMutationId}`;
+    if (byId.has(id)) continue;
+    byId.set(id, {
+      id,
+      group_id: mutation.groupId,
+      profile_id: null,
+      ghost_name: payload.name,
+      left_at: null,
+      invite_email: payload.email ?? null,
+      invite_phone: payload.phone ?? null,
+      role: 'member',
+      pending: true,
+    });
+  }
+
+  return [...byId.values()].filter((member) => member.left_at === null);
+}
+
+export interface MirrorGroup extends MirrorRow {
+  readonly id: string;
+  readonly name: string | null;
+  readonly default_currency: string;
+  readonly created_at: string;
+  readonly archived_at: string | null;
+  readonly pending?: boolean;
+}
+
+export function materialiseGroups(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+): MirrorGroup[] {
+  const byId = new Map<string, MirrorGroup>();
+  for (const row of rowsFor(state, 'groups') as MirrorGroup[]) byId.set(row.id, row);
+
+  for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (mutation.kind === 'group.create') {
+      const payload = mutation.payload as {
+        name?: string | null;
+        type?: string;
+        currency?: string;
+        emoji?: string | null;
+        simplify?: boolean;
+        country?: string | null;
+      };
+      // The id is the group id the client already chose, which is why the
+      // expenses queued behind it can name it before the server has heard of it.
+      byId.set(mutation.groupId, {
+        id: mutation.groupId,
+        name: payload.name ?? null,
+        type: payload.type ?? 'other',
+        default_currency: payload.currency ?? 'INR',
+        cover_emoji: payload.emoji ?? null,
+        simplify_debts: payload.simplify !== false,
+        country_code: payload.country ?? null,
+        created_at: mutation.clientCreatedAt,
+        archived_at: null,
+        pending: true,
+      });
+      continue;
+    }
+
+    if (mutation.kind === 'group.update') {
+      const existing = byId.get(mutation.groupId);
+      if (existing) {
+        byId.set(mutation.groupId, {
+          ...existing,
+          ...(mutation.payload as Record<string, unknown>),
+          id: existing.id,
+          pending: true,
+        });
+      }
+    }
+  }
+
+  return [...byId.values()]
+    .filter((group) => !group.archived_at)
+    .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
 }

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -1,0 +1,243 @@
+/**
+ * The pending overlay for everything that is not an expense.
+ *
+ * Expenses were the only thing the app could create without a network, so they
+ * were the only thing replayed over the mirror. Once every mutation queues, the
+ * rest have to appear too — a settlement recorded in a basement, a friend added
+ * on a plane, a group started in a tunnel. A row that sits in the queue without
+ * appearing is indistinguishable from one the app threw away, which is the
+ * failure ADR-005 exists to prevent.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+
+import {
+  emptyMirror,
+  enqueue,
+  materialiseGroups,
+  materialiseMembers,
+  materialiseSettlements,
+  reconcile,
+  type MutationEnvelope,
+  type QueuedMutation,
+} from '../src/sync/index.js';
+
+const GROUP = 'g-1';
+const AT = '2026-03-01T09:00:00Z';
+
+function envelope(
+  id: string,
+  kind: MutationEnvelope['kind'],
+  payload: Record<string, unknown>,
+  groupId = GROUP,
+): MutationEnvelope {
+  return { clientMutationId: id, kind, groupId, clientCreatedAt: AT, payload };
+}
+
+function queued(...envelopes: MutationEnvelope[]): QueuedMutation[] {
+  let queue: QueuedMutation[] = [];
+  for (const item of envelopes) queue = enqueue(queue, item);
+  return queue;
+}
+
+describe('settlements', () => {
+  const settle = envelope('m-1', 'settlement.create', {
+    settlementId: 's-1',
+    from: 'member-a',
+    to: 'member-b',
+    currency: 'INR',
+    amount: '42000',
+    method: 'upi',
+    rail: 'upi',
+  });
+
+  it('shows a settlement recorded with no network, marked as unsent', () => {
+    const rows = materialiseSettlements(emptyMirror(), queued(settle), { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 's-1',
+      from_member_id: 'member-a',
+      to_member_id: 'member-b',
+      amount: '42000',
+      pending: true,
+    });
+  });
+
+  it('never claims the other person has agreed', () => {
+    // `initiated`, not `confirmed`: a settlement that confirmed itself on the
+    // way out of the phone would clear a debt nobody acknowledged (ADR-007).
+    const [row] = materialiseSettlements(emptyMirror(), queued(settle), { groupId: GROUP });
+    expect(row?.status).toBe('initiated');
+    expect(row?.confirmed_at).toBeNull();
+  });
+
+  it('applies a queued confirmation to a settlement the server already sent', () => {
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: 'settlements',
+        groupId: GROUP,
+        seq: 1,
+        row: {
+          id: 's-9',
+          group_id: GROUP,
+          from_member_id: 'member-a',
+          to_member_id: 'member-b',
+          currency: 'INR',
+          amount: '1000',
+          status: 'initiated',
+          initiated_at: AT,
+          confirmed_at: null,
+        },
+      },
+    ]).state;
+
+    const queue = queued(envelope('m-2', 'settlement.transition', { settlementId: 's-9' }));
+    const [row] = materialiseSettlements(mirror, queue, { groupId: GROUP });
+    expect(row).toMatchObject({ id: 's-9', status: 'confirmed', pending: true });
+  });
+
+  it('leaves another group alone', () => {
+    const elsewhere = queued(
+      envelope(
+        'm-3',
+        'settlement.create',
+        { ...(settle.payload as Record<string, unknown>), settlementId: 's-2' },
+        'g-2',
+      ),
+    );
+    expect(materialiseSettlements(emptyMirror(), elsewhere, { groupId: GROUP })).toHaveLength(0);
+  });
+});
+
+describe('members', () => {
+  it('shows a ghost added offline, with the address that lets them claim later', () => {
+    const queue = queued(
+      envelope('m-1', 'member.add_ghost', {
+        memberId: 'mem-1',
+        name: 'Ravi',
+        email: 'ravi@example.com',
+        phone: null,
+      }),
+    );
+    const rows = materialiseMembers(emptyMirror(), queue, { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'mem-1',
+      ghost_name: 'Ravi',
+      invite_email: 'ravi@example.com',
+      profile_id: null,
+      pending: true,
+    });
+  });
+
+  it('does not duplicate somebody the server has since confirmed', () => {
+    // Same id both sides — the client chose it, so the row the server sends
+    // back replaces the queued one rather than sitting beside it.
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: 'group_members',
+        groupId: GROUP,
+        seq: 1,
+        row: {
+          id: 'mem-1',
+          group_id: GROUP,
+          profile_id: null,
+          ghost_name: 'Ravi',
+          left_at: null,
+        },
+      },
+    ]).state;
+
+    const queue = queued(envelope('m-1', 'member.add_ghost', { memberId: 'mem-1', name: 'Ravi' }));
+    const rows = materialiseMembers(mirror, queue, { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.pending).toBeUndefined();
+  });
+});
+
+describe('groups', () => {
+  const create = envelope('m-1', 'group.create', {
+    name: 'Goa',
+    currency: 'INR',
+    emoji: '🏖️',
+    country: 'IN',
+  });
+
+  it('shows a group started offline, under the id its expenses already name', () => {
+    const rows = materialiseGroups(emptyMirror(), queued(create));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: GROUP,
+      name: 'Goa',
+      default_currency: 'INR',
+      country_code: 'IN',
+      pending: true,
+    });
+  });
+
+  it('replays an edit over the row the server sent', () => {
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: 'groups',
+        groupId: GROUP,
+        seq: 1,
+        row: {
+          id: GROUP,
+          name: 'Goa',
+          default_currency: 'INR',
+          created_at: AT,
+          archived_at: null,
+        },
+      },
+    ]).state;
+
+    const queue = queued(envelope('m-2', 'group.update', { name: 'Goa 2026' }));
+    const [row] = materialiseGroups(mirror, queue);
+    expect(row).toMatchObject({ id: GROUP, name: 'Goa 2026', pending: true });
+  });
+
+  it('keeps an archived group out, however it was archived', () => {
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: 'groups',
+        groupId: GROUP,
+        seq: 1,
+        row: { id: GROUP, name: 'Old', default_currency: 'INR', created_at: AT, archived_at: AT },
+      },
+    ]).state;
+    expect(materialiseGroups(mirror, [])).toHaveLength(0);
+  });
+});
+
+describe('the overlay as a whole', () => {
+  it('never loses or duplicates a queued row, whatever order it was queued in', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.string({ minLength: 1, maxLength: 6 }), {
+          minLength: 0,
+          maxLength: 8,
+        }),
+        (ids) => {
+          const queue = queued(
+            ...ids.map((id) =>
+              envelope(`m-${id}`, 'settlement.create', {
+                settlementId: `s-${id}`,
+                from: 'a',
+                to: 'b',
+                currency: 'INR',
+                amount: '100',
+                method: 'cash',
+              }),
+            ),
+          );
+
+          const rows = materialiseSettlements(emptyMirror(), queue, { groupId: GROUP });
+          expect(rows).toHaveLength(ids.length);
+          expect(new Set(rows.map((row) => row.id)).size).toBe(ids.length);
+          expect(rows.every((row) => row.pending === true)).toBe(true);
+        },
+      ),
+    );
+  });
+});

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -136,7 +136,21 @@ Deno.serve(async (request) => {
     // Pull every group the client already knows about, plus any it just
     // created — otherwise a group made offline would stay invisible until the
     // next sync.
-    const groupIds = new Set<string>([...Object.keys(cursors), ...session.touchedGroups]);
+    //
+    // And every group this person is actually in, which is not the same set. A
+    // device that has never synced has no cursors to name, and a group somebody
+    // else added you to has no cursor either: without this, "read local-first"
+    // could never get its first row, and being invited would do nothing until
+    // you happened to open the group by link. The membership read runs as the
+    // caller, so it can only ever return groups their own RLS already allows.
+    const mine = await caller.from('group_members').select('group_id').is('left_at', null);
+    if (mine.error) throw new HttpError(500, 'PULL_FAILED', `memberships: ${mine.error.message}`);
+
+    const groupIds = new Set<string>([
+      ...Object.keys(cursors),
+      ...session.touchedGroups,
+      ...(mine.data ?? []).map((row) => row.group_id as string),
+    ]);
     const { changes, cursors: nextCursors } = await pull(caller, groupIds, cursors);
 
     return json({
@@ -250,6 +264,12 @@ class SyncSession {
           p_group_id: mutation.groupId,
           p_name: requireString(mutation.payload.name, 'name'),
           p_member_id: (mutation.payload.memberId as string | undefined) ?? null,
+          // An address is the whole point of adding somebody from your contacts
+          // — it is what lets them claim their share later (ADR-006). This case
+          // dropped it, so the same person added offline and online became two
+          // different rows.
+          p_email: (mutation.payload.email as string | undefined) ?? null,
+          p_phone: (mutation.payload.phone as string | undefined) ?? null,
         });
       case 'group.create':
         return await this.rpcAsCaller('baaki_create_group', {
@@ -260,6 +280,11 @@ class SyncSession {
           p_simplify: mutation.payload.simplify !== false,
           // The client already chose this id and its queued expenses reference it.
           p_group_id: mutation.groupId,
+          p_photo_path: (mutation.payload.photoPath as string | undefined) ?? null,
+          // Which country the group is in decides which payment rails it is
+          // offered (ADR-012). Dropped here, a group created offline came back
+          // with no rails and no way to settle on one.
+          p_country: (mutation.payload.country as string | undefined) ?? null,
         });
       case 'group.update': {
         await this.requireMemberId(mutation.groupId);
@@ -385,6 +410,7 @@ class SyncSession {
       to: string;
       amount: string;
       method: string;
+      rail?: string | null;
       currency?: string | null;
       note?: string | null;
       allocations?: { expenseId: string; amount: string }[];
@@ -396,6 +422,10 @@ class SyncSession {
       p_to_member_id: payload.to,
       p_amount: payload.amount,
       p_method: payload.method,
+      // The enum knows four methods; the rail is the truth (ADR-012). Without
+      // this, a settlement paid over Pix and queued offline arrived as "other"
+      // and the group lost the one detail that says how it was actually paid.
+      p_rail: payload.rail ?? payload.method,
       p_currency: payload.currency ?? null,
       p_note: payload.note ?? null,
       p_allocations: payload.allocations ?? [],


### PR DESCRIPTION
Baaki was offline-first in name only. The sync engine was built and tested — a durable SQLite outbox, backoff, a mirror, reconciliation, drafts saved per keystroke — and then almost nothing used it.

`useLocalGroups` and `useOfflineLedger`, written for exactly this, had zero callers. Every screen read react-query against Supabase with no cache persister, so a cold start with no signal opened an empty ledger. Six of the nine mutation kinds went straight to the RPCs and simply failed. The banner counted a queue that was almost always empty.

**Reads come off the mirror** (ADR-005: "the UI reads local-first, always"). The network's only job is to fill it. `group_balances` stays a network read and is still never rendered — it is the independent second opinion the ledger checks its arithmetic against (ADR-004), and reading it from the mirror would make it agree by construction.

**Every write queues.** Ids are generated on the client, because a group has to exist the moment it is made — the expenses queued behind it name it, and the server is told to use the id the client already chose.

Expenses were the only thing overlaid on the mirror, since they were the only thing that could be created offline. Now that everything queues, settlements, members and groups need the same treatment, or a settlement recorded in a basement sits in the queue invisible and looks exactly like data loss.

**Three fields the sync path silently dropped**, found by reading it against the RPCs it stands in for: a ghost member's email and phone (the whole point of adding somebody from your contacts — it is how they claim their share later), a settlement's rail (Pix and Aani both collapsed to "other"), and a group's country (which decides the rails it is offered). Queued offline, all three came back wrong.

The pull also only ever returned groups the client already named, so a device that had never synced had no way to discover its own groups, and being added to one did nothing until you opened it by link.

An unsent row is marked with a faint cloud beside the amount, not a colour. Green and red are the ledger's vocabulary and a third colour would be a second thing to decode. The row is real either way: a queued expense already counts toward the balance, because the arithmetic is the same on both sides of the wire.

**One thing only a phone could show:** `Intl.PluralRules` is absent from this Hermes build — the constructor throws, the helper caught it, and every plural in the app fell through to its `other` form. The home screen read "across 1 groups" and CI could not see it, because Node ships full ICU and always answers. The rules for the four languages Baaki speaks are written down now, Intl is asked only about a language we do not ship, and the tests delete `Intl.PluralRules` so they see what a phone sees.

## Verified on a device rather than in a test

Airplane mode on, the group and its history still open; an expense saved with no radio, appearing immediately with the cloud mark and already counted in the balance; airplane mode off, the queue flushes, the mark clears and the number does not move — the local computation had matched the server's all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ
