### PR TITLE
feat: sign in with Apple, without stranding anybody's groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,52 @@ mean the credentials are wrong rather than the devices. Without that, a wrong ke
 looks exactly like a country with its phones switched off: rows go out, failures
 climb, and nothing anywhere names the cause.
 
+## Turning on Sign in with Apple
+
+Like push, the code is here and the credential is not: Apple issues it to whoever
+owns the app. Unlike push, **two** things have to be configured, because Baaki
+reaches Apple by two different roads and they authenticate differently.
+
+The two roads, and why there are two:
+
+| Who is tapping                                                               | Road                                              | Needs                   |
+| ---------------------------------------------------------------------------- | ------------------------------------------------- | ----------------------- |
+| Nobody signed in, on an iPhone                                               | native sheet → `signInWithIdToken`                | the **bundle ID**       |
+| Everybody else — Android, and **any** guest or existing account adding Apple | web redirect → `linkIdentity` / `signInWithOAuth` | a **Services ID** + key |
+
+The second row is the common one, not the fallback. ADR-006 puts everybody
+through the guest door first, so most people who ever tap Apple are linking it to
+an account they already have — and `signInWithIdToken` has no way to add a
+provider to an existing session. Configure only the native side and Apple works
+for a fresh install and silently fails for everyone the app is actually built
+around.
+
+**In the Apple Developer console, once:**
+
+1. Enable the **Sign in with Apple** capability on the App ID `app.baaki.mobile`.
+2. Create a **Services ID** (a separate identifier — this is the web client), and
+   set its return URL to
+   `https://xvjzbpgcmotoahtqcxve.supabase.co/auth/v1/callback`.
+3. Create a **Sign in with Apple key**, and keep the `.p8` — it is downloadable
+   exactly once.
+
+**In the Supabase dashboard**, under Authentication → Providers → Apple: enable
+it, put **both** identifiers in Client IDs as a comma-separated pair
+(`app.baaki.mobile,<the Services ID>`), and paste the Team ID, Key ID and `.p8`.
+Both roads then land on the same account, which is the point of listing both.
+
+All of this needs a paid Apple Developer account. Without it, `withApple` in
+`lib/auth.tsx` still compiles and the button still renders — it is Supabase that
+refuses, and the screen shows what it said.
+
+**What is safe to skip:** nothing about a device or a build. `expo-apple-authentication`
+resolves its functions through `requireOptionalNativeModule`, and
+`lib/appleAuth.ts` reads Expo's registry before requiring the package at all, so
+an Android phone or an iOS build made before this package existed shows the plain
+fallback button rather than failing to launch. `usesAppleSignIn` in `app.json` is
+what writes the entitlement into the binary, so turning this on **needs a
+rebuild** — an existing build has no capability to use.
+
 ## Releasing, and stopping old builds
 
 The version is compiled into the binary, so a build can only ever describe

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -17,7 +17,8 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "app.baaki.mobile"
+      "bundleIdentifier": "app.baaki.mobile",
+      "usesAppleSignIn": true
     },
     "android": {
       "package": "app.baaki.mobile",
@@ -37,6 +38,7 @@
       "expo-router",
       "expo-localization",
       "expo-sqlite",
+      "expo-apple-authentication",
       [
         "expo-splash-screen",
         {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.101.4",
     "base64-arraybuffer": "^1.0.2",
     "expo": "~57.0.11",
+    "expo-apple-authentication": "~57.0.1",
     "expo-auth-session": "~57.0.6",
     "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.9",

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -36,6 +36,7 @@ import {
 
 import { Button, Card, Chip, CurvedPanel, Row, Screen, Text, useTheme } from '@baaki/ui';
 
+import { AppleSignInButton } from '@/components/AppleSignInButton';
 import { LanguagePicker } from '@/components/LanguagePicker';
 import { Onboarding } from '@/components/Onboarding';
 import { useStrings } from '@/i18n';
@@ -48,7 +49,8 @@ const TOUR_KEY = 'baaki.onboarding_seen';
 export default function SignInScreen() {
   const theme = useTheme();
   const { t } = useStrings();
-  const { sendOtp, verifyOtp, continueAsGuest, withPassword, withGoogle, isGuest } = useAuth();
+  const { sendOtp, verifyOtp, continueAsGuest, withPassword, withGoogle, withApple, isGuest } =
+    useAuth();
   const { height: screenHeight } = useWindowDimensions();
 
   /**
@@ -450,6 +452,12 @@ export default function SignInScreen() {
               fullWidth
               disabled={busy}
               onPress={() => void run(withGoogle)}
+            />
+
+            <AppleSignInButton
+              label={isGuest ? t.signIn.continueApple : t.signIn.signInApple}
+              disabled={busy}
+              onPress={() => void run(withApple)}
             />
 
             {/* ADR-006: nobody is forced to register before they can use Baaki.

--- a/apps/mobile/src/components/AppleSignInButton.tsx
+++ b/apps/mobile/src/components/AppleSignInButton.tsx
@@ -1,0 +1,80 @@
+/**
+ * Apple's own button, or ours.
+ *
+ * Apple's Human Interface Guidelines govern what this button may look like —
+ * approved wording, the official mark, set colours and proportions — and
+ * `AppleAuthenticationButton` is the native control, so it is correct by
+ * construction and localised into languages this app does not itself ship.
+ * That matters here: Baaki speaks four, and Apple speaks forty.
+ *
+ * It is rendered through `appleModule()` rather than imported, for the reason
+ * `lib/appleAuth.ts` sets out at length — the native view manager is resolved
+ * at module scope on iOS and throws on a binary built before this package
+ * existed, which expo-router turns into a launch failure rather than a missing
+ * button.
+ *
+ * Where there is no native sheet — Android, and iOS builds without the module —
+ * this falls back to an ordinary Baaki button. That is not decoration: an
+ * account created with Apple on an iPhone has to be reachable from an Android
+ * phone, and the web flow behind it is the only way in.
+ */
+
+import { useAppleSignInAvailable, appleModule } from '@/lib/appleAuth';
+import { Button, useTheme } from '@baaki/ui';
+
+interface Props {
+  /** Matches the wording of the Google button beside it. */
+  label: string;
+  disabled?: boolean;
+  onPress: () => void;
+}
+
+/** The same height as a `size="lg"` Button, so the two sit as a pair. */
+const HEIGHT = 56;
+
+export function AppleSignInButton({ label, disabled, onPress }: Props) {
+  const theme = useTheme();
+  const native = useAppleSignInAvailable();
+  const apple = native ? appleModule() : null;
+
+  if (!apple) {
+    return (
+      <Button
+        label={label}
+        variant="secondary"
+        size="lg"
+        fullWidth
+        disabled={disabled}
+        onPress={onPress}
+      />
+    );
+  }
+
+  const {
+    AppleAuthenticationButton,
+    AppleAuthenticationButtonType,
+    AppleAuthenticationButtonStyle,
+  } = apple;
+
+  return (
+    <AppleAuthenticationButton
+      // "Continue with Apple" rather than "Sign in with", for the same reason
+      // the button beside it says continue: ADR-006 means most people arrive
+      // here already holding an account full of expenses, and are adding a way
+      // back to it rather than starting one.
+      buttonType={AppleAuthenticationButtonType.CONTINUE}
+      // Apple's black on our light theme, white on our dark one — the pairing
+      // that keeps the button legible against the surface it sits on.
+      buttonStyle={
+        theme.scheme === 'dark'
+          ? AppleAuthenticationButtonStyle.WHITE
+          : AppleAuthenticationButtonStyle.BLACK
+      }
+      // Half the height, because `radius.pill` is the 999 sentinel every other
+      // button rounds itself with and Apple wants a real corner in points.
+      cornerRadius={HEIGHT / 2}
+      style={{ width: '100%', height: HEIGHT, opacity: disabled ? 0.5 : 1 }}
+      onPress={disabled ? () => {} : onPress}
+    />
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -449,6 +449,13 @@ export interface UiStrings {
     switchToSignUp: string;
     continueGoogle: string;
     signInGoogle: string;
+    /**
+     * Only ever read on Android and on iOS builds without the native module —
+     * Apple's own button draws and localises its own label, in rather more
+     * languages than these four.
+     */
+    continueApple: string;
+    signInApple: string;
     continueGuest: string;
     guestFootnote: string;
     memberFootnote: string;
@@ -1175,6 +1182,8 @@ const en: UiStrings = {
     switchToSignUp: 'I am new here — create an account',
     continueGoogle: 'Continue with Google',
     signInGoogle: 'Sign in with Google',
+    continueApple: 'Continue with Apple',
+    signInApple: 'Sign in with Apple',
     continueGuest: 'Continue as guest',
     guestFootnote:
       'Everything you have already added stays exactly where it is. This only adds a way to sign back in.',
@@ -1975,6 +1984,8 @@ const ta: UiStrings = {
     switchToSignUp: 'நான் புதியவர் — கணக்கை உருவாக்கு',
     continueGoogle: 'Google மூலம் தொடர்',
     signInGoogle: 'Google மூலம் உள்நுழை',
+    continueApple: 'Apple மூலம் தொடர்',
+    signInApple: 'Apple மூலம் உள்நுழை',
     continueGuest: 'விருந்தினராகத் தொடர்',
     guestFootnote:
       'நீங்கள் ஏற்கனவே சேர்த்த அனைத்தும் அப்படியே இருக்கும். இது மீண்டும் உள்நுழைய ஒரு வழியை மட்டுமே சேர்க்கிறது.',
@@ -2769,6 +2780,8 @@ const hi: UiStrings = {
     switchToSignUp: 'मैं नया हूँ — खाता बनाएँ',
     continueGoogle: 'Google से जारी रखें',
     signInGoogle: 'Google से साइन इन करें',
+    continueApple: 'Apple से जारी रखें',
+    signInApple: 'Apple से साइन इन करें',
     continueGuest: 'मेहमान के तौर पर जारी रखें',
     guestFootnote:
       'आपने जो जोड़ा है वह जहाँ है वहीं रहेगा। इससे सिर्फ़ दोबारा साइन इन करने का रास्ता जुड़ता है।',
@@ -3565,6 +3578,8 @@ const ar: UiStrings = {
     switchToSignUp: 'أنا جديد هنا — أنشئ حسابًا',
     continueGoogle: 'المتابعة عبر Google',
     signInGoogle: 'تسجيل الدخول عبر Google',
+    continueApple: 'المتابعة عبر Apple',
+    signInApple: 'تسجيل الدخول عبر Apple',
     continueGuest: 'المتابعة كضيف',
     guestFootnote: 'كل ما أضفته يبقى كما هو تمامًا. هذا يضيف فقط طريقة للعودة وتسجيل الدخول.',
     memberFootnote:

--- a/apps/mobile/src/lib/appleAuth.ts
+++ b/apps/mobile/src/lib/appleAuth.ts
@@ -1,0 +1,153 @@
+/**
+ * Sign in with Apple, on the one platform where it is native.
+ *
+ * **Nothing here is imported at the top of the file that can fail.**
+ * `expo-apple-authentication` is gentler than most native modules — its
+ * functions come through `requireOptionalNativeModule`, which returns a stub
+ * answering `isAvailableAsync() === false` rather than throwing. The *button*
+ * is not: `ExpoAppleAuthenticationButton` calls `requireNativeViewManager` at
+ * module scope whenever `Platform.OS === 'ios'`, and that throws on an iOS
+ * binary built before this package was added. expo-router loads every route
+ * file to build the route tree, so that is not a missing button — it is the app
+ * failing to launch, with a red screen naming a screen nobody opened.
+ *
+ * So the package is only ever required once the native side is known to be
+ * there, read from Expo's registry directly (`globalThis.expo.modules`), which
+ * is the same non-throwing check `image.ts` uses and for the same reason.
+ *
+ * A false negative costs the Apple button and nothing else: the web flow in
+ * `auth.tsx` still works, on this platform and every other one.
+ */
+
+import { useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+
+import { appleFullName } from '@baaki/core';
+
+type AppleModule = typeof import('expo-apple-authentication');
+
+/** What the sheet gives back, reduced to the two things anything here reads. */
+export interface AppleCredential {
+  /** The JWT Supabase exchanges for a session. */
+  readonly identityToken: string;
+  /**
+   * Apple hands this over **on the first authorization only**, and never again
+   * — not on a reinstall, not on a second device. If it is not captured now it
+   * is gone, and in a bill-splitting app the cost of losing it is a row in
+   * somebody's group that reads "Guest".
+   */
+  readonly fullName: string | null;
+}
+
+let cached: AppleModule | null | undefined;
+
+/** Whether this build contains the native side. False on Android and web. */
+function nativeSideExists(): boolean {
+  if (Platform.OS !== 'ios') return false;
+  const registry = (globalThis as { expo?: { modules?: Record<string, unknown> } }).expo?.modules;
+  return Boolean(registry?.ExpoAppleAuthentication);
+}
+
+function load(): AppleModule | null {
+  if (cached !== undefined) return cached;
+  if (!nativeSideExists()) {
+    cached = null;
+    return null;
+  }
+  try {
+    // Required, not imported: an import is hoisted and would be evaluated at
+    // module load, which is the thing the check above exists to avoid.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    cached = require('expo-apple-authentication') as AppleModule;
+  } catch {
+    cached = null;
+  }
+  return cached;
+}
+
+/** The lazily-loaded module, for the button to render itself from. Null elsewhere. */
+export function appleModule(): AppleModule | null {
+  return load();
+}
+
+/**
+ * Whether the native sheet can be opened at all.
+ *
+ * Two separate questions, and both have to be yes: is the module in this binary
+ * (an old build says no), and does this iOS version support Sign in with Apple
+ * (iOS 13+, so a very old phone says no). Asked before opening the sheet rather
+ * than inferred from its result, because "no sheet here" and "somebody closed
+ * the sheet" need opposite responses and are otherwise indistinguishable.
+ */
+export async function appleSignInAvailable(): Promise<boolean> {
+  const apple = load();
+  if (!apple) return false;
+  try {
+    return await apple.isAvailableAsync();
+  } catch {
+    // Unavailable is the only meaningful answer to a check that failed.
+    return false;
+  }
+}
+
+/**
+ * The same question for rendering, where an answer is needed synchronously.
+ *
+ * Starts at false, which is the safe way round: a moment without the button
+ * beats a button that throws when it is pressed.
+ */
+export function useAppleSignInAvailable(): boolean {
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void appleSignInAvailable().then((yes) => {
+      if (active) setAvailable(yes);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return available;
+}
+
+/**
+ * Open Apple's sheet and return what it gave us.
+ *
+ * Null means **somebody closed the sheet**, and nothing should happen — no
+ * error, and in particular no falling back to the browser, which would answer a
+ * person declining to sign in by opening a second thing to decline. Callers ask
+ * `appleSignInAvailable()` first; anything else that goes wrong throws, because
+ * a sheet that failed is worth saying out loud.
+ *
+ * No nonce. `signInAsync` would pass one through to Apple and Supabase would
+ * compare it, but the two disagree about whether the value travelling in the
+ * token is the raw string or its SHA-256, and getting that backwards fails
+ * every sign-in on a device this repository cannot test from. Supabase's own
+ * Expo guide omits it, the token still carries a signature and an audience that
+ * are verified server-side, and it never leaves this process except over TLS to
+ * Supabase.
+ */
+export async function signInWithApple(): Promise<AppleCredential | null> {
+  const apple = load();
+  if (!apple) return null;
+
+  try {
+    const credential = await apple.signInAsync({
+      requestedScopes: [
+        apple.AppleAuthenticationScope.FULL_NAME,
+        apple.AppleAuthenticationScope.EMAIL,
+      ],
+    });
+    if (!credential.identityToken) return null;
+
+    return {
+      identityToken: credential.identityToken,
+      fullName: appleFullName(credential.fullName),
+    };
+  } catch (error) {
+    if ((error as { code?: string })?.code === 'ERR_REQUEST_CANCELED') return null;
+    throw error;
+  }
+}

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -3,8 +3,15 @@ import type { Session } from '@supabase/supabase-js';
 import { makeRedirectUri } from 'expo-auth-session';
 import * as WebBrowser from 'expo-web-browser';
 
-import { checkPassword, planAuth, readIdentifier, type Viewer } from '@baaki/core';
+import {
+  checkPassword,
+  planAuth,
+  readIdentifier,
+  type OAuthMethod,
+  type Viewer,
+} from '@baaki/core';
 
+import { appleSignInAvailable, signInWithApple, type AppleCredential } from './appleAuth';
 import { identifyForReporting } from './observability';
 import { refreshPushToken, revokePushToken } from './push';
 import { supabase } from './supabase';
@@ -19,6 +26,95 @@ function viewerFrom(session: Session | null): Viewer {
   return session.user.is_anonymous === true
     ? { kind: 'guest', userId: session.user.id }
     : { kind: 'user', userId: session.user.id };
+}
+
+/**
+ * A provider sign-in that goes through the browser, for both providers.
+ *
+ * Apple on an iPhone gets the native sheet instead (see `withApple`), but every
+ * other case — Apple on Android, and *any* upgrade of an account that already
+ * exists — comes through here. That last one is not an edge case in this app:
+ * ADR-006 puts everybody through the guest door first, so linking is the common
+ * path and the native sheet is the exception.
+ *
+ * Returns the session to store, or `undefined` when there is nothing to change
+ * because somebody closed the browser.
+ */
+async function oauthThroughBrowser(
+  provider: OAuthMethod,
+  link: boolean,
+): Promise<Session | null | undefined> {
+  const redirectTo = makeRedirectUri({ scheme: 'baaki', path: 'auth' });
+
+  // Both calls return a URL rather than opening it: the browser has to be the
+  // in-app one, or the session comes back to a tab the app cannot see.
+  const { data, error } = link
+    ? await supabase.auth.linkIdentity({
+        provider,
+        options: { redirectTo, skipBrowserRedirect: true },
+      })
+    : await supabase.auth.signInWithOAuth({
+        provider,
+        options: { redirectTo, skipBrowserRedirect: true },
+      });
+  if (error) throw error;
+  if (!data?.url) throw new Error(`${provider} did not give us a sign-in link`);
+
+  const result = await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
+  if (result.type !== 'success') return undefined;
+
+  // The tokens come back in the URL fragment; nothing else reads them.
+  const fragment = result.url.split('#')[1] ?? '';
+  const params = new URLSearchParams(fragment);
+  const access_token = params.get('access_token');
+  const refresh_token = params.get('refresh_token');
+  if (!access_token || !refresh_token) {
+    // A link, rather than a sign-in, returns no tokens — the session it just
+    // added an identity to is the one already held.
+    const { data: current } = await supabase.auth.getSession();
+    return current.session;
+  }
+
+  const { data: signedIn, error: sessionError } = await supabase.auth.setSession({
+    access_token,
+    refresh_token,
+  });
+  if (sessionError) throw sessionError;
+  return signedIn.session;
+}
+
+/**
+ * The name Apple gave us, written down before it is gone.
+ *
+ * Apple returns a name on the **first authorization only** — never on a
+ * reinstall, never on a second device — and the id token carries none, so the
+ * `handle_new_user` trigger has nothing to seed `display_name` from and falls
+ * back to 'Guest'. Left alone, somebody who signed in with Apple appears to
+ * everybody they split a bill with as "Guest".
+ *
+ * Only ever fills the placeholder in. Somebody who signed in with Apple two
+ * years ago and has since named themselves must not be renamed by a fresh
+ * authorization on a new phone.
+ */
+async function adoptAppleName(userId: string, fullName: string): Promise<void> {
+  // The profile row is made by a trigger on auth.users, so it can land a beat
+  // after the session does. Same wait as the profile loader below.
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const { data } = await supabase
+      .from('profiles')
+      .select('display_name')
+      .eq('id', userId)
+      .maybeSingle();
+
+    if (data) {
+      const placeholder = !data.display_name || data.display_name === 'Guest';
+      if (placeholder) {
+        await supabase.from('profiles').update({ display_name: fullName }).eq('id', userId);
+      }
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+  }
 }
 
 export interface Profile {
@@ -58,6 +154,13 @@ interface AuthValue {
   ) => Promise<void>;
   /** Google. Links to the current account when there is one, for the same reason. */
   withGoogle: () => Promise<void>;
+  /**
+   * Apple. The native sheet for somebody with no account to lose, the same
+   * browser flow as Google for everybody else — because `signInWithIdToken`
+   * has no way to add a provider to a session that already exists, and using
+   * it on a guest would strand their groups on a new account.
+   */
+  withApple: () => Promise<void>;
   updateProfile: (patch: Partial<Profile>) => Promise<void>;
   /** Re-read the session after it changes underneath us (e.g. a linked email). */
   refresh: () => Promise<void>;
@@ -190,43 +293,40 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       async withGoogle() {
         const action = planAuth(viewerFrom(session), 'google');
-        const redirectTo = makeRedirectUri({ scheme: 'baaki', path: 'auth' });
+        const next = await oauthThroughBrowser('google', action.call === 'linkIdentity');
+        if (next !== undefined) setSession(next);
+      },
 
-        // Both calls return a URL rather than opening it: the browser has to be
-        // the in-app one, or the session comes back to a tab the app cannot see.
-        const { data, error } =
-          action.call === 'linkIdentity'
-            ? await supabase.auth.linkIdentity({
-                provider: 'google',
-                options: { redirectTo, skipBrowserRedirect: true },
-              })
-            : await supabase.auth.signInWithOAuth({
-                provider: 'google',
-                options: { redirectTo, skipBrowserRedirect: true },
-              });
-        if (error) throw error;
-        if (!data?.url) throw new Error('Google did not give us a sign-in link');
+      async withApple() {
+        const action = planAuth(viewerFrom(session), 'apple');
 
-        const result = await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
-        if (result.type !== 'success') return;
+        // The native sheet is bound to this one branch, and the branch is the
+        // one `planAuth` only ever returns for a viewer of kind 'nobody'
+        // (`identity.test.ts` holds that). `signInWithIdToken` resolves a token
+        // to whichever account owns that Apple ID and cannot be told to add it
+        // to the session already held, so reaching it as a guest would do
+        // exactly what ADR-006 forbids: swap the session and leave a week of
+        // expenses on an account nobody can sign in to.
+        if (action.call === 'signInWithOAuth' && (await appleSignInAvailable())) {
+          const credential: AppleCredential | null = await signInWithApple();
+          // Closed the sheet. Not an error, and emphatically not a reason to
+          // open a browser at somebody who has just declined to sign in.
+          if (!credential) return;
 
-        // The tokens come back in the URL fragment; nothing else reads them.
-        const fragment = result.url.split('#')[1] ?? '';
-        const params = new URLSearchParams(fragment);
-        const access_token = params.get('access_token');
-        const refresh_token = params.get('refresh_token');
-        if (!access_token || !refresh_token) {
-          // A link, rather than a sign-in, returns no tokens — the session it
-          // just added an identity to is the one already held.
-          const { data: current } = await supabase.auth.getSession();
-          setSession(current.session);
+          const { data, error } = await supabase.auth.signInWithIdToken({
+            provider: 'apple',
+            token: credential.identityToken,
+          });
+          if (error) throw error;
+          setSession(data.session);
+          if (credential.fullName && data.user) {
+            await adoptAppleName(data.user.id, credential.fullName);
+          }
           return;
         }
-        const { error: sessionError } = await supabase.auth.setSession({
-          access_token,
-          refresh_token,
-        });
-        if (sessionError) throw sessionError;
+
+        const next = await oauthThroughBrowser('apple', action.call === 'linkIdentity');
+        if (next !== undefined) setSession(next);
       },
 
       async updateProfile(patch) {

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -20,7 +20,16 @@
  * Nothing here talks to Supabase. It decides; the caller performs.
  */
 
-export type AuthMethod = 'email_password' | 'phone_password' | 'phone_otp' | 'google';
+export type AuthMethod = 'email_password' | 'phone_password' | 'phone_otp' | 'google' | 'apple';
+
+/** The providers reached through an identity provider rather than a credential. */
+export type OAuthMethod = 'google' | 'apple';
+
+const OAUTH: readonly AuthMethod[] = ['google', 'apple'];
+
+function isOAuth(method: AuthMethod): method is OAuthMethod {
+  return OAUTH.includes(method);
+}
 
 /** Who is asking. */
 export type Viewer =
@@ -34,14 +43,21 @@ export type AuthAction =
   /** Existing account, prove it. */
   | { readonly call: 'signInWithPassword'; readonly method: AuthMethod }
   | { readonly call: 'signInWithOtp'; readonly method: 'phone_otp' }
-  | { readonly call: 'signInWithOAuth'; readonly method: 'google' }
+  /**
+   * A fresh sign-in through an identity provider. How the caller performs it is
+   * its own business — Apple on an iPhone is the native sheet and an id token,
+   * Apple anywhere else is the same web redirect Google uses — but it is only
+   * ever *this* action, and this action is only ever reached by somebody with
+   * no account to lose.
+   */
+  | { readonly call: 'signInWithOAuth'; readonly method: OAuthMethod }
   /**
    * The upgrade. `updateUser` adds an email or phone to the account that is
    * already signed in; `linkIdentity` does the same for an OAuth provider.
    * Both keep the user id, which is what keeps the groups.
    */
   | { readonly call: 'updateUser'; readonly method: AuthMethod }
-  | { readonly call: 'linkIdentity'; readonly method: 'google' };
+  | { readonly call: 'linkIdentity'; readonly method: OAuthMethod };
 
 export class IdentityError extends Error {
   constructor(
@@ -72,23 +88,20 @@ export function planAuth(
 ): AuthAction {
   if (viewer.kind === 'guest') {
     // Whatever the screen thought it was doing, this is an upgrade.
-    return method === 'google'
-      ? { call: 'linkIdentity', method: 'google' }
-      : { call: 'updateUser', method };
+    return isOAuth(method) ? { call: 'linkIdentity', method } : { call: 'updateUser', method };
   }
 
   if (viewer.kind === 'user') {
     // Already a real account. Adding a second way in is still a link, never a
     // sign-up — somebody with an email adding Google must not end up with two
     // accounts and half their groups in each.
-    return method === 'google'
-      ? { call: 'linkIdentity', method: 'google' }
-      : { call: 'updateUser', method };
+    return isOAuth(method) ? { call: 'linkIdentity', method } : { call: 'updateUser', method };
   }
 
   switch (method) {
     case 'google':
-      return { call: 'signInWithOAuth', method: 'google' };
+    case 'apple':
+      return { call: 'signInWithOAuth', method };
     case 'phone_otp':
       return { call: 'signInWithOtp', method: 'phone_otp' };
     default:
@@ -170,6 +183,38 @@ export function checkPassword(password: string): void {
       'That is one of the first passwords anyone tries',
     );
   }
+}
+
+/**
+ * The name Apple gives back, out of the three parts it splits it into.
+ *
+ * Apple hands over a name on the **first authorization only** — never on a
+ * reinstall, never on a second device — and the id token carries none at all.
+ * So this runs exactly once per person, on a device nobody is watching, and
+ * whatever it produces is what everybody they split a bill with sees from then
+ * on. There is no second authorization to correct it from.
+ *
+ * Any part may be absent and often is: a mononym arrives as a given name and
+ * nothing else, which is ordinary in the app's first market. Apple also pads
+ * with empty strings rather than omitting keys, so joining blindly puts two
+ * spaces in the middle of a real person's name.
+ *
+ * Null, not an empty string. The caller uses it to decide whether there is
+ * anything worth writing at all, and '' would replace a display name with
+ * nothing — which is the common case, since every sign-in after the first
+ * carries no name.
+ */
+export function appleFullName(
+  parts: {
+    readonly givenName?: string | null;
+    readonly middleName?: string | null;
+    readonly familyName?: string | null;
+  } | null,
+): string | null {
+  const named = [parts?.givenName, parts?.middleName, parts?.familyName]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part));
+  return named.length > 0 ? named.join(' ') : null;
 }
 
 /**

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  appleFullName,
   checkPassword,
   IdentityError,
   normaliseEmail,
@@ -27,7 +28,13 @@ const GUEST: Viewer = { kind: 'guest', userId: 'u-guest' };
 const USER: Viewer = { kind: 'user', userId: 'u-real' };
 const NOBODY: Viewer = { kind: 'nobody' };
 
-const EVERY_METHOD: AuthMethod[] = ['email_password', 'phone_password', 'phone_otp', 'google'];
+const EVERY_METHOD: AuthMethod[] = [
+  'email_password',
+  'phone_password',
+  'phone_otp',
+  'google',
+  'apple',
+];
 
 describe('a guest is upgraded, never replaced', () => {
   it.each(EVERY_METHOD)('%s adds to the account they already have', (method) => {
@@ -46,6 +53,16 @@ describe('a guest is upgraded, never replaced', () => {
 
   it('links Google rather than signing in with it', () => {
     expect(planAuth(GUEST, 'google')).toEqual({ call: 'linkIdentity', method: 'google' });
+  });
+
+  it('links Apple rather than signing in with it', () => {
+    // Apple is the sharper version of the same trap. On an iPhone the tempting
+    // implementation is the native sheet plus `signInWithIdToken`, which has no
+    // "link" mode at all — it always resolves to whichever account owns that
+    // Apple ID, and for a guest that is a brand new one. Returning `linkIdentity`
+    // here is what sends the caller down the web flow instead, which is the only
+    // one that can add a provider to the session already held.
+    expect(planAuth(GUEST, 'apple')).toEqual({ call: 'linkIdentity', method: 'apple' });
   });
 
   it('ignores a screen that thinks it is a sign-up', () => {
@@ -89,6 +106,31 @@ describe('somebody with no account at all', () => {
 
   it('goes to the provider for Google', () => {
     expect(planAuth(NOBODY, 'google').call).toBe('signInWithOAuth');
+  });
+
+  it('goes to the provider for Apple', () => {
+    expect(planAuth(NOBODY, 'apple')).toEqual({ call: 'signInWithOAuth', method: 'apple' });
+  });
+
+  it('will not be talked into a sign-up for either provider', () => {
+    // There is no such thing as signing *up* with a provider: the first time
+    // through is the account being made. A screen passing 'sign_up' must not
+    // reach `signUp`, which wants a password there is none of.
+    expect(planAuth(NOBODY, 'google', 'sign_up').call).toBe('signInWithOAuth');
+    expect(planAuth(NOBODY, 'apple', 'sign_up').call).toBe('signInWithOAuth');
+  });
+});
+
+describe('the native Apple sheet is unreachable for anybody with data', () => {
+  // `signInWithIdToken` is the only call in the app that cannot be made safe by
+  // the caller: it takes a token from Apple and resolves it to whichever
+  // account holds that Apple ID, with no way to say "add this to the session I
+  // already have". `apps/mobile/src/lib/auth.tsx` may only use it on the
+  // `signInWithOAuth` branch, so that branch has to stay unreachable for a
+  // guest or a user. This is that guarantee, stated where it is enforced.
+  it.each([GUEST, USER])('never returns signInWithOAuth for %o', (viewer) => {
+    expect(planAuth(viewer, 'apple').call).not.toBe('signInWithOAuth');
+    expect(planAuth(viewer, 'apple', 'sign_up').call).not.toBe('signInWithOAuth');
   });
 });
 
@@ -148,6 +190,50 @@ describe('passwords', () => {
   it('refuses the ones everybody picks', () => {
     expect(() => checkPassword('password123')).toThrow(/first passwords anyone tries/);
     expect(() => checkPassword('PASSWORD123')).toThrow(IdentityError);
+  });
+});
+
+describe('the name Apple gives back, once', () => {
+  // This runs exactly once per person, on a device nobody is watching, and
+  // whatever it produces is what their whole group sees from then on. There is
+  // no second authorization to correct it from.
+
+  it('joins the parts somebody actually has', () => {
+    expect(appleFullName({ givenName: 'Asha', familyName: 'Ravi' })).toBe('Asha Ravi');
+    expect(appleFullName({ givenName: 'Asha', middleName: 'K', familyName: 'Ravi' })).toBe(
+      'Asha K Ravi',
+    );
+  });
+
+  it('keeps a mononym whole', () => {
+    // Single-name people are ordinary in the app's first market. A name is not
+    // required to have two halves.
+    expect(appleFullName({ givenName: 'Rajinikanth' })).toBe('Rajinikanth');
+    expect(appleFullName({ familyName: 'Ravi' })).toBe('Ravi');
+  });
+
+  it('does not leave a gap where an empty part was', () => {
+    // Apple pads with empty strings rather than omitting keys. Joining blindly
+    // gives "Asha  Ravi", and that is then shown to everybody in the group.
+    expect(appleFullName({ givenName: 'Asha', middleName: '', familyName: 'Ravi' })).toBe(
+      'Asha Ravi',
+    );
+    expect(appleFullName({ givenName: 'Asha', middleName: '   ', familyName: 'Ravi' })).toBe(
+      'Asha Ravi',
+    );
+  });
+
+  it('trims the parts rather than the join', () => {
+    expect(appleFullName({ givenName: '  Asha ', familyName: ' Ravi  ' })).toBe('Asha Ravi');
+  });
+
+  it('says null rather than empty when there is no name at all', () => {
+    // The ordinary case on every sign-in after the first. The difference
+    // matters: '' would replace a display name with nothing.
+    expect(appleFullName(null)).toBeNull();
+    expect(appleFullName({})).toBeNull();
+    expect(appleFullName({ givenName: '', middleName: '', familyName: '' })).toBeNull();
+    expect(appleFullName({ givenName: null, familyName: null })).toBeNull();
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       expo:
         specifier: ~57.0.11
         version: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      expo-apple-authentication:
+        specifier: ~57.0.1
+        version: 57.0.1(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       expo-auth-session:
         specifier: ~57.0.6
         version: 57.0.6(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
@@ -3724,6 +3727,13 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  expo-apple-authentication@57.0.1:
+    resolution: {integrity: sha512-pqAIaiTa/ycNl+XqNg5UMVT5TBgl6q6djTtoIcUmDItjVBA1IDHsQEs+leo+8+fG5hhuempZLSqBVVn+RJKKWA==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-application@57.0.2:
     resolution: {integrity: sha512-q31YwcXyymviAmdrtDfAg3Dld4VMxLCNAfgMHip7vZpPX4lzF/AfwsywqBJUAjQnJknzaNAkzqvMVjO5XmKYDA==}
@@ -10101,6 +10111,12 @@ snapshots:
   events@3.3.0: {}
 
   expect-type@1.4.0: {}
+
+  expo-apple-authentication@57.0.1(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+    dependencies:
+      expo: 57.0.11(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
   expo-application@57.0.2(expo@57.0.11):
     dependencies:


### PR DESCRIPTION
M1 asked for OTP, Google and Apple, and ADR-002 and ADR-006 both name Apple explicitly. Only the first two were ever built. Offering Google on iOS without Apple is also an App Store review rejection.

## Two roads, because there have to be two

| Who is tapping | Road | Needs |
| --- | --- | --- |
| Nobody signed in, on an iPhone | native sheet → `signInWithIdToken` | the **bundle ID** |
| Everybody else — Android, and **any** guest or existing account adding Apple | web redirect → `linkIdentity` / `signInWithOAuth` | a **Services ID** + key |

The second row is the common one, not the fallback. ADR-006 puts everybody through the guest door first, so most people who ever tap Apple are linking it to a week of expenses they already have.

`signInWithIdToken` has no way to add a provider to an existing session: it resolves a token to whichever account owns that Apple ID, and for a guest that is a brand new one. The session swaps, nothing errors, and the trip they have been adding to all week belongs to an account they cannot reach.

So the native sheet is bound to `planAuth`'s `signInWithOAuth` branch, which is only ever returned for a viewer of kind `nobody`. `identity.test.ts` holds that directly — the guarantee is stated where it is enforced rather than left as a property of how the screen happens to call it.

## The name

Apple gives one on the **first authorization only** — never on a reinstall, never on a second device — and the id token carries none, so the `handle_new_user` trigger has nothing to seed `display_name` from and falls back to `'Guest'`. Left alone, somebody who signed in with Apple appears to everybody they split a bill with as "Guest".

It is captured now and written **only over the placeholder**, so a name somebody chose two years ago survives a fresh authorization on a new phone. Assembling it is five tests: Apple pads with empty strings rather than omitting keys, and a mononym — ordinary in this app's first market — arrives as a given name and nothing else.

## The launch hazard

`expo-apple-authentication` is gentler than most native modules: its functions come through `requireOptionalNativeModule`, which returns a stub rather than throwing. Its **button** is not — `ExpoAppleAuthenticationButton` calls `requireNativeViewManager` at module scope whenever `Platform.OS === 'ios'`, which throws on any binary built before this package existed. expo-router loads every route file to build the route tree, so that is not a missing button but the app failing to launch.

Read before it was assumed, and handled the way the rule requires: Expo's registry is checked directly, and the package is required only once it is known to be there. An old build shows the plain fallback instead.

Apple's own control draws the button where it can, because the guidelines govern its wording, mark and proportions, and it localises itself into rather more languages than the four Baaki ships. The fallback carries the four.

## Checks

`typecheck`, `lint` and `prettier` clean. Core 402 tests (up from 397), mobile 139. The `packages/db` suite needs a local Postgres and fails identically on a clean tree — unrelated and untouched.

## Not verified on a device

This needs a paid Apple Developer account, a Services ID and a key, none of which this repository has. README says exactly what to set up and why **both** identifiers are needed — configure only the native side and Apple works for a fresh install and silently fails for everyone the app is actually built around. `usesAppleSignIn` writes the entitlement into the binary, so turning it on needs a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ
