### PR TITLE
fix: stop the crash reporter freezing the phone it crashed on

### DIFF
--- a/packages/core/src/observability/scrub.ts
+++ b/packages/core/src/observability/scrub.ts
@@ -104,14 +104,33 @@ const PASS_THROUGH_KEYS = new Set([
 
 const canonicalKey = (key: string): string => key.replace(/[_\-\s]/g, '').toLowerCase();
 
-/** `asha@example.co.in` — an address, which needs a dot in the domain. */
-const EMAIL = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
+/**
+ * `asha@example.co.in` — an address, which needs a dot in the domain.
+ *
+ * The `{1,64}` is not cosmetic and must not be relaxed to `+`. Unbounded, the
+ * engine starts at every one of n positions, consumes the whole run looking for
+ * an `@`, fails, and backtracks a character at a time — O(n²) on any long run
+ * of `[\w.+-]` that contains no `@` at all. A JWT is exactly that (base64url is
+ * `[\w-]` throughout, segments joined by dots), and so is any base64url blob.
+ * Measured on this file's own `redactText`: 20k characters took 635ms, 80k took
+ * 10.2s, 320k took over a minute.
+ *
+ * That cost lands in `beforeSend`, on the JS thread, while the app is already
+ * crashing — a frozen phone on top of the fault being reported. 64 is the limit
+ * RFC 5321 puts on a local part, so nothing real is lost by refusing to look
+ * past it; the bound is what stops the retry from every start position.
+ */
+const EMAIL = /[\w.+-]{1,64}@[\w-]+(?:\.[\w-]+)+/g;
 
 /**
  * `9876543210@ybl`, `ravi.k@okaxis` — a UPI handle, which is the same shape
  * without the dot. Checked after email so an address is never mistaken for one.
+ *
+ * Bounded for the same reason as EMAIL, and comfortably above any real handle:
+ * NPCI caps a VPA at 50 characters end to end, so 64 for the part before the
+ * `@` cannot exclude one.
  */
-const VPA = /[\w.-]{2,}@[a-z]{2,}\b/gi;
+const VPA = /[\w.-]{2,64}@[a-z]{2,}\b/gi;
 
 /**
  * `+91 98765 43210` in any of the spacings a keyboard produces. Always with a

--- a/packages/core/test/scrub.test.ts
+++ b/packages/core/test/scrub.test.ts
@@ -170,3 +170,60 @@ describe('walking an event', () => {
     expect(scrub({ when }).when).toBe(when);
   });
 });
+
+describe('a long string does not freeze the phone it crashed on', () => {
+  /**
+   * `EMAIL` and `VPA` both look for an `@` after a run of word characters. Left
+   * unbounded, the engine starts at every one of n positions, consumes the run,
+   * fails, and backtracks a character at a time — quadratic on any long run
+   * with no `@` in it. A JWT is precisely that shape, base64url being `[\w-]`
+   * throughout, and so is any base64url blob.
+   *
+   * This is not a micro-benchmark of a hot path. `scrub` runs in Sentry's
+   * `beforeSend`, on the JS thread, while the app is already crashing, and
+   * before the fix an 80k-character message took 10.2 seconds — a frozen phone
+   * on top of the fault being reported. The assertions are deliberately far
+   * looser than the real numbers (~17ms at 80k) so this fails on a restored
+   * quadratic and not on a slow CI box.
+   */
+  const timed = (input: string): number => {
+    const started = performance.now();
+    redactText(input);
+    return performance.now() - started;
+  };
+
+  it('redacts a long run with no address in it in linear time', () => {
+    expect(timed('a'.repeat(80_000))).toBeLessThan(1_000);
+  });
+
+  it('and a long JWT, which is the shape that actually turns up', () => {
+    // base64url has no `/` and no `.` inside a segment, so the whole token is
+    // one uninterrupted run of exactly the characters the pattern accepts.
+    const jwt = `eyJhbGciOiJIUzI1NiJ9.${'a'.repeat(80_000)}.c2ln`;
+    expect(timed(jwt)).toBeLessThan(1_000);
+  });
+
+  it('scales roughly with the input, not with its square', () => {
+    // The property, rather than a number: quadratic growth would make the
+    // 4x-longer input about 16x slower. A generous ceiling of 6x still catches
+    // that while leaving room for noise on a shared machine.
+    const small = Math.max(timed('a'.repeat(20_000)), 1);
+    const large = timed('a'.repeat(80_000));
+    expect(large / small).toBeLessThan(6);
+  });
+
+  it('still finds an address at the end of a long line', () => {
+    // The bound must not become a blind spot: a real address after 80k
+    // characters of noise is still an address, and still has to come out.
+    const line = `${'a '.repeat(40_000)}asha@example.co.in`;
+    expect(redactText(line)).toContain('[email]');
+    expect(redactText(line)).not.toContain('asha@example.co.in');
+  });
+
+  it('refuses to treat a 64-character-plus run as a local part', () => {
+    // What the bound gives up, stated so it is a decision rather than a
+    // surprise: nothing RFC 5321 allows, because 64 is its limit.
+    const real = `${'a'.repeat(64)}@example.com`;
+    expect(redactText(real)).toBe('[email]');
+  });
+});


### PR DESCRIPTION
`scrub` runs in Sentry's `beforeSend` on all three surfaces — the app, the guest web view and the edge functions — so every reported event passes through `redactText`, and `walk` calls it on **every string at any length**. `MAX_DEPTH` bounds how deep it goes; nothing bounds how long a string can be.

Two of the patterns it applies were quadratic:

```js
EMAIL = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g
VPA   = /[\w.-]{2,}@[a-z]{2,}\b/gi
```

Both look for an `@` after a run of word characters. On a long run with **no `@` in it**, the engine starts at each of n positions, consumes to the end, fails, and backtracks a character at a time.

| input to `redactText` | before | after |
| --- | --- | --- |
| 20,000 chars | 635 ms | ~5 ms |
| 80,000 chars | **10.2 s** | ~17 ms |
| 320,000 chars | **> 60 s** | 88 ms |

Four times the input was sixteen times the work.

## Why this shape turns up

A JWT is exactly it — base64url is `[\w-]` throughout and the segments are joined by dots, so the whole token is one uninterrupted run the pattern accepts and never resolves. So is any base64url blob. Neither is exotic in a crash report; a Supabase error carrying a token is the ordinary case.

The cost lands on the JS thread inside `beforeSend`, **while the app is already crashing** — a frozen phone on top of the fault being reported, and the freeze gets worse the more there is to say about what went wrong.

## The fix

```js
EMAIL = /[\w.+-]{1,64}@[\w-]+(?:\.[\w-]+)+/g
VPA   = /[\w.-]{2,64}@[a-z]{2,}\b/gi
```

64 is what RFC 5321 allows in a local part, and NPCI caps a whole VPA at 50, so neither bound can exclude anything real. Verified byte-for-byte against addresses, plus-addressing, hyphenated domains, multi-label domains and UPI handles — all redact exactly as before.

## The test asserts the property, not a stopwatch

A wall-clock threshold on a shared CI box is a flaky test waiting to happen. The load-bearing assertion is that the **4× longer input must not cost more than 6× the time**, where quadratic makes it 16×.

Checked by reverting both patterns and re-running:

| assertion | with the bug |
| --- | --- |
| growth ratio < 6 | **16.34** ✗ |
| 80k run < 1000 ms | **10,415 ms** ✗ |
| 80k JWT < 1000 ms | **10,466 ms** ✗ |

That 16.34 is the quadratic signature falling out of the measurement rather than being asserted at.

Two further cases guard the *fix* rather than the bug, so the bound cannot quietly become a blind spot: an address after 80k characters of noise is still redacted, and a full 64-character local part still counts as one.

## Provenance

Found by fuzzing `packages/core`. The same run put **126,589 calls** through the split engine and the simplifier — every split type, groups of 1 to 500, totals from zero to 10³⁰ — with **no invariant violations at all**.

## Note for deploying

`supabase/functions/_shared/core.js` is an untracked build artifact, so there is nothing to commit for it — but the edge functions do not get this fix until they are redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ
