### PR TITLE
fix: stop the wire parser inventing amounts out of nothing

### DIFF
--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -8,7 +8,7 @@
  * network can never double-post an expense.
  */
 
-import type { CurrencyCode } from '../money/currency';
+import { MoneyError, type CurrencyCode } from '../money/currency';
 import type { MemberId, SplitParams } from '../split/types';
 import type { SettlementAllocation, SettlementStatus } from '../balances/types';
 
@@ -132,8 +132,33 @@ export function serialiseAmount(amount: bigint): string {
   return amount.toString();
 }
 
+/**
+ * The other direction, and not a one-liner, because `BigInt` is the wrong shape
+ * of function for a wire boundary in two separate ways.
+ *
+ * It **invents numbers**. `BigInt('')` is `0n` and so is `BigInt('   ')`, so an
+ * amount that never arrived becomes a settlement of zero rather than an error
+ * — the ledger stays internally consistent and describes something nobody did.
+ * `'0x10'`, `'0b11'` and `'0o17'` are read as 16, 3 and 15, so a string that is
+ * not a decimal number at all still produces one. These are the dangerous
+ * cases: nothing throws and nothing looks wrong afterwards.
+ *
+ * And where it does refuse, it throws a bare `SyntaxError`. Every other parser
+ * here refuses with an error of this library's own, which is what lets a caller
+ * tell "the wire was malformed" from "the code above me has a bug" — a
+ * distinction the sync queue has to make, because one is worth retrying and the
+ * other never is.
+ *
+ * So the string is checked before it is converted, on the same rule as
+ * `integer()` in `split/wire.ts`: an optional sign and decimal digits, nothing
+ * else. A float is refused rather than rounded for the reason given there —
+ * rounding here would put a number in the ledger that nobody chose.
+ */
 export function parseAmount(amount: string): bigint {
-  return BigInt(amount);
+  if (typeof amount !== 'string' || !/^[+-]?\d+$/.test(amount.trim())) {
+    throw new MoneyError('INVALID_AMOUNT', `${String(amount)} is not a whole minor-unit amount`);
+  }
+  return BigInt(amount.trim());
 }
 
 export const SETTLEMENT_ALLOCATION_WIRE = {

--- a/packages/core/test/wire.test.ts
+++ b/packages/core/test/wire.test.ts
@@ -15,7 +15,10 @@ import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 
 import {
+  MoneyError,
+  parseAmount,
   parseSplitParams,
+  serialiseAmount,
   serialiseSplitParams,
   SplitWireError,
   type SplitParams,
@@ -169,5 +172,63 @@ describe('parsing what an older or stranger client sent', () => {
     expect(
       parseSplitParams({ kind: 'adjustment', adjustments: { ravi: '12000', asha: '-4000' } }),
     ).toEqual({ kind: 'adjustment', adjustments: { ravi: 12000n, asha: -4000n } });
+  });
+});
+
+describe('a single amount crossing the wire', () => {
+  it('survives the round trip, for any amount at all', () => {
+    fc.assert(
+      fc.property(fc.bigInt({ min: -(10n ** 24n), max: 10n ** 24n }), (amount) => {
+        expect(parseAmount(serialiseAmount(amount))).toBe(amount);
+      }),
+    );
+  });
+
+  it('refuses rather than inventing a number', () => {
+    // `BigInt` answers 0n to an empty string, so an amount that never arrived
+    // would become a settlement of zero: the ledger stays internally consistent
+    // and describes something nobody did. This is the case worth having a test
+    // for, because nothing throws and nothing looks wrong afterwards.
+    for (const missing of ['', '   ', '\n', '\t']) {
+      expect(() => parseAmount(missing)).toThrow(MoneyError);
+    }
+  });
+
+  it('reads decimal, and only decimal', () => {
+    // `BigInt('0x10')` is 16. A string that is not a decimal number must not
+    // quietly become one — 16 paise is a plausible-looking amount nobody wrote.
+    for (const notDecimal of ['0x10', '0b11', '0o17']) {
+      expect(() => parseAmount(notDecimal)).toThrow(MoneyError);
+    }
+  });
+
+  it('refuses a fraction rather than rounding it', () => {
+    // Same rule as `integer()` in split/wire.ts: rounding here would put a
+    // number in the ledger that nobody chose.
+    for (const fractional of ['1.5', '0.01', '1e3', '-2.0']) {
+      expect(() => parseAmount(fractional)).toThrow(MoneyError);
+    }
+  });
+
+  it('refuses junk with this library’s own error, not the engine’s', () => {
+    // A bare SyntaxError cannot be told apart from a bug in the caller, and the
+    // sync queue has to make that distinction: a malformed payload is worth
+    // giving up on, an exception in our own code is not.
+    for (const junk of ['abc', '1_000', '5n', '١٢٣', '--1', '1-', '+', '-']) {
+      expect(() => parseAmount(junk)).toThrow(MoneyError);
+    }
+  });
+
+  it('accepts the signs and the padding a real payload carries', () => {
+    expect(parseAmount('-4500')).toBe(-4500n);
+    expect(parseAmount('+4500')).toBe(4500n);
+    expect(parseAmount(' 4500 ')).toBe(4500n);
+    expect(parseAmount('0')).toBe(0n);
+    expect(parseAmount('-0')).toBe(0n);
+  });
+
+  it('keeps an amount JSON could not hold', () => {
+    // The reason amounts travel as strings at all: this is past Number.MAX_SAFE_INTEGER.
+    expect(parseAmount('9007199254740993')).toBe(9007199254740993n);
   });
 });


### PR DESCRIPTION
`parseAmount` was `return BigInt(amount)`. The reported problem — a bare `SyntaxError` escaping a parser — turned out to be the **lesser half** of it.

## `BigInt` invents numbers

| input | `BigInt` gives | should be |
| --- | --- | --- |
| `''` | **`0n`** | refused |
| `'   '` | **`0n`** | refused |
| `'0x10'` | **`16n`** | refused |
| `'0b11'` | **`3n`** | refused |
| `'0o17'` | **`15n`** | refused |

An amount that never arrived becomes a **settlement of zero** rather than an error: the ledger stays internally consistent and describes something nobody did. A string that is not a decimal number at all still produces one — 16 paise is a plausible-looking amount nobody wrote.

Nothing throws in any of those cases and nothing looks wrong afterwards, which makes them worse than the crash that prompted the fix.

And where it *does* refuse, `SyntaxError` cannot be told apart from a bug in the caller's own code. The sync queue has to make exactly that distinction: a malformed payload is worth giving up on, an exception in our own code is not.

## The fix

Checked before it is converted, on the same rule `integer()` already uses in `split/wire.ts` — an optional sign and decimal digits, nothing else — and refused with `MoneyError('INVALID_AMOUNT')`. A fraction is refused rather than rounded, for the reason that file already gives: *rounding here would put a number in the ledger that nobody chose.*

Still accepts everything a real payload carries: `-4500`, `+4500`, `' 4500 '`, `0`, `-0`, and `9007199254740993` — past `Number.MAX_SAFE_INTEGER`, which is why amounts travel as strings in the first place.

## The tests

Six added; **four fail against the old one-liner**. The split in how they fail is the point:

```
× refuses rather than inventing a number
  → expected function to throw an error, but it didn't
× reads decimal, and only decimal
  → expected function to throw an error, but it didn't
× refuses a fraction rather than rounding it
  → expected error to be instance of MoneyError
× refuses junk with this library's own error, not the engine's
  → expected error to be instance of MoneyError
```

The first two are the **silent** branch — no error at all, just a wrong number — and they are why this was worth fixing rather than noting. The last two are the reported `SyntaxError`.

A round-trip property test covers the rest: for any amount in ±10²⁴, `parseAmount(serialiseAmount(x)) === x`.

## Scope

**Still no production caller.** `SETTLEMENT_ALLOCATION_WIRE` is the only consumer and nothing uses it. This is a trap disarmed before somebody wires up the settlement-allocation path, not a live bug. Found by fuzzing `@baaki/core` — the same run that turned up the crash-reporter freeze in #75.

414 core tests pass; typecheck, lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ
