### PR TITLE
fix: three things running it on a phone showed

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -14,6 +14,7 @@ import {
   Screen,
   SectionHeader,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -25,6 +26,7 @@ import { useAuth } from '@/lib/auth';
 
 export default function ActivityScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { session } = useAuth();
   const myProfileId = session?.user.id ?? null;
@@ -49,7 +51,7 @@ export default function ActivityScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: 170,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -31,6 +31,7 @@ import {
   Screen,
   SectionHeader,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -39,6 +40,7 @@ import { plural, useStrings } from '@/i18n';
 
 export default function FriendsScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
 
   const people = useQuery({
@@ -55,7 +57,7 @@ export default function FriendsScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: 170,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -78,7 +78,16 @@ export default function HomeScreen() {
         }
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
-          <Avatar name={profile?.display_name ?? 'You'} size={46} />
+          {/* Your own face at the top of your own dashboard reads as a way in
+              to your account, so it is one. It goes to the same place the last
+              tab does rather than somewhere only reachable from here — two
+              routes to one screen, not a second screen that drifts. */}
+          <Avatar
+            name={profile?.display_name ?? 'You'}
+            size={46}
+            accessibilityLabel={t.profile}
+            onPress={() => router.navigate('/profile')}
+          />
           <View style={{ flex: 1 }}>
             <Text variant="caption" tone="muted">
               {t.greeting},

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -18,6 +18,7 @@ import {
   SectionHeader,
   Text,
   tintForKey,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -29,6 +30,7 @@ import { groupLabel } from '@/data/types';
 
 export default function HomeScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { profile, isGuest } = useAuth();
 
@@ -60,7 +62,7 @@ export default function HomeScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: 170,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -17,6 +17,7 @@ import {
   SectionHeader,
   SegmentedTabs,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -233,6 +234,7 @@ function SettledPill({ profileId, locale }: { profileId: string | null; locale: 
 
 export default function ProfileScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { profile, isGuest, updateProfile, signOut } = useAuth();
 
@@ -382,7 +384,7 @@ export default function ProfileScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: 170,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -3,7 +3,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
-import { currencyForCountry } from '@baaki/core';
+import { currencyForCountry, guessGroupEmoji } from '@baaki/core';
 import { Button, Card, ChipRow, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
@@ -13,7 +13,19 @@ import { useCreateGroup } from '@/data/hooks';
 import type { GroupType } from '@/data/types';
 import { deviceCountry, useStrings } from '@/i18n';
 
-const EMOJI = ['🏖️', '🏠', '💜', '🎉', '✈️', '🍽️', '⛰️', '🎓'];
+/**
+ * Where the icon comes from when the name has not said anything yet — which is
+ * the state this screen opens in, and the state a group called "Ravi and Asha"
+ * stays in. The kind of group is a real answer to "what is this", so it is a
+ * better fallback than one fixed emoji for everybody.
+ */
+const EMOJI_FOR_TYPE: Record<GroupType, string> = {
+  trip: '✈️',
+  home: '🏠',
+  couple: '💜',
+  event: '🎉',
+  other: '👥',
+};
 
 export default function NewGroupScreen() {
   const theme = useTheme();
@@ -24,13 +36,17 @@ export default function NewGroupScreen() {
   const [photo, setPhoto] = useState<PickedImage | null>(null);
   const [uploading, setUploading] = useState(false);
   const [type, setType] = useState<GroupType>('trip');
-  const [emoji, setEmoji] = useState(EMOJI[0] as string);
   const [ghostName, setGhostName] = useState('');
   const [ghosts, setGhosts] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   // Read once, not on every render: a phone does not change country mid-form,
   // and re-reading it would be a new value every time for `useMemo` to chase.
   const [country] = useState(() => deviceCountry());
+
+  // Derived, not held: the icon is a reading of the name, so it has no state of
+  // its own to fall out of step with. It changes under the caret as somebody
+  // types "Goa" and again if they change what kind of group this is.
+  const emoji = guessGroupEmoji(name) ?? EMOJI_FOR_TYPE[type];
 
   const submit = async (): Promise<void> => {
     setError(null);
@@ -122,29 +138,6 @@ export default function NewGroupScreen() {
                 {t.extras.blankNameHint}
               </Text>
             </View>
-          </Row>
-
-          <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
-            {EMOJI.map((option) => (
-              <Pressable
-                key={option}
-                accessibilityRole="radio"
-                accessibilityState={{ selected: emoji === option }}
-                accessibilityLabel={t.extras.iconLabel.replace('{emoji}', option)}
-                onPress={() => setEmoji(option)}
-                style={{
-                  width: 44,
-                  height: 44,
-                  borderRadius: theme.radius.pill,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  backgroundColor:
-                    emoji === option ? theme.color.brandSoft : theme.color.surfaceMuted,
-                }}
-              >
-                <Text variant="subheading">{option}</Text>
-              </Pressable>
-            ))}
           </Row>
         </Card>
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -819,7 +819,6 @@ export interface UiStrings {
   /** The rest: one or two strings each, from a dozen screens. */
   extras: {
     blankNameHint: string;
-    iconLabel: string;
     whatKindOfGroup: string;
     typeTrip: string;
     typeHome: string;
@@ -1598,7 +1597,6 @@ const en: UiStrings = {
   },
   extras: {
     blankNameHint: 'Leave it blank and the group is named after whoever is in it.',
-    iconLabel: 'Icon {emoji}',
     whatKindOfGroup: 'What kind of group?',
     typeTrip: 'Trip',
     typeHome: 'Home',
@@ -2413,7 +2411,6 @@ const ta: UiStrings = {
   },
   extras: {
     blankNameHint: 'காலியாக விட்டால், குழுவில் உள்ளவர்களின் பெயரில் குழு அமையும்.',
-    iconLabel: 'சின்னம் {emoji}',
     whatKindOfGroup: 'என்ன வகைக் குழு?',
     typeTrip: 'பயணம்',
     typeHome: 'வீடு',
@@ -3194,7 +3191,6 @@ const hi: UiStrings = {
   },
   extras: {
     blankNameHint: 'खाली छोड़ दें तो समूह का नाम उसमें शामिल लोगों पर रख दिया जाएगा।',
-    iconLabel: 'चिह्न {emoji}',
     whatKindOfGroup: 'किस तरह का समूह?',
     typeTrip: 'यात्रा',
     typeHome: 'घर',
@@ -4100,7 +4096,6 @@ const ar: UiStrings = {
   },
   extras: {
     blankNameHint: 'اتركه فارغًا فتُسمّى المجموعة بأسماء من فيها.',
-    iconLabel: 'أيقونة {emoji}',
     whatKindOfGroup: 'أي نوع من المجموعات؟',
     typeTrip: 'رحلة',
     typeHome: 'المنزل',

--- a/packages/core/src/group/icon.ts
+++ b/packages/core/src/group/icon.ts
@@ -1,0 +1,308 @@
+/**
+ * What a group is about, guessed from its name.
+ *
+ * The new-group screen used to open with eight emoji laid out as a picker. It
+ * cost a row and a half of a screen somebody is trying to get through, to ask a
+ * question that the name they are already typing almost always answers: a group
+ * called "Goa December" is a beach, "Flat 402" is a flat, "Ravi + me" is not a
+ * trip. So the picker is gone and the name drives the icon instead.
+ *
+ * Same bargain as `guessCategory`, and the same shape: lowercase whole words,
+ * never substrings — `ola` is a cab company and also the middle of "chocolate".
+ * The vocabulary is deliberately Indian for the same reason it is there: a list
+ * written elsewhere knows "vacation" and not "shaadi", and files Kasol under
+ * nothing.
+ *
+ * Returns null rather than a default when nothing matches. Null means the guess
+ * has nothing to say, and the caller — which knows what kind of group the
+ * person picked — has a better answer than this file could invent.
+ */
+
+export interface GroupIcon {
+  /** What gets drawn. The app renders this directly; no icon font involved. */
+  readonly emoji: string;
+  /** Lowercase whole words that mean this icon. */
+  readonly keywords: readonly string[];
+}
+
+/**
+ * Order is the tiebreak, so the specific sits above the general: "Goa trip"
+ * scores one for beach and one for travel, and beach is the better picture.
+ */
+export const GROUP_ICONS: readonly GroupIcon[] = [
+  {
+    emoji: '🏖️',
+    keywords: [
+      'beach',
+      'goa',
+      'pondicherry',
+      'pondy',
+      'varkala',
+      'gokarna',
+      'alibaug',
+      'andaman',
+      'maldives',
+      'bali',
+      'phuket',
+      'island',
+      'islands',
+      'sea',
+      'coast',
+      'seaside',
+      'shore',
+      'resort',
+    ],
+  },
+  {
+    emoji: '⛰️',
+    keywords: [
+      'mountain',
+      'mountains',
+      'hill',
+      'hills',
+      'trek',
+      'trekking',
+      'hike',
+      'hiking',
+      'himalaya',
+      'himalayas',
+      'manali',
+      'leh',
+      'ladakh',
+      'shimla',
+      'ooty',
+      'munnar',
+      'coorg',
+      'kodaikanal',
+      'spiti',
+      'kasol',
+      'rishikesh',
+      'camp',
+      'camping',
+    ],
+  },
+  {
+    emoji: '🎓',
+    keywords: [
+      'college',
+      'school',
+      'class',
+      'classmates',
+      'batch',
+      'university',
+      'uni',
+      'semester',
+      'alumni',
+      'seniors',
+      'juniors',
+      'fresher',
+      'freshers',
+    ],
+  },
+  {
+    emoji: '🎉',
+    keywords: [
+      'party',
+      'birthday',
+      'bday',
+      'wedding',
+      'shaadi',
+      'reception',
+      'sangeet',
+      'anniversary',
+      'celebration',
+      'farewell',
+      'reunion',
+      'newyear',
+      'diwali',
+      'holi',
+      'christmas',
+      'eid',
+      'pongal',
+      'onam',
+    ],
+  },
+  {
+    emoji: '🏠',
+    keywords: [
+      'home',
+      'house',
+      'flat',
+      'flats',
+      'flatmate',
+      'flatmates',
+      'apartment',
+      'rent',
+      'roommate',
+      'roommates',
+      'pg',
+      'hostel',
+      'villa',
+      'society',
+      'household',
+      'maintenance',
+    ],
+  },
+  {
+    emoji: '💜',
+    keywords: ['couple', 'partner', 'boyfriend', 'girlfriend', 'hubby', 'wifey', 'honeymoon'],
+  },
+  {
+    emoji: '🍽️',
+    keywords: [
+      'dinner',
+      'dinners',
+      'lunch',
+      'brunch',
+      'breakfast',
+      'food',
+      'foodie',
+      'restaurant',
+      'dining',
+      'potluck',
+      'bbq',
+      'barbecue',
+      'feast',
+      'mess',
+      'canteen',
+      'tiffin',
+    ],
+  },
+  {
+    emoji: '🏢',
+    keywords: [
+      'office',
+      'work',
+      'team',
+      'project',
+      'colleagues',
+      'coworkers',
+      'startup',
+      'client',
+      'offsite',
+      'standup',
+    ],
+  },
+  {
+    emoji: '🚗',
+    keywords: [
+      'car',
+      'bike',
+      'cab',
+      'taxi',
+      'fuel',
+      'petrol',
+      'diesel',
+      'uber',
+      'ola',
+      'rapido',
+      'commute',
+      'carpool',
+      'roadtrip',
+    ],
+  },
+  {
+    emoji: '🛒',
+    keywords: [
+      'grocery',
+      'groceries',
+      'kirana',
+      'supermarket',
+      'shopping',
+      'bigbasket',
+      'blinkit',
+      'zepto',
+      'dmart',
+      'market',
+      'ration',
+    ],
+  },
+  {
+    emoji: '🏏',
+    keywords: [
+      'cricket',
+      'match',
+      'ipl',
+      'football',
+      'turf',
+      'badminton',
+      'tennis',
+      'gym',
+      'tournament',
+    ],
+  },
+  {
+    emoji: '🎬',
+    keywords: [
+      'movie',
+      'movies',
+      'cinema',
+      'concert',
+      'gig',
+      'show',
+      'netflix',
+      'subscription',
+      'subscriptions',
+      'gaming',
+      'tickets',
+    ],
+  },
+  {
+    // Last: every one of these also appears in a name that is more specific
+    // than "somebody is going somewhere", and those should win.
+    emoji: '✈️',
+    keywords: [
+      'trip',
+      'trips',
+      'tour',
+      'travel',
+      'travels',
+      'vacation',
+      'holiday',
+      'getaway',
+      'flight',
+      'flights',
+      'backpacking',
+      'itinerary',
+      'europe',
+      'thailand',
+      'dubai',
+      'japan',
+      'singapore',
+    ],
+  },
+];
+
+/** Lowercased whole words, Unicode-aware so Tamil and Hindi survive intact. */
+function tokenise(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter((token) => token.length > 0);
+}
+
+/**
+ * The icon a group name suggests, or null when it suggests nothing.
+ *
+ * Most hits wins; ties go to whichever is listed first, so the same name gives
+ * the same icon on every device — the determinism ADR-009 asks of the money,
+ * applied to something much smaller.
+ */
+export function guessGroupEmoji(name: string): string | null {
+  const tokens = new Set(tokenise(name));
+  if (tokens.size === 0) return null;
+
+  let best: string | null = null;
+  let bestHits = 0;
+  for (const icon of GROUP_ICONS) {
+    let hits = 0;
+    for (const keyword of icon.keywords) {
+      if (tokens.has(keyword)) hits += 1;
+    }
+    if (hits > bestHits) {
+      best = icon.emoji;
+      bestHits = hits;
+    }
+  }
+  return best;
+}

--- a/packages/core/src/group/index.ts
+++ b/packages/core/src/group/index.ts
@@ -1,0 +1,1 @@
+export * from './icon';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './settlement/index';
 export * from './sync/index';
 export * from './receipt/index';
 export * from './category/index';
+export * from './group/index';
 export * from './notifications/index';
 export * from './sms/index';
 export * from './import/index';

--- a/packages/core/test/groupIcon.test.ts
+++ b/packages/core/test/groupIcon.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Guessing a group's icon from its name.
+ *
+ * This replaced a picker, so the bar is not "produces an emoji" — it is that
+ * the name somebody actually types lands on the picture they would have chosen
+ * themselves. The cases below are group names, not keywords, because a keyword
+ * test only proves the table was typed correctly.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { GROUP_ICONS, guessGroupEmoji } from '../src/index';
+
+describe('a group name suggests a picture', () => {
+  it('reads the ordinary names people give groups', () => {
+    expect(guessGroupEmoji('Goa December')).toBe('🏖️');
+    expect(guessGroupEmoji('Manali trek')).toBe('⛰️');
+    expect(guessGroupEmoji('Flat 402')).toBe('🏠');
+    expect(guessGroupEmoji('Priya wedding')).toBe('🎉');
+    expect(guessGroupEmoji('Europe trip')).toBe('✈️');
+    expect(guessGroupEmoji('Friday dinner')).toBe('🍽️');
+    expect(guessGroupEmoji('College batch')).toBe('🎓');
+    expect(guessGroupEmoji('Office offsite')).toBe('🏢');
+  });
+
+  it('lets the specific beat the general', () => {
+    // Both words are in the table. A beach is a better picture of this group
+    // than an aeroplane, and it is the one listed first.
+    expect(guessGroupEmoji('Goa trip')).toBe('🏖️');
+    expect(guessGroupEmoji('Ladakh road trip')).toBe('⛰️');
+    // Nothing more specific to lose to, so the general one still answers.
+    expect(guessGroupEmoji('Work trip')).toBe('🏢');
+  });
+
+  it('says nothing rather than guessing', () => {
+    // Null is not "other". The caller knows which kind of group was picked and
+    // has a better answer than this file could invent.
+    expect(guessGroupEmoji('')).toBeNull();
+    expect(guessGroupEmoji('   ')).toBeNull();
+    expect(guessGroupEmoji('Ravi and Asha')).toBeNull();
+    expect(guessGroupEmoji('Group 3')).toBeNull();
+  });
+
+  it('matches whole words, never fragments', () => {
+    // The bug this rule exists for: `ola` is a cab company and also the middle
+    // of "chocolate", `pg` is a flatshare and also the middle of nothing good.
+    expect(guessGroupEmoji('Chocolate fund')).toBeNull();
+    expect(guessGroupEmoji('Carnival')).toBeNull();
+    expect(guessGroupEmoji('Ola rides')).toBe('🚗');
+  });
+
+  it('survives a name that is not in Latin script', () => {
+    // Tamil and Hindi names must not be shredded into single characters by the
+    // tokeniser — they should fall through to null, not to a wrong picture.
+    expect(guessGroupEmoji('வீட்டு செலவு')).toBeNull();
+    expect(guessGroupEmoji('घर का खर्च')).toBeNull();
+    // A mixed name still finds the word it does know.
+    expect(guessGroupEmoji('கோவா trip')).toBe('✈️');
+  });
+
+  it('ignores case and punctuation', () => {
+    expect(guessGroupEmoji('GOA!!')).toBe('🏖️');
+    expect(guessGroupEmoji('flat-402')).toBe('🏠');
+    expect(guessGroupEmoji('  Wedding  ')).toBe('🎉');
+  });
+});
+
+describe('the icon table', () => {
+  it('never gives one word to two icons', () => {
+    // A word in two lists makes the answer depend on table order rather than on
+    // meaning, which is how a rename quietly changes what people see.
+    const seen = new Map<string, string>();
+    for (const icon of GROUP_ICONS) {
+      for (const keyword of icon.keywords) {
+        expect(seen.has(keyword), `${keyword} is in ${seen.get(keyword)} and ${icon.emoji}`).toBe(
+          false,
+        );
+        seen.set(keyword, icon.emoji);
+      }
+    }
+  });
+
+  it('holds only lowercase single words', () => {
+    for (const icon of GROUP_ICONS) {
+      for (const keyword of icon.keywords) {
+        expect(keyword).toBe(keyword.toLowerCase());
+        expect(keyword).not.toMatch(/\s/);
+      }
+    }
+  });
+});

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Image, View } from 'react-native';
+import { Image, Pressable, View } from 'react-native';
 
 import { useTheme } from '../theme';
 import { tints, type TintName } from '../tokens';
@@ -27,6 +27,8 @@ export function Avatar({
   /** Ghost members (ADR-006) read as provisional until somebody claims them. */
   ghost = false,
   photoUrl,
+  onPress,
+  accessibilityLabel,
 }: {
   name: string;
   emoji?: string;
@@ -38,6 +40,18 @@ export function Avatar({
    * a signed URL rather than a storage path — this component does no fetching.
    */
   photoUrl?: string | null;
+  /**
+   * Handled here rather than by wrapping this in a `Pressable` at the call
+   * site: the circle below is already an accessibility element, so a wrapper
+   * would give a screen reader two stops for one control — the button, and
+   * then the name inside it again.
+   */
+  onPress?: () => void;
+  /**
+   * Overrides the name, for when the avatar stands for a destination rather
+   * than for a person. "Account" is what tapping it does; "Guest" is not.
+   */
+  accessibilityLabel?: string;
 }) {
   const theme = useTheme();
   const resolved = theme.tint[tint ?? tintForKey(name)];
@@ -49,10 +63,12 @@ export function Avatar({
   if (broken !== null && broken !== photoUrl) setBroken(null);
   const showPhoto = Boolean(photoUrl) && broken !== photoUrl;
 
-  return (
+  const label = accessibilityLabel ?? (ghost ? `${name}, not yet joined` : name);
+
+  const body = (
     <View
-      accessible
-      accessibilityLabel={ghost ? `${name}, not yet joined` : name}
+      accessible={!onPress}
+      accessibilityLabel={onPress ? undefined : label}
       style={{
         width: size,
         height: size,
@@ -79,6 +95,13 @@ export function Avatar({
         </Text>
       )}
     </View>
+  );
+
+  if (!onPress) return body;
+  return (
+    <Pressable onPress={onPress} accessibilityRole="button" accessibilityLabel={label}>
+      {body}
+    </Pressable>
   );
 }
 

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -3,6 +3,7 @@ import { Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useTheme } from '../theme';
+import { spacing } from '../tokens';
 import { Text } from './Text';
 
 export interface PillTabItem {
@@ -10,6 +11,32 @@ export interface PillTabItem {
   label: string;
   /** Receives the resolved colour so icons match the active/inactive state. */
   icon: (color: string, focused: boolean) => ReactNode;
+}
+
+/** A destination's touch target. 44 is the floor both platforms ask for. */
+const ITEM_HEIGHT = 44;
+
+/** The capsule itself: one touch target plus the padding wrapped around it. */
+const BAR_HEIGHT = ITEM_HEIGHT + spacing.sm * 2;
+
+/** How far the capsule floats above whatever sits below it. */
+const FLOAT = spacing.lg;
+
+/**
+ * How much room a scrolling tab screen has to leave at its foot.
+ *
+ * The bar is positioned absolutely, so it covers the end of a list rather than
+ * pushing it up: without this the last row is parked underneath it and cannot
+ * be read or tapped. Derived rather than guessed at, because the two things it
+ * depends on both move — the capsule's height with the type scale, and the
+ * inset with the phone, which is the half a hardcoded number gets wrong.
+ *
+ * The trailing gap is `xxxl` rather than the list's own rhythm so the foot of
+ * the list reads as an ending rather than as a row that got cut off.
+ */
+export function useTabBarClearance(): number {
+  const insets = useSafeAreaInsets();
+  return insets.bottom + FLOAT + BAR_HEIGHT + spacing.xxxl;
 }
 
 /**
@@ -35,7 +62,12 @@ export function PillTabBar({
         position: 'absolute',
         left: theme.spacing.xl,
         right: theme.spacing.xl,
-        bottom: Math.max(insets.bottom, theme.spacing.lg),
+        // The inset clears the system bar; the float is the gap the design
+        // wants underneath the capsule. They add — taking the larger of the two
+        // spends the inset on the gap, and on Android, where edge-to-edge is
+        // the default and this view is drawn behind a 48dp navigation bar, that
+        // leaves the pill sitting flush on the buttons with its shadow clipped.
+        bottom: insets.bottom + FLOAT,
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'space-between',
@@ -60,7 +92,7 @@ export function PillTabBar({
               alignItems: 'center',
               gap: focused ? theme.spacing.sm : 0,
               paddingHorizontal: focused ? theme.spacing.lg : theme.spacing.md,
-              height: 44,
+              height: ITEM_HEIGHT,
               borderRadius: theme.radius.pill,
               backgroundColor: focused ? theme.color.brand : 'transparent',
             }}


### PR DESCRIPTION
Running the app on a real Android device turned up three things no test on this
repo was ever going to catch. One per commit.

## The tab bar sat on the navigation buttons

`PillTabBar` positioned itself with `Math.max(insets.bottom, spacing.lg)`, which
treats the safe-area inset as a *substitute* for the gap under the floating
capsule rather than as something to clear first. Android draws edge-to-edge by
default from SDK 54 on, so the bar is painted behind the system navigation bar:
on a three-button phone the inset is 48dp, the max resolves to 48, and the
capsule lands with its bottom edge exactly on the buttons and its shadow
clipped. Adding the two is what was meant — and is what `Onboarding` already
did, which is how the odd one out was found.

The four tab screens each padded their scroll view with a hardcoded `170` to
keep the last row out from under the bar. That number is blind to the inset,
which is the half that changes per device, so it is now derived from the same
constants the bar lays itself out with:

```
insets.bottom + FLOAT + BAR_HEIGHT + spacing.xxxl
```

156 on a three-button Android, 108 where there is no inset at all. Sharing
`ITEM_HEIGHT` and `FLOAT` with the component's own style is the point: a capsule
that grows and a clearance that does not is exactly the bug being replaced.

## The new-group screen asked a question the name answers

It opened with eight emoji laid out as a picker — a 44pt row plus its gap, near
the top of a form somebody is trying to get through. "Goa December" is a beach,
"Flat 402" is a flat, "Ravi + me" is not a trip.

`guessGroupEmoji` is modelled on the existing `guessCategory` and shares its
rules: lowercase whole tokens, never substrings, because `ola` is a cab company
and also the middle of "chocolate". The vocabulary is Indian for the same reason
that one is — a list written elsewhere knows "vacation" and not "shaadi", and
files Kasol under nothing.

Two decisions worth review:

- It returns `null` rather than a default. Null means the guess has nothing to
  say, and the screen falls back to the **kind** of group the person picked,
  which is a real answer. The old default was a beach for everybody.
- Order in the table is the tiebreak, so the specific beats the general: "Goa
  trip" scores beach and travel, and a beach is the better picture.

Eight tests, written as group names rather than as keywords — a keyword test
only proves the table was typed correctly. One walks the table and fails if any
word appears under two icons, since that makes the answer depend on row order
rather than on meaning.

Removing the picker also means there is **no manual override** short of setting
a photo. That is the trade this makes; say so if it is the wrong one.

## The dashboard avatar did nothing

Your own face at the top of your own dashboard reads as a way in to your
account, and it was decoration. It now goes to the profile tab — the same place
the last tab goes, so this is a second route to one screen rather than a second
screen that drifts out of step. `router.navigate` rather than `push`, matching
what `PillTabBar` itself calls.

Press is handled inside `Avatar` rather than by wrapping it at the call site:
the circle already sets `accessible` and a label on its own View, so a wrapper
would give a screen reader two stops for one control. Existing callers are
untouched — `accessible` stays true wherever `onPress` is absent.

## Checks

Typecheck, lint and prettier clean across `@baaki/core`, `@baaki/ui` and
`@baaki/mobile`. Core 415 tests, mobile 139.

Core reads 415 rather than 422 because this branch is cut from `main`: #79 adds
7 wire tests and is not in here. 407 + 8 new `groupIcon` tests = 415.

## Not verified on a device

All three are layout and navigation changes and none of them can be shown on
web — `insets.bottom` is 0 there, and reaching `/new-group` or the dashboard
means signing in, which would create an anonymous user in the production
project. A release APK is building locally to check them on the phone the bug
was reported from; the arithmetic and the guessing are covered by tests, the
pixels are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ
