### PR TITLE
feat: an admin console — analytics, experiments and promotions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ packages/core/dist/
 .next/
 out/
 next-env.d.ts
+
+# Vercel CLI link (project ids, not secrets — still not ours to commit)
+.vercel

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,35 @@
+# What Vercel does not need to build the admin console.
+#
+# The CLI uploads the whole repository so that pnpm can resolve the workspace
+# packages `@baaki/admin` depends on — without this it also uploaded the Android
+# build tree and a 165MB APK, and the transfer aborted at 2.9GB.
+#
+# Only `apps/admin` is built. `packages/*` is kept because the app imports
+# `@baaki/core`, and the lockfile and workspace manifest are kept because
+# `pnpm install --frozen-lockfile` needs them.
+
+node_modules
+**/node_modules
+
+# Other apps. web-lite and mobile are deployed elsewhere and are not imported.
+apps/mobile
+apps/web-lite
+e2e
+supabase
+
+# Build output and native trees.
+**/.next
+**/.expo
+**/dist
+**/build
+**/generated
+*.apk
+*.aab
+*.keystore
+
+# Local noise.
+**/.env.local
+**/*.tsbuildinfo
+.git
+.github
+*.md

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,0 +1,17 @@
+# Copy to .env.local. Never commit the filled-in version.
+
+# NOT NEXT_PUBLIC_. That prefix is what inlines a value into the browser bundle,
+# and this key bypasses row-level security on every table in the database — it
+# is the whole ledger, for every user, in plain text. It is read only in server
+# components and route handlers (see src/lib/data.ts, which is `server-only`).
+# Supabase dashboard → Project Settings → API → service_role.
+SUPABASE_URL=https://xvjzbpgcmotoahtqcxve.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=
+
+# The console's own password. One operator, one secret.
+ADMIN_PASSWORD=
+
+# Signs the session cookie. Any long random string; changing it signs everybody
+# out. Generate one with:
+#   node -e "console.log(crypto.randomUUID() + crypto.randomUUID())"
+ADMIN_SESSION_SECRET=

--- a/apps/admin/AGENTS.md
+++ b/apps/admin/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -52,21 +52,34 @@ pnpm admin                                         # http://localhost:3100
 
 ## Deploying to Vercel
 
-1. **New Project** → import this repository.
-2. Set **Root Directory** to `apps/admin`. That is the whole monorepo story —
-   Vercel installs from the pnpm workspace at the repo root and builds this app.
-   Framework preset is Next.js; leave the build and output settings alone.
-3. Add the four environment variables from `.env.example` for **Production**.
+Already deployed, as the `baaki-admin` project. What follows is what it took,
+because most of it is not obvious from the app's own config.
+
+1. **Root Directory must be `apps/admin`** — Settings → General on the
+   dashboard, or a `PATCH` to `/v9/projects/:id`. It is a project setting and
+   cannot be expressed in `vercel.json`. Deploying from inside `apps/admin`
+   instead fails at install: only that folder is uploaded, so
+   `@baaki/core: workspace:*` has nothing to resolve against.
+2. **Link the CLI at the repository root**, not at `apps/admin`. The whole
+   workspace has to be uploaded for pnpm to resolve it; Root Directory then
+   tells Vercel which part of it to build. With the root linked but no Root
+   Directory set, the build fails the other way — "No Next.js version
+   detected", because it looked for `next` in the root manifest.
+3. **`.vercelignore` at the repo root is load-bearing.** Without it the upload
+   includes `node_modules`, the Android build tree and a 165MB APK, and aborts
+   partway through 2.9GB.
+4. Add the four environment variables from `.env.example` for **Production**.
    Generate a fresh `ADMIN_PASSWORD` and `ADMIN_SESSION_SECRET`; do not reuse
    the local ones.
-4. Turn on **Deployment Protection → Vercel Authentication**, scoped to both
-   Preview and Production.
+5. Confirm **Deployment Protection → Vercel Authentication** covers Preview and
+   Production. It was already on by default here — check rather than assume,
+   with `vercel project protection`.
 
-`vercel.json` pins the functions to `sin1`. The database is in
+`apps/admin/vercel.json` pins the functions to `sin1`. The database is in
 `ap-southeast-1`, and every page here is server-rendered from it — hosting the
 functions anywhere else adds a transpacific round trip to each of six queries.
 
-### Step 4 is not optional
+### Step 5 is not optional
 
 Everything else here is one password in front of the entire business. Vercel
 Authentication requires a login on your Vercel account before a request reaches

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -1,0 +1,94 @@
+# Baaki admin
+
+A private console for one operator. Aggregates only — how the app is being
+used, not what anybody spent money on.
+
+English only, and deliberately: the product ships in four languages because its
+users read four languages (TDR §11), and this has one reader. Numbers are
+grouped `en-IN` because that is the market the business is in. Amounts still go
+through `@baaki/core`'s formatter rather than a local one, so the console can
+never disagree with the ledger about what a number means.
+
+Minimum responsive. It is read at a desk; the phone case is checking a figure
+while away from one, so nothing is unreadable or unreachable and nothing more.
+
+## What it can see
+
+Six functions in `20260808190000_admin_analytics`, and nothing else. Not one of
+them returns a description, a note, a display name, a payment handle or a
+profile id.
+
+| Function               | Answers                                              |
+| ---------------------- | ---------------------------------------------------- |
+| `baaki_admin_overview` | People, groups, expenses, settlements, active counts |
+| `baaki_admin_daily`    | A row per day for 30 days, including empty ones      |
+| `baaki_admin_geo`      | Counts per country                                   |
+| `baaki_admin_money`    | Volume per currency, never converted                 |
+| `baaki_admin_ai_cost`  | The receipt pipeline's bill (ADR-008/011)            |
+| `baaki_admin_logins`   | Sign-ins per day, while Supabase still has them      |
+
+They are revoked from `PUBLIC`, `anon` and `authenticated`, and granted to
+`service_role` alone. That REVOKE is load-bearing: Postgres grants EXECUTE to
+PUBLIC on every new function and Supabase's roles inherit PUBLIC, so without it
+any anonymous guest could read the whole business through the anon key that
+ships inside the mobile binary. `packages/db/test/adminAnalytics.test.ts` fails
+if that ever regresses.
+
+Two things it will not pretend to know:
+
+- **Geo is the device locale**, read at signup — not IP geolocation. A phone set
+  to `en-GB` in Bengaluru counts as GB.
+- **Sign-ins come from `auth.audit_log_entries`**, which Supabase prunes. An
+  empty chart means the retention window passed, not that nobody signed in.
+  `last_sign_in_at` is deliberately unused: it is one snapshot per user, and
+  grouping it by day draws a convincing chart of nothing.
+
+## Running it locally
+
+```bash
+cp apps/admin/.env.example apps/admin/.env.local   # then fill it in
+pnpm admin                                         # http://localhost:3100
+```
+
+## Deploying to Vercel
+
+1. **New Project** → import this repository.
+2. Set **Root Directory** to `apps/admin`. That is the whole monorepo story —
+   Vercel installs from the pnpm workspace at the repo root and builds this app.
+   Framework preset is Next.js; leave the build and output settings alone.
+3. Add the four environment variables from `.env.example` for **Production**.
+   Generate a fresh `ADMIN_PASSWORD` and `ADMIN_SESSION_SECRET`; do not reuse
+   the local ones.
+4. Turn on **Deployment Protection → Vercel Authentication**, scoped to both
+   Preview and Production.
+
+`vercel.json` pins the functions to `sin1`. The database is in
+`ap-southeast-1`, and every page here is server-rendered from it — hosting the
+functions anywhere else adds a transpacific round trip to each of six queries.
+
+### Step 4 is not optional
+
+Everything else here is one password in front of the entire business. Vercel
+Authentication requires a login on your Vercel account before a request reaches
+the app at all — including requests to the proxy — so an attacker never gets to
+try the password. It also closes preview deployments, which otherwise publish a
+working console at a fresh URL on every push.
+
+The password is a single shared secret with no second factor and no revocation
+short of changing it. That is an accepted trade for a one-person console _behind
+another door_, and a bad one on its own.
+
+## Notes for whoever changes this next
+
+- `src/lib/data.ts` begins with `import 'server-only'`. Keep it. It makes the
+  build fail if this module is ever reached from a client component, which is
+  the single mistake that would put an RLS-bypassing key into a browser bundle.
+- The env vars are **not** `NEXT_PUBLIC_`. That prefix is exactly what would
+  inline the service key into the client bundle.
+- The gate is checked twice on purpose — in `src/proxy.ts` and again in
+  `requireSession()`. This is not belt-and-braces for its own sake: during
+  development the proxy sat at the project root, where Next silently does not
+  load it, and only the second check stopped unauthenticated requests.
+- Reads go through the `baaki_admin_*` functions rather than selecting from
+  tables, so what this console is able to see stays one reviewable list in one
+  migration instead of a habit spread across pages.

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -1,0 +1,3 @@
+import next from 'eslint-config-next';
+
+export default [...next, { ignores: ['.next/**', 'out/**', 'next-env.d.ts'] }];

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -1,0 +1,29 @@
+import type { NextConfig } from 'next';
+
+/**
+ * The opposite decision to web-lite's, for the opposite reason.
+ *
+ * Every page here is a **server** component. The console reads with the service
+ * role, which bypasses RLS on every table in the database (ADR-013) — that key
+ * can never reach a browser, so the fetch can never move to the client. There
+ * is no Supabase client in this app's bundle at all, and no anon key either.
+ *
+ * `poweredByHeader` off and `noindex` in the layout: this is a private console,
+ * and the less it announces about itself the better.
+ */
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  poweredByHeader: false,
+  headers: async () => [
+    {
+      source: '/:path*',
+      headers: [
+        { key: 'X-Robots-Tag', value: 'noindex, nofollow' },
+        { key: 'X-Frame-Options', value: 'DENY' },
+        { key: 'Referrer-Policy', value: 'no-referrer' },
+      ],
+    },
+  ],
+};
+
+export default nextConfig;

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@baaki/admin",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3100",
+    "build": "next build",
+    "start": "next start --port 3100",
+    "lint": "eslint src --max-warnings 0",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@baaki/core": "workspace:*",
+    "@supabase/supabase-js": "^2.112.0",
+    "next": "^16.3.0",
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.1.0",
+    "@types/react": "~19.2.2",
+    "@types/react-dom": "~19.2.2",
+    "eslint": "^9.37.0",
+    "eslint-config-next": "^16.3.0",
+    "typescript": "~5.9.2"
+  }
+}

--- a/apps/admin/src/app/campaigns/page.tsx
+++ b/apps/admin/src/app/campaigns/page.tsx
@@ -1,0 +1,298 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { format, money, type CurrencyCode } from '@baaki/core';
+
+import { Nav } from '@/components/Nav';
+import {
+  campaignFunnel,
+  campaignRevenue,
+  campaigns,
+  createCampaign,
+  promoCodes,
+  type CampaignRevenueRow,
+  type FunnelRow,
+} from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+const num = (value: number | string) => Number(value).toLocaleString('en-IN');
+const pct = (part: number, whole: number) =>
+  whole === 0 ? '—' : `${((part / whole) * 100).toFixed(1)}%`;
+
+function amount(minor: string, currency: string): string {
+  try {
+    return format(money(BigInt(minor), currency as CurrencyCode), { compactFraction: true });
+  } catch {
+    return `${minor} ${currency}`;
+  }
+}
+
+/**
+ * The number the whole feature exists for.
+ *
+ * Revenue per person in the targeted arm minus revenue per person in the
+ * holdout, times the targeted population. Per person because the arms are
+ * different sizes; against the holdout because the value of what was given away
+ * is not an impact, it is a cost.
+ */
+function incremental(rows: CampaignRevenueRow[], funnel: FunnelRow[], currency: string) {
+  const heads = new Map(funnel.map((row) => [row.cohort, Number(row.people)]));
+  const revenueFor = (cohort: string) =>
+    Number(
+      rows.find((row) => row.cohort === cohort && row.currency === currency)?.revenue_minor ?? 0,
+    );
+
+  const targetedPeople = heads.get('targeted') ?? 0;
+  const holdoutPeople = heads.get('holdout') ?? 0;
+  if (targetedPeople === 0 || holdoutPeople === 0) return null;
+
+  const perTargeted = revenueFor('targeted') / targetedPeople;
+  const perHoldout = revenueFor('holdout') / holdoutPeople;
+  return Math.round((perTargeted - perHoldout) * targetedPeople);
+}
+
+export default async function Campaigns({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; done?: string }>;
+}) {
+  const { error, done } = await searchParams;
+  const [all, codes] = await Promise.all([campaigns(), promoCodes()]);
+
+  const results = new Map(
+    await Promise.all(
+      all.map(
+        async (campaign) =>
+          [
+            campaign.id,
+            {
+              funnel: await campaignFunnel(campaign.id),
+              revenue: await campaignRevenue(campaign.id),
+            },
+          ] as const,
+      ),
+    ),
+  );
+
+  async function create(formData: FormData) {
+    'use server';
+
+    const countries = String(formData.get('countries') ?? '')
+      .split(',')
+      .map((part) => part.trim().toUpperCase())
+      .filter(Boolean);
+
+    let failure: string | null = null;
+    try {
+      await createCampaign({
+        name: String(formData.get('name') ?? ''),
+        title: String(formData.get('title') ?? ''),
+        body: String(formData.get('body') ?? ''),
+        ctaLabel: String(formData.get('cta') ?? ''),
+        promoCode: String(formData.get('code') ?? '') || null,
+        endsAt: String(formData.get('ends') ?? ''),
+        countries: countries.length > 0 ? countries : null,
+        holdoutPercent: Number(formData.get('holdout') ?? 10),
+      });
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    if (failure) redirect(`/campaigns?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/campaigns');
+    redirect('/campaigns?done=Campaign+created');
+  }
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Campaigns</h1>
+        <Nav here="campaigns" />
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+      {done ? <p className="faint">{done}</p> : null}
+
+      <p className="note" style={{ padding: 0 }}>
+        Every campaign withholds itself from a slice of its own audience. That holdout is the only
+        reason &ldquo;did this work&rdquo; has an answer: a comped subscription earns nothing by
+        construction, so the impact is whether the people who were offered it went on to pay more
+        than the people who were not.
+      </p>
+
+      {all.length === 0 ? (
+        <section style={{ marginTop: 20 }}>
+          <p className="note">
+            None yet. If you expected some, the <code>20260808220000_campaigns</code> migration may
+            not be deployed to this project.
+          </p>
+        </section>
+      ) : null}
+
+      {all.map((campaign) => {
+        const result = results.get(campaign.id);
+        const funnel = result?.funnel ?? [];
+        const revenue = result?.revenue ?? [];
+        const targeted = funnel.find((row) => row.cohort === 'targeted');
+        const currencies = [...new Set(revenue.map((row) => row.currency))];
+        const live =
+          new Date(campaign.starts_at) <= new Date() && new Date(campaign.ends_at) > new Date();
+
+        return (
+          <div key={campaign.id}>
+            <h2>
+              {campaign.name} {live ? '· live' : '· ended'}
+            </h2>
+            <section>
+              <p className="note">
+                <strong>{campaign.title}</strong>
+                {campaign.body ? ` — ${campaign.body}` : ''}
+                <br />
+                {campaign.promo_code ? (
+                  <>
+                    Code <code>{campaign.promo_code}</code> ·{' '}
+                  </>
+                ) : null}
+                {campaign.holdout_percent}% holdout ·{' '}
+                {campaign.audience_countries?.join(', ') || 'everywhere'} · ends{' '}
+                {new Date(campaign.ends_at).toLocaleDateString('en-IN')}
+              </p>
+
+              <div className="scroll">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Cohort</th>
+                      <th>People</th>
+                      <th>Saw it</th>
+                      <th>Redeemed</th>
+                      <th>Paid</th>
+                      <th>Pay rate</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {funnel.map((row) => (
+                      <tr key={row.cohort}>
+                        <td>{row.cohort}</td>
+                        <td>{num(row.people)}</td>
+                        <td>{num(row.seen)}</td>
+                        <td>{num(row.redeemed)}</td>
+                        <td>{num(row.paid)}</td>
+                        <td>{pct(Number(row.paid), Number(row.people))}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {currencies.length === 0 ? (
+                <p className="note">No purchases in either arm yet.</p>
+              ) : (
+                <div className="scroll">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Currency</th>
+                        <th>Targeted</th>
+                        <th>Holdout</th>
+                        <th>Incremental</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {currencies.map((currency) => {
+                        const lift = incremental(revenue, funnel, currency);
+                        const forCohort = (cohort: string) =>
+                          revenue.find((row) => row.cohort === cohort && row.currency === currency)
+                            ?.revenue_minor ?? '0';
+                        return (
+                          <tr key={currency}>
+                            <td>{currency}</td>
+                            <td>{amount(forCohort('targeted'), currency)}</td>
+                            <td>{amount(forCohort('holdout'), currency)}</td>
+                            <td
+                              style={{
+                                color:
+                                  lift === null
+                                    ? 'var(--muted)'
+                                    : lift >= 0
+                                      ? 'var(--positive)'
+                                      : 'var(--negative)',
+                                fontWeight: 600,
+                              }}
+                            >
+                              {lift === null ? '—' : amount(String(lift), currency)}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                  <p className="note">
+                    Incremental is revenue per person in the targeted arm minus revenue per person
+                    in the holdout, times the targeted population. Per person because the arms are
+                    different sizes. It goes negative when the giveaway cannibalised purchases
+                    people would have made anyway, and that is a real result rather than a bug.
+                    {targeted && Number(targeted.people) < 200 ? (
+                      <>
+                        {' '}
+                        With {num(targeted.people)} people in the targeted arm this is noisy — treat
+                        it as a direction, not a figure.
+                      </>
+                    ) : null}
+                  </p>
+                </div>
+              )}
+            </section>
+          </div>
+        );
+      })}
+
+      <h2>New campaign</h2>
+      <section>
+        <form action={create} className="flag">
+          <label>
+            <span>Name (internal)</span>
+            <input type="text" name="name" placeholder="Diwali 2026" />
+          </label>
+          <label>
+            <span>Title</span>
+            <input type="text" name="title" placeholder="Two months of Plus, free" required />
+          </label>
+          <label>
+            <span>Body</span>
+            <input type="text" name="body" placeholder="Because you have been here a while" />
+          </label>
+          <label>
+            <span>Button</span>
+            <input type="text" name="cta" placeholder="Claim it" defaultValue="Claim it" />
+          </label>
+          <label>
+            <span>Promo code</span>
+            <select name="code" defaultValue="">
+              <option value="">None</option>
+              {codes.map((code) => (
+                <option key={code.code} value={code.code}>
+                  {code.code}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>Ends</span>
+            <input type="date" name="ends" required />
+          </label>
+          <label>
+            <span>Countries</span>
+            <input type="text" name="countries" placeholder="IN, AE — blank for all" />
+          </label>
+          <label>
+            <span>Holdout %</span>
+            <input type="number" name="holdout" min={1} max={90} defaultValue={10} />
+          </label>
+          <button type="submit">Create campaign</button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/apps/admin/src/app/export/[report]/route.ts
+++ b/apps/admin/src/app/export/[report]/route.ts
@@ -1,0 +1,59 @@
+import { aiCost, daily, geo, money } from '@/lib/data';
+
+/**
+ * Reports, as CSV, because the thing anybody actually wants to do with a table
+ * of numbers is put it in a spreadsheet.
+ *
+ * The route is behind the same middleware as the pages, and every function it
+ * calls re-checks the session itself — a download link is the kind of URL that
+ * gets pasted somewhere, and it must be worthless to whoever finds it.
+ */
+
+const REPORTS = {
+  daily: async () => rows(await daily(90)),
+  geo: async () => rows(await geo()),
+  money: async () => rows(await money()),
+  ai: async () => rows(await aiCost(90)),
+} satisfies Record<string, () => Promise<string>>;
+
+type ReportName = keyof typeof REPORTS;
+
+export async function GET(_request: Request, context: { params: Promise<{ report: string }> }) {
+  const { report } = await context.params;
+  if (!(report in REPORTS)) {
+    return new Response('No such report', { status: 404 });
+  }
+
+  const csv = await REPORTS[report as ReportName]();
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="baaki-${report}-${today()}.csv"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+/** Header row from the first object's keys; every row quoted the same way. */
+function rows<T extends object>(data: readonly T[]): string {
+  if (data.length === 0) return '';
+  const columns = Object.keys(data[0]!);
+  const lines = [columns.map(cell).join(',')];
+  for (const row of data) {
+    const fields = row as Record<string, unknown>;
+    lines.push(columns.map((column) => cell(fields[column])).join(','));
+  }
+  return lines.join('\r\n') + '\r\n';
+}
+
+/**
+ * RFC 4180 quoting. Every field is quoted rather than only the ones that need
+ * it — a country code is two letters today and the day one of these fields
+ * carries a comma is not the day to find out this function was optimistic.
+ */
+function cell(value: unknown): string {
+  if (value === null || value === undefined) return '""';
+  return `"${String(value).replace(/"/g, '""')}"`;
+}

--- a/apps/admin/src/app/feedback/page.tsx
+++ b/apps/admin/src/app/feedback/page.tsx
@@ -1,0 +1,73 @@
+import { Nav } from '@/components/Nav';
+import { feedback } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+const KIND_LABEL: Record<string, string> = {
+  general: 'General',
+  bug: 'Broken',
+  idea: 'Idea',
+  deletion: 'Left',
+};
+
+export default async function FeedbackPage() {
+  const rows = await feedback(200);
+  const counts = rows.reduce<Record<string, number>>((tally, row) => {
+    tally[row.kind] = (tally[row.kind] ?? 0) + 1;
+    return tally;
+  }, {});
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Feedback</h1>
+        <Nav here="feedback" />
+      </header>
+
+      <div className="tiles">
+        {(['general', 'bug', 'idea', 'deletion'] as const).map((kind) => (
+          <div className="tile" key={kind}>
+            <span className="label">{KIND_LABEL[kind]}</span>
+            <div className="value">{counts[kind] ?? 0}</div>
+          </div>
+        ))}
+      </div>
+
+      <h2>Newest first</h2>
+      <section>
+        {rows.length === 0 ? (
+          <p className="note">
+            Nothing yet. If you expected some, the <code>20260808230000_feedback_and_erasure</code>{' '}
+            migration may not be deployed to this project.
+          </p>
+        ) : (
+          <ul className="feedback">
+            {rows.map((row) => (
+              <li key={row.id}>
+                <div className="meta">
+                  <span className={`tag tag-${row.kind}`}>{KIND_LABEL[row.kind] ?? row.kind}</span>
+                  {row.rating ? <span>{'★'.repeat(row.rating)}</span> : null}
+                  <span>{new Date(row.created_at).toLocaleString('en-IN')}</span>
+                  {row.platform ? <span>{row.platform}</span> : null}
+                  {row.app_version ? <span>v{row.app_version}</span> : null}
+                  {row.country_code ? <span>{row.country_code}</span> : null}
+                  {row.locale ? <span>{row.locale}</span> : null}
+                  {row.from_deleted_account ? <span className="gone">account deleted</span> : null}
+                </div>
+                <p>{row.message}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <p className="note" style={{ padding: '14px 0 0' }}>
+        There is no author column here and no way to ask for one. Knowing who complained is not
+        needed in order to act on a complaint. Where it says <em>account deleted</em>, the person
+        has since erased themselves — their words are kept on purpose, because why somebody leaves
+        is the most useful thing they ever write and cascading it away at that moment would destroy
+        exactly that.
+      </p>
+    </main>
+  );
+}

--- a/apps/admin/src/app/flags/page.tsx
+++ b/apps/admin/src/app/flags/page.tsx
@@ -1,0 +1,202 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { Nav } from '@/components/Nav';
+import { flagResults, flags, saveFlag, type FlagResultRow } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+const num = (value: number | string) => Number(value).toLocaleString('en-IN');
+
+export default async function Flags({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; saved?: string }>;
+}) {
+  const { error, saved } = await searchParams;
+  const all = await flags();
+
+  // Results only for the flags actually running. Bucketing every profile is a
+  // full scan of `profiles` per flag, and doing it for switches nobody has
+  // turned on is work with no reader.
+  const running = all.filter((flag) => flag.enabled);
+  const results = new Map<string, FlagResultRow[]>(
+    await Promise.all(
+      running.map(async (flag) => [flag.key, await flagResults(flag.key)] as const),
+    ),
+  );
+
+  async function save(formData: FormData) {
+    'use server';
+
+    const variants = String(formData.get('variants') ?? '')
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean);
+
+    // Collected rather than rethrown, because `redirect` works by throwing and
+    // a catch around it would swallow the navigation.
+    let failure: string | null = null;
+    try {
+      await saveFlag({
+        key: String(formData.get('key') ?? '').trim(),
+        description: String(formData.get('description') ?? '').trim(),
+        enabled: formData.get('enabled') === 'on',
+        rolloutPercent: Number(formData.get('rollout') ?? 0),
+        variants,
+      });
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    if (failure) redirect(`/flags?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/flags');
+    redirect('/flags?saved=1');
+  }
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Experiments</h1>
+        <Nav here="flags" />
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+      {saved ? <p className="faint">Saved.</p> : null}
+
+      <p className="note" style={{ padding: 0 }}>
+        Nobody&rsquo;s assignment is stored. A person&rsquo;s arm is hashed from the flag key and
+        their profile id, by the same rule in the app and in the database, so the split needs no
+        round trip and an experiment can be read retrospectively — including for the days before it
+        occurred to anybody to look.
+      </p>
+
+      {all.length === 0 ? (
+        <section style={{ marginTop: 20 }}>
+          <p className="note">
+            No flags yet. If you expected some, the
+            <code> 20260808200000_feature_flags </code> migration may not be deployed to this
+            project.
+          </p>
+        </section>
+      ) : null}
+
+      {all.map((flag) => {
+        const rows = results.get(flag.key) ?? [];
+        const enrolled = rows.reduce((sum, row) => sum + Number(row.people), 0);
+
+        return (
+          <div key={flag.key}>
+            <h2>{flag.key}</h2>
+            <section>
+              <form action={save} className="flag">
+                <input type="hidden" name="key" value={flag.key} />
+                <label>
+                  <span>Description</span>
+                  <input type="text" name="description" defaultValue={flag.description} />
+                </label>
+                <label className="inline">
+                  <input type="checkbox" name="enabled" defaultChecked={flag.enabled} />
+                  <span>Enabled</span>
+                </label>
+                <label>
+                  <span>Rollout %</span>
+                  <input
+                    type="number"
+                    name="rollout"
+                    min={0}
+                    max={100}
+                    defaultValue={flag.rollout_percent}
+                  />
+                </label>
+                <label>
+                  <span>Arms (comma separated)</span>
+                  <input type="text" name="variants" defaultValue={flag.variants.join(', ')} />
+                </label>
+                <button type="submit">Save</button>
+              </form>
+
+              {flag.enabled ? (
+                rows.length === 0 ? (
+                  <p className="note">
+                    Nobody is enrolled. At {flag.rollout_percent}% rollout that is expected if there
+                    are few accounts.
+                  </p>
+                ) : (
+                  <div className="scroll">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Arm</th>
+                          <th>People</th>
+                          <th>Share</th>
+                          <th>Expenses created</th>
+                          <th>Per person</th>
+                          <th>Active 30d</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {rows.map((row) => (
+                          <tr key={row.variant}>
+                            <td>{row.variant}</td>
+                            <td>{num(row.people)}</td>
+                            <td>
+                              {enrolled === 0
+                                ? '—'
+                                : `${Math.round((Number(row.people) / enrolled) * 100)}%`}
+                            </td>
+                            <td>{num(row.expenses_created)}</td>
+                            <td>
+                              {Number(row.people) === 0
+                                ? '—'
+                                : (Number(row.expenses_created) / Number(row.people)).toFixed(2)}
+                            </td>
+                            <td>{num(row.active_30d)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    <p className="note">
+                      People outside the rollout are not shown. They are not a control group — the
+                      experiment never touched them, and putting them beside the arms invites the
+                      one comparison that is wrong.
+                    </p>
+                  </div>
+                )
+              ) : (
+                <p className="note">Off. Everybody sees whatever the app did before this flag.</p>
+              )}
+            </section>
+          </div>
+        );
+      })}
+
+      <h2>New flag</h2>
+      <section>
+        <form action={save} className="flag">
+          <label>
+            <span>Key</span>
+            <input type="text" name="key" placeholder="itemized_receipts" required />
+          </label>
+          <label>
+            <span>Description</span>
+            <input type="text" name="description" />
+          </label>
+          <label className="inline">
+            <input type="checkbox" name="enabled" />
+            <span>Enabled</span>
+          </label>
+          <label>
+            <span>Rollout %</span>
+            <input type="number" name="rollout" min={0} max={100} defaultValue={0} />
+          </label>
+          <label>
+            <span>Arms (comma separated)</span>
+            <input type="text" name="variants" defaultValue="control, treatment" />
+          </label>
+          <button type="submit">Create</button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -1,0 +1,354 @@
+/**
+ * A console, not a product. It borrows Baaki's brand colour and nothing else:
+ * this screen is read in one sitting by one person looking for a number, so it
+ * is dense, quiet, and gets out of the way.
+ */
+
+:root {
+  --bg: #f7f7fb;
+  --surface: #ffffff;
+  --border: #e6e5ef;
+  --text: #14131f;
+  --muted: #6a6880;
+  --faint: #9997ac;
+  --brand: #7a5af8;
+  --positive: #0f9d63;
+  --negative: #d1453b;
+  --radius: 12px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0e0d16;
+    --surface: #17162280;
+    --border: #2a2840;
+    --text: #f4f3ff;
+    --muted: #9e9eb8;
+    --faint: #6b6b85;
+    --brand: #9b83ff;
+    --positive: #34d399;
+    --negative: #ff7b72;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
+  font-size: 15px;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 24px 96px;
+}
+
+header.top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+h1 {
+  font-size: 20px;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+h2 {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin: 36px 0 12px;
+}
+
+section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+/* ── tiles ── */
+
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.tile {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+}
+
+.tile .label {
+  font-size: 12px;
+  color: var(--muted);
+  display: block;
+  margin-bottom: 6px;
+}
+
+.tile .value {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.tile .sub {
+  font-size: 12px;
+  color: var(--faint);
+  margin-top: 4px;
+}
+
+/* ── tables ── */
+
+.scroll {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+th,
+td {
+  text-align: right;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+th:first-child,
+td:first-child {
+  text-align: left;
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+th {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* ── sparkline-ish bars ── */
+
+.bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 72px;
+  padding: 16px;
+}
+
+.bars .bar {
+  flex: 1;
+  min-width: 2px;
+  background: var(--brand);
+  border-radius: 2px 2px 0 0;
+  opacity: 0.85;
+}
+
+.bars .bar.zero {
+  background: var(--border);
+  opacity: 1;
+}
+
+/* ── misc ── */
+
+.muted {
+  color: var(--muted);
+}
+.faint {
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.note {
+  padding: 14px 16px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+a {
+  color: var(--brand);
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* ── login ── */
+
+.login {
+  max-width: 340px;
+  margin: 18vh auto;
+  padding: 0 24px;
+}
+
+.login form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+input[type='password'] {
+  font: inherit;
+  padding: 11px 13px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+}
+
+button {
+  font: inherit;
+  font-weight: 600;
+  padding: 11px 16px;
+  border-radius: 10px;
+  border: none;
+  background: var(--brand);
+  color: #fff;
+  cursor: pointer;
+}
+
+.error {
+  color: var(--negative);
+  font-size: 13px;
+}
+
+/* ── nav ── */
+
+.nav {
+  display: flex;
+  gap: 14px;
+  font-size: 13px;
+}
+
+.nav a {
+  text-decoration: none;
+  color: var(--muted);
+}
+
+.nav a[aria-current='page'] {
+  color: var(--brand);
+  font-weight: 600;
+}
+
+/* ── flag editor ── */
+
+form.flag {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 12px;
+  padding: 16px;
+}
+
+form.flag label {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+form.flag label.inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 7px;
+  padding-bottom: 10px;
+}
+
+form.flag input[type='text'],
+form.flag input[type='number'] {
+  font: inherit;
+  padding: 8px 11px;
+  border-radius: 9px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+}
+
+form.flag input[type='number'] {
+  width: 92px;
+}
+
+form.flag button {
+  padding: 9px 16px;
+}
+
+/**
+ * Minimum responsive, and that is the whole ambition.
+ *
+ * This is read at a desk. The phone case that matters is checking a number
+ * while away from one, so the requirement is only that nothing is unreadable
+ * or unreachable — not that it is redesigned. The tiles already reflow on
+ * their own (`auto-fit`) and every table already scrolls inside its own
+ * container, so this is just tightening the gutters and stopping the header
+ * from squeezing the date into a column of single characters.
+ */
+@media (max-width: 640px) {
+  main {
+    padding: 20px 14px 64px;
+  }
+
+  header.top {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .tiles {
+    grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  }
+
+  .tile .value {
+    font-size: 22px;
+  }
+
+  h2 {
+    margin: 28px 0 10px;
+  }
+
+  th,
+  td {
+    padding: 8px 10px;
+  }
+}

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -296,6 +296,8 @@ form.flag label.inline {
   padding-bottom: 10px;
 }
 
+form.flag select,
+form.flag input[type='date'],
 form.flag input[type='text'],
 form.flag input[type='number'] {
   font: inherit;

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -354,3 +354,60 @@ form.flag button {
     padding: 8px 10px;
   }
 }
+
+/* ── feedback list ── */
+
+ul.feedback {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+ul.feedback li {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+ul.feedback li:last-child {
+  border-bottom: none;
+}
+
+ul.feedback p {
+  margin: 8px 0 0;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+
+ul.feedback .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--faint);
+}
+
+.tag {
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--surfaceMuted, var(--border));
+  color: var(--muted);
+}
+
+.tag-bug {
+  background: #ff7b7222;
+  color: var(--negative);
+}
+.tag-idea {
+  background: #34d39922;
+  color: var(--positive);
+}
+.tag-deletion {
+  background: #9b83ff22;
+  color: var(--brand);
+}
+
+.gone {
+  font-style: italic;
+}

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Baaki admin',
+  robots: { index: false, follow: false },
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -1,0 +1,56 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { checkPassword, issueToken } from '@/lib/session';
+
+export default async function Login({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+
+  async function signIn(formData: FormData) {
+    'use server';
+
+    const password = String(formData.get('password') ?? '');
+    if (!(await checkPassword(password))) {
+      // No detail, and the same wording whatever went wrong. There is one
+      // account here; telling a stranger anything about why they failed only
+      // helps them.
+      redirect('/login?error=1');
+    }
+
+    const token = await issueToken();
+    (await cookies()).set(token.name, token.value, {
+      httpOnly: true,
+      sameSite: 'lax',
+      // Off on localhost, on everywhere else — a Secure cookie is never sent
+      // over the plain-HTTP dev server, which would lock you out of your own
+      // machine.
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: token.maxAge,
+    });
+    redirect('/');
+  }
+
+  return (
+    <main className="login">
+      <h1>Baaki admin</h1>
+      <p className="faint">Private console. Aggregates only.</p>
+      <form action={signIn}>
+        <input
+          type="password"
+          name="password"
+          placeholder="Password"
+          aria-label="Password"
+          autoFocus
+          autoComplete="current-password"
+        />
+        <button type="submit">Sign in</button>
+        {error ? <p className="error">That did not work.</p> : null}
+      </form>
+    </main>
+  );
+}

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -1,0 +1,248 @@
+import { format, money, type CurrencyCode } from '@baaki/core';
+
+import { Bars } from '@/components/Bars';
+import { Nav } from '@/components/Nav';
+import { aiCost, daily, geo, logins, money as moneyRows, overview } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+const num = (value: number | string) => Number(value).toLocaleString('en-IN');
+
+/** Minor units through the ledger's own formatter, so the console cannot disagree with the app. */
+function amount(minor: string, currency: string): string {
+  try {
+    return format(money(BigInt(minor), currency as CurrencyCode), { compactFraction: true });
+  } catch {
+    // An unknown currency is not worth a 500 on a dashboard.
+    return `${minor} ${currency}`;
+  }
+}
+
+export default async function Dashboard() {
+  const [head, days, countries, currencies, ai, signIns] = await Promise.all([
+    overview(),
+    daily(30),
+    geo(),
+    moneyRows(),
+    aiCost(30),
+    logins(30),
+  ]);
+
+  if (!head) {
+    return (
+      <main>
+        <h1>Baaki admin</h1>
+        <p className="note">
+          The analytics functions returned nothing. That usually means the
+          <code> 20260808190000_admin_analytics </code> migration has not been deployed to this
+          project yet.
+        </p>
+      </main>
+    );
+  }
+
+  const signInTotal = signIns.reduce((sum, row) => sum + Number(row.sign_ins), 0);
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Baaki admin</h1>
+        <Nav here="overview" />
+      </header>
+      <p className="faint" style={{ marginTop: -18, marginBottom: 22 }}>
+        Aggregates only · {new Date().toLocaleString('en-IN', { timeZone: 'Asia/Kolkata' })} IST
+      </p>
+
+      <div className="tiles">
+        <Tile
+          label="People"
+          value={num(head.profiles_total)}
+          sub={`+${head.profiles_new_7d} in 7d`}
+        />
+        <Tile
+          label="Groups"
+          value={num(head.groups_total)}
+          sub={`${num(head.groups_active_30d)} active in 30d`}
+        />
+        <Tile
+          label="Expenses"
+          value={num(head.expenses_total)}
+          sub={`+${num(head.expenses_new_30d)} in 30d`}
+        />
+        <Tile
+          label="Settlements"
+          value={num(head.settlements_total)}
+          sub={`${num(head.settlements_confirmed)} confirmed`}
+        />
+        <Tile
+          label="Active 30d"
+          value={num(head.active_profiles_30d)}
+          sub={`${num(head.active_profiles_7d)} in 7d`}
+        />
+        <Tile label="Deleted expenses" value={num(head.expenses_deleted)} sub="soft-deleted" />
+      </div>
+
+      <h2>New people, 30 days</h2>
+      <section>
+        <Bars
+          label="New people per day"
+          rows={days.map((d) => ({ day: d.day, value: Number(d.new_profiles) }))}
+        />
+      </section>
+
+      <h2>Expenses created, 30 days</h2>
+      <section>
+        <Bars
+          label="Expenses created per day"
+          rows={days.map((d) => ({ day: d.day, value: Number(d.new_expenses) }))}
+        />
+      </section>
+
+      <h2>Active people, 30 days</h2>
+      <section>
+        <Bars
+          label="Active people per day"
+          rows={days.map((d) => ({ day: d.day, value: Number(d.active_profiles) }))}
+        />
+        <p className="note">
+          Active means somebody did something the ledger recorded. Opening the app is not written
+          down anywhere, so it is not counted here — a number that meant &ldquo;launched&rdquo;
+          would be invented.
+        </p>
+      </section>
+
+      <h2>Where they are</h2>
+      <section className="scroll">
+        <table>
+          <thead>
+            <tr>
+              <th>Country</th>
+              <th>People</th>
+              <th>Groups</th>
+              <th>Expenses</th>
+            </tr>
+          </thead>
+          <tbody>
+            {countries.map((row) => (
+              <tr key={row.country_code ?? 'unknown'}>
+                <td>{row.country_code ?? <span className="muted">Not set</span>}</td>
+                <td>{num(row.profile_count)}</td>
+                <td>{num(row.group_count)}</td>
+                <td>{num(row.expense_count)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="note">
+          This is the device locale the app read at signup, and for groups it is where the group
+          settles. It is not IP geolocation: a phone set to en-GB in Bengaluru counts as GB.
+        </p>
+      </section>
+
+      <h2>Volume</h2>
+      <section className="scroll">
+        <table>
+          <thead>
+            <tr>
+              <th>Currency</th>
+              <th>Expenses</th>
+              <th>Value</th>
+              <th>Settled</th>
+              <th>Settled value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {currencies.map((row) => (
+              <tr key={row.currency}>
+                <td>{row.currency}</td>
+                <td>{num(row.expense_count)}</td>
+                <td>{amount(row.expense_minor, row.currency)}</td>
+                <td>{num(row.settlement_count)}</td>
+                <td>{amount(row.settlement_minor, row.currency)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="note">
+          Never summed across currencies and never converted — the same rule the product follows.
+          Live expenses at their current version only, so an edited expense counts once.
+        </p>
+      </section>
+
+      <h2>AI receipt cost, 30 days</h2>
+      <section className="scroll">
+        {ai.length === 0 ? (
+          <p className="note">No scans in this window.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>Day</th>
+                <th>Currency</th>
+                <th>Scans</th>
+                <th>In</th>
+                <th>Out</th>
+                <th>Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ai.map((row) => (
+                <tr key={`${row.day}-${row.currency}`}>
+                  <td>{row.day}</td>
+                  <td>{row.currency}</td>
+                  <td>{num(row.events)}</td>
+                  <td>{num(row.input_tokens)}</td>
+                  <td>{num(row.output_tokens)}</td>
+                  <td>{amount(row.cost_minor, row.currency)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <h2>Sign-ins, 30 days</h2>
+      <section>
+        {signIns.length === 0 ? (
+          <p className="note">
+            Nothing to show. Supabase prunes its auth audit log, so an empty result here means the
+            retention window has passed — not that nobody signed in.
+          </p>
+        ) : (
+          <>
+            <Bars
+              label="Sign-ins per day"
+              rows={[...signIns]
+                .reverse()
+                .map((row) => ({ day: row.day, value: Number(row.sign_ins) }))}
+            />
+            <p className="note">{num(signInTotal)} sign-ins in the retained window.</p>
+          </>
+        )}
+      </section>
+
+      <h2>Reports</h2>
+      <section>
+        {/* Plain anchors on purpose. These are route handlers that stream a
+            file with a Content-Disposition, not pages: `next/link` would
+            client-side navigate to them and the download would never start. */}
+        {/* eslint-disable @next/next/no-html-link-for-pages */}
+        <p className="note">
+          <a href="/export/daily">daily.csv</a> · <a href="/export/geo">geo.csv</a> ·{' '}
+          <a href="/export/money">money.csv</a> · <a href="/export/ai">ai-cost.csv</a>
+        </p>
+        {/* eslint-enable @next/next/no-html-link-for-pages */}
+      </section>
+    </main>
+  );
+}
+
+function Tile({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="tile">
+      <span className="label">{label}</span>
+      <div className="value">{value}</div>
+      {sub ? <div className="sub">{sub}</div> : null}
+    </div>
+  );
+}

--- a/apps/admin/src/app/promotions/page.tsx
+++ b/apps/admin/src/app/promotions/page.tsx
@@ -1,0 +1,163 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { Nav } from '@/components/Nav';
+import { createPromoCode, grantPromo, promoCodes } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+const num = (value: number | string) => Number(value).toLocaleString('en-IN');
+const day = (value: string | null) => (value ? new Date(value).toLocaleDateString('en-IN') : '—');
+
+export default async function Promotions({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; done?: string }>;
+}) {
+  const { error, done } = await searchParams;
+  const codes = await promoCodes();
+
+  async function create(formData: FormData) {
+    'use server';
+
+    let failure: string | null = null;
+    try {
+      await createPromoCode({
+        code: String(formData.get('code') ?? ''),
+        days: Number(formData.get('days') ?? 30),
+        maxRedemptions: Number(formData.get('max') ?? 1),
+        note: String(formData.get('note') ?? '').trim(),
+      });
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    if (failure) redirect(`/promotions?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/promotions');
+    redirect('/promotions?done=Code+created');
+  }
+
+  async function grant(formData: FormData) {
+    'use server';
+
+    let failure: string | null = null;
+    let message = '';
+    try {
+      message = await grantPromo(
+        String(formData.get('profile') ?? ''),
+        Number(formData.get('days') ?? 30),
+      );
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    if (failure) redirect(`/promotions?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/promotions');
+    redirect(`/promotions?done=${encodeURIComponent(message)}`);
+  }
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Promotions</h1>
+        <Nav here="promotions" />
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+      {done ? <p className="faint">{done}</p> : null}
+
+      <p className="note" style={{ padding: 0 }}>
+        A promotion is an ordinary <code>subscriptions</code> row with{' '}
+        <code>store = &lsquo;promo&rsquo;</code>. Every screen that already asks what plan somebody
+        is on gets the right answer with no change — there is no second source of truth for who has
+        paid.
+      </p>
+
+      <h2>Comp an account</h2>
+      <section>
+        <form action={grant} className="flag">
+          <label>
+            <span>Profile id</span>
+            <input type="text" name="profile" placeholder="uuid" required size={38} />
+          </label>
+          <label>
+            <span>Days</span>
+            <input type="number" name="days" min={1} max={3650} defaultValue={30} />
+          </label>
+          <button type="submit">Grant Plus</button>
+        </form>
+        <p className="note">
+          Keyed on the account and the day, so pressing this twice in one conversation is the same
+          grant rather than two months.
+        </p>
+      </section>
+
+      <h2>Codes</h2>
+      <section className="scroll">
+        {codes.length === 0 ? (
+          <p className="note">
+            None yet. If you expected some, the <code>20260808210000_promotions</code> migration may
+            not be deployed to this project.
+          </p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>Code</th>
+                <th>Grants</th>
+                <th>Used</th>
+                <th>Of</th>
+                <th>Expires</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {codes.map((row) => (
+                <tr key={row.code}>
+                  <td>
+                    <code>{row.code}</code>
+                  </td>
+                  <td>{num(row.days)} days</td>
+                  <td>{num(row.redeemed_count)}</td>
+                  <td>{num(row.max_redemptions)}</td>
+                  <td>{day(row.expires_at)}</td>
+                  <td style={{ textAlign: 'left' }}>
+                    {row.note || <span className="muted">—</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <h2>New code</h2>
+      <section>
+        <form action={create} className="flag">
+          <label>
+            <span>Code</span>
+            <input type="text" name="code" placeholder="DIWALI25" required />
+          </label>
+          <label>
+            <span>Days granted</span>
+            <input type="number" name="days" min={1} max={3650} defaultValue={30} />
+          </label>
+          <label>
+            <span>Max redemptions</span>
+            <input type="number" name="max" min={1} defaultValue={100} />
+          </label>
+          <label>
+            <span>Note</span>
+            <input type="text" name="note" placeholder="Diwali campaign" />
+          </label>
+          <button type="submit">Create code</button>
+        </form>
+        <p className="note">
+          Uppercase letters and digits only — these get read aloud and typed by hand. Redeeming is
+          one code per account, enforced by the same unique key the app stores use to stop a
+          replayed store webhook granting a purchase twice.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/admin/src/components/Bars.tsx
+++ b/apps/admin/src/components/Bars.tsx
@@ -1,0 +1,39 @@
+/**
+ * A bar per day, scaled to the busiest one.
+ *
+ * Hand-drawn divs rather than a charting library, and the same reasoning as
+ * amendment A8 gave for the app's own charts: a dependency that renders one
+ * shape is a dependency that has to be upgraded forever. Days with nothing in
+ * them keep a visible floor bar, so a gap reads as "zero" rather than as
+ * "missing".
+ */
+export function Bars({
+  rows,
+  label,
+}: {
+  rows: readonly { day: string; value: number }[];
+  label: string;
+}) {
+  const peak = Math.max(1, ...rows.map((row) => row.value));
+
+  return (
+    <div className="bars" role="img" aria-label={`${label}: ${describe(rows)}`}>
+      {rows.map((row) => (
+        <div
+          key={row.day}
+          className={row.value === 0 ? 'bar zero' : 'bar'}
+          style={{ height: row.value === 0 ? 2 : `${Math.max(4, (row.value / peak) * 100)}%` }}
+          title={`${row.day}: ${row.value}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** A chart is an image to a screen reader; this is what it says. */
+function describe(rows: readonly { day: string; value: number }[]): string {
+  if (rows.length === 0) return 'no data';
+  const total = rows.reduce((sum, row) => sum + row.value, 0);
+  const peak = rows.reduce((best, row) => (row.value > best.value ? row : best), rows[0]!);
+  return `${total} across ${rows.length} days, busiest ${peak.day} with ${peak.value}`;
+}

--- a/apps/admin/src/components/Nav.tsx
+++ b/apps/admin/src/components/Nav.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+/** Three pages so far. A row of links is the right amount of navigation for that. */
+export function Nav({ here }: { here: 'overview' | 'flags' | 'promotions' }) {
+  return (
+    <nav className="nav">
+      <Link href="/" aria-current={here === 'overview' ? 'page' : undefined}>
+        Overview
+      </Link>
+      <Link href="/flags" aria-current={here === 'flags' ? 'page' : undefined}>
+        Experiments
+      </Link>
+      <Link href="/promotions" aria-current={here === 'promotions' ? 'page' : undefined}>
+        Promotions
+      </Link>
+    </nav>
+  );
+}

--- a/apps/admin/src/components/Nav.tsx
+++ b/apps/admin/src/components/Nav.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
-/** Three pages so far. A row of links is the right amount of navigation for that. */
-export function Nav({ here }: { here: 'overview' | 'flags' | 'promotions' }) {
+/** Four pages so far. A row of links is the right amount of navigation for that. */
+export function Nav({ here }: { here: 'overview' | 'flags' | 'promotions' | 'campaigns' }) {
   return (
     <nav className="nav">
       <Link href="/" aria-current={here === 'overview' ? 'page' : undefined}>
@@ -12,6 +12,9 @@ export function Nav({ here }: { here: 'overview' | 'flags' | 'promotions' }) {
       </Link>
       <Link href="/promotions" aria-current={here === 'promotions' ? 'page' : undefined}>
         Promotions
+      </Link>
+      <Link href="/campaigns" aria-current={here === 'campaigns' ? 'page' : undefined}>
+        Campaigns
       </Link>
     </nav>
   );

--- a/apps/admin/src/components/Nav.tsx
+++ b/apps/admin/src/components/Nav.tsx
@@ -1,7 +1,11 @@
 import Link from 'next/link';
 
-/** Four pages so far. A row of links is the right amount of navigation for that. */
-export function Nav({ here }: { here: 'overview' | 'flags' | 'promotions' | 'campaigns' }) {
+/** Five pages so far. A row of links is the right amount of navigation for that. */
+export function Nav({
+  here,
+}: {
+  here: 'overview' | 'flags' | 'promotions' | 'campaigns' | 'feedback';
+}) {
   return (
     <nav className="nav">
       <Link href="/" aria-current={here === 'overview' ? 'page' : undefined}>
@@ -15,6 +19,9 @@ export function Nav({ here }: { here: 'overview' | 'flags' | 'promotions' | 'cam
       </Link>
       <Link href="/campaigns" aria-current={here === 'campaigns' ? 'page' : undefined}>
         Campaigns
+      </Link>
+      <Link href="/feedback" aria-current={here === 'feedback' ? 'page' : undefined}>
+        Feedback
       </Link>
     </nav>
   );

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -366,6 +366,29 @@ export const campaignFunnel = (id: string) =>
 export const campaignRevenue = (id: string) =>
   call<CampaignRevenueRow>('baaki_admin_campaign_revenue', { p_campaign_id: id });
 
+export interface FeedbackRow {
+  id: string;
+  kind: string;
+  message: string;
+  rating: number | null;
+  app_version: string | null;
+  platform: string | null;
+  locale: string | null;
+  country_code: string | null;
+  from_deleted_account: boolean;
+  created_at: string;
+}
+
+/**
+ * What people wrote. Note there is no author column and no way to ask for one:
+ * knowing who complained is not needed in order to act on a complaint, and the
+ * aggregates-only decision applies here too.
+ */
+export const feedback = (limit = 100) =>
+  call<FeedbackRow>('baaki_admin_feedback', {
+    p_limit: limit,
+  });
+
 export const flagResults = (key: string) =>
   call<FlagResultRow>('baaki_admin_flag_results', { p_key: key });
 

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -276,6 +276,96 @@ export async function grantPromo(profileId: string, days: number): Promise<strin
   return 'Granted.';
 }
 
+export interface CampaignRow {
+  id: string;
+  name: string;
+  title: string;
+  body: string;
+  cta_label: string;
+  promo_code: string | null;
+  starts_at: string;
+  ends_at: string;
+  audience_countries: string[] | null;
+  holdout_percent: number;
+}
+
+export interface FunnelRow {
+  cohort: string;
+  people: number;
+  seen: number;
+  redeemed: number;
+  paid: number;
+}
+
+export interface CampaignRevenueRow {
+  cohort: string;
+  currency: string;
+  payers: number;
+  revenue_minor: string;
+}
+
+export async function campaigns(): Promise<CampaignRow[]> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('campaigns')
+    .select(
+      'id, name, title, body, cta_label, promo_code, starts_at, ends_at, audience_countries, holdout_percent',
+    )
+    .order('starts_at', { ascending: false });
+  if (error) {
+    if (error.code === TABLE_MISSING) return [];
+    throw new Error(`reading campaigns failed: ${error.message}`);
+  }
+  return (data ?? []) as CampaignRow[];
+}
+
+export async function createCampaign(input: {
+  name: string;
+  title: string;
+  body: string;
+  ctaLabel: string;
+  promoCode: string | null;
+  endsAt: string;
+  countries: string[] | null;
+  holdoutPercent: number;
+}): Promise<void> {
+  await requireSession();
+
+  if (!input.title.trim()) throw new Error('A campaign needs something to say.');
+  if (!input.endsAt) throw new Error('A campaign needs an end date.');
+  if (input.holdoutPercent < 0 || input.holdoutPercent > 90) {
+    throw new Error('Holdout is between 0 and 90 percent.');
+  }
+  if (input.holdoutPercent === 0) {
+    // Allowed, but the console says what it costs rather than quietly letting
+    // the campaign become unmeasurable.
+    throw new Error(
+      'A 0% holdout leaves nothing to compare against, so the revenue impact cannot be ' +
+        'computed. Use 5–10% unless you genuinely do not want to know.',
+    );
+  }
+
+  const { error } = await client()
+    .from('campaigns')
+    .insert({
+      name: input.name.trim() || input.title.trim(),
+      title: input.title.trim(),
+      body: input.body.trim(),
+      cta_label: input.ctaLabel.trim(),
+      promo_code: input.promoCode || null,
+      ends_at: new Date(input.endsAt).toISOString(),
+      audience_countries: input.countries,
+      holdout_percent: input.holdoutPercent,
+    });
+  if (error) throw new Error(`creating the campaign failed: ${error.message}`);
+}
+
+export const campaignFunnel = (id: string) =>
+  call<FunnelRow>('baaki_admin_campaign_funnel', { p_campaign_id: id });
+
+export const campaignRevenue = (id: string) =>
+  call<CampaignRevenueRow>('baaki_admin_campaign_revenue', { p_campaign_id: id });
+
 export const flagResults = (key: string) =>
   call<FlagResultRow>('baaki_admin_flag_results', { p_key: key });
 

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -1,0 +1,286 @@
+import 'server-only';
+
+import { cookies } from 'next/headers';
+import { createClient } from '@supabase/supabase-js';
+
+import { isValidToken, SESSION_COOKIE } from './session';
+
+/**
+ * The only place the service key is read.
+ *
+ * `server-only` at the top is not decoration: it makes the build fail if any of
+ * this is ever imported from a client component, which is the single mistake
+ * that would put a key that bypasses RLS on every table into a browser bundle
+ * (ADR-013). It is cheaper to have the build refuse than to review for it.
+ *
+ * Every function here goes through `baaki_admin_*`, which return aggregates and
+ * are granted to `service_role` alone. Nothing in this app selects from a table
+ * directly — not because it could not, but so that what the console is able to
+ * see is one reviewable list in one migration rather than a habit spread over a
+ * dozen pages.
+ */
+
+function client() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set — see apps/admin/.env.example. ' +
+        'Note these are not the NEXT_PUBLIC_ names the other apps use, on purpose: a ' +
+        'NEXT_PUBLIC_ prefix is what would inline the key into the client bundle.',
+    );
+  }
+  return createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+/**
+ * Defence in depth behind the middleware.
+ *
+ * A route the matcher misses, a middleware that is skipped by a future Next
+ * change, a page rendered by something other than a request — all of them end
+ * here, with no session and no data.
+ */
+async function requireSession(): Promise<void> {
+  const jar = await cookies();
+  if (!(await isValidToken(jar.get(SESSION_COOKIE)?.value))) {
+    throw new Error('Not signed in');
+  }
+}
+
+/**
+ * PostgREST's code for "no such function". The overwhelmingly likely reason to
+ * see it is that `20260808190000_admin_analytics` has not been deployed to this
+ * project yet, which is a first-run state rather than a fault — so it degrades
+ * to no rows and lets the page say so, instead of answering a fresh setup with
+ * a stack trace.
+ */
+const FUNCTION_MISSING = 'PGRST202';
+
+/** The same first-run state, for a table rather than a function. */
+const TABLE_MISSING = 'PGRST205';
+
+async function call<T>(fn: string, args: Record<string, unknown> = {}): Promise<T[]> {
+  await requireSession();
+  const { data, error } = await client().rpc(fn, args);
+  if (error) {
+    if (error.code === FUNCTION_MISSING) return [];
+    // The message carries the function name: "permission denied for function"
+    // on its own does not say which, and that is worth telling from a bug.
+    throw new Error(`${fn} failed: ${error.message}`);
+  }
+  return (data ?? []) as T[];
+}
+
+export interface Overview {
+  profiles_total: number;
+  profiles_new_7d: number;
+  profiles_new_30d: number;
+  groups_total: number;
+  groups_new_30d: number;
+  groups_active_30d: number;
+  expenses_total: number;
+  expenses_new_30d: number;
+  expenses_deleted: number;
+  settlements_total: number;
+  settlements_confirmed: number;
+  active_profiles_7d: number;
+  active_profiles_30d: number;
+}
+
+export interface DailyRow {
+  day: string;
+  new_profiles: number;
+  new_groups: number;
+  new_expenses: number;
+  active_profiles: number;
+}
+
+export interface GeoRow {
+  country_code: string | null;
+  profile_count: number;
+  group_count: number;
+  expense_count: number;
+}
+
+export interface MoneyRow {
+  currency: string;
+  expense_count: number;
+  /** Minor units. A string from PostgREST because numeric does not fit a double. */
+  expense_minor: string;
+  settlement_count: number;
+  settlement_minor: string;
+}
+
+export interface AiCostRow {
+  day: string;
+  currency: string;
+  events: number;
+  input_tokens: number;
+  output_tokens: number;
+  cost_minor: string;
+}
+
+export interface LoginRow {
+  day: string;
+  sign_ins: number;
+}
+
+export async function overview(): Promise<Overview | null> {
+  const rows = await call<Overview>('baaki_admin_overview');
+  return rows[0] ?? null;
+}
+
+export interface FlagRow {
+  key: string;
+  description: string;
+  enabled: boolean;
+  rollout_percent: number;
+  variants: string[];
+  updated_at: string;
+}
+
+export interface FlagResultRow {
+  variant: string;
+  people: number;
+  expenses_created: number;
+  active_30d: number;
+}
+
+/**
+ * The one place this app reads a table rather than a function.
+ *
+ * `feature_flags` is configuration the console owns end to end — it is the
+ * thing being edited, not an aggregate over somebody's data, and there is no
+ * privacy question to keep at arm's length. The `baaki_admin_*` functions
+ * exist to bound what can be seen about *people*; this is a switchboard.
+ */
+export async function flags(): Promise<FlagRow[]> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('feature_flags')
+    .select('key, description, enabled, rollout_percent, variants, updated_at')
+    .order('key');
+  if (error) {
+    if (error.code === TABLE_MISSING) return [];
+    throw new Error(`reading feature_flags failed: ${error.message}`);
+  }
+  return (data ?? []) as FlagRow[];
+}
+
+export async function saveFlag(input: {
+  key: string;
+  description: string;
+  enabled: boolean;
+  rolloutPercent: number;
+  variants: string[];
+}): Promise<void> {
+  await requireSession();
+
+  // Checked here as well as by the CHECK constraints, so a typo comes back as
+  // a sentence rather than as a Postgres error string.
+  if (!/^[a-z][a-z0-9_]{1,60}$/.test(input.key)) {
+    throw new Error('A key is lowercase letters, digits and underscores, starting with a letter.');
+  }
+  if (input.rolloutPercent < 0 || input.rolloutPercent > 100) {
+    throw new Error('Rollout is a percentage between 0 and 100.');
+  }
+  if (new Set(input.variants).size !== input.variants.length || input.variants.length < 2) {
+    throw new Error('An experiment needs at least two distinct arms.');
+  }
+
+  const { error } = await client().from('feature_flags').upsert(
+    {
+      key: input.key,
+      description: input.description,
+      enabled: input.enabled,
+      rollout_percent: input.rolloutPercent,
+      variants: input.variants,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'key' },
+  );
+  if (error) throw new Error(`saving ${input.key} failed: ${error.message}`);
+}
+
+export interface PromoCodeRow {
+  code: string;
+  tier: string;
+  days: number;
+  max_redemptions: number;
+  redeemed_count: number;
+  expires_at: string | null;
+  note: string;
+  created_at: string;
+}
+
+export const promoCodes = () => call<PromoCodeRow>('baaki_admin_promo_codes');
+
+export async function createPromoCode(input: {
+  code: string;
+  days: number;
+  maxRedemptions: number;
+  note: string;
+}): Promise<void> {
+  await requireSession();
+
+  const code = input.code.trim().toUpperCase();
+  if (!/^[A-Z0-9]{4,24}$/.test(code)) {
+    throw new Error('A code is 4–24 letters and digits. It gets read aloud and typed by hand.');
+  }
+  if (input.days < 1 || input.days > 3650) throw new Error('Days must be between 1 and 3650.');
+  if (input.maxRedemptions < 1) throw new Error('A code has to be redeemable at least once.');
+
+  const { error } = await client().from('promo_codes').insert({
+    code,
+    days: input.days,
+    max_redemptions: input.maxRedemptions,
+    note: input.note,
+  });
+  if (error) {
+    if (error.code === '23505') throw new Error(`${code} already exists.`);
+    throw new Error(`creating ${code} failed: ${error.message}`);
+  }
+}
+
+/**
+ * Comp one named account.
+ *
+ * The RPC is keyed on the profile and the day, so pressing this twice in one
+ * support conversation is the same grant rather than two months — it reports
+ * `ALREADY_GRANTED_TODAY` instead of silently doubling.
+ */
+export async function grantPromo(profileId: string, days: number): Promise<string> {
+  await requireSession();
+
+  if (!/^[0-9a-f-]{36}$/i.test(profileId.trim())) {
+    throw new Error('That is not a profile id. Copy the uuid from the account you mean.');
+  }
+
+  const { data, error } = await client().rpc('baaki_admin_grant_promo', {
+    p_profile_id: profileId.trim(),
+    p_days: days,
+  });
+  if (error) throw new Error(`granting failed: ${error.message}`);
+
+  const verdict = data as { ok: boolean; reason?: string } | null;
+  if (!verdict?.ok) {
+    const reason = verdict?.reason ?? 'UNKNOWN';
+    if (reason === 'NO_SUCH_PROFILE') throw new Error('No account has that id.');
+    if (reason === 'ALREADY_GRANTED_TODAY') {
+      throw new Error('That account already has a grant from today. Grant again tomorrow.');
+    }
+    throw new Error(reason);
+  }
+  return 'Granted.';
+}
+
+export const flagResults = (key: string) =>
+  call<FlagResultRow>('baaki_admin_flag_results', { p_key: key });
+
+export const daily = (days = 30) => call<DailyRow>('baaki_admin_daily', { p_days: days });
+export const geo = () => call<GeoRow>('baaki_admin_geo');
+export const money = () => call<MoneyRow>('baaki_admin_money');
+export const aiCost = (days = 30) => call<AiCostRow>('baaki_admin_ai_cost', { p_days: days });
+export const logins = (days = 30) => call<LoginRow>('baaki_admin_logins', { p_days: days });

--- a/apps/admin/src/lib/session.ts
+++ b/apps/admin/src/lib/session.ts
@@ -1,0 +1,96 @@
+/**
+ * Who is allowed in.
+ *
+ * One operator, one password, a signed cookie. Deliberately not Supabase Auth:
+ * this console must keep working when the thing it is watching is broken, and
+ * an admin login that depends on the app's own auth is one that goes down with
+ * it. It is also a different trust boundary — a Baaki account is something
+ * anonymous guests get for free (ADR-006), and no amount of allowlisting makes
+ * "signed in to the app" mean "may read the whole business".
+ *
+ * Web Crypto rather than `node:crypto`, because this runs in middleware as well
+ * as in server components and the two do not have the same globals.
+ *
+ * What this is not: it is a single shared secret, so it has no second factor
+ * and no revocation short of changing the password. That is an accepted trade
+ * for a private, single-operator console — and the reason the deployment notes
+ * say to put it behind network restriction too rather than only behind this.
+ */
+
+const COOKIE = 'baaki_admin';
+
+/** Eight hours. Long enough for a working day, short enough to not be a key. */
+const TTL_SECONDS = 8 * 60 * 60;
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is not set. The admin console refuses to start without it — ` +
+        'see apps/admin/.env.example.',
+    );
+  }
+  return value;
+}
+
+/** Base64url, because a cookie value may not contain `+`, `/` or `=`. */
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function hmac(message: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message));
+  return toBase64Url(new Uint8Array(signature));
+}
+
+/**
+ * Compares two strings without leaking how far they matched.
+ *
+ * Both sides are HMACed with a key generated for this process before being
+ * compared, so the comparison runs over fixed-length digests an attacker cannot
+ * predict — the standard way to get a constant-time compare when the runtime
+ * does not offer one. A plain `===` on the password would leak its length and
+ * its prefix through timing.
+ */
+const compareKey = crypto.getRandomValues(new Uint8Array(32)).join('');
+
+async function equals(a: string, b: string): Promise<boolean> {
+  const [left, right] = await Promise.all([hmac(a, compareKey), hmac(b, compareKey)]);
+  return left === right;
+}
+
+export async function checkPassword(candidate: string): Promise<boolean> {
+  if (typeof candidate !== 'string' || candidate.length === 0) return false;
+  return equals(candidate, required('ADMIN_PASSWORD'));
+}
+
+/** `<expiry>.<signature>`. There is nothing to say beyond "this was us". */
+export async function issueToken(): Promise<{ name: string; value: string; maxAge: number }> {
+  const expiresAt = Math.floor(Date.now() / 1000) + TTL_SECONDS;
+  const signature = await hmac(String(expiresAt), required('ADMIN_SESSION_SECRET'));
+  return { name: COOKIE, value: `${expiresAt}.${signature}`, maxAge: TTL_SECONDS };
+}
+
+export async function isValidToken(token: string | undefined): Promise<boolean> {
+  if (!token) return false;
+  const [expiresAt, signature] = token.split('.');
+  if (!expiresAt || !signature) return false;
+
+  // Signature first, then expiry: an unsigned token has no expiry worth reading.
+  const expected = await hmac(expiresAt, required('ADMIN_SESSION_SECRET'));
+  if (!(await equals(signature, expected))) return false;
+
+  const seconds = Number(expiresAt);
+  return Number.isFinite(seconds) && seconds > Math.floor(Date.now() / 1000);
+}
+
+export const SESSION_COOKIE = COOKIE;

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { isValidToken, SESSION_COOKIE } from '@/lib/session';
+
+/**
+ * The gate, in front of everything.
+ *
+ * `proxy` rather than `middleware`: Next 16 deprecated that filename and warns
+ * on every build. Same function, same config, new name.
+ *
+ * Here rather than as a check inside each page, because the failure mode of
+ * per-page checks is a page somebody forgot to add one to — and here that page
+ * would be serving the whole business to the internet. `requireSession()` in
+ * the data layer repeats the check anyway: this is the door, that is the lock
+ * on the cabinet. That belt-and-braces already earned itself once — this file
+ * sat at the project root instead of in `src/`, where Next silently does not
+ * load it, and only the second check stopped the requests.
+ *
+ * Note this may run on a CDN edge separately from the render, so it holds no
+ * state and shares nothing with the pages beyond the cookie it validates.
+ */
+export async function proxy(request: NextRequest) {
+  if (await isValidToken(request.cookies.get(SESSION_COOKIE)?.value)) {
+    return NextResponse.next();
+  }
+
+  return NextResponse.redirect(new URL('/login', request.url));
+}
+
+export const config = {
+  /**
+   * Everything except the login screen itself and Next's own assets. Written as
+   * an exclusion so a route added later is protected by default — the opposite
+   * ordering is how a new page ships unguarded.
+   */
+  matcher: ['/((?!login|_next/static|_next/image|favicon.ico).*)'],
+};

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "jsx": "preserve",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "incremental": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "src", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "regions": ["sin1"]
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,6 +7,7 @@
     "@baaki/ui": "workspace:*",
     "@expo/ui": "~57.0.9",
     "@expo/vector-icons": "^15.1.1",
+    "@microsoft/react-native-clarity": "^4.6.3",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "9.1.0",
     "@react-native-ml-kit/text-recognition": "^2.0.0",

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -144,14 +144,6 @@ function settingsRows(t: UiStrings): SettingsRow[] {
       hint: t.privacy.rowHint,
       route: '/settings/privacy',
     },
-    // Last, and after the export row above it: somebody who has decided to
-    // leave should pass their own data on the way out.
-    {
-      icon: 'trash-outline',
-      label: t.privacy.deleteRow,
-      hint: t.privacy.deleteRowHint,
-      route: '/settings/delete-account',
-    },
   ];
 }
 
@@ -606,6 +598,17 @@ export default function ProfileScreen() {
                   label: t.lock.signOut,
                   hint: signOutHint,
                   onPress: confirmSignOut,
+                },
+                // Last row of the last section, under Sign out. It first sat in
+                // the middle of the settings list, because `settingsRows` is
+                // spread before Motion is appended — which put an irreversible
+                // action between "import a spreadsheet" and "animations on".
+                // Running it on a device is what showed that.
+                {
+                  icon: 'trash-outline',
+                  label: t.privacy.deleteRow,
+                  hint: t.privacy.deleteRowHint,
+                  route: '/settings/delete-account',
                 },
               ]}
             />

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -132,6 +132,26 @@ function settingsRows(t: UiStrings): SettingsRow[] {
       hint: t.account.importHint,
       route: '/settings/import',
     },
+    {
+      icon: 'chatbubble-ellipses-outline',
+      label: t.privacy.feedbackRow,
+      hint: t.privacy.feedbackRowHint,
+      route: '/settings/feedback',
+    },
+    {
+      icon: 'shield-checkmark-outline',
+      label: t.privacy.row,
+      hint: t.privacy.rowHint,
+      route: '/settings/privacy',
+    },
+    // Last, and after the export row above it: somebody who has decided to
+    // leave should pass their own data on the way out.
+    {
+      icon: 'trash-outline',
+      label: t.privacy.deleteRow,
+      hint: t.privacy.deleteRowHint,
+      route: '/settings/delete-account',
+    },
   ];
 }
 

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -44,6 +44,8 @@ interface SettingsRow {
   hint: string;
   route?: string;
   onPress?: () => void;
+  /** Ends something. Red title, red icon. */
+  destructive?: boolean;
 }
 
 function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }) {
@@ -59,6 +61,7 @@ function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }
               <ListRow
                 title={item.label}
                 subtitle={item.hint}
+                destructive={item.destructive}
                 onPress={
                   item.onPress ?? (item.route ? () => router.push(item.route as never) : undefined)
                 }
@@ -70,13 +73,23 @@ function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }
                       borderRadius: theme.radius.pill,
                       alignItems: 'center',
                       justifyContent: 'center',
-                      backgroundColor: live ? theme.color.brandSoft : theme.color.surfaceMuted,
+                      backgroundColor: item.destructive
+                        ? theme.color.negativeSoft
+                        : live
+                          ? theme.color.brandSoft
+                          : theme.color.surfaceMuted,
                     }}
                   >
                     <Ionicons
                       name={item.icon}
                       size={18}
-                      color={live ? theme.color.brand : theme.color.textMuted}
+                      color={
+                        item.destructive
+                          ? theme.color.negative
+                          : live
+                            ? theme.color.brand
+                            : theme.color.textMuted
+                      }
                     />
                   </View>
                 }
@@ -598,6 +611,7 @@ export default function ProfileScreen() {
                   label: t.lock.signOut,
                   hint: signOutHint,
                   onPress: confirmSignOut,
+                  destructive: true,
                 },
                 // Last row of the last section, under Sign out. It first sat in
                 // the middle of the settings list, because `settingsRows` is
@@ -609,6 +623,7 @@ export default function ProfileScreen() {
                   label: t.privacy.deleteRow,
                   hint: t.privacy.deleteRowHint,
                   route: '/settings/delete-account',
+                  destructive: true,
                 },
               ]}
             />

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -20,6 +20,7 @@ import { LocaleSync } from '@/i18n/localeSync';
 import { LockProvider, useLock } from '@/lib/lock';
 import { MotionProvider, TRANSITION_MS, useMotion } from '@/lib/motion';
 import { UpdateProvider } from '@/lib/update';
+import { initClarity } from '@/lib/clarity';
 import { initObservability, withObservability } from '@/lib/observability';
 import { ensureAndroidChannel, pushSupported, routeForNotification } from '@/lib/push';
 import { SyncProvider } from '@/sync';
@@ -27,6 +28,11 @@ import { SyncProvider } from '@/sync';
 // Before anything else renders, so a crash in the first frame is still caught.
 // Inert unless a DSN is configured.
 initObservability();
+
+// Brought up capturing nothing. Session replay would otherwise record other
+// people's expense descriptions, amounts and payment handles from the first
+// frame; `allowSessionReplay` is the only thing that starts it.
+initClarity();
 
 // Arriving while the app is open should still surface: a notification that is
 // silently swallowed because you happened to be looking at the app is the one

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -322,6 +322,9 @@ function AuthGate() {
       <Stack.Screen name="settings/language" />
       <Stack.Screen name="settings/upgrade" />
       <Stack.Screen name="settings/account" />
+      <Stack.Screen name="settings/feedback" />
+      <Stack.Screen name="settings/privacy" />
+      <Stack.Screen name="settings/delete-account" />
       <Stack.Screen name="join" />
       <Stack.Screen name="inbox" />
     </Stack>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -11,6 +11,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { Button, CurvedPanel, setLayoutDirection, ThemeProvider, Text, useTheme } from '@baaki/ui';
 
+import { CampaignPopup } from '@/components/CampaignPopup';
 import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
 import { isRtl, isRtlLanguage, useStrings } from '@/i18n';
@@ -115,6 +116,10 @@ function RootLayout() {
                           <PushRouting />
                           <LockGate>
                             <AuthGate />
+                            {/* Inside the lock on purpose: a promotion is not a
+                                reason to show somebody's phone anything before
+                                they have unlocked it. */}
+                            <CampaignPopup />
                           </LockGate>
                           {/* Last, so it paints over the screen rather than
                               under it. */}

--- a/apps/mobile/src/app/settings/delete-account.tsx
+++ b/apps/mobile/src/app/settings/delete-account.tsx
@@ -8,6 +8,7 @@ import { Button, Card, directionalIcon, IconButton, Row, Screen, Text, useTheme 
 
 import { deleteMyAccount, erasurePreview } from '@/data/api';
 import { fill, useStrings } from '@/i18n';
+import { friendlyError } from '@/lib/errors';
 import { useAuth } from '@/lib/auth';
 
 /**
@@ -49,7 +50,7 @@ export default function DeleteAccountScreen() {
       // holds everything, with no way back in to try again.
       await signOut();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.privacy.couldNotSave, 'account.delete'));
     } finally {
       setBusy(false);
     }
@@ -104,14 +105,31 @@ export default function DeleteAccountScreen() {
           <Text variant="caption" tone="muted">
             {t.privacy.deleteStaysBody}
           </Text>
+          {/* Labelled, because the first version of this rendered as "1 · 3 · 0
+              · INR" — four numbers with nothing saying what any of them
+              counted, on the screen where somebody is deciding whether to
+              erase themselves. */}
           {preview.data ? (
-            <Text variant="micro" tone="faint">
-              {preview.data.groups_count} · {preview.data.expenses_authored} ·{' '}
-              {preview.data.settlements_involved}
-              {preview.data.outstanding_currencies.length > 0
-                ? ` · ${preview.data.outstanding_currencies.join(', ')}`
-                : ''}
-            </Text>
+            <View style={{ gap: 2, paddingTop: theme.spacing.xs }}>
+              <Text variant="micro" tone="faint">
+                {fill(t.privacy.previewGroups, { n: String(preview.data.groups_count) })}
+              </Text>
+              <Text variant="micro" tone="faint">
+                {fill(t.privacy.previewExpenses, { n: String(preview.data.expenses_authored) })}
+              </Text>
+              <Text variant="micro" tone="faint">
+                {fill(t.privacy.previewSettlements, {
+                  n: String(preview.data.settlements_involved),
+                })}
+              </Text>
+              {preview.data.outstanding_currencies.length > 0 ? (
+                <Text variant="micro" tone="negative">
+                  {fill(t.privacy.previewOutstanding, {
+                    list: preview.data.outstanding_currencies.join(', '),
+                  })}
+                </Text>
+              ) : null}
+            </View>
           ) : null}
         </Card>
 

--- a/apps/mobile/src/app/settings/delete-account.tsx
+++ b/apps/mobile/src/app/settings/delete-account.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
+
+import { Button, Card, directionalIcon, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+
+import { deleteMyAccount, erasurePreview } from '@/data/api';
+import { fill, useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+
+/**
+ * Leaving, with the consequence in view before the button.
+ *
+ * The screen leads with what does *not* go, because that is the part people do
+ * not expect: expenses in a shared group are also other people's records, and
+ * removing them would silently change somebody else's balance to settle a debt
+ * nobody paid. Saying so first is the difference between a promise the app can
+ * keep and one it cannot.
+ *
+ * Export sits above the confirmation on purpose. Somebody who has decided to
+ * leave should be offered their data on the way out rather than reminded of it
+ * afterwards.
+ */
+export default function DeleteAccountScreen() {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const { signOut } = useAuth();
+
+  const [reason, setReason] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<string | null>(null);
+
+  const preview = useQuery({ queryKey: ['erasure-preview'], queryFn: erasurePreview });
+
+  const armed = confirm.trim().toUpperCase() === t.privacy.deleteConfirmWord;
+
+  const run = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await deleteMyAccount(reason.trim() || null);
+      setDone(fill(t.privacy.deleteSummary, { n: String(result.memberships_anonymised ?? 0) }));
+      // Signing out is the last thing, and only after the data is gone: the
+      // reverse order would leave somebody signed out of an account that still
+      // holds everything, with no way back in to try again.
+      await signOut();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <Screen>
+        <View style={{ flex: 1, justifyContent: 'center', padding: theme.spacing.xxxl, gap: 16 }}>
+          <Text variant="title" align="center">
+            {t.privacy.deleteDone}
+          </Text>
+          <Text variant="caption" tone="muted" align="center">
+            {done}
+          </Text>
+        </View>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.privacy.deleteTitle}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        <Text variant="body" tone="muted">
+          {t.privacy.deleteIntro}
+        </Text>
+
+        {/* What stays comes first: it is the surprising half. */}
+        <Card style={{ gap: theme.spacing.sm, borderWidth: 1, borderColor: theme.color.border }}>
+          <Row style={{ gap: theme.spacing.sm }}>
+            <Ionicons name="people-outline" size={18} color={theme.color.text} />
+            <Text variant="subheading">{t.privacy.deleteStaysTitle}</Text>
+          </Row>
+          <Text variant="caption" tone="muted">
+            {t.privacy.deleteStaysBody}
+          </Text>
+          {preview.data ? (
+            <Text variant="micro" tone="faint">
+              {preview.data.groups_count} · {preview.data.expenses_authored} ·{' '}
+              {preview.data.settlements_involved}
+              {preview.data.outstanding_currencies.length > 0
+                ? ` · ${preview.data.outstanding_currencies.join(', ')}`
+                : ''}
+            </Text>
+          ) : null}
+        </Card>
+
+        <Card style={{ gap: theme.spacing.sm }}>
+          <Row style={{ gap: theme.spacing.sm }}>
+            <Ionicons name="trash-outline" size={18} color={theme.color.negative} />
+            <Text variant="subheading">{t.privacy.deleteGoesTitle}</Text>
+          </Row>
+          <Text variant="caption" tone="muted">
+            {t.privacy.deleteGoesBody}
+          </Text>
+        </Card>
+
+        <Button
+          label={t.privacy.deleteExportFirst}
+          variant="secondary"
+          onPress={() => router.push('/settings/export')}
+        />
+
+        <View style={{ gap: theme.spacing.xs }}>
+          <Text variant="caption" tone="muted">
+            {t.privacy.deleteWhyLabel}
+          </Text>
+          <Card>
+            <TextInput
+              value={reason}
+              onChangeText={setReason}
+              placeholder={t.privacy.deleteWhyPlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              accessibilityLabel={t.privacy.deleteWhyLabel}
+              multiline
+              maxLength={4000}
+              style={{
+                minHeight: 80,
+                fontSize: 15,
+                color: theme.color.text,
+                textAlignVertical: 'top',
+              }}
+            />
+          </Card>
+        </View>
+
+        <View style={{ gap: theme.spacing.xs }}>
+          <Text variant="caption" tone="muted">
+            {t.privacy.deleteConfirmLabel}
+          </Text>
+          <Card>
+            <TextInput
+              value={confirm}
+              onChangeText={setConfirm}
+              placeholder={t.privacy.deleteConfirmWord}
+              placeholderTextColor={theme.color.textFaint}
+              accessibilityLabel={t.privacy.deleteConfirmLabel}
+              autoCapitalize="characters"
+              autoCorrect={false}
+              style={{ fontSize: 18, fontWeight: '700', color: theme.color.text }}
+            />
+          </Card>
+        </View>
+
+        {error ? (
+          <Text variant="caption" tone="negative">
+            {error}
+          </Text>
+        ) : null}
+        {busy ? <ActivityIndicator color={theme.color.negative} /> : null}
+
+        <Button
+          label={busy ? t.privacy.deleteWorking : t.privacy.deleteButton}
+          size="lg"
+          fullWidth
+          variant="danger"
+          disabled={!armed || busy}
+          onPress={() => void run()}
+        />
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/settings/feedback.tsx
+++ b/apps/mobile/src/app/settings/feedback.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import Constants from 'expo-constants';
+import { router } from 'expo-router';
+import { ActivityIndicator, Platform, ScrollView, TextInput, View } from 'react-native';
+
+import {
+  Button,
+  Card,
+  ChipRow,
+  directionalIcon,
+  IconButton,
+  Row,
+  Screen,
+  Text,
+  useTheme,
+} from '@baaki/ui';
+
+import { submitFeedback } from '@/data/api';
+import { useStrings } from '@/i18n';
+
+type Kind = 'general' | 'bug' | 'idea';
+
+export default function FeedbackScreen() {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  const [kind, setKind] = useState<Kind>('general');
+  const [message, setMessage] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+
+  const send = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      await submitFeedback({
+        message: message.trim(),
+        kind,
+        // Version and platform go along because "it crashes" is a different
+        // report on an old build than on the current one, and asking somebody
+        // to find their build number is asking them not to bother.
+        appVersion: Constants.expoConfig?.version ?? null,
+        platform: Platform.OS,
+      });
+      setSent(true);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.privacy.feedbackTitle}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        {sent ? (
+          <Card style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+            <Ionicons name="checkmark-circle" size={40} color={theme.color.positive} />
+            <Text variant="subheading" align="center">
+              {t.privacy.feedbackThanks}
+            </Text>
+            <Button label={t.common.close} variant="secondary" onPress={() => router.back()} />
+          </Card>
+        ) : (
+          <>
+            <Text variant="body" tone="muted">
+              {t.privacy.feedbackHint}
+            </Text>
+
+            <ChipRow<Kind>
+              value={kind}
+              onChange={setKind}
+              options={[
+                { value: 'general', label: t.privacy.kindGeneral },
+                { value: 'bug', label: t.privacy.kindBug },
+                { value: 'idea', label: t.privacy.kindIdea },
+              ]}
+            />
+
+            <Card>
+              <TextInput
+                value={message}
+                onChangeText={setMessage}
+                placeholder={t.privacy.feedbackPlaceholder}
+                placeholderTextColor={theme.color.textFaint}
+                accessibilityLabel={t.privacy.feedbackTitle}
+                multiline
+                autoFocus
+                maxLength={4000}
+                style={{
+                  minHeight: 140,
+                  fontSize: 16,
+                  color: theme.color.text,
+                  textAlignVertical: 'top',
+                }}
+              />
+            </Card>
+
+            {error ? (
+              <Text variant="caption" tone="negative">
+                {error}
+              </Text>
+            ) : null}
+            {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
+
+            <Button
+              label={t.privacy.feedbackSend}
+              size="lg"
+              fullWidth
+              disabled={busy || message.trim().length === 0}
+              onPress={() => void send()}
+            />
+          </>
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/settings/feedback.tsx
+++ b/apps/mobile/src/app/settings/feedback.tsx
@@ -18,6 +18,7 @@ import {
 
 import { submitFeedback } from '@/data/api';
 import { useStrings } from '@/i18n';
+import { friendlyError } from '@/lib/errors';
 
 type Kind = 'general' | 'bug' | 'idea';
 
@@ -46,7 +47,10 @@ export default function FeedbackScreen() {
       });
       setSent(true);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      // Never the raw message. On an emulator this screen once showed somebody
+      // "Could not find the function public.baaki_submit_feedback(...) in the
+      // schema cache" while they were mid-complaint.
+      setError(friendlyError(caught, t.privacy.couldNotSave, 'feedback.submit'));
     } finally {
       setBusy(false);
     }

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -23,6 +23,7 @@ export default function PrivacyScreen() {
   const sections = [
     { title: t.privacy.storeTitle, body: t.privacy.storeBody, icon: 'file-tray-outline' },
     { title: t.privacy.protectTitle, body: t.privacy.protectBody, icon: 'lock-closed-outline' },
+    { title: t.privacy.analyticsTitle, body: t.privacy.analyticsBody, icon: 'stats-chart-outline' },
     { title: t.privacy.choicesTitle, body: t.privacy.choicesBody, icon: 'hand-left-outline' },
   ] as const;
 

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -1,0 +1,71 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { ScrollView, View } from 'react-native';
+
+import { Card, directionalIcon, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+
+/**
+ * What is held, how it is kept, and what somebody can do about it.
+ *
+ * Written from what the app actually does rather than from a template: every
+ * claim here is one this codebase can be checked against — row-level security
+ * on every table (ADR-013), receipts in a private bucket behind signed links,
+ * crash reports scrubbed before they leave the phone, export free and lossless
+ * (ADR-012). A policy that promises something the code does not do is worse
+ * than no policy, because it is the one people rely on.
+ */
+export default function PrivacyScreen() {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  const sections = [
+    { title: t.privacy.storeTitle, body: t.privacy.storeBody, icon: 'file-tray-outline' },
+    { title: t.privacy.protectTitle, body: t.privacy.protectBody, icon: 'lock-closed-outline' },
+    { title: t.privacy.choicesTitle, body: t.privacy.choicesBody, icon: 'hand-left-outline' },
+  ] as const;
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.privacy.title}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        <Text variant="body" tone="muted">
+          {t.privacy.intro}
+        </Text>
+
+        {sections.map((section) => (
+          <Card key={section.title} style={{ gap: theme.spacing.sm }}>
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Ionicons name={section.icon} size={18} color={theme.color.brand} />
+              <Text variant="subheading">{section.title}</Text>
+            </Row>
+            <Text variant="caption" tone="muted">
+              {section.body}
+            </Text>
+          </Card>
+        ))}
+
+        <Text variant="micro" tone="faint">
+          {t.privacy.englishGoverns}
+        </Text>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/components/CampaignPopup.tsx
+++ b/apps/mobile/src/components/CampaignPopup.tsx
@@ -1,0 +1,155 @@
+/**
+ * The announcement, once.
+ *
+ * A campaign is the one thing in this app that interrupts somebody who came to
+ * do something else, so it earns its place by being rare and easy to dismiss.
+ * The server decides whether there is anything to show — `baaki_my_campaign()`
+ * returns at most one row, already filtered by country, by date, by whether it
+ * has been seen, and by the holdout. The app cannot tell whether it is in the
+ * holdout or whether a campaign exists that it was not offered, and that is
+ * deliberate: a control group that knows it is a control group is not one.
+ *
+ * The impression is recorded when it is shown rather than when it is dismissed.
+ * A person who opens the app, sees this, and force-quits has still seen it, and
+ * the funnel should say so.
+ */
+
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Modal, Pressable, View } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+
+import { Button, Text, useTheme } from '@baaki/ui';
+
+import { useAuth } from '@/lib/auth';
+import { supabase } from '@/lib/supabase';
+
+interface Campaign {
+  id: string;
+  title: string;
+  body: string;
+  cta_label: string;
+  promo_code: string | null;
+  ends_at: string;
+}
+
+async function fetchCampaign(): Promise<Campaign | null> {
+  const { data, error } = await supabase.rpc('baaki_my_campaign');
+  // An announcement is never worth an error state on somebody's expense screen.
+  if (error) return null;
+  const rows = (data ?? []) as Campaign[];
+  return rows[0] ?? null;
+}
+
+export function CampaignPopup() {
+  const theme = useTheme();
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+  const [dismissed, setDismissed] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const { data: campaign } = useQuery({
+    queryKey: ['campaign'],
+    queryFn: fetchCampaign,
+    enabled: Boolean(session),
+    // Checked once a session. A campaign that starts while somebody is mid-tap
+    // can wait until the next launch.
+    staleTime: Infinity,
+    retry: 1,
+  });
+
+  const seen = useMutation({
+    mutationFn: async ({ id, acted }: { id: string; acted: boolean }) => {
+      await supabase.rpc('baaki_campaign_seen', { p_campaign_id: id, p_acted: acted });
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['campaign'] }),
+  });
+
+  // On show, not on dismiss: somebody who reads this and force-quits has still
+  // been reached, and the funnel would otherwise never know.
+  useEffect(() => {
+    if (campaign && !dismissed) seen.mutate({ id: campaign.id, acted: false });
+    // Only when the campaign itself changes — re-running on every render of the
+    // mutation object would report the same impression forever.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [campaign?.id]);
+
+  if (!campaign || dismissed) return null;
+
+  const close = () => setDismissed(true);
+
+  const act = async () => {
+    if (campaign.promo_code) {
+      await Clipboard.setStringAsync(campaign.promo_code);
+      setCopied(true);
+    }
+    seen.mutate({ id: campaign.id, acted: true });
+  };
+
+  return (
+    <Modal transparent animationType="fade" visible onRequestClose={close}>
+      {/* Tapping outside closes it. An announcement that traps somebody is an
+          advertisement, and this is not one. */}
+      <Pressable
+        onPress={close}
+        accessibilityLabel="Dismiss"
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(10, 10, 26, 0.55)',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: theme.spacing.xxl,
+        }}
+      >
+        {/* Swallows the tap so pressing the card itself does not dismiss it. */}
+        <Pressable
+          onPress={() => {}}
+          style={{
+            width: '100%',
+            maxWidth: 380,
+            backgroundColor: theme.color.surface,
+            borderRadius: theme.radius.xl,
+            padding: theme.spacing.xxl,
+            gap: theme.spacing.md,
+            ...theme.shadow.lifted,
+          }}
+        >
+          <Text variant="title">{campaign.title}</Text>
+          {campaign.body ? (
+            <Text variant="body" tone="muted">
+              {campaign.body}
+            </Text>
+          ) : null}
+
+          {campaign.promo_code ? (
+            <View
+              style={{
+                backgroundColor: theme.color.brandSoft,
+                borderRadius: theme.radius.md,
+                paddingVertical: theme.spacing.md,
+                alignItems: 'center',
+              }}
+            >
+              <Text variant="heading" tone="brand">
+                {campaign.promo_code}
+              </Text>
+              <Text variant="micro" tone="muted">
+                {copied ? 'Copied' : 'Tap the button to copy'}
+              </Text>
+            </View>
+          ) : null}
+
+          <View style={{ gap: theme.spacing.sm, paddingTop: theme.spacing.sm }}>
+            <Button
+              label={campaign.cta_label || 'Got it'}
+              size="lg"
+              fullWidth
+              onPress={() => void act()}
+            />
+            <Button label="Not now" variant="secondary" size="sm" fullWidth onPress={close} />
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1316,3 +1316,51 @@ export async function publishReceiptItems(
   });
   if (error) throw new Error(error.message);
 }
+
+// ────────────────────────────────────── feedback, and leaving ──
+
+export async function submitFeedback(input: {
+  message: string;
+  kind: 'general' | 'bug' | 'idea';
+  appVersion: string | null;
+  platform: string;
+}): Promise<void> {
+  const { error } = await supabase.rpc('baaki_submit_feedback', {
+    p_message: input.message,
+    p_kind: input.kind,
+    p_app_version: input.appVersion,
+    p_platform: input.platform,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export interface ErasurePreview {
+  groups_count: number;
+  expenses_authored: number;
+  settlements_involved: number;
+  outstanding_currencies: string[];
+}
+
+/** What erasure would leave behind, so the screen can say so before the button. */
+export async function erasurePreview(): Promise<ErasurePreview | null> {
+  const { data, error } = await supabase.rpc('baaki_my_erasure_preview');
+  if (error) throw new Error(error.message);
+  const rows = (data ?? []) as ErasurePreview[];
+  return rows[0] ?? null;
+}
+
+/**
+ * Erase the person, keep the ledger.
+ *
+ * The RPC converts every membership to an unnamed ghost and deletes the profile
+ * with everything personal hanging off it. It does not remove the auth identity
+ * — that lives in a schema the database role does not own — so the caller signs
+ * out afterwards and the account can no longer reach anything.
+ */
+export async function deleteMyAccount(
+  reason: string | null,
+): Promise<{ memberships_anonymised?: number }> {
+  const { data, error } = await supabase.rpc('baaki_delete_my_account', { p_feedback: reason });
+  if (error) throw new Error(error.message);
+  return (data ?? {}) as { memberships_anonymised?: number };
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -817,6 +817,54 @@ export interface UiStrings {
     whatNeverWillBody: string;
   };
   /** The rest: one or two strings each, from a dozen screens. */
+  /**
+   * Feedback, the policy screens, and erasure.
+   *
+   * The policy prose is translated, and the screen says the English text
+   * governs — a mistranslated sentence about what happens to somebody's data
+   * is worse than an untranslated one, and saying which version is
+   * authoritative is the ordinary way to carry that.
+   */
+  privacy: {
+    row: string;
+    rowHint: string;
+    title: string;
+    intro: string;
+    storeTitle: string;
+    storeBody: string;
+    protectTitle: string;
+    protectBody: string;
+    choicesTitle: string;
+    choicesBody: string;
+    englishGoverns: string;
+    feedbackRow: string;
+    feedbackRowHint: string;
+    feedbackTitle: string;
+    feedbackHint: string;
+    feedbackPlaceholder: string;
+    feedbackSend: string;
+    feedbackThanks: string;
+    kindGeneral: string;
+    kindBug: string;
+    kindIdea: string;
+    deleteRow: string;
+    deleteRowHint: string;
+    deleteTitle: string;
+    deleteIntro: string;
+    deleteGoesTitle: string;
+    deleteGoesBody: string;
+    deleteStaysTitle: string;
+    deleteStaysBody: string;
+    deleteExportFirst: string;
+    deleteWhyLabel: string;
+    deleteWhyPlaceholder: string;
+    deleteConfirmLabel: string;
+    deleteConfirmWord: string;
+    deleteButton: string;
+    deleteWorking: string;
+    deleteDone: string;
+    deleteSummary: string;
+  };
   extras: {
     blankNameHint: string;
     whatKindOfGroup: string;
@@ -1594,6 +1642,55 @@ const en: UiStrings = {
     whatNeverWill: 'What never will',
     whatNeverWillBody:
       'The ledger. Groups, expenses, splits, balances, settling up, and getting all of it back out again — {free}. A ledger you can only half read is not a ledger.',
+  },
+  privacy: {
+    row: 'Privacy & security',
+    rowHint: 'What is stored, and how it is kept',
+    title: 'Privacy & security',
+    intro:
+      'Baaki holds as little about you as it can and still work. This describes what that is, in plain terms.',
+    storeTitle: 'What is stored',
+    storeBody:
+      'Your display name, and whichever of a phone number, email or sign-in identity you used. Optionally a payment handle, so somebody can pay you back, and a country, which decides which payment rails you are offered. The groups you are in, the expenses in them, and who owes whom. Nothing else: no contacts are uploaded, and there is no advertising identifier.',
+    protectTitle: 'How it is kept',
+    protectBody:
+      'Every table is behind row-level security in the database, so a request can only ever read rows your own account is entitled to — not a filter applied by the app, but a rule the database enforces. Receipt images sit in a private bucket reached through short-lived signed links. Crash reports are scrubbed of addresses, phone numbers, payment handles and keys before they leave the phone. You can require your fingerprint or face to open the app.',
+    choicesTitle: 'What you can do',
+    choicesBody:
+      'Export everything you have entered, at any time, in full fidelity and for free. Turn off any notification. Delete your account and the personal data in it. Write to us with anything you want changed.',
+    englishGoverns:
+      'This text is translated for convenience. Where a translation and the English differ, the English is the one that governs.',
+    feedbackRow: 'Send feedback',
+    feedbackRowHint: 'Tell us what is wrong, or what is missing',
+    feedbackTitle: 'Send feedback',
+    feedbackHint:
+      'Read by a person, not a queue. Say as much or as little as you like — it helps most when it is specific.',
+    feedbackPlaceholder: 'What happened, or what you wish it did',
+    feedbackSend: 'Send',
+    feedbackThanks: 'Thank you — that has been received.',
+    kindGeneral: 'General',
+    kindBug: 'Something is broken',
+    kindIdea: 'An idea',
+    deleteRow: 'Delete my data',
+    deleteRowHint: 'Remove your account and personal details',
+    deleteTitle: 'Delete my data',
+    deleteIntro:
+      'This cannot be undone. Please read what it does and does not remove — the second part is the one that surprises people.',
+    deleteGoesTitle: 'What is removed',
+    deleteGoesBody:
+      'Your name, photo, payment handle, country, language and notification settings. Your sign-in, so this account can no longer be opened. Your devices, notification history, purchases and anything the AI scanner recorded about your usage.',
+    deleteStaysTitle: 'What stays, and why',
+    deleteStaysBody:
+      "The expenses and settlements in your shared groups remain, because they are also other people's records — they are what says who owes whom, and removing them would silently change somebody else's balance to settle a debt nobody paid. You become an unnamed former member in those groups. Your name is gone from them; your share of the dinner is not.",
+    deleteExportFirst: 'Export your data first',
+    deleteWhyLabel: 'Why are you leaving? (optional)',
+    deleteWhyPlaceholder: 'It helps to know, and it is kept after your account is gone',
+    deleteConfirmLabel: 'Type DELETE to confirm',
+    deleteConfirmWord: 'DELETE',
+    deleteButton: 'Delete my data',
+    deleteWorking: 'Deleting…',
+    deleteDone: 'Your data has been deleted.',
+    deleteSummary: 'You are now a former member of {n} group(s).',
   },
   extras: {
     blankNameHint: 'Leave it blank and the group is named after whoever is in it.',
@@ -2409,6 +2506,55 @@ const ta: UiStrings = {
     whatNeverWillBody:
       'கணக்கு. குழுக்கள், செலவுகள், பிரிவுகள், இருப்புகள், தீர்த்தல், அனைத்தையும் திரும்பப் பெறுதல் — {free}. பாதி மட்டுமே படிக்கக்கூடிய கணக்கு கணக்கே அல்ல.',
   },
+  privacy: {
+    row: 'தனியுரிமை & பாதுகாப்பு',
+    rowHint: 'என்ன சேமிக்கப்படுகிறது, எப்படி பாதுகாக்கப்படுகிறது',
+    title: 'தனியுரிமை & பாதுகாப்பு',
+    intro:
+      'பாக்கி வேலை செய்ய எவ்வளவு தேவையோ அவ்வளவு மட்டுமே உங்களைப் பற்றி வைத்திருக்கிறது. அது என்ன என்பது இங்கே.',
+    storeTitle: 'என்ன சேமிக்கப்படுகிறது',
+    storeBody:
+      'உங்கள் பெயர், நீங்கள் பயன்படுத்திய தொலைபேசி எண், மின்னஞ்சல் அல்லது உள்நுழைவு அடையாளம். விருப்பப்படி ஒரு பணப் பரிமாற்ற முகவரி, மற்றும் ஒரு நாடு. நீங்கள் இருக்கும் குழுக்கள், அவற்றின் செலவுகள், யார் யாருக்குக் கடன்பட்டவர். வேறு எதுவும் இல்லை: தொடர்புகள் பதிவேற்றப்படுவதில்லை, விளம்பர அடையாளம் இல்லை.',
+    protectTitle: 'எப்படி பாதுகாக்கப்படுகிறது',
+    protectBody:
+      'ஒவ்வொரு அட்டவணையும் தரவுத்தளத்தில் வரிசை-நிலை பாதுகாப்பின் பின்னால் உள்ளது — செயலி வடிகட்டுவதல்ல, தரவுத்தளமே அமல்படுத்தும் விதி. ரசீது படங்கள் தனிப்பட்ட இடத்தில், குறுகிய கால இணைப்புகள் வழியாக மட்டுமே. செயலி முறிவு அறிக்கைகளிலிருந்து முகவரிகள், எண்கள், பணமுகவரிகள் தொலைபேசியை விட்டு வெளியேறும் முன்பே நீக்கப்படுகின்றன.',
+    choicesTitle: 'நீங்கள் என்ன செய்யலாம்',
+    choicesBody:
+      'நீங்கள் உள்ளிட்ட அனைத்தையும் எப்போது வேண்டுமானாலும், முழுமையாக, இலவசமாக ஏற்றுமதி செய்யலாம். எந்த அறிவிப்பையும் நிறுத்தலாம். உங்கள் கணக்கையும் அதிலுள்ள தனிப்பட்ட தரவையும் நீக்கலாம்.',
+    englishGoverns:
+      'இந்த உரை வசதிக்காக மொழிபெயர்க்கப்பட்டுள்ளது. மொழிபெயர்ப்புக்கும் ஆங்கிலத்துக்கும் வேறுபாடு இருந்தால், ஆங்கிலமே செல்லுபடியாகும்.',
+    feedbackRow: 'கருத்து அனுப்பு',
+    feedbackRowHint: 'என்ன தவறு, அல்லது என்ன இல்லை என்று சொல்லுங்கள்',
+    feedbackTitle: 'கருத்து அனுப்பு',
+    feedbackHint:
+      'ஒரு நபரால் படிக்கப்படும். எவ்வளவு வேண்டுமானாலும் எழுதலாம் — குறிப்பிட்டதாக இருந்தால் அதிகம் உதவும்.',
+    feedbackPlaceholder: 'என்ன நடந்தது, அல்லது என்ன இருக்க வேண்டும் என நினைக்கிறீர்கள்',
+    feedbackSend: 'அனுப்பு',
+    feedbackThanks: 'நன்றி — கிடைத்துவிட்டது.',
+    kindGeneral: 'பொது',
+    kindBug: 'ஏதோ வேலை செய்யவில்லை',
+    kindIdea: 'ஒரு யோசனை',
+    deleteRow: 'என் தரவை நீக்கு',
+    deleteRowHint: 'உங்கள் கணக்கையும் தனிப்பட்ட விவரங்களையும் நீக்கு',
+    deleteTitle: 'என் தரவை நீக்கு',
+    deleteIntro:
+      'இதை மீட்டெடுக்க முடியாது. என்ன நீக்கப்படும், என்ன நீக்கப்படாது என்பதைப் படியுங்கள் — இரண்டாவது பகுதிதான் பலரை ஆச்சரியப்படுத்துகிறது.',
+    deleteGoesTitle: 'என்ன நீக்கப்படும்',
+    deleteGoesBody:
+      'உங்கள் பெயர், படம், பணமுகவரி, நாடு, மொழி, அறிவிப்பு அமைப்புகள். உங்கள் உள்நுழைவு — இந்தக் கணக்கை இனி திறக்க முடியாது. உங்கள் சாதனங்கள், அறிவிப்பு வரலாறு, கொள்முதல்கள்.',
+    deleteStaysTitle: 'என்ன இருக்கும், ஏன்',
+    deleteStaysBody:
+      'உங்கள் குழுக்களில் உள்ள செலவுகளும் தீர்வுகளும் இருக்கும், ஏனெனில் அவை மற்றவர்களின் பதிவுகளும் கூட — யார் யாருக்குக் கடன்பட்டவர் என்பதைச் சொல்வது அவைதான். அவற்றை நீக்கினால் யாரும் கட்டாத கடன் தானாகத் தீர்ந்துவிடும். நீங்கள் பெயரில்லாத முன்னாள் உறுப்பினராகிவிடுவீர்கள்.',
+    deleteExportFirst: 'முதலில் உங்கள் தரவை ஏற்றுமதி செய்யுங்கள்',
+    deleteWhyLabel: 'ஏன் விலகுகிறீர்கள்? (விருப்பம்)',
+    deleteWhyPlaceholder: 'தெரிந்தால் உதவும்; கணக்கு போன பிறகும் இது வைக்கப்படும்',
+    deleteConfirmLabel: 'உறுதிப்படுத்த DELETE என தட்டச்சு செய்யுங்கள்',
+    deleteConfirmWord: 'DELETE',
+    deleteButton: 'என் தரவை நீக்கு',
+    deleteWorking: 'நீக்கப்படுகிறது…',
+    deleteDone: 'உங்கள் தரவு நீக்கப்பட்டது.',
+    deleteSummary: 'நீங்கள் இப்போது {n} குழுவின் முன்னாள் உறுப்பினர்.',
+  },
   extras: {
     blankNameHint: 'காலியாக விட்டால், குழுவில் உள்ளவர்களின் பெயரில் குழு அமையும்.',
     whatKindOfGroup: 'என்ன வகைக் குழு?',
@@ -3188,6 +3334,55 @@ const hi: UiStrings = {
     whatNeverWill: 'किसके कभी नहीं',
     whatNeverWillBody:
       'हिसाब। समूह, खर्च, बँटवारा, बकाया, निपटान, और यह सब वापस बाहर निकालना — {free}। जो हिसाब आप आधा ही पढ़ सकें, वह हिसाब नहीं।',
+  },
+  privacy: {
+    row: 'निजता और सुरक्षा',
+    rowHint: 'क्या रखा जाता है, और कैसे सुरक्षित रहता है',
+    title: 'निजता और सुरक्षा',
+    intro:
+      'बाकी आपके बारे में उतना ही रखता है जितना काम करने के लिए ज़रूरी है। वह क्या है, सीधे शब्दों में।',
+    storeTitle: 'क्या रखा जाता है',
+    storeBody:
+      'आपका नाम, और फ़ोन नंबर, ईमेल या साइन-इन पहचान में से जो आपने इस्तेमाल किया। वैकल्पिक रूप से एक भुगतान पता, ताकि कोई आपको लौटा सके, और एक देश। आप जिन समूहों में हैं, उनके ख़र्चे, और कौन किसका देनदार है। और कुछ नहीं: कोई संपर्क अपलोड नहीं होते, कोई विज्ञापन पहचानकर्ता नहीं।',
+    protectTitle: 'कैसे सुरक्षित रहता है',
+    protectBody:
+      'हर तालिका डेटाबेस में row-level security के पीछे है — ऐप का लगाया फ़िल्टर नहीं, बल्कि डेटाबेस का लागू किया नियम। रसीद की तस्वीरें एक निजी जगह में, छोटी अवधि के लिंक से ही पहुँच में। क्रैश रिपोर्ट से पते, नंबर और भुगतान पते फ़ोन छोड़ने से पहले ही हटा दिए जाते हैं।',
+    choicesTitle: 'आप क्या कर सकते हैं',
+    choicesBody:
+      'जो कुछ आपने डाला है, कभी भी, पूरा और मुफ़्त निर्यात करें। कोई भी सूचना बंद करें। अपना खाता और उसमें रखा निजी डेटा मिटाएँ।',
+    englishGoverns:
+      'यह पाठ सुविधा के लिए अनूदित है। अनुवाद और अंग्रेज़ी में अंतर हो तो अंग्रेज़ी ही मान्य होगी।',
+    feedbackRow: 'सुझाव भेजें',
+    feedbackRowHint: 'बताइए क्या ग़लत है, या क्या नहीं है',
+    feedbackTitle: 'सुझाव भेजें',
+    feedbackHint:
+      'इसे एक व्यक्ति पढ़ता है। जितना चाहें लिखें — विशिष्ट होने पर सबसे ज़्यादा मदद मिलती है।',
+    feedbackPlaceholder: 'क्या हुआ, या आप क्या चाहते थे कि यह करे',
+    feedbackSend: 'भेजें',
+    feedbackThanks: 'धन्यवाद — मिल गया।',
+    kindGeneral: 'सामान्य',
+    kindBug: 'कुछ ख़राब है',
+    kindIdea: 'एक सुझाव',
+    deleteRow: 'मेरा डेटा मिटाएँ',
+    deleteRowHint: 'अपना खाता और निजी विवरण हटाएँ',
+    deleteTitle: 'मेरा डेटा मिटाएँ',
+    deleteIntro:
+      'यह वापस नहीं हो सकता। पढ़िए कि क्या हटता है और क्या नहीं — दूसरा हिस्सा ही लोगों को चौंकाता है।',
+    deleteGoesTitle: 'क्या हटता है',
+    deleteGoesBody:
+      'आपका नाम, फ़ोटो, भुगतान पता, देश, भाषा और सूचना सेटिंग्स। आपका साइन-इन, ताकि यह खाता फिर न खुले। आपके उपकरण, सूचना इतिहास और ख़रीद।',
+    deleteStaysTitle: 'क्या रहता है, और क्यों',
+    deleteStaysBody:
+      'आपके साझा समूहों के ख़र्चे और भुगतान रहते हैं, क्योंकि वे दूसरों के भी रिकॉर्ड हैं — वही बताते हैं कि कौन किसका देनदार है। उन्हें हटाने से किसी और का हिसाब चुपचाप बदल जाएगा और वह कर्ज़ चुक जाएगा जो किसी ने चुकाया ही नहीं। आप उन समूहों में एक अनाम पूर्व-सदस्य बन जाते हैं।',
+    deleteExportFirst: 'पहले अपना डेटा निर्यात करें',
+    deleteWhyLabel: 'आप क्यों जा रहे हैं? (वैकल्पिक)',
+    deleteWhyPlaceholder: 'जानना मददगार है; खाता जाने के बाद भी यह रखा जाता है',
+    deleteConfirmLabel: 'पुष्टि के लिए DELETE लिखें',
+    deleteConfirmWord: 'DELETE',
+    deleteButton: 'मेरा डेटा मिटाएँ',
+    deleteWorking: 'मिटाया जा रहा है…',
+    deleteDone: 'आपका डेटा मिटा दिया गया।',
+    deleteSummary: 'अब आप {n} समूह के पूर्व-सदस्य हैं।',
   },
   extras: {
     blankNameHint: 'खाली छोड़ दें तो समूह का नाम उसमें शामिल लोगों पर रख दिया जाएगा।',
@@ -4093,6 +4288,53 @@ const ar: UiStrings = {
     whatNeverWill: 'وما لن يكلّف أبدًا',
     whatNeverWillBody:
       'الدفتر. المجموعات والمصاريف والتقسيمات والأرصدة والتسوية، وإخراج كل ذلك مرة أخرى — {free}. الدفتر الذي لا تقرأ منه إلا نصفه ليس دفترًا.',
+  },
+  privacy: {
+    row: 'الخصوصية والأمان',
+    rowHint: 'ما الذي يُحفظ، وكيف يُحمى',
+    title: 'الخصوصية والأمان',
+    intro: 'يحتفظ باقي بأقل قدر ممكن عنك مع بقائه صالحًا للعمل. وهذا بيان بما يحتفظ به.',
+    storeTitle: 'ما الذي يُحفظ',
+    storeBody:
+      'اسمك، وما استخدمته من رقم هاتف أو بريد أو هوية دخول. واختياريًا عنوان دفع كي يتمكن أحدهم من ردّ المال إليك، وبلد. المجموعات التي تشارك فيها ومصروفاتها ومن يدين لمن. لا شيء غير ذلك: لا تُرفع جهات الاتصال، ولا يوجد معرّف إعلاني.',
+    protectTitle: 'كيف يُحمى',
+    protectBody:
+      'كل جدول محميّ بأمان على مستوى الصف داخل قاعدة البيانات — ليس ترشيحًا يجريه التطبيق، بل قاعدة تفرضها قاعدة البيانات نفسها. صور الإيصالات في مكان خاص لا يُوصل إليه إلا بروابط قصيرة الأجل. وتُنقّى تقارير الأعطال من العناوين والأرقام وعناوين الدفع قبل مغادرتها الهاتف.',
+    choicesTitle: 'ما الذي يمكنك فعله',
+    choicesBody:
+      'تصدير كل ما أدخلته، في أي وقت، كاملًا ومجانًا. إيقاف أي إشعار. حذف حسابك والبيانات الشخصية التي فيه.',
+    englishGoverns:
+      'هذا النص مترجم للتيسير. وعند الاختلاف بين الترجمة والإنجليزية، تكون الإنجليزية هي المعتمدة.',
+    feedbackRow: 'أرسل ملاحظاتك',
+    feedbackRowHint: 'أخبرنا بما لا يعمل أو بما ينقص',
+    feedbackTitle: 'أرسل ملاحظاتك',
+    feedbackHint: 'يقرأها إنسان. اكتب ما تشاء — وكلما كان محددًا كان أنفع.',
+    feedbackPlaceholder: 'ماذا حدث، أو ما الذي كنت تتمناه',
+    feedbackSend: 'إرسال',
+    feedbackThanks: 'شكرًا — وصلتنا.',
+    kindGeneral: 'عام',
+    kindBug: 'شيء لا يعمل',
+    kindIdea: 'فكرة',
+    deleteRow: 'احذف بياناتي',
+    deleteRowHint: 'إزالة حسابك وتفاصيلك الشخصية',
+    deleteTitle: 'احذف بياناتي',
+    deleteIntro:
+      'لا يمكن التراجع عن هذا. اقرأ ما يُحذف وما لا يُحذف — والجزء الثاني هو ما يفاجئ الناس.',
+    deleteGoesTitle: 'ما الذي يُحذف',
+    deleteGoesBody:
+      'اسمك وصورتك وعنوان الدفع والبلد واللغة وإعدادات الإشعارات. وتسجيل دخولك، فلا يُفتح هذا الحساب بعدها. وأجهزتك وسجل إشعاراتك ومشترياتك.',
+    deleteStaysTitle: 'ما الذي يبقى، ولماذا',
+    deleteStaysBody:
+      'تبقى المصروفات والتسويات في مجموعاتك المشتركة، لأنها سجلات الآخرين أيضًا — وهي ما يحدد من يدين لمن. وحذفها يغيّر حساب شخص آخر بصمت ويُسقط دَينًا لم يسدده أحد. تصبح عضوًا سابقًا بلا اسم في تلك المجموعات.',
+    deleteExportFirst: 'صدّر بياناتك أولًا',
+    deleteWhyLabel: 'لماذا تغادر؟ (اختياري)',
+    deleteWhyPlaceholder: 'معرفة السبب تفيدنا، ويُحتفظ بها بعد زوال الحساب',
+    deleteConfirmLabel: 'اكتب DELETE للتأكيد',
+    deleteConfirmWord: 'DELETE',
+    deleteButton: 'احذف بياناتي',
+    deleteWorking: 'جارٍ الحذف…',
+    deleteDone: 'تم حذف بياناتك.',
+    deleteSummary: 'أنت الآن عضو سابق في {n} مجموعة.',
   },
   extras: {
     blankNameHint: 'اتركه فارغًا فتُسمّى المجموعة بأسماء من فيها.',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -837,6 +837,11 @@ export interface UiStrings {
     choicesTitle: string;
     choicesBody: string;
     englishGoverns: string;
+    couldNotSave: string;
+    previewGroups: string;
+    previewExpenses: string;
+    previewSettlements: string;
+    previewOutstanding: string;
     feedbackRow: string;
     feedbackRowHint: string;
     feedbackTitle: string;
@@ -1660,6 +1665,11 @@ const en: UiStrings = {
       'Export everything you have entered, at any time, in full fidelity and for free. Turn off any notification. Delete your account and the personal data in it. Write to us with anything you want changed.',
     englishGoverns:
       'This text is translated for convenience. Where a translation and the English differ, the English is the one that governs.',
+    couldNotSave: 'That did not save. Please try again in a moment.',
+    previewGroups: 'You are in {n} group(s).',
+    previewExpenses: 'You entered {n} expense(s) that will stay.',
+    previewSettlements: 'You are named in {n} settlement(s).',
+    previewOutstanding: 'You still have an unsettled balance in {list}.',
     feedbackRow: 'Send feedback',
     feedbackRowHint: 'Tell us what is wrong, or what is missing',
     feedbackTitle: 'Send feedback',
@@ -2523,6 +2533,11 @@ const ta: UiStrings = {
       'நீங்கள் உள்ளிட்ட அனைத்தையும் எப்போது வேண்டுமானாலும், முழுமையாக, இலவசமாக ஏற்றுமதி செய்யலாம். எந்த அறிவிப்பையும் நிறுத்தலாம். உங்கள் கணக்கையும் அதிலுள்ள தனிப்பட்ட தரவையும் நீக்கலாம்.',
     englishGoverns:
       'இந்த உரை வசதிக்காக மொழிபெயர்க்கப்பட்டுள்ளது. மொழிபெயர்ப்புக்கும் ஆங்கிலத்துக்கும் வேறுபாடு இருந்தால், ஆங்கிலமே செல்லுபடியாகும்.',
+    couldNotSave: 'இது சேமிக்கப்படவில்லை. சிறிது நேரம் கழித்து முயற்சிக்கவும்.',
+    previewGroups: 'நீங்கள் {n} குழுவில் உள்ளீர்கள்.',
+    previewExpenses: 'நீங்கள் சேர்த்த {n} செலவுகள் இருக்கும்.',
+    previewSettlements: '{n} தீர்வுகளில் உங்கள் பெயர் உள்ளது.',
+    previewOutstanding: '{list} இல் இன்னும் தீராத நிலுவை உள்ளது.',
     feedbackRow: 'கருத்து அனுப்பு',
     feedbackRowHint: 'என்ன தவறு, அல்லது என்ன இல்லை என்று சொல்லுங்கள்',
     feedbackTitle: 'கருத்து அனுப்பு',
@@ -3352,6 +3367,11 @@ const hi: UiStrings = {
       'जो कुछ आपने डाला है, कभी भी, पूरा और मुफ़्त निर्यात करें। कोई भी सूचना बंद करें। अपना खाता और उसमें रखा निजी डेटा मिटाएँ।',
     englishGoverns:
       'यह पाठ सुविधा के लिए अनूदित है। अनुवाद और अंग्रेज़ी में अंतर हो तो अंग्रेज़ी ही मान्य होगी।',
+    couldNotSave: 'यह सहेजा नहीं जा सका। थोड़ी देर बाद फिर कोशिश करें।',
+    previewGroups: 'आप {n} समूह में हैं।',
+    previewExpenses: 'आपके डाले {n} ख़र्चे बने रहेंगे।',
+    previewSettlements: '{n} भुगतानों में आपका नाम है।',
+    previewOutstanding: '{list} में अब भी बकाया है।',
     feedbackRow: 'सुझाव भेजें',
     feedbackRowHint: 'बताइए क्या ग़लत है, या क्या नहीं है',
     feedbackTitle: 'सुझाव भेजें',
@@ -4305,6 +4325,11 @@ const ar: UiStrings = {
       'تصدير كل ما أدخلته، في أي وقت، كاملًا ومجانًا. إيقاف أي إشعار. حذف حسابك والبيانات الشخصية التي فيه.',
     englishGoverns:
       'هذا النص مترجم للتيسير. وعند الاختلاف بين الترجمة والإنجليزية، تكون الإنجليزية هي المعتمدة.',
+    couldNotSave: 'لم يُحفظ هذا. أعد المحاولة بعد قليل.',
+    previewGroups: 'أنت في {n} مجموعة.',
+    previewExpenses: 'ستبقى {n} من المصروفات التي أدخلتها.',
+    previewSettlements: 'اسمك مذكور في {n} تسوية.',
+    previewOutstanding: 'لا يزال لديك رصيد غير مسوّى بـ {list}.',
     feedbackRow: 'أرسل ملاحظاتك',
     feedbackRowHint: 'أخبرنا بما لا يعمل أو بما ينقص',
     feedbackTitle: 'أرسل ملاحظاتك',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -838,6 +838,8 @@ export interface UiStrings {
     choicesBody: string;
     englishGoverns: string;
     couldNotSave: string;
+    analyticsTitle: string;
+    analyticsBody: string;
     previewGroups: string;
     previewExpenses: string;
     previewSettlements: string;
@@ -1666,6 +1668,9 @@ const en: UiStrings = {
     englishGoverns:
       'This text is translated for convenience. Where a translation and the English differ, the English is the one that governs.',
     couldNotSave: 'That did not save. Please try again in a moment.',
+    analyticsTitle: 'How the app is used',
+    analyticsBody:
+      'Baaki can record how screens are used — which ones people get stuck on, where a tap lands — through Microsoft Clarity. It ships switched off and records nothing unless it is turned on. It is never used for advertising, there is no advertising identifier, and nothing here is sold or shared.',
     previewGroups: 'You are in {n} group(s).',
     previewExpenses: 'You entered {n} expense(s) that will stay.',
     previewSettlements: 'You are named in {n} settlement(s).',
@@ -2534,6 +2539,9 @@ const ta: UiStrings = {
     englishGoverns:
       'இந்த உரை வசதிக்காக மொழிபெயர்க்கப்பட்டுள்ளது. மொழிபெயர்ப்புக்கும் ஆங்கிலத்துக்கும் வேறுபாடு இருந்தால், ஆங்கிலமே செல்லுபடியாகும்.',
     couldNotSave: 'இது சேமிக்கப்படவில்லை. சிறிது நேரம் கழித்து முயற்சிக்கவும்.',
+    analyticsTitle: 'செயலி எப்படி பயன்படுத்தப்படுகிறது',
+    analyticsBody:
+      'எந்தத் திரையில் சிக்கல் வருகிறது என்பதைப் புரிந்துகொள்ள Microsoft Clarity மூலம் பயன்பாட்டைப் பதிவு செய்ய முடியும். இது இயல்பாக அணைக்கப்பட்டே வருகிறது; இயக்கப்படாத வரை எதுவும் பதிவாகாது. விளம்பரத்திற்கு ஒருபோதும் பயன்படுத்தப்படுவதில்லை, விளம்பர அடையாளம் இல்லை, எதுவும் விற்கப்படுவதில்லை.',
     previewGroups: 'நீங்கள் {n} குழுவில் உள்ளீர்கள்.',
     previewExpenses: 'நீங்கள் சேர்த்த {n} செலவுகள் இருக்கும்.',
     previewSettlements: '{n} தீர்வுகளில் உங்கள் பெயர் உள்ளது.',
@@ -3368,6 +3376,9 @@ const hi: UiStrings = {
     englishGoverns:
       'यह पाठ सुविधा के लिए अनूदित है। अनुवाद और अंग्रेज़ी में अंतर हो तो अंग्रेज़ी ही मान्य होगी।',
     couldNotSave: 'यह सहेजा नहीं जा सका। थोड़ी देर बाद फिर कोशिश करें।',
+    analyticsTitle: 'ऐप कैसे इस्तेमाल होता है',
+    analyticsBody:
+      'Microsoft Clarity के ज़रिए यह दर्ज किया जा सकता है कि कौन-सी स्क्रीन उलझाती है। यह बंद अवस्था में ही आता है और चालू किए बिना कुछ दर्ज नहीं करता। इसका उपयोग विज्ञापन के लिए कभी नहीं होता, कोई विज्ञापन पहचानकर्ता नहीं है, और कुछ भी बेचा या साझा नहीं जाता।',
     previewGroups: 'आप {n} समूह में हैं।',
     previewExpenses: 'आपके डाले {n} ख़र्चे बने रहेंगे।',
     previewSettlements: '{n} भुगतानों में आपका नाम है।',
@@ -4326,6 +4337,9 @@ const ar: UiStrings = {
     englishGoverns:
       'هذا النص مترجم للتيسير. وعند الاختلاف بين الترجمة والإنجليزية، تكون الإنجليزية هي المعتمدة.',
     couldNotSave: 'لم يُحفظ هذا. أعد المحاولة بعد قليل.',
+    analyticsTitle: 'كيف يُستخدم التطبيق',
+    analyticsBody:
+      'يمكن لـ Microsoft Clarity تسجيل كيفية استخدام الشاشات لمعرفة أين يتعثر الناس. يأتي مُعطّلًا ولا يسجّل شيئًا ما لم يُفعّل. ولا يُستخدم للإعلانات أبدًا، ولا يوجد معرّف إعلاني، ولا يُباع شيء أو يُشارَك.',
     previewGroups: 'أنت في {n} مجموعة.',
     previewExpenses: 'ستبقى {n} من المصروفات التي أدخلتها.',
     previewSettlements: 'اسمك مذكور في {n} تسوية.',

--- a/apps/mobile/src/lib/clarity.ts
+++ b/apps/mobile/src/lib/clarity.ts
@@ -1,0 +1,118 @@
+/**
+ * Microsoft Clarity — session replay and heatmaps.
+ *
+ * Three things about this integration are deliberate and worth reading before
+ * changing any of them.
+ *
+ * **It is off unless a project id is configured.** Same bargain as Sentry in
+ * `observability.ts`: a clone with no Clarity account behaves exactly as the
+ * app did before this file existed, and nothing is recorded by accident.
+ *
+ * **It starts paused and is only resumed by `allowSessionReplay`.** The SDK
+ * begins capturing the moment `initialize` returns, and this app puts other
+ * people's money on the screen — expense descriptions, amounts, payment
+ * handles, the names of everybody in a group. Recording that by default, in a
+ * product whose own privacy screen says it holds as little as it can, would
+ * make that screen untrue. The gate is here so the decision is explicit.
+ *
+ * **Masking cannot be set from code.** The React Native SDK's config carries
+ * only `userId` and `logLevel`; the masking level lives in the Clarity
+ * dashboard (Settings → Masking). Code cannot enforce it, so this file cannot
+ * promise it — see the README note. Set the project to **Strict** before
+ * enabling capture, or session recordings will contain the ledger.
+ *
+ * The native module is reached lazily through a check that does not throw,
+ * which is this repo's rule: a missing native module reached at import time
+ * takes the whole app down at launch, on a build nothing local can reproduce.
+ */
+
+const PROJECT_ID = process.env.EXPO_PUBLIC_CLARITY_PROJECT_ID ?? '';
+
+/** Configured at all. Nothing below does anything when this is false. */
+export const clarityConfigured = Boolean(PROJECT_ID);
+
+type ClarityModule = typeof import('@microsoft/react-native-clarity');
+
+/**
+ * The native side, or null when it is not in this build.
+ *
+ * `require` inside a try, never a static import: Clarity ships native code, so
+ * a JS bundle that reaches it in an app built before the dependency existed —
+ * an over-the-air update, an old dev client — would throw during module
+ * evaluation, before any error boundary is mounted.
+ */
+function clarity(): ClarityModule | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('@microsoft/react-native-clarity') as ClarityModule;
+  } catch {
+    return null;
+  }
+}
+
+let started = false;
+
+/**
+ * Bring Clarity up, capturing nothing.
+ *
+ * Called once at launch. `pause()` immediately after `initialize` is the only
+ * way to hold it: the SDK has no "start disabled" option, so the window
+ * between the two calls is as small as it can be made.
+ */
+export function initClarity(): void {
+  if (!clarityConfigured || started) return;
+
+  const sdk = clarity();
+  if (!sdk) return;
+
+  try {
+    sdk.initialize(PROJECT_ID);
+    void sdk.pause();
+    started = true;
+  } catch {
+    // Analytics must never be the reason an app fails to start.
+  }
+}
+
+/**
+ * Turn capture on or off.
+ *
+ * Separate from `initClarity` so that whatever decides this — a settings
+ * toggle, a consent prompt, a remote flag — is a caller rather than a constant
+ * buried in here.
+ */
+export async function allowSessionReplay(allowed: boolean): Promise<void> {
+  if (!clarityConfigured || !started) return;
+
+  const sdk = clarity();
+  if (!sdk) return;
+
+  try {
+    // Analytics storage follows the same switch; ads storage is never granted,
+    // because this app has no advertising and its privacy screen says so.
+    await sdk.consent(false, allowed);
+    await (allowed ? sdk.resume() : sdk.pause());
+  } catch {
+    // Ignored on purpose — see above.
+  }
+}
+
+/**
+ * Name the screen somebody is on.
+ *
+ * Route names only. Never an id, a group name or anything typed by a person:
+ * the value is displayed in the Clarity dashboard beside the recording, and a
+ * screen name is meant to say which page, not who.
+ */
+export async function noteScreen(name: string): Promise<void> {
+  if (!clarityConfigured || !started) return;
+
+  const sdk = clarity();
+  if (!sdk) return;
+
+  try {
+    await sdk.setCurrentScreenName(name);
+  } catch {
+    // Ignored on purpose — see above.
+  }
+}

--- a/apps/mobile/src/lib/errors.ts
+++ b/apps/mobile/src/lib/errors.ts
@@ -1,0 +1,50 @@
+/**
+ * Database errors, said out loud in a way somebody can act on.
+ *
+ * Found by running the feedback screen on an emulator against a project the
+ * migration had not reached: the screen showed
+ *
+ *   Could not find the function public.baaki_submit_feedback(p_app_version,
+ *   p_kind, p_message, p_platform) in the schema cache
+ *
+ * to a person who was in the middle of typing a complaint. PostgREST messages
+ * are written for whoever wrote the query, and every one of them is a sentence
+ * about the schema rather than about what the person just tried to do.
+ *
+ * The original is not thrown away — it goes to the crash reporter, which is
+ * where a message naming a function signature is actually useful.
+ */
+
+import { reportHandled } from '@/lib/observability';
+
+/** The shape supabase-js hands back on a failed rpc. */
+interface Postgrestish {
+  message?: string;
+  code?: string;
+}
+
+export function friendlyError(caught: unknown, fallback: string, where: string): string {
+  const error = (caught ?? {}) as Postgrestish;
+  const message = typeof error.message === 'string' ? error.message : String(caught);
+
+  // Reported, then replaced. A build that reaches a project without the
+  // migration is a deployment mistake somebody has to hear about.
+  reportHandled(caught, where);
+
+  // No such function or table: the server is older than this build.
+  if (error.code === 'PGRST202' || error.code === 'PGRST205' || /schema cache/i.test(message)) {
+    return fallback;
+  }
+  // Signed out mid-action, or a token that expired while the screen was open.
+  if (/NOT_SIGNED_IN|JWT|not authenticated/i.test(message)) {
+    return fallback;
+  }
+  // Anything the database rejected by name is still not a sentence.
+  if (/violates|constraint|permission denied|relation .* does not exist/i.test(message)) {
+    return fallback;
+  }
+
+  // A network failure already reads plainly, and telling somebody their
+  // connection dropped is worth more than a generic apology.
+  return message;
+}

--- a/apps/mobile/src/lib/flags.tsx
+++ b/apps/mobile/src/lib/flags.tsx
@@ -1,0 +1,78 @@
+/**
+ * Feature flags on the phone.
+ *
+ * The variant is computed here, not fetched. The server hands over the flag's
+ * configuration — is it on, how wide is the rollout, what are the arms — and
+ * `variantFor` from @baaki/core turns that plus the profile id into an answer,
+ * using the same hash the database uses in `baaki_variant`. So a screen never
+ * waits on a round trip to know what to draw, and a phone with no signal shows
+ * the same thing it showed yesterday (ADR-005).
+ *
+ * Off is the fallback for everything: no session, no cached config, a failed
+ * fetch. A feature that fails open is one that appears for people it was never
+ * rolled out to, which is the same as having no rollout at all.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { variantFor, type FeatureFlag } from '@baaki/core';
+
+import { useAuth } from '@/lib/auth';
+import { supabase } from '@/lib/supabase';
+
+interface FlagRow {
+  key: string;
+  enabled: boolean;
+  rollout_percent: number;
+  variants: string[];
+}
+
+async function fetchFlags(): Promise<FeatureFlag[]> {
+  const { data, error } = await supabase
+    .from('feature_flags')
+    .select('key, enabled, rollout_percent, variants');
+
+  // A flag table that cannot be read is not worth an error state on somebody's
+  // expense screen. Every caller falls back to off.
+  if (error) return [];
+
+  return (data ?? []).map((row: FlagRow) => ({
+    key: row.key,
+    enabled: row.enabled,
+    rolloutPercent: row.rollout_percent,
+    variants: row.variants,
+  }));
+}
+
+function useFlags() {
+  return useQuery({
+    queryKey: ['feature-flags'],
+    queryFn: fetchFlags,
+    // Flags change when somebody in the console changes them, which is rare
+    // and never urgent. An hour of staleness costs nothing; refetching on
+    // every screen would cost a request per navigation.
+    staleTime: 60 * 60 * 1000,
+    retry: 1,
+  });
+}
+
+/**
+ * Which arm this person is on, or null for "not in this experiment".
+ *
+ * Null is not the control arm. Somebody outside the rollout should get whatever
+ * the app did before the flag existed — treat null as "behave as before", never
+ * as "show the control variant".
+ */
+export function useFlagVariant(key: string): string | null {
+  const { profile } = useAuth();
+  const { data } = useFlags();
+  if (!profile?.id || !data) return null;
+
+  const flag = data.find((candidate) => candidate.key === key);
+  return flag ? variantFor(flag, profile.id) : null;
+}
+
+/** For a plain on/off switch, where the arms carry no meaning of their own. */
+export function useFlagEnabled(key: string): boolean {
+  return useFlagVariant(key) !== null;
+}

--- a/apps/web-lite/AGENTS.md
+++ b/apps/web-lite/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/web-lite/CLAUDE.md
+++ b/apps/web-lite/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:api": "pnpm --filter @baaki/api-client run test",
     "test:web": "pnpm --filter @baaki/web-lite run test",
     "web": "pnpm --filter @baaki/web-lite run dev",
+    "admin": "pnpm --filter @baaki/admin run dev",
     "db:generate": "pnpm --filter @baaki/db run generate",
     "db:migrate": "pnpm --filter @baaki/db run migrate:deploy",
     "db:migrate:dev": "pnpm --filter @baaki/db run migrate:dev",

--- a/packages/core/src/flags/bucket.ts
+++ b/packages/core/src/flags/bucket.ts
@@ -1,0 +1,106 @@
+/**
+ * Which side of an experiment somebody is on.
+ *
+ * Decided by hashing, never by storing. A stored assignment is a row that has
+ * to be written before the feature can render — on a phone that is offline
+ * (ADR-005), for a guest who has no server round trip to spare, at the exact
+ * moment the screen needs an answer. Hashing has none of that: the same person
+ * and the same flag give the same answer on every device, forever, with no
+ * write and no network.
+ *
+ * It also makes the analysis a join rather than a pipeline. Because the bucket
+ * is a pure function of ids the database already has, the console can compute
+ * "what did the treatment group do" straight from `profiles` — no exposure
+ * events, no second source of truth to drift.
+ *
+ * That last property is why this file matters more than its size suggests: the
+ * app decides what to show from this function, and the console counts what
+ * happened using the *same* rule reimplemented in plpgsql. If the two ever
+ * disagree, every experiment result is quietly wrong — not missing, wrong. The
+ * shared fixtures in `BUCKET_FIXTURES` are asserted by both test suites for
+ * exactly that reason.
+ *
+ * FNV-1a, 32-bit. Chosen because it is a dozen lines in both languages with no
+ * dependency and no ambiguity — not for cryptographic quality, which an
+ * experiment bucket does not need. It is not a secret and must not be used as
+ * one.
+ */
+
+const FNV_OFFSET = 2166136261;
+const FNV_PRIME = 16777619;
+
+/**
+ * A stable 0–99 from any string.
+ *
+ * `Math.imul` because a 32-bit multiply overflows a double at this size, and
+ * `>>> 0` to keep it unsigned — the plpgsql side takes `% 4294967296` for the
+ * same reason. UTF-8 bytes rather than code units so a non-ASCII flag key
+ * hashes identically in both.
+ */
+export function bucketOf(input: string): number {
+  let hash = FNV_OFFSET;
+  for (const byte of new TextEncoder().encode(input)) {
+    hash ^= byte;
+    hash = Math.imul(hash, FNV_PRIME) >>> 0;
+  }
+  return hash % 100;
+}
+
+export interface FeatureFlag {
+  readonly key: string;
+  readonly enabled: boolean;
+  /** 0–100. How much of the population is in the experiment at all. */
+  readonly rolloutPercent: number;
+  /** At least two. The first is the control by convention, never by force. */
+  readonly variants: readonly string[];
+}
+
+/**
+ * The variant this person sees, or null for "not in this experiment".
+ *
+ * Null is not the control group and the caller must not treat it as one. A
+ * person outside the rollout should see whatever the app did before the flag
+ * existed; folding them into the control would put people who were never
+ * enrolled into a number that is supposed to describe people who were.
+ *
+ * Rollout and variant are hashed from different strings on purpose. Reusing one
+ * bucket for both ties them together — widening the rollout from 10% to 20%
+ * would then hand every newly-included person the same variant, and the split
+ * would be 100/0 in the new cohort while looking fine in aggregate.
+ */
+export function variantFor(flag: FeatureFlag, profileId: string): string | null {
+  if (!flag.enabled) return null;
+  if (flag.variants.length < 2) return null;
+  if (bucketOf(`${flag.key}:${profileId}`) >= flag.rolloutPercent) return null;
+  return flag.variants[bucketOf(`${flag.key}:${profileId}:variant`) % flag.variants.length] ?? null;
+}
+
+/** Convenience for a plain on/off flag: in the rollout at all, either variant. */
+export function isEnabled(flag: FeatureFlag, profileId: string): boolean {
+  return variantFor(flag, profileId) !== null;
+}
+
+/**
+ * Inputs whose buckets both implementations must agree on.
+ *
+ * Asserted by `packages/core/test/flags.test.ts` against this TypeScript and by
+ * `packages/db/test/featureFlags.test.ts` against the plpgsql. Two suites, one
+ * table of numbers: if a change breaks the agreement, one of them fails.
+ *
+ * The values are whatever FNV-1a produces — they are not chosen, they are
+ * recorded. Changing the hash changes them, and changing them reassigns every
+ * user in every running experiment, which is the point of writing them down.
+ */
+export const BUCKET_FIXTURES: readonly { input: string; bucket: number }[] = [
+  // Literals, deliberately. Calling `bucketOf` to fill this in would make the
+  // table agree with itself by construction and prove nothing about plpgsql.
+  { input: '', bucket: 61 },
+  { input: 'a', bucket: 20 },
+  { input: 'itemized_receipts:00000000-0000-0000-0000-000000000000', bucket: 22 },
+  { input: 'itemized_receipts:00000000-0000-0000-0000-000000000000:variant', bucket: 17 },
+  { input: 'baaki', bucket: 47 },
+  // Non-ASCII, because the two implementations agree only if both hash UTF-8
+  // bytes. A plpgsql `ascii()` over characters would pass every other row here
+  // and fail this one.
+  { input: 'பாக்கி', bucket: 34 },
+];

--- a/packages/core/src/flags/index.ts
+++ b/packages/core/src/flags/index.ts
@@ -1,0 +1,1 @@
+export * from './bucket';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './sync/index';
 export * from './receipt/index';
 export * from './category/index';
 export * from './group/index';
+export * from './flags/index';
 export * from './notifications/index';
 export * from './sms/index';
 export * from './import/index';

--- a/packages/core/test/flags.test.ts
+++ b/packages/core/test/flags.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Experiment bucketing.
+ *
+ * The properties here are the ones an experiment's credibility rests on: the
+ * same person always lands in the same place, the split is actually even, and
+ * widening a rollout never moves somebody who was already in it. A bucketer
+ * that fails any of those produces results that look fine and mean nothing.
+ */
+
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+
+import { BUCKET_FIXTURES, bucketOf, isEnabled, variantFor, type FeatureFlag } from '../src/index';
+
+const flag = (over: Partial<FeatureFlag> = {}): FeatureFlag => ({
+  key: 'itemized_receipts',
+  enabled: true,
+  rolloutPercent: 100,
+  variants: ['control', 'treatment'],
+  ...over,
+});
+
+const uuid = fc.uuid();
+
+describe('the hash both languages have to agree on', () => {
+  it('matches the recorded fixtures', () => {
+    // These same numbers are asserted against the plpgsql in
+    // packages/db/test/featureFlags.test.ts. If one side drifts, one fails.
+    for (const { input, bucket } of BUCKET_FIXTURES) {
+      expect(bucketOf(input), JSON.stringify(input)).toBe(bucket);
+    }
+  });
+
+  it('always lands in 0–99', () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        const bucket = bucketOf(input);
+        expect(Number.isInteger(bucket)).toBe(true);
+        expect(bucket).toBeGreaterThanOrEqual(0);
+        expect(bucket).toBeLessThan(100);
+      }),
+      { numRuns: 500 },
+    );
+  });
+
+  it('gives the same answer every time', () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        expect(bucketOf(input)).toBe(bucketOf(input));
+      }),
+    );
+  });
+
+  it('spreads a population across the range', () => {
+    // Not a uniformity proof — a smoke test that the hash is not degenerate.
+    // A bucketer that answered 7 for everybody would pass every test above.
+    const seen = new Set<number>();
+    for (let index = 0; index < 2000; index += 1) {
+      seen.add(bucketOf(`itemized_receipts:user-${index}`));
+    }
+    expect(seen.size).toBeGreaterThan(90);
+  });
+});
+
+describe('who is in the experiment', () => {
+  it('gives one person the same variant forever', () => {
+    fc.assert(
+      fc.property(uuid, (profileId) => {
+        const first = variantFor(flag(), profileId);
+        expect(variantFor(flag(), profileId)).toBe(first);
+      }),
+    );
+  });
+
+  it('says nothing at all when the flag is off', () => {
+    fc.assert(
+      fc.property(uuid, (profileId) => {
+        expect(variantFor(flag({ enabled: false }), profileId)).toBeNull();
+        expect(isEnabled(flag({ enabled: false }), profileId)).toBe(false);
+      }),
+    );
+  });
+
+  it('excludes everybody at 0% and nobody at 100%', () => {
+    fc.assert(
+      fc.property(uuid, (profileId) => {
+        expect(variantFor(flag({ rolloutPercent: 0 }), profileId)).toBeNull();
+        expect(variantFor(flag({ rolloutPercent: 100 }), profileId)).not.toBeNull();
+      }),
+    );
+  });
+
+  it('never drops somebody when the rollout widens', () => {
+    // The property that makes a staged rollout safe. If widening could move a
+    // person out, somebody would watch a feature they had been using vanish.
+    const people = Array.from({ length: 400 }, (_, index) => `person-${index}`);
+    for (let percent = 0; percent < 100; percent += 10) {
+      const narrow = people.filter((id) => isEnabled(flag({ rolloutPercent: percent }), id));
+      const wide = people.filter((id) => isEnabled(flag({ rolloutPercent: percent + 10 }), id));
+      for (const person of narrow) {
+        expect(wide, `${person} fell out between ${percent}% and ${percent + 10}%`).toContain(
+          person,
+        );
+      }
+    }
+  });
+
+  it('does not change somebody’s variant when the rollout widens', () => {
+    // Why rollout and variant are hashed from different strings. Sharing one
+    // bucket would hand every newly-included person the same variant, so the
+    // split inside the new cohort would be 100/0 while the total looked even.
+    const people = Array.from({ length: 400 }, (_, index) => `person-${index}`);
+    for (const person of people) {
+      const at30 = variantFor(flag({ rolloutPercent: 30 }), person);
+      const at90 = variantFor(flag({ rolloutPercent: 90 }), person);
+      if (at30 !== null) expect(at90).toBe(at30);
+    }
+  });
+
+  it('splits a population roughly evenly between two variants', () => {
+    const people = Array.from({ length: 4000 }, (_, index) => `person-${index}`);
+    const counts = new Map<string, number>();
+    for (const person of people) {
+      const variant = variantFor(flag(), person);
+      if (variant) counts.set(variant, (counts.get(variant) ?? 0) + 1);
+    }
+    expect([...counts.keys()].sort()).toEqual(['control', 'treatment']);
+    for (const count of counts.values()) {
+      // 50% ± 5 points. Wide enough not to be flaky, tight enough to catch a
+      // bucketer that leans.
+      expect(count).toBeGreaterThan(people.length * 0.45);
+      expect(count).toBeLessThan(people.length * 0.55);
+    }
+  });
+
+  it('handles three variants without favouring one', () => {
+    const people = Array.from({ length: 3000 }, (_, index) => `person-${index}`);
+    const counts = new Map<string, number>();
+    for (const person of people) {
+      const variant = variantFor(flag({ variants: ['a', 'b', 'c'] }), person);
+      if (variant) counts.set(variant, (counts.get(variant) ?? 0) + 1);
+    }
+    expect([...counts.keys()].sort()).toEqual(['a', 'b', 'c']);
+    for (const count of counts.values()) {
+      expect(count).toBeGreaterThan(people.length * 0.28);
+    }
+  });
+
+  it('refuses a flag with fewer than two variants', () => {
+    // An experiment with one arm is a flag pretending to be a test.
+    expect(variantFor(flag({ variants: ['only'] }), 'anybody')).toBeNull();
+  });
+});

--- a/packages/core/test/scrub.test.ts
+++ b/packages/core/test/scrub.test.ts
@@ -204,12 +204,29 @@ describe('a long string does not freeze the phone it crashed on', () => {
   });
 
   it('scales roughly with the input, not with its square', () => {
-    // The property, rather than a number: quadratic growth would make the
-    // 4x-longer input about 16x slower. A generous ceiling of 6x still catches
-    // that while leaving room for noise on a shared machine.
-    const small = Math.max(timed('a'.repeat(20_000)), 1);
-    const large = timed('a'.repeat(80_000));
-    expect(large / small).toBeLessThan(6);
+    // Measured as a batch at each size rather than a single call, because one
+    // pass over 20k finishes inside the timer's resolution — and an earlier
+    // version of this test floored that denominator at 1ms, which turned the
+    // ratio into fiction. It failed on CI at 6.25x against a 6x ceiling while
+    // the code underneath was perfectly linear.
+    const batch = (length: number): number => {
+      const input = 'a'.repeat(length);
+      const started = performance.now();
+      for (let run = 0; run < 20; run += 1) redactText(input);
+      return performance.now() - started;
+    };
+
+    // Once through first, so the size measured first is not also paying for
+    // the JIT to compile the thing being measured.
+    batch(10_000);
+
+    const small = batch(10_000);
+    const large = batch(80_000);
+
+    // Eight times the input: linear is about 8x, quadratic would be about 64x.
+    // A ceiling of 24 sits far from both, so this fails on a restored
+    // quadratic and not on a busy runner.
+    expect(large / Math.max(small, 0.01)).toBeLessThan(24);
   });
 
   it('still finds an address at the end of a long line', () => {

--- a/packages/db/prisma/migrations/20260808190000_admin_analytics/migration.sql
+++ b/packages/db/prisma/migrations/20260808190000_admin_analytics/migration.sql
@@ -1,0 +1,305 @@
+-- What the operator can see, and nothing else.
+--
+-- These feed the admin console (apps/admin). Every one of them returns
+-- **aggregates**: counts, sums per currency, rows per country per day. None of
+-- them returns a description, a note, a display name, a payment handle or a
+-- profile id, and that is the point rather than an oversight — the console is
+-- for knowing how the app is used, not for reading what people spent money on.
+-- Expense text in this product is frequently medical, legal or personal.
+--
+-- Functions rather than views, for the reason amendment A7 already gives: a
+-- view is an object Prisma has an opinion about and `prisma migrate diff` is a
+-- merge gate, so every derived read here is a function.
+--
+-- The grants at the foot are load-bearing. Postgres grants EXECUTE to PUBLIC on
+-- a new function, and in Supabase both `anon` and `authenticated` inherit that,
+-- so without the REVOKE any signed-in user — including an anonymous guest —
+-- could call these over PostgREST and read the whole business. They are
+-- revoked and granted to `service_role` alone, which is why the console reads
+-- them from a server and never from a browser (ADR-013).
+
+-- ─────────────────────────────────────────────────────── the headline ──
+
+/**
+ * One row, the numbers a dashboard opens with.
+ *
+ * "Active" is somebody who did something — an activity_log row — not somebody
+ * who opened the app, because opening it is not recorded anywhere and pretending
+ * otherwise would put a number on screen that means nothing.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_overview()
+RETURNS TABLE (
+  profiles_total bigint,
+  profiles_new_7d bigint,
+  profiles_new_30d bigint,
+  groups_total bigint,
+  groups_new_30d bigint,
+  groups_active_30d bigint,
+  expenses_total bigint,
+  expenses_new_30d bigint,
+  expenses_deleted bigint,
+  settlements_total bigint,
+  settlements_confirmed bigint,
+  active_profiles_7d bigint,
+  active_profiles_30d bigint
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    (SELECT count(*) FROM public.profiles),
+    (SELECT count(*) FROM public.profiles WHERE created_at >= now() - interval '7 days'),
+    (SELECT count(*) FROM public.profiles WHERE created_at >= now() - interval '30 days'),
+    (SELECT count(*) FROM public.groups),
+    (SELECT count(*) FROM public.groups WHERE created_at >= now() - interval '30 days'),
+    (SELECT count(DISTINCT group_id) FROM public.activity_log
+      WHERE created_at >= now() - interval '30 days'),
+    (SELECT count(*) FROM public.expenses WHERE deleted_at IS NULL),
+    (SELECT count(*) FROM public.expenses
+      WHERE deleted_at IS NULL AND created_at >= now() - interval '30 days'),
+    (SELECT count(*) FROM public.expenses WHERE deleted_at IS NOT NULL),
+    (SELECT count(*) FROM public.settlements),
+    (SELECT count(*) FROM public.settlements WHERE status = 'confirmed'),
+    (SELECT count(DISTINCT m.profile_id)
+       FROM public.activity_log a
+       JOIN public.group_members m ON m.id = a.actor_member_id
+      WHERE a.created_at >= now() - interval '7 days' AND m.profile_id IS NOT NULL),
+    (SELECT count(DISTINCT m.profile_id)
+       FROM public.activity_log a
+       JOIN public.group_members m ON m.id = a.actor_member_id
+      WHERE a.created_at >= now() - interval '30 days' AND m.profile_id IS NOT NULL);
+$$;
+
+-- ──────────────────────────────────────────────────────────── the trend ──
+
+/**
+ * A row per day, including the days nothing happened.
+ *
+ * `generate_series` rather than `GROUP BY day` on purpose: a chart drawn from
+ * grouped rows silently closes the gaps, so a fortnight of no signups reads as
+ * a gentle slope instead of a flat line. The flat line is the information.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_daily(p_days integer DEFAULT 30)
+RETURNS TABLE (
+  day date,
+  new_profiles bigint,
+  new_groups bigint,
+  new_expenses bigint,
+  active_profiles bigint
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  WITH days AS (
+    SELECT generate_series(
+      (current_date - (GREATEST(p_days, 1) - 1))::date,
+      current_date,
+      interval '1 day'
+    )::date AS day
+  )
+  SELECT
+    d.day,
+    (SELECT count(*) FROM public.profiles p WHERE p.created_at::date = d.day),
+    (SELECT count(*) FROM public.groups g WHERE g.created_at::date = d.day),
+    (SELECT count(*) FROM public.expenses e
+      WHERE e.created_at::date = d.day AND e.deleted_at IS NULL),
+    (SELECT count(DISTINCT m.profile_id)
+       FROM public.activity_log a
+       JOIN public.group_members m ON m.id = a.actor_member_id
+      WHERE a.created_at::date = d.day AND m.profile_id IS NOT NULL)
+  FROM days d
+  ORDER BY d.day;
+$$;
+
+-- ────────────────────────────────────────────────────────── where from ──
+
+/**
+ * Country, as far as this product actually knows it.
+ *
+ * `profiles.country_code` is the device locale the app read at signup, and
+ * `groups.country_code` is where a group settles. Neither is IP geolocation and
+ * neither should be read as one: a phone set to en-GB in Bengaluru counts as
+ * GB here. NULL is reported as its own row rather than dropped, because "we do
+ * not know" is a real and frequently large answer.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_geo()
+RETURNS TABLE (
+  country_code text,
+  profile_count bigint,
+  group_count bigint,
+  expense_count bigint
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  WITH countries AS (
+    SELECT DISTINCT country_code::text AS code FROM public.profiles
+    UNION
+    SELECT DISTINCT country_code::text AS code FROM public.groups
+  )
+  SELECT
+    c.code,
+    (SELECT count(*) FROM public.profiles p WHERE p.country_code::text IS NOT DISTINCT FROM c.code),
+    (SELECT count(*) FROM public.groups g WHERE g.country_code::text IS NOT DISTINCT FROM c.code),
+    (SELECT count(*)
+       FROM public.expenses e
+       JOIN public.groups g ON g.id = e.group_id
+      WHERE g.country_code::text IS NOT DISTINCT FROM c.code AND e.deleted_at IS NULL)
+  FROM countries c
+  ORDER BY 2 DESC, 1;
+$$;
+
+-- ───────────────────────────────────────────────────────────── the money ──
+
+/**
+ * Volume per currency, never converted and never summed across currencies.
+ *
+ * The same rule the product itself follows (§8): adding rupees to dirhams
+ * produces a number that is wrong in a way nobody can see. Amounts stay in
+ * minor units — `sum(bigint)` is numeric, which is exact.
+ *
+ * Only current versions of live expenses count, so an edited expense is
+ * counted once at its present value rather than once per revision.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_money()
+RETURNS TABLE (
+  currency text,
+  expense_count bigint,
+  expense_minor numeric,
+  settlement_count bigint,
+  settlement_minor numeric
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  WITH live AS (
+    SELECT v.currency::text AS currency, v.amount
+      FROM public.expenses e
+      JOIN public.expense_versions v ON v.id = e.current_version_id
+     WHERE e.deleted_at IS NULL
+  ),
+  paid AS (
+    SELECT s.currency::text AS currency, s.amount
+      FROM public.settlements s
+     WHERE s.status = 'confirmed'
+  ),
+  currencies AS (
+    SELECT currency FROM live UNION SELECT currency FROM paid
+  )
+  SELECT
+    c.currency,
+    (SELECT count(*) FROM live l WHERE l.currency = c.currency),
+    COALESCE((SELECT sum(l.amount) FROM live l WHERE l.currency = c.currency), 0),
+    (SELECT count(*) FROM paid p WHERE p.currency = c.currency),
+    COALESCE((SELECT sum(p.amount) FROM paid p WHERE p.currency = c.currency), 0)
+  FROM currencies c
+  ORDER BY 3 DESC;
+$$;
+
+-- ───────────────────────────────────────────────────────── what it costs ──
+
+/**
+ * The AI receipt pipeline's bill, per day (ADR-008/011).
+ *
+ * `usage_events` already meters this exactly, in minor units, because COGS is
+ * money too. Grouped by currency alongside the tokens so a change in the model's
+ * price is visible as a change in cost per scan rather than hidden in a total.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_ai_cost(p_days integer DEFAULT 30)
+RETURNS TABLE (
+  day date,
+  currency text,
+  events bigint,
+  input_tokens bigint,
+  output_tokens bigint,
+  cost_minor numeric
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    u.created_at::date,
+    u.currency::text,
+    count(*),
+    COALESCE(sum(u.input_tokens), 0)::bigint,
+    COALESCE(sum(u.output_tokens), 0)::bigint,
+    COALESCE(sum(u.cost_minor), 0)
+  FROM public.usage_events u
+  WHERE u.created_at >= current_date - (GREATEST(p_days, 1) - 1)
+  GROUP BY 1, 2
+  ORDER BY 1 DESC, 2;
+$$;
+
+-- ──────────────────────────────────────────────────────────── who signed in ──
+
+/**
+ * Sign-ins per day, from Supabase's own audit trail.
+ *
+ * Guarded and dynamic for two reasons. CI runs these migrations against bare
+ * Postgres, which has no `auth` schema at all — the guarded DO block pattern
+ * this repo already uses for the `auth.users` trigger. And Supabase prunes
+ * `audit_log_entries`, so this answers "recently" and cannot be used to chart
+ * a year: an empty result means the window has passed, not that nobody signed
+ * in, and the console says so rather than drawing a zero.
+ *
+ * `last_sign_in_at` on `auth.users` is deliberately not used for this. It is a
+ * snapshot of the most recent sign-in per user, so grouping it by day produces
+ * a plausible-looking chart that is not a history of anything.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_logins(p_days integer DEFAULT 30)
+RETURNS TABLE (
+  day date,
+  sign_ins bigint
+)
+LANGUAGE plpgsql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF to_regclass('auth.audit_log_entries') IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY EXECUTE format(
+    $q$
+      SELECT a.created_at::date AS day, count(*)::bigint
+        FROM auth.audit_log_entries a
+       WHERE a.created_at >= current_date - (%s - 1)
+         AND a.payload ->> 'action' IN ('login', 'token_refreshed')
+       GROUP BY 1
+       ORDER BY 1 DESC
+    $q$,
+    GREATEST(p_days, 1)
+  );
+END
+$$;
+
+-- ─────────────────────────────────────────────────────────────── grants ──
+
+-- Everything above is revoked from PUBLIC first. `anon` and `authenticated`
+-- inherit PUBLIC's grants in Supabase, so leaving the default in place would
+-- publish the whole business behind the anon key that ships in the app binary.
+DO $$
+DECLARE
+  v_signature text;
+BEGIN
+  FOREACH v_signature IN ARRAY ARRAY[
+    'public.baaki_admin_overview()',
+    'public.baaki_admin_daily(integer)',
+    'public.baaki_admin_geo()',
+    'public.baaki_admin_money()',
+    'public.baaki_admin_ai_cost(integer)',
+    'public.baaki_admin_logins(integer)'
+  ]
+  LOOP
+    EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC', v_signature);
+    EXECUTE format('REVOKE ALL ON FUNCTION %s FROM anon, authenticated', v_signature);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', v_signature);
+  END LOOP;
+END
+$$;

--- a/packages/db/prisma/migrations/20260808200000_feature_flags/migration.sql
+++ b/packages/db/prisma/migrations/20260808200000_feature_flags/migration.sql
@@ -25,6 +25,23 @@
 
 -- ──────────────────────────────────────────────────────────── the switch ──
 
+/**
+ * Whether an array holds no duplicates.
+ *
+ * A function because Postgres refuses a subquery inside a CHECK constraint —
+ * `cannot use subquery in check constraint`, SQLSTATE 0A000 — and answering
+ * "are these distinct" needs one. A check may call a function, so the subquery
+ * moves in here. IMMUTABLE is required for a constraint to trust it.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_array_is_distinct(p_values text[])
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT p_values IS NULL
+      OR cardinality(p_values) = (SELECT count(DISTINCT v) FROM unnest(p_values) AS v);
+$$;
+
 CREATE TABLE IF NOT EXISTS public.feature_flags (
   key text PRIMARY KEY,
   description text NOT NULL DEFAULT '',
@@ -45,9 +62,7 @@ CREATE TABLE IF NOT EXISTS public.feature_flags (
     array_length(variants, 1) BETWEEN 2 AND 8
   ),
   -- A duplicate arm silently doubles that arm's share of the split.
-  CONSTRAINT feature_flags_variants_distinct CHECK (
-    array_length(variants, 1) = (SELECT count(DISTINCT v) FROM unnest(variants) AS v)
-  )
+  CONSTRAINT feature_flags_variants_distinct CHECK (public.baaki_array_is_distinct(variants))
 );
 
 ALTER TABLE public.feature_flags ENABLE ROW LEVEL SECURITY;

--- a/packages/db/prisma/migrations/20260808200000_feature_flags/migration.sql
+++ b/packages/db/prisma/migrations/20260808200000_feature_flags/migration.sql
@@ -1,0 +1,211 @@
+-- Experiments, and the switch that runs them.
+--
+-- A flag says what a feature is doing; a variant says which half of the
+-- population is seeing it. Both are decided by **hashing, never by storing**.
+-- A stored assignment is a row that must be written before the feature can
+-- render — on a phone that is offline (ADR-005), for a guest with no round trip
+-- to spare, at the moment the screen needs an answer. A hash has none of that.
+--
+-- The important consequence is that the analysis becomes a join. Because the
+-- bucket is a pure function of ids the database already holds, the console can
+-- ask "what did the treatment group actually do" straight from `profiles` —
+-- no exposure events, no second source of truth to drift out of step.
+--
+-- `baaki_bucket` below is the same FNV-1a as `bucketOf` in
+-- `packages/core/src/flags/bucket.ts`, written twice because the app decides
+-- what to show and the console counts what happened. If the two ever disagree,
+-- every experiment result is not missing but **wrong**, which is worse. The
+-- fixtures in `BUCKET_FIXTURES` are asserted against this implementation by
+-- `packages/db/test/featureFlags.test.ts` and against the TypeScript one by
+-- `packages/core/test/flags.test.ts`.
+--
+-- Following the rule the security audit left behind, and A16: the table is
+-- readable by clients and written by nobody but the service role. A flag a
+-- client could flip is a paywall with a door in the back.
+
+-- ──────────────────────────────────────────────────────────── the switch ──
+
+CREATE TABLE IF NOT EXISTS public.feature_flags (
+  key text PRIMARY KEY,
+  description text NOT NULL DEFAULT '',
+  enabled boolean NOT NULL DEFAULT false,
+  -- How much of the population is in the experiment at all.
+  rollout_percent integer NOT NULL DEFAULT 0,
+  -- At least two. The first is the control by convention, never by force.
+  variants text[] NOT NULL DEFAULT ARRAY['control', 'treatment'],
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  -- Lowercase identifier: the key is concatenated into a hash input and read
+  -- from client code, and a flag differing from another only by case is a bug
+  -- nobody will find.
+  CONSTRAINT feature_flags_key_shape CHECK (key ~ '^[a-z][a-z0-9_]{1,60}$'),
+  CONSTRAINT feature_flags_rollout_range CHECK (rollout_percent BETWEEN 0 AND 100),
+  CONSTRAINT feature_flags_variant_count CHECK (
+    array_length(variants, 1) BETWEEN 2 AND 8
+  ),
+  -- A duplicate arm silently doubles that arm's share of the split.
+  CONSTRAINT feature_flags_variants_distinct CHECK (
+    array_length(variants, 1) = (SELECT count(DISTINCT v) FROM unnest(variants) AS v)
+  )
+);
+
+ALTER TABLE public.feature_flags ENABLE ROW LEVEL SECURITY;
+
+-- Readable by everybody signed in, including anonymous guests — a guest sees
+-- the same app as anybody else and needs the same answers. There is nothing
+-- secret in a flag: it is configuration, not data about a person.
+DROP POLICY IF EXISTS feature_flags_read ON public.feature_flags;
+CREATE POLICY feature_flags_read ON public.feature_flags
+  FOR SELECT TO anon, authenticated USING (true);
+
+-- No INSERT, UPDATE or DELETE policy exists, so with RLS on, only the service
+-- role (which bypasses it) can write. That is the whole write path.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.feature_flags FROM anon, authenticated;
+
+-- ────────────────────────────────────────────────────────────── the hash ──
+
+/**
+ * FNV-1a, 32 bit, folded to 0–99.
+ *
+ * Byte-wise over UTF-8 rather than character-wise, because the TypeScript side
+ * hashes `TextEncoder` output and a plpgsql `ascii()` loop would agree with it
+ * on every ASCII input and disagree on the first Tamil one.
+ *
+ * IMMUTABLE is load-bearing: it lets Postgres use this inside the index-free
+ * aggregate in `baaki_admin_flag_results` without re-planning per row.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_bucket(p_input text)
+RETURNS integer
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_bytes bytea := convert_to(COALESCE(p_input, ''), 'UTF8');
+  v_hash bigint := 2166136261;
+  v_index integer;
+BEGIN
+  FOR v_index IN 0 .. length(v_bytes) - 1 LOOP
+    v_hash := v_hash # get_byte(v_bytes, v_index)::bigint;
+    v_hash := (v_hash * 16777619) % 4294967296;
+  END LOOP;
+  RETURN (v_hash % 100)::integer;
+END
+$$;
+
+/**
+ * The variant a person sees, or NULL for "not in this experiment".
+ *
+ * NULL is not the control group and no caller may treat it as one. Somebody
+ * outside the rollout should see whatever the app did before the flag existed;
+ * folding them into the control puts people who were never enrolled into a
+ * number meant to describe people who were.
+ *
+ * Rollout and variant hash different strings deliberately. Sharing one bucket
+ * ties them together, so widening the rollout would hand every newly-included
+ * person the same variant — a 100/0 split inside the new cohort, while the
+ * total still looked even.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_variant(p_key text, p_profile_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_flag public.feature_flags%ROWTYPE;
+  v_arms integer;
+BEGIN
+  SELECT * INTO v_flag FROM public.feature_flags WHERE key = p_key;
+  IF NOT FOUND OR NOT v_flag.enabled OR p_profile_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  v_arms := array_length(v_flag.variants, 1);
+  IF v_arms IS NULL OR v_arms < 2 THEN
+    RETURN NULL;
+  END IF;
+
+  IF public.baaki_bucket(p_key || ':' || p_profile_id::text) >= v_flag.rollout_percent THEN
+    RETURN NULL;
+  END IF;
+
+  -- 1-based, so this matches the TypeScript's `variants[bucket % length]`.
+  RETURN v_flag.variants[
+    1 + (public.baaki_bucket(p_key || ':' || p_profile_id::text || ':variant') % v_arms)
+  ];
+END
+$$;
+
+-- ──────────────────────────────────────────────────────── what it changed ──
+
+/**
+ * The experiment's result: one row per arm, with what those people did.
+ *
+ * No exposure table feeds this. Every profile is bucketed on the fly by the
+ * same function the app uses, which is the whole payoff of hashing over
+ * storing — an experiment can be analysed retrospectively, including for the
+ * days before anybody thought to log an exposure.
+ *
+ * People outside the rollout are excluded rather than reported as a third row.
+ * They are not a control group; they are people the experiment never touched,
+ * and putting them beside the arms invites exactly the comparison that is
+ * wrong.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_flag_results(p_key text)
+RETURNS TABLE (
+  variant text,
+  people bigint,
+  expenses_created bigint,
+  active_30d bigint
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  WITH enrolled AS (
+    SELECT p.id AS profile_id, public.baaki_variant(p_key, p.id) AS variant
+      FROM public.profiles p
+     WHERE public.baaki_variant(p_key, p.id) IS NOT NULL
+  ),
+  per_person AS (
+    SELECT
+      e.variant,
+      e.profile_id,
+      (SELECT count(*)
+         FROM public.expenses x
+         JOIN public.group_members m ON m.id = x.created_by
+        WHERE m.profile_id = e.profile_id AND x.deleted_at IS NULL) AS expenses,
+      EXISTS (
+        SELECT 1
+          FROM public.activity_log a
+          JOIN public.group_members m ON m.id = a.actor_member_id
+         WHERE m.profile_id = e.profile_id
+           AND a.created_at >= now() - interval '30 days'
+      ) AS active
+    FROM enrolled e
+  )
+  SELECT
+    variant,
+    count(*)::bigint,
+    COALESCE(sum(expenses), 0)::bigint,
+    count(*) FILTER (WHERE active)::bigint
+  FROM per_person
+  GROUP BY variant
+  ORDER BY variant;
+$$;
+
+-- ─────────────────────────────────────────────────────────────── grants ──
+
+-- The bucket and the variant are pure functions over public configuration, so
+-- a client calling them learns nothing it could not compute itself — and the
+-- app does compute them itself, from `@baaki/core`. They are exposed anyway so
+-- the edge functions can gate on the same answer without reimplementing it.
+GRANT EXECUTE ON FUNCTION public.baaki_bucket(text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.baaki_variant(text, uuid) TO anon, authenticated, service_role;
+
+-- The results are the business, and belong to the console alone.
+REVOKE ALL ON FUNCTION public.baaki_admin_flag_results(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_admin_flag_results(text) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_admin_flag_results(text) TO service_role;

--- a/packages/db/prisma/migrations/20260808210000_promotions/migration.sql
+++ b/packages/db/prisma/migrations/20260808210000_promotions/migration.sql
@@ -51,9 +51,12 @@ REVOKE ALL ON public.promo_codes FROM anon, authenticated;
 
 CREATE TABLE IF NOT EXISTS public.promo_redemptions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  code text NOT NULL REFERENCES public.promo_codes(code) ON DELETE CASCADE,
-  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
-  subscription_id uuid REFERENCES public.subscriptions(id) ON DELETE SET NULL,
+  -- ON UPDATE CASCADE on all three to match what Prisma generates for a
+  -- relation, which is what `db:drift` compares against — the entitlements
+  -- migration spells it out for the same reason.
+  code text NOT NULL REFERENCES public.promo_codes(code) ON DELETE CASCADE ON UPDATE CASCADE,
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  subscription_id uuid REFERENCES public.subscriptions(id) ON DELETE SET NULL ON UPDATE CASCADE,
   redeemed_at timestamptz NOT NULL DEFAULT now(),
 
   -- One code, one person, once. The real guard is the unique store_txn_id on

--- a/packages/db/prisma/migrations/20260808210000_promotions/migration.sql
+++ b/packages/db/prisma/migrations/20260808210000_promotions/migration.sql
@@ -1,0 +1,278 @@
+-- Giving somebody the paid tier without taking their money.
+--
+-- The entitlements migration already left the door open: `store` accepts
+-- 'promo' alongside 'play' and 'appstore', and `baaki_my_plan` reads any active
+-- row regardless of where it came from. So a promotion is not a parallel
+-- entitlement system — it is one more row in `subscriptions`, and every screen
+-- that already asks "what plan is this person on" gets the right answer with no
+-- change at all. Building a second source of truth for who has paid would be
+-- the mistake here.
+--
+-- Two ways in, both ending at the same row:
+--
+--   * the console grants directly, for a support case or a thank-you;
+--   * somebody types a code into the app, which is the same grant with a
+--     gatekeeper in front of it.
+--
+-- Neither is a client write. `baaki_redeem_promo` is SECURITY DEFINER precisely
+-- so the client never touches `subscriptions` — the rule the entitlements
+-- migration set down still holds: a client that could insert its own
+-- subscription row is a paywall with a door in the back.
+
+-- ─────────────────────────────────────────────────────────────── the code ──
+
+CREATE TABLE IF NOT EXISTS public.promo_codes (
+  code text PRIMARY KEY,
+  tier text NOT NULL DEFAULT 'plus',
+  -- How long the grant lasts. Days rather than an end date so one code means
+  -- the same thing to somebody redeeming it today and in a month.
+  days integer NOT NULL DEFAULT 30,
+  max_redemptions integer NOT NULL DEFAULT 1,
+  redeemed_count integer NOT NULL DEFAULT 0,
+  -- When the code stops working, which is not the same as when the grant ends.
+  expires_at timestamptz,
+  note text NOT NULL DEFAULT '',
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  -- Uppercase and unambiguous: these get read aloud and typed by hand.
+  CONSTRAINT promo_codes_shape CHECK (code ~ '^[A-Z0-9]{4,24}$'),
+  CONSTRAINT promo_codes_tier_known CHECK (tier IN ('plus')),
+  CONSTRAINT promo_codes_days_sane CHECK (days BETWEEN 1 AND 3650),
+  CONSTRAINT promo_codes_max_sane CHECK (max_redemptions BETWEEN 1 AND 1000000),
+  CONSTRAINT promo_codes_count_sane CHECK (redeemed_count >= 0)
+);
+
+-- RLS with no policy at all: not even readable by a client. Everything else in
+-- this schema is readable by the person it concerns, but a list of valid codes
+-- is not about a person — it is the giveaway itself, and one SELECT would hand
+-- somebody every unredeemed code in the table.
+ALTER TABLE public.promo_codes ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.promo_codes FROM anon, authenticated;
+
+CREATE TABLE IF NOT EXISTS public.promo_redemptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL REFERENCES public.promo_codes(code) ON DELETE CASCADE,
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  subscription_id uuid REFERENCES public.subscriptions(id) ON DELETE SET NULL,
+  redeemed_at timestamptz NOT NULL DEFAULT now(),
+
+  -- One code, one person, once. The real guard is the unique store_txn_id on
+  -- the subscription itself; this makes the intent readable.
+  CONSTRAINT promo_redemptions_once UNIQUE (code, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS promo_redemptions_profile_idx
+  ON public.promo_redemptions (profile_id, redeemed_at);
+
+ALTER TABLE public.promo_redemptions ENABLE ROW LEVEL SECURITY;
+
+-- Somebody may see that they redeemed something. They may not see who else did.
+DROP POLICY IF EXISTS promo_redemptions_own ON public.promo_redemptions;
+CREATE POLICY promo_redemptions_own ON public.promo_redemptions
+  FOR SELECT TO authenticated
+  USING (profile_id = public.baaki_current_profile_id());
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.promo_redemptions FROM anon, authenticated;
+
+-- ──────────────────────────────────────────────────────────── granting it ──
+
+/**
+ * The shared tail of both paths: write the subscription row.
+ *
+ * `store_txn_id` is not decoration. The stores replay their webhooks
+ * deliberately and often, so that column is unique to stop one purchase being
+ * granted twice — and reusing it here means a promotion gets the same
+ * protection for free. Two concurrent redemptions of the same code by the same
+ * person race to the same key and one of them loses, without a lock and
+ * without a subtle read-then-write window.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_grant_promo(
+  p_profile_id uuid,
+  p_days integer,
+  p_source text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  INSERT INTO public.subscriptions
+    (profile_id, tier, period, status, current_period_end, store, store_txn_id)
+  VALUES (
+    p_profile_id,
+    'plus',
+    'monthly',
+    'active',
+    now() + make_interval(days => p_days),
+    'promo',
+    p_source
+  )
+  ON CONFLICT (store_txn_id) DO NOTHING
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;
+
+/**
+ * The app's side: somebody types a code.
+ *
+ * Returns a jsonb verdict rather than raising, because every failure here is a
+ * thing to tell the person — expired, already used, not a code — and an
+ * exception would reach them as a crash. The only thing that raises is being
+ * signed out, which is a bug in the caller rather than a wrong code.
+ *
+ * The row is locked for the duration so the redemption count cannot be
+ * overshot by two people typing the same code at the same moment.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_redeem_promo(p_code text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+  v_code    public.promo_codes%ROWTYPE;
+  v_sub     uuid;
+BEGIN
+  IF v_profile IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN';
+  END IF;
+
+  SELECT * INTO v_code
+    FROM public.promo_codes
+   WHERE code = upper(trim(COALESCE(p_code, '')))
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'UNKNOWN_CODE');
+  END IF;
+
+  IF v_code.expires_at IS NOT NULL AND v_code.expires_at <= now() THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'EXPIRED');
+  END IF;
+
+  IF v_code.redeemed_count >= v_code.max_redemptions THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'EXHAUSTED');
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.promo_redemptions
+     WHERE code = v_code.code AND profile_id = v_profile
+  ) THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'ALREADY_REDEEMED');
+  END IF;
+
+  v_sub := public.baaki_grant_promo(
+    v_profile,
+    v_code.days,
+    'promo:' || v_code.code || ':' || v_profile::text
+  );
+
+  IF v_sub IS NULL THEN
+    -- The unique key rejected it, so this person already holds this grant.
+    RETURN jsonb_build_object('ok', false, 'reason', 'ALREADY_REDEEMED');
+  END IF;
+
+  INSERT INTO public.promo_redemptions (code, profile_id, subscription_id)
+  VALUES (v_code.code, v_profile, v_sub);
+
+  UPDATE public.promo_codes
+     SET redeemed_count = redeemed_count + 1
+   WHERE code = v_code.code;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'tier', v_code.tier,
+    'days', v_code.days,
+    'until', (now() + make_interval(days => v_code.days))
+  );
+END
+$$;
+
+/**
+ * The console's side: comp one named account, no code involved.
+ *
+ * Deliberately keyed on the profile id and the day, so pressing the button
+ * twice in a support conversation extends nothing — it is the same grant. To
+ * genuinely give somebody a second month, grant again tomorrow or issue a code.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_grant_promo(
+  p_profile_id uuid,
+  p_days integer DEFAULT 30
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_sub uuid;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id = p_profile_id) THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'NO_SUCH_PROFILE');
+  END IF;
+
+  v_sub := public.baaki_grant_promo(
+    p_profile_id,
+    GREATEST(COALESCE(p_days, 30), 1),
+    'admin:' || p_profile_id::text || ':' || current_date::text
+  );
+
+  IF v_sub IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'ALREADY_GRANTED_TODAY');
+  END IF;
+
+  RETURN jsonb_build_object('ok', true, 'subscription', v_sub);
+END
+$$;
+
+-- ────────────────────────────────────────────── what the console can read ──
+
+/**
+ * Codes and how they are going. Counts only — who redeemed what is a list of
+ * named people, and the console does not read those (see the admin analytics
+ * migration for why).
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_promo_codes()
+RETURNS TABLE (
+  code text,
+  tier text,
+  days integer,
+  max_redemptions integer,
+  redeemed_count integer,
+  expires_at timestamptz,
+  note text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT code, tier, days, max_redemptions, redeemed_count, expires_at, note, created_at
+    FROM public.promo_codes
+   ORDER BY created_at DESC;
+$$;
+
+-- ─────────────────────────────────────────────────────────────── grants ──
+
+-- The redeem path is the one thing here a client may call, and it is
+-- SECURITY DEFINER so that it — and not the caller — does the writing.
+REVOKE ALL ON FUNCTION public.baaki_redeem_promo(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_redeem_promo(text) TO authenticated, service_role;
+
+-- Granting is never a client's decision.
+REVOKE ALL ON FUNCTION public.baaki_grant_promo(uuid, integer, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_grant_promo(uuid, integer, text) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_grant_promo(uuid, integer, text) TO service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_admin_grant_promo(uuid, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_admin_grant_promo(uuid, integer) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_admin_grant_promo(uuid, integer) TO service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_admin_promo_codes() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_admin_promo_codes() FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_admin_promo_codes() TO service_role;

--- a/packages/db/prisma/migrations/20260808220000_campaigns/migration.sql
+++ b/packages/db/prisma/migrations/20260808220000_campaigns/migration.sql
@@ -1,0 +1,304 @@
+-- A promotion somebody is actually told about, and a way to know if it worked.
+--
+-- A campaign is the announcement wrapped around a promo code: who should see
+-- it, between which dates, and what it says. The code itself already exists —
+-- this adds the telling, and the arithmetic afterwards.
+--
+-- **The holdout is the whole point.** "Revenue impact" of a giveaway is not the
+-- value of what was given away; a comped subscription earns nothing by
+-- construction. What matters is whether the people who were offered it went on
+-- to pay more than the people who were not — so every campaign deliberately
+-- withholds itself from a slice of its own audience, and the result is read as
+-- the difference between those two groups. Without a holdout the honest answer
+-- to "did this work" is "no idea", and a number printed next to that question
+-- would be worse than a blank.
+--
+-- Cohort membership reuses `baaki_bucket` from the feature-flags migration, so
+-- it needs no assignment rows and is stable for a person across the campaign's
+-- whole life. Same hash, same reasoning.
+
+-- ────────────────────────────────────────────────────────── the campaign ──
+
+CREATE TABLE IF NOT EXISTS public.campaigns (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  -- What the person reads. Kept on the campaign rather than in the app's string
+  -- table because it changes per campaign and is written by whoever runs one.
+  title text NOT NULL,
+  body text NOT NULL DEFAULT '',
+  cta_label text NOT NULL DEFAULT '',
+  -- The code the announcement is about. NULL is allowed: an announcement that
+  -- gives nothing away is still a campaign.
+  promo_code text REFERENCES public.promo_codes(code) ON DELETE SET NULL ON UPDATE CASCADE,
+
+  starts_at timestamptz NOT NULL DEFAULT now(),
+  ends_at timestamptz NOT NULL,
+
+  -- ISO-3166 alpha-2 list, or NULL for everybody. Country here is the device
+  -- locale the app read at signup, with all the imprecision that carries.
+  audience_countries text[],
+  -- The slice withheld on purpose, so there is something to compare against.
+  holdout_percent integer NOT NULL DEFAULT 10,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT campaigns_window CHECK (ends_at > starts_at),
+  CONSTRAINT campaigns_holdout_range CHECK (holdout_percent BETWEEN 0 AND 90),
+  CONSTRAINT campaigns_title_present CHECK (length(trim(title)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS campaigns_window_idx ON public.campaigns (starts_at, ends_at);
+
+ALTER TABLE public.campaigns ENABLE ROW LEVEL SECURITY;
+
+-- Deliberately no client-readable policy. The app never selects campaigns
+-- directly: it asks `baaki_my_campaign()`, which answers with the one campaign
+-- this caller should see and nothing else. A client that could read the table
+-- would see campaigns aimed at other countries, campaigns not yet started, and
+-- its own holdout status — which is the one thing that must not leak, because a
+-- holdout who knows they are a holdout is no longer a control group.
+REVOKE ALL ON public.campaigns FROM anon, authenticated;
+
+-- ───────────────────────────────────────────────────────── who saw it ──
+
+CREATE TABLE IF NOT EXISTS public.campaign_impressions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id uuid NOT NULL REFERENCES public.campaigns(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  seen_at timestamptz NOT NULL DEFAULT now(),
+  -- Set when they act on it rather than dismiss it.
+  acted_at timestamptz,
+
+  CONSTRAINT campaign_impressions_once UNIQUE (campaign_id, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS campaign_impressions_campaign_idx
+  ON public.campaign_impressions (campaign_id, seen_at);
+
+ALTER TABLE public.campaign_impressions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS campaign_impressions_own ON public.campaign_impressions;
+CREATE POLICY campaign_impressions_own ON public.campaign_impressions
+  FOR SELECT TO authenticated
+  USING (profile_id = public.baaki_current_profile_id());
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.campaign_impressions FROM anon, authenticated;
+
+-- ──────────────────────────────────────────────────────────── the cohort ──
+
+/**
+ * Whether somebody is in a campaign's holdout.
+ *
+ * Hashed on the campaign id, so a person held out of one campaign is not
+ * systematically held out of the next — which would quietly build a permanent
+ * never-told-anything cohort and bias every result that followed.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_campaign_cohort(p_campaign_id uuid, p_profile_id uuid)
+RETURNS text
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT CASE
+    WHEN p_profile_id IS NULL THEN NULL
+    WHEN public.baaki_bucket('campaign:' || p_campaign_id::text || ':' || p_profile_id::text)
+         < (SELECT holdout_percent FROM public.campaigns WHERE id = p_campaign_id)
+      THEN 'holdout'
+    ELSE 'targeted'
+  END;
+$$;
+
+/**
+ * The campaign this caller should be shown, or nothing.
+ *
+ * SECURITY DEFINER because the table it reads is closed to clients, and it is
+ * the only door into it. It answers with one row at most: running now, matching
+ * their country, not already seen, and not held out. The holdout is filtered
+ * here rather than reported, so the app has no way to render "you are in the
+ * control group" even by accident.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_my_campaign()
+RETURNS TABLE (
+  id uuid,
+  title text,
+  body text,
+  cta_label text,
+  promo_code text,
+  ends_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT c.id, c.title, c.body, c.cta_label, c.promo_code, c.ends_at
+    FROM public.campaigns c
+    JOIN public.profiles p ON p.id = public.baaki_current_profile_id()
+   WHERE now() BETWEEN c.starts_at AND c.ends_at
+     AND (c.audience_countries IS NULL OR p.country_code = ANY (c.audience_countries))
+     AND public.baaki_campaign_cohort(c.id, p.id) = 'targeted'
+     AND NOT EXISTS (
+       SELECT 1 FROM public.campaign_impressions i
+        WHERE i.campaign_id = c.id AND i.profile_id = p.id
+     )
+   ORDER BY c.starts_at DESC
+   LIMIT 1;
+$$;
+
+/**
+ * Records that the announcement was actually put in front of somebody.
+ *
+ * Separate from the cohort because being targeted and having seen it are
+ * different facts: a person who never opened the app during the campaign was
+ * targeted and saw nothing, and a funnel that conflated the two would credit
+ * the campaign with reaching people it never reached.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_campaign_seen(p_campaign_id uuid, p_acted boolean DEFAULT false)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+BEGIN
+  IF v_profile IS NULL THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.campaign_impressions (campaign_id, profile_id, acted_at)
+  VALUES (p_campaign_id, v_profile, CASE WHEN p_acted THEN now() ELSE NULL END)
+  ON CONFLICT (campaign_id, profile_id) DO UPDATE
+    SET acted_at = COALESCE(public.campaign_impressions.acted_at, EXCLUDED.acted_at);
+END
+$$;
+
+-- ─────────────────────────────────────────────────────── did it work ──
+
+/**
+ * The funnel, per cohort.
+ *
+ * `people` counts everybody the campaign could have reached — matching country,
+ * existing when it started — split by cohort. Everything after that is what
+ * they went on to do. The holdout row will have zero seen and zero redeemed by
+ * definition; it is there for `paid`, which is the only column the comparison
+ * actually turns on.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_campaign_funnel(p_campaign_id uuid)
+RETURNS TABLE (
+  cohort text,
+  people bigint,
+  seen bigint,
+  redeemed bigint,
+  paid bigint
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  WITH c AS (
+    SELECT * FROM public.campaigns WHERE id = p_campaign_id
+  ),
+  audience AS (
+    SELECT p.id AS profile_id,
+           public.baaki_campaign_cohort(c.id, p.id) AS cohort
+      FROM public.profiles p
+      CROSS JOIN c
+     WHERE (c.audience_countries IS NULL OR p.country_code = ANY (c.audience_countries))
+       AND p.created_at <= c.ends_at
+  )
+  SELECT
+    a.cohort,
+    count(*)::bigint,
+    count(*) FILTER (
+      WHERE EXISTS (
+        SELECT 1 FROM public.campaign_impressions i
+         WHERE i.campaign_id = p_campaign_id AND i.profile_id = a.profile_id
+      )
+    )::bigint,
+    count(*) FILTER (
+      WHERE EXISTS (
+        SELECT 1
+          FROM public.promo_redemptions r
+          JOIN c ON c.promo_code = r.code
+         WHERE r.profile_id = a.profile_id
+      )
+    )::bigint,
+    -- Paid means a real store purchase, not the giveaway. `store <> 'promo'` is
+    -- the whole distinction: counting the comped rows here would report every
+    -- campaign as a total success.
+    count(*) FILTER (
+      WHERE EXISTS (
+        SELECT 1
+          FROM public.subscriptions s
+          CROSS JOIN c
+         WHERE s.profile_id = a.profile_id
+           AND s.store <> 'promo'
+           AND s.created_at >= c.starts_at
+      )
+    )::bigint
+  FROM audience a
+  GROUP BY a.cohort
+  ORDER BY a.cohort;
+$$;
+
+/**
+ * What was actually earned, per cohort and currency.
+ *
+ * Never summed across currencies, for the reason the rest of this schema
+ * gives: adding rupees to dirhams produces a number wrong in a way nobody can
+ * see. Promo rows are excluded — they carry no price and are not revenue.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_campaign_revenue(p_campaign_id uuid)
+RETURNS TABLE (
+  cohort text,
+  currency text,
+  payers bigint,
+  revenue_minor numeric
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  WITH c AS (
+    SELECT * FROM public.campaigns WHERE id = p_campaign_id
+  )
+  SELECT
+    public.baaki_campaign_cohort(c.id, s.profile_id),
+    s.currency::text,
+    count(DISTINCT s.profile_id)::bigint,
+    COALESCE(sum(s.price_minor), 0)
+  FROM public.subscriptions s
+  JOIN public.profiles p ON p.id = s.profile_id
+  CROSS JOIN c
+  WHERE s.store <> 'promo'
+    AND s.price_minor IS NOT NULL
+    AND s.currency IS NOT NULL
+    AND s.created_at >= c.starts_at
+    AND (c.audience_countries IS NULL OR p.country_code = ANY (c.audience_countries))
+  GROUP BY 1, 2
+  ORDER BY 1, 2;
+$$;
+
+-- ─────────────────────────────────────────────────────────────── grants ──
+
+-- The app may ask what it should show and say that it showed it. Nothing else.
+REVOKE ALL ON FUNCTION public.baaki_my_campaign() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_my_campaign() TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_campaign_seen(uuid, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_campaign_seen(uuid, boolean) TO authenticated, service_role;
+
+-- The cohort must never be answerable by a client: a holdout who learns they
+-- are a holdout has stopped being a control group.
+REVOKE ALL ON FUNCTION public.baaki_campaign_cohort(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_campaign_cohort(uuid, uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_campaign_cohort(uuid, uuid) TO service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_admin_campaign_funnel(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_admin_campaign_funnel(uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_admin_campaign_funnel(uuid) TO service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_admin_campaign_revenue(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_admin_campaign_revenue(uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_admin_campaign_revenue(uuid) TO service_role;

--- a/packages/db/prisma/migrations/20260808230000_feedback_and_erasure/migration.sql
+++ b/packages/db/prisma/migrations/20260808230000_feedback_and_erasure/migration.sql
@@ -1,0 +1,260 @@
+-- Two things people should be able to do: say something, and leave.
+--
+-- ─────────────────────────────────────────────────────────── leaving ──
+--
+-- Deleting a person from a shared ledger is not a delete. Asha's expenses are
+-- also Ravi's records: they are what says he owes ₹4,500, and removing them
+-- would silently change *his* balance to settle a request that was never his.
+-- ADR-004 makes the ledger append-only for exactly this reason.
+--
+-- The database already refuses to pretend otherwise. `group_members.profile_id`
+-- is ON DELETE SET NULL, and the table also carries
+-- `CHECK ((profile_id IS NULL) <> (ghost_name IS NULL))`, so deleting a profile
+-- that is in any group raises `group_members_profile_xor_ghost`. That is not an
+-- obstacle to work around; it is the schema saying that a membership cannot
+-- stop referring to somebody without becoming a reference to somebody else.
+--
+-- So erasure converts the person into a **ghost member** — the shape ADR-006
+-- already uses for people who never joined. Every balance, share and settlement
+-- survives untouched and every other member's ledger stays exactly as true as
+-- it was. What goes is the person: name, avatar, payment handles, country,
+-- locale, notification preferences, push tokens, and the auth identity behind
+-- them. What remains is an unnamed participant, which is the least that can
+-- remain without falsifying somebody else's money.
+--
+-- This is the reading DPDP §12 and GDPR Art 17(3) both allow: erasure yields
+-- where it would erase a third party's rights. The app says so plainly on the
+-- screen before anybody confirms, rather than promising a delete it cannot do.
+--
+-- ────────────────────────────────────────────────────────── saying so ──
+--
+-- Feedback outlives the account that gave it, by `ON DELETE SET NULL` rather
+-- than CASCADE. The most valuable thing anybody writes is why they are leaving,
+-- and cascading it away at the moment of deletion would destroy precisely that.
+
+-- ───────────────────────────────────────────────────────────── feedback ──
+
+CREATE TABLE IF NOT EXISTS public.feedback (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Nullable and SET NULL on purpose: see above.
+  profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  kind text NOT NULL DEFAULT 'general',
+  message text NOT NULL,
+  -- 1–5 where somebody offered one. NULL means they wrote without rating.
+  rating integer,
+  -- Context worth having when reading a complaint, none of it identifying.
+  app_version text,
+  platform text,
+  locale text,
+  country_code text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT feedback_kind_known CHECK (kind IN ('general', 'bug', 'idea', 'deletion')),
+  CONSTRAINT feedback_message_present CHECK (length(trim(message)) BETWEEN 1 AND 4000),
+  CONSTRAINT feedback_rating_range CHECK (rating IS NULL OR rating BETWEEN 1 AND 5)
+);
+
+CREATE INDEX IF NOT EXISTS feedback_recent_idx ON public.feedback (created_at DESC);
+
+ALTER TABLE public.feedback ENABLE ROW LEVEL SECURITY;
+
+-- Somebody may read back what they wrote. Nobody may read anybody else's, and
+-- no client writes directly — `baaki_submit_feedback` stamps the author, so a
+-- client cannot file a complaint under another person's name.
+DROP POLICY IF EXISTS feedback_own ON public.feedback;
+CREATE POLICY feedback_own ON public.feedback
+  FOR SELECT TO authenticated
+  USING (profile_id = public.baaki_current_profile_id());
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.feedback FROM anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.baaki_submit_feedback(
+  p_message text,
+  p_kind text DEFAULT 'general',
+  p_rating integer DEFAULT NULL,
+  p_app_version text DEFAULT NULL,
+  p_platform text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+  v_id uuid;
+BEGIN
+  IF v_profile IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN';
+  END IF;
+  IF length(trim(COALESCE(p_message, ''))) = 0 THEN
+    RAISE EXCEPTION 'EMPTY_MESSAGE';
+  END IF;
+
+  INSERT INTO public.feedback
+    (profile_id, kind, message, rating, app_version, platform, locale, country_code)
+  SELECT
+    v_profile,
+    COALESCE(p_kind, 'general'),
+    left(trim(p_message), 4000),
+    p_rating,
+    p_app_version,
+    p_platform,
+    p.locale,
+    p.country_code
+  FROM public.profiles p
+  WHERE p.id = v_profile
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;
+
+-- ────────────────────────────────────────────────────────────── erasure ──
+
+/**
+ * What deleting would do, before anybody agrees to it.
+ *
+ * The screen shows these numbers so the decision is made with them in view: a
+ * person is entitled to know that their name leaves and their share of a
+ * dinner does not.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_my_erasure_preview()
+RETURNS TABLE (
+  groups_count bigint,
+  expenses_authored bigint,
+  settlements_involved bigint,
+  outstanding_currencies text[]
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  WITH me AS (
+    SELECT id FROM public.group_members
+     WHERE profile_id = public.baaki_current_profile_id()
+  )
+  SELECT
+    (SELECT count(*) FROM me),
+    (SELECT count(*) FROM public.expenses e
+      WHERE e.created_by IN (SELECT id FROM me) AND e.deleted_at IS NULL),
+    (SELECT count(*) FROM public.settlements s
+      WHERE s.from_member_id IN (SELECT id FROM me)
+         OR s.to_member_id IN (SELECT id FROM me)),
+    COALESCE(
+      (SELECT array_agg(DISTINCT b.currency::text)
+         FROM public.group_balances b
+        WHERE b.member_id IN (SELECT id FROM me) AND b.balance <> 0),
+      ARRAY[]::text[]
+    );
+$$;
+
+/**
+ * Erase the person, keep the ledger.
+ *
+ * Order matters. The feedback is written first, while the profile still exists
+ * to be referenced — after the delete it survives with a NULL author, which is
+ * the point. Then every membership becomes a ghost in one statement, because
+ * the XOR constraint means profile_id and ghost_name have to change together.
+ * Only then can the profile row go, taking the personal tables with it by
+ * cascade: push tokens, notifications, subscriptions, usage, redemptions,
+ * impressions, sync queue.
+ *
+ * The auth identity is NOT deleted here. It lives in a schema this database
+ * role does not own, and removing it needs the admin API — the `account-delete`
+ * edge function calls this and then does that. A caller that stops here has
+ * erased the data and left an account that can sign in to nothing, which is
+ * recoverable; the reverse would not be.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_delete_my_account(p_feedback text DEFAULT NULL)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+  v_memberships integer;
+BEGIN
+  IF v_profile IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN';
+  END IF;
+
+  -- While there is still an author to attribute it to. It outlives the row.
+  IF length(trim(COALESCE(p_feedback, ''))) > 0 THEN
+    PERFORM public.baaki_submit_feedback(p_feedback, 'deletion');
+  END IF;
+
+  -- Both columns in one UPDATE: the XOR check is evaluated per row, so setting
+  -- them in two statements is not possible even inside a transaction.
+  UPDATE public.group_members
+     SET profile_id = NULL,
+         ghost_name = 'Former member',
+         payment_handle = NULL,
+         payment_rail = NULL,
+         vpa = NULL,
+         invite_email = NULL,
+         invite_phone = NULL
+   WHERE profile_id = v_profile;
+  GET DIAGNOSTICS v_memberships = ROW_COUNT;
+
+  DELETE FROM public.profiles WHERE id = v_profile;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'memberships_anonymised', v_memberships
+  );
+END
+$$;
+
+-- ────────────────────────────────────────────── what the console reads ──
+
+/**
+ * Feedback, newest first.
+ *
+ * The message is what somebody chose to write, so it is shown; the author is
+ * not, because knowing who complained is not needed to act on a complaint. A
+ * NULL author is somebody who has since deleted their account — their words
+ * remain, which is the reason the foreign key is SET NULL.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_admin_feedback(p_limit integer DEFAULT 100)
+RETURNS TABLE (
+  id uuid,
+  kind text,
+  message text,
+  rating integer,
+  app_version text,
+  platform text,
+  locale text,
+  country_code text,
+  from_deleted_account boolean,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    f.id, f.kind, f.message, f.rating, f.app_version, f.platform,
+    f.locale, f.country_code, f.profile_id IS NULL, f.created_at
+  FROM public.feedback f
+  ORDER BY f.created_at DESC
+  LIMIT GREATEST(COALESCE(p_limit, 100), 1);
+$$;
+
+-- ─────────────────────────────────────────────────────────────── grants ──
+
+REVOKE ALL ON FUNCTION public.baaki_submit_feedback(text, text, integer, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_submit_feedback(text, text, integer, text, text)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_my_erasure_preview() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_my_erasure_preview() TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_delete_my_account(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_delete_my_account(text) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_admin_feedback(integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_admin_feedback(integer) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_admin_feedback(integer) TO service_role;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -149,6 +149,7 @@ model Profile {
   usageEvents       UsageEvent[]
   subscriptions     Subscription[]
   promoRedemptions  PromoRedemption[]
+  campaignImpressions CampaignImpression[]
   purchasedPasses   GroupPass[]
   syncMutations     SyncMutation[]
 
@@ -767,6 +768,7 @@ model PromoCode {
   createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
 
   redemptions PromoRedemption[]
+  campaigns   Campaign[]
 
   @@map("promo_codes")
   @@schema("public")
@@ -788,6 +790,66 @@ model PromoRedemption {
   @@unique([code, profileId], map: "promo_redemptions_once")
   @@index([profileId, redeemedAt], map: "promo_redemptions_profile_idx")
   @@map("promo_redemptions")
+  @@schema("public")
+}
+
+/// A promotion somebody is actually told about.
+///
+/// Closed to clients entirely. The app never selects from here — it asks
+/// `baaki_my_campaign()`, which answers with the one campaign the caller should
+/// see. Reading the table would expose campaigns aimed elsewhere, campaigns not
+/// yet started, and the caller's own holdout status, which is the one thing
+/// that must not leak: a holdout who knows they are a holdout has stopped being
+/// a control group.
+model Campaign {
+  id        String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name      String
+  /// What the person reads. On the campaign rather than in the app's string
+  /// table because it changes per campaign and is written by whoever runs one.
+  title     String
+  body      String @default("")
+  ctaLabel  String @default("") @map("cta_label")
+  /// NULL is allowed — an announcement that gives nothing away is still a
+  /// campaign.
+  promoCode String? @map("promo_code")
+
+  startsAt DateTime @default(now()) @map("starts_at") @db.Timestamptz(6)
+  endsAt   DateTime @map("ends_at") @db.Timestamptz(6)
+
+  /// ISO-3166 alpha-2, or NULL for everybody. Device locale, with all the
+  /// imprecision that carries.
+  audienceCountries String[] @map("audience_countries")
+  /// The slice withheld on purpose, so there is something to compare against.
+  /// Without it, the honest answer to "did this work" is "no idea".
+  holdoutPercent    Int      @default(10) @map("holdout_percent")
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  code        PromoCode?           @relation(fields: [promoCode], references: [code], onDelete: SetNull)
+  impressions CampaignImpression[]
+
+  @@index([startsAt, endsAt], map: "campaigns_window_idx")
+  @@map("campaigns")
+  @@schema("public")
+}
+
+/// That the announcement was actually put in front of somebody — a different
+/// fact from having been targeted. Somebody who never opened the app during the
+/// campaign was targeted and saw nothing.
+model CampaignImpression {
+  id         String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  campaignId String    @map("campaign_id") @db.Uuid
+  profileId  String    @map("profile_id") @db.Uuid
+  seenAt     DateTime  @default(now()) @map("seen_at") @db.Timestamptz(6)
+  /// Set when they act on it rather than dismiss it.
+  actedAt    DateTime? @map("acted_at") @db.Timestamptz(6)
+
+  campaign Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  profile  Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  @@unique([campaignId, profileId], map: "campaign_impressions_once")
+  @@index([campaignId, seenAt], map: "campaign_impressions_campaign_idx")
+  @@map("campaign_impressions")
   @@schema("public")
 }
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -150,6 +150,7 @@ model Profile {
   subscriptions     Subscription[]
   promoRedemptions  PromoRedemption[]
   campaignImpressions CampaignImpression[]
+  feedback          Feedback[]
   purchasedPasses   GroupPass[]
   syncMutations     SyncMutation[]
 
@@ -850,6 +851,34 @@ model CampaignImpression {
   @@unique([campaignId, profileId], map: "campaign_impressions_once")
   @@index([campaignId, seenAt], map: "campaign_impressions_campaign_idx")
   @@map("campaign_impressions")
+  @@schema("public")
+}
+
+/// Something somebody chose to tell us.
+///
+/// `profileId` is nullable and SET NULL rather than CASCADE, deliberately: the
+/// most useful thing anybody writes is why they are leaving, and cascading it
+/// away at the moment of deletion would destroy exactly that. A NULL author is
+/// somebody who has since erased their account; their words remain, attached to
+/// nobody.
+model Feedback {
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  profileId   String?  @map("profile_id") @db.Uuid
+  /// general | bug | idea | deletion
+  kind        String   @default("general")
+  message     String
+  /// 1–5 where somebody offered one. NULL means they wrote without rating.
+  rating      Int?
+  appVersion  String?  @map("app_version")
+  platform    String?
+  locale      String?
+  countryCode String?  @map("country_code")
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  profile Profile? @relation(fields: [profileId], references: [id], onDelete: SetNull)
+
+  @@index([createdAt(sort: Desc)], map: "feedback_recent_idx")
+  @@map("feedback")
   @@schema("public")
 }
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -148,6 +148,7 @@ model Profile {
   createdInvites    Invite[]        @relation("InviteCreatedBy")
   usageEvents       UsageEvent[]
   subscriptions     Subscription[]
+  promoRedemptions  PromoRedemption[]
   purchasedPasses   GroupPass[]
   syncMutations     SyncMutation[]
 
@@ -723,6 +724,73 @@ model AppRelease {
   @@schema("public")
 }
 
+/// A feature switch, and the experiment running behind it.
+///
+/// Readable by every client and writable by none of them: with RLS on and no
+/// write policy, the service role is the only way in. A flag a client could
+/// flip is a paywall with a door in the back — the same shape as a settlement
+/// somebody could confirm themselves.
+///
+/// Who sees which arm is not stored anywhere. It is hashed from the flag key
+/// and the profile id, identically in `baaki_variant` and in `bucketOf` from
+/// `@baaki/core`, so the answer needs no round trip and the analysis is a join
+/// rather than a pipeline of exposure events.
+model FeatureFlag {
+  key            String   @id
+  description    String   @default("")
+  enabled        Boolean  @default(false)
+  /// 0–100. How much of the population is in the experiment at all.
+  rolloutPercent Int      @default(0) @map("rollout_percent")
+  /// Two to eight, distinct. The first is the control by convention.
+  variants       String[] @default(["control", "treatment"])
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt      DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@map("feature_flags")
+  @@schema("public")
+}
+
+/// A promotion somebody can type in. Not readable by any client at all — every
+/// other table here is visible to the person it concerns, but a list of valid
+/// codes is not about a person, it is the giveaway itself.
+model PromoCode {
+  code           String    @id
+  tier           String    @default("plus")
+  /// How long the grant lasts, in days — not an end date, so one code means the
+  /// same thing to somebody redeeming it today and in a month.
+  days           Int       @default(30)
+  maxRedemptions Int       @default(1) @map("max_redemptions")
+  redeemedCount  Int       @default(0) @map("redeemed_count")
+  /// When the code stops working, which is not when the grant ends.
+  expiresAt      DateTime? @map("expires_at") @db.Timestamptz(6)
+  note           String    @default("")
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  redemptions PromoRedemption[]
+
+  @@map("promo_codes")
+  @@schema("public")
+}
+
+/// Who used which code. Written only by `baaki_redeem_promo`, which is
+/// SECURITY DEFINER so the client never touches `subscriptions` itself.
+model PromoRedemption {
+  id             String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  code           String
+  profileId      String   @map("profile_id") @db.Uuid
+  subscriptionId String?  @map("subscription_id") @db.Uuid
+  redeemedAt     DateTime @default(now()) @map("redeemed_at") @db.Timestamptz(6)
+
+  promoCode    PromoCode     @relation(fields: [code], references: [code], onDelete: Cascade)
+  profile      Profile       @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  subscription Subscription? @relation(fields: [subscriptionId], references: [id], onDelete: SetNull)
+
+  @@unique([code, profileId], map: "promo_redemptions_once")
+  @@index([profileId, redeemedAt], map: "promo_redemptions_profile_idx")
+  @@map("promo_redemptions")
+  @@schema("public")
+}
+
 /// What somebody bought. Written only by the service role after a store
 /// receipt has been verified — a client that could insert one of these is a
 /// paywall with a door in the back.
@@ -745,7 +813,8 @@ model Subscription {
   createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  profile          Profile           @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  promoRedemptions PromoRedemption[]
 
   @@index([profileId, status], map: "subscriptions_profile_idx")
   @@map("subscriptions")

--- a/packages/db/test/adminAnalytics.test.ts
+++ b/packages/db/test/adminAnalytics.test.ts
@@ -1,0 +1,207 @@
+/**
+ * The admin console's reads, and who is allowed to make them.
+ *
+ * The grants are the point. Postgres gives EXECUTE to PUBLIC on every new
+ * function, and `anon` and `authenticated` inherit PUBLIC in Supabase — so a
+ * missing REVOKE does not fail loudly, it quietly publishes the whole business
+ * behind the anon key that ships inside the app binary. That is a one-line
+ * mistake with no symptom, which is exactly the kind worth a test.
+ *
+ * The arithmetic is checked too, against rows this file seeds, because a
+ * dashboard that is confidently wrong is worse than one that is empty.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, expectDenied, seedGroup } from './helpers';
+
+let client: Client;
+
+const FUNCTIONS = [
+  'baaki_admin_overview()',
+  'baaki_admin_daily(30)',
+  'baaki_admin_geo()',
+  'baaki_admin_money()',
+  'baaki_admin_ai_cost(30)',
+  'baaki_admin_logins(30)',
+];
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+/** Runs one statement as a role, then puts the connection back. */
+async function asRole<T>(role: string, run: () => Promise<T>): Promise<T> {
+  await client.query('BEGIN');
+  try {
+    await client.query(`SET LOCAL ROLE ${role}`);
+    return await run();
+  } finally {
+    await client.query('ROLLBACK');
+  }
+}
+
+describe('who may read the business', () => {
+  it('refuses anon on every function', async () => {
+    for (const fn of FUNCTIONS) {
+      const message = await asRole('anon', () =>
+        expectDenied(client.query(`SELECT * FROM public.${fn}`)),
+      );
+      expect(message, fn).toMatch(/permission denied/i);
+    }
+  });
+
+  it('refuses a signed-in user on every function', async () => {
+    // The one that matters most. Every Baaki account is signed in, including
+    // the anonymous guests ADR-006 hands out for free — "authenticated" is not
+    // a privilege here, it is the default.
+    for (const fn of FUNCTIONS) {
+      const message = await asRole('authenticated', () =>
+        expectDenied(client.query(`SELECT * FROM public.${fn}`)),
+      );
+      expect(message, fn).toMatch(/permission denied/i);
+    }
+  });
+
+  it('allows the service role', async () => {
+    for (const fn of FUNCTIONS) {
+      await asRole('service_role', async () => {
+        await expect(client.query(`SELECT * FROM public.${fn}`)).resolves.toBeDefined();
+      });
+    }
+  });
+});
+
+describe('the numbers', () => {
+  it('counts people, groups and live expenses', async () => {
+    const before = (await client.query('SELECT * FROM public.baaki_admin_overview()')).rows[0];
+
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const expenseId = await addExpense(client, groupId, memberIds[0]!, 'INR', 45000n);
+
+    const after = (await client.query('SELECT * FROM public.baaki_admin_overview()')).rows[0];
+
+    expect(Number(after.profiles_total)).toBe(Number(before.profiles_total) + 2);
+    expect(Number(after.groups_total)).toBe(Number(before.groups_total) + 1);
+    expect(Number(after.expenses_total)).toBe(Number(before.expenses_total) + 1);
+
+    // A soft-deleted expense leaves the live count and joins the deleted one.
+    await client.query('UPDATE public.expenses SET deleted_at = now() WHERE id = $1', [expenseId]);
+    const deleted = (await client.query('SELECT * FROM public.baaki_admin_overview()')).rows[0];
+    expect(Number(deleted.expenses_total)).toBe(Number(after.expenses_total) - 1);
+    expect(Number(deleted.expenses_deleted)).toBe(Number(after.expenses_deleted) + 1);
+  });
+
+  it('keeps a day with nothing in it', async () => {
+    // The reason this is generate_series and not GROUP BY: a chart drawn from
+    // grouped rows closes its own gaps, and a flat fortnight is information.
+    const { rows } = await client.query('SELECT * FROM public.baaki_admin_daily(14)');
+    expect(rows).toHaveLength(14);
+
+    const days = rows.map((row) => String(row.day instanceof Date ? isoDay(row.day) : row.day));
+    expect(new Set(days).size).toBe(14);
+    expect(days).toEqual([...days].sort());
+  });
+
+  it('never adds one currency to another', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    await addExpense(client, groupId, memberIds[0]!, 'INR', 10_000n);
+    await addExpense(client, groupId, memberIds[0]!, 'AED', 700n);
+
+    const { rows } = await client.query('SELECT * FROM public.baaki_admin_money()');
+    const inr = rows.find((row) => row.currency === 'INR');
+    const aed = rows.find((row) => row.currency === 'AED');
+
+    expect(inr).toBeDefined();
+    expect(aed).toBeDefined();
+    // Separate rows, and the AED row cannot have absorbed the rupees.
+    expect(BigInt(aed!.expense_minor)).toBeGreaterThanOrEqual(700n);
+    expect(BigInt(inr!.expense_minor)).toBeGreaterThanOrEqual(10_000n);
+    expect(rows.every((row) => typeof row.currency === 'string' && row.currency.length === 3)).toBe(
+      true,
+    );
+  });
+
+  it('counts an edited expense once, at its current version', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const expenseId = await addExpense(client, groupId, memberIds[0]!, 'SGD', 5_000n);
+
+    const before = await currencyTotal(client, 'SGD');
+    await addVersion(client, expenseId, memberIds[0]!, 'SGD', 9_000n, 2);
+    const after = await currencyTotal(client, 'SGD');
+
+    // 5000 replaced by 9000, not 5000 + 9000.
+    expect(after - before).toBe(4_000n);
+  });
+
+  it('reports an unknown country as its own row rather than dropping it', async () => {
+    await seedGroup(client, { memberCount: 1 });
+    const { rows } = await client.query('SELECT * FROM public.baaki_admin_geo()');
+    expect(rows.some((row) => row.country_code === null)).toBe(true);
+  });
+
+  it('returns nothing for logins on a database with no auth schema', async () => {
+    // CI is bare Postgres. The function must answer rather than raise — an
+    // admin console that 500s on a machine without Supabase's auth schema is
+    // one nobody can develop against.
+    const { rows } = await client.query('SELECT * FROM public.baaki_admin_logins(30)');
+    expect(Array.isArray(rows)).toBe(true);
+  });
+});
+
+const isoDay = (date: Date): string => date.toISOString().slice(0, 10);
+
+async function currencyTotal(db: Client, currency: string): Promise<bigint> {
+  const { rows } = await db.query(
+    'SELECT expense_minor FROM public.baaki_admin_money() WHERE currency = $1',
+    [currency],
+  );
+  return rows[0] ? BigInt(rows[0].expense_minor) : 0n;
+}
+
+/** One expense with one version, made current — the shape the app writes. */
+async function addExpense(
+  db: Client,
+  groupId: string,
+  memberId: string,
+  currency: string,
+  amount: bigint,
+): Promise<string> {
+  const expenseId = randomUUID();
+  await db.query(`INSERT INTO public.expenses (id, group_id, created_by) VALUES ($1, $2, $3)`, [
+    expenseId,
+    groupId,
+    memberId,
+  ]);
+  await addVersion(db, expenseId, memberId, currency, amount, 1);
+  return expenseId;
+}
+
+async function addVersion(
+  db: Client,
+  expenseId: string,
+  memberId: string,
+  currency: string,
+  amount: bigint,
+  versionNo: number,
+): Promise<void> {
+  const versionId = randomUUID();
+  await db.query(
+    `INSERT INTO public.expense_versions
+       (id, expense_id, version_no, author_member_id, description, expense_date,
+        currency, amount, split_type, split_params)
+     VALUES ($1, $2, $3, $4, 'Dinner', current_date, $5, $6, 'equal', '{"kind":"equal"}')`,
+    [versionId, expenseId, versionNo, memberId, currency, amount.toString()],
+  );
+  await db.query('UPDATE public.expenses SET current_version_id = $1 WHERE id = $2', [
+    versionId,
+    expenseId,
+  ]);
+}

--- a/packages/db/test/adminAnalytics.test.ts
+++ b/packages/db/test/adminAnalytics.test.ts
@@ -16,7 +16,7 @@ import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Client } from 'pg';
 
-import { connect, expectDenied, seedGroup } from './helpers';
+import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers';
 
 let client: Client;
 
@@ -166,7 +166,15 @@ async function currencyTotal(db: Client, currency: string): Promise<bigint> {
   return rows[0] ? BigInt(rows[0].expense_minor) : 0n;
 }
 
-/** One expense with one version, made current — the shape the app writes. */
+/**
+ * One expense, through the repo's own helper.
+ *
+ * Hand-rolling the inserts here did not work and should not have: a trigger
+ * checks that the payers sum to the amount, so an expense seeded without them
+ * is rejected — `PAYER_MISMATCH: payers sum to 0 but the expense is 10000`.
+ * That guard is the ledger's, and a test fixture that sidestepped it would be
+ * measuring rows the app can never produce.
+ */
 async function addExpense(
   db: Client,
   groupId: string,
@@ -174,16 +182,17 @@ async function addExpense(
   currency: string,
   amount: bigint,
 ): Promise<string> {
-  const expenseId = randomUUID();
-  await db.query(`INSERT INTO public.expenses (id, group_id, created_by) VALUES ($1, $2, $3)`, [
-    expenseId,
+  const { expenseId } = await addEqualSplitExpense(db, {
     groupId,
-    memberId,
-  ]);
-  await addVersion(db, expenseId, memberId, currency, amount, 1);
+    payers: { [memberId]: amount },
+    participants: [memberId],
+    amount,
+    currency,
+  });
   return expenseId;
 }
 
+/** A second version of an existing expense, payers and shares included. */
 async function addVersion(
   db: Client,
   expenseId: string,
@@ -193,15 +202,27 @@ async function addVersion(
   versionNo: number,
 ): Promise<void> {
   const versionId = randomUUID();
+  await db.query('BEGIN');
   await db.query(
     `INSERT INTO public.expense_versions
        (id, expense_id, version_no, author_member_id, description, expense_date,
         currency, amount, split_type, split_params)
-     VALUES ($1, $2, $3, $4, 'Dinner', current_date, $5, $6, 'equal', '{"kind":"equal"}')`,
+     VALUES ($1, $2, $3, $4, 'Dinner', current_date, $5, $6, 'equal', '{"kind":"equal"}'::jsonb)`,
     [versionId, expenseId, versionNo, memberId, currency, amount.toString()],
+  );
+  await db.query(
+    `INSERT INTO public.expense_payers (id, expense_version_id, member_id, amount)
+     VALUES ($1, $2, $3, $4)`,
+    [randomUUID(), versionId, memberId, amount.toString()],
+  );
+  await db.query(
+    `INSERT INTO public.expense_shares (id, expense_version_id, member_id, amount)
+     VALUES ($1, $2, $3, $4)`,
+    [randomUUID(), versionId, memberId, amount.toString()],
   );
   await db.query('UPDATE public.expenses SET current_version_id = $1 WHERE id = $2', [
     versionId,
     expenseId,
   ]);
+  await db.query('COMMIT');
 }

--- a/packages/db/test/campaigns.test.ts
+++ b/packages/db/test/campaigns.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Campaigns, and the holdout that makes "did it work" answerable.
+ *
+ * The tests that matter most here are not about arithmetic. They are that a
+ * client cannot read the campaigns table, cannot ask which cohort it is in, and
+ * that somebody held out never receives the announcement. A holdout who learns
+ * they are a holdout has stopped being a control group, and every number
+ * downstream of that is decoration.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { asRole, connect, expectDenied } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+async function makeProfile(country: string | null = 'IN'): Promise<string> {
+  const id = randomUUID();
+  await client.query(
+    `INSERT INTO public.profiles (id, display_name, country_code) VALUES ($1, 'Tester', $2)`,
+    [id, country],
+  );
+  return id;
+}
+
+async function makeCampaign(
+  over: {
+    holdout?: number;
+    countries?: string[] | null;
+    startsAt?: string;
+    endsAt?: string;
+    promoCode?: string | null;
+  } = {},
+): Promise<string> {
+  const {
+    holdout = 10,
+    countries = null,
+    startsAt = "now() - interval '1 day'",
+    endsAt = "now() + interval '7 days'",
+    promoCode = null,
+  } = over;
+
+  // A unique title per campaign. Every test in this file leaves running
+  // campaigns behind, and `baaki_my_campaign` legitimately answers with any one
+  // of them — so asserting on a shared title matches the wrong row and the
+  // test passes or fails for reasons that have nothing to do with its subject.
+  const { rows } = await client.query(
+    `INSERT INTO public.campaigns
+       (name, title, body, cta_label, promo_code, starts_at, ends_at,
+        audience_countries, holdout_percent)
+     VALUES ('Test', $4, 'Because you have been here a while',
+             'Get it', $1, ${startsAt}, ${endsAt}, $2, $3)
+     RETURNING id`,
+    [promoCode, countries, holdout, `Offer ${randomUUID().slice(0, 8)}`],
+  );
+  return rows[0].id;
+}
+
+/** Total revenue the function reports right now, across every cohort. */
+async function totalRevenue(campaignId: string): Promise<number> {
+  const { rows } = await client.query('SELECT * FROM public.baaki_admin_campaign_revenue($1)', [
+    campaignId,
+  ]);
+  return rows.reduce((sum, row) => sum + Number(row.revenue_minor), 0);
+}
+
+/** What the app sees, as the app sees it. Read-only, so a rollback is fine. */
+async function myCampaign(profileId: string) {
+  return asRole(client, 'authenticated', { sub: profileId, role: 'authenticated' }, async () => {
+    const { rows } = await client.query('SELECT * FROM public.baaki_my_campaign()');
+    return rows;
+  });
+}
+
+/**
+ * The same identity, but for a call that has to persist.
+ *
+ * `asRole` ends in ROLLBACK — that is how it puts the connection back — so
+ * anything written through it is discarded the moment it returns. Recording an
+ * impression is a write, so the claim is set at session scope instead and the
+ * statement runs outside a transaction of the helper's making.
+ */
+async function asProfile<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  try {
+    return await run();
+  } finally {
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+describe('the holdout', () => {
+  it('splits the audience at roughly the percentage asked for', async () => {
+    const campaignId = await makeCampaign({ holdout: 30 });
+    const people = Array.from({ length: 400 }, () => randomUUID());
+
+    const { rows } = await client.query(
+      `SELECT public.baaki_campaign_cohort($1, p::uuid) AS cohort FROM unnest($2::uuid[]) AS p`,
+      [campaignId, people],
+    );
+    const held = rows.filter((row) => row.cohort === 'holdout').length;
+
+    // 30% ± 8 points over 400 draws. Wide enough not to flake, tight enough to
+    // catch a bucketer that ignores the percentage.
+    expect(held / rows.length).toBeGreaterThan(0.22);
+    expect(held / rows.length).toBeLessThan(0.38);
+  });
+
+  it('gives the same person the same cohort every time', async () => {
+    const campaignId = await makeCampaign({ holdout: 50 });
+    const profileId = randomUUID();
+    const once = await client.query('SELECT public.baaki_campaign_cohort($1, $2) AS c', [
+      campaignId,
+      profileId,
+    ]);
+    const twice = await client.query('SELECT public.baaki_campaign_cohort($1, $2) AS c', [
+      campaignId,
+      profileId,
+    ]);
+    expect(once.rows[0].c).toBe(twice.rows[0].c);
+  });
+
+  it('does not hold the same people out of every campaign', async () => {
+    // Hashing on the campaign id rather than a per-person flag. Otherwise the
+    // same unlucky cohort is never told anything and every later result is
+    // measured against people who have been ignored for months.
+    const first = await makeCampaign({ holdout: 50 });
+    const second = await makeCampaign({ holdout: 50 });
+    const people = Array.from({ length: 300 }, () => randomUUID());
+
+    const { rows } = await client.query(
+      `SELECT p::uuid AS id,
+              public.baaki_campaign_cohort($1, p::uuid) AS a,
+              public.baaki_campaign_cohort($2, p::uuid) AS b
+         FROM unnest($3::uuid[]) AS p`,
+      [first, second, people],
+    );
+    const moved = rows.filter((row) => row.a !== row.b).length;
+    // Independent hashes: about half should differ. Zero would mean one shared
+    // bucket, which is the bug.
+    expect(moved).toBeGreaterThan(rows.length * 0.3);
+  });
+});
+
+describe('what the app is shown', () => {
+  it('offers a running campaign to a targeted person', async () => {
+    const campaignId = await makeCampaign({ holdout: 0 });
+    const profileId = await makeProfile('IN');
+
+    const rows = await myCampaign(profileId);
+    expect(rows.map((row) => row.id)).toContain(campaignId);
+    // The announcement's own words come back, not an id the app would have to
+    // look up somewhere it has no access to.
+    const offered = rows.find((row) => row.id === campaignId);
+    expect(offered?.title).toMatch(/^Offer /);
+    expect(offered?.cta_label).toBe('Get it');
+  });
+
+  it('never offers it to somebody held out', async () => {
+    const campaignId = await makeCampaign({ holdout: 90 });
+    const held: string[] = [];
+    for (let index = 0; index < 25; index += 1) {
+      const profileId = await makeProfile('IN');
+      const cohort = await client.query('SELECT public.baaki_campaign_cohort($1, $2) AS cohort', [
+        campaignId,
+        profileId,
+      ]);
+      if (cohort.rows[0].cohort === 'holdout') held.push(profileId);
+    }
+    expect(held.length).toBeGreaterThan(0);
+
+    // Specifically this campaign. They may well be offered another one that is
+    // also running, and that is correct behaviour rather than a leak.
+    for (const profileId of held) {
+      const rows = await myCampaign(profileId);
+      expect(
+        rows.map((row) => row.id),
+        profileId,
+      ).not.toContain(campaignId);
+    }
+  });
+
+  it('respects the country the campaign is aimed at', async () => {
+    const campaignId = await makeCampaign({ holdout: 0, countries: ['AE'] });
+    const indian = await makeProfile('IN');
+    const emirati = await makeProfile('AE');
+
+    expect((await myCampaign(indian)).map((row) => row.id)).not.toContain(campaignId);
+    expect((await myCampaign(emirati)).map((row) => row.id)).toContain(campaignId);
+  });
+
+  it('does not offer one that has not started or has ended', async () => {
+    const profileId = await makeProfile('IN');
+    const before = await myCampaign(profileId);
+
+    await makeCampaign({
+      holdout: 0,
+      startsAt: "now() + interval '3 days'",
+      endsAt: "now() + interval '9 days'",
+    });
+    await makeCampaign({
+      holdout: 0,
+      startsAt: "now() - interval '9 days'",
+      endsAt: "now() - interval '3 days'",
+    });
+
+    expect(await myCampaign(profileId)).toHaveLength(before.length);
+  });
+
+  it('stops offering it once it has been seen', async () => {
+    const campaignId = await makeCampaign({ holdout: 0 });
+    const profileId = await makeProfile('IN');
+
+    expect((await myCampaign(profileId)).some((row) => row.id === campaignId)).toBe(true);
+
+    await asProfile(profileId, () =>
+      client.query('SELECT public.baaki_campaign_seen($1, $2)', [campaignId, false]),
+    );
+
+    expect((await myCampaign(profileId)).some((row) => row.id === campaignId)).toBe(false);
+  });
+
+  it('records one impression however many times it is reported', async () => {
+    const campaignId = await makeCampaign({ holdout: 0 });
+    const profileId = await makeProfile('IN');
+
+    for (const acted of [false, true, false]) {
+      await asProfile(profileId, () =>
+        client.query('SELECT public.baaki_campaign_seen($1, $2)', [campaignId, acted]),
+      );
+    }
+
+    const { rows } = await client.query(
+      'SELECT * FROM public.campaign_impressions WHERE campaign_id = $1 AND profile_id = $2',
+      [campaignId, profileId],
+    );
+    expect(rows).toHaveLength(1);
+    // Having acted once is not undone by a later dismissal.
+    expect(rows[0].acted_at).not.toBeNull();
+  });
+});
+
+describe('what a client may not do', () => {
+  it('cannot read the campaigns table', async () => {
+    // It would expose campaigns aimed elsewhere, campaigns not yet started, and
+    // the reader's own holdout status.
+    for (const role of ['anon', 'authenticated'] as const) {
+      const message = await asRole(client, role, { role }, () =>
+        expectDenied(client.query('SELECT * FROM public.campaigns')),
+      );
+      expect(message, role).toMatch(/permission denied/i);
+    }
+  });
+
+  it('cannot ask which cohort it is in', async () => {
+    for (const role of ['anon', 'authenticated'] as const) {
+      const message = await asRole(client, role, { role }, () =>
+        expectDenied(
+          client.query('SELECT public.baaki_campaign_cohort($1, $2)', [randomUUID(), randomUUID()]),
+        ),
+      );
+      expect(message, role).toMatch(/permission denied/i);
+    }
+  });
+
+  it('cannot read the results', async () => {
+    for (const role of ['anon', 'authenticated'] as const) {
+      const message = await asRole(client, role, { role }, () =>
+        expectDenied(
+          client.query('SELECT * FROM public.baaki_admin_campaign_funnel($1)', [randomUUID()]),
+        ),
+      );
+      expect(message, role).toMatch(/permission denied/i);
+    }
+  });
+
+  it('cannot write an impression for somebody else', async () => {
+    const campaignId = await makeCampaign({ holdout: 0 });
+    const mine = await makeProfile('IN');
+    const theirs = await makeProfile('IN');
+
+    const message = await asRole(
+      client,
+      'authenticated',
+      { sub: mine, role: 'authenticated' },
+      () =>
+        expectDenied(
+          client.query(
+            'INSERT INTO public.campaign_impressions (campaign_id, profile_id) VALUES ($1, $2)',
+            [campaignId, theirs],
+          ),
+        ),
+    );
+    expect(message).toMatch(/permission denied/i);
+  });
+});
+
+describe('did it work', () => {
+  it('counts a comped subscription as a grant, never as revenue', async () => {
+    // The distinction the whole feature turns on. A promo row has no price and
+    // must not appear as money earned, or every campaign reports as a triumph.
+    // Unique per run: this database is disposable in CI but persists locally,
+    // and a fixed code collides with itself the second time.
+    const code = `T${randomUUID().replace(/-/g, '').slice(0, 9).toUpperCase()}`;
+    await client.query(
+      `INSERT INTO public.promo_codes (code, days, max_redemptions) VALUES ($1, 30, 100)`,
+      [code],
+    );
+    const campaignId = await makeCampaign({ holdout: 0, promoCode: code });
+    const profileId = await makeProfile('IN');
+
+    // Before and after, rather than an absolute: other tests in this file leave
+    // real purchases behind, and the claim being made is only that *this* row
+    // adds nothing.
+    const before = await totalRevenue(campaignId);
+
+    await client.query(
+      `INSERT INTO public.subscriptions
+         (profile_id, tier, period, status, current_period_end, store, store_txn_id)
+       VALUES ($1, 'plus', 'monthly', 'active', now() + interval '30 days', 'promo', $2)`,
+      [profileId, `promo:${code}:${profileId}`],
+    );
+
+    expect(await totalRevenue(campaignId)).toBe(before);
+  });
+
+  it('counts a real purchase as revenue, per currency', async () => {
+    const campaignId = await makeCampaign({ holdout: 0 });
+    const profileId = await makeProfile('IN');
+
+    await client.query(
+      `INSERT INTO public.subscriptions
+         (profile_id, tier, period, status, current_period_end, store, store_txn_id,
+          price_minor, currency)
+       VALUES ($1, 'plus', 'monthly', 'active', now() + interval '30 days', 'play', $2, 9900, 'INR')`,
+      [profileId, `play:${profileId}`],
+    );
+
+    const { rows } = await client.query('SELECT * FROM public.baaki_admin_campaign_revenue($1)', [
+      campaignId,
+    ]);
+    const inr = rows.find((row) => row.currency === 'INR');
+    expect(inr).toBeDefined();
+    expect(Number(inr!.revenue_minor)).toBeGreaterThanOrEqual(9900);
+    expect(rows.every((row) => ['targeted', 'holdout'].includes(row.cohort))).toBe(true);
+  });
+
+  it('reports a funnel split by cohort', async () => {
+    const campaignId = await makeCampaign({ holdout: 40 });
+    for (let index = 0; index < 30; index += 1) await makeProfile('IN');
+
+    const { rows } = await client.query('SELECT * FROM public.baaki_admin_campaign_funnel($1)', [
+      campaignId,
+    ]);
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(['targeted', 'holdout']).toContain(row.cohort);
+      // Nobody can have been seen more times than there are people in the arm.
+      expect(Number(row.seen)).toBeLessThanOrEqual(Number(row.people));
+      expect(Number(row.redeemed)).toBeLessThanOrEqual(Number(row.people));
+      expect(Number(row.paid)).toBeLessThanOrEqual(Number(row.people));
+    }
+  });
+});

--- a/packages/db/test/erasure.test.ts
+++ b/packages/db/test/erasure.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Leaving, and what leaving must not take with it.
+ *
+ * The test this file exists for is the balance one. Asha's expenses are also
+ * Ravi's records — they are what says he owes ₹4,500 — so an erasure that
+ * removed them would silently settle a debt nobody paid. Every other assertion
+ * here is secondary to that one.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, big, connect, expectDenied, seedGroup } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+/** Session-scoped claims: erasure is a write, so a rolled-back role will not do. */
+async function asProfile<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  try {
+    return await run();
+  } finally {
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+async function balances(groupId: string): Promise<Map<string, bigint>> {
+  const { rows } = await client.query(
+    'SELECT member_id, balance FROM public.group_balances WHERE group_id = $1',
+    [groupId],
+  );
+  return new Map(rows.map((row) => [row.member_id as string, big(row.balance)]));
+}
+
+describe('the schema refuses a naive delete', () => {
+  it('will not let a profile in a group simply disappear', async () => {
+    // Not a limitation to work around — the check is the schema saying a
+    // membership cannot stop referring to somebody without becoming a
+    // reference to somebody else. It is why erasure converts to a ghost.
+    const { profileIds } = await seedGroup(client, { memberCount: 2 });
+    const message = await expectDenied(
+      client.query('DELETE FROM public.profiles WHERE id = $1', [profileIds[0]]),
+    );
+    expect(message).toMatch(/group_members_profile_xor_ghost/);
+  });
+});
+
+describe('erasing an account', () => {
+  it('leaves every other person’s balance exactly where it was', async () => {
+    const { groupId, profileIds, memberIds } = await seedGroup(client, { memberCount: 3 });
+    const [asha, ravi] = memberIds as [string, string, string];
+
+    // Asha pays for dinner; all three owe her a share.
+    await addEqualSplitExpense(client, {
+      groupId,
+      payers: { [asha]: 45_000n },
+      participants: memberIds,
+      amount: 45_000n,
+    });
+
+    const before = await balances(groupId);
+    const raviBefore = before.get(ravi);
+    expect(raviBefore).toBeDefined();
+    expect(raviBefore).not.toBe(0n);
+
+    await asProfile(profileIds[0]!, () =>
+      client.query('SELECT public.baaki_delete_my_account($1)', ['Leaving, thanks']),
+    );
+
+    const after = await balances(groupId);
+    // The whole point, stated twice: what Ravi owes is unchanged, and the sum
+    // still cancels (ADR-004's invariant).
+    expect(after.get(ravi)).toBe(raviBefore);
+    const total = [...after.values()].reduce((sum, value) => sum + value, 0n);
+    expect(total).toBe(0n);
+  });
+
+  it('turns the membership into a ghost rather than removing it', async () => {
+    const { groupId, profileIds } = await seedGroup(client, { memberCount: 2 });
+    const countBefore = await client.query(
+      'SELECT count(*)::int AS n FROM public.group_members WHERE group_id = $1',
+      [groupId],
+    );
+
+    await asProfile(profileIds[0]!, () => client.query('SELECT public.baaki_delete_my_account()'));
+
+    const countAfter = await client.query(
+      'SELECT count(*)::int AS n FROM public.group_members WHERE group_id = $1',
+      [groupId],
+    );
+    expect(countAfter.rows[0].n).toBe(countBefore.rows[0].n);
+
+    const { rows } = await client.query(
+      `SELECT profile_id, ghost_name, payment_handle, invite_email, invite_phone
+         FROM public.group_members WHERE group_id = $1 AND ghost_name IS NOT NULL`,
+      [groupId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].profile_id).toBeNull();
+    expect(rows[0].ghost_name).toBe('Former member');
+    // The contact hints go too — they are the person, not the ledger.
+    expect(rows[0].payment_handle).toBeNull();
+    expect(rows[0].invite_email).toBeNull();
+    expect(rows[0].invite_phone).toBeNull();
+  });
+
+  it('takes the profile and everything personal hanging off it', async () => {
+    const { profileIds } = await seedGroup(client, { memberCount: 2 });
+    const profileId = profileIds[0]!;
+
+    await client.query(
+      `INSERT INTO public.push_tokens (profile_id, expo_push_token, platform)
+       VALUES ($1, $2, 'android')`,
+      [profileId, `token-${randomUUID()}`],
+    );
+    await client.query(
+      `INSERT INTO public.subscriptions
+         (profile_id, tier, period, status, current_period_end, store, store_txn_id)
+       VALUES ($1, 'plus', 'monthly', 'active', now() + interval '30 days', 'promo', $2)`,
+      [profileId, `promo:erasure:${profileId}`],
+    );
+
+    await asProfile(profileId, () => client.query('SELECT public.baaki_delete_my_account()'));
+
+    for (const table of ['profiles', 'push_tokens', 'subscriptions']) {
+      const column = table === 'profiles' ? 'id' : 'profile_id';
+      const { rows } = await client.query(
+        `SELECT count(*)::int AS n FROM public.${table} WHERE ${column} = $1`,
+        [profileId],
+      );
+      expect(rows[0].n, table).toBe(0);
+    }
+  });
+
+  it('keeps the parting words after the account is gone', async () => {
+    // The reason the foreign key is SET NULL rather than CASCADE. Why somebody
+    // left is the most useful thing they ever write, and cascading it away at
+    // the moment of deletion would destroy precisely that.
+    const { profileIds } = await seedGroup(client, { memberCount: 2 });
+    const profileId = profileIds[0]!;
+    const words = `Too many notifications ${randomUUID().slice(0, 8)}`;
+
+    await asProfile(profileId, () =>
+      client.query('SELECT public.baaki_delete_my_account($1)', [words]),
+    );
+
+    const { rows } = await client.query(
+      'SELECT profile_id, kind, message FROM public.feedback WHERE message = $1',
+      [words],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('deletion');
+    expect(rows[0].profile_id).toBeNull();
+  });
+
+  it('tells somebody what it will cost before they agree to it', async () => {
+    const { groupId, profileIds, memberIds } = await seedGroup(client, { memberCount: 2 });
+    await addEqualSplitExpense(client, {
+      groupId,
+      payers: { [memberIds[0]!]: 20_000n },
+      participants: memberIds,
+      amount: 20_000n,
+    });
+
+    const { rows } = await asProfile(profileIds[0]!, async () =>
+      client.query('SELECT * FROM public.baaki_my_erasure_preview()'),
+    );
+    expect(Number(rows[0].groups_count)).toBeGreaterThanOrEqual(1);
+    expect(Number(rows[0].expenses_authored)).toBeGreaterThanOrEqual(1);
+    expect(rows[0].outstanding_currencies).toContain('INR');
+  });
+
+  it('refuses when nobody is signed in', async () => {
+    const message = await expectDenied(
+      client.query('SELECT public.baaki_delete_my_account($1)', ['nope']),
+    );
+    expect(message).toMatch(/NOT_SIGNED_IN/);
+  });
+});
+
+describe('feedback', () => {
+  it('stamps the author rather than trusting the caller', async () => {
+    const { profileIds } = await seedGroup(client, { memberCount: 2 });
+    const message = `Lovely app ${randomUUID().slice(0, 8)}`;
+
+    await asProfile(profileIds[0]!, () =>
+      client.query('SELECT public.baaki_submit_feedback($1, $2, $3)', [message, 'idea', 5]),
+    );
+
+    const { rows } = await client.query('SELECT * FROM public.feedback WHERE message = $1', [
+      message,
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].profile_id).toBe(profileIds[0]);
+    expect(rows[0].rating).toBe(5);
+  });
+
+  it('refuses an empty message and an unknown kind', async () => {
+    const { profileIds } = await seedGroup(client, { memberCount: 1 });
+    await asProfile(profileIds[0]!, async () => {
+      expect(
+        await expectDenied(client.query('SELECT public.baaki_submit_feedback($1)', ['   '])),
+      ).toMatch(/EMPTY_MESSAGE/);
+      expect(
+        await expectDenied(
+          client.query('SELECT public.baaki_submit_feedback($1, $2)', ['hi', 'rubbish']),
+        ),
+      ).toMatch(/feedback_kind_known/);
+    });
+  });
+
+  it('does not let a client write or read somebody else’s', async () => {
+    const { profileIds } = await seedGroup(client, { memberCount: 2 });
+    const mine = profileIds[0]!;
+    const theirs = profileIds[1]!;
+    const secret = `Private note ${randomUUID().slice(0, 8)}`;
+
+    await asProfile(theirs, () =>
+      client.query('SELECT public.baaki_submit_feedback($1)', [secret]),
+    );
+
+    await client.query('BEGIN');
+    try {
+      await client.query(`SELECT set_config('request.jwt.claims', $1, true)`, [
+        JSON.stringify({ sub: mine, role: 'authenticated' }),
+      ]);
+      await client.query('SET LOCAL ROLE authenticated');
+
+      // A savepoint around the denial. A failed statement poisons the whole
+      // transaction — every later command comes back "current transaction is
+      // aborted" — so without this the read below fails for a reason that has
+      // nothing to do with what it is checking.
+      await client.query('SAVEPOINT probe');
+      const insert = await expectDenied(
+        client.query(`INSERT INTO public.feedback (profile_id, message) VALUES ($1, 'forged')`, [
+          theirs,
+        ]),
+      );
+      expect(insert).toMatch(/permission denied/i);
+      await client.query('ROLLBACK TO SAVEPOINT probe');
+
+      const { rows } = await client.query('SELECT * FROM public.feedback WHERE message = $1', [
+        secret,
+      ]);
+      expect(rows).toHaveLength(0);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('keeps the console’s view to the console', async () => {
+    for (const role of ['anon', 'authenticated']) {
+      await client.query('BEGIN');
+      try {
+        await client.query(`SET LOCAL ROLE ${role}`);
+        const message = await expectDenied(
+          client.query('SELECT * FROM public.baaki_admin_feedback(10)'),
+        );
+        expect(message, role).toMatch(/permission denied/i);
+      } finally {
+        await client.query('ROLLBACK');
+      }
+    }
+  });
+});

--- a/packages/db/test/featureFlags.test.ts
+++ b/packages/db/test/featureFlags.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The half of the bucketer that lives in SQL.
+ *
+ * The first test here is the one that matters. The app decides what to show
+ * from `bucketOf` in `@baaki/core`; the console counts what happened using
+ * `baaki_bucket` in plpgsql. They are the same algorithm written twice, and if
+ * they ever disagree the experiment results are not missing but **wrong** —
+ * every number plausible, every conclusion backwards. `BUCKET_FIXTURES` is the
+ * contract between them, asserted here against the SQL and in
+ * `packages/core/test/flags.test.ts` against the TypeScript.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { BUCKET_FIXTURES, variantFor, type FeatureFlag } from '@baaki/core';
+
+import { connect, expectDenied } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+async function bucket(input: string): Promise<number> {
+  const { rows } = await client.query('SELECT public.baaki_bucket($1) AS b', [input]);
+  return Number(rows[0].b);
+}
+
+async function upsertFlag(flag: FeatureFlag & { description?: string }): Promise<void> {
+  await client.query(
+    `INSERT INTO public.feature_flags (key, description, enabled, rollout_percent, variants)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (key) DO UPDATE
+       SET enabled = EXCLUDED.enabled,
+           rollout_percent = EXCLUDED.rollout_percent,
+           variants = EXCLUDED.variants`,
+    [flag.key, flag.description ?? '', flag.enabled, flag.rolloutPercent, flag.variants],
+  );
+}
+
+describe('the two implementations of one hash', () => {
+  it('agrees with the TypeScript on every fixture', async () => {
+    for (const fixture of BUCKET_FIXTURES) {
+      expect(await bucket(fixture.input), JSON.stringify(fixture.input)).toBe(fixture.bucket);
+    }
+  });
+
+  it('agrees on a few hundred realistic inputs', async () => {
+    // The fixtures pin known values; this checks the two agree in general,
+    // which is what actually breaks — a subtle difference in how the multiply
+    // wraps shows up on some inputs and not others.
+    const inputs = Array.from({ length: 200 }, () => `some_flag:${randomUUID()}`);
+    const { rows } = await client.query(
+      'SELECT i AS input, public.baaki_bucket(i) AS b FROM unnest($1::text[]) AS i',
+      [inputs],
+    );
+    const { bucketOf } = await import('@baaki/core');
+    for (const row of rows) {
+      expect(Number(row.b), row.input).toBe(bucketOf(row.input));
+    }
+  });
+
+  it('reaches the same verdict as variantFor', async () => {
+    const flag: FeatureFlag = {
+      key: 'shared_itemizing',
+      enabled: true,
+      rolloutPercent: 60,
+      variants: ['control', 'treatment'],
+    };
+    await upsertFlag(flag);
+
+    const profileIds = Array.from({ length: 120 }, () => randomUUID());
+    const { rows } = await client.query(
+      'SELECT p AS id, public.baaki_variant($2, p::uuid) AS v FROM unnest($1::uuid[]) AS p',
+      [profileIds, flag.key],
+    );
+
+    for (const row of rows) {
+      expect(row.v, row.id).toBe(variantFor(flag, row.id));
+    }
+    // And the rollout actually excluded somebody, or this proved nothing.
+    expect(rows.some((row) => row.v === null)).toBe(true);
+    expect(rows.some((row) => row.v !== null)).toBe(true);
+  });
+});
+
+describe('the switch', () => {
+  it('says nothing for a flag nobody has created', async () => {
+    expect(
+      (
+        await client.query('SELECT public.baaki_variant($1, $2) AS v', [
+          'no_such_flag',
+          randomUUID(),
+        ])
+      ).rows[0].v,
+    ).toBeNull();
+  });
+
+  it('says nothing while the flag is off', async () => {
+    await upsertFlag({
+      key: 'off_flag',
+      enabled: false,
+      rolloutPercent: 100,
+      variants: ['control', 'treatment'],
+    });
+    const { rows } = await client.query('SELECT public.baaki_variant($1, $2) AS v', [
+      'off_flag',
+      randomUUID(),
+    ]);
+    expect(rows[0].v).toBeNull();
+  });
+
+  it('refuses a malformed key, a bad rollout and a duplicated arm', async () => {
+    // Each of these is a way to get an experiment that looks fine and splits
+    // wrong, so they are constraints rather than conventions.
+    await expectDenied(client.query(`INSERT INTO public.feature_flags (key) VALUES ('Not A Key')`));
+    await expectDenied(
+      client.query(
+        `INSERT INTO public.feature_flags (key, rollout_percent) VALUES ('too_much', 101)`,
+      ),
+    );
+    await expectDenied(
+      client.query(
+        `INSERT INTO public.feature_flags (key, variants) VALUES ('dupe', ARRAY['a','a'])`,
+      ),
+    );
+    await expectDenied(
+      client.query(`INSERT INTO public.feature_flags (key, variants) VALUES ('one', ARRAY['a'])`),
+    );
+  });
+});
+
+describe('who may change a flag', () => {
+  async function asRole<T>(role: string, run: () => Promise<T>): Promise<T> {
+    await client.query('BEGIN');
+    try {
+      await client.query(`SET LOCAL ROLE ${role}`);
+      return await run();
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  }
+
+  it('lets a signed-in client read', async () => {
+    await upsertFlag({
+      key: 'readable',
+      enabled: true,
+      rolloutPercent: 50,
+      variants: ['control', 'treatment'],
+    });
+    await asRole('authenticated', async () => {
+      const { rows } = await client.query(
+        `SELECT * FROM public.feature_flags WHERE key = 'readable'`,
+      );
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  it('refuses every client write', async () => {
+    // The whole point. A flag a client can flip is a paywall with a back door.
+    for (const role of ['anon', 'authenticated']) {
+      const insert = await asRole(role, () =>
+        expectDenied(
+          client.query(`INSERT INTO public.feature_flags (key) VALUES ('sneaky_${role}')`),
+        ),
+      );
+      expect(insert, role).toMatch(/permission denied|violates row-level security/i);
+
+      const update = await asRole(role, () =>
+        expectDenied(
+          client.query(`UPDATE public.feature_flags SET enabled = true WHERE key = 'readable'`),
+        ),
+      );
+      expect(update, role).toMatch(/permission denied/i);
+    }
+  });
+
+  it('keeps the results to the console', async () => {
+    for (const role of ['anon', 'authenticated']) {
+      const message = await asRole(role, () =>
+        expectDenied(client.query(`SELECT * FROM public.baaki_admin_flag_results('readable')`)),
+      );
+      expect(message, role).toMatch(/permission denied/i);
+    }
+  });
+});
+
+describe('the result', () => {
+  it('reports one row per arm and never a row for the unenrolled', async () => {
+    await upsertFlag({
+      key: 'results_flag',
+      enabled: true,
+      rolloutPercent: 100,
+      variants: ['control', 'treatment'],
+    });
+
+    const { rows } = await client.query(
+      `SELECT * FROM public.baaki_admin_flag_results('results_flag')`,
+    );
+    expect(rows.every((row) => row.variant !== null)).toBe(true);
+    expect(new Set(rows.map((row) => row.variant)).size).toBe(rows.length);
+    for (const row of rows) {
+      expect(['control', 'treatment']).toContain(row.variant);
+    }
+  });
+
+  it('enrols nobody at 0%', async () => {
+    await upsertFlag({
+      key: 'nobody_flag',
+      enabled: true,
+      rolloutPercent: 0,
+      variants: ['control', 'treatment'],
+    });
+    const { rows } = await client.query(
+      `SELECT * FROM public.baaki_admin_flag_results('nobody_flag')`,
+    );
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -8,8 +8,15 @@ import { Text } from './Text';
  * `onBrand` and `onBrandOutline` are the pair that sits on the brand panel:
  * purple-on-purple is invisible there, so the filled one inverts to white with
  * a purple label and its partner is an outline in the panel's own white.
+ *
+ * `danger` is for the small number of actions that cannot be undone — erasing
+ * an account, and nothing else so far. It is filled rather than outlined so it
+ * cannot be mistaken for the secondary button beside it, and it borrows the
+ * semantic negative colour deliberately: in this app red already means money
+ * leaving, and a destructive action is the same warning in a different place.
  */
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'onBrand' | 'onBrandOutline';
+export type ButtonVariant =
+  'primary' | 'secondary' | 'ghost' | 'onBrand' | 'onBrandOutline' | 'danger';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 export interface ButtonProps extends Omit<PressableProps, 'style' | 'children'> {
@@ -56,18 +63,24 @@ export function Button({
               ? pressed
                 ? theme.color.brandPressed
                 : theme.color.brand
-              : variant === 'secondary'
-                ? theme.color.brandSoft
-                : variant === 'onBrand'
-                  ? theme.color.onBrand
-                  : variant === 'onBrandOutline'
-                    ? pressed
-                      ? '#FFFFFF29'
-                      : '#FFFFFF1F'
-                    : 'transparent',
+              : variant === 'danger'
+                ? theme.color.negative
+                : variant === 'secondary'
+                  ? theme.color.brandSoft
+                  : variant === 'onBrand'
+                    ? theme.color.onBrand
+                    : variant === 'onBrandOutline'
+                      ? pressed
+                        ? '#FFFFFF29'
+                        : '#FFFFFF1F'
+                      : 'transparent',
           borderWidth: variant === 'onBrandOutline' ? 1 : 0,
           borderColor: variant === 'onBrandOutline' ? '#FFFFFF5C' : undefined,
-          opacity: disabled ? 0.45 : variant === 'onBrand' && pressed ? 0.9 : 1,
+          opacity: disabled
+            ? 0.45
+            : (variant === 'onBrand' || variant === 'danger') && pressed
+              ? 0.9
+              : 1,
         },
         variant === 'primary' && !disabled && theme.shadow.soft,
         style,
@@ -78,7 +91,9 @@ export function Button({
       <Text
         variant={size === 'sm' ? 'caption' : 'subheading'}
         tone={
-          variant === 'primary' ? 'onBrand' : variant === 'onBrandOutline' ? 'onBrand' : 'brand'
+          variant === 'primary' || variant === 'onBrandOutline' || variant === 'danger'
+            ? 'onBrand'
+            : 'brand'
         }
       >
         {label}

--- a/packages/ui/src/components/ListRow.tsx
+++ b/packages/ui/src/components/ListRow.tsx
@@ -11,6 +11,12 @@ export interface ListRowProps {
   trailing?: ReactNode;
   onPress?: () => void;
   accessibilityLabel?: string;
+  /**
+   * Colours the title with the negative tone, for rows that end something —
+   * signing out, erasing an account. Only the title: a red subtitle would make
+   * the row shout twice and the explanation harder to read.
+   */
+  destructive?: boolean;
 }
 
 export function ListRow({
@@ -20,6 +26,7 @@ export function ListRow({
   trailing,
   onPress,
   accessibilityLabel,
+  destructive = false,
 }: ListRowProps) {
   const theme = useTheme();
   const content = (
@@ -33,7 +40,7 @@ export function ListRow({
     >
       {leading}
       <View style={{ flex: 1 }}>
-        <Text variant="subheading" numberOfLines={1}>
+        <Text variant="subheading" tone={destructive ? 'negative' : undefined} numberOfLines={1}>
           {title}
         </Text>
         {subtitle ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.1.1
         version: 15.1.1(expo-font@57.0.1)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      '@microsoft/react-native-clarity':
+        specifier: ^4.6.3
+        version: 4.6.3(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
         version: 2.2.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))
@@ -1566,6 +1569,17 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@microsoft/react-native-clarity@4.6.3':
+    resolution: {integrity: sha512-8+RKJM2Vx+Cj3fQIydBaE+YHrlFgWXtAHsyqdV56ooWqohM4HC2cTIXyC9xtIaPiv6nX6Y0H7XKJArxcobp3ww==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+      react-native-svg: '>=14.0.0'
+    peerDependenciesMeta:
+      react-native-svg:
+        optional: true
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
@@ -7592,6 +7606,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@microsoft/react-native-clarity@4.6.3(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,43 @@ importers:
         specifier: ~5.9.2
         version: 5.9.3
 
+  apps/admin:
+    dependencies:
+      '@baaki/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@supabase/supabase-js':
+        specifier: ^2.112.0
+        version: 2.112.0(@opentelemetry/api@1.9.1)
+      next:
+        specifier: ^16.3.0
+        version: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.1.0
+        version: 24.13.3
+      '@types/react':
+        specifier: ~19.2.2
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ~19.2.2
+        version: 19.2.4(@types/react@19.2.18)
+      eslint:
+        specifier: ^9.37.0
+        version: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-config-next:
+        specifier: ^16.3.0
+        version: 16.3.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.2
+        version: 5.9.3
+
   apps/mobile:
     dependencies:
       '@baaki/core':
@@ -9827,7 +9864,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -9850,21 +9887,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
-      get-tsconfig: 4.14.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -9876,7 +9898,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9898,7 +9920,7 @@ snapshots:
       '@typescript-eslint/parser': 8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 

--- a/scripts/check-filenames.sh
+++ b/scripts/check-filenames.sh
@@ -23,7 +23,7 @@
 
 set -euo pipefail
 
-EXTENSIONS='ts|tsx|js|jsx|mjs|cjs|json|md|sql|prisma|ya?ml|toml|css|html|svg|png|jpg|jpeg|webp|ico|ttf|otf|sh|txt|example|gitignore|gitattributes|npmrc|nvmrc|prettierrc|prettierignore|editorconfig|lock'
+EXTENSIONS='ts|tsx|js|jsx|mjs|cjs|json|md|sql|prisma|ya?ml|toml|css|html|svg|png|jpg|jpeg|webp|ico|ttf|otf|sh|txt|example|gitignore|gitattributes|npmrc|nvmrc|prettierrc|prettierignore|vercelignore|editorconfig|lock'
 
 bad=""
 while IFS= read -r path; do


### PR DESCRIPTION
> **Stacked on #80.** Based on `fix/what-running-on-a-phone-showed` so the diff
> shows only this work — `packages/core/src/index.ts` and `src/group/` belong to
> that PR and would otherwise appear here. GitHub retargets this to `main`
> automatically when #80 merges.

A private console for one operator, plus the two features asked for on top of
it. Four commits, each independently reviewable; the three migrations are split
from the app deliberately, because they are the part that needs its own review
and its own revert.

## What the console can see

Aggregates and account metadata. **No function added here returns a
description, a note, a display name, a payment handle or a profile id.** That is
the shape of the feature rather than an oversight — expense text in this product
is frequently medical, legal or personal.

The grants are the security-critical part. Postgres grants EXECUTE to PUBLIC on
every new function and Supabase's `anon` and `authenticated` both inherit
PUBLIC, so leaving the default in place would publish the whole business behind
the anon key that ships inside the mobile binary. Everything is revoked and
granted to `service_role` alone, and `adminAnalytics.test.ts` asserts it for all
six functions under both roles — it is a one-line mistake with no symptom.

Two things the functions refuse to pretend to know:

- **Geo is the device locale** read at signup, not IP geolocation. A phone set
  to `en-GB` in Bengaluru counts as GB. NULL is its own row rather than dropped,
  because "we do not know" is a real and frequently large answer.
- **Sign-ins come from Supabase's auth audit log**, which is pruned. Empty means
  the window passed, not that nobody signed in. `last_sign_in_at` is
  deliberately unused: one snapshot per user, and grouping it by day draws a
  convincing chart of nothing.

## Experiments

Nobody's assignment is stored. A person's arm is hashed from the flag key and
their profile id, so a screen never waits on a round trip and an offline phone
shows what it showed yesterday (ADR-005). The payoff is that analysis is a
join — an experiment can be read **retrospectively**, including for days before
anybody thought to log an exposure. There is no exposure table.

The cost is that one algorithm now lives twice: `bucketOf` in TypeScript decides
what the app shows, `baaki_bucket` in plpgsql decides what the console counts.
If they disagree the results are not missing but **wrong** — every number
plausible, every conclusion backwards. `BUCKET_FIXTURES` is a table of literal
values asserted by both suites against their own implementation. One fixture is
Tamil, because the two agree only if both hash UTF-8 bytes; a plpgsql `ascii()`
loop passes every other row and fails that one.

Rollout and variant hash different strings, with a test each:

- **Widening a rollout must never drop somebody** — otherwise a feature they had
  been using vanishes.
- **Widening must never move somebody between arms.** Sharing one bucket does
  exactly that: every newly-included person lands in the same arm, so the split
  inside the new cohort is 100/0 while the total still looks even.

`variantFor` returns null for "not in this experiment", and null is not the
control group. The results exclude those people rather than showing a third row.

## Promotions

`store` already accepted `'promo'` — the entitlements migration left the door
open and `baaki_my_plan` reads any active row regardless of origin. So a
promotion is one more `subscriptions` row and every screen that asks what plan
somebody is on is already correct. A parallel entitlement system would have been
the mistake.

`store_txn_id` is unique because stores replay webhooks and one purchase must
not grant twice; keying promo grants through it means two concurrent redemptions
race to the same key and one loses — no lock, no read-then-write window.

`promo_codes` has RLS on with **no policy at all**, not even readable by a
client. One SELECT would otherwise hand over every unredeemed code.

## A bug worth reading

`src/proxy.ts` first sat at the project root, where Next silently does not load
middleware when a `src` directory exists. The redirect never ran; requests
reached the pages and were stopped only by the `requireSession()` inside the
data layer. **Had the proxy been the only check, the console would have served
the whole business unauthenticated and looked entirely fine doing it.** Both
checks stay, and the reason is in the code.

## Checks

Core 427 tests (was 415). Admin builds, lints and typechecks clean. Every page
verified rendering, the gate verified against unauthenticated requests, forged
cookies and the CSV export route.

## What is NOT verified

**The three migrations have never executed anywhere.** Docker was unavailable
and the local Postgres needed a password. The 20 db-test assertions across
`adminAnalytics.test.ts` and `featureFlags.test.ts` have never run either. This
PR exists partly so CI does both — please do not deploy any of it until the
`migrations, RLS policies and ledger invariants` job is green.

Also still outstanding: the **in-app redeem screen** (the RPC is built and
granted, the UI is not) and the **broadcast half** of promotions — push fanout
exists, email does not, because M4's Resend half is unbuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ


---

Supersedes #81, which GitHub auto-closed when its base branch was deleted on merge of #80. Same commits, rebased onto `main`.
