### PR TITLE
chore: ignore the file a production deploy is held in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ apps/mobile/android/
 .env.*
 !.env.example
 
+# A production connection string, held only long enough to run
+# `prisma migrate deploy` against it. Never committed, never printed.
+.prod-url
+
 # prisma
 packages/db/generated/
 


### PR DESCRIPTION
Deploying migrations to production needs a Postgres connection string with a
password in it. Nothing else in this repo holds one — the app uses the anon
key, the console the service-role key, edge functions their own env, and all
three go over HTTP through PostgREST.

So the string lives in `packages/db/.prod-url` for the length of a deploy and
is deleted after. This ignores that path. `.env*` was already covered; this
one is not an env file and was not.

Used for real: the five admin-console migrations are now applied to
production, `migrate status` is clean and `migrate diff` reports no
difference.