### PR TITLE
fix: an organiser confirms a claim, which ADR-006 always said

### DIFF
--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -19,10 +19,17 @@ import {
 } from '@baaki/ui';
 
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
-import { useAddGhostMember, useGroup, useGroupLedger } from '@/data/hooks';
+import {
+  useAddGhostMember,
+  useDecideMemberClaim,
+  useGroup,
+  useGroupLedger,
+  useMemberClaims,
+} from '@/data/hooks';
 import { displayName, groupLabel, isGhost, vpaOf } from '@/data/types';
-import { plural, useStrings } from '@/i18n';
+import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { friendlyError } from '@/lib/errors';
 
 export default function MembersScreen() {
   const theme = useTheme();
@@ -34,15 +41,49 @@ export default function MembersScreen() {
   const { group, members } = useGroup(groupId);
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
   const addGhost = useAddGhostMember(groupId);
+  const claims = useMemberClaims(groupId);
+  const decide = useDecideMemberClaim(groupId);
 
   const [ghostName, setGhostName] = useState('');
   const [ghostContact, setGhostContact] = useState('');
   const [browsing, setBrowsing] = useState(false);
   const [adding, setAdding] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [claimError, setClaimError] = useState<string | null>(null);
 
   const currency = group.data?.default_currency ?? 'INR';
   const ghosts = (members.data ?? []).filter(isGhost);
+
+  /**
+   * Answering a claim (ADR-006).
+   *
+   * The refusals are worth their own sentences: an admin who taps Confirm a
+   * second later than another admin, or on a place somebody has since taken,
+   * is not looking at a failure — they are looking at an answer that already
+   * happened, and "something went wrong" would send them to check the network.
+   */
+  const answer = (claimId: string, approve: boolean): void => {
+    setClaimError(null);
+    decide.mutate(
+      { claimId, approve },
+      {
+        onSuccess: (verdict) => {
+          if (verdict.ok) return;
+          const said =
+            verdict.reason === 'ALREADY_DECIDED'
+              ? t.claims.alreadyDecided
+              : verdict.reason === 'ALREADY_A_MEMBER'
+                ? t.claims.theyAreAlreadyIn
+                : verdict.reason === 'NOT_CLAIMABLE'
+                  ? t.claims.placeTaken
+                  : t.claims.decideFailed;
+          setClaimError(said);
+        },
+        onError: (caught) =>
+          setClaimError(friendlyError(caught, t.claims.decideFailed, 'claims.decide')),
+      },
+    );
+  };
 
   /**
    * One field for the address, whichever kind it is. Asking somebody to first
@@ -146,6 +187,48 @@ export default function MembersScreen() {
             <Ionicons name="share-outline" size={18} color={theme.color.brand} />
           </IconButton>
         </Row>
+
+        {/* Above the member list, because it is a question and the list is not.
+            Only admins ever see anything here: the function returns no rows to
+            anybody else, so the screen does not have to know who is one. */}
+        {(claims.data ?? []).length > 0 ? (
+          <Card style={{ gap: theme.spacing.md }}>
+            <Text variant="subheading">{t.claims.requestsTitle}</Text>
+            {claimError ? (
+              <Text variant="caption" tone="negative">
+                {claimError}
+              </Text>
+            ) : null}
+            {(claims.data ?? []).map((claim) => (
+              <View key={claim.id} style={{ gap: theme.spacing.sm }}>
+                <Row style={{ gap: theme.spacing.md }}>
+                  <Avatar name={claim.ghost_name ?? '?'} ghost />
+                  <Text variant="body" style={{ flex: 1 }}>
+                    {fill(t.claims.saysTheyAre, {
+                      who: claim.requested_name ?? claim.requester_name ?? t.misc.unnamed,
+                      name: claim.ghost_name ?? t.misc.unnamed,
+                    })}
+                  </Text>
+                </Row>
+                <Row style={{ gap: theme.spacing.sm }}>
+                  <Button
+                    label={t.claims.approve}
+                    size="sm"
+                    disabled={decide.isPending}
+                    onPress={() => answer(claim.id, true)}
+                  />
+                  <Button
+                    label={t.claims.decline}
+                    size="sm"
+                    variant="secondary"
+                    disabled={decide.isPending}
+                    onPress={() => answer(claim.id, false)}
+                  />
+                </Row>
+              </View>
+            ))}
+          </Card>
+        ) : null}
 
         <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
           {(members.data ?? []).map((member, index) => (

--- a/apps/mobile/src/app/join.tsx
+++ b/apps/mobile/src/app/join.tsx
@@ -6,7 +6,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { Avatar, Badge, Button, Card, EmptyState, Row, Screen, Text, useTheme } from '@baaki/ui';
 
-import { useStrings } from '@/i18n';
+import { fill, useStrings } from '@/i18n';
 
 import { acceptInvite, previewInvite, type InvitePreview } from '@/data/api';
 import { keys } from '@/data/hooks';
@@ -31,6 +31,8 @@ export default function JoinScreen() {
   const [busy, setBusy] = useState(Boolean(token));
   const [joining, setJoining] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** The group whose admin has been asked, once a claim has been sent. */
+  const [pending, setPending] = useState<string | null>(null);
 
   /**
    * Whether the route parameters have had a chance to arrive.
@@ -69,14 +71,28 @@ export default function JoinScreen() {
     };
   }, [token]);
 
-  const join = async (): Promise<void> => {
+  /**
+   * `claim` is passed rather than read from state because "join as someone new
+   * instead" clears it and joins in the same tap — and a state update is not
+   * visible to the call that follows it, so the old claim would be sent again.
+   */
+  const join = async (claim: string | null = claimId): Promise<void> => {
     if (!token) return;
     setJoining(true);
     setError(null);
     try {
       // Nobody is forced to register to accept an invite.
       if (!session) await continueAsGuest();
-      const result = await acceptInvite({ token, claimMemberId: claimId });
+      const result = await acceptInvite({ token, claimMemberId: claim });
+
+      // Claiming somebody's place only asks. Routing into the group here would
+      // land on a screen the person cannot read yet, because they are not a
+      // member until an admin agrees.
+      if ('pending' in result) {
+        setPending(result.group.name);
+        return;
+      }
+
       await queryClient.invalidateQueries({ queryKey: keys.groups });
       router.replace(`/group/${result.group.id}`);
     } catch (caught) {
@@ -104,6 +120,52 @@ export default function JoinScreen() {
           body={shown ?? t.misc.linkExpiredBody}
           action={<Button label={t.misc.goToBaaki} onPress={() => router.replace('/')} />}
         />
+      </Screen>
+    );
+  }
+
+  if (pending) {
+    const claimed = preview.claimable.find((candidate) => candidate.memberId === claimId);
+    return (
+      <Screen edges={['top', 'bottom']}>
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            paddingHorizontal: theme.spacing.xl,
+            gap: theme.spacing.xl,
+          }}
+        >
+          <Card style={{ alignItems: 'center', gap: theme.spacing.md }}>
+            <Ionicons name="hourglass-outline" size={40} color={theme.color.brand} />
+            <Text variant="subheading" align="center">
+              {t.claims.waitingTitle}
+            </Text>
+            <Text variant="caption" tone="muted" align="center">
+              {fill(t.claims.waitingBody, {
+                group: pending,
+                name: claimed?.name ?? t.misc.unnamed,
+              })}
+            </Text>
+          </Card>
+
+          {/* The way out of waiting on an admin who never opens the app. The
+              claim is left standing: if they answer it later and this person
+              has since joined as themselves, the approval refuses rather than
+              making them a member twice. */}
+          <Button
+            label={t.claims.joinAsNewInstead}
+            variant="secondary"
+            fullWidth
+            disabled={joining}
+            onPress={() => {
+              setClaimId(null);
+              setPending(null);
+              void join(null);
+            }}
+          />
+          <Button label={t.misc.goToBaaki} variant="ghost" onPress={() => router.replace('/')} />
+        </View>
       </Screen>
     );
   }
@@ -165,7 +227,7 @@ export default function JoinScreen() {
               <Row style={{ gap: theme.spacing.sm }}>
                 <Ionicons name="information-circle-outline" size={16} color={theme.color.brand} />
                 <Text variant="micro" tone="brand" style={{ flex: 1 }}>
-                  {t.extras.theirPastBecomesYours}
+                  {`${t.extras.theirPastBecomesYours} ${t.claims.needsConfirming}`}
                 </Text>
               </Row>
             ) : null}
@@ -179,7 +241,17 @@ export default function JoinScreen() {
         ) : null}
 
         <Button
-          label={claimId ? t.misc.joinAndClaim : t.misc.joinGroup}
+          // Claiming asks; joining as somebody new does not. The button says
+          // which of the two is about to happen.
+          label={
+            claimId
+              ? fill(t.claims.askToJoinAs, {
+                  name:
+                    preview.claimable.find((candidate) => candidate.memberId === claimId)?.name ??
+                    t.misc.unnamed,
+                })
+              : t.misc.joinGroup
+          }
           size="lg"
           fullWidth
           disabled={joining}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -714,16 +714,95 @@ export async function previewInvite(token: string): Promise<InvitePreview> {
   return data as InvitePreview;
 }
 
+/**
+ * Two outcomes, because claiming a place is a request now (ADR-006).
+ *
+ * Joining as somebody new is immediate and comes back with a `memberId`.
+ * Claiming a ghost comes back `pending`: an admin of the group has to agree,
+ * and until they do the arrival is not in the group. Handing the place over on
+ * request would let anybody holding the link inherit that name's whole
+ * history.
+ */
+export type AcceptedInvite =
+  | { group: { id: string; name: string }; memberId: string; claimed?: boolean }
+  | {
+      group: { id: string; name: string };
+      pending: true;
+      claimId: string;
+      alreadyPending: boolean;
+    };
+
 export async function acceptInvite(input: {
   token: string;
   claimMemberId?: string | null;
   displayName?: string | null;
-}): Promise<{ group: { id: string; name: string }; memberId: string; claimed?: boolean }> {
+}): Promise<AcceptedInvite> {
   const { data, error } = await supabase.functions.invoke('invite-accept', {
     body: { ...input, mode: 'join' },
   });
   if (error) throw new Error(await readFunctionError(error));
-  return data as { group: { id: string; name: string }; memberId: string; claimed?: boolean };
+  return data as AcceptedInvite;
+}
+
+// ──────────────────────────── claiming somebody's place (ADR-006) ──
+
+export interface PendingClaim {
+  id: string;
+  member_id: string;
+  ghost_name: string | null;
+  requester_name: string | null;
+  requested_name: string | null;
+  created_at: string;
+}
+
+/** What an admin of this group has been asked. Empty for everybody else. */
+export async function fetchMemberClaims(groupId: string): Promise<PendingClaim[]> {
+  const { data, error } = await supabase.rpc('baaki_group_member_claims', { p_group_id: groupId });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as PendingClaim[];
+}
+
+/**
+ * An admin answering. Approving is the claim itself — one UPDATE inside the
+ * function moves the ghost row to the person, so nothing is copied and every
+ * share and settlement filed against that name comes with it.
+ */
+export async function decideMemberClaim(
+  claimId: string,
+  approve: boolean,
+): Promise<{ ok: boolean; reason?: string; status?: string }> {
+  const { data, error } = await supabase.rpc('baaki_decide_member_claim', {
+    p_claim_id: claimId,
+    p_approve: approve,
+  });
+  if (error) throw new Error(error.message);
+  return (data ?? { ok: false }) as { ok: boolean; reason?: string; status?: string };
+}
+
+export interface MyClaim {
+  id: string;
+  group_id: string;
+  group_name: string | null;
+  ghost_name: string | null;
+  status: 'pending' | 'approved' | 'declined' | 'withdrawn';
+  created_at: string;
+  decided_at: string | null;
+}
+
+/** Carries the group's name: somebody still waiting cannot read the group. */
+export async function fetchMyClaims(): Promise<MyClaim[]> {
+  const { data, error } = await supabase.rpc('baaki_my_member_claims');
+  if (error) throw new Error(error.message);
+  return (data ?? []) as MyClaim[];
+}
+
+/** The way out of waiting on an admin who never opens the app. */
+export async function withdrawMemberClaim(claimId: string): Promise<boolean> {
+  const { data, error } = await supabase.rpc('baaki_withdraw_member_claim', {
+    p_claim_id: claimId,
+  });
+  if (error) throw new Error(error.message);
+  return (data as { ok?: boolean } | null)?.ok === true;
 }
 
 /** Links are revocable at any time (ADR-006). */

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -43,6 +43,8 @@ import {
   fetchReceipt,
   fetchGroupSpending,
   fetchNotifications,
+  fetchMemberClaims,
+  decideMemberClaim,
   fetchPlanItems,
   markNotificationsRead,
   recordSettlement,
@@ -67,6 +69,7 @@ export const keys = {
   notifications: ['notifications'] as const,
   disputes: (id: string) => ['group', id, 'disputes'] as const,
   spending: (id: string) => ['group', id, 'spending'] as const,
+  memberClaims: (id: string) => ['group', id, 'member-claims'] as const,
 };
 
 /**
@@ -737,6 +740,46 @@ export function usePlanItems(groupId: string) {
     queryKey: ['plan', groupId],
     queryFn: () => fetchPlanItems(groupId),
     enabled: groupId !== '',
+  });
+}
+
+// ────────────────────────── somebody asking to be somebody (ADR-006) ──
+
+/**
+ * Claims waiting on this group's admins.
+ *
+ * Every member asks and only admins get an answer — the function returns
+ * nothing to anybody else — which is cheaper than teaching the screen who is
+ * an admin, and cannot disagree with the database about it.
+ */
+export function useMemberClaims(groupId: string) {
+  return useQuery({
+    queryKey: keys.memberClaims(groupId),
+    queryFn: () => fetchMemberClaims(groupId),
+    enabled: groupId !== '',
+  });
+}
+
+/**
+ * Answering one.
+ *
+ * Members are invalidated alongside the claims because approving *is* the
+ * claim: a ghost in the list has just become a person, and a screen still
+ * showing "not joined yet" next to their name is showing something that
+ * stopped being true in the same call.
+ */
+export function useDecideMemberClaim(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ claimId, approve }: { claimId: string; approve: boolean }) =>
+      decideMemberClaim(claimId, approve),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: keys.memberClaims(groupId) }),
+        queryClient.invalidateQueries({ queryKey: keys.members(groupId) }),
+        queryClient.invalidateQueries({ queryKey: keys.activity(groupId) }),
+      ]);
+    },
   });
 }
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -838,6 +838,26 @@ export interface UiStrings {
     alreadyRedeemed: string;
     couldNotRedeem: string;
   };
+  /**
+   * Taking over a place somebody already holds in a group, and an admin
+   * agreeing to it (ADR-006). Worded as a request throughout, because that is
+   * what it now is: approving hands over every expense filed under that name.
+   */
+  claims: {
+    askToJoinAs: string;
+    needsConfirming: string;
+    waitingTitle: string;
+    waitingBody: string;
+    joinAsNewInstead: string;
+    requestsTitle: string;
+    saysTheyAre: string;
+    approve: string;
+    decline: string;
+    decideFailed: string;
+    alreadyDecided: string;
+    placeTaken: string;
+    theyAreAlreadyIn: string;
+  };
   /** The rest: one or two strings each, from a dozen screens. */
   /**
    * Feedback, the policy screens, and erasure.
@@ -1686,6 +1706,22 @@ const en: UiStrings = {
     exhausted: 'That code has been used as many times as it allows.',
     alreadyRedeemed: 'You have already used that one.',
     couldNotRedeem: 'The code could not be checked just now. Try again in a moment.',
+  },
+  claims: {
+    askToJoinAs: 'Ask to join as {name}',
+    needsConfirming: 'An admin of the group confirms this before anything moves.',
+    waitingTitle: 'Asked',
+    waitingBody:
+      'Somebody who runs {group} has to confirm you are {name}. You will hear either way — nothing has changed in the group yet.',
+    joinAsNewInstead: 'Join as someone new instead',
+    requestsTitle: 'Waiting to join',
+    saysTheyAre: '{who} says they are {name}',
+    approve: 'Confirm',
+    decline: 'Not them',
+    decideFailed: 'That could not be answered just now. Try again in a moment.',
+    alreadyDecided: 'Somebody has already answered this one.',
+    placeTaken: 'That place belongs to somebody now.',
+    theyAreAlreadyIn: 'They are already in this group.',
   },
   privacy: {
     row: 'Privacy & security',
@@ -2575,6 +2611,22 @@ const ta: UiStrings = {
     alreadyRedeemed: 'அதை நீங்கள் ஏற்கனவே பயன்படுத்திவிட்டீர்கள்.',
     couldNotRedeem: 'இப்போது குறியீட்டைச் சரிபார்க்க முடியவில்லை. சிறிது நேரம் கழித்து முயலுங்கள்.',
   },
+  claims: {
+    askToJoinAs: '{name} ஆக சேர அனுமதி கேளுங்கள்',
+    needsConfirming: 'குழுவின் நிர்வாகி உறுதி செய்த பிறகே எதுவும் மாறும்.',
+    waitingTitle: 'கேட்கப்பட்டது',
+    waitingBody:
+      'நீங்கள் {name} தானா என்பதை {group} நடத்துபவர் உறுதி செய்ய வேண்டும். பதில் எப்படியிருந்தாலும் உங்களுக்குத் தெரிவிக்கப்படும் — குழுவில் இன்னும் எதுவும் மாறவில்லை.',
+    joinAsNewInstead: 'புதிய நபராகச் சேருங்கள்',
+    requestsTitle: 'சேர காத்திருப்பவர்கள்',
+    saysTheyAre: 'தான் {name} என்கிறார் {who}',
+    approve: 'உறுதி செய்',
+    decline: 'இவர் அல்ல',
+    decideFailed: 'இப்போது பதிலளிக்க முடியவில்லை. சிறிது நேரம் கழித்து முயலுங்கள்.',
+    alreadyDecided: 'இதற்கு ஏற்கனவே ஒருவர் பதிலளித்துவிட்டார்.',
+    placeTaken: 'அந்த இடம் இப்போது வேறு ஒருவருக்கு உரியது.',
+    theyAreAlreadyIn: 'அவர் ஏற்கனவே இந்தக் குழுவில் இருக்கிறார்.',
+  },
   privacy: {
     row: 'தனியுரிமை & பாதுகாப்பு',
     rowHint: 'என்ன சேமிக்கப்படுகிறது, எப்படி பாதுகாக்கப்படுகிறது',
@@ -3426,6 +3478,22 @@ const hi: UiStrings = {
     exhausted: 'वह कोड जितनी बार चल सकता था, उतनी बार चल चुका।',
     alreadyRedeemed: 'आप उसे पहले ही इस्तेमाल कर चुके हैं।',
     couldNotRedeem: 'अभी कोड जाँचा नहीं जा सका। थोड़ी देर बाद कोशिश करें।',
+  },
+  claims: {
+    askToJoinAs: '{name} के रूप में शामिल होने की पूछें',
+    needsConfirming: 'समूह का कोई एडमिन पुष्टि करेगा, उसके बाद ही कुछ बदलेगा।',
+    waitingTitle: 'पूछ लिया',
+    waitingBody:
+      '{group} चलाने वाले किसी को पुष्टि करनी है कि आप {name} हैं। जवाब जो भी हो, आपको पता चलेगा — समूह में अभी कुछ नहीं बदला।',
+    joinAsNewInstead: 'नए व्यक्ति के रूप में शामिल हों',
+    requestsTitle: 'शामिल होने के इंतज़ार में',
+    saysTheyAre: '{who} कहते हैं कि वे {name} हैं',
+    approve: 'पुष्टि करें',
+    decline: 'ये वो नहीं',
+    decideFailed: 'अभी जवाब नहीं दिया जा सका। थोड़ी देर बाद कोशिश करें।',
+    alreadyDecided: 'इसका जवाब कोई पहले ही दे चुका है।',
+    placeTaken: 'वह जगह अब किसी और की है।',
+    theyAreAlreadyIn: 'वे पहले से इस समूह में हैं।',
   },
   privacy: {
     row: 'निजता और सुरक्षा',
@@ -4403,6 +4471,22 @@ const ar: UiStrings = {
     exhausted: 'استُخدم هذا الرمز بالعدد المسموح به.',
     alreadyRedeemed: 'لقد استخدمته من قبل.',
     couldNotRedeem: 'تعذّر التحقق من الرمز الآن. حاول بعد قليل.',
+  },
+  claims: {
+    askToJoinAs: 'اطلب الانضمام بصفتك {name}',
+    needsConfirming: 'يؤكّد ذلك أحد مشرفي المجموعة قبل أن يتغيّر أي شيء.',
+    waitingTitle: 'تم الطلب',
+    waitingBody:
+      'على أحد القائمين على {group} أن يؤكّد أنك {name}. ستُخبَر بالنتيجة في الحالتين — ولم يتغيّر شيء في المجموعة بعد.',
+    joinAsNewInstead: 'انضم بصفتك شخصًا جديدًا',
+    requestsTitle: 'في انتظار الانضمام',
+    saysTheyAre: 'يقول {who} إنه {name}',
+    approve: 'تأكيد',
+    decline: 'ليس هو',
+    decideFailed: 'تعذّر الرد الآن. حاول بعد قليل.',
+    alreadyDecided: 'ردّ أحدهم على هذا من قبل.',
+    placeTaken: 'صار ذلك المكان لشخص آخر.',
+    theyAreAlreadyIn: 'هو بالفعل في هذه المجموعة.',
   },
   privacy: {
     row: 'الخصوصية والأمان',

--- a/apps/web-lite/src/app/join/[token]/page.tsx
+++ b/apps/web-lite/src/app/join/[token]/page.tsx
@@ -35,6 +35,8 @@ export default function JoinPage() {
   const [name, setName] = useState('');
   const [joining, setJoining] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** A claim has been sent and is waiting on an admin of the group. */
+  const [pending, setPending] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -51,25 +53,42 @@ export default function JoinPage() {
     };
   }, [token]);
 
-  const join = useCallback(async () => {
-    setError(null);
-    setJoining(true);
-    try {
-      // The guest account is made first, then the invite is accepted against
-      // it. Same account when they later add an email, so the group and its
-      // history stay theirs rather than being re-joined as a stranger.
-      await baaki.signInAsGuest();
-      const accepted = await baaki.acceptInvite({
-        token,
-        claimMemberId: claimId,
-        displayName: claimId ? null : name.trim() || null,
-      });
-      router.replace(`/g/${accepted.group.id}`);
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
-      setJoining(false);
-    }
-  }, [token, claimId, name, router]);
+  /**
+   * `claim` is a parameter rather than read from state, because "join as
+   * someone new instead" clears the claim and joins in one tap — and the state
+   * update is not visible to the call that follows it.
+   */
+  const join = useCallback(
+    async (claim: string | null = claimId) => {
+      setError(null);
+      setJoining(true);
+      try {
+        // The guest account is made first, then the invite is accepted against
+        // it. Same account when they later add an email, so the group and its
+        // history stay theirs rather than being re-joined as a stranger.
+        await baaki.signInAsGuest();
+        const accepted = await baaki.acceptInvite({
+          token,
+          claimMemberId: claim,
+          displayName: claim ? name.trim() || null : name.trim() || null,
+        });
+
+        // Claiming somebody's place only asks now (ADR-006). Routing into the
+        // group would land on a page this person cannot read: they are not a
+        // member until an admin of the group agrees.
+        if (accepted.pending) {
+          setPending(true);
+          setJoining(false);
+          return;
+        }
+        router.replace(`/g/${accepted.group.id}`);
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : String(caught));
+        setJoining(false);
+      }
+    },
+    [token, claimId, name, router],
+  );
 
   if (error && !preview) {
     return (
@@ -94,6 +113,30 @@ export default function JoinPage() {
   }
 
   const groupName = preview.group?.name?.trim() || t.join.aGroup;
+  const claimedName =
+    preview.claimable.find((person) => person.memberId === claimId)?.name ?? t.join.someone;
+
+  if (pending) {
+    return (
+      <main>
+        <div className="card">
+          <h1>{t.join.waitingTitle}</h1>
+          <p>{fill(t.join.waitingBody, { group: groupName, name: claimedName })}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setClaimId(null);
+            setPending(false);
+            void join(null);
+          }}
+          disabled={joining}
+        >
+          {t.join.joinAsNewInstead}
+        </button>
+      </main>
+    );
+  }
 
   return (
     <main>
@@ -150,7 +193,11 @@ export default function JoinPage() {
       {error ? <p className="error">{error}</p> : null}
 
       <button type="button" onClick={() => void join()} disabled={joining}>
-        {joining ? t.join.joining : fill(t.join.joinGroup, { group: groupName })}
+        {joining
+          ? t.join.joining
+          : claimId
+            ? fill(t.join.askToJoinAs, { name: claimedName })
+            : fill(t.join.joinGroup, { group: groupName })}
       </button>
     </main>
   );

--- a/apps/web-lite/src/i18n.ts
+++ b/apps/web-lite/src/i18n.ts
@@ -103,6 +103,10 @@ export interface WebStrings {
     onlyThingAsked: string;
     joining: string;
     joinGroup: string;
+    askToJoinAs: string;
+    waitingTitle: string;
+    waitingBody: string;
+    joinAsNewInstead: string;
   };
   /** The group, in a browser: less than the app, and enough for a trip. */
   group: {
@@ -169,6 +173,11 @@ const en: WebStrings = {
     onlyThingAsked: 'This is the only thing asked of you. No email, no password, no app.',
     joining: 'Joining…',
     joinGroup: 'Join {group}',
+    askToJoinAs: 'Ask to join as {name}',
+    waitingTitle: 'Asked',
+    waitingBody:
+      'Somebody who runs {group} has to confirm you are {name}. Nothing has changed in the group yet.',
+    joinAsNewInstead: 'Join as someone new instead',
   },
   group: {
     loading: 'Loading…',
@@ -238,6 +247,11 @@ const ta: WebStrings = {
       'உங்களிடம் கேட்கப்படுவது இது ஒன்றுதான். மின்னஞ்சல் இல்லை, கடவுச்சொல் இல்லை, செயலி இல்லை.',
     joining: 'சேர்கிறது…',
     joinGroup: '{group} இல் சேர்',
+    askToJoinAs: '{name} ஆக சேர அனுமதி கேளுங்கள்',
+    waitingTitle: 'கேட்கப்பட்டது',
+    waitingBody:
+      'நீங்கள் {name} தானா என்பதை {group} நடத்துபவர் உறுதி செய்ய வேண்டும். குழுவில் இன்னும் எதுவும் மாறவில்லை.',
+    joinAsNewInstead: 'புதிய நபராகச் சேருங்கள்',
   },
   group: {
     loading: 'ஏற்றுகிறது…',
@@ -307,6 +321,11 @@ const hi: WebStrings = {
     onlyThingAsked: 'आपसे बस यही पूछा जाता है। न ईमेल, न पासवर्ड, न ऐप।',
     joining: 'जुड़ रहे हैं…',
     joinGroup: '{group} में जुड़ें',
+    askToJoinAs: '{name} के रूप में शामिल होने की पूछें',
+    waitingTitle: 'पूछ लिया',
+    waitingBody:
+      '{group} चलाने वाले किसी को पुष्टि करनी है कि आप {name} हैं। समूह में अभी कुछ नहीं बदला।',
+    joinAsNewInstead: 'नए व्यक्ति के रूप में शामिल हों',
   },
   group: {
     loading: 'लोड हो रहा है…',
@@ -376,6 +395,11 @@ const ar: WebStrings = {
     onlyThingAsked: 'هذا كل ما يُطلب منك. لا بريد، ولا كلمة مرور، ولا تطبيق.',
     joining: 'جارٍ الانضمام…',
     joinGroup: 'انضم إلى {group}',
+    askToJoinAs: 'اطلب الانضمام بصفتك {name}',
+    waitingTitle: 'تم الطلب',
+    waitingBody:
+      'على أحد القائمين على {group} أن يؤكّد أنك {name}. ولم يتغيّر شيء في المجموعة بعد.',
+    joinAsNewInstead: 'انضم بصفتك شخصًا جديدًا',
   },
   group: {
     loading: 'جارٍ التحميل…',

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -91,10 +91,14 @@ export function createBaakiClient({ supabase }: BaakiClientOptions) {
     },
 
     /**
-     * Joining. `claimMemberId` takes over a ghost somebody already added, which
-     * is what keeps the expenses already filed against that name (ADR-006) —
-     * without it the arrival becomes a second person and the group has two of
-     * them.
+     * Joining. `claimMemberId` asks to take over a ghost somebody already
+     * added, which is what keeps the expenses already filed against that name
+     * (ADR-006) — without it the arrival becomes a second person and the group
+     * has two of them.
+     *
+     * Asking is not joining: a claim comes back `pending` with no `memberId`
+     * and waits on an admin of the group. Handing the place over on request
+     * would let anybody holding the link inherit that name's whole history.
      */
     acceptInvite(input: {
       token: string;

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -76,10 +76,22 @@ export interface InvitePreview {
   claimable: { memberId: string; name: string | null }[];
 }
 
+/**
+ * What came back from joining.
+ *
+ * Two shapes, because claiming somebody's place is now a request rather than a
+ * join (ADR-006): an admin of the group decides, and until they do the arrival
+ * is not a member and there is no `memberId` to give them.
+ */
 export interface AcceptedInvite {
   group: { id: string; name: string };
-  memberId: MemberId;
+  memberId?: MemberId;
   claimed?: boolean;
+  /** Waiting on an admin. `memberId` is absent. */
+  pending?: boolean;
+  claimId?: string;
+  /** They had already asked; this is the same request, not a second one. */
+  alreadyPending?: boolean;
 }
 
 /** The name web-lite shows for somebody. */

--- a/packages/core/src/notifications/copy.ts
+++ b/packages/core/src/notifications/copy.ts
@@ -39,7 +39,15 @@ export type NotificationKind =
    * copy that treats it as a dispute makes a fight out of a typo.
    */
   | 'expense_disputed'
-  | 'expense_dispute_resolved';
+  | 'expense_dispute_resolved'
+  /**
+   * Somebody saying they are the "Ravi" already listed in a group, and an
+   * admin answering (ADR-006). Approving hands over every share and settlement
+   * already filed under that name, which is why it is asked rather than taken.
+   */
+  | 'ghost_claim_requested'
+  | 'ghost_claim_approved'
+  | 'ghost_claim_declined';
 
 export interface CopyStrings {
   readonly money: {
@@ -97,6 +105,18 @@ const en: CopyStrings = {
       title: 'Your correction was answered',
       body: '{description} in {group}',
     },
+    ghost_claim_requested: {
+      title: 'Someone wants to join {group}',
+      body: 'They say they are {name}. Nothing changes until you confirm.',
+    },
+    ghost_claim_approved: {
+      title: 'You are in {group}',
+      body: 'Everything already filed under {name} is yours',
+    },
+    ghost_claim_declined: {
+      title: 'Not confirmed',
+      body: '{group} did not confirm that place. You can still join as yourself.',
+    },
   },
 };
 
@@ -145,6 +165,18 @@ const ta: CopyStrings = {
       title: 'உங்கள் திருத்தத்திற்கு பதில் வந்தது',
       body: '{description} ({group})',
     },
+    ghost_claim_requested: {
+      title: '{group} இல் சேர ஒருவர் கேட்கிறார்',
+      body: 'தாங்கள் {name} என்கிறார். நீங்கள் உறுதி செய்யும் வரை எதுவும் மாறாது.',
+    },
+    ghost_claim_approved: {
+      title: 'நீங்கள் {group} இல் சேர்ந்துவிட்டீர்கள்',
+      body: '{name} பெயரில் ஏற்கனவே பதிவானவை அனைத்தும் இப்போது உங்களுடையவை',
+    },
+    ghost_claim_declined: {
+      title: 'உறுதி செய்யப்படவில்லை',
+      body: '{group} அந்த இடத்தை உறுதி செய்யவில்லை. நீங்களாகவே சேரலாம்.',
+    },
   },
 };
 
@@ -186,6 +218,18 @@ const hi: CopyStrings = {
     expense_dispute_resolved: {
       title: 'आपके सुधार का जवाब आया',
       body: '{description} ({group})',
+    },
+    ghost_claim_requested: {
+      title: '{group} में कोई शामिल होना चाहता है',
+      body: 'उनका कहना है कि वे {name} हैं। आपकी पुष्टि तक कुछ नहीं बदलेगा।',
+    },
+    ghost_claim_approved: {
+      title: 'आप {group} में हैं',
+      body: '{name} के नाम पर जो कुछ पहले से दर्ज है, वह अब आपका है',
+    },
+    ghost_claim_declined: {
+      title: 'पुष्टि नहीं हुई',
+      body: '{group} ने वह जगह पक्की नहीं की। आप अपने नाम से शामिल हो सकते हैं।',
     },
   },
 };
@@ -234,6 +278,18 @@ const ar: CopyStrings = {
     expense_dispute_resolved: {
       title: 'وصل ردّ على تصحيحك',
       body: '{description} في {group}',
+    },
+    ghost_claim_requested: {
+      title: 'أحدهم يريد الانضمام إلى {group}',
+      body: 'يقول إنه {name}. لا يتغيّر شيء حتى تؤكّد.',
+    },
+    ghost_claim_approved: {
+      title: 'أنت الآن في {group}',
+      body: 'كل ما سُجّل باسم {name} صار لك',
+    },
+    ghost_claim_declined: {
+      title: 'لم يتم التأكيد',
+      body: 'لم تؤكّد {group} ذلك المكان. ما زال بإمكانك الانضمام باسمك.',
     },
   },
 };

--- a/packages/db/prisma/migrations/20260809000000_organiser_confirms_a_claim/migration.sql
+++ b/packages/db/prisma/migrations/20260809000000_organiser_confirms_a_claim/migration.sql
@@ -1,0 +1,504 @@
+-- Taking over somebody's place in a group now needs somebody to say yes.
+--
+-- ADR-006: "When a real person joins via link, they can claim a ghost
+-- (organizer confirms) and inherit its history atomically." The claim was
+-- built; the confirmation was not. `invite-accept` handed the ghost over the
+-- moment it was asked, which means anybody holding the link could become
+-- "Ravi" and inherit every share, payment and settlement filed against that
+-- name. An invite link is signed, expiring and revocable — and it also sits in
+-- a group chat that everyone can read, so "whoever has the link" is not a
+-- small set of people.
+--
+-- A claim is now a request. It changes nothing until an admin of the group
+-- decides, and the person waiting is told which it was.
+--
+-- The decision is a SECURITY DEFINER function rather than an edge function so
+-- that "who may approve this" is one line of SQL next to the table it guards,
+-- instead of a check in a Deno file that can be forgotten on the next path in.
+
+-- ────────────────────────────────────────────────────────── the request ──
+
+CREATE TABLE IF NOT EXISTS public.member_claims (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- ON UPDATE CASCADE on every relation to match what Prisma generates, which
+  -- is what `db:drift` compares against.
+  group_id      uuid NOT NULL REFERENCES public.groups(id)        ON DELETE CASCADE ON UPDATE CASCADE,
+  member_id     uuid NOT NULL REFERENCES public.group_members(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  requester_id  uuid NOT NULL REFERENCES public.profiles(id)      ON DELETE CASCADE ON UPDATE CASCADE,
+  -- What the arrival calls themselves. Shown to whoever decides, because
+  -- "somebody wants to be Ravi" is not a question anyone can answer.
+  requested_name text,
+  status        text NOT NULL DEFAULT 'pending',
+  -- The membership that decided, not the profile: an admin who later leaves
+  -- still decided it, and the row should still say so.
+  decided_by    uuid REFERENCES public.group_members(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  decided_at    timestamptz,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT member_claims_status_known
+    CHECK (status IN ('pending', 'approved', 'declined', 'withdrawn')),
+  -- Decided exactly when it is not pending. Without this a row can claim to be
+  -- approved with nothing recording when, which is the state that makes an
+  -- audit useless.
+  CONSTRAINT member_claims_decided_shape
+    CHECK ((status = 'pending') = (decided_at IS NULL))
+);
+
+-- Deliberately no partial unique index on (member_id, requester_id) WHERE
+-- pending, which is what "one open request per person per place" would want.
+-- Prisma's datamodel cannot express a partial index, so the one thing it would
+-- buy is a permanently red `db:drift` — the merge gate that catches the schema
+-- drifting away from what is reviewed. A plain UNIQUE including `status` is not
+-- a substitute either: it blocks the second decline of a pair that was declined
+-- once before.
+--
+-- So the check lives in `baaki_request_member_claim` instead. The window it
+-- leaves is a double-tap producing two identical pending rows, and approving
+-- either one declines the rest of the pending claims on that member.
+CREATE INDEX IF NOT EXISTS member_claims_group_id_status_created_at_idx
+  ON public.member_claims (group_id, status, created_at);
+
+CREATE INDEX IF NOT EXISTS member_claims_requester_id_created_at_idx
+  ON public.member_claims (requester_id, created_at);
+
+ALTER TABLE public.member_claims ENABLE ROW LEVEL SECURITY;
+
+-- Readable by the two sides of it and nobody else: the person who asked, and
+-- the admins of the group being asked. Deliberately not every member — a
+-- declined claim is somebody having been told they are not who they said, and
+-- that does not belong in front of the whole group.
+DROP POLICY IF EXISTS member_claims_visible ON public.member_claims;
+CREATE POLICY member_claims_visible ON public.member_claims
+  FOR SELECT TO authenticated
+  USING (
+    requester_id = public.baaki_current_profile_id()
+    OR EXISTS (
+      SELECT 1 FROM public.group_members gm
+       WHERE gm.group_id = member_claims.group_id
+         AND gm.profile_id = public.baaki_current_profile_id()
+         AND gm.role = 'admin'
+         AND gm.left_at IS NULL
+    )
+  );
+
+-- Every write goes through a function below. A client that can UPDATE this
+-- table can approve its own claim, which is the whole thing this migration
+-- exists to stop.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.member_claims FROM anon, authenticated;
+
+COMMENT ON TABLE public.member_claims IS
+  'Somebody asking to take over a ghost member. Decided by a group admin (ADR-006).';
+
+-- ───────────────────────────────────────────────────────────── asking ──
+
+/**
+ * Record a request to take a ghost's place.
+ *
+ * Service-role only, and takes the profile explicitly: the caller is
+ * `invite-accept`, which has already verified a signed invite token. The
+ * person asking is not a member of the group yet and has no other standing to
+ * be here, so there is nothing for a client-side check to check.
+ *
+ * Returns a verdict rather than raising, because every refusal is a sentence
+ * to show somebody who just tapped their own name.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_request_member_claim(
+  p_group_id   uuid,
+  p_member_id  uuid,
+  p_profile_id uuid,
+  p_name       text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_member public.group_members%ROWTYPE;
+  v_group  text;
+  v_id     uuid;
+  v_admin  record;
+BEGIN
+  SELECT * INTO v_member
+    FROM public.group_members
+   WHERE id = p_member_id AND group_id = p_group_id
+   FOR UPDATE;
+
+  IF NOT FOUND OR v_member.left_at IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'NOT_CLAIMABLE');
+  END IF;
+
+  -- Already somebody's. The check is repeated at decision time as well: this
+  -- one is for the sentence, that one is for the guarantee.
+  IF v_member.profile_id IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'ALREADY_CLAIMED');
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.group_members
+     WHERE group_id = p_group_id AND profile_id = p_profile_id AND left_at IS NULL
+  ) THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'ALREADY_A_MEMBER');
+  END IF;
+
+  -- The same person asking twice. Their existing request is the answer, and a
+  -- second notification to every admin is not. Safe under the `FOR UPDATE` on
+  -- the member above, which serialises requests for one place.
+  SELECT id INTO v_id
+    FROM public.member_claims
+   WHERE member_id = p_member_id AND requester_id = p_profile_id AND status = 'pending';
+
+  IF v_id IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', true, 'claim_id', v_id, 'already_pending', true);
+  END IF;
+
+  INSERT INTO public.member_claims (group_id, member_id, requester_id, requested_name)
+  VALUES (p_group_id, p_member_id, p_profile_id, NULLIF(btrim(COALESCE(p_name, '')), ''))
+  RETURNING id INTO v_id;
+
+  SELECT name INTO v_group FROM public.groups WHERE id = p_group_id;
+
+  -- Every admin, not just the creator. A group whose only admin has stopped
+  -- opening the app is a group where nobody can ever join again.
+  FOR v_admin IN
+    SELECT profile_id FROM public.group_members
+     WHERE group_id = p_group_id AND role = 'admin'
+       AND profile_id IS NOT NULL AND left_at IS NULL
+  LOOP
+    PERFORM public.baaki_notify(
+      v_admin.profile_id,
+      p_group_id,
+      'ghost_claim_requested',
+      'Someone wants to join ' || COALESCE(v_group, 'a group'),
+      'They say they are ' || COALESCE(v_member.ghost_name, 'someone already listed'),
+      '/group/' || p_group_id::text || '/members',
+      jsonb_build_object(
+        'claim_id', v_id,
+        'member_id', p_member_id,
+        'ghost_name', v_member.ghost_name,
+        'requested_name', NULLIF(btrim(COALESCE(p_name, '')), '')
+      ),
+      'claim:' || v_id::text || ':' || v_admin.profile_id::text
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object('ok', true, 'claim_id', v_id, 'already_pending', false);
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_request_member_claim(uuid, uuid, uuid, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_request_member_claim(uuid, uuid, uuid, text) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_request_member_claim(uuid, uuid, uuid, text) TO service_role;
+
+-- ────────────────────────────────────────────────────────── deciding ──
+
+/**
+ * An admin says yes or no.
+ *
+ * The approval is the claim: one UPDATE moves the ghost row to the person, so
+ * every share, payment and settlement already filed against that name comes
+ * with it and nothing is copied. `.profile_id IS NULL` in the WHERE is what
+ * makes two admins approving at the same moment safe — the second one changes
+ * no rows and is told the place is taken.
+ *
+ * Rejecting a claim is not a smaller version of approving it. Somebody is
+ * waiting on an answer either way, so both paths notify.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_decide_member_claim(
+  p_claim_id uuid,
+  p_approve  boolean
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile   uuid := public.baaki_current_profile_id();
+  v_claim     public.member_claims%ROWTYPE;
+  v_admin_id  uuid;
+  v_group     text;
+  v_ghost     text;
+  v_moved     integer;
+BEGIN
+  IF v_profile IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN';
+  END IF;
+
+  SELECT * INTO v_claim FROM public.member_claims WHERE id = p_claim_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'NO_SUCH_CLAIM');
+  END IF;
+
+  SELECT id INTO v_admin_id
+    FROM public.group_members
+   WHERE group_id = v_claim.group_id
+     AND profile_id = v_profile
+     AND role = 'admin'
+     AND left_at IS NULL;
+
+  -- Not an admin of this group. The same answer as a claim that does not
+  -- exist, so this cannot be used to find out which claims do.
+  IF v_admin_id IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'NO_SUCH_CLAIM');
+  END IF;
+
+  IF v_claim.status <> 'pending' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'ALREADY_DECIDED', 'status', v_claim.status);
+  END IF;
+
+  SELECT name INTO v_group FROM public.groups WHERE id = v_claim.group_id;
+  SELECT ghost_name INTO v_ghost FROM public.group_members WHERE id = v_claim.member_id;
+
+  IF NOT p_approve THEN
+    UPDATE public.member_claims
+       SET status = 'declined', decided_by = v_admin_id, decided_at = now()
+     WHERE id = p_claim_id;
+
+    PERFORM public.baaki_notify(
+      v_claim.requester_id,
+      v_claim.group_id,
+      'ghost_claim_declined',
+      'Not confirmed',
+      COALESCE(v_group, 'The group') || ' did not confirm that place. You can still join as yourself.',
+      '/join',
+      jsonb_build_object('claim_id', p_claim_id, 'group_name', v_group),
+      'claim_declined:' || p_claim_id::text
+    );
+
+    RETURN jsonb_build_object('ok', true, 'status', 'declined');
+  END IF;
+
+  -- Somebody who joined by another route while this sat waiting must not end
+  -- up as two members of one group.
+  IF EXISTS (
+    SELECT 1 FROM public.group_members
+     WHERE group_id = v_claim.group_id
+       AND profile_id = v_claim.requester_id
+       AND left_at IS NULL
+  ) THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'ALREADY_A_MEMBER');
+  END IF;
+
+  UPDATE public.group_members
+     SET profile_id = v_claim.requester_id,
+         ghost_name = NULL,
+         joined_via = 'invite_link_claim'
+   WHERE id = v_claim.member_id
+     AND profile_id IS NULL
+     AND left_at IS NULL;
+
+  GET DIAGNOSTICS v_moved = ROW_COUNT;
+  IF v_moved = 0 THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'NOT_CLAIMABLE');
+  END IF;
+
+  -- The name they gave, written only now. `invite-accept` used to set it while
+  -- claiming, which meant an unconfirmed stranger could rename their own
+  -- profile through a join request. And only over the placeholder: somebody
+  -- who named themselves two years ago must not be renamed by a group they
+  -- have just joined.
+  IF v_claim.requested_name IS NOT NULL THEN
+    UPDATE public.profiles
+       SET display_name = v_claim.requested_name
+     WHERE id = v_claim.requester_id
+       AND (display_name IS NULL OR display_name = '' OR display_name = 'Guest');
+  END IF;
+
+  UPDATE public.member_claims
+     SET status = 'approved', decided_by = v_admin_id, decided_at = now()
+   WHERE id = p_claim_id;
+
+  -- Anybody else waiting on the same place has lost it. Leaving them pending
+  -- would mean an admin later approving a claim on a member who now belongs to
+  -- somebody, and being told NOT_CLAIMABLE with no idea why.
+  UPDATE public.member_claims
+     SET status = 'declined', decided_by = v_admin_id, decided_at = now()
+   WHERE member_id = v_claim.member_id
+     AND status = 'pending'
+     AND id <> p_claim_id;
+
+  PERFORM public.baaki_notify(
+    v_claim.requester_id,
+    v_claim.group_id,
+    'ghost_claim_approved',
+    'You are in ' || COALESCE(v_group, 'the group'),
+    'Everything already filed under ' || COALESCE(v_ghost, 'that name') || ' is yours',
+    '/group/' || v_claim.group_id::text,
+    jsonb_build_object('claim_id', p_claim_id, 'group_name', v_group, 'ghost_name', v_ghost),
+    'claim_approved:' || p_claim_id::text
+  );
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (
+    v_claim.group_id,
+    v_claim.member_id,
+    'claimed',
+    'member',
+    v_claim.member_id,
+    jsonb_build_object('via', 'invite_link', 'confirmed_by', v_admin_id)
+  );
+
+  RETURN jsonb_build_object('ok', true, 'status', 'approved', 'member_id', v_claim.member_id);
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_decide_member_claim(uuid, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_decide_member_claim(uuid, boolean) TO authenticated, service_role;
+
+-- ─────────────────────────────────────────────── giving up on waiting ──
+
+/**
+ * The person who asked, withdrawing.
+ *
+ * The escape hatch from an admin who never opens the app. Without it somebody
+ * can be stuck on a screen that says "waiting" forever, with joining as
+ * themselves blocked by their own open request.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_withdraw_member_claim(p_claim_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+  v_rows    integer;
+BEGIN
+  IF v_profile IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN';
+  END IF;
+
+  UPDATE public.member_claims
+     SET status = 'withdrawn', decided_at = now()
+   WHERE id = p_claim_id
+     AND requester_id = v_profile
+     AND status = 'pending';
+
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  RETURN jsonb_build_object('ok', v_rows = 1);
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_withdraw_member_claim(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_withdraw_member_claim(uuid) TO authenticated, service_role;
+
+-- ──────────────────────────────────────────────────────────── reading ──
+
+/**
+ * What an admin has been asked.
+ *
+ * A function rather than a plain select because the answer needs the
+ * requester's display name, and a person who is not in the group is not
+ * somebody the group can read through RLS.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_group_member_claims(p_group_id uuid)
+RETURNS TABLE (
+  id             uuid,
+  member_id      uuid,
+  ghost_name     text,
+  requester_name text,
+  requested_name text,
+  created_at     timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT c.id,
+         c.member_id,
+         m.ghost_name,
+         p.display_name,
+         c.requested_name,
+         c.created_at
+    FROM public.member_claims c
+    JOIN public.group_members m ON m.id = c.member_id
+    JOIN public.profiles p      ON p.id = c.requester_id
+   WHERE c.group_id = p_group_id
+     AND c.status = 'pending'
+     AND EXISTS (
+       SELECT 1 FROM public.group_members gm
+        WHERE gm.group_id = p_group_id
+          AND gm.profile_id = public.baaki_current_profile_id()
+          AND gm.role = 'admin'
+          AND gm.left_at IS NULL
+     )
+   ORDER BY c.created_at;
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_group_member_claims(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_group_member_claims(uuid) TO authenticated, service_role;
+
+/**
+ * What the person waiting can see.
+ *
+ * Carries the group's name because somebody with a pending claim is not in the
+ * group and cannot read its row — and "waiting for approval" without saying
+ * which group is not worth showing.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_my_member_claims()
+RETURNS TABLE (
+  id          uuid,
+  group_id    uuid,
+  group_name  text,
+  ghost_name  text,
+  status      text,
+  created_at  timestamptz,
+  decided_at  timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT c.id, c.group_id, g.name, m.ghost_name, c.status, c.created_at, c.decided_at
+    FROM public.member_claims c
+    JOIN public.groups g        ON g.id = c.group_id
+    JOIN public.group_members m ON m.id = c.member_id
+   WHERE c.requester_id = public.baaki_current_profile_id()
+   ORDER BY c.created_at DESC;
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_my_member_claims() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_my_member_claims() TO authenticated, service_role;
+
+-- ──────────────────────────────────────────────── the guard's message ──
+-- `baaki_guard_membership_columns` refuses a client changing `profile_id` and
+-- names `invite-accept` as the way to claim a ghost. That is no longer where
+-- it happens, and an error message that sends somebody to the wrong file is
+-- worse than a vague one. The rule is unchanged; only the sentence moves.
+
+-- Deliberately NOT `SECURITY DEFINER`, unlike everything else in this file.
+-- The guard's first line asks whether `current_user` is a client role, and
+-- inside a SECURITY DEFINER function `current_user` is the owner no matter who
+-- called — so adding it turns the whole trigger into `RETURN NEW`. It was
+-- added here, and `security-hardening.test.ts` failed on the next run with
+-- "Expected the statement to be denied, but it succeeded".
+CREATE OR REPLACE FUNCTION public.baaki_guard_membership_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF current_user NOT IN ('anon', 'authenticated') THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.role IS DISTINCT FROM OLD.role THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a role is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.profile_id IS DISTINCT FROM OLD.profile_id THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a ghost is claimed by an admin approving a request, not by an update'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.group_id IS DISTINCT FROM OLD.group_id THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a membership cannot move between groups'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN NEW;
+END
+$$;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -153,6 +153,7 @@ model Profile {
   feedback          Feedback[]
   purchasedPasses   GroupPass[]
   syncMutations     SyncMutation[]
+  memberClaims      MemberClaim[]
 
   @@map("profiles")
   @@schema("public")
@@ -212,6 +213,7 @@ model Group {
   passes          GroupPass[]
   planItems       TripPlanItem[]
   syncMutations   SyncMutation[]
+  memberClaims    MemberClaim[]
 
   @@index([archivedAt])
   /// The nudge job only ever looks at groups that have said when they are
@@ -269,11 +271,47 @@ model GroupMember {
   pairwiseTo         PairwiseBalance[] @relation("PairwiseTo")
   createdExpenses    Expense[]        @relation("ExpenseCreatedBy")
   deletedExpenses    Expense[]        @relation("ExpenseDeletedBy")
+  claimsOnThisPlace  MemberClaim[]    @relation("ClaimTarget")
+  claimsDecided      MemberClaim[]    @relation("ClaimDecider")
 
   @@unique([groupId, profileId])
   @@index([groupId])
   @@index([groupId, updatedSeq])
   @@map("group_members")
+  @@schema("public")
+}
+
+/// Somebody asking to take a ghost member's place, and an admin of the group
+/// deciding (ADR-006). The claim itself is one UPDATE inside
+/// `baaki_decide_member_claim` — the ghost row becomes theirs, so every share
+/// and settlement already filed against that name comes with it.
+///
+/// "One open request per person per place" is enforced in that function rather
+/// than by a partial unique index: Prisma's datamodel cannot express one, and
+/// an index it cannot see is a permanently failing `db:drift`.
+model MemberClaim {
+  id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  groupId       String    @map("group_id") @db.Uuid
+  memberId      String    @map("member_id") @db.Uuid
+  requesterId   String    @map("requester_id") @db.Uuid
+  /// What the arrival calls themselves, shown to whoever decides.
+  requestedName String?   @map("requested_name")
+  /// 'pending' | 'approved' | 'declined' | 'withdrawn' (CHECK in migration SQL).
+  status        String    @default("pending")
+  /// The membership that decided, not the profile: an admin who later leaves
+  /// still decided it.
+  decidedBy     String?   @map("decided_by") @db.Uuid
+  decidedAt     DateTime? @map("decided_at") @db.Timestamptz(6)
+  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  group     Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  member    GroupMember  @relation("ClaimTarget", fields: [memberId], references: [id], onDelete: Cascade)
+  requester Profile      @relation(fields: [requesterId], references: [id], onDelete: Cascade)
+  decider   GroupMember? @relation("ClaimDecider", fields: [decidedBy], references: [id], onDelete: SetNull)
+
+  @@index([groupId, status, createdAt], map: "member_claims_group_id_status_created_at_idx")
+  @@index([requesterId, createdAt], map: "member_claims_requester_id_created_at_idx")
+  @@map("member_claims")
   @@schema("public")
 }
 

--- a/packages/db/test/memberClaims.test.ts
+++ b/packages/db/test/memberClaims.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Taking somebody's place needs somebody to say yes.
+ *
+ * The test this file exists for is the first one: before this migration,
+ * anybody holding an invite link could become the ghost "Ravi" and inherit
+ * every share and settlement filed against that name, with nobody asked. The
+ * rest of the file is about the ways that answer can go wrong — two admins
+ * deciding at once, two people wanting the same place, an admin who never
+ * answers — because a confirmation step that deadlocks is its own outage.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { asRole, connect, expectDenied, seedGroup } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+/**
+ * Session-scoped claims rather than a transaction that rolls back: deciding a
+ * claim is a write, and the rows it makes have to survive the call to be
+ * asserted on.
+ */
+async function asProfile<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  try {
+    return await run();
+  } finally {
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+/** An outsider with a profile but no membership — whoever opened the link. */
+async function newcomer(name = 'Arrival'): Promise<string> {
+  const id = randomUUID();
+  await client.query(
+    `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, $2, 'INR')`,
+    [id, name],
+  );
+  return id;
+}
+
+/**
+ * `seedGroup` hands back plain arrays, and indexing one is `string | undefined`
+ * under this repo's TypeScript settings. Asserting here rather than at twenty
+ * call sites — and loudly, because a seed that quietly produced fewer members
+ * than the test asked for would otherwise pass `null` to Postgres and fail
+ * somewhere unrelated.
+ */
+function id(value: string | undefined, what: string): string {
+  if (!value) throw new Error(`the seed produced no ${what}`);
+  return value;
+}
+
+async function request(
+  groupId: string,
+  memberId: string | undefined,
+  profileId: string,
+  name: string | null = null,
+): Promise<{ ok: boolean; reason?: string; claim_id?: string; already_pending?: boolean }> {
+  const { rows } = await client.query(
+    'SELECT public.baaki_request_member_claim($1, $2, $3, $4) AS verdict',
+    [groupId, id(memberId, 'member'), profileId, name],
+  );
+  return rows[0].verdict;
+}
+
+async function decide(
+  claimId: string,
+  approve: boolean,
+  as: string | undefined,
+): Promise<{ ok: boolean; reason?: string; status?: string }> {
+  return asProfile(id(as, 'admin profile'), async () => {
+    const { rows } = await client.query('SELECT public.baaki_decide_member_claim($1, $2) AS v', [
+      claimId,
+      approve,
+    ]);
+    return rows[0].v;
+  });
+}
+
+async function memberRow(
+  memberId: string | undefined,
+): Promise<{ profile_id: string | null; ghost_name: string | null; joined_via: string | null }> {
+  const { rows } = await client.query(
+    'SELECT profile_id, ghost_name, joined_via FROM public.group_members WHERE id = $1',
+    [id(memberId, 'member')],
+  );
+  return rows[0];
+}
+
+describe('asking is not taking', () => {
+  it('changes nothing about the ghost until somebody decides', async () => {
+    // The whole point. Before this migration the ghost was handed over inside
+    // `invite-accept` the moment it was asked for.
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2, ghostCount: 1 });
+    const ghostId = memberIds[2];
+    const arrival = await newcomer();
+
+    const verdict = await request(groupId, ghostId, arrival, 'Ravi');
+    expect(verdict.ok).toBe(true);
+
+    const ghost = await memberRow(ghostId);
+    expect(ghost.profile_id).toBeNull();
+    expect(ghost.ghost_name).toBe('Ghost 1');
+  });
+
+  it('tells every admin, once each', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 3,
+      ghostCount: 1,
+    });
+    // A second admin, so "the organizer" is not read as "the creator".
+    await client.query(`UPDATE group_members SET role = 'admin' WHERE id = $1`, [memberIds[1]]);
+
+    const arrival = await newcomer();
+    await request(groupId, memberIds[3], arrival, 'Ravi');
+
+    const { rows } = await client.query(
+      `SELECT profile_id FROM public.notifications
+        WHERE group_id = $1 AND kind = 'ghost_claim_requested'`,
+      [groupId],
+    );
+    expect(new Set(rows.map((r) => r.profile_id as string))).toEqual(
+      new Set([profileIds[0], profileIds[1]]),
+    );
+  });
+
+  it('does not notify twice when the same person asks twice', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2, ghostCount: 1 });
+    const arrival = await newcomer();
+
+    const first = await request(groupId, memberIds[2], arrival);
+    const second = await request(groupId, memberIds[2], arrival);
+
+    expect(second.already_pending).toBe(true);
+    expect(second.claim_id).toBe(first.claim_id);
+
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM public.notifications
+        WHERE group_id = $1 AND kind = 'ghost_claim_requested'`,
+      [groupId],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+});
+
+describe('deciding', () => {
+  it('hands the whole history over on approval', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const ghostId = memberIds[2];
+    const arrival = await newcomer();
+
+    const { claim_id } = await request(groupId, ghostId, arrival, 'Ravi');
+    const verdict = await decide(claim_id!, true, profileIds[0]);
+    expect(verdict.ok).toBe(true);
+    expect(verdict.status).toBe('approved');
+
+    // The same row, now theirs: nothing was copied, so every share and
+    // settlement already pointing at this member id still points at it.
+    const ghost = await memberRow(ghostId);
+    expect(ghost.profile_id).toBe(arrival);
+    expect(ghost.ghost_name).toBeNull();
+    expect(ghost.joined_via).toBe('invite_link_claim');
+  });
+
+  it('writes the name they gave only once somebody agreed', async () => {
+    // The old path set `display_name` while claiming, so an unconfirmed
+    // stranger could rename their own profile through a join request.
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const arrival = await newcomer('Guest');
+    const { claim_id } = await request(groupId, memberIds[2], arrival, 'Ravi');
+
+    const nameNow = async (): Promise<string> =>
+      (await client.query('SELECT display_name FROM public.profiles WHERE id = $1', [arrival]))
+        .rows[0].display_name;
+
+    expect(await nameNow()).toBe('Guest');
+    await decide(claim_id!, true, profileIds[0]);
+    expect(await nameNow()).toBe('Ravi');
+  });
+
+  it('does not rename somebody who already named themselves', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const arrival = await newcomer('Asha Menon');
+    const { claim_id } = await request(groupId, memberIds[2], arrival, 'Ravi');
+    await decide(claim_id!, true, profileIds[0]);
+
+    const { rows } = await client.query('SELECT display_name FROM public.profiles WHERE id = $1', [
+      arrival,
+    ]);
+    expect(rows[0].display_name).toBe('Asha Menon');
+  });
+
+  it('refuses anybody who is not an admin of that group', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const arrival = await newcomer();
+    const { claim_id } = await request(groupId, memberIds[2], arrival);
+
+    // An ordinary member of the same group.
+    const byMember = await decide(claim_id!, true, profileIds[1]);
+    expect(byMember.ok).toBe(false);
+
+    // A stranger, and the person who asked — who would otherwise approve
+    // themselves, which is the whole hole this closes.
+    const outsider = await newcomer('Nobody');
+    expect((await decide(claim_id!, true, outsider)).ok).toBe(false);
+    expect((await decide(claim_id!, true, arrival)).ok).toBe(false);
+
+    expect((await memberRow(memberIds[2])).profile_id).toBeNull();
+  });
+
+  it('says the same thing to a stranger as to a claim that does not exist', async () => {
+    // Otherwise the difference between the two answers is a way to enumerate
+    // which claim ids are real.
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2, ghostCount: 1 });
+    const arrival = await newcomer();
+    const { claim_id } = await request(groupId, memberIds[2], arrival);
+    const outsider = await newcomer('Nobody');
+
+    const real = await decide(claim_id!, true, outsider);
+    const imaginary = await decide(randomUUID(), true, outsider);
+    expect(real.reason).toBe(imaginary.reason);
+    expect(real.reason).toBe('NO_SUCH_CLAIM');
+  });
+
+  it('lets a second admin decide when the first never opens the app', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 3,
+      ghostCount: 1,
+    });
+    await client.query(`UPDATE group_members SET role = 'admin' WHERE id = $1`, [memberIds[1]]);
+    const arrival = await newcomer();
+    const { claim_id } = await request(groupId, memberIds[3], arrival);
+
+    expect((await decide(claim_id!, true, profileIds[1])).ok).toBe(true);
+  });
+
+  it('cannot be decided twice', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const arrival = await newcomer();
+    const { claim_id } = await request(groupId, memberIds[2], arrival);
+
+    expect((await decide(claim_id!, false, profileIds[0])).ok).toBe(true);
+    const again = await decide(claim_id!, true, profileIds[0]);
+    expect(again.ok).toBe(false);
+    expect(again.reason).toBe('ALREADY_DECIDED');
+  });
+
+  it('declines everybody else waiting on the same place', async () => {
+    // Two people both say they are Ravi. Approving one has to answer the
+    // other, or an admin is later told NOT_CLAIMABLE with no idea why.
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const ghostId = memberIds[2];
+    const first = await newcomer('First');
+    const second = await newcomer('Second');
+
+    const a = await request(groupId, ghostId, first);
+    const b = await request(groupId, ghostId, second);
+    await decide(a.claim_id!, true, profileIds[0]);
+
+    const { rows } = await client.query('SELECT status FROM public.member_claims WHERE id = $1', [
+      b.claim_id,
+    ]);
+    expect(rows[0].status).toBe('declined');
+  });
+
+  it('tells the person waiting, either way', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 2,
+    });
+    const yes = await newcomer('Yes');
+    const no = await newcomer('No');
+
+    const approved = await request(groupId, memberIds[2], yes);
+    const refused = await request(groupId, memberIds[3], no);
+    await decide(approved.claim_id!, true, profileIds[0]);
+    await decide(refused.claim_id!, false, profileIds[0]);
+
+    const { rows } = await client.query(
+      `SELECT profile_id, kind FROM public.notifications
+        WHERE kind IN ('ghost_claim_approved', 'ghost_claim_declined') AND group_id = $1`,
+      [groupId],
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.profile_id === yes)?.kind).toBe('ghost_claim_approved');
+    expect(rows.find((r) => r.profile_id === no)?.kind).toBe('ghost_claim_declined');
+  });
+});
+
+describe('the ways a claim stops making sense', () => {
+  it('will not take a place that already belongs to somebody', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const arrival = await newcomer();
+    const verdict = await request(groupId, memberIds[0], arrival);
+    expect(verdict).toMatchObject({ ok: false, reason: 'ALREADY_CLAIMED' });
+  });
+
+  it('will not give somebody a second membership of one group', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const verdict = await request(groupId, memberIds[2], id(profileIds[1], 'member profile'));
+    expect(verdict).toMatchObject({ ok: false, reason: 'ALREADY_A_MEMBER' });
+  });
+
+  it('refuses approval if they joined by another route while waiting', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const arrival = await newcomer();
+    const { claim_id } = await request(groupId, memberIds[2], arrival);
+
+    await client.query(
+      `INSERT INTO group_members (group_id, profile_id, joined_via) VALUES ($1, $2, 'invite_link')`,
+      [groupId, arrival],
+    );
+
+    const verdict = await decide(claim_id!, true, profileIds[0]);
+    expect(verdict).toMatchObject({ ok: false, reason: 'ALREADY_A_MEMBER' });
+  });
+
+  it('lets the person waiting give up, and nobody else give up for them', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const arrival = await newcomer();
+    const { claim_id } = await request(groupId, memberIds[2], arrival);
+
+    const byAdmin = await asProfile(id(profileIds[0], 'admin profile'), async () => {
+      const { rows } = await client.query('SELECT public.baaki_withdraw_member_claim($1) AS v', [
+        claim_id,
+      ]);
+      return rows[0].v;
+    });
+    expect(byAdmin.ok).toBe(false);
+
+    const byThem = await asProfile(arrival, async () => {
+      const { rows } = await client.query('SELECT public.baaki_withdraw_member_claim($1) AS v', [
+        claim_id,
+      ]);
+      return rows[0].v;
+    });
+    expect(byThem.ok).toBe(true);
+
+    // Withdrawn is not pending, so it can no longer be approved behind them.
+    expect((await decide(claim_id!, true, profileIds[0])).reason).toBe('ALREADY_DECIDED');
+  });
+});
+
+describe('who can see a claim', () => {
+  it('is the person who asked and the admins, and nobody else', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 3,
+      ghostCount: 1,
+    });
+    const arrival = await newcomer();
+    await request(groupId, memberIds[3], arrival);
+
+    // `asRole` and not a bare `SET LOCAL ROLE`: outside a transaction that is
+    // a no-op, and the query then runs as the table's owner with RLS bypassed
+    // — which is a test that passes no matter what the policy says. It did.
+    const visibleTo = async (profileId: string): Promise<number> =>
+      asRole(client, 'authenticated', { sub: profileId, role: 'authenticated' }, async () => {
+        const { rows } = await client.query(
+          'SELECT count(*)::int AS n FROM public.member_claims WHERE group_id = $1',
+          [groupId],
+        );
+        return rows[0].n as number;
+      });
+
+    expect(await visibleTo(id(profileIds[0], 'admin profile'))).toBe(1); // admin
+    expect(await visibleTo(arrival)).toBe(1); // the one who asked
+    // An ordinary member: a declined claim is somebody being told they are not
+    // who they said, and that is not the group's business.
+    expect(await visibleTo(id(profileIds[1], 'member profile'))).toBe(0);
+    expect(await visibleTo(await newcomer('Nobody'))).toBe(0);
+  });
+
+  it('will not let a client write the table directly', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2, ghostCount: 1 });
+    const arrival = await newcomer();
+    const { claim_id } = await request(groupId, memberIds[2], arrival);
+
+    // Approving your own claim by UPDATE is the shortest way around all of it.
+    const denied = await asRole(
+      client,
+      'authenticated',
+      { sub: arrival, role: 'authenticated' },
+      async () =>
+        expectDenied(
+          client.query(
+            `UPDATE public.member_claims
+                SET status = 'approved', decided_at = now()
+              WHERE id = $1`,
+            [claim_id],
+          ),
+        ),
+    );
+    expect(denied).toMatch(/permission denied/i);
+  });
+});

--- a/supabase/functions/invite-accept/index.ts
+++ b/supabase/functions/invite-accept/index.ts
@@ -110,27 +110,38 @@ Deno.serve(async (request) => {
         throw new HttpError(400, 'NOT_CLAIMABLE', 'That person has already been claimed');
       }
 
-      // The claim itself: the ghost row becomes this person's membership, so
-      // every share, payment and settlement already attached to it carries over
-      // untouched. No rows move, so nothing can be lost in the middle.
-      const { error: claimError } = await service
-        .from('group_members')
-        .update({
-          profile_id: profileId,
-          ghost_name: null,
-          joined_via: 'invite_link_claim',
-        })
-        .eq('id', ghost.id)
-        .is('profile_id', null); // loses safely if two people claim at once
-      if (claimError) throw new HttpError(409, 'CLAIM_FAILED', claimError.message);
-      memberId = ghost.id;
-
-      if (body.displayName) {
-        await service
-          .from('profiles')
-          .update({ display_name: body.displayName })
-          .eq('id', profileId);
+      // Asking, not taking. This used to hand the ghost over on the spot, which
+      // meant anybody holding the link could become "Ravi" and inherit every
+      // share and settlement filed under that name. ADR-006 always said the
+      // organizer confirms; now something does.
+      //
+      // Nobody joins here. The claim is decided by an admin through
+      // `baaki_decide_member_claim`, and that function — not this one — is
+      // where "who may approve this" lives, next to the table it guards.
+      const { data: verdict, error: claimError } = await service.rpc('baaki_request_member_claim', {
+        p_group_id: invite.group_id,
+        p_member_id: ghost.id,
+        p_profile_id: profileId,
+        p_name: body.displayName ?? null,
+      });
+      if (claimError) throw new HttpError(500, 'CLAIM_FAILED', claimError.message);
+      if (!verdict?.ok) {
+        throw new HttpError(
+          409,
+          verdict?.reason ?? 'NOT_CLAIMABLE',
+          'That place is no longer free to claim',
+        );
       }
+
+      // The name is not written yet: it belongs to somebody who has only said
+      // they are that person. It is carried on the claim and applied if and
+      // when an admin agrees.
+      return json({
+        group,
+        pending: true,
+        claimId: verdict.claim_id,
+        alreadyPending: verdict.already_pending === true,
+      });
     } else {
       const { data: inserted, error: insertError } = await service
         .from('group_members')


### PR DESCRIPTION
## The hole

ADR-006: *"When a real person joins via link, they can claim a ghost
(organizer confirms) and inherit its history atomically."*

The claim was built. The confirmation was not. `invite-accept` handed the
ghost over the moment it was asked for, so anybody holding an invite link
could become the "Ravi" already in the group and inherit every share, payment
and settlement filed under that name. The link is signed, expiring and
revocable — and it also sits in a WhatsApp group everyone can read.

## What changes

A claim is a request. Nothing moves until an admin of the group decides.

- `member_claims` — pending / approved / declined / withdrawn, RLS on, every
  write through a function. Visible to the person who asked and the group's
  admins, and nobody else: a declined claim is somebody being told they are
  not who they said.
- `baaki_request_member_claim` — service-role only, called by `invite-accept`,
  which has already verified the token.
- `baaki_decide_member_claim` — the approval **is** the claim. One UPDATE, so
  nothing is copied and every row already pointing at that member id still
  does. `profile_id IS NULL` in the WHERE makes two admins tapping at once
  safe.
- `baaki_withdraw_member_claim`, `baaki_group_member_claims`,
  `baaki_my_member_claims`.

UI: the join screen (app and web-lite) says "Ask to join as Ravi" and then
waits, with "join as someone new instead" as the way out. The members screen
grows a card for admins with Confirm / Not them.

## Three things found while building it

- **Every admin is notified**, not just the creator. A group whose one admin
  has stopped opening the app could otherwise never accept anybody again.
- **Approving declines everybody else waiting on the same place**, so a second
  admin is not later told `NOT_CLAIMABLE` with no idea why.
- **The name is written on approval, not on request.** The old path set
  `display_name` while claiming, which let an unconfirmed stranger rename
  their own profile through a join request. Now it only fills the `Guest`
  placeholder.

## Two judgement calls

**No partial unique index** on `(member_id, requester_id) WHERE pending`, even
though that is what "one open request per person per place" wants. Prisma's
datamodel cannot express one, so it would buy a permanently red `db:drift` —
the gate that catches the schema drifting from what is reviewed. The check is
in the function, under the row lock that already serialises requests for one
place. Worst case is a double-tap making two identical pending rows, and
approving either declines the other.

**`baaki_guard_membership_columns` is not `SECURITY DEFINER`** and that is
load-bearing. Its first line asks whether `current_user` is a client role,
which inside a definer function is always the owner. I added it; the trigger
became `RETURN NEW`; `security-hardening.test.ts` failed with "Expected the
statement to be denied, but it succeeded". The reason is now a comment above
the function.

## Verified

18 new tests in `packages/db/test/memberClaims.test.ts`, including that a
stranger and the requester both get the *same* answer as a claim that does not
exist — so the endpoint cannot be used to enumerate real claim ids.

Every migration applies from scratch into an empty database, `migrate diff`
reports no difference, 352 db / 434 core / 139 mobile tests, typecheck and
lint pass across the workspace.

Not run on a device.