### PR TITLE
fix: the console died of one panel it could not read

### DIFF
--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -41,7 +41,7 @@ export default async function Dashboard() {
     );
   }
 
-  const signInTotal = signIns.reduce((sum, row) => sum + Number(row.sign_ins), 0);
+  const signInTotal = signIns.rows.reduce((sum, row) => sum + Number(row.sign_ins), 0);
 
   return (
     <main>
@@ -203,7 +203,15 @@ export default async function Dashboard() {
 
       <h2>Sign-ins, 30 days</h2>
       <section>
-        {signIns.length === 0 ? (
+        {signIns.unavailable ? (
+          // Said plainly, and not as an empty chart. This is the only panel
+          // reading outside `public`, so it is the only one whose failure means
+          // "the grant is missing" rather than "nobody did anything".
+          <p className="note">
+            Sign-in history could not be read: <code>{signIns.unavailable}</code>. Everything else
+            on this page is unaffected.
+          </p>
+        ) : signIns.rows.length === 0 ? (
           <p className="note">
             Nothing to show. Supabase prunes its auth audit log, so an empty result here means the
             retention window has passed — not that nobody signed in.
@@ -212,7 +220,7 @@ export default async function Dashboard() {
           <>
             <Bars
               label="Sign-ins per day"
-              rows={[...signIns]
+              rows={[...signIns.rows]
                 .reverse()
                 .map((row) => ({ day: row.day, value: Number(row.sign_ins) }))}
             />

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -396,4 +396,25 @@ export const daily = (days = 30) => call<DailyRow>('baaki_admin_daily', { p_days
 export const geo = () => call<GeoRow>('baaki_admin_geo');
 export const money = () => call<MoneyRow>('baaki_admin_money');
 export const aiCost = (days = 30) => call<AiCostRow>('baaki_admin_ai_cost', { p_days: days });
-export const logins = (days = 30) => call<LoginRow>('baaki_admin_logins', { p_days: days });
+/**
+ * Sign-ins, and the one panel allowed to fail on its own.
+ *
+ * It is the only aggregate that reads outside `public` — Supabase owns
+ * `auth.audit_log_entries` and grants it to nobody by default — so it is the
+ * one with a way to be unavailable that says nothing about the business. It
+ * took the whole dashboard down once: `permission denied for table
+ * audit_log_entries` reached the browser as "A server error occurred", with
+ * five working panels behind it.
+ *
+ * Not folded into `call`, and not degraded to an empty array. Empty already
+ * means "Supabase has pruned the window", which is a fact about retention; a
+ * permission problem is a fact about deployment, and a panel that shows the
+ * first when it means the second is worse than one that shows neither.
+ */
+export async function logins(days = 30): Promise<{ rows: LoginRow[]; unavailable?: string }> {
+  try {
+    return { rows: await call<LoginRow>('baaki_admin_logins', { p_days: days }) };
+  } catch (caught) {
+    return { rows: [], unavailable: caught instanceof Error ? caught.message : String(caught) };
+  }
+}

--- a/packages/db/prisma/migrations/20260809010000_sign_ins_need_borrowed_rights/migration.sql
+++ b/packages/db/prisma/migrations/20260809010000_sign_ins_need_borrowed_rights/migration.sql
@@ -1,0 +1,86 @@
+-- The console's sign-in panel could not read the thing it counts.
+--
+-- Signing in and loading the dashboard returned a 500 and, in the browser,
+-- "A server error occurred":
+--
+--   baaki_admin_logins failed: permission denied for table audit_log_entries
+--
+-- `baaki_admin_logins` is the only one of these functions that reads outside
+-- `public`. The other five read tables `service_role` owns rights to; this one
+-- reads `auth.audit_log_entries`, which belongs to `supabase_auth_admin` and is
+-- granted to nobody. It was written without SECURITY DEFINER, so it ran as the
+-- caller — and the caller has no business in the `auth` schema.
+--
+-- Two things were wrong and both are fixed here.
+
+-- ────────────────────────────────────────── 1. borrow the owner's rights ──
+--
+-- SECURITY DEFINER, like every other function in this schema that has to reach
+-- past what the caller may see. `search_path` is pinned for the usual reason:
+-- a definer function that resolves names through the caller's path is a way to
+-- run the caller's code as the owner.
+--
+-- The `to_regclass` guard stays. CI applies these migrations to bare Postgres,
+-- which has no `auth` schema at all, and a function that cannot be created
+-- there is a function nothing tests.
+
+CREATE OR REPLACE FUNCTION public.baaki_admin_logins(p_days integer DEFAULT 30)
+RETURNS TABLE (
+  day date,
+  sign_ins bigint
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF to_regclass('auth.audit_log_entries') IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY EXECUTE format(
+    $q$
+      SELECT a.created_at::date AS day, count(*)::bigint
+        FROM auth.audit_log_entries a
+       WHERE a.created_at >= current_date - (%s - 1)
+         AND a.payload ->> 'action' IN ('login', 'token_refreshed')
+       GROUP BY 1
+       ORDER BY 1 DESC
+    $q$,
+    GREATEST(p_days, 1)
+  );
+END
+$$;
+
+-- SECURITY DEFINER changes who the function runs as, not who may call it, and
+-- CREATE OR REPLACE resets the grants a new function gets by default.
+REVOKE ALL ON FUNCTION public.baaki_admin_logins(integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_admin_logins(integer) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_admin_logins(integer) TO service_role;
+
+-- ────────────────────────────── 2. make sure the owner can read it either ──
+--
+-- Being the definer is only half of it: the owner needs the SELECT too, and on
+-- a Supabase project `postgres` does not have it on `auth.audit_log_entries`
+-- as a matter of course.
+--
+-- Wrapped in an exception handler because there are three environments here and
+-- the statement is right in one of them. On bare Postgres in CI the table does
+-- not exist; on a project where `postgres` cannot grant on another role's
+-- table, the GRANT is refused. Neither is a reason to fail a migration that has
+-- already fixed the definer half — and the console now names the remaining
+-- problem on the page instead of dying of it.
+DO $$
+BEGIN
+  IF to_regclass('auth.audit_log_entries') IS NOT NULL THEN
+    EXECUTE 'GRANT USAGE ON SCHEMA auth TO postgres';
+    EXECUTE 'GRANT SELECT ON auth.audit_log_entries TO postgres';
+  END IF;
+EXCEPTION
+  WHEN insufficient_privilege OR undefined_table OR undefined_object THEN
+    RAISE NOTICE
+      'Could not grant SELECT on auth.audit_log_entries to postgres (%). The '
+      'sign-ins panel will say so; nothing else is affected.', SQLERRM;
+END
+$$;


### PR DESCRIPTION
Signing in and opening the dashboard returned a 500 — "This page couldn't load"
in the browser. The swallowed error was:

```
baaki_admin_logins failed: permission denied for table audit_log_entries
```

`baaki_admin_logins` is the only one of the six aggregates that reads outside
`public`. `auth.audit_log_entries` belongs to `supabase_auth_admin` and is
granted to nobody, and the function had no `SECURITY DEFINER` — so it ran as
`service_role`. Five working panels were behind that error page.

## Two faults, two fixes

**The function borrows its owner's rights**, like every other function here
that reaches past what its caller may see, `search_path` pinned. A guarded
`DO` block also grants `postgres` the SELECT that makes borrowing worth
anything — with an exception handler, because the statement is correct in
exactly one of the three environments this runs in. CI applies migrations to
bare Postgres with no `auth` schema; a project where `postgres` cannot grant
on another role's table refuses it. Neither should fail a migration that has
already fixed the definer half.

**The panel may fail on its own.** Deliberately not folded into `call` and
deliberately not degraded to an empty array — empty already means "Supabase
pruned the retention window", a fact about retention, where this was a fact
about deployment. The page names the error and says the rest is unaffected.

## Verified

Reproduced locally first (the local console reads production), then fixed,
then confirmed: dashboard 200, reading 107 people / 57 groups / 117 expenses /
73 active in 30 days. Migration applies from scratch, `migrate diff` clean,
`adminAnalytics.test.ts` 9/9 — including the check that anon and authenticated
still cannot execute any of these.

Already applied to production, since the console was down.