### PR TITLE
fix(test): the rate limit tests were racing the wall clock

### DIFF
--- a/packages/db/test/rateLimit.test.ts
+++ b/packages/db/test/rateLimit.test.ts
@@ -45,6 +45,39 @@ async function hit(
   return result.rows[0].decision as Decision;
 }
 
+/**
+ * Runs `attempt`, and runs it again if the rate limit window rolled over while
+ * it was running.
+ *
+ * Windows are floored to the wall clock — `floor(epoch / window) * window` — so
+ * the boundary is a property of the time of day, not of when the test started.
+ * A burst that straddles one is counted twice from zero, and every assertion
+ * about the count is then wrong: the call that should have been refused is
+ * allowed, because as far as the limiter is concerned it is the first of a new
+ * minute.
+ *
+ * This is not hypothetical and not rare enough to ignore. It turned this file
+ * red on a pull request that changed nothing but the README, and a one-second
+ * window makes it a hundred times likelier still.
+ *
+ * `windows` names the decisions that had to share a window. Every decision the
+ * assertions depend on belongs in it — checking only the last two would miss a
+ * rollover between the first two, which shifts the count just as badly.
+ */
+async function inOneWindow<T>(
+  attempt: () => Promise<T>,
+  windows: (result: T) => readonly Decision[],
+): Promise<T> {
+  const attempts = 5;
+  for (let remaining = attempts; remaining > 0; remaining -= 1) {
+    const result = await attempt();
+    if (new Set(windows(result).map((decision) => decision.resetAt)).size === 1) return result;
+  }
+  // Not a silent pass. Five rollovers in a row is a broken clock or a limiter
+  // that no longer agrees with itself, and either is worth stopping for.
+  throw new Error(`the rate limit window rolled over on all ${attempts} attempts`);
+}
+
 beforeAll(async () => {
   client = await connect();
 });
@@ -55,18 +88,27 @@ afterAll(async () => {
 
 describe('baaki_rate_limit', () => {
   it('allows up to the limit and refuses the one after', async () => {
-    const who = subject();
+    const { first, second, third, fourth } = await inOneWindow(
+      async () => {
+        const who = subject();
+        return {
+          first: await hit(who),
+          second: await hit(who),
+          third: await hit(who),
+          fourth: await hit(who),
+        };
+      },
+      (run) => [run.first, run.second, run.third, run.fourth],
+    );
 
-    const first = await hit(who);
     expect(first.allowed).toBe(true);
     expect(first.hits).toBe(1);
     expect(first.remaining).toBe(2);
     expect(first.retryAfter).toBe(0);
 
-    expect((await hit(who)).allowed).toBe(true);
-    expect((await hit(who)).allowed).toBe(true);
+    expect(second.allowed).toBe(true);
+    expect(third.allowed).toBe(true);
 
-    const fourth = await hit(who);
     expect(fourth.allowed).toBe(false);
     expect(fourth.hits).toBe(4);
     expect(fourth.remaining).toBe(0);
@@ -77,38 +119,70 @@ describe('baaki_rate_limit', () => {
   });
 
   it('counts each subject separately', async () => {
-    const one = subject();
-    const other = subject();
+    const { fourth, stranger } = await inOneWindow(
+      async () => {
+        const one = subject();
+        const other = subject();
+        return {
+          first: await hit(one),
+          second: await hit(one),
+          third: await hit(one),
+          fourth: await hit(one),
+          stranger: await hit(other),
+        };
+      },
+      (run) => [run.first, run.second, run.third, run.fourth, run.stranger],
+    );
 
-    await hit(one);
-    await hit(one);
-    await hit(one);
-    expect((await hit(one)).allowed).toBe(false);
+    expect(fourth.allowed).toBe(false);
 
     // Somebody else's spree must not spend this person's allowance.
-    expect((await hit(other)).allowed).toBe(true);
+    expect(stranger.allowed).toBe(true);
   });
 
   it('counts each bucket separately', async () => {
-    const who = subject();
+    const { fourth, otherBucket } = await inOneWindow(
+      async () => {
+        const who = subject();
+        return {
+          first: await hit(who, 'bucket-a'),
+          second: await hit(who, 'bucket-a'),
+          third: await hit(who, 'bucket-a'),
+          fourth: await hit(who, 'bucket-a'),
+          otherBucket: await hit(who, 'bucket-b'),
+        };
+      },
+      (run) => [run.first, run.second, run.third, run.fourth, run.otherBucket],
+    );
 
-    await hit(who, 'bucket-a');
-    await hit(who, 'bucket-a');
-    await hit(who, 'bucket-a');
-    expect((await hit(who, 'bucket-a')).allowed).toBe(false);
+    expect(fourth.allowed).toBe(false);
 
     // Hitting the export limit must not stop somebody writing an expense.
-    expect((await hit(who, 'bucket-b')).allowed).toBe(true);
+    expect(otherBucket.allowed).toBe(true);
   });
 
   it('forgets everything once the window rolls over', async () => {
-    const who = subject();
-
     // A one-second window, so the rollover can actually be waited for. The
     // window is floored to the clock, so waiting past the next boundary is
     // enough — no sleeping for a whole minute.
-    expect((await hit(who, 'rollover', 1, 1)).allowed).toBe(true);
-    expect((await hit(who, 'rollover', 1, 1)).allowed).toBe(false);
+    //
+    // Which is also why the first two hits go through `inOneWindow`: at a
+    // one-second window the boundary this test is about can land *between*
+    // them, and then the second hit is allowed and the rollover being tested
+    // has already happened before the wait.
+    const { who, second } = await inOneWindow(
+      async () => {
+        const each = subject();
+        return {
+          who: each,
+          first: await hit(each, 'rollover', 1, 1),
+          second: await hit(each, 'rollover', 1, 1),
+        };
+      },
+      (run) => [run.first, run.second],
+    );
+
+    expect(second.allowed).toBe(false);
 
     await new Promise((resolve) => setTimeout(resolve, 1_100));
 
@@ -118,33 +192,42 @@ describe('baaki_rate_limit', () => {
   });
 
   it('counts correctly when many calls land at once', async () => {
-    const who = subject();
+    // A rollover here would split the twenty callers across two windows and
+    // break both assertions below — five allowed becomes ten, and the twenty
+    // distinct positions become two runs of overlapping ones.
+    const decisions = await inOneWindow(
+      async () => {
+        const who = subject();
 
-    // Twenty *connections*, not twenty queries on one. `pg` serialises queries
-    // issued on a single client — `Promise.all` over `client.query` runs them
-    // one after another and proves nothing about concurrency, which is the only
-    // thing this test exists to prove. It passed that way first.
-    const clients = await Promise.all(Array.from({ length: 20 }, () => connect()));
-    try {
-      const decisions = await Promise.all(
-        clients.map(async (each) => {
-          const result = await each.query(
-            `SELECT public.baaki_rate_limit($1, 'concurrent', 5, 60) AS decision`,
-            [who],
+        // Twenty *connections*, not twenty queries on one. `pg` serialises
+        // queries issued on a single client — `Promise.all` over `client.query`
+        // runs them one after another and proves nothing about concurrency,
+        // which is the only thing this test exists to prove. It passed that way
+        // first.
+        const clients = await Promise.all(Array.from({ length: 20 }, () => connect()));
+        try {
+          return await Promise.all(
+            clients.map(async (each) => {
+              const result = await each.query(
+                `SELECT public.baaki_rate_limit($1, 'concurrent', 5, 60) AS decision`,
+                [who],
+              );
+              return result.rows[0].decision as Decision;
+            }),
           );
-          return result.rows[0].decision as Decision;
-        }),
-      );
+        } finally {
+          await Promise.all(clients.map((each) => each.end()));
+        }
+      },
+      (all) => all,
+    );
 
-      // The reason the count is a single INSERT ... ON CONFLICT and not a
-      // SELECT followed by an UPDATE: a read-then-write lets several callers
-      // read 4 and all of them write 5.
-      expect(decisions.filter((decision) => decision.allowed)).toHaveLength(5);
-      // Every caller got a distinct position, so nothing was lost or double-counted.
-      expect(new Set(decisions.map((decision) => decision.hits)).size).toBe(20);
-    } finally {
-      await Promise.all(clients.map((each) => each.end()));
-    }
+    // The reason the count is a single INSERT ... ON CONFLICT and not a
+    // SELECT followed by an UPDATE: a read-then-write lets several callers
+    // read 4 and all of them write 5.
+    expect(decisions.filter((decision) => decision.allowed)).toHaveLength(5);
+    // Every caller got a distinct position, so nothing was lost or double-counted.
+    expect(new Set(decisions.map((decision) => decision.hits)).size).toBe(20);
   });
 
   it('refuses everything at a limit of zero, and does not divide by zero at a window of zero', async () => {
@@ -164,6 +247,48 @@ describe('baaki_rate_limit', () => {
       client.query(`SELECT public.baaki_rate_limit('', 'unit-test', 5, 60)`),
     );
     expect(message).toMatch(/needs a subject and a bucket/);
+  });
+});
+
+describe('the guard the tests above rely on', () => {
+  it('retries a burst that the window rolled over underneath', async () => {
+    let attempts = 0;
+
+    // A one-second window and a stall longer than it, so the rollover is caused
+    // rather than waited for. Without `inOneWindow` this is the shape that made
+    // CI red: the second hit is counted as the first of a new window.
+    const result = await inOneWindow(
+      async () => {
+        attempts += 1;
+        const who = subject();
+        const first = await hit(who, 'guard', 3, 1);
+        if (attempts === 1) await new Promise((resolve) => setTimeout(resolve, 1_100));
+        const second = await hit(who, 'guard', 3, 1);
+        return { first, second };
+      },
+      (run) => [run.first, run.second],
+    );
+
+    // The first attempt was thrown away rather than asserted on.
+    expect(attempts).toBeGreaterThan(1);
+    expect(result.first.resetAt).toBe(result.second.resetAt);
+    expect(result.second.hits).toBe(2);
+  });
+
+  it('gives up loudly rather than returning a split burst', async () => {
+    // If the retry ever stops working, the tests above must fail rather than
+    // quietly assert against two windows.
+    await expect(
+      inOneWindow(
+        async () => {
+          const who = subject();
+          const first = await hit(who, 'guard-always', 3, 1);
+          await new Promise((resolve) => setTimeout(resolve, 1_100));
+          return { first, second: await hit(who, 'guard-always', 3, 1) };
+        },
+        (run) => [run.first, run.second],
+      ),
+    ).rejects.toThrow(/rolled over on all 5 attempts/);
   });
 });
 


### PR DESCRIPTION
`counts each subject separately` failed CI on #89 — a pull request that changed
nothing but the README. That is not a test being flaky in the abstract; it is a
specific race, and it reproduces on demand.

## The race

The limiter floors its window to the wall clock:

```sql
v_start := to_timestamp(floor(extract(epoch FROM clock_timestamp()) / v_window) * v_window);
```

The boundary is therefore a property of the time of day, not of when the test
started. A burst of four hits that straddles one gets counted twice from zero,
and the fourth call — the one asserted to be refused — is allowed, because as
far as the limiter is concerned it is the first call of a new minute.

Reproduced against a local database by deliberately putting a minute boundary
between hit 1 and hit 4:

```
hit 1: allowed=true hits=1 resetAt=2026-08-09T04:09:00+00:00
hit 2: allowed=true hits=1 resetAt=2026-08-09T04:10:00+00:00
hit 3: allowed=true hits=2 resetAt=2026-08-09T04:10:00+00:00
hit 4: allowed=true hits=3 resetAt=2026-08-09T04:10:00+00:00
```

`allowed=true` on the fourth hit is precisely the CI failure, `expected true to
be false`. On a loaded runner nothing has to aim for this; a stall supplies it.

## The fix

`inOneWindow` runs a burst, checks every decision it was asked to care about
shared one window, and retries on a fresh subject if not — five times, then
throws.

Applied to every test whose assertions depend on a count, which is more than the
one that went red:

- **the concurrency test** — a split would turn "exactly 5 allowed" into 10, and
  "20 distinct positions" into two overlapping runs. Both assertions break.
- **the rollover test** — it uses a one-second window, so it is roughly a hundred
  times likelier to straddle, and a straddle there means the rollover under test
  has already happened before the wait that is supposed to cause it.

## The guard is itself tested

A guard that quietly stopped working would hand back the exact flake it was
written to remove, so it does not go in untested:

- one test forces a rollover mid-burst with a one-second window and asserts the
  burst was retried (`attempts > 1`);
- one makes every attempt straddle and asserts it throws rather than returning a
  split result — 5.58s, which is the five 1.1s stalls.

## What is deliberately not changed

The limiter. A fixed window lets somebody spend up to twice the allowance either
side of a boundary. That is a known property of fixed windows, and for something
the migration describes as "a way to keep people out rather than a way to keep
them honest", it errs in the lenient direction. Worth knowing; not worth a
sliding window here.

405 db tests pass locally, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ