### PR TITLE
fix(mobile): the home screen was adding dollars to rupees

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -23,7 +23,7 @@ import {
 } from '@baaki/ui';
 
 import { useGroups, useHomeSummary } from '@/data/hooks';
-import { fill, useStrings } from '@/i18n';
+import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { SyncBanner } from '@/components/SyncBanner';
 import { groupLabel } from '@/data/types';
@@ -39,6 +39,17 @@ export default function HomeScreen() {
 
   const list = groups.data ?? [];
   const loading = groups.isLoading || summary.isLoading;
+
+  /**
+   * The headline is one currency, because there is no such thing as a total
+   * across several (ADR-004). The rest are counted underneath rather than added
+   * in, which is what the profile screen already does with settled totals.
+   *
+   * With no groups there is nothing to be owed in, and the group currency the
+   * app defaults to is the one to show a zero in.
+   */
+  const headline = summary.totals[0] ?? { currency: 'INR', net: 0n, owed: 0n, owing: 0n };
+  const otherCurrencies = summary.totals.length - 1;
 
   /**
    * Which action is waiting to be told a group.
@@ -130,25 +141,31 @@ export default function HomeScreen() {
               {t.yourBaaki}
             </Text>
             <Text variant="micro" tone="onBrand" style={{ opacity: 0.8 }}>
-              {fill(t.acrossGroups, { count: list.length })}
+              {plural(locale, list.length, t.tabs.acrossGroups)}
             </Text>
           </Row>
 
           <View>
             <MoneyText
-              amount={summary.totals.net < 0n ? -summary.totals.net : summary.totals.net}
-              currency="INR"
+              amount={headline.net < 0n ? -headline.net : headline.net}
+              currency={headline.currency as never}
               locale={locale}
               tone="onBrand"
               style={{ fontSize: 40, lineHeight: 46, fontWeight: '700' }}
             />
             <Text variant="caption" tone="onBrand" style={{ opacity: 0.85 }}>
-              {summary.totals.net === 0n
+              {headline.net === 0n
                 ? t.allSettled
-                : summary.totals.net > 0n
+                : headline.net > 0n
                   ? t.overallOwed
                   : t.overallOwe}
             </Text>
+            {/* No rate turns rupees into euros, so the rest are counted, not added. */}
+            {otherCurrencies > 0 ? (
+              <Text variant="micro" tone="onBrand" style={{ opacity: 0.75 }}>
+                {plural(locale, otherCurrencies, t.account.otherCurrencies)}
+              </Text>
+            ) : null}
           </View>
 
           <Row style={{ gap: theme.spacing.xxl }}>
@@ -157,8 +174,8 @@ export default function HomeScreen() {
                 {t.youAreOwed}
               </Text>
               <MoneyText
-                amount={summary.totals.owed}
-                currency="INR"
+                amount={headline.owed}
+                currency={headline.currency as never}
                 locale={locale}
                 tone="onBrand"
               />
@@ -168,8 +185,8 @@ export default function HomeScreen() {
                 {t.youOwe}
               </Text>
               <MoneyText
-                amount={summary.totals.owing}
-                currency="INR"
+                amount={headline.owing}
+                currency={headline.currency as never}
                 locale={locale}
                 tone="onBrand"
               />
@@ -260,7 +277,7 @@ export default function HomeScreen() {
                 <View key={group.id}>
                   <ListRow
                     title={groupLabel(group, summary.membersFor(group.id), profile?.id)}
-                    subtitle={`${summary.memberCountFor(group.id)} ${t.members}`}
+                    subtitle={plural(locale, summary.memberCountFor(group.id), t.memberCount)}
                     leading={
                       <Avatar
                         name={groupLabel(group, summary.membersFor(group.id), profile?.id)}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -55,6 +55,7 @@ import {
   withdrawDispute,
   type WriteExpenseInput,
 } from './api';
+import { totalsByCurrency } from './totals';
 import type { ActivityRow, ExpenseRow, GroupRow, MemberRow, SettlementRow } from './types';
 
 export const keys = {
@@ -168,6 +169,9 @@ export function useHomeSummary(profileId: string | null) {
   const summary = useMemo(() => {
     const membersByGroup = new Map<string, MemberRow[]>();
     const byGroup = new Map<string, bigint>();
+    // Which currency each of those balances is in. Without it the totals below
+    // are a pile of numbers with no units.
+    const currencyByGroup = new Map<string, string>();
     const awaiting = new Set<string>();
 
     for (const group of materialiseGroups(mirror, queue) as unknown as GroupRow[]) {
@@ -188,21 +192,23 @@ export function useHomeSummary(profileId: string | null) {
       const mine = (membersByGroup.get(group.id) ?? []).find(
         (member) => member.profile_id === profileId,
       );
-      if (mine) byGroup.set(group.id, net.get(currency)?.get(mine.id) ?? 0n);
+      if (mine) {
+        byGroup.set(group.id, net.get(currency)?.get(mine.id) ?? 0n);
+        currencyByGroup.set(group.id, currency);
+      }
 
       if (settlements.some((settlement) => settlement.status === 'initiated')) {
         awaiting.add(group.id);
       }
     }
 
-    let owed = 0n;
-    let owing = 0n;
-    for (const balance of byGroup.values()) {
-      if (balance > 0n) owed += balance;
-      else owing += -balance;
-    }
+    const totals = totalsByCurrency(
+      [...byGroup].map(
+        ([groupId, balance]) => [currencyByGroup.get(groupId) ?? 'INR', balance] as const,
+      ),
+    );
 
-    return { byGroup, membersByGroup, awaiting, totals: { net: owed - owing, owed, owing } };
+    return { byGroup, membersByGroup, awaiting, totals };
   }, [mirror, queue, profileId]);
 
   return {

--- a/apps/mobile/src/data/totals.ts
+++ b/apps/mobile/src/data/totals.ts
@@ -1,0 +1,56 @@
+/**
+ * Adding up balances across groups, which is only ever legal within a currency.
+ *
+ * This lives outside `hooks.ts` for the same reason `activity.ts` does: what it
+ * decides is worth testing, and anything importing React Native cannot be
+ * reached from a test. The version of this that lived inside `useHomeSummary`
+ * summed every group into one number regardless of currency, and nothing could
+ * catch it.
+ */
+
+/** What is owed and owing in one currency. Never a mixture of several. */
+export interface CurrencyTotals {
+  readonly currency: string;
+  readonly net: bigint;
+  readonly owed: bigint;
+  readonly owing: bigint;
+}
+
+/**
+ * Group balances totalled per currency, and never across them.
+ *
+ * ADR-004 keeps per-currency balances and states the zero-sum invariant per
+ * currency; the TDR is blunter still — "currencies are never summed or
+ * converted". Adding a dollar balance to a rupee one produces a figure that is
+ * not money in any currency, and whatever symbol gets printed in front of it is
+ * a lie about an amount somebody is deciding whether to pay.
+ *
+ * Ordered largest first by absolute net, so a caller can lead with the currency
+ * the person has most at stake in and count the rest — the shape the profile
+ * screen already uses for settled totals.
+ */
+export function totalsByCurrency(
+  balances: Iterable<readonly [currency: string, balance: bigint]>,
+): CurrencyTotals[] {
+  const byCurrency = new Map<string, { owed: bigint; owing: bigint }>();
+
+  for (const [currency, balance] of balances) {
+    const running = byCurrency.get(currency) ?? { owed: 0n, owing: 0n };
+    if (balance > 0n) running.owed += balance;
+    else running.owing += -balance;
+    byCurrency.set(currency, running);
+  }
+
+  const abs = (value: bigint): bigint => (value < 0n ? -value : value);
+
+  return [...byCurrency]
+    .map(([currency, { owed, owing }]) => ({ currency, net: owed - owing, owed, owing }))
+    .sort((a, b) => {
+      const left = abs(a.net);
+      const right = abs(b.net);
+      // Alphabetical only as a tie-break, so the order never depends on which
+      // group happened to sync first.
+      if (left === right) return a.currency.localeCompare(b.currency);
+      return right > left ? 1 : -1;
+    });
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -183,6 +183,8 @@ export interface UiStrings {
   bankOther: string;
   perExpense: string;
   members: string;
+  /** "3 members" under a group. `members` on its own is a heading, not a count. */
+  memberCount: PluralForms;
   notJoinedYet: string;
   scansLeft: string;
   simplifyOn: string;
@@ -1001,6 +1003,7 @@ const en: UiStrings = {
   bankOther: 'Bank / other',
   perExpense: 'Apply to specific expenses',
   members: 'Members',
+  memberCount: { one: '{n} member', other: '{n} members' },
   notJoinedYet: 'not joined yet',
   scansLeft: 'scans left',
   simplifyOn: 'Simplify on',
@@ -1886,6 +1889,7 @@ const ta: UiStrings = {
   bankOther: 'வங்கி / மற்றவை',
   perExpense: 'குறிப்பிட்ட செலவுகளுக்குப் பயன்படுத்து',
   members: 'உறுப்பினர்கள்',
+  memberCount: { one: '{n} உறுப்பினர்', other: '{n} உறுப்பினர்கள்' },
   notJoinedYet: 'இன்னும் சேரவில்லை',
   scansLeft: 'ஸ்கேன் மீதம்',
   simplifyOn: 'எளிமையாக்கல் இயக்கத்தில்',
@@ -2785,6 +2789,7 @@ const hi: UiStrings = {
   bankOther: 'बैंक / अन्य',
   perExpense: 'कुछ खास खर्चों पर लगाएँ',
   members: 'सदस्य',
+  memberCount: { one: '{n} सदस्य', other: '{n} सदस्य' },
   notJoinedYet: 'अभी शामिल नहीं हुए',
   scansLeft: 'स्कैन बाकी',
   simplifyOn: 'आसान करना चालू',
@@ -3657,6 +3662,14 @@ const ar: UiStrings = {
   bankOther: 'تحويل بنكي / غير ذلك',
   perExpense: 'تطبيق على مصروفات محددة',
   members: 'الأعضاء',
+  memberCount: {
+    zero: '{n} عضو',
+    one: 'عضو واحد',
+    two: 'عضوان',
+    few: '{n} أعضاء',
+    many: '{n} عضوًا',
+    other: '{n} عضو',
+  },
   notJoinedYet: 'لم ينضم بعد',
   scansLeft: 'عمليات مسح متبقية',
   simplifyOn: 'التبسيط مفعّل',

--- a/apps/mobile/test/homeSummary.test.ts
+++ b/apps/mobile/test/homeSummary.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The home screen's headline figure.
+ *
+ * This existed as an inline loop inside `useHomeSummary` that added every
+ * group's balance together and handed the result to a `MoneyText` hardcoded to
+ * `currency="INR"`. On a phone with one group in USD the screen said ₹132.50 in
+ * the headline and $132.50 in the row underneath it — the same number, twice,
+ * under two currencies. With groups in two currencies it added dollars to
+ * rupees and put a rupee sign on the answer.
+ *
+ * ADR-004 keeps per-currency balances and states the zero-sum invariant per
+ * currency; the TDR says currencies are never summed or converted. The loop was
+ * untested because it lived inside a hook, so the rule was broken in the one
+ * place nothing could reach.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { totalsByCurrency } from '../src/data/totals';
+
+/** `[currency, balance]` pairs, as the hook collects them per group. */
+const pairs = (...entries: [string, bigint][]): [string, bigint][] => entries;
+
+describe('totalsByCurrency', () => {
+  it('never adds one currency to another', () => {
+    const totals = totalsByCurrency(pairs(['USD', 13250n], ['INR', 50000n]));
+
+    expect(totals).toHaveLength(2);
+    // The bug: a single total of 63250 labelled with whichever symbol was hardcoded.
+    expect(totals.map((total) => total.net)).not.toContain(63250n);
+    expect(totals.find((total) => total.currency === 'USD')?.net).toBe(13250n);
+    expect(totals.find((total) => total.currency === 'INR')?.net).toBe(50000n);
+  });
+
+  it('adds balances that really are the same currency', () => {
+    const totals = totalsByCurrency(pairs(['INR', 1000n], ['INR', 2500n]));
+
+    expect(totals).toHaveLength(1);
+    expect(totals[0]?.currency).toBe('INR');
+    expect(totals[0]?.net).toBe(3500n);
+    expect(totals[0]?.owed).toBe(3500n);
+    expect(totals[0]?.owing).toBe(0n);
+  });
+
+  it('keeps owed and owing apart within a currency', () => {
+    const totals = totalsByCurrency(pairs(['INR', 4000n], ['INR', -1500n]));
+
+    expect(totals[0]?.owed).toBe(4000n);
+    expect(totals[0]?.owing).toBe(1500n);
+    expect(totals[0]?.net).toBe(2500n);
+  });
+
+  it('does not net a debt in one currency against credit in another', () => {
+    // Owed $100, owe ₹100. Neither cancels the other, and a person who is up in
+    // dollars and down in rupees is not "all settled".
+    const totals = totalsByCurrency(pairs(['USD', 10000n], ['INR', -10000n]));
+
+    expect(totals.find((total) => total.currency === 'USD')?.net).toBe(10000n);
+    expect(totals.find((total) => total.currency === 'INR')?.net).toBe(-10000n);
+    expect(totals.every((total) => total.net !== 0n)).toBe(true);
+  });
+
+  it('leads with the currency holding the most, so the headline is the one that matters', () => {
+    const totals = totalsByCurrency(pairs(['INR', 100n], ['USD', 90000n], ['EUR', -500n]));
+
+    expect(totals.map((total) => total.currency)).toEqual(['USD', 'EUR', 'INR']);
+  });
+
+  it('ranks by size of the debt, not by its sign', () => {
+    // Owing a lot is as much "what matters" as being owed a lot.
+    const totals = totalsByCurrency(pairs(['INR', 100n], ['USD', -90000n]));
+
+    expect(totals[0]?.currency).toBe('USD');
+  });
+
+  it('orders ties by name rather than by whichever group synced first', () => {
+    const forwards = totalsByCurrency(pairs(['USD', 500n], ['INR', 500n]));
+    const backwards = totalsByCurrency(pairs(['INR', 500n], ['USD', 500n]));
+
+    expect(forwards.map((total) => total.currency)).toEqual(['INR', 'USD']);
+    expect(backwards.map((total) => total.currency)).toEqual(['INR', 'USD']);
+  });
+
+  it('reports a settled currency as settled rather than dropping it', () => {
+    // Zero is a fact worth showing: it is the difference between "you are square
+    // with this group" and "this group is not on your phone".
+    const totals = totalsByCurrency(pairs(['INR', 2000n], ['INR', -2000n]));
+
+    expect(totals).toHaveLength(1);
+    expect(totals[0]?.net).toBe(0n);
+  });
+
+  it('has nothing to say about no groups', () => {
+    expect(totalsByCurrency([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Found by installing the app on a Pixel 9 Pro and looking at the first screen —
not by reading the code.

## What a user sees

One group, currency USD. The home screen:

| | before | after |
|---|---|---|
| headline | **₹132.50** | **$132.50** |
| group row | $132.50 | $132.50 |
| group count | across 1 **groups** | across 1 **group** |
| member count | 2 **Members** | 2 **members** |

The same number appeared twice under two different currency symbols, on the
screen whose entire job is telling somebody what they are owed.

## Why it happened

`useHomeSummary` read each group's own currency correctly — and then discarded
it. Every group balance went into one `owed`/`owing` pair, and the screen
rendered that total with `currency="INR"` hardcoded in three places.

With one non-INR group that is a mislabel. **With groups in two currencies it
adds dollars to rupees and puts a rupee sign on the result.**

This is not a judgement call. It contradicts binding specs:

- **ADR-004** — "multi-currency groups keep per-currency balances"; the zero-sum
  invariant is stated *per currency*
- **TDR** — "Currencies are never summed or converted"

And the codebase already knows: `profile.tsx` does it correctly, with the
comment *"No rate turns rupees into euros, so the rest are counted, not added."*
The rule was understood and applied one screen over.

## The fix

`totalsByCurrency` totals within a currency and never across, ordered by
absolute net so the headline leads with the currency the person has most at
stake in. The rest are counted underneath (`and 2 other currencies`), reusing
the plural key and pattern the profile screen already uses.

It lives in `src/data/totals.ts`, not in `hooks.ts`, because **anything
importing React Native cannot be imported by a test** — which is precisely why a
loop that broke a binding ADR sat comfortably behind 1048 passing tests. The
same reason `activity.ts` lives beside the hooks rather than inside them.

## Two more on the same screen

- **"across 1 groups"** — `selectRule` in the i18n module carries a comment
  saying plurals used to fall through to `other` and *"the home screen read
  across 1 groups"*. The machinery was fixed; this call site was never moved
  over to it, and still used `fill()` on a flat string while `friends.tsx` used
  the plural table right next to it. The bug the comment describes was still on
  screen.
- **"2 Members"** — a section heading pressed into service as a count. Adds
  `memberCount` in all four languages, including the full Arabic zero/one/two/
  few/many/other set.

## Verification

- 9 new tests, written against the specific wrong answer — two currencies must
  not collapse into a single total of `63250`, and a `$100` credit must not net
  against a `₹100` debt into "all settled"
- 148 mobile tests pass; typecheck and lint clean
- Confirmed on the device after the change: headline `$132.50`, "across 1
  group", "2 members"

Display only. Nothing stored changes, and existing rows are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ