### PR TITLE
fix(mobile): every expense was called "Expense", in English, forever

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -299,7 +299,11 @@ export default function AddExpenseScreen() {
       // is on disk, so the expense is saved whether or not there is a network.
       await mutate(expenseId ? 'expense.update' : 'expense.create', groupId, {
         expenseId: targetExpenseId,
-        description: description.trim() || 'Expense',
+        // Blank stays blank. Writing the English word "Expense" here made every
+        // undescribed row identical in the list, and put a word nobody typed
+        // into an append-only ledger, the CSV export and the notification text —
+        // in one language, for an app that speaks four.
+        description: description.trim(),
         category,
         expenseDate: new Date().toISOString().slice(0, 10),
         currency,

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -32,8 +32,9 @@ import {
   useRestoreExpense,
   useWithdrawDispute,
 } from '@/data/hooks';
+import { expenseTitle } from '@/data/expenseTitle';
 import { displayName, groupLabel, isGhost } from '@/data/types';
-import { useStrings, type UiStrings } from '@/i18n';
+import { fill, plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
 function splitLabels(t: UiStrings): Record<string, string> {
@@ -130,7 +131,7 @@ export default function ExpenseDetailScreen() {
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading" numberOfLines={1}>
-              {version.description}
+              {expenseTitle(version.description, version.category, t)}
             </Text>
             <Text variant="micro" tone="muted">
               {groupLabel(group.data, members.data ?? [])}
@@ -153,14 +154,19 @@ export default function ExpenseDetailScreen() {
             variant="display"
           />
           <Text variant="caption" tone="muted">
-            {`${nameOf(version.payers[0]?.member_id ?? null)} paid · ${new Intl.DateTimeFormat(
-              locale,
-              { day: 'numeric', month: 'long', year: 'numeric' },
-            ).format(new Date(version.expense_date))}`}
+            {`${fill(t.expense.paidByName, {
+              name: nameOf(version.payers[0]?.member_id ?? null),
+            })} · ${new Intl.DateTimeFormat(locale, {
+              day: 'numeric',
+              month: 'long',
+              year: 'numeric',
+            }).format(new Date(version.expense_date))}`}
           </Text>
           <Row style={{ gap: theme.spacing.sm }}>
             <Badge label={splitLabels(t)[version.split_type] ?? version.split_type} tone="brand" />
-            {version.version_no > 1 ? <Badge label={`edited ${version.version_no - 1}×`} /> : null}
+            {version.version_no > 1 ? (
+              <Badge label={plural(locale, version.version_no - 1, t.expense.editedTimes)} />
+            ) : null}
             {deleted ? <Badge label={t.expense.deleted} tone="negative" /> : null}
           </Row>
         </Card>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -31,8 +31,9 @@ import {
   useOpenReceipts,
 } from '@/data/hooks';
 import { describeActivity, verbEmoji } from '@/data/activity';
+import { expenseTitle } from '@/data/expenseTitle';
 import { actorName, displayName, groupLabel, isGhost } from '@/data/types';
-import { useStrings } from '@/i18n';
+import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { CategoryBadge } from '@/components/Category';
 import { GroupPhoto } from '@/components/GroupPhoto';
@@ -135,7 +136,7 @@ export default function GroupScreen() {
                 {groupLabel(group.data, members.data ?? [], profile?.id)}
               </Text>
               <Text variant="micro" tone="muted">
-                {`${members.data?.length ?? 0} ${t.members}`}
+                {plural(locale, members.data?.length ?? 0, t.memberCount)}
               </Text>
             </View>
           </Row>
@@ -297,19 +298,24 @@ export default function GroupScreen() {
                 return (
                   <View key={expense.id}>
                     <ListRow
-                      title={`${version?.description ?? 'Expense'}${contested ? '  🚩' : ''}`}
-                      subtitle={`${nameOf(payer)} paid · ${
+                      title={`${expenseTitle(version?.description, version?.category, t)}${
+                        contested ? '  🚩' : ''
+                      }`}
+                      subtitle={[
+                        fill(t.expense.paidByName, { name: nameOf(payer) }),
                         version
                           ? new Intl.DateTimeFormat(locale, {
                               day: 'numeric',
                               month: 'short',
                             }).format(new Date(version.expense_date))
-                          : ''
-                      }${expense.deleted_at ? ' · deleted' : ''}${
+                          : null,
+                        expense.deleted_at ? t.expense.deleted : null,
                         (version?.version_no ?? 1) > 1
-                          ? ` · edited ×${version!.version_no - 1}`
-                          : ''
-                      }`}
+                          ? plural(locale, version!.version_no - 1, t.expense.editedTimes)
+                          : null,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')}
                       leading={<CategoryBadge category={version?.category} size={42} />}
                       onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
                       trailing={

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -22,8 +22,9 @@ import {
 } from '@baaki/ui';
 
 import { useGroup, useGroupLedger, useUpdateMember } from '@/data/hooks';
+import { expenseTitle } from '@/data/expenseTitle';
 import { displayName, groupLabel, isGhost } from '@/data/types';
-import { useStrings } from '@/i18n';
+import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
 export default function MemberScreen() {
@@ -191,7 +192,7 @@ export default function MemberScreen() {
         ) : null}
 
         <View>
-          <SectionHeader title={`In ${involved.length} expenses`} />
+          <SectionHeader title={plural(locale, involved.length, t.expense.inCount)} />
           <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
             {involved.map((expense, index) => {
               const share = expense.currentVersion?.shares.find(
@@ -200,7 +201,11 @@ export default function MemberScreen() {
               return (
                 <View key={expense.id}>
                   <ListRow
-                    title={expense.currentVersion?.description ?? 'Expense'}
+                    title={expenseTitle(
+                      expense.currentVersion?.description,
+                      expense.currentVersion?.category,
+                      t,
+                    )}
                     subtitle={
                       expense.currentVersion
                         ? new Intl.DateTimeFormat(locale, {

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -24,7 +24,7 @@ import { CountryRow } from '@/components/CountryPicker';
 import { TripDates } from '@/components/TripDates';
 import { removeGroupPhoto, uploadGroupPhoto } from '@/data/api';
 import { useGroup, useGroupLedger, useLeaveGroup, useUpdateGroup } from '@/data/hooks';
-import { useStrings } from '@/i18n';
+import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { groupLabel } from '@/data/types';
 
@@ -257,7 +257,7 @@ export default function GroupSettingsScreen() {
           <SectionHeader title={t.members} />
           <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
             <ListRow
-              title={`${members.data?.length ?? 0} ${t.members}`}
+              title={plural(locale, members.data?.length ?? 0, t.memberCount)}
               subtitle={t.group.membersHint}
               leading={<Ionicons name="people-outline" size={22} color={theme.color.textMuted} />}
               onPress={() => router.push(`/group/${groupId}/members`)}

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -29,6 +29,7 @@ import {
 } from '@baaki/ui';
 
 import { toSnapshot, useGroup, useGroupLedger, useRecordSettlement } from '@/data/hooks';
+import { expenseTitle } from '@/data/expenseTitle';
 import { displayName, isGhost, payableAt, type MemberRow } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -102,9 +103,10 @@ export default function SettleScreen() {
       ? allocateSettlement({ amount }, receivables)
       : { allocations: [], unallocated: amount };
 
-  const expenseTitle = (expenseId: string): string =>
-    expenses.rows.find((expense) => expense.id === expenseId)?.currentVersion?.description ??
-    'Expense';
+  const titleFor = (expenseId: string): string => {
+    const version = expenses.rows.find((expense) => expense.id === expenseId)?.currentVersion;
+    return expenseTitle(version?.description, version?.category, t);
+  };
 
   /**
    * Whether the button hands off to something before recording.
@@ -293,7 +295,7 @@ export default function SettleScreen() {
                 {allocation.allocations.map((entry) => (
                   <Row key={entry.expenseId} style={{ justifyContent: 'space-between' }}>
                     <Text variant="body" numberOfLines={1} style={{ flex: 1 }}>
-                      {expenseTitle(entry.expenseId)}
+                      {titleFor(entry.expenseId)}
                     </Text>
                     <MoneyText
                       amount={entry.amount}

--- a/apps/mobile/src/data/expenseTitle.ts
+++ b/apps/mobile/src/data/expenseTitle.ts
@@ -1,0 +1,40 @@
+/**
+ * What to call an expense nobody described.
+ *
+ * Describing an expense is optional, and plenty of people never do it — you are
+ * at a table, you type 480, you tap save. The app used to answer that by writing
+ * the literal English word "Expense" into the row, so a group's list read
+ * "Expense / Expense / Expense / Expense" and told you nothing you could not
+ * already see from the amounts. It also put a word nobody typed into an
+ * append-only ledger, into the CSV export, and into the sentence a notification
+ * shows somebody else.
+ *
+ * The category is the better answer, and it is already there: the row shows its
+ * icon, and the label is translated in every language. "Food & drink · Aug 8"
+ * beats "Expense · Aug 8", and it is true rather than invented.
+ *
+ * This lives in one place because five screens ask the same question, and five
+ * copies of a fallback are five chances for a list and a detail page to disagree
+ * about what the same expense is called.
+ */
+
+/** Just enough of the strings table to name an expense, so tests need no mock. */
+export interface TitleStrings {
+  readonly categories: Readonly<Record<string, string>>;
+  readonly expense: { readonly untitled: string };
+}
+
+export function expenseTitle(
+  description: string | null | undefined,
+  category: string | null | undefined,
+  t: TitleStrings,
+): string {
+  // `?? ''` is not enough: the column is NOT NULL, so "no description" arrives
+  // as an empty string far more often than as null, and whitespace is what a
+  // keyboard leaves behind when somebody thinks better of typing.
+  const said = (description ?? '').trim();
+  if (said !== '') return said;
+
+  const label = category ? t.categories[category] : undefined;
+  return label ?? t.expense.untitled;
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -601,6 +601,14 @@ export interface UiStrings {
     deleteQuestion: string;
     deleteBody: string;
     deleted: string;
+    /** An expense nobody described, shown when it has no category to fall back on. */
+    untitled: string;
+    /** "Asha paid" under a row. The name comes first in English and may not elsewhere. */
+    paidByName: string;
+    /** "edited twice" — the count is edits, so it starts at one. */
+    editedTimes: PluralForms;
+    /** "In 4 expenses" over the list on a member. */
+    inCount: PluralForms;
     whoOwesWhat: string;
     history: string;
     restore: string;
@@ -1439,6 +1447,10 @@ const en: UiStrings = {
     deleteBody:
       'It stops counting towards balances but stays in the activity feed, and anyone in the group can restore it for 30 days.',
     deleted: 'deleted',
+    untitled: 'Untitled',
+    paidByName: '{name} paid',
+    editedTimes: { one: 'edited once', other: 'edited {n} times' },
+    inCount: { one: 'In {n} expense', other: 'In {n} expenses' },
     whoOwesWhat: 'Who owes what',
     history: 'History',
     restore: 'Restore this expense',
@@ -2334,6 +2346,10 @@ const ta: UiStrings = {
     deleteBody:
       'இது இருப்புக் கணக்கில் சேராது, ஆனால் செயல்பாட்டுப் பட்டியலில் இருக்கும், 30 நாட்களுக்குள் குழுவில் யார் வேண்டுமானாலும் மீட்கலாம்.',
     deleted: 'நீக்கப்பட்டது',
+    untitled: 'பெயரிடப்படாதது',
+    paidByName: '{name} கொடுத்தார்',
+    editedTimes: { one: 'ஒருமுறை திருத்தப்பட்டது', other: '{n} முறை திருத்தப்பட்டது' },
+    inCount: { one: '{n} செலவில்', other: '{n} செலவுகளில்' },
     whoOwesWhat: 'யார் என்ன தர வேண்டும்',
     history: 'வரலாறு',
     restore: 'இந்தச் செலவை மீட்டெடு',
@@ -3217,6 +3233,10 @@ const hi: UiStrings = {
     deleteBody:
       'यह हिसाब में गिनना बंद कर देगा पर गतिविधि में बना रहेगा, और समूह का कोई भी 30 दिन तक इसे वापस ला सकता है।',
     deleted: 'हटाया गया',
+    untitled: 'बिना नाम',
+    paidByName: '{name} ने भुगतान किया',
+    editedTimes: { one: 'एक बार संपादित', other: '{n} बार संपादित' },
+    inCount: { one: '{n} खर्च में', other: '{n} खर्चों में' },
     whoOwesWhat: 'किस पर क्या बाकी',
     history: 'इतिहास',
     restore: 'यह खर्च वापस लाएँ',
@@ -4121,6 +4141,24 @@ const ar: UiStrings = {
     deleteBody:
       'سيتوقف احتسابه في الأرصدة لكنه يبقى في سجل النشاط، ويمكن لأي عضو استرجاعه خلال 30 يومًا.',
     deleted: 'محذوف',
+    untitled: 'بلا عنوان',
+    paidByName: 'دفع {name}',
+    editedTimes: {
+      zero: 'لم يُعدّل',
+      one: 'عُدّل مرة واحدة',
+      two: 'عُدّل مرتين',
+      few: 'عُدّل {n} مرات',
+      many: 'عُدّل {n} مرة',
+      other: 'عُدّل {n} مرة',
+    },
+    inCount: {
+      zero: 'في {n} مصروف',
+      one: 'في مصروف واحد',
+      two: 'في مصروفين',
+      few: 'في {n} مصروفات',
+      many: 'في {n} مصروفًا',
+      other: 'في {n} مصروف',
+    },
     whoOwesWhat: 'من عليه ماذا',
     history: 'السجل',
     restore: 'استرجاع هذا المصروف',

--- a/apps/mobile/test/expenseTitle.test.ts
+++ b/apps/mobile/test/expenseTitle.test.ts
@@ -1,0 +1,72 @@
+/**
+ * What an expense is called when nobody described it.
+ *
+ * The app used to answer this at write time by storing the English word
+ * "Expense" in the row, so a group's list read "Expense / Expense / Expense /
+ * Expense" — four rows distinguishable only by their amounts. The word also
+ * went into the append-only ledger, the CSV export and the text of anything the
+ * server said about the expense afterwards, in one language, in an app that
+ * speaks four.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { expenseTitle } from '../src/data/expenseTitle';
+
+const t = {
+  categories: { food: 'Food & drink', travel: 'Travel' },
+  expense: { untitled: 'Untitled' },
+};
+
+const tamil = {
+  categories: { food: 'உணவு & பானம்', travel: 'பயணம்' },
+  expense: { untitled: 'பெயரிடப்படாதது' },
+};
+
+describe('expenseTitle', () => {
+  it('uses what the person actually typed', () => {
+    expect(expenseTitle('Beach shack dinner', 'food', t)).toBe('Beach shack dinner');
+  });
+
+  it('falls back to the category, which is true rather than invented', () => {
+    expect(expenseTitle('', 'food', t)).toBe('Food & drink');
+    expect(expenseTitle(null, 'travel', t)).toBe('Travel');
+  });
+
+  it('never says the English word "Expense"', () => {
+    for (const title of [
+      expenseTitle('', null, t),
+      expenseTitle(null, null, t),
+      expenseTitle(undefined, undefined, t),
+      expenseTitle('   ', 'nonsense-category', t),
+    ]) {
+      expect(title).not.toBe('Expense');
+    }
+  });
+
+  it('treats an empty string like no description, because the column is NOT NULL', () => {
+    // This is the common case, not the exotic one: "no description" reaches the
+    // screen as '' far more often than as null.
+    expect(expenseTitle('', 'food', t)).toBe('Food & drink');
+  });
+
+  it('treats whitespace as nothing, because a keyboard leaves it behind', () => {
+    expect(expenseTitle('   ', 'food', t)).toBe('Food & drink');
+    expect(expenseTitle('\n\t ', null, t)).toBe('Untitled');
+  });
+
+  it('keeps meaningful text that merely has spaces around it', () => {
+    expect(expenseTitle('  Chai  ', null, t)).toBe('Chai');
+  });
+
+  it('falls back to untitled when the category is unknown to the table', () => {
+    // A category added by a newer build, read by an older one. Better a
+    // translated "Untitled" than `undefined` rendered as a blank row.
+    expect(expenseTitle(null, 'crypto-jet-fuel', t)).toBe('Untitled');
+  });
+
+  it('answers in the reader language, which a stored English word cannot', () => {
+    expect(expenseTitle('', 'food', tamil)).toBe('உணவு & பானம்');
+    expect(expenseTitle('', null, tamil)).toBe('பெயரிடப்படாதது');
+  });
+});


### PR DESCRIPTION
Second finding from driving the app on a Pixel 9 Pro. A group list of four
expenses, every row titled **"Expense"**, distinguishable only by their amounts.

## The cause is a write, not a render

Describing an expense is optional, and plenty of people never bother — you are
at a table, you type 480, you tap save. `add-expense.tsx` handled that like
this:

```ts
description: description.trim() || 'Expense',
```

That is not a placeholder shown on screen. It is **stored**. Which means the
English word "Expense", typed by nobody, ends up in:

- an append-only ledger that never forgets it (ADR-004)
- the CSV and JSON exports
- the sentence a notification shows somebody else

...in one language, in an app that ships four. A Tamil user who typed nothing
got an English noun written into their ledger.

## The fix

Blank stays blank; the **display** answers the question. The category is the
better answer and was already sitting there — the row draws its icon and the
label is translated in every language:

| before | after |
|---|---|
| Expense · Aug 8 | **Food & drink** · Aug 8 |
| Expense · Aug 8 | **Travel** · Aug 8 |

With no category either, a translated "Untitled" — never a blank row.

`expenseTitle` is one module because **five** screens asked this question, and
five copies of a fallback are five chances for a list and a detail page to
disagree about what the same expense is called. The detail screen rendered
`version.description` raw, so it needed this too — without it, stopping the
write would have left its heading blank. That one would have been a regression I
introduced.

## The English underneath

The same rows carried hardcoded English in the subtitle:

- **"paid"** → `{name} paid`, so the verb can move where a language needs it
- **"· deleted"** → `t.expense.deleted`, which already existed in all four
  languages and which this call site simply ignored
- **"edited ×3"** → a real plural phrase; `×` is not a word in any language
- **"In 4 expenses"** over a member's list, plus two more `2 Members` counts in
  the group header and settings — the same bug as #91, two call sites it didn't
  reach

Adds `untitled`, `paidByName`, `editedTimes`, `inCount` in all four languages,
with the full Arabic zero/one/two/few/many/other sets.

## Verification

- 8 new tests, including that the fallback is **never** the English word
  "Expense", that `''` is treated as absent (the column is NOT NULL, so empty is
  the common case, not null), and that it answers in the reader's language
- 156 mobile tests pass; typecheck and lint clean
- Confirmed on the device: group header now reads "2 members"

## What this does not do

**Existing rows still say "Expense"**, because that word is genuinely in the
database. The screenshot after the fix looks identical for those four rows, and
that is correct — a display fallback only fires when the description is actually
empty. Rewriting an append-only ledger to tidy up history is not something a
display fix should decide to do. New expenses are clean from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ