### PR TITLE
feat(ui): skeleton loading, where the wait is real

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -26,6 +26,7 @@ import { useGroups, useHomeSummary } from '@/data/hooks';
 import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { SyncBanner } from '@/components/SyncBanner';
+import { SkeletonList } from '@/components/Skeletons';
 import { groupLabel } from '@/data/types';
 
 export default function HomeScreen() {
@@ -251,11 +252,7 @@ export default function HomeScreen() {
         ) : null}
 
         {loading ? (
-          <Card>
-            <Text variant="caption" tone="muted">
-              {t.tabs.loadingGroups}
-            </Text>
-          </Card>
+          <SkeletonList rows={3} />
         ) : list.length === 0 ? (
           <EmptyState
             title={t.tabs.noGroups}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/data/hooks';
 import { describeActivity, verbEmoji } from '@/data/activity';
 import { expenseTitle } from '@/data/expenseTitle';
+import { GroupSkeleton } from '@/components/Skeletons';
 import { actorName, displayName, groupLabel, isGhost } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -70,15 +71,7 @@ export default function GroupScreen() {
   };
 
   if (group.isLoading) {
-    return (
-      <Screen>
-        <View style={{ padding: theme.spacing.xl }}>
-          <Text variant="caption" tone="muted">
-            {t.group.loading}
-          </Text>
-        </View>
-      </Screen>
-    );
+    return <GroupSkeleton />;
   }
 
   if (group.isError || !group.data) {

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -21,7 +21,7 @@
 import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, ScrollView, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 
 import { categoryOf, format, type CategoryId } from '@baaki/core';
 import {
@@ -43,6 +43,7 @@ import {
 } from '@baaki/ui';
 
 import { CategoryBadge } from '@/components/Category';
+import { InsightsSkeleton } from '@/components/Skeletons';
 import type { SpendingRow } from '@/data/api';
 import { useGroup, useGroupSpending } from '@/data/hooks';
 import { useStrings } from '@/i18n';
@@ -124,7 +125,7 @@ export default function InsightsScreen() {
         />
 
         {loading ? (
-          <ActivityIndicator color={theme.color.brand} />
+          <InsightsSkeleton />
         ) : currencies.length === 0 ? (
           <EmptyState title={t.nothingYet} body={t.nothingToChart} />
         ) : (

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -16,7 +16,7 @@
 import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
   budgetVariance,
@@ -40,6 +40,7 @@ import {
 
 import { addPlanItem, removePlanItem, setPlanItemDone } from '@/data/api';
 import { usePlanItems, useGroup } from '@/data/hooks';
+import { ListScreenSkeleton } from '@/components/Skeletons';
 import { useStrings } from '@/i18n';
 
 /** Today where the trip is, not where the server is. */
@@ -155,13 +156,7 @@ export default function PlanScreen() {
   };
 
   if (group.isLoading || plan.isLoading) {
-    return (
-      <Screen>
-        <View style={{ padding: theme.spacing.xl }}>
-          <ActivityIndicator color={theme.color.brand} />
-        </View>
-      </Screen>
-    );
+    return <ListScreenSkeleton rows={5} trailing={false} />;
   }
 
   return (

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -32,6 +32,7 @@ import {
 } from '@baaki/ui';
 
 import { useMarkNotificationsRead, useNotifications } from '@/data/hooks';
+import { SkeletonList } from '@/components/Skeletons';
 import type { NotificationRow } from '@/data/types';
 import { useStrings } from '@/i18n';
 
@@ -107,7 +108,15 @@ export default function InboxScreen() {
           <View style={{ width: 44 }} />
         </Row>
 
-        {rows.length === 0 ? (
+        {notifications.isLoading ? (
+          // Until the fetch answers, `rows` is empty — which is not the same as
+          // "you have no notifications". Showing the empty state here told people
+          // their inbox was empty while it was still loading.
+          <View style={{ gap: theme.spacing.md }}>
+            <SectionHeader title={t.inbox.recent} />
+            <SkeletonList rows={5} trailing={false} />
+          </View>
+        ) : rows.length === 0 ? (
           <EmptyState title={t.nothingYet} body={t.inbox.nothingYetBody} />
         ) : (
           <View>

--- a/apps/mobile/src/components/Skeletons.tsx
+++ b/apps/mobile/src/components/Skeletons.tsx
@@ -1,0 +1,191 @@
+/**
+ * Screen-shaped placeholders.
+ *
+ * The rule these follow: a skeleton is only worth showing where the person
+ * would otherwise wait looking at nothing, and it should be the shape of what
+ * is coming so the swap to real content is a fill, not a jump. A spinner in the
+ * middle of a blank screen answers "is it working"; a skeleton answers "what is
+ * loading", which on a screen full of a person's money is the better answer.
+ *
+ * These are not used for the few-millisecond flash while the local mirror
+ * hydrates on a warm screen — a placeholder that appears and vanishes inside a
+ * frame is worse than the content simply being there. They are for the cold
+ * launch, where the whole shell is empty, and for the screens that genuinely
+ * wait on the network: the inbox, spending, plan and receipt screens.
+ *
+ * Motion comes from the app's own preference, not the OS setting alone, because
+ * somebody can turn motion off inside Baaki on a phone that never asked. The
+ * `Skeleton` primitive itself knows nothing about that; it is told.
+ */
+
+import type { ReactNode } from 'react';
+import { View, type ViewStyle } from 'react-native';
+
+import { Card, Row, Screen, Skeleton, useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+import { useMotion } from '@/lib/motion';
+
+/** Marks a subtree as one loading region a screen reader announces once, not row by row. */
+function LoadingRegion({ children, style }: { children: ReactNode; style?: ViewStyle }) {
+  const { t } = useStrings();
+  return (
+    <View
+      accessible
+      accessibilityLabel={t.common.loading}
+      accessibilityRole="progressbar"
+      style={style}
+    >
+      {children}
+    </View>
+  );
+}
+
+/** One list row: a round avatar, a title line, a shorter subtitle, an amount on the end. */
+export function SkeletonRow({ trailing = true }: { trailing?: boolean }) {
+  const theme = useTheme();
+  const { animated } = useMotion();
+  return (
+    <Row style={{ gap: theme.spacing.md, paddingVertical: theme.spacing.md }}>
+      <Skeleton width={44} height={44} radius={theme.radius.pill} animated={animated} />
+      <View style={{ flex: 1, gap: theme.spacing.sm }}>
+        <Skeleton width="55%" height={15} animated={animated} />
+        <Skeleton width="32%" height={12} animated={animated} />
+      </View>
+      {trailing ? <Skeleton width={64} height={18} animated={animated} /> : null}
+    </Row>
+  );
+}
+
+/** A card of rows with hairlines between them, the way the real lists are drawn. */
+export function SkeletonList({ rows = 4, trailing = true }: { rows?: number; trailing?: boolean }) {
+  const theme = useTheme();
+  return (
+    <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+      {Array.from({ length: rows }, (_, index) => (
+        <View key={index}>
+          <SkeletonRow trailing={trailing} />
+          {index < rows - 1 ? (
+            <View style={{ height: 1, backgroundColor: theme.color.border }} />
+          ) : null}
+        </View>
+      ))}
+    </Card>
+  );
+}
+
+/** Header block used by the tabs: an avatar, a greeting line, a name. */
+function SkeletonHeader() {
+  const theme = useTheme();
+  const { animated } = useMotion();
+  return (
+    <Row style={{ paddingTop: theme.spacing.md, gap: theme.spacing.md }}>
+      <Skeleton width={46} height={46} radius={theme.radius.pill} animated={animated} />
+      <View style={{ flex: 1, gap: theme.spacing.sm }}>
+        <Skeleton width="30%" height={12} animated={animated} />
+        <Skeleton width="50%" height={18} animated={animated} />
+      </View>
+      <Skeleton width={40} height={40} radius={theme.radius.pill} animated={animated} />
+    </Row>
+  );
+}
+
+/** The home tab: header, the big balance panel, a groups list. */
+export function HomeSkeleton() {
+  const theme = useTheme();
+  const { animated } = useMotion();
+  return (
+    <Screen>
+      <LoadingRegion
+        style={{
+          flex: 1,
+          paddingHorizontal: theme.spacing.xl,
+          gap: theme.spacing.xl,
+        }}
+      >
+        <SkeletonHeader />
+        <Skeleton width="100%" height={196} radius={theme.radius.md} animated={animated} />
+        <View style={{ gap: theme.spacing.md }}>
+          <Skeleton width="40%" height={18} animated={animated} />
+          <SkeletonList rows={3} />
+        </View>
+      </LoadingRegion>
+    </Screen>
+  );
+}
+
+/** A group: header, balance card, and the expense list. */
+export function GroupSkeleton() {
+  const theme = useTheme();
+  const { animated } = useMotion();
+  return (
+    <Screen>
+      <LoadingRegion
+        style={{
+          flex: 1,
+          paddingHorizontal: theme.spacing.xl,
+          gap: theme.spacing.xl,
+        }}
+      >
+        <SkeletonHeader />
+        <Skeleton width="100%" height={150} radius={theme.radius.md} animated={animated} />
+        <Row style={{ gap: theme.spacing.sm }}>
+          <Skeleton width={110} height={40} radius={theme.radius.pill} animated={animated} />
+          <Skeleton width={110} height={40} radius={theme.radius.pill} animated={animated} />
+        </Row>
+        <SkeletonList rows={4} />
+      </LoadingRegion>
+    </Screen>
+  );
+}
+
+/**
+ * A back-headed content screen — the inbox, plan, member list. A header with a
+ * back button and a title, a section heading, then a list.
+ */
+export function ListScreenSkeleton({
+  rows = 5,
+  trailing = true,
+}: {
+  rows?: number;
+  trailing?: boolean;
+}) {
+  const theme = useTheme();
+  const { animated } = useMotion();
+  return (
+    <Screen>
+      <LoadingRegion
+        style={{
+          flex: 1,
+          paddingHorizontal: theme.spacing.xl,
+          gap: theme.spacing.xl,
+        }}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <Skeleton width={40} height={40} radius={theme.radius.pill} animated={animated} />
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Skeleton width="40%" height={18} animated={animated} />
+          </View>
+          <View style={{ width: 40 }} />
+        </Row>
+        <View style={{ gap: theme.spacing.md }}>
+          <Skeleton width="35%" height={16} animated={animated} />
+          <SkeletonList rows={rows} trailing={trailing} />
+        </View>
+      </LoadingRegion>
+    </Screen>
+  );
+}
+
+/** Insights: a heading and a couple of chart-sized blocks. */
+export function InsightsSkeleton() {
+  const theme = useTheme();
+  const { animated } = useMotion();
+  return (
+    <LoadingRegion style={{ gap: theme.spacing.xl }}>
+      <Skeleton width="45%" height={18} animated={animated} />
+      <Skeleton width="100%" height={180} radius={theme.radius.md} animated={animated} />
+      <SkeletonList rows={4} />
+    </LoadingRegion>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -240,6 +240,8 @@ export interface UiStrings {
    */
   common: {
     back: string;
+    /** Generic 'Loading…' — the spoken label a skeleton screen carries. */
+    loading: string;
     close: string;
     cancel: string;
     save: string;
@@ -1054,6 +1056,7 @@ const en: UiStrings = {
   upgrade: 'Upgrade',
   common: {
     back: 'Back',
+    loading: 'Loading…',
     close: 'Close',
     cancel: 'Cancel',
     save: 'Save',
@@ -1945,6 +1948,7 @@ const ta: UiStrings = {
   upgrade: 'மேம்படுத்தல்',
   common: {
     back: 'பின்',
+    loading: 'ஏற்றுகிறது…',
     close: 'மூடு',
     cancel: 'ரத்து',
     save: 'சேமி',
@@ -2848,6 +2852,7 @@ const hi: UiStrings = {
   upgrade: 'अपग्रेड',
   common: {
     back: 'वापस',
+    loading: 'लोड हो रहा है…',
     close: 'बंद करें',
     cancel: 'रद्द करें',
     save: 'सेव करें',
@@ -3732,6 +3737,7 @@ const ar: UiStrings = {
   upgrade: 'الترقية',
   common: {
     back: 'رجوع',
+    loading: 'جارٍ التحميل…',
     close: 'إغلاق',
     cancel: 'إلغاء',
     save: 'حفظ',

--- a/packages/ui/src/components/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import { Animated, type DimensionValue, type ViewStyle } from 'react-native';
+
+import { useTheme } from '../theme';
+
+export interface SkeletonProps {
+  /** Any RN dimension — a number of pixels or a percentage string. Defaults to filling its row. */
+  width?: DimensionValue;
+  height?: number;
+  /** Defaults to the small corner radius; pass a large number for circles (avatars). */
+  radius?: number;
+  /**
+   * Whether the placeholder breathes. Off means a flat block, which is what a
+   * person who turned motion down asked for. The app threads its motion
+   * preference in here; this primitive does not read it, so it stays a dumb
+   * design-system piece with no opinion about where the answer comes from.
+   */
+  animated?: boolean;
+  style?: ViewStyle;
+}
+
+/**
+ * One placeholder bar.
+ *
+ * A pulse in opacity, not a shimmer that sweeps across — a sweep has a
+ * direction, and this app is laid out both ways (see `direction.ts`). Fading in
+ * place says "still coming" without ever having to know which way the language
+ * runs.
+ *
+ * Hidden from screen readers: a shape standing in for text is not text, and a
+ * reader that announces four grey rectangles has told the person nothing. The
+ * screen that shows these owns the spoken "loading" instead.
+ */
+export function Skeleton({
+  width = '100%',
+  height = 14,
+  radius,
+  animated = true,
+  style,
+}: SkeletonProps) {
+  const theme = useTheme();
+  const pulse = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (!animated) {
+      pulse.setValue(1);
+      return;
+    }
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, { toValue: 0.4, duration: 700, useNativeDriver: true }),
+        Animated.timing(pulse, { toValue: 1, duration: 700, useNativeDriver: true }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [animated, pulse]);
+
+  return (
+    <Animated.View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        {
+          width,
+          height,
+          borderRadius: radius ?? theme.radius.sm,
+          backgroundColor: theme.color.skeleton,
+          opacity: animated ? pulse : 0.7,
+        },
+        style,
+      ]}
+    />
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,6 +18,7 @@ export * from './components/Chip';
 export * from './components/Avatar';
 export * from './components/MoneyText';
 export * from './components/ListRow';
+export * from './components/Skeleton';
 export * from './components/Toggle';
 export * from './components/PillTabBar';
 export * from './components/SegmentedTabs';

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -22,6 +22,8 @@ export interface Theme {
     readonly brandPressed: string;
     readonly brandSoft: string;
     readonly onBrand: string;
+    /** The bar a skeleton placeholder is painted in — a shade off the surface it sits on. */
+    readonly skeleton: string;
     /** Semantic money colours — see tokens.ts. */
     readonly positive: string;
     readonly positiveSoft: string;
@@ -72,6 +74,7 @@ const lightTheme: Theme = {
     brandPressed: palette.brand600,
     brandSoft: palette.brand100,
     onBrand: palette.white,
+    skeleton: palette.ink200,
     positive: palette.positive,
     positiveSoft: palette.mint,
     negative: palette.negative,
@@ -100,6 +103,7 @@ const darkTheme: Theme = {
     brandPressed: palette.brand500,
     brandSoft: '#2A2455',
     onBrand: palette.white,
+    skeleton: palette.night600,
     positive: '#34D399',
     positiveSoft: '#123F36',
     negative: '#FF7B72',


### PR DESCRIPTION
Adds a `Skeleton` primitive to `@baaki/ui` and screen-shaped placeholders in the
app — on the screens where a person otherwise waits looking at nothing.

Built after driving the app on a device, so the design follows what the app
actually is rather than a generic "spinner → skeleton" swap.

## The primitive

- **A pulse in opacity, not a sideways shimmer.** A sweep has a direction, and
  this app lays out both LTR and RTL (`direction.ts`). Fading in place says
  "still coming" without ever needing to know which way the language runs.
- Reads a new `skeleton` theme colour — a shade off the surface it sits on, in
  both light and dark.
- Takes an `animated` prop instead of reaching for a motion setting itself, so
  it stays a dumb design-system piece. The app's composed skeletons thread
  `useMotion().animated` in — the preference a person can set **inside Baaki**
  on a phone whose OS never asked. Motion off ⇒ a flat block.
- **Hidden from screen readers.** Four grey rectangles read aloud tell somebody
  nothing; each skeleton screen is one region that speaks a single "Loading".

## Where it is wired

| Screen | Why |
|---|---|
| **Inbox** | Fixes a real bug — see below |
| **Insights / spending** | Genuine network wait (`baaki_group_spending` RPC) |
| **Plan** | Genuine network wait (`fetchPlanItems`) |
| **Home** | Cold-launch shell |
| **Group** | Cold-launch shell |

### The inbox bug this fixes

While the notifications fetch was in flight, `rows` was `[]`, so the inbox
rendered the **"nothing here yet" empty state** — telling people their inbox was
empty when it was actually still loading. It now shows a list skeleton until the
fetch answers, then the real list or a truthful empty state.

## Where it is deliberately NOT wired

- **Inline action spinners stay spinners** — saving an expense, scanning a bill,
  adding a member. Those answer "is your tap working", a different question from
  "what is loading".
- **The few-ms local mirror hydration on a warm screen gets nothing.** A
  placeholder that appears and vanishes inside a frame is worse than the content
  simply being there. The app already gates the cold mirror-read behind a root
  splash, so the local-read skeletons are a belt-and-braces for slow devices,
  not the main event.

## Verified on a device

Caught mid-transition on a Pixel 9 Pro — the insights skeleton rendering live,
its shape matching the real "Where it went" list and chart that fill in over it:

- heading bar, chart-sized block, list rows (round avatar + two text lines +
  trailing amount)

Adds `common.loading` in all four languages. 156 mobile tests pass; typecheck
and lint clean across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ