### PR TITLE
feat(mobile): groups as bold colour cards on home

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -5,7 +5,6 @@ import { RefreshControl, ScrollView, View } from 'react-native';
 
 import {
   Avatar,
-  Badge,
   Button,
   Card,
   EmptyState,
@@ -27,7 +26,8 @@ import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { SyncBanner } from '@/components/SyncBanner';
 import { SkeletonList } from '@/components/Skeletons';
-import { groupLabel } from '@/data/types';
+import { GroupCard } from '@/components/GroupCard';
+import { displayName, groupLabel } from '@/data/types';
 
 export default function HomeScreen() {
   const theme = useTheme();
@@ -269,40 +269,36 @@ export default function HomeScreen() {
                 </Text>
               }
             />
-            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-              {list.map((group, index) => (
-                <View key={group.id}>
-                  <ListRow
-                    title={groupLabel(group, summary.membersFor(group.id), profile?.id)}
-                    subtitle={plural(locale, summary.memberCountFor(group.id), t.memberCount)}
-                    leading={
-                      <Avatar
-                        name={groupLabel(group, summary.membersFor(group.id), profile?.id)}
-                        emoji={group.cover_emoji ?? undefined}
-                        tint={tintForKey(group.id)}
-                      />
+            <View style={{ gap: theme.spacing.lg }}>
+              {list.map((group) => {
+                const members = summary.membersFor(group.id);
+                const balance = summary.balanceFor(group.id);
+                // The other people in the group, for the avatar cluster — your
+                // own face is the one at the top of the screen already.
+                const others = members
+                  .filter((member) => !member.left_at)
+                  .filter((member) => !(member.profile_id && member.profile_id === profile?.id))
+                  .map((member) => displayName(member, profile?.id));
+                return (
+                  <GroupCard
+                    key={group.id}
+                    id={group.id}
+                    title={groupLabel(group, members, profile?.id)}
+                    memberLabel={plural(locale, summary.memberCountFor(group.id), t.memberCount)}
+                    memberNames={others}
+                    coverEmoji={group.cover_emoji}
+                    balance={balance}
+                    currency={group.default_currency}
+                    locale={locale}
+                    statusLabel={
+                      balance === 0n ? t.allSettled : balance > 0n ? t.youAreOwed : t.youOwe
                     }
+                    pendingLabel={summary.hasPending(group.id) ? t.pendingConfirmation : null}
                     onPress={() => router.push(`/group/${group.id}`)}
-                    trailing={
-                      <View style={{ alignItems: 'flex-end', gap: 4 }}>
-                        <MoneyText
-                          amount={summary.balanceFor(group.id)}
-                          currency={group.default_currency}
-                          locale={locale}
-                          mode="balance"
-                        />
-                        {summary.hasPending(group.id) ? (
-                          <Badge label={t.pendingConfirmation} tone="brand" />
-                        ) : null}
-                      </View>
-                    }
                   />
-                  {index < list.length - 1 ? (
-                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                  ) : null}
-                </View>
-              ))}
-            </Card>
+                );
+              })}
+            </View>
           </View>
         )}
       </ScrollView>

--- a/apps/mobile/src/components/GroupCard.tsx
+++ b/apps/mobile/src/components/GroupCard.tsx
@@ -1,0 +1,139 @@
+/**
+ * A group as a bold, full-colour card.
+ *
+ * The reference the look is drawn from puts each item on its own saturated
+ * panel with the amount as the thing your eye lands on first. Baaki already
+ * gives every group a stable tint (`tintForKey`), so the colour is not
+ * decoration invented per screen — it is the same colour the group's avatar
+ * wears everywhere else, now filling the whole card.
+ *
+ * Money colour, on purpose, is NOT the mint/red pair here. On a saturated
+ * surface green-on-mint disappears and red-on-pink muddies; the balance is
+ * painted in the tint's own ink for contrast and the owed/owe meaning is
+ * carried by the label beneath it and the sign. This is the same concession
+ * the brand hero already makes with white money on purple — a surface that
+ * owns its contrast reads the amount, not the colour (see MoneyText `tone`).
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, View } from 'react-native';
+
+import type { CurrencyCode } from '@baaki/core';
+import {
+  AvatarStack,
+  Badge,
+  directionalIcon,
+  MoneyText,
+  Row,
+  Text,
+  TintCard,
+  tintForKey,
+  useTheme,
+} from '@baaki/ui';
+
+export function GroupCard({
+  id,
+  title,
+  memberLabel,
+  memberNames,
+  coverEmoji,
+  balance,
+  currency,
+  locale,
+  statusLabel,
+  pendingLabel,
+  onPress,
+}: {
+  id: string;
+  title: string;
+  /** "4 members", already pluralised for the locale. */
+  memberLabel: string;
+  memberNames: readonly string[];
+  coverEmoji?: string | null;
+  balance: bigint;
+  currency: CurrencyCode;
+  locale: string;
+  /** "you're owed" / "you owe" / "all settled" — the sign in words. */
+  statusLabel: string;
+  /** Badge text when a settlement is awaiting confirmation, else null. */
+  pendingLabel: string | null;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  const tint = tintForKey(id);
+  const ink = theme.tint[tint].ink;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
+    >
+      <TintCard
+        tint={tint}
+        style={{ borderRadius: theme.radius.xl, padding: theme.spacing.xl, gap: theme.spacing.lg }}
+      >
+        <Row style={{ justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <Row style={{ flex: 1, gap: theme.spacing.md }}>
+            {coverEmoji ? (
+              <View
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: theme.radius.pill,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: theme.color.surface,
+                }}
+              >
+                <Text variant="subheading">{coverEmoji}</Text>
+              </View>
+            ) : null}
+            <View style={{ flex: 1 }}>
+              <Text variant="heading" numberOfLines={1} style={{ color: ink }}>
+                {title}
+              </Text>
+              <Text variant="caption" style={{ color: ink, opacity: 0.7 }}>
+                {memberLabel}
+              </Text>
+            </View>
+          </Row>
+          {memberNames.length > 0 ? <AvatarStack names={memberNames} size={30} max={3} /> : null}
+        </Row>
+
+        <Row style={{ justifyContent: 'space-between', alignItems: 'flex-end' }}>
+          <View style={{ flex: 1 }}>
+            <MoneyText
+              amount={balance < 0n ? -balance : balance}
+              currency={currency}
+              locale={locale}
+              tone="default"
+              style={{ color: ink, fontSize: 30, lineHeight: 36, fontWeight: '700' }}
+            />
+            <Text variant="caption" style={{ color: ink, opacity: 0.8 }}>
+              {statusLabel}
+            </Text>
+            {pendingLabel ? (
+              <View style={{ marginTop: theme.spacing.xs, alignSelf: 'flex-start' }}>
+                <Badge label={pendingLabel} tone="brand" />
+              </View>
+            ) : null}
+          </View>
+          <View
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: theme.radius.pill,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.color.text,
+            }}
+          >
+            <Ionicons name={directionalIcon('arrow-forward')} size={20} color={theme.color.bg} />
+          </View>
+        </Row>
+      </TintCard>
+    </Pressable>
+  );
+}


### PR DESCRIPTION
First screen of the full-app reskin toward the bold colour-card look from the reference board.

## What changed
- Home group list: white `ListRow`s in one card → one saturated **tint card per group** (`GroupCard`), balance as the focal point, member avatar cluster, round tap affordance.
- New `apps/mobile/src/components/GroupCard.tsx`. Built on primitives that already existed (`TintCard`, `AvatarStack`, `MoneyText`) and the stable per-group `tintForKey` — the card wears the same colour the group's avatar already does.

## Money-colour semantics (deliberate)
On a saturated tint the mint/red money pair is illegible (green-on-mint vanishes). The balance is painted in the tint's **ink**; owed/owe meaning is carried by the label and the sign — the same concession the brand hero already makes with white money on purple (sanctioned by `MoneyText`'s `tone` override).

## Verified
- `tsc --noEmit`, `expo lint`, `prettier --check`: clean.
- Ran on the Android emulator: the group renders as a sky-tint card — emoji chip, name, "2 members", avatar cluster, "$132.50 / You are owed", dark arrow. RTL-safe (arrow via `directionalIcon`).

Anchor PR; the rest of the screens follow once the direction is confirmed against this real render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)