### PR TITLE
feat(mobile): member hero wears the money colour

### DIFF
--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -18,6 +18,7 @@ import {
   Screen,
   SectionHeader,
   Text,
+  TintCard,
   useTheme,
 } from '@baaki/ui';
 
@@ -57,6 +58,12 @@ export default function MemberScreen() {
   const ghost = isGhost(member);
   const vpaValid = vpa.trim() === '' || isValidVpa(vpa.trim());
   const balance = ledger.balances.get(member.id) ?? 0n;
+  // The hero wears the money colour for its meaning — mint when this person is
+  // owed, pink when they owe — and a neutral lilac when they are square, so a
+  // settled member is never painted a direction they are not in. Ink from the
+  // pair keeps the amount readable on the tint.
+  const heroTint = balance > 0n ? 'mint' : balance < 0n ? 'pink' : 'lilac';
+  const heroInk = theme.tint[heroTint].ink;
 
   // Expenses this person is actually part of.
   const involved = expenses.rows.filter((expense) =>
@@ -98,7 +105,15 @@ export default function MemberScreen() {
           <View style={{ width: 44 }} />
         </Row>
 
-        <Card style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+        <TintCard
+          tint={heroTint}
+          style={{
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+            borderRadius: theme.radius.xl,
+            padding: theme.spacing.xl,
+          }}
+        >
           <Avatar name={displayName(member)} ghost={ghost} size={78} />
           <MoneyText
             amount={balance}
@@ -106,6 +121,8 @@ export default function MemberScreen() {
             locale={locale}
             mode="balance"
             variant="title"
+            tone="default"
+            style={{ color: heroInk }}
           />
           <Row style={{ gap: theme.spacing.sm }}>
             {ghost ? <Badge label={t.notJoinedYet} /> : null}
@@ -115,7 +132,7 @@ export default function MemberScreen() {
           {balance !== 0n && !isMe ? (
             <Button label={t.settleUp} onPress={() => router.push(`/group/${groupId}/settle`)} />
           ) : null}
-        </Card>
+        </TintCard>
 
         {ghost ? (
           <Card style={{ gap: theme.spacing.md }}>


### PR DESCRIPTION
Reskin, screen 4 (after #94 home, #95 group, #96 friends).

## What changed
- The balance card at the top of a member's page becomes a **tint card** in the money colour, same rule as Friends: mint when the person is owed, pink when they owe, neutral **lilac** when square (so a settled member is never painted a direction they're not in). Amount in the tint pair's ink; `mode="balance"` keeps the spoken label + absolute value.
- The "expenses they're in" list and the ghost-name / UPI edit cards stay white — forms and dense rows read better on a plain surface.

## Verification note (honest)
`tsc --noEmit`, `expo lint`, `prettier`: clean. This hero uses the **identical** `TintCard` + tint-ink + `mode="balance"` pattern already rendered on-device for #95 (group hero) and #96 (friends mint/pink cards) — so it's verified by the shared, proven pattern plus green CI. I couldn't grab a fresh screenshot: reaching member detail needs the group's ellipsis → settings → members, and on this emulator the Expo dev-menu bubble sits exactly on that ellipsis. No behaviour changed — only the wrapper element and the balance's colour override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)