### PR TITLE
feat(mobile): activity feed & inbox as colour cards

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -1,19 +1,19 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useQuery } from '@tanstack/react-query';
 import { router } from 'expo-router';
-import { RefreshControl, ScrollView, View } from 'react-native';
+import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
 
 import {
   Avatar,
-  Card,
   EmptyState,
   IconButton,
-  ListRow,
   MoneyText,
   Row,
   Screen,
   SectionHeader,
   Text,
+  TintCard,
+  tintForKey,
   useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
@@ -98,43 +98,58 @@ export default function ActivityScreen() {
                   month: 'short',
                 }).format(new Date(day))}
               />
-              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-                {dayEntries.map((entry, index) => (
-                  <View key={entry.id}>
-                    <ListRow
-                      title={describeActivity(entry, myProfileId)}
-                      subtitle={`${entry.group?.name ?? t.tabs.group} · ${new Intl.DateTimeFormat(
-                        locale,
-                        {
-                          hour: 'numeric',
-                          minute: '2-digit',
-                        },
-                      ).format(new Date(entry.created_at))}`}
-                      leading={
-                        <Avatar
-                          name={entry.group?.name ?? t.tabs.group}
-                          emoji={entry.group?.cover_emoji ?? undefined}
-                          size={40}
-                        />
-                      }
+              <View style={{ gap: theme.spacing.md }}>
+                {dayEntries.map((entry) => {
+                  // The entry wears its group's colour, tying the feed back to
+                  // the group cards on home. The amount is a recorded figure,
+                  // not a balance, so it is neutral in the tint's ink.
+                  const tint = tintForKey(entry.group_id);
+                  const ink = theme.tint[tint].ink;
+                  return (
+                    <Pressable
+                      key={entry.id}
+                      accessibilityRole="button"
+                      accessibilityLabel={describeActivity(entry, myProfileId)}
                       onPress={() => router.push(`/group/${entry.group_id}`)}
-                      trailing={
-                        typeof entry.payload.amount === 'string' ? (
-                          <MoneyText
-                            amount={BigInt(entry.payload.amount)}
-                            currency={(entry.payload.currency as string) ?? 'INR'}
-                            locale={locale}
-                            variant="subheading"
+                      style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
+                    >
+                      <TintCard
+                        tint={tint}
+                        style={{ borderRadius: theme.radius.lg, padding: theme.spacing.lg }}
+                      >
+                        <Row style={{ gap: theme.spacing.md, alignItems: 'flex-start' }}>
+                          <Avatar
+                            name={entry.group?.name ?? t.tabs.group}
+                            emoji={entry.group?.cover_emoji ?? undefined}
+                            size={40}
                           />
-                        ) : null
-                      }
-                    />
-                    {index < dayEntries.length - 1 ? (
-                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                    ) : null}
-                  </View>
-                ))}
-              </Card>
+                          <View style={{ flex: 1 }}>
+                            <Text variant="subheading" style={{ color: ink }}>
+                              {describeActivity(entry, myProfileId)}
+                            </Text>
+                            <Text variant="caption" style={{ color: ink, opacity: 0.7 }}>
+                              {`${entry.group?.name ?? t.tabs.group} · ${new Intl.DateTimeFormat(
+                                locale,
+                                { hour: 'numeric', minute: '2-digit' },
+                              ).format(new Date(entry.created_at))}`}
+                            </Text>
+                          </View>
+                          {typeof entry.payload.amount === 'string' ? (
+                            <MoneyText
+                              amount={BigInt(entry.payload.amount)}
+                              currency={(entry.payload.currency as string) ?? 'INR'}
+                              locale={locale}
+                              variant="subheading"
+                              tone="default"
+                              style={{ color: ink }}
+                            />
+                          ) : null}
+                        </Row>
+                      </TintCard>
+                    </Pressable>
+                  );
+                })}
+              </View>
             </View>
           ))
         )}

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -15,19 +15,19 @@
 import { useEffect } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { RefreshControl, ScrollView, View } from 'react-native';
+import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
 
 import { renderNotification } from '@baaki/core';
 import {
-  Card,
   directionalIcon,
   EmptyState,
   IconButton,
-  ListRow,
   Row,
   Screen,
   SectionHeader,
   Text,
+  TintCard,
+  tintForKey,
   useTheme,
 } from '@baaki/ui';
 
@@ -119,65 +119,74 @@ export default function InboxScreen() {
         ) : rows.length === 0 ? (
           <EmptyState title={t.nothingYet} body={t.inbox.nothingYetBody} />
         ) : (
-          <View>
+          <View style={{ gap: theme.spacing.md }}>
             <SectionHeader title={t.inbox.recent} />
-            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-              {rows.map((row, index) => {
-                const { title, body } = renderNotification(row.kind, factsOf(row), locale, {
-                  title: row.title,
-                  body: row.body,
-                });
-                const unreadRow = row.read_at === null;
-                return (
-                  <View key={row.id}>
-                    <ListRow
-                      title={title}
-                      subtitle={body}
-                      onPress={
-                        row.group_id
-                          ? () => router.push(`/group/${row.group_id}` as never)
-                          : undefined
-                      }
-                      leading={
+            {rows.map((row) => {
+              const { title, body } = renderNotification(row.kind, factsOf(row), locale, {
+                title: row.title,
+                body: row.body,
+              });
+              const unreadRow = row.read_at === null;
+              // Each notice is a card in a stable colour for its kind, so a run
+              // of the same kind reads as a run. A read one is dimmed; the icon
+              // sits in a white chip with the tint's ink.
+              const tint = tintForKey(row.kind);
+              const ink = theme.tint[tint].ink;
+              return (
+                <Pressable
+                  key={row.id}
+                  accessibilityRole={row.group_id ? 'button' : undefined}
+                  accessibilityLabel={title}
+                  onPress={
+                    row.group_id ? () => router.push(`/group/${row.group_id}` as never) : undefined
+                  }
+                  style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
+                >
+                  <TintCard
+                    tint={tint}
+                    style={{
+                      borderRadius: theme.radius.lg,
+                      padding: theme.spacing.lg,
+                      opacity: unreadRow ? 1 : 0.7,
+                    }}
+                  >
+                    <Row style={{ gap: theme.spacing.md, alignItems: 'flex-start' }}>
+                      <View
+                        style={{
+                          width: 40,
+                          height: 40,
+                          borderRadius: theme.radius.pill,
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          backgroundColor: theme.color.surface,
+                        }}
+                      >
+                        <Ionicons name={ICONS[row.kind] ?? 'notifications'} size={18} color={ink} />
+                      </View>
+                      <View style={{ flex: 1 }}>
+                        <Text variant="subheading" style={{ color: ink }}>
+                          {title}
+                        </Text>
+                        <Text variant="caption" style={{ color: ink, opacity: 0.75 }}>
+                          {body}
+                        </Text>
+                      </View>
+                      {unreadRow ? (
                         <View
                           style={{
-                            width: 40,
-                            height: 40,
-                            borderRadius: theme.radius.pill,
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            backgroundColor: unreadRow
-                              ? theme.color.brandSoft
-                              : theme.color.surfaceMuted,
+                            width: 8,
+                            height: 8,
+                            borderRadius: 4,
+                            marginTop: 6,
+                            backgroundColor: ink,
                           }}
-                        >
-                          <Ionicons
-                            name={ICONS[row.kind] ?? 'notifications'}
-                            size={18}
-                            color={unreadRow ? theme.color.brand : theme.color.textMuted}
-                          />
-                        </View>
-                      }
-                      trailing={
-                        unreadRow ? (
-                          <View
-                            style={{
-                              width: 8,
-                              height: 8,
-                              borderRadius: 4,
-                              backgroundColor: theme.color.brand,
-                            }}
-                          />
-                        ) : null
-                      }
-                    />
-                    {index < rows.length - 1 ? (
-                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                    ) : null}
-                  </View>
-                );
-              })}
-            </Card>
+                        />
+                      ) : null}
+                    </Row>
+                  </TintCard>
+                </Pressable>
+              );
+            })}
           </View>
         )}
 


### PR DESCRIPTION
Data-dense rollout, part 2 — the two chronological logs, matching the reference's history frame.

## What changed
- **Activity feed** (`(tabs)/activity.tsx`): white rows in day-cards → stacked colour cards, each in **its group's colour** (`tintForKey(group_id)`), tying the feed back to the home group cards. Recorded amount neutral in the tint's ink.
- **Inbox** (`inbox.tsx`): notices become colour cards with a **stable colour per kind** (so a run of the same kind reads as a run), icon in a white chip, read notices dimmed.
- Neither amount is a balance → the green/red money pair is untouched.

## Verified
- `tsc --noEmit`, `expo lint`, `prettier`: clean.
- Ran on the Android emulator: **Activity renders fully** — stacked sky cards ("You added Expense / Pill · 10:24 AM / $223", "You confirmed a settlement", grouped by day). Screenshot in thread.
- **Inbox is empty for the guest test account** ("Nothing here yet"), so the notification cards had no data to show — the empty state renders correctly, and inbox uses the *identical* TintCard + tint-ink + icon-chip pattern that Activity rendered, so it's covered by the shared proven pattern plus green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)