### PR TITLE
feat(sign-in): language dropdown, and name the email path

### DIFF
--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -34,7 +34,7 @@ import {
   View,
 } from 'react-native';
 
-import { Button, Card, Chip, CurvedPanel, Row, Screen, Text, useTheme } from '@baaki/ui';
+import { Button, Card, CurvedPanel, Screen, SegmentedTabs, Text, useTheme } from '@baaki/ui';
 
 import { AppleSignInButton } from '@/components/AppleSignInButton';
 import { LanguagePicker } from '@/components/LanguagePicker';
@@ -267,24 +267,21 @@ export default function SignInScreen() {
             <LanguagePicker />
 
             <Card style={{ gap: theme.spacing.lg }}>
-              <Row style={{ gap: theme.spacing.sm }}>
-                <Chip
-                  label={t.signIn.sendMeACode}
-                  selected={mode === 'otp'}
-                  onPress={() => {
-                    setMode('otp');
-                    setError(null);
-                  }}
-                />
-                <Chip
-                  label={t.signIn.useAPassword}
-                  selected={mode === 'password'}
-                  onPress={() => {
-                    setMode('password');
-                    setError(null);
-                  }}
-                />
-              </Row>
+              {/* Two ways in, named for what they ask for. The password face
+                  says "email" out loud: somebody looking for an email field
+                  should not have to guess it lives behind a tab about
+                  passwords. */}
+              <SegmentedTabs<Mode>
+                value={mode}
+                onChange={(next) => {
+                  setMode(next);
+                  setError(null);
+                }}
+                tabs={[
+                  { value: 'otp', label: t.signIn.sendMeACode },
+                  { value: 'password', label: t.signIn.useAPassword },
+                ]}
+              />
 
               {mode === 'otp' && stage === 'phone' ? (
                 <>

--- a/apps/mobile/src/components/LanguagePicker.tsx
+++ b/apps/mobile/src/components/LanguagePicker.tsx
@@ -7,19 +7,22 @@
  * face of it, and scroll, all in a language they opened by accident. So the
  * choice is also offered flat, on the way in.
  *
- * Four chips, each written in its own script and nothing else. No "follow my
- * phone" option here: following the phone is what the app is already doing, and
- * a row of five where one of them is a sentence in English is a row that has
- * stopped being scannable. Tapping a script is the whole interaction.
+ * A compact selector rather than a row of scripts: a globe, the language you
+ * are in written in its own script, and a menu of the four. The globe is the
+ * part that reads the same in every language — somebody who opened the app in a
+ * script they cannot read is hunting for a symbol, and a symbol is what this
+ * leads with. Tapping opens the list; the endonyms are the whole interaction.
  *
  * Choosing Arabic changes the words at once and the *direction* only after the
  * app is opened again — `@/i18n/language` explains why at length. Here that
  * costs one line of small print, and only while it is true.
  */
 
-import { View } from 'react-native';
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Modal, Pressable, View } from 'react-native';
 
-import { Chip, Row, Text, useTheme } from '@baaki/ui';
+import { Text, useTheme } from '@baaki/ui';
 
 import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES, useStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
@@ -28,34 +31,122 @@ export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-
   const theme = useTheme();
   const { t } = useStrings();
   const { language, setLanguage, restartNeeded } = useLanguage();
+  const [open, setOpen] = useState(false);
+
+  const current = LANGUAGE_NAMES[language].own;
 
   return (
-    <View style={{ gap: theme.spacing.sm }}>
-      {/* Wrapping rather than scrolling. Four is few enough to show all four,
-          and a language hidden off the edge of a rail is a language somebody
-          who cannot read the screen will never find. */}
-      <Row
-        gap={theme.spacing.sm}
-        style={{ justifyContent: align, flexWrap: 'wrap' }}
-        accessibilityRole="radiogroup"
+    <View
+      style={{ gap: theme.spacing.sm, alignItems: align === 'center' ? 'center' : 'flex-start' }}
+    >
+      {/* The trigger. Globe first, because it is the one part somebody who
+          opened the wrong language can still recognise. */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${t.language}: ${current}`}
+        onPress={() => setOpen(true)}
+        style={({ pressed }) => ({
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: theme.spacing.sm,
+          height: 44,
+          paddingHorizontal: theme.spacing.lg,
+          borderRadius: theme.radius.pill,
+          backgroundColor: theme.color.surface,
+          borderWidth: 1,
+          borderColor: theme.color.border,
+          opacity: pressed ? 0.85 : 1,
+        })}
       >
-        {LANGUAGES.map((entry) => (
-          <Chip
-            key={entry}
-            // The endonym alone. Somebody hunting for their own language is
-            // matching the shape of their script, not reading a label.
-            label={LANGUAGE_NAMES[entry].own}
-            selected={entry === language}
-            onPress={() => void setLanguage(entry)}
-          />
-        ))}
-      </Row>
+        <Ionicons name="globe-outline" size={18} color={theme.color.brand} />
+        <Text variant="caption" style={{ fontWeight: '600' }}>
+          {current}
+        </Text>
+        <Ionicons name="chevron-down" size={16} color={theme.color.textMuted} />
+      </Pressable>
 
       {restartNeeded ? (
         <Text variant="micro" tone="faint" align={align === 'center' ? 'center' : 'left'}>
           {isRtlLanguage(language) ? t.signIn.restartToMirror : t.signIn.restartToUnmirror}
         </Text>
       ) : null}
+
+      <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+        {/* Backdrop closes; the card swallows its own taps so a miss inside the
+            menu does not dismiss it. */}
+        <Pressable
+          onPress={() => setOpen(false)}
+          style={{
+            flex: 1,
+            backgroundColor: 'rgba(15, 10, 40, 0.4)',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: theme.spacing.xxxl,
+          }}
+        >
+          <Pressable
+            onPress={() => {}}
+            style={{
+              width: '100%',
+              maxWidth: 340,
+              backgroundColor: theme.color.surface,
+              borderRadius: theme.radius.xl,
+              paddingVertical: theme.spacing.sm,
+              ...theme.shadow.lifted,
+            }}
+          >
+            <Text
+              variant="caption"
+              tone="faint"
+              style={{ paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.sm }}
+            >
+              {t.language}
+            </Text>
+            {LANGUAGES.map((entry) => {
+              const active = entry === language;
+              return (
+                <Pressable
+                  key={entry}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  accessibilityLabel={LANGUAGE_NAMES[entry].own}
+                  onPress={() => {
+                    setOpen(false);
+                    // Re-choosing the current language would fire the restart
+                    // machinery for nothing.
+                    if (!active) void setLanguage(entry);
+                  }}
+                  style={({ pressed }) => ({
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    marginHorizontal: theme.spacing.sm,
+                    paddingVertical: theme.spacing.md,
+                    paddingHorizontal: theme.spacing.md,
+                    borderRadius: theme.radius.md,
+                    backgroundColor: active
+                      ? theme.color.brandSoft
+                      : pressed
+                        ? theme.color.surfaceMuted
+                        : 'transparent',
+                  })}
+                >
+                  <Text
+                    variant="body"
+                    tone={active ? 'brand' : 'default'}
+                    style={{ fontWeight: active ? '700' : '500' }}
+                  >
+                    {LANGUAGE_NAMES[entry].own}
+                  </Text>
+                  {active ? (
+                    <Ionicons name="checkmark" size={18} color={theme.color.brand} />
+                  ) : null}
+                </Pressable>
+              );
+            })}
+          </Pressable>
+        </Pressable>
+      </Modal>
     </View>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1286,7 +1286,7 @@ const en: UiStrings = {
     guestAddWay: 'Add a way to sign in, so this account is still yours on your next phone.',
     signInHowever: 'Sign in however you set it up.',
     sendMeACode: 'Send me a code',
-    useAPassword: 'Use a password',
+    useAPassword: 'Email or password',
     phoneNumber: 'Phone number',
     countryCodeHint:
       'Start with your country code. Baaki never assumes +91 — a trip is exactly when foreign numbers turn up.',
@@ -2183,7 +2183,7 @@ const ta: UiStrings = {
       'உள்நுழைய ஒரு வழியைச் சேர்க்கவும், அடுத்த ஃபோனிலும் இந்தக் கணக்கு உங்களுடையதாக இருக்கும்.',
     signInHowever: 'நீங்கள் அமைத்த முறையில் உள்நுழையவும்.',
     sendMeACode: 'எனக்கு ஒரு குறியீடு அனுப்பு',
-    useAPassword: 'கடவுச்சொல்லைப் பயன்படுத்து',
+    useAPassword: 'மின்னஞ்சல் அல்லது கடவுச்சொல்',
     phoneNumber: 'தொலைபேசி எண்',
     countryCodeHint:
       'நாட்டுக் குறியீட்டுடன் தொடங்குங்கள். பாக்கி +91 என்று ஊகிப்பதே இல்லை — வெளிநாட்டு எண்கள் வருவது பயணத்தின்போதுதான்.',
@@ -3077,7 +3077,7 @@ const hi: UiStrings = {
     guestAddWay: 'साइन इन का कोई तरीका जोड़ें, ताकि अगले फ़ोन पर भी यह खाता आपका ही रहे।',
     signInHowever: 'जैसे सेट किया था वैसे साइन इन करें।',
     sendMeACode: 'मुझे कोड भेजें',
-    useAPassword: 'पासवर्ड इस्तेमाल करें',
+    useAPassword: 'ईमेल या पासवर्ड',
     phoneNumber: 'फ़ोन नंबर',
     countryCodeHint:
       'देश कोड से शुरू करें। बाकी +91 कभी नहीं मान लेता — विदेशी नंबर सफ़र में ही तो आते हैं।',
@@ -3977,7 +3977,7 @@ const ar: UiStrings = {
     guestAddWay: 'أضف طريقة لتسجيل الدخول، ليبقى هذا الحساب لك على هاتفك التالي.',
     signInHowever: 'سجّل الدخول بالطريقة التي أعددتها.',
     sendMeACode: 'أرسل لي رمزًا',
-    useAPassword: 'استخدم كلمة مرور',
+    useAPassword: 'البريد الإلكتروني أو كلمة المرور',
     phoneNumber: 'رقم الهاتف',
     countryCodeHint:
       'ابدأ برمز بلدك. لا يفترض باقي أبدًا رمزًا بعينه — فالأرقام الأجنبية تظهر في السفر تحديدًا.',


### PR DESCRIPTION
Two things somebody standing at the front door could not find on the sign-in screen.

## Language: a dropdown, not four chips
The row of four script-chips becomes one compact selector — a globe, the language you are in written in its own script, and a menu of the four. The globe leads because it is the part that reads the same in every language: someone who opened the app in a script they cannot read is hunting for a symbol. `LanguagePicker` is only used on the sign-in screen, so nothing else in the app moves.

## Email: name it
The password tab is renamed **"Email or password"** (en/ta/hi/ar), and the two `Chip`s become `SegmentedTabs`. Email was always accepted in that identifier field — the tab just never said so, and a field for an email hidden behind a tab about *passwords* is a field nobody finds.

## Verified on the Android emulator
- Welcome screen + options screen both show the dropdown pill.
- The menu opens with all four scripts, the current one checked.
- The **Email or password** tab reveals the email/phone field (`asha@example.com …`) + password.
- `tsc --noEmit` clean, `expo lint` clean, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)