### PR TITLE
fix(sync): discover the caller's groups on an empty mirror

### DIFF
--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -214,13 +214,16 @@ export class SyncEngine {
     const cursors = { ...this.state.mirror.cursors };
     for (const groupId of options.groupIds ?? []) cursors[groupId] ??= 0;
 
-    // Nothing to push and nowhere to pull from: a first run before any group
-    // exists. Asking the server would just be a round trip for an empty answer.
-    if (batch.length === 0 && Object.keys(cursors).length === 0) {
-      this.set({ status: 'idle' });
-      return;
-    }
-
+    // An empty mirror with nothing queued is not "nothing to do" — it is exactly
+    // the first run that has to ask. Signing in on a new phone, or into an
+    // account whose groups were created on another device, leaves the mirror
+    // empty, and the only place the group ids live is the server: the `sync`
+    // function reads the caller's own memberships and hands them back whatever
+    // the cursors say (see its `group_members` query). Skipping the call here
+    // meant those groups never arrived and home stayed empty until a deep link
+    // happened to name one. The `!online` case already returned above, so the
+    // one round trip this costs a brand-new guest is against their own empty
+    // ledger, once, and tells them the truth either way.
     this.set({ status: 'syncing' });
 
     try {


### PR DESCRIPTION
## The bug
Signing into an existing account on a **fresh device** showed an empty home — 0 groups, ₹0 — even though the account had groups, expenses and balances on the server. It stayed empty until a deep link happened to name a specific group.

Found while verifying a seeded test account: server-side the account had 3 groups, 21 active memberships and 10 expenses, and the client PostgREST query (as that user) returned all 3 — but home showed nothing.

## Root cause
Home is backed by the offline **sync mirror**, populated by `runFlush` in `apps/mobile/src/sync/engine.ts`. It bailed out early whenever there was nothing queued **and** no cursors:

```ts
if (batch.length === 0 && Object.keys(cursors).length === 0) { set idle; return; }
```

But the `sync` edge function reads the caller's own `group_members` and returns those groups **regardless of cursors** (`supabase/functions/sync/index.ts`). An empty mirror is exactly when that discovery must run — and the early return skipped the only call that would have populated it.

## The fix
Remove the early return. The `!online` case already returns above it, so the only new behaviour is a single round trip on a genuinely empty ledger, against the caller's own (empty) data — which is correct.

## Verified
- Android emulator: a password account whose groups were created server-side now shows all three `[TEST]` groups on home after sign-in — ₹57,349.50 owed across 3 groups, balances matching.
- `expo lint` clean, `tsc` clean, **156 mobile tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)