### PR TITLE
feat(admin): rate-limit controls + user search / confirm email / upgrade

### DIFF
--- a/apps/admin/src/app/rate-limits/page.tsx
+++ b/apps/admin/src/app/rate-limits/page.tsx
@@ -1,0 +1,173 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { Nav } from '@/components/Nav';
+import {
+  rateLimitEnabled,
+  rateLimitRules,
+  saveRateLimitRule,
+  setRateLimitEnabled,
+  type RateLimitRuleRow,
+} from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+/** Seconds rendered as the unit an operator thinks in. */
+function window(seconds: number): string {
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
+
+export default async function RateLimits({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; saved?: string }>;
+}) {
+  const { error, saved } = await searchParams;
+  const [enabled, rules] = await Promise.all([rateLimitEnabled(), rateLimitRules()]);
+
+  async function toggleMaster(formData: FormData) {
+    'use server';
+    let failure: string | null = null;
+    try {
+      await setRateLimitEnabled(formData.get('enabled') === 'on');
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+    if (failure) redirect(`/rate-limits?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/rate-limits');
+    redirect('/rate-limits?saved=1');
+  }
+
+  async function saveRule(formData: FormData) {
+    'use server';
+    let failure: string | null = null;
+    try {
+      await saveRateLimitRule({
+        bucket: String(formData.get('bucket') ?? '').trim(),
+        enabled: formData.get('enabled') === 'on',
+        maxCalls: Number(formData.get('max_calls') ?? 0),
+        windowSeconds: Number(formData.get('window_seconds') ?? 0),
+      });
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+    if (failure) redirect(`/rate-limits?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/rate-limits');
+    redirect('/rate-limits?saved=1');
+  }
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Rate limits</h1>
+        <Nav here="rate-limits" />
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+      {saved ? <p className="faint">Saved.</p> : null}
+
+      <p className="note" style={{ padding: 0 }}>
+        The app&rsquo;s own abuse limiter, not Supabase&rsquo;s auth limiter (that one lives in the
+        Supabase dashboard under Authentication &rsquo; Rate limits). Each bucket allows so many
+        calls per window; a call over the line comes back <code>429 RATE_LIMITED</code>. A bucket
+        with no row here uses the default compiled into <code>_shared/rateLimit.ts</code>. The
+        counting fails open — if the database cannot be reached the call is allowed — so this is
+        abuse control, never the paywall.
+      </p>
+
+      <h2>Master switch</h2>
+      <section>
+        <form action={toggleMaster} className="flag">
+          <label className="inline">
+            <input type="checkbox" name="enabled" defaultChecked={enabled} />
+            <span>Rate limiting enabled</span>
+          </label>
+          <p className="note">
+            Off exempts every bucket at once — the escape hatch for letting a support engineer
+            replay a stuck queue. Nothing is counted while it is off, so turning it back on starts
+            each bucket from a clean window.
+          </p>
+          <button type="submit">Save</button>
+        </form>
+      </section>
+
+      <h2>Buckets</h2>
+      {!enabled ? (
+        <p className="note">The master switch is off, so these limits are not being applied.</p>
+      ) : null}
+      {rules.length === 0 ? (
+        <section style={{ marginTop: 12 }}>
+          <p className="note">
+            No bucket rows. If you expected some, the
+            <code> 20260809040000_rate_limit_controls </code> migration may not be deployed to this
+            project — the app is still limited by the code defaults until it is.
+          </p>
+        </section>
+      ) : null}
+
+      {rules.map((rule: RateLimitRuleRow) => (
+        <section key={rule.bucket}>
+          <h3 style={{ margin: '0 0 8px' }}>
+            <code>{rule.bucket}</code>{' '}
+            <span className="faint">
+              — {rule.max_calls} / {window(rule.window_seconds)}
+              {rule.enabled ? '' : ' · off'}
+            </span>
+          </h3>
+          <form action={saveRule} className="flag">
+            <input type="hidden" name="bucket" value={rule.bucket} />
+            <label className="inline">
+              <input type="checkbox" name="enabled" defaultChecked={rule.enabled} />
+              <span>Enabled</span>
+            </label>
+            <label>
+              <span>Max calls</span>
+              <input type="number" name="max_calls" min={0} defaultValue={rule.max_calls} />
+            </label>
+            <label>
+              <span>Window (seconds)</span>
+              <input
+                type="number"
+                name="window_seconds"
+                min={1}
+                defaultValue={rule.window_seconds}
+              />
+            </label>
+            <button type="submit">Save</button>
+          </form>
+        </section>
+      ))}
+
+      <h2>Add a bucket</h2>
+      <section>
+        <form action={saveRule} className="flag">
+          <label>
+            <span>Bucket</span>
+            <input type="text" name="bucket" placeholder="expense-write" required />
+          </label>
+          <label className="inline">
+            <input type="checkbox" name="enabled" defaultChecked />
+            <span>Enabled</span>
+          </label>
+          <label>
+            <span>Max calls</span>
+            <input type="number" name="max_calls" min={0} defaultValue={60} />
+          </label>
+          <label>
+            <span>Window (seconds)</span>
+            <input type="number" name="window_seconds" min={1} defaultValue={60} />
+          </label>
+          <button type="submit">Add</button>
+        </form>
+        <p className="note">
+          Only a bucket the code actually calls will ever be consulted — adding a name here does not
+          create a limiter, it overrides one. The names in use today are <code>sync</code>,{' '}
+          <code>expense-write</code>, <code>export-data</code>, <code>fx-rate</code>,{' '}
+          <code>invite-mint</code>, <code>invite-accept</code> and <code>receipt-parse</code>.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/admin/src/app/users/page.tsx
+++ b/apps/admin/src/app/users/page.tsx
@@ -1,0 +1,129 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { Nav } from '@/components/Nav';
+import { confirmUserEmail, searchUsers, upgradeUser, type AdminUserRow } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+function when(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-IN', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export default async function Users({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string; error?: string; done?: string }>;
+}) {
+  const { q, error, done } = await searchParams;
+  const query = (q ?? '').trim();
+  const results: AdminUserRow[] = query ? await searchUsers(query) : [];
+
+  async function search(formData: FormData) {
+    'use server';
+    const next = String(formData.get('q') ?? '').trim();
+    redirect(next ? `/users?q=${encodeURIComponent(next)}` : '/users');
+  }
+
+  async function confirm(formData: FormData) {
+    'use server';
+    const id = String(formData.get('id') ?? '');
+    const back = String(formData.get('q') ?? '');
+    let failure: string | null = null;
+    try {
+      await confirmUserEmail(id);
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+    const base = `/users?q=${encodeURIComponent(back)}`;
+    if (failure) redirect(`${base}&error=${encodeURIComponent(failure)}`);
+    revalidatePath('/users');
+    redirect(`${base}&done=${encodeURIComponent('Email confirmed.')}`);
+  }
+
+  async function upgrade(formData: FormData) {
+    'use server';
+    const id = String(formData.get('id') ?? '');
+    const days = Number(formData.get('days') ?? 365);
+    const back = String(formData.get('q') ?? '');
+    let message: string | null = null;
+    let failure: string | null = null;
+    try {
+      message = await upgradeUser(id, days);
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+    const base = `/users?q=${encodeURIComponent(back)}`;
+    if (failure) redirect(`${base}&error=${encodeURIComponent(failure)}`);
+    revalidatePath('/users');
+    redirect(`${base}&done=${encodeURIComponent(message ?? 'Upgraded.')}`);
+  }
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Users</h1>
+        <Nav here="users" />
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+      {done ? <p className="faint">{done}</p> : null}
+
+      <section>
+        <form action={search} className="flag">
+          <label>
+            <span>Search by email, phone or id</span>
+            <input type="text" name="q" defaultValue={query} placeholder="asha@example.com" />
+          </label>
+          <button type="submit">Search</button>
+        </form>
+        <p className="note">
+          There is no server-side search in the auth directory, so this walks the first pages and
+          matches here — enough for support, not a report. Names come from <code>profiles</code>.
+        </p>
+      </section>
+
+      {query && results.length === 0 ? (
+        <p className="note">Nobody matched &ldquo;{query}&rdquo;.</p>
+      ) : null}
+
+      {results.map((u) => (
+        <section key={u.id}>
+          <h2 style={{ marginBottom: 4 }}>{u.display_name ?? u.email ?? u.id}</h2>
+          <p className="faint" style={{ marginTop: 0 }}>
+            {u.email ?? u.phone ?? '(no contact)'} · {u.is_anonymous ? 'guest' : 'account'} ·{' '}
+            {u.email_confirmed ? 'email confirmed' : 'email NOT confirmed'} · joined{' '}
+            {when(u.created_at)}
+          </p>
+          <p className="faint" style={{ marginTop: 0, fontSize: 12 }}>
+            <code>{u.id}</code>
+          </p>
+
+          <div className="scroll" style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+            {u.email_confirmed ? null : (
+              <form action={confirm} className="flag">
+                <input type="hidden" name="id" value={u.id} />
+                <input type="hidden" name="q" value={query} />
+                <button type="submit">Confirm email</button>
+              </form>
+            )}
+            <form action={upgrade} className="flag">
+              <input type="hidden" name="id" value={u.id} />
+              <input type="hidden" name="q" value={query} />
+              <label>
+                <span>Upgrade — days</span>
+                <input type="number" name="days" min={1} max={3650} defaultValue={365} />
+              </label>
+              <button type="submit">Upgrade to paid</button>
+            </form>
+          </div>
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/apps/admin/src/components/Nav.tsx
+++ b/apps/admin/src/components/Nav.tsx
@@ -1,18 +1,24 @@
 import Link from 'next/link';
 
-/** Five pages so far. A row of links is the right amount of navigation for that. */
+/** A row of links is the right amount of navigation for a console this size. */
 export function Nav({
   here,
 }: {
-  here: 'overview' | 'flags' | 'promotions' | 'campaigns' | 'feedback';
+  here: 'overview' | 'users' | 'flags' | 'rate-limits' | 'promotions' | 'campaigns' | 'feedback';
 }) {
   return (
     <nav className="nav">
       <Link href="/" aria-current={here === 'overview' ? 'page' : undefined}>
         Overview
       </Link>
+      <Link href="/users" aria-current={here === 'users' ? 'page' : undefined}>
+        Users
+      </Link>
       <Link href="/flags" aria-current={here === 'flags' ? 'page' : undefined}>
         Experiments
+      </Link>
+      <Link href="/rate-limits" aria-current={here === 'rate-limits' ? 'page' : undefined}>
+        Rate limits
       </Link>
       <Link href="/promotions" aria-current={here === 'promotions' ? 'page' : undefined}>
         Promotions

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -392,6 +392,173 @@ export const feedback = (limit = 100) =>
 export const flagResults = (key: string) =>
   call<FlagResultRow>('baaki_admin_flag_results', { p_key: key });
 
+// ─────────────────────────────────────────────────── rate limiting ──
+// The abuse limiter's numbers, made editable. `baaki_rate_limit` reads these
+// tables on every call; a bucket with no row falls back to the code default in
+// `_shared/rateLimit.ts`, and the master switch exempts everything at once.
+
+export interface RateLimitRuleRow {
+  bucket: string;
+  enabled: boolean;
+  max_calls: number;
+  window_seconds: number;
+  updated_at: string;
+}
+
+/** The master switch. Defaults to on if the table is not deployed yet. */
+export async function rateLimitEnabled(): Promise<boolean> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('rate_limit_settings')
+    .select('enabled')
+    .eq('id', true)
+    .maybeSingle();
+  if (error) {
+    if (error.code === TABLE_MISSING) return true;
+    throw new Error(`reading rate_limit_settings failed: ${error.message}`);
+  }
+  return data?.enabled ?? true;
+}
+
+export async function rateLimitRules(): Promise<RateLimitRuleRow[]> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('rate_limit_rules')
+    .select('bucket, enabled, max_calls, window_seconds, updated_at')
+    .order('bucket');
+  if (error) {
+    if (error.code === TABLE_MISSING) return [];
+    throw new Error(`reading rate_limit_rules failed: ${error.message}`);
+  }
+  return (data ?? []) as RateLimitRuleRow[];
+}
+
+export async function setRateLimitEnabled(enabled: boolean): Promise<void> {
+  await requireSession();
+  const { error } = await client()
+    .from('rate_limit_settings')
+    .update({ enabled, updated_at: new Date().toISOString() })
+    .eq('id', true);
+  if (error) throw new Error(`saving the master switch failed: ${error.message}`);
+}
+
+export async function saveRateLimitRule(input: {
+  bucket: string;
+  enabled: boolean;
+  maxCalls: number;
+  windowSeconds: number;
+}): Promise<void> {
+  await requireSession();
+
+  const bucket = input.bucket.trim();
+  if (!bucket) throw new Error('A rule needs a bucket name.');
+  if (!Number.isInteger(input.maxCalls) || input.maxCalls < 0) {
+    throw new Error('Max calls is a whole number, zero or more.');
+  }
+  if (!Number.isInteger(input.windowSeconds) || input.windowSeconds < 1) {
+    throw new Error('The window is a whole number of seconds, at least one.');
+  }
+
+  const { error } = await client().from('rate_limit_rules').upsert(
+    {
+      bucket,
+      enabled: input.enabled,
+      max_calls: input.maxCalls,
+      window_seconds: input.windowSeconds,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'bucket' },
+  );
+  if (error) throw new Error(`saving ${bucket} failed: ${error.message}`);
+}
+
+// ─────────────────────────────────────────────────────── user admin ──
+// The one place the console reaches into `auth`. Supabase owns that schema and
+// grants it to nobody, so these go through the GoTrue admin API on the service
+// client rather than a SQL read — searching, confirming an address by hand, and
+// comping a paid grant for one named account.
+
+export interface AdminUserRow {
+  id: string;
+  email: string | null;
+  phone: string | null;
+  email_confirmed: boolean;
+  is_anonymous: boolean;
+  created_at: string;
+  last_sign_in_at: string | null;
+  display_name: string | null;
+}
+
+/**
+ * Find a handful of accounts matching a typed fragment.
+ *
+ * GoTrue has no server-side search, so this pages through the directory and
+ * filters here. Fine at the scale a support console works at; capped so a large
+ * project cannot turn one lookup into a walk of every user.
+ */
+export async function searchUsers(query: string): Promise<AdminUserRow[]> {
+  await requireSession();
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  const matches: AdminUserRow[] = [];
+  for (let page = 1; page <= 10 && matches.length < 25; page += 1) {
+    const { data, error } = await client().auth.admin.listUsers({ page, perPage: 200 });
+    if (error) throw new Error(`listing users failed: ${error.message}`);
+    for (const u of data.users) {
+      const hay = `${u.email ?? ''} ${u.phone ?? ''} ${u.id}`.toLowerCase();
+      if (hay.includes(q)) {
+        matches.push({
+          id: u.id,
+          email: u.email ?? null,
+          phone: u.phone ?? null,
+          email_confirmed: Boolean(u.email_confirmed_at),
+          is_anonymous: (u as { is_anonymous?: boolean }).is_anonymous ?? false,
+          created_at: u.created_at,
+          last_sign_in_at: u.last_sign_in_at ?? null,
+          display_name: null,
+        });
+      }
+      if (matches.length >= 25) break;
+    }
+    if (data.users.length < 200) break;
+  }
+
+  // Names live in `profiles`, keyed by the same id. One round trip fills them.
+  if (matches.length > 0) {
+    const { data: profiles } = await client()
+      .from('profiles')
+      .select('id, display_name')
+      .in(
+        'id',
+        matches.map((m) => m.id),
+      );
+    const names = new Map((profiles ?? []).map((p) => [p.id, p.display_name as string]));
+    for (const row of matches) row.display_name = names.get(row.id) ?? null;
+  }
+
+  return matches;
+}
+
+/** Mark an address confirmed by hand — the OTP a person never received. */
+export async function confirmUserEmail(userId: string): Promise<void> {
+  await requireSession();
+  if (!/^[0-9a-f-]{36}$/i.test(userId.trim())) throw new Error('That is not a user id.');
+  const { error } = await client().auth.admin.updateUserById(userId.trim(), {
+    email_confirm: true,
+  });
+  if (error) throw new Error(`confirming failed: ${error.message}`);
+}
+
+/**
+ * Comp a paid grant for one account. The same SECURITY DEFINER path the
+ * promotions page uses, keyed on the profile and the day so pressing it twice
+ * in one conversation is the same grant rather than two.
+ */
+export async function upgradeUser(userId: string, days: number): Promise<string> {
+  return grantPromo(userId, days);
+}
+
 export const daily = (days = 30) => call<DailyRow>('baaki_admin_daily', { p_days: days });
 export const geo = () => call<GeoRow>('baaki_admin_geo');
 export const money = () => call<MoneyRow>('baaki_admin_money');

--- a/packages/db/prisma/migrations/20260809040000_rate_limit_controls/migration.sql
+++ b/packages/db/prisma/migrations/20260809040000_rate_limit_controls/migration.sql
@@ -1,0 +1,161 @@
+-- ============================================================================
+-- Rate limiting becomes something the console can see and turn.
+--
+-- Until now every allowance lived in `_shared/rateLimit.ts` as a constant, and
+-- the only way to loosen one during an incident — or switch the whole thing off
+-- to let a support engineer replay a stuck queue — was a deploy. This adds two
+-- small config tables and teaches `baaki_rate_limit` to read them, so the same
+-- numbers can be edited from the admin panel and take effect on the next call.
+--
+-- The code constants stay as the fallback: a bucket with no row here is limited
+-- exactly as before. Nothing about the counting changes; only where the limit
+-- and the on/off come from.
+-- ============================================================================
+
+-- ─────────────────────────────────────────── the master switch (one row) ──
+-- A single boolean, in a table pinned to one row by a CHECK on the primary key,
+-- so "rate limiting is off" is one fact in one place rather than a column that
+-- has to be set on every bucket.
+CREATE TABLE IF NOT EXISTS public.rate_limit_settings (
+  id         boolean     PRIMARY KEY DEFAULT true,
+  enabled    boolean     NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT rate_limit_settings_singleton CHECK (id)
+);
+
+INSERT INTO public.rate_limit_settings (id, enabled) VALUES (true, true)
+  ON CONFLICT (id) DO NOTHING;
+
+-- ─────────────────────────────────────────────── per-bucket overrides ──
+-- One row per bucket. `enabled` off exempts just that bucket; `max_calls` and
+-- `window_seconds` override the code defaults when the row is present.
+CREATE TABLE IF NOT EXISTS public.rate_limit_rules (
+  bucket         text        PRIMARY KEY,
+  enabled        boolean     NOT NULL DEFAULT true,
+  max_calls      integer     NOT NULL,
+  window_seconds integer     NOT NULL,
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT rate_limit_rules_max_calls_nonneg CHECK (max_calls >= 0),
+  CONSTRAINT rate_limit_rules_window_positive  CHECK (window_seconds >= 1)
+);
+
+-- Seed the buckets that exist today with their current values, so the console
+-- opens on the real configuration rather than a blank page. Kept in step with
+-- `LIMITS` in `supabase/functions/_shared/rateLimit.ts`.
+INSERT INTO public.rate_limit_rules (bucket, enabled, max_calls, window_seconds) VALUES
+  ('sync',           true, 120,  60),
+  ('expense-write',  true,  60,  60),
+  ('export-data',    true,  10, 3600),
+  ('fx-rate',        true,  60,  60),
+  ('invite-mint',    true,  30, 3600),
+  ('invite-accept',  true,  30, 3600),
+  ('receipt-parse',  true,  10,  60)
+ON CONFLICT (bucket) DO NOTHING;
+
+-- ───────────────────────────────────────────────────────── locked down ──
+-- Config, not data: readable and writable by the service role alone. The RPC
+-- below is SECURITY DEFINER and reads these regardless of RLS; no client ever
+-- touches them, exactly like `feature_flags` write access.
+ALTER TABLE public.rate_limit_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rate_limit_rules    ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.rate_limit_settings FROM PUBLIC;
+REVOKE ALL ON TABLE public.rate_limit_settings FROM anon, authenticated;
+REVOKE ALL ON TABLE public.rate_limit_rules    FROM PUBLIC;
+REVOKE ALL ON TABLE public.rate_limit_rules    FROM anon, authenticated;
+GRANT SELECT, UPDATE          ON TABLE public.rate_limit_settings TO service_role;
+GRANT SELECT, INSERT, UPDATE  ON TABLE public.rate_limit_rules    TO service_role;
+
+-- ─────────────────────────────── the limiter now consults the config ──
+CREATE OR REPLACE FUNCTION public.baaki_rate_limit(
+  p_subject        text,
+  p_bucket         text,
+  p_limit          integer,
+  p_window_seconds integer
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_window       integer;
+  v_limit        integer;
+  v_start        timestamptz;
+  v_hits         integer;
+  v_allowed      boolean;
+  v_master       boolean;
+  v_rule_enabled boolean;
+  v_rule_calls   integer;
+  v_rule_window  integer;
+BEGIN
+  IF p_subject IS NULL OR p_subject = '' OR p_bucket IS NULL OR p_bucket = '' THEN
+    RAISE EXCEPTION 'baaki_rate_limit needs a subject and a bucket';
+  END IF;
+
+  -- Master off, or this bucket switched off: let it straight through. Nothing is
+  -- counted, so turning the limit back on starts from a clean window rather than
+  -- from whatever piled up while it was off.
+  SELECT enabled INTO v_master FROM public.rate_limit_settings WHERE id = true;
+  IF v_master IS NOT NULL AND NOT v_master THEN
+    RETURN jsonb_build_object(
+      'allowed', true, 'hits', 0, 'limit', 0,
+      'remaining', 2147483647, 'retryAfter', 0, 'resetAt', clock_timestamp()
+    );
+  END IF;
+
+  -- The code default is the fallback; a row for this bucket overrides it.
+  v_window := GREATEST(COALESCE(p_window_seconds, 60), 1);
+  v_limit  := GREATEST(COALESCE(p_limit, 0), 0);
+
+  SELECT enabled, max_calls, window_seconds
+    INTO v_rule_enabled, v_rule_calls, v_rule_window
+    FROM public.rate_limit_rules
+   WHERE bucket = p_bucket;
+
+  IF FOUND THEN
+    IF NOT v_rule_enabled THEN
+      RETURN jsonb_build_object(
+        'allowed', true, 'hits', 0, 'limit', 0,
+        'remaining', 2147483647, 'retryAfter', 0, 'resetAt', clock_timestamp()
+      );
+    END IF;
+    v_limit  := GREATEST(v_rule_calls, 0);
+    v_window := GREATEST(v_rule_window, 1);
+  END IF;
+
+  -- Floor the clock to the window. Every caller in the same window agrees on
+  -- the same `window_start` without anybody having to store when it opened.
+  v_start := to_timestamp(
+    floor(extract(epoch FROM clock_timestamp()) / v_window) * v_window
+  );
+
+  INSERT INTO public.rate_limit_hits AS existing (subject, bucket, window_start, hits)
+  VALUES (p_subject, p_bucket, v_start, 1)
+  ON CONFLICT (subject, bucket, window_start)
+    DO UPDATE SET hits = existing.hits + 1
+  RETURNING existing.hits INTO v_hits;
+
+  v_allowed := v_hits <= v_limit;
+
+  RETURN jsonb_build_object(
+    'allowed',   v_allowed,
+    'hits',      v_hits,
+    'limit',     v_limit,
+    'remaining', GREATEST(v_limit - v_hits, 0),
+    'retryAfter', CASE
+                    WHEN v_allowed THEN 0
+                    ELSE GREATEST(
+                      ceil(extract(epoch FROM (v_start + make_interval(secs => v_window))
+                                              - clock_timestamp()))::integer,
+                      1
+                    )
+                  END,
+    'resetAt',   v_start + make_interval(secs => v_window)
+  );
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_rate_limit(text, text, integer, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_rate_limit(text, text, integer, integer) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_rate_limit(text, text, integer, integer) TO service_role;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1052,3 +1052,28 @@ model RateLimitHit {
   @@map("rate_limit_hits")
   @@schema("public")
 }
+
+/// Admin-editable overrides for the abuse limiter. A row per bucket overrides
+/// the code default in `_shared/rateLimit.ts`; a bucket with no row is limited
+/// exactly as the code says. `baaki_rate_limit` reads this on every call.
+model RateLimitRule {
+  bucket        String   @id
+  enabled       Boolean  @default(true)
+  maxCalls      Int      @map("max_calls")
+  windowSeconds Int      @map("window_seconds")
+  updatedAt     DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@map("rate_limit_rules")
+  @@schema("public")
+}
+
+/// The master switch, pinned to a single row. Off exempts every bucket at once
+/// — the escape hatch for replaying a stuck queue during an incident.
+model RateLimitSetting {
+  id        Boolean  @id @default(true)
+  enabled   Boolean  @default(true)
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@map("rate_limit_settings")
+  @@schema("public")
+}


### PR DESCRIPTION
Two things the admin console could not do — both because the only way was a deploy or the Supabase dashboard.

## Rate limits (`/rate-limits`)
The app's own abuse limiter was a constant table in `_shared/rateLimit.ts`, changeable only by shipping. This makes it editable:

- **`rate_limit_settings`** — a master switch pinned to one row. Off exempts every bucket at once (the escape hatch for replaying a stuck queue during an incident).
- **`rate_limit_rules`** — a row per bucket (`enabled`, `max_calls`, `window_seconds`), seeded with the current seven buckets so the page opens on the real config.
- **`baaki_rate_limit`** now reads both: master off → allow; bucket row overrides the code default; **no row → limited exactly as before**. Counting is unchanged and still fails open.

The page states plainly this is the app's limiter, **not** Supabase's auth rate limiter (which lives in the Supabase dashboard — and is what was blocking signups earlier).

## Users (`/users`)
- **Search** by email / phone / id (paged over the GoTrue directory and filtered server-side, since GoTrue has no search), names joined from `profiles`.
- **Confirm email** by hand — the OTP a person never received (`auth.admin.updateUserById`).
- **Upgrade to paid** — the same `baaki_admin_grant_promo` SECURITY DEFINER grant the promotions page uses.

These reach into `auth` (which Supabase grants to nobody), so they go through the GoTrue admin API on the existing service-role client in `data.ts`.

## Verified
- Migration applied to a local Postgres; `baaki_rate_limit` exercised through all four paths — default, per-bucket override, bucket disabled, master off.
- `next build` compiles both new routes; admin `tsc`, `eslint`, and `prisma validate` all clean.

## Deploy note
The rate-limit tables need this migration deployed before the page shows rows; until then it degrades to a "not deployed yet" note and the app keeps using the code defaults. The Users page needs no migration and works against the current project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)