### PR TITLE
feat(devices): free-tier two-device cap, remote sign-out, devices activity

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -607,6 +607,12 @@ export default function ProfileScreen() {
                   route: '/settings/lock',
                 },
                 {
+                  icon: 'phone-portrait-outline',
+                  label: t.devices.row,
+                  hint: t.devices.rowHint,
+                  route: '/settings/devices',
+                },
+                {
                   icon: 'log-out-outline',
                   label: t.lock.signOut,
                   hint: signOutHint,

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -14,6 +14,7 @@ import { Button, CurvedPanel, setLayoutDirection, ThemeProvider, Text, useTheme 
 import { CampaignPopup } from '@/components/CampaignPopup';
 import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
+import { DeviceSessionProvider } from '@/lib/deviceSession';
 import { isRtl, isRtlLanguage, useStrings } from '@/i18n';
 import { LanguageProvider, useLanguage } from '@/i18n/language';
 import { LocaleSync } from '@/i18n/localeSync';
@@ -121,11 +122,16 @@ function RootLayout() {
                         <UpdateGate>
                           <PushRouting />
                           <LockGate>
-                            <AuthGate />
-                            {/* Inside the lock on purpose: a promotion is not a
-                                reason to show somebody's phone anything before
-                                they have unlocked it. */}
-                            <CampaignPopup />
+                            {/* Inside the lock so the two-device gate never
+                                paints over the lock screen, and past auth so it
+                                only ever asks a signed-in account. */}
+                            <DeviceSessionProvider>
+                              <AuthGate />
+                              {/* Inside the lock on purpose: a promotion is not a
+                                  reason to show somebody's phone anything before
+                                  they have unlocked it. */}
+                              <CampaignPopup />
+                            </DeviceSessionProvider>
                           </LockGate>
                           {/* Last, so it paints over the screen rather than
                               under it. */}
@@ -324,6 +330,7 @@ function AuthGate() {
       <Stack.Screen name="settings/export" />
       <Stack.Screen name="settings/import" />
       <Stack.Screen name="settings/lock" />
+      <Stack.Screen name="settings/devices" />
       <Stack.Screen name="settings/motion" />
       <Stack.Screen name="settings/language" />
       <Stack.Screen name="settings/upgrade" />

--- a/apps/mobile/src/app/settings/devices.tsx
+++ b/apps/mobile/src/app/settings/devices.tsx
@@ -50,9 +50,7 @@ export default function DevicesScreen() {
   // The server already returns the last three months, newest first.
   const devices = useQuery({ queryKey: ['devices'], queryFn: fetchDevices });
   const rows = devices.data ?? [];
-  const otherLiveCount = rows.filter(
-    (row) => row.deviceId !== myDeviceId && !row.revokedAt,
-  ).length;
+  const otherLiveCount = rows.filter((row) => row.deviceId !== myDeviceId && !row.revokedAt).length;
 
   async function onSignOutOthers() {
     setBusy(true);

--- a/apps/mobile/src/app/settings/devices.tsx
+++ b/apps/mobile/src/app/settings/devices.tsx
@@ -1,0 +1,177 @@
+/**
+ * Where this account is signed in, and the one button that trims it.
+ *
+ * The free tier is two devices at a time (see `deviceSession.tsx`); this is the
+ * screen that makes that legible — the phones seen in the last three months,
+ * this one marked, and "log out all other devices" for when the list has
+ * somebody on it you do not recognise. Signing the others out here is the same
+ * action the over-limit gate offers, reached calmly rather than because you are
+ * blocked.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { router } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { ScrollView, View } from 'react-native';
+
+import { type DeviceSession } from '@baaki/core';
+import {
+  Badge,
+  Button,
+  Card,
+  directionalIcon,
+  IconButton,
+  Row,
+  Screen,
+  Text,
+  useTheme,
+} from '@baaki/ui';
+
+import { plural, useStrings } from '@/i18n';
+import { fetchDevices } from '@/data/api';
+import { deviceId } from '@/lib/device';
+import { useDeviceSession } from '@/lib/deviceSession';
+
+export default function DevicesScreen() {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const queryClient = useQueryClient();
+  const { signOutOthers } = useDeviceSession();
+
+  const [myDeviceId, setMyDeviceId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    void deviceId().then(setMyDeviceId);
+  }, []);
+
+  // The server already returns the last three months, newest first.
+  const devices = useQuery({ queryKey: ['devices'], queryFn: fetchDevices });
+  const rows = devices.data ?? [];
+  const otherLiveCount = rows.filter(
+    (row) => row.deviceId !== myDeviceId && !row.revokedAt,
+  ).length;
+
+  async function onSignOutOthers() {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const revoked = await signOutOthers();
+      setMessage(plural(locale, revoked, t.devices.signedOutOthers));
+      await queryClient.invalidateQueries({ queryKey: ['devices'] });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.devices.title}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        <Text variant="caption" tone="muted">
+          {t.devices.intro}
+        </Text>
+
+        <View style={{ gap: theme.spacing.md }}>
+          {rows.map((row) => (
+            <DeviceCard
+              key={`${row.deviceId}-${row.lastSeenAt}`}
+              row={row}
+              current={row.deviceId === myDeviceId}
+              locale={locale}
+              t={t}
+            />
+          ))}
+        </View>
+
+        {otherLiveCount === 0 ? (
+          <Text variant="caption" tone="muted" align="center">
+            {t.devices.onlyThisDevice}
+          </Text>
+        ) : (
+          <Card style={{ gap: theme.spacing.md }}>
+            <Text variant="caption" tone="muted">
+              {t.devices.signOutOthersHint}
+            </Text>
+            <Button
+              label={t.devices.signOutOthers}
+              variant="danger"
+              disabled={busy}
+              onPress={() => void onSignOutOthers()}
+            />
+          </Card>
+        )}
+
+        {message ? (
+          <Text variant="caption" tone="muted" align="center">
+            {message}
+          </Text>
+        ) : null}
+
+        <Text variant="micro" tone="faint" align="center">
+          {t.devices.historyNote}
+        </Text>
+      </ScrollView>
+    </Screen>
+  );
+}
+
+function DeviceCard({
+  row,
+  current,
+  locale,
+  t,
+}: {
+  row: DeviceSession;
+  current: boolean;
+  locale: string;
+  t: ReturnType<typeof useStrings>['t'];
+}) {
+  const theme = useTheme();
+  const when = new Date(row.lastSeenAt).toLocaleDateString(locale, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+
+  return (
+    <Card style={{ gap: 4, opacity: row.revokedAt ? 0.6 : 1 }}>
+      <Row style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text variant="subheading" numberOfLines={1}>
+            {row.label}
+          </Text>
+          <Text variant="caption" tone="muted">
+            {row.platform}
+          </Text>
+          <Text variant="caption" tone="muted">
+            {t.devices.lastActive.replace('{when}', when)}
+          </Text>
+        </View>
+        {current ? (
+          <Badge label={t.devices.thisDevice} tone="brand" />
+        ) : row.revokedAt ? (
+          <Badge label={t.devices.signedOut} tone="neutral" />
+        ) : null}
+      </Row>
+    </Card>
+  );
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -15,6 +15,8 @@ import {
   normalisePhone,
   serialiseSplitParams,
   type CurrencyCode,
+  type DeviceLimitStatus,
+  type DeviceSession,
   type FxRecord,
   type ParsedReceipt,
   type ReceiptCheck,
@@ -22,6 +24,7 @@ import {
 } from '@baaki/core';
 
 import { activeStrings } from '@/i18n';
+import type { DeviceIdentity } from '@/lib/device';
 import { supabase } from '@/lib/supabase';
 import type {
   ActivityGroup,
@@ -1486,4 +1489,42 @@ export async function deleteMyAccount(
   const { data, error } = await supabase.rpc('baaki_delete_my_account', { p_feedback: reason });
   if (error) throw new Error(error.message);
   return (data ?? {}) as { memberships_anonymised?: number };
+}
+
+// ─────────────────────────────────────────────────────────────── devices ──
+
+/**
+ * Register (or refresh) this phone and learn where the account stands against
+ * its device cap. The counting and the tier are the database's to decide — this
+ * only reports the answer back up (`overLimit` drives the gate).
+ */
+export async function registerDevice(identity: DeviceIdentity): Promise<DeviceLimitStatus> {
+  const { data, error } = await supabase.rpc('baaki_register_device', {
+    p_device_id: identity.deviceId,
+    p_label: identity.label,
+    p_platform: identity.platform,
+    p_app_version: identity.appVersion,
+  });
+  if (error) throw new Error(error.message);
+  return data as DeviceLimitStatus;
+}
+
+/** The caller's devices seen in the last three months, newest first. */
+export async function fetchDevices(): Promise<DeviceSession[]> {
+  const { data, error } = await supabase.rpc('baaki_list_devices');
+  if (error) throw new Error(error.message);
+  return (data ?? []) as DeviceSession[];
+}
+
+/**
+ * Mark every other device revoked in the table. The caller pairs this with
+ * `supabase.auth.signOut({ scope: 'others' })`, which tears down the actual
+ * sessions; doing both keeps the devices list honest about what just happened.
+ */
+export async function signOutOtherDevices(currentDeviceId: string): Promise<number> {
+  const { data, error } = await supabase.rpc('baaki_sign_out_other_devices', {
+    p_device_id: currentDeviceId,
+  });
+  if (error) throw new Error(error.message);
+  return (data ?? 0) as number;
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1180,7 +1180,10 @@ const en: UiStrings = {
     lastActive: 'Last active {when}',
     signOutOthers: 'Log out all other devices',
     signOutOthersHint: 'Signs out every device except this one. They ask for a login next time.',
-    signedOutOthers: { one: 'Signed out {n} other device.', other: 'Signed out {n} other devices.' },
+    signedOutOthers: {
+      one: 'Signed out {n} other device.',
+      other: 'Signed out {n} other devices.',
+    },
     onlyThisDevice: 'This is the only device signed in.',
     historyNote: 'Showing the last three months.',
     row: 'Devices',
@@ -2091,7 +2094,8 @@ const ta: UiStrings = {
     signedOut: 'வெளியேற்றப்பட்டது',
     lastActive: 'கடைசியாகச் செயலில் {when}',
     signOutOthers: 'மற்ற எல்லா சாதனங்களிலும் வெளியேறு',
-    signOutOthersHint: 'இந்தச் சாதனம் தவிர மற்ற அனைத்திலும் வெளியேற்றும். அடுத்த முறை உள்நுழைவு கேட்கப்படும்.',
+    signOutOthersHint:
+      'இந்தச் சாதனம் தவிர மற்ற அனைத்திலும் வெளியேற்றும். அடுத்த முறை உள்நுழைவு கேட்கப்படும்.',
     signedOutOthers: {
       one: '{n} சாதனத்தில் வெளியேற்றப்பட்டது.',
       other: '{n} சாதனங்களில் வெளியேற்றப்பட்டது.',
@@ -3014,8 +3018,12 @@ const hi: UiStrings = {
     signedOut: 'साइन आउट',
     lastActive: 'आख़िरी बार सक्रिय {when}',
     signOutOthers: 'बाकी सभी डिवाइस से साइन आउट करें',
-    signOutOthersHint: 'इस डिवाइस को छोड़कर हर डिवाइस से साइन आउट कर देता है। अगली बार उन पर लॉगिन माँगा जाएगा।',
-    signedOutOthers: { one: '{n} अन्य डिवाइस से साइन आउट किया।', other: '{n} अन्य डिवाइसों से साइन आउट किया।' },
+    signOutOthersHint:
+      'इस डिवाइस को छोड़कर हर डिवाइस से साइन आउट कर देता है। अगली बार उन पर लॉगिन माँगा जाएगा।',
+    signedOutOthers: {
+      one: '{n} अन्य डिवाइस से साइन आउट किया।',
+      other: '{n} अन्य डिवाइसों से साइन आउट किया।',
+    },
     onlyThisDevice: 'सिर्फ़ यही डिवाइस साइन इन है।',
     historyNote: 'पिछले तीन महीने दिखाए जा रहे हैं।',
     row: 'डिवाइस',
@@ -3932,7 +3940,8 @@ const ar: UiStrings = {
     signedOut: 'تم تسجيل الخروج',
     lastActive: 'آخر نشاط {when}',
     signOutOthers: 'تسجيل الخروج من كل الأجهزة الأخرى',
-    signOutOthersHint: 'يُسجّل الخروج من كل جهاز عدا هذا الجهاز. ستُطلب منها تسجيل الدخول في المرة القادمة.',
+    signOutOthersHint:
+      'يُسجّل الخروج من كل جهاز عدا هذا الجهاز. ستُطلب منها تسجيل الدخول في المرة القادمة.',
     signedOutOthers: {
       zero: 'تم تسجيل الخروج من {n} جهاز آخر.',
       one: 'تم تسجيل الخروج من جهاز آخر.',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -325,6 +325,25 @@ export interface UiStrings {
     staySignedIn: string;
     footnote: string;
   };
+  /** The devices screen and the free-tier two-device cap. */
+  devices: {
+    title: string;
+    intro: string;
+    thisDevice: string;
+    signedOut: string;
+    lastActive: string;
+    signOutOthers: string;
+    signOutOthersHint: string;
+    signedOutOthers: PluralForms;
+    onlyThisDevice: string;
+    historyNote: string;
+    row: string;
+    rowHint: string;
+    gateTitle: string;
+    gateBody: string;
+    gateAction: string;
+    gateDismiss: string;
+  };
   /** The account screen and its three faces. */
   account: {
     faceYou: string;
@@ -1151,6 +1170,26 @@ const en: UiStrings = {
     staySignedIn: 'Stay signed in',
     footnote:
       'This guards the screen, not the data — your ledger is protected by row-level security on the server whether the lock is on or not.',
+  },
+  devices: {
+    title: 'Devices',
+    intro:
+      'The free plan covers two devices at a time. A device you have not opened in a while stops counting on its own.',
+    thisDevice: 'This device',
+    signedOut: 'Signed out',
+    lastActive: 'Last active {when}',
+    signOutOthers: 'Log out all other devices',
+    signOutOthersHint: 'Signs out every device except this one. They ask for a login next time.',
+    signedOutOthers: { one: 'Signed out {n} other device.', other: 'Signed out {n} other devices.' },
+    onlyThisDevice: 'This is the only device signed in.',
+    historyNote: 'Showing the last three months.',
+    row: 'Devices',
+    rowHint: 'See where you are signed in',
+    gateTitle: 'Signed in on too many devices',
+    gateBody:
+      'The free plan covers two devices at a time, and this account is over that. Log out the others to keep using Baaki on this one.',
+    gateAction: 'Log out other devices',
+    gateDismiss: 'Not now',
   },
   account: {
     faceYou: 'You',
@@ -2043,6 +2082,29 @@ const ta: UiStrings = {
     staySignedIn: 'உள்ளேயே இரு',
     footnote:
       'இது திரையைக் காக்கிறது, தரவை அல்ல — பூட்டு இருந்தாலும் இல்லாவிட்டாலும் உங்கள் கணக்கு சர்வரில் வரிசை அளவிலான பாதுகாப்பால் காக்கப்படுகிறது.',
+  },
+  devices: {
+    title: 'சாதனங்கள்',
+    intro:
+      'இலவசத் திட்டத்தில் ஒரே நேரத்தில் இரண்டு சாதனங்கள். சிறிது காலம் திறக்காத சாதனம் தானாகவே கணக்கில் இருந்து விலகும்.',
+    thisDevice: 'இந்தச் சாதனம்',
+    signedOut: 'வெளியேற்றப்பட்டது',
+    lastActive: 'கடைசியாகச் செயலில் {when}',
+    signOutOthers: 'மற்ற எல்லா சாதனங்களிலும் வெளியேறு',
+    signOutOthersHint: 'இந்தச் சாதனம் தவிர மற்ற அனைத்திலும் வெளியேற்றும். அடுத்த முறை உள்நுழைவு கேட்கப்படும்.',
+    signedOutOthers: {
+      one: '{n} சாதனத்தில் வெளியேற்றப்பட்டது.',
+      other: '{n} சாதனங்களில் வெளியேற்றப்பட்டது.',
+    },
+    onlyThisDevice: 'இந்தச் சாதனம் மட்டுமே உள்நுழைந்துள்ளது.',
+    historyNote: 'கடந்த மூன்று மாதங்கள் காட்டப்படுகின்றன.',
+    row: 'சாதனங்கள்',
+    rowHint: 'எங்கு உள்நுழைந்துள்ளீர்கள் என்பதைப் பார்க்கவும்',
+    gateTitle: 'மிக அதிக சாதனங்களில் உள்நுழைந்துள்ளது',
+    gateBody:
+      'இலவசத் திட்டத்தில் ஒரே நேரத்தில் இரண்டு சாதனங்கள் மட்டுமே; இந்தக் கணக்கு அதைத் தாண்டியுள்ளது. இந்தச் சாதனத்தில் பாக்கியைத் தொடர மற்றவற்றில் வெளியேறவும்.',
+    gateAction: 'மற்ற சாதனங்களில் வெளியேறு',
+    gateDismiss: 'இப்போது வேண்டாம்',
   },
   account: {
     faceYou: 'நீங்கள்',
@@ -2944,6 +3006,26 @@ const hi: UiStrings = {
     footnote:
       'यह स्क्रीन की रक्षा करता है, डेटा की नहीं — लॉक चालू हो या बंद, आपका हिसाब सर्वर पर रो-लेवल सुरक्षा से सुरक्षित है।',
   },
+  devices: {
+    title: 'डिवाइस',
+    intro:
+      'मुफ़्त प्लान में एक साथ दो डिवाइस चलते हैं। जो डिवाइस कुछ समय से नहीं खुला, वह अपने आप गिनती से हट जाता है।',
+    thisDevice: 'यह डिवाइस',
+    signedOut: 'साइन आउट',
+    lastActive: 'आख़िरी बार सक्रिय {when}',
+    signOutOthers: 'बाकी सभी डिवाइस से साइन आउट करें',
+    signOutOthersHint: 'इस डिवाइस को छोड़कर हर डिवाइस से साइन आउट कर देता है। अगली बार उन पर लॉगिन माँगा जाएगा।',
+    signedOutOthers: { one: '{n} अन्य डिवाइस से साइन आउट किया।', other: '{n} अन्य डिवाइसों से साइन आउट किया।' },
+    onlyThisDevice: 'सिर्फ़ यही डिवाइस साइन इन है।',
+    historyNote: 'पिछले तीन महीने दिखाए जा रहे हैं।',
+    row: 'डिवाइस',
+    rowHint: 'देखें कि आप कहाँ-कहाँ साइन इन हैं',
+    gateTitle: 'बहुत ज़्यादा डिवाइस पर साइन इन',
+    gateBody:
+      'मुफ़्त प्लान में एक साथ दो डिवाइस चलते हैं, और यह अकाउंट उससे ऊपर है। इस डिवाइस पर बाकी इस्तेमाल करते रहने के लिए बाकियों से साइन आउट करें।',
+    gateAction: 'दूसरे डिवाइस से साइन आउट करें',
+    gateDismiss: 'अभी नहीं',
+  },
   account: {
     faceYou: 'आप',
     facePaying: 'भुगतान',
@@ -3841,6 +3923,33 @@ const ar: UiStrings = {
     staySignedIn: 'ابقَ مسجّل الدخول',
     footnote:
       'هذا يحمي الشاشة لا البيانات — دفترك محمي على الخادم بأمان على مستوى الصفوف سواء كان القفل مفعّلًا أم لا.',
+  },
+  devices: {
+    title: 'الأجهزة',
+    intro:
+      'الخطة المجانية تشمل جهازين في وقت واحد. الجهاز الذي لم تفتحه منذ فترة يتوقف عن العدّ من تلقاء نفسه.',
+    thisDevice: 'هذا الجهاز',
+    signedOut: 'تم تسجيل الخروج',
+    lastActive: 'آخر نشاط {when}',
+    signOutOthers: 'تسجيل الخروج من كل الأجهزة الأخرى',
+    signOutOthersHint: 'يُسجّل الخروج من كل جهاز عدا هذا الجهاز. ستُطلب منها تسجيل الدخول في المرة القادمة.',
+    signedOutOthers: {
+      zero: 'تم تسجيل الخروج من {n} جهاز آخر.',
+      one: 'تم تسجيل الخروج من جهاز آخر.',
+      two: 'تم تسجيل الخروج من جهازين آخرين.',
+      few: 'تم تسجيل الخروج من {n} أجهزة أخرى.',
+      many: 'تم تسجيل الخروج من {n} جهازًا آخر.',
+      other: 'تم تسجيل الخروج من {n} جهاز آخر.',
+    },
+    onlyThisDevice: 'هذا هو الجهاز الوحيد المسجّل الدخول.',
+    historyNote: 'يتم عرض آخر ثلاثة أشهر.',
+    row: 'الأجهزة',
+    rowHint: 'اطّلع على أماكن تسجيل دخولك',
+    gateTitle: 'مسجّل الدخول على أجهزة أكثر من اللازم',
+    gateBody:
+      'الخطة المجانية تشمل جهازين في وقت واحد، وهذا الحساب تجاوز ذلك. سجّل الخروج من الأجهزة الأخرى لمواصلة استخدام باقي على هذا الجهاز.',
+    gateAction: 'تسجيل الخروج من الأجهزة الأخرى',
+    gateDismiss: 'ليس الآن',
   },
   account: {
     faceYou: 'أنت',

--- a/apps/mobile/src/lib/device.ts
+++ b/apps/mobile/src/lib/device.ts
@@ -1,0 +1,98 @@
+/**
+ * This phone's stable identity, for the device cap (free tier: two at a time).
+ *
+ * The id is generated once and kept in the device keystore, so a token refresh,
+ * an app update or a new sign-in is still recognisably the same phone rather
+ * than a third device that quietly pushes somebody over their limit. It is a
+ * random id and nothing derived from hardware — a value the app owns and can
+ * throw away on sign-out, not a fingerprint.
+ *
+ * Nothing here throws. A keystore read can fail (a locked device, a platform
+ * without SecureStore), and the fallback is a fresh id for the session rather
+ * than a crash at launch — the worst case is one extra row, never a blank app.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { randomUUID } from 'expo-crypto';
+import Constants from 'expo-constants';
+import * as Device from 'expo-device';
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
+
+const KEY = 'baaki.device.id';
+
+export interface DeviceIdentity {
+  readonly deviceId: string;
+  readonly label: string;
+  readonly platform: string;
+  readonly appVersion: string | null;
+}
+
+// SecureStore has no web build; web falls back to AsyncStorage, which is enough
+// for an id that is not a secret so much as a stable name.
+async function readStoredId(): Promise<string | null> {
+  try {
+    return Platform.OS === 'web' ? await AsyncStorage.getItem(KEY) : await SecureStore.getItemAsync(KEY);
+  } catch {
+    return null;
+  }
+}
+
+async function writeStoredId(id: string): Promise<void> {
+  try {
+    if (Platform.OS === 'web') await AsyncStorage.setItem(KEY, id);
+    else await SecureStore.setItemAsync(KEY, id);
+  } catch {
+    /* a device that will not persist the id gets a fresh one next launch */
+  }
+}
+
+let cached: string | null = null;
+
+/** The stable id for this install, minted and stored on first ask. */
+export async function deviceId(): Promise<string> {
+  if (cached) return cached;
+  let id = await readStoredId();
+  if (!id) {
+    id = randomUUID();
+    await writeStoredId(id);
+  }
+  cached = id;
+  return id;
+}
+
+/** Signing out must not leave the next account inheriting this device row. */
+export async function clearDeviceId(): Promise<void> {
+  cached = null;
+  try {
+    if (Platform.OS === 'web') await AsyncStorage.removeItem(KEY);
+    else await SecureStore.deleteItemAsync(KEY);
+  } catch {
+    /* nothing to undo */
+  }
+}
+
+/** What a person would call this phone: its model, falling back to the OS. */
+export function deviceLabel(): string {
+  const model = Device.modelName ?? Device.deviceName ?? null;
+  if (model) return model;
+  return Platform.OS === 'ios' ? 'iPhone' : Platform.OS === 'android' ? 'Android phone' : 'This device';
+}
+
+/** The platform line under the label, e.g. "android 15". */
+export function devicePlatform(): string {
+  return Device.osVersion ? `${Platform.OS} ${Device.osVersion}` : Platform.OS;
+}
+
+export function appVersion(): string | null {
+  return Constants.expoConfig?.version ?? null;
+}
+
+export async function deviceIdentity(): Promise<DeviceIdentity> {
+  return {
+    deviceId: await deviceId(),
+    label: deviceLabel(),
+    platform: devicePlatform(),
+    appVersion: appVersion(),
+  };
+}

--- a/apps/mobile/src/lib/device.ts
+++ b/apps/mobile/src/lib/device.ts
@@ -32,7 +32,9 @@ export interface DeviceIdentity {
 // for an id that is not a secret so much as a stable name.
 async function readStoredId(): Promise<string | null> {
   try {
-    return Platform.OS === 'web' ? await AsyncStorage.getItem(KEY) : await SecureStore.getItemAsync(KEY);
+    return Platform.OS === 'web'
+      ? await AsyncStorage.getItem(KEY)
+      : await SecureStore.getItemAsync(KEY);
   } catch {
     return null;
   }
@@ -76,7 +78,11 @@ export async function clearDeviceId(): Promise<void> {
 export function deviceLabel(): string {
   const model = Device.modelName ?? Device.deviceName ?? null;
   if (model) return model;
-  return Platform.OS === 'ios' ? 'iPhone' : Platform.OS === 'android' ? 'Android phone' : 'This device';
+  return Platform.OS === 'ios'
+    ? 'iPhone'
+    : Platform.OS === 'android'
+      ? 'Android phone'
+      : 'This device';
 }
 
 /** The platform line under the label, e.g. "android 15". */

--- a/apps/mobile/src/lib/deviceSession.tsx
+++ b/apps/mobile/src/lib/deviceSession.tsx
@@ -18,7 +18,15 @@
  * skipped entirely.
  */
 
-import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { AppState, Modal, Pressable, View } from 'react-native';
 
 import { type DeviceLimitStatus } from '@baaki/core';
@@ -135,7 +143,9 @@ export function DeviceSessionProvider({ children }: { children: ReactNode }) {
   return (
     <DeviceSessionContext.Provider value={{ status, signOutOthers, refresh }}>
       {children}
-      {showGate ? <DeviceLimitGate onDismiss={() => setDismissed(true)} onSignOutOthers={signOutOthers} /> : null}
+      {showGate ? (
+        <DeviceLimitGate onDismiss={() => setDismissed(true)} onSignOutOthers={signOutOthers} />
+      ) : null}
     </DeviceSessionContext.Provider>
   );
 }

--- a/apps/mobile/src/lib/deviceSession.tsx
+++ b/apps/mobile/src/lib/deviceSession.tsx
@@ -1,0 +1,198 @@
+/**
+ * The device cap, wired to a running app (free tier: two phones at a time).
+ *
+ * Three jobs, all quiet until they are not:
+ *
+ * It **registers** this phone whenever an account is signed in, and refreshes
+ * that registration when the app comes back to the foreground — the heartbeat
+ * that keeps a phone in daily use counted, and lets one left in a drawer fall
+ * out of the count on its own after two weeks.
+ *
+ * It **reports** where the account stands. The database decides whether the
+ * account is over its limit; this holds that answer and hands it to the gate.
+ *
+ * It **gates**, softly. A free account over the line is shown a sheet asking it
+ * to sign the other phones out — never a locked door. Signing in on a phone can
+ * always continue; what the person chooses is which two phones keep the session.
+ * Guests have no cap (an anonymous account is one device by definition) and are
+ * skipped entirely.
+ */
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { AppState, Modal, Pressable, View } from 'react-native';
+
+import { type DeviceLimitStatus } from '@baaki/core';
+import { Button, Text, useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+import { registerDevice, signOutOtherDevices } from '@/data/api';
+import { deviceIdentity } from '@/lib/device';
+import { useAuth } from '@/lib/auth';
+import { supabase } from '@/lib/supabase';
+
+/** How stale a registration may get before a foreground refreshes it. */
+const HEARTBEAT_MS = 60 * 60 * 1000;
+
+interface DeviceSessionValue {
+  /** Null until the first registration answers, or for guests. */
+  status: DeviceLimitStatus | null;
+  /** Sign out every other device — GoTrue sessions and the table both. */
+  signOutOthers: () => Promise<number>;
+  /** Re-ask the server where the account stands. */
+  refresh: () => Promise<void>;
+}
+
+const DeviceSessionContext = createContext<DeviceSessionValue | null>(null);
+
+export function useDeviceSession(): DeviceSessionValue {
+  const value = useContext(DeviceSessionContext);
+  if (!value) throw new Error('useDeviceSession must be used inside DeviceSessionProvider');
+  return value;
+}
+
+export function DeviceSessionProvider({ children }: { children: ReactNode }) {
+  const { session, isGuest } = useAuth();
+  const userId = session?.user?.id ?? null;
+  const eligible = Boolean(userId) && !isGuest;
+
+  const [status, setStatus] = useState<DeviceLimitStatus | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const lastBeatAt = useRef(0);
+
+  // Reset in render rather than an effect (the pattern `AuthProvider` uses):
+  // the previous account's answer must not flash on the next one, and clearing
+  // it here avoids a render that shows it.
+  const [answeredFor, setAnsweredFor] = useState<string | null>(null);
+  if (userId !== answeredFor) {
+    setAnsweredFor(userId);
+    setStatus(null);
+    setDismissed(false);
+  }
+
+  const register = useCallback(async () => {
+    if (!eligible) return;
+    try {
+      const identity = await deviceIdentity();
+      const next = await registerDevice(identity);
+      lastBeatAt.current = Date.now();
+      setStatus(next);
+    } catch {
+      // Registration is best-effort: a failed call must never keep somebody out
+      // of their own app. The next foreground tries again.
+    }
+  }, [eligible]);
+
+  // Register on sign-in. Sign-out is handled by the render-phase reset above.
+  // The work is an async IIFE (the pattern `AuthProvider` uses) so the state
+  // update lands after the round trip rather than synchronously in the effect.
+  useEffect(() => {
+    if (!eligible) return;
+    let active = true;
+    void (async () => {
+      try {
+        const identity = await deviceIdentity();
+        const next = await registerDevice(identity);
+        if (!active) return;
+        lastBeatAt.current = Date.now();
+        setStatus(next);
+      } catch {
+        // Best-effort: a failed registration must never keep somebody out of
+        // their own app. The next foreground tries again.
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [eligible, userId]);
+
+  // Heartbeat: a foreground, throttled, is enough to keep last-seen fresh.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active' && Date.now() - lastBeatAt.current > HEARTBEAT_MS) {
+        void register();
+      }
+    });
+    return () => sub.remove();
+  }, [register]);
+
+  const signOutOthers = useCallback(async () => {
+    const identity = await deviceIdentity();
+    // The real sessions first — this is the part that actually logs the other
+    // phones out; the table update below is what makes the list say so.
+    await supabase.auth.signOut({ scope: 'others' });
+    const revoked = await signOutOtherDevices(identity.deviceId);
+    await register();
+    setDismissed(true);
+    return revoked;
+  }, [register]);
+
+  const refresh = useCallback(async () => {
+    await register();
+  }, [register]);
+
+  const showGate = eligible && status?.overLimit === true && !dismissed;
+
+  return (
+    <DeviceSessionContext.Provider value={{ status, signOutOthers, refresh }}>
+      {children}
+      {showGate ? <DeviceLimitGate onDismiss={() => setDismissed(true)} onSignOutOthers={signOutOthers} /> : null}
+    </DeviceSessionContext.Provider>
+  );
+}
+
+function DeviceLimitGate({
+  onDismiss,
+  onSignOutOthers,
+}: {
+  onDismiss: () => void;
+  onSignOutOthers: () => Promise<number>;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const [busy, setBusy] = useState(false);
+
+  return (
+    <Modal transparent animationType="fade" visible onRequestClose={onDismiss}>
+      <Pressable
+        onPress={onDismiss}
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(20,20,43,0.45)',
+          justifyContent: 'center',
+          padding: theme.spacing.xl,
+        }}
+      >
+        <Pressable
+          onPress={() => {}}
+          style={{
+            backgroundColor: theme.color.surface,
+            borderRadius: theme.radius.xl,
+            padding: theme.spacing.xl,
+            gap: theme.spacing.lg,
+            ...theme.shadow.lifted,
+          }}
+        >
+          <Text variant="heading">{t.devices.gateTitle}</Text>
+          <Text variant="body" tone="muted">
+            {t.devices.gateBody}
+          </Text>
+          <View style={{ gap: theme.spacing.md }}>
+            <Button
+              label={t.devices.gateAction}
+              disabled={busy}
+              onPress={async () => {
+                setBusy(true);
+                try {
+                  await onSignOutOthers();
+                } finally {
+                  setBusy(false);
+                }
+              }}
+            />
+            <Button label={t.devices.gateDismiss} variant="secondary" onPress={onDismiss} />
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,4 +23,5 @@ export * from './auth/identity';
 export * from './observability/index';
 export * from './version/index';
 export * from './billing/index';
+export * from './session/index';
 export * from './trip/index';

--- a/packages/core/src/session/devices.ts
+++ b/packages/core/src/session/devices.ts
@@ -1,0 +1,133 @@
+/**
+ * How many phones one account may hold at once, and which of them still count.
+ *
+ * The free tier is two devices at a time. "At a time" is the whole difficulty:
+ * GoTrue knows about refresh tokens, not about whether the phone in a drawer is
+ * ever coming back, so "simultaneous" here means *seen recently*. A device that
+ * has not checked in for {@link DEVICE_ACTIVE_WINDOW_DAYS} days stops occupying
+ * a slot on its own, which is what keeps a closed phone from locking somebody
+ * out of the account they are holding.
+ *
+ * None of this is enforced on the device — a client that counted its own
+ * devices is a client somebody could edit, the same mistake as trusting a row
+ * to say who it belongs to (see `readEntitlement`). The numbers are decided by
+ * `baaki_register_device` in the database; this module is the shared vocabulary
+ * both sides speak, and the part worth testing without a phone.
+ */
+
+import type { PlanTier } from '../billing/plans';
+
+/** Two at a time on the house. */
+export const FREE_DEVICE_LIMIT = 2;
+/** Paid is not "unlimited" — an account signed in on ten phones is a shared
+ *  password, not a subscriber — but it is generous enough never to nag. */
+export const PLUS_DEVICE_LIMIT = 10;
+/** A device silent longer than this has given its slot back. */
+export const DEVICE_ACTIVE_WINDOW_DAYS = 14;
+/** The devices view looks back a quarter and no further (the request was three
+ *  months); older rows are history nobody is going to act on. */
+export const DEVICE_HISTORY_DAYS = 90;
+
+const DAY_MS = 86_400_000;
+
+/**
+ * One registered phone. Timestamps are ISO strings because that is what crosses
+ * the wire and what SQLite stores; comparisons parse them rather than trusting
+ * their order as text.
+ */
+export interface DeviceSession {
+  readonly deviceId: string;
+  readonly label: string;
+  readonly platform: string;
+  readonly appVersion: string | null;
+  readonly createdAt: string;
+  readonly lastSeenAt: string;
+  /** Set when this device was signed out from elsewhere; null while it lives. */
+  readonly revokedAt: string | null;
+  /** True for the phone doing the asking. Decided by device id, not the server. */
+  readonly current?: boolean;
+}
+
+export function deviceLimitFor(tier: PlanTier): number {
+  return tier === 'plus' ? PLUS_DEVICE_LIMIT : FREE_DEVICE_LIMIT;
+}
+
+/**
+ * Whether a device still counts toward the cap: not revoked, and seen inside
+ * the window. A revoked device is out the moment it is revoked, whatever its
+ * last-seen says — signing it out is a decision, not a timeout.
+ */
+export function isDeviceActive(
+  session: DeviceSession,
+  now: number,
+  windowDays: number = DEVICE_ACTIVE_WINDOW_DAYS,
+): boolean {
+  if (session.revokedAt) return false;
+  const seen = Date.parse(session.lastSeenAt);
+  if (!Number.isFinite(seen)) return false;
+  return now - seen <= windowDays * DAY_MS;
+}
+
+/**
+ * The active devices, one per device id. Rows can repeat a device id — the same
+ * phone re-registering keeps the same id — so the most recently seen row wins,
+ * and the cap is counted in phones, not rows.
+ */
+export function activeDevices(
+  sessions: readonly DeviceSession[],
+  now: number,
+  windowDays: number = DEVICE_ACTIVE_WINDOW_DAYS,
+): DeviceSession[] {
+  const byDevice = new Map<string, DeviceSession>();
+  for (const session of sessions) {
+    if (!isDeviceActive(session, now, windowDays)) continue;
+    const held = byDevice.get(session.deviceId);
+    if (!held || Date.parse(session.lastSeenAt) > Date.parse(held.lastSeenAt)) {
+      byDevice.set(session.deviceId, session);
+    }
+  }
+  return [...byDevice.values()];
+}
+
+export interface DeviceLimitStatus {
+  readonly limit: number;
+  readonly activeCount: number;
+  /** True when this account is holding more phones than its tier allows. */
+  readonly overLimit: boolean;
+}
+
+/**
+ * The count the gate reads. `overLimit` is strictly greater than the limit: a
+ * free account is allowed to be *at* two, and only the phone that makes it three
+ * is over.
+ */
+export function deviceLimitStatus(
+  sessions: readonly DeviceSession[],
+  tier: PlanTier,
+  now: number,
+  windowDays: number = DEVICE_ACTIVE_WINDOW_DAYS,
+): DeviceLimitStatus {
+  const limit = deviceLimitFor(tier);
+  const activeCount = activeDevices(sessions, now, windowDays).length;
+  return { limit, activeCount, overLimit: activeCount > limit };
+}
+
+/**
+ * What the devices activity view shows: everything seen in the last quarter,
+ * newest first, revoked ones included — being told a device *was* signed out is
+ * the point of the list, not noise to filter from it.
+ */
+export function recentDevices(
+  sessions: readonly DeviceSession[],
+  now: number,
+  historyDays: number = DEVICE_HISTORY_DAYS,
+): DeviceSession[] {
+  const cutoff = now - historyDays * DAY_MS;
+  return sessions
+    .filter((session) => {
+      const seen = Date.parse(session.lastSeenAt);
+      return Number.isFinite(seen) && seen >= cutoff;
+    })
+    .slice()
+    .sort((a, b) => Date.parse(b.lastSeenAt) - Date.parse(a.lastSeenAt));
+}

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -1,0 +1,1 @@
+export * from './devices';

--- a/packages/core/test/devices.test.ts
+++ b/packages/core/test/devices.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The two-devices rule, and what "at a time" is allowed to mean.
+ *
+ * The interesting cases are all about time and identity: a phone that went
+ * quiet frees its slot, the same phone re-registering is still one phone, and a
+ * device signed out from elsewhere is out now rather than in fourteen days.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEVICE_ACTIVE_WINDOW_DAYS,
+  activeDevices,
+  deviceLimitFor,
+  deviceLimitStatus,
+  isDeviceActive,
+  recentDevices,
+  type DeviceSession,
+} from '../src/session/devices';
+
+const NOW = Date.parse('2026-08-09T12:00:00.000Z');
+const DAY = 86_400_000;
+const daysAgo = (n: number) => new Date(NOW - n * DAY).toISOString();
+
+function device(over: Partial<DeviceSession> = {}): DeviceSession {
+  return {
+    deviceId: over.deviceId ?? 'd1',
+    label: over.label ?? 'Pixel 8',
+    platform: over.platform ?? 'android',
+    appVersion: over.appVersion ?? '1.0.0',
+    createdAt: over.createdAt ?? daysAgo(1),
+    lastSeenAt: over.lastSeenAt ?? daysAgo(0),
+    revokedAt: over.revokedAt ?? null,
+    ...over,
+  };
+}
+
+describe('deviceLimitFor', () => {
+  it('gives free two and plus more', () => {
+    expect(deviceLimitFor('free')).toBe(2);
+    expect(deviceLimitFor('plus')).toBeGreaterThan(2);
+  });
+});
+
+describe('isDeviceActive', () => {
+  it('counts a device seen inside the window', () => {
+    expect(isDeviceActive(device({ lastSeenAt: daysAgo(13) }), NOW)).toBe(true);
+  });
+
+  it('counts one seen exactly on the boundary', () => {
+    expect(isDeviceActive(device({ lastSeenAt: daysAgo(DEVICE_ACTIVE_WINDOW_DAYS) }), NOW)).toBe(
+      true,
+    );
+  });
+
+  it('drops one a minute past the window', () => {
+    const past = new Date(NOW - DEVICE_ACTIVE_WINDOW_DAYS * DAY - 60_000).toISOString();
+    expect(isDeviceActive(device({ lastSeenAt: past }), NOW)).toBe(false);
+  });
+
+  it('drops a revoked device however recently it was seen', () => {
+    expect(isDeviceActive(device({ lastSeenAt: daysAgo(0), revokedAt: daysAgo(0) }), NOW)).toBe(
+      false,
+    );
+  });
+});
+
+describe('activeDevices', () => {
+  it('counts phones, not rows: the same device id is one device', () => {
+    const rows = [
+      device({ deviceId: 'a', lastSeenAt: daysAgo(2) }),
+      device({ deviceId: 'a', lastSeenAt: daysAgo(0) }),
+      device({ deviceId: 'b', lastSeenAt: daysAgo(1) }),
+    ];
+    const active = activeDevices(rows, NOW);
+    expect(active).toHaveLength(2);
+    // The winning row for 'a' is the most recently seen one.
+    expect(active.find((d) => d.deviceId === 'a')?.lastSeenAt).toBe(daysAgo(0));
+  });
+
+  it('excludes the silent and the revoked', () => {
+    const rows = [
+      device({ deviceId: 'a', lastSeenAt: daysAgo(0) }),
+      device({ deviceId: 'b', lastSeenAt: daysAgo(40) }),
+      device({ deviceId: 'c', lastSeenAt: daysAgo(0), revokedAt: daysAgo(0) }),
+    ];
+    expect(activeDevices(rows, NOW).map((d) => d.deviceId)).toEqual(['a']);
+  });
+});
+
+describe('deviceLimitStatus', () => {
+  it('lets a free account sit at exactly two', () => {
+    const rows = [
+      device({ deviceId: 'a' }),
+      device({ deviceId: 'b' }),
+    ];
+    const status = deviceLimitStatus(rows, 'free', NOW);
+    expect(status).toEqual({ limit: 2, activeCount: 2, overLimit: false });
+  });
+
+  it('flags the third phone as over the line', () => {
+    const rows = [
+      device({ deviceId: 'a' }),
+      device({ deviceId: 'b' }),
+      device({ deviceId: 'c' }),
+    ];
+    expect(deviceLimitStatus(rows, 'free', NOW).overLimit).toBe(true);
+  });
+
+  it('does not flag three phones on plus', () => {
+    const rows = [
+      device({ deviceId: 'a' }),
+      device({ deviceId: 'b' }),
+      device({ deviceId: 'c' }),
+    ];
+    expect(deviceLimitStatus(rows, 'plus', NOW).overLimit).toBe(false);
+  });
+
+  it('a freed slot brings a would-be-third back under the limit', () => {
+    const rows = [
+      device({ deviceId: 'a', lastSeenAt: daysAgo(0) }),
+      device({ deviceId: 'b', lastSeenAt: daysAgo(40) }), // silent: slot freed
+      device({ deviceId: 'c', lastSeenAt: daysAgo(0) }),
+    ];
+    expect(deviceLimitStatus(rows, 'free', NOW).overLimit).toBe(false);
+  });
+});
+
+describe('recentDevices', () => {
+  it('keeps the last three months, newest first, revoked included', () => {
+    const rows = [
+      device({ deviceId: 'old', lastSeenAt: daysAgo(120) }), // dropped: older than 90d
+      device({ deviceId: 'mid', lastSeenAt: daysAgo(40) }),
+      device({ deviceId: 'new', lastSeenAt: daysAgo(1) }),
+      device({ deviceId: 'gone', lastSeenAt: daysAgo(3), revokedAt: daysAgo(2) }),
+    ];
+    expect(recentDevices(rows, NOW).map((d) => d.deviceId)).toEqual(['new', 'gone', 'mid']);
+  });
+
+  it('has nothing to say about no devices', () => {
+    expect(recentDevices([], NOW)).toEqual([]);
+  });
+});

--- a/packages/core/test/devices.test.ts
+++ b/packages/core/test/devices.test.ts
@@ -90,29 +90,18 @@ describe('activeDevices', () => {
 
 describe('deviceLimitStatus', () => {
   it('lets a free account sit at exactly two', () => {
-    const rows = [
-      device({ deviceId: 'a' }),
-      device({ deviceId: 'b' }),
-    ];
+    const rows = [device({ deviceId: 'a' }), device({ deviceId: 'b' })];
     const status = deviceLimitStatus(rows, 'free', NOW);
     expect(status).toEqual({ limit: 2, activeCount: 2, overLimit: false });
   });
 
   it('flags the third phone as over the line', () => {
-    const rows = [
-      device({ deviceId: 'a' }),
-      device({ deviceId: 'b' }),
-      device({ deviceId: 'c' }),
-    ];
+    const rows = [device({ deviceId: 'a' }), device({ deviceId: 'b' }), device({ deviceId: 'c' })];
     expect(deviceLimitStatus(rows, 'free', NOW).overLimit).toBe(true);
   });
 
   it('does not flag three phones on plus', () => {
-    const rows = [
-      device({ deviceId: 'a' }),
-      device({ deviceId: 'b' }),
-      device({ deviceId: 'c' }),
-    ];
+    const rows = [device({ deviceId: 'a' }), device({ deviceId: 'b' }), device({ deviceId: 'c' })];
     expect(deviceLimitStatus(rows, 'plus', NOW).overLimit).toBe(false);
   });
 

--- a/packages/db/prisma/migrations/20260809120000_device_sessions/migration.sql
+++ b/packages/db/prisma/migrations/20260809120000_device_sessions/migration.sql
@@ -1,0 +1,192 @@
+-- Device sessions and the free-tier two-device cap.
+--
+-- GoTrue tracks refresh tokens but nothing a person would recognise as "my
+-- phones": no label, no last-seen, and nothing the client may read. This table
+-- is that missing thing — one row per (account, device) — written only through
+-- the SECURITY DEFINER functions below so the client can register and read its
+-- own devices but never forge somebody else's or lift its own cap.
+--
+-- The cap itself is soft on purpose (see baaki_register_device): the database
+-- reports "over the line", the app asks the person to sign the others out, and
+-- nothing here can ever leave an account locked out of its own data.
+
+CREATE TABLE public.device_sessions (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id  uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  -- A stable id the app keeps in the device keystore, so a token refresh does
+  -- not look like a new phone. One row per (profile, device).
+  device_id   text        NOT NULL,
+  label       text        NOT NULL DEFAULT 'This device',
+  platform    text        NOT NULL DEFAULT 'unknown',
+  app_version text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  -- Set when this device is signed out from another one. It stays in the table
+  -- so the activity view can say "signed out" rather than simply forgetting it.
+  revoked_at  timestamptz,
+  CONSTRAINT device_sessions_one_per_device UNIQUE (profile_id, device_id)
+);
+
+CREATE INDEX device_sessions_profile_seen_idx
+  ON public.device_sessions (profile_id, last_seen_at DESC);
+
+-- Row-level security: a person may read their own devices and nothing else.
+-- Every write goes through the definer functions, so no direct-write grant.
+ALTER TABLE public.device_sessions ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.device_sessions FROM anon, authenticated;
+GRANT SELECT ON public.device_sessions TO authenticated;
+
+CREATE POLICY device_sessions_own_read ON public.device_sessions
+  FOR SELECT TO authenticated
+  USING (profile_id = public.baaki_current_profile_id());
+
+-- ─────────────────────────────────────────────────────────── registering ──
+
+/**
+ * Register (or refresh) the calling device, and report where the account stands
+ * against its cap.
+ *
+ * Upsert rather than insert: the same phone opening the app again is a
+ * last-seen bump, not a new device, and re-registering a phone that had been
+ * signed out elsewhere brings it back (revoked_at cleared) — signing in again
+ * is exactly how you undo a remote sign-out.
+ *
+ * The tier and the counting are decided here, never by the caller. "Active"
+ * means not revoked and seen in the last 14 days, counted per device_id, so a
+ * phone left in a drawer stops holding a slot on its own. The answer is a
+ * report, not a verdict: this function never refuses. A free account already
+ * holding two other live phones is told overLimit=true and the app takes it
+ * from there.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_register_device(
+  p_device_id   text,
+  p_label       text DEFAULT 'This device',
+  p_platform    text DEFAULT 'unknown',
+  p_app_version text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+  v_tier    text := public.baaki_my_plan() ->> 'tier';
+  v_limit   int;
+  v_active  int;
+BEGIN
+  IF v_profile IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN: only a signed-in account has devices'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_device_id IS NULL OR length(trim(p_device_id)) = 0 THEN
+    RAISE EXCEPTION 'BAD_DEVICE_ID: a device id is required'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  INSERT INTO public.device_sessions
+    (profile_id, device_id, label, platform, app_version, last_seen_at, revoked_at)
+  VALUES
+    (v_profile, p_device_id, COALESCE(NULLIF(trim(p_label), ''), 'This device'),
+     COALESCE(NULLIF(trim(p_platform), ''), 'unknown'), p_app_version, now(), NULL)
+  ON CONFLICT (profile_id, device_id) DO UPDATE
+    SET label        = EXCLUDED.label,
+        platform     = EXCLUDED.platform,
+        app_version  = EXCLUDED.app_version,
+        last_seen_at = now(),
+        revoked_at   = NULL;
+
+  v_limit := CASE WHEN v_tier = 'plus' THEN 10 ELSE 2 END;
+
+  SELECT count(*) INTO v_active
+  FROM public.device_sessions
+  WHERE profile_id = v_profile
+    AND revoked_at IS NULL
+    AND last_seen_at > now() - interval '14 days';
+
+  RETURN jsonb_build_object(
+    'tier', v_tier,
+    'limit', v_limit,
+    'activeCount', v_active,
+    'overLimit', v_active > v_limit
+  );
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_register_device(text, text, text, text) TO authenticated;
+
+-- ───────────────────────────────────────────────────────────── listing ──
+
+/**
+ * The devices activity view: the caller's phones seen in the last three months,
+ * newest first, revoked ones included. Older than that is history nobody is
+ * going to act on, and the request was explicit about three months.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_list_devices()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'deviceId', device_id,
+        'label', label,
+        'platform', platform,
+        'appVersion', app_version,
+        'createdAt', created_at,
+        'lastSeenAt', last_seen_at,
+        'revokedAt', revoked_at
+      )
+      ORDER BY last_seen_at DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM public.device_sessions
+  WHERE profile_id = public.baaki_current_profile_id()
+    AND last_seen_at > now() - interval '90 days';
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_list_devices() TO authenticated;
+
+-- ────────────────────────────────────────────── signing the others out ──
+
+/**
+ * Mark every other device of the caller's revoked, and say how many.
+ *
+ * This is the bookkeeping half: the actual token revocation is the client
+ * calling GoTrue's signOut({ scope: 'others' }), which cannot itself write this
+ * table. Doing both keeps the activity view honest — the phones it now shows as
+ * signed out are the same ones whose sessions were just torn down.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_sign_out_other_devices(p_device_id text)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+  v_count   int;
+BEGIN
+  IF v_profile IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN: only a signed-in account has devices'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  UPDATE public.device_sessions
+  SET revoked_at = now()
+  WHERE profile_id = v_profile
+    AND device_id <> p_device_id
+    AND revoked_at IS NULL;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_sign_out_other_devices(text) TO authenticated;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -159,6 +159,7 @@ model Profile {
   purchasedPasses   GroupPass[]
   syncMutations     SyncMutation[]
   memberClaims      MemberClaim[]
+  deviceSessions    DeviceSession[]
 
   @@map("profiles")
   @@schema("public")
@@ -970,6 +971,30 @@ model Subscription {
 
   @@index([profileId, status], map: "subscriptions_profile_idx")
   @@map("subscriptions")
+  @@schema("public")
+}
+
+/// One phone signed into one account. GoTrue tracks refresh tokens; this tracks
+/// the thing a person recognises — a labelled device with a last-seen — and is
+/// what the free-tier two-device cap counts. Written only by
+/// `baaki_register_device` / `baaki_sign_out_other_devices`; the client reads
+/// its own rows and never writes them.
+model DeviceSession {
+  id         String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  profileId  String    @map("profile_id") @db.Uuid
+  deviceId   String    @map("device_id")
+  label      String    @default("This device")
+  platform   String    @default("unknown")
+  appVersion String?   @map("app_version")
+  createdAt  DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  lastSeenAt DateTime  @default(now()) @map("last_seen_at") @db.Timestamptz(6)
+  revokedAt  DateTime? @map("revoked_at") @db.Timestamptz(6)
+
+  profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  @@unique([profileId, deviceId], map: "device_sessions_one_per_device")
+  @@index([profileId, lastSeenAt(sort: Desc)], map: "device_sessions_profile_seen_idx")
+  @@map("device_sessions")
   @@schema("public")
 }
 


### PR DESCRIPTION
Requested: free users limited to two simultaneous devices; notify when over; a settings option to log out all other devices from the current one; a devices activity view scoped to the last three months.

## Decisions (confirmed)
- **Soft gate.** A 3rd device signs in, then a full-screen sheet asks the account to log the others out. GoTrue can't cleanly abort a login mid-flight, and a hard block can lock someone out of their own data if a stale device still counts as active.
- **14-day active window.** A phone not opened in two weeks frees its slot on its own, so "simultaneous" doesn't punish a closed phone.

## Server — the device never counts itself
- `device_sessions` table: one row per (account, device), RLS **own-read only**, all writes via `SECURITY DEFINER`.
- `baaki_register_device` — upserts this phone, returns `{ tier, limit, activeCount, overLimit }`. Active = not revoked and seen ≤14 days, counted per `device_id`.
- `baaki_list_devices` — the caller's phones from the last **90 days**, newest first (revoked included, so the list can say "signed out").
- `baaki_sign_out_other_devices` — marks the rest revoked; the client pairs it with `supabase.auth.signOut({ scope: 'others' })`, which tears down the actual sessions.

## Core (`@baaki/core/session`)
The shared vocabulary — limits per tier, the active window, over-limit detection, the three-month view — **property-tested without a device (13 tests)**: the boundary of the window, the same phone re-registering counting once, a revoked device out immediately, a freed slot bringing a would-be-third back under.

## Mobile
- Stable device id in the keystore (SecureStore / AsyncStorage), so a token refresh isn't a new phone.
- `DeviceSessionProvider` (mounted past the lock): registers on sign-in, heartbeats on foreground, renders the over-limit gate.
- **Settings → Devices**: the activity list, this device marked, one **Log out all other devices** button.
- Strings in **en / ta / hi / ar**.

## Verification
- Migration applies on top of **every** prior migration on a fresh Postgres; **drift clean** (`migrate diff` → no difference).
- RPCs exercised through all paths on local pg: 1st/2nd `overLimit:false`, 3rd `overLimit:true`, `sign_out_others` revokes the other two and frees the slots, re-register `overLimit:false`.
- `@baaki/core` **486** green, mobile **156** green, typecheck + lint clean.

## Follow-ups
- **Not in the TDR** — built on request; the spec needs amending.
- The mobile provider + gate **have not been run on a device yet** (no device test harness in this repo; logic that could be is in core).
- The migration must be **deployed to prod** (same manual pipeline as the rate-limit one) before the feature is live there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)