### PR TITLE
feat(people): fall back to a Gravatar when a contact has no photo

### DIFF
--- a/packages/db/prisma/migrations/20260809130000_contact_gravatar/migration.sql
+++ b/packages/db/prisma/migrations/20260809130000_contact_gravatar/migration.sql
@@ -1,0 +1,100 @@
+-- A contact's photo from a public source, when we have an email to ask with.
+--
+-- Gravatar maps an email to whatever picture its owner has set publicly. We
+-- never send the address itself — only its hash, which is what Gravatar's URL
+-- scheme is — and only for an address the caller already holds (the one they
+-- invited this person at). `d=404` means "no picture, no placeholder": Gravatar
+-- returns a 404 rather than a generic silhouette, so the client's avatar falls
+-- back to its own initials instead of a stranger's grey head.
+--
+-- This fills `avatar_url` where a person has no profile photo of their own, so
+-- it flows to every people-list the app already renders without a client
+-- change. A joined member's own email lives in the auth schema this INVOKER
+-- function cannot read, so the fallback is the invite email — exactly the
+-- "somebody I added by email" case.
+
+CREATE OR REPLACE FUNCTION public.baaki_gravatar_url(p_email text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+  SELECT CASE
+    WHEN p_email IS NULL OR btrim(p_email) = '' THEN NULL
+    ELSE 'https://www.gravatar.com/avatar/' || md5(lower(btrim(p_email))) || '?d=404&s=200'
+  END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_gravatar_url(text) TO authenticated, anon;
+
+-- Replace the people list to fall back to a Gravatar when the counterparty has
+-- no profile picture. Only the `avatar_url` expression changes; everything else
+-- is the function as it stood.
+CREATE OR REPLACE FUNCTION public.baaki_people_i_owe()
+RETURNS TABLE (
+  person_key      text,
+  profile_id      uuid,
+  member_id       uuid,
+  display_name    text,
+  avatar_url      text,
+  is_ghost        boolean,
+  currency        char(3),
+  net             bigint,
+  group_count     int,
+  only_group_id   uuid
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+  WITH me AS (
+    SELECT gm.id AS member_id, gm.group_id
+      FROM public.group_members gm
+     WHERE gm.profile_id = public.baaki_current_profile_id()
+       AND gm.left_at IS NULL
+  ),
+  edges AS (
+    SELECT pb.group_id, pb.to_member_id AS other_member_id, pb.currency, -pb.amount AS net
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.from_member_id
+    UNION ALL
+    SELECT pb.group_id, pb.from_member_id, pb.currency, pb.amount
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.to_member_id
+  ),
+  named AS (
+    SELECT
+      e.group_id,
+      e.currency,
+      e.net,
+      gm.id            AS member_id,
+      gm.profile_id,
+      COALESCE(gm.profile_id::text, gm.id::text) AS person_key,
+      COALESCE(p.display_name, gm.ghost_name, 'Someone') AS display_name,
+      -- The one change: a person's own photo, else one from the email we have.
+      COALESCE(p.avatar_url, public.baaki_gravatar_url(gm.invite_email)) AS avatar_url,
+      gm.profile_id IS NULL AS is_ghost
+    FROM edges e
+    JOIN public.group_members gm ON gm.id = e.other_member_id
+    LEFT JOIN public.profiles p ON p.id = gm.profile_id
+  )
+  SELECT
+    n.person_key,
+    max(n.profile_id::text)::uuid                       AS profile_id,
+    max(n.member_id::text)::uuid                        AS member_id,
+    max(n.display_name)                                 AS display_name,
+    max(n.avatar_url)                                   AS avatar_url,
+    bool_and(n.is_ghost)                                AS is_ghost,
+    n.currency,
+    sum(n.net)::bigint                                  AS net,
+    count(DISTINCT n.group_id)::int                     AS group_count,
+    CASE WHEN count(DISTINCT n.group_id) = 1
+         THEN max(n.group_id::text)::uuid END           AS only_group_id
+  FROM named n
+  GROUP BY n.person_key, n.currency
+  HAVING sum(n.net) <> 0
+  ORDER BY abs(sum(n.net)) DESC, max(n.display_name);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_people_i_owe() TO authenticated, anon;


### PR DESCRIPTION
Requested: if a contact has a linked email, try to show their profile photo from a public source.

## Approach — server-side, where the emails live
The public source is **Gravatar** (email → hash → their public picture). The client rows carry no email (`PersonBalanceRow` has only `avatar_url`; a joined user's email is in the `auth` schema), so the natural place is the people RPC, which already has `group_members.invite_email` in scope.

- `baaki_gravatar_url(email)` — `IMMUTABLE`, builds `…/avatar/<md5(lower(trim(email)))>?d=404&s=200`. Only the **hash** leaves the server, and `d=404` means "no picture" returns nothing so the client avatar keeps its initials.
- `baaki_people_i_owe` — one line changes: `COALESCE(p.avatar_url, baaki_gravatar_url(gm.invite_email))`. Everything else is the function as it stood.

**No client change.** Every people list already renders `avatar_url` and already falls back to initials on a failed image load, so the photo just appears.

## Scope
- Covers people invited by email (the "in contacts / added by email" case).
- A joined member's own email is in `auth`, unreadable by this `SECURITY INVOKER` function, so they still rely on the profile photo they set — unchanged.
- Group-member lists read avatars from the local mirror; extending the same fallback there is a small follow-up (either the sync projection or a client compute from `invite_email`) if you want photos there too.

## Verification (local Postgres)
- `baaki_gravatar_url('  Someone@Example.com ')` → normalised md5 URL; `NULL`/`''` → `NULL`.
- `baaki_people_i_owe()` still compiles and runs.
- `prisma migrate deploy` clean on a fresh DB with every migration; **drift: no difference**.

## Follow-up
Server-only; the migration needs deploying to prod (same manual pipeline as the device-cap and rate-limit ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)