### PR TITLE
feat(admin): browsable signup directory with filters + pagination

### DIFF
--- a/apps/admin/src/app/users/page.tsx
+++ b/apps/admin/src/app/users/page.tsx
@@ -1,9 +1,11 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { confirmUserEmail, searchUsers, upgradeUser, type AdminUserRow } from '@/lib/data';
+import { confirmUserEmail, listUsers, upgradeUser, type AdminUserListRow } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
+
+const PAGE = 25;
 
 function when(iso: string | null): string {
   if (!iso) return '—';
@@ -14,42 +16,75 @@ function when(iso: string | null): string {
   });
 }
 
+function kind(u: AdminUserListRow): { label: string; cls: string } {
+  if (u.is_anonymous) return { label: 'guest', cls: 'tag' };
+  if (u.is_plus) return { label: 'plus', cls: 'tag tag-deletion' };
+  return { label: 'free', cls: 'tag tag-idea' };
+}
+
+/** Carry the current filter + page through an action's redirect. */
+function backTo(name: string, country: string, offset: number): string {
+  const p = new URLSearchParams();
+  if (name) p.set('name', name);
+  if (country) p.set('country', country);
+  if (offset) p.set('offset', String(offset));
+  const qs = p.toString();
+  return qs ? `/users?${qs}` : '/users';
+}
+
 export default async function Users({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; error?: string; done?: string }>;
+  searchParams: Promise<{
+    name?: string;
+    country?: string;
+    offset?: string;
+    error?: string;
+    done?: string;
+  }>;
 }) {
-  const { q, error, done } = await searchParams;
-  const query = (q ?? '').trim();
-  const results: AdminUserRow[] = query ? await searchUsers(query) : [];
+  const sp = await searchParams;
+  const name = (sp.name ?? '').trim();
+  const country = (sp.country ?? '').trim();
+  const offset = Math.max(0, Number(sp.offset ?? 0) || 0);
 
-  async function search(formData: FormData) {
+  const { total, rows } = await listUsers({ limit: PAGE, offset, namePrefix: name, country });
+  const back = backTo(name, country, offset);
+
+  async function filter(formData: FormData) {
     'use server';
-    const next = String(formData.get('q') ?? '').trim();
-    redirect(next ? `/users?q=${encodeURIComponent(next)}` : '/users');
+    const p = new URLSearchParams();
+    const n = String(formData.get('name') ?? '').trim();
+    const c = String(formData.get('country') ?? '')
+      .trim()
+      .toUpperCase();
+    if (n) p.set('name', n);
+    if (c) p.set('country', c);
+    const qs = p.toString();
+    redirect(qs ? `/users?${qs}` : '/users');
   }
 
   async function confirm(formData: FormData) {
     'use server';
     const id = String(formData.get('id') ?? '');
-    const back = String(formData.get('q') ?? '');
+    const to = String(formData.get('back') ?? '/users');
     let failure: string | null = null;
     try {
       await confirmUserEmail(id);
     } catch (caught) {
       failure = caught instanceof Error ? caught.message : String(caught);
     }
-    const base = `/users?q=${encodeURIComponent(back)}`;
-    if (failure) redirect(`${base}&error=${encodeURIComponent(failure)}`);
+    const sep = to.includes('?') ? '&' : '?';
+    if (failure) redirect(`${to}${sep}error=${encodeURIComponent(failure)}`);
     revalidatePath('/users');
-    redirect(`${base}&done=${encodeURIComponent('Email confirmed.')}`);
+    redirect(`${to}${sep}done=${encodeURIComponent('Email confirmed.')}`);
   }
 
   async function upgrade(formData: FormData) {
     'use server';
     const id = String(formData.get('id') ?? '');
     const days = Number(formData.get('days') ?? 365);
-    const back = String(formData.get('q') ?? '');
+    const to = String(formData.get('back') ?? '/users');
     let message: string | null = null;
     let failure: string | null = null;
     try {
@@ -57,71 +92,160 @@ export default async function Users({
     } catch (caught) {
       failure = caught instanceof Error ? caught.message : String(caught);
     }
-    const base = `/users?q=${encodeURIComponent(back)}`;
-    if (failure) redirect(`${base}&error=${encodeURIComponent(failure)}`);
+    const sep = to.includes('?') ? '&' : '?';
+    if (failure) redirect(`${to}${sep}error=${encodeURIComponent(failure)}`);
     revalidatePath('/users');
-    redirect(`${base}&done=${encodeURIComponent(message ?? 'Upgraded.')}`);
+    redirect(`${to}${sep}done=${encodeURIComponent(message ?? 'Upgraded.')}`);
   }
+
+  const from = total === 0 ? 0 : offset + 1;
+  const to = Math.min(offset + PAGE, total);
 
   return (
     <main>
       <header className="top">
-        <h1>Users</h1>{' '}
+        <h1>Users</h1>
+        <p className="faint">{total.toLocaleString('en-IN')} signups</p>
       </header>
 
-      {error ? <p className="error">{error}</p> : null}
-      {done ? <p className="faint">{done}</p> : null}
+      {sp.error ? <p className="error">{sp.error}</p> : null}
+      {sp.done ? <p className="faint">{sp.done}</p> : null}
 
       <section>
-        <form action={search} className="flag">
+        <form action={filter} className="flag">
           <label>
-            <span>Search by email, phone or id</span>
-            <input type="text" name="q" defaultValue={query} placeholder="asha@example.com" />
+            <span>Name or email starts with</span>
+            <input type="text" name="name" defaultValue={name} placeholder="asha" />
           </label>
-          <button type="submit">Search</button>
+          <label>
+            <span>Country</span>
+            <input
+              type="text"
+              name="country"
+              defaultValue={country}
+              placeholder="IN"
+              maxLength={2}
+            />
+          </label>
+          <button type="submit">Filter</button>
+          {name || country ? (
+            <a className="faint" href="/users" style={{ alignSelf: 'center' }}>
+              Clear
+            </a>
+          ) : null}
         </form>
         <p className="note">
-          There is no server-side search in the auth directory, so this walks the first pages and
-          matches here — enough for support, not a report. Names come from <code>profiles</code>.
+          Sorted newest first. Type, devices and app version come from the account, its subscription
+          and the devices it has registered — device columns fill in once the device-session feature
+          is live on this project.
         </p>
       </section>
 
-      {query && results.length === 0 ? (
-        <p className="note">Nobody matched &ldquo;{query}&rdquo;.</p>
-      ) : null}
+      <section className="scroll" style={{ marginTop: 12 }}>
+        {rows.length === 0 ? (
+          <p className="note">No signups match this filter.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>User</th>
+                <th>Type</th>
+                <th>Country</th>
+                <th>Devices</th>
+                <th>App</th>
+                <th>Joined</th>
+                <th>Last seen</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((u) => {
+                const k = kind(u);
+                return (
+                  <tr key={u.id}>
+                    <td style={{ textAlign: 'left', maxWidth: 260 }}>
+                      <div style={{ fontWeight: 600 }}>{u.display_name ?? '—'}</div>
+                      <div className="faint" style={{ fontSize: 12 }}>
+                        {u.email ?? u.phone ?? '(no contact)'}
+                        {u.email && !u.email_confirmed ? ' · unconfirmed' : ''}
+                      </div>
+                    </td>
+                    <td>
+                      <span className={k.cls}>{k.label}</span>
+                    </td>
+                    <td>{u.country_code ?? <span className="muted">—</span>}</td>
+                    <td>
+                      {u.device_count > 0 ? u.device_count : <span className="muted">0</span>}
+                    </td>
+                    <td>
+                      {u.app_version ? (
+                        <span>
+                          {u.app_version}
+                          {u.platform ? <span className="faint"> · {u.platform}</span> : null}
+                        </span>
+                      ) : (
+                        <span className="muted">—</span>
+                      )}
+                    </td>
+                    <td>{when(u.created_at)}</td>
+                    <td>{when(u.last_sign_in_at)}</td>
+                    <td>
+                      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                        {u.email_confirmed || !u.email ? null : (
+                          <form action={confirm}>
+                            <input type="hidden" name="id" value={u.id} />
+                            <input type="hidden" name="back" value={back} />
+                            <button type="submit" title="Confirm this email by hand">
+                              Confirm
+                            </button>
+                          </form>
+                        )}
+                        <form
+                          action={upgrade}
+                          style={{ display: 'flex', gap: 4, alignItems: 'center' }}
+                        >
+                          <input type="hidden" name="id" value={u.id} />
+                          <input type="hidden" name="back" value={back} />
+                          <input
+                            type="number"
+                            name="days"
+                            min={1}
+                            max={3650}
+                            defaultValue={365}
+                            aria-label="Days"
+                            style={{ width: 64 }}
+                          />
+                          <button type="submit" title="Comp a paid grant">
+                            Upgrade
+                          </button>
+                        </form>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </section>
 
-      {results.map((u) => (
-        <section key={u.id}>
-          <h2 style={{ marginBottom: 4 }}>{u.display_name ?? u.email ?? u.id}</h2>
-          <p className="faint" style={{ marginTop: 0 }}>
-            {u.email ?? u.phone ?? '(no contact)'} · {u.is_anonymous ? 'guest' : 'account'} ·{' '}
-            {u.email_confirmed ? 'email confirmed' : 'email NOT confirmed'} · joined{' '}
-            {when(u.created_at)}
-          </p>
-          <p className="faint" style={{ marginTop: 0, fontSize: 12 }}>
-            <code>{u.id}</code>
-          </p>
-
-          <div className="scroll" style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
-            {u.email_confirmed ? null : (
-              <form action={confirm} className="flag">
-                <input type="hidden" name="id" value={u.id} />
-                <input type="hidden" name="q" value={query} />
-                <button type="submit">Confirm email</button>
-              </form>
-            )}
-            <form action={upgrade} className="flag">
-              <input type="hidden" name="id" value={u.id} />
-              <input type="hidden" name="q" value={query} />
-              <label>
-                <span>Upgrade — days</span>
-                <input type="number" name="days" min={1} max={3650} defaultValue={365} />
-              </label>
-              <button type="submit">Upgrade to paid</button>
-            </form>
-          </div>
-        </section>
-      ))}
+      <div className="row" style={{ justifyContent: 'space-between', marginTop: 14 }}>
+        <span className="faint">
+          {from}–{to} of {total.toLocaleString('en-IN')}
+        </span>
+        <span className="row" style={{ gap: 8 }}>
+          {offset > 0 ? (
+            <a href={backTo(name, country, Math.max(0, offset - PAGE))}>← Previous</a>
+          ) : (
+            <span className="muted">← Previous</span>
+          )}
+          {offset + PAGE < total ? (
+            <a href={backTo(name, country, offset + PAGE)}>Next →</a>
+          ) : (
+            <span className="muted">Next →</span>
+          )}
+        </span>
+      </div>
     </main>
   );
 }

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -540,6 +540,58 @@ export async function searchUsers(query: string): Promise<AdminUserRow[]> {
   return matches;
 }
 
+export interface AdminUserListRow {
+  id: string;
+  email: string | null;
+  phone: string | null;
+  email_confirmed: boolean;
+  is_anonymous: boolean;
+  created_at: string;
+  last_sign_in_at: string | null;
+  display_name: string | null;
+  country_code: string | null;
+  is_plus: boolean;
+  device_count: number;
+  app_version: string | null;
+  platform: string | null;
+}
+
+export interface AdminUserList {
+  total: number;
+  rows: AdminUserListRow[];
+}
+
+/**
+ * A page of the signup directory, filtered and sorted in SQL.
+ *
+ * Unlike `searchUsers`, which walks the GoTrue directory in Node because that
+ * is all the admin API offers, this goes through `baaki_admin_users` — a
+ * SECURITY DEFINER function that can read `auth.users` and join it to profiles,
+ * subscriptions and device_sessions in one query. That is what lets it filter
+ * by name or country and return a real total for pagination. A missing function
+ * (first run before the migration is deployed) degrades to an empty page.
+ */
+export async function listUsers(params: {
+  limit: number;
+  offset: number;
+  namePrefix?: string;
+  country?: string;
+}): Promise<AdminUserList> {
+  await requireSession();
+  const { data, error } = await client().rpc('baaki_admin_users', {
+    p_limit: params.limit,
+    p_offset: params.offset,
+    p_name_prefix: params.namePrefix?.trim() || null,
+    p_country: params.country?.trim() || null,
+  });
+  if (error) {
+    if (error.code === FUNCTION_MISSING) return { total: 0, rows: [] };
+    throw new Error(`baaki_admin_users failed: ${error.message}`);
+  }
+  const payload = (data ?? {}) as { total?: number | string; rows?: AdminUserListRow[] };
+  return { total: Number(payload.total ?? 0), rows: payload.rows ?? [] };
+}
+
 /** Mark an address confirmed by hand — the OTP a person never received. */
 export async function confirmUserEmail(userId: string): Promise<void> {
   await requireSession();

--- a/packages/db/prisma/migrations/20260809140000_admin_users_list/migration.sql
+++ b/packages/db/prisma/migrations/20260809140000_admin_users_list/migration.sql
@@ -1,0 +1,108 @@
+-- A browsable signup directory for the console.
+--
+-- This is a deliberate step past the aggregates-only line the other
+-- `baaki_admin_*` functions hold (ADR-013): it returns names, contacts,
+-- country and per-account facts, not counts. It is justified the same way the
+-- existing user-admin actions are — confirming an address, comping a grant —
+-- which already read one named account at a time through the GoTrue admin API.
+-- The difference here is that support needs to *find* the account (by the name
+-- someone gives on a call, by country) before acting on it, and paging the
+-- whole GoTrue directory in Node to do that is both slow and unfilterable.
+-- So this does the finding in SQL: filter, sort and paginate server-side, and
+-- hand back only the page asked for.
+--
+-- SECURITY DEFINER because it reads `auth.users`, which Supabase grants to
+-- nobody — the function runs as its owner (the migration role) instead. It is
+-- revoked from PUBLIC/anon/authenticated and granted to `service_role` alone,
+-- exactly like the aggregate functions, so it is reachable only from the admin
+-- server and never from a browser holding the anon key.
+--
+-- Guarded on `auth.users` existing: CI runs migrations against bare Postgres,
+-- which has no `auth` schema at all, so there it returns an empty page rather
+-- than failing to plan. The body is dynamic for the same reason — the
+-- reference to `auth.users` is parsed at call time, after the guard.
+
+CREATE OR REPLACE FUNCTION public.baaki_admin_users(
+  p_limit       integer DEFAULT 25,
+  p_offset      integer DEFAULT 0,
+  p_name_prefix text    DEFAULT NULL,
+  p_country     text    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_total  bigint := 0;
+  v_rows   jsonb  := '[]'::jsonb;
+  v_prefix text   := nullif(btrim(coalesce(p_name_prefix, '')), '');
+  v_country text  := nullif(upper(btrim(coalesce(p_country, ''))), '');
+  -- The page size is clamped so one lookup cannot become a walk of the whole
+  -- directory, and the offset floored at zero.
+  v_limit  int    := least(greatest(coalesce(p_limit, 25), 1), 100);
+  v_offset int    := greatest(coalesce(p_offset, 0), 0);
+BEGIN
+  IF to_regclass('auth.users') IS NULL THEN
+    RETURN jsonb_build_object('total', 0, 'rows', '[]'::jsonb, 'unavailable', 'no auth schema');
+  END IF;
+
+  EXECUTE format(
+    $q$
+      WITH base AS (
+        SELECT
+          u.id,
+          u.email,
+          u.phone,
+          (u.email_confirmed_at IS NOT NULL)  AS email_confirmed,
+          COALESCE(u.is_anonymous, false)     AS is_anonymous,
+          u.created_at,
+          u.last_sign_in_at,
+          p.display_name,
+          p.country_code,
+          EXISTS (
+            SELECT 1 FROM public.subscriptions s
+             WHERE s.profile_id = u.id
+               AND s.tier = 'plus'
+               AND s.status IN ('active', 'grace')
+          ) AS is_plus,
+          (SELECT count(*) FROM public.device_sessions d
+             WHERE d.profile_id = u.id AND d.revoked_at IS NULL) AS device_count,
+          (SELECT d.app_version FROM public.device_sessions d
+             WHERE d.profile_id = u.id AND d.app_version IS NOT NULL
+             ORDER BY d.last_seen_at DESC LIMIT 1) AS app_version,
+          (SELECT d.platform FROM public.device_sessions d
+             WHERE d.profile_id = u.id
+             ORDER BY d.last_seen_at DESC LIMIT 1) AS platform
+        FROM auth.users u
+        LEFT JOIN public.profiles p ON p.id = u.id
+        WHERE (%1$L IS NULL OR p.display_name ILIKE %2$L OR u.email ILIKE %2$L)
+          AND (%3$L IS NULL OR p.country_code = %3$L)
+      )
+      SELECT
+        (SELECT count(*) FROM base),
+        COALESCE(
+          (SELECT jsonb_agg(to_jsonb(t))
+             FROM (SELECT * FROM base ORDER BY created_at DESC OFFSET %4$s LIMIT %5$s) t),
+          '[]'::jsonb
+        )
+    $q$,
+    v_prefix,                 -- %1$L  null check
+    v_prefix || '%',          -- %2$L  prefix match (name + email)
+    v_country,                -- %3$L  country null check + equality
+    v_offset,                 -- %4$s
+    v_limit                   -- %5$s
+  )
+  INTO v_total, v_rows;
+
+  RETURN jsonb_build_object('total', v_total, 'rows', v_rows);
+END
+$fn$;
+
+-- Same grant discipline as the aggregate functions: Postgres grants EXECUTE to
+-- PUBLIC by default and anon/authenticated inherit it in Supabase, so this is
+-- revoked and handed to service_role alone.
+REVOKE ALL ON FUNCTION public.baaki_admin_users(integer, integer, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_admin_users(integer, integer, text, text) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_admin_users(integer, integer, text, text) TO service_role;


### PR DESCRIPTION
Reopens #109 against `main` (that PR auto-closed when its stacked base branch was deleted on merge of #108). Branch rebased onto main — only the users-directory commit remains.

## What

Turns the search-only Users page into a **browsable signup directory**:

- **Filter** by name/email prefix and by country.
- **Columns**: user (name + contact), type (`guest` / `free` / `plus`), country, live device count, latest app version + platform, joined, last seen.
- **Pagination** — prev/next with a real total (`N–M of T`).
- Existing **confirm-email** and **comp-a-grant** actions inline per row; current filter + page survive their redirects.

## Backend — `baaki_admin_users`

SECURITY DEFINER function joining `auth.users` → `profiles` → `subscriptions` → `device_sessions`, filtering/sorting/paginating in SQL, returning `{ total, rows }`.

- Granted to `service_role` alone (REVOKE from PUBLIC/anon/authenticated).
- Guarded on `auth.users` existing, so CI's bare Postgres returns an empty page.
- Page size clamped 1–100.

## Deviation flagged

Crosses the console's **aggregates-only** line (ADR-013) on purpose — returns names/contacts/country, not counts. Justified like existing per-account user-admin actions: support must find an account before acting. Same class as device-cap and contact-photo; spec needs the amendment.

## Verification

- RPC logic proven on local Postgres in a rolled-back transaction (15 assertions).
- `tsc`, `eslint --max-warnings 0`, `prettier --check`, `next build` — clean.
- Apply-on-all-prior + drift via CI migrations job (function-only; no Prisma datamodel change).

## Deploy note

`20260809140000_admin_users_list` joins `device_sessions`, so deploys after `20260809120000_device_sessions` — order holds by timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)