### PR TITLE
fix(friends): turn the ghost badge into an Invite action

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -186,7 +186,27 @@ function FriendCard({
             tone="default"
             style={{ color: ink }}
           />
-          {row.is_ghost ? <Badge label={t.tabs.notJoined} /> : null}
+          {row.is_ghost ? (
+            // A ghost is somebody you added who has no Baaki account yet, so the
+            // badge is the useful action rather than a verdict: send them this
+            // group's invite link, which is the same link that lets them claim
+            // this very row (A25). Only offered when a single group explains the
+            // balance — otherwise there is no one link to share. Its own
+            // Pressable so tapping it invites rather than opening the group.
+            row.only_group_id ? (
+              <Pressable
+                onPress={() => router.push(`/group/${row.only_group_id}/invite`)}
+                accessibilityRole="button"
+                accessibilityLabel={t.people.invite}
+                hitSlop={8}
+                style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+              >
+                <Badge label={t.people.invite} tone="brand" />
+              </Pressable>
+            ) : (
+              <Badge label={t.tabs.notJoined} />
+            )
+          ) : null}
         </View>
       </Row>
     </TintCard>


### PR DESCRIPTION
## Why

On the Friends "Owes you" list, every counterparty showed a **"Not joined"** badge (see report). On a green *owes-you* card it reads as a fault stamped on the person, when it just means they have no Baaki account yet — and because seed data is all ghosts, it was on every row.

## What

The badge becomes the useful thing instead of a verdict:

- **Ghost + single group** → an **Invite** pill (brand tone, its own `Pressable`) that opens that group's invite screen — the same "anyone with link" link that lets them **claim this very row** (A25/ADR-006). Tapping the pill invites; tapping the rest of the card still opens the group.
- **Ghost across multiple groups** → no single link explains the balance, so it falls back to the passive label.
- Reuses the existing `people.invite` string (all 4 locales); no new copy.

## Not a data change

`is_ghost` still means `profile_id IS NULL` — a real, correct state. This only changes how it's presented.

## Verification

- `tsc --noEmit` and `eslint` clean.
- Not run on a device (no device in this environment) — the pill routes to the existing, unchanged invite screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)