### PR TITLE
fix: settle offering a negative payment to a same-side member

### DIFF
--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -64,12 +64,21 @@ export default function SettleScreen() {
   const method = rail ?? defaultRailFor(country);
   const myMemberId = ledger.myMemberId;
 
+  // Only people on the other side of my ledger can settle with me: if I am owed
+  // overall I can be paid by a debtor, and if I owe I can pay a creditor. Listing
+  // a fellow debtor (or fellow creditor) offered a settlement that nets negative
+  // — the amount below went below zero and the button stayed enabled, so the
+  // server got a payment for a negative sum and refused it in the user's face.
   const counterparties = useMemo(
     () =>
-      (members.data ?? []).filter(
-        (member) => member.id !== myMemberId && (ledger.balances.get(member.id) ?? 0n) !== 0n,
-      ),
-    [members.data, myMemberId, ledger.balances],
+      (members.data ?? []).filter((member) => {
+        if (member.id === myMemberId) return false;
+        const balance = ledger.balances.get(member.id) ?? 0n;
+        if (ledger.myBalance > 0n) return balance < 0n;
+        if (ledger.myBalance < 0n) return balance > 0n;
+        return false;
+      }),
+    [members.data, myMemberId, ledger.balances, ledger.myBalance],
   );
 
   const counterparty: MemberRow | undefined =
@@ -77,11 +86,15 @@ export default function SettleScreen() {
 
   const theirBalance = counterparty ? (ledger.balances.get(counterparty.id) ?? 0n) : 0n;
   const iPay = ledger.myBalance < 0n && theirBalance > 0n;
-  const amount = counterparty
+  const rawAmount = counterparty
     ? iPay
       ? min(-ledger.myBalance, theirBalance)
       : min(ledger.myBalance, theirBalance < 0n ? -theirBalance : 0n)
     : 0n;
+  // Never below zero: the counterparty filter already keeps us on opposite sides,
+  // and this is the belt to that braces — a settlement is a positive movement or
+  // it is nothing, and the button below disables on 0.
+  const amount = rawAmount > 0n ? rawAmount : 0n;
 
   // What the payer still owes the payee, expense by expense — the settle sheet
   // applies the payment against these oldest-first (ADR-007).

--- a/packages/core/src/sms/parse.ts
+++ b/packages/core/src/sms/parse.ts
@@ -56,9 +56,12 @@ export const SMS_LOW_CONFIDENCE = 0.7;
  */
 const CURRENCY_MARKERS: ReadonlyArray<readonly [RegExp, CurrencyCode]> = [
   [/(?:INR|Rs\.?|₹)/i, 'INR'],
-  [/(?:USD|\$)/, 'USD'],
-  [/(?:EUR|€)/, 'EUR'],
-  [/(?:GBP|£)/, 'GBP'],
+  // The amount regex matches case-insensitively, so "usd 42" yields an amount;
+  // without `i` here the code fell through every marker and defaulted the
+  // currency to INR, mislabelling the proposed expense.
+  [/(?:USD|\$)/i, 'USD'],
+  [/(?:EUR|€)/i, 'EUR'],
+  [/(?:GBP|£)/i, 'GBP'],
   [/AED/i, 'AED'],
   [/SGD/i, 'SGD'],
   [/THB/i, 'THB'],

--- a/packages/core/test/sms.test.ts
+++ b/packages/core/test/sms.test.ts
@@ -57,6 +57,12 @@ describe('a real debit', () => {
     const parsed = parseSms('Rs.900 debited at 05-Aug-2026 14:30 to ANJAPPAR');
     expect(parsed?.occurredAt).toBe('2026-08-05T14:30:00.000Z');
   });
+
+  it('detects a lowercase currency word instead of defaulting to INR', () => {
+    const parsed = parseSms('usd 42.50 spent on card XX1234 at STARBUCKS');
+    expect(parsed?.amount.currency).toBe('USD');
+    expect(parsed?.amount.minor).toBe(4250n);
+  });
 });
 
 describe('messages that must not become expenses', () => {


### PR DESCRIPTION
Two defects found in a bug sweep of the money paths. Core split/balance/settlement/fx logic was reviewed line-by-line and is clean (486 property/unit tests pass); these live in surfaces the tests do not reach.

## 1. Settle screen offered a negative payment to a same-side member
`settle.tsx` listed every member with a nonzero balance as a counterparty, regardless of side. In any group with two debtors, selecting the *other* debtor computed `min(myBalance<0, -theirBalance>0)` → negative `amount`. The button guard only checked `amount === 0n`, so it stayed enabled and posted a settlement for a negative sum. The server rejected it and the user saw an error for doing nothing wrong.

**Fix:** counterparties are filtered to the opposite side of the ledger (a creditor can only be paid by a debtor and vice-versa); `amount` is floored at zero as defence-in-depth.

## 2. Lowercase currency word in a bank SMS mislabelled as INR
`sms/parse.ts` currency markers for USD/EUR/GBP lacked the `i` flag while the amount regex is case-insensitive. `"usd 42 debited"` parsed the amount but fell through every marker and tagged the proposed expense INR.

**Fix:** added `i` to those markers + a regression test.

## Verification
- `@baaki/core` tests: 487 pass (added one)
- `@baaki/mobile` typecheck: clean
- prettier: clean on all three files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
