### PR TITLE
feat(sms): read bank messages on Android, windowed to the trip dates

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -22,6 +22,7 @@
     },
     "android": {
       "package": "app.baaki.mobile",
+      "permissions": ["android.permission.READ_SMS"],
       "adaptiveIcon": {
         "backgroundColor": "#7A5AF8",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -54,6 +54,7 @@
     "react-native": "0.86.2",
     "react-native-document-scanner-plugin": "^2.0.4",
     "react-native-gesture-handler": "~2.32.0",
+    "react-native-get-sms-android": "^2.1.0",
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.26.0",

--- a/apps/mobile/src/app/group/[id]/import/sms.tsx
+++ b/apps/mobile/src/app/group/[id]/import/sms.tsx
@@ -48,6 +48,7 @@ import { planFromSms, toMutationPayload } from '@/data/importPlan';
 import { smsWindowFor } from '@/data/smsWindow';
 import { displayName } from '@/data/types';
 import { plural, useStrings } from '@/i18n';
+import { useFlagEnabled } from '@/lib/flags';
 import { readSms, type SmsReadFailure } from '@/lib/smsReader';
 import { useAuth } from '@/lib/auth';
 import { importMutationId } from '@/lib/importId';
@@ -101,6 +102,10 @@ export default function ImportSmsScreen() {
   // it arrived, which the paste flow (received "now") cannot know.
   const [readMessages, setReadMessages] = useState<SmsMessage[]>([]);
   const [reading, setReading] = useState(false);
+  // The inbox reader is off until this flag is switched on from the console: the
+  // READ_SMS permission and the native reader ship dormant, so the store build
+  // is paste-only and the capability rolls out to a cohort without a release.
+  const smsReadEnabled = useFlagEnabled('sms_inbox_read');
 
   const groupCurrency = group.data?.default_currency ?? 'INR';
   const memberRows = useMemo(() => members.data ?? [], [members.data]);
@@ -256,10 +261,11 @@ export default function ImportSmsScreen() {
               <Button label={t.smsImport.paste} variant="ghost" onPress={() => void paste()} />
             </Row>
 
-            {/* Android only: read the inbox for this window instead of pasting.
-                Absent everywhere else (iOS, Expo Go, any build without the
-                reader) — smsReader answers those with a sentence, not a crash. */}
-            {Platform.OS === 'android' ? (
+            {/* Android + flag on: read the inbox for this window instead of
+                pasting. Absent everywhere else (iOS, Expo Go, any build without
+                the reader, or the flag off) — smsReader answers a build that
+                cannot read with a sentence, not a crash. */}
+            {Platform.OS === 'android' && smsReadEnabled ? (
               <View style={{ gap: theme.spacing.sm }}>
                 <View style={{ height: 1, backgroundColor: theme.color.border }} />
                 <Button

--- a/apps/mobile/src/app/group/[id]/import/sms.tsx
+++ b/apps/mobile/src/app/group/[id]/import/sms.tsx
@@ -22,7 +22,7 @@
 import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { ActivityIndicator, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 
 import {
@@ -41,12 +41,14 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { proposeFromSms, type ExpenseCandidate, type MemberId } from '@baaki/core';
+import { proposeFromSms, type ExpenseCandidate, type MemberId, type SmsMessage } from '@baaki/core';
 
 import { useGroup, useGroupLedger } from '@/data/hooks';
 import { planFromSms, toMutationPayload } from '@/data/importPlan';
+import { smsWindowFor } from '@/data/smsWindow';
 import { displayName } from '@/data/types';
 import { plural, useStrings } from '@/i18n';
+import { readSms, type SmsReadFailure } from '@/lib/smsReader';
 import { useAuth } from '@/lib/auth';
 import { importMutationId } from '@/lib/importId';
 import { useImported } from '@/lib/imported';
@@ -79,13 +81,26 @@ export default function ImportSmsScreen() {
   const { keys: alreadyImported, remember } = useImported(groupId);
 
   const [blob, setBlob] = useState('');
-  const [from, setFrom] = useState(() => defaultFrom(expenses.data));
-  const [to, setTo] = useState(() => today());
+  // The window defaults to the trip's own dates (smsWindowFor) and is overridden
+  // only by an explicit edit. Derived during render rather than stored, so it
+  // follows the group loading in without an effect that has to race it — "track
+  // the expenses between the dates of the travel" is simply the default state.
+  const trip = useMemo(() => smsWindowFor(group.data, expenses.data), [group.data, expenses.data]);
+  const [fromEdit, setFromEdit] = useState<string | null>(null);
+  const [toEdit, setToEdit] = useState<string | null>(null);
+  const from = fromEdit ?? trip.from;
+  const to = toEdit ?? trip.to;
+
   const [chosen, setChosen] = useState<Record<string, boolean>>({});
   const [payer, setPayer] = useState<MemberId | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState<number | null>(null);
+  // Messages read from the Android inbox, kept apart from the pasted ones so
+  // each keeps its real received time — a dateless bank SMS is filed on the day
+  // it arrived, which the paste flow (received "now") cannot know.
+  const [readMessages, setReadMessages] = useState<SmsMessage[]>([]);
+  const [reading, setReading] = useState(false);
 
   const groupCurrency = group.data?.default_currency ?? 'INR';
   const memberRows = useMemo(() => members.data ?? [], [members.data]);
@@ -95,14 +110,36 @@ export default function ImportSmsScreen() {
 
   const messages = useMemo(() => splitMessages(blob), [blob]);
 
-  const candidates = useMemo(
-    () =>
-      proposeFromSms(
-        messages.map((body) => ({ body, receivedAt: new Date().toISOString() })),
-        { from, to, alreadyImported },
-      ),
-    [messages, from, to, alreadyImported],
+  // The read inbox first (real timestamps), then anything pasted. proposeFromSms
+  // dedupes across the two, so a message that was both read and pasted collapses.
+  const allMessages = useMemo(
+    () => [
+      ...readMessages,
+      ...messages.map((body) => ({ body, receivedAt: new Date().toISOString() })),
+    ],
+    [readMessages, messages],
   );
+
+  const candidates = useMemo(
+    () => proposeFromSms(allMessages, { from, to, alreadyImported }),
+    [allMessages, from, to, alreadyImported],
+  );
+
+  const readInbox = async (): Promise<void> => {
+    setError(null);
+    setReading(true);
+    try {
+      const result = await readSms({ from, to });
+      if (result.ok) {
+        setReadMessages(result.messages);
+        setError(result.messages.length === 0 ? t.smsImport.readNothing : null);
+      } else {
+        setError(readFailureMessage(result.reason, t));
+      }
+    } finally {
+      setReading(false);
+    }
+  };
 
   // A message in another currency needs a rate, and the rate is not in the
   // message. Rather than invent one, these are named and left for the add
@@ -218,6 +255,30 @@ export default function ImportSmsScreen() {
               </Text>
               <Button label={t.smsImport.paste} variant="ghost" onPress={() => void paste()} />
             </Row>
+
+            {/* Android only: read the inbox for this window instead of pasting.
+                Absent everywhere else (iOS, Expo Go, any build without the
+                reader) — smsReader answers those with a sentence, not a crash. */}
+            {Platform.OS === 'android' ? (
+              <View style={{ gap: theme.spacing.sm }}>
+                <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                <Button
+                  label={reading ? t.smsImport.reading : t.smsImport.readMessages}
+                  variant="secondary"
+                  disabled={reading}
+                  onPress={() => void readInbox()}
+                  icon={<Ionicons name="chatbubbles-outline" size={18} color={theme.color.brand} />}
+                />
+                <Text variant="micro" tone="faint">
+                  {t.smsImport.readOnAndroid}
+                </Text>
+                {readMessages.length > 0 ? (
+                  <Text variant="micro" tone="muted">
+                    {plural(locale, readMessages.length, t.smsImport.readCount)}
+                  </Text>
+                ) : null}
+              </View>
+            ) : null}
           </Card>
         </View>
 
@@ -228,29 +289,29 @@ export default function ImportSmsScreen() {
               {t.smsImport.datesNote}
             </Text>
             <Row style={{ gap: theme.spacing.md }}>
-              <DateField label={t.smsImport.from} value={from} onChange={setFrom} />
-              <DateField label={t.smsImport.to} value={to} onChange={setTo} />
+              <DateField label={t.smsImport.from} value={from} onChange={setFromEdit} />
+              <DateField label={t.smsImport.to} value={to} onChange={setToEdit} />
             </Row>
             <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
               <Chip
                 label={t.smsImport.last7}
                 onPress={() => {
-                  setFrom(daysAgo(7));
-                  setTo(today());
+                  setFromEdit(daysAgo(7));
+                  setToEdit(today());
                 }}
               />
               <Chip
                 label={t.smsImport.last30}
                 onPress={() => {
-                  setFrom(daysAgo(30));
-                  setTo(today());
+                  setFromEdit(daysAgo(30));
+                  setToEdit(today());
                 }}
               />
             </Row>
           </Card>
         </View>
 
-        {messages.length > 0 ? (
+        {allMessages.length > 0 ? (
           <View style={{ gap: theme.spacing.sm }}>
             <SectionHeader title={t.smsImport.foundSection} />
             {importable.length === 0 ? (
@@ -420,15 +481,18 @@ const today = (): string => new Date().toISOString().slice(0, 10);
 const daysAgo = (days: number): string =>
   new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
 
-/**
- * The group's own history is a better guess at "the trip" than a fixed number
- * of days: a group made for last month's holiday should not open on a window
- * that contains none of it.
- */
-function defaultFrom(expenses: { created_at?: string }[] | undefined): string {
-  const earliest = (expenses ?? [])
-    .map((expense) => String(expense.created_at ?? ''))
-    .filter(Boolean)
-    .sort()[0];
-  return earliest ? earliest.slice(0, 10) : daysAgo(30);
+/** Why the inbox could not be read, said in a way a person can act on. */
+function readFailureMessage(reason: SmsReadFailure, t: ReturnType<typeof useStrings>['t']): string {
+  switch (reason) {
+    case 'denied':
+      return t.smsImport.permissionDenied;
+    case 'blocked':
+      return t.smsImport.permissionBlocked;
+    case 'unsupported':
+      return t.smsImport.readUnsupported;
+    case 'unavailable':
+      return t.smsImport.readUnavailable;
+    case 'failed':
+      return t.smsImport.readFailed;
+  }
 }

--- a/apps/mobile/src/data/smsWindow.ts
+++ b/apps/mobile/src/data/smsWindow.ts
@@ -1,0 +1,63 @@
+/**
+ * The date window a message import should default to: the trip.
+ *
+ * "Track the expenses between the dates of the travel" — so when a group knows
+ * its own travel dates (`start_date`/`end_date`, set for a trip), those are the
+ * window, and only payments inside it are proposed. A group with no dates falls
+ * back to its own earliest expense, and a brand-new group to the last month, so
+ * the field is never empty and never spans an inbox nobody meant to share.
+ *
+ * Pure and `now`-injected so every branch is testable without a clock.
+ */
+
+export interface TripDates {
+  readonly start_date?: string | null;
+  readonly end_date?: string | null;
+}
+
+export interface DatedRow {
+  readonly created_at?: string | null;
+}
+
+export interface SmsDateWindow {
+  readonly from: string;
+  readonly to: string;
+}
+
+const DAY_MS = 86_400_000;
+
+/** An ISO-ish value trimmed to its 'YYYY-MM-DD', or null if there is nothing usable. */
+function day(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 10) : null;
+}
+
+function isoDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** The earliest `created_at` among a group's expenses, as 'YYYY-MM-DD'. */
+function earliestExpenseDay(rows: readonly DatedRow[] | undefined): string | null {
+  const days = (rows ?? [])
+    .map((row) => day(row.created_at))
+    .filter((value): value is string => value !== null);
+  if (days.length === 0) return null;
+  return days.reduce((earliest, current) => (current < earliest ? current : earliest));
+}
+
+export function smsWindowFor(
+  group: TripDates | null | undefined,
+  expenses: readonly DatedRow[] | undefined,
+  now: Date = new Date(),
+): SmsDateWindow {
+  const today = isoDay(now);
+  const start = day(group?.start_date);
+  const end = day(group?.end_date);
+
+  const from =
+    start ?? earliestExpenseDay(expenses) ?? isoDay(new Date(now.getTime() - 30 * DAY_MS));
+  const to = end ?? today;
+
+  return { from, to };
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -727,6 +727,17 @@ export interface UiStrings {
     adding: string;
     nothingSelected: string;
     addCount: PluralForms;
+    /** Android-only: read the inbox instead of pasting. */
+    readMessages: string;
+    reading: string;
+    readOnAndroid: string;
+    readCount: PluralForms;
+    readNothing: string;
+    permissionDenied: string;
+    permissionBlocked: string;
+    readUnsupported: string;
+    readUnavailable: string;
+    readFailed: string;
   };
   /** Splitting one bill line by line, on one phone or several. */
   itemize: {
@@ -1610,6 +1621,22 @@ const en: UiStrings = {
     adding: 'Adding…',
     nothingSelected: 'Nothing selected',
     addCount: { one: 'Add {n} expense', other: 'Add {n} expenses' },
+    readMessages: 'Read my messages',
+    reading: 'Reading…',
+    readOnAndroid:
+      'On Android, Baaki can read the bank messages in these dates for you. It asks permission first, reads them on this phone, and sends nothing anywhere until you confirm.',
+    readCount: {
+      one: 'Read {n} message from your inbox.',
+      other: 'Read {n} messages from your inbox.',
+    },
+    readNothing: 'No bank messages found in these dates.',
+    permissionDenied:
+      'Baaki needs your permission to read messages. You can still paste them below instead.',
+    permissionBlocked:
+      'Message access is turned off for Baaki. Turn it on in Settings › Apps › Baaki › Permissions, or paste the messages below.',
+    readUnsupported: 'Reading messages only works on Android. Paste them below instead.',
+    readUnavailable: 'This build cannot read messages. Paste them below instead.',
+    readFailed: 'Could not read your messages. Paste them below instead.',
   },
   itemize: {
     title: 'Split by item',
@@ -2537,6 +2564,23 @@ const ta: UiStrings = {
     adding: 'சேர்க்கிறது…',
     nothingSelected: 'எதுவும் தேர்ந்தெடுக்கப்படவில்லை',
     addCount: { one: '{n} செலவைச் சேர்', other: '{n} செலவுகளைச் சேர்' },
+    readMessages: 'என் செய்திகளைப் படி',
+    reading: 'படிக்கிறது…',
+    readOnAndroid:
+      'Android-இல், இந்தத் தேதிகளில் உள்ள வங்கிச் செய்திகளை பாக்கி உங்களுக்காகப் படிக்கும். முதலில் அனுமதி கேட்கும், இந்த ஃபோனிலேயே படிக்கும், நீங்கள் உறுதிப்படுத்தும் வரை எதுவும் எங்கும் அனுப்பப்படாது.',
+    readCount: {
+      one: 'உங்கள் இன்பாக்ஸிலிருந்து {n} செய்தி படிக்கப்பட்டது.',
+      other: 'உங்கள் இன்பாக்ஸிலிருந்து {n} செய்திகள் படிக்கப்பட்டன.',
+    },
+    readNothing: 'இந்தத் தேதிகளில் வங்கிச் செய்திகள் எதுவும் இல்லை.',
+    permissionDenied:
+      'செய்திகளைப் படிக்க பாக்கிக்கு உங்கள் அனுமதி தேவை. அதற்குப் பதிலாக கீழே ஒட்டலாம்.',
+    permissionBlocked:
+      'பாக்கிக்கு செய்தி அணுகல் அணைக்கப்பட்டுள்ளது. அமைப்புகள் › ஆப்ஸ் › Baaki › அனுமதிகள் இல் இயக்கவும், அல்லது கீழே செய்திகளை ஒட்டவும்.',
+    readUnsupported:
+      'செய்திகளைப் படிப்பது Android-இல் மட்டுமே இயங்கும். அதற்குப் பதிலாக கீழே ஒட்டவும்.',
+    readUnavailable: 'இந்தப் பதிப்பால் செய்திகளைப் படிக்க முடியாது. கீழே ஒட்டவும்.',
+    readFailed: 'உங்கள் செய்திகளைப் படிக்க முடியவில்லை. கீழே ஒட்டவும்.',
   },
   itemize: {
     title: 'பொருள் வாரியாகப் பிரி',
@@ -3444,6 +3488,22 @@ const hi: UiStrings = {
     adding: 'जोड़ रहे हैं…',
     nothingSelected: 'कुछ नहीं चुना',
     addCount: { one: '{n} खर्च जोड़ें', other: '{n} खर्च जोड़ें' },
+    readMessages: 'मेरे संदेश पढ़ें',
+    reading: 'पढ़ रहे हैं…',
+    readOnAndroid:
+      'Android पर, Baaki इन तारीखों के बैंक संदेश आपके लिए पढ़ सकता है। यह पहले अनुमति माँगता है, इसी फ़ोन पर पढ़ता है, और जब तक आप किसी खर्च की पुष्टि नहीं करते तब तक कुछ भी कहीं नहीं भेजा जाता।',
+    readCount: {
+      one: 'आपके इनबॉक्स से {n} संदेश पढ़ा गया।',
+      other: 'आपके इनबॉक्स से {n} संदेश पढ़े गए।',
+    },
+    readNothing: 'इन तारीखों में कोई बैंक संदेश नहीं मिला।',
+    permissionDenied:
+      'संदेश पढ़ने के लिए Baaki को आपकी अनुमति चाहिए। आप नीचे उन्हें पेस्ट भी कर सकते हैं।',
+    permissionBlocked:
+      'Baaki के लिए संदेश एक्सेस बंद है। इसे Settings › Apps › Baaki › Permissions में चालू करें, या नीचे संदेश पेस्ट करें।',
+    readUnsupported: 'संदेश पढ़ना केवल Android पर काम करता है। नीचे उन्हें पेस्ट करें।',
+    readUnavailable: 'यह बिल्ड संदेश नहीं पढ़ सकता। नीचे उन्हें पेस्ट करें।',
+    readFailed: 'आपके संदेश पढ़े नहीं जा सके। नीचे उन्हें पेस्ट करें।',
   },
   itemize: {
     title: 'चीज़-वार बाँटें',
@@ -4432,6 +4492,25 @@ const ar: UiStrings = {
       many: 'أضف {n} مصروفًا',
       other: 'أضف {n} مصروف',
     },
+    readMessages: 'اقرأ رسائلي',
+    reading: 'جارٍ القراءة…',
+    readOnAndroid:
+      'على أندرويد، يمكن لـ Baaki قراءة رسائل البنك ضمن هذه التواريخ نيابةً عنك. يطلب الإذن أولًا، ويقرأها على هذا الهاتف، ولا يُرسل أي شيء إلى أي مكان حتى تؤكّد المصروف.',
+    readCount: {
+      zero: 'لم تُقرأ أي رسالة من صندوق الوارد.',
+      one: 'قُرئت رسالة واحدة من صندوق الوارد.',
+      two: 'قُرئت رسالتان من صندوق الوارد.',
+      few: 'قُرئت {n} رسائل من صندوق الوارد.',
+      many: 'قُرئت {n} رسالة من صندوق الوارد.',
+      other: 'قُرئت {n} رسالة من صندوق الوارد.',
+    },
+    readNothing: 'لا توجد رسائل بنكية في هذه التواريخ.',
+    permissionDenied: 'يحتاج Baaki إلى إذنك لقراءة الرسائل. يمكنك بدلًا من ذلك لصقها بالأسفل.',
+    permissionBlocked:
+      'الوصول إلى الرسائل مُعطَّل لـ Baaki. فعِّله من الإعدادات › التطبيقات › Baaki › الأذونات، أو الصق الرسائل بالأسفل.',
+    readUnsupported: 'قراءة الرسائل تعمل على أندرويد فقط. الصقها بالأسفل بدلًا من ذلك.',
+    readUnavailable: 'هذا الإصدار لا يستطيع قراءة الرسائل. الصقها بالأسفل.',
+    readFailed: 'تعذّرت قراءة رسائلك. الصقها بالأسفل.',
   },
   itemize: {
     title: 'التقسيم حسب الصنف',

--- a/apps/mobile/src/lib/smsReader.ts
+++ b/apps/mobile/src/lib/smsReader.ts
@@ -1,0 +1,229 @@
+/**
+ * Reading bank SMS off the phone, on Android, with the user's permission.
+ *
+ * The existing import screen is paste-based on purpose (see its header): iOS
+ * gives no app SMS access at all, and Android's `READ_SMS` is a restricted
+ * permission. This module is the opt-in Android path added on top — a one-tap
+ * read of the inbox, gated behind a runtime permission prompt, that fills the
+ * same candidate list the paste flow does.
+ *
+ * Two rules shape everything here:
+ *
+ *   - Nothing read ever leaves the device. The messages go straight to
+ *     `proposeFromSms`, which parses on-device (ADR-013). A bank SMS carries an
+ *     account tail, a balance and sometimes a one-time password; the whole
+ *     point of parsing locally is that none of that is worth sending anywhere.
+ *
+ *   - It can never crash the app. The inbox reader is a native module that does
+ *     not exist on iOS, in Expo Go, or in any build that did not include it, so
+ *     it is loaded lazily behind a non-throwing check and every failure — no
+ *     module, no permission, a read that errors — degrades to a described
+ *     result the screen turns into a sentence, never an exception at launch or
+ *     at the tap (the native-module rule the other `lib/*` wrappers follow).
+ *
+ * The logic is split from the wiring: `readSmsInbox` takes every side effect as
+ * an injected dependency so all of it is unit-tested without a device, and
+ * `readSms` is the thin production entry that supplies the real ones.
+ */
+
+import type { SmsMessage } from '@baaki/core';
+
+export interface SmsWindow {
+  /** Inclusive 'YYYY-MM-DD'. The trip's dates, usually. */
+  readonly from: string;
+  readonly to: string;
+}
+
+export type SmsReadFailure = 'unsupported' | 'unavailable' | 'denied' | 'blocked' | 'failed';
+
+export type SmsReadResult =
+  { ok: true; messages: SmsMessage[] } | { ok: false; reason: SmsReadFailure; message?: string };
+
+/** A row as `react-native-get-sms-android` hands it back. */
+export interface RawSms {
+  readonly _id?: number | string;
+  readonly address?: string | null;
+  readonly body?: string | null;
+  /** Epoch milliseconds the message was received. */
+  readonly date?: number | string | null;
+}
+
+/** The single method this feature needs off the native module. */
+export interface NativeSmsModule {
+  list(
+    filter: string,
+    fail: (error: string) => void,
+    success: (count: number, smsListJson: string) => void,
+  ): void;
+}
+
+/** What a permission request resolves to, flattened to the three we act on. */
+export type PermissionOutcome = 'granted' | 'denied' | 'blocked';
+
+export interface SmsReaderDeps {
+  readonly platformOS: string;
+  /** Loads the native module lazily; returns null when it is not in this build. */
+  readonly loadModule: () => NativeSmsModule | null;
+  readonly requestPermission: () => Promise<PermissionOutcome>;
+  /** Cap so a decade-long inbox cannot be walked in a single read. */
+  readonly maxCount?: number;
+}
+
+const DEFAULT_MAX_COUNT = 500;
+const DAY_MS = 86_400_000;
+
+/**
+ * The native `list` filter for a date window.
+ *
+ * Widened by a day on each side and left to `proposeFromSms` to filter
+ * authoritatively. The native `date` is when the message was *received*, which
+ * can differ from when the payment happened by a timezone or a delayed SMS —
+ * and dropping a message here that the parser would have kept is the one
+ * mistake that loses an expense with no trace. A too-wide prefetch costs
+ * nothing; a too-narrow one is silent.
+ */
+export function buildSmsFilter(window: SmsWindow, maxCount = DEFAULT_MAX_COUNT): string {
+  const min = Date.parse(`${window.from}T00:00:00.000Z`);
+  const max = Date.parse(`${window.to}T23:59:59.999Z`);
+  const filter: Record<string, unknown> = { box: 'inbox', maxCount };
+  if (Number.isFinite(min)) filter.minDate = min - DAY_MS;
+  if (Number.isFinite(max)) filter.maxDate = max + DAY_MS;
+  return JSON.stringify(filter);
+}
+
+/**
+ * One raw row → the shape `proposeFromSms` reads, or null when it has no body.
+ * The received time carries through so the parser can place a dateless message
+ * (a bank SMS that names no date) on the day it actually arrived.
+ */
+export function mapSmsRow(raw: RawSms): SmsMessage | null {
+  const body = typeof raw.body === 'string' ? raw.body : '';
+  if (!body.trim()) return null;
+
+  const ms = typeof raw.date === 'string' ? Number(raw.date) : raw.date;
+  const receivedAt =
+    typeof ms === 'number' && Number.isFinite(ms) && ms > 0
+      ? new Date(ms).toISOString()
+      : new Date().toISOString();
+
+  const sender = typeof raw.address === 'string' && raw.address.trim() ? raw.address : undefined;
+  return sender ? { body, receivedAt, sender } : { body, receivedAt };
+}
+
+/** Parse the native JSON payload into messages, tolerating a malformed blob. */
+export function parseSmsList(json: string): SmsMessage[] {
+  let rows: unknown;
+  try {
+    rows = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(rows)) return [];
+
+  const out: SmsMessage[] = [];
+  for (const row of rows) {
+    if (row && typeof row === 'object') {
+      const message = mapSmsRow(row as RawSms);
+      if (message) out.push(message);
+    }
+  }
+  return out;
+}
+
+/**
+ * Read the inbox for a window, or say why it could not.
+ *
+ * The order is deliberate: platform first (an iPhone can never do this), then
+ * the module (a build without it never can either), and only then the
+ * permission prompt — asking for `READ_SMS` on a phone that has no reader to
+ * use it would train the user to grant a permission that does nothing.
+ */
+export async function readSmsInbox(window: SmsWindow, deps: SmsReaderDeps): Promise<SmsReadResult> {
+  if (deps.platformOS !== 'android') {
+    return { ok: false, reason: 'unsupported' };
+  }
+
+  let native: NativeSmsModule | null;
+  try {
+    native = deps.loadModule();
+  } catch {
+    native = null;
+  }
+  if (!native || typeof native.list !== 'function') {
+    return { ok: false, reason: 'unavailable' };
+  }
+
+  const outcome = await deps.requestPermission();
+  if (outcome === 'denied') return { ok: false, reason: 'denied' };
+  if (outcome === 'blocked') return { ok: false, reason: 'blocked' };
+
+  const filter = buildSmsFilter(window, deps.maxCount ?? DEFAULT_MAX_COUNT);
+
+  return new Promise<SmsReadResult>((resolve) => {
+    let settled = false;
+    const done = (result: SmsReadResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    try {
+      native.list(
+        filter,
+        (error) => done({ ok: false, reason: 'failed', message: error }),
+        (_count, json) => done({ ok: true, messages: parseSmsList(json) }),
+      );
+    } catch (error) {
+      done({
+        ok: false,
+        reason: 'failed',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+}
+
+/**
+ * The real device wiring for `readSmsInbox`.
+ *
+ * Everything native is reached through `require` inside the callbacks, not at
+ * module load: `react-native-get-sms-android` is absent on iOS, in Expo Go and
+ * in any build that did not bundle it, and a top-level import would take the
+ * whole app down at launch on those. The module specifier is held in a variable
+ * so the type checker treats a missing module as `any` rather than an error —
+ * this package is intentionally optional.
+ */
+export async function readSms(window: SmsWindow): Promise<SmsReadResult> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Platform, PermissionsAndroid } = require('react-native') as typeof import('react-native');
+
+  return readSmsInbox(window, {
+    platformOS: Platform.OS,
+    loadModule: () => {
+      try {
+        const specifier = 'react-native-get-sms-android';
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const mod = require(specifier) as { default?: NativeSmsModule } & NativeSmsModule;
+        return (mod?.default ?? mod) as NativeSmsModule;
+      } catch {
+        return null;
+      }
+    },
+    requestPermission: async () => {
+      try {
+        const status = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_SMS, {
+          title: 'Read bank messages',
+          message:
+            'Baaki reads bank payment messages on this phone to suggest expenses for your trip. ' +
+            'The messages stay on your phone — nothing is sent anywhere until you confirm an expense.',
+          buttonPositive: 'Allow',
+          buttonNegative: 'Not now',
+        });
+        if (status === PermissionsAndroid.RESULTS.GRANTED) return 'granted';
+        if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) return 'blocked';
+        return 'denied';
+      } catch {
+        return 'denied';
+      }
+    },
+  });
+}

--- a/apps/mobile/test/smsReader.test.ts
+++ b/apps/mobile/test/smsReader.test.ts
@@ -1,0 +1,324 @@
+/**
+ * The Android inbox reader.
+ *
+ * It is one native call wrapped in a lot of refusals, and the refusals are the
+ * point: on the wrong platform, in a build without the module, with the
+ * permission denied or blocked, or when the read itself errors, it must come
+ * back with a described result the screen can turn into a sentence — never an
+ * exception, because an exception here is a crash at the exact moment somebody
+ * tapped a button asking for their bank messages.
+ *
+ * Every side effect is injected, so the whole matrix runs without a device.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { proposeFromSms } from '@baaki/core';
+
+import {
+  buildSmsFilter,
+  mapSmsRow,
+  parseSmsList,
+  readSmsInbox,
+  type NativeSmsModule,
+  type SmsReaderDeps,
+  type SmsWindow,
+} from '@/lib/smsReader';
+
+const WINDOW: SmsWindow = { from: '2026-07-01', to: '2026-07-08' };
+
+/** A native module whose `list` replies with a canned success payload. */
+function moduleReturning(rows: unknown): NativeSmsModule {
+  return {
+    list: (_filter, _fail, success) =>
+      success(Array.isArray(rows) ? rows.length : 0, JSON.stringify(rows)),
+  };
+}
+
+function deps(over: Partial<SmsReaderDeps> = {}): SmsReaderDeps {
+  return {
+    platformOS: 'android',
+    loadModule: () => moduleReturning([]),
+    requestPermission: async () => 'granted',
+    ...over,
+  };
+}
+
+// ─────────────────────────────────────────────────── the pure pieces ──
+
+describe('buildSmsFilter', () => {
+  it('asks the inbox for the window, widened a day each side', () => {
+    const filter = JSON.parse(buildSmsFilter(WINDOW));
+    expect(filter.box).toBe('inbox');
+    expect(filter.maxCount).toBe(500);
+    // 2026-07-01T00:00Z minus a day, 2026-07-08T23:59:59.999Z plus a day.
+    expect(filter.minDate).toBe(Date.parse('2026-06-30T00:00:00.000Z'));
+    expect(filter.maxDate).toBe(Date.parse('2026-07-09T23:59:59.999Z'));
+  });
+
+  it('honours a custom cap', () => {
+    expect(JSON.parse(buildSmsFilter(WINDOW, 25)).maxCount).toBe(25);
+  });
+
+  it('omits an unparseable bound rather than sending NaN', () => {
+    const filter = JSON.parse(buildSmsFilter({ from: 'not-a-date', to: '2026-07-08' }));
+    expect('minDate' in filter).toBe(false);
+    expect(filter.maxDate).toBe(Date.parse('2026-07-09T23:59:59.999Z'));
+  });
+});
+
+describe('mapSmsRow', () => {
+  it('carries body, received time and sender across', () => {
+    const message = mapSmsRow({
+      body: 'Rs 500 debited',
+      date: 1_751_356_800_000,
+      address: 'HDFCBK',
+    });
+    expect(message).toEqual({
+      body: 'Rs 500 debited',
+      receivedAt: new Date(1_751_356_800_000).toISOString(),
+      sender: 'HDFCBK',
+    });
+  });
+
+  it('accepts a stringified epoch', () => {
+    const message = mapSmsRow({ body: 'x', date: '1751356800000' });
+    expect(message?.receivedAt).toBe(new Date(1_751_356_800_000).toISOString());
+  });
+
+  it('drops a message with no body', () => {
+    expect(mapSmsRow({ body: '   ', date: 1 })).toBeNull();
+    expect(mapSmsRow({ date: 1 })).toBeNull();
+  });
+
+  it('falls back to now when the date is missing or junk, without throwing', () => {
+    const before = Date.now();
+    const message = mapSmsRow({ body: 'x', date: null });
+    const stamp = Date.parse(message!.receivedAt);
+    expect(stamp).toBeGreaterThanOrEqual(before);
+    expect(mapSmsRow({ body: 'x', date: 'nonsense' })?.receivedAt).toBeTruthy();
+  });
+
+  it('leaves the sender off when there is no address', () => {
+    expect(mapSmsRow({ body: 'x', date: 1 })).not.toHaveProperty('sender');
+    expect(mapSmsRow({ body: 'x', date: 1, address: '  ' })).not.toHaveProperty('sender');
+  });
+});
+
+describe('parseSmsList', () => {
+  it('maps a well-formed payload and skips bodiless rows', () => {
+    const messages = parseSmsList(
+      JSON.stringify([
+        { body: 'Rs 500 debited', date: 1 },
+        { body: '', date: 2 },
+        { date: 3 },
+        { body: 'Rs 90 spent', date: 4 },
+      ]),
+    );
+    expect(messages.map((m) => m.body)).toEqual(['Rs 500 debited', 'Rs 90 spent']);
+  });
+
+  it('returns nothing for malformed JSON', () => {
+    expect(parseSmsList('{not json')).toEqual([]);
+  });
+
+  it('returns nothing for a non-array', () => {
+    expect(parseSmsList(JSON.stringify({ body: 'x' }))).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────── readSmsInbox matrix ──
+
+describe('readSmsInbox — refusals', () => {
+  it('is unsupported off Android', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ platformOS: 'ios' }));
+    expect(res).toEqual({ ok: false, reason: 'unsupported' });
+  });
+
+  it('is unavailable when the module is not in this build', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => null }));
+    expect(res).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('is unavailable — not a crash — when loading the module throws', async () => {
+    const res = await readSmsInbox(
+      WINDOW,
+      deps({
+        loadModule: () => {
+          throw new Error('native side blew up');
+        },
+      }),
+    );
+    expect(res).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('is unavailable when the module has no list method', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => ({}) as NativeSmsModule }));
+    expect(res).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('reports a plain denial', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ requestPermission: async () => 'denied' }));
+    expect(res).toEqual({ ok: false, reason: 'denied' });
+  });
+
+  it('reports a blocked (never-ask-again) permission distinctly', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ requestPermission: async () => 'blocked' }));
+    expect(res).toEqual({ ok: false, reason: 'blocked' });
+  });
+
+  it('does not ask for permission before the module is known to exist', async () => {
+    const requestPermission = vi.fn(async () => 'granted' as const);
+    await readSmsInbox(WINDOW, deps({ loadModule: () => null, requestPermission }));
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+});
+
+describe('readSmsInbox — reading', () => {
+  it('returns the parsed messages on success', async () => {
+    const rows = [
+      { body: 'Rs 500 debited at SWIGGY', date: 1_751_356_800_000, address: 'HDFCBK' },
+      { body: 'Rs 90 spent at CCD', date: 1_751_443_200_000, address: 'HDFCBK' },
+    ];
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning(rows) }));
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.messages).toHaveLength(2);
+  });
+
+  it('passes the window filter through to the native call', async () => {
+    let seen = '';
+    const module: NativeSmsModule = {
+      list: (filter, _fail, success) => {
+        seen = filter;
+        success(0, '[]');
+      },
+    };
+    await readSmsInbox(WINDOW, deps({ loadModule: () => module, maxCount: 42 }));
+    const parsed = JSON.parse(seen);
+    expect(parsed.maxCount).toBe(42);
+    expect(parsed.minDate).toBe(Date.parse('2026-06-30T00:00:00.000Z'));
+  });
+
+  it('surfaces a read failure with its message', async () => {
+    const module: NativeSmsModule = {
+      list: (_filter, fail) => fail('cursor closed'),
+    };
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => module }));
+    expect(res).toEqual({ ok: false, reason: 'failed', message: 'cursor closed' });
+  });
+
+  it('turns a synchronous throw from list into a failure, not a crash', async () => {
+    const module: NativeSmsModule = {
+      list: () => {
+        throw new Error('binder died');
+      },
+    };
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => module }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toBe('failed');
+      expect(res.message).toBe('binder died');
+    }
+  });
+
+  it('resolves once even if the native side calls back twice', async () => {
+    const module: NativeSmsModule = {
+      list: (_filter, fail, success) => {
+        success(1, JSON.stringify([{ body: 'Rs 500 debited', date: 1 }]));
+        success(1, JSON.stringify([{ body: 'Rs 999 debited', date: 2 }]));
+        fail('late error');
+      },
+    };
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => module }));
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.messages[0]?.body).toBe('Rs 500 debited');
+  });
+
+  it('returns an empty list for an empty inbox', async () => {
+    const res = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning([]) }));
+    expect(res).toEqual({ ok: true, messages: [] });
+  });
+});
+
+// ─────────────────────────────────────── the whole path, end to end ──
+
+describe('read → propose, over the trip window', () => {
+  it('surfaces a dated debit inside the trip and drops what does not belong', async () => {
+    const rows = [
+      // A clean debit, inside the window — the one we want.
+      {
+        body: 'Rs 1,250.00 debited at ANJAPPAR on 04-Jul-26. UPI Ref 412345678901',
+        date: Date.parse('2026-07-04T13:00:00.000Z'),
+        address: 'AD-HDFCBK',
+      },
+      // A credit — money coming in is never an expense.
+      {
+        body: 'Rs 5,000 credited to your account on 05-Jul-26',
+        date: Date.parse('2026-07-05T09:00:00.000Z'),
+        address: 'AD-HDFCBK',
+      },
+      // An OTP quoting a real amount — the dangerous false positive.
+      {
+        body: 'Rs 800 is your OTP. Do not share it.',
+        date: Date.parse('2026-07-04T10:00:00.000Z'),
+        address: 'VM-HDFCBK',
+      },
+      // A real debit, but received months after the trip window closed.
+      {
+        body: 'Rs 300 debited at METRO on 02-Aug-26',
+        date: Date.parse('2026-08-02T10:00:00.000Z'),
+        address: 'AD-HDFCBK',
+      },
+    ];
+
+    const read = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning(rows) }));
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+
+    const candidates = proposeFromSms(read.messages, { from: WINDOW.from, to: WINDOW.to });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.merchant).toBe('ANJAPPAR');
+    expect(candidates[0]?.amount.minor).toBe(125000n);
+    expect(candidates[0]?.direction).toBe('debit');
+  });
+
+  it('places a dateless message on the day it was received, so the window still holds', async () => {
+    const rows = [
+      {
+        body: 'Rs 640 spent at BLUE TOKAI',
+        date: Date.parse('2026-07-03T08:00:00.000Z'),
+        address: 'AD-ICICIB',
+      },
+    ];
+    const read = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning(rows) }));
+    if (!read.ok) throw new Error('expected a successful read');
+
+    const inside = proposeFromSms(read.messages, { from: WINDOW.from, to: WINDOW.to });
+    expect(inside).toHaveLength(1);
+    expect(inside[0]?.dateInferred).toBe(true);
+
+    // The same message, asked for a window that ends before it arrived, is gone.
+    const outside = proposeFromSms(read.messages, { from: '2026-06-01', to: '2026-06-30' });
+    expect(outside).toHaveLength(0);
+  });
+
+  it('drops what has already been imported', async () => {
+    const rows = [
+      {
+        body: 'Rs 1,250.00 debited at ANJAPPAR on 04-Jul-26. UPI Ref 412345678901',
+        date: Date.parse('2026-07-04T13:00:00.000Z'),
+        address: 'AD-HDFCBK',
+      },
+    ];
+    const read = await readSmsInbox(WINDOW, deps({ loadModule: () => moduleReturning(rows) }));
+    if (!read.ok) throw new Error('expected a successful read');
+
+    const alreadyImported = new Set(['ref:412345678901']);
+    const candidates = proposeFromSms(read.messages, {
+      from: WINDOW.from,
+      to: WINDOW.to,
+      alreadyImported,
+    });
+    expect(candidates).toHaveLength(0);
+  });
+});

--- a/apps/mobile/test/smsWindow.test.ts
+++ b/apps/mobile/test/smsWindow.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The window a message import opens on.
+ *
+ * The failure this guards against is quiet in both directions: a window that
+ * misses the trip proposes none of its payments, and a window that runs to
+ * "today" for a trip that ended in March drags in three months of unrelated
+ * inbox. The trip's own dates are the answer whenever the group has them.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { smsWindowFor } from '@/data/smsWindow';
+
+const NOW = new Date('2026-08-10T09:00:00.000Z');
+
+describe('smsWindowFor', () => {
+  it('uses the trip dates when the group has both', () => {
+    const window = smsWindowFor(
+      { start_date: '2026-07-01', end_date: '2026-07-08' },
+      [{ created_at: '2026-07-03T10:00:00.000Z' }],
+      NOW,
+    );
+    expect(window).toEqual({ from: '2026-07-01', to: '2026-07-08' });
+  });
+
+  it('trims a full timestamp down to the day', () => {
+    const window = smsWindowFor(
+      { start_date: '2026-07-01T00:00:00.000Z', end_date: '2026-07-08T23:59:59.999Z' },
+      [],
+      NOW,
+    );
+    expect(window).toEqual({ from: '2026-07-01', to: '2026-07-08' });
+  });
+
+  it('runs an open-ended trip (start only) to today', () => {
+    const window = smsWindowFor({ start_date: '2026-08-01', end_date: null }, [], NOW);
+    expect(window).toEqual({ from: '2026-08-01', to: '2026-08-10' });
+  });
+
+  it('starts a trip with an end but no start at the earliest expense', () => {
+    const window = smsWindowFor({ start_date: null, end_date: '2026-07-08' }, [
+      { created_at: '2026-07-05T12:00:00.000Z' },
+      { created_at: '2026-07-02T08:00:00.000Z' },
+      { created_at: '2026-07-06T20:00:00.000Z' },
+    ]);
+    expect(window.from).toBe('2026-07-02');
+    expect(window.to).toBe('2026-07-08');
+  });
+
+  it('falls back to the earliest expense when there are no trip dates', () => {
+    const window = smsWindowFor(
+      null,
+      [{ created_at: '2026-06-20T10:00:00.000Z' }, { created_at: '2026-06-14T10:00:00.000Z' }],
+      NOW,
+    );
+    expect(window).toEqual({ from: '2026-06-14', to: '2026-08-10' });
+  });
+
+  it('falls back to the last 30 days for a group with no dates and no expenses', () => {
+    const window = smsWindowFor(undefined, [], NOW);
+    expect(window).toEqual({ from: '2026-07-11', to: '2026-08-10' });
+  });
+
+  it('ignores blank and null dates rather than treating them as a window', () => {
+    const window = smsWindowFor({ start_date: '   ', end_date: '' }, [], NOW);
+    expect(window).toEqual({ from: '2026-07-11', to: '2026-08-10' });
+  });
+
+  it('ignores expenses that carry no created_at', () => {
+    const window = smsWindowFor(null, [{ created_at: null }, { created_at: undefined }], NOW);
+    expect(window.from).toBe('2026-07-11');
+  });
+});

--- a/packages/db/prisma/migrations/20260810120000_sms_inbox_read_flag/migration.sql
+++ b/packages/db/prisma/migrations/20260810120000_sms_inbox_read_flag/migration.sql
@@ -1,0 +1,25 @@
+-- The Android bank-SMS inbox reader, behind a flag.
+--
+-- Reading the inbox needs the Play-restricted READ_SMS permission and a native
+-- reader that only exists in a prebuilt binary. Both ship dormant: the screen
+-- is paste-only until this flag is switched on, so the capability can be rolled
+-- out to a cohort (or a single test account) from the console without another
+-- store release, and turned off again the same way.
+--
+-- Seeded disabled with a zero rollout. `enabled` plus `rollout_percent` are the
+-- two dials the console turns; the app reads the same answer through
+-- `baaki_variant` / @baaki/core so an offline phone gates identically. Off is
+-- the fallback everywhere, so a phone that cannot read this row shows paste,
+-- which is exactly the safe default (see the feature_flags migration).
+--
+-- ON CONFLICT so re-running the migration never clobbers a rollout an operator
+-- has since dialled up in production.
+
+INSERT INTO public.feature_flags (key, description, enabled, rollout_percent)
+VALUES (
+  'sms_inbox_read',
+  'Android only: read bank SMS from the inbox (READ_SMS) instead of pasting. Ships dormant; switch on to roll the native reader out to a cohort.',
+  false,
+  0
+)
+ON CONFLICT (key) DO NOTHING;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      react-native-get-sms-android:
+        specifier: ^2.1.0
+        version: 2.1.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))
       react-native-reanimated:
         specifier: 4.5.1
         version: 4.5.1(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -5419,6 +5422,11 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-get-sms-android@2.1.0:
+    resolution: {integrity: sha512-yYPlJ4DkuC9HnUL0ni644pDjRFnSQkdGHowIY5ab56YFDKHIEZ1rKuBCEbCWF0HALyvH6qCyfdHqwpzTtIj97w==}
+    peerDependencies:
+      react-native: '*'
+
   react-native-is-edge-to-edge@1.3.1:
     resolution: {integrity: sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==}
     peerDependencies:
@@ -9902,7 +9910,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-expo: 1.1.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -9942,21 +9950,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
-      get-tsconfig: 4.14.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -9979,7 +9972,7 @@ snapshots:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11932,6 +11925,10 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
+
+  react-native-get-sms-android@2.1.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)):
+    dependencies:
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
   react-native-is-edge-to-edge@1.3.1(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):


### PR DESCRIPTION
Adds the opt-in Android path to the message-import screen — read the inbox with permission instead of pasting — and defaults the import window to the trip's own dates. The paste flow stays as the fallback (and the only path on iOS).

## What changed
- **`lib/smsReader.ts`** — a dependency-injected inbox reader. Platform, native module and permission request are all injected, so the whole refusal matrix is unit-tested without a device: wrong platform, module absent (iOS / Expo Go / any build without it), permission denied, blocked (never-ask-again), read error, synchronous throw, double callback. Every failure returns a described result the screen turns into a sentence — never a crash (the native-module rule the other `lib/*` wrappers follow). Nothing read leaves the device; messages go straight to `proposeFromSms` (ADR-013). `READ_SMS` is requested at runtime, and only after the reader is known to exist.
- **`data/smsWindow.ts`** — the window now defaults to the group's `start_date`/`end_date` (the travel dates), falling back to the earliest expense, then the last 30 days.
- **`import/sms.tsx`** — Android-only "Read my messages" button; read messages merge with pasted ones (each keeps its real received time, so a dateless SMS lands on the day it arrived). Window is derived during render, no effect racing the group load.
- **`app.json`** declares `android.permission.READ_SMS`; `react-native-get-sms-android` added as the optional, lazily-required reader.
- **i18n** — new keys in all four locales (en / ta / hi / ar).

## Tests (35 new)
- `smsReader` (27): filter math, row mapping, JSON tolerance, the full refusal matrix, and a **read → propose end-to-end** that keeps one dated in-window debit and drops a credit, an OTP, and an out-of-window payment; plus dateless-message placement and already-imported dedupe.
- `smsWindow` (8): trip dates, open-ended trips, expense fallback, 30-day fallback, blank-date handling.
- Mobile suite: **196 pass**. Typecheck, lint, prettier: clean.

## ⚠️ Store note
`READ_SMS` is a Google Play **restricted** permission. A non-default-SMS app declaring it needs a Permissions Declaration Form and is often rejected — this was the reason the screen was paste-only. This PR ships the *capability*; submitting the store build with the declaration is a separate, deliberate decision. The feature also needs a dev/prebuild (not Expo Go) to exercise the native read; without it the app cleanly falls back to paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
