### PR TITLE
fix(db): reload PostgREST schema cache so /rate-limits sees its tables

### DIFF
--- a/packages/db/prisma/migrations/20260810130000_reload_postgrest_schema/migration.sql
+++ b/packages/db/prisma/migrations/20260810130000_reload_postgrest_schema/migration.sql
@@ -1,0 +1,19 @@
+-- Reload PostgREST's schema cache.
+--
+-- The rate-limit tables (20260809040000_rate_limit_controls) were deployed, but
+-- the admin /rate-limits page kept reporting them missing. PostgREST caches the
+-- database schema when it boots and only refreshes when told to, and nothing
+-- told it. A read of a table it has not cached comes back PGRST205 — the very
+-- same code as a table that genuinely is not there — so the page could not tell
+-- "not deployed" from "not reloaded", and guessed the first (see TABLE_MISSING
+-- in apps/admin/src/lib/data.ts).
+--
+-- NOTIFY on the `pgrst` channel is the signal PostgREST listens for. It fires on
+-- commit; with no listener — CI's bare Postgres, or any database without
+-- PostgREST attached — it is a harmless no-op, so this is safe to run anywhere.
+--
+-- Going forward, any migration that adds a table, view or function the API
+-- serves should end with this same line, so a deploy never leaves the cache a
+-- step behind what the schema now holds.
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## The problem
The `rate_limit_controls` tables were deployed to prod, but `/rate-limits` kept reporting them missing. PostgREST caches the database schema at boot and only refreshes when it receives `NOTIFY pgrst, 'reload schema'` — and no migration ever sent it. A read of the not-yet-cached tables returns **PGRST205**, which is the *same* code PostgREST returns for a table that truly does not exist (`TABLE_MISSING` in `apps/admin/src/lib/data.ts:62`). So the admin page could not distinguish "not deployed" from "not reloaded" and guessed the former — the confusing message.

## The fix
A one-line migration that issues `NOTIFY pgrst, 'reload schema';`. It fires on commit and is a harmless no-op anywhere no PostgREST is listening (CI's bare Postgres). Deploying it refreshes the prod cache — no hand-run SQL, and `/rate-limits` starts reading the tables. The comment documents the pattern so future table/view/function migrations end the same way.

## Verify
CI `migrations, RLS policies and ledger invariants` runs this against bare Postgres (no listener) — proves it applies cleanly as a no-op. Function-only/notify-only change, no Prisma datamodel change, so no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
