### PR TITLE
feat(mobile): a motion pass — stagger, count-up, press, and an opening

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -4,9 +4,11 @@ import { Tabs } from 'expo-router';
 import { PillTabBar, type PillTabItem } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
+import { useMotion } from '@/lib/motion';
 
 export default function TabsLayout() {
   const { t } = useStrings();
+  const { animated } = useMotion();
 
   const items: PillTabItem[] = [
     {
@@ -39,6 +41,7 @@ export default function TabsLayout() {
           items={items}
           activeKey={state.routes[state.index]?.name ?? 'index'}
           onSelect={(key) => navigation.navigate(key)}
+          animated={animated}
         />
       )}
     >

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -11,7 +11,6 @@ import {
   Gradient,
   IconButton,
   ListRow,
-  MoneyText,
   Row,
   Screen,
   SectionHeader,
@@ -22,6 +21,7 @@ import {
 } from '@baaki/ui';
 
 import { useGroups, useHomeSummary } from '@/data/hooks';
+import { CountUpMoney, Stagger } from '@/lib/anim';
 import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { SyncBanner } from '@/components/SyncBanner';
@@ -147,7 +147,7 @@ export default function HomeScreen() {
           </Row>
 
           <View>
-            <MoneyText
+            <CountUpMoney
               amount={headline.net < 0n ? -headline.net : headline.net}
               currency={headline.currency as never}
               locale={locale}
@@ -174,7 +174,7 @@ export default function HomeScreen() {
               <Text variant="micro" tone="onBrand" style={{ opacity: 0.75 }}>
                 {t.youAreOwed}
               </Text>
-              <MoneyText
+              <CountUpMoney
                 amount={headline.owed}
                 currency={headline.currency as never}
                 locale={locale}
@@ -185,7 +185,7 @@ export default function HomeScreen() {
               <Text variant="micro" tone="onBrand" style={{ opacity: 0.75 }}>
                 {t.youOwe}
               </Text>
-              <MoneyText
+              <CountUpMoney
                 amount={headline.owing}
                 currency={headline.currency as never}
                 locale={locale}
@@ -270,7 +270,7 @@ export default function HomeScreen() {
               }
             />
             <View style={{ gap: theme.spacing.lg }}>
-              {list.map((group) => {
+              {list.map((group, index) => {
                 const members = summary.membersFor(group.id);
                 const balance = summary.balanceFor(group.id);
                 // The other people in the group, for the avatar cluster — your
@@ -280,22 +280,23 @@ export default function HomeScreen() {
                   .filter((member) => !(member.profile_id && member.profile_id === profile?.id))
                   .map((member) => displayName(member, profile?.id));
                 return (
-                  <GroupCard
-                    key={group.id}
-                    id={group.id}
-                    title={groupLabel(group, members, profile?.id)}
-                    memberLabel={plural(locale, summary.memberCountFor(group.id), t.memberCount)}
-                    memberNames={others}
-                    coverEmoji={group.cover_emoji}
-                    balance={balance}
-                    currency={group.default_currency}
-                    locale={locale}
-                    statusLabel={
-                      balance === 0n ? t.allSettled : balance > 0n ? t.youAreOwed : t.youOwe
-                    }
-                    pendingLabel={summary.hasPending(group.id) ? t.pendingConfirmation : null}
-                    onPress={() => router.push(`/group/${group.id}`)}
-                  />
+                  <Stagger key={group.id} index={index}>
+                    <GroupCard
+                      id={group.id}
+                      title={groupLabel(group, members, profile?.id)}
+                      memberLabel={plural(locale, summary.memberCountFor(group.id), t.memberCount)}
+                      memberNames={others}
+                      coverEmoji={group.cover_emoji}
+                      balance={balance}
+                      currency={group.default_currency}
+                      locale={locale}
+                      statusLabel={
+                        balance === 0n ? t.allSettled : balance > 0n ? t.youAreOwed : t.youOwe
+                      }
+                      pendingLabel={summary.hasPending(group.id) ? t.pendingConfirmation : null}
+                      onPress={() => router.push(`/group/${group.id}`)}
+                    />
+                  </Stagger>
                 );
               })}
             </View>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -39,6 +39,7 @@ import { GroupSkeleton } from '@/components/Skeletons';
 import { actorName, displayName, groupLabel, isGhost } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { DetailEnter } from '@/lib/anim';
 import { CategoryBadge } from '@/components/Category';
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { PendingMark } from '@/components/PendingMark';
@@ -101,378 +102,383 @@ export default function GroupScreen() {
 
   return (
     <Screen>
-      <ScrollView
-        contentContainerStyle={{
-          paddingHorizontal: theme.spacing.xl,
-          paddingBottom: 180,
-          gap: theme.spacing.xl,
-        }}
-        showsVerticalScrollIndicator={false}
-        refreshControl={
-          <RefreshControl
-            refreshing={expenses.isFetching && !expenses.isLoading}
-            onRefresh={() => {
-              void expenses.refetch();
-              void settlements.refetch();
-              void activity.refetch();
-            }}
-            tintColor={theme.color.brand}
-          />
-        }
-      >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
-          </IconButton>
-          <Row style={{ flex: 1, gap: theme.spacing.md, justifyContent: 'center' }}>
-            <GroupPhoto
-              photoPath={group.data.photo_path}
-              emoji={group.data.cover_emoji}
-              size={38}
+      <DetailEnter>
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: 180,
+            gap: theme.spacing.xl,
+          }}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl
+              refreshing={expenses.isFetching && !expenses.isLoading}
+              onRefresh={() => {
+                void expenses.refetch();
+                void settlements.refetch();
+                void activity.refetch();
+              }}
+              tintColor={theme.color.brand}
             />
-            <View style={{ flexShrink: 1 }}>
-              <Text variant="heading" numberOfLines={1}>
-                {groupLabel(group.data, members.data ?? [], profile?.id)}
-              </Text>
-              <Text variant="micro" tone="muted">
-                {plural(locale, members.data?.length ?? 0, t.memberCount)}
-              </Text>
-            </View>
-          </Row>
-          {/* Only where there is a trip to plan. A planner on a flatshare
-              group is a tab nobody opens twice. */}
-          {group.data.type === 'trip' ? (
-            <IconButton label={t.plan} onPress={() => router.push(`/group/${groupId}/plan`)}>
-              <Ionicons name="map-outline" size={19} color={theme.color.text} />
+          }
+        >
+          <Row style={{ paddingTop: theme.spacing.md }}>
+            <IconButton label={t.common.back} onPress={() => router.back()}>
+              <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
             </IconButton>
-          ) : null}
-          <IconButton label={t.spending} onPress={() => router.push(`/group/${groupId}/insights`)}>
-            <Ionicons name="pie-chart-outline" size={19} color={theme.color.text} />
-          </IconButton>
-          <IconButton
-            label={t.group.settings}
-            onPress={() => router.push(`/group/${groupId}/settings`)}
-          >
-            <Ionicons name="ellipsis-horizontal" size={20} color={theme.color.text} />
-          </IconButton>
-        </Row>
-
-        <SyncBanner groupId={groupId} />
-
-        {/* If the two independent balance computations ever disagree, say so
-            rather than showing a number that might be wrong (ADR-004). */}
-        {ledger.mismatch ? (
-          <Card style={{ backgroundColor: theme.color.negativeSoft, gap: theme.spacing.sm }}>
-            <Text variant="subheading" tone="negative">
-              {t.group.mismatch}
-            </Text>
-            <Text variant="caption" tone="muted">
-              {t.group.mismatchBody}
-            </Text>
-          </Card>
-        ) : null}
-
-        {/* A bill somebody at this table scanned and shared. Without this the
-            second person has no way to reach it, and the claims CRDT is
-            plumbing with no tap. */}
-        {(openReceipts.data ?? []).map((receipt) => (
-          <Pressable
-            key={receipt.id}
-            accessibilityRole="button"
-            accessibilityLabel={`Split ${receipt.parsed?.merchant ?? 'the bill'} by item`}
-            onPress={() => router.push(`/group/${groupId}/itemize?receipt=${receipt.id}`)}
-          >
-            <Card style={{ gap: theme.spacing.sm }}>
-              <Row style={{ gap: theme.spacing.sm }}>
-                <Ionicons name="receipt-outline" size={18} color={theme.color.brand} />
-                <Text variant="subheading" style={{ flex: 1 }} numberOfLines={1}>
-                  {receipt.parsed?.merchant ?? 'A bill'}
+            <Row style={{ flex: 1, gap: theme.spacing.md, justifyContent: 'center' }}>
+              <GroupPhoto
+                photoPath={group.data.photo_path}
+                emoji={group.data.cover_emoji}
+                size={38}
+              />
+              <View style={{ flexShrink: 1 }}>
+                <Text variant="heading" numberOfLines={1}>
+                  {groupLabel(group.data, members.data ?? [], profile?.id)}
                 </Text>
-                <Ionicons
-                  name={directionalIcon('chevron-forward')}
-                  size={18}
-                  color={theme.color.textFaint}
-                />
-              </Row>
+                <Text variant="micro" tone="muted">
+                  {plural(locale, members.data?.length ?? 0, t.memberCount)}
+                </Text>
+              </View>
+            </Row>
+            {/* Only where there is a trip to plan. A planner on a flatshare
+              group is a tab nobody opens twice. */}
+            {group.data.type === 'trip' ? (
+              <IconButton label={t.plan} onPress={() => router.push(`/group/${groupId}/plan`)}>
+                <Ionicons name="map-outline" size={19} color={theme.color.text} />
+              </IconButton>
+            ) : null}
+            <IconButton
+              label={t.spending}
+              onPress={() => router.push(`/group/${groupId}/insights`)}
+            >
+              <Ionicons name="pie-chart-outline" size={19} color={theme.color.text} />
+            </IconButton>
+            <IconButton
+              label={t.group.settings}
+              onPress={() => router.push(`/group/${groupId}/settings`)}
+            >
+              <Ionicons name="ellipsis-horizontal" size={20} color={theme.color.text} />
+            </IconButton>
+          </Row>
+
+          <SyncBanner groupId={groupId} />
+
+          {/* If the two independent balance computations ever disagree, say so
+            rather than showing a number that might be wrong (ADR-004). */}
+          {ledger.mismatch ? (
+            <Card style={{ backgroundColor: theme.color.negativeSoft, gap: theme.spacing.sm }}>
+              <Text variant="subheading" tone="negative">
+                {t.group.mismatch}
+              </Text>
               <Text variant="caption" tone="muted">
-                {receipt.claimed === 0
-                  ? `${receipt.items} lines, nobody has claimed one yet. Tap what you had.`
-                  : `${receipt.claimed} of ${receipt.items} lines claimed. Tap what you had.`}
+                {t.group.mismatchBody}
               </Text>
             </Card>
-          </Pressable>
-        ))}
+          ) : null}
 
-        <TintCard
-          tint={tintForKey(groupId)}
-          style={{
-            borderRadius: theme.radius.xl,
-            padding: theme.spacing.xl,
-            gap: theme.spacing.lg,
-          }}
-        >
-          <Row style={{ justifyContent: 'space-between' }}>
-            <Text variant="caption" style={{ color: ink, opacity: 0.8 }}>
-              {ledger.myBalance >= 0n ? t.youAreOwed : t.youOwe}
-            </Text>
-            {ledger.pending !== 0n ? <Badge label={t.pendingConfirmation} tone="brand" /> : null}
-          </Row>
+          {/* A bill somebody at this table scanned and shared. Without this the
+            second person has no way to reach it, and the claims CRDT is
+            plumbing with no tap. */}
+          {(openReceipts.data ?? []).map((receipt) => (
+            <Pressable
+              key={receipt.id}
+              accessibilityRole="button"
+              accessibilityLabel={`Split ${receipt.parsed?.merchant ?? 'the bill'} by item`}
+              onPress={() => router.push(`/group/${groupId}/itemize?receipt=${receipt.id}`)}
+            >
+              <Card style={{ gap: theme.spacing.sm }}>
+                <Row style={{ gap: theme.spacing.sm }}>
+                  <Ionicons name="receipt-outline" size={18} color={theme.color.brand} />
+                  <Text variant="subheading" style={{ flex: 1 }} numberOfLines={1}>
+                    {receipt.parsed?.merchant ?? 'A bill'}
+                  </Text>
+                  <Ionicons
+                    name={directionalIcon('chevron-forward')}
+                    size={18}
+                    color={theme.color.textFaint}
+                  />
+                </Row>
+                <Text variant="caption" tone="muted">
+                  {receipt.claimed === 0
+                    ? `${receipt.items} lines, nobody has claimed one yet. Tap what you had.`
+                    : `${receipt.claimed} of ${receipt.items} lines claimed. Tap what you had.`}
+                </Text>
+              </Card>
+            </Pressable>
+          ))}
 
-          {/* mode="balance" keeps the spoken "You are owed ₹X" label and the
-              absolute value; the colour is overridden to ink for the surface. */}
-          <MoneyText
-            amount={ledger.myBalance}
-            currency={currency}
-            locale={locale}
-            mode="balance"
-            variant="display"
-            tone="default"
-            style={{ color: ink }}
-          />
-
-          <Row style={{ gap: theme.spacing.md }}>
-            <Button
-              label={t.settleUp}
-              onPress={() => router.push(`/group/${groupId}/settle`)}
-              icon={<Ionicons name="swap-horizontal" size={18} color={theme.color.onBrand} />}
-            />
-            <Button
-              label={group.data.simplify_debts ? t.simplify : t.whoPaysWhom}
-              variant="secondary"
-              onPress={() => router.push(`/group/${groupId}/simplify`)}
-            />
-          </Row>
-        </TintCard>
-
-        {pendingForMe.map((settlement) => (
-          <Card key={settlement.id} style={{ gap: theme.spacing.md }}>
-            <Text variant="subheading">
-              {`${nameOf(settlement.from_member_id)} says they paid you`}
-            </Text>
-            <Row style={{ gap: theme.spacing.sm }}>
-              <MoneyText
-                amount={BigInt(settlement.amount)}
-                currency={settlement.currency}
-                locale={locale}
-                variant="title"
-              />
-              {settlement.pending ? <PendingMark size={16} /> : null}
+          <TintCard
+            tint={tintForKey(groupId)}
+            style={{
+              borderRadius: theme.radius.xl,
+              padding: theme.spacing.xl,
+              gap: theme.spacing.lg,
+            }}
+          >
+            <Row style={{ justifyContent: 'space-between' }}>
+              <Text variant="caption" style={{ color: ink, opacity: 0.8 }}>
+                {ledger.myBalance >= 0n ? t.youAreOwed : t.youOwe}
+              </Text>
+              {ledger.pending !== 0n ? <Badge label={t.pendingConfirmation} tone="brand" /> : null}
             </Row>
+
+            {/* mode="balance" keeps the spoken "You are owed ₹X" label and the
+              absolute value; the colour is overridden to ink for the surface. */}
+            <MoneyText
+              amount={ledger.myBalance}
+              currency={currency}
+              locale={locale}
+              mode="balance"
+              variant="display"
+              tone="default"
+              style={{ color: ink }}
+            />
+
             <Row style={{ gap: theme.spacing.md }}>
               <Button
-                label={t.group.confirmReceived}
-                onPress={() => confirmSettlement.mutate(settlement.id)}
-                disabled={confirmSettlement.isPending}
+                label={t.settleUp}
+                onPress={() => router.push(`/group/${groupId}/settle`)}
+                icon={<Ionicons name="swap-horizontal" size={18} color={theme.color.onBrand} />}
               />
-              <Text variant="micro" tone="faint" style={{ flex: 1 }}>
-                {t.group.autoConfirms}
+              <Button
+                label={group.data.simplify_debts ? t.simplify : t.whoPaysWhom}
+                variant="secondary"
+                onPress={() => router.push(`/group/${groupId}/simplify`)}
+              />
+            </Row>
+          </TintCard>
+
+          {pendingForMe.map((settlement) => (
+            <Card key={settlement.id} style={{ gap: theme.spacing.md }}>
+              <Text variant="subheading">
+                {`${nameOf(settlement.from_member_id)} says they paid you`}
+              </Text>
+              <Row style={{ gap: theme.spacing.sm }}>
+                <MoneyText
+                  amount={BigInt(settlement.amount)}
+                  currency={settlement.currency}
+                  locale={locale}
+                  variant="title"
+                />
+                {settlement.pending ? <PendingMark size={16} /> : null}
+              </Row>
+              <Row style={{ gap: theme.spacing.md }}>
+                <Button
+                  label={t.group.confirmReceived}
+                  onPress={() => confirmSettlement.mutate(settlement.id)}
+                  disabled={confirmSettlement.isPending}
+                />
+                <Text variant="micro" tone="faint" style={{ flex: 1 }}>
+                  {t.group.autoConfirms}
+                </Text>
+              </Row>
+            </Card>
+          ))}
+
+          <ChipRow<Tab>
+            value={tab}
+            onChange={setTab}
+            options={[
+              { value: 'expenses', label: t.expenses },
+              { value: 'balances', label: t.balances },
+              { value: 'activity', label: t.activity },
+            ]}
+          />
+
+          {tab === 'expenses' ? (
+            <Row style={{ justifyContent: 'flex-end', marginTop: -theme.spacing.md }}>
+              <Text
+                variant="caption"
+                tone="muted"
+                onPress={() => setShowDeleted((current) => !current)}
+              >
+                {showDeleted ? t.group.hideDeleted : t.group.showDeleted}
               </Text>
             </Row>
-          </Card>
-        ))}
+          ) : null}
 
-        <ChipRow<Tab>
-          value={tab}
-          onChange={setTab}
-          options={[
-            { value: 'expenses', label: t.expenses },
-            { value: 'balances', label: t.balances },
-            { value: 'activity', label: t.activity },
-          ]}
-        />
-
-        {tab === 'expenses' ? (
-          <Row style={{ justifyContent: 'flex-end', marginTop: -theme.spacing.md }}>
-            <Text
-              variant="caption"
-              tone="muted"
-              onPress={() => setShowDeleted((current) => !current)}
-            >
-              {showDeleted ? t.group.hideDeleted : t.group.showDeleted}
-            </Text>
-          </Row>
-        ) : null}
-
-        {tab === 'expenses' ? (
-          visibleExpenses.length === 0 ? (
-            <EmptyState title={t.nothingYet} body={t.nothingYetBody} />
-          ) : (
-            <View style={{ gap: theme.spacing.md }}>
-              {visibleExpenses.map((expense) => {
-                const version = expense.currentVersion;
-                const payer = version?.payers[0]?.member_id ?? null;
-                // Somebody disagreeing with an expense is worth seeing from the
-                // list. A disagreement you only find by opening the row is one
-                // that sits there unanswered.
-                const contested = openDisputes.has(expense.id);
-                // Each row is a card in its category's colour — the amount is a
-                // total, shown neutral in the tint's ink. A deleted row is dimmed
-                // rather than hidden, so the ledger stays visibly append-only.
-                const catTint = categoryOf(version?.category).tint;
-                const catInk = theme.tint[catTint].ink;
-                const title = expenseTitle(version?.description, version?.category, t);
-                return (
-                  <Pressable
-                    key={expense.id}
-                    onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
-                    accessibilityRole="button"
-                    accessibilityLabel={title}
-                    style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
-                  >
-                    <TintCard
-                      tint={catTint}
-                      style={{
-                        borderRadius: theme.radius.lg,
-                        padding: theme.spacing.lg,
-                        opacity: expense.deleted_at ? 0.55 : 1,
-                      }}
+          {tab === 'expenses' ? (
+            visibleExpenses.length === 0 ? (
+              <EmptyState title={t.nothingYet} body={t.nothingYetBody} />
+            ) : (
+              <View style={{ gap: theme.spacing.md }}>
+                {visibleExpenses.map((expense) => {
+                  const version = expense.currentVersion;
+                  const payer = version?.payers[0]?.member_id ?? null;
+                  // Somebody disagreeing with an expense is worth seeing from the
+                  // list. A disagreement you only find by opening the row is one
+                  // that sits there unanswered.
+                  const contested = openDisputes.has(expense.id);
+                  // Each row is a card in its category's colour — the amount is a
+                  // total, shown neutral in the tint's ink. A deleted row is dimmed
+                  // rather than hidden, so the ledger stays visibly append-only.
+                  const catTint = categoryOf(version?.category).tint;
+                  const catInk = theme.tint[catTint].ink;
+                  const title = expenseTitle(version?.description, version?.category, t);
+                  return (
+                    <Pressable
+                      key={expense.id}
+                      onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
+                      accessibilityRole="button"
+                      accessibilityLabel={title}
+                      style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
                     >
-                      <Row style={{ gap: theme.spacing.md }}>
-                        <CategoryBadge category={version?.category} size={40} />
-                        <View style={{ flex: 1 }}>
-                          <Text variant="subheading" numberOfLines={1} style={{ color: catInk }}>
-                            {`${title}${contested ? '  🚩' : ''}`}
-                          </Text>
-                          <Text
-                            variant="caption"
-                            numberOfLines={1}
-                            style={{ color: catInk, opacity: 0.7 }}
-                          >
-                            {[
-                              fill(t.expense.paidByName, { name: nameOf(payer) }),
-                              version
-                                ? new Intl.DateTimeFormat(locale, {
-                                    day: 'numeric',
-                                    month: 'short',
-                                  }).format(new Date(version.expense_date))
-                                : null,
-                              expense.deleted_at ? t.expense.deleted : null,
-                              (version?.version_no ?? 1) > 1
-                                ? plural(locale, version!.version_no - 1, t.expense.editedTimes)
-                                : null,
-                            ]
-                              .filter(Boolean)
-                              .join(' · ')}
-                          </Text>
-                        </View>
-                        {version ? (
-                          <Row style={{ gap: theme.spacing.sm }}>
-                            <MoneyText
-                              amount={BigInt(version.amount)}
-                              currency={version.currency}
-                              locale={locale}
-                              tone="default"
-                              style={{ color: catInk, fontWeight: '700' }}
-                            />
-                            {expense.pending ? <PendingMark /> : null}
-                          </Row>
-                        ) : null}
+                      <TintCard
+                        tint={catTint}
+                        style={{
+                          borderRadius: theme.radius.lg,
+                          padding: theme.spacing.lg,
+                          opacity: expense.deleted_at ? 0.55 : 1,
+                        }}
+                      >
+                        <Row style={{ gap: theme.spacing.md }}>
+                          <CategoryBadge category={version?.category} size={40} />
+                          <View style={{ flex: 1 }}>
+                            <Text variant="subheading" numberOfLines={1} style={{ color: catInk }}>
+                              {`${title}${contested ? '  🚩' : ''}`}
+                            </Text>
+                            <Text
+                              variant="caption"
+                              numberOfLines={1}
+                              style={{ color: catInk, opacity: 0.7 }}
+                            >
+                              {[
+                                fill(t.expense.paidByName, { name: nameOf(payer) }),
+                                version
+                                  ? new Intl.DateTimeFormat(locale, {
+                                      day: 'numeric',
+                                      month: 'short',
+                                    }).format(new Date(version.expense_date))
+                                  : null,
+                                expense.deleted_at ? t.expense.deleted : null,
+                                (version?.version_no ?? 1) > 1
+                                  ? plural(locale, version!.version_no - 1, t.expense.editedTimes)
+                                  : null,
+                              ]
+                                .filter(Boolean)
+                                .join(' · ')}
+                            </Text>
+                          </View>
+                          {version ? (
+                            <Row style={{ gap: theme.spacing.sm }}>
+                              <MoneyText
+                                amount={BigInt(version.amount)}
+                                currency={version.currency}
+                                locale={locale}
+                                tone="default"
+                                style={{ color: catInk, fontWeight: '700' }}
+                              />
+                              {expense.pending ? <PendingMark /> : null}
+                            </Row>
+                          ) : null}
+                        </Row>
+                      </TintCard>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            )
+          ) : null}
+
+          {tab === 'balances' ? (
+            <View style={{ gap: theme.spacing.md }}>
+              {(members.data ?? []).map((member) => {
+                // Each member is a card in the money colour for its meaning: mint
+                // when they are owed, pink when they owe, lilac when square. The
+                // balance is drawn in the pair's ink to stay legible on the tint.
+                const balance = ledger.balances.get(member.id) ?? 0n;
+                const rowTint = balance > 0n ? 'mint' : balance < 0n ? 'pink' : 'lilac';
+                const rowInk = theme.tint[rowTint].ink;
+                return (
+                  <TintCard
+                    key={member.id}
+                    tint={rowTint}
+                    style={{ borderRadius: theme.radius.lg, padding: theme.spacing.lg }}
+                  >
+                    <Row style={{ gap: theme.spacing.md }}>
+                      <Avatar name={displayName(member)} ghost={isGhost(member)} size={40} />
+                      <View style={{ flex: 1 }}>
+                        <Text variant="subheading" numberOfLines={1} style={{ color: rowInk }}>
+                          {displayName(member, profile?.id)}
+                        </Text>
+                        <Text
+                          variant="caption"
+                          numberOfLines={1}
+                          style={{ color: rowInk, opacity: 0.7 }}
+                        >
+                          {isGhost(member)
+                            ? t.notJoinedYet
+                            : (member.vpa ?? member.profile?.default_vpa ?? '—')}
+                        </Text>
+                      </View>
+                      <Row style={{ gap: theme.spacing.sm }}>
+                        <MoneyText
+                          amount={balance}
+                          currency={currency}
+                          locale={locale}
+                          mode="balance"
+                          tone="default"
+                          style={{ color: rowInk }}
+                        />
+                        {member.pending ? <PendingMark /> : null}
                       </Row>
-                    </TintCard>
-                  </Pressable>
+                    </Row>
+                  </TintCard>
                 );
               })}
             </View>
-          )
-        ) : null}
+          ) : null}
 
-        {tab === 'balances' ? (
-          <View style={{ gap: theme.spacing.md }}>
-            {(members.data ?? []).map((member) => {
-              // Each member is a card in the money colour for its meaning: mint
-              // when they are owed, pink when they owe, lilac when square. The
-              // balance is drawn in the pair's ink to stay legible on the tint.
-              const balance = ledger.balances.get(member.id) ?? 0n;
-              const rowTint = balance > 0n ? 'mint' : balance < 0n ? 'pink' : 'lilac';
-              const rowInk = theme.tint[rowTint].ink;
-              return (
-                <TintCard
-                  key={member.id}
-                  tint={rowTint}
-                  style={{ borderRadius: theme.radius.lg, padding: theme.spacing.lg }}
-                >
-                  <Row style={{ gap: theme.spacing.md }}>
-                    <Avatar name={displayName(member)} ghost={isGhost(member)} size={40} />
-                    <View style={{ flex: 1 }}>
-                      <Text variant="subheading" numberOfLines={1} style={{ color: rowInk }}>
-                        {displayName(member, profile?.id)}
-                      </Text>
-                      <Text
-                        variant="caption"
-                        numberOfLines={1}
-                        style={{ color: rowInk, opacity: 0.7 }}
-                      >
-                        {isGhost(member)
-                          ? t.notJoinedYet
-                          : (member.vpa ?? member.profile?.default_vpa ?? '—')}
-                      </Text>
-                    </View>
-                    <Row style={{ gap: theme.spacing.sm }}>
-                      <MoneyText
-                        amount={balance}
-                        currency={currency}
-                        locale={locale}
-                        mode="balance"
-                        tone="default"
-                        style={{ color: rowInk }}
-                      />
-                      {member.pending ? <PendingMark /> : null}
-                    </Row>
-                  </Row>
-                </TintCard>
-              );
-            })}
-          </View>
-        ) : null}
-
-        {tab === 'activity' ? (
-          (activity.data ?? []).length === 0 ? (
-            <EmptyState title={t.nothingYet} body={t.group.activityEmptyBody} />
-          ) : (
-            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-              {(activity.data ?? []).map((entry, index) => (
-                <View key={entry.id}>
-                  <ListRow
-                    title={describeActivity(entry, profile?.id ?? null)}
-                    subtitle={new Intl.DateTimeFormat(locale, {
-                      day: 'numeric',
-                      month: 'short',
-                      hour: 'numeric',
-                      minute: '2-digit',
-                    }).format(new Date(entry.created_at))}
-                    leading={
-                      <Avatar
-                        name={actorName(entry.actor, profile?.id ?? null)}
-                        emoji={verbEmoji(entry.verb)}
-                        size={38}
-                      />
-                    }
-                    trailing={
-                      typeof entry.payload.amount === 'string' ? (
-                        <MoneyText
-                          amount={BigInt(entry.payload.amount)}
-                          currency={(entry.payload.currency as string) ?? currency}
-                          locale={locale}
-                          variant="caption"
+          {tab === 'activity' ? (
+            (activity.data ?? []).length === 0 ? (
+              <EmptyState title={t.nothingYet} body={t.group.activityEmptyBody} />
+            ) : (
+              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                {(activity.data ?? []).map((entry, index) => (
+                  <View key={entry.id}>
+                    <ListRow
+                      title={describeActivity(entry, profile?.id ?? null)}
+                      subtitle={new Intl.DateTimeFormat(locale, {
+                        day: 'numeric',
+                        month: 'short',
+                        hour: 'numeric',
+                        minute: '2-digit',
+                      }).format(new Date(entry.created_at))}
+                      leading={
+                        <Avatar
+                          name={actorName(entry.actor, profile?.id ?? null)}
+                          emoji={verbEmoji(entry.verb)}
+                          size={38}
                         />
-                      ) : null
-                    }
-                  />
-                  {index < (activity.data?.length ?? 0) - 1 ? (
-                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                  ) : null}
-                </View>
-              ))}
-            </Card>
-          )
-        ) : null}
-      </ScrollView>
+                      }
+                      trailing={
+                        typeof entry.payload.amount === 'string' ? (
+                          <MoneyText
+                            amount={BigInt(entry.payload.amount)}
+                            currency={(entry.payload.currency as string) ?? currency}
+                            locale={locale}
+                            variant="caption"
+                          />
+                        ) : null
+                      }
+                    />
+                    {index < (activity.data?.length ?? 0) - 1 ? (
+                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                    ) : null}
+                  </View>
+                ))}
+              </Card>
+            )
+          ) : null}
+        </ScrollView>
 
-      <Fab
-        label={t.addExpense}
-        onPress={() => router.push(`/group/${groupId}/add-expense`)}
-        icon={<Ionicons name="add" size={22} color={theme.color.onBrand} />}
-      />
+        <Fab
+          label={t.addExpense}
+          onPress={() => router.push(`/group/${groupId}/add-expense`)}
+          icon={<Ionicons name="add" size={22} color={theme.color.onBrand} />}
+        />
+      </DetailEnter>
     </Screen>
   );
 }

--- a/apps/mobile/src/components/GroupCard.tsx
+++ b/apps/mobile/src/components/GroupCard.tsx
@@ -16,7 +16,7 @@
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { CurrencyCode } from '@baaki/core';
 import {
@@ -30,6 +30,8 @@ import {
   tintForKey,
   useTheme,
 } from '@baaki/ui';
+
+import { PressableScale } from '@/lib/anim';
 
 export function GroupCard({
   id,
@@ -64,12 +66,7 @@ export function GroupCard({
   const ink = theme.tint[tint].ink;
 
   return (
-    <Pressable
-      onPress={onPress}
-      accessibilityRole="button"
-      accessibilityLabel={title}
-      style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
-    >
+    <PressableScale onPress={onPress} accessibilityRole="button" accessibilityLabel={title}>
       <TintCard
         tint={tint}
         style={{ borderRadius: theme.radius.xl, padding: theme.spacing.xl, gap: theme.spacing.lg }}
@@ -134,6 +131,6 @@ export function GroupCard({
           </View>
         </Row>
       </TintCard>
-    </Pressable>
+    </PressableScale>
   );
 }

--- a/apps/mobile/src/lib/anim.tsx
+++ b/apps/mobile/src/lib/anim.tsx
@@ -1,0 +1,224 @@
+/**
+ * The app's motion, in one place and behind one switch.
+ *
+ * Every primitive here reads `useMotion()` and does nothing when it says off —
+ * so a phone with reduce-motion set, or somebody who turned animation off in
+ * settings, gets the same still screens they asked for and none of this runs.
+ * Motion is a response, not a scene (see `lib/motion`): entrances are short,
+ * the count keeps to well under a second, and a press answers under the finger.
+ *
+ * The pure maths lives at the bottom, exported, because a count that lands on
+ * the wrong number or a stagger that never stops is a bug you want to catch in
+ * a test rather than by watching the screen.
+ */
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Pressable, type PressableProps, type ViewStyle } from 'react-native';
+import Animated, {
+  FadeInDown,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+  type EntryExitAnimationFunction,
+} from 'react-native-reanimated';
+
+import { MoneyText, type MoneyTextProps } from '@baaki/ui';
+
+import { useMotion } from './motion';
+import { easeOutCubic, lerpBig, MAX_SAFE_MINOR, staggerDelay } from './motionMath';
+
+export { easeOutCubic, lerpBig, MAX_SAFE_MINOR, staggerDelay } from './motionMath';
+
+/** Whether motion should play at all. The one gate every primitive here reads. */
+export function useMotionEnabled(): boolean {
+  return useMotion().animated;
+}
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+/** The spring a press answers with: quick, barely overshooting, back to rest. */
+const PRESS_SPRING = { damping: 18, stiffness: 280, mass: 0.5 } as const;
+
+/**
+ * A list item that arrives rather than appears.
+ *
+ * Each card fades up a beat after the one above it (`staggerDelay`), which is
+ * what makes a list read as one thing settling into place instead of a block
+ * that blinks on. The delay is capped, so a long list finishes rather than
+ * dribbling in for a second and a half.
+ *
+ * The entrance plays once, when the row mounts — a data refetch that keeps the
+ * same keys does not remount, so the list does not re-stagger every pull.
+ */
+export function Stagger({ index = 0, children }: { index?: number; children: ReactNode }) {
+  const enabled = useMotionEnabled();
+  if (!enabled) return <>{children}</>;
+  return (
+    <Animated.View entering={FadeInDown.duration(340).delay(staggerDelay(index))}>
+      {children}
+    </Animated.View>
+  );
+}
+
+/**
+ * A pressable that dips under the finger.
+ *
+ * Replaces the flat opacity blink with a spring scale, which is the difference
+ * between a card that registers a tap and one that feels like a button. With
+ * motion off it falls back to the same opacity feedback the rest of the app
+ * uses, so nothing loses its "I heard you" — only the movement goes.
+ */
+export function PressableScale({
+  children,
+  style,
+  onPressIn,
+  onPressOut,
+  ...rest
+}: Omit<PressableProps, 'style'> & { children: ReactNode; style?: ViewStyle }) {
+  const enabled = useMotionEnabled();
+  // `.get()`/`.set()` rather than `.value`: the same shared value, through the
+  // method API Reanimated 4 added — a call, not an assignment to a property the
+  // React compiler treats as immutable and refuses inside a handler.
+  const scale = useSharedValue(1);
+  const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.get() }] }));
+
+  if (!enabled) {
+    return (
+      <Pressable
+        style={({ pressed }) => [style, { opacity: pressed ? 0.9 : 1 }]}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        {...rest}
+      >
+        {children}
+      </Pressable>
+    );
+  }
+
+  return (
+    <AnimatedPressable
+      style={[animatedStyle, style]}
+      onPressIn={(event) => {
+        scale.set(withSpring(0.96, PRESS_SPRING));
+        onPressIn?.(event);
+      }}
+      onPressOut={(event) => {
+        scale.set(withSpring(1, PRESS_SPRING));
+        onPressOut?.(event);
+      }}
+      {...rest}
+    >
+      {children}
+    </AnimatedPressable>
+  );
+}
+
+/**
+ * The detail screen a card opens onto, arriving as if it grew from the tap.
+ *
+ * Reanimated 4 dropped the shared-element transition tag, so this is not a
+ * literal morph of the card into the screen — it is the screen's own content
+ * springing up from just under full size while it fades in, which reads as an
+ * opening rather than a slide. Paired with `PressableScale` on the card that
+ * launched it, the tap and the arrival belong to each other.
+ */
+export function DetailEnter({ children, style }: { children: ReactNode; style?: ViewStyle }) {
+  const enabled = useMotionEnabled();
+  return (
+    <Animated.View style={[{ flex: 1 }, style]} entering={enabled ? detailEntering : undefined}>
+      {children}
+    </Animated.View>
+  );
+}
+
+/**
+ * The open, as a declarative entrance rather than a mount effect: content starts
+ * a shade under full size and transparent, then springs up and fades in. Written
+ * this way — a worklet Reanimated runs on the UI thread — so nothing here mutates
+ * a value from an effect, which the screen never needed and the linter rightly
+ * refuses.
+ */
+const detailEntering: EntryExitAnimationFunction = () => {
+  'worklet';
+  return {
+    initialValues: { opacity: 0, transform: [{ scale: 0.97 }] },
+    animations: {
+      opacity: withTiming(1, { duration: 220 }),
+      transform: [{ scale: withSpring(1, { damping: 20, stiffness: 200 }) }],
+    },
+  };
+};
+
+/**
+ * A money value that rolls up to its figure instead of printing at once.
+ *
+ * Wraps `MoneyText` and animates the amount from where it was to where it is,
+ * so a balance counts up on first load and slides to the new number when it
+ * changes. Everything else — the currency, the faded paise, the spoken label —
+ * is `MoneyText`'s, unchanged; this only feeds it a moving `amount`. Motion off
+ * means it renders the final figure and never moves.
+ */
+export function CountUpMoney(props: MoneyTextProps): ReactNode {
+  const enabled = useMotionEnabled();
+  const shown = useCountUp(props.amount, enabled);
+  return <MoneyText {...props} amount={shown} />;
+}
+
+/** Roughly the length of a screen transition — long enough to read, short enough to trust. */
+const COUNT_MS = 650;
+
+/**
+ * Tween a bigint towards `target`, easing out, on the JS thread.
+ *
+ * Off, or a figure too large to hold in a Number without losing paise, snaps
+ * straight to the target — a wrong number is worse than a still one. Otherwise
+ * it animates from whatever is on screen now, so a mid-flight change redirects
+ * smoothly rather than jumping back to zero.
+ */
+export function useCountUp(target: bigint, enabled: boolean): bigint {
+  // The start figure is decided here rather than in the effect: motion off, or a
+  // number too large to tween as a Number, begins on the target and never moves.
+  const [value, setValue] = useState<bigint>(() =>
+    enabled && !tooLargeToTween(target) ? 0n : target,
+  );
+  const frame = useRef<number | null>(null);
+
+  useEffect(() => {
+    // Snapping is a state change too, so it goes through a frame rather than
+    // running synchronously in the effect body — the same reason the tween does.
+    if (!enabled || tooLargeToTween(target)) {
+      frame.current = requestAnimationFrame(() => setValue(target));
+      return () => {
+        if (frame.current !== null) cancelAnimationFrame(frame.current);
+      };
+    }
+
+    const started = Date.now();
+    // The figure on screen when this frame first fires is where the tween starts,
+    // read through the updater so a mid-flight target change redirects from the
+    // current number rather than jumping back to zero — and without a ref written
+    // during render to carry it.
+    let from: bigint | null = null;
+    const step = (): void => {
+      const progress = Math.min(1, (Date.now() - started) / COUNT_MS);
+      setValue((current) => {
+        if (from === null) from = current;
+        return lerpBig(from, target, easeOutCubic(progress));
+      });
+      if (progress < 1) frame.current = requestAnimationFrame(step);
+    };
+    frame.current = requestAnimationFrame(step);
+
+    return () => {
+      if (frame.current !== null) cancelAnimationFrame(frame.current);
+    };
+  }, [target, enabled]);
+
+  return value;
+}
+
+/** A magnitude past the Number safe-integer ceiling would lose paise mid-tween. */
+function tooLargeToTween(target: bigint): boolean {
+  return (target < 0n ? -target : target) > MAX_SAFE_MINOR;
+}

--- a/apps/mobile/src/lib/motionMath.ts
+++ b/apps/mobile/src/lib/motionMath.ts
@@ -1,0 +1,33 @@
+/**
+ * The arithmetic behind the app's motion, with no React or React Native in it.
+ *
+ * Kept apart from `anim` on purpose: a count that lands on the wrong figure or a
+ * stagger that never stops is a bug worth a test, and a test should not have to
+ * boot a native animation runtime to check a number. Everything here is pure.
+ */
+
+/** The largest minor-unit amount a Number can carry without dropping paise. */
+export const MAX_SAFE_MINOR = BigInt(Number.MAX_SAFE_INTEGER);
+
+/** Standard ease-out cubic: fast off the mark, settling gently onto the value. */
+export function easeOutCubic(t: number): number {
+  const remaining = 1 - Math.min(1, Math.max(0, t));
+  return 1 - remaining * remaining * remaining;
+}
+
+/** Interpolate between two bigints at progress `p` in [0, 1], rounded to the unit. */
+export function lerpBig(from: bigint, to: bigint, p: number): bigint {
+  if (p >= 1) return to;
+  if (p <= 0) return from;
+  return from + BigInt(Math.round(Number(to - from) * p));
+}
+
+/**
+ * How long the row at `index` waits before it arrives. Capped, so a long list
+ * lands in a bounded window rather than staggering on for as long as it is.
+ */
+export function staggerDelay(index: number): number {
+  const STEP_MS = 55;
+  const CAP = 8;
+  return Math.min(Math.max(0, index), CAP) * STEP_MS;
+}

--- a/apps/mobile/test/motionMath.test.ts
+++ b/apps/mobile/test/motionMath.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The count-up and the stagger, checked as numbers.
+ *
+ * These are the two ways the motion can be wrong without looking wrong on the
+ * screen it runs on: a balance that eases to the wrong figure, or a list whose
+ * stagger grows without bound the longer the list is. Both are caught here.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { easeOutCubic, lerpBig, MAX_SAFE_MINOR, staggerDelay } from '@/lib/motionMath';
+
+describe('easeOutCubic', () => {
+  it('pins the ends and eases in between', () => {
+    expect(easeOutCubic(0)).toBe(0);
+    expect(easeOutCubic(1)).toBe(1);
+    // Ease-out is past halfway at the midpoint — most of the distance early.
+    expect(easeOutCubic(0.5)).toBeGreaterThan(0.5);
+  });
+
+  it('clamps input outside [0, 1] rather than overshooting', () => {
+    expect(easeOutCubic(-1)).toBe(0);
+    expect(easeOutCubic(2)).toBe(1);
+  });
+});
+
+describe('lerpBig', () => {
+  it('lands exactly on the target at the end, to the paise', () => {
+    // The whole point: a count-up must finish on the real number, not near it.
+    expect(lerpBig(0n, 45_000n, 1)).toBe(45_000n);
+    expect(lerpBig(0n, 45_000n, 0)).toBe(0n);
+  });
+
+  it('rounds to the unit part-way through', () => {
+    expect(lerpBig(0n, 100n, 0.5)).toBe(50n);
+    expect(lerpBig(0n, 3n, 0.5)).toBe(2n); // Math.round(1.5) === 2
+  });
+
+  it('counts down as readily as up', () => {
+    expect(lerpBig(1000n, 0n, 0.25)).toBe(750n);
+  });
+
+  it('snaps to the ends when progress runs past them', () => {
+    expect(lerpBig(0n, 500n, 1.5)).toBe(500n);
+    expect(lerpBig(0n, 500n, -0.5)).toBe(0n);
+  });
+});
+
+describe('staggerDelay', () => {
+  it('steps the delay up one row at a time', () => {
+    expect(staggerDelay(0)).toBe(0);
+    expect(staggerDelay(1)).toBe(55);
+    expect(staggerDelay(3)).toBe(165);
+  });
+
+  it('caps, so a long list still finishes arriving', () => {
+    expect(staggerDelay(8)).toBe(440);
+    expect(staggerDelay(50)).toBe(440);
+    expect(staggerDelay(8)).toBe(staggerDelay(200));
+  });
+
+  it('treats a negative index as the first row', () => {
+    expect(staggerDelay(-5)).toBe(0);
+  });
+});
+
+describe('MAX_SAFE_MINOR', () => {
+  it('is the Number safe-integer ceiling, as a bigint', () => {
+    expect(MAX_SAFE_MINOR).toBe(9_007_199_254_740_991n);
+  });
+});

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import { Pressable, View } from 'react-native';
+import { useEffect, useRef, type ReactNode } from 'react';
+import { Animated, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useTheme } from '../theme';
@@ -43,15 +43,22 @@ export function useTabBarClearance(): number {
  * The floating pill navigation from the reference boards: a white capsule that
  * hovers over the content, with the active destination expanding into a filled
  * purple pill that also shows its label.
+ *
+ * `animated` gives each destination a dip under the finger and fades its label
+ * in as it becomes active. It defaults off so the bar is still and deterministic
+ * unless a caller opts in — the tabs layout passes the app's motion preference,
+ * so a phone with reduce-motion set keeps the plain switch.
  */
 export function PillTabBar({
   items,
   activeKey,
   onSelect,
+  animated = false,
 }: {
   items: readonly PillTabItem[];
   activeKey: string;
   onSelect: (key: string) => void;
+  animated?: boolean;
 }) {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
@@ -78,34 +85,95 @@ export function PillTabBar({
         ...theme.shadow.lifted,
       }}
     >
-      {items.map((item) => {
-        const focused = item.key === activeKey;
-        return (
-          <Pressable
-            key={item.key}
-            accessibilityRole="tab"
-            accessibilityState={{ selected: focused }}
-            accessibilityLabel={item.label}
-            onPress={() => onSelect(item.key)}
-            style={{
-              flexDirection: 'row',
-              alignItems: 'center',
-              gap: focused ? theme.spacing.sm : 0,
-              paddingHorizontal: focused ? theme.spacing.lg : theme.spacing.md,
-              height: ITEM_HEIGHT,
-              borderRadius: theme.radius.pill,
-              backgroundColor: focused ? theme.color.brand : 'transparent',
-            }}
-          >
-            {item.icon(focused ? theme.color.onBrand : theme.color.textMuted, focused)}
-            {focused ? (
-              <Text variant="caption" tone="onBrand">
-                {item.label}
-              </Text>
-            ) : null}
-          </Pressable>
-        );
-      })}
+      {items.map((item) => (
+        <TabItem
+          key={item.key}
+          item={item}
+          focused={item.key === activeKey}
+          animated={animated}
+          onSelect={onSelect}
+        />
+      ))}
     </View>
+  );
+}
+
+function TabItem({
+  item,
+  focused,
+  animated,
+  onSelect,
+}: {
+  item: PillTabItem;
+  focused: boolean;
+  animated: boolean;
+  onSelect: (key: string) => void;
+}) {
+  const theme = useTheme();
+
+  // Built on core Animated, both on the native driver: the press scale and the
+  // label fade are transform and opacity, which the UI thread owns, so neither
+  // waits on JavaScript. Kept out of the UI package's dependencies on purpose —
+  // this is the one bit of motion the shared kit needs, and it does not need a
+  // whole animation library to get it.
+  const scale = useRef(new Animated.Value(1)).current;
+  const labelOpacity = useRef(new Animated.Value(focused ? 1 : 0)).current;
+
+  useEffect(() => {
+    if (!focused) return;
+    if (!animated) {
+      labelOpacity.setValue(1);
+      return;
+    }
+    labelOpacity.setValue(0);
+    Animated.timing(labelOpacity, {
+      toValue: 1,
+      duration: 180,
+      useNativeDriver: true,
+    }).start();
+  }, [focused, animated, labelOpacity]);
+
+  const press = (to: number): void => {
+    if (!animated) return;
+    Animated.spring(scale, {
+      toValue: to,
+      damping: 18,
+      stiffness: 280,
+      mass: 0.5,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  return (
+    <Pressable
+      accessibilityRole="tab"
+      accessibilityState={{ selected: focused }}
+      accessibilityLabel={item.label}
+      onPress={() => onSelect(item.key)}
+      onPressIn={() => press(0.9)}
+      onPressOut={() => press(1)}
+    >
+      <Animated.View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: focused ? theme.spacing.sm : 0,
+          paddingHorizontal: focused ? theme.spacing.lg : theme.spacing.md,
+          height: ITEM_HEIGHT,
+          borderRadius: theme.radius.pill,
+          backgroundColor: focused ? theme.color.brand : 'transparent',
+          transform: [{ scale }],
+        }}
+      >
+        {item.icon(focused ? theme.color.onBrand : theme.color.textMuted, focused)}
+        {focused ? (
+          <Animated.View style={{ opacity: labelOpacity }}>
+            <Text variant="caption" tone="onBrand">
+              {item.label}
+            </Text>
+          </Animated.View>
+        ) : null}
+      </Animated.View>
+    </Pressable>
   );
 }


### PR DESCRIPTION
## What

A motion pass on the app, drawn from a Shakuro fintech-app reel. Four movements, **all gated by the existing motion switch** (`lib/motion` — on / off / follow the phone's reduce-motion). A phone with reduce-motion set, or anyone who turned animation off in settings, gets the same still screens and none of this runs. TDR §11 treats accessibility settings as inputs, not hints.

## The four

| Movement | Where | What |
|---|---|---|
| **Stagger** | home group list | cards fade up one after the next; the per-row delay is capped, so a long list lands in a bounded window instead of dribbling in |
| **Count-up** | home balance + you-owe / you-are-owed | figures roll to their number on load and slide to it on change. Wraps `MoneyText`, so currency, faded paise and the spoken label are unchanged — only the amount moves. A figure too large to hold in a Number snaps rather than tweens (a wrong number is worse than a still one) |
| **Press** | group cards | dip under the finger on a spring, replacing the flat opacity blink; the plain opacity feedback is the motion-off fallback |
| **Opening** | group detail screen | content springs up from just under full size while it fades in |

**On the opening:** Reanimated 4 dropped `sharedTransitionTag`, so this is an *opening* animation rather than a literal card-to-screen morph. Paired with the card scaling under the tap, the two still read as belonging to each other — without pulling in a shared-element library.

## Notes

- **`PillTabBar` gains `animated` (default off).** Each destination dips on press and fades its label in, built on **core `Animated`'s native driver** — so the shared UI kit takes on no animation dependency. The tabs layout passes the app's motion preference.
- **Reanimated 4** is already installed; `babel-preset-expo@57` auto-enables the worklets plugin, so no config change was needed. All movement uses `.get()`/`.set()` and declarative `entering` worklets — nothing mutates a value from an effect (which the React-19 compiler lint rightly refuses).
- **The pure maths is split out and tested.** `motionMath` (no React, no RN) holds the ease, the bigint interpolation and the stagger cap; 10 cases pin that a count lands *exactly* on its figure and a stagger never grows without bound.

## Tests

- `@baaki/mobile` full suite **206/206** (10 new in `motionMath.test.ts`)
- mobile + `@baaki/ui` typecheck clean; mobile lint clean; prettier clean

## Not verified

The animations themselves are **not visually verified** — no device or simulator was run here. The logic (gating, count arithmetic, stagger cap) is tested; the look needs a dev build. Reduce-motion / animation-off paths are wired to render the current still screens unchanged, so the worst case of a wrong timing value is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
