### PR TITLE
fix: show a skeleton on friends and contacts, not a false verdict

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -36,6 +36,7 @@ import {
 } from '@baaki/ui';
 
 import { fetchPeopleBalances, type PersonBalanceRow } from '@/data/api';
+import { PeopleSkeleton } from '@/components/Skeletons';
 import { plural, useStrings } from '@/i18n';
 
 export default function FriendsScreen() {
@@ -80,7 +81,9 @@ export default function FriendsScreen() {
           />
         </Row>
 
-        {rows.length === 0 ? (
+        {people.isLoading ? (
+          <PeopleSkeleton />
+        ) : rows.length === 0 ? (
           <EmptyState title={t.tabs.allSquare} body={t.tabs.allSquareBody} />
         ) : (
           <>

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -36,6 +36,7 @@ import {
 import { Avatar, Button, Card, EmptyState, Row, Text, useTheme } from '@baaki/ui';
 
 import { plural, useStrings } from '@/i18n';
+import { SkeletonList } from '@/components/Skeletons';
 
 export interface PickedContact {
   readonly name: string;
@@ -231,13 +232,10 @@ export function ContactPicker({
   }, []);
 
   if (access === 'asking') {
-    return (
-      <Card>
-        <Text variant="caption" tone="muted">
-          Looking through your contacts…
-        </Text>
-      </Card>
-    );
+    // Reading a full address book is a real wait, so this is the shape of the
+    // list that is coming — rows of a face and a name — not a line of text.
+    // No trailing block: a contact row ends in a tick, not an amount.
+    return <SkeletonList rows={6} trailing={false} />;
   }
 
   if (access === 'denied') {

--- a/apps/mobile/src/components/Skeletons.tsx
+++ b/apps/mobile/src/components/Skeletons.tsx
@@ -177,6 +177,27 @@ export function ListScreenSkeleton({
   );
 }
 
+/**
+ * The friends tab: the two balance sections — owed to you, and what you owe —
+ * each a heading and a short list. Shaped like the real screen so the swap is a
+ * fill, and shown in place of it rather than the "all square" empty state,
+ * which is a verdict on somebody's money the query has not returned yet.
+ */
+export function PeopleSkeleton() {
+  const theme = useTheme();
+  const { animated } = useMotion();
+  return (
+    <LoadingRegion style={{ gap: theme.spacing.xl }}>
+      {[0, 1].map((section) => (
+        <View key={section} style={{ gap: theme.spacing.md }}>
+          <Skeleton width="35%" height={16} animated={animated} />
+          <SkeletonList rows={2} />
+        </View>
+      ))}
+    </LoadingRegion>
+  );
+}
+
 /** Insights: a heading and a couple of chart-sized blocks. */
 export function InsightsSkeleton() {
   const theme = useTheme();


### PR DESCRIPTION
## What

Two screens rendered a loaded state while still loading.

**Friends tab** rendered straight from an empty query result during a cold launch, so the first thing shown was the **"all square" empty state** — a verdict on somebody's money before the balances query returned — which then flipped to real numbers a beat later. Now gated on `isLoading` with a new `PeopleSkeleton` shaped like the two balance sections (owed to you / you owe), the way the home tab already does it.

**Contacts picker** showed a line of text ("Looking through your contacts…") while reading the address book. Reading a full book is a real wait, so it now shows a `SkeletonList` shaped like the contact rows that are coming (no trailing block — a contact row ends in a tick, not an amount).

## Notes

- New `PeopleSkeleton` added alongside the existing `HomeSkeleton`/`GroupSkeleton` in `Skeletons.tsx`, wrapped in the same `LoadingRegion` so a screen reader announces it once.
- Typecheck + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)