### PR TITLE
fix: animate tab switches instead of hard-cutting between them

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -35,7 +35,14 @@ export default function TabsLayout() {
 
   return (
     <Tabs
-      screenOptions={{ headerShown: false }}
+      screenOptions={{
+        headerShown: false,
+        // Tabs hard-cut without this. Scenes shift-and-fade as you move between
+        // them, which reads as the tabs sitting side by side rather than
+        // stacking. Honours the app's own motion switch: somebody who turned
+        // motion off gets the instant swap, not a jump they did not ask for.
+        animation: animated ? 'shift' : 'none',
+      }}
       tabBar={({ state, navigation }) => (
         <PillTabBar
           items={items}


### PR DESCRIPTION
## What

The bottom tab navigator defaults to `animation: 'none'`, so moving between **Home / Friends / Activity / Profile** swapped one screen for the next in a single frame — no transition. Set the vendored bottom-tabs `'shift'` animation, so scenes slide-and-fade across the four tabs, reading as them sitting side by side rather than stacking.

## Motion preference

Gated on the app's own motion switch (`useMotion().animated`) — a user who turned motion off inside Baaki still gets the instant swap, not a transition they opted out of. Same pattern the skeletons already follow.

## Verification

Typecheck + lint green. **Not device-verified** — no emulator in this environment; the `'shift'` value is the documented bottom-tabs option and typechecks against expo-router 57's vendored navigator. Worth an eyes-on pass on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)