### PR TITLE
fix: stop NOT_A_MEMBER when creating a group with people in it

### DIFF
--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
@@ -8,8 +9,9 @@ import { Button, Card, ChipRow, IconButton, Row, Screen, Text, useTheme } from '
 
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { pickGroupPhoto, type PickedImage } from '@/lib/image';
-import { addGhostMember, uploadGroupPhoto } from '@/data/api';
+import { uploadGroupPhoto } from '@/data/api';
 import { useCreateGroup } from '@/data/hooks';
+import { useSync } from '@/sync';
 import type { GroupType } from '@/data/types';
 import { deviceCountry, useStrings } from '@/i18n';
 
@@ -31,6 +33,7 @@ export default function NewGroupScreen() {
   const theme = useTheme();
   const { t } = useStrings();
   const createGroup = useCreateGroup();
+  const { mutate, flush } = useSync();
 
   const [name, setName] = useState('');
   const [photo, setPhoto] = useState<PickedImage | null>(null);
@@ -65,14 +68,29 @@ export default function NewGroupScreen() {
         simplify: type === 'trip' || type === 'event',
       });
       // ADR-006: people who have not installed anything are still participants.
+      //
+      // Queued through the same offline pipe as the group, not sent as a direct
+      // RPC. The create above only resolves once it is on disk, not once it has
+      // reached the server — so a direct `baaki_add_ghost_member` here raced the
+      // create and hit a group the server had never seen, which is exactly the
+      // membership check it fails: `NOT_A_MEMBER`. Behind the create in one
+      // ordered queue, each ghost applies after the group it belongs to exists.
       for (const ghost of ghosts) {
-        await addGhostMember(groupId, ghost);
+        await mutate('member.add_ghost', groupId, {
+          memberId: randomUUID(),
+          name: ghost,
+          email: null,
+          phone: null,
+        });
       }
-      // After the group exists, because the storage policy is "members of this
-      // group only" and there is no membership until there is a group.
+      // The photo lives in Storage, not the offline queue, and the storage
+      // policy is "members of this group only" — which needs the group, and the
+      // membership row, to actually be on the server. Flush the queued create
+      // (and the ghosts behind it) before writing an object under its id.
       if (photo) {
         setUploading(true);
         try {
+          await flush([groupId]);
           await uploadGroupPhoto({ groupId, base64: photo.base64, mimeType: photo.mimeType });
         } catch {
           // A photo that would not upload is not worth losing the group over;


### PR DESCRIPTION
## Symptom

Creating a group with a ghost member in one go failed with **`NOT_A_MEMBER: you are not in that group`** — on the group you had just created. (Screenshot: New group → add "Ren test 1" → Create group.)

## Cause

A race between two different write paths:

- `useCreateGroup` queues `group.create` through the **offline sync engine** and resolves as soon as the mutation is **durably on disk**, not once it has reached the server.
- `new-group.tsx` then called `addGhostMember` — a **direct `baaki_add_ghost_member` RPC** against the server.

When the create hadn't flushed yet, that RPC hit a group the server had never seen. Its first check — is the caller a member of this group — found no `group_members` row and raised `NOT_A_MEMBER`.

## Fix

Queue the ghosts through the **same sync engine**, behind the create in one ordered queue, so each `member.add_ghost` applies only after the `group.create` ahead of it. `member.add_ghost` was already a first-class mutation kind (`useAddGhostMember` uses it) — the screen was just using the wrong door.

Also flush the queued create before the **cover photo** upload: Storage's "members of this group only" policy needs the group + membership row on the server first, so the same race silently dropped photos on freshly created groups.

## Bonus

Creating a group with people in it now works **offline**, which the direct RPC never did.

## Verification

Typecheck + lint green. **Not device-verified** (no emulator here) — worth reproducing the exact screenshot flow on a device once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)