### PR TITLE
feat(ui): a Callout for errors, instead of red text under the button

### DIFF
--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -5,7 +5,7 @@ import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import { currencyForCountry, guessGroupEmoji } from '@baaki/core';
-import { Button, Card, ChipRow, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import { Button, Callout, Card, ChipRow, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { pickGroupPhoto, type PickedImage } from '@/lib/image';
@@ -243,9 +243,12 @@ export default function NewGroupScreen() {
         </Card>
 
         {error ? (
-          <Text variant="caption" tone="negative">
+          <Callout
+            tone="negative"
+            icon={(color) => <Ionicons name="alert-circle" size={20} color={color} />}
+          >
             {error}
-          </Text>
+          </Callout>
         ) : null}
         {createGroup.isPending || uploading ? (
           <ActivityIndicator color={theme.color.brand} />

--- a/packages/ui/src/components/Callout.tsx
+++ b/packages/ui/src/components/Callout.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from 'react';
+import { View, type ViewStyle } from 'react-native';
+
+import { useTheme, type Theme } from '../theme';
+import { Text } from './Text';
+
+/**
+ * A message the screen wants a person to actually read — a submit that failed,
+ * a warning before an irreversible tap, a note that something worked.
+ *
+ * It exists because the alternative kept turning up: a bare line of
+ * `<Text tone="negative">` wedged between the form and the button, the same red
+ * as a hundred other things, easy to miss and easy to mistake for a field
+ * label. A message worth showing is worth giving a shape — a tinted panel in
+ * its own colour, an icon that says at a glance which of the four this is, and
+ * air around the words. This is that shape, in one place, so every screen says
+ * "that did not work" the same way.
+ *
+ * Icon-agnostic on purpose: this package carries no icon library, the way
+ * `PillTabBar` does not. The screen passes a render function and is handed back
+ * the colour the icon should be, so the glyph always matches the tone without
+ * the caller having to look it up.
+ */
+export type CalloutTone = 'negative' | 'warning' | 'positive' | 'info';
+
+interface CalloutColors {
+  readonly fg: string;
+  readonly bg: string;
+}
+
+function calloutColors(theme: Theme, tone: CalloutTone): CalloutColors {
+  switch (tone) {
+    case 'warning':
+      return { fg: theme.color.warning, bg: theme.color.warningSoft };
+    case 'positive':
+      return { fg: theme.color.positive, bg: theme.color.positiveSoft };
+    case 'info':
+      return { fg: theme.color.brand, bg: theme.color.brandSoft };
+    case 'negative':
+    default:
+      return { fg: theme.color.negative, bg: theme.color.negativeSoft };
+  }
+}
+
+export function Callout({
+  tone = 'negative',
+  icon,
+  title,
+  children,
+  style,
+}: {
+  tone?: CalloutTone;
+  /**
+   * Rendered at the leading edge, handed the tone's colour so it matches
+   * without the caller resolving it. Omit for a message that needs no glyph.
+   */
+  icon?: (color: string) => ReactNode;
+  /** An optional bold line above the body — a short name for what happened. */
+  title?: string;
+  /** The message. A string in the common case; nodes when it needs a link. */
+  children: ReactNode;
+  style?: ViewStyle;
+}) {
+  const theme = useTheme();
+  const { fg, bg } = calloutColors(theme, tone);
+  return (
+    <View
+      accessible
+      accessibilityRole={tone === 'negative' ? 'alert' : 'text'}
+      style={[
+        {
+          flexDirection: 'row',
+          alignItems: title ? 'flex-start' : 'center',
+          gap: theme.spacing.md,
+          backgroundColor: bg,
+          borderRadius: theme.radius.md,
+          padding: theme.spacing.lg,
+        },
+        style,
+      ]}
+    >
+      {/* Nudged onto the first line's optical centre when there is a title
+          stacked above the body; centred with the single line otherwise. */}
+      {icon ? <View style={{ marginTop: title ? 1 : 0 }}>{icon(fg)}</View> : null}
+      <View style={{ flex: 1, gap: 2 }}>
+        {title ? (
+          <Text variant="subheading" style={{ color: fg }}>
+            {title}
+          </Text>
+        ) : null}
+        <Text variant="caption" style={{ color: fg }}>
+          {children}
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -11,6 +11,7 @@ export * from './theme';
 export * from './curve';
 export * from './components/Text';
 export * from './components/Surfaces';
+export * from './components/Callout';
 export * from './components/CurvedPanel';
 export * from './components/Gradient';
 export * from './components/Button';

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -29,6 +29,8 @@ export interface Theme {
     readonly positiveSoft: string;
     readonly negative: string;
     readonly negativeSoft: string;
+    readonly warning: string;
+    readonly warningSoft: string;
   };
   readonly gradient: {
     /** Stops for the brand wash, in paint order. */
@@ -79,6 +81,8 @@ const lightTheme: Theme = {
     positiveSoft: palette.mint,
     negative: palette.negative,
     negativeSoft: palette.pink,
+    warning: palette.warning,
+    warningSoft: palette.peach,
   },
   gradient: { brand: gradients.light },
   tint: lightTints,
@@ -108,6 +112,8 @@ const darkTheme: Theme = {
     positiveSoft: '#123F36',
     negative: '#FF7B72',
     negativeSoft: '#4A2A31',
+    warning: '#E8A54B',
+    warningSoft: '#463020',
   },
   gradient: { brand: gradients.dark },
   tint: darkTints,


### PR DESCRIPTION
## Why

You flagged the error UX as not user-friendly. Every screen surfaced a failure the same threadbare way — a bare `<Text tone="negative">` wedged between the form and the submit button: same red as everything else, no shape, easy to miss, easy to mistake for a field label. On the new-group screen a raw `NOT_A_MEMBER` in that style read like a caption.

## What

A `Callout` primitive in `@baaki/ui`:

- Tinted panel in the message's **own colour** (`negative` / `warning` / `positive` / `info`), not the same flat red as field labels.
- A **leading icon** that says at a glance which kind it is — icon-agnostic like `PillTabBar`: the screen passes `icon={(color) => …}` and gets handed the tone colour, so the glyph always matches.
- Room around the words; optional bold `title` above the body.
- `accessibilityRole="alert"` on the negative case, so a screen reader **announces** the failure instead of leaving it as silent text.

Adds `warning` / `warningSoft` to the theme to complete the four tones (only the solid `warning` existed).

## Scope

Wired into **new-group** as the first use — the screen you screenshotted. The other ~15 screens still on raw `tone="negative"` can move over one at a time; I kept this PR to the primitive + one reference screen rather than a blind sweep, since some of those are inline field errors, not submit banners. Happy to do the sweep next if you want it.

## Verification

Typecheck (ui + mobile) + lint green. **Not device-verified** (no emulator here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)