### PR TITLE
refactor(mobile): every action error is a Callout, not bare red text

### DIFF
--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -25,6 +25,7 @@ import {
   Avatar,
   AvatarStack,
   Button,
+  Callout,
   Card,
   directionalIcon,
   Divider,
@@ -243,11 +244,7 @@ function ChooseGroup({
       )}
 
       {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
-      {error ? (
-        <Text variant="caption" tone="negative">
-          {error}
-        </Text>
-      ) : null}
+      {error ? <Callout tone="negative">{error}</Callout> : null}
 
       <Text variant="micro" tone="faint">
         {t.extras.ghostShareNote}

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -16,6 +16,7 @@ import {
   AmountKeypad,
   Avatar,
   Button,
+  Callout,
   Card,
   ChipRow,
   EmptyState,
@@ -690,11 +691,7 @@ export default function AddExpenseScreen() {
           ) : null}
         </Card>
 
-        {error ? (
-          <Text variant="caption" tone="negative">
-            {error}
-          </Text>
-        ) : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
 
         <Button
           label={editing ? t.expense.saveChanges : t.save}

--- a/apps/mobile/src/app/group/[id]/import/csv.tsx
+++ b/apps/mobile/src/app/group/[id]/import/csv.tsx
@@ -25,6 +25,7 @@ import { randomUUID } from 'expo-crypto';
 import {
   Badge,
   Button,
+  Callout,
   Card,
   Chip,
   IconButton,
@@ -324,11 +325,7 @@ export default function ImportCsvScreen() {
           </>
         ) : null}
 
-        {error ? (
-          <Text variant="caption" tone="negative">
-            {error}
-          </Text>
-        ) : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
 
         {parsed ? (
           <Button

--- a/apps/mobile/src/app/group/[id]/import/sms.tsx
+++ b/apps/mobile/src/app/group/[id]/import/sms.tsx
@@ -28,6 +28,7 @@ import * as Clipboard from 'expo-clipboard';
 import {
   Badge,
   Button,
+  Callout,
   Card,
   Chip,
   EmptyState,
@@ -414,11 +415,7 @@ export default function ImportSmsScreen() {
           </View>
         ) : null}
 
-        {error ? (
-          <Text variant="caption" tone="negative">
-            {error}
-          </Text>
-        ) : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
 
         {saved !== null ? (
           <Card>

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -27,6 +27,7 @@ import { categoryOf, format, type CategoryId } from '@baaki/core';
 import {
   type BarDatum,
   BarList,
+  Callout,
   Card,
   ChipRow,
   ColumnChart,
@@ -143,9 +144,9 @@ export default function InsightsScreen() {
         )}
 
         {spending.error ? (
-          <Text variant="caption" tone="negative">
+          <Callout tone="negative">
             {spending.error instanceof Error ? spending.error.message : String(spending.error)}
-          </Text>
+          </Callout>
         ) : null}
 
         <Text variant="micro" tone="faint" align="center">

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -4,7 +4,7 @@ import * as Clipboard from 'expo-clipboard';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Linking, Platform, ScrollView, Share, View } from 'react-native';
 
-import { Badge, Button, Card, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import { Badge, Button, Callout, Card, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { mintInvite, type MintedInvite } from '@/data/api';
 import { useGroup } from '@/data/hooks';
@@ -187,11 +187,7 @@ export default function InviteScreen() {
         )}
 
         {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
-        {error ? (
-          <Text variant="caption" tone="negative">
-            {error}
-          </Text>
-        ) : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
       </ScrollView>
     </Screen>
   );

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -17,6 +17,7 @@ import {
   Avatar,
   Badge,
   Button,
+  Callout,
   Card,
   EmptyState,
   IconButton,
@@ -714,11 +715,7 @@ export default function ItemizeScreen() {
           ) : null}
         </Card>
 
-        {error ? (
-          <Text variant="caption" tone="negative">
-            {error}
-          </Text>
-        ) : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
 
         <Button
           label={t.save}

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -7,6 +7,7 @@ import {
   Avatar,
   Badge,
   Button,
+  Callout,
   Card,
   directionalIcon,
   IconButton,
@@ -194,11 +195,7 @@ export default function MembersScreen() {
         {(claims.data ?? []).length > 0 ? (
           <Card style={{ gap: theme.spacing.md }}>
             <Text variant="subheading">{t.claims.requestsTitle}</Text>
-            {claimError ? (
-              <Text variant="caption" tone="negative">
-                {claimError}
-              </Text>
-            ) : null}
+            {claimError ? <Callout tone="negative">{claimError}</Callout> : null}
             {(claims.data ?? []).map((claim) => (
               <View key={claim.id} style={{ gap: theme.spacing.sm }}>
                 <Row style={{ gap: theme.spacing.md }}>
@@ -323,11 +320,7 @@ export default function MembersScreen() {
             everything already recorded under their name.
           </Text>
           {addGhost.isPending || adding ? <ActivityIndicator color={theme.color.brand} /> : null}
-          {error ? (
-            <Text variant="caption" tone="negative">
-              {error}
-            </Text>
-          ) : null}
+          {error ? <Callout tone="negative">{error}</Callout> : null}
         </Card>
 
         {ghosts.length > 0 ? (

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -17,6 +17,7 @@ import {
   Avatar,
   Badge,
   Button,
+  Callout,
   Card,
   ChipRow,
   EmptyState,
@@ -346,11 +347,7 @@ export default function SettleScreen() {
               </Card>
             ) : null}
 
-            {error ? (
-              <Text variant="caption" tone="negative">
-                {error}
-              </Text>
-            ) : null}
+            {error ? <Callout tone="negative">{error}</Callout> : null}
 
             <Button
               label={settleLabel}

--- a/apps/mobile/src/app/join.tsx
+++ b/apps/mobile/src/app/join.tsx
@@ -4,7 +4,18 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { Avatar, Badge, Button, Card, EmptyState, Row, Screen, Text, useTheme } from '@baaki/ui';
+import {
+  Avatar,
+  Badge,
+  Button,
+  Callout,
+  Card,
+  EmptyState,
+  Row,
+  Screen,
+  Text,
+  useTheme,
+} from '@baaki/ui';
 
 import { fill, useStrings } from '@/i18n';
 
@@ -234,11 +245,7 @@ export default function JoinScreen() {
           </Card>
         ) : null}
 
-        {shown ? (
-          <Text variant="caption" tone="negative" align="center">
-            {shown}
-          </Text>
-        ) : null}
+        {shown ? <Callout tone="negative">{shown}</Callout> : null}
 
         <Button
           // Claiming asks; joining as somebody new does not. The button says

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -242,14 +242,7 @@ export default function NewGroupScreen() {
           ) : null}
         </Card>
 
-        {error ? (
-          <Callout
-            tone="negative"
-            icon={(color) => <Ionicons name="alert-circle" size={20} color={color} />}
-          >
-            {error}
-          </Callout>
-        ) : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
         {createGroup.isPending || uploading ? (
           <ActivityIndicator color={theme.color.brand} />
         ) : null}

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -15,6 +15,7 @@ import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 import {
   Badge,
   Button,
+  Callout,
   Card,
   ChipRow,
   directionalIcon,
@@ -215,11 +216,7 @@ export default function AccountScreen() {
               {t.contact.added}
             </Text>
           ) : null}
-          {error ? (
-            <Text variant="caption" tone="negative">
-              {error}
-            </Text>
-          ) : null}
+          {error ? <Callout tone="negative">{error}</Callout> : null}
         </Card>
 
         <Text variant="micro" tone="faint" align="center">

--- a/apps/mobile/src/app/settings/delete-account.tsx
+++ b/apps/mobile/src/app/settings/delete-account.tsx
@@ -4,7 +4,17 @@ import { router } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 
-import { Button, Card, directionalIcon, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import {
+  Button,
+  Callout,
+  Card,
+  directionalIcon,
+  IconButton,
+  Row,
+  Screen,
+  Text,
+  useTheme,
+} from '@baaki/ui';
 
 import { deleteMyAccount, erasurePreview } from '@/data/api';
 import { fill, useStrings } from '@/i18n';
@@ -190,11 +200,7 @@ export default function DeleteAccountScreen() {
           </Card>
         </View>
 
-        {error ? (
-          <Text variant="caption" tone="negative">
-            {error}
-          </Text>
-        ) : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
         {busy ? <ActivityIndicator color={theme.color.negative} /> : null}
 
         <Button

--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -8,6 +8,7 @@ import { ActivityIndicator, Platform, ScrollView, View } from 'react-native';
 import {
   Badge,
   Button,
+  Callout,
   Card,
   ChipRow,
   directionalIcon,
@@ -159,11 +160,7 @@ export default function ExportScreen() {
           </Card>
         ) : null}
 
-        {error ? (
-          <Text variant="caption" tone="negative">
-            {error}
-          </Text>
-        ) : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
 
         <Button
           label={t.exportData.importInstead}

--- a/apps/mobile/src/app/settings/feedback.tsx
+++ b/apps/mobile/src/app/settings/feedback.tsx
@@ -6,6 +6,7 @@ import { ActivityIndicator, Platform, ScrollView, TextInput, View } from 'react-
 
 import {
   Button,
+  Callout,
   Card,
   ChipRow,
   directionalIcon,
@@ -120,11 +121,7 @@ export default function FeedbackScreen() {
               />
             </Card>
 
-            {error ? (
-              <Text variant="caption" tone="negative">
-                {error}
-              </Text>
-            ) : null}
+            {error ? <Callout tone="negative">{error}</Callout> : null}
             {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
 
             <Button

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -37,6 +37,7 @@ import {
 import {
   Badge,
   Button,
+  Callout,
   Card,
   ChipRow,
   directionalIcon,
@@ -553,11 +554,7 @@ export default function ImportScreen() {
           </Card>
         ) : null}
 
-        {error ? (
-          <Text variant="caption" tone="negative">
-            {error}
-          </Text>
-        ) : null}
+        {error ? <Callout tone="negative">{error}</Callout> : null}
       </ScrollView>
     </Screen>
   );

--- a/apps/mobile/src/app/settings/redeem.tsx
+++ b/apps/mobile/src/app/settings/redeem.tsx
@@ -17,7 +17,17 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 
-import { Button, Card, directionalIcon, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import {
+  Button,
+  Callout,
+  Card,
+  directionalIcon,
+  IconButton,
+  Row,
+  Screen,
+  Text,
+  useTheme,
+} from '@baaki/ui';
 
 import { redeemPromoCode, type PromoOutcome } from '@/data/api';
 import { fill, useStrings, type UiStrings } from '@/i18n';
@@ -142,11 +152,7 @@ export default function RedeemScreen() {
               />
             </Card>
 
-            {error ? (
-              <Text variant="caption" tone="negative">
-                {error}
-              </Text>
-            ) : null}
+            {error ? <Callout tone="negative">{error}</Callout> : null}
             {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
 
             <Button

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -34,7 +34,16 @@ import {
   View,
 } from 'react-native';
 
-import { Button, Card, CurvedPanel, Screen, SegmentedTabs, Text, useTheme } from '@baaki/ui';
+import {
+  Button,
+  Callout,
+  Card,
+  CurvedPanel,
+  Screen,
+  SegmentedTabs,
+  Text,
+  useTheme,
+} from '@baaki/ui';
 
 import { AppleSignInButton } from '@/components/AppleSignInButton';
 import { LanguagePicker } from '@/components/LanguagePicker';
@@ -193,11 +202,7 @@ export default function SignInScreen() {
           </View>
 
           {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
-          {error ? (
-            <Text variant="caption" tone="negative" align="center">
-              {error}
-            </Text>
-          ) : null}
+          {error ? <Callout tone="negative">{error}</Callout> : null}
         </View>
 
         {/* Under the buttons, not above them. The decision this screen exists
@@ -435,11 +440,7 @@ export default function SignInScreen() {
               ) : null}
 
               {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
-              {error ? (
-                <Text variant="caption" tone="negative">
-                  {error}
-                </Text>
-              ) : null}
+              {error ? <Callout tone="negative">{error}</Callout> : null}
             </Card>
 
             <Button

--- a/apps/mobile/src/components/CurrencyRate.tsx
+++ b/apps/mobile/src/components/CurrencyRate.tsx
@@ -32,7 +32,7 @@ import {
   toFxRecord,
   type FxRecord,
 } from '@baaki/core';
-import { Button, Card, ChipRow, Text, useTheme } from '@baaki/ui';
+import { Button, Callout, Card, ChipRow, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -243,11 +243,7 @@ export function CurrencyRate({
             </Text>
           )}
 
-          {error ? (
-            <Text variant="caption" tone="negative">
-              {error}
-            </Text>
-          ) : null}
+          {error ? <Callout tone="negative">{error}</Callout> : null}
         </>
       ) : null}
     </Card>

--- a/packages/ui/src/components/Callout.tsx
+++ b/packages/ui/src/components/Callout.tsx
@@ -12,14 +12,14 @@ import { Text } from './Text';
  * `<Text tone="negative">` wedged between the form and the button, the same red
  * as a hundred other things, easy to miss and easy to mistake for a field
  * label. A message worth showing is worth giving a shape — a tinted panel in
- * its own colour, an icon that says at a glance which of the four this is, and
+ * its own colour, a mark that says at a glance which of the four this is, and
  * air around the words. This is that shape, in one place, so every screen says
  * "that did not work" the same way.
  *
- * Icon-agnostic on purpose: this package carries no icon library, the way
- * `PillTabBar` does not. The screen passes a render function and is handed back
- * the colour the icon should be, so the glyph always matches the tone without
- * the caller having to look it up.
+ * The leading mark is drawn from plain views, not an icon font, because this
+ * package carries no icon library (the way `PillTabBar` does not). A screen
+ * that wants its own glyph passes `icon` and is handed back the tone's colour,
+ * so an overriding icon still matches without the caller looking it up.
  */
 export type CalloutTone = 'negative' | 'warning' | 'positive' | 'info';
 
@@ -42,6 +42,44 @@ function calloutColors(theme: Theme, tone: CalloutTone): CalloutColors {
   }
 }
 
+/** The glyph in the drawn badge: a tick for good news, otherwise a bare mark. */
+function calloutGlyph(tone: CalloutTone): string {
+  switch (tone) {
+    case 'positive':
+      return '✓';
+    case 'info':
+      return 'i';
+    case 'warning':
+    case 'negative':
+    default:
+      return '!';
+  }
+}
+
+/** A filled disc in the tone colour with a white glyph — the default leading mark. */
+function CalloutBadge({ tone, color }: { tone: CalloutTone; color: string }) {
+  const theme = useTheme();
+  return (
+    <View
+      style={{
+        width: 22,
+        height: 22,
+        borderRadius: 11,
+        backgroundColor: color,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Text
+        variant="micro"
+        style={{ color: theme.color.onBrand, fontWeight: '800', lineHeight: 14 }}
+      >
+        {calloutGlyph(tone)}
+      </Text>
+    </View>
+  );
+}
+
 export function Callout({
   tone = 'negative',
   icon,
@@ -51,8 +89,8 @@ export function Callout({
 }: {
   tone?: CalloutTone;
   /**
-   * Rendered at the leading edge, handed the tone's colour so it matches
-   * without the caller resolving it. Omit for a message that needs no glyph.
+   * Overrides the drawn badge, handed the tone's colour so it matches without
+   * the caller resolving it. Omit for the built-in mark.
    */
   icon?: (color: string) => ReactNode;
   /** An optional bold line above the body — a short name for what happened. */
@@ -81,7 +119,9 @@ export function Callout({
     >
       {/* Nudged onto the first line's optical centre when there is a title
           stacked above the body; centred with the single line otherwise. */}
-      {icon ? <View style={{ marginTop: title ? 1 : 0 }}>{icon(fg)}</View> : null}
+      <View style={{ marginTop: title ? 1 : 0 }}>
+        {icon ? icon(fg) : <CalloutBadge tone={tone} color={fg} />}
+      </View>
       <View style={{ flex: 1, gap: 2 }}>
         {title ? (
           <Text variant="subheading" style={{ color: fg }}>


### PR DESCRIPTION
## What

App-wide sweep onto the `Callout` from #122. Every screen that surfaced a failed submit with a bare `<Text tone="negative">` wedged under the button now uses the shared tinted, marked, screen-reader-announced Callout.

**18 screens converted:** sign-in, join, new-group, add-expense, settle, itemize, invite, members (×2), CSV import, SMS import, insights, and settings — account, export, import, delete-account, feedback, redeem — plus the currency-rate panel and the contacts picker.

`Callout` gained a built-in leading badge drawn from plain views (this package ships no icon font), so a caller is just `<Callout tone="negative">{error}</Callout>`. new-group dropped its explicit icon to match.

## Left as-is (on purpose)

Not action-failure messages, so not swept:
- **Inline field validation** — the split-must-add-up hint on add-expense (`micro`, sits under the field it validates).
- **Status badges** — `deleted`, `unclaimed`.
- **Already-bespoke banners** with their own icon + structure — `SyncBanner`, `DisputePanel`, the ledger-mismatch card on the group screen.

## Verification

Typecheck (ui + mobile) + lint + prettier green. **Not device-verified** (no emulator here) — worth a glance on a phone, but each change is a like-for-like swap of the same error string into a better container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)