### PR TITLE
feat(sign-in): social login as an icon-tile row, not stacked buttons

### DIFF
--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -21,13 +21,15 @@
  * settings row they cannot read, is a door that only opens from the inside.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   ScrollView,
   TextInput,
   useWindowDimensions,
@@ -45,7 +47,6 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { AppleSignInButton } from '@/components/AppleSignInButton';
 import { LanguagePicker } from '@/components/LanguagePicker';
 import { Onboarding } from '@/components/Onboarding';
 import { useStrings } from '@/i18n';
@@ -443,20 +444,42 @@ export default function SignInScreen() {
               {error ? <Callout tone="negative">{error}</Callout> : null}
             </Card>
 
-            <Button
-              label={isGuest ? t.signIn.continueGoogle : t.signIn.signInGoogle}
-              variant="secondary"
-              size="lg"
-              fullWidth
-              disabled={busy}
-              onPress={() => void run(withGoogle)}
-            />
+            {/* Icon-only tiles rather than two stacked full-width buttons: the
+                provider is a small choice next to the account above, and a row
+                of marks reads as "one of these" in a glance where a stack of
+                labelled bars reads as two more things to do.
 
-            <AppleSignInButton
-              label={isGuest ? t.signIn.continueApple : t.signIn.signInApple}
-              disabled={busy}
-              onPress={() => void run(withApple)}
-            />
+                Apple's mark is a custom tile here, not its native button. The
+                native sheet is still what opens — `withApple` calls it directly
+                (see auth.tsx), the widget was only ever the surface — so on an
+                iPhone this tile brings up the same system sign-in. */}
+            <View style={{ gap: theme.spacing.md }}>
+              <Text variant="caption" tone="muted" align="center">
+                {t.signIn.orSignInWith}
+              </Text>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  justifyContent: 'center',
+                  gap: theme.spacing.lg,
+                }}
+              >
+                <ProviderTile
+                  label={isGuest ? t.signIn.continueApple : t.signIn.signInApple}
+                  disabled={busy}
+                  onPress={() => void run(withApple)}
+                >
+                  <Ionicons name="logo-apple" size={26} color={theme.color.text} />
+                </ProviderTile>
+                <ProviderTile
+                  label={isGuest ? t.signIn.continueGoogle : t.signIn.signInGoogle}
+                  disabled={busy}
+                  onPress={() => void run(withGoogle)}
+                >
+                  <Ionicons name="logo-google" size={26} color={theme.color.text} />
+                </ProviderTile>
+              </View>
+            </View>
 
             {/* ADR-006: nobody is forced to register before they can use Baaki.
               Still here, one step back from the welcome, for somebody who came
@@ -479,5 +502,46 @@ export default function SignInScreen() {
         </ScrollView>
       </KeyboardAvoidingView>
     </Screen>
+  );
+}
+
+/**
+ * A square, icon-only social button — one mark in the row under "or sign in
+ * with". Icon-only, so it carries the provider's name as its accessibility
+ * label; a screen reader hears "Sign in with Google", not "button".
+ */
+function ProviderTile({
+  label,
+  disabled,
+  onPress,
+  children,
+}: {
+  label: string;
+  disabled?: boolean;
+  onPress: () => void;
+  children: ReactNode;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled: Boolean(disabled) }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        width: 64,
+        height: 64,
+        borderRadius: theme.radius.md,
+        borderWidth: 1,
+        borderColor: theme.color.border,
+        backgroundColor: theme.color.surface,
+        alignItems: 'center',
+        justifyContent: 'center',
+        opacity: disabled ? 0.5 : pressed ? 0.7 : 1,
+      })}
+    >
+      {children}
+    </Pressable>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -491,6 +491,7 @@ export interface UiStrings {
      */
     continueApple: string;
     signInApple: string;
+    orSignInWith: string;
     continueGuest: string;
     guestFootnote: string;
     memberFootnote: string;
@@ -1361,6 +1362,7 @@ const en: UiStrings = {
     signInGoogle: 'Sign in with Google',
     continueApple: 'Continue with Apple',
     signInApple: 'Sign in with Apple',
+    orSignInWith: 'or sign in with',
     continueGuest: 'Continue as guest',
     guestFootnote:
       'Everything you have already added stays exactly where it is. This only adds a way to sign back in.',
@@ -2298,6 +2300,7 @@ const ta: UiStrings = {
     signInGoogle: 'Google மூலம் உள்நுழை',
     continueApple: 'Apple மூலம் தொடர்',
     signInApple: 'Apple மூலம் உள்நுழை',
+    orSignInWith: 'அல்லது இதன் மூலம் உள்நுழை',
     continueGuest: 'விருந்தினராகத் தொடர்',
     guestFootnote:
       'நீங்கள் ஏற்கனவே சேர்த்த அனைத்தும் அப்படியே இருக்கும். இது மீண்டும் உள்நுழைய ஒரு வழியை மட்டுமே சேர்க்கிறது.',
@@ -3232,6 +3235,7 @@ const hi: UiStrings = {
     signInGoogle: 'Google से साइन इन करें',
     continueApple: 'Apple से जारी रखें',
     signInApple: 'Apple से साइन इन करें',
+    orSignInWith: 'या इसके ज़रिए साइन इन करें',
     continueGuest: 'मेहमान के तौर पर जारी रखें',
     guestFootnote:
       'आपने जो जोड़ा है वह जहाँ है वहीं रहेगा। इससे सिर्फ़ दोबारा साइन इन करने का रास्ता जुड़ता है।',
@@ -4176,6 +4180,7 @@ const ar: UiStrings = {
     signInGoogle: 'تسجيل الدخول عبر Google',
     continueApple: 'المتابعة عبر Apple',
     signInApple: 'تسجيل الدخول عبر Apple',
+    orSignInWith: 'أو سجّل الدخول عبر',
     continueGuest: 'المتابعة كضيف',
     guestFootnote: 'كل ما أضفته يبقى كما هو تمامًا. هذا يضيف فقط طريقة للعودة وتسجيل الدخول.',
     memberFootnote:


### PR DESCRIPTION
## What

Reworks the social sign-in options to match the requested pattern (GoDaddy-style): an **"or sign in with"** divider, then a **centred row of square, icon-only tiles** — Apple and Google — instead of two stacked full-width buttons.

![reference](the screenshot you shared)

## Apple button note

Apple is a **custom tile** here, not its native `AppleAuthenticationButton`. This is safe functionally: `withApple()` calls `signInAsync` directly (`auth.tsx`), so the native widget was only ever the *surface* — on an iPhone this tile still brings up the same system sign-in sheet, and the same web OAuth fallback everywhere else. You chose this trade-off (custom tile, both providers matching) over keeping the native button.

## Details

- Two providers only (**Apple + Google**) — the app has no Facebook provider, so it's two tiles, not three.
- Tiles are icon-only (`logo-apple` / `logo-google`), so each carries the provider's full label as its **accessibility label** — a screen reader still hears "Sign in with Google", not "button".
- Adds the `orSignInWith` string across all four locales (en / ta / hi / ar); the i18n parity test passes.
- `AppleSignInButton` is now unused on this screen; left in place since it still encapsulates the native-vs-web decision for any future caller.

## Verification

Typecheck + lint green; mobile test suite 206/206 (incl. the strings parity test). **Not device-verified** — worth confirming on an actual iPhone that the tile still raises the native Apple sheet, since that's the one behaviour a simulator-free check can't prove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)