### PR TITLE
fix: show a skeleton on the activity tab, not a false "nothing yet"

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -20,6 +20,7 @@ import {
 
 import { describeActivity } from '@/data/activity';
 import { fetchRecentActivity } from '@/data/api';
+import { FeedSkeleton } from '@/components/Skeletons';
 import { useNotifications } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -86,7 +87,9 @@ export default function ActivityScreen() {
           </IconButton>
         </Row>
 
-        {entries.length === 0 ? (
+        {activity.isLoading ? (
+          <FeedSkeleton />
+        ) : entries.length === 0 ? (
           <EmptyState title={t.nothingYet} body={t.tabs.activityEmptyBody} />
         ) : (
           Object.entries(byDay).map(([day, dayEntries]) => (

--- a/apps/mobile/src/components/Skeletons.tsx
+++ b/apps/mobile/src/components/Skeletons.tsx
@@ -198,6 +198,35 @@ export function PeopleSkeleton() {
   );
 }
 
+/**
+ * The activity tab: a day heading and a few full-width entry cards, the shape
+ * of the real feed. Shown in place of it while the first page loads, so the
+ * cold screen is not the "nothing yet" empty state — which is a verdict the
+ * query has not returned yet, not the answer.
+ */
+export function FeedSkeleton() {
+  const theme = useTheme();
+  const { animated } = useMotion();
+  return (
+    <LoadingRegion style={{ gap: theme.spacing.xl }}>
+      {[0, 1].map((section) => (
+        <View key={section} style={{ gap: theme.spacing.md }}>
+          <Skeleton width="35%" height={16} animated={animated} />
+          {[0, 1, 2].map((card) => (
+            <Skeleton
+              key={card}
+              width="100%"
+              height={72}
+              radius={theme.radius.lg}
+              animated={animated}
+            />
+          ))}
+        </View>
+      ))}
+    </LoadingRegion>
+  );
+}
+
 /** Insights: a heading and a couple of chart-sized blocks. */
 export function InsightsSkeleton() {
   const theme = useTheme();


### PR DESCRIPTION
Same class of bug as the friends/contacts skeleton fix. The activity tab had no `isLoading` branch, so a cold launch flashed the "nothing yet" empty state — a verdict on an empty feed the query hadn't returned yet — before the real entries loaded in.

Adds a `FeedSkeleton` (day heading + full-width entry-card placeholders, shaped like the real feed) and gates the empty state behind `activity.isLoading`.

Typecheck + lint green. Not device-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)