### PR TITLE
feat(settings): link Google or Apple to sign in with later

### DIFF
--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -33,7 +33,7 @@ import { useAuth } from '@/lib/auth';
 export default function AccountScreen() {
   const theme = useTheme();
   const { t } = useStrings();
-  const { session, isGuest, refresh } = useAuth();
+  const { session, isGuest, refresh, withGoogle, withApple } = useAuth();
 
   const [channel, setChannel] = useState<ContactChannel>('email');
   const [value, setValue] = useState('');
@@ -45,6 +45,28 @@ export default function AccountScreen() {
 
   const existing =
     channel === 'email' ? (session?.user.email ?? null) : (session?.user.phone ?? null);
+
+  // Which providers already sign this account in, so a linked one shows as done
+  // rather than offering to link what is already linked. Adding one goes through
+  // the same `withGoogle`/`withApple` the sign-in screen uses: for somebody
+  // already signed in, `planAuth` turns that into a link, never a fresh sign-in
+  // that would strand this account (ADR-006).
+  const linkedProviders = new Set(
+    (session?.user.identities ?? []).map((identity) => identity.provider),
+  );
+
+  const link = async (start: () => Promise<void>): Promise<void> => {
+    setError(null);
+    setBusy(true);
+    try {
+      await start();
+      await refresh();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
 
   const looksValid =
     channel === 'email'
@@ -219,10 +241,78 @@ export default function AccountScreen() {
           {error ? <Callout tone="negative">{error}</Callout> : null}
         </Card>
 
+        {/* Linking a social account, so it can sign this same account in later
+            on another phone — the OAuth complement to the email/phone above.
+            Only Google and Apple today; the row is built to take more. */}
+        <Card style={{ gap: theme.spacing.md }}>
+          <Text variant="subheading">{t.contact.signInMethodsTitle}</Text>
+          <Text variant="caption" tone="muted">
+            {t.contact.signInMethodsBody}
+          </Text>
+          <View style={{ gap: theme.spacing.md }}>
+            <ProviderRow
+              name="Google"
+              icon="logo-google"
+              linked={linkedProviders.has('google')}
+              busy={busy}
+              linkLabel={t.contact.link}
+              linkedLabel={t.contact.linked}
+              onLink={() => void link(withGoogle)}
+            />
+            <ProviderRow
+              name="Apple"
+              icon="logo-apple"
+              linked={linkedProviders.has('apple')}
+              busy={busy}
+              linkLabel={t.contact.link}
+              linkedLabel={t.contact.linked}
+              onLink={() => void link(withApple)}
+            />
+          </View>
+        </Card>
+
         <Text variant="micro" tone="faint" align="center">
           {t.contact.footnote}
         </Text>
       </ScrollView>
     </Screen>
+  );
+}
+
+/**
+ * One provider in the "ways to sign in" list: its mark, its name, and either a
+ * Linked badge or a button to link it. Icon-and-name so the row reads at a
+ * glance; the action says exactly what it does.
+ */
+function ProviderRow({
+  name,
+  icon,
+  linked,
+  busy,
+  linkLabel,
+  linkedLabel,
+  onLink,
+}: {
+  name: string;
+  icon: 'logo-google' | 'logo-apple';
+  linked: boolean;
+  busy: boolean;
+  linkLabel: string;
+  linkedLabel: string;
+  onLink: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Row style={{ justifyContent: 'space-between' }}>
+      <Row style={{ gap: theme.spacing.md }}>
+        <Ionicons name={icon} size={22} color={theme.color.text} />
+        <Text variant="body">{name}</Text>
+      </Row>
+      {linked ? (
+        <Badge label={linkedLabel} tone="positive" />
+      ) : (
+        <Button label={linkLabel} size="sm" variant="secondary" disabled={busy} onPress={onLink} />
+      )}
+    </Row>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -452,6 +452,10 @@ export interface UiStrings {
     sendCodePhone: string;
     useDifferent: string;
     added: string;
+    signInMethodsTitle: string;
+    signInMethodsBody: string;
+    link: string;
+    linked: string;
     footnote: string;
   };
   /** The welcome and the ways in (ADR-006: nobody registers to split a bill). */
@@ -1324,6 +1328,10 @@ const en: UiStrings = {
     sendCodePhone: 'Text me a code',
     useDifferent: 'Use a different one',
     added: 'Added. You can sign in with it on another phone now.',
+    signInMethodsTitle: 'Ways to sign in',
+    signInMethodsBody: 'Link an account and you can sign in with it next time, on any phone.',
+    link: 'Link',
+    linked: 'Linked',
     footnote:
       'Baaki never asks for this to let you in, and never shares it with anyone in your groups. People see the name you choose, nothing else.',
   },
@@ -2260,6 +2268,10 @@ const ta: UiStrings = {
     sendCodePhone: 'குறுஞ்செய்தியில் குறியீடு அனுப்பு',
     useDifferent: 'வேறொன்றைப் பயன்படுத்து',
     added: 'சேர்க்கப்பட்டது. இப்போது வேறு ஃபோனிலும் இதைக் கொண்டு உள்நுழையலாம்.',
+    signInMethodsTitle: 'உள்நுழையும் வழிகள்',
+    signInMethodsBody: 'ஒரு கணக்கை இணைத்தால், அடுத்த முறை எந்த ஃபோனிலும் அதன் மூலம் உள்நுழையலாம்.',
+    link: 'இணை',
+    linked: 'இணைக்கப்பட்டது',
     footnote:
       'உள்ளே விடுவதற்கு பாக்கி இதை ஒருபோதும் கேட்பதில்லை, உங்கள் குழுக்களில் உள்ள யாருடனும் இதைப் பகிர்வதும் இல்லை. நீங்கள் தேர்ந்தெடுத்த பெயரை மட்டுமே மற்றவர்கள் பார்ப்பார்கள்.',
   },
@@ -3196,6 +3208,10 @@ const hi: UiStrings = {
     sendCodePhone: 'मैसेज पर कोड भेजें',
     useDifferent: 'कोई दूसरा इस्तेमाल करें',
     added: 'जुड़ गया। अब आप इससे किसी दूसरे फ़ोन पर साइन इन कर सकते हैं।',
+    signInMethodsTitle: 'साइन इन करने के तरीके',
+    signInMethodsBody: 'कोई खाता लिंक करें और अगली बार किसी भी फ़ोन पर उससे साइन इन कर सकते हैं।',
+    link: 'लिंक करें',
+    linked: 'लिंक किया गया',
     footnote:
       'अंदर आने देने के लिए बाकी यह कभी नहीं माँगता, और आपके समूह में किसी के साथ इसे साझा नहीं करता। लोग सिर्फ़ वही नाम देखते हैं जो आप चुनते हैं।',
   },
@@ -4141,6 +4157,10 @@ const ar: UiStrings = {
     sendCodePhone: 'أرسل الرمز برسالة',
     useDifferent: 'استخدم غيره',
     added: 'تمت الإضافة. يمكنك الآن تسجيل الدخول به على هاتف آخر.',
+    signInMethodsTitle: 'طرق تسجيل الدخول',
+    signInMethodsBody: 'اربط حسابًا لتتمكن من تسجيل الدخول به في المرة القادمة، على أي هاتف.',
+    link: 'ربط',
+    linked: 'مرتبط',
     footnote:
       'لا يطلب باقي هذا ليسمح لك بالدخول، ولا يشاركه مع أحد في مجموعاتك. يرى الناس الاسم الذي تختاره، لا غير.',
   },


### PR DESCRIPTION
## What

You asked to be able to link social accounts for login from settings. The account screen let you attach an **email or phone** so the account outlives the phone, but not a **social login** — even though the auth plumbing was already there.

Adds a **"Ways to sign in"** card to `settings/account`: shows which providers are linked, and links **Google** or **Apple**.

## How

- Reuses the sign-in screen's `withGoogle` / `withApple` **unchanged**. For a signed-in user, `planAuth` turns those into a `linkIdentity`, not a fresh `signInWithOAuth` — so a provider is *added* to the account you already have, never a new one that strands your expenses (ADR-006).
- Linked providers read off `session.user.identities` → a **Linked** badge instead of a Link button.
- The row takes a provider name + icon, so a **third method later is one entry, not a rewrite** ("...for login in future").

Adds four strings (`signInMethodsTitle`, `signInMethodsBody`, `link`, `linked`) across all four locales; i18n parity test passes.

## Not included

- **Unlink** — deliberately left out for now: removing your last sign-in method locks you out, so it needs a guard ("you can't remove your only way in") worth its own change.
- Only Google + Apple (the providers the app supports).

## Verification

Typecheck + lint green; mobile suite 206/206. **Not device-verified** — the link round-trip (OAuth browser / native Apple sheet → identity added) is the part worth confirming on a real phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)