### PR TITLE
feat(nudge): remind someone who owes you to settle

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -14,10 +14,11 @@
  * account are followed across groups, because a profile id is proof.
  */
 
+import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { router } from 'expo-router';
-import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, View } from 'react-native';
 
 import {
   Avatar,
@@ -35,7 +36,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { fetchPeopleBalances, type PersonBalanceRow } from '@/data/api';
+import { fetchPeopleBalances, nudgeToSettle, type PersonBalanceRow } from '@/data/api';
 import { PeopleSkeleton } from '@/components/Skeletons';
 import { plural, useStrings } from '@/i18n';
 
@@ -209,6 +210,11 @@ function FriendCard({
             ) : (
               <Badge label={t.tabs.notJoined} />
             )
+          ) : owed && row.only_group_id ? (
+            // They owe you and one group explains it, so there is a single pair
+            // to nudge. The server keeps it honest — one a day, never to a
+            // ghost, never for nothing — so the button only has to ask (ADR-010).
+            <RemindButton row={row} />
           ) : null}
         </View>
       </Row>
@@ -224,6 +230,57 @@ function FriendCard({
       style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
     >
       {body}
+    </Pressable>
+  );
+}
+
+/**
+ * The one-tap nudge on a card for somebody who owes you.
+ *
+ * Once tapped it does not offer to be tapped again — it settles into a quiet
+ * "Reminded", and if the server says the daily limit is already spent it says
+ * "Nudged today" in the same muted voice rather than an error. Being told off
+ * for caring twice is exactly the collections-agency feeling ADR-010 forbids,
+ * so a rate limit reads here as reassurance that it already went, not a wall.
+ * Its own Pressable, so a tap nudges rather than opening the group behind it.
+ */
+function RemindButton({ row }: { row: PersonBalanceRow }): React.JSX.Element | null {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const [note, setNote] = useState<string | null>(null);
+
+  const nudge = useMutation({
+    mutationFn: () =>
+      nudgeToSettle({
+        groupId: row.only_group_id ?? '',
+        toMemberId: row.member_id,
+        currency: row.currency,
+      }),
+    onSuccess: () => setNote(t.people.reminded),
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      setNote(message.includes('NUDGE_RATE_LIMIT') ? t.people.remindedToday : message);
+    },
+  });
+
+  if (note) {
+    return (
+      <Text variant="micro" tone="muted">
+        {note}
+      </Text>
+    );
+  }
+  if (nudge.isPending) return <ActivityIndicator size="small" color={theme.color.brand} />;
+
+  return (
+    <Pressable
+      onPress={() => nudge.mutate()}
+      accessibilityRole="button"
+      accessibilityLabel={t.people.remind}
+      hitSlop={8}
+      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+    >
+      <Badge label={t.people.remind} tone="brand" />
     </Pressable>
   );
 }

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1206,6 +1206,29 @@ export async function fetchPeopleBalances(): Promise<PersonBalanceRow[]> {
   return (data ?? []) as PersonBalanceRow[];
 }
 
+/**
+ * Tap somebody who owes you on the shoulder about it (ADR-010).
+ *
+ * The server does the deciding: it only sends when they genuinely owe you in
+ * this group and currency, at most once a day, and never to a ghost. All the
+ * client passes is who, where, and in which currency — the amount and the
+ * wording are the server's to keep honest. The `NUDGE_RATE_LIMIT` message that
+ * comes back on a second nudge the same day is a normal outcome, not a fault,
+ * and the screen says so gently rather than in red.
+ */
+export async function nudgeToSettle(input: {
+  groupId: string;
+  toMemberId: string;
+  currency: string;
+}): Promise<void> {
+  const { error } = await supabase.rpc('baaki_nudge_to_settle', {
+    p_group_id: input.groupId,
+    p_to_member_id: input.toMemberId,
+    p_currency: input.currency,
+  });
+  if (error) throw new Error(error.message);
+}
+
 // ─────────────────────────────────────────────── where the money went ──
 
 export interface SpendingRow {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -601,6 +601,10 @@ export interface UiStrings {
     expires: string;
     hideContacts: string;
     browseContacts: string;
+    /** Reminding somebody who owes you to settle, gently (ADR-010). */
+    remind: string;
+    reminded: string;
+    remindedToday: string;
   };
   /** Adding and editing an expense, and reading one off a bill. */
   expense: {
@@ -1485,6 +1489,9 @@ const en: UiStrings = {
     expires: 'expires {when}',
     hideContacts: 'Hide contacts',
     browseContacts: 'Browse my contacts',
+    remind: 'Remind',
+    reminded: 'Reminded',
+    remindedToday: 'Nudged today',
   },
   expense: {
     edit: 'Edit expense',
@@ -2429,6 +2436,9 @@ const ta: UiStrings = {
     expires: '{when} க்கு காலாவதி',
     hideContacts: 'தொடர்புகளை மறை',
     browseContacts: 'என் தொடர்புகளைப் பார்',
+    remind: 'நினைவூட்டு',
+    reminded: 'நினைவூட்டப்பட்டது',
+    remindedToday: 'இன்று நினைவூட்டிவிட்டீர்கள்',
   },
   expense: {
     edit: 'செலவைத் திருத்து',
@@ -3364,6 +3374,9 @@ const hi: UiStrings = {
     expires: '{when} को खत्म',
     hideContacts: 'संपर्क छिपाएँ',
     browseContacts: 'मेरे संपर्क देखें',
+    remind: 'याद दिलाएँ',
+    reminded: 'याद दिला दिया',
+    remindedToday: 'आज याद दिला चुके',
   },
   expense: {
     edit: 'खर्च बदलें',
@@ -4324,6 +4337,9 @@ const ar: UiStrings = {
     expires: 'ينتهي {when}',
     hideContacts: 'إخفاء جهات الاتصال',
     browseContacts: 'تصفّح جهات اتصالي',
+    remind: 'ذكّر',
+    reminded: 'تم التذكير',
+    remindedToday: 'ذُكّر اليوم',
   },
   expense: {
     edit: 'تعديل المصروف',

--- a/packages/db/prisma/migrations/20260810160000_nudge_to_settle/migration.sql
+++ b/packages/db/prisma/migrations/20260810160000_nudge_to_settle/migration.sql
@@ -1,0 +1,138 @@
+-- Nudge to settle — the sending half of the `nudge` notification (ADR-010,
+-- TDR §7.1).
+--
+-- Everything the reminder needs to arrive already shipped in M4: the
+-- `reminders` table, the one-per-pair-per-day rate-limit trigger, the `nudge`
+-- copy in four languages, its inbox icon and its notification preference.
+-- Nothing ever wrote the row. This is that writer, and nothing more.
+--
+-- Tone is the whole feature (ADR-010: friendly vasool, never a collections
+-- agency). One debtor at a time, at most once a day, and only when they
+-- genuinely owe you in the group you name. There is no bulk "remind everyone",
+-- and there is no second reminder the same day — both are refused down here in
+-- SQL, where no client bug can talk Baaki into becoming the thing it promised
+-- not to be.
+
+CREATE OR REPLACE FUNCTION public.baaki_nudge_to_settle(
+  p_group_id     uuid,
+  p_to_member_id uuid,
+  p_currency     char(3)
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_me            uuid;   -- my member in this group: the one who is owed
+  v_my_name       text;
+  v_their_profile uuid;
+  v_group_name    text;
+  v_amount        bigint;
+  v_notification  uuid;
+BEGIN
+  -- The caller must be a present member of the group. Anyone else has no
+  -- business reading who owes whom in it, let alone tapping them on the
+  -- shoulder about it.
+  SELECT gm.id, COALESCE(p.display_name, 'Someone')
+    INTO v_me, v_my_name
+    FROM public.group_members gm
+    JOIN public.profiles p ON p.id = gm.profile_id
+   WHERE gm.group_id = p_group_id
+     AND gm.profile_id = public.baaki_current_profile_id()
+     AND gm.left_at IS NULL;
+
+  IF v_me IS NULL THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_to_member_id = v_me THEN
+    RAISE EXCEPTION 'CANNOT_NUDGE_SELF: that is you'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- The person being nudged must be a present member with an account. A ghost
+  -- has no inbox for it to land in — they are invited, not reminded (A25).
+  SELECT gm.profile_id, g.name
+    INTO v_their_profile, v_group_name
+    FROM public.group_members gm
+    JOIN public.groups g ON g.id = gm.group_id
+   WHERE gm.id = p_to_member_id
+     AND gm.group_id = p_group_id
+     AND gm.left_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: they are not in that group'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF v_their_profile IS NULL THEN
+    RAISE EXCEPTION 'GHOST_NO_INBOX: they have not joined yet — invite them instead'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- What they owe me in this currency, netting the two orientations the pair
+  -- may be stored in (pairwise_balances holds each pair once, as `from` owing
+  -- `to`). A nudge over a debt that is not there is the one thing that would
+  -- make the reminder a lie, so a non-positive figure is refused rather than
+  -- sent. Currency is explicit: two people can owe each other in two
+  -- currencies at once, and there is no honest single number across them
+  -- (ADR-003).
+  SELECT COALESCE(
+           (SELECT amount FROM public.pairwise_balances
+             WHERE group_id = p_group_id AND from_member_id = p_to_member_id
+               AND to_member_id = v_me AND currency = p_currency), 0)
+       - COALESCE(
+           (SELECT amount FROM public.pairwise_balances
+             WHERE group_id = p_group_id AND from_member_id = v_me
+               AND to_member_id = p_to_member_id AND currency = p_currency), 0)
+    INTO v_amount;
+
+  IF v_amount <= 0 THEN
+    RAISE EXCEPTION 'NOTHING_OWED: they do not owe you in %', p_currency
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Record the nudge. The unique index on (group, from, to) makes this an
+  -- upsert; the BEFORE UPDATE trigger refuses a second touch inside a day with
+  -- NUDGE_RATE_LIMIT. The INSERT path — the pair's first ever nudge — is not
+  -- rate-limited, which is right: there is nothing for it to be too soon after.
+  INSERT INTO public.reminders (group_id, from_member_id, to_member_id, last_nudged_at)
+  VALUES (p_group_id, v_me, p_to_member_id, now())
+  ON CONFLICT (group_id, from_member_id, to_member_id)
+  DO UPDATE SET last_nudged_at = now();
+
+  -- Land it in their inbox. The English title/body are the fallback a client
+  -- shows only for a kind it does not know; every current build renders the
+  -- real sentence from `kind` + `payload` in the reader's own language, so the
+  -- `counterparty`/`amount`/`currency`/`group` facts are what actually matter.
+  -- The dedupe key is per pair per day — a belt to the rate limit's braces, so
+  -- even a retried call is a no-op rather than a second buzz.
+  v_notification := public.baaki_notify(
+    v_their_profile,
+    p_group_id,
+    'nudge',
+    'A gentle nudge from ' || v_my_name,
+    'You have a pending baaki in ' || v_group_name,
+    'baaki://group/' || p_group_id::text,
+    jsonb_build_object(
+      'counterparty', v_my_name,
+      'amount',       v_amount::text,
+      'currency',     p_currency,
+      'group',        v_group_name
+    ),
+    'nudge:' || p_group_id::text || ':' || v_me::text || ':' || p_to_member_id::text
+      || ':' || to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD')
+  );
+
+  RETURN v_notification;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_nudge_to_settle(uuid, uuid, char) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.baaki_nudge_to_settle(uuid, uuid, char) TO authenticated;
+
+-- A new function the API serves; tell PostgREST so the RPC is callable the
+-- moment this lands, not on its next restart.
+NOTIFY pgrst, 'reload schema';

--- a/packages/db/test/m4-nudge-to-settle.test.ts
+++ b/packages/db/test/m4-nudge-to-settle.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Nudging somebody who owes you to settle (ADR-010).
+ *
+ * The tone is the feature, and the tone lives in the refusals — so those are
+ * what is pinned here:
+ *
+ *   - a nudge only goes when the debt is real, in the currency named;
+ *   - a second nudge the same day is refused, so Baaki cannot be turned into a
+ *     machine that pesters;
+ *   - a ghost, who has no inbox, is never nudged;
+ *   - and only a member of the group can nudge inside it.
+ *
+ * The happy path is here too, but it is the least interesting line: what makes
+ * this a reminder and not a collections agency is everything it declines to do.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+async function profile(name: string): Promise<string> {
+  const id = randomUUID();
+  await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, $2)`, [id, name]);
+  return id;
+}
+
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+async function makeGroup(owner: string): Promise<string> {
+  return asUser(owner, async () => {
+    const { rows } = await client.query(
+      `SELECT baaki_create_group('Goa', 'trip', 'INR', NULL, false, NULL, NULL) AS id`,
+    );
+    return String(rows[0].id);
+  });
+}
+
+async function join(groupId: string, profileId: string): Promise<void> {
+  await client.query(
+    `INSERT INTO group_members (group_id, profile_id, joined_via) VALUES ($1, $2, 'invite_link')`,
+    [groupId, profileId],
+  );
+}
+
+async function addGhost(owner: string, groupId: string, name: string): Promise<string> {
+  return asUser(owner, async () => {
+    const { rows } = await client.query(`SELECT baaki_add_ghost_member($1::uuid, $2::text) AS id`, [
+      groupId,
+      name,
+    ]);
+    return String(rows[0].id);
+  });
+}
+
+async function myMember(groupId: string, profileId: string): Promise<string> {
+  const { rows } = await client.query(
+    `SELECT id FROM group_members WHERE group_id = $1 AND profile_id = $2`,
+    [groupId, profileId],
+  );
+  return String(rows[0].id);
+}
+
+/** `payer` pays `amount`, split equally between payer and `other`; recorded by `owner`. */
+async function expense(
+  owner: string,
+  groupId: string,
+  payer: string,
+  other: string,
+  amount: bigint,
+): Promise<void> {
+  const half = amount / 2n;
+  const author = await myMember(groupId, owner);
+  await asUser(owner, () =>
+    client.query(
+      `SELECT baaki_apply_expense($1::uuid, $2::uuid, $3::uuid, 'Dinner', NULL::text,
+                                  '2026-08-06'::date, 'INR'::char(3), $4::bigint,
+                                  'equal'::text, '{"kind":"equal"}'::jsonb,
+                                  $5::jsonb, $6::jsonb, $7::uuid)`,
+      [
+        groupId,
+        randomUUID(),
+        author,
+        amount.toString(),
+        JSON.stringify([{ memberId: payer, amount: amount.toString() }]),
+        JSON.stringify([
+          { memberId: payer, amount: half.toString() },
+          { memberId: other, amount: (amount - half).toString() },
+        ]),
+        randomUUID(),
+      ],
+    ),
+  );
+}
+
+function nudge(caller: string, groupId: string, toMemberId: string, currency = 'INR') {
+  return asUser(caller, () =>
+    client.query(`SELECT baaki_nudge_to_settle($1::uuid, $2::uuid, $3::char(3)) AS id`, [
+      groupId,
+      toMemberId,
+      currency,
+    ]),
+  );
+}
+
+/**
+ * A group where Ravi owes Asha ₹500 in one shared dinner. Returned ids are the
+ * two profiles and their members, so a test can nudge in either direction.
+ */
+async function owingPair(): Promise<{
+  asha: string;
+  ravi: string;
+  groupId: string;
+  ashaMember: string;
+  raviMember: string;
+}> {
+  const asha = await profile('Asha');
+  const ravi = await profile('Ravi');
+  const groupId = await makeGroup(asha);
+  await join(groupId, ravi);
+  const ashaMember = await myMember(groupId, asha);
+  const raviMember = await myMember(groupId, ravi);
+  await expense(asha, groupId, ashaMember, raviMember, 1000n);
+  return { asha, ravi, groupId, ashaMember, raviMember };
+}
+
+describe('a nudge that is real', () => {
+  it('writes the debtor an inbox row with the amount they owe', async () => {
+    const { asha, ravi, groupId, ashaMember, raviMember } = await owingPair();
+
+    const result = await nudge(asha, groupId, raviMember);
+    expect(result.rows[0].id).not.toBeNull();
+
+    const { rows } = await client.query(
+      `SELECT kind, group_id, payload FROM notifications WHERE profile_id = $1`,
+      [ravi],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('nudge');
+    expect(String(rows[0].group_id)).toBe(groupId);
+    expect(rows[0].payload.amount).toBe('500');
+    expect(rows[0].payload.currency).toBe('INR');
+    expect(rows[0].payload.counterparty).toBe('Asha');
+    expect(rows[0].payload.group).toBe('Goa');
+
+    const reminder = await client.query(
+      `SELECT last_nudged_at FROM reminders
+        WHERE group_id = $1 AND from_member_id = $2 AND to_member_id = $3`,
+      [groupId, ashaMember, raviMember],
+    );
+    expect(reminder.rows).toHaveLength(1);
+    expect(reminder.rows[0].last_nudged_at).not.toBeNull();
+  });
+});
+
+describe('the refusals that keep it kind', () => {
+  it('refuses a second nudge the same day', async () => {
+    const { asha, groupId, raviMember } = await owingPair();
+    await nudge(asha, groupId, raviMember);
+    await expect(nudge(asha, groupId, raviMember)).rejects.toThrow(/NUDGE_RATE_LIMIT/);
+  });
+
+  it('refuses to nudge over a debt that runs the other way', async () => {
+    // Ravi owes Asha, so Ravi has nothing to reproach Asha with.
+    const { ravi, groupId, ashaMember } = await owingPair();
+    await expect(nudge(ravi, groupId, ashaMember)).rejects.toThrow(/NOTHING_OWED/);
+  });
+
+  it('refuses to nudge in a currency that is square even when another is not', async () => {
+    const { asha, groupId, raviMember } = await owingPair();
+    await expect(nudge(asha, groupId, raviMember, 'EUR')).rejects.toThrow(/NOTHING_OWED/);
+  });
+
+  it('refuses to nudge a ghost, who has no inbox', async () => {
+    const asha = await profile('Asha');
+    const groupId = await makeGroup(asha);
+    const ghost = await addGhost(asha, groupId, 'Unclaimed Ravi');
+    await expect(nudge(asha, groupId, ghost)).rejects.toThrow(/GHOST_NO_INBOX/);
+  });
+
+  it('refuses a caller who is not in the group', async () => {
+    const { groupId, raviMember } = await owingPair();
+    const stranger = await profile('Stranger');
+    await expect(nudge(stranger, groupId, raviMember)).rejects.toThrow(/NOT_A_MEMBER/);
+  });
+});


### PR DESCRIPTION
## What

Wires the **send** half of the `nudge` notification. Everything else shipped in M4 — the `reminders` table, the one-per-pair-per-day rate-limit trigger, the four-language copy, the inbox icon, the preference toggle — but nothing ever wrote the row. This adds the sender.

## Server

`baaki_nudge_to_settle(p_group_id, p_to_member_id, p_currency)` — SECURITY DEFINER RPC that:
- refuses a caller who isn't a present member (`NOT_A_MEMBER`) and a self-nudge (`CANNOT_NUDGE_SELF`)
- refuses a ghost target — no inbox to receive it (`GHOST_NO_INBOX`)
- computes what they owe **you** in the given currency, netting both stored orientations, and refuses a non-positive figure (`NOTHING_OWED`) — no reminder over a debt that isn't there, and no summing across currencies (ADR-003)
- upserts the `reminders` row (the existing BEFORE UPDATE trigger enforces `NUDGE_RATE_LIMIT`, one/day)
- writes the debtor's inbox via `baaki_notify`, dedupe-keyed per pair per day

Ends with `NOTIFY pgrst, 'reload schema'` per the deploy convention.

## Client

- Friends tab: a **Remind** badge on each person who owes you where a single group explains the balance (never on ghosts — those still show Invite; never across multiple groups — no single pair to nudge). Tapped, it settles into a quiet *Reminded*; a spent daily limit reads as *Nudged today* in the same muted voice, not red. Being scolded for caring twice is the collections-agency feeling ADR-010 forbids.
- `nudgeToSettle` api client; `people.remind` / `reminded` / `remindedToday` in en/ta/hi/ar.

## Tests

Six DB tests against real Postgres — the real send (inbox row + amount + reminder), and the five refusals (rate limit, wrong-direction debt, square-in-this-currency, ghost, non-member). Mobile typecheck + lint + 206 tests (incl. strings parity) green.

## Deploy note

Migration `20260810160000_nudge_to_settle` is **not deployed** — it joins the undeployed M4 batch. The feature is dark until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ