### PR TITLE
feat: group settings polish + New group adopts the settings look

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { Alert, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { Alert, ScrollView, TextInput, View } from 'react-native';
 
 import {
   Button,
@@ -21,14 +21,13 @@ import {
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { pickGroupPhoto } from '@/lib/image';
 import { CountryRow } from '@/components/CountryPicker';
+import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
 import { TripDates } from '@/components/TripDates';
 import { removeGroupPhoto, uploadGroupPhoto } from '@/data/api';
 import { useGroup, useGroupLedger, useLeaveGroup, useUpdateGroup } from '@/data/hooks';
 import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { groupLabel } from '@/data/types';
-
-const EMOJI = ['🏖️', '🏠', '💜', '🎉', '✈️', '🍽️', '⛰️', '🎓', '👥'];
 
 export default function GroupSettingsScreen() {
   const theme = useTheme();
@@ -167,7 +166,10 @@ export default function GroupSettingsScreen() {
             </View>
           </Row>
 
-          <Row style={{ gap: theme.spacing.sm }}>
+          {/* The cover is set two ways from here: the photo by tapping the
+              picture above, and the icon by the picker — which now opens a wide,
+              scrollable set instead of a fixed nine crammed into the card. */}
+          <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
             <Button
               label={t.group.saveName}
               size="sm"
@@ -182,6 +184,10 @@ export default function GroupSettingsScreen() {
                 )
               }
             />
+            <CoverEmojiPicker
+              value={group.data.cover_emoji}
+              onChange={(emoji) => updateGroup.mutate({ cover_emoji: emoji })}
+            />
             {group.data.photo_path ? (
               <Button
                 label={t.group.removePhoto}
@@ -190,31 +196,6 @@ export default function GroupSettingsScreen() {
                 onPress={() => void dropPhoto()}
               />
             ) : null}
-          </Row>
-
-          <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
-            {EMOJI.map((option) => (
-              <Pressable
-                key={option}
-                accessibilityRole="radio"
-                accessibilityState={{ selected: group.data?.cover_emoji === option }}
-                accessibilityLabel={`Icon ${option}`}
-                onPress={() => updateGroup.mutate({ cover_emoji: option })}
-                style={{
-                  width: 42,
-                  height: 42,
-                  borderRadius: theme.radius.pill,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  backgroundColor:
-                    group.data?.cover_emoji === option
-                      ? theme.color.brandSoft
-                      : theme.color.surfaceMuted,
-                }}
-              >
-                <Text variant="subheading">{option}</Text>
-              </Pressable>
-            ))}
           </Row>
         </Card>
 

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -5,9 +5,23 @@ import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import { currencyForCountry, guessGroupEmoji } from '@baaki/core';
-import { Button, Callout, Card, ChipRow, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import {
+  Button,
+  Callout,
+  Card,
+  ChipRow,
+  IconButton,
+  Row,
+  Screen,
+  Text,
+  Toggle,
+  useTheme,
+} from '@baaki/ui';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
+import { CountryRow } from '@/components/CountryPicker';
+import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
+import { TripDates, type TripDatesValue } from '@/components/TripDates';
 import { pickGroupPhoto, type PickedImage } from '@/lib/image';
 import { uploadGroupPhoto } from '@/data/api';
 import { useCreateGroup } from '@/data/hooks';
@@ -29,9 +43,22 @@ const EMOJI_FOR_TYPE: Record<GroupType, string> = {
   other: '👥',
 };
 
+const deviceZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Kolkata';
+
+/**
+ * Making a group, wearing the same clothes as the settings that edit one.
+ *
+ * The two screens used to look nothing alike, which made creating a group feel
+ * like a different app from configuring it. So this is the settings screen's
+ * cards — the name-and-icon card, the flagged country row, the trip-dates
+ * editor, the simplify toggle — filled from local state instead of a saved
+ * group. Nothing is written until Create is tapped, so backing out leaves no
+ * half-made group behind; everything picked here is applied in one ordered
+ * burst once the group exists.
+ */
 export default function NewGroupScreen() {
   const theme = useTheme();
-  const { t } = useStrings();
+  const { t, locale } = useStrings();
   const createGroup = useCreateGroup();
   const { mutate, flush } = useSync();
 
@@ -42,14 +69,30 @@ export default function NewGroupScreen() {
   const [ghostName, setGhostName] = useState('');
   const [ghosts, setGhosts] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
-  // Read once, not on every render: a phone does not change country mid-form,
-  // and re-reading it would be a new value every time for `useMemo` to chase.
-  const [country] = useState(() => deviceCountry());
+  // Read once, not on every render: a phone does not change country mid-form.
+  const [country, setCountry] = useState<string | null>(() => deviceCountry());
+  // Null until somebody picks: the icon is otherwise read from the name, so an
+  // untouched group still gets a sensible cover.
+  const [pickedEmoji, setPickedEmoji] = useState<string | null>(null);
+  // Null until toggled, so it can follow the group type's default until then.
+  const [simplify, setSimplify] = useState<boolean | null>(null);
+  const [tripDates, setTripDates] = useState<TripDatesValue>(() => ({
+    start_date: null,
+    end_date: null,
+    time_zone: deviceZone(),
+    remind_daily: true,
+    remind_morning_at: '09:00:00',
+    remind_evening_at: '20:00:00',
+  }));
 
-  // Derived, not held: the icon is a reading of the name, so it has no state of
-  // its own to fall out of step with. It changes under the caret as somebody
-  // types "Goa" and again if they change what kind of group this is.
-  const emoji = guessGroupEmoji(name) ?? EMOJI_FOR_TYPE[type];
+  // The icon is a reading of the name, unless somebody has chosen one; it
+  // changes under the caret as they type "Goa" and again if they change the
+  // kind of group.
+  const emoji = pickedEmoji ?? guessGroupEmoji(name) ?? EMOJI_FOR_TYPE[type];
+  // Trips and events benefit most from simplification; a two-person group does
+  // not. Follows the type until somebody says otherwise.
+  const effectiveSimplify = simplify ?? (type === 'trip' || type === 'event');
+  const currency = currencyForCountry(country) ?? 'INR';
 
   const submit = async (): Promise<void> => {
     setError(null);
@@ -62,19 +105,17 @@ export default function NewGroupScreen() {
         // Dubai defaulting to rupees is the small wrongness that makes an app
         // feel written for somewhere else.
         country,
-        currency: currencyForCountry(country) ?? 'INR',
+        currency,
         emoji,
-        // Trips benefit most from simplification; a two-person group does not.
-        simplify: type === 'trip' || type === 'event',
+        simplify: effectiveSimplify,
       });
+
       // ADR-006: people who have not installed anything are still participants.
-      //
-      // Queued through the same offline pipe as the group, not sent as a direct
-      // RPC. The create above only resolves once it is on disk, not once it has
-      // reached the server — so a direct `baaki_add_ghost_member` here raced the
-      // create and hit a group the server had never seen, which is exactly the
-      // membership check it fails: `NOT_A_MEMBER`. Behind the create in one
-      // ordered queue, each ghost applies after the group it belongs to exists.
+      // Queued behind the create in one ordered pipe, not sent as a direct RPC —
+      // the create resolves once it is on disk, not once the server has seen it,
+      // so a direct add would race a group the server does not know yet and fail
+      // its membership check (NOT_A_MEMBER). Behind the create, each applies
+      // after the group it belongs to exists.
       for (const ghost of ghosts) {
         await mutate('member.add_ghost', groupId, {
           memberId: randomUUID(),
@@ -83,10 +124,25 @@ export default function NewGroupScreen() {
           phone: null,
         });
       }
-      // The photo lives in Storage, not the offline queue, and the storage
-      // policy is "members of this group only" — which needs the group, and the
-      // membership row, to actually be on the server. Flush the queued create
-      // (and the ghosts behind it) before writing an object under its id.
+
+      // Trip dates are not part of the create call, so they ride behind it as
+      // an update on the same ordered queue — only when a trip was actually
+      // given a start and end, since that is what turns the reminders on.
+      if (tripDates.start_date && tripDates.end_date) {
+        await mutate('group.update', groupId, {
+          start_date: tripDates.start_date,
+          end_date: tripDates.end_date,
+          time_zone: tripDates.time_zone,
+          remind_daily: tripDates.remind_daily,
+          remind_morning_at: tripDates.remind_morning_at,
+          remind_evening_at: tripDates.remind_evening_at,
+        });
+      }
+
+      // The photo lives in Storage, not the offline queue, and its policy is
+      // "members of this group only" — which needs the group and the membership
+      // row actually on the server. Flush the queued create (and everything
+      // behind it) before writing an object under its id.
       if (photo) {
         setUploading(true);
         try {
@@ -114,6 +170,7 @@ export default function NewGroupScreen() {
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.close} onPress={() => router.back()}>
@@ -136,7 +193,7 @@ export default function NewGroupScreen() {
             />
             <View style={{ flex: 1, gap: theme.spacing.xs }}>
               <Text variant="caption" tone="muted">
-                Group name (optional)
+                {t.group.nameOptional}
               </Text>
               <TextInput
                 value={name}
@@ -157,6 +214,10 @@ export default function NewGroupScreen() {
               </Text>
             </View>
           </Row>
+
+          <Row style={{ gap: theme.spacing.sm }}>
+            <CoverEmojiPicker value={emoji} onChange={setPickedEmoji} />
+          </Row>
         </Card>
 
         <View style={{ gap: theme.spacing.md }}>
@@ -175,6 +236,34 @@ export default function NewGroupScreen() {
             ]}
           />
         </View>
+
+        {/* Decides which payment rails the settle screen offers, and what a new
+            expense starts in. The same flagged row the settings screen uses. */}
+        <CountryRow countryCode={country} onChange={setCountry} />
+
+        <TripDates
+          group={tripDates}
+          locale={locale}
+          onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
+        />
+
+        {/* ADR-009: simplification is presentation only — the pairwise ledger
+            underneath is untouched. */}
+        <Card>
+          <Row style={{ justifyContent: 'space-between' }}>
+            <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
+              <Text variant="subheading">{t.group.simplifyDebts}</Text>
+              <Text variant="caption" tone="muted">
+                {t.group.simplifyDebtsBody}
+              </Text>
+            </View>
+            <Toggle
+              value={effectiveSimplify}
+              onValueChange={setSimplify}
+              accessibilityLabel={t.group.simplifyDebts}
+            />
+          </Row>
+        </Card>
 
         <Card style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">

--- a/apps/mobile/src/components/CountryPicker.tsx
+++ b/apps/mobile/src/components/CountryPicker.tsx
@@ -17,7 +17,7 @@
 import { useState } from 'react';
 import { Modal, Pressable, ScrollView, View } from 'react-native';
 
-import { COUNTRIES, countryName, railsFor } from '@baaki/core';
+import { COUNTRIES, countryFlag, countryName, railsFor } from '@baaki/core';
 import { Button, Card, ListRow, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
@@ -43,6 +43,8 @@ export function CountryRow({
     <>
       <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
         <ListRow
+          // A globe stands in for "no country set", where a flag would be a lie.
+          leading={<Text style={{ fontSize: 26 }}>{countryFlag(countryCode) ?? '🌐'}</Text>}
           title={t.pickers.country}
           subtitle={t.pickers.settlesWith
             .replace(
@@ -78,6 +80,7 @@ export function CountryRow({
             showsVerticalScrollIndicator={false}
           >
             <Choice
+              flag="🌐"
               label={t.pickers.notSet}
               hint={t.pickers.notSetRails}
               selected={countryCode === null}
@@ -89,6 +92,7 @@ export function CountryRow({
             {COUNTRIES.map((country) => (
               <Choice
                 key={country.code}
+                flag={countryFlag(country.code) ?? '🌐'}
                 label={country.name}
                 hint={railsFor(country.code)
                   .slice(0, 3)
@@ -118,11 +122,13 @@ export function CountryRow({
 }
 
 function Choice({
+  flag,
   label,
   hint,
   selected,
   onPress,
 }: {
+  flag: string;
   label: string;
   hint: string;
   selected: boolean;
@@ -141,8 +147,9 @@ function Choice({
         backgroundColor: selected ? theme.color.brandSoft : theme.color.surface,
       }}
     >
-      <Row style={{ justifyContent: 'space-between' }}>
-        <View style={{ flex: 1, paddingRight: theme.spacing.md }}>
+      <Row style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
+        <Text style={{ fontSize: 26 }}>{flag}</Text>
+        <View style={{ flex: 1 }}>
           <Text variant="subheading">{label}</Text>
           <Text variant="micro" tone="muted">
             {hint}

--- a/apps/mobile/src/components/CoverEmojiPicker.tsx
+++ b/apps/mobile/src/components/CoverEmojiPicker.tsx
@@ -1,0 +1,111 @@
+/**
+ * Picking the little icon a group wears.
+ *
+ * The old control was nine emoji crammed under the name field with no way to
+ * reach a tenth — fine until the group is a badminton league or a wedding, and
+ * then it is a wall. This is the same idea with room to breathe: one button that
+ * opens a wide, curated set, grouped so the eye can find the row it wants.
+ *
+ * Deliberately not the whole emoji keyboard. A shared-expense group wants a
+ * cover somebody recognises at a glance in a list, not 🫠 — so the set is the
+ * trips, homes, meals, journeys and pastimes a group is actually named after.
+ * Whatever is picked is stored as a single character, same as before.
+ */
+
+import { useState } from 'react';
+import { Modal, Pressable, ScrollView, View } from 'react-native';
+
+import { Button, Card, Row, Screen, Text, useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+
+const EMOJI_GROUPS: readonly (readonly string[])[] = [
+  ['🏖️', '🏝️', '⛰️', '🏔️', '🏕️', '🏜️', '🗺️', '✈️', '🚗', '🚕', '🚌', '🚆', '⛵', '🛵'],
+  ['🏠', '🏡', '🏢', '🏨', '🏬', '🛏️', '🛋️', '🔑', '🧹', '💡', '🧾', '💰'],
+  ['🍽️', '🍕', '🍔', '🍜', '🍣', '🍻', '☕', '🍩', '🎂', '🥡', '🛒'],
+  ['🎉', '🎁', '🎈', '💜', '❤️', '🎵', '🎬', '🎮', '⚽', '🏀', '🏏', '🏸', '🧗', '🏊'],
+  ['🎓', '💼', '📚', '👥', '🐶', '🐱', '🌱', '🌸', '⭐', '🌈'],
+];
+
+export function CoverEmojiPicker({
+  value,
+  onChange,
+}: {
+  value: string | null;
+  onChange: (emoji: string) => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        label={t.group.chooseIcon}
+        size="sm"
+        variant="secondary"
+        onPress={() => setOpen(true)}
+      />
+
+      <Modal visible={open} animationType="slide" onRequestClose={() => setOpen(false)}>
+        <Screen edges={['top', 'bottom']}>
+          <View style={{ paddingHorizontal: theme.spacing.xl, paddingBottom: theme.spacing.md }}>
+            <Text variant="heading">{t.group.chooseIcon}</Text>
+          </View>
+
+          <ScrollView
+            contentContainerStyle={{
+              paddingHorizontal: theme.spacing.xl,
+              paddingBottom: theme.spacing.xxxl,
+              gap: theme.spacing.lg,
+            }}
+            showsVerticalScrollIndicator={false}
+          >
+            {EMOJI_GROUPS.map((emojis, index) => (
+              <Card key={index} style={{ gap: theme.spacing.sm }}>
+                <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
+                  {emojis.map((emoji) => {
+                    const selected = value === emoji;
+                    return (
+                      <Pressable
+                        key={emoji}
+                        accessibilityRole="radio"
+                        accessibilityState={{ selected }}
+                        accessibilityLabel={emoji}
+                        onPress={() => {
+                          onChange(emoji);
+                          setOpen(false);
+                        }}
+                        style={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: theme.radius.pill,
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          backgroundColor: selected
+                            ? theme.color.brandSoft
+                            : theme.color.surfaceMuted,
+                        }}
+                      >
+                        <Text style={{ fontSize: 24 }}>{emoji}</Text>
+                      </Pressable>
+                    );
+                  })}
+                </Row>
+              </Card>
+            ))}
+          </ScrollView>
+
+          <View style={{ paddingHorizontal: theme.spacing.xl, paddingBottom: theme.spacing.lg }}>
+            <Button
+              label={t.common.close}
+              variant="ghost"
+              fullWidth
+              onPress={() => setOpen(false)}
+            />
+          </View>
+        </Screen>
+      </Modal>
+    </>
+  );
+}

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -117,6 +117,10 @@ export function TripDates({
   const theme = useTheme();
   const { t } = useStrings();
   const [editing, setEditing] = useState<Field | null>(null);
+  // The why-does-this-exist paragraph is long, and once you have read it once
+  // you do not need it every time you open settings. Folded behind the info
+  // icon by default; the dates themselves stay in view.
+  const [showInfo, setShowInfo] = useState(false);
 
   const hasDates = Boolean(group.start_date && group.end_date);
 
@@ -152,12 +156,30 @@ export function TripDates({
   return (
     <Card style={{ gap: theme.spacing.lg }}>
       <View style={{ gap: theme.spacing.xs }}>
-        <Text variant="subheading">Trip dates</Text>
-        <Text variant="caption" tone="muted">
-          While the trip is on, everybody gets a nudge to add what they spent — at breakfast about
-          yesterday, and at the end of the day about today. Nobody is asked about a day they have
-          already added to.
-        </Text>
+        <Row style={{ justifyContent: 'space-between', gap: theme.spacing.sm }}>
+          <Text variant="subheading">Trip dates</Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityState={{ expanded: showInfo }}
+            accessibilityLabel="About trip dates"
+            hitSlop={8}
+            onPress={() => setShowInfo((open) => !open)}
+            style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+          >
+            <Ionicons
+              name={showInfo ? 'information-circle' : 'information-circle-outline'}
+              size={20}
+              color={showInfo ? theme.color.brand : theme.color.textFaint}
+            />
+          </Pressable>
+        </Row>
+        {showInfo ? (
+          <Text variant="caption" tone="muted">
+            While the trip is on, everybody gets a nudge to add what they spent — at breakfast about
+            yesterday, and at the end of the day about today. Nobody is asked about a day they have
+            already added to.
+          </Text>
+        ) : null}
       </View>
 
       <Row style={{ gap: theme.spacing.lg }}>

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -23,7 +23,20 @@ import { Button, Card, Row, Text, Toggle, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 
-import type { GroupRow } from '@/data/types';
+/**
+ * Only the fields this card reads and writes — not a whole `GroupRow`. A saved
+ * group satisfies it structurally, and so does the local state of a group being
+ * created, which is what lets the create screen reuse this editor before there
+ * is a group to point at.
+ */
+export interface TripDatesValue {
+  start_date: string | null;
+  end_date: string | null;
+  time_zone: string;
+  remind_daily: boolean;
+  remind_morning_at: string;
+  remind_evening_at: string;
+}
 
 type Field = 'start' | 'end' | 'morning' | 'evening';
 
@@ -110,7 +123,7 @@ export function TripDates({
   locale,
   onChange,
 }: {
-  group: GroupRow;
+  group: TripDatesValue;
   locale: string;
   onChange: (patch: TripDatesPatch) => void;
 }) {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -548,6 +548,8 @@ export interface UiStrings {
     nameOptional: string;
     groupName: string;
     saveName: string;
+    /** Opens the group cover-emoji picker. */
+    chooseIcon: string;
     removePhoto: string;
     simplifyDebts: string;
     simplifyDebtsBody: string;
@@ -1432,6 +1434,7 @@ const en: UiStrings = {
     nameOptional: 'Name (optional)',
     groupName: 'Group name',
     saveName: 'Save name',
+    chooseIcon: 'Choose an icon',
     removePhoto: 'Remove photo',
     simplifyDebts: 'Simplify debts',
     simplifyDebtsBody:
@@ -2377,6 +2380,7 @@ const ta: UiStrings = {
     nameOptional: 'பெயர் (விருப்பம்)',
     groupName: 'குழுவின் பெயர்',
     saveName: 'பெயரைச் சேமி',
+    chooseIcon: 'ஐகானைத் தேர்ந்தெடு',
     removePhoto: 'புகைப்படத்தை நீக்கு',
     simplifyDebts: 'கடன்களை எளிமையாக்கு',
     simplifyDebtsBody:
@@ -3318,6 +3322,7 @@ const hi: UiStrings = {
     nameOptional: 'नाम (वैकल्पिक)',
     groupName: 'समूह का नाम',
     saveName: 'नाम सेव करें',
+    chooseIcon: 'आइकन चुनें',
     removePhoto: 'फ़ोटो हटाएँ',
     simplifyDebts: 'हिसाब सरल करें',
     simplifyDebtsBody:
@@ -4276,6 +4281,7 @@ const ar: UiStrings = {
     nameOptional: 'الاسم (اختياري)',
     groupName: 'اسم المجموعة',
     saveName: 'حفظ الاسم',
+    chooseIcon: 'اختر أيقونة',
     removePhoto: 'إزالة الصورة',
     simplifyDebts: 'تبسيط الديون',
     simplifyDebtsBody:

--- a/packages/core/src/money/region.ts
+++ b/packages/core/src/money/region.ts
@@ -126,3 +126,20 @@ export function countryName(countryCode: string | null | undefined): string | nu
   const country = (countryCode ?? '').trim().toUpperCase();
   return COUNTRIES.find((entry) => entry.code === country)?.name ?? null;
 }
+
+/**
+ * The flag for an ISO-3166 alpha-2 code, built from the two Unicode regional
+ * indicator symbols — 'IN' becomes 🇮🇳. Returns null for a missing or malformed
+ * code so the caller can show a globe or nothing, never an accidental bare
+ * "IN".
+ *
+ * The glyph is only as good as the reader's font: some Android builds ship no
+ * flag emoji and fall back to rendering the two letters. That fallback is still
+ * a true, legible label, which is why this is safe to show without checking.
+ */
+export function countryFlag(countryCode: string | null | undefined): string | null {
+  const code = (countryCode ?? '').trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(code)) return null;
+  const base = 0x1f1e6; // 🇦 — regional indicator 'A'
+  return String.fromCodePoint(base + code.charCodeAt(0) - 65, base + code.charCodeAt(1) - 65);
+}

--- a/packages/core/test/region.test.ts
+++ b/packages/core/test/region.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { COUNTRIES, countryName, currencyForCountry, isCountryCode } from '../src/money/region';
+import {
+  COUNTRIES,
+  countryFlag,
+  countryName,
+  currencyForCountry,
+  isCountryCode,
+} from '../src/money/region';
 import { isCurrencyCode, minorUnitExponent } from '../src/money/currency';
 
 describe('what a country counts in', () => {
@@ -96,5 +102,21 @@ describe('the country list', () => {
     expect(isCountryCode('UAE')).toBe(false);
     expect(isCountryCode('')).toBe(false);
     expect(isCountryCode(null)).toBe(false);
+  });
+
+  it('builds a flag from regional indicators, and refuses a bad code', () => {
+    // 🇮🇳 is U+1F1EE U+1F1F3 — the two regional indicators for I and N.
+    expect(countryFlag('IN')).toBe('\u{1F1EE}\u{1F1F3}');
+    expect(countryFlag('us')).toBe('\u{1F1FA}\u{1F1F8}');
+    expect(countryFlag(null)).toBeNull();
+    expect(countryFlag('')).toBeNull();
+    expect(countryFlag('USA')).toBeNull();
+    expect(countryFlag('1N')).toBeNull();
+  });
+
+  it('has a flag for every country it lists', () => {
+    for (const entry of COUNTRIES) {
+      expect(countryFlag(entry.code), entry.code).not.toBeNull();
+    }
   });
 });


### PR DESCRIPTION
Two related pieces of the same idea — make the group settings screen nice, then make **creating** a group feel like the same app as configuring one.

## Group settings polish
Three papercuts from a device walkthrough:

- **Country wears its flag.** New `countryFlag()` in `@baaki/core` turns an ISO-3166 code into its two regional-indicator symbols (`IN` → 🇮🇳), on the row and every picker choice; 🌐 for "Not set". Some Android builds ship no flag glyphs and render the two letters — still a true label.
- **Trip-dates explainer folds away** behind an info icon next to the title, collapsed by default; the dates stay in view.
- **Cover icon is a real picker** — the fixed nine emoji become a "Choose an icon" button opening a wide, grouped, scrollable set (~55). New `CoverEmojiPicker`.

## New group adopts the settings look
The create page looked nothing like settings. It now uses the **same cards** — name-and-icon, flagged country row, trip-dates editor, simplify toggle — filled from local state.

- **No half-made groups:** nothing is written until Create. On Create everything applies in one ordered burst: group → ghosts → trip-dates update (if a trip got dates) → photo (once the group is on the server).
- Keeps group **type** and **add-people-by-name**, which a plain "create then open settings" redirect would have lost.
- `TripDates` now takes a narrow `TripDatesValue` (the six fields it touches) instead of a whole `GroupRow`, so the create screen can drive it before a group exists. A saved group still satisfies it structurally — settings unchanged.

## Tests
- `countryFlag` unit tests; core **499** + mobile **206** (incl. strings parity — `group.chooseIcon` in en/ta/hi/ar).
- Typecheck + lint green.

**Device pass wanted:** flag rendering on this Android build; the icon-picker modal on a small screen; the new create flow end-to-end (create → ghosts → dates → photo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ