### PR TITLE
feat(new-group): pick from contacts; fold section blurbs behind an info icon

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -22,6 +22,7 @@ import { GroupPhoto } from '@/components/GroupPhoto';
 import { pickGroupPhoto } from '@/lib/image';
 import { CountryRow } from '@/components/CountryPicker';
 import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
+import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates } from '@/components/TripDates';
 import { removeGroupPhoto, uploadGroupPhoto } from '@/data/api';
 import { useGroup, useGroupLedger, useLeaveGroup, useUpdateGroup } from '@/data/hooks';
@@ -219,19 +220,17 @@ export default function GroupSettingsScreen() {
         {/* ADR-009: simplification is presentation only — the pairwise ledger
             underneath is untouched, so this is safe to toggle at any time. */}
         <Card>
-          <Row style={{ justifyContent: 'space-between' }}>
-            <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-              <Text variant="subheading">{t.group.simplifyDebts}</Text>
-              <Text variant="caption" tone="muted">
-                {t.group.simplifyDebtsBody}
-              </Text>
-            </View>
-            <Toggle
-              value={group.data.simplify_debts}
-              onValueChange={(value) => updateGroup.mutate({ simplify_debts: value })}
-              accessibilityLabel={t.group.simplifyDebts}
-            />
-          </Row>
+          <InfoDisclosure
+            title={t.group.simplifyDebts}
+            info={t.group.simplifyDebtsBody}
+            right={
+              <Toggle
+                value={group.data.simplify_debts}
+                onValueChange={(value) => updateGroup.mutate({ simplify_debts: value })}
+                accessibilityLabel={t.group.simplifyDebts}
+              />
+            }
+          />
         </Card>
 
         <View>

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -19,8 +19,10 @@ import {
 } from '@baaki/ui';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
+import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
 import { CountryRow } from '@/components/CountryPicker';
 import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
+import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates, type TripDatesValue } from '@/components/TripDates';
 import { pickGroupPhoto, type PickedImage } from '@/lib/image';
 import { uploadGroupPhoto } from '@/data/api';
@@ -67,7 +69,11 @@ export default function NewGroupScreen() {
   const [uploading, setUploading] = useState(false);
   const [type, setType] = useState<GroupType>('trip');
   const [ghostName, setGhostName] = useState('');
-  const [ghosts, setGhosts] = useState<string[]>([]);
+  // People to add on Create — a typed name carries no address, a contact carries
+  // whatever the phone had. Same shape either way, so the create loop treats
+  // them alike.
+  const [ghosts, setGhosts] = useState<PickedContact[]>([]);
+  const [browsing, setBrowsing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Read once, not on every render: a phone does not change country mid-form.
   const [country, setCountry] = useState<string | null>(() => deviceCountry());
@@ -119,9 +125,9 @@ export default function NewGroupScreen() {
       for (const ghost of ghosts) {
         await mutate('member.add_ghost', groupId, {
           memberId: randomUUID(),
-          name: ghost,
-          email: null,
-          phone: null,
+          name: ghost.name,
+          email: ghost.email,
+          phone: ghost.phone,
         });
       }
 
@@ -161,6 +167,45 @@ export default function NewGroupScreen() {
     }
   };
 
+  // The address first, because that is what tells two people of the same name
+  // apart; the name only carries the difference when neither has an address.
+  const keyOfGhost = (ghost: PickedContact): string =>
+    `${ghost.email ?? ''}|${ghost.phone ?? ''}|${ghost.name}`;
+
+  const addTypedGhost = (): void => {
+    const name = ghostName.trim();
+    if (!name) return;
+    setGhosts((current) => [...current, { name, email: null, phone: null }]);
+    setGhostName('');
+  };
+
+  // Ticked out of the phone's contacts. Merged rather than replaced — somebody
+  // may have typed a name or picked already — and de-duplicated so the same
+  // person picked twice is added once.
+  const addContacts = (people: readonly PickedContact[]): void => {
+    setGhosts((current) => {
+      const seen = new Set(current.map(keyOfGhost));
+      const merged = [...current];
+      for (const person of people) {
+        const key = keyOfGhost(person);
+        if (!seen.has(key)) {
+          seen.add(key);
+          merged.push(person);
+        }
+      }
+      return merged;
+    });
+    setBrowsing(false);
+  };
+
+  // The contacts already queued, so the picker greys them rather than letting
+  // somebody add the same person twice.
+  const alreadyPicked = new Set(
+    ghosts.flatMap((ghost) =>
+      [ghost.email, ghost.phone].filter((value): value is string => Boolean(value)),
+    ),
+  );
+
   return (
     <Screen edges={['top', 'bottom']}>
       <ScrollView
@@ -192,9 +237,11 @@ export default function NewGroupScreen() {
               onPress={() => void pickGroupPhoto().then(setPhoto)}
             />
             <View style={{ flex: 1, gap: theme.spacing.xs }}>
-              <Text variant="caption" tone="muted">
-                {t.group.nameOptional}
-              </Text>
+              <InfoDisclosure
+                title={t.group.nameOptional}
+                info={t.extras.blankNameHint}
+                titleVariant="caption"
+              />
               <TextInput
                 value={name}
                 onChangeText={setName}
@@ -209,9 +256,6 @@ export default function NewGroupScreen() {
                   paddingVertical: theme.spacing.sm,
                 }}
               />
-              <Text variant="micro" tone="faint">
-                {t.extras.blankNameHint}
-              </Text>
             </View>
           </Row>
 
@@ -250,28 +294,25 @@ export default function NewGroupScreen() {
         {/* ADR-009: simplification is presentation only — the pairwise ledger
             underneath is untouched. */}
         <Card>
-          <Row style={{ justifyContent: 'space-between' }}>
-            <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-              <Text variant="subheading">{t.group.simplifyDebts}</Text>
-              <Text variant="caption" tone="muted">
-                {t.group.simplifyDebtsBody}
-              </Text>
-            </View>
-            <Toggle
-              value={effectiveSimplify}
-              onValueChange={setSimplify}
-              accessibilityLabel={t.group.simplifyDebts}
-            />
-          </Row>
+          <InfoDisclosure
+            title={t.group.simplifyDebts}
+            info={t.group.simplifyDebtsBody}
+            right={
+              <Toggle
+                value={effectiveSimplify}
+                onValueChange={setSimplify}
+                accessibilityLabel={t.group.simplifyDebts}
+              />
+            }
+          />
         </Card>
 
         <Card style={{ gap: theme.spacing.md }}>
-          <Text variant="caption" tone="muted">
-            {t.extras.addPeopleByName}
-          </Text>
-          <Text variant="micro" tone="faint">
-            {t.extras.ghostNote}
-          </Text>
+          <InfoDisclosure
+            title={t.extras.addPeopleByName}
+            info={t.extras.ghostNote}
+            titleVariant="caption"
+          />
           <Row>
             <TextInput
               value={ghostName}
@@ -279,12 +320,7 @@ export default function NewGroupScreen() {
               placeholder={t.people.namePlaceholder}
               placeholderTextColor={theme.color.textFaint}
               accessibilityLabel={t.misc.personName}
-              onSubmitEditing={() => {
-                if (ghostName.trim()) {
-                  setGhosts((current) => [...current, ghostName.trim()]);
-                  setGhostName('');
-                }
-              }}
+              onSubmitEditing={addTypedGhost}
               style={{
                 flex: 1,
                 fontSize: 17,
@@ -298,20 +334,34 @@ export default function NewGroupScreen() {
               size="sm"
               variant="secondary"
               disabled={!ghostName.trim()}
-              onPress={() => {
-                setGhosts((current) => [...current, ghostName.trim()]);
-                setGhostName('');
-              }}
+              onPress={addTypedGhost}
             />
           </Row>
+
+          {/* The same phone-contacts picker the Members screen uses. It reads
+              the address book on the device and only the people ticked come
+              back — nobody's book is uploaded (ADR-006). */}
+          <Button
+            label={browsing ? t.people.hideContacts : t.people.browseContacts}
+            variant="ghost"
+            onPress={() => setBrowsing((open) => !open)}
+          />
+
+          {browsing ? (
+            // Tall enough that the letter rail has something to aim at — a
+            // short window turns a thousand contacts back into a peephole.
+            <View style={{ height: 480 }}>
+              <ContactPicker onConfirm={addContacts} existing={alreadyPicked} />
+            </View>
+          ) : null}
 
           {ghosts.length > 0 ? (
             <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
               {ghosts.map((ghost, index) => (
                 <Pressable
-                  key={`${ghost}-${index}`}
+                  key={`${keyOfGhost(ghost)}-${index}`}
                   accessibilityRole="button"
-                  accessibilityLabel={`Remove ${ghost}`}
+                  accessibilityLabel={`Remove ${ghost.name}`}
                   onPress={() => setGhosts((current) => current.filter((_, i) => i !== index))}
                   style={{
                     flexDirection: 'row',
@@ -323,7 +373,7 @@ export default function NewGroupScreen() {
                     backgroundColor: theme.color.surfaceMuted,
                   }}
                 >
-                  <Text variant="caption">{ghost}</Text>
+                  <Text variant="caption">{ghost.name}</Text>
                   <Ionicons name="close" size={14} color={theme.color.textMuted} />
                 </Pressable>
               ))}

--- a/apps/mobile/src/components/InfoDisclosure.tsx
+++ b/apps/mobile/src/components/InfoDisclosure.tsx
@@ -1,0 +1,69 @@
+/**
+ * A section's heading with its explanation folded behind an info icon.
+ *
+ * The settings and new-group screens had grown a paragraph under every heading,
+ * and a page that explains itself a dozen times is a page nobody reads. The
+ * words are kept for the one time somebody wants them — tap the ⓘ — but the
+ * resting state is just the title and whatever control sits beside it.
+ *
+ * `right` is that control (a Toggle, usually); it stays on the title row so the
+ * thing you act on never moves when the explanation opens or closes.
+ */
+
+import { useState, type ReactNode } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, View } from 'react-native';
+
+import { Row, Text, useTheme } from '@baaki/ui';
+
+export function InfoDisclosure({
+  title,
+  info,
+  right,
+  titleVariant = 'subheading',
+}: {
+  title: string;
+  info: string;
+  right?: ReactNode;
+  /** 'subheading' for a card heading, 'caption' for a muted field label. */
+  titleVariant?: 'subheading' | 'caption';
+}) {
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <View style={{ gap: theme.spacing.xs }}>
+      <Row style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
+        <Row style={{ gap: theme.spacing.sm, flex: 1 }}>
+          {titleVariant === 'caption' ? (
+            <Text variant="caption" tone="muted">
+              {title}
+            </Text>
+          ) : (
+            <Text variant="subheading">{title}</Text>
+          )}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityState={{ expanded: open }}
+            accessibilityLabel={`About ${title}`}
+            hitSlop={8}
+            onPress={() => setOpen((value) => !value)}
+            style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+          >
+            <Ionicons
+              name={open ? 'information-circle' : 'information-circle-outline'}
+              size={18}
+              color={open ? theme.color.brand : theme.color.textFaint}
+            />
+          </Pressable>
+        </Row>
+        {right}
+      </Row>
+      {open ? (
+        <Text variant="caption" tone="muted">
+          {info}
+        </Text>
+      ) : null}
+    </View>
+  );
+}


### PR DESCRIPTION
Two asks from a walkthrough of the group-create surface.

## 1. Pick from phone contacts on New group
The add-people section gets the **same on-device contacts picker the Members screen uses**. *Browse contacts* opens the phone's address book; only the ticked people come back — no book is ever uploaded (ADR-006).

- Picked people carry whatever email/phone the contact had and queue as ghost members created on **Create**, alongside anyone typed by name.
- The pending list is now `PickedContact[]` (name + email + phone), de-duplicated by address, greying contacts already queued.

## 2. Section blurbs fold behind an info icon
New `InfoDisclosure`: a section's heading keeps its control on the row and tucks the explanatory paragraph behind an ⓘ, collapsed by default (the pattern Trip dates already used).

- **New group:** name hint, simplify, add-people note.
- **Group settings:** simplify. (Trip dates already folds; Country/Members/Import stay as compact list rows where the subtitle is the value, not a paragraph.)
- **No new strings** — same copy, just not shouting on every open.

## Tests
Mobile typecheck + lint + 206 (strings parity unaffected — reused existing keys). 

**Device pass wanted:** contacts permission + picker inside New group, and the info-icon toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ