### PR TITLE
feat(spending): drill from a month into its days and expenses

### DIFF
--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -133,12 +133,15 @@ export default function InsightsScreen() {
           currencies.map((currency) => (
             <CurrencySection
               key={currency}
+              groupId={groupId}
+              scope={scope}
               currency={currency}
               locale={locale}
               rows={rows.filter((row) => row.currency === currency)}
               labels={t.categories}
               byCategoryTitle={t.byCategory}
               byMonthTitle={t.byMonth}
+              tapHint={t.tapMonthForDays}
             />
           ))
         )}
@@ -159,19 +162,25 @@ export default function InsightsScreen() {
 }
 
 function CurrencySection({
+  groupId,
+  scope,
   currency,
   locale,
   rows,
   labels,
   byCategoryTitle,
   byMonthTitle,
+  tapHint,
 }: {
+  groupId: string;
+  scope: Scope;
   currency: string;
   locale: string;
   rows: SpendingRow[];
   labels: Record<CategoryId, string>;
   byCategoryTitle: string;
   byMonthTitle: string;
+  tapHint: string;
 }) {
   const theme = useTheme();
 
@@ -237,8 +246,18 @@ function CurrencySection({
 
       <View style={{ gap: theme.spacing.md }}>
         <SectionHeader title={byMonthTitle} />
-        <Card>
-          <ColumnChart data={months} />
+        <Card style={{ gap: theme.spacing.md }}>
+          <ColumnChart
+            data={months}
+            onSelect={(month) =>
+              router.push(
+                `/group/${groupId}/month?month=${month}&currency=${currency}&scope=${scope}`,
+              )
+            }
+          />
+          <Text variant="micro" tone="faint" align="center">
+            {tapHint}
+          </Text>
         </Card>
       </View>
     </View>

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -177,7 +177,9 @@ export default function SpendingMonthScreen() {
 
             {days.map(([day, bucket]) => (
               <View key={day} style={{ gap: theme.spacing.md }}>
-                <Row style={{ justifyContent: 'space-between', paddingHorizontal: theme.spacing.xs }}>
+                <Row
+                  style={{ justifyContent: 'space-between', paddingHorizontal: theme.spacing.xs }}
+                >
                   <Text variant="subheading">{dayLabel(day)}</Text>
                   <MoneyText
                     amount={bucket.total}

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -1,0 +1,254 @@
+/**
+ * One month of spending, day by day (the drill under the Spending chart).
+ *
+ * The insights screen answers "what did we spend, month by month". A column
+ * there is a total with no way in — this is the way in: tap a month and land
+ * on its days, tap an expense and land on the expense. Nothing new is summed
+ * server-side; it reads the same local expenses the group page shows and slices
+ * them to the month and currency the tapped column stood for.
+ *
+ * It honours the scope the chart was in. In "group" scope a row is the whole
+ * expense; in "mine" scope it is this person's share of it, and expenses they
+ * had no share in are not shown — so the day subtotals and the screen total add
+ * back up to the column that was tapped, and never to a different number.
+ */
+
+import { useMemo } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
+
+import { categoryOf } from '@baaki/core';
+import {
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  MoneyText,
+  Row,
+  Screen,
+  Text,
+  TintCard,
+  useTheme,
+} from '@baaki/ui';
+
+import { CategoryBadge } from '@/components/Category';
+import { memberLookup, useGroup } from '@/data/hooks';
+import { expenseTitle } from '@/data/expenseTitle';
+import { displayName, groupLabel, type ExpenseRow } from '@/data/types';
+import { fill, plural, useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+
+/** Sum of this member's shares in a version, in minor units. */
+function myShare(shares: { member_id: string; amount: string }[], memberId: string | null): bigint {
+  if (!memberId) return 0n;
+  return shares
+    .filter((share) => share.member_id === memberId)
+    .reduce((sum, share) => sum + BigInt(share.amount), 0n);
+}
+
+export default function SpendingMonthScreen() {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const params = useLocalSearchParams<{
+    id: string;
+    month: string;
+    currency: string;
+    scope: string;
+  }>();
+  const groupId = params.id ?? '';
+  const month = (params.month ?? '').slice(0, 7); // 'YYYY-MM'
+  const currency = params.currency ?? '';
+  const mine = params.scope === 'mine';
+  const { profile } = useAuth();
+
+  const { group, members, expenses } = useGroup(groupId);
+
+  const myMemberId = useMemo(
+    () => (members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ?? null,
+    [members.data, profile?.id],
+  );
+
+  const lookup = memberLookup(members.data);
+  const nameOf = (memberId: string | null): string => {
+    const member = memberId ? lookup.get(memberId) : undefined;
+    return member ? displayName(member, profile?.id) : 'Someone';
+  };
+
+  // The expenses that make up the tapped column: live, in this currency, in this
+  // month, and — in "mine" scope — ones this person actually had a share in.
+  // Paired with the amount the row should show, so the day maths never re-reads
+  // the scope.
+  const rows = useMemo(() => {
+    const out: { expense: ExpenseRow; amount: bigint; day: string }[] = [];
+    for (const expense of expenses.rows) {
+      if (expense.deleted_at) continue;
+      const version = expense.currentVersion;
+      if (!version || version.currency !== currency) continue;
+      if (version.expense_date.slice(0, 7) !== month) continue;
+      const amount = mine ? myShare(version.shares, myMemberId) : BigInt(version.amount);
+      if (mine && amount === 0n) continue;
+      out.push({ expense, amount, day: version.expense_date.slice(0, 10) });
+    }
+    return out;
+  }, [expenses.rows, currency, month, mine, myMemberId]);
+
+  // Newest day first, and newest expense first within a day — a ledger reads
+  // most-recent-down, same as the group page.
+  const days = useMemo(() => {
+    const byDay = new Map<string, { total: bigint; items: typeof rows }>();
+    for (const row of rows) {
+      const bucket = byDay.get(row.day) ?? { total: 0n, items: [] };
+      bucket.total += row.amount;
+      bucket.items.push(row);
+      byDay.set(row.day, bucket);
+    }
+    return [...byDay.entries()].sort((a, b) => b[0].localeCompare(a[0]));
+  }, [rows]);
+
+  const total = rows.reduce((sum, row) => sum + row.amount, 0n);
+
+  const [year, monthNo] = month.split('-');
+  const monthTitle = new Intl.DateTimeFormat(locale, {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(Number(year), Number(monthNo) - 1, 1)));
+
+  // 'YYYY-MM-DD' read with the parts, in UTC, so a phone east of the line does
+  // not label the 1st as the last of the month before.
+  const dayLabel = (day: string): string => {
+    const [y, m, d] = day.split('-');
+    return new Intl.DateTimeFormat(locale, {
+      weekday: 'short',
+      day: 'numeric',
+      month: 'short',
+      timeZone: 'UTC',
+    }).format(new Date(Date.UTC(Number(y), Number(m) - 1, Number(d))));
+  };
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{monthTitle}</Text>
+            <Text variant="micro" tone="muted">
+              {`${mine ? t.extras.justMe : t.extras.theGroup} · ${groupLabel(
+                group.data,
+                members.data ?? [],
+              )}`}
+            </Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        {expenses.isLoading ? (
+          <View style={{ padding: theme.spacing.xl }}>
+            <ActivityIndicator color={theme.color.brand} />
+          </View>
+        ) : rows.length === 0 ? (
+          <EmptyState title={t.nothingYet} body={t.nothingToChart} />
+        ) : (
+          <>
+            <TintCard
+              tint="lilac"
+              style={{
+                alignItems: 'center',
+                gap: theme.spacing.xs,
+                borderRadius: theme.radius.xl,
+                padding: theme.spacing.xl,
+              }}
+            >
+              <MoneyText amount={total} currency={currency} locale={locale} variant="display" />
+              <Text variant="caption" tone="muted">
+                {plural(locale, rows.length, t.importLedger.expenseCount)}
+              </Text>
+            </TintCard>
+
+            {days.map(([day, bucket]) => (
+              <View key={day} style={{ gap: theme.spacing.md }}>
+                <Row style={{ justifyContent: 'space-between', paddingHorizontal: theme.spacing.xs }}>
+                  <Text variant="subheading">{dayLabel(day)}</Text>
+                  <MoneyText
+                    amount={bucket.total}
+                    currency={currency}
+                    locale={locale}
+                    variant="caption"
+                    tone="muted"
+                  />
+                </Row>
+
+                <View style={{ gap: theme.spacing.md }}>
+                  {bucket.items.map(({ expense, amount }) => {
+                    const version = expense.currentVersion;
+                    const payer = version?.payers[0]?.member_id ?? null;
+                    const catTint = categoryOf(version?.category).tint;
+                    const catInk = theme.tint[catTint].ink;
+                    const title = expenseTitle(version?.description, version?.category, t);
+                    return (
+                      <Pressable
+                        key={expense.id}
+                        onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
+                        accessibilityRole="button"
+                        accessibilityLabel={title}
+                        style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
+                      >
+                        <TintCard
+                          tint={catTint}
+                          style={{ borderRadius: theme.radius.lg, padding: theme.spacing.lg }}
+                        >
+                          <Row style={{ gap: theme.spacing.md }}>
+                            <CategoryBadge category={version?.category} size={40} />
+                            <View style={{ flex: 1 }}>
+                              <Text
+                                variant="subheading"
+                                numberOfLines={1}
+                                style={{ color: catInk }}
+                              >
+                                {title}
+                              </Text>
+                              <Text
+                                variant="caption"
+                                numberOfLines={1}
+                                style={{ color: catInk, opacity: 0.7 }}
+                              >
+                                {fill(t.expense.paidByName, { name: nameOf(payer) })}
+                              </Text>
+                            </View>
+                            <MoneyText
+                              amount={amount}
+                              currency={currency}
+                              locale={locale}
+                              tone="default"
+                              style={{ color: catInk, fontWeight: '700' }}
+                            />
+                          </Row>
+                        </TintCard>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+            ))}
+
+            {mine ? (
+              <Text variant="micro" tone="faint" align="center">
+                {t.extras.justMe} — each amount is your share, not the whole expense.
+              </Text>
+            ) : null}
+          </>
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -196,6 +196,8 @@ export interface UiStrings {
   spending: string;
   byCategory: string;
   byMonth: string;
+  /** Under the month chart — says the columns are a way in, not just a picture. */
+  tapMonthForDays: string;
   nothingToChart: string;
   /** The ten categories of TDR §8, in the language the phone is set to. */
   categories: Record<CategoryId, string>;
@@ -1066,6 +1068,7 @@ const en: UiStrings = {
   spending: 'Spending',
   byCategory: 'Where it went',
   byMonth: 'Month by month',
+  tapMonthForDays: 'Tap a month to see its days.',
   nothingToChart: 'Add a few expenses and this fills in.',
   categories: {
     food: 'Food & drink',
@@ -2005,6 +2008,7 @@ const ta: UiStrings = {
   spending: 'செலவு',
   byCategory: 'எதற்குச் சென்றது',
   byMonth: 'மாதம் வாரியாக',
+  tapMonthForDays: 'நாட்களைக் காண மாதத்தைத் தட்டவும்.',
   nothingToChart: 'சில செலவுகளைச் சேர்த்தால் இது நிரம்பும்.',
   categories: {
     food: 'உணவு',
@@ -2960,6 +2964,7 @@ const hi: UiStrings = {
   spending: 'खर्च',
   byCategory: 'कहाँ गया',
   byMonth: 'महीने के हिसाब से',
+  tapMonthForDays: 'दिन देखने के लिए महीने पर टैप करें।',
   nothingToChart: 'कुछ खर्च जोड़ें, यह अपने आप भर जाएगा।',
   categories: {
     food: 'खाना-पीना',
@@ -3894,6 +3899,7 @@ const ar: UiStrings = {
   spending: 'الإنفاق',
   byCategory: 'أين ذهبت',
   byMonth: 'شهراً بشهر',
+  tapMonthForDays: 'اضغط على شهر لرؤية أيامه.',
   nothingToChart: 'أضف بعض المصروفات وسيمتلئ هذا.',
   categories: {
     food: 'طعام وشراب',

--- a/packages/ui/src/components/Chart.tsx
+++ b/packages/ui/src/components/Chart.tsx
@@ -14,7 +14,7 @@
  * ledger, and this is the one screen where a wrong number looks like a fact.
  */
 
-import { View, type ViewStyle } from 'react-native';
+import { Pressable, View, type ViewStyle } from 'react-native';
 
 import { useTheme } from '../theme';
 import { Text } from './Text';
@@ -107,15 +107,23 @@ export interface ColumnDatum {
   formatted: string;
 }
 
-/** Months across the bottom, height by amount. */
+/**
+ * Months across the bottom, height by amount.
+ *
+ * `onSelect` makes a column a way in, not just a picture: a month total is the
+ * top of a stack of days and expenses, and the tap is how you get down to them.
+ * Left off, the columns stay plain views and nothing is pressable.
+ */
 export function ColumnChart({
   data,
   height = 120,
   style,
+  onSelect,
 }: {
   data: readonly ColumnDatum[];
   height?: number;
   style?: ViewStyle;
+  onSelect?: (key: string) => void;
 }) {
   const theme = useTheme();
   const largest = data.reduce((max, datum) => (datum.value > max ? datum.value : max), 0n);
@@ -132,13 +140,8 @@ export function ColumnChart({
       >
         {data.map((datum) => {
           const percent = largest > 0n ? Number((datum.value * 100n) / largest) : 0;
-          return (
-            <View
-              key={datum.key}
-              accessible
-              accessibilityLabel={`${datum.label}: ${datum.formatted}`}
-              style={{ flex: 1, justifyContent: 'flex-end', gap: 4 }}
-            >
+          const column = (
+            <>
               <Text variant="micro" tone="muted" align="center" numberOfLines={1}>
                 {datum.formatted}
               </Text>
@@ -156,6 +159,27 @@ export function ColumnChart({
                   }}
                 />
               </View>
+            </>
+          );
+          const shared = { flex: 1, justifyContent: 'flex-end', gap: 4 } as const;
+          return onSelect ? (
+            <Pressable
+              key={datum.key}
+              accessibilityRole="button"
+              accessibilityLabel={`${datum.label}: ${datum.formatted}`}
+              onPress={() => onSelect(datum.key)}
+              style={({ pressed }) => [shared, { opacity: pressed ? 0.6 : 1 }]}
+            >
+              {column}
+            </Pressable>
+          ) : (
+            <View
+              key={datum.key}
+              accessible
+              accessibilityLabel={`${datum.label}: ${datum.formatted}`}
+              style={shared}
+            >
+              {column}
             </View>
           );
         })}


### PR DESCRIPTION
## Why

In the Spending screen, the month-by-month chart was a dead end — a column showed a total with no way to ask *what made it up*. This makes each column a way in: month → days → expense detail.

## What

- **`ColumnChart`** takes an optional `onSelect`. With it, columns become pressable (accessible as buttons); without it, they stay plain views — no behaviour change anywhere else.
- **New `group/[id]/month` screen**: slices the same local expenses the group page already shows to the tapped month + currency, groups them by day with per-day subtotals, and links each row to the existing expense detail screen.
- **Honours the chart's scope.** In *group* scope a row is the whole expense; in *mine* scope it's this person's share, and expenses they had no share in are dropped — so the day subtotals and the screen total add back up to the exact column that was tapped, never a different number. No currency conversion, no re-division — same rules as the ledger.
- **Discoverability**: a one-line hint under the chart (`tapMonthForDays`, added to all four locales).

## Verification

- `apps/mobile` typecheck ✅ · `packages/ui` typecheck ✅ · lint 0 ✅ · 206 tests incl. strings parity ✅
- ⚠️ Not device-verified (no emulator here) — the drill navigation and day grouping want a look on a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ