### PR TITLE
fix: stop a failed session read crashing the app at launch

### DIFF
--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -12,7 +12,7 @@ import {
 } from '@baaki/core';
 
 import { appleSignInAvailable, signInWithApple, type AppleCredential } from './appleAuth';
-import { identifyForReporting } from './observability';
+import { identifyForReporting, reportHandled } from './observability';
 import { refreshPushToken, revokePushToken } from './push';
 import { supabase } from './supabase';
 
@@ -177,11 +177,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let active = true;
 
-    supabase.auth.getSession().then(({ data }) => {
-      if (!active) return;
-      setSession(data.session);
-      setLoading(false);
-    });
+    // No `.catch` here used to mean a rejected getSession — a corrupt stored
+    // session, a storage read that fails, no network on a cold start — became
+    // an unhandled rejection at boot ("Uncaught (in promise, id: 0)") and left
+    // the app stuck on the loading spinner, because `setLoading(false)` only
+    // ran on the happy path. A failure to read a session is a signed-out
+    // launch, not a dead one: clear it and let the auth gate send them to
+    // sign-in.
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (!active) return;
+        setSession(data.session);
+      })
+      .catch((caught) => {
+        reportHandled(caught, 'auth.getSession');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
 
     const { data: subscription } = supabase.auth.onAuthStateChange((_event, next) => {
       setSession(next);


### PR DESCRIPTION
## Symptom

"Uncaught (in promise, id: 0)" on app launch.

## Cause

`AuthProvider` bootstrapped the session with `supabase.auth.getSession().then(...)` and **no `.catch`** (`apps/mobile/src/lib/auth.tsx`). `id: 0` is the first promise created at boot — so a rejection there (corrupt stored session, a failing AsyncStorage read, no network on a cold start) surfaced as an unhandled rejection in the first frame. Worse, `setLoading(false)` only ran on the resolved path, so the same failure also left the app stuck on the loading spinner.

## Fix

A session that can't be read is a **signed-out** launch, not a dead one:
- `.catch` the rejection, reported through observability (scrubbed like everything else).
- Move `setLoading(false)` into `finally`, so the auth gate always runs and routes to sign-in.

## Verification

- `apps/mobile` typecheck ✅ · 206 tests ✅
- ⚠️ **Not device-verified** — I can't reproduce the launch on a device from here. This is the one genuinely-uncaught promise at boot and matches the `id: 0` (first-promise) signature, but if the red box persists on the next build, the component-stack line beneath it will pinpoint the exact source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ