### PR TITLE
chore(mobile): use expo/config-plugins sub-export, drop the direct dep

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -63,7 +63,6 @@
     "react-native-worklets": "0.10.1"
   },
   "devDependencies": {
-    "@expo/config-plugins": "^57.0.7",
     "@types/react": "~19.2.2",
     "eslint": "^9.39.5",
     "eslint-config-expo": "~57.0.1",

--- a/apps/mobile/plugins/withShortNativeBuildPath.js
+++ b/apps/mobile/plugins/withShortNativeBuildPath.js
@@ -29,7 +29,11 @@
  * outside the project is a surprise worth avoiding where it buys nothing.
  */
 
-const { withSettingsGradle } = require('@expo/config-plugins');
+// The `expo/config-plugins` sub-export, not the `@expo/config-plugins` package
+// directly: same module, but the version is then pinned to the installed expo
+// rather than a second copy this repo would have to keep in step (expo-doctor
+// flags the direct dependency for exactly this reason).
+const { withSettingsGradle } = require('expo/config-plugins');
 
 const MARKER = 'baaki:short-native-build-path';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,6 @@ importers:
         specifier: 0.10.1
         version: 0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
     devDependencies:
-      '@expo/config-plugins':
-        specifier: ^57.0.7
-        version: 57.0.7(supports-color@8.1.1)(typescript@6.0.3)
       '@types/react':
         specifier: ~19.2.2
         version: 19.2.18


### PR DESCRIPTION
## Why

`expo-doctor` flags a direct dependency on `@expo/config-plugins`: it's a second copy of a module the `expo` package already re-exports, and the two can drift out of step.

## What

- The one place we use it — `plugins/withShortNativeBuildPath.js` (the Windows CMake short-path plugin) — switches `require('@expo/config-plugins')` → `require('expo/config-plugins')`, pinning it to the installed expo.
- Removed the `@expo/config-plugins` devDependency + lockfile entry.

No behaviour change: same module, same `withSettingsGradle`. Verified the sub-export resolves and that doctor check now passes.

## Not in scope

Two other doctor notes, left deliberately:
- **app.json "not used by app.config.ts"** — false positive. `app.config.ts` imports `./app.json` and spreads `appJson.expo`; doctor's static check can't see the import. The split is intentional (static self-description + runtime-only Sentry/FCM).
- **10 packages out of date** — pre-existing patch-level SDK drift, unrelated to this change. Worth a separate `expo install --fix` pass if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ