### PR TITLE
feat(mobile): collapse the group header into one overflow menu

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -41,6 +41,7 @@ import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { DetailEnter } from '@/lib/anim';
 import { CategoryBadge } from '@/components/Category';
+import { GroupMenu } from '@/components/GroupMenu';
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { PendingMark } from '@/components/PendingMark';
 import { SyncBanner } from '@/components/SyncBanner';
@@ -142,25 +143,9 @@ export default function GroupScreen() {
                 </Text>
               </View>
             </Row>
-            {/* Only where there is a trip to plan. A planner on a flatshare
-              group is a tab nobody opens twice. */}
-            {group.data.type === 'trip' ? (
-              <IconButton label={t.plan} onPress={() => router.push(`/group/${groupId}/plan`)}>
-                <Ionicons name="map-outline" size={19} color={theme.color.text} />
-              </IconButton>
-            ) : null}
-            <IconButton
-              label={t.spending}
-              onPress={() => router.push(`/group/${groupId}/insights`)}
-            >
-              <Ionicons name="pie-chart-outline" size={19} color={theme.color.text} />
-            </IconButton>
-            <IconButton
-              label={t.group.settings}
-              onPress={() => router.push(`/group/${groupId}/settings`)}
-            >
-              <Ionicons name="ellipsis-horizontal" size={20} color={theme.color.text} />
-            </IconButton>
+            {/* Planner, spending and settings live behind one menu now, so the
+              name has the row to itself. Planner only shows for a trip. */}
+            <GroupMenu groupId={groupId} isTrip={group.data.type === 'trip'} />
           </Row>
 
           <SyncBanner groupId={groupId} />

--- a/apps/mobile/src/components/GroupMenu.tsx
+++ b/apps/mobile/src/components/GroupMenu.tsx
@@ -1,0 +1,115 @@
+/**
+ * The group screen's overflow menu.
+ *
+ * The header used to line up a back button, the group's name, and then three
+ * more circular buttons — planner, spending, settings — all competing for the
+ * same row. On a narrow phone the name was the thing that gave way. So the
+ * three collapse into one `•••`, which now opens a real menu rather than
+ * jumping straight to settings: three dots that behave like three dots.
+ *
+ * Planner only appears where there is a trip to plan; a flatshare has no use
+ * for it, and a menu row nobody taps is just another thing to read past.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Modal, Pressable, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Card, directionalIcon, IconButton, ListRow, Text, useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+
+export function GroupMenu({ groupId, isTrip }: { groupId: string; isTrip: boolean }) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useStrings();
+  const [open, setOpen] = useState(false);
+
+  const go = (path: string): void => {
+    setOpen(false);
+    router.push(path as never);
+  };
+
+  const chip = (name: keyof typeof Ionicons.glyphMap) => (
+    <View
+      style={{
+        width: 40,
+        height: 40,
+        borderRadius: theme.radius.pill,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: theme.color.surfaceMuted,
+      }}
+    >
+      <Ionicons name={name} size={19} color={theme.color.brand} />
+    </View>
+  );
+
+  const chevron = (
+    <Ionicons name={directionalIcon('chevron-forward')} size={18} color={theme.color.textFaint} />
+  );
+
+  return (
+    <>
+      <IconButton label={t.group.more} onPress={() => setOpen(true)}>
+        <Ionicons name="ellipsis-horizontal" size={20} color={theme.color.text} />
+      </IconButton>
+
+      <Modal visible={open} transparent animationType="slide" onRequestClose={() => setOpen(false)}>
+        {/* Backdrop: a tap anywhere off the sheet closes it. */}
+        <Pressable
+          accessibilityLabel={t.common.close}
+          onPress={() => setOpen(false)}
+          style={{ flex: 1, backgroundColor: '#00000066', justifyContent: 'flex-end' }}
+        >
+          {/* Stop taps on the sheet itself from reaching the backdrop. */}
+          <Pressable onPress={() => {}}>
+            <Card
+              style={{
+                borderTopLeftRadius: theme.radius.xxl,
+                borderTopRightRadius: theme.radius.xxl,
+                borderBottomLeftRadius: 0,
+                borderBottomRightRadius: 0,
+                paddingBottom: insets.bottom + theme.spacing.md,
+                gap: theme.spacing.xs,
+              }}
+            >
+              <View
+                style={{
+                  alignSelf: 'center',
+                  width: 40,
+                  height: 4,
+                  borderRadius: 2,
+                  backgroundColor: theme.color.border,
+                  marginBottom: theme.spacing.sm,
+                }}
+              />
+              <ListRow
+                title={t.spending}
+                leading={chip('pie-chart-outline')}
+                trailing={chevron}
+                onPress={() => go(`/group/${groupId}/insights`)}
+              />
+              {isTrip ? (
+                <ListRow
+                  title={t.plan}
+                  leading={chip('map-outline')}
+                  trailing={chevron}
+                  onPress={() => go(`/group/${groupId}/plan`)}
+                />
+              ) : null}
+              <ListRow
+                title={t.group.settings}
+                leading={chip('settings-outline')}
+                trailing={chevron}
+                onPress={() => go(`/group/${groupId}/settings`)}
+              />
+            </Card>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -539,6 +539,7 @@ export interface UiStrings {
     notFoundArchived: string;
     loading: string;
     settings: string;
+    more: string;
     mismatch: string;
     mismatchBody: string;
     confirmReceived: string;
@@ -1441,6 +1442,7 @@ const en: UiStrings = {
     notFoundArchived: 'It may have been archived.',
     loading: 'Loading…',
     settings: 'Group settings',
+    more: 'More',
     mismatch: 'Balances need a refresh',
     mismatchBody:
       'This device and the server disagree about this group’s balances. Pull to refresh; if it persists, the ledger below is the source of truth.',
@@ -2412,6 +2414,7 @@ const ta: UiStrings = {
     notFoundArchived: 'அது காப்பகப்படுத்தப்பட்டிருக்கலாம்.',
     loading: 'ஏற்றப்படுகிறது…',
     settings: 'குழு அமைப்புகள்',
+    more: 'மேலும்',
     mismatch: 'இருப்புகளைப் புதுப்பிக்க வேண்டும்',
     mismatchBody:
       'இந்தக் குழுவின் இருப்புகள் குறித்து இந்தச் சாதனமும் சர்வரும் ஒத்துப்போகவில்லை. இழுத்துப் புதுப்பிக்கவும்; தொடர்ந்தால் கீழே உள்ள கணக்கே சரியானது.',
@@ -3382,6 +3385,7 @@ const hi: UiStrings = {
     notFoundArchived: 'हो सकता है यह संग्रहित कर दिया गया हो।',
     loading: 'आ रहा है…',
     settings: 'समूह सेटिंग्स',
+    more: 'और',
     mismatch: 'बाकी को ताज़ा करना होगा',
     mismatchBody:
       'इस समूह के हिसाब पर यह डिवाइस और सर्वर सहमत नहीं हैं। खींचकर ताज़ा करें; फिर भी बना रहे तो नीचे का हिसाब ही सही है।',
@@ -4367,6 +4371,7 @@ const ar: UiStrings = {
     notFoundArchived: 'ربما أُرشفت.',
     loading: 'جارٍ التحميل…',
     settings: 'إعدادات المجموعة',
+    more: 'المزيد',
     mismatch: 'الأرصدة بحاجة إلى تحديث',
     mismatchBody:
       'هذا الجهاز والخادم لا يتفقان على أرصدة هذه المجموعة. اسحب للتحديث؛ وإن استمر الأمر فالدفتر بالأسفل هو المرجع.',


### PR DESCRIPTION
## Problem (audit follow-ups #1 and #2)

The group header packed **up to five tap targets into one row** — back, group photo + name, planner, spending, settings — and on a narrow phone the group name (`flexShrink: 1`, wedged between the buttons) was what gave way. Separately, the settings button used a `•••` icon but navigated straight to Settings — three dots that don't behave like three dots.

## Fix

Fold planner, spending, and settings into a single `•••` that opens a bottom-sheet menu (`GroupMenu`):

- Header is now **back · name · •••** — the name has the row to itself
- `•••` opens a real menu (grab handle, dimmed backdrop, tap-off to close), so the icon now matches its behaviour
- **Settings** row wears a **gear**, not the three dots
- **Planner** row only appears for a trip (same condition as before)

New `t.group.more` label, en/ta/hi/ar. Reuses the existing `t.spending` / `t.plan` / `t.group.settings` / `t.common.close`.

## Smoke test (emulator, live)

Verified on emulator-5554: header shows the single `•••`, tapping opens the sheet (Spending + Group settings; no Plan on a flatshare), and tapping **Spending** navigated to insights and closed the sheet. Screenshots below.

- `tsc --noEmit` green · tests **206/206** incl. strings parity · Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ