### PR TITLE
fix(ui): gradient falls back to flat brand when its native view is missing

### DIFF
--- a/packages/ui/src/components/Gradient.tsx
+++ b/packages/ui/src/components/Gradient.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import React, { Component, type ReactNode } from 'react';
 import { View, type ViewStyle } from 'react-native';
 
 import { useTheme } from '../theme';
@@ -19,35 +19,67 @@ export interface GradientProps {
  * disagree with the rest of the app about what purple is.
  *
  * `expo-linear-gradient` is a native module, and a native module missing from
- * a build is how this app has previously lost a whole screen. So it is
- * required lazily behind a check that cannot throw, and a build without it
- * paints the flat brand colour and carries on — the balance is still legible,
- * still white on purple, and nobody sees a crash because a decoration was
- * unavailable.
+ * a build is how this app has previously lost a whole screen. There are two
+ * ways it can be missing, and both fall back to the flat brand colour rather
+ * than crash:
+ *
+ *   1. The JS package is absent — `require` throws, caught below.
+ *   2. The JS package is present but the *native* view manager is not in the
+ *      binary (`Can't find ViewManager 'ExpoLinearGradient'`). That does not
+ *      throw from `require`; it throws when React mounts the view, so a
+ *      `require` check cannot see it. An error boundary does — it catches the
+ *      mount failure and paints the flat colour, and latches off for the rest
+ *      of the session so the next gradient does not retry the same crash.
+ *
+ * Either way the balance stays legible, still white on purple, and nobody sees
+ * a red box because a decoration was unavailable.
  */
 export function Gradient({ children, radius, style }: GradientProps) {
   const theme = useTheme();
   const LinearGradient = loadLinearGradient();
   const borderRadius = radius ?? theme.radius.md;
 
-  if (!LinearGradient) {
-    return (
-      <View style={[{ backgroundColor: theme.color.brand, borderRadius }, style]}>{children}</View>
-    );
-  }
+  const flat = (
+    <View style={[{ backgroundColor: theme.color.brand, borderRadius }, style]}>{children}</View>
+  );
+
+  if (!LinearGradient) return flat;
 
   return (
-    <LinearGradient
-      colors={theme.gradient.brand}
-      // Top-left to bottom-right: the reference sweeps diagonally, and a
-      // vertical wash on a short card reads as a printing error.
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      style={[{ borderRadius }, style]}
-    >
-      {children}
-    </LinearGradient>
+    <GradientBoundary fallback={flat}>
+      <LinearGradient
+        colors={theme.gradient.brand}
+        // Top-left to bottom-right: the reference sweeps diagonally, and a
+        // vertical wash on a short card reads as a printing error.
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={[{ borderRadius }, style]}
+      >
+        {children}
+      </LinearGradient>
+    </GradientBoundary>
   );
+}
+
+/**
+ * Catches a mount failure from the native gradient view and shows the flat
+ * fallback instead. On the first failure it disables the gradient for the whole
+ * session, so a screen with several gradients does not throw once per gradient.
+ */
+class GradientBoundary extends Component<{ fallback: ReactNode; children: ReactNode }> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  override componentDidCatch() {
+    disabled = true;
+  }
+
+  override render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
 }
 
 type LinearGradientComponent = (props: {
@@ -59,8 +91,11 @@ type LinearGradientComponent = (props: {
 }) => React.JSX.Element;
 
 let resolved: LinearGradientComponent | null | undefined;
+/** Latched on once the native view fails to mount; keeps every gradient flat after. */
+let disabled = false;
 
 function loadLinearGradient(): LinearGradientComponent | null {
+  if (disabled) return null;
   if (resolved !== undefined) return resolved;
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
## What prompted this

A crash surfaced during dev-client reload churn:

```
IllegalViewOperationException: Can't find ViewManager 'ExpoLinearGradient'
  … in ViewManagerRegistry, existing names are: […ExpoUI…, …ExpoImage…]
```

The live app renders the gradient fine — this was a transient Fast-Refresh registry window, and it does not reproduce on a clean launch. **No shipped code regressed** (nothing recent touched native deps). But it exposed a real gap.

## The gap

`Gradient` already documents: *"a build without it paints the flat brand colour and carries on."* That promise was only half-kept — the guard catches the JS package being **absent** (`require` throws), but not the JS package being **present while the native view manager is missing from the binary**. That second case doesn't throw from `require`; it throws when React **mounts** the view, which a `require` check can't see.

## Fix

Wrap the native `<LinearGradient>` in an error boundary that catches the mount failure, renders the flat brand fallback, and **latches the gradient off for the session** so a screen with several gradients doesn't throw once per gradient. Completes the fallback the component already promised.

- `@baaki/ui` + `@baaki/mobile` typecheck green · `expo lint` clean
- Verified live: gradient still renders normally with the boundary in place (no happy-path regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ