### PR TITLE
fix(group): expenses/balances/activity is a tab, not a chip

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -9,7 +9,6 @@ import {
   Badge,
   Button,
   Card,
-  ChipRow,
   directionalIcon,
   EmptyState,
   Fab,
@@ -18,6 +17,7 @@ import {
   MoneyText,
   Row,
   Screen,
+  SegmentedTabs,
   Text,
   TintCard,
   tintForKey,
@@ -267,10 +267,13 @@ export default function GroupScreen() {
             </Card>
           ))}
 
-          <ChipRow<Tab>
+          {/* The page has three faces — expenses, balances, activity. This is a
+              tab, not a choice on a form, so it wears the underlined tab look
+              rather than the selection pills the rest of the app fills in. */}
+          <SegmentedTabs<Tab>
             value={tab}
             onChange={setTab}
-            options={[
+            tabs={[
               { value: 'expenses', label: t.expenses },
               { value: 'balances', label: t.balances },
               { value: 'activity', label: t.activity },


### PR DESCRIPTION
## Problem (audit follow-up #3)

`ChipRow` was doing two different jobs with one look. It's the app's **form selection** control (split kind, currency, group type, feedback kind…), but the group screen also used it to switch **views** — expenses / balances / activity. Same pills, two meanings: a tab that navigates looked identical to a chip that picks a value.

## Fix

Switch the group screen's view switch to **`SegmentedTabs`** — the component already in the codebase for exactly this ("tabs that divide one screen, not the app": underline + small caps, reads as part of the page). `profile.tsx` already models the split; this brings the group screen in line.

`ChipRow` stays for genuine single choices on a form — unchanged everywhere else.

## Verified live (emulator)

Group screen now shows underlined **EXPENSES · BALANCES · ACTIVITY**; tapping BALANCES moves the underline and switches the content. Distinct from the selection pills.

- `tsc --noEmit` green · `expo lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ