### PR TITLE
chore(mobile): metro config that ships Sentry source maps

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,0 +1,29 @@
+// Metro configuration.
+//
+// This exists for one reason: Sentry source maps. `getSentryExpoConfig` is
+// Expo's own `getDefaultConfig` with two things added — a debug ID stamped into
+// every bundle and its source map so a minified production stack trace can be
+// symbolicated, and a serializer that uploads those maps at build time. Without
+// it, crashes from a release build arrive as unreadable one-letter frames.
+//
+// It is a drop-in for `expo/metro-config`: same monorepo detection, same
+// defaults. The only options set are ours —
+//
+//   includeWebReplay: false
+//     Session replay is not part of this app's Sentry setup (see
+//     `src/lib/observability.ts` — crash and session tracking only, and a
+//     screen here is a full view of someone's ledger). There is a web target
+//     (`app.json` output: static), so without this the web bundle would pull
+//     the replay packages for a feature that is deliberately off.
+//
+// Reporting itself is still gated on `EXPO_PUBLIC_SENTRY_DSN`, and source-map
+// upload on `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` at build time
+// (see `app.config.ts`). A clone with none of those set bundles exactly as
+// before — this config changes how the bundle is built, not whether anything
+// is sent.
+
+const { getSentryExpoConfig } = require('@sentry/react-native/metro');
+
+const config = getSentryExpoConfig(__dirname, { includeWebReplay: false });
+
+module.exports = config;


### PR DESCRIPTION
## What

Adds `apps/mobile/metro.config.js` wrapping `getSentryExpoConfig` (from `@sentry/react-native/metro`). The app had no metro config — Expo default. This is the one thing `@sentry/wizard` would add that the repo was missing.

## Why

`getSentryExpoConfig` stamps a **debug ID** into every bundle + its source map and registers the serializer that **uploads those maps at build time**. Without it, a crash from a production build symbolicates to unreadable one-letter frames. The `@sentry/react-native/expo` config plugin (already in `app.config.ts`) handles the upload credentials; this closes the bundle side.

## Not the wizard

Ran the wizard's effect by hand instead of the wizard, which would have clobbered the hand-tuned `observability.ts` (scrubbing, PII off, screenshots off) with a raw `Sentry.init` and written an auth token into a committed `sentry.properties`. Metro config is the only genuine gap; everything else was already wired.

## Choices

- **Drop-in for `expo/metro-config`** — same monorepo detection (verified: 9 workspace watch folders, custom serializer present).
- **`includeWebReplay: false`** — Sentry setup here is crash/session only; there's a web target (`app.json` output: static) that would otherwise pull replay packages for a disabled feature.

## Safety

Reporting stays gated on `EXPO_PUBLIC_SENTRY_DSN`; source-map upload on `SENTRY_ORG`/`SENTRY_PROJECT`/`SENTRY_AUTH_TOKEN`. A clone with none set bundles exactly as before — this changes how the bundle is built, not whether anything is sent.

## Test

- `node -e require('./metro.config.js')` loads clean, `serializer.customSerializer` present, 9 watchFolders (monorepo intact).
- `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ