### PR TITLE
feat(privacy): a consent switch for Clarity session replay

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -24,6 +24,7 @@ import { UpdateProvider } from '@/lib/update';
 import { initClarity } from '@/lib/clarity';
 import { initObservability, withObservability } from '@/lib/observability';
 import { ensureAndroidChannel, pushSupported, routeForNotification } from '@/lib/push';
+import { applyStoredSessionReplayConsent } from '@/lib/sessionReplay';
 import { SyncProvider } from '@/sync';
 
 // Before anything else renders, so a crash in the first frame is still caught.
@@ -34,6 +35,10 @@ initObservability();
 // people's expense descriptions, amounts and payment handles from the first
 // frame; `allowSessionReplay` is the only thing that starts it.
 initClarity();
+
+// Resume capture only for someone who opted in on a previous run; everyone
+// else stays paused where `initClarity` left them. Async, and it fails to off.
+void applyStoredSessionReplayConsent();
 
 // Arriving while the app is open should still surface: a notification that is
 // silently swallowed because you happened to be looking at the app is the one

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -1,10 +1,13 @@
+import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ScrollView, View } from 'react-native';
 
-import { Card, directionalIcon, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import { Card, directionalIcon, IconButton, Row, Screen, Text, Toggle, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
+import { clarityConfigured } from '@/lib/clarity';
+import { sessionReplayConsent, setSessionReplayConsent } from '@/lib/sessionReplay';
 
 /**
  * What is held, how it is kept, and what somebody can do about it.
@@ -20,11 +23,44 @@ export default function PrivacyScreen() {
   const theme = useTheme();
   const { t } = useStrings();
 
+  // The session-replay opt-in, mirrored from storage. Only meaningful when a
+  // Clarity project is configured; on a build without one the switch is hidden
+  // rather than shown doing nothing.
+  const [replay, setReplay] = useState(false);
+  useEffect(() => {
+    void sessionReplayConsent().then(setReplay);
+  }, []);
+
+  const onReplayChange = (value: boolean): void => {
+    setReplay(value);
+    void setSessionReplayConsent(value);
+  };
+
   const sections = [
-    { title: t.privacy.storeTitle, body: t.privacy.storeBody, icon: 'file-tray-outline' },
-    { title: t.privacy.protectTitle, body: t.privacy.protectBody, icon: 'lock-closed-outline' },
-    { title: t.privacy.analyticsTitle, body: t.privacy.analyticsBody, icon: 'stats-chart-outline' },
-    { title: t.privacy.choicesTitle, body: t.privacy.choicesBody, icon: 'hand-left-outline' },
+    {
+      id: 'store',
+      title: t.privacy.storeTitle,
+      body: t.privacy.storeBody,
+      icon: 'file-tray-outline',
+    },
+    {
+      id: 'protect',
+      title: t.privacy.protectTitle,
+      body: t.privacy.protectBody,
+      icon: 'lock-closed-outline',
+    },
+    {
+      id: 'analytics',
+      title: t.privacy.analyticsTitle,
+      body: t.privacy.analyticsBody,
+      icon: 'stats-chart-outline',
+    },
+    {
+      id: 'choices',
+      title: t.privacy.choicesTitle,
+      body: t.privacy.choicesBody,
+      icon: 'hand-left-outline',
+    },
   ] as const;
 
   return (
@@ -52,7 +88,7 @@ export default function PrivacyScreen() {
         </Text>
 
         {sections.map((section) => (
-          <Card key={section.title} style={{ gap: theme.spacing.sm }}>
+          <Card key={section.id} style={{ gap: theme.spacing.sm }}>
             <Row style={{ gap: theme.spacing.sm }}>
               <Ionicons name={section.icon} size={18} color={theme.color.brand} />
               <Text variant="subheading">{section.title}</Text>
@@ -60,6 +96,22 @@ export default function PrivacyScreen() {
             <Text variant="caption" tone="muted">
               {section.body}
             </Text>
+
+            {/* The control the analytics text describes, sat under it so the
+                explanation and the switch are one thing. Hidden entirely on a
+                build with no Clarity project, where it would toggle nothing. */}
+            {section.id === 'analytics' && clarityConfigured ? (
+              <Row style={{ gap: theme.spacing.md, justifyContent: 'space-between' }}>
+                <Text variant="body" style={{ flex: 1 }}>
+                  {t.privacy.sessionReplayRow}
+                </Text>
+                <Toggle
+                  value={replay}
+                  onValueChange={onReplayChange}
+                  accessibilityLabel={t.privacy.sessionReplayRow}
+                />
+              </Row>
+            ) : null}
           </Card>
         ))}
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -966,6 +966,7 @@ export interface UiStrings {
     couldNotSave: string;
     analyticsTitle: string;
     analyticsBody: string;
+    sessionReplayRow: string;
     previewGroups: string;
     previewExpenses: string;
     previewSettlements: string;
@@ -1910,6 +1911,7 @@ const en: UiStrings = {
     analyticsTitle: 'How the app is used',
     analyticsBody:
       'Baaki can record how screens are used — which ones people get stuck on, where a tap lands — through Microsoft Clarity. It ships switched off and records nothing unless it is turned on. It is never used for advertising, there is no advertising identifier, and nothing here is sold or shared.',
+    sessionReplayRow: 'Record how I use the app',
     previewGroups: 'You are in {n} group(s).',
     previewExpenses: 'You entered {n} expense(s) that will stay.',
     previewSettlements: 'You are named in {n} settlement(s).',
@@ -2901,6 +2903,7 @@ const ta: UiStrings = {
     analyticsTitle: 'செயலி எப்படி பயன்படுத்தப்படுகிறது',
     analyticsBody:
       'எந்தத் திரையில் சிக்கல் வருகிறது என்பதைப் புரிந்துகொள்ள Microsoft Clarity மூலம் பயன்பாட்டைப் பதிவு செய்ய முடியும். இது இயல்பாக அணைக்கப்பட்டே வருகிறது; இயக்கப்படாத வரை எதுவும் பதிவாகாது. விளம்பரத்திற்கு ஒருபோதும் பயன்படுத்தப்படுவதில்லை, விளம்பர அடையாளம் இல்லை, எதுவும் விற்கப்படுவதில்லை.',
+    sessionReplayRow: 'நான் செயலியைப் பயன்படுத்தும் விதத்தைப் பதிவு செய்',
     previewGroups: 'நீங்கள் {n} குழுவில் உள்ளீர்கள்.',
     previewExpenses: 'நீங்கள் சேர்த்த {n} செலவுகள் இருக்கும்.',
     previewSettlements: '{n} தீர்வுகளில் உங்கள் பெயர் உள்ளது.',
@@ -3853,6 +3856,7 @@ const hi: UiStrings = {
     analyticsTitle: 'ऐप कैसे इस्तेमाल होता है',
     analyticsBody:
       'Microsoft Clarity के ज़रिए यह दर्ज किया जा सकता है कि कौन-सी स्क्रीन उलझाती है। यह बंद अवस्था में ही आता है और चालू किए बिना कुछ दर्ज नहीं करता। इसका उपयोग विज्ञापन के लिए कभी नहीं होता, कोई विज्ञापन पहचानकर्ता नहीं है, और कुछ भी बेचा या साझा नहीं जाता।',
+    sessionReplayRow: 'ऐप के मेरे इस्तेमाल को दर्ज करने दें',
     previewGroups: 'आप {n} समूह में हैं।',
     previewExpenses: 'आपके डाले {n} ख़र्चे बने रहेंगे।',
     previewSettlements: '{n} भुगतानों में आपका नाम है।',
@@ -4968,6 +4972,7 @@ const ar: UiStrings = {
     analyticsTitle: 'كيف يُستخدم التطبيق',
     analyticsBody:
       'يمكن لـ Microsoft Clarity تسجيل كيفية استخدام الشاشات لمعرفة أين يتعثر الناس. يأتي مُعطّلًا ولا يسجّل شيئًا ما لم يُفعّل. ولا يُستخدم للإعلانات أبدًا، ولا يوجد معرّف إعلاني، ولا يُباع شيء أو يُشارَك.',
+    sessionReplayRow: 'سجّل كيف أستخدم التطبيق',
     previewGroups: 'أنت في {n} مجموعة.',
     previewExpenses: 'ستبقى {n} من المصروفات التي أدخلتها.',
     previewSettlements: 'اسمك مذكور في {n} تسوية.',

--- a/apps/mobile/src/lib/sessionReplay.ts
+++ b/apps/mobile/src/lib/sessionReplay.ts
@@ -1,0 +1,45 @@
+/**
+ * The consent behind session replay.
+ *
+ * `clarity.ts` deliberately keeps no opinion about *whether* to record — it
+ * boots paused and exposes `allowSessionReplay` for "whatever decides this" to
+ * call. This is that decider: a preference the person sets on the privacy
+ * screen, remembered between launches, and re-applied at startup so a recording
+ * somebody opted into survives a restart without asking again.
+ *
+ * The default is off, and off is also every failure: an unreadable store, no
+ * Clarity account, a value that was never written. Recording other people's
+ * money is the kind of thing that has to be reached for, never arrived at.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { allowSessionReplay, clarityConfigured } from './clarity';
+
+const KEY = 'baaki.session_replay_consent';
+
+/** What the person last chose. False unless they explicitly turned it on. */
+export async function sessionReplayConsent(): Promise<boolean> {
+  if (!clarityConfigured) return false;
+  const saved = await AsyncStorage.getItem(KEY).catch(() => null);
+  return saved === 'true';
+}
+
+/**
+ * Record the choice and act on it in one step, so the switch on screen and the
+ * SDK's capture state can never disagree.
+ */
+export async function setSessionReplayConsent(allowed: boolean): Promise<void> {
+  await AsyncStorage.setItem(KEY, String(allowed)).catch(() => undefined);
+  await allowSessionReplay(allowed);
+}
+
+/**
+ * Called once at launch, after `initClarity`. Resumes capture only for someone
+ * who had already opted in; everyone else stays paused, which is where
+ * `initClarity` left them.
+ */
+export async function applyStoredSessionReplayConsent(): Promise<void> {
+  if (!clarityConfigured) return;
+  if (await sessionReplayConsent()) await allowSessionReplay(true);
+}


### PR DESCRIPTION
## What

Gives the privacy screen a switch that turns Microsoft Clarity session replay on or off, and makes that choice stick across launches. Until now Clarity shipped **configured-but-silent**: `initClarity()` boots it paused and nothing ever called `allowSessionReplay`, so even with a project id set it recorded nothing. This is the missing decider.

## Where it sits

Under the "How the app is used" card — the analytics text already explains what Clarity is and that it "records nothing unless it is turned on"; the toggle is that switch, so explanation and control are one thing.

## How

- **`lib/sessionReplay.ts`** (new) — persists the choice in AsyncStorage (default **off**, and off on every failure: unreadable store, no Clarity account, never-written value). `setSessionReplayConsent` writes *and* calls `allowSessionReplay` in one step so the on-screen switch and the SDK's capture state can't disagree. The consent decision lives here, not in `clarity.ts` — that file's whole design is to hold no opinion about whether to record and leave it to a caller.
- **`_layout.tsx`** — `applyStoredSessionReplayConsent()` at launch (after `initClarity`) resumes capture only for someone who had already opted in; everyone else stays paused. Async, fails to off.
- **`privacy.tsx`** — the `Toggle`, rendered **only when `clarityConfigured`**. On a build with no Clarity project it's hidden, not shown doing nothing.
- **i18n** — `sessionReplayRow` in en/ta/hi/ar.

## Deliberately not done

- **No masking promise in the copy.** The RN SDK can't set masking from code (dashboard-only — confirmed in the types: config carries only `userId`/`logLevel`). The label says what the switch does, not what it hides. Set the Clarity project to **Strict** before enabling, per the `clarity.ts` note.
- **Sentry untouched** — crash reporting is a separate concern (scrubbed, no PII) and stays as-is.

## Test

- `pnpm --filter @baaki/mobile typecheck` clean.
- `pnpm test:app` — 206 pass, incl. `strings.test.ts` key parity across all 4 locales.
- `expo lint` clean, `prettier --check` clean.
- Persistence mirrors the in-repo `motion.tsx` pattern.
- **Not device-verified**: the toggle is gated on a Clarity project id this dev box doesn't have, so it renders hidden here. Happy to spin the emulator with a temp `EXPO_PUBLIC_CLARITY_PROJECT_ID` to eyeball it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ