### PR TITLE
fix(mobile): four polish fixes from a hands-on user-test pass

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -22,7 +22,7 @@ import {
 
 import { useGroups, useHomeSummary } from '@/data/hooks';
 import { CountUpMoney, Stagger } from '@/lib/anim';
-import { plural, useStrings } from '@/i18n';
+import { deviceDefaultCurrency, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { SyncBanner } from '@/components/SyncBanner';
 import { SkeletonList } from '@/components/Skeletons';
@@ -46,10 +46,16 @@ export default function HomeScreen() {
    * across several (ADR-004). The rest are counted underneath rather than added
    * in, which is what the profile screen already does with settled totals.
    *
-   * With no groups there is nothing to be owed in, and the group currency the
-   * app defaults to is the one to show a zero in.
+   * With no groups there is nothing to be owed in, so the zero is shown in the
+   * same currency a new group would start in on this phone — otherwise the
+   * empty state reads ₹0 and the first group then counts in dollars.
    */
-  const headline = summary.totals[0] ?? { currency: 'INR', net: 0n, owed: 0n, owing: 0n };
+  const headline = summary.totals[0] ?? {
+    currency: deviceDefaultCurrency(),
+    net: 0n,
+    owed: 0n,
+    owing: 0n,
+  };
   const otherCurrencies = summary.totals.length - 1;
 
   /**

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -74,6 +74,14 @@ export default function ExpenseDetailScreen() {
     const member = memberId ? lookup.get(memberId) : undefined;
     return member ? displayName(member, profile?.id) : 'Someone';
   };
+  // The label reads "You"; the avatar keeps the real name so the current user's
+  // circle is the same initial and colour here as on every other screen — a
+  // balances row keys the avatar off the real name too. Passing "You" to the
+  // avatar made it a lone pink "Y" next to a blue "G" elsewhere for one person.
+  const avatarNameOf = (memberId: string | null): string => {
+    const member = memberId ? lookup.get(memberId) : undefined;
+    return member ? displayName(member) : 'Someone';
+  };
 
   if (expenses.isLoading) {
     return (
@@ -215,7 +223,7 @@ export default function ExpenseDetailScreen() {
                 <View key={payer.member_id}>
                   <ListRow
                     title={nameOf(payer.member_id)}
-                    leading={<Avatar name={nameOf(payer.member_id)} size={38} />}
+                    leading={<Avatar name={avatarNameOf(payer.member_id)} size={38} />}
                     trailing={
                       <MoneyText
                         amount={BigInt(payer.amount)}
@@ -246,7 +254,7 @@ export default function ExpenseDetailScreen() {
                     subtitle={member && isGhost(member) ? 'not joined yet' : undefined}
                     leading={
                       <Avatar
-                        name={nameOf(share.member_id)}
+                        name={avatarNameOf(share.member_id)}
                         ghost={member ? isGhost(member) : false}
                         size={38}
                       />

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -97,6 +97,10 @@ export default function GroupScreen() {
   const ink = theme.tint[tintForKey(groupId)].ink;
   const inkMuted = theme.tint[tintForKey(groupId)].inkMuted;
   const visibleExpenses = expenses.rows.filter((expense) => showDeleted || !expense.deleted_at);
+  // The show/hide-deleted toggle only earns its place once something has been
+  // deleted. On a group whose ledger has never lost a row it is an answer to a
+  // question nobody asked.
+  const hasDeleted = expenses.rows.some((expense) => Boolean(expense.deleted_at));
   const pendingForMe = (settlements.data ?? []).filter(
     (settlement) =>
       settlement.status === 'initiated' && settlement.to_member_id === ledger.myMemberId,
@@ -280,7 +284,7 @@ export default function GroupScreen() {
             ]}
           />
 
-          {tab === 'expenses' ? (
+          {tab === 'expenses' && hasDeleted ? (
             <Row style={{ justifyContent: 'flex-end', marginTop: -theme.spacing.md }}>
               <Text
                 variant="caption"

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -211,7 +211,7 @@ export default function NewGroupScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: theme.spacing.xl,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
@@ -380,7 +380,22 @@ export default function NewGroupScreen() {
             </Row>
           ) : null}
         </Card>
+      </ScrollView>
 
+      {/* The primary action is pinned rather than parked at the foot of a long
+          scroll: name, kind, country, dates, simplify and people all sit above
+          it, and "just make the group" should not depend on scrolling past all
+          of them first. */}
+      <View
+        style={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.md,
+          gap: theme.spacing.sm,
+          borderTopWidth: 1,
+          borderTopColor: theme.color.border,
+          backgroundColor: theme.color.bg,
+        }}
+      >
         {error ? <Callout tone="negative">{error}</Callout> : null}
         {createGroup.isPending || uploading ? (
           <ActivityIndicator color={theme.color.brand} />
@@ -393,7 +408,7 @@ export default function NewGroupScreen() {
           disabled={createGroup.isPending || uploading}
           onPress={() => void submit()}
         />
-      </ScrollView>
+      </View>
     </Screen>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -32,7 +32,7 @@
 import { createContext, useContext } from 'react';
 import { getLocales } from 'expo-localization';
 
-import type { CategoryId } from '@baaki/core';
+import { currencyForCountry, type CategoryId, type CurrencyCode } from '@baaki/core';
 
 export type Language = 'en' | 'ta' | 'hi' | 'ar';
 
@@ -5124,6 +5124,20 @@ export function deviceLocale(): string {
 export function deviceCountry(): string | null {
   const region = getLocales()[0]?.regionCode ?? null;
   return region && /^[A-Za-z]{2}$/.test(region) ? region.toUpperCase() : null;
+}
+
+/**
+ * The currency a brand-new group starts in on this phone — and therefore the
+ * one to show a zero in before any group exists.
+ *
+ * The new-group form derives its currency the same way (`currencyForCountry`
+ * of the device country, INR when the country is unknown), so the home
+ * screen's empty state and a group made a moment later agree instead of the
+ * home showing ₹0 and the group then counting in dollars. India is the last
+ * resort, not an American fallback: an unrecognised country is not the US.
+ */
+export function deviceDefaultCurrency(): CurrencyCode {
+  return currencyForCountry(deviceCountry()) ?? 'INR';
 }
 
 /**


### PR DESCRIPTION
Found by driving the app end-to-end as a new guest (onboarding → group → expense → settle → balances → detail → tabs). No crashes. None of these change money maths — each is a screen contradicting itself or another.

## Fixes

**1. Home empty-state currency now matches a new group's.**
`(tabs)/index.tsx` hardcoded `₹0` for the empty state, but a new group derives its currency from the device country (`currencyForCountry(deviceCountry())`). On an en-US phone this meant **₹0 on Home, then a group counting in dollars**. Both now go through one new helper `deviceDefaultCurrency()` (device country → currency, `INR` only as the last resort — an unrecognised country is not the US). On an Indian phone it's ₹ throughout, unchanged.

**2. The current user's avatar is consistent everywhere.**
The balances row (and every other screen) keys the avatar off the real name; the expense-detail screen keyed it off `"You"`, so the same person was a **pink "Y"** on the expense and a **blue "G"** on balances. Expense detail now keeps `"You"` as the *label* but the real name for the *avatar* (new `avatarNameOf`). Verified: expense-detail "You" is now the same blue "G" as balances.

**3. "Show deleted" only appears once something's been deleted.**
`group/[id]` showed the toggle on every expenses list, including a group whose ledger has never lost a row. Gated on `hasDeleted`.

**4. "Create group" pinned to a sticky footer.**
`new-group` parked the primary CTA at the foot of a long scroll (name, kind, country, dates, simplify, people). Now pinned above the keyboard, always reachable.

## Dropped from the report

A suspected "add-member placeholder reuses the typed name" was a **false alarm** — the placeholder is the fixed example `namePlaceholder: 'Rahul'`, and I'd typed "Rahul". No change.

## Test

- `typecheck` / `expo lint` / `prettier --check` all clean.
- Verified live on the Android dev build: #2 avatar matches balances, #3 toggle gone on a clean ledger, #5 button sits above the keyboard with no scroll. #1 is logic-verified (identical code path to new-group's currency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ