### PR TITLE
fix(mobile): translate the invite screen's share text

### DIFF
--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -46,7 +46,9 @@ export default function InviteScreen() {
   };
 
   const label = groupLabel(group.data, members.data ?? [], profile?.id);
-  const message = `Join ${label} on Baaki to split expenses — no app or account needed to start: ${link}`;
+  const message = t.people.shareMessage
+    .replace('{group}', label)
+    .replace('{link}', link ?? '');
 
   const share = async (): Promise<void> => {
     if (!link) return;
@@ -67,7 +69,7 @@ export default function InviteScreen() {
           ? // iOS wants '&body=', Android wants '?body=' — the separator is the
             // only difference, and getting it wrong silently drops the text.
             `sms:${Platform.OS === 'ios' ? '&' : '?'}body=${encodeURIComponent(message)}`
-          : `mailto:?subject=${encodeURIComponent(`Join ${label} on Baaki`)}&body=${encodeURIComponent(message)}`;
+          : `mailto:?subject=${encodeURIComponent(t.people.emailSubject.replace('{group}', label))}&body=${encodeURIComponent(message)}`;
 
     try {
       await Linking.openURL(url);
@@ -134,7 +136,7 @@ export default function InviteScreen() {
                     }).format(new Date(invite.expiresAt)),
                   )}
                 />
-                <Badge label={`${invite.maxUses} uses`} />
+                <Badge label={t.people.usesBadge.replace('{count}', String(invite.maxUses))} />
               </Row>
             </Card>
 
@@ -172,8 +174,7 @@ export default function InviteScreen() {
             </Row>
 
             <Text variant="micro" tone="faint" align="center">
-              Made a link by mistake? Mint a new one — the old link keeps working until it expires,
-              so only share links you mean to.
+              {t.people.mintMistakeNote}
             </Text>
           </>
         ) : (

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -46,9 +46,7 @@ export default function InviteScreen() {
   };
 
   const label = groupLabel(group.data, members.data ?? [], profile?.id);
-  const message = t.people.shareMessage
-    .replace('{group}', label)
-    .replace('{link}', link ?? '');
+  const message = t.people.shareMessage.replace('{group}', label).replace('{link}', link ?? '');
 
   const share = async (): Promise<void> => {
     if (!link) return;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -604,6 +604,10 @@ export interface UiStrings {
     createLink: string;
     linkCopied: string;
     expires: string;
+    usesBadge: string;
+    shareMessage: string;
+    emailSubject: string;
+    mintMistakeNote: string;
     hideContacts: string;
     browseContacts: string;
     /** Reminding somebody who owes you to settle, gently (ADR-010). */
@@ -1512,6 +1516,12 @@ const en: UiStrings = {
     createLink: 'Create an invite link',
     linkCopied: 'Link copied',
     expires: 'expires {when}',
+    usesBadge: '{count} uses',
+    shareMessage:
+      'Join {group} on Baaki to split expenses — no app or account needed to start: {link}',
+    emailSubject: 'Join {group} on Baaki',
+    mintMistakeNote:
+      'Made a link by mistake? Mint a new one — the old link keeps working until it expires, so only share links you mean to.',
     hideContacts: 'Hide contacts',
     browseContacts: 'Browse my contacts',
     remind: 'Remind',
@@ -2487,6 +2497,12 @@ const ta: UiStrings = {
     createLink: 'அழைப்பு இணைப்பை உருவாக்கு',
     linkCopied: 'இணைப்பு நகலெடுக்கப்பட்டது',
     expires: '{when} க்கு காலாவதி',
+    usesBadge: '{count} பயன்பாடுகள்',
+    shareMessage:
+      'செலவுகளைப் பிரிக்க Baaki-ல் {group} குழுவில் சேரவும் — தொடங்க ஆப் அல்லது கணக்கு தேவையில்லை: {link}',
+    emailSubject: 'Baaki-ல் {group} குழுவில் சேரவும்',
+    mintMistakeNote:
+      'தவறுதலாக இணைப்பு உருவாக்கினீர்களா? புதிதாக ஒன்றை உருவாக்கவும் — பழைய இணைப்பு காலாவதியாகும் வரை வேலை செய்யும், எனவே நீங்கள் நினைத்த இணைப்புகளை மட்டும் பகிரவும்.',
     hideContacts: 'தொடர்புகளை மறை',
     browseContacts: 'என் தொடர்புகளைப் பார்',
     remind: 'நினைவூட்டு',
@@ -3456,6 +3472,12 @@ const hi: UiStrings = {
     createLink: 'निमंत्रण लिंक बनाएँ',
     linkCopied: 'लिंक कॉपी हो गया',
     expires: '{when} को खत्म',
+    usesBadge: '{count} उपयोग',
+    shareMessage:
+      'खर्च बाँटने के लिए Baaki पर {group} में शामिल हों — शुरू करने के लिए कोई ऐप या खाता ज़रूरी नहीं: {link}',
+    emailSubject: 'Baaki पर {group} में शामिल हों',
+    mintMistakeNote:
+      'गलती से लिंक बना लिया? नया बनाएँ — पुराना लिंक खत्म होने तक चलता रहेगा, इसलिए वही लिंक साझा करें जो आप चाहते हैं।',
     hideContacts: 'संपर्क छिपाएँ',
     browseContacts: 'मेरे संपर्क देखें',
     remind: 'याद दिलाएँ',
@@ -4448,6 +4470,12 @@ const ar: UiStrings = {
     createLink: 'أنشئ رابط دعوة',
     linkCopied: 'تم نسخ الرابط',
     expires: 'ينتهي {when}',
+    usesBadge: '{count} استخدامات',
+    shareMessage:
+      'انضم إلى {group} على Baaki لتقسيم المصروفات — لا حاجة إلى تطبيق أو حساب للبدء: {link}',
+    emailSubject: 'انضم إلى {group} على Baaki',
+    mintMistakeNote:
+      'أنشأت رابطًا بالخطأ؟ أنشئ رابطًا جديدًا — يظل الرابط القديم صالحًا حتى ينتهي، لذا شارك فقط الروابط التي تقصدها.',
     hideContacts: 'إخفاء جهات الاتصال',
     browseContacts: 'تصفّح جهات اتصالي',
     remind: 'ذكّر',


### PR DESCRIPTION
## What

The invite screen mixed localized UI with four hardcoded English strings:

- the share-sheet **message** (`Join {group} on Baaki…`)
- the email **subject**
- the **`{n} uses`** badge
- the **mint-mistake footer** note

On a Tamil, Hindi, or Arabic phone the screen read in-language until you shared — then the message that actually reaches the invitee was English.

## Change

Moved all four into the `people` block of the i18n catalog with `{group}` / `{link}` / `{count}` placeholders, filled at the call site with the same `.replace('{when}', …)` pattern already used for `expires`. Added to all four locales (en/ta/hi/ar).

## Checks

- `typecheck` ✓
- `lint` ✓
- `test:app` ✓ — 206 tests, incl `strings.test.ts` locale key-parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ