### PR TITLE
test(e2e): guest ceilings against live RPC and edge functions

### DIFF
--- a/e2e/guest-ceilings.mjs
+++ b/e2e/guest-ceilings.mjs
@@ -1,0 +1,199 @@
+/**
+ * The guest ceilings, against live infrastructure (ADR-006 addendum, PR #146).
+ *
+ * The point of this test is server enforcement, not the app's own guard: every
+ * call here is made straight to the RPC or the edge function, exactly as a
+ * client that had patched out `useGuestGuard` would make it. If the ceiling only
+ * lived in the mobile UI, all of these would pass when they must fail.
+ *
+ * What it proves:
+ *   - a guest may create their first group, and only their first;
+ *   - joining a group counts against the same one-group ceiling (the "any
+ *     membership" rule), whether they created it or accepted an invite;
+ *   - a brand-new guest's first join is never blocked;
+ *   - being at the limit does not cost a guest their read access;
+ *   - upgrading in place lifts the ceiling on the very same account, with the
+ *     group they made as a guest still theirs.
+ *
+ * What it deliberately does NOT cover: the ten-day read-only expiry. That turns
+ * on `auth.users.created_at`, which no client key can move, so it cannot be
+ * reached end-to-end from here — it is unit-tested at the boundary in
+ * packages/core/test/guestLimits.test.ts instead. The trial number is asserted
+ * present below only as a guard against it silently drifting to zero.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+import { GUEST_GROUP_LIMIT, GUEST_TRIAL_DAYS } from '../supabase/functions/_shared/core.js';
+
+const URL = process.env.SUPABASE_URL ?? 'https://xvjzbpgcmotoahtqcxve.supabase.co';
+const ANON = process.env.ANON_KEY;
+const SERVICE = process.env.SERVICE_KEY;
+
+const pass = [];
+const fail = [];
+const check = (label, condition, detail = '') => {
+  (condition ? pass : fail).push(label);
+  console.log(`${condition ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`);
+};
+const skip = (label, why) => console.log(`SKIP  ${label} — ${why}`);
+
+/** The code an edge function rejected with, dug out of its JSON body. */
+async function edgeCode(error) {
+  const context = error?.context;
+  if (context && typeof context.json === 'function') {
+    try {
+      return (await context.json()).code ?? '';
+    } catch {
+      /* fall through */
+    }
+  }
+  return error?.message ?? '';
+}
+
+const client = (key) =>
+  createClient(URL, key, { auth: { persistSession: false, autoRefreshToken: false } });
+const service = createClient(URL, SERVICE, { auth: { persistSession: false } });
+
+const named = async (label) => {
+  const c = client(ANON);
+  await c.auth.signInAnonymously();
+  const id = (await c.auth.getUser()).data.user.id;
+  await c.from('profiles').update({ display_name: label }).eq('id', id);
+  return { c, id };
+};
+
+const activeGroupCount = async (profileId) => {
+  const { count } = await service
+    .from('group_members')
+    .select('id', { count: 'exact', head: true })
+    .eq('profile_id', profileId)
+    .is('left_at', null);
+  return count ?? 0;
+};
+
+// The two numbers are what everything else here is checking against; if the
+// build ever ships them as 0 the rest of this file would pass vacuously.
+check('the group ceiling is one, not zero', GUEST_GROUP_LIMIT === 1, `${GUEST_GROUP_LIMIT}`);
+check('the trial is a positive number of days', GUEST_TRIAL_DAYS > 0, `${GUEST_TRIAL_DAYS}`);
+
+// ── a guest gets exactly one group of their own ─────────────────────────────
+const asha = await named('Asha');
+
+const { data: first, error: firstError } = await asha.c.rpc('baaki_create_group', {
+  p_name: 'Goa trip',
+  p_type: 'trip',
+  p_currency: 'INR',
+  p_emoji: '🏖️',
+});
+check('a guest can create their first group', !firstError && !!first, firstError?.message);
+
+const { data: second, error: secondError } = await asha.c.rpc('baaki_create_group', {
+  p_name: 'Second trip',
+  p_type: 'trip',
+  p_currency: 'INR',
+});
+check(
+  'the RPC refuses a guest a second group',
+  !second && /GUEST_GROUP_LIMIT/.test(secondError?.message ?? ''),
+  secondError?.message,
+);
+check('and no phantom group was created', (await activeGroupCount(asha.id)) === 1);
+
+// ── joining counts against the same ceiling ─────────────────────────────────
+// A separate organiser stands up a group nobody in this test belongs to yet,
+// and mints a link with room for every join attempt below.
+const organiser = await named('Bharat');
+const { data: hostGroup } = await organiser.c.rpc('baaki_create_group', {
+  p_name: 'Flatmates',
+  p_type: 'home',
+  p_currency: 'INR',
+});
+const { data: invite, error: mintError } = await organiser.c.functions.invoke('invite-mint', {
+  body: { groupId: hostGroup, expiresInDays: 7 },
+});
+check('the organiser can mint an invite', !mintError && !!invite?.token, await edgeCode(mintError));
+
+// Asha already holds her one group, so accepting a second must be refused — by
+// the edge function, not by a screen she never loaded.
+const { error: ashaJoinError } = await asha.c.functions.invoke('invite-accept', {
+  body: { token: invite.token, mode: 'join' },
+});
+check(
+  'invite-accept refuses a guest already in a group',
+  (await edgeCode(ashaJoinError)) === 'GUEST_GROUP_LIMIT',
+  await edgeCode(ashaJoinError),
+);
+check('the refused join added no membership', (await activeGroupCount(asha.id)) === 1);
+
+// A brand-new guest with nothing yet joins their first group — the growth loop
+// must stay open, so this one is allowed.
+const chandra = await named('Chandra');
+const { data: chandraJoin, error: chandraJoinError } = await chandra.c.functions.invoke(
+  'invite-accept',
+  { body: { token: invite.token, mode: 'join' } },
+);
+check(
+  "a fresh guest's first join is allowed",
+  !chandraJoinError && !!chandraJoin?.memberId,
+  await edgeCode(chandraJoinError),
+);
+
+// …and now that Chandra holds one group by joining, creating one of their own is
+// the second, which proves a joined group counts the same as a created one.
+const { data: chandraSecond, error: chandraSecondError } = await chandra.c.rpc(
+  'baaki_create_group',
+  { p_name: 'My own', p_type: 'other', p_currency: 'INR' },
+);
+check(
+  'a joined group fills the ceiling just as a created one does',
+  !chandraSecond && /GUEST_GROUP_LIMIT/.test(chandraSecondError?.message ?? ''),
+  chandraSecondError?.message,
+);
+
+// ── the ceiling caps writing, not reading ───────────────────────────────────
+// Asha is at her limit, but her one group and its ledger must stay fully hers.
+const { data: readBack, error: readError } = await asha.c
+  .from('groups')
+  .select('id, name')
+  .eq('id', first);
+check(
+  'a capped guest can still read the group they have',
+  !readError && readBack?.[0]?.id === first,
+  readError?.message,
+);
+
+// ── upgrading in place lifts the ceiling on the same account ────────────────
+// The whole reason the ceiling is safe: signing up does not start over. Confirm
+// an email onto Asha's anonymous account (what the app's updateUser upgrade does
+// under the hood), then the same account may create beyond the guest limit —
+// with the group she made as a guest still there.
+const upgradeEmail = `ceiling-${crypto.randomUUID()}@example.com`;
+const { error: upgradeError } = await service.auth.admin.updateUserById(asha.id, {
+  email: upgradeEmail,
+  email_confirm: true,
+});
+const stillAnonymous =
+  (await service.auth.admin.getUserById(asha.id)).data.user?.is_anonymous === true;
+
+if (upgradeError || stillAnonymous) {
+  skip(
+    'upgrading lifts the ceiling',
+    upgradeError ? await edgeCode(upgradeError) : 'account still anonymous after adding an email',
+  );
+} else {
+  const { data: postUpgrade, error: postUpgradeError } = await asha.c.rpc('baaki_create_group', {
+    p_name: 'Second, as a member',
+    p_type: 'trip',
+    p_currency: 'INR',
+  });
+  check(
+    'a signed-up account is no longer capped',
+    !postUpgradeError && !!postUpgrade,
+    postUpgradeError?.message,
+  );
+  const { data: kept } = await service.from('groups').select('id').eq('id', first).single();
+  check('the group made as a guest is still theirs after upgrading', kept?.id === first);
+}
+
+console.log(`\n${pass.length} passed, ${fail.length} failed`);
+if (fail.length) process.exit(1);

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "m1": "node m1-acceptance.mjs"
+    "m1": "node m1-acceptance.mjs",
+    "guest-ceilings": "node guest-ceilings.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.112.0"


### PR DESCRIPTION
## What

A server-side e2e companion to the `guestGate` unit tests from #146. Every call goes **straight to `baaki_create_group` and `invite-accept`** — the way a client with `useGuestGuard` patched out would call them — so it fails if the one-group ceiling ever lives only in the mobile UI.

## Covers (end to end, live infra)

- ✅ a guest creates their **first** group — allowed
- ✅ the **second** group — refused by the RPC (`GUEST_GROUP_LIMIT`), and no phantom row left behind
- ✅ `invite-accept` refuses a guest **already in a group**
- ✅ a **fresh** guest's first join — allowed (growth loop stays open)
- ✅ a **joined** group fills the ceiling exactly as a created one does (the "any membership" rule)
- ✅ a capped guest can still **read** their group (cap limits writing, not reading)
- ✅ an **in-place upgrade** lifts the ceiling, with the group made as a guest still theirs

## Deliberately not covered here

The **ten-day read-only expiry** turns on `auth.users.created_at`, which no client key can move — so it can't be reached end-to-end. It's unit-tested at the boundary in `packages/core/test/guestLimits.test.ts`. The test says so, and asserts both limit numbers are non-trivial so nothing passes vacuously.

## Running

Like the other `e2e/*.mjs`, against live infra: `ANON_KEY` + `SERVICE_KEY` in env, `node e2e/guest-ceilings.mjs` (or `pnpm --filter @baaki/e2e guest-ceilings`).

⚠️ **Goes green only once #146's server halves are live** — the migration applied and the `sync` + `invite-accept` edge functions deployed (`pnpm edge:build && edge:deploy`). Against today's prod the ceiling checks fail because enforcement isn't deployed yet.

The `e2e` CI job is `if: false` (no build profile yet), so this is a reviewed, runnable artifact rather than a gate — same status as every other flow in `e2e/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ