### PR TITLE
feat(web): full web client — Phase 3 (settle, friends, activity, inbox)

### DIFF
--- a/apps/web/src/app/activity/page.tsx
+++ b/apps/web/src/app/activity/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+/**
+ * Everything that has happened across every group I am in, newest first.
+ *
+ * The overview shows the last dozen; this is the whole feed. It reads the same
+ * `activity_log` rows the phone does and words each one from the reader's point
+ * of view through the shared `describeActivity` (mirrors mobile), so the browser
+ * and the app never narrate the same event two different ways. RLS decides which
+ * rows come back — there is no group filter here to disagree with it (ADR-013).
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+import type { ActivityGroup, ActivityRow } from '@baaki/api-client';
+
+import { AppFrame } from '@/components/AppFrame';
+import { baaki } from '@/lib/baaki';
+import { describeActivity, verbEmoji } from '@/lib/activity';
+import { useStrings } from '@/i18n-context';
+
+type FeedRow = ActivityRow & { group: ActivityGroup | null };
+
+export default function ActivityPage() {
+  return (
+    <AppFrame current="activity">
+      {({ profileId, query }) => <ActivityFeed profileId={profileId} query={query} />}
+    </AppFrame>
+  );
+}
+
+function ActivityFeed({ profileId, query }: { profileId: string; query: string }) {
+  const { t } = useStrings();
+  const [rows, setRows] = useState<FeedRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const feed = await baaki.recentActivity(200);
+        if (active) setRows(feed);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const q = query.trim().toLowerCase();
+  const shown = q
+    ? rows.filter((entry) => describeActivity(entry, profileId).toLowerCase().includes(q))
+    : rows;
+
+  return (
+    <div className="app-body">
+      <div className="app-main">
+        <div className="page-head">
+          <h1>{t.activity.title}</h1>
+        </div>
+
+        <section className="panel">
+          {loading ? (
+            <p className="muted">{t.activity.loading}</p>
+          ) : shown.length === 0 ? (
+            <p className="muted">{t.activity.empty}</p>
+          ) : (
+            <div className="list">
+              {shown.map((entry) => {
+                const line = (
+                  <>
+                    <span className="tile-emoji" aria-hidden>
+                      {verbEmoji(entry.verb)}
+                    </span>
+                    <span className="grow">
+                      <span className="title" style={{ fontWeight: 500, whiteSpace: 'normal' }}>
+                        {describeActivity(entry, profileId)}
+                      </span>
+                      <span className="meta">{entry.group?.name?.trim() ?? ''}</span>
+                    </span>
+                  </>
+                );
+                // A row about an expense links to it; the rest are not clickable.
+                return entry.object_type === 'expense' && entry.object_id ? (
+                  <Link
+                    key={entry.id}
+                    className="item"
+                    href={`/g/${entry.group_id}/expense/${entry.object_id}`}
+                  >
+                    {line}
+                  </Link>
+                ) : (
+                  <div key={entry.id} className="item" style={{ cursor: 'default' }}>
+                    {line}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </div>
+      <aside className="detail" />
+    </div>
+  );
+}

--- a/apps/web/src/app/friends/page.tsx
+++ b/apps/web/src/app/friends/page.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+/**
+ * Everyone you are not square with, netted across every group you share.
+ *
+ * The `baaki_people_i_owe` RPC does the netting server-side — one row per person
+ * per currency — because "what do I owe Priya, all told" spans groups and can't
+ * be added up from any single one. Per currency and never across: a net that
+ * mixed rupees and dollars would be money in no currency at all (ADR-004).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+
+import type { PersonBalanceRow } from '@baaki/api-client';
+
+import { AppFrame } from '@/components/AppFrame';
+import { baaki } from '@/lib/baaki';
+import { money } from '@/lib/money';
+import { plural } from '@/i18n';
+import { useStrings } from '@/i18n-context';
+
+interface Person {
+  key: string;
+  name: string;
+  isGhost: boolean;
+  groupCount: number;
+  onlyGroupId: string | null;
+  /** One entry per currency this person and I are out of balance in. */
+  nets: { currency: string; net: bigint }[];
+}
+
+export default function FriendsPage() {
+  return <AppFrame current="friends">{({ query }) => <Friends query={query} />}</AppFrame>;
+}
+
+function Friends({ query }: { query: string }) {
+  const { t, locale } = useStrings();
+  const [rows, setRows] = useState<PersonBalanceRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const people = await baaki.peopleBalances();
+        if (active) setRows(people);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const people = useMemo(() => groupByPerson(rows), [rows]);
+
+  const q = query.trim().toLowerCase();
+  const shown = q ? people.filter((person) => person.name.toLowerCase().includes(q)) : people;
+
+  return (
+    <div className="app-body">
+      <div className="app-main">
+        <div className="page-head">
+          <h1>{t.friends.title}</h1>
+        </div>
+
+        <section className="panel">
+          {loading ? (
+            <p className="muted">{t.friends.loading}</p>
+          ) : shown.length === 0 ? (
+            <p className="muted">{t.friends.empty}</p>
+          ) : (
+            <div className="list">
+              {shown.map((person) => (
+                <div key={person.key} className="item" style={{ cursor: 'default' }}>
+                  <span className="avatar" aria-hidden style={{ width: 38, height: 38 }}>
+                    {person.name.trim().charAt(0).toUpperCase() || '🙂'}
+                  </span>
+                  <span className="grow">
+                    <span className="title">{person.name}</span>
+                    <span className="meta">
+                      {plural(locale, person.groupCount, t.friends.inGroups)}
+                    </span>
+                  </span>
+                  <span
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'flex-end',
+                      gap: 2,
+                    }}
+                  >
+                    {person.nets.map((row) => {
+                      // Positive: they owe you. Negative: you owe them.
+                      const owed = row.net > 0n;
+                      return (
+                        <span key={row.currency} className={`amount ${owed ? 'pos' : 'neg'}`}>
+                          {money(row.net < 0n ? -row.net : row.net, row.currency, locale)}
+                          <span className="faint" style={{ marginInlineStart: 6, fontWeight: 500 }}>
+                            {owed ? t.friends.owesYou : t.friends.youOwe}
+                          </span>
+                        </span>
+                      );
+                    })}
+                    <Link
+                      className="btn soft"
+                      href={person.onlyGroupId ? `/settle?group=${person.onlyGroupId}` : '/settle'}
+                      style={{ marginTop: 4 }}
+                    >
+                      {t.friends.settleUp}
+                    </Link>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+      <aside className="detail" />
+    </div>
+  );
+}
+
+/** One block per person, gathering their currencies; drops any that netted to zero. */
+function groupByPerson(rows: readonly PersonBalanceRow[]): Person[] {
+  const byPerson = new Map<string, Person>();
+  for (const row of rows) {
+    const net = BigInt(row.net);
+    if (net === 0n) continue;
+    let person = byPerson.get(row.person_key);
+    if (!person) {
+      person = {
+        key: row.person_key,
+        name: row.display_name,
+        isGhost: row.is_ghost,
+        groupCount: row.group_count,
+        onlyGroupId: row.only_group_id,
+        nets: [],
+      };
+      byPerson.set(row.person_key, person);
+    }
+    person.nets.push({ currency: row.currency, net });
+  }
+  return [...byPerson.values()];
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -686,6 +686,25 @@ select:focus {
   text-align: end;
 }
 
+/* The inline settle sheet that drops under a "you owe" row */
+.settle-form {
+  margin: 4px 6px 12px;
+  padding: 14px 16px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+}
+
+/* An unread mark in the inbox */
+.unread-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--brand, #d1495b);
+  margin-inline-start: 8px;
+  flex: none;
+}
+
 /* Small inline status badge next to a heading */
 .pill-badge {
   display: inline-block;

--- a/apps/web/src/app/inbox/page.tsx
+++ b/apps/web/src/app/inbox/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * The inbox — everything Baaki has told this person, whether or not a push ever
+ * reached a device (TDR §7.1 calls it the ledger of record). Which rows are
+ * whose is the `notifications_select_own` policy's call, not a filter here.
+ *
+ * Reads are live; the only writes are marking things read, which goes through
+ * the same `baaki_mark_notifications_read` RPC the phone uses.
+ */
+
+import { useEffect, useState } from 'react';
+
+import type { NotificationRow } from '@baaki/api-client';
+
+import { AppFrame } from '@/components/AppFrame';
+import { baaki } from '@/lib/baaki';
+import { useStrings } from '@/i18n-context';
+
+export default function InboxPage() {
+  return <AppFrame current="inbox">{() => <Inbox />}</AppFrame>;
+}
+
+function Inbox() {
+  const { t } = useStrings();
+  const [rows, setRows] = useState<NotificationRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const inbox = await baaki.notifications(100);
+        if (active) setRows(inbox);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const unread = rows.filter((row) => !row.read_at);
+
+  async function markRead(ids: string[]) {
+    if (ids.length === 0) return;
+    const now = new Date().toISOString();
+    // Optimistic: the RPC is the authority, but the inbox should not wait a
+    // round-trip to stop shouting at somebody who has read the thing.
+    setRows((prev) =>
+      prev.map((row) => (ids.includes(row.id) ? { ...row, read_at: row.read_at ?? now } : row)),
+    );
+    try {
+      await baaki.markNotificationsRead(ids);
+    } catch {
+      // Put the dots back if the server refused — better than a lie.
+      setRows((prev) =>
+        prev.map((row) => (ids.includes(row.id) ? { ...row, read_at: null } : row)),
+      );
+    }
+  }
+
+  return (
+    <div className="app-body">
+      <div className="app-main">
+        <div className="page-head">
+          <h1>{t.inbox.title}</h1>
+          {unread.length > 0 ? (
+            <button
+              type="button"
+              className="btn soft"
+              onClick={() => void markRead(unread.map((row) => row.id))}
+            >
+              {t.inbox.markAllRead}
+            </button>
+          ) : null}
+        </div>
+
+        <section className="panel">
+          {loading ? (
+            <p className="muted">{t.inbox.loading}</p>
+          ) : rows.length === 0 ? (
+            <p className="muted">{t.inbox.empty}</p>
+          ) : (
+            <div className="list">
+              {rows.map((row) => (
+                <button
+                  key={row.id}
+                  type="button"
+                  className="item"
+                  onClick={() => void markRead([row.id])}
+                  style={{ textAlign: 'start', width: '100%' }}
+                >
+                  <span className="tile-emoji" aria-hidden>
+                    {row.read_at ? '📭' : '📬'}
+                  </span>
+                  <span className="grow">
+                    <span
+                      className="title"
+                      style={{ whiteSpace: 'normal', fontWeight: row.read_at ? 500 : 700 }}
+                    >
+                      {row.title}
+                    </span>
+                    <span className="meta" style={{ whiteSpace: 'normal' }}>
+                      {row.body}
+                    </span>
+                  </span>
+                  {row.read_at ? null : <span className="unread-dot" aria-hidden />}
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+      <aside className="detail" />
+    </div>
+  );
+}

--- a/apps/web/src/app/settle/page.tsx
+++ b/apps/web/src/app/settle/page.tsx
@@ -1,0 +1,477 @@
+'use client';
+
+/**
+ * Settling up, in the browser (ADR-007).
+ *
+ * The debts shown are @baaki/core's, simplified to the fewest payments that
+ * square everybody (the same `who pays whom` the group page draws). Recording a
+ * payment is not performing it: the ledger tracks what people say they paid,
+ * made real only when whoever was paid confirms. Every write is a SECURITY
+ * DEFINER RPC — nothing here writes a balance, and the server recomputes what it
+ * is handed rather than trusting it (TDR §4).
+ *
+ * The pay link, when a rail publishes one, is built by @baaki/core so the phone
+ * and the browser hand off to UPI the same way. A rail with no published link is
+ * the ordinary case, not a failure — you record that you paid in cash instead.
+ */
+
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+import {
+  computeLedger,
+  memberName,
+  type Expense,
+  type GroupRow,
+  type MemberRow,
+  type Settlement,
+} from '@baaki/api-client';
+import {
+  buildPaymentUri,
+  defaultRailFor,
+  railById,
+  railsFor,
+  toMajorString,
+  type CurrencyCode,
+} from '@baaki/core';
+
+import { AppFrame } from '@/components/AppFrame';
+import { baaki } from '@/lib/baaki';
+import { money } from '@/lib/money';
+import { useStrings } from '@/i18n-context';
+
+export default function SettlePage() {
+  return (
+    <AppFrame current="settle">
+      {({ profileId }) => (
+        <Suspense fallback={null}>
+          <Settle profileId={profileId} />
+        </Suspense>
+      )}
+    </AppFrame>
+  );
+}
+
+function Settle({ profileId }: { profileId: string }) {
+  const { t } = useStrings();
+  const search = useSearchParams();
+  const wantedGroup = search.get('group');
+
+  const [groups, setGroups] = useState<GroupRow[]>([]);
+  const [membersByGroup, setMembersByGroup] = useState<Map<string, MemberRow[]>>(new Map());
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const [g, m] = await Promise.all([baaki.myGroups(), baaki.membersByGroup()]);
+        if (!active) return;
+        setGroups(g);
+        setMembersByGroup(m);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // The clicked group if still present, else the one asked for in the URL, else
+  // the first — derived, never a setState-in-effect that fights the URL.
+  const effectiveId =
+    (selectedId && groups.some((group) => group.id === selectedId) && selectedId) ||
+    (wantedGroup && groups.some((group) => group.id === wantedGroup) && wantedGroup) ||
+    groups[0]?.id ||
+    null;
+
+  if (loading) {
+    return (
+      <div className="app-body">
+        <div className="app-main">
+          <p className="muted">{t.settle.loading}</p>
+        </div>
+        <aside className="detail" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="app-body">
+      <div className="app-main">
+        <div className="page-head">
+          <h1>{t.settle.title}</h1>
+        </div>
+
+        {groups.length > 1 ? (
+          <div className="people" style={{ marginBottom: 14 }}>
+            {groups.map((group) => (
+              <button
+                key={group.id}
+                type="button"
+                className="chip"
+                aria-pressed={group.id === effectiveId}
+                onClick={() => setSelectedId(group.id)}
+              >
+                {group.cover_emoji ? `${group.cover_emoji} ` : ''}
+                {group.name?.trim() || t.settle.pickGroup}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        {effectiveId ? (
+          <GroupSettle
+            key={effectiveId}
+            group={groups.find((group) => group.id === effectiveId)!}
+            members={membersByGroup.get(effectiveId) ?? []}
+            profileId={profileId}
+          />
+        ) : (
+          <section className="panel">
+            <p className="muted">{t.dash.noGroups}</p>
+          </section>
+        )}
+      </div>
+      <aside className="detail" />
+    </div>
+  );
+}
+
+function GroupSettle({
+  group,
+  members,
+  profileId,
+}: {
+  group: GroupRow;
+  members: MemberRow[];
+  profileId: string;
+}) {
+  const { t, locale } = useStrings();
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [settlements, setSettlements] = useState<Settlement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [reload, setReload] = useState(0);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [nudged, setNudged] = useState<Set<string>>(new Set());
+  const [openSettle, setOpenSettle] = useState<string | null>(null);
+
+  useEffect(() => {
+    // The component is keyed by group id, so a group switch remounts with
+    // loading already true; a `reload` bump refetches in place without blanking
+    // what is on screen (the row's own button carries the busy state).
+    let active = true;
+    void (async () => {
+      try {
+        const [e, s] = await Promise.all([baaki.expenses(group.id), baaki.settlements(group.id)]);
+        if (!active) return;
+        setExpenses(e);
+        setSettlements(s);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [group.id, reload]);
+
+  const byId = useMemo(() => new Map(members.map((member) => [member.id, member])), [members]);
+  const myMemberId = members.find((member) => member.profile_id === profileId)?.id ?? null;
+
+  const ledger = useMemo(
+    () => computeLedger(expenses, settlements, group.default_currency),
+    [expenses, settlements, group.default_currency],
+  );
+
+  if (loading) {
+    return (
+      <section className="panel">
+        <p className="muted">{t.settle.loading}</p>
+      </section>
+    );
+  }
+
+  const iOwe = ledger.transfers.filter((transfer) => transfer.from === myMemberId);
+  const owesMe = ledger.transfers.filter((transfer) => transfer.to === myMemberId);
+  const pending = settlements.filter((settlement) => settlement.status === 'initiated');
+
+  if (iOwe.length === 0 && owesMe.length === 0 && pending.length === 0) {
+    return (
+      <section className="panel">
+        <p className="muted">{t.settle.allSettled}</p>
+      </section>
+    );
+  }
+
+  async function refresh() {
+    setReload((n) => n + 1);
+  }
+
+  async function confirm(settlementId: string) {
+    setBusy(settlementId);
+    try {
+      await baaki.confirmSettlement(settlementId);
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function nudge(toMemberId: string, currency: string) {
+    setBusy(toMemberId);
+    try {
+      await baaki.nudgeToSettle({ groupId: group.id, toMemberId, currency });
+      setNudged((prev) => new Set(prev).add(toMemberId));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <>
+      {iOwe.length > 0 ? (
+        <section className="panel">
+          <div className="panel-head">
+            <h2>{t.settle.youOweHead}</h2>
+          </div>
+          <div className="list">
+            {iOwe.map((transfer) => {
+              const payee = byId.get(transfer.to);
+              const open = openSettle === transfer.to;
+              return (
+                <div key={transfer.to}>
+                  <div className="item" style={{ cursor: 'default' }}>
+                    <span className="grow">
+                      <span className="title">{payee ? memberName(payee) : t.settle.title}</span>
+                    </span>
+                    <span className="amount neg">
+                      {money(transfer.amount, transfer.currency, locale)}
+                    </span>
+                    <button
+                      type="button"
+                      className="btn"
+                      style={{ marginInlineStart: 10 }}
+                      onClick={() => setOpenSettle(open ? null : transfer.to)}
+                    >
+                      {t.settle.settleUp}
+                    </button>
+                  </div>
+                  {open && myMemberId && payee ? (
+                    <SettleForm
+                      group={group}
+                      payee={payee}
+                      fromMemberId={myMemberId}
+                      amount={transfer.amount}
+                      currency={transfer.currency}
+                      onCancel={() => setOpenSettle(null)}
+                      onRecorded={async () => {
+                        setOpenSettle(null);
+                        await refresh();
+                      }}
+                    />
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      {owesMe.length > 0 ? (
+        <section className="panel">
+          <div className="panel-head">
+            <h2>{t.settle.owesYouHead}</h2>
+          </div>
+          <div className="list">
+            {owesMe.map((transfer) => {
+              const payer = byId.get(transfer.from);
+              const isNudged = nudged.has(transfer.from);
+              return (
+                <div key={transfer.from} className="item" style={{ cursor: 'default' }}>
+                  <span className="grow">
+                    <span className="title">{payer ? memberName(payer) : t.settle.title}</span>
+                  </span>
+                  <span className="amount pos">
+                    {money(transfer.amount, transfer.currency, locale)}
+                  </span>
+                  <button
+                    type="button"
+                    className="btn soft"
+                    style={{ marginInlineStart: 10 }}
+                    disabled={isNudged || busy === transfer.from}
+                    onClick={() => void nudge(transfer.from, transfer.currency)}
+                  >
+                    {isNudged ? t.settle.nudged : t.settle.nudge}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      {pending.length > 0 ? (
+        <section className="panel">
+          <div className="panel-head">
+            <h2>{t.settle.pendingHead}</h2>
+          </div>
+          <div className="list">
+            {pending.map((settlement) => {
+              const mineToConfirm = settlement.to_member_id === myMemberId;
+              const other = byId.get(
+                mineToConfirm ? settlement.from_member_id : settlement.to_member_id,
+              );
+              return (
+                <div key={settlement.id} className="item" style={{ cursor: 'default' }}>
+                  <span className="grow">
+                    <span className="title">{other ? memberName(other) : t.settle.title}</span>
+                  </span>
+                  <span className="amount">
+                    {money(BigInt(settlement.amount), settlement.currency, locale)}
+                  </span>
+                  {mineToConfirm ? (
+                    <button
+                      type="button"
+                      className="btn"
+                      style={{ marginInlineStart: 10 }}
+                      disabled={busy === settlement.id}
+                      onClick={() => void confirm(settlement.id)}
+                    >
+                      {busy === settlement.id ? t.settle.confirming : t.settle.confirm}
+                    </button>
+                  ) : (
+                    <span className="faint" style={{ marginInlineStart: 10 }}>
+                      {other
+                        ? t.settle.waitingConfirm.replace('{name}', memberName(other))
+                        : t.settle.pendingHead}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+    </>
+  );
+}
+
+/** Pick a rail, hand off to it when it has a link, and record the payment. */
+function SettleForm({
+  group,
+  payee,
+  fromMemberId,
+  amount,
+  currency,
+  onCancel,
+  onRecorded,
+}: {
+  group: GroupRow;
+  payee: MemberRow;
+  fromMemberId: string;
+  amount: bigint;
+  currency: string;
+  onCancel: () => void;
+  onRecorded: () => Promise<void>;
+}) {
+  const { t, locale } = useStrings();
+  const rails = useMemo(() => railsFor(group.country_code), [group.country_code]);
+  const [rail, setRail] = useState<string>(() => defaultRailFor(group.country_code));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handle = payee.vpa ?? payee.profile?.default_vpa ?? '';
+  const railInfo = railById(rail);
+  const needsHandle = railInfo ? railInfo.handle !== 'none' : false;
+
+  const payLink =
+    handle && needsHandle
+      ? buildPaymentUri(
+          {
+            railId: rail,
+            handle,
+            payeeName: memberName(payee),
+            amount,
+            currency: currency as CurrencyCode,
+            note: `Baaki ${group.name ?? ''}`.trim(),
+          },
+          (value, code) => toMajorString({ minor: value, currency: code }),
+        )
+      : null;
+
+  async function record() {
+    setSaving(true);
+    setError(null);
+    try {
+      await baaki.recordSettlement({
+        groupId: group.id,
+        fromMemberId,
+        toMemberId: payee.id,
+        amount,
+        rail,
+        currency,
+      });
+      await onRecorded();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="settle-form">
+      <label style={{ display: 'block', marginBottom: 10 }}>
+        <span className="k" style={{ display: 'block', marginBottom: 6 }}>
+          {t.settle.howPaid}
+        </span>
+        <select
+          className="split-input"
+          value={rail}
+          onChange={(event) => setRail(event.target.value)}
+          style={{ width: '100%' }}
+        >
+          {rails.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="detail-field">
+        <span className="k">{t.settle.amountLabel}</span>
+        <span className="v amount">{money(amount, currency, locale)}</span>
+      </div>
+
+      {needsHandle && !handle ? (
+        <p className="faint">{t.settle.noHandle.replace('{name}', memberName(payee))}</p>
+      ) : null}
+
+      {payLink ? (
+        <a
+          className="btn soft block"
+          href={payLink.uri}
+          target="_blank"
+          rel="noreferrer"
+          style={{ marginTop: 10 }}
+        >
+          {t.settle.payWith.replace('{rail}', railInfo?.label ?? rail)}
+        </a>
+      ) : null}
+
+      {error ? <p className="dispute-note">{error}</p> : null}
+
+      <div style={{ display: 'flex', gap: 10, marginTop: 12 }}>
+        <button type="button" className="btn" onClick={() => void record()} disabled={saving}>
+          {saving ? t.settle.recording : t.settle.record}
+        </button>
+        <button type="button" className="btn soft" onClick={onCancel} disabled={saving}>
+          {t.settle.cancel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 /**
- * The frame every signed-in page sits in: brand, the section tabs, search, and
- * the account menu. Only Overview is built in Phase 1 — the other tabs are
- * shown but inert, so the shape is right and the later phases have somewhere to
- * land (PLAN.md).
+ * The frame every signed-in page sits in: brand, the section tabs, search, the
+ * inbox bell, and the account menu. Phases 1–3 have filled every tab in; each
+ * one is a real route now rather than an inert button (PLAN.md).
  */
 
 import { useEffect, useRef, useState, type ReactNode } from 'react';
+import Link from 'next/link';
 
 import { useStrings } from '@/i18n-context';
 
-export type Section = 'overview' | 'groups' | 'activity' | 'friends' | 'settle';
+export type Section = 'overview' | 'groups' | 'activity' | 'friends' | 'settle' | 'inbox';
 
 export function Shell({
   current,
@@ -47,12 +47,15 @@ export function Shell({
     return () => document.removeEventListener('mousedown', onClick);
   }, [menuOpen]);
 
-  const tabs: { key: Section; label: string }[] = [
-    { key: 'overview', label: t.dash.nav.overview },
-    { key: 'groups', label: t.dash.nav.groups },
-    { key: 'activity', label: t.dash.nav.activity },
-    { key: 'friends', label: t.dash.nav.friends },
-    { key: 'settle', label: t.dash.nav.settle },
+  // Groups has no index of its own yet — the overview is where the groups
+  // live, and a group opens at /g/[id]; the tab shares the home route and still
+  // lights up on a group page, which is where `current: 'groups'` comes from.
+  const tabs: { key: Section; label: string; href: string }[] = [
+    { key: 'overview', label: t.dash.nav.overview, href: '/' },
+    { key: 'groups', label: t.dash.nav.groups, href: '/' },
+    { key: 'activity', label: t.dash.nav.activity, href: '/activity' },
+    { key: 'friends', label: t.dash.nav.friends, href: '/friends' },
+    { key: 'settle', label: t.dash.nav.settle, href: '/settle' },
   ];
 
   const initial = userName.trim().charAt(0).toUpperCase() || '🙂';
@@ -70,21 +73,30 @@ export function Shell({
 
           <div className="navtabs" role="tablist">
             {tabs.map((tab) => (
-              <button
+              <Link
                 key={tab.key}
-                type="button"
+                href={tab.href}
                 className="navtab"
                 role="tab"
                 aria-current={tab.key === current}
-                aria-disabled={tab.key !== 'overview'}
-                disabled={tab.key !== 'overview'}
               >
                 {tab.label}
-              </button>
+              </Link>
             ))}
           </div>
 
           <div className="nav-right">
+            <Link
+              href="/inbox"
+              className="avatar icon-btn"
+              aria-current={current === 'inbox'}
+              title={t.inbox.title}
+              aria-label={t.inbox.title}
+              style={{ width: 38, height: 38, textDecoration: 'none' }}
+            >
+              <span aria-hidden>🔔</span>
+            </Link>
+
             <label className="search">
               <span aria-hidden>🔍</span>
               <input

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -228,6 +228,52 @@ export interface WebStrings {
       itemized: string;
     };
   };
+  /** The cross-group activity feed. */
+  activity: {
+    title: string;
+    empty: string;
+    loading: string;
+  };
+  /** Everyone you are not square with, netted across every shared group. */
+  friends: {
+    title: string;
+    empty: string;
+    owesYou: string;
+    youOwe: string;
+    inGroups: PluralForms;
+    settleUp: string;
+    loading: string;
+  };
+  /** Recording and confirming settlements (ADR-007). */
+  settle: {
+    title: string;
+    pickGroup: string;
+    allSettled: string;
+    youOweHead: string;
+    owesYouHead: string;
+    pendingHead: string;
+    settleUp: string;
+    howPaid: string;
+    amountLabel: string;
+    payWith: string;
+    noHandle: string;
+    record: string;
+    recording: string;
+    cancel: string;
+    confirm: string;
+    confirming: string;
+    waitingConfirm: string;
+    nudge: string;
+    nudged: string;
+    loading: string;
+  };
+  /** The inbox — everything Baaki has told you, whether a push reached you or not. */
+  inbox: {
+    title: string;
+    empty: string;
+    markAllRead: string;
+    loading: string;
+  };
 }
 
 const en: WebStrings = {
@@ -382,6 +428,48 @@ const en: WebStrings = {
       adjustment: 'With adjustments',
       itemized: 'Itemised',
     },
+  },
+  activity: {
+    title: 'Activity',
+    empty: 'Nothing has happened yet.',
+    loading: 'Loading…',
+  },
+  friends: {
+    title: 'Friends',
+    empty: "You're square with everyone.",
+    owesYou: 'owes you',
+    youOwe: 'you owe',
+    inGroups: { one: 'in {n} group', other: 'across {n} groups' },
+    settleUp: 'Settle up',
+    loading: 'Loading…',
+  },
+  settle: {
+    title: 'Settle up',
+    pickGroup: 'Pick a group',
+    allSettled: "Everyone's square here. Nothing to settle.",
+    youOweHead: 'You owe',
+    owesYouHead: 'Owes you',
+    pendingHead: 'Waiting to be confirmed',
+    settleUp: 'Settle up',
+    howPaid: 'How did you pay?',
+    amountLabel: 'Amount',
+    payWith: 'Open {rail}',
+    noHandle: "{name} hasn't shared how they're paid — settle in cash, or ask them to add it.",
+    record: 'Mark as paid',
+    recording: 'Recording…',
+    cancel: 'Cancel',
+    confirm: 'Confirm it reached you',
+    confirming: 'Confirming…',
+    waitingConfirm: 'Waiting for {name} to confirm',
+    nudge: 'Nudge',
+    nudged: 'Nudged',
+    loading: 'Loading…',
+  },
+  inbox: {
+    title: 'Inbox',
+    empty: 'Nothing in your inbox yet.',
+    markAllRead: 'Mark all read',
+    loading: 'Loading…',
   },
 };
 
@@ -545,6 +633,49 @@ const ta: WebStrings = {
       itemized: 'பொருள்வாரியாக',
     },
   },
+  activity: {
+    title: 'செயல்பாடு',
+    empty: 'இன்னும் எதுவும் நடக்கவில்லை.',
+    loading: 'ஏற்றுகிறது…',
+  },
+  friends: {
+    title: 'நண்பர்கள்',
+    empty: 'அனைவருடனும் கணக்கு தீர்ந்தது.',
+    owesYou: 'உங்களுக்குத் தர வேண்டும்',
+    youOwe: 'நீங்கள் தர வேண்டும்',
+    inGroups: { one: '{n} குழுவில்', other: '{n} குழுக்களில்' },
+    settleUp: 'கணக்கு தீர்',
+    loading: 'ஏற்றுகிறது…',
+  },
+  settle: {
+    title: 'கணக்கு தீர்',
+    pickGroup: 'ஒரு குழுவைத் தேர்வு',
+    allSettled: 'இங்கே அனைவரின் கணக்கும் தீர்ந்தது. தீர்க்க எதுவும் இல்லை.',
+    youOweHead: 'நீங்கள் தர வேண்டியது',
+    owesYouHead: 'உங்களுக்குத் தர வேண்டியது',
+    pendingHead: 'உறுதிப்படுத்த காத்திருப்பவை',
+    settleUp: 'கணக்கு தீர்',
+    howPaid: 'எப்படிக் கொடுத்தீர்கள்?',
+    amountLabel: 'தொகை',
+    payWith: '{rail} திற',
+    noHandle:
+      '{name} எப்படிப் பணம் பெறுகிறார் என்பதைப் பகிரவில்லை — பணமாகத் தீர்க்கவும், அல்லது சேர்க்கச் சொல்லவும்.',
+    record: 'கொடுத்ததாகக் குறி',
+    recording: 'பதிவுசெய்கிறது…',
+    cancel: 'ரத்து',
+    confirm: 'உங்களுக்கு வந்ததை உறுதிசெய்',
+    confirming: 'உறுதிசெய்கிறது…',
+    waitingConfirm: '{name} உறுதிசெய்ய காத்திருக்கிறது',
+    nudge: 'நினைவூட்டு',
+    nudged: 'நினைவூட்டப்பட்டது',
+    loading: 'ஏற்றுகிறது…',
+  },
+  inbox: {
+    title: 'இன்பாக்ஸ்',
+    empty: 'உங்கள் இன்பாக்ஸில் இன்னும் எதுவும் இல்லை.',
+    markAllRead: 'அனைத்தையும் படித்ததாகக் குறி',
+    loading: 'ஏற்றுகிறது…',
+  },
 };
 
 const hi: WebStrings = {
@@ -700,6 +831,49 @@ const hi: WebStrings = {
       adjustment: 'समायोजन के साथ',
       itemized: 'मद-वार',
     },
+  },
+  activity: {
+    title: 'गतिविधि',
+    empty: 'अभी तक कुछ नहीं हुआ।',
+    loading: 'लोड हो रहा है…',
+  },
+  friends: {
+    title: 'दोस्त',
+    empty: 'सबके साथ हिसाब बराबर है।',
+    owesYou: 'आपको मिलने हैं',
+    youOwe: 'आपको देने हैं',
+    inGroups: { one: '{n} समूह में', other: '{n} समूहों में' },
+    settleUp: 'हिसाब चुकाएँ',
+    loading: 'लोड हो रहा है…',
+  },
+  settle: {
+    title: 'हिसाब चुकाएँ',
+    pickGroup: 'कोई समूह चुनें',
+    allSettled: 'यहाँ सबका हिसाब बराबर है। चुकाने को कुछ नहीं।',
+    youOweHead: 'आपको देने हैं',
+    owesYouHead: 'आपको मिलने हैं',
+    pendingHead: 'पुष्टि का इंतज़ार',
+    settleUp: 'हिसाब चुकाएँ',
+    howPaid: 'आपने कैसे दिया?',
+    amountLabel: 'रकम',
+    payWith: '{rail} खोलें',
+    noHandle:
+      '{name} ने नहीं बताया कि उन्हें कैसे भुगतान मिलता है — नकद चुकाएँ, या उनसे जोड़ने को कहें।',
+    record: 'भुगतान किया, दर्ज करें',
+    recording: 'दर्ज हो रहा है…',
+    cancel: 'रद्द करें',
+    confirm: 'पुष्टि करें कि मिल गया',
+    confirming: 'पुष्टि हो रही है…',
+    waitingConfirm: '{name} की पुष्टि का इंतज़ार',
+    nudge: 'याद दिलाएँ',
+    nudged: 'याद दिला दिया',
+    loading: 'लोड हो रहा है…',
+  },
+  inbox: {
+    title: 'इनबॉक्स',
+    empty: 'आपके इनबॉक्स में अभी कुछ नहीं।',
+    markAllRead: 'सभी पढ़ा हुआ चिह्नित करें',
+    loading: 'लोड हो रहा है…',
   },
 };
 
@@ -890,6 +1064,55 @@ const ar: WebStrings = {
       adjustment: 'مع تعديلات',
       itemized: 'بالأصناف',
     },
+  },
+  activity: {
+    title: 'النشاط',
+    empty: 'لم يحدث شيء بعد.',
+    loading: 'جارٍ التحميل…',
+  },
+  friends: {
+    title: 'الأصدقاء',
+    empty: 'حسابك مسوّى مع الجميع.',
+    owesYou: 'لك',
+    youOwe: 'عليك',
+    inGroups: {
+      zero: 'في لا مجموعة',
+      one: 'في مجموعة واحدة',
+      two: 'في مجموعتين',
+      few: 'في {n} مجموعات',
+      many: 'في {n} مجموعة',
+      other: 'في {n} مجموعة',
+    },
+    settleUp: 'سوِّ الحساب',
+    loading: 'جارٍ التحميل…',
+  },
+  settle: {
+    title: 'تسوية الحساب',
+    pickGroup: 'اختر مجموعة',
+    allSettled: 'حساب الجميع هنا مسوّى. لا شيء للتسوية.',
+    youOweHead: 'عليك',
+    owesYouHead: 'لك',
+    pendingHead: 'بانتظار التأكيد',
+    settleUp: 'سوِّ الحساب',
+    howPaid: 'كيف دفعت؟',
+    amountLabel: 'المبلغ',
+    payWith: 'افتح {rail}',
+    noHandle: 'لم يشارك {name} كيف يُدفع له — سوِّ نقدًا، أو اطلب منه إضافتها.',
+    record: 'سجّل أنك دفعت',
+    recording: 'جارٍ التسجيل…',
+    cancel: 'إلغاء',
+    confirm: 'أكّد أنه وصلك',
+    confirming: 'جارٍ التأكيد…',
+    waitingConfirm: 'بانتظار تأكيد {name}',
+    nudge: 'تذكير',
+    nudged: 'تم التذكير',
+    loading: 'جارٍ التحميل…',
+  },
+  inbox: {
+    title: 'صندوق الوارد',
+    empty: 'لا شيء في صندوق واردك بعد.',
+    markAllRead: 'وسم الكل كمقروء',
+    loading: 'جارٍ التحميل…',
   },
 };
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -19,15 +19,17 @@
 import type { Session, SupabaseClient } from '@supabase/supabase-js';
 
 import type { AcceptedInvite, Expense, Group, InvitePreview, Member, Settlement } from './types';
-import type {
-  ActivityGroup,
-  ActivityRow,
-  BalanceRow,
-  DisputeRow,
-  ExpenseVersionSummary,
-  GroupRow,
-  MemberRow,
-  PersonBalanceRow,
+import {
+  coarseMethod,
+  type ActivityGroup,
+  type ActivityRow,
+  type BalanceRow,
+  type DisputeRow,
+  type ExpenseVersionSummary,
+  type GroupRow,
+  type MemberRow,
+  type NotificationRow,
+  type PersonBalanceRow,
 } from './rows';
 
 const GROUP_ROW_COLUMNS = `
@@ -403,6 +405,84 @@ export function createBaakiClient({ supabase }: BaakiClientOptions) {
     /** Every person you are not square with, across every group, per currency. */
     peopleBalances(): Promise<PersonBalanceRow[]> {
       return read<PersonBalanceRow>(supabase.rpc('baaki_people_i_owe'));
+    },
+
+    // ─────────────────────────────────────────────── settling up (ADR-007) ──
+    // Recording a settlement is not performing it: the ledger tracks what people
+    // say they paid, made real only when whoever was paid confirms it. Every
+    // write is a SECURITY DEFINER RPC — the settlements table takes no client
+    // write — and the server recomputes nothing it was handed.
+
+    /**
+     * "I paid them." The coarse `method` enum is derived server-side from the
+     * finer rail, so a rail the enum never heard of still records rather than
+     * being refused. `clientMutationId` makes a double-tapped Save harmless.
+     */
+    async recordSettlement(input: {
+      groupId: string;
+      fromMemberId: string;
+      toMemberId: string;
+      amount: bigint;
+      /** A `RailId` from @baaki/core — `upi`, `pix`, `cash`, … */
+      rail: string;
+      currency?: string | null;
+      note?: string | null;
+      allocations?: { expenseId: string; amount: bigint }[];
+      clientMutationId?: string;
+    }): Promise<string> {
+      return String(
+        await rpc('baaki_record_settlement', {
+          p_group_id: input.groupId,
+          p_from_member_id: input.fromMemberId,
+          p_to_member_id: input.toMemberId,
+          p_amount: input.amount.toString(),
+          p_method: coarseMethod(input.rail),
+          p_rail: input.rail,
+          p_currency: input.currency ?? null,
+          p_note: input.note?.trim() || null,
+          p_allocations: (input.allocations ?? []).map((allocation) => ({
+            expenseId: allocation.expenseId,
+            amount: allocation.amount.toString(),
+          })),
+          p_client_mutation_id: input.clientMutationId ?? crypto.randomUUID(),
+        }),
+      );
+    },
+
+    /** "Yes, that reached me." Only the payee may confirm (server-checked). */
+    confirmSettlement(settlementId: string): Promise<void> {
+      return rpc('baaki_confirm_settlement', { p_settlement_id: settlementId }).then(
+        () => undefined,
+      );
+    },
+
+    /** A gentle poke to someone who owes you in a currency (ADR-010 prefs apply). */
+    nudgeToSettle(input: { groupId: string; toMemberId: string; currency: string }): Promise<void> {
+      return rpc('baaki_nudge_to_settle', {
+        p_group_id: input.groupId,
+        p_to_member_id: input.toMemberId,
+        p_currency: input.currency,
+      }).then(() => undefined);
+    },
+
+    // ─────────────────────────────────────────────────────── the inbox ──
+    // Everything Baaki has told this person, kept whether or not a push ever
+    // landed. No profile filter: `notifications_select_own` decides whose inbox
+    // this is, and a second, weaker check here would only invite disagreement.
+
+    notifications(limit = 50): Promise<NotificationRow[]> {
+      return read<NotificationRow>(
+        supabase
+          .from('notifications')
+          .select('id, group_id, kind, title, body, deep_link, payload, read_at, created_at')
+          .order('created_at', { ascending: false })
+          .limit(limit),
+      );
+    },
+
+    async markNotificationsRead(ids: string[]): Promise<number> {
+      if (ids.length === 0) return 0;
+      return Number(await rpc('baaki_mark_notifications_read', { p_ids: ids }));
     },
 
     /**

--- a/packages/api-client/src/rows.ts
+++ b/packages/api-client/src/rows.ts
@@ -108,6 +108,43 @@ export interface ExpenseVersionSummary {
   split_type: string;
 }
 
+export type SettlementMethod = 'upi' | 'cash' | 'bank' | 'other';
+
+export type SettlementStatus =
+  'initiated' | 'confirmed' | 'auto_confirmed' | 'disputed' | 'cancelled';
+
+/**
+ * The coarse `method` enum the settlements table stores, derived from the finer
+ * `RailId` the group actually settled on. A rail the enum has never heard of —
+ * Pix, PayNow, Wise — records as `other` while the exact rail rides alongside
+ * in its own column, so a new country is data, not a new enum value (see
+ * `@baaki/core`'s rails). Kept pure and exported so the mapping is tested once
+ * and cannot drift between the phone and the browser.
+ */
+export function coarseMethod(rail: string): SettlementMethod {
+  return (['upi', 'cash', 'bank', 'other'] as const).includes(rail as SettlementMethod)
+    ? (rail as SettlementMethod)
+    : 'other';
+}
+
+/**
+ * A line in the inbox — everything Baaki has told this person, whether or not a
+ * push ever reached the device (TDR §7.1 calls it the ledger of record). Which
+ * rows are whose is decided by the `notifications_select_own` RLS policy, not
+ * by any filter here.
+ */
+export interface NotificationRow {
+  id: string;
+  group_id: string | null;
+  kind: string;
+  title: string;
+  body: string;
+  deep_link: string | null;
+  payload: Record<string, unknown>;
+  read_at: string | null;
+  created_at: string;
+}
+
 /** One row per person per currency, from the `baaki_people_i_owe` RPC. */
 export interface PersonBalanceRow {
   person_key: string;

--- a/packages/api-client/test/settlement.test.ts
+++ b/packages/api-client/test/settlement.test.ts
@@ -1,0 +1,36 @@
+/**
+ * The one piece of logic on the settle write path: turning the fine-grained
+ * rail a group actually settled on into the coarse `method` enum the table
+ * stores. The rest of `recordSettlement` is a straight pass-through to a
+ * SECURITY DEFINER RPC and carries no arithmetic to get wrong.
+ *
+ * The trap this guards is a *silent* one — a new rail (Pix, Wise) that the enum
+ * has never heard of must land as `other`, not throw and not slip in as an
+ * invalid enum value, so a group in a new country can still record that it
+ * settled. This must give the same answer as the phone's inline mapping, or the
+ * two clients would file the same payment under two different methods.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { coarseMethod } from '../src/index';
+
+describe('coarseMethod', () => {
+  it('keeps the four the enum knows', () => {
+    expect(coarseMethod('upi')).toBe('upi');
+    expect(coarseMethod('cash')).toBe('cash');
+    expect(coarseMethod('bank')).toBe('bank');
+    expect(coarseMethod('other')).toBe('other');
+  });
+
+  it('folds every other rail down to other', () => {
+    for (const rail of ['pix', 'paynow', 'promptpay', 'wise', 'zelle', 'venmo', 'revolut']) {
+      expect(coarseMethod(rail)).toBe('other');
+    }
+  });
+
+  it('does not mistake an unknown string for a known method', () => {
+    expect(coarseMethod('')).toBe('other');
+    expect(coarseMethod('UPI')).toBe('other'); // case matters — the enum is lower-case
+  });
+});


### PR DESCRIPTION
Phase 3 of the full web client (PLAN.md), stacked on #151. Signed-in users can now settle, see who they owe across groups, read the whole activity feed, and open their inbox — all through the same server-authoritative paths the phone uses.

### What's here
- **Settle-up** (`/settle`, ADR-007) — the group's debts as `@baaki/core`'s simplified transfers; record a payment, confirm one that reached you, or nudge someone who owes you. Recording goes through the `baaki_record_settlement` SECURITY DEFINER RPC and is made real only on the payee's confirm. The pay link (UPI + every other rail) is built by `@baaki/core`, so the browser and the app hand off identically; a rail with no published link shows the handle to settle in cash.
- **Friends** (`/friends`) — everyone you're not square with, netted per person per currency from `baaki_people_i_owe` (never summed across currencies, ADR-004). Settle-up jumps straight to the group when the debt lives in only one.
- **Activity** (`/activity`) — the whole cross-group feed (overview shows only the last dozen), worded through the shared `describeActivity` so browser and app never narrate an event two ways; expense rows link to their detail.
- **Inbox** (`/inbox`) — the ledger-of-record notifications (TDR §7.1), read live and marked read through `baaki_mark_notifications_read`, optimistically.
- Shell nav tabs are **real routes** now (inert through Phases 1–2); a bell reaches the inbox.

### api-client
`recordSettlement` / `confirmSettlement` / `nudgeToSettle` and `notifications` / `markNotificationsRead`, ported so the web settles and reads through the same RPCs as the phone. `coarseMethod` (rail → coarse `method` enum) extracted as a pure, tested helper so the mapping can't drift between clients.

### Trust boundary (unchanged)
No new trust to the browser: every write is an Edge Function / SECURITY DEFINER RPC that recomputes what it's handed (TDR §4); reads are RLS-scoped (ADR-013); balances are `@baaki/core`'s.

### Gates
- web: typecheck ✅ · lint (max-warnings 0) ✅ · 24 tests ✅ · `next build` ✅ (all four routes compile) · dev server 200 on `/activity` `/friends` `/settle` `/inbox`
- api-client: 12 tests ✅ (added `coarseMethod`) · typecheck ✅

### i18n
`activity` / `friends` / `settle` / `inbox` blocks in all four languages (en/ta/hi/ar) under the closed `WebStrings` interface — the i18n test enforces no blank strings and placeholder parity.

### Merge order
#150 → main, then retarget #151 → main, then this → main.

### Follow-up (next PR, not here)
Convert the whole web app off the hand-written `globals.css` design system to **Tailwind v4** (latest), keeping the pastel tokens as the theme. Isolated so Phase 3 stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ