### PR TITLE
chore(web): vercel project config

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "regions": ["sin1"]
+}


### PR DESCRIPTION
Adds `apps/web/vercel.json` mirroring `apps/admin` (Next.js framework, `sin1` region) so the apps/web Vercel project builds with the right defaults once created.

**This does not create the deployment** — that needs Vercel account access. To go live:
1. Vercel dashboard → **Add New → Project** → import `dmadan86/baaki`.
2. **Root Directory:** `apps/web`.
3. **Environment variables:** `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` (same values as the app's `.env.local`).
4. Deploy — thereafter pushes to `main` auto-deploy via the existing Git integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ