### PR TITLE
test(web): Playwright e2e for the unauthenticated surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,32 @@ jobs:
           TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/baaki
         run: pnpm test:db
 
+  web-e2e:
+    name: web e2e (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # The one browser these smoke tests drive. --with-deps pulls the system
+      # libraries a headless Chromium needs on a bare runner.
+      - name: Install Chromium
+        run: pnpm --filter @baaki/web exec playwright install --with-deps chromium
+      # The suite boots its own dev server (playwright.config.ts) with placeholder
+      # Supabase env — the unauthenticated surface it drives makes no network call.
+      - name: Playwright
+        run: pnpm --filter @baaki/web e2e
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7
+
   e2e:
     name: e2e (Maestro)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ next-env.d.ts
 
 # Vercel CLI link (project ids, not secrets — still not ours to commit)
 .vercel
+
+# Playwright (web e2e)
+apps/web/playwright-report/
+apps/web/test-results/
+apps/web/blob-report/
+apps/web/playwright/.cache/

--- a/apps/web/e2e/i18n.spec.ts
+++ b/apps/web/e2e/i18n.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * The language and text direction are decided on the server from
+ * Accept-Language (layout.tsx), so `<html lang>` / `<html dir>` are right in the
+ * first paint rather than corrected after hydration. An Arabic reader should
+ * find the page already the right way round.
+ */
+test.describe('language from Accept-Language', () => {
+  test('English by default — left to right', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+  });
+
+  test.describe('Arabic', () => {
+    test.use({ locale: 'ar', extraHTTPHeaders: { 'Accept-Language': 'ar' } });
+
+    test('renders right to left, with the Arabic sign-in copy', async ({ page }) => {
+      await page.goto('/');
+      await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+      await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+      await expect(page.getByRole('button', { name: /المتابعة عبر Google/ })).toBeVisible();
+    });
+  });
+});

--- a/apps/web/e2e/responsive.spec.ts
+++ b/apps/web/e2e/responsive.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * The app should be responsive: the sign-in card stays usable and, crucially,
+ * nothing pushes the page wider than the viewport at a phone width — a sideways
+ * scrollbar on a 360px screen is the failure this guards.
+ */
+const VIEWPORTS = [
+  { name: 'phone', width: 360, height: 740 },
+  { name: 'tablet', width: 820, height: 1180 },
+  { name: 'desktop', width: 1280, height: 800 },
+] as const;
+
+for (const vp of VIEWPORTS) {
+  test(`no horizontal overflow at ${vp.name} (${vp.width}px)`, async ({ page }) => {
+    await page.setViewportSize({ width: vp.width, height: vp.height });
+    await page.goto('/');
+
+    await expect(page.getByRole('button', { name: /google/i })).toBeVisible();
+
+    const overflows = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(overflows, 'page must not scroll horizontally').toBe(false);
+  });
+}

--- a/apps/web/e2e/signin.spec.ts
+++ b/apps/web/e2e/signin.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * The front door. With no session, `/` routes to the sign-in card (AppFrame),
+ * which offers both providers ADR-006 names — Google and a passwordless email
+ * link — plus the note that an invite link is the guest way in.
+ */
+test.describe('sign-in (the unauthenticated front door)', () => {
+  test('offers Google and the email magic link', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('button', { name: /continue with google/i })).toBeVisible();
+    await expect(page.getByPlaceholder('you@email.com')).toBeVisible();
+    await expect(page.getByRole('button', { name: /email me a sign-in link/i })).toBeVisible();
+    // The guest path is signposted, not hidden.
+    await expect(page.getByText(/open an invite link/i)).toBeVisible();
+  });
+
+  test('catches a malformed email before any round trip', async ({ page }) => {
+    await page.goto('/');
+
+    // Passes the browser's native type=email check (has an @) but not the app's
+    // own regex (no dot), so the client-side guard is what fires — no network.
+    await page.getByPlaceholder('you@email.com').fill('foo@bar');
+    await page.getByRole('button', { name: /email me a sign-in link/i }).click();
+
+    await expect(page.getByText(/does not look like an email/i)).toBeVisible();
+    // Still on the sign-in screen; nothing navigated or was sent.
+    await expect(page.getByRole('button', { name: /continue with google/i })).toBeVisible();
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint src --max-warnings 0",
     "test": "vitest run",
+    "e2e": "playwright test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -20,6 +21,7 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/node": "^24.1.0",
     "@types/react": "~19.2.2",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * End-to-end tests for the web client — the app as a browser meets it.
+ *
+ * These drive the *unauthenticated* surface (the sign-in front door, the
+ * language/direction the server picks from Accept-Language, and that nothing
+ * overflows a phone). That is the part with no live backend behind it: a real
+ * session's data lives under RLS in a Supabase project, and exercising it is a
+ * heavier suite that needs test credentials — the mobile app's live Maestro
+ * flows are the model for that, and it is deliberately out of scope here.
+ *
+ * The dev server is booted with placeholder Supabase env: the client is
+ * constructed (it throws at import without them) but the pages under test never
+ * make a network call, so no real project is touched.
+ */
+
+const PORT = 4020;
+const baseURL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `pnpm exec next dev --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      // Not a real project — the sign-in surface never calls it.
+      NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'e2e-anon-key-not-real',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         version: 3.0.6(echarts@6.1.0)(react@19.2.3)
       next:
         specifier: ^16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -269,13 +269,13 @@ importers:
         version: link:../../packages/core
       '@sentry/nextjs':
         specifier: ^10.69.0
-        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@supabase/supabase-js':
         specifier: ^2.112.0
         version: 2.112.0(@opentelemetry/api@1.9.1)
       next:
         specifier: ^16.3.0
-        version: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -283,6 +283,9 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -1729,6 +1732,11 @@ packages:
   '@opentelemetry/semantic-conventions@1.43.0':
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@prisma/client@6.19.1':
     resolution: {integrity: sha512-4SXj4Oo6HyQkLUWT8Ke5R0PTAfVOKip5Roo+6+b2EDTkFg5be0FnBWiuRJc0BC0sRQIWGMLKW1XguhVfW/z3/A==}
@@ -4341,6 +4349,11 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5431,6 +5444,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
@@ -7925,6 +7948,10 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@prisma/client@6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
       prisma: 6.19.1(typescript@5.9.3)
@@ -8590,7 +8617,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.69.0
 
-  '@sentry/nextjs@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@sentry/nextjs@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.4)
@@ -8604,7 +8631,7 @@ snapshots:
       '@sentry/server-utils': 10.69.0(supports-color@8.1.1)
       '@sentry/vercel-edge': 10.69.0
       '@sentry/webpack-plugin': 5.4.0(rollup@4.62.4)(supports-color@8.1.1)(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
-      next: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rollup: 4.62.4
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -10982,6 +11009,9 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -11842,7 +11872,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -11862,6 +11892,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.3.0
       '@next/swc-win32-x64-msvc': 16.3.0
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.62.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.35.3(@types/node@24.13.3)
     transitivePeerDependencies:
@@ -12076,6 +12107,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.1.1
       pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.1:
     dependencies:


### PR DESCRIPTION
Adds web end-to-end tests (Playwright, latest) — the app driven as a browser meets it, not another unit layer.

### What it drives
- **Sign-in front door** (`signin.spec.ts`): `/` with no session routes to the sign-in card; both ADR-006 providers present (Continue with Google, email magic link); a malformed email (`foo@bar` — passes native `type=email` but not the app's regex) trips the **client-side guard before any round trip**, and the screen doesn't navigate.
- **Language & direction** (`i18n.spec.ts`): the server picks language from `Accept-Language` (layout.tsx) so `<html lang>`/`<html dir>` are right in the first paint — `en`→ltr; `ar`→rtl with the Arabic sign-in copy.
- **Responsive** (`responsive.spec.ts`): no horizontal overflow at phone (360), tablet (820) and desktop (1280) — a sideways scrollbar on a phone is the failure this guards.

### How it runs without a backend
`playwright.config.ts` boots `next dev` on :4020 with **placeholder** Supabase env. The client is constructed (it throws at import without the vars) but the unauthenticated surface makes **no network call**, so no real project is touched.

### CI
New **web e2e (Playwright)** job: installs Chromium `--with-deps`, runs the suite, uploads the HTML report artifact. (Replaces nothing — the disabled mobile Maestro job stays.)

### Result
`7 passed` locally. typecheck green (config + specs compile). Not linted (eslint scopes `src`); Prettier-clean.

### Out of scope (follow-up)
Data-path e2e — a real session under RLS with seeded rows — needs test credentials and is modelled on the mobile live Maestro flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VjxFSKQpryWiyPYYPZujQ