### PR TITLE
fix(security): close IDOR, mass-assignment, settlement forgery, invite TOCTOU; harden token storage; shrink admin bundle

### DIFF
--- a/apps/admin/src/components/charts/AreaTrend.tsx
+++ b/apps/admin/src/components/charts/AreaTrend.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import type { EChartsOption } from 'echarts';
-import ReactECharts from 'echarts-for-react';
 import { useState } from 'react';
 
+import { ReactEChartsCore } from './echarts-core';
 import { PALETTE } from './palette';
 
 export interface TrendDay {
@@ -96,7 +96,12 @@ export function AreaTrend({ days }: { days: TrendDay[] }) {
         </div>
       </div>
       <div className="echart">
-        <ReactECharts option={option} style={{ height: 240 }} opts={{ renderer: 'svg' }} notMerge />
+        <ReactEChartsCore
+          option={option}
+          style={{ height: 240 }}
+          opts={{ renderer: 'svg' }}
+          notMerge
+        />
       </div>
     </>
   );

--- a/apps/admin/src/components/charts/DonutChart.tsx
+++ b/apps/admin/src/components/charts/DonutChart.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import type { EChartsOption } from 'echarts';
-import ReactECharts from 'echarts-for-react';
 
+import { ReactEChartsCore } from './echarts-core';
 import { WHEEL } from './palette';
 
 export interface Slice {
@@ -76,6 +76,6 @@ export function DonutChart({
   };
 
   return (
-    <ReactECharts option={option} style={{ height: 260 }} opts={{ renderer: 'svg' }} notMerge />
+    <ReactEChartsCore option={option} style={{ height: 260 }} opts={{ renderer: 'svg' }} notMerge />
   );
 }

--- a/apps/admin/src/components/charts/echarts-core.ts
+++ b/apps/admin/src/components/charts/echarts-core.ts
@@ -1,0 +1,18 @@
+'use client';
+
+/**
+ * Tree-shaken ECharts entry. Importing `echarts-for-react` (or `echarts`)
+ * whole pulls the entire chart/renderer set — ~600-800 KB — when the admin only
+ * ever draws a pie and a line, both as SVG. Registering just those keeps the
+ * bundle to what is actually painted. Every chart component imports its renderer
+ * from here, never from `echarts-for-react` directly.
+ */
+import { use } from 'echarts/core';
+import { PieChart, LineChart } from 'echarts/charts';
+import { TooltipComponent, LegendComponent, GridComponent } from 'echarts/components';
+import { SVGRenderer } from 'echarts/renderers';
+import ReactEChartsCore from 'echarts-for-react/lib/core';
+
+use([PieChart, LineChart, TooltipComponent, LegendComponent, GridComponent, SVGRenderer]);
+
+export { ReactEChartsCore };

--- a/apps/mobile/src/lib/secureStorage.ts
+++ b/apps/mobile/src/lib/secureStorage.ts
@@ -1,0 +1,78 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
+
+/**
+ * A Supabase auth-storage adapter that keeps the session — access **and**
+ * refresh token — in the OS keystore (Keychain / Keystore) via expo-secure-store
+ * instead of AsyncStorage, which is plaintext app-private storage recoverable on
+ * a rooted device or from a backup. The refresh token is the crown jewel: it
+ * mints access tokens indefinitely, so it must not sit in the clear.
+ *
+ * SecureStore rejects values past ~2KB on Android and the session JSON (a JWT
+ * plus a refresh token) is bigger, so values are split into chunks. A stored
+ * `<key>.pn` holds the chunk count; `<key>.p0..pn-1` hold the pieces.
+ *
+ * Web has no SecureStore; there it falls back to AsyncStorage (the previous,
+ * unchanged behaviour) — the web session model is localStorage-based anyway.
+ */
+
+const CHUNK = 1800;
+const countKey = (key: string) => `${key}.pn`;
+const partKey = (key: string, i: number) => `${key}.p${i}`;
+
+const isWeb = Platform.OS === 'web';
+
+async function getItem(key: string): Promise<string | null> {
+  if (isWeb) return AsyncStorage.getItem(key);
+
+  const countRaw = await SecureStore.getItemAsync(countKey(key));
+  if (countRaw === null) {
+    // One-time migration: a session written by the old AsyncStorage adapter is
+    // adopted into SecureStore on first read, so upgrading does not sign anyone
+    // out. Removed from AsyncStorage once it is safely in the keystore.
+    const legacy = await AsyncStorage.getItem(key);
+    if (legacy !== null) {
+      await setItem(key, legacy);
+      await AsyncStorage.removeItem(key);
+    }
+    return legacy;
+  }
+
+  const count = Number(countRaw);
+  if (!Number.isInteger(count) || count < 1) return null;
+  const parts: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const part = await SecureStore.getItemAsync(partKey(key, i));
+    if (part === null) return null; // a torn write is no session, not half of one
+    parts.push(part);
+  }
+  return parts.join('');
+}
+
+async function setItem(key: string, value: string): Promise<void> {
+  if (isWeb) return AsyncStorage.setItem(key, value);
+
+  const prev = Number(await SecureStore.getItemAsync(countKey(key))) || 0;
+  const count = Math.max(1, Math.ceil(value.length / CHUNK));
+  await SecureStore.setItemAsync(countKey(key), String(count));
+  for (let i = 0; i < count; i++) {
+    await SecureStore.setItemAsync(partKey(key, i), value.slice(i * CHUNK, (i + 1) * CHUNK));
+  }
+  // A shorter new value leaves orphan chunks from the old one; clear them.
+  for (let i = count; i < prev; i++) {
+    await SecureStore.deleteItemAsync(partKey(key, i));
+  }
+}
+
+async function removeItem(key: string): Promise<void> {
+  if (isWeb) return AsyncStorage.removeItem(key);
+
+  const count = Number(await SecureStore.getItemAsync(countKey(key))) || 0;
+  for (let i = 0; i < count; i++) {
+    await SecureStore.deleteItemAsync(partKey(key, i));
+  }
+  await SecureStore.deleteItemAsync(countKey(key));
+}
+
+export const secureAuthStorage = { getItem, setItem, removeItem };

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -1,8 +1,9 @@
 import 'react-native-url-polyfill/auto';
 
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
 import { AppState, Platform } from 'react-native';
+
+import { secureAuthStorage } from './secureStorage';
 
 const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const anonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
@@ -26,7 +27,9 @@ const isServer = typeof window === 'undefined';
 
 export const supabase = createClient(url, anonKey, {
   auth: {
-    storage: isServer ? undefined : AsyncStorage,
+    // Native keeps the session (incl. the long-lived refresh token) in the OS
+    // keystore, not plaintext AsyncStorage; web falls back inside the adapter.
+    storage: isServer ? undefined : secureAuthStorage,
     autoRefreshToken: !isServer,
     persistSession: !isServer,
     // No URL-based session handoff on native; deep links are handled explicitly.

--- a/packages/db/prisma/migrations/20260814120000_settlement_initiator_is_a_party/migration.sql
+++ b/packages/db/prisma/migrations/20260814120000_settlement_initiator_is_a_party/migration.sql
@@ -1,0 +1,105 @@
+-- A settlement's initiator must be one of its two parties.
+--
+-- `baaki_record_settlement` checked `is_group_member()` — "may you touch this
+-- group" — but never "are you in this payment". Any member could record a
+-- settlement between two *other* members. It lands `initiated`, so balances do
+-- not move immediately; but `baaki_auto_confirm_settlements` flips any
+-- `initiated` row older than 7 days to `auto_confirmed`, which does move them.
+-- So an insider could fabricate a payment between two other people, and if the
+-- payee never noticed the notification within the week, a real debt was
+-- silently zeroed by the cron job.
+--
+-- Confirmation being social is by design (ADR-007); the *initiator* being
+-- unrelated to the payment is not. Every legitimate client flow already has the
+-- caller as a party — `settle.tsx` sends `from = me` when I pay and `to = me`
+-- when they pay me — so requiring the caller's member id to be one of the two
+-- parties rejects only the forged case.
+--
+-- Signature is unchanged, so CREATE OR REPLACE alone; no DROP, no grant change.
+-- The body below is the deployed function with one guard added after the
+-- membership check; everything else (mutation-id replay, currency fallback,
+-- allocations, activity entry) is untouched.
+
+CREATE OR REPLACE FUNCTION public.baaki_record_settlement(
+  p_group_id           uuid,
+  p_from_member_id     uuid,
+  p_to_member_id       uuid,
+  p_amount             bigint,
+  p_method             text,
+  p_currency           char(3) DEFAULT NULL,
+  p_note               text DEFAULT NULL,
+  p_allocations        jsonb DEFAULT '[]'::jsonb,
+  p_client_mutation_id uuid DEFAULT NULL,
+  p_rail               text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_settlement_id uuid;
+  v_currency      char(3);
+  v_actor         uuid;
+  v_allocation    jsonb;
+  v_rail          text := COALESCE(NULLIF(btrim(p_rail), ''), p_method);
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in this group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Resolve the caller's own member id up front: it is both the authorization
+  -- check below and the actor on the activity entry further down.
+  v_actor := public.baaki_my_member_id(p_group_id);
+  IF v_actor IS NULL OR v_actor NOT IN (p_from_member_id, p_to_member_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: you can only record a settlement you are part of'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: settle a positive amount' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying the same mutation must not create a second settlement (ADR-005).
+  IF p_client_mutation_id IS NOT NULL THEN
+    SELECT id INTO v_settlement_id
+    FROM public.settlements WHERE client_mutation_id = p_client_mutation_id;
+    IF v_settlement_id IS NOT NULL THEN
+      RETURN v_settlement_id;
+    END IF;
+  END IF;
+
+  SELECT COALESCE(p_currency, default_currency) INTO v_currency
+  FROM public.groups WHERE id = p_group_id;
+
+  INSERT INTO public.settlements
+    (group_id, from_member_id, to_member_id, currency, amount, method, rail, status, note,
+     client_mutation_id)
+  VALUES
+    (p_group_id, p_from_member_id, p_to_member_id, upper(v_currency), p_amount,
+     CASE WHEN p_method IN ('upi', 'cash', 'bank', 'other') THEN p_method ELSE 'other' END
+       ::"SettlementMethod",
+     v_rail, 'initiated', p_note, p_client_mutation_id)
+  RETURNING id INTO v_settlement_id;
+
+  FOR v_allocation IN SELECT * FROM jsonb_array_elements(COALESCE(p_allocations, '[]'::jsonb))
+  LOOP
+    INSERT INTO public.settlement_allocations (settlement_id, expense_id, amount)
+    VALUES (
+      v_settlement_id,
+      (v_allocation ->> 'expenseId')::uuid,
+      (v_allocation ->> 'amount')::bigint
+    )
+    ON CONFLICT (settlement_id, expense_id)
+    DO UPDATE SET amount = public.settlement_allocations.amount + EXCLUDED.amount;
+  END LOOP;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (p_group_id, v_actor, 'settled', 'settlement', v_settlement_id,
+          jsonb_build_object('amount', p_amount, 'currency', v_currency,
+                             'method', p_method, 'rail', v_rail));
+
+  RETURN v_settlement_id;
+END
+$$;

--- a/packages/db/prisma/migrations/20260814120500_atomic_invite_consume/migration.sql
+++ b/packages/db/prisma/migrations/20260814120500_atomic_invite_consume/migration.sql
@@ -1,0 +1,35 @@
+-- Consuming an invite must be atomic, or `max_uses` is a suggestion.
+--
+-- invite-accept read `use_count`, checked it against `max_uses`, and much later
+-- wrote `use_count + 1`. Two redemptions of the same still-valid link race
+-- through that gap: both read the same count, both pass the check, both insert a
+-- membership, both write count+1. A link capped at one use admits two (or ten),
+-- so a leaked/shared link is redeemable well past its cap.
+--
+-- The fix is a single conditional UPDATE that Postgres executes atomically: the
+-- row is locked for the increment, and `WHERE use_count < max_uses` is evaluated
+-- against the locked row, so exactly one concurrent caller can win the last
+-- slot. It also re-checks revocation and expiry, closing the same race on those.
+-- Returns true when a slot was taken, false when the link is spent/invalid —
+-- the caller treats false exactly like the read-time invalid case.
+--
+-- service_role only: invite-accept calls it with the service client (the invite
+-- row is not visible to the joining user), and no client should reach it.
+
+CREATE OR REPLACE FUNCTION public.baaki_consume_invite(p_invite_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  UPDATE public.invites
+  SET use_count = use_count + 1
+  WHERE id = p_invite_id
+    AND revoked_at IS NULL
+    AND expires_at > now()
+    AND use_count < max_uses
+  RETURNING true;
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_consume_invite(uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_consume_invite(uuid) TO service_role;

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -36,6 +36,19 @@ export class HttpError extends Error {
   }
 }
 
+/**
+ * Parse a minor-unit money string to BigInt, or fail with a 400 — never a 500.
+ * A bare `BigInt(value)` on a malformed field throws a SyntaxError that escapes
+ * as a generic 500 INTERNAL, which `/sync` then treats as retryable and replays.
+ * Bad client input is a client error and must be reported as one.
+ */
+export function parseMinor(value: unknown, field: string): bigint {
+  if (typeof value !== 'string' || !/^-?\d+$/.test(value)) {
+    throw new HttpError(400, 'INVALID_AMOUNT', `${field} must be an integer in minor units`);
+  }
+  return BigInt(value);
+}
+
 export function json(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
     status,

--- a/supabase/functions/expense-write/index.ts
+++ b/supabase/functions/expense-write/index.ts
@@ -25,6 +25,7 @@ import {
   errorResponse,
   HttpError,
   json,
+  parseMinor,
   requireMembership,
 } from '../_shared/auth.ts';
 import { enforceRateLimit } from '../_shared/rateLimit.ts';
@@ -88,11 +89,11 @@ Deno.serve(async (request) => {
       });
     }
 
-    const amount = BigInt(body.amount);
+    const amount = parseMinor(body.amount, 'amount');
     if (amount < 0n) throw new HttpError(400, 'INVALID_AMOUNT', 'Amount cannot be negative');
 
     const payers = Object.entries(body.payers ?? {}).map(
-      ([id, value]) => [id, BigInt(value)] as const,
+      ([id, value]) => [id, parseMinor(value, 'payer amount')] as const,
     );
     const paid = payers.reduce((total, [, value]) => total + value, 0n);
     if (paid !== amount) {

--- a/supabase/functions/export-data/index.ts
+++ b/supabase/functions/export-data/index.ts
@@ -140,7 +140,13 @@ Deno.serve(async (request) => {
 
     const separator = body.csvSeparator ?? ',';
     const escape = (value: unknown): string => {
-      const text = value === null || value === undefined ? '' : String(value);
+      let text = value === null || value === undefined ? '' : String(value);
+      // Formula injection: a cell an app opens as a spreadsheet treats a leading
+      // =, +, -, @ (or tab/CR) as a formula, so `=HYPERLINK(...)` in an expense
+      // description would run on open. Descriptions and names are user-typed and
+      // land here verbatim. Neutralise by prefixing a single quote, then quote
+      // as usual.
+      if (/^[=+\-@\t\r]/.test(text)) text = `'${text}`;
       return /["\n]|,|;/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
     };
 

--- a/supabase/functions/invite-accept/index.ts
+++ b/supabase/functions/invite-accept/index.ts
@@ -136,6 +136,19 @@ Deno.serve(async (request) => {
       }
     }
 
+    // Reserve a use atomically before creating anything. A plain read-then-write
+    // let two redemptions of the same link race past `max_uses`; this conditional
+    // increment lets exactly one of them win the last slot (and re-checks
+    // revocation/expiry under the row lock). Placed after the already-a-member
+    // and guest-ceiling short-circuits so those never burn a use.
+    const { data: consumed, error: consumeError } = await service.rpc('baaki_consume_invite', {
+      p_invite_id: invite.id,
+    });
+    if (consumeError) throw new HttpError(500, 'INTERNAL', consumeError.message);
+    if (consumed !== true) {
+      throw new HttpError(404, 'INVITE_INVALID', 'This invite link is no longer valid');
+    }
+
     let memberId: string;
 
     if (body.claimMemberId) {
@@ -187,11 +200,6 @@ Deno.serve(async (request) => {
       if (insertError) throw new HttpError(500, 'INTERNAL', insertError.message);
       memberId = inserted.id;
     }
-
-    await service
-      .from('invites')
-      .update({ use_count: invite.use_count + 1 })
-      .eq('id', invite.id);
 
     await service.from('activity_log').insert({
       group_id: invite.group_id,

--- a/supabase/functions/receipt-parse/index.ts
+++ b/supabase/functions/receipt-parse/index.ts
@@ -185,6 +185,13 @@ Deno.serve(async (request) => {
 
     const content: unknown[] = [];
     if (body.storagePath) {
+      // IDOR guard: the download runs with the service role, which bypasses
+      // bucket RLS. `groupId` was checked by requireMembership above; the client
+      // uploads to `${groupId}/${receiptId}.ext`, so require that prefix or a
+      // caller could read another group's receipt by passing its object path.
+      if (!body.storagePath.startsWith(`${body.groupId}/`)) {
+        throw new HttpError(403, 'FORBIDDEN', 'That image does not belong to this group');
+      }
       // Downloaded with the service role and sent as base64: the model never
       // gets a URL into our storage, signed or otherwise.
       const { data: file, error: downloadError } = await service.storage
@@ -296,7 +303,7 @@ Deno.serve(async (request) => {
       status,
       parsed,
       check,
-      quota: { used: used + 1, limit: MONTHLY_SCAN_LIMIT },
+      quota: { used: used + 1, limit },
     });
   } catch (error) {
     return errorResponse(error, { fn: 'receipt-parse' });

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -40,6 +40,7 @@ import {
   errorResponse,
   HttpError,
   json,
+  parseMinor,
 } from '../_shared/auth.ts';
 import { enforceRateLimit } from '../_shared/rateLimit.ts';
 
@@ -60,6 +61,31 @@ interface MutationEnvelope {
   groupId: string;
   clientCreatedAt: string;
   payload: Record<string, unknown>;
+}
+
+/** Columns a member is allowed to set via `group.update` (mirrors client `updateGroup`). */
+const GROUP_UPDATABLE_FIELDS = [
+  'name',
+  'cover_emoji',
+  'photo_path',
+  'simplify_debts',
+  'default_currency',
+  'country_code',
+  'archived_at',
+  'start_date',
+  'end_date',
+  'time_zone',
+  'remind_daily',
+  'remind_morning_at',
+  'remind_evening_at',
+] as const;
+
+function pick(source: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) out[key] = source[key];
+  }
+  return out;
 }
 
 interface SyncRequest {
@@ -314,10 +340,16 @@ class SyncSession {
         });
       case 'group.update': {
         await this.requireMemberId(mutation.groupId);
-        const { error } = await this.caller
-          .from('groups')
-          .update(mutation.payload)
-          .eq('id', mutation.groupId);
+        // Whitelist the columns a member may set. RLS scopes the row, not the
+        // columns, and PostgREST grants UPDATE on every column of `groups` to
+        // `authenticated` — so spreading the raw payload let a member write any
+        // column (e.g. poison `updated_seq` and break every member's sync).
+        // These are exactly the fields `updateGroup` in the client sends.
+        const patch = pick(mutation.payload, GROUP_UPDATABLE_FIELDS);
+        if (Object.keys(patch).length === 0) {
+          throw new HttpError(400, 'VALIDATION_FAILED', 'No updatable fields in payload');
+        }
+        const { error } = await this.caller.from('groups').update(patch).eq('id', mutation.groupId);
         if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
         return { groupId: mutation.groupId };
       }
@@ -355,11 +387,11 @@ class SyncSession {
       baseVersionNo?: number;
     };
 
-    const amount = BigInt(payload.amount);
+    const amount = parseMinor(payload.amount, 'amount');
     if (amount < 0n) throw new HttpError(400, 'INVALID_AMOUNT', 'Amount cannot be negative');
 
     const payers = Object.entries(payload.payers ?? {}).map(
-      ([id, value]) => [id, BigInt(value)] as const,
+      ([id, value]) => [id, parseMinor(value, 'payer amount')] as const,
     );
     const paid = payers.reduce((total, [, value]) => total + value, 0n);
     if (paid !== amount) {


### PR DESCRIPTION
Senior-dev pass off four parallel audits (edge functions, client apps, DB/RLS, bundle size). Fixes ranked below by severity.

## Security

**High**
- **receipt-parse IDOR** — `storagePath` reached a service-role download (which bypasses bucket RLS) with no ownership check; any member could read another group's receipt. Now required to sit under the caller's already-verified `${groupId}/` prefix. Also fixed a live `ReferenceError` (`MONTHLY_SCAN_LIMIT` → `limit`) that 500'd every *successful* scan after the quota was already spent.
- **sync `group.update` mass-assignment** — raw client `payload` was spread into `.update()`. RLS scopes rows, not columns, so a member could write any `groups` column (e.g. poison `updated_seq` and break everyone's sync). Now whitelisted to the 13 columns the client legitimately sends.

**Medium**
- **Settlement forgery** (migration `..._settlement_initiator_is_a_party`) — `baaki_record_settlement` checked group membership but not that the caller was a party. Any member could record a payment between two *others*; the 7-day auto-confirm cron would then settle it, zeroing a real debt. Now requires caller ∈ {from, to}.
- **Invite `max_uses` TOCTOU** (migration `..._atomic_invite_consume` + edge) — read-then-write let concurrent redemptions of a shared link race past the cap. New atomic conditional-increment RPC `baaki_consume_invite`; the slot is reserved before membership is created.
- **CSV formula injection** (export-data) — cells leading `= + - @` / tab / CR are neutralized.
- **Mobile refresh token** — session moved from plaintext AsyncStorage to the OS keystore via a chunked `expo-secure-store` adapter, with a one-time migration so existing users aren't logged out. Web unchanged.

**Low**
- `parseMinor()` guard in expense-write + sync — malformed amounts now 400, not a 500 (which `/sync` treated as retryable).

## Size
- Admin echarts: full build → tree-shaken core (Pie + Line + SVG only), ~300 KB gzip off the client bundle.

## Verification
- Typecheck clean across all 7 workspaces.
- Tests green: core (517) + api-client (12) + db (436) = 965.
- All migrations — including the two new ones — apply cleanly to a fresh Postgres 17.

## Not included (need a decision, not code)
- invite-mint lets any member mint links — product call.
- Forged `initiated` settlements *already in prod* will still auto-confirm — data remediation, out of scope here.
- Low/by-design: non-constant-time service-role bearer compare; co-member `profiles` SELECT exposes `notification_prefs`; `ALTER DEFAULT PRIVILEGES` fail-open posture (mitigated by the CI RLS-invariant test).

## Deploy notes
Requires, in order: `pnpm db:migrate` (2 migrations), edge deploy (receipt-parse, sync, invite-accept, export-data, expense-write, _shared), then mobile + admin builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)