### PR TITLE
refactor: string-literal unions → TS string enums

### DIFF
--- a/apps/admin/src/components/charts/AreaTrend.tsx
+++ b/apps/admin/src/components/charts/AreaTrend.tsx
@@ -13,15 +13,19 @@ export interface TrendDay {
   active: number;
 }
 
-type Metric = 'newProfiles' | 'newExpenses' | 'active';
+enum Metric {
+  NewProfiles = 'newProfiles',
+  NewExpenses = 'newExpenses',
+  Active = 'active',
+}
 
 const SERIES: Record<Metric, { label: string; color: string }> = {
-  newProfiles: { label: 'New people', color: PALETTE.purple },
-  newExpenses: { label: 'Expenses', color: PALETTE.blue },
-  active: { label: 'Active', color: PALETTE.green },
+  [Metric.NewProfiles]: { label: 'New people', color: PALETTE.purple },
+  [Metric.NewExpenses]: { label: 'Expenses', color: PALETTE.blue },
+  [Metric.Active]: { label: 'Active', color: PALETTE.green },
 };
 
-const ORDER: Metric[] = ['newProfiles', 'newExpenses', 'active'];
+const ORDER: Metric[] = [Metric.NewProfiles, Metric.NewExpenses, Metric.Active];
 
 /**
  * One smooth area over the 30-day series, with a segmented switch to change
@@ -30,7 +34,7 @@ const ORDER: Metric[] = ['newProfiles', 'newExpenses', 'active'];
  * the same side of the server/client line.
  */
 export function AreaTrend({ days }: { days: TrendDay[] }) {
-  const [metric, setMetric] = useState<Metric>('newProfiles');
+  const [metric, setMetric] = useState<Metric>(Metric.NewProfiles);
   const active = SERIES[metric];
 
   const option: EChartsOption = {

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -27,7 +27,7 @@ import { useGuestGuard } from '@/lib/guestGuard';
 import { SyncBanner } from '@/components/SyncBanner';
 import { SkeletonList } from '@/components/Skeletons';
 import { GroupCard } from '@/components/GroupCard';
-import { groupLabel, type GroupType } from '@/data/types';
+import { groupLabel, GroupType } from '@/data/types';
 import { usePullRefresh } from '@/lib/pullRefresh';
 
 export default function HomeScreen() {
@@ -85,7 +85,7 @@ export default function HomeScreen() {
   // trip's own timezone, not the phone's — a Goa trip run from Dubai turns over
   // at midnight in Goa (the same rule `dayNumber` and the planner already use).
   const activeTrips: readonly TripSlide[] = list
-    .filter((g) => g.type === 'trip' && g.start_date && g.end_date)
+    .filter((g) => g.type === GroupType.Trip && g.start_date && g.end_date)
     .map((g) => {
       const day = dayNumber(todayIn(g.time_zone), g.start_date, g.end_date);
       if (day === null) return null;
@@ -228,29 +228,35 @@ export default function HomeScreen() {
 }
 
 /** The group types in the order chips appear — matches the new-group picker. */
-const GROUP_TYPE_ORDER: readonly GroupType[] = ['trip', 'home', 'couple', 'event', 'other'];
+const GROUP_TYPE_ORDER: readonly GroupType[] = [
+  GroupType.Trip,
+  GroupType.Home,
+  GroupType.Couple,
+  GroupType.Event,
+  GroupType.Other,
+];
 
 /** One Ionicon per group type, echoing the emoji the new-group picker uses. */
 const CATEGORY_ICON: Record<GroupType, keyof typeof Ionicons.glyphMap> = {
-  trip: 'airplane',
-  home: 'home',
-  couple: 'heart',
-  event: 'sparkles',
-  other: 'people',
+  [GroupType.Trip]: 'airplane',
+  [GroupType.Home]: 'home',
+  [GroupType.Couple]: 'heart',
+  [GroupType.Event]: 'sparkles',
+  [GroupType.Other]: 'people',
 };
 
 /** The localized label for a group type, from the same strings the picker uses. */
 function categoryLabel(type: GroupType, t: UiStrings): string {
   switch (type) {
-    case 'trip':
+    case GroupType.Trip:
       return t.extras.typeTrip;
-    case 'home':
+    case GroupType.Home:
       return t.extras.typeHome;
-    case 'couple':
+    case GroupType.Couple:
       return t.extras.typeCouple;
-    case 'event':
+    case GroupType.Event:
       return t.extras.typeEvent;
-    case 'other':
+    case GroupType.Other:
       return t.extras.typeOther;
   }
 }

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -163,7 +163,11 @@ function settingsRows(t: UiStrings): SettingsRow[] {
 }
 
 /** The three faces of this screen. */
-type Face = 'you' | 'paying' | 'settings';
+enum Face {
+  You = 'you',
+  Paying = 'paying',
+  Settings = 'settings',
+}
 
 /**
  * One Save, shown on whichever face you are looking at.
@@ -290,7 +294,7 @@ export default function ProfileScreen() {
   const [handle, setHandle] = useState(profile?.payment_handle ?? profile?.default_vpa ?? '');
   const [status, setStatus] = useState<string | null>(null);
   const [photoBusy, setPhotoBusy] = useState(false);
-  const [face, setFace] = useState<Face>('you');
+  const [face, setFace] = useState<Face>(Face.You);
 
   /**
    * Pick, shrink, upload, then tell the profile where it landed. The upload
@@ -463,13 +467,13 @@ export default function ProfileScreen() {
           tabs={[
             // Not `t.profile` — that reads "Account", which is the whole
             // screen. A tab has to name the part, not the page.
-            { value: 'you', label: t.account.faceYou },
-            { value: 'paying', label: t.account.facePaying },
-            { value: 'settings', label: t.account.faceSettings },
+            { value: Face.You, label: t.account.faceYou },
+            { value: Face.Paying, label: t.account.facePaying },
+            { value: Face.Settings, label: t.account.faceSettings },
           ]}
         />
 
-        {face === 'you' ? (
+        {face === Face.You ? (
           <>
             <Card style={{ gap: theme.spacing.lg }}>
               <View style={{ gap: theme.spacing.xs }}>
@@ -522,7 +526,7 @@ export default function ProfileScreen() {
           </>
         ) : null}
 
-        {face === 'paying' ? (
+        {face === Face.Paying ? (
           <>
             {/* The country decides which rails exist below, so it sits above
                 them and is changeable here — the device guess is only a start. */}
@@ -585,7 +589,7 @@ export default function ProfileScreen() {
           </>
         ) : null}
 
-        {face !== 'settings' ? null : (
+        {face !== Face.Settings ? null : (
           <>
             {/* Its own section, above the settings rather than among them.
                 Paying for something is not a preference, and a row that sells

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -7,6 +7,7 @@ import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react
 import {
   computeShares,
   guessCategory,
+  MutationKind,
   type CategoryId,
   type FxRecord,
   type MemberId,
@@ -46,8 +47,8 @@ import {
   formatEntry,
   parseEntry,
   splitProblem,
+  SplitKind,
   type SplitEntries,
-  type SplitKind,
 } from '@/lib/split';
 import { clearDraft, syncEngine, useDraft, useRestoredDraft, useSync } from '@/sync';
 
@@ -102,7 +103,7 @@ export default function AddExpenseScreen() {
 
   const [amount, setAmount] = useState<bigint>(0n);
   const [description, setDescription] = useState('');
-  const [splitKind, setSplitKind] = useState<SplitKind>('equal');
+  const [splitKind, setSplitKind] = useState<SplitKind>(SplitKind.Equal);
   const [payer, setPayer] = useState<MemberId | null>(null);
   const [participants, setParticipants] = useState<MemberId[]>([]);
   // What was typed into each member's field, as text. Two maps, not one: the
@@ -175,10 +176,10 @@ export default function AddExpenseScreen() {
       setParticipants(version.shares.map((share) => share.member_id));
       setSplitKind(
         version.split_type === 'percent'
-          ? 'percent'
+          ? SplitKind.Percent
           : version.split_type === 'shares'
-            ? 'shares'
-            : 'equal',
+            ? SplitKind.Shares
+            : SplitKind.Equal,
       );
       // The numbers somebody chose the first time, back in the fields they were
       // typed into — an edit that silently re-divided them equally would be a
@@ -207,18 +208,18 @@ export default function AddExpenseScreen() {
   // Everybody in a weighted split needs a number to start from, and the set
   // changes as people are ticked on and off. `fillEntries` returns null once
   // there is nothing left to fill, which is what stops this looping.
-  if (splitKind === 'shares') {
+  if (splitKind === SplitKind.Shares) {
     const filled = fillEntries('shares', weights, participants);
     if (filled) setWeights(filled);
-  } else if (splitKind === 'percent') {
+  } else if (splitKind === SplitKind.Percent) {
     const filled = fillEntries('percent', percents, participants);
     if (filled) setPercents(filled);
   }
 
-  const entries = splitKind === 'shares' ? weights : percents;
+  const entries = splitKind === SplitKind.Shares ? weights : percents;
   const setEntry = (memberId: MemberId, text: string): void => {
     const update = (current: SplitEntries): SplitEntries => ({ ...current, [memberId]: text });
-    if (splitKind === 'shares') setWeights(update);
+    if (splitKind === SplitKind.Shares) setWeights(update);
     else setPercents(update);
   };
   const splitIssue = splitProblem(splitKind, entries, participants);
@@ -246,10 +247,10 @@ export default function AddExpenseScreen() {
   );
 
   const splitParams: SplitParams = useMemo(() => {
-    if (splitKind === 'shares') {
+    if (splitKind === SplitKind.Shares) {
       return { kind: 'shares', weights: entryValues('shares', weights, participants) };
     }
-    if (splitKind === 'percent') {
+    if (splitKind === SplitKind.Percent) {
       return { kind: 'percent', basisPoints: entryValues('percent', percents, participants) };
     }
     return { kind: 'equal' };
@@ -303,7 +304,7 @@ export default function AddExpenseScreen() {
     try {
       // Straight into the durable queue: this returns as soon as the mutation
       // is on disk, so the expense is saved whether or not there is a network.
-      await mutate(expenseId ? 'expense.update' : 'expense.create', groupId, {
+      await mutate(expenseId ? MutationKind.ExpenseUpdate : MutationKind.ExpenseCreate, groupId, {
         expenseId: targetExpenseId,
         // Blank stays blank. Writing the English word "Expense" here made every
         // undescribed row identical in the list, and put a word nobody typed
@@ -348,7 +349,7 @@ export default function AddExpenseScreen() {
   const lineAmount = (memberId: MemberId): bigint => {
     const previewed = preview?.get(memberId);
     if (previewed !== undefined) return previewed;
-    if (splitKind !== 'percent') return 0n;
+    if (splitKind !== SplitKind.Percent) return 0n;
     const basisPoints = parseEntry('percent', percents[memberId] ?? '') ?? 0;
     return (amount * BigInt(basisPoints)) / 10000n;
   };
@@ -560,9 +561,9 @@ export default function AddExpenseScreen() {
             value={splitKind}
             onChange={setSplitKind}
             options={[
-              { value: 'equal', label: t.expense.equally },
-              { value: 'shares', label: t.expense.shares },
-              { value: 'percent', label: t.expense.percent },
+              { value: SplitKind.Equal, label: t.expense.equally },
+              { value: SplitKind.Shares, label: t.expense.shares },
+              { value: SplitKind.Percent, label: t.expense.percent },
             ]}
           />
         </View>
@@ -645,17 +646,17 @@ export default function AddExpenseScreen() {
                   </View>
                 </Pressable>
 
-                {splitKind !== 'equal' && selected ? (
+                {splitKind !== SplitKind.Equal && selected ? (
                   <Row style={{ gap: 2, alignItems: 'center', flexGrow: 0, flexShrink: 0 }}>
                     <TextInput
                       value={entries[member.id] ?? ''}
                       onChangeText={(text) => setEntry(member.id, text)}
-                      keyboardType={splitKind === 'percent' ? 'decimal-pad' : 'number-pad'}
+                      keyboardType={splitKind === SplitKind.Percent ? 'decimal-pad' : 'number-pad'}
                       selectTextOnFocus
-                      placeholder={splitKind === 'percent' ? '0' : '1'}
+                      placeholder={splitKind === SplitKind.Percent ? '0' : '1'}
                       placeholderTextColor={theme.color.textFaint}
                       accessibilityLabel={
-                        splitKind === 'percent' ? `${name}'s percentage` : `${name}'s shares`
+                        splitKind === SplitKind.Percent ? `${name}'s percentage` : `${name}'s shares`
                       }
                       style={{
                         width: 72,
@@ -670,7 +671,7 @@ export default function AddExpenseScreen() {
                       }}
                     />
                     <Text variant="micro" tone="muted">
-                      {splitKind === 'percent' ? '%' : '×'}
+                      {splitKind === SplitKind.Percent ? '%' : '×'}
                     </Text>
                   </Row>
                 ) : null}

--- a/apps/mobile/src/app/group/[id]/import/csv.tsx
+++ b/apps/mobile/src/app/group/[id]/import/csv.tsx
@@ -38,7 +38,12 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { importSplitwiseCsv, type MemberId, type SplitwiseImport } from '@baaki/core';
+import {
+  importSplitwiseCsv,
+  MutationKind,
+  type MemberId,
+  type SplitwiseImport,
+} from '@baaki/core';
 
 import { useGroup } from '@/data/hooks';
 import { planFromCsv, toMutationPayload, UnmappedPersonError } from '@/data/importPlan';
@@ -131,7 +136,7 @@ export default function ImportCsvScreen() {
         const choice = mapping[person];
         if (choice === NEW_PERSON) {
           const memberId = randomUUID();
-          await mutate('member.add_ghost', groupId, { name: person, memberId });
+          await mutate(MutationKind.MemberAddGhost, groupId, { name: person, memberId });
           resolved[person] = memberId;
         } else if (choice) {
           resolved[person] = choice;
@@ -143,7 +148,7 @@ export default function ImportCsvScreen() {
         const expenseId = await importMutationId(groupId, `expense:${plan.seed}`);
         const clientMutationId = await importMutationId(groupId, plan.seed);
         await mutate(
-          'expense.create',
+          MutationKind.ExpenseCreate,
           groupId,
           toMutationPayload(plan, { expenseId }),
           clientMutationId,

--- a/apps/mobile/src/app/group/[id]/import/sms.tsx
+++ b/apps/mobile/src/app/group/[id]/import/sms.tsx
@@ -42,7 +42,13 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { proposeFromSms, type ExpenseCandidate, type MemberId, type SmsMessage } from '@baaki/core';
+import {
+  MutationKind,
+  proposeFromSms,
+  type ExpenseCandidate,
+  type MemberId,
+  type SmsMessage,
+} from '@baaki/core';
 
 import { useGroup, useGroupLedger } from '@/data/hooks';
 import { planFromSms, toMutationPayload } from '@/data/importPlan';
@@ -50,7 +56,7 @@ import { smsWindowFor } from '@/data/smsWindow';
 import { displayName } from '@/data/types';
 import { plural, useStrings } from '@/i18n';
 import { useFlagEnabled } from '@/lib/flags';
-import { readSms, type SmsReadFailure } from '@/lib/smsReader';
+import { readSms, SmsReadFailure } from '@/lib/smsReader';
 import { useAuth } from '@/lib/auth';
 import { importMutationId } from '@/lib/importId';
 import { useImported } from '@/lib/imported';
@@ -179,7 +185,7 @@ export default function ImportSmsScreen() {
         const expenseId = await importMutationId(groupId, `expense:${plan.seed}`);
         const clientMutationId = await importMutationId(groupId, plan.seed);
         await mutate(
-          'expense.create',
+          MutationKind.ExpenseCreate,
           groupId,
           toMutationPayload(plan, { expenseId }),
           clientMutationId,
@@ -487,15 +493,15 @@ const daysAgo = (days: number): string =>
 /** Why the inbox could not be read, said in a way a person can act on. */
 function readFailureMessage(reason: SmsReadFailure, t: ReturnType<typeof useStrings>['t']): string {
   switch (reason) {
-    case 'denied':
+    case SmsReadFailure.Denied:
       return t.smsImport.permissionDenied;
-    case 'blocked':
+    case SmsReadFailure.Blocked:
       return t.smsImport.permissionBlocked;
-    case 'unsupported':
+    case SmsReadFailure.Unsupported:
       return t.smsImport.readUnsupported;
-    case 'unavailable':
+    case SmsReadFailure.Unavailable:
       return t.smsImport.readUnavailable;
-    case 'failed':
+    case SmsReadFailure.Failed:
       return t.smsImport.readFailed;
   }
 }

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -47,7 +47,11 @@ import { PendingMark } from '@/components/PendingMark';
 import { SyncBanner } from '@/components/SyncBanner';
 import { usePullRefresh } from '@/lib/pullRefresh';
 
-type Tab = 'expenses' | 'balances' | 'activity';
+enum Tab {
+  Expenses = 'expenses',
+  Balances = 'balances',
+  Activity = 'activity',
+}
 
 export default function GroupScreen() {
   const theme = useTheme();
@@ -56,7 +60,7 @@ export default function GroupScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
   const { profile } = useAuth();
-  const [tab, setTab] = useState<Tab>('expenses');
+  const [tab, setTab] = useState<Tab>(Tab.Expenses);
   const [showDeleted, setShowDeleted] = useState(false);
 
   // Live updates from the other devices in this group (TDR §1).
@@ -284,13 +288,13 @@ export default function GroupScreen() {
             value={tab}
             onChange={setTab}
             tabs={[
-              { value: 'expenses', label: t.expenses },
-              { value: 'balances', label: t.balances },
-              { value: 'activity', label: t.activity },
+              { value: Tab.Expenses, label: t.expenses },
+              { value: Tab.Balances, label: t.balances },
+              { value: Tab.Activity, label: t.activity },
             ]}
           />
 
-          {tab === 'expenses' && hasDeleted ? (
+          {tab === Tab.Expenses && hasDeleted ? (
             <Row style={{ justifyContent: 'flex-end', marginTop: -theme.spacing.md }}>
               <Text
                 variant="caption"
@@ -302,7 +306,7 @@ export default function GroupScreen() {
             </Row>
           ) : null}
 
-          {tab === 'expenses' ? (
+          {tab === Tab.Expenses ? (
             visibleExpenses.length === 0 ? (
               <EmptyState title={t.nothingYet} body={t.nothingYetBody} />
             ) : (
@@ -386,7 +390,7 @@ export default function GroupScreen() {
             )
           ) : null}
 
-          {tab === 'balances' ? (
+          {tab === Tab.Balances ? (
             <View style={{ gap: theme.spacing.md }}>
               {(members.data ?? []).map((member) => {
                 // Each member is a card in the money colour for its meaning: mint
@@ -441,7 +445,7 @@ export default function GroupScreen() {
             </View>
           ) : null}
 
-          {tab === 'activity' ? (
+          {tab === Tab.Activity ? (
             (activity.data ?? []).length === 0 ? (
               <EmptyState title={t.nothingYet} body={t.group.activityEmptyBody} />
             ) : (

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -50,7 +50,10 @@ import { useGroup, useGroupSpending } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
-type Scope = 'group' | 'mine';
+enum Scope {
+  Group = 'group',
+  Mine = 'mine',
+}
 
 /** How many months of columns fit on a phone without becoming a smear. */
 const MONTHS_SHOWN = 6;
@@ -65,7 +68,7 @@ export default function InsightsScreen() {
   const { group, members } = useGroup(groupId);
   const spending = useGroupSpending(groupId);
 
-  const [scope, setScope] = useState<Scope>('group');
+  const [scope, setScope] = useState<Scope>(Scope.Group);
 
   const myMemberId = useMemo(
     () => (members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ?? null,
@@ -78,7 +81,7 @@ export default function InsightsScreen() {
 
   const rows = useMemo(() => {
     const all = spending.data ?? [];
-    if (scope === 'mine') {
+    if (scope === Scope.Mine) {
       return myMemberId ? all.filter((row) => row.member_id === myMemberId) : [];
     }
     return all;
@@ -120,8 +123,8 @@ export default function InsightsScreen() {
           value={scope}
           onChange={setScope}
           options={[
-            { value: 'group', label: t.extras.theGroup },
-            { value: 'mine', label: t.extras.justMe },
+            { value: Scope.Group, label: t.extras.theGroup },
+            { value: Scope.Mine, label: t.extras.justMe },
           ]}
         />
 

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -4,7 +4,7 @@ import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
-import { currencyForCountry, guessGroupEmoji } from '@baaki/core';
+import { currencyForCountry, guessGroupEmoji, MutationKind } from '@baaki/core';
 import {
   Button,
   Callout,
@@ -29,7 +29,7 @@ import { uploadGroupPhoto } from '@/data/api';
 import { useCreateGroup } from '@/data/hooks';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { useSync } from '@/sync';
-import type { GroupType } from '@/data/types';
+import { GroupType } from '@/data/types';
 import { deviceCountry, useStrings } from '@/i18n';
 
 /**
@@ -39,11 +39,11 @@ import { deviceCountry, useStrings } from '@/i18n';
  * better fallback than one fixed emoji for everybody.
  */
 const EMOJI_FOR_TYPE: Record<GroupType, string> = {
-  trip: '✈️',
-  home: '🏠',
-  couple: '💜',
-  event: '🎉',
-  other: '👥',
+  [GroupType.Trip]: '✈️',
+  [GroupType.Home]: '🏠',
+  [GroupType.Couple]: '💜',
+  [GroupType.Event]: '🎉',
+  [GroupType.Other]: '👥',
 };
 
 const deviceZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Kolkata';
@@ -69,7 +69,7 @@ export default function NewGroupScreen() {
   const [name, setName] = useState('');
   const [photo, setPhoto] = useState<PickedImage | null>(null);
   const [uploading, setUploading] = useState(false);
-  const [type, setType] = useState<GroupType>('trip');
+  const [type, setType] = useState<GroupType>(GroupType.Trip);
   const [ghostName, setGhostName] = useState('');
   // People to add on Create — a typed name carries no address, a contact carries
   // whatever the phone had. Same shape either way, so the create loop treats
@@ -129,7 +129,7 @@ export default function NewGroupScreen() {
       // its membership check (NOT_A_MEMBER). Behind the create, each applies
       // after the group it belongs to exists.
       for (const ghost of ghosts) {
-        await mutate('member.add_ghost', groupId, {
+        await mutate(MutationKind.MemberAddGhost, groupId, {
           memberId: randomUUID(),
           name: ghost.name,
           email: ghost.email,
@@ -141,7 +141,7 @@ export default function NewGroupScreen() {
       // an update on the same ordered queue — only when a trip was actually
       // given a start and end, since that is what turns the reminders on.
       if (tripDates.start_date && tripDates.end_date) {
-        await mutate('group.update', groupId, {
+        await mutate(MutationKind.GroupUpdate, groupId, {
           start_date: tripDates.start_date,
           end_date: tripDates.end_date,
           time_zone: tripDates.time_zone,
@@ -278,11 +278,11 @@ export default function NewGroupScreen() {
             value={type}
             onChange={setType}
             options={[
-              { value: 'trip', label: t.extras.typeTrip },
-              { value: 'home', label: t.extras.typeHome },
-              { value: 'couple', label: t.extras.typeCouple },
-              { value: 'event', label: t.extras.typeEvent },
-              { value: 'other', label: t.extras.typeOther },
+              { value: GroupType.Trip, label: t.extras.typeTrip },
+              { value: GroupType.Home, label: t.extras.typeHome },
+              { value: GroupType.Couple, label: t.extras.typeCouple },
+              { value: GroupType.Event, label: t.extras.typeEvent },
+              { value: GroupType.Other, label: t.extras.typeOther },
             ]}
           />
         </View>

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -26,7 +26,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { confirmContact, startAddingContact, type ContactChannel } from '@/data/api';
+import { confirmContact, startAddingContact, ContactChannel } from '@/data/api';
 import { deviceDialingCode, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
@@ -46,7 +46,7 @@ export default function AccountScreen() {
         ? t.contact.gateExpiredBody
         : null;
 
-  const [channel, setChannel] = useState<ContactChannel>('email');
+  const [channel, setChannel] = useState<ContactChannel>(ContactChannel.Email);
   const [value, setValue] = useState('');
   const [code, setCode] = useState('');
   const [sent, setSent] = useState(false);
@@ -55,7 +55,7 @@ export default function AccountScreen() {
   const [done, setDone] = useState(false);
 
   const existing =
-    channel === 'email' ? (session?.user.email ?? null) : (session?.user.phone ?? null);
+    channel === ContactChannel.Email ? (session?.user.email ?? null) : (session?.user.phone ?? null);
 
   // Which providers already sign this account in, so a linked one shows as done
   // rather than offering to link what is already linked. Adding one goes through
@@ -80,7 +80,7 @@ export default function AccountScreen() {
   };
 
   const looksValid =
-    channel === 'email'
+    channel === ContactChannel.Email
       ? /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
       : /^\+?[0-9]{8,15}$/.test(value.trim().replace(/[\s-]/g, ''));
 
@@ -162,8 +162,8 @@ export default function AccountScreen() {
               setValue('');
             }}
             options={[
-              { value: 'email', label: t.contact.email },
-              { value: 'phone', label: t.contact.phone },
+              { value: ContactChannel.Email, label: t.contact.email },
+              { value: ContactChannel.Phone, label: t.contact.phone },
             ]}
           />
 
@@ -175,7 +175,7 @@ export default function AccountScreen() {
 
           <View style={{ gap: theme.spacing.xs }}>
             <Text variant="caption" tone="muted">
-              {channel === 'email' ? t.contact.emailAddress : t.contact.phoneNumber}
+              {channel === ContactChannel.Email ? t.contact.emailAddress : t.contact.phoneNumber}
             </Text>
             <TextInput
               value={value}
@@ -186,13 +186,13 @@ export default function AccountScreen() {
               }}
               editable={!busy}
               autoCapitalize="none"
-              autoComplete={channel === 'email' ? 'email' : 'tel'}
-              keyboardType={channel === 'email' ? 'email-address' : 'phone-pad'}
+              autoComplete={channel === ContactChannel.Email ? 'email' : 'tel'}
+              keyboardType={channel === ContactChannel.Email ? 'email-address' : 'phone-pad'}
               accessibilityLabel={
-                channel === 'email' ? t.contact.emailAddress : t.contact.phoneNumber
+                channel === ContactChannel.Email ? t.contact.emailAddress : t.contact.phoneNumber
               }
               placeholder={
-                channel === 'email'
+                channel === ContactChannel.Email
                   ? t.contact.emailPlaceholder
                   : t.contact.phonePlaceholder.replace('{code}', deviceDialingCode())
               }
@@ -209,7 +209,7 @@ export default function AccountScreen() {
           {sent ? (
             <View style={{ gap: theme.spacing.xs }}>
               <Text variant="caption" tone="muted">
-                {channel === 'email' ? t.contact.codeEmailed : t.contact.codeTexted}
+                {channel === ContactChannel.Email ? t.contact.codeEmailed : t.contact.codeTexted}
               </Text>
               <TextInput
                 value={code}
@@ -237,7 +237,7 @@ export default function AccountScreen() {
             label={
               sent
                 ? t.contact.confirm
-                : channel === 'email'
+                : channel === ContactChannel.Email
                   ? t.contact.sendCodeEmail
                   : t.contact.sendCodePhone
             }

--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -24,7 +24,10 @@ import { useGroups } from '@/data/hooks';
 import { groupLabel } from '@/data/types';
 import { useStrings } from '@/i18n';
 
-type Format = 'json' | 'csv';
+enum Format {
+  Json = 'json',
+  Csv = 'csv',
+}
 
 /**
  * ADR-012: your ledger leaves whenever you want it to, in full, for free.
@@ -36,7 +39,7 @@ export default function ExportScreen() {
   const groups = useGroups();
   const { t } = useStrings();
 
-  const [format, setFormat] = useState<Format>('json');
+  const [format, setFormat] = useState<Format>(Format.Json);
   const [scope, setScope] = useState<string>('all');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -62,7 +65,7 @@ export default function ExportScreen() {
         await Sharing.shareAsync(file.uri, {
           mimeType: result.contentType,
           dialogTitle: t.exportData.shareTitle,
-          UTI: format === 'json' ? 'public.json' : 'public.comma-separated-values-text',
+          UTI: format === Format.Json ? 'public.json' : 'public.comma-separated-values-text',
         });
       }
       setDone(`${result.filename} · ${Math.ceil(result.content.length / 1024)} KB`);
@@ -111,8 +114,8 @@ export default function ExportScreen() {
             value={format}
             onChange={setFormat}
             options={[
-              { value: 'json', label: t.exportData.json },
-              { value: 'csv', label: t.exportData.csv },
+              { value: Format.Json, label: t.exportData.json },
+              { value: Format.Csv, label: t.exportData.csv },
             ]}
           />
         </View>

--- a/apps/mobile/src/app/settings/feedback.tsx
+++ b/apps/mobile/src/app/settings/feedback.tsx
@@ -21,13 +21,17 @@ import { submitFeedback } from '@/data/api';
 import { useStrings } from '@/i18n';
 import { friendlyError } from '@/lib/errors';
 
-type Kind = 'general' | 'bug' | 'idea';
+enum Kind {
+  General = 'general',
+  Bug = 'bug',
+  Idea = 'idea',
+}
 
 export default function FeedbackScreen() {
   const theme = useTheme();
   const { t } = useStrings();
 
-  const [kind, setKind] = useState<Kind>('general');
+  const [kind, setKind] = useState<Kind>(Kind.General);
   const [message, setMessage] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -96,9 +100,9 @@ export default function FeedbackScreen() {
               value={kind}
               onChange={setKind}
               options={[
-                { value: 'general', label: t.privacy.kindGeneral },
-                { value: 'bug', label: t.privacy.kindBug },
-                { value: 'idea', label: t.privacy.kindIdea },
+                { value: Kind.General, label: t.privacy.kindGeneral },
+                { value: Kind.Bug, label: t.privacy.kindBug },
+                { value: Kind.Idea, label: t.privacy.kindIdea },
               ]}
             />
 

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -54,7 +54,7 @@ import {
 import { createGroup, fetchMembers, importLedger, type ImportPerson } from '@/data/api';
 import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useGroups } from '@/data/hooks';
-import { displayName, groupLabel, type MemberRow } from '@/data/types';
+import { displayName, groupLabel, GroupType, type MemberRow } from '@/data/types';
 import { useAuth } from '@/lib/auth';
 
 /** What a column in the file has been mapped to. */
@@ -271,7 +271,7 @@ export default function ImportScreen() {
       if (groupId === NEW_GROUP) {
         groupId = await createGroup({
           name: parsed.suggestedName || t.importLedger.importedGroup,
-          type: 'other',
+          type: GroupType.Other,
           currency: parsed.currency,
         });
       }

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/data/api';
 import { useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
-import { enablePush, pushPermission, type PushFailure, type PushPermission } from '@/lib/push';
+import { enablePush, PushFailure, PushPermission, pushPermission } from '@/lib/push';
 
 function rows(t: UiStrings): { key: keyof NotificationPrefs; title: string; body: string }[] {
   return [
@@ -62,11 +62,11 @@ function rows(t: UiStrings): { key: keyof NotificationPrefs; title: string; body
  */
 function pushFailureCopy(t: UiStrings): Record<PushFailure, string> {
   return {
-    denied: t.notifications.failDenied,
-    unsupported: t.notifications.failUnsupported,
-    not_signed_in: t.notifications.failNotSignedIn,
-    not_configured: t.notifications.failNotConfigured,
-    save_failed: t.notifications.failSaveFailed,
+    [PushFailure.Denied]: t.notifications.failDenied,
+    [PushFailure.Unsupported]: t.notifications.failUnsupported,
+    [PushFailure.NotSignedIn]: t.notifications.failNotSignedIn,
+    [PushFailure.NotConfigured]: t.notifications.failNotConfigured,
+    [PushFailure.SaveFailed]: t.notifications.failSaveFailed,
   };
 }
 
@@ -78,7 +78,7 @@ export default function NotificationSettingsScreen() {
   const [prefs, setPrefs] = useState<NotificationPrefs>(DEFAULT_NOTIFICATION_PREFS);
   const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState<string | null>(null);
-  const [permission, setPermission] = useState<PushPermission>('undetermined');
+  const [permission, setPermission] = useState<PushPermission>(PushPermission.Undetermined);
   const [asking, setAsking] = useState(false);
 
   useEffect(() => {

--- a/apps/mobile/src/app/settings/theme.tsx
+++ b/apps/mobile/src/app/settings/theme.tsx
@@ -15,7 +15,7 @@ import { ScrollView, View } from 'react-native';
 import { Card, directionalIcon, IconButton, ListRow, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
-import { useThemePreference, type SchemePreference } from '@/lib/theme';
+import { SchemePreference, useThemePreference } from '@/lib/theme';
 
 export default function ThemeSettingsScreen() {
   const theme = useTheme();
@@ -27,7 +27,7 @@ export default function ThemeSettingsScreen() {
     title: string;
     subtitle: string;
     icon: keyof typeof Ionicons.glyphMap;
-    value: SchemePreference;
+    value: SchemePreference | null;
   }[] = [
     {
       key: 'system',
@@ -44,14 +44,14 @@ export default function ThemeSettingsScreen() {
       title: t.theme.light,
       subtitle: t.theme.lightHint,
       icon: 'sunny-outline',
-      value: 'light',
+      value: SchemePreference.Light,
     },
     {
       key: 'dark',
       title: t.theme.dark,
       subtitle: t.theme.darkHint,
       icon: 'moon-outline',
-      value: 'dark',
+      value: SchemePreference.Dark,
     },
   ];
 

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -56,7 +56,10 @@ import { Onboarding } from '@/components/Onboarding';
 import { deviceCountry, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
-type Mode = 'otp' | 'password';
+enum Mode {
+  Otp = 'otp',
+  Password = 'password',
+}
 
 const TOUR_KEY = 'baaki.onboarding_seen';
 
@@ -112,7 +115,7 @@ export default function SignInScreen() {
   });
   const dialCode = dialingCodeForCountry(country) ?? '+91';
 
-  const [mode, setMode] = useState<Mode>('otp');
+  const [mode, setMode] = useState<Mode>(Mode.Otp);
   const [phone, setPhone] = useState('');
   // What actually goes to Supabase: the dial code and the local digits, no
   // spaces or punctuation — E.164 in all but the leading-zero rules the server
@@ -228,7 +231,7 @@ export default function SignInScreen() {
                 disabled={busy}
                 onPress={() => {
                   setIntent('sign_in');
-                  setMode('password');
+                  setMode(Mode.Password);
                   setShowOptions(true);
                 }}
               />
@@ -240,7 +243,7 @@ export default function SignInScreen() {
                 disabled={busy}
                 onPress={() => {
                   setIntent('sign_up');
-                  setMode('password');
+                  setMode(Mode.Password);
                   setShowOptions(true);
                 }}
               />
@@ -366,12 +369,12 @@ export default function SignInScreen() {
                   setError(null);
                 }}
                 tabs={[
-                  { value: 'otp', label: t.signIn.sendMeACode },
-                  { value: 'password', label: t.signIn.useAPassword },
+                  { value: Mode.Otp, label: t.signIn.sendMeACode },
+                  { value: Mode.Password, label: t.signIn.useAPassword },
                 ]}
               />
 
-              {mode === 'otp' && stage === 'phone' ? (
+              {mode === Mode.Otp && stage === 'phone' ? (
                 <>
                   <Text variant="caption" tone="muted">
                     {t.signIn.phoneNumber}
@@ -415,7 +418,7 @@ export default function SignInScreen() {
                 </>
               ) : null}
 
-              {mode === 'otp' && stage === 'code' ? (
+              {mode === Mode.Otp && stage === 'code' ? (
                 <>
                   <Text variant="caption" tone="muted">
                     {t.signIn.codeSentTo.replace('{value}', `${dialCode} ${phone}`)}
@@ -454,7 +457,7 @@ export default function SignInScreen() {
                 </>
               ) : null}
 
-              {mode === 'password' ? (
+              {mode === Mode.Password ? (
                 <>
                   {/* The way between sign-in and sign-up sits above the fields, not
                       below the submit: on Android the keyboard opens over the

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -66,7 +66,12 @@ interface ContactPickerProps {
  * failure into the same sentence does not just lose the reason — it prints a
  * confident lie.
  */
-type Access = 'asking' | 'granted' | 'denied' | 'unavailable';
+enum Access {
+  Asking = 'asking',
+  Granted = 'granted',
+  Denied = 'denied',
+  Unavailable = 'unavailable',
+}
 
 /**
  * Only these. Asking for less than the platform offers is the cheapest privacy
@@ -99,7 +104,7 @@ export function ContactPicker({
 }: ContactPickerProps): React.JSX.Element {
   const theme = useTheme();
   const { t, locale } = useStrings();
-  const [access, setAccess] = useState<Access>('asking');
+  const [access, setAccess] = useState<Access>(Access.Asking);
   const [contacts, setContacts] = useState<PickedContact[]>([]);
   const [query, setQuery] = useState('');
   const [picked, setPicked] = useState<ReadonlyMap<string, PickedContact>>(new Map());
@@ -114,12 +119,12 @@ export function ContactPicker({
     } catch {
       // Permission itself could not be asked: no contacts module on this
       // platform (web) or an OS that refused the question.
-      if (!cancelled.current) setAccess('unavailable');
+      if (!cancelled.current) setAccess(Access.Unavailable);
       return;
     }
     if (cancelled.current) return;
     if (!granted) {
-      setAccess('denied');
+      setAccess(Access.Denied);
       return;
     }
 
@@ -127,7 +132,7 @@ export function ContactPicker({
     try {
       rows = await Contact.getAllDetails(FIELDS);
     } catch {
-      if (!cancelled.current) setAccess('unavailable');
+      if (!cancelled.current) setAccess(Access.Unavailable);
       return;
     }
     if (cancelled.current) return;
@@ -144,7 +149,7 @@ export function ContactPicker({
         .filter((contact) => contact.name && (contact.email || contact.phone))
         .sort((a, b) => a.name.localeCompare(b.name)),
     );
-    setAccess('granted');
+    setAccess(Access.Granted);
   }, []);
 
   // Read on a tick rather than in the effect body: the React Compiler counts a
@@ -166,7 +171,7 @@ export function ContactPicker({
    */
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (state) => {
-      if (state === 'active' && access === 'denied') void load();
+      if (state === 'active' && access === Access.Denied) void load();
     });
     return () => subscription.remove();
   }, [access, load]);
@@ -231,14 +236,14 @@ export function ContactPicker({
     });
   }, []);
 
-  if (access === 'asking') {
+  if (access === Access.Asking) {
     // Reading a full address book is a real wait, so this is the shape of the
     // list that is coming — rows of a face and a name — not a line of text.
     // No trailing block: a contact row ends in a tick, not an amount.
     return <SkeletonList rows={6} trailing={false} />;
   }
 
-  if (access === 'denied') {
+  if (access === Access.Denied) {
     return (
       <Card style={{ gap: theme.spacing.sm }}>
         <Text variant="caption" tone="muted">

--- a/apps/mobile/src/components/CurrencyRate.tsx
+++ b/apps/mobile/src/components/CurrencyRate.tsx
@@ -41,7 +41,11 @@ import { fetchFxRate } from '@/data/api';
 /** Enough for the currencies an India-first app actually sees. */
 const COMMON = ['INR', 'USD', 'EUR', 'GBP', 'AED', 'SGD', 'AUD', 'THB', 'JPY', 'LKR', 'NPR'];
 
-type Method = 'charged' | 'typed' | 'fetched';
+enum Method {
+  Charged = 'charged',
+  Typed = 'typed',
+  Fetched = 'fetched',
+}
 
 export interface CurrencyRateProps {
   /** What the group settles in. */
@@ -66,7 +70,7 @@ export function CurrencyRate({
   const theme = useTheme();
   const { t } = useStrings();
   const [open, setOpen] = useState(false);
-  const [method, setMethod] = useState<Method>('charged');
+  const [method, setMethod] = useState<Method>(Method.Charged);
   const [chargedText, setChargedText] = useState('');
   const [rateText, setRateText] = useState('');
   const [busy, setBusy] = useState(false);
@@ -168,13 +172,13 @@ export function CurrencyRate({
               setError(null);
             }}
             options={[
-              { value: 'charged', label: t.misc.whatIWasCharged },
-              { value: 'typed', label: t.extras.iKnowTheRate },
-              { value: 'fetched', label: "Today's rate" },
+              { value: Method.Charged, label: t.misc.whatIWasCharged },
+              { value: Method.Typed, label: t.extras.iKnowTheRate },
+              { value: Method.Fetched, label: "Today's rate" },
             ]}
           />
 
-          {method === 'charged' ? (
+          {method === Method.Charged ? (
             <View style={{ gap: theme.spacing.xs }}>
               <Text variant="caption" tone="muted">
                 {`Amount on your statement, in ${groupCurrency}`}
@@ -194,7 +198,7 @@ export function CurrencyRate({
             </View>
           ) : null}
 
-          {method === 'typed' ? (
+          {method === Method.Typed ? (
             <View style={{ gap: theme.spacing.xs }}>
               <Text variant="caption" tone="muted">
                 {`1 ${currency} = ? ${groupCurrency}`}
@@ -211,7 +215,7 @@ export function CurrencyRate({
             </View>
           ) : null}
 
-          {method === 'fetched' ? (
+          {method === Method.Fetched ? (
             <Button
               label={
                 busy

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -38,7 +38,12 @@ export interface TripDatesValue {
   remind_evening_at: string;
 }
 
-type Field = 'start' | 'end' | 'morning' | 'evening';
+enum Field {
+  Start = 'start',
+  End = 'end',
+  Morning = 'morning',
+  Evening = 'evening',
+}
 
 export interface TripDatesPatch {
   start_date?: string | null;
@@ -144,7 +149,7 @@ export function TripDates({
     if (event.type === 'dismissed' || !picked) return;
 
     switch (field) {
-      case 'start': {
+      case Field.Start: {
         const start = isoDate(picked);
         // An end date before the start is not a trip. Dragging the start past
         // the end moves the end rather than refusing the tap.
@@ -152,13 +157,13 @@ export function TripDates({
         onChange({ start_date: start, end_date: end ?? start, time_zone: group.time_zone });
         return;
       }
-      case 'end': {
+      case Field.End: {
         const end = isoDate(picked);
         const start = group.start_date && group.start_date > end ? end : group.start_date;
         onChange({ end_date: end, start_date: start ?? end });
         return;
       }
-      case 'morning':
+      case Field.Morning:
         onChange({ remind_morning_at: isoTime(picked) });
         return;
       default:
@@ -199,12 +204,12 @@ export function TripDates({
         <FieldRow
           label={t.pickers.starts}
           value={showDate(group.start_date, locale)}
-          onPress={() => setEditing('start')}
+          onPress={() => setEditing(Field.Start)}
         />
         <FieldRow
           label={t.pickers.ends}
           value={showDate(group.end_date, locale)}
-          onPress={() => setEditing('end')}
+          onPress={() => setEditing(Field.End)}
         />
       </Row>
 
@@ -232,12 +237,12 @@ export function TripDates({
                 <FieldRow
                   label={t.pickers.breakfast}
                   value={showTime(group.remind_morning_at, locale)}
-                  onPress={() => setEditing('morning')}
+                  onPress={() => setEditing(Field.Morning)}
                 />
                 <FieldRow
                   label={t.pickers.endOfDay}
                   value={showTime(group.remind_evening_at, locale)}
-                  onPress={() => setEditing('evening')}
+                  onPress={() => setEditing(Field.Evening)}
                 />
               </Row>
 
@@ -273,18 +278,18 @@ export function TripDates({
       {editing ? (
         <DateTimePicker
           value={
-            editing === 'start'
+            editing === Field.Start
               ? dateFrom(group.start_date)
-              : editing === 'end'
+              : editing === Field.End
                 ? dateFrom(group.end_date)
                 : timeFrom(
-                    editing === 'morning' ? group.remind_morning_at : group.remind_evening_at,
+                    editing === Field.Morning ? group.remind_morning_at : group.remind_evening_at,
                   )
           }
-          mode={editing === 'start' || editing === 'end' ? 'date' : 'time'}
+          mode={editing === Field.Start || editing === Field.End ? 'date' : 'time'}
           // The end of a trip cannot be before its beginning, so the picker
           // does not offer it.
-          minimumDate={editing === 'end' ? dateFrom(group.start_date) : undefined}
+          minimumDate={editing === Field.End ? dateFrom(group.start_date) : undefined}
           onChange={(event, picked) => apply(editing, event, picked)}
         />
       ) : null}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1043,7 +1043,10 @@ export async function saveNotificationPrefs(
 // number later is what makes the account reachable from a second device — it
 // does not create a new account, so nothing entered as a guest is lost.
 
-export type ContactChannel = 'email' | 'phone';
+export enum ContactChannel {
+  Email = 'email',
+  Phone = 'phone',
+}
 
 /**
  * Attach a contact to the current (possibly anonymous) user. Supabase sends a

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -19,9 +19,11 @@ import {
   materialiseGroups,
   materialiseMembers,
   materialiseSettlements,
+  MutationKind,
   overlayPending,
   rowsFor,
   simplify,
+  SyncTable,
   type ExpenseSnapshot,
   type MemberId,
   type MirrorExpense,
@@ -59,6 +61,7 @@ import {
   type WriteExpenseInput,
 } from './api';
 import { totalsByCurrency } from './totals';
+import { SettlementStatus } from './types';
 import type { ActivityRow, ExpenseRow, GroupRow, MemberRow, SettlementRow } from './types';
 
 export const keys = {
@@ -143,14 +146,15 @@ export function useSettledTotals(profileId: string | null): LocalRead<Map<string
 
   const totals = useMemo(() => {
     const mine = new Set(
-      (rowsFor(mirror, 'group_members') as unknown as MemberRow[])
+      (rowsFor(mirror, SyncTable.GroupMembers) as unknown as MemberRow[])
         .filter((member) => member.profile_id === profileId)
         .map((member) => member.id),
     );
 
     const out = new Map<string, bigint>();
-    for (const row of rowsFor(mirror, 'settlements') as unknown as SettlementRow[]) {
-      if (row.status !== 'confirmed' && row.status !== 'auto_confirmed') continue;
+    for (const row of rowsFor(mirror, SyncTable.Settlements) as unknown as SettlementRow[]) {
+      if (row.status !== SettlementStatus.Confirmed && row.status !== SettlementStatus.AutoConfirmed)
+        continue;
       if (!mine.has(row.from_member_id) && !mine.has(row.to_member_id)) continue;
       out.set(row.currency, (out.get(row.currency) ?? 0n) + BigInt(row.amount));
     }
@@ -202,7 +206,7 @@ export function useHomeSummary(profileId: string | null) {
         currencyByGroup.set(group.id, currency);
       }
 
-      if (settlements.some((settlement) => settlement.status === 'initiated')) {
+      if (settlements.some((settlement) => settlement.status === SettlementStatus.Initiated)) {
         awaiting.add(group.id);
       }
     }
@@ -262,7 +266,7 @@ export function useGroup(groupId: string) {
     const settlements = materialiseSettlements(mirror, queue, {
       groupId,
     }) as unknown as SettlementRow[];
-    const activity = (rowsFor(mirror, 'activity_log', groupId) as unknown as ActivityRow[]).sort(
+    const activity = (rowsFor(mirror, SyncTable.ActivityLog, groupId) as unknown as ActivityRow[]).sort(
       (a, b) => String(b.created_at).localeCompare(String(a.created_at)),
     );
 
@@ -270,7 +274,7 @@ export function useGroup(groupId: string) {
     // the second; anything checking what the server actually knows wants the
     // first, and conflating them is how a queued expense starts looking real
     // enough to reconcile against.
-    const stored = (rowsFor(mirror, 'expenses', groupId) as unknown as ExpenseRow[]).sort((a, b) =>
+    const stored = (rowsFor(mirror, SyncTable.Expenses, groupId) as unknown as ExpenseRow[]).sort((a, b) =>
       String(b.created_at).localeCompare(String(a.created_at)),
     );
     const withPending = materialiseExpenses(mirror, queue, {
@@ -531,7 +535,7 @@ export function useCreateGroup() {
   return useMutation({
     mutationFn: async (input: Parameters<typeof createGroup>[0]) => {
       const groupId = input.groupId ?? randomUUID();
-      await mutate('group.create', groupId, {
+      await mutate(MutationKind.GroupCreate, groupId, {
         name: input.name?.trim() || null,
         type: input.type,
         currency: input.currency,
@@ -550,7 +554,7 @@ export function useWriteExpense(groupId: string) {
   return useMutation({
     mutationFn: async (input: Omit<WriteExpenseInput, 'groupId'>) => {
       const expenseId = input.expenseId ?? randomUUID();
-      await mutate(input.expenseId ? 'expense.update' : 'expense.create', groupId, {
+      await mutate(input.expenseId ? MutationKind.ExpenseUpdate : MutationKind.ExpenseCreate, groupId, {
         ...serialiseExpense(input),
         expenseId,
       });
@@ -562,14 +566,14 @@ export function useWriteExpense(groupId: string) {
 export function useDeleteExpense(groupId: string) {
   const { mutate } = useSync();
   return useMutation({
-    mutationFn: (expenseId: string) => mutate('expense.delete', groupId, { expenseId }),
+    mutationFn: (expenseId: string) => mutate(MutationKind.ExpenseDelete, groupId, { expenseId }),
   });
 }
 
 export function useRestoreExpense(groupId: string) {
   const { mutate } = useSync();
   return useMutation({
-    mutationFn: (expenseId: string) => mutate('expense.restore', groupId, { expenseId }),
+    mutationFn: (expenseId: string) => mutate(MutationKind.ExpenseRestore, groupId, { expenseId }),
   });
 }
 
@@ -578,7 +582,7 @@ export function useRecordSettlement(groupId: string) {
   return useMutation({
     mutationFn: (input: Parameters<typeof recordSettlement>[0]) =>
       mutate(
-        'settlement.create',
+        MutationKind.SettlementCreate,
         input.groupId,
         {
           // Chosen here so the overlay has a stable row to show while it waits.
@@ -609,7 +613,7 @@ export function useConfirmSettlement(groupId: string) {
   const { mutate } = useSync();
   return useMutation({
     mutationFn: (settlementId: string) =>
-      mutate('settlement.transition', groupId, { settlementId }),
+      mutate(MutationKind.SettlementTransition, groupId, { settlementId }),
   });
 }
 
@@ -691,7 +695,7 @@ export function useAddGhostMember(groupId: string) {
       // them. Adding somebody and immediately splitting a bill with them is one
       // action to a person, and offline it has to work like one.
       const memberId = randomUUID();
-      await mutate('member.add_ghost', groupId, {
+      await mutate(MutationKind.MemberAddGhost, groupId, {
         memberId,
         name: person.name,
         email: 'email' in person ? (person.email ?? null) : null,
@@ -719,7 +723,7 @@ export function useUpdateGroup(groupId: string) {
   const { mutate } = useSync();
   return useMutation({
     mutationFn: (patch: Parameters<typeof updateGroup>[1]) =>
-      mutate('group.update', groupId, patch as Record<string, unknown>),
+      mutate(MutationKind.GroupUpdate, groupId, patch as Record<string, unknown>),
   });
 }
 

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -1,9 +1,25 @@
 import type { MemberId, SplitParams } from '@baaki/core';
 
-export type GroupType = 'trip' | 'home' | 'couple' | 'event' | 'other';
-export type SettlementMethod = 'upi' | 'cash' | 'bank' | 'other';
-export type SettlementStatus =
-  'initiated' | 'confirmed' | 'auto_confirmed' | 'disputed' | 'cancelled';
+export enum GroupType {
+  Trip = 'trip',
+  Home = 'home',
+  Couple = 'couple',
+  Event = 'event',
+  Other = 'other',
+}
+export enum SettlementMethod {
+  Upi = 'upi',
+  Cash = 'cash',
+  Bank = 'bank',
+  Other = 'other',
+}
+export enum SettlementStatus {
+  Initiated = 'initiated',
+  Confirmed = 'confirmed',
+  AutoConfirmed = 'auto_confirmed',
+  Disputed = 'disputed',
+  Cancelled = 'cancelled',
+}
 
 export interface GroupRow {
   id: string;
@@ -92,7 +108,12 @@ export interface ExpenseRow {
   pending?: boolean;
 }
 
-export type DisputeStatus = 'open' | 'resolved' | 'withdrawn' | 'rejected';
+export enum DisputeStatus {
+  Open = 'open',
+  Resolved = 'resolved',
+  Withdrawn = 'withdrawn',
+  Rejected = 'rejected',
+}
 
 /**
  * Somebody saying an expense is wrong. Never changes a balance on its own —

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -39,13 +39,23 @@ import {
   type CurrencyCode,
 } from '@baaki/core';
 
-export type Language = 'en' | 'ta' | 'hi' | 'ar';
+export enum Language {
+  En = 'en',
+  Ta = 'ta',
+  Hi = 'hi',
+  Ar = 'ar',
+}
 
 /** Every language this app speaks, in the order the picker lists them. */
-export const LANGUAGES: readonly Language[] = ['en', 'ta', 'hi', 'ar'];
+export const LANGUAGES: readonly Language[] = [
+  Language.En,
+  Language.Ta,
+  Language.Hi,
+  Language.Ar,
+];
 
 /** The languages that read right to left. */
-export const RTL_LANGUAGES: readonly Language[] = ['ar'];
+export const RTL_LANGUAGES: readonly Language[] = [Language.Ar];
 
 /**
  * What each language calls itself, and what English calls it.
@@ -56,10 +66,10 @@ export const RTL_LANGUAGES: readonly Language[] = ['ar'];
  * read. The English gloss follows for everyone else.
  */
 export const LANGUAGE_NAMES: Readonly<Record<Language, { own: string; english: string }>> = {
-  en: { own: 'English', english: 'English' },
-  ta: { own: 'தமிழ்', english: 'Tamil' },
-  hi: { own: 'हिन्दी', english: 'Hindi' },
-  ar: { own: 'العربية', english: 'Arabic' },
+  [Language.En]: { own: 'English', english: 'English' },
+  [Language.Ta]: { own: 'தமிழ்', english: 'Tamil' },
+  [Language.Hi]: { own: 'हिन्दी', english: 'Hindi' },
+  [Language.Ar]: { own: 'العربية', english: 'Arabic' },
 };
 
 export function isRtlLanguage(language: Language): boolean {
@@ -5287,7 +5297,12 @@ const ar: UiStrings = {
   },
 };
 
-const STRINGS: Record<Language, UiStrings> = { en, ta, hi, ar };
+const STRINGS: Record<Language, UiStrings> = {
+  [Language.En]: en,
+  [Language.Ta]: ta,
+  [Language.Hi]: hi,
+  [Language.Ar]: ar,
+};
 
 /**
  * The tables themselves, so a test can check that every language says
@@ -5299,7 +5314,13 @@ export const STRINGS_BY_LANGUAGE = STRINGS;
 
 export function deviceLanguage(): Language {
   const tag = getLocales()[0]?.languageCode ?? 'en';
-  return tag === 'ta' || tag === 'hi' || tag === 'ar' ? tag : 'en';
+  return tag === 'ta'
+    ? Language.Ta
+    : tag === 'hi'
+      ? Language.Hi
+      : tag === 'ar'
+        ? Language.Ar
+        : Language.En;
 }
 
 /**

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -4,10 +4,11 @@ import { makeRedirectUri } from 'expo-auth-session';
 import * as WebBrowser from 'expo-web-browser';
 
 import {
+  AuthMethod,
   checkPassword,
+  OAuthMethod,
   planAuth,
   readIdentifier,
-  type OAuthMethod,
   type Viewer,
 } from '@baaki/core';
 
@@ -284,7 +285,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       async withPassword(identifier, password, intent) {
         const who = readIdentifier(identifier);
         checkPassword(password);
-        const method = who.kind === 'email' ? 'email_password' : 'phone_password';
+        const method =
+          who.kind === 'email' ? AuthMethod.EmailPassword : AuthMethod.PhonePassword;
         const credential = who.kind === 'email' ? { email: who.value } : { phone: who.value };
         const action = planAuth(viewerFrom(session), method, intent);
 
@@ -306,13 +308,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       },
 
       async withGoogle() {
-        const action = planAuth(viewerFrom(session), 'google');
-        const next = await oauthThroughBrowser('google', action.call === 'linkIdentity');
+        const action = planAuth(viewerFrom(session), AuthMethod.Google);
+        const next = await oauthThroughBrowser(OAuthMethod.Google, action.call === 'linkIdentity');
         if (next !== undefined) setSession(next);
       },
 
       async withApple() {
-        const action = planAuth(viewerFrom(session), 'apple');
+        const action = planAuth(viewerFrom(session), AuthMethod.Apple);
 
         // The native sheet is bound to this one branch, and the branch is the
         // one `planAuth` only ever returns for a viewer of kind 'nobody'
@@ -339,7 +341,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           return;
         }
 
-        const next = await oauthThroughBrowser('apple', action.call === 'linkIdentity');
+        const next = await oauthThroughBrowser(OAuthMethod.Apple, action.call === 'linkIdentity');
         if (next !== undefined) setSession(next);
       },
 

--- a/apps/mobile/src/lib/push.ts
+++ b/apps/mobile/src/lib/push.ts
@@ -60,12 +60,20 @@ function projectId(): string | null {
   return extra?.eas?.projectId ?? null;
 }
 
-export type PushPermission = 'granted' | 'denied' | 'undetermined';
+export enum PushPermission {
+  Granted = 'granted',
+  Denied = 'denied',
+  Undetermined = 'undetermined',
+}
 
 export async function pushPermission(): Promise<PushPermission> {
-  if (!pushSupported || !Device.isDevice) return 'denied';
+  if (!pushSupported || !Device.isDevice) return PushPermission.Denied;
   const { status } = await Notifications.getPermissionsAsync();
-  return status as PushPermission;
+  return status === 'granted'
+    ? PushPermission.Granted
+    : status === 'undetermined'
+      ? PushPermission.Undetermined
+      : PushPermission.Denied;
 }
 
 /**
@@ -74,17 +82,18 @@ export async function pushPermission(): Promise<PushPermission> {
  * when the real problem is a missing Firebase key sends them somewhere that
  * cannot help them.
  */
-export type PushFailure =
+export enum PushFailure {
   /** Web, or a simulator — neither has a push token to give. */
-  | 'unsupported'
+  Unsupported = 'unsupported',
   /** They said no, which is an answer. */
-  | 'denied'
+  Denied = 'denied',
   /** Nobody is signed in, so there is no profile to hang the token on. */
-  | 'not_signed_in'
+  NotSignedIn = 'not_signed_in',
   /** This build has no FCM/APNs credentials. Ours to fix, not theirs. */
-  | 'not_configured'
+  NotConfigured = 'not_configured',
   /** We got a token and could not store it. */
-  | 'save_failed';
+  SaveFailed = 'save_failed',
+}
 
 export type PushResult = { readonly ok: true } | { readonly ok: false; readonly why: PushFailure };
 
@@ -95,14 +104,14 @@ export type PushResult = { readonly ok: true } | { readonly ok: false; readonly 
 export async function enablePush(): Promise<PushResult> {
   // A simulator has no push token to give, and web has no push at all. Failing
   // loudly here would make every development run look broken.
-  if (!pushSupported || !Device.isDevice) return { ok: false, why: 'unsupported' };
+  if (!pushSupported || !Device.isDevice) return { ok: false, why: PushFailure.Unsupported };
 
   const existing = await Notifications.getPermissionsAsync();
   const status =
     existing.status === 'granted'
       ? existing.status
       : (await Notifications.requestPermissionsAsync()).status;
-  if (status !== 'granted') return { ok: false, why: 'denied' };
+  if (status !== 'granted') return { ok: false, why: PushFailure.Denied };
 
   // Android 13+ wants the channel to exist before the token is asked for.
   await ensureAndroidChannel();
@@ -117,16 +126,16 @@ export async function enablePush(): Promise<PushResult> {
  * silently stops working.
  */
 export async function refreshPushToken(): Promise<PushResult> {
-  if (!pushSupported || !Device.isDevice) return { ok: false, why: 'unsupported' };
+  if (!pushSupported || !Device.isDevice) return { ok: false, why: PushFailure.Unsupported };
   const { status } = await Notifications.getPermissionsAsync();
-  if (status !== 'granted') return { ok: false, why: 'denied' };
+  if (status !== 'granted') return { ok: false, why: PushFailure.Denied };
 
   const id = projectId();
-  if (!id) return { ok: false, why: 'not_configured' };
+  if (!id) return { ok: false, why: PushFailure.NotConfigured };
 
   const { data: session } = await supabase.auth.getSession();
   const profileId = session.session?.user?.id;
-  if (!profileId) return { ok: false, why: 'not_signed_in' };
+  if (!profileId) return { ok: false, why: PushFailure.NotSignedIn };
 
   let token: string;
   try {
@@ -138,7 +147,7 @@ export async function refreshPushToken(): Promise<PushResult> {
     // None of them are anything the person can act on, and none of them are
     // worth taking the app down for.
     console.warn('push token unavailable:', (caught as Error).message);
-    return { ok: false, why: 'not_configured' };
+    return { ok: false, why: PushFailure.NotConfigured };
   }
 
   const { error } = await supabase.from('push_tokens').upsert(
@@ -153,7 +162,7 @@ export async function refreshPushToken(): Promise<PushResult> {
     },
     { onConflict: 'expo_push_token' },
   );
-  return error ? { ok: false, why: 'save_failed' } : { ok: true };
+  return error ? { ok: false, why: PushFailure.SaveFailed } : { ok: true };
 }
 
 /** On the way out. Leaves the row, so a return is recognised as a return. */

--- a/apps/mobile/src/lib/smsReader.ts
+++ b/apps/mobile/src/lib/smsReader.ts
@@ -34,7 +34,13 @@ export interface SmsWindow {
   readonly to: string;
 }
 
-export type SmsReadFailure = 'unsupported' | 'unavailable' | 'denied' | 'blocked' | 'failed';
+export enum SmsReadFailure {
+  Unsupported = 'unsupported',
+  Unavailable = 'unavailable',
+  Denied = 'denied',
+  Blocked = 'blocked',
+  Failed = 'failed',
+}
 
 export type SmsReadResult =
   { ok: true; messages: SmsMessage[] } | { ok: false; reason: SmsReadFailure; message?: string };
@@ -58,7 +64,11 @@ export interface NativeSmsModule {
 }
 
 /** What a permission request resolves to, flattened to the three we act on. */
-export type PermissionOutcome = 'granted' | 'denied' | 'blocked';
+export enum PermissionOutcome {
+  Granted = 'granted',
+  Denied = 'denied',
+  Blocked = 'blocked',
+}
 
 export interface SmsReaderDeps {
   readonly platformOS: string;
@@ -140,7 +150,7 @@ export function parseSmsList(json: string): SmsMessage[] {
  */
 export async function readSmsInbox(window: SmsWindow, deps: SmsReaderDeps): Promise<SmsReadResult> {
   if (deps.platformOS !== 'android') {
-    return { ok: false, reason: 'unsupported' };
+    return { ok: false, reason: SmsReadFailure.Unsupported };
   }
 
   let native: NativeSmsModule | null;
@@ -150,12 +160,12 @@ export async function readSmsInbox(window: SmsWindow, deps: SmsReaderDeps): Prom
     native = null;
   }
   if (!native || typeof native.list !== 'function') {
-    return { ok: false, reason: 'unavailable' };
+    return { ok: false, reason: SmsReadFailure.Unavailable };
   }
 
   const outcome = await deps.requestPermission();
-  if (outcome === 'denied') return { ok: false, reason: 'denied' };
-  if (outcome === 'blocked') return { ok: false, reason: 'blocked' };
+  if (outcome === PermissionOutcome.Denied) return { ok: false, reason: SmsReadFailure.Denied };
+  if (outcome === PermissionOutcome.Blocked) return { ok: false, reason: SmsReadFailure.Blocked };
 
   const filter = buildSmsFilter(window, deps.maxCount ?? DEFAULT_MAX_COUNT);
 
@@ -169,13 +179,13 @@ export async function readSmsInbox(window: SmsWindow, deps: SmsReaderDeps): Prom
     try {
       native.list(
         filter,
-        (error) => done({ ok: false, reason: 'failed', message: error }),
+        (error) => done({ ok: false, reason: SmsReadFailure.Failed, message: error }),
         (_count, json) => done({ ok: true, messages: parseSmsList(json) }),
       );
     } catch (error) {
       done({
         ok: false,
-        reason: 'failed',
+        reason: SmsReadFailure.Failed,
         message: error instanceof Error ? error.message : String(error),
       });
     }
@@ -218,11 +228,11 @@ export async function readSms(window: SmsWindow): Promise<SmsReadResult> {
           buttonPositive: 'Allow',
           buttonNegative: 'Not now',
         });
-        if (status === PermissionsAndroid.RESULTS.GRANTED) return 'granted';
-        if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) return 'blocked';
-        return 'denied';
+        if (status === PermissionsAndroid.RESULTS.GRANTED) return PermissionOutcome.Granted;
+        if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) return PermissionOutcome.Blocked;
+        return PermissionOutcome.Denied;
       } catch {
-        return 'denied';
+        return PermissionOutcome.Denied;
       }
     },
   });

--- a/apps/mobile/src/lib/split.ts
+++ b/apps/mobile/src/lib/split.ts
@@ -13,7 +13,11 @@
  * ledger that nobody chose.
  */
 
-export type SplitKind = 'equal' | 'shares' | 'percent';
+export enum SplitKind {
+  Equal = 'equal',
+  Shares = 'shares',
+  Percent = 'percent',
+}
 
 /** What a weighted split kind holds: one line of text per member. */
 export type SplitEntries = Record<string, string>;

--- a/apps/mobile/src/lib/theme.tsx
+++ b/apps/mobile/src/lib/theme.tsx
@@ -27,11 +27,14 @@ import { useColorScheme } from 'react-native';
 const KEY = 'baaki.theme_scheme';
 
 /** What the user picked. Null means "follow the phone". */
-export type SchemePreference = 'light' | 'dark' | null;
+export enum SchemePreference {
+  Light = 'light',
+  Dark = 'dark',
+}
 
 interface ThemeValue {
   /** The user's choice, or null when following the phone. */
-  preference: SchemePreference;
+  preference: SchemePreference | null;
   /** The scheme actually in force once the phone's setting is resolved. */
   resolved: 'light' | 'dark';
   /** What the phone's own setting says, for explaining the default. */
@@ -39,7 +42,7 @@ interface ThemeValue {
   /** True while the stored preference is still being read. */
   loading: boolean;
   /** Null puts it back under the system setting's control. */
-  setPreference: (value: SchemePreference) => Promise<void>;
+  setPreference: (value: SchemePreference | null) => Promise<void>;
   /** Whether the person has overridden the system setting. */
   overridden: boolean;
 }
@@ -50,7 +53,7 @@ export function ThemePreferenceProvider({ children }: { children: ReactNode }) {
   const systemRaw = useColorScheme();
   const systemScheme: 'light' | 'dark' = systemRaw === 'dark' ? 'dark' : 'light';
 
-  const [stored, setStored] = useState<SchemePreference>(null);
+  const [stored, setStored] = useState<SchemePreference | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -58,7 +61,13 @@ export function ThemePreferenceProvider({ children }: { children: ReactNode }) {
     void (async () => {
       const saved = await AsyncStorage.getItem(KEY).catch(() => null);
       if (!active) return;
-      setStored(saved === 'light' || saved === 'dark' ? saved : null);
+      setStored(
+        saved === 'light'
+          ? SchemePreference.Light
+          : saved === 'dark'
+            ? SchemePreference.Dark
+            : null,
+      );
       setLoading(false);
     })();
     return () => {
@@ -66,7 +75,7 @@ export function ThemePreferenceProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const setPreference = useCallback(async (value: SchemePreference) => {
+  const setPreference = useCallback(async (value: SchemePreference | null) => {
     setStored(value);
     if (value === null) await AsyncStorage.removeItem(KEY).catch(() => undefined);
     else await AsyncStorage.setItem(KEY, value).catch(() => undefined);
@@ -75,7 +84,12 @@ export function ThemePreferenceProvider({ children }: { children: ReactNode }) {
   const value = useMemo<ThemeValue>(
     () => ({
       preference: stored,
-      resolved: stored ?? systemScheme,
+      resolved:
+        stored === SchemePreference.Dark
+          ? 'dark'
+          : stored === SchemePreference.Light
+            ? 'light'
+            : systemScheme,
       systemScheme,
       loading,
       setPreference,

--- a/apps/mobile/src/lib/update.tsx
+++ b/apps/mobile/src/lib/update.tsx
@@ -38,7 +38,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
 import { AppState, Linking, Platform } from 'react-native';
 
-import { decideUpdate, type UpdateDecision } from '@baaki/core';
+import { decideUpdate, UpdateDecision } from '@baaki/core';
 
 import { fetchReleasePolicy } from '@/data/api';
 
@@ -148,7 +148,7 @@ export function UpdateProvider({ children }: { children: ReactNode }) {
         latestVersion: policy.latestVersion,
         minimumVersion: policy.minimumVersion,
       })
-    : 'none';
+    : UpdateDecision.None;
 
   const dismiss = useCallback(() => {
     const version = policy?.latestVersion;

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -34,7 +34,12 @@ import { supabase } from '@/lib/supabase';
 
 import { createLocalStore, type LocalStore, type StoredRow } from './store';
 
-export type SyncStatus = 'idle' | 'syncing' | 'offline' | 'error';
+export enum SyncStatus {
+  Idle = 'idle',
+  Syncing = 'syncing',
+  Offline = 'offline',
+  Error = 'error',
+}
 
 export interface RejectedMutation {
   clientMutationId: string;
@@ -73,7 +78,7 @@ const POLL_INTERVAL_MS = 30_000;
 export class SyncEngine {
   private store: LocalStore = createLocalStore();
   private state: SyncState = {
-    status: 'idle',
+    status: SyncStatus.Idle,
     hydrated: false,
     mirror: emptyMirror(),
     queue: [],
@@ -139,7 +144,7 @@ export class SyncEngine {
       mirror: emptyMirror(),
       queue: [],
       rejected: [],
-      status: 'idle',
+      status: SyncStatus.Idle,
       lastError: null,
       lastSyncedAt: null,
     });
@@ -192,7 +197,7 @@ export class SyncEngine {
         // uncaught promise rejection instead. The banner is where this belongs.
         const message = error instanceof Error ? error.message : String(error);
         reportHandled(error, 'sync.flush');
-        this.set({ status: 'error', lastError: message });
+        this.set({ status: SyncStatus.Error, lastError: message });
       })
       .finally(() => {
         this.flushing = null;
@@ -205,7 +210,7 @@ export class SyncEngine {
 
     const online = await isOnline();
     if (!online) {
-      this.set({ status: 'offline' });
+      this.set({ status: SyncStatus.Offline });
       return;
     }
 
@@ -224,7 +229,7 @@ export class SyncEngine {
     // happened to name one. The `!online` case already returned above, so the
     // one round trip this costs a brand-new guest is against their own empty
     // ledger, once, and tells them the truth either way.
-    this.set({ status: 'syncing' });
+    this.set({ status: SyncStatus.Syncing });
 
     try {
       const { data, error } = await supabase.functions.invoke('sync', {
@@ -278,7 +283,7 @@ export class SyncEngine {
       await this.persist(response.changes ?? [], mirror, folded.queue);
 
       this.set({
-        status: 'idle',
+        status: SyncStatus.Idle,
         mirror,
         queue: folded.queue,
         rejected: [...this.state.rejected, ...rejected],
@@ -288,7 +293,7 @@ export class SyncEngine {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const queue = markFailed(this.state.queue, batch, message, now);
-      this.set({ status: 'error', queue, lastError: message });
+      this.set({ status: SyncStatus.Error, queue, lastError: message });
       // Writing down *why* the sync failed must not itself become a louder
       // failure that replaces the reason. The attempt counts are already in
       // memory and the next flush writes them again.

--- a/apps/mobile/src/sync/hooks.ts
+++ b/apps/mobile/src/sync/hooks.ts
@@ -15,6 +15,7 @@ import {
   materialiseExpenses,
   rowsFor,
   simplify,
+  SyncTable,
   toExpenseSnapshot,
   type ExpenseSnapshot,
   type MemberId,
@@ -40,7 +41,7 @@ export function useLocalGroups(): GroupRow[] {
   const { mirror } = useSync();
   return useMemo(
     () =>
-      (rowsFor(mirror, 'groups') as unknown as GroupRow[])
+      (rowsFor(mirror, SyncTable.Groups) as unknown as GroupRow[])
         .filter((group) => !group.archived_at)
         .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at))),
     [mirror],
@@ -52,10 +53,10 @@ export function useLocalGroup(groupId: string): LocalGroup {
 
   return useMemo(() => {
     const group = (mirror.tables.groups[groupId] as unknown as GroupRow | undefined) ?? null;
-    const members = (rowsFor(mirror, 'group_members', groupId) as unknown as MemberRow[]).filter(
+    const members = (rowsFor(mirror, SyncTable.GroupMembers, groupId) as unknown as MemberRow[]).filter(
       (member) => !member.left_at,
     );
-    const settlements = rowsFor(mirror, 'settlements', groupId) as unknown as SettlementRow[];
+    const settlements = rowsFor(mirror, SyncTable.Settlements, groupId) as unknown as SettlementRow[];
     const expenses = materialiseExpenses(mirror, queue, { groupId });
 
     return {

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -6,34 +6,40 @@
  * already typed, and turning a platform error code into a blank screen.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { dictationError, mergeTranscript, speechLocale } from '@/lib/dictation';
+import { Language } from '@/i18n';
+
+// The Language enum lives in the i18n module, which imports expo-localization
+// (and through it react-native) at load. This test only needs the enum, so the
+// native dependency is stubbed out — the same shim language.test.ts uses.
+vi.mock('expo-localization', () => ({ getLocales: () => [] }));
 
 describe('speechLocale', () => {
   it('keeps the phone’s own region when it agrees with the app language', () => {
     // Somebody in London is recognised as British English, not corrected to
     // Indian English because the app happens to be India-first.
-    expect(speechLocale('en', 'en-GB')).toBe('en-GB');
-    expect(speechLocale('ta', 'ta-LK')).toBe('ta-LK');
+    expect(speechLocale(Language.En, 'en-GB')).toBe('en-GB');
+    expect(speechLocale(Language.Ta, 'ta-LK')).toBe('ta-LK');
   });
 
   it('falls back to India when the tag carries no region', () => {
     // Bare "ta" is a lottery on Android — some recognisers take it, some
     // return language-not-supported.
-    expect(speechLocale('ta', 'ta')).toBe('ta-IN');
-    expect(speechLocale('hi', 'hi')).toBe('hi-IN');
+    expect(speechLocale(Language.Ta, 'ta')).toBe('ta-IN');
+    expect(speechLocale(Language.Hi, 'hi')).toBe('hi-IN');
   });
 
   it('follows the app language, not the phone, when they disagree', () => {
     // The app is showing Tamil, so Tamil is what the user is about to speak.
-    expect(speechLocale('ta', 'en-US')).toBe('ta-IN');
+    expect(speechLocale(Language.Ta, 'en-US')).toBe('ta-IN');
   });
 
   it('survives the shapes a locale tag actually arrives in', () => {
-    expect(speechLocale('en', 'en_IN')).toBe('en-IN');
-    expect(speechLocale('en', 'en-in')).toBe('en-IN');
-    expect(speechLocale('en', '')).toBe('en-IN');
+    expect(speechLocale(Language.En, 'en_IN')).toBe('en-IN');
+    expect(speechLocale(Language.En, 'en-in')).toBe('en-IN');
+    expect(speechLocale(Language.En, '')).toBe('en-IN');
   });
 });
 

--- a/apps/mobile/test/importPlan.test.ts
+++ b/apps/mobile/test/importPlan.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { TransactionDirection } from '@baaki/core';
 import type { ExpenseCandidate, ImportedExpense } from '@baaki/core';
 
 import {
@@ -21,7 +22,7 @@ import {
 function candidate(over: Partial<ExpenseCandidate> = {}): ExpenseCandidate {
   return {
     amount: { minor: 45000n, currency: 'INR' },
-    direction: 'debit',
+    direction: TransactionDirection.Debit,
     merchant: 'SWIGGY',
     accountTail: '4821',
     reference: '412345678901',

--- a/apps/mobile/test/language.test.ts
+++ b/apps/mobile/test/language.test.ts
@@ -10,6 +10,8 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { Language } from '../src/i18n';
+
 interface FakeLocale {
   languageCode?: string;
   regionCode?: string;
@@ -59,8 +61,8 @@ describe('the languages on offer', () => {
     for (const language of LANGUAGES) {
       expect(isRtlLanguage(language), language).toBe(RTL_LANGUAGES.includes(language));
     }
-    expect(isRtlLanguage('ar')).toBe(true);
-    expect(isRtlLanguage('en')).toBe(false);
+    expect(isRtlLanguage(Language.Ar)).toBe(true);
+    expect(isRtlLanguage(Language.En)).toBe(false);
   });
 });
 
@@ -69,18 +71,18 @@ describe('the locale a chosen language is formatted in', () => {
     // Reading the app in Hindi in Dubai does not move you to India. Dates and
     // currency belong to where somebody is, not to what they read.
     locales = [{ languageCode: 'ar', regionCode: 'AE', languageTag: 'ar-AE' }];
-    expect(localeFor('hi')).toBe('hi-AE');
-    expect(localeFor('en')).toBe('en-AE');
+    expect(localeFor(Language.Hi)).toBe('hi-AE');
+    expect(localeFor(Language.En)).toBe('en-AE');
   });
 
   it('falls back to the bare language when the phone will not say where it is', () => {
     locales = [{ languageCode: 'en' }];
-    expect(localeFor('ta')).toBe('ta');
+    expect(localeFor(Language.Ta)).toBe('ta');
   });
 
   it('ignores a region the phone reports as nonsense', () => {
     locales = [{ languageCode: 'en', regionCode: '419' }];
-    expect(localeFor('en')).toBe('en');
+    expect(localeFor(Language.En)).toBe('en');
   });
 
   it('produces a tag Intl will actually take', () => {
@@ -145,7 +147,7 @@ describe('what every table owes the others', () => {
   it('keeps every placeholder the English says', () => {
     const english = new Map(leaves(STRINGS_BY_LANGUAGE.en));
     for (const language of LANGUAGES) {
-      if (language === 'en') continue;
+      if (language === Language.En) continue;
       for (const [path, text] of leaves(STRINGS_BY_LANGUAGE[language])) {
         const source = english.get(path);
         // Plural tables legitimately have forms English does not (Arabic's

--- a/apps/mobile/test/smsReader.test.ts
+++ b/apps/mobile/test/smsReader.test.ts
@@ -19,6 +19,7 @@ import {
   buildSmsFilter,
   mapSmsRow,
   parseSmsList,
+  PermissionOutcome,
   readSmsInbox,
   type NativeSmsModule,
   type SmsReaderDeps,
@@ -39,7 +40,7 @@ function deps(over: Partial<SmsReaderDeps> = {}): SmsReaderDeps {
   return {
     platformOS: 'android',
     loadModule: () => moduleReturning([]),
-    requestPermission: async () => 'granted',
+    requestPermission: async () => PermissionOutcome.Granted,
     ...over,
   };
 }
@@ -158,17 +159,23 @@ describe('readSmsInbox — refusals', () => {
   });
 
   it('reports a plain denial', async () => {
-    const res = await readSmsInbox(WINDOW, deps({ requestPermission: async () => 'denied' }));
+    const res = await readSmsInbox(
+      WINDOW,
+      deps({ requestPermission: async () => PermissionOutcome.Denied }),
+    );
     expect(res).toEqual({ ok: false, reason: 'denied' });
   });
 
   it('reports a blocked (never-ask-again) permission distinctly', async () => {
-    const res = await readSmsInbox(WINDOW, deps({ requestPermission: async () => 'blocked' }));
+    const res = await readSmsInbox(
+      WINDOW,
+      deps({ requestPermission: async () => PermissionOutcome.Blocked }),
+    );
     expect(res).toEqual({ ok: false, reason: 'blocked' });
   });
 
   it('does not ask for permission before the module is known to exist', async () => {
-    const requestPermission = vi.fn(async () => 'granted' as const);
+    const requestPermission = vi.fn(async () => PermissionOutcome.Granted);
     await readSmsInbox(WINDOW, deps({ loadModule: () => null, requestPermission }));
     expect(requestPermission).not.toHaveBeenCalled();
   });

--- a/apps/mobile/test/split.test.ts
+++ b/apps/mobile/test/split.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import { computeShares } from '@baaki/core';
 
-import { entryValues, fillEntries, formatEntry, parseEntry, splitProblem } from '../src/lib/split';
+import {
+  entryValues,
+  fillEntries,
+  formatEntry,
+  parseEntry,
+  SplitKind,
+  splitProblem,
+} from '../src/lib/split';
 
 describe('parseEntry', () => {
   it('reads whole shares', () => {
@@ -53,32 +60,32 @@ describe('splitProblem', () => {
   const people = ['a', 'b', 'c'];
 
   it('says nothing about an equal split', () => {
-    expect(splitProblem('equal', {}, people)).toBeNull();
+    expect(splitProblem(SplitKind.Equal, {}, people)).toBeNull();
   });
 
   it('accepts shares with at least one positive weight', () => {
-    expect(splitProblem('shares', { a: '2', b: '1', c: '0' }, people)).toBeNull();
+    expect(splitProblem(SplitKind.Shares, { a: '2', b: '1', c: '0' }, people)).toBeNull();
   });
 
   it('refuses shares that are all zero', () => {
-    expect(splitProblem('shares', { a: '0', b: '0', c: '0' }, people)).toMatch(/at least one/);
+    expect(splitProblem(SplitKind.Shares, { a: '0', b: '0', c: '0' }, people)).toMatch(/at least one/);
   });
 
   it('says how much percentage is left, and how much is too much', () => {
-    expect(splitProblem('percent', { a: '30', b: '30', c: '30' }, people)).toBe(
+    expect(splitProblem(SplitKind.Percent, { a: '30', b: '30', c: '30' }, people)).toBe(
       'That is 90% — 10% left to give out.',
     );
-    expect(splitProblem('percent', { a: '50', b: '30', c: '30' }, people)).toBe(
+    expect(splitProblem(SplitKind.Percent, { a: '50', b: '30', c: '30' }, people)).toBe(
       'That is 110% — 10% too much.',
     );
   });
 
   it('accepts percentages that sum to exactly 100', () => {
-    expect(splitProblem('percent', { a: '33.34', b: '33.33', c: '33.33' }, people)).toBeNull();
+    expect(splitProblem(SplitKind.Percent, { a: '33.34', b: '33.33', c: '33.33' }, people)).toBeNull();
   });
 
   it('ignores members who are not in the split', () => {
-    expect(splitProblem('percent', { a: '50', b: '50', c: '80' }, ['a', 'b'])).toBeNull();
+    expect(splitProblem(SplitKind.Percent, { a: '50', b: '50', c: '80' }, ['a', 'b'])).toBeNull();
   });
 });
 
@@ -87,7 +94,7 @@ describe('fillEntries', () => {
 
   it('opens a fresh percent split on something valid', () => {
     const filled = fillEntries('percent', {}, people);
-    expect(splitProblem('percent', filled ?? {}, people)).toBeNull();
+    expect(splitProblem(SplitKind.Percent, filled ?? {}, people)).toBeNull();
   });
 
   it('starts somebody added later at zero rather than rewriting the others', () => {
@@ -137,7 +144,7 @@ describe('what the screen hands to the money engine', () => {
 
   it('never reaches the engine while the problem message is showing', () => {
     const entries = { a: '30', b: '30', c: '30' };
-    expect(splitProblem('percent', entries, people)).not.toBeNull();
+    expect(splitProblem(SplitKind.Percent, entries, people)).not.toBeNull();
     expect(() =>
       computeShares({
         amount: 10000n,

--- a/apps/web/src/app/activity/page.tsx
+++ b/apps/web/src/app/activity/page.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link';
 import type { ActivityGroup, ActivityRow } from '@baaki/api-client';
 
 import { AppFrame } from '@/components/AppFrame';
+import { Section } from '@/components/Shell';
 import { SkeletonRows } from '@/components/Skeleton';
 import { baaki } from '@/lib/baaki';
 import { describeActivity, verbEmoji } from '@/lib/activity';
@@ -25,7 +26,7 @@ type FeedRow = ActivityRow & { group: ActivityGroup | null };
 
 export default function ActivityPage() {
   return (
-    <AppFrame current="activity">
+    <AppFrame current={Section.Activity}>
       {({ profileId, query }) => <ActivityFeed profileId={profileId} query={query} />}
     </AppFrame>
   );

--- a/apps/web/src/app/friends/page.tsx
+++ b/apps/web/src/app/friends/page.tsx
@@ -15,6 +15,7 @@ import Link from 'next/link';
 import type { PersonBalanceRow } from '@baaki/api-client';
 
 import { AppFrame } from '@/components/AppFrame';
+import { Section } from '@/components/Shell';
 import { SkeletonRows } from '@/components/Skeleton';
 import { baaki } from '@/lib/baaki';
 import { money } from '@/lib/money';
@@ -32,7 +33,7 @@ interface Person {
 }
 
 export default function FriendsPage() {
-  return <AppFrame current="friends">{({ query }) => <Friends query={query} />}</AppFrame>;
+  return <AppFrame current={Section.Friends}>{({ query }) => <Friends query={query} />}</AppFrame>;
 }
 
 function Friends({ query }: { query: string }) {

--- a/apps/web/src/app/g/[groupId]/add/page.tsx
+++ b/apps/web/src/app/g/[groupId]/add/page.tsx
@@ -13,11 +13,12 @@ import { Suspense } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 
 import { AppFrame } from '@/components/AppFrame';
+import { Section } from '@/components/Shell';
 import { ExpenseForm } from '@/components/ExpenseForm';
 
 export default function AddExpensePage() {
   return (
-    <AppFrame current="groups">
+    <AppFrame current={Section.Groups}>
       {({ profileId }) => (
         <Suspense fallback={null}>
           <AddOrEdit profileId={profileId} />

--- a/apps/web/src/app/g/[groupId]/expense/[expenseId]/page.tsx
+++ b/apps/web/src/app/g/[groupId]/expense/[expenseId]/page.tsx
@@ -23,6 +23,7 @@ import {
 } from '@baaki/api-client';
 
 import { AppFrame } from '@/components/AppFrame';
+import { Section } from '@/components/Shell';
 import { SkeletonRows } from '@/components/Skeleton';
 import { baaki } from '@/lib/baaki';
 import { money } from '@/lib/money';
@@ -31,7 +32,7 @@ import { useStrings } from '@/i18n-context';
 
 export default function ExpensePage() {
   return (
-    <AppFrame current="groups">
+    <AppFrame current={Section.Groups}>
       {({ profileId }) => <ExpenseDetail profileId={profileId} />}
     </AppFrame>
   );

--- a/apps/web/src/app/g/[groupId]/page.tsx
+++ b/apps/web/src/app/g/[groupId]/page.tsx
@@ -24,6 +24,7 @@ import {
 } from '@baaki/api-client';
 
 import { AppFrame } from '@/components/AppFrame';
+import { Section } from '@/components/Shell';
 import { SkeletonRows } from '@/components/Skeleton';
 import { baaki } from '@/lib/baaki';
 import { money } from '@/lib/money';
@@ -32,7 +33,7 @@ import { useStrings } from '@/i18n-context';
 
 export default function GroupPage() {
   return (
-    <AppFrame current="groups">
+    <AppFrame current={Section.Groups}>
       {({ profileId, query }) => <GroupDetail profileId={profileId} query={query} />}
     </AppFrame>
   );

--- a/apps/web/src/app/inbox/page.tsx
+++ b/apps/web/src/app/inbox/page.tsx
@@ -14,12 +14,13 @@ import { useEffect, useState } from 'react';
 import type { NotificationRow } from '@baaki/api-client';
 
 import { AppFrame } from '@/components/AppFrame';
+import { Section } from '@/components/Shell';
 import { SkeletonRows } from '@/components/Skeleton';
 import { baaki } from '@/lib/baaki';
 import { useStrings } from '@/i18n-context';
 
 export default function InboxPage() {
-  return <AppFrame current="inbox">{() => <Inbox />}</AppFrame>;
+  return <AppFrame current={Section.Inbox}>{() => <Inbox />}</AppFrame>;
 }
 
 function Inbox() {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -11,11 +11,12 @@
  */
 
 import { AppFrame } from '@/components/AppFrame';
+import { Section } from '@/components/Shell';
 import { Overview } from '@/components/Overview';
 
 export default function Home() {
   return (
-    <AppFrame current="overview">
+    <AppFrame current={Section.Overview}>
       {({ profileId, query }) => <Overview profileId={profileId} query={query} />}
     </AppFrame>
   );

--- a/apps/web/src/app/settle/page.tsx
+++ b/apps/web/src/app/settle/page.tsx
@@ -36,6 +36,7 @@ import {
 } from '@baaki/core';
 
 import { AppFrame } from '@/components/AppFrame';
+import { Section } from '@/components/Shell';
 import { SkeletonRows } from '@/components/Skeleton';
 import { baaki } from '@/lib/baaki';
 import { money } from '@/lib/money';
@@ -43,7 +44,7 @@ import { useStrings } from '@/i18n-context';
 
 export default function SettlePage() {
   return (
-    <AppFrame current="settle">
+    <AppFrame current={Section.Settle}>
       {({ profileId }) => (
         <Suspense fallback={null}>
           <Settle profileId={profileId} />

--- a/apps/web/src/components/ExpenseForm.tsx
+++ b/apps/web/src/components/ExpenseForm.tsx
@@ -32,8 +32,13 @@ import { money as fmtMoney } from '@/lib/money';
 import { fill } from '@/i18n';
 import { useStrings } from '@/i18n-context';
 
-type SplitKind = 'equal' | 'exact' | 'percent' | 'shares';
-const KINDS: SplitKind[] = ['equal', 'exact', 'percent', 'shares'];
+enum SplitKind {
+  Equal = 'equal',
+  Exact = 'exact',
+  Percent = 'percent',
+  Shares = 'shares',
+}
+const KINDS: SplitKind[] = [SplitKind.Equal, SplitKind.Exact, SplitKind.Percent, SplitKind.Shares];
 
 export function ExpenseForm({
   groupId,
@@ -58,7 +63,7 @@ export function ExpenseForm({
   const [expenseDate, setExpenseDate] = useState(() => new Date().toISOString().slice(0, 10));
   const [payer, setPayer] = useState<string | null>(null);
   const [participants, setParticipants] = useState<string[]>([]);
-  const [kind, setKind] = useState<SplitKind>('equal');
+  const [kind, setKind] = useState<SplitKind>(SplitKind.Equal);
   // Per-member raw text, kept as typed; parsed only when building the params.
   const [exact, setExact] = useState<Record<string, string>>({});
   const [percent, setPercent] = useState<Record<string, string>>({});
@@ -93,10 +98,10 @@ export function ExpenseForm({
           const parsed = parseSplitParams(version.split_params);
           switch (parsed.kind) {
             case 'equal':
-              setKind('equal');
+              setKind(SplitKind.Equal);
               break;
             case 'exact':
-              setKind('exact');
+              setKind(SplitKind.Exact);
               setExact(
                 Object.fromEntries(
                   Object.entries(parsed.amounts).map(([id, minor]) => [
@@ -107,7 +112,7 @@ export function ExpenseForm({
               );
               break;
             case 'percent':
-              setKind('percent');
+              setKind(SplitKind.Percent);
               setPercent(
                 Object.fromEntries(
                   Object.entries(parsed.basisPoints).map(([id, bp]) => [id, String(bp / 100)]),
@@ -115,7 +120,7 @@ export function ExpenseForm({
               );
               break;
             case 'shares':
-              setKind('shares');
+              setKind(SplitKind.Shares);
               setWeights(
                 Object.fromEntries(
                   Object.entries(parsed.weights).map(([id, w]) => [id, String(w)]),
@@ -155,16 +160,16 @@ export function ExpenseForm({
     if (participants.length === 0) return null;
     try {
       switch (kind) {
-        case 'equal':
+        case SplitKind.Equal:
           return { kind: 'equal' };
-        case 'exact': {
+        case SplitKind.Exact: {
           const amounts: Record<string, bigint> = {};
           for (const id of participants) {
             amounts[id] = parseMajor(exact[id]?.trim() || '0', currency).minor;
           }
           return { kind: 'exact', amounts };
         }
-        case 'percent': {
+        case SplitKind.Percent: {
           const basisPoints: Record<string, number> = {};
           for (const id of participants) {
             const value = Number.parseFloat(percent[id]?.trim() || '0');
@@ -173,7 +178,7 @@ export function ExpenseForm({
           }
           return { kind: 'percent', basisPoints };
         }
-        case 'shares': {
+        case SplitKind.Shares: {
           const w: Record<string, number> = {};
           for (const id of participants) {
             const value = Number.parseInt(weights[id]?.trim() || '0', 10);
@@ -366,29 +371,33 @@ export function ExpenseForm({
             ))}
           </div>
 
-          {kind !== 'equal' ? (
+          {kind !== SplitKind.Equal ? (
             <div className="list" style={{ marginTop: 12 }}>
               {participants.map((id) => {
                 const member = members.find((m) => m.id === id);
                 const value =
-                  kind === 'exact'
+                  kind === SplitKind.Exact
                     ? (exact[id] ?? '')
-                    : kind === 'percent'
+                    : kind === SplitKind.Percent
                       ? (percent[id] ?? '')
                       : (weights[id] ?? '');
                 const setter =
-                  kind === 'exact' ? setExact : kind === 'percent' ? setPercent : setWeights;
+                  kind === SplitKind.Exact
+                    ? setExact
+                    : kind === SplitKind.Percent
+                      ? setPercent
+                      : setWeights;
                 return (
                   <div key={id} className="split-input">
                     <span className="grow">{member ? nameOf(member) : id}</span>
                     <input
                       value={value}
-                      inputMode={kind === 'shares' ? 'numeric' : 'decimal'}
+                      inputMode={kind === SplitKind.Shares ? 'numeric' : 'decimal'}
                       onChange={(e) => setter((cur) => ({ ...cur, [id]: e.target.value }))}
                       aria-label={member ? nameOf(member) : id}
                     />
                     <span className="unit">
-                      {kind === 'exact' ? currency : kind === 'percent' ? '%' : '×'}
+                      {kind === SplitKind.Exact ? currency : kind === SplitKind.Percent ? '%' : '×'}
                     </span>
                   </div>
                 );

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -14,7 +14,14 @@ import Link from 'next/link';
 
 import { useStrings } from '@/i18n-context';
 
-export type Section = 'overview' | 'groups' | 'activity' | 'friends' | 'settle' | 'inbox';
+export enum Section {
+  Overview = 'overview',
+  Groups = 'groups',
+  Activity = 'activity',
+  Friends = 'friends',
+  Settle = 'settle',
+  Inbox = 'inbox',
+}
 
 export function Shell({
   current,
@@ -53,14 +60,14 @@ export function Shell({
   // A group page reports `current: 'groups'`, but there is no separate Groups
   // destination in the rail — the groups live on the overview — so it lights the
   // overview item rather than nothing.
-  const activeKey: Section = current === 'groups' ? 'overview' : current;
+  const activeKey: Section = current === Section.Groups ? Section.Overview : current;
 
   const nav: { key: Section; label: string; href: string; icon: string }[] = [
-    { key: 'overview', label: t.dash.nav.overview, href: '/', icon: '▤' },
-    { key: 'activity', label: t.dash.nav.activity, href: '/activity', icon: '📈' },
-    { key: 'friends', label: t.dash.nav.friends, href: '/friends', icon: '🙂' },
-    { key: 'settle', label: t.dash.nav.settle, href: '/settle', icon: '⇄' },
-    { key: 'inbox', label: t.inbox.title, href: '/inbox', icon: '🔔' },
+    { key: Section.Overview, label: t.dash.nav.overview, href: '/', icon: '▤' },
+    { key: Section.Activity, label: t.dash.nav.activity, href: '/activity', icon: '📈' },
+    { key: Section.Friends, label: t.dash.nav.friends, href: '/friends', icon: '🙂' },
+    { key: Section.Settle, label: t.dash.nav.settle, href: '/settle', icon: '⇄' },
+    { key: Section.Inbox, label: t.inbox.title, href: '/inbox', icon: '🔔' },
   ];
 
   const pageTitle = nav.find((item) => item.key === activeKey)?.label ?? t.dash.nav.overview;

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -14,12 +14,22 @@
  * the page turn around.
  */
 
-export type Language = 'en' | 'ta' | 'hi' | 'ar';
+export enum Language {
+  En = 'en',
+  Ta = 'ta',
+  Hi = 'hi',
+  Ar = 'ar',
+}
 
-export const LANGUAGES: readonly Language[] = ['en', 'ta', 'hi', 'ar'];
+export const LANGUAGES: readonly Language[] = [
+  Language.En,
+  Language.Ta,
+  Language.Hi,
+  Language.Ar,
+];
 
 export function isRtlLanguage(language: Language): boolean {
-  return language === 'ar';
+  return language === Language.Ar;
 }
 
 /**
@@ -30,7 +40,7 @@ export function isRtlLanguage(language: Language): boolean {
  * is the answer, and English is the answer when none of them is.
  */
 export function pickLanguage(acceptLanguage: string | null | undefined): Language {
-  if (!acceptLanguage) return 'en';
+  if (!acceptLanguage) return Language.En;
   for (const part of acceptLanguage.split(',')) {
     const tag = part.split(';')[0]?.trim().toLowerCase();
     const subtag = tag?.split('-')[0];
@@ -38,7 +48,7 @@ export function pickLanguage(acceptLanguage: string | null | undefined): Languag
       return subtag as Language;
     }
   }
-  return 'en';
+  return Language.En;
 }
 
 /**
@@ -1141,7 +1151,12 @@ const ar: WebStrings = {
   },
 };
 
-export const STRINGS_BY_LANGUAGE: Record<Language, WebStrings> = { en, ta, hi, ar };
+export const STRINGS_BY_LANGUAGE: Record<Language, WebStrings> = {
+  [Language.En]: en,
+  [Language.Ta]: ta,
+  [Language.Hi]: hi,
+  [Language.Ar]: ar,
+};
 
 export function stringsFor(language: Language): WebStrings {
   return STRINGS_BY_LANGUAGE[language];

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -18,7 +18,7 @@
 
 import type { Session, SupabaseClient } from '@supabase/supabase-js';
 
-import { checkPassword, planAuth, readIdentifier, type Viewer } from '@baaki/core';
+import { AuthMethod, checkPassword, planAuth, readIdentifier, type Viewer } from '@baaki/core';
 
 import type { AcceptedInvite, Expense, Group, InvitePreview, Member, Settlement } from './types';
 import {
@@ -175,7 +175,7 @@ export function createBaakiClient({ supabase }: BaakiClientOptions) {
     ): Promise<void> {
       const who = readIdentifier(identifier);
       checkPassword(password);
-      const method = who.kind === 'email' ? 'email_password' : 'phone_password';
+      const method = who.kind === 'email' ? AuthMethod.EmailPassword : AuthMethod.PhonePassword;
       const credential = who.kind === 'email' ? { email: who.value } : { phone: who.value };
 
       const { data } = await supabase.auth.getSession();

--- a/packages/api-client/src/rows.ts
+++ b/packages/api-client/src/rows.ts
@@ -9,7 +9,13 @@
  * a number.
  */
 
-export type GroupType = 'trip' | 'home' | 'couple' | 'event' | 'other';
+export enum GroupType {
+  Trip = 'trip',
+  Home = 'home',
+  Couple = 'couple',
+  Event = 'event',
+  Other = 'other',
+}
 
 export interface GroupRow {
   id: string;
@@ -77,7 +83,12 @@ export interface ActivityRow {
   group?: ActivityGroup | null;
 }
 
-export type DisputeStatus = 'open' | 'resolved' | 'withdrawn' | 'rejected';
+export enum DisputeStatus {
+  Open = 'open',
+  Resolved = 'resolved',
+  Withdrawn = 'withdrawn',
+  Rejected = 'rejected',
+}
 
 /**
  * Somebody saying an expense is wrong. Never moves a balance on its own — a
@@ -108,10 +119,20 @@ export interface ExpenseVersionSummary {
   split_type: string;
 }
 
-export type SettlementMethod = 'upi' | 'cash' | 'bank' | 'other';
+export enum SettlementMethod {
+  Upi = 'upi',
+  Cash = 'cash',
+  Bank = 'bank',
+  Other = 'other',
+}
 
-export type SettlementStatus =
-  'initiated' | 'confirmed' | 'auto_confirmed' | 'disputed' | 'cancelled';
+export enum SettlementStatus {
+  Initiated = 'initiated',
+  Confirmed = 'confirmed',
+  AutoConfirmed = 'auto_confirmed',
+  Disputed = 'disputed',
+  Cancelled = 'cancelled',
+}
 
 /**
  * The coarse `method` enum the settlements table stores, derived from the finer
@@ -122,9 +143,16 @@ export type SettlementStatus =
  * and cannot drift between the phone and the browser.
  */
 export function coarseMethod(rail: string): SettlementMethod {
-  return (['upi', 'cash', 'bank', 'other'] as const).includes(rail as SettlementMethod)
+  return (
+    [
+      SettlementMethod.Upi,
+      SettlementMethod.Cash,
+      SettlementMethod.Bank,
+      SettlementMethod.Other,
+    ] as const
+  ).includes(rail as SettlementMethod)
     ? (rail as SettlementMethod)
-    : 'other';
+    : SettlementMethod.Other;
 }
 
 /**

--- a/packages/api-client/test/settlement.test.ts
+++ b/packages/api-client/test/settlement.test.ts
@@ -13,24 +13,24 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { coarseMethod } from '../src/index';
+import { coarseMethod, SettlementMethod } from '../src/index';
 
 describe('coarseMethod', () => {
   it('keeps the four the enum knows', () => {
-    expect(coarseMethod('upi')).toBe('upi');
-    expect(coarseMethod('cash')).toBe('cash');
-    expect(coarseMethod('bank')).toBe('bank');
-    expect(coarseMethod('other')).toBe('other');
+    expect(coarseMethod('upi')).toBe(SettlementMethod.Upi);
+    expect(coarseMethod('cash')).toBe(SettlementMethod.Cash);
+    expect(coarseMethod('bank')).toBe(SettlementMethod.Bank);
+    expect(coarseMethod('other')).toBe(SettlementMethod.Other);
   });
 
   it('folds every other rail down to other', () => {
     for (const rail of ['pix', 'paynow', 'promptpay', 'wise', 'zelle', 'venmo', 'revolut']) {
-      expect(coarseMethod(rail)).toBe('other');
+      expect(coarseMethod(rail)).toBe(SettlementMethod.Other);
     }
   });
 
   it('does not mistake an unknown string for a known method', () => {
-    expect(coarseMethod('')).toBe('other');
-    expect(coarseMethod('UPI')).toBe('other'); // case matters — the enum is lower-case
+    expect(coarseMethod('')).toBe(SettlementMethod.Other);
+    expect(coarseMethod('UPI')).toBe(SettlementMethod.Other); // case matters — the enum is lower-case
   });
 });

--- a/packages/core/src/auth/guestLimits.ts
+++ b/packages/core/src/auth/guestLimits.ts
@@ -39,7 +39,10 @@ export interface GuestGate {
 }
 
 /** Why a guest is being asked to sign up, or `null` when nothing blocks them. */
-export type GuestBlock = 'group_limit' | 'trial_expired';
+export enum GuestBlock {
+  GroupLimit = 'group_limit',
+  TrialExpired = 'trial_expired',
+}
 
 /**
  * Where a guest stands against both limits.
@@ -80,12 +83,12 @@ export function guestGate(input: {
 
 /** The reason to gate a "start or join a group" action, or `null` to allow it. */
 export function guestGroupBlock(gate: GuestGate): GuestBlock | null {
-  if (gate.expired) return 'trial_expired';
-  if (gate.atGroupLimit) return 'group_limit';
+  if (gate.expired) return GuestBlock.TrialExpired;
+  if (gate.atGroupLimit) return GuestBlock.GroupLimit;
   return null;
 }
 
 /** The reason to gate any other write, or `null` to allow it. */
 export function guestWriteBlock(gate: GuestGate): GuestBlock | null {
-  return gate.expired ? 'trial_expired' : null;
+  return gate.expired ? GuestBlock.TrialExpired : null;
 }

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -20,15 +20,35 @@
  * Nothing here talks to Supabase. It decides; the caller performs.
  */
 
-export type AuthMethod = 'email_password' | 'phone_password' | 'phone_otp' | 'google' | 'apple';
+export enum AuthMethod {
+  EmailPassword = 'email_password',
+  PhonePassword = 'phone_password',
+  PhoneOtp = 'phone_otp',
+  Google = 'google',
+  Apple = 'apple',
+}
 
 /** The providers reached through an identity provider rather than a credential. */
-export type OAuthMethod = 'google' | 'apple';
+export enum OAuthMethod {
+  Google = 'google',
+  Apple = 'apple',
+}
 
-const OAUTH: readonly AuthMethod[] = ['google', 'apple'];
-
-function isOAuth(method: AuthMethod): method is OAuthMethod {
-  return OAUTH.includes(method);
+/**
+ * The OAuth providers, as their own enum. `AuthMethod` and `OAuthMethod` share
+ * the same string values but are distinct enums, so an `AuthMethod` is mapped
+ * across rather than assigned; `null` means this method is a credential, not an
+ * identity provider.
+ */
+function asOAuth(method: AuthMethod): OAuthMethod | null {
+  switch (method) {
+    case AuthMethod.Google:
+      return OAuthMethod.Google;
+    case AuthMethod.Apple:
+      return OAuthMethod.Apple;
+    default:
+      return null;
+  }
 }
 
 /** Who is asking. */
@@ -86,23 +106,25 @@ export function planAuth(
   method: AuthMethod,
   intent: 'sign_in' | 'sign_up' = 'sign_in',
 ): AuthAction {
+  const oauth = asOAuth(method);
+
   if (viewer.kind === 'guest') {
     // Whatever the screen thought it was doing, this is an upgrade.
-    return isOAuth(method) ? { call: 'linkIdentity', method } : { call: 'updateUser', method };
+    return oauth ? { call: 'linkIdentity', method: oauth } : { call: 'updateUser', method };
   }
 
   if (viewer.kind === 'user') {
     // Already a real account. Adding a second way in is still a link, never a
     // sign-up — somebody with an email adding Google must not end up with two
     // accounts and half their groups in each.
-    return isOAuth(method) ? { call: 'linkIdentity', method } : { call: 'updateUser', method };
+    return oauth ? { call: 'linkIdentity', method: oauth } : { call: 'updateUser', method };
   }
 
   switch (method) {
-    case 'google':
-    case 'apple':
-      return { call: 'signInWithOAuth', method };
-    case 'phone_otp':
+    case AuthMethod.Google:
+    case AuthMethod.Apple:
+      return { call: 'signInWithOAuth', method: oauth! };
+    case AuthMethod.PhoneOtp:
       return { call: 'signInWithOtp', method: 'phone_otp' };
     default:
       return intent === 'sign_up'

--- a/packages/core/src/balances/types.ts
+++ b/packages/core/src/balances/types.ts
@@ -17,8 +17,13 @@ export interface ExpenseSnapshot {
   readonly deletedAt?: string | null;
 }
 
-export type SettlementStatus =
-  'initiated' | 'confirmed' | 'auto_confirmed' | 'disputed' | 'cancelled';
+export enum SettlementStatus {
+  Initiated = 'initiated',
+  Confirmed = 'confirmed',
+  AutoConfirmed = 'auto_confirmed',
+  Disputed = 'disputed',
+  Cancelled = 'cancelled',
+}
 
 export interface SettlementAllocation {
   readonly expenseId: string;

--- a/packages/core/src/billing/plans.ts
+++ b/packages/core/src/billing/plans.ts
@@ -24,13 +24,16 @@
 
 import type { CurrencyCode } from '../money/currency';
 
-export type PlanTier = 'free' | 'plus';
+export enum PlanTier {
+  Free = 'free',
+  Plus = 'plus',
+}
 
-export type BillingPeriod =
-  | 'monthly'
-  | 'yearly'
+export enum BillingPeriod {
+  Monthly = 'monthly',
+  Yearly = 'yearly',
   /** Bought once. India converts on one-time purchases where it will not on subscriptions. */
-  | 'lifetime'
+  Lifetime = 'lifetime',
   /**
    * One group, thirty days, bought by one person and enjoyed by everyone in it.
    *
@@ -40,7 +43,8 @@ export type BillingPeriod =
    * makes the buyer generous rather than out of pocket, and puts the paid
    * features in front of five people who did not buy.
    */
-  | 'trip_pass';
+  TripPass = 'trip_pass',
+}
 
 export interface Price {
   readonly minor: bigint;
@@ -61,52 +65,52 @@ export const PLUS_MONTHLY_SCANS = 300;
  */
 const PRICES: Readonly<Record<string, Readonly<Record<BillingPeriod, Price>>>> = {
   IN: {
-    monthly: { minor: 7900n, currency: 'INR' },
-    yearly: { minor: 69900n, currency: 'INR' },
-    lifetime: { minor: 199900n, currency: 'INR' },
-    trip_pass: { minor: 14900n, currency: 'INR' },
+    [BillingPeriod.Monthly]: { minor: 7900n, currency: 'INR' },
+    [BillingPeriod.Yearly]: { minor: 69900n, currency: 'INR' },
+    [BillingPeriod.Lifetime]: { minor: 199900n, currency: 'INR' },
+    [BillingPeriod.TripPass]: { minor: 14900n, currency: 'INR' },
   },
   AE: {
-    monthly: { minor: 1499n, currency: 'AED' },
-    yearly: { minor: 12900n, currency: 'AED' },
-    lifetime: { minor: 34900n, currency: 'AED' },
-    trip_pass: { minor: 2900n, currency: 'AED' },
+    [BillingPeriod.Monthly]: { minor: 1499n, currency: 'AED' },
+    [BillingPeriod.Yearly]: { minor: 12900n, currency: 'AED' },
+    [BillingPeriod.Lifetime]: { minor: 34900n, currency: 'AED' },
+    [BillingPeriod.TripPass]: { minor: 2900n, currency: 'AED' },
   },
   SA: {
-    monthly: { minor: 1499n, currency: 'SAR' },
-    yearly: { minor: 12900n, currency: 'SAR' },
-    lifetime: { minor: 34900n, currency: 'SAR' },
-    trip_pass: { minor: 2900n, currency: 'SAR' },
+    [BillingPeriod.Monthly]: { minor: 1499n, currency: 'SAR' },
+    [BillingPeriod.Yearly]: { minor: 12900n, currency: 'SAR' },
+    [BillingPeriod.Lifetime]: { minor: 34900n, currency: 'SAR' },
+    [BillingPeriod.TripPass]: { minor: 2900n, currency: 'SAR' },
   },
   US: {
-    monthly: { minor: 499n, currency: 'USD' },
-    yearly: { minor: 3999n, currency: 'USD' },
-    lifetime: { minor: 9999n, currency: 'USD' },
-    trip_pass: { minor: 799n, currency: 'USD' },
+    [BillingPeriod.Monthly]: { minor: 499n, currency: 'USD' },
+    [BillingPeriod.Yearly]: { minor: 3999n, currency: 'USD' },
+    [BillingPeriod.Lifetime]: { minor: 9999n, currency: 'USD' },
+    [BillingPeriod.TripPass]: { minor: 799n, currency: 'USD' },
   },
   CA: {
-    monthly: { minor: 699n, currency: 'CAD' },
-    yearly: { minor: 5499n, currency: 'CAD' },
-    lifetime: { minor: 13999n, currency: 'CAD' },
-    trip_pass: { minor: 1099n, currency: 'CAD' },
+    [BillingPeriod.Monthly]: { minor: 699n, currency: 'CAD' },
+    [BillingPeriod.Yearly]: { minor: 5499n, currency: 'CAD' },
+    [BillingPeriod.Lifetime]: { minor: 13999n, currency: 'CAD' },
+    [BillingPeriod.TripPass]: { minor: 1099n, currency: 'CAD' },
   },
   AU: {
-    monthly: { minor: 799n, currency: 'AUD' },
-    yearly: { minor: 5999n, currency: 'AUD' },
-    lifetime: { minor: 14999n, currency: 'AUD' },
-    trip_pass: { minor: 1199n, currency: 'AUD' },
+    [BillingPeriod.Monthly]: { minor: 799n, currency: 'AUD' },
+    [BillingPeriod.Yearly]: { minor: 5999n, currency: 'AUD' },
+    [BillingPeriod.Lifetime]: { minor: 14999n, currency: 'AUD' },
+    [BillingPeriod.TripPass]: { minor: 1199n, currency: 'AUD' },
   },
   BR: {
-    monthly: { minor: 1490n, currency: 'BRL' },
-    yearly: { minor: 12900n, currency: 'BRL' },
-    lifetime: { minor: 29900n, currency: 'BRL' },
-    trip_pass: { minor: 2490n, currency: 'BRL' },
+    [BillingPeriod.Monthly]: { minor: 1490n, currency: 'BRL' },
+    [BillingPeriod.Yearly]: { minor: 12900n, currency: 'BRL' },
+    [BillingPeriod.Lifetime]: { minor: 29900n, currency: 'BRL' },
+    [BillingPeriod.TripPass]: { minor: 2490n, currency: 'BRL' },
   },
   GB: {
-    monthly: { minor: 399n, currency: 'GBP' },
-    yearly: { minor: 2999n, currency: 'GBP' },
-    lifetime: { minor: 7999n, currency: 'GBP' },
-    trip_pass: { minor: 599n, currency: 'GBP' },
+    [BillingPeriod.Monthly]: { minor: 399n, currency: 'GBP' },
+    [BillingPeriod.Yearly]: { minor: 2999n, currency: 'GBP' },
+    [BillingPeriod.Lifetime]: { minor: 7999n, currency: 'GBP' },
+    [BillingPeriod.TripPass]: { minor: 599n, currency: 'GBP' },
   },
 };
 
@@ -145,7 +149,7 @@ export interface Entitlement {
 }
 
 export const FREE_ENTITLEMENT: Entitlement = {
-  tier: 'free',
+  tier: PlanTier.Free,
   until: null,
   source: 'free',
   scanLimit: FREE_MONTHLY_SCANS,
@@ -164,7 +168,7 @@ export function readEntitlement(value: unknown): Entitlement {
   if (typeof value !== 'object' || value === null) return FREE_ENTITLEMENT;
   const row = value as Record<string, unknown>;
 
-  const tier = row.tier === 'plus' ? 'plus' : 'free';
+  const tier = row.tier === 'plus' ? PlanTier.Plus : PlanTier.Free;
   const source =
     row.source === 'subscription' || row.source === 'lifetime' || row.source === 'trip_pass'
       ? row.source
@@ -176,11 +180,11 @@ export function readEntitlement(value: unknown): Entitlement {
     until: typeof row.until === 'string' ? row.until : null,
     // A free tier with a paid source, or the reverse, is a database that has
     // been edited by hand. Trust the tier and let the source be cosmetic.
-    source: tier === 'free' ? 'free' : source === 'free' ? 'subscription' : source,
+    source: tier === PlanTier.Free ? 'free' : source === 'free' ? 'subscription' : source,
     scanLimit:
       Number.isFinite(limit) && limit > 0
         ? Math.floor(limit)
-        : tier === 'plus'
+        : tier === PlanTier.Plus
           ? PLUS_MONTHLY_SCANS
           : FREE_MONTHLY_SCANS,
   };

--- a/packages/core/src/category/categories.ts
+++ b/packages/core/src/category/categories.ts
@@ -22,17 +22,18 @@
 
 import { keywordsForMarket } from './markets';
 
-export type CategoryId =
-  | 'food'
-  | 'groceries'
-  | 'travel'
-  | 'stay'
-  | 'shopping'
-  | 'entertainment'
-  | 'home'
-  | 'health'
-  | 'gifts'
-  | 'other';
+export enum CategoryId {
+  Food = 'food',
+  Groceries = 'groceries',
+  Travel = 'travel',
+  Stay = 'stay',
+  Shopping = 'shopping',
+  Entertainment = 'entertainment',
+  Home = 'home',
+  Health = 'health',
+  Gifts = 'gifts',
+  Other = 'other',
+}
 
 export interface Category {
   readonly id: CategoryId;
@@ -48,7 +49,7 @@ export interface Category {
 
 export const CATEGORIES: readonly Category[] = [
   {
-    id: 'food',
+    id: CategoryId.Food,
     label: 'Food & drink',
     icon: 'restaurant-outline',
     tint: 'peach',
@@ -94,7 +95,7 @@ export const CATEGORIES: readonly Category[] = [
     ],
   },
   {
-    id: 'groceries',
+    id: CategoryId.Groceries,
     label: 'Groceries',
     icon: 'basket-outline',
     tint: 'mint',
@@ -123,7 +124,7 @@ export const CATEGORIES: readonly Category[] = [
     ],
   },
   {
-    id: 'travel',
+    id: CategoryId.Travel,
     label: 'Travel',
     icon: 'car-outline',
     tint: 'sky',
@@ -161,7 +162,7 @@ export const CATEGORIES: readonly Category[] = [
     ],
   },
   {
-    id: 'stay',
+    id: CategoryId.Stay,
     label: 'Stay',
     icon: 'bed-outline',
     tint: 'lilac',
@@ -185,7 +186,7 @@ export const CATEGORIES: readonly Category[] = [
     ],
   },
   {
-    id: 'shopping',
+    id: CategoryId.Shopping,
     label: 'Shopping',
     icon: 'bag-handle-outline',
     tint: 'pink',
@@ -210,7 +211,7 @@ export const CATEGORIES: readonly Category[] = [
     ],
   },
   {
-    id: 'entertainment',
+    id: CategoryId.Entertainment,
     label: 'Fun',
     icon: 'game-controller-outline',
     tint: 'coral',
@@ -242,7 +243,7 @@ export const CATEGORIES: readonly Category[] = [
     ],
   },
   {
-    id: 'home',
+    id: CategoryId.Home,
     label: 'Home & bills',
     icon: 'home-outline',
     tint: 'lilac',
@@ -276,7 +277,7 @@ export const CATEGORIES: readonly Category[] = [
     ],
   },
   {
-    id: 'health',
+    id: CategoryId.Health,
     label: 'Health',
     icon: 'medkit-outline',
     tint: 'mint',
@@ -300,7 +301,7 @@ export const CATEGORIES: readonly Category[] = [
     ],
   },
   {
-    id: 'gifts',
+    id: CategoryId.Gifts,
     label: 'Gifts',
     icon: 'gift-outline',
     tint: 'pink',
@@ -318,7 +319,7 @@ export const CATEGORIES: readonly Category[] = [
     ],
   },
   {
-    id: 'other',
+    id: CategoryId.Other,
     label: 'Other',
     icon: 'ellipsis-horizontal-circle-outline',
     tint: 'sky',

--- a/packages/core/src/category/markets.ts
+++ b/packages/core/src/category/markets.ts
@@ -27,8 +27,21 @@ import type { CategoryId } from './categories';
  * currencies and shops are keyed by — not a language, which several of these
  * share.
  */
-export type MarketId =
-  'IN' | 'AE' | 'SA' | 'QA' | 'KW' | 'BH' | 'OM' | 'BR' | 'SG' | 'ID' | 'US' | 'CA' | 'AU';
+export enum MarketId {
+  IN = 'IN',
+  AE = 'AE',
+  SA = 'SA',
+  QA = 'QA',
+  KW = 'KW',
+  BH = 'BH',
+  OM = 'OM',
+  BR = 'BR',
+  SG = 'SG',
+  ID = 'ID',
+  US = 'US',
+  CA = 'CA',
+  AU = 'AU',
+}
 
 type Keywords = Partial<Record<CategoryId, readonly string[]>>;
 
@@ -120,16 +133,16 @@ export const MARKET_KEYWORDS: Readonly<Record<MarketId, Keywords>> = {
   // India's vocabulary already lives in the shared list, where it was the
   // starting point. Nothing to add here; the entry exists so the type is
   // complete and so it is obvious the omission is deliberate.
-  IN: {},
+  [MarketId.IN]: {},
 
-  AE: GULF,
-  SA: GULF,
-  QA: GULF,
-  KW: GULF,
-  BH: GULF,
-  OM: GULF,
+  [MarketId.AE]: GULF,
+  [MarketId.SA]: GULF,
+  [MarketId.QA]: GULF,
+  [MarketId.KW]: GULF,
+  [MarketId.BH]: GULF,
+  [MarketId.OM]: GULF,
 
-  BR: {
+  [MarketId.BR]: {
     food: ['ifood', 'rappi', 'padaria', 'churrasco', 'lanche', 'almoco', 'jantar', 'cafe'],
     groceries: ['mercado', 'supermercado', 'carrefour', 'assai', 'atacadao', 'feira', 'hortifruti'],
     travel: ['uber', 'noventa', 'metro', 'onibus', 'gasolina', 'posto', 'pedagio', 'latam', 'gol'],
@@ -140,7 +153,7 @@ export const MARKET_KEYWORDS: Readonly<Record<MarketId, Keywords>> = {
     shopping: ['shopping', 'americanas', 'magalu'],
   },
 
-  US: {
+  [MarketId.US]: {
     ...ANGLOSPHERE,
     groceries: [
       ...(ANGLOSPHERE.groceries ?? []),
@@ -156,7 +169,7 @@ export const MARKET_KEYWORDS: Readonly<Record<MarketId, Keywords>> = {
     health: [...(ANGLOSPHERE.health ?? []), 'cvs', 'walgreens'],
   },
 
-  CA: {
+  [MarketId.CA]: {
     ...ANGLOSPHERE,
     food: [...(ANGLOSPHERE.food ?? []), 'tims', 'timhortons', 'skipthedishes', 'poutine'],
     groceries: [
@@ -174,7 +187,7 @@ export const MARKET_KEYWORDS: Readonly<Record<MarketId, Keywords>> = {
     home: [...(ANGLOSPHERE.home ?? []), 'hydro', 'rogers', 'telus', 'bell'],
   },
 
-  AU: {
+  [MarketId.AU]: {
     ...ANGLOSPHERE,
     food: [...(ANGLOSPHERE.food ?? []), 'menulog', 'deliveroo', 'maccas', 'brekkie'],
     groceries: [...(ANGLOSPHERE.groceries ?? []), 'woolworths', 'woolies', 'coles', 'iga'],
@@ -184,7 +197,7 @@ export const MARKET_KEYWORDS: Readonly<Record<MarketId, Keywords>> = {
     shopping: [...(ANGLOSPHERE.shopping ?? []), 'bunnings', 'kmart', 'bigw'],
   },
 
-  SG: {
+  [MarketId.SG]: {
     food: ['grabfood', 'foodpanda', 'hawker', 'kopitiam', 'zichar', 'chicken', 'laksa'],
     groceries: ['ntuc', 'fairprice', 'coldstorage', 'sheng', 'giant', 'redmart'],
     travel: ['grab', 'gojek', 'mrt', 'ez-link', 'ezlink', 'comfort', 'erp'],
@@ -192,7 +205,7 @@ export const MARKET_KEYWORDS: Readonly<Record<MarketId, Keywords>> = {
     home: ['sp', 'singtel', 'starhub', 'conservancy'],
   },
 
-  ID: {
+  [MarketId.ID]: {
     food: ['gofood', 'grabfood', 'warung', 'padang', 'bakso', 'nasi', 'sate', 'kopi'],
     groceries: ['indomaret', 'alfamart', 'hypermart', 'superindo', 'pasar'],
     travel: ['gojek', 'grab', 'transjakarta', 'krl', 'pertamina', 'bensin', 'tol', 'garuda'],

--- a/packages/core/src/import/baaki.ts
+++ b/packages/core/src/import/baaki.ts
@@ -30,6 +30,7 @@
  */
 
 import type { CurrencyCode } from '../money/currency';
+import { ImportProblemKind } from './splitwise';
 import type { ImportProblem } from './splitwise';
 
 /** Statuses that move a balance (TDR §3.3). The rest are carried as history. */
@@ -137,7 +138,11 @@ export function parseBaakiExport(text: string): BaakiImport {
       schemaVersion: 0,
       groups: [],
       problems: [
-        { kind: 'unparseable_row', row: null, message: 'That file is not a Baaki export.' },
+        {
+          kind: ImportProblemKind.UnparseableRow,
+          row: null,
+          message: 'That file is not a Baaki export.',
+        },
       ],
     };
   }
@@ -148,7 +153,7 @@ export function parseBaakiExport(text: string): BaakiImport {
 
   if (!root || groupsRaw.length === 0) {
     problems.push({
-      kind: 'no_rows',
+      kind: ImportProblemKind.NoRows,
       row: null,
       message: 'That file has no groups in it.',
     });
@@ -157,7 +162,7 @@ export function parseBaakiExport(text: string): BaakiImport {
     // silently drop, and dropping half of somebody's ledger without saying so
     // is exactly what this whole module exists to avoid.
     problems.push({
-      kind: 'unparseable_row',
+      kind: ImportProblemKind.UnparseableRow,
       row: null,
       message: `That file was written by a newer version of Baaki (format ${schemaVersion}). Update the app and try again.`,
     });
@@ -204,7 +209,7 @@ function parseGroup(entry: unknown): BaakiImportGroup {
 
   if (people.length === 0) {
     problems.push({
-      kind: 'no_people',
+      kind: ImportProblemKind.NoPeople,
       row: null,
       message: 'That group has nobody in it.',
     });
@@ -231,7 +236,7 @@ function parseGroup(entry: unknown): BaakiImportGroup {
 
     if (amount === null || payers === null || shares === null) {
       problems.push({
-        kind: 'unparseable_row',
+        kind: ImportProblemKind.UnparseableRow,
         row,
         message: `"${String(current.description ?? 'An expense')}" holds an amount that could not be read.`,
       });
@@ -245,7 +250,7 @@ function parseGroup(entry: unknown): BaakiImportGroup {
       // breaks it would be rejected server-side anyway; saying so here names
       // the row instead of failing the whole import with a constraint error.
       problems.push({
-        kind: 'row_does_not_balance',
+        kind: ImportProblemKind.RowDoesNotBalance,
         row,
         message: `"${String(current.description ?? 'An expense')}" does not add up: paid ${paid}, owed ${owed}, total ${amount}.`,
       });
@@ -272,7 +277,7 @@ function parseGroup(entry: unknown): BaakiImportGroup {
     const amount = minor(settlement.amount);
     if (!from || !to || amount === null) {
       problems.push({
-        kind: 'unparseable_row',
+        kind: ImportProblemKind.UnparseableRow,
         row: index + 1,
         message: 'A settlement names somebody who is not in the file.',
       });

--- a/packages/core/src/import/splitwise.ts
+++ b/packages/core/src/import/splitwise.ts
@@ -26,8 +26,13 @@
 import { minorUnitExponent, type CurrencyCode } from '../money/currency';
 import type { ExactParams } from '../split/types';
 
-export type ImportProblemKind =
-  'unparseable_row' | 'row_does_not_balance' | 'unknown_currency' | 'no_people' | 'no_rows';
+export enum ImportProblemKind {
+  UnparseableRow = 'unparseable_row',
+  RowDoesNotBalance = 'row_does_not_balance',
+  UnknownCurrency = 'unknown_currency',
+  NoPeople = 'no_people',
+  NoRows = 'no_rows',
+}
 
 export interface ImportProblem {
   readonly kind: ImportProblemKind;
@@ -208,7 +213,7 @@ export function importSplitwiseCsv(csv: string): SplitwiseImport {
 
   if (fixedCount < FIXED_COLUMNS.length || people.length === 0) {
     problems.push({
-      kind: 'no_people',
+      kind: ImportProblemKind.NoPeople,
       row: 1,
       message:
         'This does not look like a Splitwise export — expected Date, Description, Category, Cost, Currency and then one column per person.',
@@ -232,7 +237,7 @@ export function importSplitwiseCsv(csv: string): SplitwiseImport {
     const rowCurrency = (fields[4] ?? '').trim().toUpperCase() || currency;
     if (!/^[A-Z]{3}$/.test(rowCurrency)) {
       problems.push({
-        kind: 'unknown_currency',
+        kind: ImportProblemKind.UnknownCurrency,
         row: rowNumber,
         message: `Row ${rowNumber}: "${fields[4]}" is not a currency code.`,
       });
@@ -243,7 +248,7 @@ export function importSplitwiseCsv(csv: string): SplitwiseImport {
     const amount = parseCsvAmount(fields[3] ?? '', rowCurrency);
     if (!date || amount === null) {
       problems.push({
-        kind: 'unparseable_row',
+        kind: ImportProblemKind.UnparseableRow,
         row: rowNumber,
         message: `Row ${rowNumber}: could not read ${!date ? 'the date' : 'the cost'}.`,
       });
@@ -264,7 +269,7 @@ export function importSplitwiseCsv(csv: string): SplitwiseImport {
     // so it is named and skipped rather than adjusted into shape.
     if (net !== 0n) {
       problems.push({
-        kind: 'row_does_not_balance',
+        kind: ImportProblemKind.RowDoesNotBalance,
         row: rowNumber,
         message: `Row ${rowNumber} ("${description}"): the people's columns add up to ${net}, not 0.`,
       });
@@ -289,7 +294,11 @@ export function importSplitwiseCsv(csv: string): SplitwiseImport {
   }
 
   if (expenses.length === 0 && problems.length === 0) {
-    problems.push({ kind: 'no_rows', row: null, message: 'There were no expenses in this file.' });
+    problems.push({
+      kind: ImportProblemKind.NoRows,
+      row: null,
+      message: 'There were no expenses in this file.',
+    });
   }
 
   return {

--- a/packages/core/src/money/currency.ts
+++ b/packages/core/src/money/currency.ts
@@ -64,7 +64,7 @@ export function isCurrencyCode(value: string): boolean {
 
 export function assertCurrencyCode(value: string): asserts value is CurrencyCode {
   if (!isCurrencyCode(value)) {
-    throw new MoneyError('INVALID_CURRENCY', `Not an ISO-4217 alpha-3 code: "${value}"`);
+    throw new MoneyError(MoneyErrorCode.InvalidCurrency, `Not an ISO-4217 alpha-3 code: "${value}"`);
   }
 }
 
@@ -79,12 +79,13 @@ export function minorUnitScale(currency: CurrencyCode): bigint {
   return 10n ** BigInt(minorUnitExponent(currency));
 }
 
-export type MoneyErrorCode =
-  | 'INVALID_CURRENCY'
-  | 'CURRENCY_MISMATCH'
-  | 'INVALID_AMOUNT'
-  | 'NEGATIVE_AMOUNT'
-  | 'INVALID_FX_RATE';
+export enum MoneyErrorCode {
+  InvalidCurrency = 'INVALID_CURRENCY',
+  CurrencyMismatch = 'CURRENCY_MISMATCH',
+  InvalidAmount = 'INVALID_AMOUNT',
+  NegativeAmount = 'NEGATIVE_AMOUNT',
+  InvalidFxRate = 'INVALID_FX_RATE',
+}
 
 export class MoneyError extends Error {
   readonly code: MoneyErrorCode;

--- a/packages/core/src/money/format.ts
+++ b/packages/core/src/money/format.ts
@@ -96,12 +96,16 @@ export function currencySymbol(currency: CurrencyCode, locale: Locale = DEFAULT_
   return parts.find((part) => part.type === 'currency')?.value ?? currency;
 }
 
-export type BalanceDirection = 'owed_to_you' | 'you_owe' | 'settled';
+export enum BalanceDirection {
+  OwedToYou = 'owed_to_you',
+  YouOwe = 'you_owe',
+  Settled = 'settled',
+}
 
 export function balanceDirection(minor: bigint): BalanceDirection {
-  if (minor > 0n) return 'owed_to_you';
-  if (minor < 0n) return 'you_owe';
-  return 'settled';
+  if (minor > 0n) return BalanceDirection.OwedToYou;
+  if (minor < 0n) return BalanceDirection.YouOwe;
+  return BalanceDirection.Settled;
 }
 
 /**
@@ -119,11 +123,11 @@ export function moneyAccessibilityLabel(
     options,
   );
   switch (direction) {
-    case 'owed_to_you':
+    case BalanceDirection.OwedToYou:
       return strings.owedToYou.replace('{amount}', rendered);
-    case 'you_owe':
+    case BalanceDirection.YouOwe:
       return strings.youOwe.replace('{amount}', rendered);
-    case 'settled':
+    case BalanceDirection.Settled:
       return strings.settled;
   }
 }

--- a/packages/core/src/money/fx.ts
+++ b/packages/core/src/money/fx.ts
@@ -3,7 +3,7 @@
  * its provenance, so any conversion can be reproduced byte-for-byte later.
  */
 
-import { MoneyError, minorUnitExponent, type CurrencyCode } from './currency';
+import { MoneyError, MoneyErrorCode, minorUnitExponent, type CurrencyCode } from './currency';
 import { divideRoundHalfAwayFromZero, money, type Money } from './money';
 
 export interface FxRate {
@@ -20,11 +20,14 @@ export interface FxRate {
 
 export function fxRate(rate: FxRate): FxRate {
   if (rate.num <= 0n || rate.den <= 0n) {
-    throw new MoneyError('INVALID_FX_RATE', 'FX rate numerator and denominator must be positive');
+    throw new MoneyError(
+      MoneyErrorCode.InvalidFxRate,
+      'FX rate numerator and denominator must be positive',
+    );
   }
   if (rate.from === rate.to) {
     throw new MoneyError(
-      'INVALID_FX_RATE',
+      MoneyErrorCode.InvalidFxRate,
       'FX rate must convert between two different currencies',
     );
   }
@@ -39,7 +42,7 @@ export function fxRate(rate: FxRate): FxRate {
 export function convert(amount: Money, rate: FxRate): Money {
   if (amount.currency !== rate.from) {
     throw new MoneyError(
-      'CURRENCY_MISMATCH',
+      MoneyErrorCode.CurrencyMismatch,
       `Rate converts ${rate.from}→${rate.to}, but amount is ${amount.currency}`,
     );
   }
@@ -115,7 +118,7 @@ export function rateFromDecimal(
 ): FxRate {
   const trimmed = decimal.trim();
   if (!/^\d+(\.\d+)?$/.test(trimmed)) {
-    throw new MoneyError('INVALID_FX_RATE', `"${decimal}" is not a rate`);
+    throw new MoneyError(MoneyErrorCode.InvalidFxRate, `"${decimal}" is not a rate`);
   }
   const [whole = '0', fraction = ''] = trimmed.split('.');
   return fxRate({
@@ -143,7 +146,10 @@ export function rateFromAmounts(
   options: { ts?: string; source?: string } = {},
 ): FxRate {
   if (spent.minor <= 0n || charged.minor <= 0n) {
-    throw new MoneyError('INVALID_FX_RATE', 'Both amounts must be positive to imply a rate');
+    throw new MoneyError(
+      MoneyErrorCode.InvalidFxRate,
+      'Both amounts must be positive to imply a rate',
+    );
   }
   // Both sides are in minor units, so the exponents have to come back out or a
   // JPY↔INR rate would be wrong by a factor of a hundred.

--- a/packages/core/src/money/money.ts
+++ b/packages/core/src/money/money.ts
@@ -8,6 +8,7 @@
 import {
   assertCurrencyCode,
   MoneyError,
+  MoneyErrorCode,
   minorUnitExponent,
   minorUnitScale,
   type CurrencyCode,
@@ -23,7 +24,10 @@ export function money(minor: bigint | number, currency: CurrencyCode): Money {
   assertCurrencyCode(currency);
   if (typeof minor === 'number') {
     if (!Number.isSafeInteger(minor)) {
-      throw new MoneyError('INVALID_AMOUNT', `Minor units must be a safe integer, got ${minor}`);
+      throw new MoneyError(
+        MoneyErrorCode.InvalidAmount,
+        `Minor units must be a safe integer, got ${minor}`,
+      );
     }
     return { minor: BigInt(minor), currency };
   }
@@ -37,7 +41,7 @@ export function zero(currency: CurrencyCode): Money {
 function sameCurrency(a: Money, b: Money): void {
   if (a.currency !== b.currency) {
     throw new MoneyError(
-      'CURRENCY_MISMATCH',
+      MoneyErrorCode.CurrencyMismatch,
       `Cannot combine ${a.currency} with ${b.currency}. Convert explicitly with an FX rate.`,
     );
   }
@@ -66,7 +70,7 @@ export function sum(items: readonly Money[], currency: CurrencyCode): Money {
   for (const item of items) {
     if (item.currency !== currency) {
       throw new MoneyError(
-        'CURRENCY_MISMATCH',
+        MoneyErrorCode.CurrencyMismatch,
         `Expected all amounts in ${currency}, found ${item.currency}`,
       );
     }
@@ -97,7 +101,7 @@ export function equals(a: Money, b: Money): boolean {
 /** Integer division rounding halves away from zero. Deterministic on negatives. */
 export function divideRoundHalfAwayFromZero(numerator: bigint, denominator: bigint): bigint {
   if (denominator === 0n) {
-    throw new MoneyError('INVALID_AMOUNT', 'Division by zero');
+    throw new MoneyError(MoneyErrorCode.InvalidAmount, 'Division by zero');
   }
   const negative = numerator < 0n !== denominator < 0n;
   const absNumerator = numerator < 0n ? -numerator : numerator;
@@ -117,12 +121,15 @@ export function parseMajor(input: string, currency: CurrencyCode): Money {
   const exponent = minorUnitExponent(currency);
   const match = /^(-)?(\d+)(?:\.(\d+))?$/.exec(input.trim());
   if (!match) {
-    throw new MoneyError('INVALID_AMOUNT', `Cannot parse "${input}" as a ${currency} amount`);
+    throw new MoneyError(
+      MoneyErrorCode.InvalidAmount,
+      `Cannot parse "${input}" as a ${currency} amount`,
+    );
   }
   const [, sign, whole = '0', fractionRaw = ''] = match;
   if (fractionRaw.length > exponent) {
     throw new MoneyError(
-      'INVALID_AMOUNT',
+      MoneyErrorCode.InvalidAmount,
       `${currency} has ${exponent} decimal places, got "${input}"`,
     );
   }

--- a/packages/core/src/notifications/copy.ts
+++ b/packages/core/src/notifications/copy.ts
@@ -11,43 +11,49 @@
  * rather than a surprise on somebody's lock screen.
  */
 
-export type LanguageCode = 'en' | 'ta' | 'hi' | 'ar';
+export enum LanguageCode {
+  En = 'en',
+  Ta = 'ta',
+  Hi = 'hi',
+  Ar = 'ar',
+}
 
-export type NotificationKind =
-  | 'expense_added'
-  | 'expense_edited'
-  | 'expense_deleted'
-  | 'you_owe'
-  | 'settlement_initiated'
-  | 'settlement_confirm_request'
-  | 'settlement_confirmed'
-  | 'nudge'
-  | 'ghost_claimed'
-  | 'group_invite_accepted'
-  | 'digest_daily'
+export enum NotificationKind {
+  ExpenseAdded = 'expense_added',
+  ExpenseEdited = 'expense_edited',
+  ExpenseDeleted = 'expense_deleted',
+  YouOwe = 'you_owe',
+  SettlementInitiated = 'settlement_initiated',
+  SettlementConfirmRequest = 'settlement_confirm_request',
+  SettlementConfirmed = 'settlement_confirmed',
+  Nudge = 'nudge',
+  GhostClaimed = 'ghost_claimed',
+  GroupInviteAccepted = 'group_invite_accepted',
+  DigestDaily = 'digest_daily',
   /**
    * The two reminders that run for the length of a trip. Asked at breakfast
    * about yesterday and at the end of the day about today, because a ledger is
    * only as good as the habit of adding to it, and the habit needs prompting
    * while the receipts still exist.
    */
-  | 'trip_nudge_morning'
-  | 'trip_nudge_evening'
+  TripNudgeMorning = 'trip_nudge_morning',
+  TripNudgeEvening = 'trip_nudge_evening',
   /**
    * Somebody saying an expense is wrong. Worded as a correction rather than an
    * accusation on purpose (ADR-010): the common case is a genuine mistake, and
    * copy that treats it as a dispute makes a fight out of a typo.
    */
-  | 'expense_disputed'
-  | 'expense_dispute_resolved'
+  ExpenseDisputed = 'expense_disputed',
+  ExpenseDisputeResolved = 'expense_dispute_resolved',
   /**
    * Somebody saying they are the "Ravi" already listed in a group, and an
    * admin answering (ADR-006). Approving hands over every share and settlement
    * already filed under that name, which is why it is asked rather than taken.
    */
-  | 'ghost_claim_requested'
-  | 'ghost_claim_approved'
-  | 'ghost_claim_declined';
+  GhostClaimRequested = 'ghost_claim_requested',
+  GhostClaimApproved = 'ghost_claim_approved',
+  GhostClaimDeclined = 'ghost_claim_declined',
+}
 
 /**
  * The wrapping around a notification when it goes out as mail (TDR §7.3).
@@ -96,51 +102,51 @@ const en: CopyStrings = {
     netNegative: 'Your baaki is {amount}',
   },
   notifications: {
-    expense_added: {
+    [NotificationKind.ExpenseAdded]: {
       title: '{actor} added an expense',
       body: '{description} · {amount} in {group}',
     },
-    expense_edited: { title: '{actor} edited an expense', body: '{description} in {group}' },
-    expense_deleted: { title: '{actor} removed an expense', body: '{description} in {group}' },
-    you_owe: { title: 'You owe {amount}', body: '{description} in {group}' },
-    settlement_initiated: {
+    [NotificationKind.ExpenseEdited]: { title: '{actor} edited an expense', body: '{description} in {group}' },
+    [NotificationKind.ExpenseDeleted]: { title: '{actor} removed an expense', body: '{description} in {group}' },
+    [NotificationKind.YouOwe]: { title: 'You owe {amount}', body: '{description} in {group}' },
+    [NotificationKind.SettlementInitiated]: {
       title: '{actor} paid you {amount}',
       body: 'Tap to confirm you received it',
     },
-    settlement_confirm_request: {
+    [NotificationKind.SettlementConfirmRequest]: {
       title: '{actor} says they paid you {amount}',
       body: 'Confirm so your baaki stays right',
     },
-    settlement_confirmed: { title: 'Settled with {actor}', body: '{amount} in {group}' },
-    nudge: { title: 'A gentle nudge from {actor}', body: '{amount} pending in {group}' },
-    ghost_claimed: { title: '{actor} joined {group}', body: 'Their past expenses are now linked' },
-    group_invite_accepted: { title: '{actor} joined {group}', body: 'Say hello' },
-    digest_daily: { title: 'Today in {group}', body: '{count} updates · your baaki is {amount}' },
-    trip_nudge_morning: {
+    [NotificationKind.SettlementConfirmed]: { title: 'Settled with {actor}', body: '{amount} in {group}' },
+    [NotificationKind.Nudge]: { title: 'A gentle nudge from {actor}', body: '{amount} pending in {group}' },
+    [NotificationKind.GhostClaimed]: { title: '{actor} joined {group}', body: 'Their past expenses are now linked' },
+    [NotificationKind.GroupInviteAccepted]: { title: '{actor} joined {group}', body: 'Say hello' },
+    [NotificationKind.DigestDaily]: { title: 'Today in {group}', body: '{count} updates · your baaki is {amount}' },
+    [NotificationKind.TripNudgeMorning]: {
       title: 'Anything from yesterday?',
       body: 'Add what you spent on {group} while you still remember it',
     },
-    trip_nudge_evening: {
+    [NotificationKind.TripNudgeEvening]: {
       title: 'Before you forget',
       body: 'What did you pay for today on {group}?',
     },
-    expense_disputed: {
+    [NotificationKind.ExpenseDisputed]: {
       title: '{actor} thinks something is off',
       body: '{description} in {group} — take a look',
     },
-    expense_dispute_resolved: {
+    [NotificationKind.ExpenseDisputeResolved]: {
       title: 'Your correction was answered',
       body: '{description} in {group}',
     },
-    ghost_claim_requested: {
+    [NotificationKind.GhostClaimRequested]: {
       title: 'Someone wants to join {group}',
       body: 'They say they are {name}. Nothing changes until you confirm.',
     },
-    ghost_claim_approved: {
+    [NotificationKind.GhostClaimApproved]: {
       title: 'You are in {group}',
       body: 'Everything already filed under {name} is yours',
     },
-    ghost_claim_declined: {
+    [NotificationKind.GhostClaimDeclined]: {
       title: 'Not confirmed',
       body: '{group} did not confirm that place. You can still join as yourself.',
     },
@@ -164,51 +170,51 @@ const ta: CopyStrings = {
     netNegative: 'உங்கள் பாக்கி {amount}',
   },
   notifications: {
-    expense_added: {
+    [NotificationKind.ExpenseAdded]: {
       title: '{actor} ஒரு செலவைச் சேர்த்தார்',
       body: '{description} · {amount} ({group})',
     },
-    expense_edited: { title: '{actor} செலவைத் திருத்தினார்', body: '{description} ({group})' },
-    expense_deleted: { title: '{actor} செலவை நீக்கினார்', body: '{description} ({group})' },
-    you_owe: { title: 'நீங்கள் {amount} தர வேண்டும்', body: '{description} ({group})' },
-    settlement_initiated: {
+    [NotificationKind.ExpenseEdited]: { title: '{actor} செலவைத் திருத்தினார்', body: '{description} ({group})' },
+    [NotificationKind.ExpenseDeleted]: { title: '{actor} செலவை நீக்கினார்', body: '{description} ({group})' },
+    [NotificationKind.YouOwe]: { title: 'நீங்கள் {amount} தர வேண்டும்', body: '{description} ({group})' },
+    [NotificationKind.SettlementInitiated]: {
       title: '{actor} உங்களுக்கு {amount} அனுப்பியுள்ளார்',
       body: 'கிடைத்ததா என உறுதிப்படுத்தவும்',
     },
-    settlement_confirm_request: {
+    [NotificationKind.SettlementConfirmRequest]: {
       title: '{actor} {amount} கொடுத்ததாகச் சொல்கிறார்',
       body: 'உறுதிப்படுத்தினால் பாக்கி சரியாக இருக்கும்',
     },
-    settlement_confirmed: { title: '{actor} உடன் தீர்ந்தது', body: '{amount} ({group})' },
-    nudge: { title: '{actor} இடமிருந்து ஒரு நினைவூட்டல்', body: '{group} இல் {amount} பாக்கி' },
-    ghost_claimed: { title: '{actor} {group} இல் இணைந்தார்', body: 'பழைய செலவுகள் இணைக்கப்பட்டன' },
-    group_invite_accepted: { title: '{actor} {group} இல் இணைந்தார்', body: 'வரவேற்கலாம்' },
-    digest_daily: { title: 'இன்று {group} இல்', body: '{count} புதுப்பிப்புகள் · பாக்கி {amount}' },
-    trip_nudge_morning: {
+    [NotificationKind.SettlementConfirmed]: { title: '{actor} உடன் தீர்ந்தது', body: '{amount} ({group})' },
+    [NotificationKind.Nudge]: { title: '{actor} இடமிருந்து ஒரு நினைவூட்டல்', body: '{group} இல் {amount} பாக்கி' },
+    [NotificationKind.GhostClaimed]: { title: '{actor} {group} இல் இணைந்தார்', body: 'பழைய செலவுகள் இணைக்கப்பட்டன' },
+    [NotificationKind.GroupInviteAccepted]: { title: '{actor} {group} இல் இணைந்தார்', body: 'வரவேற்கலாம்' },
+    [NotificationKind.DigestDaily]: { title: 'இன்று {group} இல்', body: '{count} புதுப்பிப்புகள் · பாக்கி {amount}' },
+    [NotificationKind.TripNudgeMorning]: {
       title: 'நேற்று ஏதாவது இருக்கா?',
       body: 'நினைவிருக்கும் போதே {group} செலவுகளைச் சேர்க்கவும்',
     },
-    trip_nudge_evening: {
+    [NotificationKind.TripNudgeEvening]: {
       title: 'மறப்பதற்கு முன்',
       body: 'இன்று {group} இல் என்ன செலவு செய்தீர்கள்?',
     },
-    expense_disputed: {
+    [NotificationKind.ExpenseDisputed]: {
       title: '{actor} ஏதோ தவறு என்கிறார்',
       body: '{description} ({group}) — பார்க்கவும்',
     },
-    expense_dispute_resolved: {
+    [NotificationKind.ExpenseDisputeResolved]: {
       title: 'உங்கள் திருத்தத்திற்கு பதில் வந்தது',
       body: '{description} ({group})',
     },
-    ghost_claim_requested: {
+    [NotificationKind.GhostClaimRequested]: {
       title: '{group} இல் சேர ஒருவர் கேட்கிறார்',
       body: 'தாங்கள் {name} என்கிறார். நீங்கள் உறுதி செய்யும் வரை எதுவும் மாறாது.',
     },
-    ghost_claim_approved: {
+    [NotificationKind.GhostClaimApproved]: {
       title: 'நீங்கள் {group} இல் சேர்ந்துவிட்டீர்கள்',
       body: '{name} பெயரில் ஏற்கனவே பதிவானவை அனைத்தும் இப்போது உங்களுடையவை',
     },
-    ghost_claim_declined: {
+    [NotificationKind.GhostClaimDeclined]: {
       title: 'உறுதி செய்யப்படவில்லை',
       body: '{group} அந்த இடத்தை உறுதி செய்யவில்லை. நீங்களாகவே சேரலாம்.',
     },
@@ -232,45 +238,45 @@ const hi: CopyStrings = {
     netNegative: 'आपकी बाकी {amount} है',
   },
   notifications: {
-    expense_added: { title: '{actor} ने खर्च जोड़ा', body: '{description} · {amount} ({group})' },
-    expense_edited: { title: '{actor} ने खर्च बदला', body: '{description} ({group})' },
-    expense_deleted: { title: '{actor} ने खर्च हटाया', body: '{description} ({group})' },
-    you_owe: { title: 'आपको {amount} देने हैं', body: '{description} ({group})' },
-    settlement_initiated: { title: '{actor} ने आपको {amount} भेजे', body: 'मिलने की पुष्टि करें' },
-    settlement_confirm_request: {
+    [NotificationKind.ExpenseAdded]: { title: '{actor} ने खर्च जोड़ा', body: '{description} · {amount} ({group})' },
+    [NotificationKind.ExpenseEdited]: { title: '{actor} ने खर्च बदला', body: '{description} ({group})' },
+    [NotificationKind.ExpenseDeleted]: { title: '{actor} ने खर्च हटाया', body: '{description} ({group})' },
+    [NotificationKind.YouOwe]: { title: 'आपको {amount} देने हैं', body: '{description} ({group})' },
+    [NotificationKind.SettlementInitiated]: { title: '{actor} ने आपको {amount} भेजे', body: 'मिलने की पुष्टि करें' },
+    [NotificationKind.SettlementConfirmRequest]: {
       title: '{actor} कहते हैं उन्होंने {amount} भेजे',
       body: 'पुष्टि करें ताकि बाकी सही रहे',
     },
-    settlement_confirmed: { title: '{actor} के साथ हिसाब बराबर', body: '{amount} ({group})' },
-    nudge: { title: '{actor} की ओर से एक याद', body: '{group} में {amount} बाकी' },
-    ghost_claimed: { title: '{actor} {group} में शामिल हुए', body: 'पुराने खर्च जुड़ गए' },
-    group_invite_accepted: { title: '{actor} {group} में शामिल हुए', body: 'नमस्ते कहें' },
-    digest_daily: { title: 'आज {group} में', body: '{count} अपडेट · बाकी {amount}' },
-    trip_nudge_morning: {
+    [NotificationKind.SettlementConfirmed]: { title: '{actor} के साथ हिसाब बराबर', body: '{amount} ({group})' },
+    [NotificationKind.Nudge]: { title: '{actor} की ओर से एक याद', body: '{group} में {amount} बाकी' },
+    [NotificationKind.GhostClaimed]: { title: '{actor} {group} में शामिल हुए', body: 'पुराने खर्च जुड़ गए' },
+    [NotificationKind.GroupInviteAccepted]: { title: '{actor} {group} में शामिल हुए', body: 'नमस्ते कहें' },
+    [NotificationKind.DigestDaily]: { title: 'आज {group} में', body: '{count} अपडेट · बाकी {amount}' },
+    [NotificationKind.TripNudgeMorning]: {
       title: 'कल का कुछ बाकी है?',
       body: 'याद रहते ही {group} के खर्च जोड़ दें',
     },
-    trip_nudge_evening: {
+    [NotificationKind.TripNudgeEvening]: {
       title: 'भूलने से पहले',
       body: 'आज {group} में आपने किस चीज़ का भुगतान किया?',
     },
-    expense_disputed: {
+    [NotificationKind.ExpenseDisputed]: {
       title: '{actor} को कुछ गड़बड़ लग रहा है',
       body: '{description} ({group}) — देख लें',
     },
-    expense_dispute_resolved: {
+    [NotificationKind.ExpenseDisputeResolved]: {
       title: 'आपके सुधार का जवाब आया',
       body: '{description} ({group})',
     },
-    ghost_claim_requested: {
+    [NotificationKind.GhostClaimRequested]: {
       title: '{group} में कोई शामिल होना चाहता है',
       body: 'उनका कहना है कि वे {name} हैं। आपकी पुष्टि तक कुछ नहीं बदलेगा।',
     },
-    ghost_claim_approved: {
+    [NotificationKind.GhostClaimApproved]: {
       title: 'आप {group} में हैं',
       body: '{name} के नाम पर जो कुछ पहले से दर्ज है, वह अब आपका है',
     },
-    ghost_claim_declined: {
+    [NotificationKind.GhostClaimDeclined]: {
       title: 'पुष्टि नहीं हुई',
       body: '{group} ने वह जगह पक्की नहीं की। आप अपने नाम से शामिल हो सकते हैं।',
     },
@@ -294,51 +300,51 @@ const ar: CopyStrings = {
     netNegative: 'باقيك {amount}',
   },
   notifications: {
-    expense_added: {
+    [NotificationKind.ExpenseAdded]: {
       title: 'أضاف {actor} مصروفًا',
       body: '{description} · {amount} في {group}',
     },
-    expense_edited: { title: 'عدّل {actor} مصروفًا', body: '{description} في {group}' },
-    expense_deleted: { title: 'حذف {actor} مصروفًا', body: '{description} في {group}' },
-    you_owe: { title: 'عليك {amount}', body: '{description} في {group}' },
-    settlement_initiated: {
+    [NotificationKind.ExpenseEdited]: { title: 'عدّل {actor} مصروفًا', body: '{description} في {group}' },
+    [NotificationKind.ExpenseDeleted]: { title: 'حذف {actor} مصروفًا', body: '{description} في {group}' },
+    [NotificationKind.YouOwe]: { title: 'عليك {amount}', body: '{description} في {group}' },
+    [NotificationKind.SettlementInitiated]: {
       title: 'دفع لك {actor} مبلغ {amount}',
       body: 'اضغط لتأكيد استلامه',
     },
-    settlement_confirm_request: {
+    [NotificationKind.SettlementConfirmRequest]: {
       title: 'يقول {actor} إنه دفع لك {amount}',
       body: 'أكّد حتى يبقى باقيك صحيحًا',
     },
-    settlement_confirmed: { title: 'تمت التسوية مع {actor}', body: '{amount} في {group}' },
-    nudge: { title: 'تذكير لطيف من {actor}', body: '{amount} معلّقة في {group}' },
-    ghost_claimed: { title: 'انضم {actor} إلى {group}', body: 'رُبطت مصروفاته السابقة' },
-    group_invite_accepted: { title: 'انضم {actor} إلى {group}', body: 'ألقِ التحية' },
-    digest_daily: { title: 'اليوم في {group}', body: '{count} تحديثات · باقيك {amount}' },
-    trip_nudge_morning: {
+    [NotificationKind.SettlementConfirmed]: { title: 'تمت التسوية مع {actor}', body: '{amount} في {group}' },
+    [NotificationKind.Nudge]: { title: 'تذكير لطيف من {actor}', body: '{amount} معلّقة في {group}' },
+    [NotificationKind.GhostClaimed]: { title: 'انضم {actor} إلى {group}', body: 'رُبطت مصروفاته السابقة' },
+    [NotificationKind.GroupInviteAccepted]: { title: 'انضم {actor} إلى {group}', body: 'ألقِ التحية' },
+    [NotificationKind.DigestDaily]: { title: 'اليوم في {group}', body: '{count} تحديثات · باقيك {amount}' },
+    [NotificationKind.TripNudgeMorning]: {
       title: 'هل بقي شيء من الأمس؟',
       body: 'أضف ما أنفقته على {group} ما دمت تتذكره',
     },
-    trip_nudge_evening: {
+    [NotificationKind.TripNudgeEvening]: {
       title: 'قبل أن تنسى',
       body: 'ماذا دفعت اليوم في {group}؟',
     },
-    expense_disputed: {
+    [NotificationKind.ExpenseDisputed]: {
       title: 'يرى {actor} أن هناك خطأً',
       body: '{description} في {group} — ألقِ نظرة',
     },
-    expense_dispute_resolved: {
+    [NotificationKind.ExpenseDisputeResolved]: {
       title: 'وصل ردّ على تصحيحك',
       body: '{description} في {group}',
     },
-    ghost_claim_requested: {
+    [NotificationKind.GhostClaimRequested]: {
       title: 'أحدهم يريد الانضمام إلى {group}',
       body: 'يقول إنه {name}. لا يتغيّر شيء حتى تؤكّد.',
     },
-    ghost_claim_approved: {
+    [NotificationKind.GhostClaimApproved]: {
       title: 'أنت الآن في {group}',
       body: 'كل ما سُجّل باسم {name} صار لك',
     },
-    ghost_claim_declined: {
+    [NotificationKind.GhostClaimDeclined]: {
       title: 'لم يتم التأكيد',
       body: 'لم تؤكّد {group} ذلك المكان. ما زال بإمكانك الانضمام باسمك.',
     },
@@ -353,7 +359,12 @@ const ar: CopyStrings = {
   },
 };
 
-export const COPY: Readonly<Record<LanguageCode, CopyStrings>> = { en, ta, hi, ar };
+export const COPY: Readonly<Record<LanguageCode, CopyStrings>> = {
+  [LanguageCode.En]: en,
+  [LanguageCode.Ta]: ta,
+  [LanguageCode.Hi]: hi,
+  [LanguageCode.Ar]: ar,
+};
 
 export function copyFor(language: string): CopyStrings {
   const base = language.slice(0, 2).toLowerCase() as LanguageCode;

--- a/packages/core/src/notifications/email.ts
+++ b/packages/core/src/notifications/email.ts
@@ -39,7 +39,11 @@ import { copyFor, interpolate } from './copy';
  * signed URL in the same response. Adding renderers for them now would be
  * three untested code paths waiting for a feature.
  */
-export type EmailTemplate = 'settlement-confirm' | 'digest' | 'nudge';
+export enum EmailTemplate {
+  SettlementConfirm = 'settlement-confirm',
+  Digest = 'digest',
+  Nudge = 'nudge',
+}
 
 /**
  * Which notification kinds leave the building as mail.
@@ -49,14 +53,14 @@ export type EmailTemplate = 'settlement-confirm' | 'digest' | 'nudge';
  * people to filter the sender.
  */
 export const TEMPLATE_FOR_KIND: Readonly<Record<string, EmailTemplate>> = {
-  settlement_initiated: 'settlement-confirm',
-  settlement_confirm_request: 'settlement-confirm',
-  digest_daily: 'digest',
+  settlement_initiated: EmailTemplate.SettlementConfirm,
+  settlement_confirm_request: EmailTemplate.SettlementConfirm,
+  digest_daily: EmailTemplate.Digest,
   /**
    * A nudge is mailed only when the person has no live device — TDR §7.4. That
    * condition is not checked here; it is checked in SQL, where the tokens are.
    */
-  nudge: 'nudge',
+  nudge: EmailTemplate.Nudge,
 };
 
 export function templateForKind(kind: string): EmailTemplate | null {

--- a/packages/core/src/receipt/types.ts
+++ b/packages/core/src/receipt/types.ts
@@ -7,7 +7,11 @@
  * exists between the photograph and the expense.
  */
 
-export type ReceiptSource = 'camera' | 'gallery' | 'text_paste';
+export enum ReceiptSource {
+  Camera = 'camera',
+  Gallery = 'gallery',
+  TextPaste = 'text_paste',
+}
 
 export interface ParsedReceiptLine {
   readonly label: string;

--- a/packages/core/src/settlement/apply.ts
+++ b/packages/core/src/settlement/apply.ts
@@ -18,11 +18,12 @@ export interface Receivable {
   readonly amount: bigint;
 }
 
-export type SettlementErrorCode =
-  | 'ALLOCATION_EXCEEDS_SETTLEMENT'
-  | 'ALLOCATION_EXCEEDS_RECEIVABLE'
-  | 'UNKNOWN_RECEIVABLE'
-  | 'NON_POSITIVE_AMOUNT';
+export enum SettlementErrorCode {
+  AllocationExceedsSettlement = 'ALLOCATION_EXCEEDS_SETTLEMENT',
+  AllocationExceedsReceivable = 'ALLOCATION_EXCEEDS_RECEIVABLE',
+  UnknownReceivable = 'UNKNOWN_RECEIVABLE',
+  NonPositiveAmount = 'NON_POSITIVE_AMOUNT',
+}
 
 export class SettlementError extends Error {
   readonly code: SettlementErrorCode;
@@ -50,7 +51,10 @@ export function allocateSettlement(
   receivables: readonly Receivable[],
 ): AllocationResult {
   if (settlement.amount <= 0n) {
-    throw new SettlementError('NON_POSITIVE_AMOUNT', 'A settlement must be for a positive amount');
+    throw new SettlementError(
+      SettlementErrorCode.NonPositiveAmount,
+      'A settlement must be for a positive amount',
+    );
   }
 
   const outstanding = new Map<string, bigint>();
@@ -66,24 +70,27 @@ export function allocateSettlement(
 
   for (const explicit of settlement.allocations ?? []) {
     if (explicit.amount <= 0n) {
-      throw new SettlementError('NON_POSITIVE_AMOUNT', 'Allocation amounts must be positive');
+      throw new SettlementError(
+        SettlementErrorCode.NonPositiveAmount,
+        'Allocation amounts must be positive',
+      );
     }
     if (!outstanding.has(explicit.expenseId)) {
       throw new SettlementError(
-        'UNKNOWN_RECEIVABLE',
+        SettlementErrorCode.UnknownReceivable,
         `Expense ${explicit.expenseId} carries no debt between these two members`,
       );
     }
     const available = outstanding.get(explicit.expenseId) ?? 0n;
     if (explicit.amount > available) {
       throw new SettlementError(
-        'ALLOCATION_EXCEEDS_RECEIVABLE',
+        SettlementErrorCode.AllocationExceedsReceivable,
         `Allocated ${explicit.amount} to expense ${explicit.expenseId} but only ${available} is outstanding`,
       );
     }
     if (explicit.amount > remaining) {
       throw new SettlementError(
-        'ALLOCATION_EXCEEDS_SETTLEMENT',
+        SettlementErrorCode.AllocationExceedsSettlement,
         'Allocations add up to more than the settlement amount',
       );
     }
@@ -144,7 +151,10 @@ export function buildUpiIntentUri(
   formatMajor: (amount: bigint, currency: CurrencyCode) => string,
 ): string {
   if (!isValidVpa(input.vpa)) {
-    throw new SettlementError('UNKNOWN_RECEIVABLE', `"${input.vpa}" is not a valid UPI ID`);
+    throw new SettlementError(
+      SettlementErrorCode.UnknownReceivable,
+      `"${input.vpa}" is not a valid UPI ID`,
+    );
   }
   // Built by hand rather than with URLSearchParams: this package has to compile
   // unchanged for React Native, Deno and the browser, with no lib assumptions.
@@ -166,13 +176,23 @@ export function buildUpiIntentUri(
 /** Settlement state machine (ADR-007). */
 export const SETTLEMENT_AUTO_CONFIRM_DAYS = 7;
 
-export type SettlementTransition = 'confirm' | 'dispute' | 'cancel' | 'auto_confirm';
+export enum SettlementTransition {
+  Confirm = 'confirm',
+  Dispute = 'dispute',
+  Cancel = 'cancel',
+  AutoConfirm = 'auto_confirm',
+}
 
 const TRANSITIONS: Readonly<Record<string, readonly SettlementTransition[]>> = {
-  initiated: ['confirm', 'dispute', 'cancel', 'auto_confirm'],
+  initiated: [
+    SettlementTransition.Confirm,
+    SettlementTransition.Dispute,
+    SettlementTransition.Cancel,
+    SettlementTransition.AutoConfirm,
+  ],
   confirmed: [],
-  auto_confirmed: ['dispute'],
-  disputed: ['confirm', 'cancel'],
+  auto_confirmed: [SettlementTransition.Dispute],
+  disputed: [SettlementTransition.Confirm, SettlementTransition.Cancel],
   cancelled: [],
 };
 

--- a/packages/core/src/settlement/rails.ts
+++ b/packages/core/src/settlement/rails.ts
@@ -32,43 +32,45 @@
 
 import type { CurrencyCode } from '../money/currency';
 
-export type RailId =
+export enum RailId {
   // Instant, national, free at the point of use.
-  | 'upi' // India
-  | 'pix' // Brazil
-  | 'paynow' // Singapore
-  | 'promptpay' // Thailand
-  | 'qris' // Indonesia
-  | 'aani' // United Arab Emirates
-  | 'payid' // Australia
+  Upi = 'upi', // India
+  Pix = 'pix', // Brazil
+  Paynow = 'paynow', // Singapore
+  Promptpay = 'promptpay', // Thailand
+  Qris = 'qris', // Indonesia
+  Aani = 'aani', // United Arab Emirates
+  Payid = 'payid', // Australia
   // Consumer apps.
-  | 'zelle'
-  | 'venmo'
-  | 'cashapp'
-  | 'interac'
-  | 'wise'
-  | 'revolut'
-  | 'paypal'
+  Zelle = 'zelle',
+  Venmo = 'venmo',
+  Cashapp = 'cashapp',
+  Interac = 'interac',
+  Wise = 'wise',
+  Revolut = 'revolut',
+  Paypal = 'paypal',
   // Always available, everywhere.
-  | 'bank'
-  | 'cash'
-  | 'other';
+  Bank = 'bank',
+  Cash = 'cash',
+  Other = 'other',
+}
 
 /** What you need from the person being paid before anything can happen. */
-export type HandleKind =
+export enum HandleKind {
   /** UPI ID — `name@bank`. */
-  | 'vpa'
+  Vpa = 'vpa',
   /** A Pix key: CPF, phone, email or a random UUID. Anything goes. */
-  | 'pix_key'
+  PixKey = 'pix_key',
   /** A mobile number, usually with country code. */
-  | 'phone'
-  | 'email'
+  Phone = 'phone',
+  Email = 'email',
   /** `$cashtag`, `@venmo-handle`. */
-  | 'tag'
+  Tag = 'tag',
   /** IBAN, or an account and sort code, or whatever the country uses. */
-  | 'account'
+  Account = 'account',
   /** Nothing to collect — cash changed hands. */
-  | 'none';
+  None = 'none',
+}
 
 export interface PaymentRail {
   readonly id: RailId;
@@ -106,99 +108,99 @@ export interface PaymentRail {
  */
 export const PAYMENT_RAILS: readonly PaymentRail[] = [
   {
-    id: 'upi',
+    id: RailId.Upi,
     label: 'UPI',
     icon: 'flash-outline',
     countries: ['IN'],
-    handle: 'vpa',
+    handle: HandleKind.Vpa,
     handleHint: 'Their UPI ID, like ravi@okhdfcbank',
     link: 'app',
   },
   {
-    id: 'pix',
+    id: RailId.Pix,
     label: 'Pix',
     icon: 'flash-outline',
     countries: ['BR'],
-    handle: 'pix_key',
+    handle: HandleKind.PixKey,
     // A Pix key is whatever the person registered — that is the whole design of
     // it, and pretending it is one shape rejects valid keys.
     handleHint: 'Their Pix key — CPF, phone, email or random key',
     link: null,
   },
   {
-    id: 'paynow',
+    id: RailId.Paynow,
     label: 'PayNow',
     icon: 'flash-outline',
     countries: ['SG'],
-    handle: 'phone',
+    handle: HandleKind.Phone,
     handleHint: 'Their mobile number or NRIC',
     link: null,
   },
   {
-    id: 'promptpay',
+    id: RailId.Promptpay,
     label: 'PromptPay',
     icon: 'flash-outline',
     countries: ['TH'],
-    handle: 'phone',
+    handle: HandleKind.Phone,
     handleHint: 'Their mobile number or national ID',
     link: null,
   },
   {
-    id: 'qris',
+    id: RailId.Qris,
     label: 'QRIS',
     icon: 'qr-code-outline',
     countries: ['ID'],
-    handle: 'phone',
+    handle: HandleKind.Phone,
     handleHint: 'Their registered mobile number',
     link: null,
   },
   {
-    id: 'aani',
+    id: RailId.Aani,
     label: 'Aani',
     icon: 'flash-outline',
     // The UAE's instant payment service. Transfers settle by mobile number
     // inside the bank apps; there is no public intent to hand off to.
     countries: ['AE'],
-    handle: 'phone',
+    handle: HandleKind.Phone,
     handleHint: 'Their mobile number, like +971 50 123 4567',
     link: null,
   },
   {
-    id: 'payid',
+    id: RailId.Payid,
     label: 'PayID',
     icon: 'flash-outline',
     // Australia's instant rail over the NPP. Like Aani and PayNow, it settles
     // inside the bank apps by mobile number or email, with no public intent.
     countries: ['AU'],
-    handle: 'phone',
+    handle: HandleKind.Phone,
     handleHint: 'Their PayID — mobile number or email',
     link: null,
   },
   {
-    id: 'zelle',
+    id: RailId.Zelle,
     label: 'Zelle',
     icon: 'send-outline',
     countries: ['US'],
-    handle: 'phone',
+    handle: HandleKind.Phone,
     handleHint: 'The mobile number or email on their Zelle',
     // Zelle lives inside each bank's own app and publishes nothing to link to.
     link: null,
   },
   {
-    id: 'venmo',
+    id: RailId.Venmo,
     label: 'Venmo',
     icon: 'send-outline',
     countries: ['US'],
-    handle: 'tag',
+    handle: HandleKind.Tag,
     handleHint: 'Their Venmo handle, like @ravi-kumar',
     link: null,
   },
   {
-    id: 'cashapp',
+    id: RailId.Cashapp,
     label: 'Cash App',
     icon: 'send-outline',
     countries: ['US', 'GB'],
-    handle: 'tag',
+    handle: HandleKind.Tag,
     handleHint: 'Their $cashtag',
     // `cash.app/$tag/25` is a public, long-standing URL: it opens the app when
     // it is installed and a web page when it is not, so there is no silent
@@ -206,69 +208,69 @@ export const PAYMENT_RAILS: readonly PaymentRail[] = [
     link: 'web',
   },
   {
-    id: 'paypal',
+    id: RailId.Paypal,
     label: 'PayPal',
     icon: 'globe-outline',
     // PayPal.me works in every market Baaki is going to, and is the one link
     // somebody in the US, Canada or Australia can send to somebody in India.
     countries: 'any',
-    handle: 'tag',
+    handle: HandleKind.Tag,
     handleHint: 'Their PayPal.me name',
     link: 'web',
   },
   {
-    id: 'interac',
+    id: RailId.Interac,
     label: 'Interac e-Transfer',
     icon: 'send-outline',
     countries: ['CA'],
-    handle: 'email',
+    handle: HandleKind.Email,
     handleHint: 'The email on their Interac',
     link: null,
   },
   {
-    id: 'wise',
+    id: RailId.Wise,
     label: 'Wise',
     icon: 'globe-outline',
     // The one that matters for a group split across countries, which is most
     // trips: everybody can receive into it.
     countries: 'any',
-    handle: 'email',
+    handle: HandleKind.Email,
     handleHint: 'The email on their Wise account',
     link: null,
   },
   {
-    id: 'revolut',
+    id: RailId.Revolut,
     label: 'Revolut',
     icon: 'globe-outline',
     countries: 'any',
-    handle: 'tag',
+    handle: HandleKind.Tag,
     handleHint: 'Their @revtag',
     link: null,
   },
   {
-    id: 'bank',
+    id: RailId.Bank,
     label: 'Bank transfer',
     icon: 'business-outline',
     countries: 'any',
-    handle: 'account',
+    handle: HandleKind.Account,
     handleHint: 'Their IBAN or account number',
     link: null,
   },
   {
-    id: 'cash',
+    id: RailId.Cash,
     label: 'Cash',
     icon: 'cash-outline',
     countries: 'any',
-    handle: 'none',
+    handle: HandleKind.None,
     handleHint: '',
     link: null,
   },
   {
-    id: 'other',
+    id: RailId.Other,
     label: 'Something else',
     icon: 'ellipsis-horizontal-outline',
     countries: 'any',
-    handle: 'none',
+    handle: HandleKind.None,
     handleHint: '',
     link: null,
   },
@@ -281,7 +283,7 @@ export function railById(id: string): PaymentRail | null {
 }
 
 /** Rails that always appear, wherever somebody is. Cash is never not an option. */
-const UNIVERSAL_LAST: readonly RailId[] = ['bank', 'cash', 'other'];
+const UNIVERSAL_LAST: readonly RailId[] = [RailId.Bank, RailId.Cash, RailId.Other];
 
 /**
  * What this country can pay with, best first.
@@ -315,7 +317,7 @@ export function railsFor(countryCode: string | null | undefined): readonly Payme
 
 /** The rail a country leads with — what the settle screen selects by default. */
 export function defaultRailFor(countryCode: string | null | undefined): RailId {
-  return railsFor(countryCode)[0]?.id ?? 'cash';
+  return railsFor(countryCode)[0]?.id ?? RailId.Cash;
 }
 
 // ─────────────────────────────────────────────────── handles ──
@@ -341,21 +343,21 @@ export function isValidHandle(railId: string, handle: string): boolean {
   if (!rail) return false;
 
   const value = handle.trim();
-  if (rail.handle === 'none') return true;
+  if (rail.handle === HandleKind.None) return true;
   if (value === '') return false;
 
   switch (rail.handle) {
-    case 'vpa':
+    case HandleKind.Vpa:
       return VPA_RE.test(value);
-    case 'email':
+    case HandleKind.Email:
       return EMAIL_RE.test(value);
-    case 'phone':
+    case HandleKind.Phone:
       return PHONE_RE.test(value);
-    case 'tag':
+    case HandleKind.Tag:
       return TAG_RE.test(value);
-    case 'account':
+    case HandleKind.Account:
       return ACCOUNT_RE.test(value);
-    case 'pix_key':
+    case HandleKind.PixKey:
       // Deliberately permissive: a Pix key is a CPF, a phone, an email or a
       // UUID, and the person registering it chose which.
       return value.length >= 4 && value.length <= 77;
@@ -403,7 +405,7 @@ export function buildPaymentUri(
   const handle = input.handle.trim();
   const major = formatMajor(input.amount, input.currency);
 
-  if (rail.id === 'upi') {
+  if (rail.id === RailId.Upi) {
     // Built by hand rather than with URLSearchParams: this package has to
     // compile unchanged for React Native, Deno and the browser.
     const params: [string, string][] = [
@@ -419,7 +421,7 @@ export function buildPaymentUri(
     return { kind: 'app', uri: `upi://pay?${query}` };
   }
 
-  if (rail.id === 'cashapp') {
+  if (rail.id === RailId.Cashapp) {
     // Cash App settles in dollars. A link carrying "25" for an amount that is
     // 25 pounds would open a request for 25 of something else, which is worse
     // than no link — so anything but USD copies the handle instead.
@@ -427,7 +429,7 @@ export function buildPaymentUri(
     return { kind: 'web', uri: `https://cash.app/${encodeURIComponent(cashtag(handle))}/${major}` };
   }
 
-  if (rail.id === 'paypal') {
+  if (rail.id === RailId.Paypal) {
     // PayPal.me takes the currency in the path, so unlike Cash App it is safe
     // in any of them.
     const name = handle.replace(/^@/, '');

--- a/packages/core/src/sms/parse.ts
+++ b/packages/core/src/sms/parse.ts
@@ -23,7 +23,10 @@
 import { minorUnitExponent, type CurrencyCode } from '../money/currency';
 import { money, type Money } from '../money/money';
 
-export type TransactionDirection = 'debit' | 'credit';
+export enum TransactionDirection {
+  Debit = 'debit',
+  Credit = 'credit',
+}
 
 export interface ParsedSms {
   /** What moved, in minor units. */
@@ -216,7 +219,7 @@ export function parseSms(text: string): ParsedSms | null {
 
   return {
     amount: money(minor, currency),
-    direction: debit ? 'debit' : 'credit',
+    direction: debit ? TransactionDirection.Debit : TransactionDirection.Credit,
     merchant,
     accountTail,
     reference,
@@ -275,7 +278,7 @@ export function proposeFromSms(
     if (!parsed) continue;
     // Money coming in is not an expense. Refunds are real and worth showing one
     // day, but as a reversal of a known expense — not as a negative one.
-    if (parsed.direction !== 'debit') continue;
+    if (parsed.direction !== TransactionDirection.Debit) continue;
 
     const at = parsed.occurredAt ?? message.receivedAt;
     const stamp = Date.parse(at);

--- a/packages/core/src/split/computeShares.ts
+++ b/packages/core/src/split/computeShares.ts
@@ -14,24 +14,25 @@ import {
 } from './remainder';
 import {
   SplitError,
+  SplitErrorCode,
+  SplitType,
   type ComputeSharesInput,
   type ItemizedParams,
   type MemberId,
   type ShareMap,
   type SplitParams,
-  type SplitType,
 } from './types';
 
 const TOTAL_BASIS_POINTS = 10000;
 
 export function splitTypeOf(params: SplitParams): SplitType {
-  return params.kind;
+  return params.kind as SplitType;
 }
 
 export function computeShares(input: ComputeSharesInput): ShareMap {
   const participants = validateParticipants(input.participants);
   if (input.amount < 0n) {
-    throw new SplitError('NEGATIVE_TOTAL', 'Expense total cannot be negative');
+    throw new SplitError(SplitErrorCode.NegativeTotal, 'Expense total cannot be negative');
   }
 
   const shares = computeByType(input, participants);
@@ -61,7 +62,7 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
       }
       if (total !== input.amount) {
         throw new SplitError(
-          'EXACT_SUM_MISMATCH',
+          SplitErrorCode.ExactSumMismatch,
           `Exact shares sum to ${total} but the expense is ${input.amount}`,
         );
       }
@@ -75,7 +76,7 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
         requireParticipant(member, participants);
         if (!Number.isInteger(basisPoints) || basisPoints < 0) {
           throw new SplitError(
-            'INVALID_WEIGHT',
+            SplitErrorCode.InvalidWeight,
             `Basis points must be non-negative integers, got ${basisPoints} for ${member}`,
           );
         }
@@ -84,7 +85,7 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
       }
       if (total !== TOTAL_BASIS_POINTS) {
         throw new SplitError(
-          'PERCENT_SUM_MISMATCH',
+          SplitErrorCode.PercentSumMismatch,
           `Percentages must sum to 100% (10000 basis points), got ${total}`,
         );
       }
@@ -98,7 +99,7 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
         requireParticipant(member, participants);
         if (!Number.isInteger(weight) || weight < 0) {
           throw new SplitError(
-            'INVALID_WEIGHT',
+            SplitErrorCode.InvalidWeight,
             `Weights must be non-negative integers, got ${weight} for ${member}`,
           );
         }
@@ -106,7 +107,10 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
         weights.set(member, BigInt(weight));
       }
       if (!positive) {
-        throw new SplitError('NO_POSITIVE_WEIGHT', 'At least one member needs a positive weight');
+        throw new SplitError(
+          SplitErrorCode.NoPositiveWeight,
+          'At least one member needs a positive weight',
+        );
       }
       return distributeProportionally(input.amount, weights, input.seed);
     }
@@ -157,7 +161,7 @@ function splitItemized(
   seed: string,
 ): ShareMap {
   if (params.items.length === 0) {
-    throw new SplitError('INVALID_ITEM', 'An itemized split needs at least one line item');
+    throw new SplitError(SplitErrorCode.InvalidItem, 'An itemized split needs at least one line item');
   }
 
   const subtotals = new Map<MemberId, bigint>();
@@ -166,13 +170,16 @@ function splitItemized(
   let itemsTotal = 0n;
   params.items.forEach((item, index) => {
     if (item.total < 0n) {
-      throw new SplitError('INVALID_ITEM', `Line ${index} has a negative total`);
+      throw new SplitError(SplitErrorCode.InvalidItem, `Line ${index} has a negative total`);
     }
     const claimers = params.claims[index] ?? [];
     if (claimers.length === 0) {
       // ADR-008: unclaimed items block finalization — the UI must chase the
       // last person before the expense can be created.
-      throw new SplitError('UNCLAIMED_ITEM', `Line ${index} ("${item.label ?? ''}") is unclaimed`);
+      throw new SplitError(
+        SplitErrorCode.UnclaimedItem,
+        `Line ${index} ("${item.label ?? ''}") is unclaimed`,
+      );
     }
     for (const claimer of claimers) requireParticipant(claimer, participants);
 
@@ -191,7 +198,7 @@ function splitItemized(
 
   if (itemsTotal + extras !== amount) {
     throw new SplitError(
-      'ITEMIZED_TOTAL_MISMATCH',
+      SplitErrorCode.ItemizedTotalMismatch,
       `Items (${itemsTotal}) plus tax/tip/discounts (${extras}) is ${itemsTotal + extras}, but the expense total is ${amount}`,
     );
   }
@@ -214,18 +221,21 @@ function splitItemized(
 
 function validateParticipants(participants: readonly MemberId[]): MemberId[] {
   if (participants.length === 0) {
-    throw new SplitError('EMPTY_PARTICIPANTS', 'An expense needs at least one participant');
+    throw new SplitError(SplitErrorCode.EmptyParticipants, 'An expense needs at least one participant');
   }
   const unique = new Set(participants);
   if (unique.size !== participants.length) {
-    throw new SplitError('DUPLICATE_PARTICIPANT', 'Participants must be unique');
+    throw new SplitError(SplitErrorCode.DuplicateParticipant, 'Participants must be unique');
   }
   return [...participants];
 }
 
 function requireParticipant(member: MemberId, participants: readonly MemberId[]): void {
   if (!participants.includes(member)) {
-    throw new SplitError('UNKNOWN_MEMBER', `"${member}" is not a participant in this expense`);
+    throw new SplitError(
+      SplitErrorCode.UnknownMember,
+      `"${member}" is not a participant in this expense`,
+    );
   }
 }
 
@@ -239,7 +249,7 @@ function assertSumsTo(shares: ShareMap, amount: bigint): void {
   const total = sumShares(shares);
   if (total !== amount) {
     throw new SplitError(
-      'SHARE_MISMATCH',
+      SplitErrorCode.ShareMismatch,
       `Computed shares sum to ${total}, expected ${amount}. This is a bug in computeShares.`,
     );
   }

--- a/packages/core/src/split/types.ts
+++ b/packages/core/src/split/types.ts
@@ -2,7 +2,14 @@ import type { CurrencyCode } from '../money/currency';
 
 export type MemberId = string;
 
-export type SplitType = 'equal' | 'exact' | 'percent' | 'shares' | 'adjustment' | 'itemized';
+export enum SplitType {
+  Equal = 'equal',
+  Exact = 'exact',
+  Percent = 'percent',
+  Shares = 'shares',
+  Adjustment = 'adjustment',
+  Itemized = 'itemized',
+}
 
 /** Everyone in `participants` pays the same, remainder rotated (TDR §3.1). */
 export interface EqualParams {
@@ -77,19 +84,20 @@ export interface ComputeSharesInput {
   readonly seed: string;
 }
 
-export type SplitErrorCode =
-  | 'EMPTY_PARTICIPANTS'
-  | 'DUPLICATE_PARTICIPANT'
-  | 'UNKNOWN_MEMBER'
-  | 'NEGATIVE_TOTAL'
-  | 'EXACT_SUM_MISMATCH'
-  | 'PERCENT_SUM_MISMATCH'
-  | 'INVALID_WEIGHT'
-  | 'NO_POSITIVE_WEIGHT'
-  | 'UNCLAIMED_ITEM'
-  | 'INVALID_ITEM'
-  | 'ITEMIZED_TOTAL_MISMATCH'
-  | 'SHARE_MISMATCH';
+export enum SplitErrorCode {
+  EmptyParticipants = 'EMPTY_PARTICIPANTS',
+  DuplicateParticipant = 'DUPLICATE_PARTICIPANT',
+  UnknownMember = 'UNKNOWN_MEMBER',
+  NegativeTotal = 'NEGATIVE_TOTAL',
+  ExactSumMismatch = 'EXACT_SUM_MISMATCH',
+  PercentSumMismatch = 'PERCENT_SUM_MISMATCH',
+  InvalidWeight = 'INVALID_WEIGHT',
+  NoPositiveWeight = 'NO_POSITIVE_WEIGHT',
+  UnclaimedItem = 'UNCLAIMED_ITEM',
+  InvalidItem = 'INVALID_ITEM',
+  ItemizedTotalMismatch = 'ITEMIZED_TOTAL_MISMATCH',
+  ShareMismatch = 'SHARE_MISMATCH',
+}
 
 export class SplitError extends Error {
   readonly code: SplitErrorCode;

--- a/packages/core/src/split/verify.ts
+++ b/packages/core/src/split/verify.ts
@@ -11,7 +11,7 @@
  * computed one for.
  */
 
-import { SplitError, type MemberId, type ShareMap } from './types';
+import { SplitError, SplitErrorCode, type MemberId, type ShareMap } from './types';
 
 /**
  * Compare the authoritative shares against what the client believed.
@@ -34,13 +34,13 @@ export function verifyClientShares(
     const raw = claimed[member];
     if (raw === undefined) {
       throw new SplitError(
-        'SHARE_MISMATCH',
+        SplitErrorCode.ShareMismatch,
         `Server computed ${share} for ${member}, client said nothing`,
       );
     }
     if (toBigInt(raw, member) !== share) {
       throw new SplitError(
-        'SHARE_MISMATCH',
+        SplitErrorCode.ShareMismatch,
         `Server computed ${share} for ${member}, client said ${String(raw)}`,
       );
     }
@@ -52,7 +52,7 @@ export function verifyClientShares(
   for (const member of Object.keys(claimed)) {
     if (!computed.has(member)) {
       throw new SplitError(
-        'SHARE_MISMATCH',
+        SplitErrorCode.ShareMismatch,
         `Client claimed a share for ${member}, who is not in this split`,
       );
     }
@@ -64,6 +64,6 @@ function toBigInt(value: string | bigint, member: MemberId): bigint {
   try {
     return BigInt(value);
   } catch {
-    throw new SplitError('SHARE_MISMATCH', `Client sent "${value}" as ${member}'s share`);
+    throw new SplitError(SplitErrorCode.ShareMismatch, `Client sent "${value}" as ${member}'s share`);
   }
 }

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -20,12 +20,12 @@ import type { MemberId, SplitParams, SplitType } from '../split/types';
 import type { CurrencyCode } from '../money/currency';
 import type { ExpenseSnapshot } from '../balances/types';
 
+import { SyncTable } from './protocol';
 import type {
   ExpenseCreatePayload,
   ExpenseDeletePayload,
   MutationEnvelope,
   SyncChange,
-  SyncTable,
 } from './protocol';
 import type { QueuedMutation } from './queue';
 
@@ -39,15 +39,15 @@ export interface MirrorState {
 }
 
 const TABLES: readonly SyncTable[] = [
-  'groups',
-  'group_members',
-  'expenses',
-  'expense_versions',
-  'expense_payers',
-  'expense_shares',
-  'settlements',
-  'settlement_allocations',
-  'activity_log',
+  SyncTable.Groups,
+  SyncTable.GroupMembers,
+  SyncTable.Expenses,
+  SyncTable.ExpenseVersions,
+  SyncTable.ExpensePayers,
+  SyncTable.ExpenseShares,
+  SyncTable.Settlements,
+  SyncTable.SettlementAllocations,
+  SyncTable.ActivityLog,
 ];
 
 export function emptyMirror(): MirrorState {
@@ -161,7 +161,7 @@ export function materialiseExpenses(
   options: MaterialiseOptions,
 ): MirrorExpense[] {
   return overlayPending(
-    rowsFor(state, 'expenses', options.groupId) as MirrorExpense[],
+    rowsFor(state, SyncTable.Expenses, options.groupId) as MirrorExpense[],
     queue,
     options,
   );
@@ -216,7 +216,7 @@ function applyPending(
           expense_date: payload.expenseDate,
           currency: payload.currency,
           amount: payload.amount,
-          split_type: payload.splitParams.kind,
+          split_type: payload.splitParams.kind as SplitType,
           split_params: payload.splitParams,
           author_member_id: options.authorMemberId ?? null,
           notes: payload.notes ?? null,
@@ -317,7 +317,7 @@ export function materialiseSettlements(
   options: { readonly groupId: string },
 ): MirrorSettlement[] {
   const byId = new Map<string, MirrorSettlement>();
-  for (const row of rowsFor(state, 'settlements', options.groupId) as MirrorSettlement[]) {
+  for (const row of rowsFor(state, SyncTable.Settlements, options.groupId) as MirrorSettlement[]) {
     byId.set(row.id, row);
   }
 
@@ -395,7 +395,7 @@ export function materialiseMembers(
   options: { readonly groupId: string },
 ): MirrorMember[] {
   const byId = new Map<string, MirrorMember>();
-  for (const row of rowsFor(state, 'group_members', options.groupId) as MirrorMember[]) {
+  for (const row of rowsFor(state, SyncTable.GroupMembers, options.groupId) as MirrorMember[]) {
     byId.set(row.id, row);
   }
 
@@ -439,7 +439,7 @@ export function materialiseGroups(
   queue: readonly QueuedMutation[],
 ): MirrorGroup[] {
   const byId = new Map<string, MirrorGroup>();
-  for (const row of rowsFor(state, 'groups') as MirrorGroup[]) byId.set(row.id, row);
+  for (const row of rowsFor(state, SyncTable.Groups) as MirrorGroup[]) byId.set(row.id, row);
 
   for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
     if (mutation.kind === 'group.create') {

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -8,20 +8,21 @@
  * network can never double-post an expense.
  */
 
-import { MoneyError, type CurrencyCode } from '../money/currency';
+import { MoneyError, MoneyErrorCode, type CurrencyCode } from '../money/currency';
 import type { MemberId, SplitParams } from '../split/types';
 import type { SettlementAllocation, SettlementStatus } from '../balances/types';
 
-export type MutationKind =
-  | 'expense.create'
-  | 'expense.update'
-  | 'expense.delete'
-  | 'expense.restore'
-  | 'settlement.create'
-  | 'settlement.transition'
-  | 'member.add_ghost'
-  | 'group.create'
-  | 'group.update';
+export enum MutationKind {
+  ExpenseCreate = 'expense.create',
+  ExpenseUpdate = 'expense.update',
+  ExpenseDelete = 'expense.delete',
+  ExpenseRestore = 'expense.restore',
+  SettlementCreate = 'settlement.create',
+  SettlementTransition = 'settlement.transition',
+  MemberAddGhost = 'member.add_ghost',
+  GroupCreate = 'group.create',
+  GroupUpdate = 'group.update',
+}
 
 export interface MutationEnvelope<K extends MutationKind = MutationKind, P = unknown> {
   /** Client-generated UUID v4. The idempotency key. */
@@ -91,13 +92,14 @@ export type SyncMutationOutcome =
       readonly message: string;
     };
 
-export type SyncRejectionCode =
-  | 'SHARE_MISMATCH'
-  | 'NOT_A_MEMBER'
-  | 'GROUP_ARCHIVED'
-  | 'VALIDATION_FAILED'
-  | 'CONFLICT_SUPERSEDED'
-  | 'RATE_LIMITED';
+export enum SyncRejectionCode {
+  ShareMismatch = 'SHARE_MISMATCH',
+  NotAMember = 'NOT_A_MEMBER',
+  GroupArchived = 'GROUP_ARCHIVED',
+  ValidationFailed = 'VALIDATION_FAILED',
+  ConflictSuperseded = 'CONFLICT_SUPERSEDED',
+  RateLimited = 'RATE_LIMITED',
+}
 
 export interface SyncResponse {
   readonly outcomes: readonly SyncMutationOutcome[];
@@ -116,16 +118,17 @@ export interface SyncChange {
   readonly deleted?: boolean;
 }
 
-export type SyncTable =
-  | 'groups'
-  | 'group_members'
-  | 'expenses'
-  | 'expense_versions'
-  | 'expense_payers'
-  | 'expense_shares'
-  | 'settlements'
-  | 'settlement_allocations'
-  | 'activity_log';
+export enum SyncTable {
+  Groups = 'groups',
+  GroupMembers = 'group_members',
+  Expenses = 'expenses',
+  ExpenseVersions = 'expense_versions',
+  ExpensePayers = 'expense_payers',
+  ExpenseShares = 'expense_shares',
+  Settlements = 'settlements',
+  SettlementAllocations = 'settlement_allocations',
+  ActivityLog = 'activity_log',
+}
 
 /** bigint ↔ string at the wire boundary; JSON has no integers this size. */
 export function serialiseAmount(amount: bigint): string {
@@ -156,7 +159,10 @@ export function serialiseAmount(amount: bigint): string {
  */
 export function parseAmount(amount: string): bigint {
   if (typeof amount !== 'string' || !/^[+-]?\d+$/.test(amount.trim())) {
-    throw new MoneyError('INVALID_AMOUNT', `${String(amount)} is not a whole minor-unit amount`);
+    throw new MoneyError(
+      MoneyErrorCode.InvalidAmount,
+      `${String(amount)} is not a whole minor-unit amount`,
+    );
   }
   return BigInt(amount.trim());
 }

--- a/packages/core/src/version/index.ts
+++ b/packages/core/src/version/index.ts
@@ -21,7 +21,11 @@
  */
 
 /** What to do about the installed version. */
-export type UpdateDecision = 'none' | 'suggested' | 'required';
+export enum UpdateDecision {
+  None = 'none',
+  Suggested = 'suggested',
+  Required = 'required',
+}
 
 /** What the server says about a platform's builds. */
 export interface ReleasePolicy {
@@ -79,10 +83,10 @@ export function compareVersions(a: string, b: string): number | null {
 export function decideUpdate(installed: string, policy: ReleasePolicy): UpdateDecision {
   const belowMinimum = compareVersions(installed, policy.minimumVersion);
   const minimumIsReal = (compareVersions(policy.minimumVersion, policy.latestVersion) ?? 1) <= 0;
-  if (minimumIsReal && belowMinimum !== null && belowMinimum < 0) return 'required';
+  if (minimumIsReal && belowMinimum !== null && belowMinimum < 0) return UpdateDecision.Required;
 
   const behindLatest = compareVersions(installed, policy.latestVersion);
-  if (behindLatest !== null && behindLatest < 0) return 'suggested';
+  if (behindLatest !== null && behindLatest < 0) return UpdateDecision.Suggested;
 
-  return 'none';
+  return UpdateDecision.None;
 }

--- a/packages/core/test/balances.property.test.ts
+++ b/packages/core/test/balances.property.test.ts
@@ -13,6 +13,7 @@ import {
   computePairwiseBalances,
   netFromPairwise,
 } from '../src/balances/balances.js';
+import { SettlementStatus } from '../src/balances/types.js';
 import type { ExpenseSnapshot, SettlementSnapshot } from '../src/balances/types.js';
 import { computeShares } from '../src/split/computeShares.js';
 import type { MemberId } from '../src/split/types.js';
@@ -48,10 +49,10 @@ const groupLedger = fc
           fromIndex: fc.integer({ min: 0, max: members.length - 1 }),
           toOffset: fc.integer({ min: 1, max: Math.max(1, members.length - 1) }),
           status: fc.constantFrom(
-            'initiated' as const,
-            'confirmed' as const,
-            'auto_confirmed' as const,
-            'cancelled' as const,
+            SettlementStatus.Initiated,
+            SettlementStatus.Confirmed,
+            SettlementStatus.AutoConfirmed,
+            SettlementStatus.Cancelled,
           ),
         }),
         { minLength: settlementCount, maxLength: settlementCount },
@@ -184,7 +185,7 @@ describe('derived balances', () => {
       to: 'asha',
       currency: INR,
       amount: 5000n,
-      status: 'initiated',
+      status: SettlementStatus.Initiated,
       at: '2026-03-02T00:00:00Z',
     };
 
@@ -193,7 +194,7 @@ describe('derived balances', () => {
       computeNetBalances([expense], [pending], { includePending: true }).get(INR)?.get('ravi'),
     ).toBe(0n);
     expect(
-      computeNetBalances([expense], [{ ...pending, status: 'confirmed' }])
+      computeNetBalances([expense], [{ ...pending, status: SettlementStatus.Confirmed }])
         .get(INR)
         ?.get('ravi'),
     ).toBe(0n);

--- a/packages/core/test/devices.test.ts
+++ b/packages/core/test/devices.test.ts
@@ -17,6 +17,7 @@ import {
   recentDevices,
   type DeviceSession,
 } from '../src/session/devices';
+import { PlanTier } from '../src/billing/plans';
 
 const NOW = Date.parse('2026-08-09T12:00:00.000Z');
 const DAY = 86_400_000;
@@ -37,8 +38,8 @@ function device(over: Partial<DeviceSession> = {}): DeviceSession {
 
 describe('deviceLimitFor', () => {
   it('gives free two and plus more', () => {
-    expect(deviceLimitFor('free')).toBe(2);
-    expect(deviceLimitFor('plus')).toBeGreaterThan(2);
+    expect(deviceLimitFor(PlanTier.Free)).toBe(2);
+    expect(deviceLimitFor(PlanTier.Plus)).toBeGreaterThan(2);
   });
 });
 
@@ -91,18 +92,18 @@ describe('activeDevices', () => {
 describe('deviceLimitStatus', () => {
   it('lets a free account sit at exactly two', () => {
     const rows = [device({ deviceId: 'a' }), device({ deviceId: 'b' })];
-    const status = deviceLimitStatus(rows, 'free', NOW);
+    const status = deviceLimitStatus(rows, PlanTier.Free, NOW);
     expect(status).toEqual({ limit: 2, activeCount: 2, overLimit: false });
   });
 
   it('flags the third phone as over the line', () => {
     const rows = [device({ deviceId: 'a' }), device({ deviceId: 'b' }), device({ deviceId: 'c' })];
-    expect(deviceLimitStatus(rows, 'free', NOW).overLimit).toBe(true);
+    expect(deviceLimitStatus(rows, PlanTier.Free, NOW).overLimit).toBe(true);
   });
 
   it('does not flag three phones on plus', () => {
     const rows = [device({ deviceId: 'a' }), device({ deviceId: 'b' }), device({ deviceId: 'c' })];
-    expect(deviceLimitStatus(rows, 'plus', NOW).overLimit).toBe(false);
+    expect(deviceLimitStatus(rows, PlanTier.Plus, NOW).overLimit).toBe(false);
   });
 
   it('a freed slot brings a would-be-third back under the limit', () => {
@@ -111,7 +112,7 @@ describe('deviceLimitStatus', () => {
       device({ deviceId: 'b', lastSeenAt: daysAgo(40) }), // silent: slot freed
       device({ deviceId: 'c', lastSeenAt: daysAgo(0) }),
     ];
-    expect(deviceLimitStatus(rows, 'free', NOW).overLimit).toBe(false);
+    expect(deviceLimitStatus(rows, PlanTier.Free, NOW).overLimit).toBe(false);
   });
 });
 

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -20,7 +20,7 @@ import {
   normalisePhone,
   planAuth,
   readIdentifier,
-  type AuthMethod,
+  AuthMethod,
   type Viewer,
 } from '../src/index';
 
@@ -29,11 +29,11 @@ const USER: Viewer = { kind: 'user', userId: 'u-real' };
 const NOBODY: Viewer = { kind: 'nobody' };
 
 const EVERY_METHOD: AuthMethod[] = [
-  'email_password',
-  'phone_password',
-  'phone_otp',
-  'google',
-  'apple',
+  AuthMethod.EmailPassword,
+  AuthMethod.PhonePassword,
+  AuthMethod.PhoneOtp,
+  AuthMethod.Google,
+  AuthMethod.Apple,
 ];
 
 describe('a guest is upgraded, never replaced', () => {
@@ -52,7 +52,7 @@ describe('a guest is upgraded, never replaced', () => {
   });
 
   it('links Google rather than signing in with it', () => {
-    expect(planAuth(GUEST, 'google')).toEqual({ call: 'linkIdentity', method: 'google' });
+    expect(planAuth(GUEST, AuthMethod.Google)).toEqual({ call: 'linkIdentity', method: 'google' });
   });
 
   it('links Apple rather than signing in with it', () => {
@@ -62,14 +62,14 @@ describe('a guest is upgraded, never replaced', () => {
     // Apple ID, and for a guest that is a brand new one. Returning `linkIdentity`
     // here is what sends the caller down the web flow instead, which is the only
     // one that can add a provider to the session already held.
-    expect(planAuth(GUEST, 'apple')).toEqual({ call: 'linkIdentity', method: 'apple' });
+    expect(planAuth(GUEST, AuthMethod.Apple)).toEqual({ call: 'linkIdentity', method: 'apple' });
   });
 
   it('ignores a screen that thinks it is a sign-up', () => {
     // The screen does not get a say. Whatever it believes it is doing, a guest
     // with data can only ever be upgraded.
-    expect(planAuth(GUEST, 'email_password', 'sign_up').call).toBe('updateUser');
-    expect(planAuth(GUEST, 'email_password', 'sign_in').call).toBe('updateUser');
+    expect(planAuth(GUEST, AuthMethod.EmailPassword, 'sign_up').call).toBe('updateUser');
+    expect(planAuth(GUEST, AuthMethod.EmailPassword, 'sign_in').call).toBe('updateUser');
   });
 });
 
@@ -84,14 +84,14 @@ describe('somebody who already has an account', () => {
 
 describe('somebody with no account at all', () => {
   it('signs in with a password', () => {
-    expect(planAuth(NOBODY, 'email_password')).toEqual({
+    expect(planAuth(NOBODY, AuthMethod.EmailPassword)).toEqual({
       call: 'signInWithPassword',
       method: 'email_password',
     });
   });
 
   it('signs up when that is what they asked for', () => {
-    expect(planAuth(NOBODY, 'email_password', 'sign_up')).toEqual({
+    expect(planAuth(NOBODY, AuthMethod.EmailPassword, 'sign_up')).toEqual({
       call: 'signUp',
       method: 'email_password',
     });
@@ -100,24 +100,24 @@ describe('somebody with no account at all', () => {
   it('sends a code for phone OTP whichever they asked for', () => {
     // There is no separate sign-up for an OTP: the code both proves the number
     // and creates the account.
-    expect(planAuth(NOBODY, 'phone_otp').call).toBe('signInWithOtp');
-    expect(planAuth(NOBODY, 'phone_otp', 'sign_up').call).toBe('signInWithOtp');
+    expect(planAuth(NOBODY, AuthMethod.PhoneOtp).call).toBe('signInWithOtp');
+    expect(planAuth(NOBODY, AuthMethod.PhoneOtp, 'sign_up').call).toBe('signInWithOtp');
   });
 
   it('goes to the provider for Google', () => {
-    expect(planAuth(NOBODY, 'google').call).toBe('signInWithOAuth');
+    expect(planAuth(NOBODY, AuthMethod.Google).call).toBe('signInWithOAuth');
   });
 
   it('goes to the provider for Apple', () => {
-    expect(planAuth(NOBODY, 'apple')).toEqual({ call: 'signInWithOAuth', method: 'apple' });
+    expect(planAuth(NOBODY, AuthMethod.Apple)).toEqual({ call: 'signInWithOAuth', method: 'apple' });
   });
 
   it('will not be talked into a sign-up for either provider', () => {
     // There is no such thing as signing *up* with a provider: the first time
     // through is the account being made. A screen passing 'sign_up' must not
     // reach `signUp`, which wants a password there is none of.
-    expect(planAuth(NOBODY, 'google', 'sign_up').call).toBe('signInWithOAuth');
-    expect(planAuth(NOBODY, 'apple', 'sign_up').call).toBe('signInWithOAuth');
+    expect(planAuth(NOBODY, AuthMethod.Google, 'sign_up').call).toBe('signInWithOAuth');
+    expect(planAuth(NOBODY, AuthMethod.Apple, 'sign_up').call).toBe('signInWithOAuth');
   });
 });
 
@@ -129,8 +129,8 @@ describe('the native Apple sheet is unreachable for anybody with data', () => {
   // `signInWithOAuth` branch, so that branch has to stay unreachable for a
   // guest or a user. This is that guarantee, stated where it is enforced.
   it.each([GUEST, USER])('never returns signInWithOAuth for %o', (viewer) => {
-    expect(planAuth(viewer, 'apple').call).not.toBe('signInWithOAuth');
-    expect(planAuth(viewer, 'apple', 'sign_up').call).not.toBe('signInWithOAuth');
+    expect(planAuth(viewer, AuthMethod.Apple).call).not.toBe('signInWithOAuth');
+    expect(planAuth(viewer, AuthMethod.Apple, 'sign_up').call).not.toBe('signInWithOAuth');
   });
 });
 

--- a/packages/core/test/money.test.ts
+++ b/packages/core/test/money.test.ts
@@ -7,6 +7,7 @@ import {
   formatParts,
   balanceDirection,
   moneyAccessibilityLabel,
+  BalanceDirection,
 } from '../src/money/format.js';
 import { convert, fxRate, fromFxRecord, invertRate, toFxRecord } from '../src/money/fx.js';
 import {
@@ -99,7 +100,7 @@ describe('parse and render', () => {
 
   it('labels money for screen readers (TDR §11)', () => {
     const strings = copyFor('en').money;
-    const label = moneyAccessibilityLabel(money(42000n, 'INR'), 'owed_to_you', strings, {
+    const label = moneyAccessibilityLabel(money(42000n, 'INR'), BalanceDirection.OwedToYou, strings, {
       locale: 'en-IN',
       compactFraction: true,
     });

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -18,7 +18,9 @@ import {
   materialiseGroups,
   materialiseMembers,
   materialiseSettlements,
+  MutationKind,
   reconcile,
+  SyncTable,
   type MutationEnvelope,
   type QueuedMutation,
 } from '../src/sync/index.js';
@@ -42,7 +44,7 @@ function queued(...envelopes: MutationEnvelope[]): QueuedMutation[] {
 }
 
 describe('settlements', () => {
-  const settle = envelope('m-1', 'settlement.create', {
+  const settle = envelope('m-1', MutationKind.SettlementCreate, {
     settlementId: 's-1',
     from: 'member-a',
     to: 'member-b',
@@ -75,7 +77,7 @@ describe('settlements', () => {
   it('applies a queued confirmation to a settlement the server already sent', () => {
     const mirror = reconcile(emptyMirror(), [
       {
-        table: 'settlements',
+        table: SyncTable.Settlements,
         groupId: GROUP,
         seq: 1,
         row: {
@@ -92,7 +94,7 @@ describe('settlements', () => {
       },
     ]).state;
 
-    const queue = queued(envelope('m-2', 'settlement.transition', { settlementId: 's-9' }));
+    const queue = queued(envelope('m-2', MutationKind.SettlementTransition, { settlementId: 's-9' }));
     const [row] = materialiseSettlements(mirror, queue, { groupId: GROUP });
     expect(row).toMatchObject({ id: 's-9', status: 'confirmed', pending: true });
   });
@@ -101,7 +103,7 @@ describe('settlements', () => {
     const elsewhere = queued(
       envelope(
         'm-3',
-        'settlement.create',
+        MutationKind.SettlementCreate,
         { ...(settle.payload as Record<string, unknown>), settlementId: 's-2' },
         'g-2',
       ),
@@ -113,7 +115,7 @@ describe('settlements', () => {
 describe('members', () => {
   it('shows a ghost added offline, with the address that lets them claim later', () => {
     const queue = queued(
-      envelope('m-1', 'member.add_ghost', {
+      envelope('m-1', MutationKind.MemberAddGhost, {
         memberId: 'mem-1',
         name: 'Ravi',
         email: 'ravi@example.com',
@@ -136,7 +138,7 @@ describe('members', () => {
     // back replaces the queued one rather than sitting beside it.
     const mirror = reconcile(emptyMirror(), [
       {
-        table: 'group_members',
+        table: SyncTable.GroupMembers,
         groupId: GROUP,
         seq: 1,
         row: {
@@ -149,7 +151,7 @@ describe('members', () => {
       },
     ]).state;
 
-    const queue = queued(envelope('m-1', 'member.add_ghost', { memberId: 'mem-1', name: 'Ravi' }));
+    const queue = queued(envelope('m-1', MutationKind.MemberAddGhost, { memberId: 'mem-1', name: 'Ravi' }));
     const rows = materialiseMembers(mirror, queue, { groupId: GROUP });
     expect(rows).toHaveLength(1);
     expect(rows[0]?.pending).toBeUndefined();
@@ -157,7 +159,7 @@ describe('members', () => {
 });
 
 describe('groups', () => {
-  const create = envelope('m-1', 'group.create', {
+  const create = envelope('m-1', MutationKind.GroupCreate, {
     name: 'Goa',
     currency: 'INR',
     emoji: '🏖️',
@@ -179,7 +181,7 @@ describe('groups', () => {
   it('replays an edit over the row the server sent', () => {
     const mirror = reconcile(emptyMirror(), [
       {
-        table: 'groups',
+        table: SyncTable.Groups,
         groupId: GROUP,
         seq: 1,
         row: {
@@ -192,7 +194,7 @@ describe('groups', () => {
       },
     ]).state;
 
-    const queue = queued(envelope('m-2', 'group.update', { name: 'Goa 2026' }));
+    const queue = queued(envelope('m-2', MutationKind.GroupUpdate, { name: 'Goa 2026' }));
     const [row] = materialiseGroups(mirror, queue);
     expect(row).toMatchObject({ id: GROUP, name: 'Goa 2026', pending: true });
   });
@@ -200,7 +202,7 @@ describe('groups', () => {
   it('keeps an archived group out, however it was archived', () => {
     const mirror = reconcile(emptyMirror(), [
       {
-        table: 'groups',
+        table: SyncTable.Groups,
         groupId: GROUP,
         seq: 1,
         row: { id: GROUP, name: 'Old', default_currency: 'INR', created_at: AT, archived_at: AT },
@@ -221,7 +223,7 @@ describe('the overlay as a whole', () => {
         (ids) => {
           const queue = queued(
             ...ids.map((id) =>
-              envelope(`m-${id}`, 'settlement.create', {
+              envelope(`m-${id}`, MutationKind.SettlementCreate, {
                 settlementId: `s-${id}`,
                 from: 'a',
                 to: 'b',

--- a/packages/core/test/plans.test.ts
+++ b/packages/core/test/plans.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  BillingPeriod,
   FREE_ENTITLEMENT,
   FREE_MONTHLY_SCANS,
   PLUS_MONTHLY_SCANS,
@@ -20,14 +21,19 @@ describe('prices', () => {
     // ₹79 is about $0.95. Charging that in the United States leaves most of the
     // revenue on the floor; charging $4.99 in India sells nothing. That is the
     // whole reason this is a table and not an exchange rate.
-    expect(priceFor('IN', 'monthly')).toEqual({ minor: 7900n, currency: 'INR' });
-    expect(priceFor('US', 'monthly')).toEqual({ minor: 499n, currency: 'USD' });
-    expect(priceFor('AU', 'monthly')).toEqual({ minor: 799n, currency: 'AUD' });
+    expect(priceFor('IN', BillingPeriod.Monthly)).toEqual({ minor: 7900n, currency: 'INR' });
+    expect(priceFor('US', BillingPeriod.Monthly)).toEqual({ minor: 499n, currency: 'USD' });
+    expect(priceFor('AU', BillingPeriod.Monthly)).toEqual({ minor: 799n, currency: 'AUD' });
   });
 
   it('prices every period in every market it names', () => {
     for (const country of PRICED_COUNTRIES) {
-      for (const period of ['monthly', 'yearly', 'lifetime', 'trip_pass'] as const) {
+      for (const period of [
+        BillingPeriod.Monthly,
+        BillingPeriod.Yearly,
+        BillingPeriod.Lifetime,
+        BillingPeriod.TripPass,
+      ]) {
         const price = priceFor(country, period);
         expect(price.minor, `${country} ${period}`).toBeGreaterThan(0n);
         expect(isCurrencyCode(price.currency), `${country} ${period}`).toBe(true);
@@ -41,7 +47,7 @@ describe('prices', () => {
     for (const country of PRICED_COUNTRIES) {
       const expected = currencyForCountry(country);
       if (!expected) continue;
-      expect(priceFor(country, 'monthly').currency, country).toBe(expected);
+      expect(priceFor(country, BillingPeriod.Monthly).currency, country).toBe(expected);
     }
   });
 
@@ -49,8 +55,8 @@ describe('prices', () => {
     // If it is not, the yearly plan is a worse deal than the thing it is meant
     // to convert people away from.
     for (const country of PRICED_COUNTRIES) {
-      const monthly = priceFor(country, 'monthly').minor;
-      const yearly = priceFor(country, 'yearly').minor;
+      const monthly = priceFor(country, BillingPeriod.Monthly).minor;
+      const yearly = priceFor(country, BillingPeriod.Yearly).minor;
       expect(yearly, country).toBeLessThan(monthly * 12n);
     }
   });
@@ -59,16 +65,16 @@ describe('prices', () => {
     // Cheap enough that one person covers a group without thinking, dear
     // enough that it does not undercut the subscription it feeds.
     for (const country of PRICED_COUNTRIES) {
-      const pass = priceFor(country, 'trip_pass').minor;
-      expect(pass, country).toBeGreaterThan(priceFor(country, 'monthly').minor);
-      expect(pass, country).toBeLessThan(priceFor(country, 'yearly').minor);
+      const pass = priceFor(country, BillingPeriod.TripPass).minor;
+      expect(pass, country).toBeGreaterThan(priceFor(country, BillingPeriod.Monthly).minor);
+      expect(pass, country).toBeLessThan(priceFor(country, BillingPeriod.Yearly).minor);
     }
   });
 
   it('falls back rather than returning nothing for a country with no row', () => {
-    expect(priceFor('ZZ', 'monthly')).toEqual(priceFor('US', 'monthly'));
-    expect(priceFor(null, 'yearly')).toEqual(priceFor('US', 'yearly'));
-    expect(priceFor(' in ', 'monthly').currency).toBe('INR');
+    expect(priceFor('ZZ', BillingPeriod.Monthly)).toEqual(priceFor('US', BillingPeriod.Monthly));
+    expect(priceFor(null, BillingPeriod.Yearly)).toEqual(priceFor('US', BillingPeriod.Yearly));
+    expect(priceFor(' in ', BillingPeriod.Monthly).currency).toBe('INR');
   });
 });
 

--- a/packages/core/test/receipt.test.ts
+++ b/packages/core/test/receipt.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { checkReceipt, toItemizedParams } from '../src/receipt/reconcile.js';
 import { LOW_CONFIDENCE, type ParsedReceipt } from '../src/receipt/types.js';
 import { computeShares } from '../src/split/computeShares.js';
-import { SplitError, type SplitErrorCode } from '../src/split/types.js';
+import { SplitError, SplitErrorCode } from '../src/split/types.js';
 
 /** The code is the contract a client branches on; the prose is not. */
 function expectSplitError(run: () => unknown, code: SplitErrorCode): void {
@@ -179,7 +179,7 @@ describe('turning a receipt into an expense', () => {
           participants: ['asha'],
           seed: 'receipt-2',
         }),
-      'ITEMIZED_TOTAL_MISMATCH',
+      SplitErrorCode.ItemizedTotalMismatch,
     );
   });
 
@@ -196,7 +196,7 @@ describe('turning a receipt into an expense', () => {
           participants: ['asha', 'ravi'],
           seed: 'receipt-3',
         }),
-      'UNCLAIMED_ITEM',
+      SplitErrorCode.UnclaimedItem,
     );
   });
 });

--- a/packages/core/test/settlement.test.ts
+++ b/packages/core/test/settlement.test.ts
@@ -7,8 +7,10 @@ import {
   canTransition,
   isValidVpa,
   SettlementError,
+  SettlementTransition,
   type Receivable,
 } from '../src/settlement/apply.js';
+import { SettlementStatus } from '../src/balances/types.js';
 import { toMajorString } from '../src/money/money.js';
 
 const formatMajor = (amount: bigint, currency: string): string =>
@@ -112,13 +114,13 @@ describe('UPI intent (ADR-007: Baaki never moves the money)', () => {
 
 describe('settlement state machine', () => {
   it('allows confirm, dispute, cancel and auto-confirm from initiated', () => {
-    expect(canTransition('initiated', 'confirm')).toBe(true);
-    expect(canTransition('initiated', 'auto_confirm')).toBe(true);
+    expect(canTransition(SettlementStatus.Initiated, SettlementTransition.Confirm)).toBe(true);
+    expect(canTransition(SettlementStatus.Initiated, SettlementTransition.AutoConfirm)).toBe(true);
   });
 
   it('is terminal once confirmed or cancelled, but auto-confirmed can be disputed', () => {
-    expect(canTransition('confirmed', 'cancel')).toBe(false);
-    expect(canTransition('cancelled', 'confirm')).toBe(false);
-    expect(canTransition('auto_confirmed', 'dispute')).toBe(true);
+    expect(canTransition(SettlementStatus.Confirmed, SettlementTransition.Cancel)).toBe(false);
+    expect(canTransition(SettlementStatus.Cancelled, SettlementTransition.Confirm)).toBe(false);
+    expect(canTransition(SettlementStatus.AutoConfirmed, SettlementTransition.Dispute)).toBe(true);
   });
 });

--- a/packages/core/test/split.combinations.test.ts
+++ b/packages/core/test/split.combinations.test.ts
@@ -26,12 +26,7 @@ import { describe, expect, it } from 'vitest';
 
 import { computeShares, sumShares } from '../src/split/computeShares.js';
 import { verifyClientShares } from '../src/split/verify.js';
-import {
-  SplitError,
-  type MemberId,
-  type ShareMap,
-  type SplitErrorCode,
-} from '../src/split/types.js';
+import { SplitError, SplitErrorCode, type MemberId, type ShareMap } from '../src/split/types.js';
 
 /**
  * Assert on the machine-readable code rather than the prose. The message is for
@@ -183,7 +178,7 @@ describe('percentage splits — every composition of 100%', () => {
             participants: ids,
             seed: SEED,
           }),
-        'PERCENT_SUM_MISMATCH',
+        SplitErrorCode.PercentSumMismatch,
       );
     }
   });
@@ -200,7 +195,7 @@ describe('percentage splits — every composition of 100%', () => {
             participants: ids,
             seed: SEED,
           }),
-        'INVALID_WEIGHT',
+        SplitErrorCode.InvalidWeight,
       );
     }
   });
@@ -299,7 +294,7 @@ describe('share splits — every composition of ten shares', () => {
           participants: ids,
           seed: SEED,
         }),
-      'NO_POSITIVE_WEIGHT',
+      SplitErrorCode.NoPositiveWeight,
     );
   });
 
@@ -315,7 +310,7 @@ describe('share splits — every composition of ten shares', () => {
             participants: ids,
             seed: SEED,
           }),
-        'INVALID_WEIGHT',
+        SplitErrorCode.InvalidWeight,
       );
     }
   });
@@ -363,7 +358,7 @@ describe('fixed value splits — exact amounts per person', () => {
             participants: ids,
             seed: SEED,
           }),
-        'EXACT_SUM_MISMATCH',
+        SplitErrorCode.ExactSumMismatch,
       );
     }
   });
@@ -408,7 +403,7 @@ describe('rules that apply to every split type', () => {
     it(`${name}: refuses an expense with no participants`, () => {
       expectSplitError(
         () => computeShares({ amount: 1000n, currency: INR, params, participants: [], seed: SEED }),
-        'EMPTY_PARTICIPANTS',
+        SplitErrorCode.EmptyParticipants,
       );
     });
 
@@ -422,7 +417,7 @@ describe('rules that apply to every split type', () => {
             participants: ['m1', 'm2', 'm1'],
             seed: SEED,
           }),
-        'DUPLICATE_PARTICIPANT',
+        SplitErrorCode.DuplicateParticipant,
       );
     });
 
@@ -436,7 +431,7 @@ describe('rules that apply to every split type', () => {
             participants: ['m1', 'm2'],
             seed: SEED,
           }),
-        'NEGATIVE_TOTAL',
+        SplitErrorCode.NegativeTotal,
       );
     });
   }
@@ -457,7 +452,7 @@ describe('rules that apply to every split type', () => {
             participants: ['m1', 'm2'],
             seed: SEED,
           }),
-        'UNKNOWN_MEMBER',
+        SplitErrorCode.UnknownMember,
       );
     }
   });
@@ -527,13 +522,13 @@ describe('the server is the one that decides (TDR §4)', () => {
   it('rejects a client that is one paisa out', () => {
     const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
     claimed.m1 = (BigInt(claimed.m1 ?? '0') + 1n).toString();
-    expectSplitError(() => verifyClientShares(authoritative, claimed), 'SHARE_MISMATCH');
+    expectSplitError(() => verifyClientShares(authoritative, claimed), SplitErrorCode.ShareMismatch);
   });
 
   it('rejects a client that omits somebody', () => {
     const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
     delete claimed.m3;
-    expectSplitError(() => verifyClientShares(authoritative, claimed), 'SHARE_MISMATCH');
+    expectSplitError(() => verifyClientShares(authoritative, claimed), SplitErrorCode.ShareMismatch);
   });
 
   it('rejects a client that invents somebody', () => {
@@ -542,13 +537,13 @@ describe('the server is the one that decides (TDR §4)', () => {
     // wave this through.
     const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
     claimed.mallory = '0';
-    expectSplitError(() => verifyClientShares(authoritative, claimed), 'SHARE_MISMATCH');
+    expectSplitError(() => verifyClientShares(authoritative, claimed), SplitErrorCode.ShareMismatch);
   });
 
   it('rejects a client that sends something that is not a number', () => {
     const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
     claimed.m1 = 'five hundred';
-    expectSplitError(() => verifyClientShares(authoritative, claimed), 'SHARE_MISMATCH');
+    expectSplitError(() => verifyClientShares(authoritative, claimed), SplitErrorCode.ShareMismatch);
   });
 
   it('cannot be told what a share should be — it is a function of the inputs only', () => {

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -25,10 +25,13 @@ import {
   liveExpenses,
   markFailed,
   materialiseExpenses,
+  MutationKind,
   nextBatch,
   overlayPending,
   reconcile,
   retryNow,
+  SyncRejectionCode,
+  SyncTable,
   toExpenseSnapshot,
   type MirrorExpense,
   type MirrorState,
@@ -86,7 +89,7 @@ class ModelServer {
         outcomes.push({
           clientMutationId: mutation.clientMutationId,
           status: 'rejected',
-          code: 'VALIDATION_FAILED',
+          code: SyncRejectionCode.ValidationFailed,
           message: error instanceof Error ? error.message : String(error),
         });
       }
@@ -96,7 +99,7 @@ class ModelServer {
     const changes: SyncChange[] = [...this.expenses.values()]
       .filter((row) => row.updated_seq > since)
       .sort((a, b) => a.updated_seq - b.updated_seq)
-      .map((row) => ({ table: 'expenses' as const, groupId: GROUP, seq: row.updated_seq, row }));
+      .map((row) => ({ table: SyncTable.Expenses, groupId: GROUP, seq: row.updated_seq, row }));
 
     return {
       outcomes,
@@ -176,7 +179,7 @@ class Device {
   add(payload: ExpenseCreatePayload, clientMutationId: string, at: string): void {
     this.queue = enqueue(this.queue, {
       clientMutationId,
-      kind: 'expense.create',
+      kind: MutationKind.ExpenseCreate,
       groupId: GROUP,
       clientCreatedAt: at,
       payload,
@@ -309,8 +312,8 @@ describe('the M2 acceptance scenario (TDR §10)', () => {
 describe('reconciliation', () => {
   it('is idempotent — re-applying a pull changes nothing', () => {
     const changes: SyncChange[] = [
-      { table: 'expenses', groupId: GROUP, seq: 1, row: { id: 'e1', group_id: GROUP } },
-      { table: 'expenses', groupId: GROUP, seq: 2, row: { id: 'e2', group_id: GROUP } },
+      { table: SyncTable.Expenses, groupId: GROUP, seq: 1, row: { id: 'e1', group_id: GROUP } },
+      { table: SyncTable.Expenses, groupId: GROUP, seq: 2, row: { id: 'e2', group_id: GROUP } },
     ];
     const once = reconcile(emptyMirror(), changes);
     const twice = reconcile(once.state, changes);
@@ -324,7 +327,7 @@ describe('reconciliation', () => {
     fc.assert(
       fc.property(fc.shuffledSubarray([1, 2, 3, 4, 5], { minLength: 5 }), (order) => {
         const changes: SyncChange[] = order.map((seq) => ({
-          table: 'expenses' as const,
+          table: SyncTable.Expenses,
           groupId: GROUP,
           seq,
           row: { id: 'e1', group_id: GROUP, version: seq },
@@ -339,10 +342,10 @@ describe('reconciliation', () => {
 
   it('never moves a cursor backwards', () => {
     const ahead = reconcile(emptyMirror(), [
-      { table: 'expenses', groupId: GROUP, seq: 9, row: { id: 'e1', group_id: GROUP } },
+      { table: SyncTable.Expenses, groupId: GROUP, seq: 9, row: { id: 'e1', group_id: GROUP } },
     ]).state;
     const stale = reconcile(ahead, [
-      { table: 'expenses', groupId: GROUP, seq: 3, row: { id: 'e2', group_id: GROUP } },
+      { table: SyncTable.Expenses, groupId: GROUP, seq: 3, row: { id: 'e2', group_id: GROUP } },
     ]).state;
 
     expect(stale.cursors[GROUP]).toBe(9);
@@ -371,7 +374,7 @@ describe('reconciliation', () => {
 
     device.queue = enqueue(device.queue, {
       clientMutationId: 'm-2',
-      kind: 'expense.delete',
+      kind: MutationKind.ExpenseDelete,
       groupId: GROUP,
       clientCreatedAt: '2026-03-02T00:00:00Z',
       payload: { expenseId: 'e1' },
@@ -400,7 +403,8 @@ describe('the mutation queue', () => {
 
   it('sends in the order the user made the changes', () => {
     let queue: QueuedMutation[] = [];
-    for (const id of ['a', 'b', 'c']) queue = enqueue(queue, envelope(id, GROUP, 'expense.create'));
+    for (const id of ['a', 'b', 'c'])
+      queue = enqueue(queue, envelope(id, GROUP, MutationKind.ExpenseCreate));
     expect(nextBatch(queue, { now: 0 }).map((item) => item.clientMutationId)).toEqual([
       'a',
       'b',
@@ -410,9 +414,9 @@ describe('the mutation queue', () => {
 
   it('holds back a group whose head is in backoff, but not other groups', () => {
     let queue: QueuedMutation[] = [];
-    queue = enqueue(queue, envelope('a1', 'g1', 'expense.create'));
-    queue = enqueue(queue, envelope('a2', 'g1', 'expense.create'));
-    queue = enqueue(queue, envelope('b1', 'g2', 'expense.create'));
+    queue = enqueue(queue, envelope('a1', 'g1', MutationKind.ExpenseCreate));
+    queue = enqueue(queue, envelope('a2', 'g1', MutationKind.ExpenseCreate));
+    queue = enqueue(queue, envelope('b1', 'g2', MutationKind.ExpenseCreate));
 
     const head = queue.filter((item) => item.clientMutationId === 'a1');
     queue = markFailed(queue, head, 'network down', 1_000);
@@ -429,14 +433,14 @@ describe('the mutation queue', () => {
 
   it('treats applied and duplicate identically — both mean the server has it', () => {
     let queue: QueuedMutation[] = [];
-    queue = enqueue(queue, envelope('a', GROUP, 'expense.create'));
-    queue = enqueue(queue, envelope('b', GROUP, 'expense.create'));
-    queue = enqueue(queue, envelope('c', GROUP, 'expense.create'));
+    queue = enqueue(queue, envelope('a', GROUP, MutationKind.ExpenseCreate));
+    queue = enqueue(queue, envelope('b', GROUP, MutationKind.ExpenseCreate));
+    queue = enqueue(queue, envelope('c', GROUP, MutationKind.ExpenseCreate));
 
     const result = applyOutcomes(queue, [
       { clientMutationId: 'a', status: 'applied' },
       { clientMutationId: 'b', status: 'duplicate' },
-      { clientMutationId: 'c', status: 'rejected', code: 'SHARE_MISMATCH', message: 'no' },
+      { clientMutationId: 'c', status: 'rejected', code: SyncRejectionCode.ShareMismatch, message: 'no' },
     ]);
 
     expect(result.queue).toHaveLength(0);
@@ -449,7 +453,7 @@ describe('the mutation queue', () => {
     expect(backoffMs(2)).toBe(4000);
     expect(backoffMs(99)).toBe(5 * 60_000);
 
-    let queue: QueuedMutation[] = [enqueue([], envelope('a', GROUP, 'expense.create'))[0]!];
+    let queue: QueuedMutation[] = [enqueue([], envelope('a', GROUP, MutationKind.ExpenseCreate))[0]!];
     for (let attempt = 0; attempt < 8; attempt += 1) {
       queue = markFailed(queue, queue, 'offline', 0);
     }
@@ -464,7 +468,7 @@ describe('the mutation queue', () => {
   it('collapses un-sent consecutive edits of the same expense', () => {
     const edit = (id: string, description: string): MutationEnvelope => ({
       clientMutationId: id,
-      kind: 'expense.update',
+      kind: MutationKind.ExpenseUpdate,
       groupId: GROUP,
       clientCreatedAt: '2026-03-01T00:00:00Z',
       payload: { expenseId: 'e1', description },
@@ -484,7 +488,7 @@ describe('the mutation queue', () => {
   it('never collapses an edit the server has already seen', () => {
     const edit = (id: string): MutationEnvelope => ({
       clientMutationId: id,
-      kind: 'expense.update',
+      kind: MutationKind.ExpenseUpdate,
       groupId: GROUP,
       clientCreatedAt: '2026-03-01T00:00:00Z',
       payload: { expenseId: 'e1' },
@@ -502,7 +506,7 @@ describe('the mutation queue', () => {
   it('does not collapse edits of different expenses', () => {
     const edit = (id: string, expenseId: string): MutationEnvelope => ({
       clientMutationId: id,
-      kind: 'expense.update',
+      kind: MutationKind.ExpenseUpdate,
       groupId: GROUP,
       clientCreatedAt: '2026-03-01T00:00:00Z',
       payload: { expenseId },
@@ -567,7 +571,7 @@ describe('the pending overlay', () => {
     ];
     const queue = enqueue([], {
       clientMutationId: 'm-1',
-      kind: 'expense.create',
+      kind: MutationKind.ExpenseCreate,
       groupId: GROUP,
       clientCreatedAt: '2026-03-02T00:00:00Z',
       payload: {

--- a/packages/ui/src/components/MoneyText.tsx
+++ b/packages/ui/src/components/MoneyText.tsx
@@ -2,10 +2,10 @@ import { StyleSheet, Text as RNText, type TextStyle } from 'react-native';
 
 import {
   balanceDirection,
+  BalanceDirection,
   copyFor,
   formatParts,
   moneyAccessibilityLabel,
-  type BalanceDirection,
   type CurrencyCode,
   type Money,
 } from '@baaki/core';
@@ -86,9 +86,9 @@ export function MoneyText({
   const resolvedTone =
     tone ??
     (mode === 'balance'
-      ? resolvedDirection === 'owed_to_you'
+      ? resolvedDirection === BalanceDirection.OwedToYou
         ? 'positive'
-        : resolvedDirection === 'you_owe'
+        : resolvedDirection === BalanceDirection.YouOwe
           ? 'negative'
           : 'muted'
       : 'default');


### PR DESCRIPTION
Converts domain/state string-literal union types (`type X = 'a' | 'b'`) to same-named TypeScript **string `enum`s** across packages and apps. String enums keep the exact runtime value, so **all wire/DB/JSON payloads are unchanged** — only the type identity becomes nominal and call sites now reference `X.Member`.

## Scope — 57 enums
- **packages/core** (26): SplitType, AuthMethod, OAuthMethod, GuestBlock, SettlementStatus/Transition, PlanTier, BillingPeriod, CategoryId, MarketId, RailId, HandleKind, BalanceDirection, ReceiptSource, TransactionDirection, NotificationKind, MutationKind, SyncTable, SyncRejectionCode, LanguageCode, UpdateDecision + the `*ErrorCode`/`*ProblemKind` families.
- **packages/api-client** (4): GroupType, DisputeStatus, SettlementMethod, SettlementStatus.
- **apps/mobile** (23): GroupType, SettlementMethod, DisputeStatus, Language, SyncStatus, SplitKind, push/sms permission+failure unions, SchemePreference, ContactChannel, and local screen-state unions (Mode, Access, Tab, Scope, Field, Face, Kind, Format, Method).
- **apps/web** (3): Language, Section, SplitKind.
- **apps/admin** (1): Metric.

## Deliberately NOT converted (open for discussion)
- **Presentational component-variant props** in `packages/ui` — `ButtonSize`, `ButtonVariant`, `CalloutTone`, `TextTone`. Enum-typing JSX props turns every `<Button size="sm">` into `size={ButtonSize.Sm}` across all call sites for zero domain benefit.
- **Inline field unions** that are not `type X =` aliases — e.g. `role?: 'admin' | 'member'`, and core's `SplitParams` discriminant `kind`, which must stay string literals for structural object construction.
- **`supabase/functions/*`** — deployed Deno edge code whose JSON strings are a live wire contract on a separate deploy pipeline.

## Verification (all green)
- `tsc --noEmit` across all 7 workspace projects.
- Lint: mobile + web exit 0. (Pre-existing `apps/admin/echarts-core.ts` `react-hooks/rules-of-hooks` error exists on `main`, unrelated.)
- Tests: core 517 · api-client 12 · db 436 · mobile 206 · web 24 — **0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)