### PR TITLE
feat(mobile): new-group UX pass — icon pill, chip icons, contacts entry, trip-only dates

### DIFF
--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -48,9 +48,15 @@ const EMOJI_FOR_TYPE: Record<GroupType, string> = {
 
 const deviceZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Kolkata';
 
-/** A chip icon renderer that takes the chip's resolved colour (selected/not). */
+/**
+ * A chip icon renderer that takes the chip's resolved colour (selected/not).
+ * Not a component — a render callback the Chip calls with its own ink colour, so
+ * the display-name rule (which assumes a returned element means a component) does
+ * not apply here.
+ */
 const iconFor =
   (name: keyof typeof Ionicons.glyphMap) =>
+  // eslint-disable-next-line react/display-name
   (color: string): ReactNode => <Ionicons name={name} size={16} color={color} />;
 
 /**
@@ -104,7 +110,7 @@ export default function NewGroupScreen() {
   const emoji = pickedEmoji ?? guessGroupEmoji(name) ?? EMOJI_FOR_TYPE[type];
   // Trips and events benefit most from simplification; a two-person group does
   // not. Follows the type until somebody says otherwise.
-  const effectiveSimplify = simplify ?? (type === 'trip' || type === 'event');
+  const effectiveSimplify = simplify ?? (type === GroupType.Trip || type === GroupType.Event);
   const currency = currencyForCountry(country) ?? 'INR';
 
   const submit = async (): Promise<void> => {
@@ -145,7 +151,7 @@ export default function NewGroupScreen() {
       // Trip dates are not part of the create call, so they ride behind it as
       // an update on the same ordered queue — only when a trip was actually
       // given a start and end, since that is what turns the reminders on.
-      if (tripDates.start_date && tripDates.end_date) {
+      if (type === GroupType.Trip && tripDates.start_date && tripDates.end_date) {
         await mutate(MutationKind.GroupUpdate, groupId, {
           start_date: tripDates.start_date,
           end_date: tripDates.end_date,
@@ -288,11 +294,15 @@ export default function NewGroupScreen() {
             expense starts in. The same flagged row the settings screen uses. */}
         <CountryRow countryCode={country} onChange={setCountry} />
 
-        <TripDates
-          group={tripDates}
-          locale={locale}
-          onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
-        />
+        {/* Dates and their daily nudges only mean anything for a trip — a
+            flatshare or a couple has no start and end. Shown only for trips. */}
+        {type === GroupType.Trip ? (
+          <TripDates
+            group={tripDates}
+            locale={locale}
+            onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
+          />
+        ) : null}
 
         {/* ADR-009: simplification is presentation only — the pairwise ledger
             underneath is untouched. */}

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
@@ -47,6 +47,11 @@ const EMOJI_FOR_TYPE: Record<GroupType, string> = {
 };
 
 const deviceZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Kolkata';
+
+/** A chip icon renderer that takes the chip's resolved colour (selected/not). */
+const iconFor =
+  (name: keyof typeof Ionicons.glyphMap) =>
+  (color: string): ReactNode => <Ionicons name={name} size={16} color={color} />;
 
 /**
  * Making a group, wearing the same clothes as the settings that edit one.
@@ -204,14 +209,6 @@ export default function NewGroupScreen() {
     setBrowsing(false);
   };
 
-  // The contacts already queued, so the picker greys them rather than letting
-  // somebody add the same person twice.
-  const alreadyPicked = new Set(
-    ghosts.flatMap((ghost) =>
-      [ghost.email, ghost.phone].filter((value): value is string => Boolean(value)),
-    ),
-  );
-
   return (
     <Screen edges={['top', 'bottom']}>
       <ScrollView
@@ -262,11 +259,11 @@ export default function NewGroupScreen() {
                   paddingVertical: theme.spacing.sm,
                 }}
               />
+              {/* A compact swatch rather than a full-width button — the icon is
+                  already shown large on the avatar beside it, so this only needs
+                  to be a way in, not a billboard. */}
+              <CoverEmojiPicker value={emoji} onChange={setPickedEmoji} compact />
             </View>
-          </Row>
-
-          <Row style={{ gap: theme.spacing.sm }}>
-            <CoverEmojiPicker value={emoji} onChange={setPickedEmoji} />
           </Row>
         </Card>
 
@@ -278,11 +275,11 @@ export default function NewGroupScreen() {
             value={type}
             onChange={setType}
             options={[
-              { value: GroupType.Trip, label: t.extras.typeTrip },
-              { value: GroupType.Home, label: t.extras.typeHome },
-              { value: GroupType.Couple, label: t.extras.typeCouple },
-              { value: GroupType.Event, label: t.extras.typeEvent },
-              { value: GroupType.Other, label: t.extras.typeOther },
+              { value: GroupType.Trip, label: t.extras.typeTrip, icon: iconFor('airplane') },
+              { value: GroupType.Home, label: t.extras.typeHome, icon: iconFor('home') },
+              { value: GroupType.Couple, label: t.extras.typeCouple, icon: iconFor('heart') },
+              { value: GroupType.Event, label: t.extras.typeEvent, icon: iconFor('sparkles') },
+              { value: GroupType.Other, label: t.extras.typeOther, icon: iconFor('people') },
             ]}
           />
         </View>
@@ -318,6 +315,33 @@ export default function NewGroupScreen() {
             title={t.extras.addPeopleByName}
             info={t.extras.ghostNote}
             titleVariant="caption"
+            right={
+              // The same phone-contacts picker, moved to the section heading so
+              // it reads as an action on People rather than a stray button below
+              // the name field. Nobody's book is uploaded (ADR-006).
+              <Pressable
+                accessibilityRole="button"
+                accessibilityState={{ expanded: browsing }}
+                accessibilityLabel={browsing ? t.people.hideContacts : t.people.browseContacts}
+                hitSlop={8}
+                onPress={() => setBrowsing((open) => !open)}
+                style={({ pressed }) => ({
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 6,
+                  opacity: pressed ? 0.6 : 1,
+                })}
+              >
+                <Ionicons
+                  name={browsing ? 'people' : 'people-outline'}
+                  size={16}
+                  color={theme.color.brand}
+                />
+                <Text variant="caption" style={{ color: theme.color.brand }}>
+                  {t.people.contacts}
+                </Text>
+              </Pressable>
+            }
           />
           <Row>
             <TextInput
@@ -344,20 +368,18 @@ export default function NewGroupScreen() {
             />
           </Row>
 
-          {/* The same phone-contacts picker the Members screen uses. It reads
-              the address book on the device and only the people ticked come
-              back — nobody's book is uploaded (ADR-006). */}
-          <Button
-            label={browsing ? t.people.hideContacts : t.people.browseContacts}
-            variant="ghost"
-            onPress={() => setBrowsing((open) => !open)}
-          />
-
           {browsing ? (
             // Tall enough that the letter rail has something to aim at — a
             // short window turns a thousand contacts back into a peephole.
-            <View style={{ height: 480 }}>
-              <ContactPicker onConfirm={addContacts} existing={alreadyPicked} />
+            <View style={{ gap: theme.spacing.sm }}>
+              <Text variant="caption" tone="muted">
+                {t.misc.fromYourContacts}
+              </Text>
+              <View style={{ height: 480 }}>
+                {/* Seeded with whoever is already added, so the people already
+                    selected show ticked here rather than the picker opening blank. */}
+                <ContactPicker onConfirm={addContacts} initialSelected={ghosts} />
+              </View>
             </View>
           ) : null}
 

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -49,6 +49,9 @@ interface ContactPickerProps {
   onConfirm: (contacts: readonly PickedContact[]) => void;
   /** Already in the group — shown greyed rather than hidden, so it is obvious why. */
   existing?: ReadonlySet<string>;
+  /** Already chosen elsewhere on the screen — opens ticked and in the strip, so
+   *  the picker reflects who is already selected rather than starting blank. */
+  initialSelected?: readonly PickedContact[];
   /** The verb on the confirm button. The count and noun are added here. */
   confirmVerb?: string;
   /** Disables confirming while the caller is still writing the last lot away. */
@@ -99,6 +102,7 @@ const STRIP_HEIGHT = 62;
 export function ContactPicker({
   onConfirm,
   existing,
+  initialSelected,
   confirmVerb = 'Add',
   busy = false,
 }: ContactPickerProps): React.JSX.Element {
@@ -107,7 +111,11 @@ export function ContactPicker({
   const [access, setAccess] = useState<Access>(Access.Asking);
   const [contacts, setContacts] = useState<PickedContact[]>([]);
   const [query, setQuery] = useState('');
-  const [picked, setPicked] = useState<ReadonlyMap<string, PickedContact>>(new Map());
+  // Seeded from whoever is already chosen, so opening the picker shows them
+  // ticked and in the strip rather than an empty selection.
+  const [picked, setPicked] = useState<ReadonlyMap<string, PickedContact>>(
+    () => new Map((initialSelected ?? []).map((contact) => [keyOf(contact), contact])),
+  );
   const cancelled = useRef(false);
 
   const load = useCallback(async (): Promise<void> => {

--- a/apps/mobile/src/components/CoverEmojiPicker.tsx
+++ b/apps/mobile/src/components/CoverEmojiPicker.tsx
@@ -30,9 +30,12 @@ const EMOJI_GROUPS: readonly (readonly string[])[] = [
 export function CoverEmojiPicker({
   value,
   onChange,
+  compact = false,
 }: {
   value: string | null;
   onChange: (emoji: string) => void;
+  /** A small emoji-swatch pill instead of a full button, for tight layouts. */
+  compact?: boolean;
 }) {
   const theme = useTheme();
   const { t } = useStrings();
@@ -40,12 +43,36 @@ export function CoverEmojiPicker({
 
   return (
     <>
-      <Button
-        label={t.group.chooseIcon}
-        size="sm"
-        variant="secondary"
-        onPress={() => setOpen(true)}
-      />
+      {compact ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t.group.chooseIcon}
+          onPress={() => setOpen(true)}
+          style={({ pressed }) => ({
+            flexDirection: 'row',
+            alignItems: 'center',
+            alignSelf: 'flex-start',
+            gap: 6,
+            height: 32,
+            paddingHorizontal: theme.spacing.md,
+            borderRadius: theme.radius.pill,
+            backgroundColor: theme.color.surfaceMuted,
+            opacity: pressed ? 0.7 : 1,
+          })}
+        >
+          <Text style={{ fontSize: 16 }}>{value ?? '🙂'}</Text>
+          <Text variant="caption" tone="muted">
+            {t.group.chooseIcon}
+          </Text>
+        </Pressable>
+      ) : (
+        <Button
+          label={t.group.chooseIcon}
+          size="sm"
+          variant="secondary"
+          onPress={() => setOpen(true)}
+        />
+      )}
 
       <Modal visible={open} animationType="slide" onRequestClose={() => setOpen(false)}>
         <Screen edges={['top', 'bottom']}>

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -257,14 +257,7 @@ export function TripDates({
             </>
           ) : null}
         </>
-      ) : (
-        <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
-          <Ionicons name="information-circle-outline" size={16} color={theme.color.textFaint} />
-          <Text variant="micro" tone="faint" style={{ flex: 1 }}>
-            A flatshare has no start and no end — leave these empty and nothing is sent.
-          </Text>
-        </Row>
-      )}
+      ) : null}
 
       {group.start_date && group.end_date ? (
         <Button

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -665,6 +665,8 @@ export interface UiStrings {
     mintMistakeNote: string;
     hideContacts: string;
     browseContacts: string;
+    /** Short label for the phone-contacts entry point. */
+    contacts: string;
     /** Reminding somebody who owes you to settle, gently (ADR-010). */
     remind: string;
     reminded: string;
@@ -1618,6 +1620,7 @@ const en: UiStrings = {
       'Made a link by mistake? Mint a new one — the old link keeps working until it expires, so only share links you mean to.',
     hideContacts: 'Hide contacts',
     browseContacts: 'Browse my contacts',
+    contacts: 'Contacts',
     remind: 'Remind',
     reminded: 'Reminded',
     remindedToday: 'Nudged today',
@@ -2062,7 +2065,7 @@ const en: UiStrings = {
     typeCouple: 'Couple',
     typeEvent: 'Event',
     typeOther: 'Other',
-    addPeopleByName: 'Add people by name',
+    addPeopleByName: 'Add friends',
     ghostNote: 'They do not need the app. Add them now and they can claim their history later.',
     claimHistoryNote: 'Pick your name and everything already recorded for you comes with you.',
     theirPastBecomesYours: 'Their past expenses and balances become yours.',
@@ -2639,6 +2642,7 @@ const ta: UiStrings = {
       'தவறுதலாக இணைப்பு உருவாக்கினீர்களா? புதிதாக ஒன்றை உருவாக்கவும் — பழைய இணைப்பு காலாவதியாகும் வரை வேலை செய்யும், எனவே நீங்கள் நினைத்த இணைப்புகளை மட்டும் பகிரவும்.',
     hideContacts: 'தொடர்புகளை மறை',
     browseContacts: 'என் தொடர்புகளைப் பார்',
+    contacts: 'தொடர்புகள்',
     remind: 'நினைவூட்டு',
     reminded: 'நினைவூட்டப்பட்டது',
     remindedToday: 'இன்று நினைவூட்டிவிட்டீர்கள்',
@@ -3100,7 +3104,7 @@ const ta: UiStrings = {
     typeCouple: 'தம்பதி',
     typeEvent: 'நிகழ்வு',
     typeOther: 'மற்றவை',
-    addPeopleByName: 'பெயரால் நபர்களைச் சேர்',
+    addPeopleByName: 'நண்பர்களைச் சேர்',
     ghostNote:
       'அவர்களுக்குச் செயலி தேவையில்லை. இப்போதே சேருங்கள், பிறகு அவர்கள் தங்கள் வரலாற்றைக் கோரலாம்.',
     claimHistoryNote:
@@ -3652,6 +3656,7 @@ const hi: UiStrings = {
       'गलती से लिंक बना लिया? नया बनाएँ — पुराना लिंक खत्म होने तक चलता रहेगा, इसलिए वही लिंक साझा करें जो आप चाहते हैं।',
     hideContacts: 'संपर्क छिपाएँ',
     browseContacts: 'मेरे संपर्क देखें',
+    contacts: 'संपर्क',
     remind: 'याद दिलाएँ',
     reminded: 'याद दिला दिया',
     remindedToday: 'आज याद दिला चुके',
@@ -4097,7 +4102,7 @@ const hi: UiStrings = {
     typeCouple: 'जोड़ा',
     typeEvent: 'आयोजन',
     typeOther: 'अन्य',
-    addPeopleByName: 'नाम से लोग जोड़ें',
+    addPeopleByName: 'दोस्त जोड़ें',
     ghostNote: 'उन्हें ऐप की ज़रूरत नहीं। अभी जोड़ दें, बाद में वे अपना इतिहास ले सकते हैं।',
     claimHistoryNote: 'अपना नाम चुनें और आपके लिए जो कुछ पहले से दर्ज है, सब साथ आ जाएगा।',
     theirPastBecomesYours: 'उनके पुराने खर्च और हिसाब आपके हो जाएँगे।',
@@ -4687,6 +4692,7 @@ const ar: UiStrings = {
       'أنشأت رابطًا بالخطأ؟ أنشئ رابطًا جديدًا — يظل الرابط القديم صالحًا حتى ينتهي، لذا شارك فقط الروابط التي تقصدها.',
     hideContacts: 'إخفاء جهات الاتصال',
     browseContacts: 'تصفّح جهات اتصالي',
+    contacts: 'جهات الاتصال',
     remind: 'ذكّر',
     reminded: 'تم التذكير',
     remindedToday: 'ذُكّر اليوم',
@@ -5255,7 +5261,7 @@ const ar: UiStrings = {
     typeCouple: 'ثنائي',
     typeEvent: 'مناسبة',
     typeOther: 'أخرى',
-    addPeopleByName: 'أضف أشخاصًا بالاسم',
+    addPeopleByName: 'أضف أصدقاء',
     ghostNote: 'لا يحتاجون التطبيق. أضفهم الآن ويمكنهم المطالبة بسجلّهم لاحقًا.',
     claimHistoryNote: 'اختر اسمك فيأتي معك كل ما سُجّل لك من قبل.',
     theirPastBecomesYours: 'تصبح مصاريفهم وأرصدتهم السابقة لك.',

--- a/packages/ui/src/components/Chip.tsx
+++ b/packages/ui/src/components/Chip.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Pressable, ScrollView, View } from 'react-native';
 
 import { useTheme } from '../theme';
@@ -7,10 +8,13 @@ export interface ChipProps {
   label: string;
   selected?: boolean;
   onPress?: () => void;
+  /** Receives the resolved colour so the icon matches the selected state. */
+  icon?: (color: string) => ReactNode;
 }
 
-export function Chip({ label, selected = false, onPress }: ChipProps) {
+export function Chip({ label, selected = false, onPress, icon }: ChipProps) {
   const theme = useTheme();
+  const color = selected ? theme.color.onBrand : theme.color.textMuted;
   return (
     <Pressable
       accessibilityRole="button"
@@ -18,14 +22,17 @@ export function Chip({ label, selected = false, onPress }: ChipProps) {
       accessibilityLabel={label}
       onPress={onPress}
       style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: theme.spacing.xs,
         paddingHorizontal: theme.spacing.lg,
         height: 36,
-        justifyContent: 'center',
         borderRadius: theme.radius.pill,
         backgroundColor: selected ? theme.color.brand : theme.color.surface,
         opacity: pressed ? 0.85 : 1,
       })}
     >
+      {icon ? icon(color) : null}
       <Text variant="caption" tone={selected ? 'onBrand' : 'muted'}>
         {label}
       </Text>
@@ -38,7 +45,7 @@ export function ChipRow<T extends string>({
   value,
   onChange,
 }: {
-  options: readonly { value: T; label: string }[];
+  options: readonly { value: T; label: string; icon?: (color: string) => ReactNode }[];
   value: T;
   onChange: (value: T) => void;
 }) {
@@ -53,6 +60,7 @@ export function ChipRow<T extends string>({
         <Chip
           key={option.value}
           label={option.label}
+          icon={option.icon}
           selected={option.value === value}
           onPress={() => onChange(option.value)}
         />


### PR DESCRIPTION
UX pass on the New group screen, verified on an Android device.

## Changes
- **Group-type chips carry icons** — `ChipRow`/`Chip` gained an optional per-option `icon` (color-passed render fn, matching the PillTabBar pattern; no Ionicons import in `@baaki/ui`). Trip ✈️ / Home 🏠 / Couple ❤️ / Event ✨ / Other 👥.
- **Choose-icon is a compact swatch pill** inline under the name, not a full-width button — the icon is already shown large on the avatar. New `compact` mode on `CoverEmojiPicker`; settings screen unchanged.
- **Trip dates**: removed the "flatshare has no start/end" hint block; and the whole card now renders **only when the group type is `trip`** (submit guards so stale dates aren't sent after a type switch).
- **People section → "Add friends"**: browse control moved to the section heading and relabelled **"Contacts"**; opening it shows a **"From your contacts"** subsection. `ContactPicker` gained `initialSelected` so already-added people open **ticked and in the strip** instead of blank.
- i18n: `addPeopleByName` → "Add friends"; new `people.contacts` (4 locales).

## Verification
- Typecheck clean on touched files.
- Manually verified on Android emulator: chip icons, compact pill, trip-only dates (Home hides the card), contacts permission → picker → "From your contacts" → seeded selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)