### PR TITLE
feat(mobile): tidy dashboard nav — inbox to bottom bar, fix header avatar

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -27,6 +27,13 @@ export default function TabsLayout() {
       icon: (color) => <Ionicons name="pulse" size={20} color={color} />,
     },
     {
+      // The notifications inbox is a stacked route, not a tab screen, so it is
+      // reached with a push rather than a tab navigate (handled in onSelect).
+      key: 'inbox',
+      label: t.tabs.inbox,
+      icon: (color) => <Ionicons name="file-tray-outline" size={20} color={color} />,
+    },
+    {
       key: 'profile',
       label: t.profile,
       icon: (color) => <Ionicons name="person" size={20} color={color} />,
@@ -47,13 +54,8 @@ export default function TabsLayout() {
         <PillTabBar
           items={items}
           activeKey={state.routes[state.index]?.name ?? 'index'}
-          onSelect={(key) => navigation.navigate(key)}
+          onSelect={(key) => (key === 'inbox' ? router.push('/inbox') : navigation.navigate(key))}
           animated={animated}
-          centerAction={{
-            accessibilityLabel: t.newGroup,
-            icon: (color) => <Ionicons name="add" size={30} color={color} />,
-            onPress: () => router.push('/new-group'),
-          }}
         />
       )}
     >

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -27,6 +27,7 @@ import { useGuestGuard } from '@/lib/guestGuard';
 import { SyncBanner } from '@/components/SyncBanner';
 import { SkeletonList } from '@/components/Skeletons';
 import { GroupCard } from '@/components/GroupCard';
+import { useAvatarUrl } from '@/components/ProfileAvatar';
 import { groupLabel, GroupType } from '@/data/types';
 import { usePullRefresh } from '@/lib/pullRefresh';
 
@@ -36,6 +37,11 @@ export default function HomeScreen() {
   const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { profile, isGuest } = useAuth();
+  // The header avatar sits in the private bucket, so its path has to be signed
+  // before an Image can show it — the same resolution the profile screen does.
+  // Without this the dashboard falls back to initials while settings shows the
+  // photo, which reads as the picture "not loading" on the home screen.
+  const avatarUrl = useAvatarUrl(profile?.avatar_url);
 
   const groups = useGroups();
   const summary = useHomeSummary(profile?.id ?? null);
@@ -132,6 +138,7 @@ export default function HomeScreen() {
           <Avatar
             name={profile?.display_name ?? 'You'}
             size={46}
+            photoUrl={avatarUrl}
             accessibilityLabel={t.profile}
             onPress={() => router.navigate('/profile')}
           />
@@ -145,16 +152,6 @@ export default function HomeScreen() {
           </View>
           <IconButton label={t.captures.captureCta} onPress={() => router.push('/capture')}>
             <Ionicons name="camera-outline" size={22} color={theme.color.text} />
-          </IconButton>
-          <IconButton
-            label={t.captures.title}
-            badge={captureCount > 0}
-            onPress={() => router.push('/captures')}
-          >
-            <Ionicons name="file-tray-outline" size={22} color={theme.color.text} />
-          </IconButton>
-          <IconButton label={t.tabs.inbox} onPress={() => router.push('/inbox')}>
-            <Ionicons name="notifications-outline" size={22} color={theme.color.text} />
           </IconButton>
         </Row>
 


### PR DESCRIPTION
## What

Dashboard nav cleanup + a header avatar fix.

- **Header** — dropped the captures-tray and notifications-bell icons; only the capture camera remains. Captures stay reachable via the dashboard "Unassigned" card.
- **Bottom bar** — added an **Inbox** destination: `Home · Friends · Activity · Inbox · Profile`. Inbox is a stacked route (not a tab screen), so `onSelect` pushes `/inbox` instead of navigating the tab navigator.
- **Bottom bar** — removed the raised center **+** (new-group). New group is still reached from the home "new group" action and the empty state.
- **Header avatar** — resolved `avatar_url` through `useAvatarUrl` so the private-bucket photo is signed and displayed, matching the profile/settings screen. It was falling back to initials on the dashboard while settings showed the photo.

## Design note

The bottom "Inbox" opens the **notifications** inbox (`/inbox`), not the captures inbox (`/captures`). Rationale: notifications had no entry point outside the removed header bell, whereas captures keep their "Unassigned" card. Easy to repoint if the other reading was intended.

## Verification

- `tsc --noEmit` on `@baaki/mobile` — clean
- `eslint` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)