### PR TITLE
feat(mobile): scan receipts — OCR itemize, device save, personal-cloud backup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,17 @@ DIRECT_URL="postgresql://postgres:postgres@localhost:54330/baaki?schema=public"
 EXPO_PUBLIC_SUPABASE_URL="http://127.0.0.1:54321"
 EXPO_PUBLIC_SUPABASE_ANON_KEY=""
 
+# Personal-cloud receipt backup (A34). PUBLIC installed-app OAuth client ids —
+# PKCE flow, so no client secret ships in the app; blank disables that provider
+# (the Backup settings screen shows "not set up"). Register one app per provider
+# on its console with redirect URI `baaki://oauthredirect`:
+#   - Google Cloud console → OAuth client (Android/iOS), Drive API enabled
+#   - Dropbox App Console → scoped app, files.content.write
+#   - Microsoft Entra (Azure) → app registration, Files.ReadWrite.AppFolder
+EXPO_PUBLIC_CLOUD_GDRIVE_CLIENT_ID=""
+EXPO_PUBLIC_CLOUD_DROPBOX_CLIENT_ID=""
+EXPO_PUBLIC_CLOUD_ONEDRIVE_CLIENT_ID=""
+
 # Edge functions only — never referenced from apps/*
 SUPABASE_SERVICE_ROLE_KEY=""
 ANTHROPIC_API_KEY=""

--- a/apps/admin/src/components/charts/echarts-core.ts
+++ b/apps/admin/src/components/charts/echarts-core.ts
@@ -7,12 +7,16 @@
  * bundle to what is actually painted. Every chart component imports its renderer
  * from here, never from `echarts-for-react` directly.
  */
-import { use } from 'echarts/core';
+// Aliased: ECharts' registrar is named `use`, which the React hooks lint rule
+// flags as a hook called at the top level. It is not a hook — it is the
+// tree-shaking registration below — so the alias both silences the false
+// positive and reads as what it does.
+import { use as registerECharts } from 'echarts/core';
 import { PieChart, LineChart } from 'echarts/charts';
 import { TooltipComponent, LegendComponent, GridComponent } from 'echarts/components';
 import { SVGRenderer } from 'echarts/renderers';
 import ReactEChartsCore from 'echarts-for-react/lib/core';
 
-use([PieChart, LineChart, TooltipComponent, LegendComponent, GridComponent, SVGRenderer]);
+registerECharts([PieChart, LineChart, TooltipComponent, LegendComponent, GridComponent, SVGRenderer]);
 
 export { ReactEChartsCore };

--- a/apps/admin/src/components/charts/echarts-core.ts
+++ b/apps/admin/src/components/charts/echarts-core.ts
@@ -17,6 +17,13 @@ import { TooltipComponent, LegendComponent, GridComponent } from 'echarts/compon
 import { SVGRenderer } from 'echarts/renderers';
 import ReactEChartsCore from 'echarts-for-react/lib/core';
 
-registerECharts([PieChart, LineChart, TooltipComponent, LegendComponent, GridComponent, SVGRenderer]);
+registerECharts([
+  PieChart,
+  LineChart,
+  TooltipComponent,
+  LegendComponent,
+  GridComponent,
+  SVGRenderer,
+]);
 
 export { ReactEChartsCore };

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -143,7 +143,10 @@ export default function HomeScreen() {
               {profile?.display_name ?? 'You'}
             </Text>
           </View>
-          <IconButton label={t.captures.captureCta} onPress={() => router.push('/capture')}>
+          {/* Straight to the camera: the icon is a scanner, so it opens one
+              rather than a form to fill in first (the capture screen reads the
+              `scan` flag and launches the camera on mount). */}
+          <IconButton label={t.captures.captureCta} onPress={() => router.push('/capture?scan=1')}>
             <Ionicons name="camera-outline" size={22} color={theme.color.text} />
           </IconButton>
           <IconButton

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -148,6 +148,12 @@ function settingsRows(t: UiStrings): SettingsRow[] {
       route: '/settings/import',
     },
     {
+      icon: 'cloud-done-outline',
+      label: t.backup.title,
+      hint: t.backup.subtitle,
+      route: '/settings/backup',
+    },
+    {
       icon: 'chatbubble-ellipses-outline',
       label: t.privacy.feedbackRow,
       hint: t.privacy.feedbackRowHint,

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -12,6 +12,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Button, CurvedPanel, setLayoutDirection, ThemeProvider, Text, useTheme } from '@baaki/ui';
 
 import { CampaignPopup } from '@/components/CampaignPopup';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
 import { DeviceSessionProvider } from '@/lib/deviceSession';
@@ -172,7 +173,14 @@ export default withObservability(RootLayout);
  */
 function ThemedRoot({ children }: { children: React.ReactNode }) {
   const { preference } = useThemePreference();
-  return <ThemeProvider forceScheme={preference ?? undefined}>{children}</ThemeProvider>;
+  return (
+    <ThemeProvider forceScheme={preference ?? undefined}>
+      {/* Inside the theme so the recover screen is themed, and around the whole
+          app below it so a render error on any screen lands here instead of on a
+          blank root. */}
+      <ErrorBoundary>{children}</ErrorBoundary>
+    </ThemeProvider>
+  );
 }
 
 /**

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -20,6 +20,7 @@ import { LanguageProvider, useLanguage } from '@/i18n/language';
 import { LocaleSync } from '@/i18n/localeSync';
 import { LockProvider, useLock } from '@/lib/lock';
 import { MotionProvider, TRANSITION_MS, useMotion } from '@/lib/motion';
+import { BackupProvider } from '@/lib/cloud/BackupProvider';
 import { ThemePreferenceProvider, useThemePreference } from '@/lib/theme';
 import { UpdateProvider } from '@/lib/update';
 import { initClarity } from '@/lib/clarity';
@@ -119,6 +120,7 @@ function RootLayout() {
               <SyncProvider>
                 <LockProvider>
                   <MotionProvider>
+                    <BackupProvider>
                     <UpdateProvider>
                       <ThemePreferenceProvider>
                         <ThemedRoot>
@@ -147,6 +149,7 @@ function RootLayout() {
                         </ThemedRoot>
                       </ThemePreferenceProvider>
                     </UpdateProvider>
+                    </BackupProvider>
                   </MotionProvider>
                 </LockProvider>
               </SyncProvider>
@@ -370,6 +373,7 @@ function AuthGate() {
       <Stack.Screen name="group/[id]/invite" options={modal} />
       <Stack.Screen name="group/[id]/itemize" options={modal} />
       <Stack.Screen name="friends/contacts" />
+      <Stack.Screen name="settings/backup" />
       <Stack.Screen name="settings/notifications" />
       <Stack.Screen name="settings/export" />
       <Stack.Screen name="settings/import" />

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -122,34 +122,34 @@ function RootLayout() {
                 <LockProvider>
                   <MotionProvider>
                     <BackupProvider>
-                    <UpdateProvider>
-                      <ThemePreferenceProvider>
-                        <ThemedRoot>
-                          <ThemedStatusBar />
-                          {/* Outside the lock and the auth gate on purpose: a build
+                      <UpdateProvider>
+                        <ThemePreferenceProvider>
+                          <ThemedRoot>
+                            <ThemedStatusBar />
+                            {/* Outside the lock and the auth gate on purpose: a build
                             we have stopped trusting should not be unlocking a
                             ledger or signing anybody in either. */}
-                          <UpdateGate>
-                            <PushRouting />
-                            <LockGate>
-                              {/* Inside the lock so the two-device gate never
+                            <UpdateGate>
+                              <PushRouting />
+                              <LockGate>
+                                {/* Inside the lock so the two-device gate never
                                 paints over the lock screen, and past auth so it
                                 only ever asks a signed-in account. */}
-                              <DeviceSessionProvider>
-                                <AuthGate />
-                                {/* Inside the lock on purpose: a promotion is not a
+                                <DeviceSessionProvider>
+                                  <AuthGate />
+                                  {/* Inside the lock on purpose: a promotion is not a
                                   reason to show somebody's phone anything before
                                   they have unlocked it. */}
-                                <CampaignPopup />
-                              </DeviceSessionProvider>
-                            </LockGate>
-                            {/* Last, so it paints over the screen rather than
+                                  <CampaignPopup />
+                                </DeviceSessionProvider>
+                              </LockGate>
+                              {/* Last, so it paints over the screen rather than
                               under it. */}
-                            <UpdateBanner />
-                          </UpdateGate>
-                        </ThemedRoot>
-                      </ThemePreferenceProvider>
-                    </UpdateProvider>
+                              <UpdateBanner />
+                            </UpdateGate>
+                          </ThemedRoot>
+                        </ThemePreferenceProvider>
+                      </UpdateProvider>
                     </BackupProvider>
                   </MotionProvider>
                 </LockProvider>

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -30,6 +30,19 @@ import { saveReceipt } from '@/lib/receiptStore';
 import { markPending } from '@/lib/receiptIndex';
 import { useBackup } from '@/lib/cloud/BackupProvider';
 
+/**
+ * An OCR-derived number turned into a safe minor-unit bigint.
+ *
+ * The values here come off a photograph through a heuristic parser, so they are
+ * never fully trusted: a stray `NaN`, an `Infinity`, or a non-integer would make
+ * `BigInt()` throw — and a throw during render is a white screen, not a bad
+ * total. Anything that is not a finite number collapses to zero, which the UI
+ * already knows how to show (an amount the person types themselves).
+ */
+function safeMinor(value: number): bigint {
+  return Number.isFinite(value) ? BigInt(Math.round(value)) : 0n;
+}
+
 /** Today as `YYYY-MM-DD` in the phone's own zone — never midnight UTC. */
 function todayIso(): string {
   const now = new Date();
@@ -122,9 +135,21 @@ export default function CaptureScreen() {
    * sent to be parsed — the amount stays the user's to type.
    */
   const addReceipt = async (): Promise<void> => {
-    const picked = await captureReceipt();
-    if (!picked) return;
     setError(null);
+
+    // The camera and the document scanner are native, and a native failure —
+    // a denied permission mid-flow, a scanner that will not open, an out-of-
+    // memory during the resize — must not escape as an unhandled rejection and
+    // take the screen down. A failed capture is simply no photo: the person
+    // types the amount, exactly as before this feature existed.
+    let picked: PickedImage | null = null;
+    try {
+      picked = await captureReceipt();
+    } catch {
+      picked = null;
+    }
+    if (!picked) return;
+
     setPhoto(picked);
     setScanning(true);
     try {
@@ -138,7 +163,7 @@ export default function CaptureScreen() {
       const receipt = recognised ? parseReceiptText(recognised.text, { currency }) : null;
       setParsed(receipt);
       if (receipt && receipt.grandTotal > 0) {
-        setAmount(BigInt(receipt.grandTotal));
+        setAmount(safeMinor(receipt.grandTotal));
         if (receipt.merchant && description.trim().length === 0) setDescription(receipt.merchant);
       }
     } catch {
@@ -341,14 +366,14 @@ export default function CaptureScreen() {
                   <Text variant="body" numberOfLines={1} style={{ flex: 1 }}>
                     {item.label}
                   </Text>
-                  <MoneyText amount={BigInt(item.total)} currency={currency as never} locale={locale} variant="body" />
+                  <MoneyText amount={safeMinor(item.total)} currency={currency as never} locale={locale} variant="body" />
                 </Row>
               ))}
               <Divider />
               <Row style={{ justifyContent: 'space-between' }}>
                 <Text variant="subheading">{t.captures.amount}</Text>
                 <MoneyText
-                  amount={BigInt(parsed.grandTotal)}
+                  amount={safeMinor(parsed.grandTotal)}
                   currency={currency as never}
                   locale={locale}
                   variant="subheading"

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -1,18 +1,20 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { randomUUID } from 'expo-crypto';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
 
-import { guessCategory, type CategoryId } from '@baaki/core';
+import { guessCategory, parseReceiptText, type CategoryId, type HeuristicReceipt } from '@baaki/core';
 import {
   AmountField,
   Button,
   Callout,
   Card,
+  Divider,
   IconButton,
+  MoneyText,
   Row,
   Screen,
   Text,
@@ -20,12 +22,13 @@ import {
 } from '@baaki/ui';
 
 import { CategoryPicker } from '@/components/Category';
-import { uploadCapturePhoto } from '@/data/api';
 import { useCreateCapture } from '@/data/hooks';
-import { deviceDefaultCurrency, useStrings } from '@/i18n';
-import { useAuth } from '@/lib/auth';
+import { deviceDefaultCurrency, plural, useStrings } from '@/i18n';
 import { captureReceipt, type PickedImage } from '@/lib/image';
 import { recogniseReceipt } from '@/lib/ocr';
+import { saveReceipt } from '@/lib/receiptStore';
+import { markPending } from '@/lib/receiptIndex';
+import { useBackup } from '@/lib/cloud/BackupProvider';
 
 /** Today as `YYYY-MM-DD` in the phone's own zone — never midnight UTC. */
 function todayIso(): string {
@@ -72,8 +75,11 @@ function showDate(iso: string, locale: string): string {
 export default function CaptureScreen() {
   const theme = useTheme();
   const { t, locale } = useStrings();
-  const { session } = useAuth();
   const createCapture = useCreateCapture();
+  const backup = useBackup();
+  // The dashboard camera opens this screen with `?scan=1` to mean "go straight
+  // to the camera", rather than showing an empty form to fill in first.
+  const { scan } = useLocalSearchParams<{ scan?: string }>();
 
   // Chosen here so the photo can be uploaded under it before the row exists —
   // the storage path keys off the capture id, exactly as add-expense seeds its
@@ -89,6 +95,9 @@ export default function CaptureScreen() {
   const [editingDate, setEditingDate] = useState(false);
   const [photo, setPhoto] = useState<PickedImage | null>(null);
   const [rawText, setRawText] = useState<string | null>(null);
+  // What the on-device parser recovered from the bill: total, item count, lines.
+  // Null until a receipt is read; low `confidence` means show it as a draft.
+  const [parsed, setParsed] = useState<HeuristicReceipt | null>(null);
   const [scanning, setScanning] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -121,29 +130,71 @@ export default function CaptureScreen() {
     try {
       const recognised = await recogniseReceipt(picked.uri);
       setRawText(recognised?.text ?? null);
+
+      // Read the total and the line items off the OCR text on the phone (A34 /
+      // A5). The model path (`receipt-parse`) stays the eventual source of truth
+      // once it is funded, but the heuristic is what makes the amount appear now
+      // rather than leaving it for the user to type off the photo.
+      const receipt = recognised ? parseReceiptText(recognised.text, { currency }) : null;
+      setParsed(receipt);
+      if (receipt && receipt.grandTotal > 0) {
+        setAmount(BigInt(receipt.grandTotal));
+        if (receipt.merchant && description.trim().length === 0) setDescription(receipt.merchant);
+      }
     } catch {
       setRawText(null);
+      setParsed(null);
     } finally {
       setScanning(false);
     }
   };
 
+  // "Straight to the camera": when opened from the dashboard scanner icon, fire
+  // the capture once on mount rather than waiting for a tap on "Add receipt".
+  // The ref guards against the effect running twice (React 18 strict mode, or a
+  // re-render mid-scan).
+  const autoScanned = useRef(false);
+  useEffect(() => {
+    if (scan && !autoScanned.current) {
+      autoScanned.current = true;
+      void addReceipt();
+    }
+    // addReceipt is stable enough for a one-shot; deps intentionally minimal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scan]);
+
   const submit = async (): Promise<void> => {
     setError(null);
     setSaving(true);
     try {
-      // The photo lives in the owner-scoped bucket, uploaded before the row is
-      // queued so its path can ride in the create payload (like new-group's
-      // cover, but keyed on the capture id rather than a group id).
-      let photoPath: string | null = null;
-      if (photo && session?.user?.id) {
-        photoPath = await uploadCapturePhoto({
-          ownerUserId: session.user.id,
-          captureId,
+      // The receipt photo is deliberately NOT uploaded to Baaki. It is written
+      // to the on-device vault and, if the person connected a personal cloud,
+      // queued for backup there — the privacy choice behind this feature. Only
+      // the parsed fields (amount, text, itemisation) ride the capture sync, so
+      // `photoPath` on the synced row is always null.
+      if (photo) {
+        const saved = saveReceipt(captureId, {
           base64: photo.base64,
-          mimeType: photo.mimeType,
+          sidecar: {
+            captureId,
+            currency,
+            amountMinor: Number(amount),
+            itemCount: parsed?.items.length ?? 0,
+            items: (parsed?.items ?? []).map((item) => ({ label: item.label, total: item.total })),
+            date,
+            category,
+            rawText,
+            createdAt: new Date().toISOString(),
+          },
         });
+        if (saved) {
+          await markPending(captureId, saved, new Date().toISOString());
+          // Try to back it up now; the queue itself no-ops when offline, when a
+          // Wi‑Fi-only policy is set on mobile data, or when no provider is set.
+          void backup.kick();
+        }
       }
+
       await createCapture.mutateAsync({
         captureId,
         description: description.trim(),
@@ -151,8 +202,9 @@ export default function CaptureScreen() {
         expenseDate: date,
         currency,
         amount,
-        photoPath,
+        photoPath: null,
         rawText,
+        parsed: parsed ? (parsed as unknown as Record<string, unknown>) : null,
       });
       router.back();
     } catch (caught) {
@@ -268,6 +320,43 @@ export default function CaptureScreen() {
               contentFit="cover"
               transition={150}
             />
+          ) : null}
+
+          {/* What the phone read off the bill. A confident parse shows the lines
+              and the total it filled in; a scan it could not make sense of says
+              so and leaves the amount to the person. */}
+          {parsed && parsed.items.length > 0 ? (
+            <View style={{ gap: theme.spacing.sm }}>
+              <Divider />
+              <Row style={{ justifyContent: 'space-between' }}>
+                <Text variant="caption" tone="muted">
+                  {t.captures.itemizedTitle}
+                </Text>
+                <Text variant="caption" tone="muted">
+                  {plural(locale, parsed.items.length, t.captures.itemCount)}
+                </Text>
+              </Row>
+              {parsed.items.map((item, index) => (
+                <Row key={`${item.label}-${index}`} style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
+                  <Text variant="body" numberOfLines={1} style={{ flex: 1 }}>
+                    {item.label}
+                  </Text>
+                  <MoneyText amount={BigInt(item.total)} currency={currency as never} locale={locale} variant="body" />
+                </Row>
+              ))}
+              <Divider />
+              <Row style={{ justifyContent: 'space-between' }}>
+                <Text variant="subheading">{t.captures.amount}</Text>
+                <MoneyText
+                  amount={BigInt(parsed.grandTotal)}
+                  currency={currency as never}
+                  locale={locale}
+                  variant="subheading"
+                />
+              </Row>
+            </View>
+          ) : parsed && photo ? (
+            <Callout tone="info">{t.captures.couldNotRead}</Callout>
           ) : null}
         </Card>
       </ScrollView>

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -6,7 +6,12 @@ import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
 
-import { guessCategory, parseReceiptText, type CategoryId, type HeuristicReceipt } from '@baaki/core';
+import {
+  guessCategory,
+  parseReceiptText,
+  type CategoryId,
+  type HeuristicReceipt,
+} from '@baaki/core';
 import {
   AmountField,
   Button,
@@ -362,11 +367,19 @@ export default function CaptureScreen() {
                 </Text>
               </Row>
               {parsed.items.map((item, index) => (
-                <Row key={`${item.label}-${index}`} style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
+                <Row
+                  key={`${item.label}-${index}`}
+                  style={{ justifyContent: 'space-between', gap: theme.spacing.md }}
+                >
                   <Text variant="body" numberOfLines={1} style={{ flex: 1 }}>
                     {item.label}
                   </Text>
-                  <MoneyText amount={safeMinor(item.total)} currency={currency as never} locale={locale} variant="body" />
+                  <MoneyText
+                    amount={safeMinor(item.total)}
+                    currency={currency as never}
+                    locale={locale}
+                    variant="body"
+                  />
                 </Row>
               ))}
               <Divider />

--- a/apps/mobile/src/app/group/[id]/import/csv.tsx
+++ b/apps/mobile/src/app/group/[id]/import/csv.tsx
@@ -38,12 +38,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import {
-  importSplitwiseCsv,
-  MutationKind,
-  type MemberId,
-  type SplitwiseImport,
-} from '@baaki/core';
+import { importSplitwiseCsv, MutationKind, type MemberId, type SplitwiseImport } from '@baaki/core';
 
 import { useGroup } from '@/data/hooks';
 import { planFromCsv, toMutationPayload, UnmappedPersonError } from '@/data/importPlan';

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -55,7 +55,9 @@ export default function AccountScreen() {
   const [done, setDone] = useState(false);
 
   const existing =
-    channel === ContactChannel.Email ? (session?.user.email ?? null) : (session?.user.phone ?? null);
+    channel === ContactChannel.Email
+      ? (session?.user.email ?? null)
+      : (session?.user.phone ?? null);
 
   // Which providers already sign this account in, so a linked one shows as done
   // rather than offering to link what is already linked. Adding one goes through

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -1,0 +1,213 @@
+/**
+ * Receipt backup settings — where scanned receipts go, and over which network.
+ *
+ * The privacy promise this screen makes is the whole point of the feature: the
+ * photo of your bill lives on your phone and, if you connect one, on a cloud
+ * drive that is *yours*. It never goes to Baaki. So the screen leads with that
+ * sentence, then offers the single choice that makes it true — pick one provider
+ * as the place receipts are copied to — plus the one guard people actually ask
+ * for, which is "not on my mobile data".
+ *
+ * One provider is primary at a time. Connecting a provider makes it primary if
+ * nothing else was; after that the radio chooses between the ones you have
+ * connected. A provider with no client id in this build says so and cannot be
+ * connected, rather than opening a broken consent page.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, ScrollView, View } from 'react-native';
+
+import {
+  Badge,
+  Button,
+  Card,
+  Divider,
+  directionalIcon,
+  IconButton,
+  Row,
+  Screen,
+  SectionHeader,
+  SegmentedTabs,
+  Text,
+  useTheme,
+} from '@baaki/ui';
+
+import { plural, useStrings } from '@/i18n';
+import { useBackup } from '@/lib/cloud/BackupProvider';
+import { allProviders } from '@/lib/cloud/providers';
+import type { BackupNetworkPolicy, CloudProviderId } from '@/lib/cloud/types';
+
+export default function BackupSettingsScreen() {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const backup = useBackup();
+  const [busy, setBusy] = useState<CloudProviderId | null>(null);
+
+  const providers = allProviders();
+
+  const onConnect = async (id: CloudProviderId): Promise<void> => {
+    setBusy(id);
+    try {
+      await backup.connect(id);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xxxl,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.backup.title}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        <Text variant="caption" tone="muted">
+          {t.backup.primaryBody}
+        </Text>
+
+        <View>
+          <SectionHeader title={t.backup.primaryTitle} />
+          <Card style={{ gap: theme.spacing.md }}>
+            {/* "Off" — receipts stay on the device only. */}
+            <SelectRow
+              label={t.backup.off}
+              selected={backup.primary === null}
+              onPress={() => void backup.setPrimary(null)}
+            />
+
+            {providers.map((provider) => {
+              const configured = provider.isConfigured();
+              const connected = backup.connected[provider.id];
+              const isPrimary = backup.primary === provider.id;
+              return (
+                <View key={provider.id} style={{ gap: theme.spacing.md }}>
+                  <Divider />
+                  <Row style={{ justifyContent: 'space-between', alignItems: 'center', gap: theme.spacing.md }}>
+                    <SelectRow
+                      label={provider.label}
+                      // Only a connected provider can be the destination.
+                      selected={isPrimary}
+                      disabled={!connected}
+                      status={
+                        !configured
+                          ? t.backup.notConfigured
+                          : connected
+                            ? t.backup.connected
+                            : undefined
+                      }
+                      onPress={() => (connected ? void backup.setPrimary(provider.id) : undefined)}
+                    />
+                    {!configured ? (
+                      <Badge label={t.backup.notConfigured} tone="neutral" />
+                    ) : connected ? (
+                      <Button
+                        label={t.backup.disconnect}
+                        variant="ghost"
+                        size="sm"
+                        onPress={() => void backup.disconnect(provider.id)}
+                      />
+                    ) : (
+                      <Button
+                        label={t.backup.connect}
+                        variant="secondary"
+                        size="sm"
+                        disabled={busy === provider.id}
+                        onPress={() => void onConnect(provider.id)}
+                      />
+                    )}
+                  </Row>
+                </View>
+              );
+            })}
+          </Card>
+        </View>
+
+        {/* Only worth choosing a network policy once something will actually be
+            uploaded. */}
+        {backup.primary ? (
+          <View style={{ gap: theme.spacing.md }}>
+            <SectionHeader title={t.backup.networkTitle} />
+            <SegmentedTabs<BackupNetworkPolicy>
+              value={backup.policy}
+              onChange={(value) => void backup.setPolicy(value)}
+              tabs={[
+                { value: 'wifi', label: t.backup.wifiOnly },
+                { value: 'any', label: t.backup.wifiAndData },
+              ]}
+            />
+            <Text variant="caption" tone="muted">
+              {backup.pending > 0
+                ? plural(locale, backup.pending, t.backup.pending)
+                : t.backup.allBackedUp}
+            </Text>
+          </View>
+        ) : null}
+
+        <Text variant="micro" tone="faint" align="center">
+          {t.backup.privacyNote}
+        </Text>
+      </ScrollView>
+    </Screen>
+  );
+}
+
+/** A radio-style selectable line: a mark, a label, and an optional status word. */
+function SelectRow({
+  label,
+  selected,
+  disabled = false,
+  status,
+  onPress,
+}: {
+  label: string;
+  selected: boolean;
+  disabled?: boolean;
+  status?: string;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="radio"
+      accessibilityState={{ selected, disabled }}
+      accessibilityLabel={label}
+      onPress={disabled ? undefined : onPress}
+      style={{
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: theme.spacing.md,
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      <Ionicons
+        name={selected ? 'radio-button-on' : 'radio-button-off'}
+        size={22}
+        color={selected ? theme.color.brand : theme.color.textFaint}
+      />
+      <View style={{ flex: 1 }}>
+        <Text variant="subheading">{label}</Text>
+        {status ? (
+          <Text variant="caption" tone="muted">
+            {status}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -97,7 +97,13 @@ export default function BackupSettingsScreen() {
               return (
                 <View key={provider.id} style={{ gap: theme.spacing.md }}>
                   <Divider />
-                  <Row style={{ justifyContent: 'space-between', alignItems: 'center', gap: theme.spacing.md }}>
+                  <Row
+                    style={{
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      gap: theme.spacing.md,
+                    }}
+                  >
                     <SelectRow
                       label={provider.label}
                       // Only a connected provider can be the destination.

--- a/apps/mobile/src/components/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ErrorBoundary.tsx
@@ -1,0 +1,89 @@
+/**
+ * The last line before a white screen.
+ *
+ * React has one rule about a component that throws while rendering: the whole
+ * tree below the nearest error boundary is unmounted. With no boundary that
+ * nearest point is the root, so a single bad render — a malformed number, an
+ * unexpected shape from the network, a library that throws on an edge case —
+ * takes the entire app down to a blank screen with no way back. `Sentry.wrap`
+ * adds tracing and a native crash handler, but not a React error boundary, so
+ * this is the one that keeps a rendering bug from ending the session.
+ *
+ * In development the red box still shows first — this does not swallow anything
+ * a developer needs to see. In production it catches, reports the error through
+ * the same scrubbed pipeline as every other event, and offers the one action
+ * that reliably recovers: drop back to a known-good screen and re-mount.
+ */
+
+import { Component, type ReactNode } from 'react';
+import { router } from 'expo-router';
+import { View } from 'react-native';
+
+import { Button, Screen, Text, useTheme } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+import { reportHandled } from '@/lib/observability';
+
+interface Props {
+  readonly children: ReactNode;
+}
+
+interface State {
+  readonly hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown): void {
+    // Reported, not hidden: the point of catching is to keep the app usable,
+    // not to lose the bug. `reportHandled` is a no-op with no Sentry DSN set.
+    reportHandled(error, 'render');
+  }
+
+  private reset = (): void => {
+    this.setState({ hasError: false });
+    // Home is the one route that always exists and needs nothing from the tree
+    // that just failed, so re-mounting there cannot land back on the bad screen.
+    router.replace('/');
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) return <Fallback onReset={this.reset} />;
+    return this.props.children;
+  }
+}
+
+/** The recover screen. A function so it can read theme and strings via hooks. */
+function Fallback({ onReset }: { onReset: () => void }) {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  return (
+    <Screen>
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingHorizontal: theme.spacing.xxxl,
+          gap: theme.spacing.lg,
+        }}
+      >
+        <Text variant="display" align="center">
+          {t.errorBoundary.title}
+        </Text>
+        <Text variant="body" tone="muted" align="center">
+          {t.errorBoundary.body}
+        </Text>
+        <View style={{ paddingTop: theme.spacing.md, alignSelf: 'stretch' }}>
+          <Button label={t.errorBoundary.action} size="lg" fullWidth onPress={onReset} />
+        </View>
+      </View>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1146,6 +1146,11 @@ export interface UiStrings {
     savedStraightAway: string;
     nothingOverwritten: string;
   };
+  errorBoundary: {
+    title: string;
+    body: string;
+    action: string;
+  };
 }
 
 const en: UiStrings = {
@@ -2201,6 +2206,11 @@ const en: UiStrings = {
       'Saved on this phone straight away, with or without a signal. The server recomputes every share before it is stored, so no device can push a wrong number into the ledger.',
     nothingOverwritten:
       'Nothing here is ever overwritten. Every version above is kept, and a deleted expense can be brought back for 30 days.',
+  },
+  errorBoundary: {
+    title: 'Something went wrong',
+    body: 'That screen hit an error. Nothing you saved is lost — go back and try again.',
+    action: 'Back to home',
   },
 };
 
@@ -3301,6 +3311,11 @@ const ta: UiStrings = {
     nothingOverwritten:
       'இங்கே எதுவும் மேலெழுதப்படுவதில்லை. மேலே உள்ள ஒவ்வொரு பதிப்பும் வைக்கப்படுகிறது, நீக்கப்பட்ட செலவை 30 நாட்களுக்கு மீட்கலாம்.',
   },
+  errorBoundary: {
+    title: 'ஏதோ தவறாகிவிட்டது',
+    body: 'அந்தத் திரையில் பிழை ஏற்பட்டது. நீங்கள் சேமித்தது எதுவும் இழக்கப்படவில்லை — திரும்பிச் சென்று மீண்டும் முயலுங்கள்.',
+    action: 'முகப்புக்குத் திரும்பு',
+  },
 };
 
 const hi: UiStrings = {
@@ -4352,6 +4367,11 @@ const hi: UiStrings = {
       'सिग्नल हो या न हो, इसी फ़ोन पर तुरंत सेव। सर्वर हर हिस्सा दोबारा जोड़कर ही रखता है, इसलिए कोई डिवाइस हिसाब में ग़लत आँकड़ा नहीं डाल सकती।',
     nothingOverwritten:
       'यहाँ कुछ भी मिटाकर ऊपर नहीं लिखा जाता। ऊपर का हर संस्करण रखा जाता है, और हटाया गया खर्च 30 दिन तक वापस लाया जा सकता है।',
+  },
+  errorBoundary: {
+    title: 'कुछ गड़बड़ हो गई',
+    body: 'उस स्क्रीन में कोई त्रुटि आ गई। आपका सहेजा हुआ कुछ भी नहीं खोया — वापस जाकर फिर कोशिश करें।',
+    action: 'होम पर वापस',
   },
 };
 
@@ -5579,6 +5599,11 @@ const ar: UiStrings = {
       'يُحفظ على هذا الهاتف فورًا، بإشارة أو بدونها. يعيد الخادم حساب كل حصة قبل تخزينها، فلا يستطيع أي جهاز دفع رقم خاطئ إلى الدفتر.',
     nothingOverwritten:
       'لا يُستبدل هنا شيء أبدًا. تُحفظ كل نسخة أعلاه، ويمكن استرجاع مصروف محذوف خلال 30 يومًا.',
+  },
+  errorBoundary: {
+    title: 'حدث خطأ ما',
+    body: 'واجهت تلك الشاشة خطأ. لم يُفقد أي شيء حفظته — ارجع وحاول مرة أخرى.',
+    action: 'العودة إلى الرئيسية',
   },
 };
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1618,7 +1618,8 @@ const en: UiStrings = {
     title: 'Receipt backup',
     subtitle: 'Keep scanned receipts on your own cloud',
     primaryTitle: 'Back up receipts to',
-    primaryBody: 'Scanned receipts are saved on this device and copied to the drive you choose. They never touch Baaki’s servers.',
+    primaryBody:
+      'Scanned receipts are saved on this device and copied to the drive you choose. They never touch Baaki’s servers.',
     off: 'Off',
     connect: 'Connect',
     disconnect: 'Disconnect',
@@ -1632,7 +1633,8 @@ const en: UiStrings = {
       other: '{n} receipts waiting to back up',
     },
     allBackedUp: 'All receipts backed up',
-    privacyNote: 'The photo stays on your phone and your chosen cloud. Baaki only ever sees the amount you save.',
+    privacyNote:
+      'The photo stays on your phone and your chosen cloud. Baaki only ever sees the amount you save.',
   },
   group: {
     notFound: 'Group not found',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -600,7 +600,29 @@ export interface UiStrings {
     delete: string;
     unassigned: string;
     unassignedBody: PluralForms;
+    itemizedTitle: string;
+    itemCount: PluralForms;
+    couldNotRead: string;
+    savedOnDevice: string;
     save: string;
+  };
+  /** Backing up scanned receipts to the user's own cloud drive (Drive/Dropbox/OneDrive). */
+  backup: {
+    title: string;
+    subtitle: string;
+    primaryTitle: string;
+    primaryBody: string;
+    off: string;
+    connect: string;
+    disconnect: string;
+    connected: string;
+    notConfigured: string;
+    networkTitle: string;
+    wifiOnly: string;
+    wifiAndData: string;
+    pending: PluralForms;
+    allBackedUp: string;
+    privacyNote: string;
   };
   /** A group: its screen, its settings, and the ways out of it. */
   group: {
@@ -1578,7 +1600,34 @@ const en: UiStrings = {
       one: '{n} capture waiting for a group',
       other: '{n} captures waiting for a group',
     },
+    itemizedTitle: 'Itemized',
+    itemCount: {
+      one: '{n} item',
+      other: '{n} items',
+    },
+    couldNotRead: "Couldn't read this bill — enter the amount yourself.",
+    savedOnDevice: 'Saved on this device',
     save: 'Save capture',
+  },
+  backup: {
+    title: 'Receipt backup',
+    subtitle: 'Keep scanned receipts on your own cloud',
+    primaryTitle: 'Back up receipts to',
+    primaryBody: 'Scanned receipts are saved on this device and copied to the drive you choose. They never touch Baaki’s servers.',
+    off: 'Off',
+    connect: 'Connect',
+    disconnect: 'Disconnect',
+    connected: 'Connected',
+    notConfigured: 'Not set up in this build',
+    networkTitle: 'Upload over',
+    wifiOnly: 'Wi‑Fi only',
+    wifiAndData: 'Wi‑Fi & mobile data',
+    pending: {
+      one: '{n} receipt waiting to back up',
+      other: '{n} receipts waiting to back up',
+    },
+    allBackedUp: 'All receipts backed up',
+    privacyNote: 'The photo stays on your phone and your chosen cloud. Baaki only ever sees the amount you save.',
   },
   group: {
     notFound: 'Group not found',
@@ -2625,7 +2674,36 @@ const ta: UiStrings = {
       one: 'குழுவுக்காகக் காத்திருக்கும் {n} பதிவு',
       other: 'குழுவுக்காகக் காத்திருக்கும் {n} பதிவுகள்',
     },
+    itemizedTitle: 'உருப்படிகள்',
+    itemCount: {
+      one: '{n} உருப்படி',
+      other: '{n} உருப்படிகள்',
+    },
+    couldNotRead: 'இந்த ரசீதைப் படிக்க முடியவில்லை — தொகையை நீங்களே உள்ளிடவும்.',
+    savedOnDevice: 'இந்தச் சாதனத்தில் சேமிக்கப்பட்டது',
     save: 'சேமி',
+  },
+  backup: {
+    title: 'ரசீது காப்புப்படி',
+    subtitle: 'ஸ்கேன் செய்த ரசீதுகளை உங்கள் சொந்த கிளவுடில் வைத்திருங்கள்',
+    primaryTitle: 'ரசீதுகளை காப்புப்பிடி',
+    primaryBody:
+      'ஸ்கேன் செய்த ரசீதுகள் இந்தச் சாதனத்தில் சேமிக்கப்பட்டு நீங்கள் தேர்ந்தெடுத்த கிளவுடுக்கு நகலெடுக்கப்படும். அவை Baaki சேவையகங்களைத் தொடாது.',
+    off: 'அணை',
+    connect: 'இணை',
+    disconnect: 'துண்டி',
+    connected: 'இணைக்கப்பட்டது',
+    notConfigured: 'இந்த பதிப்பில் அமைக்கப்படவில்லை',
+    networkTitle: 'இதன் மூலம் பதிவேற்று',
+    wifiOnly: 'வைஃபை மட்டும்',
+    wifiAndData: 'வைஃபை & மொபைல் டேட்டா',
+    pending: {
+      one: '{n} ரசீது காப்புப்படிக்கக் காத்திருக்கிறது',
+      other: '{n} ரசீதுகள் காப்புப்படிக்கக் காத்திருக்கின்றன',
+    },
+    allBackedUp: 'அனைத்து ரசீதுகளும் காப்புப்படி எடுக்கப்பட்டன',
+    privacyNote:
+      'புகைப்படம் உங்கள் ஃபோனிலும் நீங்கள் தேர்ந்தெடுத்த கிளவுடிலும் இருக்கும். Baaki நீங்கள் சேமிக்கும் தொகையை மட்டுமே பார்க்கும்.',
   },
   group: {
     notFound: 'குழு கிடைக்கவில்லை',
@@ -3672,7 +3750,36 @@ const hi: UiStrings = {
       one: 'समूह की प्रतीक्षा में {n} प्रविष्टि',
       other: 'समूह की प्रतीक्षा में {n} प्रविष्टियाँ',
     },
+    itemizedTitle: 'मदवार',
+    itemCount: {
+      one: '{n} वस्तु',
+      other: '{n} वस्तुएँ',
+    },
+    couldNotRead: 'यह रसीद पढ़ी नहीं जा सकी — राशि स्वयं दर्ज करें।',
+    savedOnDevice: 'इस डिवाइस पर सहेजा गया',
     save: 'सहेजें',
+  },
+  backup: {
+    title: 'रसीद बैकअप',
+    subtitle: 'स्कैन की गई रसीदें अपने क्लाउड पर रखें',
+    primaryTitle: 'रसीदें यहाँ बैकअप करें',
+    primaryBody:
+      'स्कैन की गई रसीदें इस डिवाइस पर सहेजी जाती हैं और आपके चुने हुए क्लाउड पर कॉपी होती हैं। वे Baaki के सर्वर पर कभी नहीं जातीं।',
+    off: 'बंद',
+    connect: 'कनेक्ट करें',
+    disconnect: 'डिसकनेक्ट करें',
+    connected: 'कनेक्टेड',
+    notConfigured: 'इस बिल्ड में सेट नहीं है',
+    networkTitle: 'इसके ज़रिए अपलोड करें',
+    wifiOnly: 'केवल वाई‑फाई',
+    wifiAndData: 'वाई‑फाई और मोबाइल डेटा',
+    pending: {
+      one: '{n} रसीद बैकअप के लिए प्रतीक्षारत',
+      other: '{n} रसीदें बैकअप के लिए प्रतीक्षारत',
+    },
+    allBackedUp: 'सभी रसीदें बैकअप हो गईं',
+    privacyNote:
+      'फ़ोटो आपके फ़ोन और आपके चुने हुए क्लाउड पर रहती है। Baaki केवल वह राशि देखता है जो आप सहेजते हैं।',
   },
   group: {
     notFound: 'समूह नहीं मिला',
@@ -4735,7 +4842,42 @@ const ar: UiStrings = {
       many: '{n} التقاطًا تنتظر مجموعة',
       other: '{n} التقاط ينتظر مجموعة',
     },
+    itemizedTitle: 'مفصّل',
+    itemCount: {
+      one: 'عنصر واحد',
+      two: 'عنصران',
+      few: '{n} عناصر',
+      many: '{n} عنصرًا',
+      other: '{n} عنصر',
+    },
+    couldNotRead: 'تعذّر قراءة هذا الإيصال — أدخل المبلغ بنفسك.',
+    savedOnDevice: 'محفوظ على هذا الجهاز',
     save: 'حفظ',
+  },
+  backup: {
+    title: 'نسخ الإيصالات احتياطيًا',
+    subtitle: 'احتفظ بالإيصالات الممسوحة على سحابتك الخاصة',
+    primaryTitle: 'انسخ الإيصالات احتياطيًا إلى',
+    primaryBody:
+      'تُحفظ الإيصالات الممسوحة على هذا الجهاز وتُنسخ إلى السحابة التي تختارها. لا تصل أبدًا إلى خوادم Baaki.',
+    off: 'إيقاف',
+    connect: 'اتصال',
+    disconnect: 'قطع الاتصال',
+    connected: 'متصل',
+    notConfigured: 'غير مُهيّأ في هذه النسخة',
+    networkTitle: 'الرفع عبر',
+    wifiOnly: 'واي‑فاي فقط',
+    wifiAndData: 'واي‑فاي وبيانات الجوال',
+    pending: {
+      zero: 'لا إيصالات بانتظار النسخ',
+      one: 'إيصال واحد بانتظار النسخ الاحتياطي',
+      two: 'إيصالان بانتظار النسخ',
+      few: '{n} إيصالات بانتظار النسخ',
+      many: '{n} إيصالًا بانتظار النسخ',
+      other: '{n} إيصال بانتظار النسخ',
+    },
+    allBackedUp: 'تم نسخ جميع الإيصالات احتياطيًا',
+    privacyNote: 'تبقى الصورة على هاتفك وسحابتك المختارة. لا يرى Baaki سوى المبلغ الذي تحفظه.',
   },
   group: {
     notFound: 'المجموعة غير موجودة',

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -285,8 +285,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       async withPassword(identifier, password, intent) {
         const who = readIdentifier(identifier);
         checkPassword(password);
-        const method =
-          who.kind === 'email' ? AuthMethod.EmailPassword : AuthMethod.PhonePassword;
+        const method = who.kind === 'email' ? AuthMethod.EmailPassword : AuthMethod.PhonePassword;
         const credential = who.kind === 'email' ? { email: who.value } : { phone: who.value };
         const action = planAuth(viewerFrom(session), method, intent);
 

--- a/apps/mobile/src/lib/cloud/BackupProvider.tsx
+++ b/apps/mobile/src/lib/cloud/BackupProvider.tsx
@@ -29,11 +29,7 @@ import { pendingCount as readPendingCount } from '../receiptIndex';
 import { runBackup, type BackupContext, type BackupSkip } from './backupQueue';
 import { providerFor } from './providers';
 import { clearTokens, isConnected, saveTokens } from './tokens';
-import {
-  CLOUD_PROVIDER_IDS,
-  type BackupNetworkPolicy,
-  type CloudProviderId,
-} from './types';
+import { CLOUD_PROVIDER_IDS, type BackupNetworkPolicy, type CloudProviderId } from './types';
 
 const PRIMARY_KEY = 'baaki.cloud.primary';
 const POLICY_KEY = 'baaki.cloud.policy';
@@ -128,38 +124,50 @@ export function BackupProvider({ children }: { children: ReactNode }) {
     };
   }, [kick]);
 
-  const setPrimary = useCallback(async (id: CloudProviderId | null): Promise<void> => {
-    setPrimaryState(id);
-    if (id) await AsyncStorage.setItem(PRIMARY_KEY, id).catch(() => undefined);
-    else await AsyncStorage.removeItem(PRIMARY_KEY).catch(() => undefined);
-    ctxRef.current = { ...ctxRef.current, primary: id };
-    void kick();
-  }, [kick]);
+  const setPrimary = useCallback(
+    async (id: CloudProviderId | null): Promise<void> => {
+      setPrimaryState(id);
+      if (id) await AsyncStorage.setItem(PRIMARY_KEY, id).catch(() => undefined);
+      else await AsyncStorage.removeItem(PRIMARY_KEY).catch(() => undefined);
+      ctxRef.current = { ...ctxRef.current, primary: id };
+      void kick();
+    },
+    [kick],
+  );
 
-  const setPolicy = useCallback(async (next: BackupNetworkPolicy): Promise<void> => {
-    setPolicyState(next);
-    await AsyncStorage.setItem(POLICY_KEY, next).catch(() => undefined);
-    ctxRef.current = { ...ctxRef.current, policy: next };
-    void kick();
-  }, [kick]);
+  const setPolicy = useCallback(
+    async (next: BackupNetworkPolicy): Promise<void> => {
+      setPolicyState(next);
+      await AsyncStorage.setItem(POLICY_KEY, next).catch(() => undefined);
+      ctxRef.current = { ...ctxRef.current, policy: next };
+      void kick();
+    },
+    [kick],
+  );
 
-  const connect = useCallback(async (id: CloudProviderId): Promise<boolean> => {
-    const tokens = await providerFor(id).connect();
-    if (!tokens) return false;
-    await saveTokens(id, tokens);
-    await refreshConnected();
-    // First provider connected becomes primary, so a single tap is enough to
-    // start backing up without a second trip to change the default.
-    if (!ctxRef.current.primary) await setPrimary(id);
-    else void kick();
-    return true;
-  }, [refreshConnected, setPrimary, kick]);
+  const connect = useCallback(
+    async (id: CloudProviderId): Promise<boolean> => {
+      const tokens = await providerFor(id).connect();
+      if (!tokens) return false;
+      await saveTokens(id, tokens);
+      await refreshConnected();
+      // First provider connected becomes primary, so a single tap is enough to
+      // start backing up without a second trip to change the default.
+      if (!ctxRef.current.primary) await setPrimary(id);
+      else void kick();
+      return true;
+    },
+    [refreshConnected, setPrimary, kick],
+  );
 
-  const disconnect = useCallback(async (id: CloudProviderId): Promise<void> => {
-    await clearTokens(id);
-    await refreshConnected();
-    if (ctxRef.current.primary === id) await setPrimary(null);
-  }, [refreshConnected, setPrimary]);
+  const disconnect = useCallback(
+    async (id: CloudProviderId): Promise<void> => {
+      await clearTokens(id);
+      await refreshConnected();
+      if (ctxRef.current.primary === id) await setPrimary(null);
+    },
+    [refreshConnected, setPrimary],
+  );
 
   const value = useMemo<BackupValue>(
     () => ({
@@ -175,7 +183,19 @@ export function BackupProvider({ children }: { children: ReactNode }) {
       disconnect,
       kick,
     }),
-    [loading, primary, policy, connected, pending, lastSkip, setPrimary, setPolicy, connect, disconnect, kick],
+    [
+      loading,
+      primary,
+      policy,
+      connected,
+      pending,
+      lastSkip,
+      setPrimary,
+      setPolicy,
+      connect,
+      disconnect,
+      kick,
+    ],
   );
 
   return <BackupCtx.Provider value={value}>{children}</BackupCtx.Provider>;

--- a/apps/mobile/src/lib/cloud/BackupProvider.tsx
+++ b/apps/mobile/src/lib/cloud/BackupProvider.tsx
@@ -1,0 +1,188 @@
+/**
+ * The app-wide state behind receipt backup: which provider is primary, whether
+ * uploads may use mobile data, which providers are connected, and how many
+ * receipts are still waiting to go up.
+ *
+ * It also owns the *when*: a pass runs when the app comes to the foreground and
+ * whenever the network changes, plus on demand right after a capture is saved.
+ * Those are the moments a stuck upload can suddenly become possible — a phone
+ * that walks back onto Wi‑Fi, an app reopened in signal — so they are the
+ * moments to try again. Modeled on `MotionProvider`: preferences in
+ * AsyncStorage, read once, written through.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AppState } from 'react-native';
+import * as Network from 'expo-network';
+
+import { pendingCount as readPendingCount } from '../receiptIndex';
+import { runBackup, type BackupContext, type BackupSkip } from './backupQueue';
+import { providerFor } from './providers';
+import { clearTokens, isConnected, saveTokens } from './tokens';
+import {
+  CLOUD_PROVIDER_IDS,
+  type BackupNetworkPolicy,
+  type CloudProviderId,
+} from './types';
+
+const PRIMARY_KEY = 'baaki.cloud.primary';
+const POLICY_KEY = 'baaki.cloud.policy';
+
+type ConnectedMap = Record<CloudProviderId, boolean>;
+
+const NONE_CONNECTED: ConnectedMap = { gdrive: false, dropbox: false, onedrive: false };
+
+interface BackupValue {
+  readonly loading: boolean;
+  readonly primary: CloudProviderId | null;
+  readonly policy: BackupNetworkPolicy;
+  readonly connected: ConnectedMap;
+  readonly pending: number;
+  readonly lastSkip: BackupSkip | null;
+  setPrimary: (id: CloudProviderId | null) => Promise<void>;
+  setPolicy: (policy: BackupNetworkPolicy) => Promise<void>;
+  /** Run the OAuth flow for a provider; returns true on success. */
+  connect: (id: CloudProviderId) => Promise<boolean>;
+  disconnect: (id: CloudProviderId) => Promise<void>;
+  /** Try to upload anything pending now. Safe to call freely. */
+  kick: () => Promise<void>;
+}
+
+const BackupCtx = createContext<BackupValue | null>(null);
+
+export function BackupProvider({ children }: { children: ReactNode }) {
+  const [loading, setLoading] = useState(true);
+  const [primary, setPrimaryState] = useState<CloudProviderId | null>(null);
+  const [policy, setPolicyState] = useState<BackupNetworkPolicy>('wifi');
+  const [connected, setConnected] = useState<ConnectedMap>(NONE_CONNECTED);
+  const [pending, setPending] = useState(0);
+  const [lastSkip, setLastSkip] = useState<BackupSkip | null>(null);
+
+  // A ref so the AppState/network listeners always kick with current settings
+  // without being torn down and re-added on every preference change. Kept in
+  // sync from an effect (never written during render); the setters below also
+  // write it eagerly so a kick fired right after a change sees the new value.
+  const ctxRef = useRef<BackupContext>({ primary: null, policy: 'wifi' });
+  useEffect(() => {
+    ctxRef.current = { primary, policy };
+  }, [primary, policy]);
+
+  const refreshConnected = useCallback(async (): Promise<void> => {
+    const entries = await Promise.all(
+      CLOUD_PROVIDER_IDS.map(async (id) => [id, await isConnected(id)] as const),
+    );
+    setConnected(Object.fromEntries(entries) as ConnectedMap);
+  }, []);
+
+  const refreshPending = useCallback(async (): Promise<void> => {
+    setPending(await readPendingCount());
+  }, []);
+
+  const kick = useCallback(async (): Promise<void> => {
+    const outcome = await runBackup(ctxRef.current);
+    setLastSkip(outcome.skipped);
+    await refreshPending();
+  }, [refreshPending]);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const [savedPrimary, savedPolicy] = await Promise.all([
+        AsyncStorage.getItem(PRIMARY_KEY).catch(() => null),
+        AsyncStorage.getItem(POLICY_KEY).catch(() => null),
+      ]);
+      if (!active) return;
+      if (savedPrimary && (CLOUD_PROVIDER_IDS as string[]).includes(savedPrimary)) {
+        setPrimaryState(savedPrimary as CloudProviderId);
+      }
+      if (savedPolicy === 'any' || savedPolicy === 'wifi') setPolicyState(savedPolicy);
+      await refreshConnected();
+      await refreshPending();
+      setLoading(false);
+      void kick();
+    })();
+    return () => {
+      active = false;
+    };
+  }, [refreshConnected, refreshPending, kick]);
+
+  // Foreground and network changes are the moments a stuck upload can proceed.
+  useEffect(() => {
+    const app = AppState.addEventListener('change', (state) => {
+      if (state === 'active') void kick();
+    });
+    const net = Network.addNetworkStateListener(() => void kick());
+    return () => {
+      app.remove();
+      net.remove();
+    };
+  }, [kick]);
+
+  const setPrimary = useCallback(async (id: CloudProviderId | null): Promise<void> => {
+    setPrimaryState(id);
+    if (id) await AsyncStorage.setItem(PRIMARY_KEY, id).catch(() => undefined);
+    else await AsyncStorage.removeItem(PRIMARY_KEY).catch(() => undefined);
+    ctxRef.current = { ...ctxRef.current, primary: id };
+    void kick();
+  }, [kick]);
+
+  const setPolicy = useCallback(async (next: BackupNetworkPolicy): Promise<void> => {
+    setPolicyState(next);
+    await AsyncStorage.setItem(POLICY_KEY, next).catch(() => undefined);
+    ctxRef.current = { ...ctxRef.current, policy: next };
+    void kick();
+  }, [kick]);
+
+  const connect = useCallback(async (id: CloudProviderId): Promise<boolean> => {
+    const tokens = await providerFor(id).connect();
+    if (!tokens) return false;
+    await saveTokens(id, tokens);
+    await refreshConnected();
+    // First provider connected becomes primary, so a single tap is enough to
+    // start backing up without a second trip to change the default.
+    if (!ctxRef.current.primary) await setPrimary(id);
+    else void kick();
+    return true;
+  }, [refreshConnected, setPrimary, kick]);
+
+  const disconnect = useCallback(async (id: CloudProviderId): Promise<void> => {
+    await clearTokens(id);
+    await refreshConnected();
+    if (ctxRef.current.primary === id) await setPrimary(null);
+  }, [refreshConnected, setPrimary]);
+
+  const value = useMemo<BackupValue>(
+    () => ({
+      loading,
+      primary,
+      policy,
+      connected,
+      pending,
+      lastSkip,
+      setPrimary,
+      setPolicy,
+      connect,
+      disconnect,
+      kick,
+    }),
+    [loading, primary, policy, connected, pending, lastSkip, setPrimary, setPolicy, connect, disconnect, kick],
+  );
+
+  return <BackupCtx.Provider value={value}>{children}</BackupCtx.Provider>;
+}
+
+export function useBackup(): BackupValue {
+  const value = useContext(BackupCtx);
+  if (!value) throw new Error('useBackup must be used inside BackupProvider');
+  return value;
+}

--- a/apps/mobile/src/lib/cloud/backupQueue.ts
+++ b/apps/mobile/src/lib/cloud/backupQueue.ts
@@ -30,13 +30,7 @@ export interface BackupContext {
  * Surfaced to the settings screen so "not syncing" can say why.
  */
 export type BackupSkip =
-  | 'busy'
-  | 'no-provider'
-  | 'not-configured'
-  | 'not-connected'
-  | 'offline'
-  | 'policy'
-  | 'auth';
+  'busy' | 'no-provider' | 'not-configured' | 'not-connected' | 'offline' | 'policy' | 'auth';
 
 export interface BackupOutcome {
   readonly uploaded: number;
@@ -94,7 +88,11 @@ export async function runBackup(ctx: BackupContext): Promise<BackupOutcome> {
           imageUri: entry.imageUri,
           jsonUri: entry.jsonUri,
         });
-        await markSynced(entry.captureId, { provider: ctx.primary, remoteId: result.remoteId }, nowIso());
+        await markSynced(
+          entry.captureId,
+          { provider: ctx.primary, remoteId: result.remoteId },
+          nowIso(),
+        );
         uploaded += 1;
       } catch (error) {
         await markError(entry.captureId, messageOf(error), nowIso());

--- a/apps/mobile/src/lib/cloud/backupQueue.ts
+++ b/apps/mobile/src/lib/cloud/backupQueue.ts
@@ -1,0 +1,112 @@
+/**
+ * The pump that moves saved receipts to the user's chosen cloud.
+ *
+ * It is intentionally dumb and idempotent: read what the index says is still
+ * pending, upload each to the primary provider, mark the outcome. It never
+ * holds state of its own beyond a re-entrancy guard, so it is safe to call from
+ * anywhere — after a save, when the app comes to the foreground, when the
+ * network changes — and calling it when there is nothing to do costs one cheap
+ * network-state read.
+ *
+ * The two gates that decide *whether* to run are the user's, not ours: which
+ * provider is primary, and whether uploads are allowed off Wi‑Fi. Both are
+ * checked here so no caller can bypass a data-plan preference by accident.
+ */
+
+import * as Network from 'expo-network';
+
+import { markError, markSynced, pendingEntries } from '../receiptIndex';
+import { providerFor } from './providers';
+import { loadTokens, saveTokens } from './tokens';
+import type { BackupNetworkPolicy, CloudProviderId } from './types';
+
+export interface BackupContext {
+  readonly primary: CloudProviderId | null;
+  readonly policy: BackupNetworkPolicy;
+}
+
+/**
+ * Why a run did nothing, or null when it uploaded (or had nothing pending).
+ * Surfaced to the settings screen so "not syncing" can say why.
+ */
+export type BackupSkip =
+  | 'busy'
+  | 'no-provider'
+  | 'not-configured'
+  | 'not-connected'
+  | 'offline'
+  | 'policy'
+  | 'auth';
+
+export interface BackupOutcome {
+  readonly uploaded: number;
+  readonly skipped: BackupSkip | null;
+}
+
+/** After this many failures a receipt is left alone until something changes. */
+const MAX_ATTEMPTS = 8;
+
+// Module-level guard: only one pass runs at a time, so overlapping triggers
+// (a save that lands just as the network flips) don't double-upload.
+let running = false;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function runBackup(ctx: BackupContext): Promise<BackupOutcome> {
+  if (running) return { uploaded: 0, skipped: 'busy' };
+  if (!ctx.primary) return { uploaded: 0, skipped: 'no-provider' };
+
+  const provider = providerFor(ctx.primary);
+  if (!provider.isConfigured()) return { uploaded: 0, skipped: 'not-configured' };
+
+  const net = await Network.getNetworkStateAsync();
+  if (!net.isConnected || net.isInternetReachable === false) {
+    return { uploaded: 0, skipped: 'offline' };
+  }
+  if (ctx.policy === 'wifi' && net.type !== Network.NetworkStateType.WIFI) {
+    return { uploaded: 0, skipped: 'policy' };
+  }
+
+  const pending = await pendingEntries();
+  if (pending.length === 0) return { uploaded: 0, skipped: null };
+
+  const stored = await loadTokens(ctx.primary);
+  if (!stored) return { uploaded: 0, skipped: 'not-connected' };
+
+  running = true;
+  let uploaded = 0;
+  try {
+    // Refresh once up front; every upload in this pass reuses the fresh token.
+    const tokens = await provider.ensureValid(stored);
+    await saveTokens(ctx.primary, tokens);
+
+    for (const entry of pending) {
+      if (entry.attempts >= MAX_ATTEMPTS) continue;
+      try {
+        const result = await provider.upload(tokens, {
+          captureId: entry.captureId,
+          imageUri: entry.imageUri,
+          jsonUri: entry.jsonUri,
+        });
+        await markSynced(entry.captureId, { provider: ctx.primary, remoteId: result.remoteId }, nowIso());
+        uploaded += 1;
+      } catch (error) {
+        await markError(entry.captureId, messageOf(error), nowIso());
+      }
+    }
+  } catch {
+    // A failed refresh means the whole pass can't authenticate — leave the
+    // receipts pending rather than marking each one errored for one bad token.
+    return { uploaded, skipped: 'auth' };
+  } finally {
+    running = false;
+  }
+
+  return { uploaded, skipped: null };
+}

--- a/apps/mobile/src/lib/cloud/config.ts
+++ b/apps/mobile/src/lib/cloud/config.ts
@@ -1,0 +1,33 @@
+/**
+ * The OAuth client ids for the three backup providers.
+ *
+ * These are *public* installed-app client ids, not secrets: the flow is PKCE
+ * (no client secret ships in the app), so a client id is safe to embed and safe
+ * to leave blank. They come from the environment rather than being hard-coded
+ * because they name developer accounts that belong to whoever builds Baaki, not
+ * to this repository — exactly like the Sentry and FCM credentials in
+ * `app.config.ts`. `EXPO_PUBLIC_*` is inlined by Metro at build time.
+ *
+ * A blank id is a supported state, not a misconfiguration: the provider reports
+ * itself unconfigured and the settings screen shows "not set up" instead of a
+ * Connect button that would open a broken consent screen.
+ */
+
+import type { CloudProviderId } from './types';
+
+export const CLOUD_CLIENT_IDS: Record<CloudProviderId, string> = {
+  gdrive: process.env.EXPO_PUBLIC_CLOUD_GDRIVE_CLIENT_ID ?? '',
+  dropbox: process.env.EXPO_PUBLIC_CLOUD_DROPBOX_CLIENT_ID ?? '',
+  onedrive: process.env.EXPO_PUBLIC_CLOUD_ONEDRIVE_CLIENT_ID ?? '',
+};
+
+export function clientId(id: CloudProviderId): string {
+  return CLOUD_CLIENT_IDS[id];
+}
+
+export function isConfigured(id: CloudProviderId): boolean {
+  return CLOUD_CLIENT_IDS[id].length > 0;
+}
+
+/** The folder receipts are filed under in the user's drive, on every provider. */
+export const BACKUP_FOLDER = 'Baaki Receipts';

--- a/apps/mobile/src/lib/cloud/dropbox.ts
+++ b/apps/mobile/src/lib/cloud/dropbox.ts
@@ -1,0 +1,70 @@
+/**
+ * Dropbox as a receipt backup.
+ *
+ * Dropbox takes the upload as raw bytes with the destination path in a
+ * `Dropbox-API-Arg` header, so there is no metadata pre-step — the path names
+ * the file and the folder is created implicitly. `token_access_type=offline` on
+ * the authorize call is Dropbox's switch for handing back a refresh token, the
+ * equivalent of Google's `access_type=offline`.
+ *
+ * Scope is `files.content.write` (plus read for completeness); the app can only
+ * touch what it writes.
+ */
+
+import { authorize, isExpired, refresh, type OAuthConfig } from './oauth';
+import { uploadFile } from './http';
+import { BACKUP_FOLDER, clientId, isConfigured as clientConfigured } from './config';
+import type { CloudProvider, CloudTokens, CloudUploadInput, CloudUploadResult } from './types';
+
+const DISCOVERY = {
+  authorizationEndpoint: 'https://www.dropbox.com/oauth2/authorize',
+  tokenEndpoint: 'https://api.dropboxapi.com/oauth2/token',
+};
+
+function config(): OAuthConfig {
+  return {
+    clientId: clientId('dropbox'),
+    scopes: ['files.content.write', 'files.content.read'],
+    discovery: DISCOVERY,
+    extraParams: { token_access_type: 'offline' },
+  };
+}
+
+async function putFile(
+  tokens: CloudTokens,
+  localUri: string,
+  name: string,
+  mimeType: string,
+): Promise<string> {
+  const arg = {
+    path: `/${BACKUP_FOLDER}/${name}`,
+    // Overwrite so a re-scan of the same capture replaces cleanly rather than
+    // piling up "(1)" copies.
+    mode: 'overwrite',
+    mute: true,
+    autorename: false,
+  };
+  const result = await uploadFile(localUri, 'https://content.dropboxapi.com/2/files/upload', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${tokens.accessToken}`,
+      'Dropbox-API-Arg': JSON.stringify(arg),
+    },
+    // Dropbox requires an octet-stream content type on the content endpoint.
+    mimeType: 'application/octet-stream',
+  });
+  return (result.id as string | undefined) ?? name;
+}
+
+export const dropbox: CloudProvider = {
+  id: 'dropbox',
+  label: 'Dropbox',
+  isConfigured: () => clientConfigured('dropbox'),
+  connect: () => authorize(config()),
+  ensureValid: (tokens) => (isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens)),
+  async upload(tokens: CloudTokens, input: CloudUploadInput): Promise<CloudUploadResult> {
+    const remoteId = await putFile(tokens, input.imageUri, `${input.captureId}.jpg`, 'image/jpeg');
+    await putFile(tokens, input.jsonUri, `${input.captureId}.json`, 'application/json');
+    return { remoteId };
+  },
+};

--- a/apps/mobile/src/lib/cloud/dropbox.ts
+++ b/apps/mobile/src/lib/cloud/dropbox.ts
@@ -61,7 +61,8 @@ export const dropbox: CloudProvider = {
   label: 'Dropbox',
   isConfigured: () => clientConfigured('dropbox'),
   connect: () => authorize(config()),
-  ensureValid: (tokens) => (isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens)),
+  ensureValid: (tokens) =>
+    isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens),
   async upload(tokens: CloudTokens, input: CloudUploadInput): Promise<CloudUploadResult> {
     const remoteId = await putFile(tokens, input.imageUri, `${input.captureId}.jpg`, 'image/jpeg');
     await putFile(tokens, input.jsonUri, `${input.captureId}.json`, 'application/json');

--- a/apps/mobile/src/lib/cloud/googleDrive.ts
+++ b/apps/mobile/src/lib/cloud/googleDrive.ts
@@ -1,0 +1,100 @@
+/**
+ * Google Drive as a receipt backup.
+ *
+ * Scope is `drive.file`, the narrow one: the app can only see and touch files it
+ * created, never the rest of the user's Drive. Receipts go into a "Baaki
+ * Receipts" folder created on first upload; because of the scope, the folder
+ * search only ever returns that folder, so there is nothing to collide with.
+ *
+ * A file is made in two steps — create the metadata (name + parent), then send
+ * the bytes to the upload endpoint for that id — so the image lands already
+ * named and filed rather than as an "Untitled" the user has to sort out.
+ */
+
+import { authorize, isExpired, refresh, type OAuthConfig } from './oauth';
+import { requestJson, uploadFile } from './http';
+import { BACKUP_FOLDER, clientId, isConfigured as clientConfigured } from './config';
+import type { CloudProvider, CloudTokens, CloudUploadInput, CloudUploadResult } from './types';
+
+const DISCOVERY = {
+  authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+  tokenEndpoint: 'https://oauth2.googleapis.com/token',
+  revocationEndpoint: 'https://oauth2.googleapis.com/revoke',
+};
+
+function config(): OAuthConfig {
+  return {
+    clientId: clientId('gdrive'),
+    scopes: ['https://www.googleapis.com/auth/drive.file'],
+    discovery: DISCOVERY,
+    // `offline` + a forced consent is what makes Google hand back a refresh
+    // token; without it the backup would stop working an hour after connecting.
+    extraParams: { access_type: 'offline', prompt: 'consent' },
+  };
+}
+
+function authHeader(tokens: CloudTokens): Record<string, string> {
+  return { Authorization: `Bearer ${tokens.accessToken}` };
+}
+
+/** Find the "Baaki Receipts" folder or create it; returns its id. */
+async function ensureFolder(tokens: CloudTokens): Promise<string> {
+  const query = encodeURIComponent(
+    `name='${BACKUP_FOLDER}' and mimeType='application/vnd.google-apps.folder' and trashed=false`,
+  );
+  const found = await requestJson(
+    `https://www.googleapis.com/drive/v3/files?q=${query}&spaces=drive&fields=files(id)`,
+    { headers: authHeader(tokens) },
+  );
+  const files = (found.files as { id: string }[] | undefined) ?? [];
+  if (files[0]?.id) return files[0].id;
+
+  const created = await requestJson('https://www.googleapis.com/drive/v3/files?fields=id', {
+    method: 'POST',
+    headers: authHeader(tokens),
+    body: { name: BACKUP_FOLDER, mimeType: 'application/vnd.google-apps.folder' },
+  });
+  return created.id as string;
+}
+
+/** Create a named file in the folder, then stream its bytes in. Returns the id. */
+async function putFile(
+  tokens: CloudTokens,
+  folderId: string,
+  localUri: string,
+  name: string,
+  mimeType: string,
+): Promise<string> {
+  const meta = await requestJson('https://www.googleapis.com/drive/v3/files?fields=id', {
+    method: 'POST',
+    headers: authHeader(tokens),
+    body: { name, parents: [folderId] },
+  });
+  const id = meta.id as string;
+  await uploadFile(localUri, `https://www.googleapis.com/upload/drive/v3/files/${id}?uploadType=media`, {
+    method: 'PATCH',
+    headers: authHeader(tokens),
+    mimeType,
+  });
+  return id;
+}
+
+export const googleDrive: CloudProvider = {
+  id: 'gdrive',
+  label: 'Google Drive',
+  isConfigured: () => clientConfigured('gdrive'),
+  connect: () => authorize(config()),
+  ensureValid: (tokens) => (isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens)),
+  async upload(tokens: CloudTokens, input: CloudUploadInput): Promise<CloudUploadResult> {
+    const folderId = await ensureFolder(tokens);
+    const remoteId = await putFile(
+      tokens,
+      folderId,
+      input.imageUri,
+      `${input.captureId}.jpg`,
+      'image/jpeg',
+    );
+    await putFile(tokens, folderId, input.jsonUri, `${input.captureId}.json`, 'application/json');
+    return { remoteId };
+  },
+};

--- a/apps/mobile/src/lib/cloud/googleDrive.ts
+++ b/apps/mobile/src/lib/cloud/googleDrive.ts
@@ -71,11 +71,15 @@ async function putFile(
     body: { name, parents: [folderId] },
   });
   const id = meta.id as string;
-  await uploadFile(localUri, `https://www.googleapis.com/upload/drive/v3/files/${id}?uploadType=media`, {
-    method: 'PATCH',
-    headers: authHeader(tokens),
-    mimeType,
-  });
+  await uploadFile(
+    localUri,
+    `https://www.googleapis.com/upload/drive/v3/files/${id}?uploadType=media`,
+    {
+      method: 'PATCH',
+      headers: authHeader(tokens),
+      mimeType,
+    },
+  );
   return id;
 }
 
@@ -84,7 +88,8 @@ export const googleDrive: CloudProvider = {
   label: 'Google Drive',
   isConfigured: () => clientConfigured('gdrive'),
   connect: () => authorize(config()),
-  ensureValid: (tokens) => (isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens)),
+  ensureValid: (tokens) =>
+    isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens),
   async upload(tokens: CloudTokens, input: CloudUploadInput): Promise<CloudUploadResult> {
     const folderId = await ensureFolder(tokens);
     const remoteId = await putFile(

--- a/apps/mobile/src/lib/cloud/http.ts
+++ b/apps/mobile/src/lib/cloud/http.ts
@@ -1,0 +1,66 @@
+/**
+ * The two HTTP shapes the providers need, kept in one place.
+ *
+ * `uploadFile` streams a local file's bytes as the raw request body using
+ * expo-file-system's native uploader — no base64 round trip through JS, which
+ * for a 2000px receipt is megabytes of string we would otherwise build, hold
+ * and hand across the bridge. `postJson` is the ordinary small metadata call.
+ *
+ * Both throw a `CloudHttpError` carrying the status and body on a non-2xx, so
+ * the backup queue can tell a retryable network blip from a dead token.
+ */
+
+import { File, UploadType } from 'expo-file-system';
+
+export class CloudHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`cloud request failed (${status}): ${body.slice(0, 300)}`);
+    this.name = 'CloudHttpError';
+  }
+}
+
+/** Upload a local file as the raw body; returns the parsed JSON response. */
+export async function uploadFile(
+  localUri: string,
+  url: string,
+  options: { method?: 'POST' | 'PUT' | 'PATCH'; headers: Record<string, string>; mimeType: string },
+): Promise<Record<string, unknown>> {
+  const result = await new File(localUri).upload(url, {
+    httpMethod: options.method ?? 'POST',
+    uploadType: UploadType.BINARY_CONTENT,
+    headers: options.headers,
+    mimeType: options.mimeType,
+  });
+
+  if (result.status < 200 || result.status >= 300) {
+    throw new CloudHttpError(result.status, result.body);
+  }
+  return parse(result.body);
+}
+
+/** A JSON request (metadata create, folder lookup); returns the parsed body. */
+export async function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: unknown },
+): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    method: options.method ?? 'GET',
+    headers: { 'Content-Type': 'application/json', ...options.headers },
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  const text = await response.text();
+  if (!response.ok) throw new CloudHttpError(response.status, text);
+  return parse(text);
+}
+
+function parse(text: string): Record<string, unknown> {
+  if (!text) return {};
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { raw: text };
+  }
+}

--- a/apps/mobile/src/lib/cloud/oauth.ts
+++ b/apps/mobile/src/lib/cloud/oauth.ts
@@ -94,7 +94,11 @@ export async function authorize(config: OAuthConfig): Promise<CloudTokens | null
 export async function refresh(config: OAuthConfig, tokens: CloudTokens): Promise<CloudTokens> {
   if (!tokens.refreshToken) return tokens;
   const token = await refreshAsync(
-    { clientId: config.clientId, refreshToken: tokens.refreshToken, extraParams: config.extraParams },
+    {
+      clientId: config.clientId,
+      refreshToken: tokens.refreshToken,
+      extraParams: config.extraParams,
+    },
     config.discovery,
   );
   return toTokens(token, tokens.refreshToken);

--- a/apps/mobile/src/lib/cloud/oauth.ts
+++ b/apps/mobile/src/lib/cloud/oauth.ts
@@ -1,0 +1,109 @@
+/**
+ * The one OAuth dance, shared by all three providers.
+ *
+ * Drive, Dropbox and OneDrive are all authorization-code + PKCE providers that
+ * differ only in their endpoints, scopes and a couple of extra query params to
+ * coax out a refresh token. So the flow lives here once — build a PKCE request,
+ * open the system browser, swap the returned code for tokens — and each provider
+ * supplies its discovery document and scopes.
+ *
+ * PKCE means no client secret is embedded in the app (there is nowhere safe to
+ * put one on a phone). The redirect comes back to the app's own `baaki://`
+ * scheme, the same mechanism the Supabase sign-in already uses.
+ */
+
+import {
+  AuthRequest,
+  exchangeCodeAsync,
+  makeRedirectUri,
+  refreshAsync,
+  type AuthDiscoveryDocument,
+  type TokenResponse,
+} from 'expo-auth-session';
+import * as WebBrowser from 'expo-web-browser';
+
+import type { CloudTokens } from './types';
+
+// Lets the auth popup hand its result back and close itself when the app is
+// re-focused after the redirect. A no-op on native, required on web.
+WebBrowser.maybeCompleteAuthSession();
+
+/** The endpoints for one provider. `revocationEndpoint` is optional. */
+export interface OAuthEndpoints extends AuthDiscoveryDocument {
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+}
+
+export interface OAuthConfig {
+  readonly clientId: string;
+  readonly scopes: readonly string[];
+  readonly discovery: OAuthEndpoints;
+  /** Provider-specific query params, e.g. Google's `access_type=offline`. */
+  readonly extraParams?: Record<string, string>;
+}
+
+/** All providers redirect back here — one path, distinct from `auth` sign-in. */
+function redirectUri(): string {
+  return makeRedirectUri({ scheme: 'baaki', path: 'oauthredirect' });
+}
+
+function toTokens(response: TokenResponse, previousRefresh?: string | null): CloudTokens {
+  return {
+    accessToken: response.accessToken,
+    // A refresh returns a new refresh token only sometimes; keep the old one
+    // when it doesn't, or the next refresh has nothing to present.
+    refreshToken: response.refreshToken ?? previousRefresh ?? null,
+    expiresAt: response.expiresIn ? Date.now() + response.expiresIn * 1000 : null,
+  };
+}
+
+/**
+ * Run the interactive flow. Resolves to tokens, or null if the person closed
+ * the browser without granting — a cancel, not an error.
+ */
+export async function authorize(config: OAuthConfig): Promise<CloudTokens | null> {
+  const request = new AuthRequest({
+    clientId: config.clientId,
+    scopes: [...config.scopes],
+    redirectUri: redirectUri(),
+    usePKCE: true,
+    extraParams: config.extraParams,
+  });
+
+  const result = await request.promptAsync(config.discovery);
+  if (result.type !== 'success' || !result.params.code) return null;
+
+  const token = await exchangeCodeAsync(
+    {
+      clientId: config.clientId,
+      code: result.params.code,
+      redirectUri: redirectUri(),
+      // PKCE proof: the verifier behind the challenge sent in the auth request.
+      extraParams: { code_verifier: request.codeVerifier ?? '' },
+    },
+    config.discovery,
+  );
+
+  return toTokens(token);
+}
+
+/**
+ * Trade a refresh token for a fresh access token. Returns the input unchanged
+ * when there is no refresh token to use — the caller then re-authorises.
+ */
+export async function refresh(config: OAuthConfig, tokens: CloudTokens): Promise<CloudTokens> {
+  if (!tokens.refreshToken) return tokens;
+  const token = await refreshAsync(
+    { clientId: config.clientId, refreshToken: tokens.refreshToken, extraParams: config.extraParams },
+    config.discovery,
+  );
+  return toTokens(token, tokens.refreshToken);
+}
+
+/** A minute's grace, so a token that expires mid-upload is refreshed first. */
+const EXPIRY_SKEW_MS = 60_000;
+
+/** True when the access token is missing or about to expire. */
+export function isExpired(tokens: CloudTokens): boolean {
+  return tokens.expiresAt !== null && tokens.expiresAt - EXPIRY_SKEW_MS <= Date.now();
+}

--- a/apps/mobile/src/lib/cloud/onedrive.ts
+++ b/apps/mobile/src/lib/cloud/onedrive.ts
@@ -1,0 +1,62 @@
+/**
+ * OneDrive (Microsoft Graph) as a receipt backup.
+ *
+ * Scope is `Files.ReadWrite.AppFolder`: the app gets its own sandboxed folder
+ * under the user's OneDrive and can touch nothing else. A small file is written
+ * with a single PUT to the item's `:/content` path, which creates the folder
+ * tree implicitly — so, like Dropbox, there is no metadata pre-step.
+ *
+ * `offline_access` is the scope that yields a refresh token here (Microsoft
+ * puts it in the scope list rather than a query param).
+ */
+
+import { authorize, isExpired, refresh, type OAuthConfig } from './oauth';
+import { uploadFile } from './http';
+import { clientId, isConfigured as clientConfigured } from './config';
+import type { CloudProvider, CloudTokens, CloudUploadInput, CloudUploadResult } from './types';
+
+const DISCOVERY = {
+  authorizationEndpoint: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+  tokenEndpoint: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+};
+
+function config(): OAuthConfig {
+  return {
+    clientId: clientId('onedrive'),
+    scopes: ['Files.ReadWrite.AppFolder', 'offline_access'],
+    discovery: DISCOVERY,
+  };
+}
+
+/** PUT bytes to the app folder under `Receipts/<name>`; returns the item id. */
+async function putFile(
+  tokens: CloudTokens,
+  localUri: string,
+  name: string,
+  mimeType: string,
+): Promise<string> {
+  const path = `Receipts/${name}`;
+  const result = await uploadFile(
+    localUri,
+    `https://graph.microsoft.com/v1.0/me/drive/special/approot:/${encodeURI(path)}:/content`,
+    {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${tokens.accessToken}` },
+      mimeType,
+    },
+  );
+  return (result.id as string | undefined) ?? name;
+}
+
+export const oneDrive: CloudProvider = {
+  id: 'onedrive',
+  label: 'OneDrive',
+  isConfigured: () => clientConfigured('onedrive'),
+  connect: () => authorize(config()),
+  ensureValid: (tokens) => (isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens)),
+  async upload(tokens: CloudTokens, input: CloudUploadInput): Promise<CloudUploadResult> {
+    const remoteId = await putFile(tokens, input.imageUri, `${input.captureId}.jpg`, 'image/jpeg');
+    await putFile(tokens, input.jsonUri, `${input.captureId}.json`, 'application/json');
+    return { remoteId };
+  },
+};

--- a/apps/mobile/src/lib/cloud/onedrive.ts
+++ b/apps/mobile/src/lib/cloud/onedrive.ts
@@ -53,7 +53,8 @@ export const oneDrive: CloudProvider = {
   label: 'OneDrive',
   isConfigured: () => clientConfigured('onedrive'),
   connect: () => authorize(config()),
-  ensureValid: (tokens) => (isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens)),
+  ensureValid: (tokens) =>
+    isExpired(tokens) ? refresh(config(), tokens) : Promise.resolve(tokens),
   async upload(tokens: CloudTokens, input: CloudUploadInput): Promise<CloudUploadResult> {
     const remoteId = await putFile(tokens, input.imageUri, `${input.captureId}.jpg`, 'image/jpeg');
     await putFile(tokens, input.jsonUri, `${input.captureId}.json`, 'application/json');

--- a/apps/mobile/src/lib/cloud/providers.ts
+++ b/apps/mobile/src/lib/cloud/providers.ts
@@ -1,0 +1,20 @@
+/** The provider registry — the one place that knows all three implementations. */
+
+import { googleDrive } from './googleDrive';
+import { dropbox } from './dropbox';
+import { oneDrive } from './onedrive';
+import { CLOUD_PROVIDER_IDS, type CloudProvider, type CloudProviderId } from './types';
+
+const REGISTRY: Record<CloudProviderId, CloudProvider> = {
+  gdrive: googleDrive,
+  dropbox,
+  onedrive: oneDrive,
+};
+
+export function providerFor(id: CloudProviderId): CloudProvider {
+  return REGISTRY[id];
+}
+
+export function allProviders(): readonly CloudProvider[] {
+  return CLOUD_PROVIDER_IDS.map((id) => REGISTRY[id]);
+}

--- a/apps/mobile/src/lib/cloud/tokens.ts
+++ b/apps/mobile/src/lib/cloud/tokens.ts
@@ -1,0 +1,36 @@
+/**
+ * Where a provider's OAuth tokens live: the OS keystore, not AsyncStorage.
+ *
+ * A refresh token for someone's Google Drive is exactly the kind of long-lived
+ * credential the app's own session hardening moved out of plaintext, so it
+ * rides the same chunked SecureStore adapter (`secureAuthStorage`) that the
+ * Supabase session uses — Keychain on iOS, Keystore on Android, AsyncStorage
+ * only on web where there is no keystore.
+ */
+
+import { secureAuthStorage } from '../secureStorage';
+import type { CloudProviderId, CloudTokens } from './types';
+
+const key = (id: CloudProviderId): string => `baaki.cloud.tokens.${id}`;
+
+export async function loadTokens(id: CloudProviderId): Promise<CloudTokens | null> {
+  const raw = await secureAuthStorage.getItem(key(id)).catch(() => null);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as CloudTokens;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveTokens(id: CloudProviderId, tokens: CloudTokens): Promise<void> {
+  await secureAuthStorage.setItem(key(id), JSON.stringify(tokens)).catch(() => undefined);
+}
+
+export async function clearTokens(id: CloudProviderId): Promise<void> {
+  await secureAuthStorage.removeItem(key(id)).catch(() => undefined);
+}
+
+export async function isConnected(id: CloudProviderId): Promise<boolean> {
+  return (await loadTokens(id)) !== null;
+}

--- a/apps/mobile/src/lib/cloud/types.ts
+++ b/apps/mobile/src/lib/cloud/types.ts
@@ -1,0 +1,52 @@
+/**
+ * The shape every personal-cloud backend is reduced to.
+ *
+ * Drive, Dropbox and OneDrive disagree about almost everything — how you
+ * authorise, where a file goes, what an upload returns — but the backup queue
+ * should not have to care. Each provider implements this interface, and the
+ * queue talks only to the interface: connect once, keep the tokens fresh,
+ * upload an image and its sidecar, get back an id it can remember.
+ */
+
+export type CloudProviderId = 'gdrive' | 'dropbox' | 'onedrive';
+
+export const CLOUD_PROVIDER_IDS: readonly CloudProviderId[] = ['gdrive', 'dropbox', 'onedrive'];
+
+/** OAuth tokens for one provider, as stored in the keystore. */
+export interface CloudTokens {
+  readonly accessToken: string;
+  /** Null when the provider issued no refresh token (re-auth needed on expiry). */
+  readonly refreshToken: string | null;
+  /** Epoch ms the access token expires, or null when the provider didn't say. */
+  readonly expiresAt: number | null;
+}
+
+/** One receipt to back up: the local files plus what to name them remotely. */
+export interface CloudUploadInput {
+  readonly captureId: string;
+  /** Local file URI of the receipt image. */
+  readonly imageUri: string;
+  /** Local file URI of the JSON sidecar. */
+  readonly jsonUri: string;
+}
+
+export interface CloudUploadResult {
+  /** The provider's id for the uploaded image — remembered for de-dup/delete. */
+  readonly remoteId: string;
+}
+
+export interface CloudProvider {
+  readonly id: CloudProviderId;
+  readonly label: string;
+  /** False when this build has no client id for the provider — "Connect" is inert. */
+  isConfigured(): boolean;
+  /** Interactive OAuth. Resolves to tokens, or null if the user cancelled. */
+  connect(): Promise<CloudTokens | null>;
+  /** Return tokens good to use now, refreshing first if they are near expiry. */
+  ensureValid(tokens: CloudTokens): Promise<CloudTokens>;
+  /** Upload the image and its sidecar; resolve with the image's remote id. */
+  upload(tokens: CloudTokens, input: CloudUploadInput): Promise<CloudUploadResult>;
+}
+
+/** Wi‑Fi only, or Wi‑Fi and mobile data. Defaults to Wi‑Fi to protect data plans. */
+export type BackupNetworkPolicy = 'wifi' | 'any';

--- a/apps/mobile/src/lib/receiptIndex.ts
+++ b/apps/mobile/src/lib/receiptIndex.ts
@@ -1,0 +1,135 @@
+/**
+ * The ledger of which saved receipts still need backing up, and where the ones
+ * already backed up ended up.
+ *
+ * The files in the vault ({@link receiptStore}) are the receipts; this is the
+ * bookkeeping around them. It is a separate store because "is this file on the
+ * user's cloud yet?" is not a property of the file — it depends on which
+ * provider is primary, whether the network was allowed, and whether the last
+ * attempt failed. Keeping it here means the backup queue has one place to ask
+ * "what is still pending?" without stat-ing the whole folder.
+ *
+ * One AsyncStorage key holds the whole map, read and written as a blob. The
+ * volume is tiny (one small record per receipt) and every mutation is a
+ * read‑modify‑write, which is safe because the only writer is the backup queue
+ * plus the capture screen, never two at once.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { CloudProviderId } from './cloud/types';
+
+const KEY = 'baaki.receipt_backup_index';
+
+export type BackupState = 'pending' | 'synced' | 'error';
+
+export interface ReceiptIndexEntry {
+  readonly captureId: string;
+  readonly imageUri: string;
+  readonly jsonUri: string;
+  readonly state: BackupState;
+  /** Which provider it was uploaded to, once synced. */
+  readonly provider: CloudProviderId | null;
+  /** The provider's id for the uploaded image, for de-dup and later deletion. */
+  readonly remoteId: string | null;
+  /** Failed attempts since the last success — drives the backoff. */
+  readonly attempts: number;
+  /** Last error message, for the settings screen to show. */
+  readonly error: string | null;
+  /** ISO instant of the last change. */
+  readonly updatedAt: string;
+}
+
+type IndexMap = Record<string, ReceiptIndexEntry>;
+
+async function readMap(): Promise<IndexMap> {
+  try {
+    const raw = await AsyncStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as IndexMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeMap(map: IndexMap): Promise<void> {
+  await AsyncStorage.setItem(KEY, JSON.stringify(map)).catch(() => undefined);
+}
+
+export async function allEntries(): Promise<ReceiptIndexEntry[]> {
+  return Object.values(await readMap());
+}
+
+export async function pendingEntries(): Promise<ReceiptIndexEntry[]> {
+  return (await allEntries()).filter((entry) => entry.state !== 'synced');
+}
+
+/**
+ * Record a freshly saved receipt as needing backup. Called the moment the
+ * capture screen writes the files, before any network is involved, so a receipt
+ * caught offline is remembered and uploaded later rather than lost.
+ */
+export async function markPending(
+  captureId: string,
+  files: { imageUri: string; jsonUri: string },
+  now: string,
+): Promise<void> {
+  const map = await readMap();
+  map[captureId] = {
+    captureId,
+    imageUri: files.imageUri,
+    jsonUri: files.jsonUri,
+    state: 'pending',
+    provider: null,
+    remoteId: null,
+    attempts: 0,
+    error: null,
+    updatedAt: now,
+  };
+  await writeMap(map);
+}
+
+export async function markSynced(
+  captureId: string,
+  result: { provider: CloudProviderId; remoteId: string },
+  now: string,
+): Promise<void> {
+  const map = await readMap();
+  const entry = map[captureId];
+  if (!entry) return;
+  map[captureId] = {
+    ...entry,
+    state: 'synced',
+    provider: result.provider,
+    remoteId: result.remoteId,
+    attempts: 0,
+    error: null,
+    updatedAt: now,
+  };
+  await writeMap(map);
+}
+
+export async function markError(captureId: string, message: string, now: string): Promise<void> {
+  const map = await readMap();
+  const entry = map[captureId];
+  if (!entry) return;
+  map[captureId] = {
+    ...entry,
+    state: 'error',
+    attempts: entry.attempts + 1,
+    error: message,
+    updatedAt: now,
+  };
+  await writeMap(map);
+}
+
+export async function removeEntry(captureId: string): Promise<void> {
+  const map = await readMap();
+  if (!(captureId in map)) return;
+  delete map[captureId];
+  await writeMap(map);
+}
+
+/** How many receipts are still waiting to reach the cloud — for the badge/label. */
+export async function pendingCount(): Promise<number> {
+  return (await pendingEntries()).length;
+}

--- a/apps/mobile/src/lib/receiptStore.ts
+++ b/apps/mobile/src/lib/receiptStore.ts
@@ -1,0 +1,138 @@
+/**
+ * The receipt vault — where a scanned bill lives on the phone.
+ *
+ * A capture's photo is deliberately never uploaded to Baaki (the privacy choice
+ * behind this feature): a receipt is a record of what somebody bought and
+ * where, and it has no business on our servers. So the image and a small JSON
+ * sidecar of what we parsed off it are written into the app's own document
+ * directory instead — kept out of the OS's reach (unlike the cache), readable
+ * offline, and the source the personal-cloud backup uploads from.
+ *
+ * The pair is keyed by the capture id, exactly as the Supabase path used to be:
+ * `<captureId>.jpg` beside `<captureId>.json`. The sidecar is what makes the
+ * archive worth having on its own — a folder of photos tells you nothing, a
+ * photo next to its total, date and line items is a record you can browse.
+ *
+ * Nothing here throws for the ordinary "not there" cases; a missing receipt
+ * reads back as null so the caller does not have to wrap every read.
+ */
+
+import { Directory, File, Paths } from 'expo-file-system';
+import { Platform } from 'react-native';
+
+/** The folder under the document directory that holds every saved receipt. */
+const FOLDER = 'receipts';
+
+/**
+ * What we write beside the image: everything the parser recovered, in the same
+ * minor-unit integers the ledger uses (ADR-003). Enough to rebuild the capture,
+ * or to read the archive without the app.
+ */
+export interface ReceiptSidecar {
+  readonly captureId: string;
+  readonly currency: string;
+  /** Grand total, minor units. */
+  readonly amountMinor: number;
+  readonly itemCount: number;
+  readonly items: readonly { readonly label: string; readonly total: number }[];
+  /** ISO date on the receipt, or the capture date. */
+  readonly date: string | null;
+  readonly category: string | null;
+  /** The raw OCR text, so a better parser can re-read it later. */
+  readonly rawText: string | null;
+  /** When this receipt was captured, ISO instant. */
+  readonly createdAt: string;
+}
+
+export interface SavedReceipt {
+  readonly imageUri: string;
+  readonly jsonUri: string;
+}
+
+/** Web has no document directory; the vault is a device-only feature. */
+function unavailable(): boolean {
+  return Platform.OS === 'web';
+}
+
+function folder(): Directory {
+  return new Directory(Paths.document, FOLDER);
+}
+
+function ensureFolder(): Directory {
+  const dir = folder();
+  if (!dir.exists) dir.create({ intermediates: true });
+  return dir;
+}
+
+/**
+ * Write a receipt's image and sidecar, overwriting any earlier attempt for the
+ * same capture. `overwrite` rather than a fresh name so a ret‑scan replaces
+ * cleanly and the backup queue re-uploads one file, not two.
+ */
+export function saveReceipt(
+  captureId: string,
+  input: { base64: string; sidecar: ReceiptSidecar },
+): SavedReceipt | null {
+  if (unavailable()) return null;
+  ensureFolder();
+
+  const image = new File(folder(), `${captureId}.jpg`);
+  image.create({ overwrite: true });
+  image.write(input.base64, { encoding: 'base64' });
+
+  const json = new File(folder(), `${captureId}.json`);
+  json.create({ overwrite: true });
+  json.write(JSON.stringify(input.sidecar, null, 2), { encoding: 'utf8' });
+
+  return { imageUri: image.uri, jsonUri: json.uri };
+}
+
+/** The local URIs for a saved receipt, or null when nothing was saved for it. */
+export function receiptFiles(captureId: string): SavedReceipt | null {
+  if (unavailable()) return null;
+  const image = new File(folder(), `${captureId}.jpg`);
+  const json = new File(folder(), `${captureId}.json`);
+  if (!image.exists) return null;
+  return { imageUri: image.uri, jsonUri: json.exists ? json.uri : image.uri };
+}
+
+/** The parsed sidecar for a saved receipt, or null. */
+export async function readReceipt(captureId: string): Promise<ReceiptSidecar | null> {
+  if (unavailable()) return null;
+  const json = new File(folder(), `${captureId}.json`);
+  if (!json.exists) return null;
+  try {
+    return JSON.parse(await json.text()) as ReceiptSidecar;
+  } catch {
+    return null;
+  }
+}
+
+/** Every saved receipt's sidecar, newest first. Skips any that fail to parse. */
+export async function listReceipts(): Promise<ReceiptSidecar[]> {
+  if (unavailable()) return [];
+  const dir = folder();
+  if (!dir.exists) return [];
+
+  const sidecars: ReceiptSidecar[] = [];
+  for (const entry of dir.list()) {
+    if (entry instanceof File && entry.name.endsWith('.json')) {
+      try {
+        sidecars.push(JSON.parse(await entry.text()) as ReceiptSidecar);
+      } catch {
+        // A truncated write from a killed process — skip it rather than fail the
+        // whole listing.
+      }
+    }
+  }
+  return sidecars.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/** Remove a receipt's image and sidecar. A missing file is not an error. */
+export function deleteReceipt(captureId: string): void {
+  if (unavailable()) return;
+  for (const name of [`${captureId}.jpg`, `${captureId}.json`]) {
+    const file = new File(folder(), name);
+    if (file.exists) file.delete();
+  }
+}

--- a/apps/mobile/src/sync/hooks.ts
+++ b/apps/mobile/src/sync/hooks.ts
@@ -53,10 +53,14 @@ export function useLocalGroup(groupId: string): LocalGroup {
 
   return useMemo(() => {
     const group = (mirror.tables.groups[groupId] as unknown as GroupRow | undefined) ?? null;
-    const members = (rowsFor(mirror, SyncTable.GroupMembers, groupId) as unknown as MemberRow[]).filter(
-      (member) => !member.left_at,
-    );
-    const settlements = rowsFor(mirror, SyncTable.Settlements, groupId) as unknown as SettlementRow[];
+    const members = (
+      rowsFor(mirror, SyncTable.GroupMembers, groupId) as unknown as MemberRow[]
+    ).filter((member) => !member.left_at);
+    const settlements = rowsFor(
+      mirror,
+      SyncTable.Settlements,
+      groupId,
+    ) as unknown as SettlementRow[];
     const expenses = materialiseExpenses(mirror, queue, { groupId });
 
     return {

--- a/apps/mobile/test/split.test.ts
+++ b/apps/mobile/test/split.test.ts
@@ -68,7 +68,9 @@ describe('splitProblem', () => {
   });
 
   it('refuses shares that are all zero', () => {
-    expect(splitProblem(SplitKind.Shares, { a: '0', b: '0', c: '0' }, people)).toMatch(/at least one/);
+    expect(splitProblem(SplitKind.Shares, { a: '0', b: '0', c: '0' }, people)).toMatch(
+      /at least one/,
+    );
   });
 
   it('says how much percentage is left, and how much is too much', () => {
@@ -81,7 +83,9 @@ describe('splitProblem', () => {
   });
 
   it('accepts percentages that sum to exactly 100', () => {
-    expect(splitProblem(SplitKind.Percent, { a: '33.34', b: '33.33', c: '33.33' }, people)).toBeNull();
+    expect(
+      splitProblem(SplitKind.Percent, { a: '33.34', b: '33.33', c: '33.33' }, people),
+    ).toBeNull();
   });
 
   it('ignores members who are not in the split', () => {

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -21,12 +21,7 @@ export enum Language {
   Ar = 'ar',
 }
 
-export const LANGUAGES: readonly Language[] = [
-  Language.En,
-  Language.Ta,
-  Language.Hi,
-  Language.Ar,
-];
+export const LANGUAGES: readonly Language[] = [Language.En, Language.Ta, Language.Hi, Language.Ar];
 
 export function isRtlLanguage(language: Language): boolean {
   return language === Language.Ar;

--- a/packages/core/src/money/currency.ts
+++ b/packages/core/src/money/currency.ts
@@ -64,7 +64,10 @@ export function isCurrencyCode(value: string): boolean {
 
 export function assertCurrencyCode(value: string): asserts value is CurrencyCode {
   if (!isCurrencyCode(value)) {
-    throw new MoneyError(MoneyErrorCode.InvalidCurrency, `Not an ISO-4217 alpha-3 code: "${value}"`);
+    throw new MoneyError(
+      MoneyErrorCode.InvalidCurrency,
+      `Not an ISO-4217 alpha-3 code: "${value}"`,
+    );
   }
 }
 

--- a/packages/core/src/notifications/copy.ts
+++ b/packages/core/src/notifications/copy.ts
@@ -106,8 +106,14 @@ const en: CopyStrings = {
       title: '{actor} added an expense',
       body: '{description} · {amount} in {group}',
     },
-    [NotificationKind.ExpenseEdited]: { title: '{actor} edited an expense', body: '{description} in {group}' },
-    [NotificationKind.ExpenseDeleted]: { title: '{actor} removed an expense', body: '{description} in {group}' },
+    [NotificationKind.ExpenseEdited]: {
+      title: '{actor} edited an expense',
+      body: '{description} in {group}',
+    },
+    [NotificationKind.ExpenseDeleted]: {
+      title: '{actor} removed an expense',
+      body: '{description} in {group}',
+    },
     [NotificationKind.YouOwe]: { title: 'You owe {amount}', body: '{description} in {group}' },
     [NotificationKind.SettlementInitiated]: {
       title: '{actor} paid you {amount}',
@@ -117,11 +123,23 @@ const en: CopyStrings = {
       title: '{actor} says they paid you {amount}',
       body: 'Confirm so your baaki stays right',
     },
-    [NotificationKind.SettlementConfirmed]: { title: 'Settled with {actor}', body: '{amount} in {group}' },
-    [NotificationKind.Nudge]: { title: 'A gentle nudge from {actor}', body: '{amount} pending in {group}' },
-    [NotificationKind.GhostClaimed]: { title: '{actor} joined {group}', body: 'Their past expenses are now linked' },
+    [NotificationKind.SettlementConfirmed]: {
+      title: 'Settled with {actor}',
+      body: '{amount} in {group}',
+    },
+    [NotificationKind.Nudge]: {
+      title: 'A gentle nudge from {actor}',
+      body: '{amount} pending in {group}',
+    },
+    [NotificationKind.GhostClaimed]: {
+      title: '{actor} joined {group}',
+      body: 'Their past expenses are now linked',
+    },
     [NotificationKind.GroupInviteAccepted]: { title: '{actor} joined {group}', body: 'Say hello' },
-    [NotificationKind.DigestDaily]: { title: 'Today in {group}', body: '{count} updates · your baaki is {amount}' },
+    [NotificationKind.DigestDaily]: {
+      title: 'Today in {group}',
+      body: '{count} updates · your baaki is {amount}',
+    },
     [NotificationKind.TripNudgeMorning]: {
       title: 'Anything from yesterday?',
       body: 'Add what you spent on {group} while you still remember it',
@@ -174,9 +192,18 @@ const ta: CopyStrings = {
       title: '{actor} ஒரு செலவைச் சேர்த்தார்',
       body: '{description} · {amount} ({group})',
     },
-    [NotificationKind.ExpenseEdited]: { title: '{actor} செலவைத் திருத்தினார்', body: '{description} ({group})' },
-    [NotificationKind.ExpenseDeleted]: { title: '{actor} செலவை நீக்கினார்', body: '{description} ({group})' },
-    [NotificationKind.YouOwe]: { title: 'நீங்கள் {amount} தர வேண்டும்', body: '{description} ({group})' },
+    [NotificationKind.ExpenseEdited]: {
+      title: '{actor} செலவைத் திருத்தினார்',
+      body: '{description} ({group})',
+    },
+    [NotificationKind.ExpenseDeleted]: {
+      title: '{actor} செலவை நீக்கினார்',
+      body: '{description} ({group})',
+    },
+    [NotificationKind.YouOwe]: {
+      title: 'நீங்கள் {amount} தர வேண்டும்',
+      body: '{description} ({group})',
+    },
     [NotificationKind.SettlementInitiated]: {
       title: '{actor} உங்களுக்கு {amount} அனுப்பியுள்ளார்',
       body: 'கிடைத்ததா என உறுதிப்படுத்தவும்',
@@ -185,11 +212,26 @@ const ta: CopyStrings = {
       title: '{actor} {amount} கொடுத்ததாகச் சொல்கிறார்',
       body: 'உறுதிப்படுத்தினால் பாக்கி சரியாக இருக்கும்',
     },
-    [NotificationKind.SettlementConfirmed]: { title: '{actor} உடன் தீர்ந்தது', body: '{amount} ({group})' },
-    [NotificationKind.Nudge]: { title: '{actor} இடமிருந்து ஒரு நினைவூட்டல்', body: '{group} இல் {amount} பாக்கி' },
-    [NotificationKind.GhostClaimed]: { title: '{actor} {group} இல் இணைந்தார்', body: 'பழைய செலவுகள் இணைக்கப்பட்டன' },
-    [NotificationKind.GroupInviteAccepted]: { title: '{actor} {group} இல் இணைந்தார்', body: 'வரவேற்கலாம்' },
-    [NotificationKind.DigestDaily]: { title: 'இன்று {group} இல்', body: '{count} புதுப்பிப்புகள் · பாக்கி {amount}' },
+    [NotificationKind.SettlementConfirmed]: {
+      title: '{actor} உடன் தீர்ந்தது',
+      body: '{amount} ({group})',
+    },
+    [NotificationKind.Nudge]: {
+      title: '{actor} இடமிருந்து ஒரு நினைவூட்டல்',
+      body: '{group} இல் {amount} பாக்கி',
+    },
+    [NotificationKind.GhostClaimed]: {
+      title: '{actor} {group} இல் இணைந்தார்',
+      body: 'பழைய செலவுகள் இணைக்கப்பட்டன',
+    },
+    [NotificationKind.GroupInviteAccepted]: {
+      title: '{actor} {group} இல் இணைந்தார்',
+      body: 'வரவேற்கலாம்',
+    },
+    [NotificationKind.DigestDaily]: {
+      title: 'இன்று {group} இல்',
+      body: '{count} புதுப்பிப்புகள் · பாக்கி {amount}',
+    },
     [NotificationKind.TripNudgeMorning]: {
       title: 'நேற்று ஏதாவது இருக்கா?',
       body: 'நினைவிருக்கும் போதே {group} செலவுகளைச் சேர்க்கவும்',
@@ -238,20 +280,47 @@ const hi: CopyStrings = {
     netNegative: 'आपकी बाकी {amount} है',
   },
   notifications: {
-    [NotificationKind.ExpenseAdded]: { title: '{actor} ने खर्च जोड़ा', body: '{description} · {amount} ({group})' },
-    [NotificationKind.ExpenseEdited]: { title: '{actor} ने खर्च बदला', body: '{description} ({group})' },
-    [NotificationKind.ExpenseDeleted]: { title: '{actor} ने खर्च हटाया', body: '{description} ({group})' },
+    [NotificationKind.ExpenseAdded]: {
+      title: '{actor} ने खर्च जोड़ा',
+      body: '{description} · {amount} ({group})',
+    },
+    [NotificationKind.ExpenseEdited]: {
+      title: '{actor} ने खर्च बदला',
+      body: '{description} ({group})',
+    },
+    [NotificationKind.ExpenseDeleted]: {
+      title: '{actor} ने खर्च हटाया',
+      body: '{description} ({group})',
+    },
     [NotificationKind.YouOwe]: { title: 'आपको {amount} देने हैं', body: '{description} ({group})' },
-    [NotificationKind.SettlementInitiated]: { title: '{actor} ने आपको {amount} भेजे', body: 'मिलने की पुष्टि करें' },
+    [NotificationKind.SettlementInitiated]: {
+      title: '{actor} ने आपको {amount} भेजे',
+      body: 'मिलने की पुष्टि करें',
+    },
     [NotificationKind.SettlementConfirmRequest]: {
       title: '{actor} कहते हैं उन्होंने {amount} भेजे',
       body: 'पुष्टि करें ताकि बाकी सही रहे',
     },
-    [NotificationKind.SettlementConfirmed]: { title: '{actor} के साथ हिसाब बराबर', body: '{amount} ({group})' },
-    [NotificationKind.Nudge]: { title: '{actor} की ओर से एक याद', body: '{group} में {amount} बाकी' },
-    [NotificationKind.GhostClaimed]: { title: '{actor} {group} में शामिल हुए', body: 'पुराने खर्च जुड़ गए' },
-    [NotificationKind.GroupInviteAccepted]: { title: '{actor} {group} में शामिल हुए', body: 'नमस्ते कहें' },
-    [NotificationKind.DigestDaily]: { title: 'आज {group} में', body: '{count} अपडेट · बाकी {amount}' },
+    [NotificationKind.SettlementConfirmed]: {
+      title: '{actor} के साथ हिसाब बराबर',
+      body: '{amount} ({group})',
+    },
+    [NotificationKind.Nudge]: {
+      title: '{actor} की ओर से एक याद',
+      body: '{group} में {amount} बाकी',
+    },
+    [NotificationKind.GhostClaimed]: {
+      title: '{actor} {group} में शामिल हुए',
+      body: 'पुराने खर्च जुड़ गए',
+    },
+    [NotificationKind.GroupInviteAccepted]: {
+      title: '{actor} {group} में शामिल हुए',
+      body: 'नमस्ते कहें',
+    },
+    [NotificationKind.DigestDaily]: {
+      title: 'आज {group} में',
+      body: '{count} अपडेट · बाकी {amount}',
+    },
     [NotificationKind.TripNudgeMorning]: {
       title: 'कल का कुछ बाकी है?',
       body: 'याद रहते ही {group} के खर्च जोड़ दें',
@@ -304,8 +373,14 @@ const ar: CopyStrings = {
       title: 'أضاف {actor} مصروفًا',
       body: '{description} · {amount} في {group}',
     },
-    [NotificationKind.ExpenseEdited]: { title: 'عدّل {actor} مصروفًا', body: '{description} في {group}' },
-    [NotificationKind.ExpenseDeleted]: { title: 'حذف {actor} مصروفًا', body: '{description} في {group}' },
+    [NotificationKind.ExpenseEdited]: {
+      title: 'عدّل {actor} مصروفًا',
+      body: '{description} في {group}',
+    },
+    [NotificationKind.ExpenseDeleted]: {
+      title: 'حذف {actor} مصروفًا',
+      body: '{description} في {group}',
+    },
     [NotificationKind.YouOwe]: { title: 'عليك {amount}', body: '{description} في {group}' },
     [NotificationKind.SettlementInitiated]: {
       title: 'دفع لك {actor} مبلغ {amount}',
@@ -315,11 +390,26 @@ const ar: CopyStrings = {
       title: 'يقول {actor} إنه دفع لك {amount}',
       body: 'أكّد حتى يبقى باقيك صحيحًا',
     },
-    [NotificationKind.SettlementConfirmed]: { title: 'تمت التسوية مع {actor}', body: '{amount} في {group}' },
-    [NotificationKind.Nudge]: { title: 'تذكير لطيف من {actor}', body: '{amount} معلّقة في {group}' },
-    [NotificationKind.GhostClaimed]: { title: 'انضم {actor} إلى {group}', body: 'رُبطت مصروفاته السابقة' },
-    [NotificationKind.GroupInviteAccepted]: { title: 'انضم {actor} إلى {group}', body: 'ألقِ التحية' },
-    [NotificationKind.DigestDaily]: { title: 'اليوم في {group}', body: '{count} تحديثات · باقيك {amount}' },
+    [NotificationKind.SettlementConfirmed]: {
+      title: 'تمت التسوية مع {actor}',
+      body: '{amount} في {group}',
+    },
+    [NotificationKind.Nudge]: {
+      title: 'تذكير لطيف من {actor}',
+      body: '{amount} معلّقة في {group}',
+    },
+    [NotificationKind.GhostClaimed]: {
+      title: 'انضم {actor} إلى {group}',
+      body: 'رُبطت مصروفاته السابقة',
+    },
+    [NotificationKind.GroupInviteAccepted]: {
+      title: 'انضم {actor} إلى {group}',
+      body: 'ألقِ التحية',
+    },
+    [NotificationKind.DigestDaily]: {
+      title: 'اليوم في {group}',
+      body: '{count} تحديثات · باقيك {amount}',
+    },
     [NotificationKind.TripNudgeMorning]: {
       title: 'هل بقي شيء من الأمس؟',
       body: 'أضف ما أنفقته على {group} ما دمت تتذكره',

--- a/packages/core/src/receipt/heuristic.ts
+++ b/packages/core/src/receipt/heuristic.ts
@@ -1,0 +1,301 @@
+/**
+ * Reading a receipt's numbers off its OCR text, on the phone, without a model.
+ *
+ * The vision model (`receipt-parse`) understands layout and is what ADR-008
+ * ultimately relies on. But it costs money and a network round trip, and while
+ * the Anthropic account is unfunded it returns nothing at all. A capture caught
+ * with no group has no reason to wait on any of that: ML Kit has already turned
+ * the photo into lines of text on the device, and most receipts are regular
+ * enough that a total and a list of priced lines can be recovered from those
+ * lines by rule rather than by inference.
+ *
+ * This is deliberately a floor, not a ceiling. It is approximate on a crumpled
+ * thermal bill and it does not pretend otherwise — every result carries a
+ * `confidence`, computed by the same {@link checkReceipt} arithmetic the model
+ * path uses, so the caller can prefer the model the moment it is available and
+ * fall back here when it is not. The number it is surest about is the printed
+ * grand total; the itemisation is a best effort the user can override.
+ *
+ * Every amount it produces is an integer in minor units, like the rest of the
+ * ledger (ADR-003). A price written with two decimals is read as those decimals
+ * (`12.50` → 1250); a bare whole number is taken to be a two-decimal currency's
+ * major unit (`12` → 1200). That assumption is wrong for a zero-decimal
+ * currency such as JPY, which is a known limit of reading without the model.
+ */
+
+import { checkReceipt } from './reconcile';
+import { LOW_CONFIDENCE, type ParsedReceipt, type ParsedReceiptCharge } from './types';
+
+/** A parsed receipt plus how much the caller should trust it (0–1). */
+export interface HeuristicReceipt extends ParsedReceipt {
+  /**
+   * 0–1. High when the lines add up to the printed total and items were found;
+   * low when the arithmetic does not close, the total had to be inferred, or no
+   * items were recognised. Below {@link LOW_CONFIDENCE} the caller should treat
+   * the itemisation as a draft and lean on the single editable amount instead.
+   */
+  readonly confidence: number;
+}
+
+export interface ParseReceiptTextOptions {
+  /** Currency to assume when the text carries no symbol or code. */
+  readonly currency?: string;
+}
+
+/** Currency symbols and codes we can recognise in the raw text. */
+const CURRENCY_HINTS: readonly { readonly pattern: RegExp; readonly code: string }[] = [
+  { pattern: /₹|\bRs\.?\b|\bINR\b/i, code: 'INR' },
+  { pattern: /\$|\bUSD\b/i, code: 'USD' },
+  { pattern: /€|\bEUR\b/i, code: 'EUR' },
+  { pattern: /£|\bGBP\b/i, code: 'GBP' },
+  { pattern: /\bAED\b|\bDhs?\b/i, code: 'AED' },
+];
+
+/**
+ * A line whose trailing number is the receipt's grand total. Ordered by how
+ * unambiguous the wording is — "grand total" beats a lone "total", which in
+ * turn beats "balance", because a receipt often prints several of these and the
+ * last, most-specific one is the amount that actually left the wallet.
+ */
+const TOTAL_LABELS: readonly RegExp[] = [
+  /\bgrand\s*total\b/i,
+  /\b(?:amount|balance)\s*(?:due|payable)\b/i,
+  /\bnet\s*(?:payable|amount|total)\b/i,
+  /\btotal\b/i,
+];
+
+const SUBTOTAL = /\bsub[\s-]*total\b/i;
+const TAX = /\b(?:tax|gst|cgst|sgst|igst|vat|hst|pst)\b/i;
+const SERVICE = /\bservice\s*(?:charge|fee|tax)?\b/i;
+const TIP = /\b(?:tip|gratuity)\b/i;
+const DISCOUNT = /\b(?:discount|coupon|savings?|promo|%?\s*off)\b/i;
+const DELIVERY = /\b(?:delivery|packing|packaging|convenience|handling)\b/i;
+
+/**
+ * Lines that carry a number but are never an item or a charge — payment
+ * mechanics, identifiers and pleasantries. Left in, each would be counted as a
+ * priced line and wreck the arithmetic.
+ */
+const NOISE =
+  /\b(?:cash|change|tendered|card|visa|master|upi|paid|balance\b(?!\s*due)|invoice|bill\s*no|receipt|gstin|tin|vat\s*no|phone|tel|mobile|table|token|order\s*no|qty|thank|welcome|www\.|\.com)\b/i;
+
+/**
+ * Parse OCR text into a receipt. Never throws: text that is not a receipt at
+ * all comes back as an empty, zero-total, zero-confidence result rather than an
+ * exception, because the caller's fallback is "let the person type it", not
+ * "handle an error".
+ */
+export function parseReceiptText(text: string, opts: ParseReceiptTextOptions = {}): HeuristicReceipt {
+  const fallbackCurrency = opts.currency ?? 'USD';
+  const currency = detectCurrency(text) ?? fallbackCurrency;
+  const date = detectDate(text);
+
+  const rawLines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const items: { label: string; total: number; confidence: number }[] = [];
+  const taxes: ParsedReceiptCharge[] = [];
+  const discounts: ParsedReceiptCharge[] = [];
+  let subtotal: number | null = null;
+  let serviceCharge: number | null = null;
+  let tip: number | null = null;
+  let totalCandidate: { amount: number; rank: number } | null = null;
+
+  let merchant: string | null = null;
+
+  for (const line of rawLines) {
+    const money = trailingAmount(line);
+
+    // A line with no price is either the merchant (the first wordy line) or
+    // noise. It never becomes an item, so nothing downstream depends on it.
+    if (money === null) {
+      if (merchant === null && hasWords(line) && !NOISE.test(line)) merchant = line;
+      continue;
+    }
+
+    const label = money.label;
+    const amount = money.amount;
+    const lower = label.toLowerCase();
+
+    // Order matters: "subtotal" contains "total", and "service tax" contains
+    // "tax", so the most specific bucket has to be tested first.
+    if (SUBTOTAL.test(lower)) {
+      subtotal = amount;
+      continue;
+    }
+    const totalRank = TOTAL_LABELS.findIndex((pattern) => pattern.test(lower));
+    if (totalRank !== -1) {
+      // Keep the most specific wording seen; on a tie keep the later (lower)
+      // line, which on a real receipt is the final amount payable.
+      if (!totalCandidate || totalRank <= totalCandidate.rank) {
+        totalCandidate = { amount, rank: totalRank };
+      }
+      continue;
+    }
+    if (DISCOUNT.test(lower)) {
+      discounts.push({ label, amount: Math.abs(amount) });
+      continue;
+    }
+    if (TIP.test(lower)) {
+      tip = (tip ?? 0) + amount;
+      continue;
+    }
+    if (SERVICE.test(lower)) {
+      serviceCharge = (serviceCharge ?? 0) + amount;
+      continue;
+    }
+    if (TAX.test(lower) || DELIVERY.test(lower)) {
+      taxes.push({ label, amount });
+      continue;
+    }
+    if (NOISE.test(lower)) continue;
+
+    // Everything else with a price is an item. A "label" that is really just
+    // more digits (a stray total, a code) is kept but marked unsure, so
+    // `checkReceipt` surfaces it rather than the parser silently trusting it.
+    items.push({
+      label: label.length > 0 ? label : '—',
+      total: amount,
+      confidence: hasWords(label) ? 0.9 : 0.4,
+    });
+  }
+
+  const itemsTotal = items.reduce((sum, item) => sum + item.total, 0);
+  const extras =
+    taxes.reduce((sum, tax) => sum + tax.amount, 0) +
+    (serviceCharge ?? 0) +
+    (tip ?? 0) -
+    discounts.reduce((sum, discount) => sum + discount.amount, 0);
+
+  // The printed total is authoritative when the receipt gave us one; otherwise
+  // it is the only thing we can say — the sum of what we read.
+  const inferredTotal = totalCandidate === null;
+  const grandTotal = totalCandidate?.amount ?? Math.max(0, itemsTotal + extras);
+
+  const receipt: ParsedReceipt = {
+    merchant,
+    date,
+    currency,
+    items: items.map((item) => ({
+      label: item.label,
+      qty: 1,
+      unitPrice: null,
+      total: item.total,
+      confidence: item.confidence,
+    })),
+    subtotal,
+    taxes,
+    serviceCharge,
+    tip,
+    discounts,
+    grandTotal,
+  };
+
+  return { ...receipt, confidence: scoreConfidence(receipt, { inferredTotal }) };
+}
+
+/**
+ * How much to trust the parse, on the receipt's own checksum.
+ *
+ * A receipt whose lines add up to its printed total is almost certainly read
+ * correctly, so it scores high. One that does not reconcile, or whose total we
+ * had to invent because none was printed, or that yielded no items at all, is a
+ * draft — scored below {@link LOW_CONFIDENCE} so the caller keeps the manual
+ * amount in front of the user.
+ */
+function scoreConfidence(receipt: ParsedReceipt, flags: { inferredTotal: boolean }): number {
+  if (receipt.items.length === 0 && receipt.grandTotal === 0) return 0;
+
+  const check = checkReceipt(receipt);
+  let score = check.reconciles ? 0.92 : 0.5;
+  if (flags.inferredTotal) score -= 0.25;
+  if (receipt.items.length === 0) score -= 0.3;
+  // A single unreadable item name drags trust down a little, as it does in the
+  // model path — the same LOW_CONFIDENCE threshold decides "look at this".
+  if (receipt.items.some((item) => item.confidence < LOW_CONFIDENCE)) score -= 0.1;
+
+  return Math.max(0, Math.min(1, score));
+}
+
+/**
+ * The money at the end of a line, in minor units, with the rest as its label.
+ *
+ * Anchored to the end of the line because that is where a receipt prints its
+ * price; a number in the middle (a quantity, a date, an SKU) is left in the
+ * label rather than mistaken for the amount. A value in parentheses or led by a
+ * minus is negative — how thermal printers show a discount.
+ */
+function trailingAmount(line: string): { label: string; amount: number } | null {
+  // e.g. "Cheese Naan          2  240.00", "TOTAL: ₹1,240.50", "Off  (-50.00)"
+  const match = line.match(
+    /^(.*?)[\s:]*[(-]?\s*(?:₹|Rs\.?|INR|\$|USD|€|EUR|£|GBP|AED|Dhs?)?\s*(\d[\d,]*(?:\.\d{1,2})?)\s*\)?\s*$/i,
+  );
+  if (!match) return null;
+
+  const [, rawLabel = '', rawNumber = ''] = match;
+  const amount = parseMoney(rawNumber);
+  if (amount === null) return null;
+
+  const negative = /[(-]\s*$|^\s*-/.test(line.slice(rawLabel.length));
+  const label = rawLabel.replace(/[\s:.\-–]+$/, '').trim();
+  return { label, amount: negative ? -amount : amount };
+}
+
+/**
+ * A number as printed → minor units. `1,240.50` → 124050, `12` → 1200.
+ *
+ * Grouping separators are dropped; a two-decimal fraction becomes the minor
+ * part; a bare integer is scaled by 100 on the assumption of a two-decimal
+ * currency (the ADR-003 convention almost every target currency here follows).
+ */
+function parseMoney(raw: string): number | null {
+  const cleaned = raw.replace(/[\s,]/g, '');
+  if (cleaned.length === 0) return null;
+
+  const dot = cleaned.indexOf('.');
+  if (dot === -1) {
+    const whole = Number(cleaned);
+    return Number.isFinite(whole) ? Math.round(whole) * 100 : null;
+  }
+
+  const whole = Number(cleaned.slice(0, dot) || '0');
+  const fraction = cleaned.slice(dot + 1).padEnd(2, '0').slice(0, 2);
+  const minor = Number(fraction);
+  if (!Number.isFinite(whole) || !Number.isFinite(minor)) return null;
+  return Math.round(whole) * 100 + minor;
+}
+
+/** At least two letters — enough to call it a name rather than a code. */
+function hasWords(text: string): boolean {
+  return (text.match(/[A-Za-zÀ-ɏऀ-෿]/g)?.length ?? 0) >= 2;
+}
+
+function detectCurrency(text: string): string | null {
+  for (const { pattern, code } of CURRENCY_HINTS) {
+    if (pattern.test(text)) return code;
+  }
+  return null;
+}
+
+/**
+ * A date on the receipt as `YYYY-MM-DD`, or null. Reads the common numeric
+ * forms; an ambiguous `03/04/2026` is taken as day-first, which is the majority
+ * convention in the markets this app serves (TDR §6 leaves this to the client).
+ */
+function detectDate(text: string): string | null {
+  const iso = text.match(/\b(\d{4})-(\d{2})-(\d{2})\b/);
+  if (iso) return `${iso[1]}-${iso[2]}-${iso[3]}`;
+
+  const dmy = text.match(/\b(\d{1,2})[/.](\d{1,2})[/.](\d{2,4})\b/);
+  if (dmy) {
+    const day = dmy[1]!.padStart(2, '0');
+    const month = dmy[2]!.padStart(2, '0');
+    const year = dmy[3]!.length === 2 ? `20${dmy[3]}` : dmy[3]!;
+    if (Number(month) >= 1 && Number(month) <= 12 && Number(day) >= 1 && Number(day) <= 31) {
+      return `${year}-${month}-${day}`;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/receipt/heuristic.ts
+++ b/packages/core/src/receipt/heuristic.ts
@@ -85,7 +85,10 @@ const NOISE =
  * exception, because the caller's fallback is "let the person type it", not
  * "handle an error".
  */
-export function parseReceiptText(text: string, opts: ParseReceiptTextOptions = {}): HeuristicReceipt {
+export function parseReceiptText(
+  text: string,
+  opts: ParseReceiptTextOptions = {},
+): HeuristicReceipt {
   const fallbackCurrency = opts.currency ?? 'USD';
   const currency = detectCurrency(text) ?? fallbackCurrency;
   const date = detectDate(text);
@@ -261,7 +264,10 @@ function parseMoney(raw: string): number | null {
   }
 
   const whole = Number(cleaned.slice(0, dot) || '0');
-  const fraction = cleaned.slice(dot + 1).padEnd(2, '0').slice(0, 2);
+  const fraction = cleaned
+    .slice(dot + 1)
+    .padEnd(2, '0')
+    .slice(0, 2);
   const minor = Number(fraction);
   if (!Number.isFinite(whole) || !Number.isFinite(minor)) return null;
   return Math.round(whole) * 100 + minor;

--- a/packages/core/src/receipt/index.ts
+++ b/packages/core/src/receipt/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './reconcile';
+export * from './heuristic';

--- a/packages/core/src/split/computeShares.ts
+++ b/packages/core/src/split/computeShares.ts
@@ -161,7 +161,10 @@ function splitItemized(
   seed: string,
 ): ShareMap {
   if (params.items.length === 0) {
-    throw new SplitError(SplitErrorCode.InvalidItem, 'An itemized split needs at least one line item');
+    throw new SplitError(
+      SplitErrorCode.InvalidItem,
+      'An itemized split needs at least one line item',
+    );
   }
 
   const subtotals = new Map<MemberId, bigint>();
@@ -221,7 +224,10 @@ function splitItemized(
 
 function validateParticipants(participants: readonly MemberId[]): MemberId[] {
   if (participants.length === 0) {
-    throw new SplitError(SplitErrorCode.EmptyParticipants, 'An expense needs at least one participant');
+    throw new SplitError(
+      SplitErrorCode.EmptyParticipants,
+      'An expense needs at least one participant',
+    );
   }
   const unique = new Set(participants);
   if (unique.size !== participants.length) {

--- a/packages/core/src/split/verify.ts
+++ b/packages/core/src/split/verify.ts
@@ -64,6 +64,9 @@ function toBigInt(value: string | bigint, member: MemberId): bigint {
   try {
     return BigInt(value);
   } catch {
-    throw new SplitError(SplitErrorCode.ShareMismatch, `Client sent "${value}" as ${member}'s share`);
+    throw new SplitError(
+      SplitErrorCode.ShareMismatch,
+      `Client sent "${value}" as ${member}'s share`,
+    );
   }
 }

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -109,7 +109,10 @@ describe('somebody with no account at all', () => {
   });
 
   it('goes to the provider for Apple', () => {
-    expect(planAuth(NOBODY, AuthMethod.Apple)).toEqual({ call: 'signInWithOAuth', method: 'apple' });
+    expect(planAuth(NOBODY, AuthMethod.Apple)).toEqual({
+      call: 'signInWithOAuth',
+      method: 'apple',
+    });
   });
 
   it('will not be talked into a sign-up for either provider', () => {

--- a/packages/core/test/money.test.ts
+++ b/packages/core/test/money.test.ts
@@ -100,10 +100,15 @@ describe('parse and render', () => {
 
   it('labels money for screen readers (TDR §11)', () => {
     const strings = copyFor('en').money;
-    const label = moneyAccessibilityLabel(money(42000n, 'INR'), BalanceDirection.OwedToYou, strings, {
-      locale: 'en-IN',
-      compactFraction: true,
-    });
+    const label = moneyAccessibilityLabel(
+      money(42000n, 'INR'),
+      BalanceDirection.OwedToYou,
+      strings,
+      {
+        locale: 'en-IN',
+        compactFraction: true,
+      },
+    );
     expect(label).toMatch(/^You are owed/);
     expect(balanceDirection(-1n)).toBe('you_owe');
     expect(balanceDirection(0n)).toBe('settled');

--- a/packages/core/test/receipt-heuristic.test.ts
+++ b/packages/core/test/receipt-heuristic.test.ts
@@ -13,9 +13,13 @@ import { LOW_CONFIDENCE, checkReceipt, parseReceiptText } from '../src/receipt/i
 describe('parseReceiptText', () => {
   it('reads a clean grocery bill: items, total, count, reconciles', () => {
     const receipt = parseReceiptText(
-      ['FreshMart', 'Milk 1L        2.50', 'Bread          1.20', 'Eggs x6        3.00', 'TOTAL          6.70'].join(
-        '\n',
-      ),
+      [
+        'FreshMart',
+        'Milk 1L        2.50',
+        'Bread          1.20',
+        'Eggs x6        3.00',
+        'TOTAL          6.70',
+      ].join('\n'),
     );
 
     expect(receipt.items).toHaveLength(3);
@@ -78,9 +82,13 @@ describe('parseReceiptText', () => {
 
   it('drops payment-mechanics noise instead of counting it as an item', () => {
     const receipt = parseReceiptText(
-      ['Deli', 'Sandwich       8.00', 'Total          8.00', 'Cash          10.00', 'Change         2.00'].join(
-        '\n',
-      ),
+      [
+        'Deli',
+        'Sandwich       8.00',
+        'Total          8.00',
+        'Cash          10.00',
+        'Change         2.00',
+      ].join('\n'),
     );
     expect(receipt.items).toHaveLength(1);
     expect(receipt.grandTotal).toBe(800);

--- a/packages/core/test/receipt-heuristic.test.ts
+++ b/packages/core/test/receipt-heuristic.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The on-device receipt parser (heuristic.ts).
+ *
+ * These assert the floor the parser has to clear without a model: recover a
+ * total and a list of priced lines from the kind of text ML Kit hands back, in
+ * minor units, and be honest — through `confidence` — when it could not.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { LOW_CONFIDENCE, checkReceipt, parseReceiptText } from '../src/receipt/index';
+
+describe('parseReceiptText', () => {
+  it('reads a clean grocery bill: items, total, count, reconciles', () => {
+    const receipt = parseReceiptText(
+      ['FreshMart', 'Milk 1L        2.50', 'Bread          1.20', 'Eggs x6        3.00', 'TOTAL          6.70'].join(
+        '\n',
+      ),
+    );
+
+    expect(receipt.items).toHaveLength(3);
+    expect(receipt.items.map((item) => item.total)).toEqual([250, 120, 300]);
+    expect(receipt.grandTotal).toBe(670);
+    expect(receipt.merchant).toBe('FreshMart');
+    expect(checkReceipt(receipt).reconciles).toBe(true);
+    expect(receipt.confidence).toBeGreaterThanOrEqual(LOW_CONFIDENCE);
+  });
+
+  it('separates tax, tip and subtotal from items on a restaurant bill', () => {
+    const receipt = parseReceiptText(
+      [
+        'Cafe Rio',
+        'Burger         10.00',
+        'Fries           4.00',
+        'Subtotal       14.00',
+        'Tax             1.40',
+        'Tip             2.00',
+        'Total          17.40',
+      ].join('\n'),
+    );
+
+    expect(receipt.items).toHaveLength(2);
+    expect(receipt.subtotal).toBe(1400);
+    expect(receipt.taxes.reduce((sum, tax) => sum + tax.amount, 0)).toBe(140);
+    expect(receipt.tip).toBe(200);
+    expect(receipt.grandTotal).toBe(1740);
+    expect(checkReceipt(receipt).reconciles).toBe(true);
+  });
+
+  it('treats a discount as a negative extra, not an item', () => {
+    const receipt = parseReceiptText(
+      ['Store', 'Shirt          20.00', 'Discount       -5.00', 'Total          15.00'].join('\n'),
+    );
+
+    expect(receipt.items).toHaveLength(1);
+    expect(receipt.items[0]?.total).toBe(2000);
+    expect(receipt.discounts).toHaveLength(1);
+    expect(receipt.discounts[0]?.amount).toBe(500);
+    expect(receipt.grandTotal).toBe(1500);
+    expect(checkReceipt(receipt).reconciles).toBe(true);
+  });
+
+  it('detects the currency from a symbol in the text', () => {
+    const receipt = parseReceiptText(['Chai        ₹40.00', 'TOTAL      ₹40.00'].join('\n'));
+    expect(receipt.currency).toBe('INR');
+    expect(receipt.grandTotal).toBe(4000);
+  });
+
+  it('falls back to the caller currency when the text carries none', () => {
+    const receipt = parseReceiptText('Coffee 3.00\nTotal 3.00', { currency: 'EUR' });
+    expect(receipt.currency).toBe('EUR');
+  });
+
+  it('scales a decimal-free amount to minor units', () => {
+    const receipt = parseReceiptText('Water 20\nTotal 20', { currency: 'INR' });
+    expect(receipt.grandTotal).toBe(2000);
+  });
+
+  it('drops payment-mechanics noise instead of counting it as an item', () => {
+    const receipt = parseReceiptText(
+      ['Deli', 'Sandwich       8.00', 'Total          8.00', 'Cash          10.00', 'Change         2.00'].join(
+        '\n',
+      ),
+    );
+    expect(receipt.items).toHaveLength(1);
+    expect(receipt.grandTotal).toBe(800);
+    expect(checkReceipt(receipt).reconciles).toBe(true);
+  });
+
+  it('returns an empty, zero-confidence result for unreadable text', () => {
+    const receipt = parseReceiptText('~~~ receipt unreadable ~~~\n????\n@@@@');
+    expect(receipt.items).toHaveLength(0);
+    expect(receipt.grandTotal).toBe(0);
+    expect(receipt.confidence).toBe(0);
+  });
+
+  it('lowers confidence when no total was printed and it had to be inferred', () => {
+    const withTotal = parseReceiptText('Tea 2.00\nCake 3.00\nTotal 5.00');
+    const noTotal = parseReceiptText('Tea 2.00\nCake 3.00');
+    expect(noTotal.grandTotal).toBe(500);
+    expect(noTotal.confidence).toBeLessThan(withTotal.confidence);
+  });
+
+  it('never throws on arbitrary input', () => {
+    expect(() => parseReceiptText('')).not.toThrow();
+    expect(() => parseReceiptText('\n\n\n')).not.toThrow();
+    expect(() => parseReceiptText('12345')).not.toThrow();
+  });
+});

--- a/packages/core/test/split.combinations.test.ts
+++ b/packages/core/test/split.combinations.test.ts
@@ -522,13 +522,19 @@ describe('the server is the one that decides (TDR §4)', () => {
   it('rejects a client that is one paisa out', () => {
     const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
     claimed.m1 = (BigInt(claimed.m1 ?? '0') + 1n).toString();
-    expectSplitError(() => verifyClientShares(authoritative, claimed), SplitErrorCode.ShareMismatch);
+    expectSplitError(
+      () => verifyClientShares(authoritative, claimed),
+      SplitErrorCode.ShareMismatch,
+    );
   });
 
   it('rejects a client that omits somebody', () => {
     const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
     delete claimed.m3;
-    expectSplitError(() => verifyClientShares(authoritative, claimed), SplitErrorCode.ShareMismatch);
+    expectSplitError(
+      () => verifyClientShares(authoritative, claimed),
+      SplitErrorCode.ShareMismatch,
+    );
   });
 
   it('rejects a client that invents somebody', () => {
@@ -537,13 +543,19 @@ describe('the server is the one that decides (TDR §4)', () => {
     // wave this through.
     const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
     claimed.mallory = '0';
-    expectSplitError(() => verifyClientShares(authoritative, claimed), SplitErrorCode.ShareMismatch);
+    expectSplitError(
+      () => verifyClientShares(authoritative, claimed),
+      SplitErrorCode.ShareMismatch,
+    );
   });
 
   it('rejects a client that sends something that is not a number', () => {
     const claimed = Object.fromEntries([...authoritative].map(([id, s]) => [id, s.toString()]));
     claimed.m1 = 'five hundred';
-    expectSplitError(() => verifyClientShares(authoritative, claimed), SplitErrorCode.ShareMismatch);
+    expectSplitError(
+      () => verifyClientShares(authoritative, claimed),
+      SplitErrorCode.ShareMismatch,
+    );
   });
 
   it('cannot be told what a share should be — it is a function of the inputs only', () => {

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -440,7 +440,12 @@ describe('the mutation queue', () => {
     const result = applyOutcomes(queue, [
       { clientMutationId: 'a', status: 'applied' },
       { clientMutationId: 'b', status: 'duplicate' },
-      { clientMutationId: 'c', status: 'rejected', code: SyncRejectionCode.ShareMismatch, message: 'no' },
+      {
+        clientMutationId: 'c',
+        status: 'rejected',
+        code: SyncRejectionCode.ShareMismatch,
+        message: 'no',
+      },
     ]);
 
     expect(result.queue).toHaveLength(0);
@@ -453,7 +458,9 @@ describe('the mutation queue', () => {
     expect(backoffMs(2)).toBe(4000);
     expect(backoffMs(99)).toBe(5 * 60_000);
 
-    let queue: QueuedMutation[] = [enqueue([], envelope('a', GROUP, MutationKind.ExpenseCreate))[0]!];
+    let queue: QueuedMutation[] = [
+      enqueue([], envelope('a', GROUP, MutationKind.ExpenseCreate))[0]!,
+    ];
     for (let attempt = 0; attempt < 8; attempt += 1) {
       queue = markFailed(queue, queue, 'offline', 0);
     }


### PR DESCRIPTION
## What

Turns the dashboard camera icon into a one-tap **scan receipt** flow, and adds a private receipt archive.

- **Straight to camera** — the icon opens the camera immediately (`/capture?scan=1`), not a blank form.
- **On-device OCR → itemize** — ML Kit reads the bill, then a new offline heuristic parser recovers **total, item count, and line items**; the amount is prefilled and the breakdown shown. No model, no cost, works offline.
- **Saved on the device** — the image + a JSON sidecar are written to the app's document directory. The photo **never goes to Baaki** — only the parsed fields ride the existing capture sync (`photoPath: null`).
- **Personal-cloud backup** — connect **Google Drive, Dropbox, or OneDrive** (one primary, chosen in Settings); the image + sidecar upload to your own drive when online.
- **Network policy** — Settings toggle for **Wi‑Fi only** vs **Wi‑Fi + mobile data**; the queue also runs on app-foreground and network-change.

## Design decisions (confirmed with the user)
- All three providers implemented.
- Image lives **device + your cloud only, never Baaki**.
- **Heuristic parser now**, model (`receipt-parse`) takes over automatically once it's funded.
- Backup payload = **image + parsed JSON sidecar**.

## Structure
- `packages/core/src/receipt/heuristic.ts` — `parseReceiptText` → `ParsedReceipt` + confidence (minor units); confidence from the existing `checkReceipt`. +10 tests.
- `apps/mobile/src/lib/receiptStore.ts` / `receiptIndex.ts` — device vault + backup ledger.
- `apps/mobile/src/lib/cloud/*` — one `CloudProvider` interface, three implementations over a shared **PKCE** OAuth helper; tokens in the keystore (`secureAuthStorage`); `backupQueue` + `BackupProvider`.
- `capture.tsx`, `settings/backup.tsx` (+ route + row), i18n `backup` namespace (en/ta/hi/ar).

## Setup needed to go live
Client ids are **public installed-app** ids (PKCE, no secret) read from `EXPO_PUBLIC_CLOUD_*` — see `.env.example`. Register one app per provider with redirect `baaki://oauthredirect`. Blank id ⇒ provider shows "not set up". **Live OAuth/upload can't be exercised until these are supplied.**

## Verification
- `@baaki/core`: `vitest run` — 533 pass (incl. 10 new heuristic tests).
- `@baaki/mobile`: `tsc --noEmit` clean; `expo lint` clean.
- No backend/schema change (captures already carry `parsed`/`photoPath`).

## Notes / limits
- A second Baaki device sees the parsed capture but not the photo (by design — the personal cloud is the cross-device archive).
- Heuristic parsing is approximate on messy bills; the single amount stays editable.
- Zero-decimal currencies (e.g. JPY) are over-scaled by the minor-unit assumption — a known limit of parsing without the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)