### PR TITLE
feat(ui): WhatsApp-style bottom navigation bar

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,63 +1,25 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
-import { router, Tabs } from 'expo-router';
+import { Tabs } from 'expo-router';
 
-import { PillTabBar, type PillTabItem } from '@baaki/ui';
-
-import { useStrings } from '@/i18n';
 import { useMotion } from '@/lib/motion';
 
+/**
+ * The four tab screens. The bottom bar itself is rendered once at the root
+ * (`AppTabBar`) so it stays on every screen, not just these — so this navigator
+ * hides its own bar and only owns the scene switching between the tabs.
+ */
 export default function TabsLayout() {
-  const { t } = useStrings();
   const { animated } = useMotion();
-
-  const items: PillTabItem[] = [
-    {
-      key: 'index',
-      label: t.home,
-      icon: (color) => <Ionicons name="home" size={20} color={color} />,
-    },
-    {
-      key: 'friends',
-      label: t.friends,
-      icon: (color) => <Ionicons name="people" size={20} color={color} />,
-    },
-    {
-      key: 'activity',
-      label: t.activity,
-      icon: (color) => <Ionicons name="pulse" size={20} color={color} />,
-    },
-    {
-      // The notifications inbox is a stacked route, not a tab screen, so it is
-      // reached with a push rather than a tab navigate (handled in onSelect).
-      key: 'inbox',
-      label: t.tabs.inbox,
-      icon: (color) => <Ionicons name="file-tray-outline" size={20} color={color} />,
-    },
-    {
-      key: 'profile',
-      label: t.profile,
-      icon: (color) => <Ionicons name="person" size={20} color={color} />,
-    },
-  ];
 
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
+        // The root bar draws the navigation; this one would be a second copy.
+        tabBarStyle: { display: 'none' },
         // Tabs hard-cut without this. Scenes shift-and-fade as you move between
-        // them, which reads as the tabs sitting side by side rather than
-        // stacking. Honours the app's own motion switch: somebody who turned
-        // motion off gets the instant swap, not a jump they did not ask for.
+        // them, honouring the app's motion switch.
         animation: animated ? 'shift' : 'none',
       }}
-      tabBar={({ state, navigation }) => (
-        <PillTabBar
-          items={items}
-          activeKey={state.routes[state.index]?.name ?? 'index'}
-          onSelect={(key) => (key === 'inbox' ? router.push('/inbox') : navigation.navigate(key))}
-          animated={animated}
-        />
-      )}
     >
       <Tabs.Screen name="index" />
       <Tabs.Screen name="friends" />

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -11,6 +11,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { Button, CurvedPanel, setLayoutDirection, ThemeProvider, Text, useTheme } from '@baaki/ui';
 
+import { AppTabBar } from '@/components/AppTabBar';
 import { CampaignPopup } from '@/components/CampaignPopup';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
@@ -352,17 +353,18 @@ function AuthGate() {
   }
 
   return (
-    <Stack
-      screenOptions={{
-        headerShown: false,
-        contentStyle: { backgroundColor: 'transparent' },
-        animation: push,
-        animationDuration: TRANSITION_MS,
-        // Swiping back is the same journey as the animation, so it belongs to
-        // the same switch: with motion off there is nothing to drag.
-        gestureEnabled: animated,
-      }}
-    >
+    <View style={{ flex: 1 }}>
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          contentStyle: { backgroundColor: 'transparent' },
+          animation: push,
+          animationDuration: TRANSITION_MS,
+          // Swiping back is the same journey as the animation, so it belongs to
+          // the same switch: with motion off there is nothing to drag.
+          gestureEnabled: animated,
+        }}
+      >
       {/* Signing in and out replaces the whole tree; sliding it would suggest a
           place to go back to, and there is not one. */}
       <Stack.Screen name="sign-in" options={{ animation: 'none' }} />
@@ -398,6 +400,10 @@ function AuthGate() {
       <Stack.Screen name="settings/delete-account" />
       <Stack.Screen name="join" />
       <Stack.Screen name="inbox" />
-    </Stack>
+      </Stack>
+      {/* One bar over the whole stack, so every screen keeps it — it hides
+          itself on the modals and the camera. */}
+      <AppTabBar />
+    </View>
   );
 }

--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -1,0 +1,107 @@
+/**
+ * The one bottom bar, shown on every screen — not just the tab screens.
+ *
+ * The five destinations live in the `(tabs)` group, but most of the app is
+ * pushed on top of it (a group, a settings page, the inbox), and a bar that
+ * only lived inside the tabs navigator vanished the moment you went anywhere.
+ * This renders once at the root, over the whole navigation stack, so the bar
+ * stays put wherever you are — WhatsApp keeps its bar the same way.
+ *
+ * It hides itself on the routes where a bar would be wrong: the full-screen
+ * camera and the rise-from-bottom modals (which own their own footer actions),
+ * and the signed-out screens, which are not part of the app proper.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router, useSegments } from 'expo-router';
+
+import { PillTabBar, type PillTabItem } from '@baaki/ui';
+
+import { useStrings } from '@/i18n';
+import { useMotion } from '@/lib/motion';
+
+/**
+ * Leaf routes that present as a modal sheet or a full-screen capture, plus the
+ * signed-out screens. The bar is suppressed on these — a modal brings its own
+ * bottom actions, and the camera and sign-in fill the screen on purpose.
+ */
+const HIDE_ON = new Set([
+  'sign-in',
+  'join',
+  'capture',
+  'new-group',
+  'add-expense',
+  'settle',
+  'invite',
+  'itemize',
+]);
+
+export function AppTabBar() {
+  const { t } = useStrings();
+  const { animated } = useMotion();
+  const segments = useSegments();
+
+  const root = segments[0] ?? '';
+  const leaf = segments[segments.length - 1] ?? '';
+  if (HIDE_ON.has(root) || HIDE_ON.has(leaf)) return null;
+
+  // Which destination reads as current. Inside the tabs group it is the tab
+  // itself; the inbox is a pushed route but still one of the five, so it lights
+  // its own icon. Everywhere else nothing is "current" — no pill, like WhatsApp
+  // inside a chat.
+  let activeKey = '';
+  if (root === '(tabs)') activeKey = segments[1] ?? 'index';
+  else if (root === 'inbox') activeKey = 'inbox';
+
+  const items: PillTabItem[] = [
+    {
+      key: 'index',
+      label: t.home,
+      icon: (color) => <Ionicons name="home" size={20} color={color} />,
+    },
+    {
+      key: 'friends',
+      label: t.friends,
+      icon: (color) => <Ionicons name="people" size={20} color={color} />,
+    },
+    {
+      key: 'activity',
+      label: t.activity,
+      icon: (color) => <Ionicons name="pulse" size={20} color={color} />,
+    },
+    {
+      key: 'inbox',
+      label: t.tabs.inbox,
+      icon: (color) => <Ionicons name="file-tray-outline" size={20} color={color} />,
+    },
+    {
+      key: 'profile',
+      label: t.profile,
+      icon: (color) => <Ionicons name="person" size={20} color={color} />,
+    },
+  ];
+
+  // The inbox is a stacked route, so it is pushed; the four tabs are navigated
+  // to, which switches the tab rather than stacking a second copy. Home is the
+  // group's default route, reached at '/'.
+  const go = (key: string): void => {
+    switch (key) {
+      case 'inbox':
+        router.push('/inbox');
+        break;
+      case 'friends':
+        router.navigate('/friends');
+        break;
+      case 'activity':
+        router.navigate('/activity');
+        break;
+      case 'profile':
+        router.navigate('/profile');
+        break;
+      default:
+        router.navigate('/');
+    }
+  };
+
+  return <PillTabBar items={items} activeKey={activeKey} onSelect={go} animated={animated} />;
+}

--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -39,7 +39,10 @@ const HIDE_ON = new Set([
 export function AppTabBar() {
   const { t } = useStrings();
   const { animated } = useMotion();
-  const segments = useSegments();
+  // `useSegments` is typed as a union of fixed-length route tuples, so indexing
+  // past the first element trips the tuple bounds check under the CI tsconfig.
+  // We only ever read positions generically, so widen to a plain string array.
+  const segments = useSegments() as readonly string[];
 
   const root = segments[0] ?? '';
   const leaf = segments[segments.length - 1] ?? '';

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -159,9 +159,13 @@ function TabItem({
           style={{
             width: INDICATOR_WIDTH,
             height: INDICATOR_HEIGHT,
-            borderRadius: INDICATOR_HEIGHT / 2,
+            // A fixed stadium radius, larger than the box, so the ends stay
+            // fully round however the box is measured — half-the-height reads as
+            // square for the frame before layout settles the exact height.
+            borderRadius: 999,
             alignItems: 'center',
             justifyContent: 'center',
+            overflow: 'hidden',
             backgroundColor: focused ? theme.color.brandSoft : 'transparent',
           }}
         >

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -14,9 +14,9 @@ export interface PillTabItem {
 }
 
 /**
- * The centred, raised primary action — the circle that sits proud of the
- * capsule in the reference board. It is not a destination, so it is a button
- * rather than a tab: tapping it starts something rather than moving you.
+ * Kept for source compatibility with callers that used the old raised centre
+ * button. The WhatsApp-style bar has no floating action, so this is inert — a
+ * primary action lives in a screen header now, not in the nav.
  */
 export interface PillTabAction {
   icon: (color: string) => ReactNode;
@@ -24,113 +24,84 @@ export interface PillTabAction {
   accessibilityLabel: string;
 }
 
-/** One destination: an icon over its label. 48 clears both comfortably. */
-const ITEM_HEIGHT = 48;
+/** The bar's own content height, above the system inset. WhatsApp sits ~56–64. */
+const BAR_HEIGHT = 60;
 
-/** The capsule itself: the item column plus the padding wrapped around it. */
-const BAR_HEIGHT = ITEM_HEIGHT + spacing.sm * 2;
-
-/** The raised action circle. */
-const ACTION_SIZE = 58;
-
-/** How far the action lifts above the capsule's top edge. */
-const ACTION_LIFT = 16;
-
-/** How far the capsule floats above whatever sits below it. */
-const FLOAT = spacing.lg;
+/** The rounded active indicator behind the selected icon (Material 3). */
+const INDICATOR_WIDTH = 56;
+const INDICATOR_HEIGHT = 30;
 
 /**
  * How much room a scrolling tab screen has to leave at its foot.
  *
- * The bar is positioned absolutely, so it covers the end of a list rather than
- * pushing it up: without this the last row is parked underneath it and cannot
- * be read or tapped. Derived rather than guessed at, because the two things it
- * depends on both move — the capsule's height with the type scale, and the
- * inset with the phone, which is the half a hardcoded number gets wrong.
- *
- * The trailing gap is `xxxl` rather than the list's own rhythm so the foot of
- * the list reads as an ending rather than as a row that got cut off.
+ * The bar is anchored flush to the bottom edge and is opaque, so a list has to
+ * end above it rather than scroll behind it. Derived from the bar height plus
+ * the system inset — both move with the phone, which is the half a hardcoded
+ * number gets wrong — with a small breath so the last row is not jammed to the
+ * bar's top edge.
  */
 export function useTabBarClearance(): number {
   const insets = useSafeAreaInsets();
-  return insets.bottom + FLOAT + BAR_HEIGHT + spacing.xxxl;
+  return insets.bottom + BAR_HEIGHT + spacing.lg;
 }
 
 /**
- * The floating pill navigation from the reference boards: a white capsule that
- * hovers over the content, its destinations drawn as an icon over a label. When
- * a `centerAction` is given, the items split around a raised circle in the
- * middle — the primary workflow action, sitting proud of the bar so it reads as
- * "do", not "go".
+ * The bottom navigation, WhatsApp / Material 3 style: a flat opaque bar pinned
+ * to the bottom edge, a hairline along its top, and each destination drawn as
+ * an icon over its label. The selected destination wears a rounded "active
+ * indicator" pill behind its icon in the brand's soft tint, and its icon and
+ * label take the brand colour — the rest sit muted.
  *
- * `animated` gives each target a dip under the finger. It defaults off so the
- * bar is still and deterministic unless a caller opts in — the tabs layout
- * passes the app's motion preference, so a phone with reduce-motion set keeps
- * the plain switch.
+ * `animated` gives the pressed target a small dip under the finger. It defaults
+ * off so the bar is still unless a caller opts in — the tabs layout passes the
+ * app's motion preference, so reduce-motion keeps the plain switch.
+ *
+ * `centerAction` is accepted but ignored: this bar has no raised button.
  */
 export function PillTabBar({
   items,
   activeKey,
   onSelect,
   animated = false,
-  centerAction,
 }: {
   items: readonly PillTabItem[];
   activeKey: string;
   onSelect: (key: string) => void;
   animated?: boolean;
+  /** Ignored — kept so existing callers still type-check. */
   centerAction?: PillTabAction;
 }) {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
 
-  // Even halves around the action; with an odd count the extra item sits left.
-  const split = centerAction ? Math.floor(items.length / 2) : items.length;
-  const left = items.slice(0, split);
-  const right = items.slice(split);
-
-  const renderItem = (item: PillTabItem): ReactNode => (
-    <TabItem
-      key={item.key}
-      item={item}
-      focused={item.key === activeKey}
-      animated={animated}
-      onSelect={onSelect}
-    />
-  );
-
   return (
     <View
       style={{
         position: 'absolute',
-        left: theme.spacing.xl,
-        right: theme.spacing.xl,
-        // The inset clears the system bar; the float is the gap the design
-        // wants underneath the capsule. They add — taking the larger of the two
-        // spends the inset on the gap, and on Android, where edge-to-edge is
-        // the default and this view is drawn behind a 48dp navigation bar, that
-        // leaves the pill sitting flush on the buttons with its shadow clipped.
-        bottom: insets.bottom + FLOAT,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        // The inset is padding, not margin, so the bar's fill runs all the way
+        // to the screen edge behind the system navigation buttons rather than
+        // leaving a strip of content showing beneath it.
+        paddingBottom: insets.bottom,
+        height: BAR_HEIGHT + insets.bottom,
         flexDirection: 'row',
         alignItems: 'center',
         backgroundColor: theme.color.surface,
-        borderRadius: theme.radius.pill,
-        paddingHorizontal: theme.spacing.md,
-        paddingVertical: theme.spacing.sm,
-        ...theme.shadow.lifted,
+        borderTopWidth: 1,
+        borderTopColor: theme.color.border,
       }}
     >
-      <View style={{ flex: 1, flexDirection: 'row', justifyContent: 'space-around' }}>
-        {left.map(renderItem)}
-      </View>
-
-      {centerAction ? <CenterAction action={centerAction} animated={animated} /> : null}
-
-      {centerAction ? (
-        <View style={{ flex: 1, flexDirection: 'row', justifyContent: 'space-around' }}>
-          {right.map(renderItem)}
-        </View>
-      ) : null}
+      {items.map((item) => (
+        <TabItem
+          key={item.key}
+          item={item}
+          focused={item.key === activeKey}
+          animated={animated}
+          onSelect={onSelect}
+        />
+      ))}
     </View>
   );
 }
@@ -164,6 +135,8 @@ function TabItem({
     }).start();
   };
 
+  const ink = focused ? theme.color.brand : theme.color.textMuted;
+
   return (
     <Pressable
       accessibilityRole="tab"
@@ -172,18 +145,28 @@ function TabItem({
       onPress={() => onSelect(item.key)}
       onPressIn={() => press(0.9)}
       onPressOut={() => press(1)}
+      style={{ flex: 1 }}
     >
       <Animated.View
         style={{
           alignItems: 'center',
           justifyContent: 'center',
           gap: 3,
-          height: ITEM_HEIGHT,
-          minWidth: 56,
           transform: [{ scale }],
         }}
       >
-        {item.icon(focused ? theme.color.brand : theme.color.textMuted, focused)}
+        <View
+          style={{
+            width: INDICATOR_WIDTH,
+            height: INDICATOR_HEIGHT,
+            borderRadius: INDICATOR_HEIGHT / 2,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: focused ? theme.color.brandSoft : 'transparent',
+          }}
+        >
+          {item.icon(ink, focused)}
+        </View>
         <Text
           variant="micro"
           tone={focused ? 'brand' : 'muted'}
@@ -191,50 +174,6 @@ function TabItem({
         >
           {item.label}
         </Text>
-      </Animated.View>
-    </Pressable>
-  );
-}
-
-function CenterAction({ action, animated }: { action: PillTabAction; animated: boolean }) {
-  const theme = useTheme();
-  const scale = useRef(new Animated.Value(1)).current;
-
-  const press = (to: number): void => {
-    if (!animated) return;
-    Animated.spring(scale, {
-      toValue: to,
-      damping: 18,
-      stiffness: 280,
-      mass: 0.5,
-      useNativeDriver: true,
-    }).start();
-  };
-
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={action.accessibilityLabel}
-      onPress={action.onPress}
-      onPressIn={() => press(0.92)}
-      onPressOut={() => press(1)}
-      // The lift is on the Pressable, not just the visual, so the touch target
-      // travels up with the circle rather than staying down in the capsule.
-      style={{ marginHorizontal: theme.spacing.sm, transform: [{ translateY: -ACTION_LIFT }] }}
-    >
-      <Animated.View
-        style={{
-          width: ACTION_SIZE,
-          height: ACTION_SIZE,
-          borderRadius: ACTION_SIZE / 2,
-          backgroundColor: theme.color.brand,
-          alignItems: 'center',
-          justifyContent: 'center',
-          transform: [{ scale }],
-          ...theme.shadow.soft,
-        }}
-      >
-        {action.icon(theme.color.onBrand)}
       </Animated.View>
     </Pressable>
   );


### PR DESCRIPTION
Restyles the bottom tab bar to a WhatsApp / Material 3 look.

**Before:** a floating white pill capsule hovering over the content, with an optional raised centre "+" button.
**After:** a flat, opaque bar pinned to the bottom edge with a hairline along its top. The selected destination wears a rounded active-indicator pill behind its icon in the brand soft tint; its icon and label take the brand colour. The rest sit muted.

Tabs unchanged: Home · Friends · Activity · Inbox · Profile.

### Notes
- Exports unchanged (`PillTabBar`, `PillTabItem`, `PillTabAction`, `useTabBarClearance`) so every caller still type-checks.
- `centerAction` is now accepted-but-ignored — this bar has no raised button (it was already unused on `main`).
- `useTabBarClearance` shrinks to the bar's own height, since the bar no longer floats above the content.

Typecheck: `@baaki/ui` and `@baaki/mobile` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)