### PR TITLE
feat(mobile): dashboard polish, bar clearance, full i18n sweep

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -65,8 +65,11 @@ tablet width, where `xl` reads as a gentle curve; on a phone the same radius eat
 into a card only a few hundred points wide and the panel starts to look like a
 pill, and pills are for things you tap.
 
-Exactly two shadows: `soft` for resting cards, `lifted` for the floating tab bar
-and the FAB. Depth means "this floats above the page", never "this is pretty".
+Exactly two shadows: `soft` for resting cards, `lifted` for the header overflow
+menu and the FAB. Depth means "this floats above the page", never "this is
+pretty". The bottom bar is the exception that proves it — it sits flat on the
+page behind a top hairline rather than floating on a shadow (see **Bottom
+navigation**).
 
 The doorway screens — the welcome and the lock screen — open with a brand-purple
 panel whose bottom edge sweeps rather than cuts (`CurvedPanel`). It is the one
@@ -123,10 +126,11 @@ The account screen opens with a hero rather than a title: the avatar, the name,
 and one number in a pill under it. Below that, `SegmentedTabs` splits what used
 to be a single long scroll into **You · Paying · Settings**.
 
-`SegmentedTabs` is not `PillTabBar`. The pill bar floats above everything and
-moves you between destinations; this sits in the page, under a rule, because the
-page you are on has three faces and this chooses which one. Two floating pills on
-one screen would be two things claiming to be the navigation.
+`SegmentedTabs` is not `PillTabBar`. The bottom bar spans the foot of every
+screen and moves you between destinations; this sits in the page, under a rule,
+because the page you are on has three faces and this chooses which one. A bar and
+an in-page switch read as two different things — where you can go, and which face
+of this page you are on — which is the point.
 
 The pill under the name is **what has actually changed hands through you** —
 settled settlements only, per currency, in both directions. The board this was
@@ -215,8 +219,29 @@ Notifications and Export is a row dressed up as a setting.
 ## Spacing
 
 4px base: `xs 4 · sm 8 · md 12 · lg 16 · xl 20 · xxl 24 · xxxl 32`. Screens use
-`xl` horizontal padding; scroll containers reserve ~170px at the bottom so the
-floating tab bar never covers the last row.
+`xl` horizontal padding; scroll containers reserve room at the bottom
+(`useTabBarClearance`) so the opaque bottom bar never covers the last row.
+
+## Bottom navigation
+
+The bar is flat and pinned to the bottom edge on **every** screen, WhatsApp
+style — a top hairline, no float, no shadow. The selected destination wears a
+rounded active-indicator pill behind its icon in the brand's soft tint; its icon
+and label take the brand colour, the rest sit muted.
+
+It is rendered once at the root over the whole navigation stack (`AppTabBar`),
+not inside the tabs navigator, so it stays put when a screen is pushed on top —
+a group, a settings page, the inbox. The tabs navigator keeps the scene
+switching but hides its own bar so there is never a second copy. The rules for
+when it hides (the camera and the rise-from-bottom modals, the signed-out
+screens) and which destination reads as current are pure and tested in
+`lib/tabBar.ts` / `test/tabBar.test.ts`.
+
+Four destinations: **Home · Friends · Activity · Inbox**. The account is not one
+of them — it is reached from the header avatar, and its settings from the
+header's three-dot overflow menu (`OverflowMenu`), a small rounded card that
+drops from the top-right over a tap-away scrim. A face you own is a way in, not a
+tab.
 
 ## Components
 

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -60,13 +60,14 @@ body {
   padding: 0;
   background: var(--bg);
   color: var(--text);
+  /* Same system-font stack as apps/web (globals.css --font-sans), so admin and
+     the web client resolve to the same UI font on every platform. */
   font-family:
-    ui-sans-serif,
-    system-ui,
     -apple-system,
+    BlinkMacSystemFont,
     'Segoe UI',
     Roboto,
-    Helvetica,
+    'Helvetica Neue',
     Arial,
     sans-serif;
   font-size: 15px;

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -10,7 +10,6 @@ import {
   Card,
   EmptyState,
   Gradient,
-  IconButton,
   Row,
   Screen,
   SectionHeader,
@@ -168,17 +167,30 @@ export default function HomeScreen() {
           <Text variant="heading" numberOfLines={1} style={{ flex: 1 }}>
             {profile?.display_name ?? t.account.you}
           </Text>
-          {/* Straight to the camera: the icon is a scanner, so it opens one
-              rather than a form to fill in first (the capture screen reads the
-              `scan` flag and launches the camera on mount). */}
-          <IconButton label={t.captures.captureCta} onPress={() => router.push('/capture?scan=1')}>
-            <Ionicons name="camera-outline" size={22} color={theme.color.text} />
-          </IconButton>
+          {/* Bare icons, no button chrome — the header reads as a title row, not
+              a toolbar of pills. Straight to the camera: the icon is a scanner,
+              so it opens one rather than a form to fill in first (the capture
+              screen reads the `scan` flag and launches the camera on mount). */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.captures.captureCta}
+            onPress={() => router.push('/capture?scan=1')}
+            hitSlop={10}
+            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+          >
+            <Ionicons name="camera-outline" size={24} color={theme.color.text} />
+          </Pressable>
           {/* The overflow: the settings and the less-used destinations, dropped
               from here rather than owning a tab. */}
-          <IconButton label={t.account.faceSettings} onPress={() => setMenuOpen(true)}>
-            <Ionicons name="ellipsis-vertical" size={22} color={theme.color.text} />
-          </IconButton>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.account.faceSettings}
+            onPress={() => setMenuOpen(true)}
+            hitSlop={10}
+            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+          >
+            <Ionicons name="ellipsis-vertical" size={24} color={theme.color.text} />
+          </Pressable>
         </Row>
 
         <OverflowMenu visible={menuOpen} onClose={() => setMenuOpen(false)} items={menuItems} />

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -157,16 +157,16 @@ export default function HomeScreen() {
               tab does rather than somewhere only reachable from here — two
               routes to one screen, not a second screen that drifts. */}
           <Avatar
-            name={profile?.display_name ?? 'You'}
+            name={profile?.display_name ?? t.account.you}
             size={44}
             photoUrl={avatarUrl}
             accessibilityLabel={t.profile}
             onPress={() => router.navigate('/profile')}
           />
-          {/* Just the name, sized up — the greeting was a word that said nothing
-              and pushed the name down into a caption. */}
-          <Text variant="title" numberOfLines={1} style={{ flex: 1 }}>
-            {profile?.display_name ?? 'You'}
+          {/* Just the name, next to the avatar — the greeting was a word that
+              said nothing and pushed the name down into a caption. */}
+          <Text variant="heading" numberOfLines={1} style={{ flex: 1 }}>
+            {profile?.display_name ?? t.account.you}
           </Text>
           {/* Straight to the camera: the icon is a scanner, so it opens one
               rather than a form to fill in first (the capture screen reads the

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -365,41 +365,41 @@ function AuthGate() {
           gestureEnabled: animated,
         }}
       >
-      {/* Signing in and out replaces the whole tree; sliding it would suggest a
+        {/* Signing in and out replaces the whole tree; sliding it would suggest a
           place to go back to, and there is not one. */}
-      <Stack.Screen name="sign-in" options={{ animation: 'none' }} />
-      <Stack.Screen name="(tabs)" options={{ animation: 'none' }} />
-      <Stack.Screen name="new-group" options={modal} />
-      <Stack.Screen name="capture" options={modal} />
-      <Stack.Screen name="captures" />
-      <Stack.Screen name="group/[id]/index" />
-      <Stack.Screen name="group/[id]/add-expense" options={modal} />
-      <Stack.Screen name="group/[id]/settle" options={modal} />
-      <Stack.Screen name="group/[id]/simplify" />
-      <Stack.Screen name="group/[id]/settings" />
-      <Stack.Screen name="group/[id]/members" />
-      <Stack.Screen name="group/[id]/member/[memberId]" />
-      <Stack.Screen name="group/[id]/expense/[expenseId]" />
-      <Stack.Screen name="group/[id]/invite" options={modal} />
-      <Stack.Screen name="group/[id]/itemize" options={modal} />
-      <Stack.Screen name="friends/contacts" />
-      <Stack.Screen name="settings/backup" />
-      <Stack.Screen name="settings/notifications" />
-      <Stack.Screen name="settings/export" />
-      <Stack.Screen name="settings/import" />
-      <Stack.Screen name="settings/lock" />
-      <Stack.Screen name="settings/devices" />
-      <Stack.Screen name="settings/motion" />
-      <Stack.Screen name="settings/theme" />
-      <Stack.Screen name="settings/language" />
-      <Stack.Screen name="settings/upgrade" />
-      <Stack.Screen name="settings/redeem" />
-      <Stack.Screen name="settings/account" />
-      <Stack.Screen name="settings/feedback" />
-      <Stack.Screen name="settings/privacy" />
-      <Stack.Screen name="settings/delete-account" />
-      <Stack.Screen name="join" />
-      <Stack.Screen name="inbox" />
+        <Stack.Screen name="sign-in" options={{ animation: 'none' }} />
+        <Stack.Screen name="(tabs)" options={{ animation: 'none' }} />
+        <Stack.Screen name="new-group" options={modal} />
+        <Stack.Screen name="capture" options={modal} />
+        <Stack.Screen name="captures" />
+        <Stack.Screen name="group/[id]/index" />
+        <Stack.Screen name="group/[id]/add-expense" options={modal} />
+        <Stack.Screen name="group/[id]/settle" options={modal} />
+        <Stack.Screen name="group/[id]/simplify" />
+        <Stack.Screen name="group/[id]/settings" />
+        <Stack.Screen name="group/[id]/members" />
+        <Stack.Screen name="group/[id]/member/[memberId]" />
+        <Stack.Screen name="group/[id]/expense/[expenseId]" />
+        <Stack.Screen name="group/[id]/invite" options={modal} />
+        <Stack.Screen name="group/[id]/itemize" options={modal} />
+        <Stack.Screen name="friends/contacts" />
+        <Stack.Screen name="settings/backup" />
+        <Stack.Screen name="settings/notifications" />
+        <Stack.Screen name="settings/export" />
+        <Stack.Screen name="settings/import" />
+        <Stack.Screen name="settings/lock" />
+        <Stack.Screen name="settings/devices" />
+        <Stack.Screen name="settings/motion" />
+        <Stack.Screen name="settings/theme" />
+        <Stack.Screen name="settings/language" />
+        <Stack.Screen name="settings/upgrade" />
+        <Stack.Screen name="settings/redeem" />
+        <Stack.Screen name="settings/account" />
+        <Stack.Screen name="settings/feedback" />
+        <Stack.Screen name="settings/privacy" />
+        <Stack.Screen name="settings/delete-account" />
+        <Stack.Screen name="join" />
+        <Stack.Screen name="inbox" />
       </Stack>
       {/* One bar over the whole stack, so every screen keeps it — it hides
           itself on the modals and the camera. */}

--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -24,6 +24,7 @@ import {
   Row,
   Screen,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -86,6 +87,7 @@ function CaptureThumb({ path, size }: { path: string; size: number }) {
 
 export default function CapturesScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const pull = usePullRefresh();
   const { profile } = useAuth();
@@ -146,7 +148,7 @@ export default function CapturesScreen() {
         <ScrollView
           contentContainerStyle={{
             paddingHorizontal: theme.spacing.xl,
-            paddingBottom: theme.spacing.xl,
+            paddingBottom: clearance,
             gap: theme.spacing.md,
           }}
           showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -35,6 +35,7 @@ import {
   Screen,
   SectionHeader,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -174,12 +175,13 @@ function ChooseGroup({
   onChoose: (groupId: string) => void;
 }): React.JSX.Element {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
   const only = contacts.length === 1 ? contacts[0] : undefined;
 
   return (
     <ScrollView
-      contentContainerStyle={{ paddingBottom: theme.spacing.xxxl, gap: theme.spacing.lg }}
+      contentContainerStyle={{ paddingBottom: clearance, gap: theme.spacing.lg }}
       showsVerticalScrollIndicator={false}
     >
       <Card style={{ gap: theme.spacing.xs }}>

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -72,7 +72,7 @@ export default function ExpenseDetailScreen() {
   const lookup = memberLookup(members.data);
   const nameOf = (memberId: string | null): string => {
     const member = memberId ? lookup.get(memberId) : undefined;
-    return member ? displayName(member, profile?.id) : 'Someone';
+    return member ? displayName(member, profile?.id) : t.misc.someone;
   };
   // The label reads "You"; the avatar keeps the real name so the current user's
   // circle is the same initial and colour here as on every other screen — a
@@ -80,7 +80,7 @@ export default function ExpenseDetailScreen() {
   // avatar made it a lone pink "Y" next to a blue "G" elsewhere for one person.
   const avatarNameOf = (memberId: string | null): string => {
     const member = memberId ? lookup.get(memberId) : undefined;
-    return member ? displayName(member) : 'Someone';
+    return member ? displayName(member) : t.misc.someone;
   };
 
   if (expenses.isLoading) {

--- a/apps/mobile/src/app/group/[id]/import/csv.tsx
+++ b/apps/mobile/src/app/group/[id]/import/csv.tsx
@@ -219,9 +219,9 @@ export default function ImportCsvScreen() {
             {!currencyMatches ? (
               <Card>
                 <Text variant="caption" tone="negative">
-                  This file is in {parsed.currency} and this group keeps its money in{' '}
-                  {groupCurrency}. Importing it would need a rate for every row, and the file does
-                  not carry one — start a {parsed.currency} group for it instead.
+                  {t.misc.csvCurrencyMismatch
+                    .replace(/\{fileCur\}/g, parsed.currency)
+                    .replace('{groupCur}', groupCurrency)}
                 </Text>
               </Card>
             ) : null}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -78,7 +78,7 @@ export default function GroupScreen() {
   const lookup = memberLookup(members.data);
   const nameOf = (memberId: string | null): string => {
     const member = memberId ? lookup.get(memberId) : undefined;
-    return member ? displayName(member, profile?.id) : 'Someone';
+    return member ? displayName(member, profile?.id) : t.misc.someone;
   };
 
   if (group.isLoading) {

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -156,8 +156,7 @@ export default function InsightsScreen() {
         ) : null}
 
         <Text variant="micro" tone="faint" align="center">
-          Live expenses only — an edited expense counts at what it now says, and a deleted one does
-          not count at all. Amounts are never converted between currencies.
+          {t.misc.insightsLiveNote}
         </Text>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -232,7 +232,7 @@ export default function MembersScreen() {
             <View key={member.id}>
               <ListRow
                 title={displayName(member, profile?.id)}
-                subtitle={isGhost(member) ? t.notJoinedYet : (vpaOf(member) ?? 'no UPI ID yet')}
+                subtitle={isGhost(member) ? t.notJoinedYet : (vpaOf(member) ?? t.misc.noUpiYet)}
                 leading={<Avatar name={displayName(member)} ghost={isGhost(member)} />}
                 onPress={() => router.push(`/group/${groupId}/member/${member.id}`)}
                 trailing={
@@ -320,9 +320,7 @@ export default function MembersScreen() {
             </View>
           ) : null}
           <Text variant="micro" tone="faint">
-            A name alone is enough — nobody needs the app, or an email, to be part of the split. An
-            address just means you can send them the link. When they join later they can claim
-            everything already recorded under their name.
+            {t.misc.nameAloneBody}
           </Text>
           {addGhost.isPending || adding ? <ActivityIndicator color={theme.color.brand} /> : null}
           {error ? <Callout tone="negative">{error}</Callout> : null}

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -71,7 +71,7 @@ export default function SpendingMonthScreen() {
   const lookup = memberLookup(members.data);
   const nameOf = (memberId: string | null): string => {
     const member = memberId ? lookup.get(memberId) : undefined;
-    return member ? displayName(member, profile?.id) : 'Someone';
+    return member ? displayName(member, profile?.id) : t.misc.someone;
   };
 
   // The expenses that make up the tapped column: live, in this currency, in this

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -182,8 +182,8 @@ export default function SettleScreen() {
 
     if (!payable) {
       Alert.alert(
-        `No ${railInfo?.label ?? 'payment'} details yet`,
-        `${displayName(counterparty)} hasn't added how they're paid. Settle in cash, or ask them to add it.`,
+        t.misc.settleNoDetailsTitle.replace('{rail}', railInfo?.label ?? t.misc.settleRailFallback),
+        t.misc.settleNoDetailsBody.replace('{name}', displayName(counterparty)),
       );
       return;
     }
@@ -210,18 +210,20 @@ export default function SettleScreen() {
     if (uri && canOpen) {
       await Linking.openURL(uri.uri);
       Alert.alert(t.extras.paymentWentThrough, t.extras.onlyIfCompleted, [
-        { text: 'No', style: 'cancel' },
-        { text: 'Yes, record it', onPress: () => void record() },
+        { text: t.misc.recordNo, style: 'cancel' },
+        { text: t.misc.recordYes, onPress: () => void record() },
       ]);
       return;
     }
 
     Alert.alert(
-      `Pay ${displayName(counterparty)}`,
-      `${railById(payable.rail)?.label ?? 'Send to'}\n${payable.handle}\n\nThen come back and record it.`,
+      t.misc.settlePayTitle.replace('{name}', displayName(counterparty)),
+      t.misc.settlePayBody
+        .replace('{rail}', railById(payable.rail)?.label ?? t.misc.settleSendTo)
+        .replace('{handle}', payable.handle),
       [
-        { text: 'Cancel', style: 'cancel' },
-        { text: 'Record it', onPress: () => void record() },
+        { text: t.common.cancel, style: 'cancel' },
+        { text: t.misc.recordIt, onPress: () => void record() },
       ],
     );
   };
@@ -265,7 +267,7 @@ export default function SettleScreen() {
           <>
             <Card style={{ gap: theme.spacing.md }}>
               <Text variant="caption" tone="muted">
-                With
+                {t.misc.withLabel}
               </Text>
               <Row style={{ flexWrap: 'wrap', gap: theme.spacing.lg }}>
                 {counterparties.map((member) => (

--- a/apps/mobile/src/app/group/[id]/simplify.tsx
+++ b/apps/mobile/src/app/group/[id]/simplify.tsx
@@ -34,7 +34,7 @@ export default function SimplifyScreen() {
 
   const nameOf = (memberId: string): string => {
     const member = lookup.get(memberId);
-    return member ? displayName(member, profile?.id) : 'Someone';
+    return member ? displayName(member, profile?.id) : t.misc.someone;
   };
 
   return (

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -28,6 +28,7 @@ import {
   Text,
   TintCard,
   tintForKey,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -65,6 +66,7 @@ function factsOf(row: NotificationRow): Record<string, string | undefined> {
 
 export default function InboxScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const pull = usePullRefresh();
   const { t, locale } = useStrings();
   const notifications = useNotifications();
@@ -88,7 +90,7 @@ export default function InboxScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -23,6 +23,7 @@ import {
   Row,
   Screen,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -32,6 +33,7 @@ import { useAuth } from '@/lib/auth';
 
 export default function AccountScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
   const { session, isGuest, refresh, withGoogle, withApple } = useAuth();
 
@@ -120,7 +122,7 @@ export default function AccountScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -31,6 +31,7 @@ import {
   SectionHeader,
   SegmentedTabs,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -41,6 +42,7 @@ import type { BackupNetworkPolicy, CloudProviderId } from '@/lib/cloud/types';
 
 export default function BackupSettingsScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const backup = useBackup();
   const [busy, setBusy] = useState<CloudProviderId | null>(null);
@@ -61,7 +63,7 @@ export default function BackupSettingsScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/delete-account.tsx
+++ b/apps/mobile/src/app/settings/delete-account.tsx
@@ -13,6 +13,7 @@ import {
   Row,
   Screen,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -36,6 +37,7 @@ import { useAuth } from '@/lib/auth';
  */
 export default function DeleteAccountScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
   const { signOut } = useAuth();
 
@@ -86,7 +88,7 @@ export default function DeleteAccountScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/settings/devices.tsx
+++ b/apps/mobile/src/app/settings/devices.tsx
@@ -25,6 +25,7 @@ import {
   Row,
   Screen,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -35,6 +36,7 @@ import { useDeviceSession } from '@/lib/deviceSession';
 
 export default function DevicesScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const queryClient = useQueryClient();
   const { signOutOthers } = useDeviceSession();
@@ -69,7 +71,7 @@ export default function DevicesScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -16,6 +16,7 @@ import {
   Row,
   Screen,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -36,6 +37,7 @@ enum Format {
  */
 export default function ExportScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const groups = useGroups();
   const { t } = useStrings();
 
@@ -81,7 +83,7 @@ export default function ExportScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/feedback.tsx
+++ b/apps/mobile/src/app/settings/feedback.tsx
@@ -14,6 +14,7 @@ import {
   Row,
   Screen,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -29,6 +30,7 @@ enum Kind {
 
 export default function FeedbackScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
 
   const [kind, setKind] = useState<Kind>(Kind.General);
@@ -66,7 +68,7 @@ export default function FeedbackScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -254,7 +254,7 @@ export default function ImportScreen() {
 
   const describeMapping = (person: string): string => {
     const chosen = mapping[person] ?? { kind: 'ghost' };
-    if (chosen.kind === 'me') return 'You';
+    if (chosen.kind === 'me') return t.account.you;
     if (chosen.kind === 'ghost') return t.importLedger.newPerson;
     const member = members.find((one) => one.id === chosen.memberId);
     return member ? displayName(member, profile?.id) : t.importLedger.newPerson;

--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -25,6 +25,7 @@ import {
   Row,
   Screen,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -34,6 +35,7 @@ import { canRestart, restartApp } from '@/lib/restart';
 
 export default function LanguageSettingsScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
   const { stored, language, phoneLanguage, setLanguage, restartNeeded } = useLanguage();
 
@@ -59,7 +61,7 @@ export default function LanguageSettingsScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/lock.tsx
+++ b/apps/mobile/src/app/settings/lock.tsx
@@ -22,6 +22,7 @@ import {
   Screen,
   Text,
   Toggle,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -31,6 +32,7 @@ import { describeGrace, GRACE_CHOICES, useLock } from '@/lib/lock';
 
 export default function LockSettingsScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { enabled, supported, graceSeconds, setEnabled, setGraceSeconds } = useLock();
   const { isGuest, signOut } = useAuth();
@@ -56,7 +58,7 @@ export default function LockSettingsScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
       >

--- a/apps/mobile/src/app/settings/motion.tsx
+++ b/apps/mobile/src/app/settings/motion.tsx
@@ -22,6 +22,7 @@ import {
   Screen,
   Text,
   Toggle,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -30,6 +31,7 @@ import { useMotion } from '@/lib/motion';
 
 export default function MotionSettingsScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
   const { animated, systemReducesMotion, overridden, setAnimated } = useMotion();
 
@@ -38,7 +40,7 @@ export default function MotionSettingsScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -14,6 +14,7 @@ import {
   SectionHeader,
   Text,
   Toggle,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -72,6 +73,7 @@ function pushFailureCopy(t: UiStrings): Record<PushFailure, string> {
 
 export default function NotificationSettingsScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
   const { profile } = useAuth();
 
@@ -141,7 +143,7 @@ export default function NotificationSettingsScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -3,7 +3,17 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ScrollView, View } from 'react-native';
 
-import { Card, directionalIcon, IconButton, Row, Screen, Text, Toggle, useTheme } from '@baaki/ui';
+import {
+  Card,
+  directionalIcon,
+  IconButton,
+  Row,
+  Screen,
+  Text,
+  Toggle,
+  useTabBarClearance,
+  useTheme,
+} from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 import { clarityConfigured } from '@/lib/clarity';
@@ -21,6 +31,7 @@ import { sessionReplayConsent, setSessionReplayConsent } from '@/lib/sessionRepl
  */
 export default function PrivacyScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
 
   // The session-replay opt-in, mirrored from storage. Only meaningful when a
@@ -68,7 +79,7 @@ export default function PrivacyScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/redeem.tsx
+++ b/apps/mobile/src/app/settings/redeem.tsx
@@ -26,6 +26,7 @@ import {
   Row,
   Screen,
   Text,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -58,6 +59,7 @@ function refusal(reason: Extract<PromoOutcome, { ok: false }>['reason'], t: UiSt
 
 export default function RedeemScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
 
   const [code, setCode] = useState('');
@@ -86,7 +88,7 @@ export default function RedeemScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/settings/theme.tsx
+++ b/apps/mobile/src/app/settings/theme.tsx
@@ -12,13 +12,24 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ScrollView, View } from 'react-native';
 
-import { Card, directionalIcon, IconButton, ListRow, Row, Screen, Text, useTheme } from '@baaki/ui';
+import {
+  Card,
+  directionalIcon,
+  IconButton,
+  ListRow,
+  Row,
+  Screen,
+  Text,
+  useTabBarClearance,
+  useTheme,
+} from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 import { SchemePreference, useThemePreference } from '@/lib/theme';
 
 export default function ThemeSettingsScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
   const { preference, systemScheme, setPreference } = useThemePreference();
 
@@ -60,7 +71,7 @@ export default function ThemeSettingsScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/upgrade.tsx
+++ b/apps/mobile/src/app/settings/upgrade.tsx
@@ -17,7 +17,17 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { ScrollView, View } from 'react-native';
 
-import { Card, directionalIcon, IconButton, ListRow, Row, Screen, Text, useTheme } from '@baaki/ui';
+import {
+  Card,
+  directionalIcon,
+  IconButton,
+  ListRow,
+  Row,
+  Screen,
+  Text,
+  useTabBarClearance,
+  useTheme,
+} from '@baaki/ui';
 
 import { useStrings, type UiStrings } from '@/i18n';
 
@@ -41,6 +51,7 @@ function conveniences(
 
 export default function UpgradeScreen() {
   const theme = useTheme();
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
 
   return (
@@ -48,7 +59,7 @@ export default function UpgradeScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -1,15 +1,16 @@
 /**
  * The one bottom bar, shown on every screen — not just the tab screens.
  *
- * The five destinations live in the `(tabs)` group, but most of the app is
- * pushed on top of it (a group, a settings page, the inbox), and a bar that
- * only lived inside the tabs navigator vanished the moment you went anywhere.
- * This renders once at the root, over the whole navigation stack, so the bar
- * stays put wherever you are — WhatsApp keeps its bar the same way.
+ * The destinations live in the `(tabs)` group, but most of the app is pushed on
+ * top of it (a group, a settings page, the inbox), and a bar that only lived
+ * inside the tabs navigator vanished the moment you went anywhere. This renders
+ * once at the root, over the whole navigation stack, so the bar stays put
+ * wherever you are — WhatsApp keeps its bar the same way.
  *
- * It hides itself on the routes where a bar would be wrong: the full-screen
- * camera and the rise-from-bottom modals (which own their own footer actions),
- * and the signed-out screens, which are not part of the app proper.
+ * It hides itself on the routes where a bar would be wrong (see `resolveTabBar`):
+ * the full-screen camera and the rise-from-bottom modals, and the signed-out
+ * screens. The account is reached from the header avatar rather than a tab, so
+ * it is not one of the bar's destinations.
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -19,22 +20,7 @@ import { PillTabBar, type PillTabItem } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 import { useMotion } from '@/lib/motion';
-
-/**
- * Leaf routes that present as a modal sheet or a full-screen capture, plus the
- * signed-out screens. The bar is suppressed on these — a modal brings its own
- * bottom actions, and the camera and sign-in fill the screen on purpose.
- */
-const HIDE_ON = new Set([
-  'sign-in',
-  'join',
-  'capture',
-  'new-group',
-  'add-expense',
-  'settle',
-  'invite',
-  'itemize',
-]);
+import { resolveTabBar } from '@/lib/tabBar';
 
 export function AppTabBar() {
   const { t } = useStrings();
@@ -44,17 +30,8 @@ export function AppTabBar() {
   // We only ever read positions generically, so widen to a plain string array.
   const segments = useSegments() as readonly string[];
 
-  const root = segments[0] ?? '';
-  const leaf = segments[segments.length - 1] ?? '';
-  if (HIDE_ON.has(root) || HIDE_ON.has(leaf)) return null;
-
-  // Which destination reads as current. Inside the tabs group it is the tab
-  // itself; the inbox is a pushed route but still one of the five, so it lights
-  // its own icon. Everywhere else nothing is "current" — no pill, like WhatsApp
-  // inside a chat.
-  let activeKey = '';
-  if (root === '(tabs)') activeKey = segments[1] ?? 'index';
-  else if (root === 'inbox') activeKey = 'inbox';
+  const { hidden, activeKey } = resolveTabBar(segments);
+  if (hidden) return null;
 
   const items: PillTabItem[] = [
     {
@@ -77,15 +54,10 @@ export function AppTabBar() {
       label: t.tabs.inbox,
       icon: (color) => <Ionicons name="file-tray-outline" size={20} color={color} />,
     },
-    {
-      key: 'profile',
-      label: t.profile,
-      icon: (color) => <Ionicons name="person" size={20} color={color} />,
-    },
   ];
 
-  // The inbox is a stacked route, so it is pushed; the four tabs are navigated
-  // to, which switches the tab rather than stacking a second copy. Home is the
+  // The inbox is a stacked route, so it is pushed; the tabs are navigated to,
+  // which switches the tab rather than stacking a second copy. Home is the
   // group's default route, reached at '/'.
   const go = (key: string): void => {
     switch (key) {
@@ -97,9 +69,6 @@ export function AppTabBar() {
         break;
       case 'activity':
         router.navigate('/activity');
-        break;
-      case 'profile':
-        router.navigate('/profile');
         break;
       default:
         router.navigate('/');

--- a/apps/mobile/src/components/CampaignPopup.tsx
+++ b/apps/mobile/src/components/CampaignPopup.tsx
@@ -21,6 +21,7 @@ import * as Clipboard from 'expo-clipboard';
 
 import { Button, Text, useTheme } from '@baaki/ui';
 
+import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { supabase } from '@/lib/supabase';
 
@@ -43,6 +44,7 @@ async function fetchCampaign(): Promise<Campaign | null> {
 
 export function CampaignPopup() {
   const theme = useTheme();
+  const { t } = useStrings();
   const { session } = useAuth();
   const queryClient = useQueryClient();
   const [dismissed, setDismissed] = useState(false);
@@ -92,7 +94,7 @@ export function CampaignPopup() {
           advertisement, and this is not one. */}
       <Pressable
         onPress={close}
-        accessibilityLabel="Dismiss"
+        accessibilityLabel={t.common.close}
         style={{
           flex: 1,
           backgroundColor: 'rgba(10, 10, 26, 0.55)',
@@ -134,19 +136,19 @@ export function CampaignPopup() {
                 {campaign.promo_code}
               </Text>
               <Text variant="micro" tone="muted">
-                {copied ? 'Copied' : 'Tap the button to copy'}
+                {copied ? t.misc.copied : t.misc.tapToCopy}
               </Text>
             </View>
           ) : null}
 
           <View style={{ gap: theme.spacing.sm, paddingTop: theme.spacing.sm }}>
             <Button
-              label={campaign.cta_label || 'Got it'}
+              label={campaign.cta_label || t.misc.gotIt}
               size="lg"
               fullWidth
               onPress={() => void act()}
             />
-            <Button label="Not now" variant="secondary" size="sm" fullWidth onPress={close} />
+            <Button label={t.misc.notNow} variant="secondary" size="sm" fullWidth onPress={close} />
           </View>
         </Pressable>
       </Pressable>

--- a/apps/mobile/src/components/CountryPicker.tsx
+++ b/apps/mobile/src/components/CountryPicker.tsx
@@ -65,7 +65,7 @@ export function CountryRow({
               gap: theme.spacing.xs,
             }}
           >
-            <Text variant="heading">Where does this group settle?</Text>
+            <Text variant="heading">{t.misc.whereSettle}</Text>
             <Text variant="caption" tone="muted">
               {t.pickers.countryNote}
             </Text>

--- a/apps/mobile/src/components/CurrencyRate.tsx
+++ b/apps/mobile/src/components/CurrencyRate.tsx
@@ -193,7 +193,7 @@ export function CurrencyRate({
                 style={inputStyle(theme)}
               />
               <Text variant="micro" tone="faint">
-                Your bank&apos;s rate, markup included — this is what your statement says.
+                {t.misc.bankRateNote}
               </Text>
             </View>
           ) : null}

--- a/apps/mobile/src/components/DictateVoice.tsx
+++ b/apps/mobile/src/components/DictateVoice.tsx
@@ -156,7 +156,7 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
 
       {listening ? (
         <Text variant="micro" tone="brand">
-          Listening…
+          {t.misc.listening}
         </Text>
       ) : null}
 

--- a/apps/mobile/src/components/DisputePanel.tsx
+++ b/apps/mobile/src/components/DisputePanel.tsx
@@ -92,7 +92,7 @@ export function DisputePanel({
           <Text variant="caption" tone="muted">
             {`${nameOf(row.member_id)} says:`}
           </Text>
-          <Text variant="body">{row.reason ?? 'No reason given'}</Text>
+          <Text variant="body">{row.reason ?? t.misc.noReasonGiven}</Text>
 
           {canAnswer ? (
             answering === row.id ? (
@@ -152,11 +152,10 @@ export function DisputePanel({
             </Text>
           ) : null}
           <Text variant="micro" tone="faint">
-            Nothing has changed yet — your share stands until the expense is corrected. That is
-            deliberate: a share anybody could drop on their own would not be a ledger.
+            {t.misc.disputeStands}
           </Text>
           <Button
-            label="Never mind, it’s fine"
+            label={t.misc.neverMind}
             size="sm"
             variant="ghost"
             disabled={busy}
@@ -166,7 +165,7 @@ export function DisputePanel({
       ) : writing ? (
         <View style={{ gap: theme.spacing.sm }}>
           <Text variant="caption" tone="muted">
-            What’s wrong with it?
+            {t.misc.whatsWrongWithIt}
           </Text>
           <TextInput
             value={reason}
@@ -209,7 +208,7 @@ export function DisputePanel({
               say, so it is offered first and equally. */}
           <Button label={t.dispute.fixItMyself} size="sm" variant="secondary" onPress={onEdit} />
           <Button
-            label="Something’s wrong"
+            label={t.misc.somethingsWrong}
             size="sm"
             variant="ghost"
             onPress={() => setWriting(true)}

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -175,11 +175,11 @@ export function TripDates({
     <Card style={{ gap: theme.spacing.lg }}>
       <View style={{ gap: theme.spacing.xs }}>
         <Row style={{ justifyContent: 'space-between', gap: theme.spacing.sm }}>
-          <Text variant="subheading">Trip dates</Text>
+          <Text variant="subheading">{t.misc.tripDatesTitle}</Text>
           <Pressable
             accessibilityRole="button"
             accessibilityState={{ expanded: showInfo }}
-            accessibilityLabel="About trip dates"
+            accessibilityLabel={t.misc.aboutTripDates}
             hitSlop={8}
             onPress={() => setShowInfo((open) => !open)}
             style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
@@ -193,9 +193,7 @@ export function TripDates({
         </Row>
         {showInfo ? (
           <Text variant="caption" tone="muted">
-            While the trip is on, everybody gets a nudge to add what they spent — at breakfast about
-            yesterday, and at the end of the day about today. Nobody is asked about a day they have
-            already added to.
+            {t.misc.tripDatesBody}
           </Text>
         ) : null}
       </View>

--- a/apps/mobile/src/components/UpdateGate.tsx
+++ b/apps/mobile/src/components/UpdateGate.tsx
@@ -81,8 +81,8 @@ function BlockingScreen(): React.JSX.Element {
       </View>
 
       <Text variant="micro" tone="faint" align="center">
-        You have {installed}
-        {latest ? ` · ${latest} is available` : ''}
+        {t.misc.youHaveVersion.replace('{installed}', installed)}
+        {latest ? t.misc.versionAvailable.replace('{latest}', latest) : ''}
       </Text>
     </View>
   );

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -815,6 +815,39 @@ export interface UiStrings {
     followMyPhone: string;
     currentlyLanguage: string;
     rightToLeft: string;
+    // Settle payment alerts, dispute panel, trip dates, currency-rate note,
+    // dictation status, country picker, update footer, campaign popup,
+    // insights note, members note, and the CSV currency mismatch.
+    withLabel: string;
+    settleNoDetailsTitle: string;
+    settleNoDetailsBody: string;
+    settleRailFallback: string;
+    settlePayTitle: string;
+    settlePayBody: string;
+    settleSendTo: string;
+    recordYes: string;
+    recordNo: string;
+    recordIt: string;
+    noReasonGiven: string;
+    disputeStands: string;
+    neverMind: string;
+    whatsWrongWithIt: string;
+    somethingsWrong: string;
+    tripDatesTitle: string;
+    aboutTripDates: string;
+    tripDatesBody: string;
+    bankRateNote: string;
+    listening: string;
+    whereSettle: string;
+    youHaveVersion: string;
+    versionAvailable: string;
+    gotIt: string;
+    copied: string;
+    tapToCopy: string;
+    insightsLiveNote: string;
+    nameAloneBody: string;
+    noUpiYet: string;
+    csvCurrencyMismatch: string;
   };
   /** Pasting bank messages in, and what can be made of them (TDR §10). */
   smsImport: {
@@ -1838,6 +1871,42 @@ const en: UiStrings = {
     followMyPhone: 'Follow my phone',
     currentlyLanguage: 'Currently {language}',
     rightToLeft: 'right to left',
+    withLabel: 'With',
+    settleNoDetailsTitle: 'No {rail} details yet',
+    settleNoDetailsBody:
+      "{name} hasn't added how they're paid. Settle in cash, or ask them to add it.",
+    settleRailFallback: 'payment',
+    settlePayTitle: 'Pay {name}',
+    settlePayBody: '{rail}\n{handle}\n\nThen come back and record it.',
+    settleSendTo: 'Send to',
+    recordYes: 'Yes, record it',
+    recordNo: 'No',
+    recordIt: 'Record it',
+    noReasonGiven: 'No reason given',
+    disputeStands:
+      'Nothing has changed yet — your share stands until the expense is corrected. That is deliberate: a share anybody could drop on their own would not be a ledger.',
+    neverMind: 'Never mind, it’s fine',
+    whatsWrongWithIt: 'What’s wrong with it?',
+    somethingsWrong: 'Something’s wrong',
+    tripDatesTitle: 'Trip dates',
+    aboutTripDates: 'About trip dates',
+    tripDatesBody:
+      'While the trip is on, everybody gets a nudge to add what they spent — at breakfast about yesterday, and at the end of the day about today. Nobody is asked about a day they have already added to.',
+    bankRateNote: 'Your bank’s rate, markup included — this is what your statement says.',
+    listening: 'Listening…',
+    whereSettle: 'Where does this group settle?',
+    youHaveVersion: 'You have {installed}',
+    versionAvailable: ' · {latest} is available',
+    gotIt: 'Got it',
+    copied: 'Copied',
+    tapToCopy: 'Tap the button to copy',
+    insightsLiveNote:
+      'Live expenses only — an edited expense counts at what it now says, and a deleted one does not count at all. Amounts are never converted between currencies.',
+    nameAloneBody:
+      'A name alone is enough — nobody needs the app, or an email, to be part of the split. An address just means you can send them the link. When they join later they can claim everything already recorded under their name.',
+    noUpiYet: 'no UPI ID yet',
+    csvCurrencyMismatch:
+      'This file is in {fileCur} and this group keeps its money in {groupCur}. Importing it would need a rate for every row, and the file does not carry one — start a {fileCur} group for it instead.',
   },
   smsImport: {
     title: 'Import from messages',
@@ -2928,6 +2997,43 @@ const ta: UiStrings = {
     followMyPhone: 'என் ஃபோனைப் பின்பற்று',
     currentlyLanguage: 'தற்போது {language}',
     rightToLeft: 'வலமிருந்து இடம்',
+    withLabel: 'உடன்',
+    settleNoDetailsTitle: '{rail} விவரங்கள் இன்னும் இல்லை',
+    settleNoDetailsBody:
+      '{name} தாங்கள் எப்படி பணம் பெறுகிறார்கள் என்பதைச் சேர்க்கவில்லை. பணமாகத் தீர்த்துக்கொள்ளுங்கள் அல்லது அதைச் சேர்க்கச் சொல்லுங்கள்.',
+    settleRailFallback: 'கட்டணம்',
+    settlePayTitle: '{name}க்குச் செலுத்து',
+    settlePayBody: '{rail}\n{handle}\n\nபிறகு திரும்பி வந்து பதிவு செய்யுங்கள்.',
+    settleSendTo: 'இதற்கு அனுப்பு',
+    recordYes: 'ஆம், பதிவு செய்',
+    recordNo: 'இல்லை',
+    recordIt: 'பதிவு செய்',
+    noReasonGiven: 'காரணம் எதுவும் தரப்படவில்லை',
+    disputeStands:
+      'இன்னும் எதுவும் மாறவில்லை — செலவு திருத்தப்படும் வரை உங்கள் பங்கு நிலைக்கும். இது வேண்டுமென்றே: யாரும் தாமாகவே நீக்கக்கூடிய பங்கு ஒரு கணக்கேடாக இருக்காது.',
+    neverMind: 'பரவாயில்லை, சரிதான்',
+    whatsWrongWithIt: 'இதில் என்ன தவறு?',
+    somethingsWrong: 'ஏதோ தவறு',
+    tripDatesTitle: 'பயணத் தேதிகள்',
+    aboutTripDates: 'பயணத் தேதிகள் பற்றி',
+    tripDatesBody:
+      'பயணம் நடக்கும்போது, செலவழித்ததைச் சேர்க்க அனைவருக்கும் நினைவூட்டல் வரும் — காலை உணவின்போது நேற்றைக்கும், நாள் முடிவில் இன்றைக்கும். ஏற்கனவே சேர்த்த நாளைப் பற்றி யாரையும் கேட்கப்படாது.',
+    bankRateNote:
+      'உங்கள் வங்கியின் விகிதம், கூடுதல் கட்டணம் உட்பட — இதுதான் உங்கள் அறிக்கையில் இருக்கும்.',
+    listening: 'கேட்கிறது…',
+    whereSettle: 'இந்தக் குழு எங்கே தீர்த்துக்கொள்கிறது?',
+    youHaveVersion: 'உங்களிடம் {installed} உள்ளது',
+    versionAvailable: ' · {latest} கிடைக்கிறது',
+    gotIt: 'சரி',
+    copied: 'நகலெடுக்கப்பட்டது',
+    tapToCopy: 'நகலெடுக்க பொத்தானைத் தட்டவும்',
+    insightsLiveNote:
+      'நேரடிச் செலவுகள் மட்டும் — திருத்தப்பட்ட செலவு இப்போது சொல்வதன்படி கணக்கிடப்படும், நீக்கப்பட்டது கணக்கில் வராது. தொகைகள் நாணயங்களுக்கிடையே மாற்றப்படாது.',
+    nameAloneBody:
+      'ஒரு பெயர் மட்டும் போதும் — பிரிவில் பங்கேற்க யாருக்கும் ஆப் அல்லது மின்னஞ்சல் தேவையில்லை. முகவரி என்பது அவர்களுக்கு இணைப்பை அனுப்பலாம் என்பதுதான். பின்னர் அவர்கள் சேரும்போது தங்கள் பெயரில் பதிவான அனைத்தையும் உரிமை கொள்ளலாம்.',
+    noUpiYet: 'இன்னும் UPI ஐடி இல்லை',
+    csvCurrencyMismatch:
+      'இந்தக் கோப்பு {fileCur} இல் உள்ளது, இந்தக் குழு தன் பணத்தை {groupCur} இல் வைத்திருக்கிறது. இதை இறக்குமதி செய்ய ஒவ்வொரு வரிசைக்கும் ஒரு விகிதம் தேவை, கோப்பு அதைக் கொண்டிருக்கவில்லை — அதற்குப் பதிலாக ஒரு {fileCur} குழுவைத் தொடங்குங்கள்.',
   },
   smsImport: {
     title: 'செய்திகளிலிருந்து இறக்குமதி',
@@ -4000,6 +4106,42 @@ const hi: UiStrings = {
     followMyPhone: 'मेरे फ़ोन के अनुसार',
     currentlyLanguage: 'अभी {language}',
     rightToLeft: 'दाएँ से बाएँ',
+    withLabel: 'किसके साथ',
+    settleNoDetailsTitle: '{rail} का विवरण अभी नहीं है',
+    settleNoDetailsBody:
+      '{name} ने यह नहीं जोड़ा कि उन्हें भुगतान कैसे मिलता है। नकद में निपटाएँ, या उनसे जोड़ने को कहें।',
+    settleRailFallback: 'भुगतान',
+    settlePayTitle: '{name} को भुगतान करें',
+    settlePayBody: '{rail}\n{handle}\n\nफिर वापस आकर दर्ज करें।',
+    settleSendTo: 'यहाँ भेजें',
+    recordYes: 'हाँ, दर्ज करें',
+    recordNo: 'नहीं',
+    recordIt: 'दर्ज करें',
+    noReasonGiven: 'कोई कारण नहीं दिया गया',
+    disputeStands:
+      'अभी कुछ नहीं बदला — खर्च ठीक होने तक आपका हिस्सा बना रहता है। यह जानबूझकर है: जिस हिस्से को कोई अकेले हटा सके, वह बहीखाता नहीं होगा।',
+    neverMind: 'कोई बात नहीं, ठीक है',
+    whatsWrongWithIt: 'इसमें क्या गलत है?',
+    somethingsWrong: 'कुछ गलत है',
+    tripDatesTitle: 'यात्रा की तारीखें',
+    aboutTripDates: 'यात्रा की तारीखों के बारे में',
+    tripDatesBody:
+      'जब तक यात्रा चलती है, सभी को खर्च जोड़ने का संकेत मिलता है — नाश्ते के समय कल के बारे में, और दिन के अंत में आज के बारे में। जिस दिन को पहले ही जोड़ लिया गया, उसके बारे में किसी से नहीं पूछा जाता।',
+    bankRateNote: 'आपके बैंक की दर, मार्कअप सहित — यही आपके स्टेटमेंट में दिखता है।',
+    listening: 'सुन रहा है…',
+    whereSettle: 'यह समूह कहाँ निपटान करता है?',
+    youHaveVersion: 'आपके पास {installed} है',
+    versionAvailable: ' · {latest} उपलब्ध है',
+    gotIt: 'समझ गया',
+    copied: 'कॉपी हो गया',
+    tapToCopy: 'कॉपी करने के लिए बटन दबाएँ',
+    insightsLiveNote:
+      'केवल सक्रिय खर्च — संपादित खर्च अब जो कहता है उसी पर गिना जाता है, और हटाया गया बिल्कुल नहीं गिना जाता। रकम कभी मुद्राओं के बीच नहीं बदली जाती।',
+    nameAloneBody:
+      'सिर्फ़ एक नाम काफ़ी है — बँटवारे में शामिल होने के लिए किसी को ऐप या ईमेल की ज़रूरत नहीं। पता होने का मतलब बस इतना कि आप उन्हें लिंक भेज सकते हैं। बाद में जब वे जुड़ते हैं, तो अपने नाम पर दर्ज सब कुछ अपना बना सकते हैं।',
+    noUpiYet: 'अभी कोई UPI आईडी नहीं',
+    csvCurrencyMismatch:
+      'यह फ़ाइल {fileCur} में है और यह समूह अपना पैसा {groupCur} में रखता है। इसे आयात करने के लिए हर पंक्ति के लिए एक दर चाहिए, और फ़ाइल में वह नहीं है — इसके बजाय एक {fileCur} समूह शुरू करें।',
   },
   smsImport: {
     title: 'संदेशों से आयात',
@@ -5141,6 +5283,42 @@ const ar: UiStrings = {
     followMyPhone: 'اتبع هاتفي',
     currentlyLanguage: 'حاليًا {language}',
     rightToLeft: 'من اليمين إلى اليسار',
+    withLabel: 'مع',
+    settleNoDetailsTitle: 'لا توجد تفاصيل {rail} بعد',
+    settleNoDetailsBody:
+      'لم يُضِف {name} كيفية استلامه للمدفوعات. سوِّ نقدًا، أو اطلب منه إضافتها.',
+    settleRailFallback: 'الدفع',
+    settlePayTitle: 'ادفع إلى {name}',
+    settlePayBody: '{rail}\n{handle}\n\nثم عُد وسجِّل ذلك.',
+    settleSendTo: 'أرسل إلى',
+    recordYes: 'نعم، سجِّلها',
+    recordNo: 'لا',
+    recordIt: 'سجِّلها',
+    noReasonGiven: 'لم يُذكر سبب',
+    disputeStands:
+      'لم يتغيّر شيء بعد — يبقى نصيبك قائمًا حتى يُصحَّح المصروف. هذا مقصود: نصيب يستطيع أي شخص إسقاطه بمفرده لن يكون دفترًا.',
+    neverMind: 'لا بأس، الأمر جيّد',
+    whatsWrongWithIt: 'ما الخطأ فيه؟',
+    somethingsWrong: 'هناك خطأ ما',
+    tripDatesTitle: 'تواريخ الرحلة',
+    aboutTripDates: 'حول تواريخ الرحلة',
+    tripDatesBody:
+      'أثناء الرحلة، يتلقّى الجميع تذكيرًا بإضافة ما أنفقوه — عند الإفطار عن الأمس، وفي نهاية اليوم عن اليوم. لا يُسأل أحد عن يوم سبق أن أضافه.',
+    bankRateNote: 'سعر بنكك، شاملًا الهامش — هذا ما يقوله كشف حسابك.',
+    listening: 'يستمع…',
+    whereSettle: 'أين تُسوّي هذه المجموعة حساباتها؟',
+    youHaveVersion: 'لديك {installed}',
+    versionAvailable: ' · {latest} متاح',
+    gotIt: 'حسنًا',
+    copied: 'تم النسخ',
+    tapToCopy: 'اضغط الزر للنسخ',
+    insightsLiveNote:
+      'المصروفات الحيّة فقط — المصروف المُعدَّل يُحتسب بما يقوله الآن، والمحذوف لا يُحتسب إطلاقًا. لا تُحوَّل المبالغ بين العملات أبدًا.',
+    nameAloneBody:
+      'الاسم وحده يكفي — لا يحتاج أحد إلى التطبيق أو بريد إلكتروني ليكون جزءًا من التقسيم. العنوان يعني فقط أنه يمكنك إرسال الرابط إليه. وعندما ينضمّون لاحقًا يمكنهم المطالبة بكل ما سُجِّل باسمهم.',
+    noUpiYet: 'لا يوجد معرّف UPI بعد',
+    csvCurrencyMismatch:
+      'هذا الملف بعملة {fileCur} وهذه المجموعة تحتفظ بأموالها بعملة {groupCur}. استيراده يحتاج إلى سعر لكل صف، والملف لا يحمل ذلك — ابدأ بدلًا من ذلك مجموعة بعملة {fileCur}.',
   },
   smsImport: {
     title: 'استيراد من الرسائل',

--- a/apps/mobile/src/lib/tabBar.ts
+++ b/apps/mobile/src/lib/tabBar.ts
@@ -1,0 +1,56 @@
+/**
+ * The rules the root bottom bar follows, kept pure so they can be tested.
+ *
+ * The bar is rendered once over the whole navigation stack (see `AppTabBar`),
+ * and two questions decide what it does on any given screen: should it show at
+ * all, and which of the five destinations reads as current. Both are a function
+ * of the route segments alone, so they live here away from the component.
+ */
+
+/**
+ * Leaf or root route names the bar hides on: the full-screen camera and the
+ * rise-from-bottom modals (which own their own footer actions), and the
+ * signed-out screens, which are not part of the app proper.
+ */
+export const TAB_BAR_HIDDEN_ROUTES: ReadonlySet<string> = new Set([
+  'sign-in',
+  'join',
+  'capture',
+  'new-group',
+  'add-expense',
+  'settle',
+  'invite',
+  'itemize',
+]);
+
+export interface TabBarState {
+  /** True when the bar should not render on this route at all. */
+  readonly hidden: boolean;
+  /**
+   * The destination key that reads as current: one of the four tabs, or
+   * 'inbox', or '' when nothing is current (inside a group, settings, etc.).
+   */
+  readonly activeKey: string;
+}
+
+/**
+ * Resolve the bar's state from the current route segments.
+ *
+ * `hidden` wins first: a modal or the camera or a signed-out screen shows no
+ * bar. Otherwise the active destination is the tab inside the `(tabs)` group,
+ * or the pushed inbox, or nothing when you are deeper in the app.
+ */
+export function resolveTabBar(segments: readonly string[]): TabBarState {
+  const root = segments[0] ?? '';
+  const leaf = segments[segments.length - 1] ?? '';
+
+  if (TAB_BAR_HIDDEN_ROUTES.has(root) || TAB_BAR_HIDDEN_ROUTES.has(leaf)) {
+    return { hidden: true, activeKey: '' };
+  }
+
+  let activeKey = '';
+  if (root === '(tabs)') activeKey = segments[1] ?? 'index';
+  else if (root === 'inbox') activeKey = 'inbox';
+
+  return { hidden: false, activeKey };
+}

--- a/apps/mobile/test/tabBar.test.ts
+++ b/apps/mobile/test/tabBar.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTabBar } from '../src/lib/tabBar';
+
+describe('resolveTabBar', () => {
+  it('lights the current tab inside the tabs group', () => {
+    expect(resolveTabBar(['(tabs)', 'index'])).toEqual({ hidden: false, activeKey: 'index' });
+    expect(resolveTabBar(['(tabs)', 'friends'])).toEqual({ hidden: false, activeKey: 'friends' });
+    expect(resolveTabBar(['(tabs)', 'activity'])).toEqual({ hidden: false, activeKey: 'activity' });
+  });
+
+  it('defaults to home when the tabs group has no leaf yet', () => {
+    expect(resolveTabBar(['(tabs)'])).toEqual({ hidden: false, activeKey: 'index' });
+  });
+
+  it('lights the inbox on its pushed route', () => {
+    expect(resolveTabBar(['inbox'])).toEqual({ hidden: false, activeKey: 'inbox' });
+  });
+
+  it('shows the bar with nothing current deeper in the app', () => {
+    expect(resolveTabBar(['group', '[id]'])).toEqual({ hidden: false, activeKey: '' });
+    expect(resolveTabBar(['settings', 'notifications'])).toEqual({ hidden: false, activeKey: '' });
+    expect(resolveTabBar(['captures'])).toEqual({ hidden: false, activeKey: '' });
+  });
+
+  it('does not light the removed account tab even when on it', () => {
+    // The profile screen still exists and is reached from the header avatar,
+    // but it is no longer a bar destination, so nothing lights.
+    const state = resolveTabBar(['(tabs)', 'profile']);
+    expect(state.hidden).toBe(false);
+    expect(['index', 'friends', 'activity', 'inbox']).not.toContain(state.activeKey);
+  });
+
+  it('hides on the full-screen camera and the signed-out screens', () => {
+    expect(resolveTabBar(['capture']).hidden).toBe(true);
+    expect(resolveTabBar(['sign-in']).hidden).toBe(true);
+    expect(resolveTabBar(['join']).hidden).toBe(true);
+    expect(resolveTabBar(['new-group']).hidden).toBe(true);
+  });
+
+  it('hides on the rise-from-bottom modals nested under a group', () => {
+    expect(resolveTabBar(['group', '[id]', 'add-expense']).hidden).toBe(true);
+    expect(resolveTabBar(['group', '[id]', 'settle']).hidden).toBe(true);
+    expect(resolveTabBar(['group', '[id]', 'invite']).hidden).toBe(true);
+    expect(resolveTabBar(['group', '[id]', 'itemize']).hidden).toBe(true);
+  });
+
+  it('keeps the bar on non-modal group sub-screens', () => {
+    expect(resolveTabBar(['group', '[id]', 'members']).hidden).toBe(false);
+    expect(resolveTabBar(['group', '[id]', 'settings']).hidden).toBe(false);
+  });
+
+  it('treats an empty segment list as the resting home state', () => {
+    expect(resolveTabBar([])).toEqual({ hidden: false, activeKey: '' });
+  });
+});


### PR DESCRIPTION
Follow-up polish on the new bottom bar + header, an app-wide i18n sweep, and two small consistency fixes.

## Dashboard header
- Name at `heading` size (was oversized), `You` fallback now `t.account.you`.
- Header icons (camera + three-dot overflow) rendered **bare** — no rounded IconButton pill.

## Bottom bar
- Account/Profile removed as a destination (reached via the header avatar + overflow menu). Bar is now Home · Friends · Activity · Inbox.
- Hide/active-key logic extracted to `lib/tabBar.ts` with `test/tabBar.test.ts` (9 cases).
- **Clearance fix:** 17 pushed scroll screens (settings/*, captures, inbox, contacts) now reserve `useTabBarClearance` so their last row no longer sits under the bar (reported on Privacy).

## i18n sweep
Every remaining hardcoded user-visible English literal audited and wired through i18n. Reused existing keys where possible; added **30 new keys** under `misc` across **all four locales (en/ta/hi/ar)**. Files: settle alerts, DisputePanel, TripDates, CurrencyRate, DictateVoice, CountryPicker, UpdateGate, CampaignPopup, insights, members, import/csv, group name fallbacks, settings/import.
> ⚠️ The ta/hi/ar strings are machine-authored — worth a native-speaker review before release.

## Consistency
- DESIGN.md: new "Bottom navigation" section; stale floating-pill text corrected.
- Admin CSS font stack aligned to the web app's (both now resolve to the same system UI font). Font audit confirmed: no custom typeface anywhere, no ad-hoc `fontFamily`, all copy goes through the shared `Text`/`variant`.

## Verification
typecheck ✓ · lint ✓ · prettier ✓ · 215/215 mobile tests ✓ (incl. locale-parity + new tab-bar cases). Verified live on the Pixel_9_Pro emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)