### PR TITLE
fix(security): groups column-guard + app security headers + CI dep/secret scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Weekly dependency PRs. The CI `security` job blocks a merge on a high-severity
+# advisory in production code; this is the other half — the routine bumps that
+# keep us off those advisories in the first place, across the workspace and the
+# GitHub Actions we pin.
+version: 2
+updates:
+  - package-ecosystem: npm # pnpm workspaces use the npm ecosystem
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # One PR for the routine patch/minor noise instead of dozens; majors still
+      # come as their own reviewable PRs.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,35 @@ jobs:
           path: apps/web/playwright-report/
           retention-days: 7
 
+  security:
+    name: secret + dependency scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # Full history so the secret scan sees every commit, not just the tip —
+        # a key added and "removed" in a later commit still lives in the history.
+        with:
+          fetch-depth: 0
+      - name: Secret scan (gitleaks)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Merge-blocking only on CRITICAL production advisories — the ones worth
+      # stopping a release for. The tree currently carries several high-severity
+      # advisories that live entirely in transitive build tooling (metro's
+      # image-size, postcss's nanoid, prisma's effect) with no non-major fix at
+      # our level; gating merges on those would wedge every PR for something we
+      # cannot patch. High/moderate remediation is the weekly Dependabot PRs'
+      # job (.github/dependabot.yml); this gate catches a genuine critical.
+      - name: Dependency audit (production, critical)
+        run: pnpm audit --prod --audit-level=critical
+
   e2e:
     name: e2e (Maestro)
     runs-on: ubuntu-latest

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -21,6 +21,16 @@ const nextConfig: NextConfig = {
         { key: 'X-Robots-Tag', value: 'noindex, nofollow' },
         { key: 'X-Frame-Options', value: 'DENY' },
         { key: 'Referrer-Policy', value: 'no-referrer' },
+        // Added alongside the existing three: pin HTTPS, stop MIME sniffing,
+        // and forbid framing at the CSP level too. A private console has no
+        // reason ever to be embedded or served over plaintext.
+        { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+        { key: 'X-Content-Type-Options', value: 'nosniff' },
+        { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        {
+          key: 'Content-Security-Policy',
+          value: "frame-ancestors 'none'; upgrade-insecure-requests",
+        },
       ],
     },
   ],

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -21,8 +21,30 @@ import type { NextConfig } from 'next';
  * be known at build time. Changing the link shape to a query string would
  * break every link already sent.
  */
+/**
+ * Response security headers for every route.
+ *
+ * This app is a public SPA behind an invite token, so the headers are the
+ * conservative, framework-agnostic set that cannot break script loading:
+ * HSTS to pin HTTPS, `nosniff`, a strict referrer policy, and clickjacking
+ * protection via both `X-Frame-Options` and a CSP `frame-ancestors 'none'`.
+ * `upgrade-insecure-requests` is the only CSP directive here — a full
+ * script/style CSP needs per-request nonces this static config cannot mint,
+ * and a wrong one would silently break hydration, so it is deliberately left
+ * to a follow-up rather than shipped untested.
+ */
+const SECURITY_HEADERS = [
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  { key: 'Content-Security-Policy', value: "frame-ancestors 'none'; upgrade-insecure-requests" },
+];
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  headers: async () => [{ source: '/:path*', headers: SECURITY_HEADERS }],
 };
 
 /**

--- a/packages/db/prisma/migrations/20260815120000_groups_write_column_guard/migration.sql
+++ b/packages/db/prisma/migrations/20260815120000_groups_write_column_guard/migration.sql
@@ -1,0 +1,72 @@
+-- Pinning the columns of `public.groups` a client may never write.
+--
+-- The 2026-08-07 hardening revoked direct client writes on the ledger tables
+-- and column-guarded `group_members`, but `groups` was missed: it still carries
+-- the broad `groups_update` RLS policy (row-scoped by `is_group_member(id)`,
+-- 20260804163800) with no column guard. `/sync` narrows a `group.update` to a
+-- whitelist (`GROUP_UPDATABLE_FIELDS`), but that whitelist lives in the edge
+-- function — a member can bypass it entirely with a direct
+-- `PATCH /groups?id=eq.<X>` under their own JWT and set ANY column.
+--
+-- The dangerous one is `updated_seq`. It is the pull high-water mark every
+-- member's sync compares against (`gt('updated_seq', since)`); the
+-- `groups_stamp_seq` BEFORE-UPDATE trigger only auto-bumps it when the client
+-- did NOT supply a value, so a client-supplied `updated_seq` passes straight
+-- through. Poisoning it to a large number makes every member's cursor jump past
+-- it, after which all real future changes are silently skipped — group-wide
+-- ledger divergence, no error anywhere.
+--
+-- Same shape as `baaki_guard_membership_columns`: a BEFORE-UPDATE trigger that
+-- lets service-role / SECURITY DEFINER / migration paths through untouched and
+-- forbids a signed-in client from moving the structural columns. The whitelist
+-- fields (name, currency, reminders, …) are untouched, so both `/sync` (which
+-- runs as the caller) and any legitimate direct field edit keep working.
+--
+-- Trigger fire order matters: BEFORE triggers run alphabetically by name, so
+-- `groups_guard_columns` fires before `groups_stamp_seq`. On a legitimate edit
+-- the client never sends `updated_seq`, the guard sees no change and returns,
+-- and the stamp trigger then bumps it as before.
+
+CREATE OR REPLACE FUNCTION public.baaki_guard_group_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Service-role jobs, SECURITY DEFINER functions (run as owner) and migrations
+  -- are the only paths that legitimately touch these columns. A signed-in
+  -- client — `anon` or `authenticated` — is never one of them.
+  IF current_user NOT IN ('anon', 'authenticated') THEN
+    RETURN NEW;
+  END IF;
+
+  -- The sync high-water mark. Only `groups_stamp_seq` (a trigger, owner-run)
+  -- may advance it; a client that sets it can desync the whole group.
+  IF NEW.updated_seq IS DISTINCT FROM OLD.updated_seq THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: updated_seq is set by the server, not the client'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Provenance and identity are fixed at creation.
+  IF NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creator is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.id IS DISTINCT FROM OLD.id THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s id is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creation time is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS groups_guard_columns ON public.groups;
+CREATE TRIGGER groups_guard_columns
+  BEFORE UPDATE ON public.groups
+  FOR EACH ROW EXECUTE FUNCTION public.baaki_guard_group_columns();

--- a/packages/db/test/security-hardening.test.ts
+++ b/packages/db/test/security-hardening.test.ts
@@ -314,6 +314,51 @@ describe('a membership is not yours to rewrite', () => {
   });
 });
 
+describe('a group’s own columns are not a member’s to rewrite', () => {
+  it('refuses poisoning updated_seq straight through the table', async () => {
+    // `groups_update` checks membership on the row, not the columns, and the
+    // sync whitelist that would have stopped this lives in the edge function —
+    // a direct PATCH went around it. Setting `updated_seq` to a large number
+    // jumps every member's pull cursor past all future real changes.
+    await asClient(scene.profiles[1] as string, async () => {
+      const message = await expectDenied(
+        client.query(`UPDATE groups SET updated_seq = 999999 WHERE id = $1`, [scene.groupId]),
+      );
+      expect(message).toMatch(/FORBIDDEN_COLUMN/);
+    });
+  });
+
+  it('refuses rewriting who created the group', async () => {
+    await asClient(scene.profiles[1] as string, async () => {
+      const message = await expectDenied(
+        client.query(`UPDATE groups SET created_by = $2 WHERE id = $1`, [
+          scene.groupId,
+          scene.profiles[1],
+        ]),
+      );
+      expect(message).toMatch(/FORBIDDEN_COLUMN/);
+    });
+  });
+
+  it('still lets a member rename the group, and stamps the sequence itself', async () => {
+    await asClient(scene.profiles[1] as string, async () => {
+      const before = await client.query(`SELECT updated_seq FROM groups WHERE id = $1`, [
+        scene.groupId,
+      ]);
+      const renamed = await client.query(`UPDATE groups SET name = 'Goa 2' WHERE id = $1`, [
+        scene.groupId,
+      ]);
+      expect(renamed.rowCount).toBe(1);
+      const after = await client.query(`SELECT updated_seq FROM groups WHERE id = $1`, [
+        scene.groupId,
+      ]);
+      // The guard runs before the stamp trigger, so a legitimate edit still
+      // gets its cursor bumped by the server.
+      expect(BigInt(after.rows[0].updated_seq)).toBeGreaterThan(BigInt(before.rows[0].updated_seq));
+    });
+  });
+});
+
 describe('the parts of the database that are nobody’s business', () => {
   it('hides the migration ledger', async () => {
     // Prisma creates this table outside the migration that turns RLS on, so it


### PR DESCRIPTION
Follow-up hardening from a full audit of the repo against the 14-item security baseline. Three of the four selected fixes; **CORS allowlist is a separate PR** (touches 13 edge functions on the `edge:deploy` path).

## 🔴 P0 — data integrity: `groups` column guard
The 2026-08-07 hardening revoked client writes on the ledger tables and column-guarded `group_members`, but **`public.groups` was missed**. It still carries the broad `groups_update` RLS policy (row-scoped by `is_group_member(id)`, no column guard). `/sync` narrows a `group.update` to `GROUP_UPDATABLE_FIELDS`, but that whitelist lives in the edge function — a member bypasses it with a direct `PATCH /groups?id=eq.X` under their own JWT and writes **any** column.

Worst case: set `groups.updated_seq` (the pull high-water mark) to a huge value → every member's cursor jumps past it → `gt('updated_seq', since)` silently skips all future real changes → **group-wide ledger divergence, no error anywhere**.

**Fix** (`20260815120000_groups_write_column_guard`): `baaki_guard_group_columns` BEFORE UPDATE trigger, same shape as `baaki_guard_membership_columns` — pins `updated_seq`/`created_by`/`id`/`created_at` for `anon`/`authenticated`; service role, SECURITY DEFINER and the `groups_stamp_seq` trigger pass through. Guard sorts before the stamp trigger, so legitimate edits still get their cursor bumped. Three regression tests added to `security-hardening.test.ts` (poison `updated_seq` → denied, rewrite `created_by` → denied, rename still works + auto-stamps).

## 🟡 P1 — security headers
- **apps/web** had none → adds HSTS, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `X-Frame-Options: DENY`, `Permissions-Policy`, and a CSP (`frame-ancestors 'none'; upgrade-insecure-requests`).
- **apps/admin** gains HSTS, nosniff, Permissions-Policy and the CSP alongside its existing X-Frame-Options / Referrer-Policy / noindex.
- Full script/style CSP deferred — needs per-request nonces this static config can't mint; a wrong one silently breaks hydration.

## 🟢 P2 — supply chain
- CI `security` job: **gitleaks** (full history) + **`pnpm audit --prod`** gated at **critical** (0 today). High/moderate advisories are all unfixable transitive build tooling (metro→image-size, next/expo→nanoid, prisma→effect); gating on those would wedge every merge, so they go to Dependabot instead.
- `.github/dependabot.yml`: weekly npm (grouped minor/patch) + github-actions.

## Audit result (for the record)
Clean already: hidden keys, RLS coverage, field-tampering (sync recomputes money + whitelists), input validation, output escaping, endpoint rate-limiting, response trimming, HTTPS, keystore secrets, hashed auth (delegated to Supabase). Gaps found: the `groups` write path (P0, fixed here), headers (P1, fixed), CI scans (P2, fixed), CORS `*` (separate PR).

## Verification
`typecheck`, `lint`, `prettier`, and prod audit (critical) green locally. DB trigger + new tests execute in CI's `database` job against fresh Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added stronger security headers to the web and admin applications, including clickjacking, MIME-sniffing, permissions, and content-security protections.
  * Prevented unauthorized changes to protected group fields while preserving legitimate group updates.

* **Bug Fixes**
  * Group name changes now remain supported and automatically update change tracking.

* **Tests**
  * Added coverage verifying group update protections and valid update behavior.

* **Chores**
  * Added automated dependency update management.
  * Added CI checks for exposed secrets and critical production dependency vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->