### PR TITLE
fix(security): lock edge CORS to an allowlist instead of wildcard

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -20,6 +20,56 @@ export const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
+/**
+ * The origins allowed to read a response in a browser, from `ALLOWED_ORIGINS`
+ * (comma-separated). Left empty the value is `*` — the historical default —
+ * so nothing changes until the env var is set; every function goes through the
+ * same list the moment it is.
+ *
+ * This only ever matters to a browser: these APIs authenticate on the
+ * `Authorization` header, never a cookie, and set no `Allow-Credentials`, so a
+ * permissive value cannot be turned into credentialed cross-origin theft. The
+ * allowlist is defence in depth against a stray site scripting the API in a
+ * signed-in user's browser, not the thing standing between an attacker and the
+ * data. Native clients send no `Origin` and ignore CORS entirely.
+ */
+const ALLOWED_ORIGINS = (Deno.env.get('ALLOWED_ORIGINS') ?? '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+function allowedOrigin(request: Request): string {
+  if (ALLOWED_ORIGINS.length === 0) return '*';
+  const origin = request.headers.get('origin');
+  if (origin && ALLOWED_ORIGINS.includes(origin)) return origin;
+  // A configured origin the browser did not send: any real allowlisted value
+  // works as a deliberate non-match, so an unlisted site's request fails the
+  // browser's own origin check.
+  return ALLOWED_ORIGINS[0];
+}
+
+/**
+ * `Deno.serve` with CORS handled once, in one place: the preflight is answered
+ * and every response leaves with the resolved `Access-Control-Allow-Origin`
+ * (overriding the `*` that `json()` still carries for the no-allowlist case).
+ * Functions call this instead of `Deno.serve` and drop their own OPTIONS line.
+ */
+export function serveWithCors(handler: (request: Request) => Promise<Response>): void {
+  Deno.serve(async (request) => {
+    if (request.method === 'OPTIONS') {
+      return new Response('ok', {
+        headers: { ...CORS_HEADERS, 'Access-Control-Allow-Origin': allowedOrigin(request) },
+      });
+    }
+    const response = await handler(request);
+    response.headers.set('Access-Control-Allow-Origin', allowedOrigin(request));
+    // Cached by any proxy keyed on the origin it was resolved for, never reused
+    // across origins.
+    if (ALLOWED_ORIGINS.length > 0) response.headers.set('Vary', 'Origin');
+    return response;
+  });
+}
+
 export class HttpError extends Error {
   constructor(
     readonly status: number,

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -25,7 +25,7 @@
 import {
   asCaller,
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -37,9 +37,7 @@ interface DeleteRequest {
   reason?: string | null;
 }
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
 

--- a/supabase/functions/campaign-broadcast/index.ts
+++ b/supabase/functions/campaign-broadcast/index.ts
@@ -27,7 +27,7 @@
 
 import {
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -54,9 +54,7 @@ const MAX_PER_RUN = 150;
 
 const UUID = /^[0-9a-f-]{36}$/i;
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') {
       throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'POST a campaign id to broadcast it');

--- a/supabase/functions/email-events/index.ts
+++ b/supabase/functions/email-events/index.ts
@@ -18,7 +18,7 @@
  * quietly frozen at whatever it happened to hold.
  */
 
-import { asService, CORS_HEADERS, errorResponse, HttpError, json } from '../_shared/auth.ts';
+import { asService, errorResponse, serveWithCors, HttpError, json } from '../_shared/auth.ts';
 import { verifyWebhookSignature } from '../_shared/core.js';
 
 interface ResendWebhook {
@@ -35,9 +35,7 @@ function eventNameOf(type: string): string {
   return type.startsWith('email.') ? type.slice('email.'.length) : type;
 }
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
 

--- a/supabase/functions/email-unsubscribe/index.ts
+++ b/supabase/functions/email-unsubscribe/index.ts
@@ -17,7 +17,14 @@
  * button; the button posts.
  */
 
-import { asService, CORS_HEADERS, errorResponse, HttpError, json } from '../_shared/auth.ts';
+import {
+  asService,
+  CORS_HEADERS,
+  errorResponse,
+  HttpError,
+  json,
+  serveWithCors,
+} from '../_shared/auth.ts';
 import { normaliseAddress, verifyUnsubscribe } from '../_shared/core.js';
 
 const HTML_HEADERS = { ...CORS_HEADERS, 'content-type': 'text/html; charset=utf-8' };
@@ -46,9 +53,7 @@ function escape(value: string): string {
     .replace(/"/g, '&quot;');
 }
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     const url = new URL(request.url);
     let address = url.searchParams.get('address') ?? '';

--- a/supabase/functions/expense-write/index.ts
+++ b/supabase/functions/expense-write/index.ts
@@ -21,7 +21,7 @@ import {
 import {
   asCaller,
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -57,11 +57,7 @@ interface ExpenseWriteRequest {
   clientMutationId: string;
 }
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') {
-    return new Response('ok', { headers: CORS_HEADERS });
-  }
-
+serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') {
       throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');

--- a/supabase/functions/export-data/index.ts
+++ b/supabase/functions/export-data/index.ts
@@ -12,7 +12,7 @@
 import {
   asCaller,
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -28,9 +28,7 @@ interface ExportRequest {
   csvSeparator?: string;
 }
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
 

--- a/supabase/functions/fx-rate/index.ts
+++ b/supabase/functions/fx-rate/index.ts
@@ -20,7 +20,7 @@
 import {
   asCaller,
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -49,9 +49,7 @@ function toRational(value: number): { num: string; den: string } {
   };
 }
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     const url = new URL(request.url);
     const from = (url.searchParams.get('from') ?? '').toUpperCase();

--- a/supabase/functions/invite-accept/index.ts
+++ b/supabase/functions/invite-accept/index.ts
@@ -17,7 +17,7 @@ import { GUEST_GROUP_LIMIT, GUEST_TRIAL_DAYS } from '../_shared/core.js';
 import {
   asCaller,
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -37,9 +37,7 @@ async function sha256Hex(value: string): Promise<string> {
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
 

--- a/supabase/functions/invite-mint/index.ts
+++ b/supabase/functions/invite-mint/index.ts
@@ -9,7 +9,7 @@
 import {
   asCaller,
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -34,9 +34,7 @@ async function sha256Hex(value: string): Promise<string> {
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
 

--- a/supabase/functions/notify-fanout/index.ts
+++ b/supabase/functions/notify-fanout/index.ts
@@ -27,7 +27,7 @@ import {
 } from '../_shared/core.js';
 import {
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -77,9 +77,7 @@ function factsOf(payload: Record<string, unknown>): Record<string, string | unde
   };
 }
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     // A plain comparison against the service key rather than a JWT check: this
     // is machine-to-machine, the caller is a scheduler, and the key never

--- a/supabase/functions/receipt-parse/index.ts
+++ b/supabase/functions/receipt-parse/index.ts
@@ -16,7 +16,7 @@ import { checkReceipt, type ParsedReceipt } from '../_shared/core.js';
 import {
   asCaller,
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -140,9 +140,7 @@ const MODEL = 'claude-opus-5';
  */
 const FALLBACK_SCAN_LIMIT = 20;
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
 

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -36,7 +36,7 @@ import {
 import {
   asCaller,
   asService,
-  CORS_HEADERS,
+  serveWithCors,
   errorResponse,
   HttpError,
   json,
@@ -144,9 +144,7 @@ const SETTLEMENT_SELECT = `
   allocations:settlement_allocations ( expense_id, amount )
 `;
 
-Deno.serve(async (request) => {
-  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
-
+serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
 


### PR DESCRIPTION
Fourth and final item from the security-baseline audit (follow-up to #169).

## What
All 12 edge functions answered CORS with `Access-Control-Allow-Origin: *`, shared from `_shared/auth.ts`. This replaces the wildcard with an env-driven allowlist.

## Why (and why it's low-risk)
The APIs authenticate on the `Authorization` header, never a cookie, and set no `Allow-Credentials` — so `*` can't be leveraged for credentialed cross-origin theft. This is defence-in-depth against a stray site scripting the API inside a signed-in user's browser, not a critical hole. Tightening it is hygiene.

## How
New `serveWithCors` wrapper in `_shared/auth.ts` replaces each function's `Deno.serve` + hand-rolled `OPTIONS` line:
- answers the preflight, and
- stamps the resolved `Access-Control-Allow-Origin` + `Vary: Origin` on **every** response, in one place.

Origin resolves against `ALLOWED_ORIGINS` (comma-separated env var). **Left unset it resolves to `*`** — the historical behaviour — so this ships **inert**: zero behaviour change until the env var is set on the project, at which point the allowlist takes effect across all functions at once. `email-unsubscribe` keeps `CORS_HEADERS` for its HTML responses; all others dropped the import.

## Deploy
- No behaviour change on deploy (still `*` until `ALLOWED_ORIGINS` is set).
- Needs `pnpm edge:deploy` (all 12 functions).
- To activate: set `ALLOWED_ORIGINS` (e.g. the web + admin origins) in the Supabase project env, then redeploy.

## Verification
`edge:build` green; prettier green. No Deno typecheck in CI or locally (no deno on this machine) — changes are mechanical (`Deno.serve` → `serveWithCors`, OPTIONS removed) and reviewed per-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)