### PR TITLE
feat(mobile): balance cards by verdict + group header polish

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -163,10 +163,21 @@ export default function HomeScreen() {
             onPress={() => router.navigate('/profile')}
           />
           {/* Just the name, next to the avatar — the greeting was a word that
-              said nothing and pushed the name down into a caption. */}
-          <Text variant="heading" numberOfLines={1} style={{ flex: 1 }}>
-            {profile?.display_name ?? t.account.you}
-          </Text>
+              said nothing and pushed the name down into a caption. The name is
+              a tap target too, to the same account screen the avatar opens: the
+              whole name-and-face cluster reads as one way in, not a live icon
+              beside dead text. */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.profile}
+            onPress={() => router.navigate('/profile')}
+            hitSlop={8}
+            style={({ pressed }) => ({ flex: 1, opacity: pressed ? 0.5 : 1 })}
+          >
+            <Text variant="heading" numberOfLines={1}>
+              {profile?.display_name ?? t.account.you}
+            </Text>
+          </Pressable>
           {/* Bare icons, no button chrome — the header reads as a title row, not
               a toolbar of pills. Straight to the camera: the icon is a scanner,
               so it opens one rather than a form to fill in first (the capture

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -523,11 +523,26 @@ function BalanceCarousel({
   );
 }
 
-/** One balance card: the brand wash, the net big, the owed/owe split beneath. */
+/**
+ * One balance card, coloured by its verdict: a green wash when the net is owed
+ * to you, red when you owe, and the neutral brand wash once everything is
+ * settled — so the card's colour, not just its number, tells you where you
+ * stand at a glance. The net big, the owed/owe split beneath.
+ */
 function BalanceCard({ total, locale, t }: { total: CurrencyTotal; locale: string; t: UiStrings }) {
   const theme = useTheme();
+  const wash =
+    total.net > 0n
+      ? theme.gradient.positive
+      : total.net < 0n
+        ? theme.gradient.negative
+        : theme.gradient.brand;
   return (
-    <Gradient radius={theme.radius.md} style={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}>
+    <Gradient
+      colors={wash}
+      radius={theme.radius.lg}
+      style={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
+    >
       <Row style={{ justifyContent: 'space-between' }}>
         <Text variant="caption" tone="onBrand">
           {t.yourBaaki}
@@ -594,7 +609,7 @@ function TripCard({ trip, locale, t }: { trip: TripSlide; locale: string; t: UiS
     >
       <Gradient
         colors={theme.gradient.accent}
-        radius={theme.radius.md}
+        radius={theme.radius.lg}
         style={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
       >
         <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -140,7 +140,22 @@ export default function GroupScreen() {
             >
               <Ionicons name={directionalIcon('chevron-back')} size={24} color={theme.color.text} />
             </Pressable>
-            <Row style={{ flex: 1, gap: theme.spacing.md, justifyContent: 'flex-start' }}>
+            {/* The photo-and-name cluster is itself the way into settings, the
+              way tapping a chat's title bar opens its info in WhatsApp — so the
+              name is a tap target, not just a label above a menu. */}
+            <Pressable
+              onPress={() => router.push(`/group/${groupId}/settings`)}
+              accessibilityRole="button"
+              accessibilityLabel={t.group.settings}
+              style={({ pressed }) => ({
+                flex: 1,
+                flexDirection: 'row',
+                gap: theme.spacing.md,
+                justifyContent: 'flex-start',
+                alignItems: 'center',
+                opacity: pressed ? 0.6 : 1,
+              })}
+            >
               <GroupPhoto
                 photoPath={group.data.photo_path}
                 emoji={group.data.cover_emoji}
@@ -154,7 +169,7 @@ export default function GroupScreen() {
                   {plural(locale, members.data?.length ?? 0, t.memberCount)}
                 </Text>
               </View>
-            </Row>
+            </Pressable>
             {/* Planner, spending and settings live behind this one menu; planner
               only shows for a trip. Bare icon, no chip, to match the back
               arrow. */}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -12,7 +12,6 @@ import {
   directionalIcon,
   EmptyState,
   Fab,
-  IconButton,
   ListRow,
   MoneyText,
   Row,
@@ -62,6 +61,7 @@ export default function GroupScreen() {
   const { profile } = useAuth();
   const [tab, setTab] = useState<Tab>(Tab.Expenses);
   const [showDeleted, setShowDeleted] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   // Live updates from the other devices in this group (TDR §1).
   useGroupRealtime(groupId);
@@ -130,11 +130,17 @@ export default function GroupScreen() {
             />
           }
         >
-          <Row style={{ paddingTop: theme.spacing.md }}>
-            <IconButton label={t.common.back} onPress={() => router.back()}>
-              <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
-            </IconButton>
-            <Row style={{ flex: 1, gap: theme.spacing.md, justifyContent: 'center' }}>
+          <Row style={{ paddingTop: theme.spacing.md, gap: theme.spacing.sm }}>
+            {/* Just the arrow and its tap target — no chip behind it. */}
+            <Pressable
+              onPress={() => router.back()}
+              accessibilityRole="button"
+              accessibilityLabel={t.common.back}
+              hitSlop={10}
+            >
+              <Ionicons name={directionalIcon('chevron-back')} size={24} color={theme.color.text} />
+            </Pressable>
+            <Row style={{ flex: 1, gap: theme.spacing.md, justifyContent: 'flex-start' }}>
               <GroupPhoto
                 photoPath={group.data.photo_path}
                 emoji={group.data.cover_emoji}
@@ -149,10 +155,25 @@ export default function GroupScreen() {
                 </Text>
               </View>
             </Row>
-            {/* Planner, spending and settings live behind one menu now, so the
-              name has the row to itself. Planner only shows for a trip. */}
-            <GroupMenu groupId={groupId} isTrip={group.data.type === 'trip'} />
+            {/* Planner, spending and settings live behind this one menu; planner
+              only shows for a trip. Bare icon, no chip, to match the back
+              arrow. */}
+            <Pressable
+              onPress={() => setMenuOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel={t.group.more}
+              hitSlop={10}
+            >
+              <Ionicons name="ellipsis-vertical" size={22} color={theme.color.text} />
+            </Pressable>
           </Row>
+
+          <GroupMenu
+            groupId={groupId}
+            isTrip={group.data.type === 'trip'}
+            open={menuOpen}
+            onClose={() => setMenuOpen(false)}
+          />
 
           <SyncBanner groupId={groupId} />
 

--- a/apps/mobile/src/components/GroupMenu.tsx
+++ b/apps/mobile/src/components/GroupMenu.tsx
@@ -1,34 +1,46 @@
 /**
- * The group screen's overflow menu.
+ * The group screen's overflow menu — the sheet only.
  *
  * The header used to line up a back button, the group's name, and then three
  * more circular buttons — planner, spending, settings — all competing for the
  * same row. On a narrow phone the name was the thing that gave way. So the
- * three collapse into one `•••`, which now opens a real menu rather than
- * jumping straight to settings: three dots that behave like three dots.
+ * three collapse into one menu, and the separate `•••` button has now gone too:
+ * the group's own icon and name in the header are the tap target that opens it,
+ * so the header carries a single control instead of two.
+ *
+ * This component is therefore controlled — the caller owns `open` and renders
+ * whatever trigger it likes — and is just the bottom sheet.
  *
  * Planner only appears where there is a trip to plan; a flatshare has no use
  * for it, and a menu row nobody taps is just another thing to read past.
  */
 
-import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { Modal, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Card, directionalIcon, IconButton, ListRow, useTheme } from '@baaki/ui';
+import { Card, directionalIcon, ListRow, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 
-export function GroupMenu({ groupId, isTrip }: { groupId: string; isTrip: boolean }) {
+export function GroupMenu({
+  groupId,
+  isTrip,
+  open,
+  onClose,
+}: {
+  groupId: string;
+  isTrip: boolean;
+  open: boolean;
+  onClose: () => void;
+}) {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
   const { t } = useStrings();
-  const [open, setOpen] = useState(false);
 
   const go = (path: string): void => {
-    setOpen(false);
+    onClose();
     router.push(path as never);
   };
 
@@ -52,64 +64,58 @@ export function GroupMenu({ groupId, isTrip }: { groupId: string; isTrip: boolea
   );
 
   return (
-    <>
-      <IconButton label={t.group.more} onPress={() => setOpen(true)}>
-        <Ionicons name="ellipsis-horizontal" size={20} color={theme.color.text} />
-      </IconButton>
-
-      <Modal visible={open} transparent animationType="slide" onRequestClose={() => setOpen(false)}>
-        {/* Backdrop: a tap anywhere off the sheet closes it. */}
-        <Pressable
-          accessibilityLabel={t.common.close}
-          onPress={() => setOpen(false)}
-          style={{ flex: 1, backgroundColor: '#00000066', justifyContent: 'flex-end' }}
-        >
-          {/* Stop taps on the sheet itself from reaching the backdrop. */}
-          <Pressable onPress={() => {}}>
-            <Card
+    <Modal visible={open} transparent animationType="slide" onRequestClose={onClose}>
+      {/* Backdrop: a tap anywhere off the sheet closes it. */}
+      <Pressable
+        accessibilityLabel={t.common.close}
+        onPress={onClose}
+        style={{ flex: 1, backgroundColor: '#00000066', justifyContent: 'flex-end' }}
+      >
+        {/* Stop taps on the sheet itself from reaching the backdrop. */}
+        <Pressable onPress={() => {}}>
+          <Card
+            style={{
+              borderTopLeftRadius: theme.radius.xxl,
+              borderTopRightRadius: theme.radius.xxl,
+              borderBottomLeftRadius: 0,
+              borderBottomRightRadius: 0,
+              paddingBottom: insets.bottom + theme.spacing.md,
+              gap: theme.spacing.xs,
+            }}
+          >
+            <View
               style={{
-                borderTopLeftRadius: theme.radius.xxl,
-                borderTopRightRadius: theme.radius.xxl,
-                borderBottomLeftRadius: 0,
-                borderBottomRightRadius: 0,
-                paddingBottom: insets.bottom + theme.spacing.md,
-                gap: theme.spacing.xs,
+                alignSelf: 'center',
+                width: 40,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: theme.color.border,
+                marginBottom: theme.spacing.sm,
               }}
-            >
-              <View
-                style={{
-                  alignSelf: 'center',
-                  width: 40,
-                  height: 4,
-                  borderRadius: 2,
-                  backgroundColor: theme.color.border,
-                  marginBottom: theme.spacing.sm,
-                }}
-              />
+            />
+            <ListRow
+              title={t.spending}
+              leading={chip('pie-chart-outline')}
+              trailing={chevron}
+              onPress={() => go(`/group/${groupId}/insights`)}
+            />
+            {isTrip ? (
               <ListRow
-                title={t.spending}
-                leading={chip('pie-chart-outline')}
+                title={t.plan}
+                leading={chip('map-outline')}
                 trailing={chevron}
-                onPress={() => go(`/group/${groupId}/insights`)}
+                onPress={() => go(`/group/${groupId}/plan`)}
               />
-              {isTrip ? (
-                <ListRow
-                  title={t.plan}
-                  leading={chip('map-outline')}
-                  trailing={chevron}
-                  onPress={() => go(`/group/${groupId}/plan`)}
-                />
-              ) : null}
-              <ListRow
-                title={t.group.settings}
-                leading={chip('settings-outline')}
-                trailing={chevron}
-                onPress={() => go(`/group/${groupId}/settings`)}
-              />
-            </Card>
-          </Pressable>
+            ) : null}
+            <ListRow
+              title={t.group.settings}
+              leading={chip('settings-outline')}
+              trailing={chevron}
+              onPress={() => go(`/group/${groupId}/settings`)}
+            />
+          </Card>
         </Pressable>
-      </Modal>
-    </>
+      </Pressable>
+    </Modal>
   );
 }

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -129,10 +129,13 @@ export function IconButton({
           borderRadius: theme.radius.pill,
           alignItems: 'center',
           justifyContent: 'center',
-          backgroundColor: tone === 'brand' ? theme.color.brand : theme.color.surface,
+          // Default (surface) is a bare icon — no chip, no shadow — so a top bar
+          // reads as just its icons and their actions. `brand` stays a filled
+          // circle: it marks the one deliberate call to action, not navigation.
+          backgroundColor: tone === 'brand' ? theme.color.brand : 'transparent',
           opacity: pressed ? 0.8 : 1,
         },
-        theme.shadow.soft,
+        tone === 'brand' ? theme.shadow.soft : null,
       ]}
     >
       {children}

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -40,6 +40,10 @@ export interface Theme {
     readonly brand: readonly string[];
     /** A second, blue wash for the paired action tile. */
     readonly accent: readonly string[];
+    /** Green wash for a balance in your favour. */
+    readonly positive: readonly string[];
+    /** Red wash for a balance you owe. */
+    readonly negative: readonly string[];
   };
   readonly tint: Readonly<Record<TintName, TintPair>>;
   readonly radius: typeof radius;
@@ -92,7 +96,12 @@ const lightTheme: Theme = {
     warning: palette.warning,
     warningSoft: palette.peach,
   },
-  gradient: { brand: gradients.light, accent: gradients.accentLight },
+  gradient: {
+    brand: gradients.light,
+    accent: gradients.accentLight,
+    positive: gradients.positiveLight,
+    negative: gradients.negativeLight,
+  },
   tint: lightTints,
   radius,
   spacing,
@@ -123,7 +132,12 @@ const darkTheme: Theme = {
     warning: '#E8A54B',
     warningSoft: '#463020',
   },
-  gradient: { brand: gradients.dark, accent: gradients.accentDark },
+  gradient: {
+    brand: gradients.dark,
+    accent: gradients.accentDark,
+    positive: gradients.positiveDark,
+    negative: gradients.negativeDark,
+  },
   tint: darkTints,
 };
 

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -94,6 +94,16 @@ export const gradients = {
   // and off warning amber so it never reads as a status. Every stop holds white.
   accentLight: ['#0369A1', '#2563EB', '#4F46E5'],
   accentDark: ['#0C4A6E', '#1E40AF', '#3730A3'],
+  // The balance card wears its verdict: a green wash when the net is in your
+  // favour, a red one when you owe. Both are the money hues (positive/negative)
+  // deepened across three stops so the white balance and its small labels stay
+  // legible on every corner — the same rule the brand wash follows above. The
+  // neutral, all-settled state keeps the brand wash, so colour only ever
+  // appears when there is a debt to point at.
+  positiveLight: ['#065F46', '#0A6E4E', '#0E9F6E'],
+  positiveDark: ['#053D2E', '#065F46', '#0A7E59'],
+  negativeLight: ['#8C1D3F', '#B01D50', '#D22C63'],
+  negativeDark: ['#611228', '#8C1D3F', '#A81F4C'],
 } as const;
 
 /** The pastel family, in the order groups cycle through it. */


### PR DESCRIPTION
Two dashboard/group UI tweaks from a live iteration.

## Balance card — coloured by verdict
The dashboard balance card was always the brand purple wash. Now the saturated fill reflects the net:
- **owed to you → green**, **you owe → red**, **all settled → brand** (neutral)

So colour appears only when there's a debt to point at, and the card's hue tells you where you stand before you read the number.

- New `positive` / `negative` gradient tokens (`tokens.ts`) — the `positive`/`negative` money hues deepened across three stops so the white balance + small labels stay legible on every corner, in light and dark. Wired into `theme.gradient` (both themes) + the `Theme` type.
- `BalanceCard` picks the wash from `total.net`; corners bumped to radius `lg`, trip card matched.

## Group header polish
- Title + group icon **left-aligned** (was centred).
- **Back arrow** is now a bare icon + tap target — no background chip.
- Overflow menu is a **vertical ⋮** (also chip-free), on the right.
- `GroupMenu` refactored to a **controlled** bottom sheet (caller owns `open` + the trigger) instead of bundling its own button. Settings / Spending / Plan routes unchanged.

## Verification
`typecheck`, `lint`, `prettier` clean; `test:app` 215/215 pass. Pure UI — no data/logic touched. Not yet exercised on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group menus can now be opened and dismissed from the group screen using streamlined controls.
  * Profile names in the home header are now tappable and open the profile screen.
  * Added distinct visual treatments for positive, negative, and neutral balances.

* **Style**
  * Updated balance and trip cards with larger corner radii.
  * Improved light and dark theme gradients for clearer balance states.
  * Refined icon button appearance for surface and brand styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->