### PR TITLE
feat(mobile): WhatsApp-style flat lists + activity timeline

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -4,21 +4,18 @@ import { router } from 'expo-router';
 import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
 
 import {
-  Avatar,
   EmptyState,
   IconButton,
   MoneyText,
   Row,
   Screen,
-  SectionHeader,
   Text,
-  TintCard,
   tintForKey,
   useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
-import { describeActivity } from '@/data/activity';
+import { describeActivity, verbEmoji } from '@/data/activity';
 import { fetchRecentActivity } from '@/data/api';
 import { FeedSkeleton } from '@/components/Skeletons';
 import { useNotifications } from '@/data/hooks';
@@ -43,12 +40,6 @@ export default function ActivityScreen() {
   const notifications = useNotifications();
   const unread = (notifications.data ?? []).filter((row) => row.read_at === null).length;
 
-  const byDay = entries.reduce<Record<string, typeof entries>>((groups, entry) => {
-    const day = entry.created_at.slice(0, 10);
-    groups[day] = [...(groups[day] ?? []), entry];
-    return groups;
-  }, {});
-
   return (
     <Screen>
       <ScrollView
@@ -67,7 +58,10 @@ export default function ActivityScreen() {
         }
       >
         <Row style={{ paddingTop: theme.spacing.md, justifyContent: 'space-between' }}>
-          <Text variant="title">{t.activity}</Text>
+          <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+            <Ionicons name="pulse" size={22} color={theme.color.brand} />
+            <Text variant="title">{t.activity}</Text>
+          </Row>
           {/* The feed is what happened in the groups; the inbox is what Baaki
               said to you. Related enough to sit together, different enough not
               to be interleaved. */}
@@ -94,72 +88,102 @@ export default function ActivityScreen() {
         ) : entries.length === 0 ? (
           <EmptyState title={t.nothingYet} body={t.tabs.activityEmptyBody} />
         ) : (
-          Object.entries(byDay).map(([day, dayEntries]) => (
-            <View key={day}>
-              <SectionHeader
-                title={new Intl.DateTimeFormat(locale, {
-                  weekday: 'short',
-                  day: 'numeric',
-                  month: 'short',
-                }).format(new Date(day))}
-              />
-              <View style={{ gap: theme.spacing.md }}>
-                {dayEntries.map((entry) => {
-                  // The entry wears its group's colour, tying the feed back to
-                  // the group cards on home. The amount is a recorded figure,
-                  // not a balance, so it is neutral in the tint's ink.
-                  const tint = tintForKey(entry.group_id);
-                  const ink = theme.tint[tint].ink;
-                  const inkMuted = theme.tint[tint].inkMuted;
-                  return (
-                    <Pressable
-                      key={entry.id}
-                      accessibilityRole="button"
-                      accessibilityLabel={describeActivity(entry, myProfileId)}
-                      onPress={() => router.push(`/group/${entry.group_id}`)}
-                      style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
-                    >
-                      <TintCard
-                        tint={tint}
-                        style={{ borderRadius: theme.radius.lg, padding: theme.spacing.lg }}
+          // A single vertical timeline: each event is a node on a connector line
+          // running down the left, its icon in a soft circle tinted by the group
+          // it belongs to, the sentence beside it and the relative time beneath.
+          <View>
+            {entries.map((entry, index) => {
+              const isLast = index === entries.length - 1;
+              const tint = tintForKey(entry.group_id);
+              return (
+                <Pressable
+                  key={entry.id}
+                  accessibilityRole="button"
+                  accessibilityLabel={describeActivity(entry, myProfileId)}
+                  onPress={() => router.push(`/group/${entry.group_id}`)}
+                  style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+                >
+                  <Row style={{ alignItems: 'stretch' }}>
+                    {/* The rail: the node, then the line running down to the next
+                        node — dropped for the last row so it stops, not dangles. */}
+                    <View style={{ width: 38, alignItems: 'center' }}>
+                      <View
+                        style={{
+                          width: 38,
+                          height: 38,
+                          borderRadius: 19,
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          backgroundColor: theme.tint[tint].bg,
+                        }}
                       >
-                        <Row style={{ gap: theme.spacing.md, alignItems: 'flex-start' }}>
-                          <Avatar
-                            name={entry.group?.name ?? t.tabs.group}
-                            emoji={entry.group?.cover_emoji ?? undefined}
-                            size={40}
+                        <Text style={{ fontSize: 16 }}>{verbEmoji(entry.verb)}</Text>
+                      </View>
+                      {!isLast ? (
+                        <View
+                          style={{
+                            flex: 1,
+                            width: 2,
+                            marginVertical: 2,
+                            backgroundColor: theme.color.border,
+                          }}
+                        />
+                      ) : null}
+                    </View>
+
+                    <View
+                      style={{
+                        flex: 1,
+                        paddingLeft: theme.spacing.md,
+                        paddingBottom: isLast ? 0 : theme.spacing.xl,
+                      }}
+                    >
+                      <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
+                        <Text variant="body" numberOfLines={3} style={{ flex: 1 }}>
+                          {describeActivity(entry, myProfileId)}
+                        </Text>
+                        {typeof entry.payload.amount === 'string' ? (
+                          <MoneyText
+                            amount={BigInt(entry.payload.amount)}
+                            currency={(entry.payload.currency as string) ?? 'INR'}
+                            locale={locale}
+                            variant="subheading"
+                            tone="default"
                           />
-                          <View style={{ flex: 1 }}>
-                            <Text variant="subheading" style={{ color: ink }}>
-                              {describeActivity(entry, myProfileId)}
-                            </Text>
-                            <Text variant="caption" style={{ color: inkMuted }}>
-                              {`${entry.group?.name ?? t.tabs.group} · ${new Intl.DateTimeFormat(
-                                locale,
-                                { hour: 'numeric', minute: '2-digit' },
-                              ).format(new Date(entry.created_at))}`}
-                            </Text>
-                          </View>
-                          {typeof entry.payload.amount === 'string' ? (
-                            <MoneyText
-                              amount={BigInt(entry.payload.amount)}
-                              currency={(entry.payload.currency as string) ?? 'INR'}
-                              locale={locale}
-                              variant="subheading"
-                              tone="default"
-                              style={{ color: ink }}
-                            />
-                          ) : null}
-                        </Row>
-                      </TintCard>
-                    </Pressable>
-                  );
-                })}
-              </View>
-            </View>
-          ))
+                        ) : null}
+                      </Row>
+                      <Text variant="micro" tone="muted" style={{ marginTop: 2 }}>
+                        {relativeTime(locale, entry.created_at)}
+                      </Text>
+                    </View>
+                  </Row>
+                </Pressable>
+              );
+            })}
+          </View>
         )}
       </ScrollView>
     </Screen>
   );
+}
+
+/**
+ * "19m ago", "yesterday" — a localized relative time for a timeline entry.
+ *
+ * Intl.RelativeTimeFormat does the wording and the plural in every locale, and
+ * `numeric: 'auto'` is what turns "1 day ago" into "yesterday". The unit is the
+ * largest that leaves a count of at least one, so a three-hour-old event reads
+ * in hours, not 180 minutes.
+ */
+function relativeTime(locale: string, iso: string): string {
+  const seconds = Math.round((Date.parse(iso) - Date.now()) / 1000);
+  const abs = Math.abs(seconds);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+  if (abs < 60) return rtf.format(Math.round(seconds), 'second');
+  if (abs < 3600) return rtf.format(Math.round(seconds / 60), 'minute');
+  if (abs < 86400) return rtf.format(Math.round(seconds / 3600), 'hour');
+  if (abs < 604800) return rtf.format(Math.round(seconds / 86400), 'day');
+  if (abs < 2629800) return rtf.format(Math.round(seconds / 604800), 'week');
+  if (abs < 31557600) return rtf.format(Math.round(seconds / 2629800), 'month');
+  return rtf.format(Math.round(seconds / 31557600), 'year');
 }

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -39,7 +39,6 @@ import {
   Screen,
   SectionHeader,
   Text,
-  TintCard,
   useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
@@ -137,13 +136,17 @@ export default function FriendsScreen() {
         }
       >
         <Row style={{ justifyContent: 'space-between', paddingTop: theme.spacing.md }}>
-          <Text variant="title">{t.friends}</Text>
+          <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+            <Ionicons name="people" size={22} color={theme.color.brand} />
+            <Text variant="title">{t.friends}</Text>
+          </Row>
           <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
             <Button
               label={t.tabs.fromContacts}
               size="sm"
-              icon={<Ionicons name="person-add-outline" size={16} color={theme.color.onBrand} />}
+              icon={<Ionicons name="person-add-outline" size={15} color={theme.color.onBrand} />}
               onPress={() => router.push('/friends/contacts')}
+              style={{ height: 32, paddingHorizontal: theme.spacing.md, gap: theme.spacing.xs }}
             />
             {/* The sort control — a bare vertical three-dot beside the button,
                 opening the same corner dropdown the rest of the app uses. */}
@@ -221,9 +224,16 @@ function FriendsSection({
           </Text>
         </Card>
       ) : (
-        rows.map((row) => (
-          <FriendCard key={`${row.person_key}-${row.currency}`} row={row} locale={locale} t={t} />
-        ))
+        <View>
+          {rows.map((row, index) => (
+            <View key={`${row.person_key}-${row.currency}`}>
+              <FriendCard row={row} locale={locale} t={t} />
+              {index < rows.length - 1 ? (
+                <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              ) : null}
+            </View>
+          ))}
+        </View>
       )}
     </View>
   );
@@ -239,73 +249,66 @@ function FriendCard({
   t: ReturnType<typeof useStrings>['t'];
 }): React.JSX.Element {
   const theme = useTheme();
-  // The card colour is the money colour, used for its one sanctioned meaning:
-  // mint when they owe you, pink when you owe them. The section already sorts
-  // by that, so the colour never disagrees with the number on it. Ink from the
-  // same pair keeps the amount legible without breaking the semantic.
+  // Flat WhatsApp row: the money colour is gone from the background, the amount
+  // reads in ordinary ink, and the owed/owe meaning is carried by the sign and
+  // the section this row sits under. The avatar keeps the person's own colour.
   const owed = BigInt(row.net) > 0n;
-  const tint = owed ? 'mint' : 'pink';
-  const ink = theme.tint[tint].ink;
-  const inkMuted = theme.tint[tint].inkMuted;
   // Only linkable when there is a single group to link to; otherwise this
   // amount is a sum and no one group explains it.
   const onPress = row.only_group_id ? () => router.push(`/group/${row.only_group_id}`) : undefined;
 
   const body = (
-    <TintCard tint={tint} style={{ borderRadius: theme.radius.lg, padding: theme.spacing.lg }}>
-      <Row style={{ justifyContent: 'space-between' }}>
-        <Row style={{ flex: 1, gap: theme.spacing.md }}>
-          <Avatar name={row.display_name} size={40} />
-          <View style={{ flex: 1 }}>
-            <Text variant="subheading" numberOfLines={1} style={{ color: ink }}>
-              {row.display_name}
-            </Text>
-            <Text variant="caption" style={{ color: inkMuted }}>
-              {row.group_count === 1
-                ? t.tabs.inOneGroup
-                : plural(locale, row.group_count, t.tabs.acrossGroups)}
-            </Text>
-          </View>
-        </Row>
-        <View style={{ alignItems: 'flex-end', gap: 2 }}>
-          <MoneyText
-            amount={BigInt(row.net)}
-            currency={row.currency}
-            locale={locale}
-            variant="subheading"
-            mode="balance"
-            tone="default"
-            style={{ color: ink }}
-          />
-          {row.is_ghost ? (
-            // A ghost is somebody you added who has no Baaki account yet, so the
-            // badge is the useful action rather than a verdict: send them this
-            // group's invite link, which is the same link that lets them claim
-            // this very row (A25). Only offered when a single group explains the
-            // balance — otherwise there is no one link to share. Its own
-            // Pressable so tapping it invites rather than opening the group.
-            row.only_group_id ? (
-              <Pressable
-                onPress={() => router.push(`/group/${row.only_group_id}/invite`)}
-                accessibilityRole="button"
-                accessibilityLabel={t.people.invite}
-                hitSlop={8}
-                style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
-              >
-                <Badge label={t.people.invite} tone="brand" />
-              </Pressable>
-            ) : (
-              <Badge label={t.tabs.notJoined} />
-            )
-          ) : owed && row.only_group_id ? (
-            // They owe you and one group explains it, so there is a single pair
-            // to nudge. The server keeps it honest — one a day, never to a
-            // ghost, never for nothing — so the button only has to ask (ADR-010).
-            <RemindButton row={row} />
-          ) : null}
+    <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
+      <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
+        <Avatar name={row.display_name} size={44} ghost={row.is_ghost} />
+        <View style={{ flex: 1 }}>
+          <Text variant="subheading" numberOfLines={1}>
+            {row.display_name}
+          </Text>
+          <Text variant="caption" tone="muted" numberOfLines={1}>
+            {row.group_count === 1
+              ? t.tabs.inOneGroup
+              : plural(locale, row.group_count, t.tabs.acrossGroups)}
+          </Text>
         </View>
       </Row>
-    </TintCard>
+      <View style={{ alignItems: 'flex-end', gap: 2 }}>
+        <MoneyText
+          amount={BigInt(row.net)}
+          currency={row.currency}
+          locale={locale}
+          variant="subheading"
+          mode="balance"
+          tone="default"
+        />
+        {row.is_ghost ? (
+          // A ghost is somebody you added who has no Baaki account yet, so the
+          // badge is the useful action rather than a verdict: send them this
+          // group's invite link, which is the same link that lets them claim
+          // this very row (A25). Only offered when a single group explains the
+          // balance — otherwise there is no one link to share. Its own
+          // Pressable so tapping it invites rather than opening the group.
+          row.only_group_id ? (
+            <Pressable
+              onPress={() => router.push(`/group/${row.only_group_id}/invite`)}
+              accessibilityRole="button"
+              accessibilityLabel={t.people.invite}
+              hitSlop={8}
+              style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+            >
+              <Badge label={t.people.invite} tone="brand" />
+            </Pressable>
+          ) : (
+            <Badge label={t.tabs.notJoined} />
+          )
+        ) : owed && row.only_group_id ? (
+          // They owe you and one group explains it, so there is a single pair
+          // to nudge. The server keeps it honest — one a day, never to a
+          // ghost, never for nothing — so the button only has to ask (ADR-010).
+          <RemindButton row={row} />
+        ) : null}
+      </View>
+    </Row>
   );
 
   if (!onPress) return body;
@@ -408,62 +411,69 @@ function SortMenu({
             top: insets.top + 56,
             right: theme.spacing.xl,
             minWidth: 220,
-            backgroundColor: theme.color.surface,
             borderRadius: theme.radius.lg,
-            borderWidth: 1,
-            borderColor: theme.color.border,
-            paddingVertical: theme.spacing.xs,
             ...theme.shadow.lifted,
           }}
         >
-          <Text
-            variant="micro"
-            tone="faint"
-            style={{ paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.xs }}
+          <View
+            style={{
+              borderRadius: theme.radius.lg,
+              borderWidth: 1,
+              borderColor: theme.color.border,
+              backgroundColor: theme.color.surface,
+              paddingVertical: theme.spacing.xs,
+              overflow: 'hidden',
+            }}
           >
-            {t.sort.by}
-          </Text>
-          {SORT_ORDER.map((key) => {
-            const active = key === sortKey;
-            const label =
-              key === 'amount' ? t.sort.amount : key === 'date' ? t.sort.date : t.sort.name;
-            return (
-              <Pressable
-                key={key}
-                onPress={() => onPick(key)}
-                accessibilityRole="button"
-                accessibilityLabel={label}
-                accessibilityState={{ selected: active }}
-                style={({ pressed }) => ({
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: theme.spacing.md,
-                  paddingHorizontal: theme.spacing.lg,
-                  paddingVertical: theme.spacing.md,
-                  backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',
-                })}
-              >
-                <Ionicons
-                  name={SORT_META[key].icon}
-                  size={20}
-                  color={active ? theme.color.brand : theme.color.textMuted}
-                />
-                <Text
-                  variant="body"
-                  style={{ flex: 1, color: active ? theme.color.brand : theme.color.text }}
+            <Text
+              variant="micro"
+              tone="faint"
+              style={{ paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.xs }}
+            >
+              {t.sort.by}
+            </Text>
+            {SORT_ORDER.map((key) => {
+              const active = key === sortKey;
+              const label =
+                key === 'amount' ? t.sort.amount : key === 'date' ? t.sort.date : t.sort.name;
+              return (
+                <Pressable
+                  key={key}
+                  onPress={() => onPick(key)}
+                  accessibilityRole="button"
+                  accessibilityLabel={label}
+                  accessibilityState={{ selected: active }}
+                  style={({ pressed }) => ({
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: theme.spacing.md,
+                    paddingHorizontal: theme.spacing.lg,
+                    paddingVertical: theme.spacing.md,
+                    backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',
+                  })}
                 >
-                  {label}
-                </Text>
-                {active ? (
                   <Ionicons
-                    name={sortDir === 'asc' ? 'arrow-up' : 'arrow-down'}
-                    size={18}
-                    color={theme.color.brand}
+                    name={SORT_META[key].icon}
+                    size={20}
+                    color={active ? theme.color.brand : theme.color.textMuted}
                   />
-                ) : null}
-              </Pressable>
-            );
-          })}
+                  <Text
+                    variant="body"
+                    style={{ flex: 1, color: active ? theme.color.brand : theme.color.text }}
+                  >
+                    {label}
+                  </Text>
+                  {active ? (
+                    <Ionicons
+                      name={sortDir === 'asc' ? 'arrow-up' : 'arrow-down'}
+                      size={18}
+                      color={theme.color.brand}
+                    />
+                  ) : null}
+                </Pressable>
+              );
+            })}
+          </View>
         </View>
       </Pressable>
     </Modal>

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -289,15 +289,16 @@ export default function HomeScreen() {
                 <Button
                   label={t.newGroup}
                   size="sm"
-                  icon={<Ionicons name="add" size={16} color={theme.color.onBrand} />}
+                  icon={<Ionicons name="add" size={15} color={theme.color.onBrand} />}
                   onPress={openNewGroup}
+                  style={{ height: 32, paddingHorizontal: theme.spacing.md, gap: theme.spacing.xs }}
                 />
               }
             />
             {presentTypes.length > 1 ? (
               <CategoryStrip types={presentTypes} active={active} onSelect={setCategory} t={t} />
             ) : null}
-            <View style={{ gap: theme.spacing.md }}>
+            <View>
               {visible.map((group, index) => {
                 const members = summary.membersFor(group.id);
                 const balance = summary.balanceFor(group.id);
@@ -317,6 +318,9 @@ export default function HomeScreen() {
                       pendingLabel={summary.hasPending(group.id) ? t.pendingConfirmation : null}
                       onPress={() => router.push(`/group/${group.id}`)}
                     />
+                    {index < visible.length - 1 ? (
+                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                    ) : null}
                   </Stagger>
                 );
               })}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -3,7 +3,6 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
 
-import { categoryOf } from '@baaki/core';
 import {
   Avatar,
   Badge,
@@ -358,48 +357,41 @@ export default function GroupScreen() {
             visibleExpenses.length === 0 ? (
               <EmptyState title={t.nothingYet} body={t.nothingYetBody} />
             ) : (
-              <View style={{ gap: theme.spacing.md }}>
-                {visibleExpenses.map((expense) => {
+              <View>
+                {visibleExpenses.map((expense, index) => {
                   const version = expense.currentVersion;
                   const payer = version?.payers[0]?.member_id ?? null;
                   // Somebody disagreeing with an expense is worth seeing from the
                   // list. A disagreement you only find by opening the row is one
                   // that sits there unanswered.
                   const contested = openDisputes.has(expense.id);
-                  // Each row is a card in its category's colour — the amount is a
-                  // total, shown neutral in the tint's ink. A deleted row is dimmed
-                  // rather than hidden, so the ledger stays visibly append-only.
-                  const catTint = categoryOf(version?.category).tint;
-                  const catInk = theme.tint[catTint].ink;
-                  const catInkMuted = theme.tint[catTint].inkMuted;
+                  // Flat row: the category is the badge on the left, not the row's
+                  // colour. A deleted row is dimmed rather than hidden, so the
+                  // ledger stays visibly append-only.
                   const title = expenseTitle(version?.description, version?.category, t);
                   return (
-                    <Pressable
-                      key={expense.id}
-                      onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
-                      accessibilityRole="button"
-                      accessibilityLabel={title}
-                      style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
-                    >
-                      <TintCard
-                        tint={catTint}
-                        style={{
-                          borderRadius: theme.radius.lg,
-                          padding: theme.spacing.lg,
-                          opacity: expense.deleted_at ? 0.55 : 1,
-                        }}
+                    <View key={expense.id}>
+                      <Pressable
+                        onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
+                        accessibilityRole="button"
+                        accessibilityLabel={title}
+                        style={({ pressed }) => ({
+                          opacity: pressed ? 0.6 : expense.deleted_at ? 0.55 : 1,
+                        })}
                       >
-                        <Row style={{ gap: theme.spacing.md }}>
+                        <Row
+                          style={{
+                            gap: theme.spacing.md,
+                            alignItems: 'center',
+                            paddingVertical: theme.spacing.md,
+                          }}
+                        >
                           <CategoryBadge category={version?.category} size={40} />
                           <View style={{ flex: 1 }}>
-                            <Text variant="subheading" numberOfLines={1} style={{ color: catInk }}>
+                            <Text variant="subheading" numberOfLines={1}>
                               {`${title}${contested ? '  🚩' : ''}`}
                             </Text>
-                            <Text
-                              variant="caption"
-                              numberOfLines={1}
-                              style={{ color: catInkMuted }}
-                            >
+                            <Text variant="caption" tone="muted" numberOfLines={1}>
                               {[
                                 fill(t.expense.paidByName, { name: nameOf(payer) }),
                                 version
@@ -418,20 +410,23 @@ export default function GroupScreen() {
                             </Text>
                           </View>
                           {version ? (
-                            <Row style={{ gap: theme.spacing.sm }}>
+                            <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
                               <MoneyText
                                 amount={BigInt(version.amount)}
                                 currency={version.currency}
                                 locale={locale}
                                 tone="default"
-                                style={{ color: catInk, fontWeight: '700' }}
+                                style={{ fontWeight: '700' }}
                               />
                               {expense.pending ? <PendingMark /> : null}
                             </Row>
                           ) : null}
                         </Row>
-                      </TintCard>
-                    </Pressable>
+                      </Pressable>
+                      {index < visibleExpenses.length - 1 ? (
+                        <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                      ) : null}
+                    </View>
                   );
                 })}
               </View>
@@ -439,55 +434,51 @@ export default function GroupScreen() {
           ) : null}
 
           {tab === Tab.Balances ? (
-            <View style={{ gap: theme.spacing.md }}>
-              {(members.data ?? []).map((member) => {
-                // Each member is a card in the money colour for its meaning: mint
-                // when they are owed, pink when they owe, lilac when square. The
-                // balance is drawn in the pair's ink to stay legible on the tint.
+            <View>
+              {(members.data ?? []).map((member, index, arr) => {
+                // Flat row: the money meaning is the sign on the amount and its
+                // "you are owed / you owe" label, not the row's colour.
                 const balance = ledger.balances.get(member.id) ?? 0n;
-                const rowTint = balance > 0n ? 'mint' : balance < 0n ? 'pink' : 'lilac';
-                const rowInk = theme.tint[rowTint].ink;
-                const rowInkMuted = theme.tint[rowTint].inkMuted;
                 return (
-                  <TintCard
-                    key={member.id}
-                    tint={rowTint}
-                    style={{ borderRadius: theme.radius.lg, padding: theme.spacing.lg }}
-                  >
-                    <Row style={{ gap: theme.spacing.md }}>
+                  <View key={member.id}>
+                    <Row
+                      style={{
+                        gap: theme.spacing.md,
+                        alignItems: 'center',
+                        paddingVertical: theme.spacing.md,
+                      }}
+                    >
                       <Avatar name={displayName(member)} ghost={isGhost(member)} size={40} />
                       <View style={{ flex: 1 }}>
                         <Row style={{ gap: theme.spacing.sm }}>
-                          <Text
-                            variant="subheading"
-                            numberOfLines={1}
-                            style={{ color: rowInk, flexShrink: 1 }}
-                          >
+                          <Text variant="subheading" numberOfLines={1} style={{ flexShrink: 1 }}>
                             {displayName(member, profile?.id)}
                           </Text>
                           {member.role === 'admin' && !isGhost(member) ? (
                             <Badge label={t.people.admin} tone="brand" />
                           ) : null}
                         </Row>
-                        <Text variant="caption" numberOfLines={1} style={{ color: rowInkMuted }}>
+                        <Text variant="caption" tone="muted" numberOfLines={1}>
                           {isGhost(member)
                             ? t.notJoinedYet
                             : (member.vpa ?? member.profile?.default_vpa ?? '—')}
                         </Text>
                       </View>
-                      <Row style={{ gap: theme.spacing.sm }}>
+                      <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
                         <MoneyText
                           amount={balance}
                           currency={currency}
                           locale={locale}
                           mode="balance"
                           tone="default"
-                          style={{ color: rowInk }}
                         />
                         {member.pending ? <PendingMark /> : null}
                       </Row>
                     </Row>
-                  </TintCard>
+                    {index < arr.length - 1 ? (
+                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                    ) : null}
+                  </View>
                 );
               })}
             </View>

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -18,7 +18,6 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
 
-import { categoryOf } from '@baaki/core';
 import {
   directionalIcon,
   EmptyState,
@@ -190,41 +189,32 @@ export default function SpendingMonthScreen() {
                   />
                 </Row>
 
-                <View style={{ gap: theme.spacing.md }}>
-                  {bucket.items.map(({ expense, amount }) => {
+                <View>
+                  {bucket.items.map(({ expense, amount }, index, arr) => {
                     const version = expense.currentVersion;
                     const payer = version?.payers[0]?.member_id ?? null;
-                    const catTint = categoryOf(version?.category).tint;
-                    const catInk = theme.tint[catTint].ink;
-                    const catInkMuted = theme.tint[catTint].inkMuted;
                     const title = expenseTitle(version?.description, version?.category, t);
                     return (
-                      <Pressable
-                        key={expense.id}
-                        onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
-                        accessibilityRole="button"
-                        accessibilityLabel={title}
-                        style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
-                      >
-                        <TintCard
-                          tint={catTint}
-                          style={{ borderRadius: theme.radius.lg, padding: theme.spacing.lg }}
+                      <View key={expense.id}>
+                        <Pressable
+                          onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
+                          accessibilityRole="button"
+                          accessibilityLabel={title}
+                          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
                         >
-                          <Row style={{ gap: theme.spacing.md }}>
+                          <Row
+                            style={{
+                              gap: theme.spacing.md,
+                              alignItems: 'center',
+                              paddingVertical: theme.spacing.md,
+                            }}
+                          >
                             <CategoryBadge category={version?.category} size={40} />
                             <View style={{ flex: 1 }}>
-                              <Text
-                                variant="subheading"
-                                numberOfLines={1}
-                                style={{ color: catInk }}
-                              >
+                              <Text variant="subheading" numberOfLines={1}>
                                 {title}
                               </Text>
-                              <Text
-                                variant="caption"
-                                numberOfLines={1}
-                                style={{ color: catInkMuted }}
-                              >
+                              <Text variant="caption" tone="muted" numberOfLines={1}>
                                 {fill(t.expense.paidByName, { name: nameOf(payer) })}
                               </Text>
                             </View>
@@ -233,11 +223,14 @@ export default function SpendingMonthScreen() {
                               currency={currency}
                               locale={locale}
                               tone="default"
-                              style={{ color: catInk, fontWeight: '700' }}
+                              style={{ fontWeight: '700' }}
                             />
                           </Row>
-                        </TintCard>
-                      </Pressable>
+                        </Pressable>
+                        {index < arr.length - 1 ? (
+                          <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                        ) : null}
+                      </View>
                     );
                   })}
                 </View>

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -130,7 +130,10 @@ export default function GroupSettingsScreen() {
             <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.group.settings}</Text>
+            <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+              <Ionicons name="settings-outline" size={18} color={theme.color.brand} />
+              <Text variant="heading">{t.group.settings}</Text>
+            </Row>
             <Text variant="micro" tone="muted">
               {groupLabel(group.data, members.data ?? [])}
             </Text>

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -26,7 +26,6 @@ import {
   Screen,
   SectionHeader,
   Text,
-  TintCard,
   tintForKey,
   useTabBarClearance,
   useTheme,
@@ -125,73 +124,80 @@ export default function InboxScreen() {
         ) : (
           <View style={{ gap: theme.spacing.md }}>
             <SectionHeader title={t.inbox.recent} />
-            {rows.map((row) => {
-              const { title, body } = renderNotification(row.kind, factsOf(row), locale, {
-                title: row.title,
-                body: row.body,
-              });
-              const unreadRow = row.read_at === null;
-              // Each notice is a card in a stable colour for its kind, so a run
-              // of the same kind reads as a run. A read one is dimmed; the icon
-              // sits in a white chip with the tint's ink.
-              const tint = tintForKey(row.kind);
-              const ink = theme.tint[tint].ink;
-              const inkMuted = theme.tint[tint].inkMuted;
-              return (
-                <Pressable
-                  key={row.id}
-                  accessibilityRole={row.group_id ? 'button' : undefined}
-                  accessibilityLabel={title}
-                  onPress={
-                    row.group_id ? () => router.push(`/group/${row.group_id}` as never) : undefined
-                  }
-                  style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
-                >
-                  <TintCard
-                    tint={tint}
-                    style={{
-                      borderRadius: theme.radius.lg,
-                      padding: theme.spacing.lg,
-                      opacity: unreadRow ? 1 : 0.7,
-                    }}
-                  >
-                    <Row style={{ gap: theme.spacing.md, alignItems: 'flex-start' }}>
-                      <View
+            <View>
+              {rows.map((row, index) => {
+                const { title, body } = renderNotification(row.kind, factsOf(row), locale, {
+                  title: row.title,
+                  body: row.body,
+                });
+                const unreadRow = row.read_at === null;
+                // Flat row: the kind's colour lives in the icon chip on the left,
+                // not the whole row. A read one is dimmed.
+                const tint = tintForKey(row.kind);
+                return (
+                  <View key={row.id}>
+                    <Pressable
+                      accessibilityRole={row.group_id ? 'button' : undefined}
+                      accessibilityLabel={title}
+                      onPress={
+                        row.group_id
+                          ? () => router.push(`/group/${row.group_id}` as never)
+                          : undefined
+                      }
+                      style={({ pressed }) => ({
+                        opacity: pressed ? 0.6 : unreadRow ? 1 : 0.7,
+                      })}
+                    >
+                      <Row
                         style={{
-                          width: 40,
-                          height: 40,
-                          borderRadius: theme.radius.pill,
+                          gap: theme.spacing.md,
                           alignItems: 'center',
-                          justifyContent: 'center',
-                          backgroundColor: theme.color.surface,
+                          paddingVertical: theme.spacing.md,
                         }}
                       >
-                        <Ionicons name={ICONS[row.kind] ?? 'notifications'} size={18} color={ink} />
-                      </View>
-                      <View style={{ flex: 1 }}>
-                        <Text variant="subheading" style={{ color: ink }}>
-                          {title}
-                        </Text>
-                        <Text variant="caption" style={{ color: inkMuted }}>
-                          {body}
-                        </Text>
-                      </View>
-                      {unreadRow ? (
                         <View
                           style={{
-                            width: 8,
-                            height: 8,
-                            borderRadius: 4,
-                            marginTop: 6,
-                            backgroundColor: ink,
+                            width: 40,
+                            height: 40,
+                            borderRadius: theme.radius.pill,
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            backgroundColor: theme.tint[tint].bg,
                           }}
-                        />
-                      ) : null}
-                    </Row>
-                  </TintCard>
-                </Pressable>
-              );
-            })}
+                        >
+                          <Ionicons
+                            name={ICONS[row.kind] ?? 'notifications'}
+                            size={18}
+                            color={theme.tint[tint].ink}
+                          />
+                        </View>
+                        <View style={{ flex: 1 }}>
+                          <Text variant="subheading" numberOfLines={2}>
+                            {title}
+                          </Text>
+                          <Text variant="caption" tone="muted" numberOfLines={2}>
+                            {body}
+                          </Text>
+                        </View>
+                        {unreadRow ? (
+                          <View
+                            style={{
+                              width: 8,
+                              height: 8,
+                              borderRadius: 4,
+                              backgroundColor: theme.color.brand,
+                            }}
+                          />
+                        ) : null}
+                      </Row>
+                    </Pressable>
+                    {index < rows.length - 1 ? (
+                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                    ) : null}
+                  </View>
+                );
+              })}
+            </View>
           </View>
         )}
 

--- a/apps/mobile/src/components/GroupCard.tsx
+++ b/apps/mobile/src/components/GroupCard.tsx
@@ -1,27 +1,19 @@
 /**
- * A group as a compact, full-colour row.
+ * A group as one flat list row, WhatsApp-style.
  *
- * The tint is the same colour the group's avatar wears everywhere else
- * (`tintForKey`), now filling the whole card — so a list of groups reads as a
- * stack of stable, recognisable colours rather than a wall of white.
- *
- * It used to be a tall two-row panel: a 30pt balance, an avatar cluster, and
- * generous padding meant three or four groups filled the screen and a longer
- * list was all scrolling. This is the same information on one row — name and
- * member count on the left, the balance and its owed/owe word on the right —
- * so twice as many groups fit before anybody has to scroll.
- *
- * Money colour, on purpose, is NOT the mint/red pair here. On a saturated
- * surface green-on-mint disappears and red-on-pink muddies; the balance is
- * painted in the tint's own ink for contrast and the owed/owe meaning is
- * carried by the label beneath it and the sign (see MoneyText `tone`).
+ * This used to be a full-colour `TintCard` — the group's tint filling the whole
+ * card. The list is now flat rows on a plain surface, separated by hairlines
+ * rather than by colour: an avatar carries the group's identity (and its
+ * colour), the name and member count read in the ordinary ink, and the balance
+ * sits at the trailing edge. The owed/owe meaning is the word beneath the
+ * amount and the amount's sign, not the row's background.
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { View } from 'react-native';
 
 import type { CurrencyCode } from '@baaki/core';
-import { directionalIcon, MoneyText, Row, Text, TintCard, tintForKey, useTheme } from '@baaki/ui';
+import { Avatar, directionalIcon, MoneyText, Row, Text, tintForKey, useTheme } from '@baaki/ui';
 
 import { PressableScale } from '@/lib/anim';
 
@@ -52,10 +44,6 @@ export function GroupCard({
   onPress: () => void;
 }) {
   const theme = useTheme();
-  const tint = tintForKey(id);
-  const ink = theme.tint[tint].ink;
-  const inkMuted = theme.tint[tint].inkMuted;
-  const initial = title.trim().charAt(0).toUpperCase() || '•';
 
   return (
     <PressableScale
@@ -63,74 +51,54 @@ export function GroupCard({
       accessibilityRole="button"
       accessibilityLabel={`${title}, ${statusLabel}${pendingLabel ? `, ${pendingLabel}` : ''}`}
     >
-      <TintCard tint={tint} style={{ borderRadius: theme.radius.lg, padding: theme.spacing.lg }}>
-        <Row style={{ gap: theme.spacing.md }}>
-          {/* A white chip carries the emoji (or the name's first letter) at
-              full contrast, whatever the card's tint. */}
-          <View
-            style={{
-              width: 44,
-              height: 44,
-              borderRadius: theme.radius.pill,
-              alignItems: 'center',
-              justifyContent: 'center',
-              backgroundColor: theme.color.surface,
-            }}
-          >
-            {coverEmoji ? (
-              <Text variant="subheading">{coverEmoji}</Text>
-            ) : (
-              <Text variant="subheading" style={{ color: ink }}>
-                {initial}
-              </Text>
-            )}
-          </View>
+      <Row
+        style={{ gap: theme.spacing.md, alignItems: 'center', paddingVertical: theme.spacing.md }}
+      >
+        {/* The avatar keeps the group's colour and initial — WhatsApp rows are
+            flat, but the face on the left still tells one row from the next. */}
+        <Avatar name={title} emoji={coverEmoji ?? undefined} size={46} tint={tintForKey(id)} />
 
-          <View style={{ flex: 1, minWidth: 0 }}>
-            <Text variant="subheading" numberOfLines={1} style={{ color: ink }}>
-              {title}
-            </Text>
-            <Text variant="caption" numberOfLines={1} style={{ color: inkMuted }}>
-              {memberLabel}
-            </Text>
-          </View>
+        <View style={{ flex: 1, minWidth: 0 }}>
+          <Text variant="subheading" numberOfLines={1}>
+            {title}
+          </Text>
+          <Text variant="caption" tone="muted" numberOfLines={1}>
+            {memberLabel}
+          </Text>
+        </View>
 
-          <View style={{ alignItems: 'flex-end' }}>
-            <Row style={{ gap: theme.spacing.xs }}>
-              {/* A pending settlement gets a quiet dot rather than a full-width
-                  badge — the row has no room for a sentence. */}
-              {pendingLabel ? (
-                <View
-                  style={{
-                    width: 7,
-                    height: 7,
-                    borderRadius: 4,
-                    backgroundColor: theme.color.brand,
-                  }}
-                />
-              ) : null}
-              <MoneyText
-                amount={balance < 0n ? -balance : balance}
-                currency={currency}
-                locale={locale}
-                tone="default"
-                variant="heading"
-                style={{ color: ink }}
+        <View style={{ alignItems: 'flex-end' }}>
+          <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+            {/* A pending settlement gets a quiet dot rather than a badge. */}
+            {pendingLabel ? (
+              <View
+                style={{
+                  width: 7,
+                  height: 7,
+                  borderRadius: 4,
+                  backgroundColor: theme.color.brand,
+                }}
               />
-            </Row>
-            <Text variant="micro" style={{ color: inkMuted }}>
-              {statusLabel}
-            </Text>
-          </View>
+            ) : null}
+            <MoneyText
+              amount={balance < 0n ? -balance : balance}
+              currency={currency}
+              locale={locale}
+              tone="default"
+              variant="subheading"
+            />
+          </Row>
+          <Text variant="micro" tone="muted">
+            {statusLabel}
+          </Text>
+        </View>
 
-          <Ionicons
-            name={directionalIcon('chevron-forward')}
-            size={18}
-            color={ink}
-            style={{ opacity: 0.5 }}
-          />
-        </Row>
-      </TintCard>
+        <Ionicons
+          name={directionalIcon('chevron-forward')}
+          size={18}
+          color={theme.color.textFaint}
+        />
+      </Row>
     </PressableScale>
   );
 }

--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -48,39 +48,50 @@ export function OverflowMenu({
       >
         <View
           // Dropped from the top-right, clear of the status bar and roughly
-          // where the header's three-dot sits.
+          // where the header's three-dot sits. The shadow and the radius live on
+          // this outer layer; the inner one clips the rows so a pressed row's
+          // highlight follows the rounded corner instead of poking a square
+          // through it (`overflow: 'hidden'` would eat the shadow if they shared
+          // a layer, so they do not).
           style={{
             position: 'absolute',
             top: insets.top + 56,
             right: theme.spacing.xl,
             minWidth: 220,
-            backgroundColor: theme.color.surface,
             borderRadius: theme.radius.lg,
-            borderWidth: 1,
-            borderColor: theme.color.border,
-            paddingVertical: theme.spacing.xs,
             ...theme.shadow.lifted,
           }}
         >
-          {items.map((item) => (
-            <Pressable
-              key={item.label}
-              onPress={() => go(item.route)}
-              accessibilityRole="button"
-              accessibilityLabel={item.label}
-              style={({ pressed }) => ({
-                flexDirection: 'row',
-                alignItems: 'center',
-                gap: theme.spacing.md,
-                paddingHorizontal: theme.spacing.lg,
-                paddingVertical: theme.spacing.md,
-                backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',
-              })}
-            >
-              <Ionicons name={item.icon} size={20} color={theme.color.textMuted} />
-              <Text variant="body">{item.label}</Text>
-            </Pressable>
-          ))}
+          <View
+            style={{
+              borderRadius: theme.radius.lg,
+              borderWidth: 1,
+              borderColor: theme.color.border,
+              backgroundColor: theme.color.surface,
+              paddingVertical: theme.spacing.xs,
+              overflow: 'hidden',
+            }}
+          >
+            {items.map((item) => (
+              <Pressable
+                key={item.label}
+                onPress={() => go(item.route)}
+                accessibilityRole="button"
+                accessibilityLabel={item.label}
+                style={({ pressed }) => ({
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: theme.spacing.md,
+                  paddingHorizontal: theme.spacing.lg,
+                  paddingVertical: theme.spacing.md,
+                  backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',
+                })}
+              >
+                <Ionicons name={item.icon} size={20} color={theme.color.textMuted} />
+                <Text variant="body">{item.label}</Text>
+              </Pressable>
+            ))}
+          </View>
         </View>
       </Pressable>
     </Modal>


### PR DESCRIPTION
Unifies every list in the app to a flat, WhatsApp-style row and rebuilds the activity feed as a timeline.

## Flat lists (replaces the bold tint-card reskin)
Colored `TintCard` rows → transparent rows with a hairline divider, an avatar/icon carrying identity colour on the left, and neutral ink. **No card shell, no shadow, no container padding** — rows sit on the screen gutter. Flattened: dashboard groups, Friends, group **Expenses** + **Balances** tabs, **inbox**, **month** detail. The single tinted *hero* panels (group balance, settle, month header) are left as-is.

## Activity timeline
The feed is now one continuous vertical timeline: each event is a node on a connector line down the left, its verb icon in a soft group-tinted circle, the sentence beside it, and a localized relative time (`19m ago`, `yesterday`) beneath via `Intl.RelativeTimeFormat`.

## Polish
- **Dropdown corner clip** — the overflow/sort menus wrap rows in an inner `overflow:hidden` layer beneath the shadow layer, so a pressed row's highlight follows the rounded corner instead of poking a square through it.
- **Smaller buttons** — dashboard "new group" and Friends "from contacts".
- **Header icons** — leading icons on the Friends, Activity, and group Settings headers.

## Verification
typecheck ✓ · lint ✓ · prettier ✓ · app 215 ✓. No backend/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed mobile screens with flatter layouts, clearer separators, and more consistent spacing.
  * Redesigned activity as a vertical timeline with emoji markers, connector lines, amounts, and localized relative timestamps.
  * Updated Friends, Groups, Inbox, and group detail rows with cleaner surfaces and improved visual hierarchy.
  * Added contextual header icons for Activity, Friends, and Group Settings.
  * Refined overflow menu styling, contacts controls, and group creation actions while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->