### PR TITLE
refactor(mobile): icon sizes from an iconSize token

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -6,6 +6,7 @@ import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
 import {
   EmptyState,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -59,14 +60,14 @@ export default function ActivityScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md, justifyContent: 'space-between' }}>
           <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
-            <Ionicons name="pulse" size={22} color={theme.color.brand} />
+            <Ionicons name="pulse" size={iconSize.xl} color={theme.color.brand} />
             <Text variant="title">{t.activity}</Text>
           </Row>
           {/* The feed is what happened in the groups; the inbox is what Baaki
               said to you. Related enough to sit together, different enough not
               to be interleaved. */}
           <IconButton label={t.tabs.inbox} onPress={() => router.push('/inbox' as never)}>
-            <Ionicons name="notifications-outline" size={20} color={theme.color.text} />
+            <Ionicons name="notifications-outline" size={iconSize.lg} color={theme.color.text} />
             {unread > 0 ? (
               <View
                 style={{

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -34,6 +34,7 @@ import {
   Button,
   Card,
   EmptyState,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -137,14 +138,20 @@ export default function FriendsScreen() {
       >
         <Row style={{ justifyContent: 'space-between', paddingTop: theme.spacing.md }}>
           <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
-            <Ionicons name="people" size={22} color={theme.color.brand} />
+            <Ionicons name="people" size={iconSize.xl} color={theme.color.brand} />
             <Text variant="title">{t.friends}</Text>
           </Row>
           <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
             <Button
               label={t.tabs.fromContacts}
               size="sm"
-              icon={<Ionicons name="person-add-outline" size={15} color={theme.color.onBrand} />}
+              icon={
+                <Ionicons
+                  name="person-add-outline"
+                  size={iconSize.base}
+                  color={theme.color.onBrand}
+                />
+              }
               onPress={() => router.push('/friends/contacts')}
               style={{ height: 32, paddingHorizontal: theme.spacing.md, gap: theme.spacing.xs }}
             />
@@ -157,7 +164,7 @@ export default function FriendsScreen() {
               hitSlop={10}
               style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
             >
-              <Ionicons name="ellipsis-vertical" size={22} color={theme.color.text} />
+              <Ionicons name="ellipsis-vertical" size={iconSize.xl} color={theme.color.text} />
             </Pressable>
           </Row>
         </Row>
@@ -454,7 +461,7 @@ function SortMenu({
                 >
                   <Ionicons
                     name={SORT_META[key].icon}
-                    size={20}
+                    size={iconSize.lg}
                     color={active ? theme.color.brand : theme.color.textMuted}
                   />
                   <Text
@@ -466,7 +473,7 @@ function SortMenu({
                   {active ? (
                     <Ionicons
                       name={sortDir === 'asc' ? 'arrow-up' : 'arrow-down'}
-                      size={18}
+                      size={iconSize.md}
                       color={theme.color.brand}
                     />
                   ) : null}

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -10,6 +10,7 @@ import {
   Card,
   EmptyState,
   Gradient,
+  iconSize,
   Row,
   Screen,
   SectionHeader,
@@ -190,7 +191,7 @@ export default function HomeScreen() {
             hitSlop={10}
             style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
           >
-            <Ionicons name="camera-outline" size={24} color={theme.color.text} />
+            <Ionicons name="camera-outline" size={iconSize.xxl} color={theme.color.text} />
           </Pressable>
           {/* The overflow: the settings and the less-used destinations, dropped
               from here rather than owning a tab. */}
@@ -201,7 +202,7 @@ export default function HomeScreen() {
             hitSlop={10}
             style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
           >
-            <Ionicons name="ellipsis-vertical" size={24} color={theme.color.text} />
+            <Ionicons name="ellipsis-vertical" size={iconSize.xxl} color={theme.color.text} />
           </Pressable>
         </Row>
 
@@ -229,7 +230,11 @@ export default function HomeScreen() {
                   backgroundColor: theme.color.brandSoft,
                 }}
               >
-                <Ionicons name="file-tray-full-outline" size={22} color={theme.color.brand} />
+                <Ionicons
+                  name="file-tray-full-outline"
+                  size={iconSize.xl}
+                  color={theme.color.brand}
+                />
               </View>
               <View style={{ flex: 1, minWidth: 0 }}>
                 <Text variant="subheading">{t.captures.unassigned}</Text>
@@ -237,7 +242,7 @@ export default function HomeScreen() {
                   {plural(locale, captureCount, t.captures.unassignedBody)}
                 </Text>
               </View>
-              <Ionicons name="chevron-forward" size={20} color={theme.color.textFaint} />
+              <Ionicons name="chevron-forward" size={iconSize.lg} color={theme.color.textFaint} />
             </Card>
           </Pressable>
         ) : null}
@@ -289,7 +294,7 @@ export default function HomeScreen() {
                 <Button
                   label={t.newGroup}
                   size="sm"
-                  icon={<Ionicons name="add" size={15} color={theme.color.onBrand} />}
+                  icon={<Ionicons name="add" size={iconSize.base} color={theme.color.onBrand} />}
                   onPress={openNewGroup}
                   style={{ height: 32, paddingHorizontal: theme.spacing.md, gap: theme.spacing.xs }}
                 />
@@ -426,7 +431,7 @@ function CategoryStrip({
             >
               <Ionicons
                 name={chip.icon}
-                size={22}
+                size={iconSize.xl}
                 color={selected ? theme.color.onBrand : theme.color.textMuted}
               />
               <Text variant="micro" numberOfLines={1} style={{ color: ink }}>

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -10,6 +10,7 @@ import {
   Card,
   ChipRow,
   directionalIcon,
+  iconSize,
   ListRow,
   MoneyText,
   Row,
@@ -85,7 +86,7 @@ function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }
                   >
                     <Ionicons
                       name={item.icon}
-                      size={18}
+                      size={iconSize.md}
                       color={
                         item.destructive
                           ? theme.color.negative
@@ -100,7 +101,7 @@ function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }
                   item.route ? (
                     <Ionicons
                       name={directionalIcon('chevron-forward')}
-                      size={18}
+                      size={iconSize.md}
                       color={theme.color.textFaint}
                     />
                   ) : null
@@ -244,7 +245,7 @@ function SettledPill({ profileId, locale }: { profileId: string | null; locale: 
           backgroundColor: theme.color.brandSoft,
         }}
       >
-        <Ionicons name="checkmark-done" size={16} color={theme.color.brand} />
+        <Ionicons name="checkmark-done" size={iconSize.base} color={theme.color.brand} />
         <Row style={{ gap: 4 }}>
           <MoneyText
             amount={top[1]}

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -9,7 +9,15 @@ import { ActivityIndicator, useWindowDimensions, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
-import { Button, CurvedPanel, setLayoutDirection, ThemeProvider, Text, useTheme } from '@baaki/ui';
+import {
+  Button,
+  CurvedPanel,
+  iconSize,
+  setLayoutDirection,
+  Text,
+  ThemeProvider,
+  useTheme,
+} from '@baaki/ui';
 
 import { AppTabBar } from '@/components/AppTabBar';
 import { CampaignPopup } from '@/components/CampaignPopup';
@@ -267,7 +275,7 @@ function LockGate({ children }: { children: React.ReactNode }) {
           >
             பாக்கி
           </Text>
-          <Ionicons name="lock-closed" size={22} color={theme.color.onBrand} />
+          <Ionicons name="lock-closed" size={iconSize.xl} color={theme.color.onBrand} />
         </View>
       </CurvedPanel>
 

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -19,6 +19,7 @@ import {
   Card,
   Divider,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -258,7 +259,7 @@ export default function CaptureScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={20} color={theme.color.text} />
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.captures.newTitle}</Text>
@@ -339,7 +340,7 @@ export default function CaptureScreen() {
               size="sm"
               disabled={scanning || saving}
               onPress={() => void addReceipt()}
-              icon={<Ionicons name="camera-outline" size={18} color={theme.color.brand} />}
+              icon={<Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />}
             />
           </Row>
           {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}

--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -20,6 +20,7 @@ import {
   Card,
   EmptyState,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -124,13 +125,13 @@ export default function CapturesScreen() {
     <Screen edges={['top', 'bottom']}>
       <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
         <IconButton label={t.common.back} onPress={() => router.back()}>
-          <Ionicons name="chevron-back" size={22} color={theme.color.text} />
+          <Ionicons name="chevron-back" size={iconSize.xl} color={theme.color.text} />
         </IconButton>
         <View style={{ flex: 1, alignItems: 'center' }}>
           <Text variant="heading">{t.captures.title}</Text>
         </View>
         <IconButton label={t.captures.captureCta} onPress={() => router.push('/capture')}>
-          <Ionicons name="add" size={24} color={theme.color.brand} />
+          <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
         </IconButton>
       </Row>
 
@@ -198,7 +199,7 @@ export default function CapturesScreen() {
                   label={t.captures.delete}
                   onPress={() => void deleteCapture.mutateAsync(capture.id)}
                 >
-                  <Ionicons name="trash-outline" size={20} color={theme.color.textMuted} />
+                  <Ionicons name="trash-outline" size={iconSize.lg} color={theme.color.textMuted} />
                 </IconButton>
               </Row>
             </Card>
@@ -270,7 +271,11 @@ export default function CapturesScreen() {
                       <Text variant="body" numberOfLines={1} style={{ flex: 1 }}>
                         {groupLabel(group, summary.membersFor(group.id), profile?.id)}
                       </Text>
-                      <Ionicons name="chevron-forward" size={18} color={theme.color.textFaint} />
+                      <Ionicons
+                        name="chevron-forward"
+                        size={iconSize.md}
+                        color={theme.color.textFaint}
+                      />
                     </Pressable>
                   ))}
                 </View>

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -30,6 +30,7 @@ import {
   directionalIcon,
   Divider,
   IconButton,
+  iconSize,
   ListRow,
   Row,
   Screen,
@@ -116,7 +117,11 @@ export default function ContactsScreen(): React.JSX.Element {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.misc.fromYourContacts}</Text>
@@ -234,7 +239,7 @@ function ChooseGroup({
                 trailing={
                   <Ionicons
                     name={directionalIcon('chevron-forward')}
-                    size={18}
+                    size={iconSize.md}
                     color={theme.color.textFaint}
                   />
                 }

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -22,6 +22,7 @@ import {
   ChipRow,
   EmptyState,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -475,7 +476,7 @@ export default function AddExpenseScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={20} color={theme.color.text} />
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{editing ? t.expense.edit : t.addExpense}</Text>
@@ -490,7 +491,7 @@ export default function AddExpenseScreen() {
               label={t.expense.splitByItem}
               onPress={() => router.replace(`/group/${groupId}/itemize`)}
             >
-              <Ionicons name="list-outline" size={20} color={theme.color.brand} />
+              <Ionicons name="list-outline" size={iconSize.lg} color={theme.color.brand} />
             </IconButton>
           )}
         </Row>
@@ -523,7 +524,7 @@ export default function AddExpenseScreen() {
               variant="secondary"
               disabled={scanning || saving}
               onPress={() => void scan()}
-              icon={<Ionicons name="camera-outline" size={18} color={theme.color.brand} />}
+              icon={<Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />}
             />
           </Row>
           {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
@@ -727,7 +728,7 @@ export default function AddExpenseScreen() {
                 >
                   <Ionicons
                     name={selected ? 'checkmark-circle' : 'ellipse-outline'}
-                    size={22}
+                    size={iconSize.xl}
                     color={selected ? theme.color.brand : theme.color.textFaint}
                   />
                 </Pressable>

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -11,6 +11,7 @@ import {
   directionalIcon,
   EmptyState,
   IconButton,
+  iconSize,
   ListRow,
   MoneyText,
   Row,
@@ -143,7 +144,11 @@ export default function ExpenseDetailScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading" numberOfLines={1}>
@@ -157,7 +162,7 @@ export default function ExpenseDetailScreen() {
             label={t.common.edit}
             onPress={() => router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}`)}
           >
-            <Ionicons name="create-outline" size={18} color={theme.color.text} />
+            <Ionicons name="create-outline" size={iconSize.md} color={theme.color.text} />
           </IconButton>
         </Row>
 

--- a/apps/mobile/src/app/group/[id]/import/csv.tsx
+++ b/apps/mobile/src/app/group/[id]/import/csv.tsx
@@ -29,6 +29,7 @@ import {
   Card,
   Chip,
   IconButton,
+  iconSize,
   ListRow,
   MoneyText,
   Row,
@@ -189,7 +190,7 @@ export default function ImportCsvScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={22} color={theme.color.text} />
+            <Ionicons name="close" size={iconSize.xl} color={theme.color.text} />
           </IconButton>
           <Text variant="subheading" style={{ marginLeft: theme.spacing.md }}>
             {t.importLedger.splitwiseTitle}

--- a/apps/mobile/src/app/group/[id]/import/sms.tsx
+++ b/apps/mobile/src/app/group/[id]/import/sms.tsx
@@ -33,6 +33,7 @@ import {
   Chip,
   EmptyState,
   IconButton,
+  iconSize,
   ListRow,
   MoneyText,
   Row,
@@ -225,7 +226,7 @@ export default function ImportSmsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={22} color={theme.color.text} />
+            <Ionicons name="close" size={iconSize.xl} color={theme.color.text} />
           </IconButton>
           <Text variant="subheading" style={{ marginLeft: theme.spacing.md }}>
             {t.smsImport.title}
@@ -280,7 +281,13 @@ export default function ImportSmsScreen() {
                   variant="secondary"
                   disabled={reading}
                   onPress={() => void readInbox()}
-                  icon={<Ionicons name="chatbubbles-outline" size={18} color={theme.color.brand} />}
+                  icon={
+                    <Ionicons
+                      name="chatbubbles-outline"
+                      size={iconSize.md}
+                      color={theme.color.brand}
+                    />
+                  }
                 />
                 <Text variant="micro" tone="faint">
                   {t.smsImport.readOnAndroid}
@@ -361,7 +368,7 @@ export default function ImportSmsScreen() {
                           leading={
                             <Ionicons
                               name={picked ? 'checkbox' : 'square-outline'}
-                              size={24}
+                              size={iconSize.xxl}
                               color={picked ? theme.color.brand : theme.color.textFaint}
                             />
                           }

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -11,6 +11,7 @@ import {
   directionalIcon,
   EmptyState,
   Fab,
+  iconSize,
   ListRow,
   MoneyText,
   Row,
@@ -154,7 +155,11 @@ export default function GroupScreen() {
               accessibilityLabel={t.common.back}
               hitSlop={10}
             >
-              <Ionicons name={directionalIcon('chevron-back')} size={24} color={theme.color.text} />
+              <Ionicons
+                name={directionalIcon('chevron-back')}
+                size={iconSize.xxl}
+                color={theme.color.text}
+              />
             </Pressable>
             {/* The photo-and-name cluster is itself the way into settings, the
               way tapping a chat's title bar opens its info in WhatsApp — so the
@@ -195,7 +200,7 @@ export default function GroupScreen() {
               accessibilityLabel={t.group.more}
               hitSlop={10}
             >
-              <Ionicons name="ellipsis-vertical" size={22} color={theme.color.text} />
+              <Ionicons name="ellipsis-vertical" size={iconSize.xl} color={theme.color.text} />
             </Pressable>
           </Row>
 
@@ -230,13 +235,13 @@ export default function GroupScreen() {
             >
               <Card style={{ gap: theme.spacing.sm }}>
                 <Row style={{ gap: theme.spacing.sm }}>
-                  <Ionicons name="receipt-outline" size={18} color={theme.color.brand} />
+                  <Ionicons name="receipt-outline" size={iconSize.md} color={theme.color.brand} />
                   <Text variant="subheading" style={{ flex: 1 }} numberOfLines={1}>
                     {receipt.parsed?.merchant ?? t.expense.aBill}
                   </Text>
                   <Ionicons
                     name={directionalIcon('chevron-forward')}
-                    size={18}
+                    size={iconSize.md}
                     color={theme.color.textFaint}
                   />
                 </Row>
@@ -289,7 +294,9 @@ export default function GroupScreen() {
               <Button
                 label={t.settleUp}
                 onPress={() => router.push(`/group/${groupId}/settle`)}
-                icon={<Ionicons name="swap-horizontal" size={18} color={theme.color.onBrand} />}
+                icon={
+                  <Ionicons name="swap-horizontal" size={iconSize.md} color={theme.color.onBrand} />
+                }
                 style={{ flex: 1, paddingHorizontal: theme.spacing.md }}
               />
               <Button
@@ -530,7 +537,7 @@ export default function GroupScreen() {
         <Fab
           label={t.addExpense}
           onPress={() => router.push(`/group/${groupId}/add-expense`)}
-          icon={<Ionicons name="add" size={22} color={theme.color.onBrand} />}
+          icon={<Ionicons name="add" size={iconSize.xl} color={theme.color.onBrand} />}
         />
       </DetailEnter>
     </Screen>

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -25,21 +25,22 @@ import { ScrollView, View } from 'react-native';
 
 import { categoryOf, format, type CategoryId } from '@baaki/core';
 import {
-  type BarDatum,
   BarList,
   Callout,
   Card,
   ChipRow,
   ColumnChart,
-  type ColumnDatum,
   directionalIcon,
   EmptyState,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
   SectionHeader,
   Text,
+  type BarDatum,
+  type ColumnDatum,
   useTheme,
 } from '@baaki/ui';
 
@@ -108,7 +109,11 @@ export default function InsightsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.spending}</Text>

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -4,7 +4,18 @@ import * as Clipboard from 'expo-clipboard';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Linking, Platform, ScrollView, Share, View } from 'react-native';
 
-import { Badge, Button, Callout, Card, IconButton, Row, Screen, Text, useTheme } from '@baaki/ui';
+import {
+  Badge,
+  Button,
+  Callout,
+  Card,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  useTheme,
+} from '@baaki/ui';
 
 import { mintInvite, type MintedInvite } from '@/data/api';
 import { useGroup } from '@/data/hooks';
@@ -97,7 +108,7 @@ export default function InviteScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={20} color={theme.color.text} />
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.people.inviteTitle}</Text>
@@ -151,7 +162,9 @@ export default function InviteScreen() {
                   label={option.label}
                   variant="secondary"
                   onPress={() => void shareVia(option.channel)}
-                  icon={<Ionicons name={option.icon} size={18} color={theme.color.brand} />}
+                  icon={
+                    <Ionicons name={option.icon} size={iconSize.md} color={theme.color.brand} />
+                  }
                 />
               ))}
             </Row>
@@ -161,7 +174,9 @@ export default function InviteScreen() {
                 label={t.people.shareAnotherWay}
                 size="lg"
                 onPress={() => void share()}
-                icon={<Ionicons name="share-outline" size={18} color={theme.color.onBrand} />}
+                icon={
+                  <Ionicons name="share-outline" size={iconSize.md} color={theme.color.onBrand} />
+                }
               />
               <Button
                 label={copied ? t.people.linkCopied : t.people.copyLink}

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -21,6 +21,7 @@ import {
   Card,
   EmptyState,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -409,7 +410,7 @@ export default function ItemizeScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={20} color={theme.color.text} />
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.itemize.title}</Text>
@@ -425,7 +426,7 @@ export default function ItemizeScreen() {
              is say who had what. Everybody sees everybody else's taps. */
           <Card style={{ gap: theme.spacing.sm }}>
             <Row style={{ gap: theme.spacing.sm }}>
-              <Ionicons name="people-outline" size={18} color={theme.color.brand} />
+              <Ionicons name="people-outline" size={iconSize.md} color={theme.color.brand} />
               <Text variant="subheading" style={{ flex: 1 }}>
                 {t.itemize.splittingTogether}
               </Text>
@@ -449,7 +450,9 @@ export default function ItemizeScreen() {
                 variant="secondary"
                 disabled={scanning}
                 onPress={() => void scan()}
-                icon={<Ionicons name="camera-outline" size={18} color={theme.color.brand} />}
+                icon={
+                  <Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />
+                }
               />
             </Row>
             {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
@@ -474,7 +477,7 @@ export default function ItemizeScreen() {
               variant="secondary"
               disabled={publishing}
               onPress={() => void publish()}
-              icon={<Ionicons name="people-outline" size={18} color={theme.color.brand} />}
+              icon={<Ionicons name="people-outline" size={iconSize.md} color={theme.color.brand} />}
             />
           </Card>
         ) : null}
@@ -563,7 +566,7 @@ export default function ItemizeScreen() {
                     setItems((current) => current.filter((row) => row.key !== item.key))
                   }
                 >
-                  <Ionicons name="trash-outline" size={18} color={theme.color.textFaint} />
+                  <Ionicons name="trash-outline" size={iconSize.md} color={theme.color.textFaint} />
                 </Pressable>
               )}
             </Row>

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -12,6 +12,7 @@ import {
   directionalIcon,
   EmptyState,
   IconButton,
+  iconSize,
   ListRow,
   MoneyText,
   Row,
@@ -96,7 +97,11 @@ export default function MemberScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{displayName(member, profile?.id)}</Text>

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -11,6 +11,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   ListRow,
   MoneyText,
   Row,
@@ -173,7 +174,11 @@ export default function MembersScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.members}</Text>
@@ -185,7 +190,7 @@ export default function MembersScreen() {
             label={t.people.invite}
             onPress={() => router.push(`/group/${groupId}/invite`)}
           >
-            <Ionicons name="share-outline" size={18} color={theme.color.brand} />
+            <Ionicons name="share-outline" size={iconSize.md} color={theme.color.brand} />
           </IconButton>
         </Row>
 

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -22,6 +22,7 @@ import {
   directionalIcon,
   EmptyState,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -137,7 +138,11 @@ export default function SpendingMonthScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{monthTitle}</Text>

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -35,12 +35,13 @@ import {
   directionalIcon,
   EmptyState,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
   Text,
-  useTheme,
   type Theme,
+  useTheme,
 } from '@baaki/ui';
 
 import {
@@ -315,7 +316,11 @@ export default function PlanScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md, gap: theme.spacing.sm }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <Text variant="heading">{t.plan}</Text>
         </Row>
@@ -445,7 +450,7 @@ export default function PlanScreen() {
                   <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
                     <Ionicons
                       name={myShare ? 'checkbox' : 'square-outline'}
-                      size={20}
+                      size={iconSize.lg}
                       color={myShare ? theme.color.brand : theme.color.textFaint}
                     />
                     <Text variant="caption">{myShare ? t.shareWithGroup : t.budgetPrivate}</Text>
@@ -548,7 +553,7 @@ export default function PlanScreen() {
                   >
                     <Ionicons
                       name={item.done ? 'checkmark-circle' : 'ellipse-outline'}
-                      size={22}
+                      size={iconSize.xl}
                       color={item.done ? theme.color.positive : theme.color.textFaint}
                     />
                   </Pressable>
@@ -577,7 +582,7 @@ export default function PlanScreen() {
                     accessibilityLabel={`Remove ${item.title}`}
                     hitSlop={10}
                   >
-                    <Ionicons name="close" size={18} color={theme.color.textFaint} />
+                    <Ionicons name="close" size={iconSize.md} color={theme.color.textFaint} />
                   </Pressable>
                 </Row>
               ))}
@@ -589,7 +594,11 @@ export default function PlanScreen() {
                   key={expense.id}
                   style={{ paddingVertical: theme.spacing.sm, gap: theme.spacing.md }}
                 >
-                  <Ionicons name="receipt-outline" size={18} color={theme.color.textFaint} />
+                  <Ionicons
+                    name="receipt-outline"
+                    size={iconSize.md}
+                    color={theme.color.textFaint}
+                  />
                   <Text variant="caption" tone="muted" style={{ flex: 1 }} numberOfLines={1}>
                     {expense.description}
                   </Text>
@@ -681,7 +690,9 @@ function BudgetBar({
     <View style={{ gap: theme.spacing.xs }}>
       <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
         <Row style={{ gap: theme.spacing.xs, alignItems: 'center', flex: 1 }}>
-          {badge ? <Ionicons name={badge} size={12} color={theme.color.textFaint} /> : null}
+          {badge ? (
+            <Ionicons name={badge} size={iconSize.xs} color={theme.color.textFaint} />
+          ) : null}
           <Text variant="caption" numberOfLines={1} style={{ flex: 1 }}>
             {label}
           </Text>

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -9,6 +9,7 @@ import {
   directionalIcon,
   EmptyState,
   IconButton,
+  iconSize,
   ListRow,
   Row,
   Screen,
@@ -127,11 +128,15 @@ export default function GroupSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-              <Ionicons name="settings-outline" size={18} color={theme.color.brand} />
+              <Ionicons name="settings-outline" size={iconSize.md} color={theme.color.brand} />
               <Text variant="heading">{t.group.settings}</Text>
             </Row>
             <Text variant="micro" tone="muted">
@@ -242,12 +247,14 @@ export default function GroupSettingsScreen() {
             <ListRow
               title={plural(locale, members.data?.length ?? 0, t.memberCount)}
               subtitle={t.group.membersHint}
-              leading={<Ionicons name="people-outline" size={22} color={theme.color.textMuted} />}
+              leading={
+                <Ionicons name="people-outline" size={iconSize.xl} color={theme.color.textMuted} />
+              }
               onPress={() => router.push(`/group/${groupId}/members`)}
               trailing={
                 <Ionicons
                   name={directionalIcon('chevron-forward')}
-                  size={18}
+                  size={iconSize.md}
                   color={theme.color.textFaint}
                 />
               }
@@ -256,12 +263,14 @@ export default function GroupSettingsScreen() {
             <ListRow
               title={t.group.invitePeople}
               subtitle={t.group.invitePeopleHint}
-              leading={<Ionicons name="share-outline" size={22} color={theme.color.textMuted} />}
+              leading={
+                <Ionicons name="share-outline" size={iconSize.xl} color={theme.color.textMuted} />
+              }
               onPress={() => router.push(`/group/${groupId}/invite`)}
               trailing={
                 <Ionicons
                   name={directionalIcon('chevron-forward')}
-                  size={18}
+                  size={iconSize.md}
                   color={theme.color.textFaint}
                 />
               }
@@ -276,13 +285,17 @@ export default function GroupSettingsScreen() {
               title={t.group.importMessages}
               subtitle={t.group.importMessagesHint}
               leading={
-                <Ionicons name="chatbox-ellipses-outline" size={22} color={theme.color.textMuted} />
+                <Ionicons
+                  name="chatbox-ellipses-outline"
+                  size={iconSize.xl}
+                  color={theme.color.textMuted}
+                />
               }
               onPress={() => router.push(`/group/${groupId}/import/sms`)}
               trailing={
                 <Ionicons
                   name={directionalIcon('chevron-forward')}
-                  size={18}
+                  size={iconSize.md}
                   color={theme.color.textFaint}
                 />
               }
@@ -292,13 +305,17 @@ export default function GroupSettingsScreen() {
               title={t.group.importSplitwise}
               subtitle={t.group.importSplitwiseHint}
               leading={
-                <Ionicons name="document-text-outline" size={22} color={theme.color.textMuted} />
+                <Ionicons
+                  name="document-text-outline"
+                  size={iconSize.xl}
+                  color={theme.color.textMuted}
+                />
               }
               onPress={() => router.push(`/group/${groupId}/import/csv`)}
               trailing={
                 <Ionicons
                   name={directionalIcon('chevron-forward')}
-                  size={18}
+                  size={iconSize.md}
                   color={theme.color.textFaint}
                 />
               }

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -22,6 +22,7 @@ import {
   ChipRow,
   EmptyState,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -250,7 +251,7 @@ export default function SettleScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={20} color={theme.color.text} />
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.settleUp}</Text>
@@ -364,7 +365,7 @@ export default function SettleScreen() {
               onPress={() => (handsOff ? void payThen() : void record())}
               icon={
                 handsOff ? (
-                  <Ionicons name="open-outline" size={18} color={theme.color.onBrand} />
+                  <Ionicons name="open-outline" size={iconSize.md} color={theme.color.onBrand} />
                 ) : undefined
               }
             />

--- a/apps/mobile/src/app/group/[id]/simplify.tsx
+++ b/apps/mobile/src/app/group/[id]/simplify.tsx
@@ -9,6 +9,7 @@ import {
   directionalIcon,
   EmptyState,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -49,7 +50,11 @@ export default function SimplifyScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.whoPaysWhom}</Text>
@@ -87,7 +92,7 @@ export default function SimplifyScreen() {
                   <Avatar name={nameOf(transfer.from)} size={38} />
                   <Ionicons
                     name={directionalIcon('arrow-forward')}
-                    size={16}
+                    size={iconSize.base}
                     color={theme.color.textFaint}
                   />
                   <Avatar name={nameOf(transfer.to)} size={38} />

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -22,6 +22,7 @@ import {
   directionalIcon,
   EmptyState,
   IconButton,
+  iconSize,
   Row,
   Screen,
   SectionHeader,
@@ -103,7 +104,11 @@ export default function InboxScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.inbox.title}</Text>
@@ -167,7 +172,7 @@ export default function InboxScreen() {
                         >
                           <Ionicons
                             name={ICONS[row.kind] ?? 'notifications'}
-                            size={18}
+                            size={iconSize.md}
                             color={theme.tint[tint].ink}
                           />
                         </View>

--- a/apps/mobile/src/app/join.tsx
+++ b/apps/mobile/src/app/join.tsx
@@ -11,6 +11,7 @@ import {
   Callout,
   Card,
   EmptyState,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -154,7 +155,7 @@ export default function JoinScreen() {
           }}
         >
           <Card style={{ alignItems: 'center', gap: theme.spacing.md }}>
-            <Ionicons name="hourglass-outline" size={40} color={theme.color.brand} />
+            <Ionicons name="hourglass-outline" size={iconSize.hero} color={theme.color.brand} />
             <Text variant="subheading" align="center">
               {t.claims.waitingTitle}
             </Text>
@@ -242,7 +243,11 @@ export default function JoinScreen() {
             </Row>
             {claimId ? (
               <Row style={{ gap: theme.spacing.sm }}>
-                <Ionicons name="information-circle-outline" size={16} color={theme.color.brand} />
+                <Ionicons
+                  name="information-circle-outline"
+                  size={iconSize.base}
+                  color={theme.color.brand}
+                />
                 <Text variant="micro" tone="brand" style={{ flex: 1 }}>
                   {`${t.extras.theirPastBecomesYours} ${t.claims.needsConfirming}`}
                 </Text>

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -11,6 +11,7 @@ import {
   Card,
   ChipRow,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -57,7 +58,7 @@ const deviceZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZon
 const iconFor =
   (name: keyof typeof Ionicons.glyphMap) =>
   // eslint-disable-next-line react/display-name
-  (color: string): ReactNode => <Ionicons name={name} size={16} color={color} />;
+  (color: string): ReactNode => <Ionicons name={name} size={iconSize.base} color={color} />;
 
 /**
  * Making a group, wearing the same clothes as the settings that edit one.
@@ -228,7 +229,7 @@ export default function NewGroupScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={20} color={theme.color.text} />
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.newGroup}</Text>
@@ -344,7 +345,7 @@ export default function NewGroupScreen() {
               >
                 <Ionicons
                   name={browsing ? 'people' : 'people-outline'}
-                  size={16}
+                  size={iconSize.base}
                   color={theme.color.brand}
                 />
                 <Text variant="caption" style={{ color: theme.color.brand }}>
@@ -412,7 +413,7 @@ export default function NewGroupScreen() {
                   }}
                 >
                   <Text variant="caption">{ghost.name}</Text>
-                  <Ionicons name="close" size={14} color={theme.color.textMuted} />
+                  <Ionicons name="close" size={iconSize.sm} color={theme.color.textMuted} />
                 </Pressable>
               ))}
             </Row>

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -20,6 +20,7 @@ import {
   ChipRow,
   directionalIcon,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -129,7 +130,11 @@ export default function AccountScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.contact.title}</Text>
@@ -327,7 +332,7 @@ function ProviderRow({
   return (
     <Row style={{ justifyContent: 'space-between' }}>
       <Row style={{ gap: theme.spacing.md }}>
-        <Ionicons name={icon} size={22} color={theme.color.text} />
+        <Ionicons name={icon} size={iconSize.xl} color={theme.color.text} />
         <Text variant="body">{name}</Text>
       </Row>
       {linked ? (

--- a/apps/mobile/src/app/settings/archived.tsx
+++ b/apps/mobile/src/app/settings/archived.tsx
@@ -21,6 +21,7 @@ import {
   directionalIcon,
   EmptyState,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -70,7 +71,11 @@ export default function ArchivedGroupsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.group.archivedTitle}</Text>

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -23,9 +23,10 @@ import {
   Badge,
   Button,
   Card,
-  Divider,
   directionalIcon,
+  Divider,
   IconButton,
+  iconSize,
   Row,
   Screen,
   SectionHeader,
@@ -70,7 +71,11 @@ export default function BackupSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.backup.title}</Text>
@@ -205,7 +210,7 @@ function SelectRow({
     >
       <Ionicons
         name={selected ? 'radio-button-on' : 'radio-button-off'}
-        size={22}
+        size={iconSize.xl}
         color={selected ? theme.color.brand : theme.color.textFaint}
       />
       <View style={{ flex: 1 }}>

--- a/apps/mobile/src/app/settings/delete-account.tsx
+++ b/apps/mobile/src/app/settings/delete-account.tsx
@@ -10,6 +10,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -96,7 +97,11 @@ export default function DeleteAccountScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.privacy.deleteTitle}</Text>
@@ -111,7 +116,7 @@ export default function DeleteAccountScreen() {
         {/* What stays comes first: it is the surprising half. */}
         <Card style={{ gap: theme.spacing.sm, borderWidth: 1, borderColor: theme.color.border }}>
           <Row style={{ gap: theme.spacing.sm }}>
-            <Ionicons name="people-outline" size={18} color={theme.color.text} />
+            <Ionicons name="people-outline" size={iconSize.md} color={theme.color.text} />
             <Text variant="subheading">{t.privacy.deleteStaysTitle}</Text>
           </Row>
           <Text variant="caption" tone="muted">
@@ -147,7 +152,7 @@ export default function DeleteAccountScreen() {
 
         <Card style={{ gap: theme.spacing.sm }}>
           <Row style={{ gap: theme.spacing.sm }}>
-            <Ionicons name="trash-outline" size={18} color={theme.color.negative} />
+            <Ionicons name="trash-outline" size={iconSize.md} color={theme.color.negative} />
             <Text variant="subheading">{t.privacy.deleteGoesTitle}</Text>
           </Row>
           <Text variant="caption" tone="muted">

--- a/apps/mobile/src/app/settings/devices.tsx
+++ b/apps/mobile/src/app/settings/devices.tsx
@@ -22,6 +22,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -78,7 +79,11 @@ export default function DevicesScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.devices.title}</Text>

--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -13,6 +13,7 @@ import {
   ChipRow,
   directionalIcon,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -90,7 +91,11 @@ export default function ExportScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.exportData.title}</Text>
@@ -145,7 +150,7 @@ export default function ExportScreen() {
           fullWidth
           disabled={busy}
           onPress={() => void run()}
-          icon={<Ionicons name="download-outline" size={18} color={theme.color.onBrand} />}
+          icon={<Ionicons name="download-outline" size={iconSize.md} color={theme.color.onBrand} />}
         />
         {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
 
@@ -172,7 +177,9 @@ export default function ExportScreen() {
           variant="ghost"
           fullWidth
           onPress={() => router.push('/settings/import')}
-          icon={<Ionicons name="cloud-upload-outline" size={18} color={theme.color.brand} />}
+          icon={
+            <Ionicons name="cloud-upload-outline" size={iconSize.md} color={theme.color.brand} />
+          }
         />
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/settings/feedback.tsx
+++ b/apps/mobile/src/app/settings/feedback.tsx
@@ -11,6 +11,7 @@ import {
   ChipRow,
   directionalIcon,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -76,7 +77,11 @@ export default function FeedbackScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.privacy.feedbackTitle}</Text>
@@ -86,7 +91,7 @@ export default function FeedbackScreen() {
 
         {sent ? (
           <Card style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-            <Ionicons name="checkmark-circle" size={40} color={theme.color.positive} />
+            <Ionicons name="checkmark-circle" size={iconSize.hero} color={theme.color.positive} />
             <Text variant="subheading" align="center">
               {t.privacy.feedbackThanks}
             </Text>

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -43,6 +43,7 @@ import {
   directionalIcon,
   Divider,
   IconButton,
+  iconSize,
   MoneyText,
   Row,
   Screen,
@@ -342,7 +343,11 @@ export default function ImportScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.importLedger.ledgerTitle}</Text>
@@ -370,7 +375,7 @@ export default function ImportScreen() {
           icon={
             <Ionicons
               name="document-attach-outline"
-              size={18}
+              size={iconSize.md}
               color={file ? theme.color.brand : theme.color.onBrand}
             />
           }
@@ -519,7 +524,11 @@ export default function ImportScreen() {
                   disabled={busy || !claimedByMe}
                   onPress={() => void run()}
                   icon={
-                    <Ionicons name="cloud-upload-outline" size={18} color={theme.color.onBrand} />
+                    <Ionicons
+                      name="cloud-upload-outline"
+                      size={iconSize.md}
+                      color={theme.color.onBrand}
+                    />
                   }
                 />
                 {!claimedByMe ? (
@@ -588,7 +597,7 @@ function TargetRow({
         </View>
         <Ionicons
           name={selected ? 'radio-button-on' : 'radio-button-off'}
-          size={22}
+          size={iconSize.xl}
           color={selected ? theme.color.brand : theme.color.textFaint}
         />
       </Row>

--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -21,6 +21,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   ListRow,
   Row,
   Screen,
@@ -68,7 +69,11 @@ export default function LanguageSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.language}</Text>
@@ -82,7 +87,7 @@ export default function LanguageSettingsScreen() {
         {restartNeeded ? (
           <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.sm }}>
             <Row style={{ gap: theme.spacing.sm }}>
-              <Ionicons name="refresh" size={18} color={theme.color.brand} />
+              <Ionicons name="refresh" size={iconSize.md} color={theme.color.brand} />
               <Text variant="subheading" tone="brand">
                 {t.account.restartTitle}
               </Text>
@@ -117,7 +122,7 @@ export default function LanguageSettingsScreen() {
                   accessibilityLabel={`${row.title}${chosen ? ', selected' : ''}`}
                   trailing={
                     chosen ? (
-                      <Ionicons name="checkmark" size={20} color={theme.color.brand} />
+                      <Ionicons name="checkmark" size={iconSize.lg} color={theme.color.brand} />
                     ) : null
                   }
                 />

--- a/apps/mobile/src/app/settings/lock.tsx
+++ b/apps/mobile/src/app/settings/lock.tsx
@@ -18,6 +18,7 @@ import {
   Chip,
   directionalIcon,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -64,7 +65,11 @@ export default function LockSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.lock.title}</Text>

--- a/apps/mobile/src/app/settings/motion.tsx
+++ b/apps/mobile/src/app/settings/motion.tsx
@@ -18,6 +18,7 @@ import {
   directionalIcon,
   Divider,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -47,7 +48,11 @@ export default function MotionSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.motion.title}</Text>

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -9,6 +9,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   Row,
   Screen,
   SectionHeader,
@@ -150,7 +151,11 @@ export default function NotificationSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.notifications.title}</Text>

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -7,6 +7,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -86,7 +87,11 @@ export default function PrivacyScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.privacy.title}</Text>
@@ -101,7 +106,7 @@ export default function PrivacyScreen() {
         {sections.map((section) => (
           <Card key={section.id} style={{ gap: theme.spacing.sm }}>
             <Row style={{ gap: theme.spacing.sm }}>
-              <Ionicons name={section.icon} size={18} color={theme.color.brand} />
+              <Ionicons name={section.icon} size={iconSize.md} color={theme.color.brand} />
               <Text variant="subheading">{section.title}</Text>
             </Row>
             <Text variant="caption" tone="muted">

--- a/apps/mobile/src/app/settings/redeem.tsx
+++ b/apps/mobile/src/app/settings/redeem.tsx
@@ -23,6 +23,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   Row,
   Screen,
   Text,
@@ -96,7 +97,11 @@ export default function RedeemScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.promo.title}</Text>
@@ -106,7 +111,7 @@ export default function RedeemScreen() {
 
         {granted ? (
           <Card style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-            <Ionicons name="checkmark-circle" size={40} color={theme.color.positive} />
+            <Ionicons name="checkmark-circle" size={iconSize.hero} color={theme.color.positive} />
             <Text variant="subheading" align="center">
               {t.promo.granted}
             </Text>

--- a/apps/mobile/src/app/settings/sync.tsx
+++ b/apps/mobile/src/app/settings/sync.tsx
@@ -15,6 +15,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   ListRow,
   Row,
   Screen,
@@ -74,7 +75,11 @@ export default function SyncSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.sync.title}</Text>
@@ -92,10 +97,10 @@ export default function SyncSettingsScreen() {
                   subtitle={row.subtitle}
                   onPress={() => void setPreference(row.value)}
                   accessibilityLabel={`${row.title}${chosen ? ', selected' : ''}`}
-                  leading={<Ionicons name={row.icon} size={22} color={theme.color.text} />}
+                  leading={<Ionicons name={row.icon} size={iconSize.xl} color={theme.color.text} />}
                   trailing={
                     chosen ? (
-                      <Ionicons name="checkmark" size={20} color={theme.color.brand} />
+                      <Ionicons name="checkmark" size={iconSize.lg} color={theme.color.brand} />
                     ) : null
                   }
                 />

--- a/apps/mobile/src/app/settings/theme.tsx
+++ b/apps/mobile/src/app/settings/theme.tsx
@@ -16,6 +16,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   ListRow,
   Row,
   Screen,
@@ -78,7 +79,11 @@ export default function ThemeSettingsScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.theme.title}</Text>
@@ -96,10 +101,10 @@ export default function ThemeSettingsScreen() {
                   subtitle={row.subtitle}
                   onPress={() => void setPreference(row.value)}
                   accessibilityLabel={`${row.title}${chosen ? ', selected' : ''}`}
-                  leading={<Ionicons name={row.icon} size={22} color={theme.color.text} />}
+                  leading={<Ionicons name={row.icon} size={iconSize.xl} color={theme.color.text} />}
                   trailing={
                     chosen ? (
-                      <Ionicons name="checkmark" size={20} color={theme.color.brand} />
+                      <Ionicons name="checkmark" size={iconSize.lg} color={theme.color.brand} />
                     ) : null
                   }
                 />

--- a/apps/mobile/src/app/settings/upgrade.tsx
+++ b/apps/mobile/src/app/settings/upgrade.tsx
@@ -21,6 +21,7 @@ import {
   Card,
   directionalIcon,
   IconButton,
+  iconSize,
   ListRow,
   Row,
   Screen,
@@ -66,7 +67,11 @@ export default function UpgradeScreen() {
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons name={directionalIcon('chevron-back')} size={20} color={theme.color.text} />
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.upgrade}</Text>
@@ -93,7 +98,7 @@ export default function UpgradeScreen() {
           {conveniences(t).map((item) => (
             <Card key={item.title} style={{ gap: theme.spacing.sm }}>
               <Row style={{ gap: theme.spacing.sm }}>
-                <Ionicons name={item.icon} size={18} color={theme.color.brand} />
+                <Ionicons name={item.icon} size={iconSize.md} color={theme.color.brand} />
                 <Text variant="subheading">{item.title}</Text>
               </Row>
               <Text variant="caption" tone="muted">
@@ -105,7 +110,7 @@ export default function UpgradeScreen() {
 
         <Card style={{ gap: theme.spacing.sm }}>
           <Row style={{ gap: theme.spacing.sm }}>
-            <Ionicons name="lock-open-outline" size={18} color={theme.color.positive} />
+            <Ionicons name="lock-open-outline" size={iconSize.md} color={theme.color.positive} />
             <Text variant="subheading">{t.upgradeScreen.whatNeverWill}</Text>
           </Row>
           <Text variant="caption" tone="muted">
@@ -120,11 +125,13 @@ export default function UpgradeScreen() {
           <ListRow
             title={t.promo.row}
             subtitle={t.promo.rowHint}
-            leading={<Ionicons name="pricetag-outline" size={20} color={theme.color.brand} />}
+            leading={
+              <Ionicons name="pricetag-outline" size={iconSize.lg} color={theme.color.brand} />
+            }
             trailing={
               <Ionicons
                 name={directionalIcon('chevron-forward')}
-                size={18}
+                size={iconSize.md}
                 color={theme.color.textFaint}
               />
             }

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -41,6 +41,7 @@ import {
   Callout,
   Card,
   CurvedPanel,
+  iconSize,
   Row,
   Screen,
   SegmentedTabs,
@@ -283,14 +284,14 @@ export default function SignInScreen() {
                 disabled={busy}
                 onPress={() => void run(withApple)}
               >
-                <Ionicons name="logo-apple" size={26} color={theme.color.text} />
+                <Ionicons name="logo-apple" size={iconSize.xxxl} color={theme.color.text} />
               </ProviderTile>
               <ProviderTile
                 label={t.signIn.signInGoogle}
                 disabled={busy}
                 onPress={() => void run(withGoogle)}
               >
-                <Ionicons name="logo-google" size={26} color={theme.color.text} />
+                <Ionicons name="logo-google" size={iconSize.xxxl} color={theme.color.text} />
               </ProviderTile>
             </View>
 
@@ -565,14 +566,14 @@ export default function SignInScreen() {
                   disabled={busy}
                   onPress={() => void run(withApple)}
                 >
-                  <Ionicons name="logo-apple" size={26} color={theme.color.text} />
+                  <Ionicons name="logo-apple" size={iconSize.xxxl} color={theme.color.text} />
                 </ProviderTile>
                 <ProviderTile
                   label={isGuest ? t.signIn.continueGoogle : t.signIn.signInGoogle}
                   disabled={busy}
                   onPress={() => void run(withGoogle)}
                 >
-                  <Ionicons name="logo-google" size={26} color={theme.color.text} />
+                  <Ionicons name="logo-google" size={iconSize.xxxl} color={theme.color.text} />
                 </ProviderTile>
               </View>
             </View>

--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -16,7 +16,7 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useSegments } from 'expo-router';
 
-import { PillTabBar, type PillTabItem } from '@baaki/ui';
+import { iconSize, PillTabBar, type PillTabItem } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 import { useMotion } from '@/lib/motion';
@@ -37,22 +37,22 @@ export function AppTabBar() {
     {
       key: 'index',
       label: t.home,
-      icon: (color) => <Ionicons name="home" size={20} color={color} />,
+      icon: (color) => <Ionicons name="home" size={iconSize.lg} color={color} />,
     },
     {
       key: 'friends',
       label: t.friends,
-      icon: (color) => <Ionicons name="people" size={20} color={color} />,
+      icon: (color) => <Ionicons name="people" size={iconSize.lg} color={color} />,
     },
     {
       key: 'activity',
       label: t.activity,
-      icon: (color) => <Ionicons name="pulse" size={20} color={color} />,
+      icon: (color) => <Ionicons name="pulse" size={iconSize.lg} color={color} />,
     },
     {
       key: 'inbox',
       label: t.tabs.inbox,
-      icon: (color) => <Ionicons name="file-tray-outline" size={20} color={color} />,
+      icon: (color) => <Ionicons name="file-tray-outline" size={iconSize.lg} color={color} />,
     },
   ];
 

--- a/apps/mobile/src/components/Category.tsx
+++ b/apps/mobile/src/components/Category.tsx
@@ -16,7 +16,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { Pressable, ScrollView, View } from 'react-native';
 
 import { CATEGORIES, categoryOf, type CategoryId } from '@baaki/core';
-import { Text, useTheme } from '@baaki/ui';
+import { iconSize, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -93,7 +93,7 @@ export function CategoryPicker({
           >
             <Ionicons
               name={category.icon as keyof typeof Ionicons.glyphMap}
-              size={15}
+              size={iconSize.base}
               color={selected ? tint.ink : theme.color.textMuted}
             />
             <Text variant="caption" style={{ color: selected ? tint.ink : theme.color.textMuted }}>

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -33,7 +33,7 @@ import {
   type LayoutChangeEvent,
 } from 'react-native';
 
-import { Avatar, Button, Card, EmptyState, Row, Text, useTheme } from '@baaki/ui';
+import { Avatar, Button, Card, EmptyState, iconSize, Row, Text, useTheme } from '@baaki/ui';
 
 import { plural, useStrings } from '@/i18n';
 import { SkeletonList } from '@/components/Skeletons';
@@ -295,7 +295,7 @@ export function ContactPicker({
           backgroundColor: theme.color.surfaceMuted,
         }}
       >
-        <Ionicons name="search" size={18} color={theme.color.textFaint} />
+        <Ionicons name="search" size={iconSize.md} color={theme.color.textFaint} />
         <TextInput
           value={query}
           onChangeText={setQuery}
@@ -315,7 +315,7 @@ export function ContactPicker({
             accessibilityLabel={t.pickers.clearSearch}
             hitSlop={8}
           >
-            <Ionicons name="close-circle" size={18} color={theme.color.textFaint} />
+            <Ionicons name="close-circle" size={iconSize.md} color={theme.color.textFaint} />
           </Pressable>
         ) : null}
       </View>
@@ -486,7 +486,7 @@ function ContactRow({
         </View>
         <Ionicons
           name={selected ? 'checkmark-circle' : 'ellipse-outline'}
-          size={24}
+          size={iconSize.xxl}
           color={selected ? theme.color.brand : theme.color.border}
         />
       </Row>
@@ -548,7 +548,7 @@ function PickedStrip({
                 borderColor: theme.color.bg,
               }}
             >
-              <Ionicons name="close" size={10} color={theme.color.surface} />
+              <Ionicons name="close" size={iconSize.micro} color={theme.color.surface} />
             </View>
           </View>
           {/* Full width and centred, or Android measures the label against the

--- a/apps/mobile/src/components/CountryCodePicker.tsx
+++ b/apps/mobile/src/components/CountryCodePicker.tsx
@@ -18,7 +18,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import { COUNTRIES, countryFlag, dialingCodeForCountry } from '@baaki/core';
-import { Button, Row, Screen, Text, useTheme } from '@baaki/ui';
+import { Button, iconSize, Row, Screen, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -77,7 +77,7 @@ export function CountryCodePicker({
       >
         <Text style={{ fontSize: 20 }}>{flag}</Text>
         <Text variant="subheading">{dial}</Text>
-        <Ionicons name="chevron-down" size={16} color={theme.color.textMuted} />
+        <Ionicons name="chevron-down" size={iconSize.base} color={theme.color.textMuted} />
       </Pressable>
 
       <Modal visible={open} animationType="slide" onRequestClose={close}>

--- a/apps/mobile/src/components/DictateVoice.tsx
+++ b/apps/mobile/src/components/DictateVoice.tsx
@@ -19,7 +19,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { ExpoSpeechRecognitionModule, useSpeechRecognitionEvent } from 'expo-speech-recognition';
 import { Linking, Pressable, View } from 'react-native';
 
-import { Text, useTheme } from '@baaki/ui';
+import { iconSize, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 import { dictationError, mergeTranscript, speechLocale } from '@/lib/dictation';
@@ -149,7 +149,7 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
       >
         <Ionicons
           name={listening ? 'stop' : 'mic-outline'}
-          size={20}
+          size={iconSize.lg}
           color={listening ? theme.color.onBrand : theme.color.brand}
         />
       </Pressable>

--- a/apps/mobile/src/components/DisputePanel.tsx
+++ b/apps/mobile/src/components/DisputePanel.tsx
@@ -19,7 +19,7 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { TextInput, View } from 'react-native';
 
-import { Badge, Button, Card, Row, Text, useTheme } from '@baaki/ui';
+import { Badge, Button, Card, iconSize, Row, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -78,7 +78,7 @@ export function DisputePanel({
     <Card style={{ gap: theme.spacing.lg }}>
       {open.length > 0 ? (
         <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
-          <Ionicons name="alert-circle" size={18} color={theme.color.negative} />
+          <Ionicons name="alert-circle" size={iconSize.md} color={theme.color.negative} />
           <Text variant="subheading" tone="negative">
             {open.length === 1
               ? 'Someone thinks this is off'

--- a/apps/mobile/src/components/GroupCard.tsx
+++ b/apps/mobile/src/components/GroupCard.tsx
@@ -13,7 +13,16 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { View } from 'react-native';
 
 import type { CurrencyCode } from '@baaki/core';
-import { Avatar, directionalIcon, MoneyText, Row, Text, tintForKey, useTheme } from '@baaki/ui';
+import {
+  Avatar,
+  directionalIcon,
+  iconSize,
+  MoneyText,
+  Row,
+  Text,
+  tintForKey,
+  useTheme,
+} from '@baaki/ui';
 
 import { PressableScale } from '@/lib/anim';
 
@@ -95,7 +104,7 @@ export function GroupCard({
 
         <Ionicons
           name={directionalIcon('chevron-forward')}
-          size={18}
+          size={iconSize.md}
           color={theme.color.textFaint}
         />
       </Row>

--- a/apps/mobile/src/components/InfoDisclosure.tsx
+++ b/apps/mobile/src/components/InfoDisclosure.tsx
@@ -14,7 +14,7 @@ import { useState, type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Pressable, View } from 'react-native';
 
-import { Row, Text, useTheme } from '@baaki/ui';
+import { iconSize, Row, Text, useTheme } from '@baaki/ui';
 
 export function InfoDisclosure({
   title,
@@ -52,7 +52,7 @@ export function InfoDisclosure({
           >
             <Ionicons
               name={open ? 'information-circle' : 'information-circle-outline'}
-              size={18}
+              size={iconSize.md}
               color={open ? theme.color.brand : theme.color.textFaint}
             />
           </Pressable>

--- a/apps/mobile/src/components/LanguagePicker.tsx
+++ b/apps/mobile/src/components/LanguagePicker.tsx
@@ -22,7 +22,7 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Modal, Pressable, View } from 'react-native';
 
-import { Text, useTheme } from '@baaki/ui';
+import { iconSize, Text, useTheme } from '@baaki/ui';
 
 import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES, useStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
@@ -58,11 +58,11 @@ export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-
           opacity: pressed ? 0.85 : 1,
         })}
       >
-        <Ionicons name="globe-outline" size={18} color={theme.color.brand} />
+        <Ionicons name="globe-outline" size={iconSize.md} color={theme.color.brand} />
         <Text variant="caption" style={{ fontWeight: '600' }}>
           {current}
         </Text>
-        <Ionicons name="chevron-down" size={16} color={theme.color.textMuted} />
+        <Ionicons name="chevron-down" size={iconSize.base} color={theme.color.textMuted} />
       </Pressable>
 
       {restartNeeded ? (
@@ -139,7 +139,7 @@ export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-
                     {LANGUAGE_NAMES[entry].own}
                   </Text>
                   {active ? (
-                    <Ionicons name="checkmark" size={18} color={theme.color.brand} />
+                    <Ionicons name="checkmark" size={iconSize.md} color={theme.color.brand} />
                   ) : null}
                 </Pressable>
               );

--- a/apps/mobile/src/components/Onboarding.tsx
+++ b/apps/mobile/src/components/Onboarding.tsx
@@ -25,7 +25,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { directionalIcon, isRtlLayout, Text, useTheme, type TintName } from '@baaki/ui';
+import { directionalIcon, iconSize, isRtlLayout, Text, type TintName, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 import { pageForSlide, pageOrder, slideForPage } from '@/lib/carousel';
@@ -207,7 +207,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                   // not, and this one kept pointing right in a mirrored screen
                   // — "next" pointing backwards, on the very first screen.
                   name={last ? 'checkmark' : directionalIcon('arrow-forward')}
-                  size={24}
+                  size={iconSize.xxl}
                   color={theme.color.text}
                 />
               </Pressable>

--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -12,7 +12,7 @@ import { router, type Href } from 'expo-router';
 import { Modal, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Text, useTheme } from '@baaki/ui';
+import { iconSize, Text, useTheme } from '@baaki/ui';
 
 export interface OverflowMenuItem {
   icon: keyof typeof Ionicons.glyphMap;
@@ -87,7 +87,7 @@ export function OverflowMenu({
                   backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',
                 })}
               >
-                <Ionicons name={item.icon} size={20} color={theme.color.textMuted} />
+                <Ionicons name={item.icon} size={iconSize.lg} color={theme.color.textMuted} />
                 <Text variant="body">{item.label}</Text>
               </Pressable>
             ))}

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -10,7 +10,7 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Pressable, View } from 'react-native';
 
-import { Card, Row, Text, useTheme } from '@baaki/ui';
+import { Card, iconSize, Row, Text, useTheme } from '@baaki/ui';
 
 import { plural, useStrings } from '@/i18n';
 
@@ -31,7 +31,7 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
     return (
       <Card style={{ backgroundColor: theme.color.negativeSoft, gap: theme.spacing.md }}>
         <Row style={{ gap: theme.spacing.sm }}>
-          <Ionicons name="alert-circle" size={18} color={theme.color.negative} />
+          <Ionicons name="alert-circle" size={iconSize.md} color={theme.color.negative} />
           <Text variant="subheading" tone="negative">
             {t.extras.oneChangeFailed}
           </Text>
@@ -70,7 +70,7 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
     return (
       <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.xs }}>
         <Row style={{ gap: theme.spacing.sm }}>
-          <Ionicons name="cloud-offline-outline" size={18} color={theme.color.brand} />
+          <Ionicons name="cloud-offline-outline" size={iconSize.md} color={theme.color.brand} />
           <View style={{ flex: 1 }}>
             <Text variant="caption" tone="brand">
               {syncNetwork === SyncNetworkPreference.Cellular
@@ -113,7 +113,7 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
   return (
     <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.xs }}>
       <Row style={{ gap: theme.spacing.sm }}>
-        <Ionicons name={icon} size={18} color={theme.color.brand} />
+        <Ionicons name={icon} size={iconSize.md} color={theme.color.brand} />
         <View style={{ flex: 1 }}>
           <Text variant="caption" tone="brand">
             {message}

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -19,7 +19,7 @@ import DateTimePicker, { type DateTimePickerEvent } from '@react-native-communit
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Platform, Pressable, View } from 'react-native';
 
-import { Button, Card, Row, Text, Toggle, useTheme } from '@baaki/ui';
+import { Button, Card, iconSize, Row, Text, Toggle, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -186,7 +186,7 @@ export function TripDates({
           >
             <Ionicons
               name={showInfo ? 'information-circle' : 'information-circle-outline'}
-              size={20}
+              size={iconSize.lg}
               color={showInfo ? theme.color.brand : theme.color.textFaint}
             />
           </Pressable>

--- a/apps/mobile/src/components/UpdateGate.tsx
+++ b/apps/mobile/src/components/UpdateGate.tsx
@@ -14,7 +14,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Button, Card, Row, Text, useTheme } from '@baaki/ui';
+import { Button, Card, iconSize, Row, Text, useTheme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -52,7 +52,7 @@ function BlockingScreen(): React.JSX.Element {
           backgroundColor: theme.color.brandSoft,
         }}
       >
-        <Ionicons name="arrow-up-circle" size={36} color={theme.color.brand} />
+        <Ionicons name="arrow-up-circle" size={iconSize.huge} color={theme.color.brand} />
       </View>
 
       <Text variant="heading" align="center">
@@ -114,7 +114,7 @@ export function UpdateBanner(): React.JSX.Element | null {
     >
       <Card style={{ gap: theme.spacing.sm, ...theme.shadow.lifted }}>
         <Row style={{ gap: theme.spacing.md }}>
-          <Ionicons name="arrow-up-circle-outline" size={22} color={theme.color.brand} />
+          <Ionicons name="arrow-up-circle-outline" size={iconSize.xl} color={theme.color.brand} />
           <View style={{ flex: 1 }}>
             <Text variant="caption">
               {latest ? `Baaki ${latest} is out` : 'A new Baaki is out'}

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -119,6 +119,27 @@ export const radius = {
   pill: 999,
 } as const;
 
+/**
+ * Icon glyph sizes — the `size` a vector icon (Ionicons, etc.) is drawn at.
+ * A named scale so a screen asks for `iconSize.lg`, not a bare `20` nobody can
+ * find or keep consistent. These are icon sizes only; avatar/photo/badge
+ * dimensions are component props, not this scale.
+ */
+export const iconSize = {
+  micro: 10,
+  xs: 12,
+  sm: 14,
+  base: 16,
+  md: 18,
+  lg: 20,
+  xl: 22,
+  xxl: 24,
+  xxxl: 26,
+  jumbo: 30,
+  huge: 36,
+  hero: 40,
+} as const;
+
 /** 4px base scale. */
 export const spacing = {
   xs: 4,


### PR DESCRIPTION
Every `Ionicons` glyph size in `apps/mobile` was a bare magic number — **146 of them across 58 files** — with no single place to see or keep the scale consistent.

- Adds an `iconSize` scale to `@baaki/ui` (`micro` 10 … `hero` 40, exact pixels preserved).
- Routes every vector-icon `size` through it (`size={iconSize.xl}` etc.).
- Component dimensions (`Avatar`, `GroupPhoto`, `CategoryBadge`, `PendingMark`, `ProfileAvatar`) are deliberately left as their own props — this scale is icon glyphs only.

No visual change (values preserved; the two 15px icons normalized to 16).

Verified: typecheck ✓ · lint ✓ · prettier ✓ · app 215 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized icon sizing across mobile screens and shared components for a more consistent visual experience.
  * Updated navigation, settings, group, capture, profile, onboarding, and authentication icons to use consistent size scales.
  * Improved consistency for tab bar, picker, menu, notification, and action icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->