### PR TITLE
fix(mobile): Activity crash on Android — Intl.RelativeTimeFormat absent in Hermes

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -17,7 +17,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { describeActivity, verbEmoji } from '@/data/activity';
+import { describeActivity, relativeTime, verbEmoji } from '@/data/activity';
 import { fetchRecentActivity } from '@/data/api';
 import { FeedSkeleton } from '@/components/Skeletons';
 import { useNotifications } from '@/data/hooks';
@@ -175,25 +175,4 @@ export default function ActivityScreen() {
       </ScrollView>
     </Screen>
   );
-}
-
-/**
- * "19m ago", "yesterday" — a localized relative time for a timeline entry.
- *
- * Intl.RelativeTimeFormat does the wording and the plural in every locale, and
- * `numeric: 'auto'` is what turns "1 day ago" into "yesterday". The unit is the
- * largest that leaves a count of at least one, so a three-hour-old event reads
- * in hours, not 180 minutes.
- */
-function relativeTime(locale: string, iso: string): string {
-  const seconds = Math.round((Date.parse(iso) - Date.now()) / 1000);
-  const abs = Math.abs(seconds);
-  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
-  if (abs < 60) return rtf.format(Math.round(seconds), 'second');
-  if (abs < 3600) return rtf.format(Math.round(seconds / 60), 'minute');
-  if (abs < 86400) return rtf.format(Math.round(seconds / 3600), 'hour');
-  if (abs < 604800) return rtf.format(Math.round(seconds / 86400), 'day');
-  if (abs < 2629800) return rtf.format(Math.round(seconds / 604800), 'week');
-  if (abs < 31557600) return rtf.format(Math.round(seconds / 2629800), 'month');
-  return rtf.format(Math.round(seconds / 31557600), 'year');
 }

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -102,3 +102,46 @@ export function verbEmoji(verb: string): string {
       return '•';
   }
 }
+
+/**
+ * "19m ago", "yesterday" — a localized relative time for a timeline entry.
+ *
+ * `Intl.RelativeTimeFormat` does the wording and the plural in every locale, and
+ * `numeric: 'auto'` is what turns "1 day ago" into "yesterday". The unit is the
+ * largest that leaves a count of at least one, so a three-hour-old event reads
+ * in hours, not 180 minutes.
+ *
+ * Android's Hermes ships `Intl.DateTimeFormat`/`NumberFormat` but not always
+ * `RelativeTimeFormat` — reaching for it there is a constructor on `undefined`,
+ * which took the whole Activity screen down. So it is feature-detected, and when
+ * it is missing the entry falls back to a short absolute date/time, which Hermes
+ * always has. Degraded wording, never a crash.
+ *
+ * `now` is injectable so the two branches are testable without a live clock.
+ */
+export function relativeTime(locale: string, iso: string, now: number = Date.now()): string {
+  const seconds = Math.round((Date.parse(iso) - now) / 1000);
+  const abs = Math.abs(seconds);
+
+  const RTF = Intl.RelativeTimeFormat as typeof Intl.RelativeTimeFormat | undefined;
+  if (typeof RTF === 'function') {
+    const rtf = new RTF(locale, { numeric: 'auto' });
+    if (abs < 60) return rtf.format(Math.round(seconds), 'second');
+    if (abs < 3600) return rtf.format(Math.round(seconds / 60), 'minute');
+    if (abs < 86400) return rtf.format(Math.round(seconds / 3600), 'hour');
+    if (abs < 604800) return rtf.format(Math.round(seconds / 86400), 'day');
+    if (abs < 2629800) return rtf.format(Math.round(seconds / 604800), 'week');
+    if (abs < 31557600) return rtf.format(Math.round(seconds / 2629800), 'month');
+    return rtf.format(Math.round(seconds / 31557600), 'year');
+  }
+
+  // Fallback: a short absolute stamp. Same-year events drop the year.
+  const withinYear = abs < 31557600;
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'short',
+    ...(withinYear ? {} : { year: 'numeric' }),
+    hour: withinYear ? 'numeric' : undefined,
+    minute: withinYear ? '2-digit' : undefined,
+  }).format(new Date(Date.parse(iso)));
+}

--- a/apps/mobile/test/activity.test.ts
+++ b/apps/mobile/test/activity.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { describeActivity, verbEmoji } from '@/data/activity';
+import { describeActivity, relativeTime, verbEmoji } from '@/data/activity';
 import type { ActivityActor, ActivityRow } from '@/data/types';
 
 const RAVI: ActivityActor = {
@@ -201,5 +201,37 @@ describe('somebody says an expense is wrong', () => {
     const line = describeActivity(row({ verb: 'auto_confirmed', payload: {} }), null);
     expect(line).not.toContain('Ravi');
     expect(line).toContain('automatically');
+  });
+});
+
+describe('how long ago', () => {
+  const now = Date.parse('2026-08-15T12:00:00Z');
+  const ago = (seconds: number): string =>
+    relativeTime('en', new Date(now - seconds * 1000).toISOString(), now);
+
+  it('words a recent event in minutes, not seconds', () => {
+    // 19 minutes reads in minutes; the largest unit with a count of at least one.
+    expect(ago(19 * 60)).toBe('19 minutes ago');
+  });
+
+  it('turns a day into "yesterday" (numeric: auto)', () => {
+    expect(ago(24 * 3600)).toBe('yesterday');
+  });
+
+  it('never throws when Intl.RelativeTimeFormat is missing (Android Hermes)', () => {
+    // The exact crash that took the Activity screen down: `new
+    // Intl.RelativeTimeFormat` is a constructor on `undefined` there. The
+    // fallback must produce a string, not blow up.
+    const mutable = Intl as unknown as { RelativeTimeFormat?: typeof Intl.RelativeTimeFormat };
+    const original = mutable.RelativeTimeFormat;
+    try {
+      delete mutable.RelativeTimeFormat;
+      const stamp = relativeTime('en', new Date(now - 19 * 60 * 1000).toISOString(), now);
+      expect(typeof stamp).toBe('string');
+      expect(stamp.length).toBeGreaterThan(0);
+      expect(stamp).not.toContain('undefined');
+    } finally {
+      mutable.RelativeTimeFormat = original;
+    }
   });
 });


### PR DESCRIPTION
## The crash
On a real Android device the Activity tab died with **"undefined cannot be used as a constructor"** in `relativeTime`. Root cause: Android's Hermes ships `Intl.DateTimeFormat`/`NumberFormat` but **not** `Intl.RelativeTimeFormat`, so `new Intl.RelativeTimeFormat(...)` is a constructor call on `undefined`. This is exactly the native-quirk trap that never shows up in Metro/typecheck/tests on a dev machine.

The timeline's `relativeTime` (from the earlier Activity-feed rebuild) reached for it unconditionally.

## The fix
`relativeTime` now **feature-detects** `RelativeTimeFormat` and, when it is missing, falls back to a short **absolute** `Intl.DateTimeFormat` stamp (always present in Hermes). Degraded wording, never a crash.

Moved out of the screen into the pure `data/activity.ts` module (no RN imports) with an injectable `now`, and **pinned with tests** for both branches — including a test that deletes `Intl.RelativeTimeFormat` to reproduce the exact crash and assert the fallback returns a real string.

## Verification
- `pnpm typecheck` ✅ · `pnpm --filter @baaki/mobile lint` ✅ · `pnpm test:app` ✅ **218/218** (3 new)
- filename guard ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity timestamps now display localized relative times, such as “5 minutes ago” or “yesterday.”
  * Date and time formatting adapts to the selected locale and supports events spanning seconds through years.
* **Bug Fixes**
  * Activity timestamps now continue displaying safely on devices that do not support relative-time formatting, using a localized date and time instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->