### PR TITLE
fix(mobile): last row reachable on pushed screens — clear the system nav bar

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -20,6 +20,7 @@ import {
   Text,
   TintCard,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { CategoryBadge } from '@/components/Category';
@@ -53,6 +54,7 @@ function splitLabels(t: UiStrings): Record<string, string> {
 
 export default function ExpenseDetailScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id, expenseId } = useLocalSearchParams<{ id: string; expenseId: string }>();
   const groupId = id ?? '';
@@ -137,7 +139,7 @@ export default function ExpenseDetailScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/group/[id]/import/csv.tsx
+++ b/apps/mobile/src/app/group/[id]/import/csv.tsx
@@ -37,6 +37,7 @@ import {
   SectionHeader,
   Text,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { importSplitwiseCsv, MutationKind, type MemberId, type SplitwiseImport } from '@baaki/core';
@@ -54,6 +55,7 @@ const NEW_PERSON = '__new__';
 
 export default function ImportCsvScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -179,11 +181,11 @@ export default function ImportCsvScreen() {
   }
 
   return (
-    <Screen edges={['top', 'bottom']}>
+    <Screen>
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/group/[id]/import/sms.tsx
+++ b/apps/mobile/src/app/group/[id]/import/sms.tsx
@@ -41,6 +41,7 @@ import {
   SectionHeader,
   Text,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import {
@@ -79,6 +80,7 @@ function splitMessages(blob: string): string[] {
 
 export default function ImportSmsScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -214,11 +216,11 @@ export default function ImportSmsScreen() {
   }
 
   return (
-    <Screen edges={['top', 'bottom']}>
+    <Screen>
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -21,6 +21,7 @@ import {
   TintCard,
   tintForKey,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import {
@@ -54,6 +55,7 @@ enum Tab {
 
 export default function GroupScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance(112);
   const pull = usePullRefresh();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -135,7 +137,7 @@ export default function GroupScreen() {
         <ScrollView
           contentContainerStyle={{
             paddingHorizontal: theme.spacing.xl,
-            paddingBottom: 180,
+            paddingBottom: clearance,
             gap: theme.spacing.xl,
           }}
           showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -42,6 +42,7 @@ import {
   type BarDatum,
   type ColumnDatum,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { CategoryBadge } from '@/components/Category';
@@ -61,6 +62,7 @@ const MONTHS_SHOWN = 6;
 
 export default function InsightsScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -102,7 +104,7 @@ export default function InsightsScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: 140,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -15,6 +15,7 @@ import {
   Screen,
   Text,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { mintInvite, type MintedInvite } from '@/data/api';
@@ -31,6 +32,7 @@ const INVITE_BASE = 'https://baaki.app/join';
 
 export default function InviteScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -97,11 +99,11 @@ export default function InviteScreen() {
   };
 
   return (
-    <Screen edges={['top', 'bottom']}>
+    <Screen>
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -27,6 +27,7 @@ import {
   Screen,
   Text,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { captureReceipt } from '@/lib/image';
@@ -76,6 +77,7 @@ interface DraftItem {
  */
 export default function ItemizeScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id, receipt: receiptParam } = useLocalSearchParams<{ id: string; receipt?: string }>();
   const groupId = id ?? '';
@@ -398,11 +400,11 @@ export default function ItemizeScreen() {
   };
 
   return (
-    <Screen edges={['top', 'bottom']}>
+    <Screen>
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -21,6 +21,7 @@ import {
   Text,
   TintCard,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { useGroup, useGroupLedger, useSetMemberRole, useUpdateMember } from '@/data/hooks';
@@ -31,6 +32,7 @@ import { useAuth } from '@/lib/auth';
 
 export default function MemberScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id, memberId } = useLocalSearchParams<{ id: string; memberId: string }>();
   const groupId = id ?? '';
@@ -89,7 +91,7 @@ export default function MemberScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -18,6 +18,7 @@ import {
   Screen,
   Text,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
@@ -35,6 +36,7 @@ import { friendlyError } from '@/lib/errors';
 
 export default function MembersScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -166,7 +168,7 @@ export default function MembersScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -30,6 +30,7 @@ import {
   TintCard,
   tintForKey,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { CategoryBadge } from '@/components/Category';
@@ -49,6 +50,7 @@ function myShare(shares: { member_id: string; amount: string }[], memberId: stri
 
 export default function SpendingMonthScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const params = useLocalSearchParams<{
     id: string;
@@ -132,7 +134,7 @@ export default function SpendingMonthScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -41,6 +41,7 @@ import {
   Screen,
   Text,
   type Theme,
+  useScreenClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -81,6 +82,7 @@ function dayLabel(day: string, locale: string): string {
 
 export default function PlanScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -305,11 +307,11 @@ export default function PlanScreen() {
   }
 
   return (
-    <Screen edges={['top', 'bottom']}>
+    <Screen>
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.lg,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -17,6 +17,7 @@ import {
   Text,
   Toggle,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
@@ -33,6 +34,7 @@ import { groupLabel } from '@/data/types';
 
 export default function GroupSettingsScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -120,7 +122,7 @@ export default function GroupSettingsScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -30,6 +30,7 @@ import {
   TintCard,
   tintForKey,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { toSnapshot, useGroup, useGroupLedger, useRecordSettlement } from '@/data/hooks';
@@ -41,6 +42,7 @@ import { useGuestGuard } from '@/lib/guestGuard';
 
 export default function SettleScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -240,11 +242,11 @@ export default function SettleScreen() {
   }
 
   return (
-    <Screen edges={['top', 'bottom']}>
+    <Screen>
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/group/[id]/simplify.tsx
+++ b/apps/mobile/src/app/group/[id]/simplify.tsx
@@ -15,6 +15,7 @@ import {
   Screen,
   Text,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { memberLookup, useGroup, useGroupLedger } from '@/data/hooks';
@@ -24,6 +25,7 @@ import { useAuth } from '@/lib/auth';
 
 export default function SimplifyScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
@@ -43,7 +45,7 @@ export default function SimplifyScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: 140,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -50,6 +50,7 @@ import {
   SectionHeader,
   Text,
   useTheme,
+  useScreenClearance,
 } from '@baaki/ui';
 
 import { createGroup, fetchMembers, importLedger, type ImportPerson } from '@/data/api';
@@ -110,6 +111,7 @@ function fromBaaki(group: BaakiImportGroup, fallbackName: string): Loaded {
 
 export default function ImportScreen() {
   const theme = useTheme();
+  const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const groups = useGroups();
   const { profile } = useAuth();
@@ -336,7 +338,7 @@ export default function ImportScreen() {
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
-          paddingBottom: theme.spacing.xxxl,
+          paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -46,6 +46,22 @@ export function useTabBarClearance(): number {
 }
 
 /**
+ * How much room a scrolling screen that is NOT under the tab bar has to leave at
+ * its foot — a pushed detail screen, a settings page, a modal.
+ *
+ * The app draws edge-to-edge, so the system navigation bar (gesture pill or the
+ * three buttons) sits *over* the bottom of the content. A fixed `paddingBottom`
+ * that ignores it leaves the last row hidden behind the bar — you scroll to the
+ * end and the end is under the system UI. This is the system inset plus a
+ * caller-chosen breath, so the last row always clears it on every phone. Pass a
+ * larger `base` on a screen with a floating action or a pinned footer.
+ */
+export function useScreenClearance(base: number = spacing.xxxl): number {
+  const insets = useSafeAreaInsets();
+  return insets.bottom + base;
+}
+
+/**
  * The bottom navigation, WhatsApp / Material 3 style: a flat opaque bar pinned
  * to the bottom edge, a hairline along its top, and each destination drawn as
  * an icon over its label. The selected destination wears a rounded "active


### PR DESCRIPTION
## The bug
On many pushed screens (you flagged the **plan** screen), scrolling to the end doesn't reach the end — the last row sits under the Android system navigation bar.

**Cause:** the app draws edge-to-edge, so the nav bar (gesture pill / 3-button) overlays the bottom of the content. These screens set a **fixed** `ScrollView` `paddingBottom` (`spacing.xxxl`, `140`, `180`) that ignores the system inset, so the final row is hidden behind the bar. Tab screens already avoided this via `useTabBarClearance` (which adds `insets.bottom`); pushed screens had no equivalent.

## The fix
New **`useScreenClearance(base = spacing.xxxl)`** hook — `insets.bottom + base`, the non-tab-bar sibling of `useTabBarClearance`. Applied to every affected scroll screen so the last row always clears the nav bar on every device:

`plan`, `settle`, `simplify`, `insights`, `members`, `month`, `itemize`, `invite`, `import/csv`, `import/sms`, `settings/import`, `expense/[id]`, `member/[id]`, group `settings`, and group home (larger base to also clear its FAB).

Also dropped the redundant `edges={['top','bottom']}` on the plain-scroll screens so the bottom inset is applied **once**, not doubled.

## Verification
- `pnpm typecheck` ✅ · `pnpm --filter @baaki/mobile lint` ✅ · `pnpm test:app` ✅ 218/218
- filename guard ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom spacing across mobile screens to adapt to device safe areas and screen layouts.
  * Reduced the risk of content being obscured by system UI or navigation elements.
  * Standardized spacing on expense, import, group, member, settings, planning, and settlement screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->