### PR TITLE
fix(mobile): skeletons match loaded layout on friends + activity — seamless fill

### DIFF
--- a/apps/mobile/src/components/Skeletons.tsx
+++ b/apps/mobile/src/components/Skeletons.tsx
@@ -223,7 +223,13 @@ export function PeopleSkeleton() {
       ))}
       {/* The per-currency footnote holds its spot so nothing shifts up under it
           when the real note arrives. */}
-      <Skeleton width="70%" height={11} radius={theme.radius.sm} animated={animated} style={{ alignSelf: 'center' }} />
+      <Skeleton
+        width="70%"
+        height={11}
+        radius={theme.radius.sm}
+        animated={animated}
+        style={{ alignSelf: 'center' }}
+      />
     </LoadingRegion>
   );
 }
@@ -281,12 +287,7 @@ export function FeedSkeleton({ rows = 5 }: { rows?: number }) {
                 <Skeleton width={56} height={16} animated={animated} />
               </Row>
               {/* The relative time, at its 11px height and the same 2px drop. */}
-              <Skeleton
-                width="26%"
-                height={11}
-                animated={animated}
-                style={{ marginTop: 2 }}
-              />
+              <Skeleton width="26%" height={11} animated={animated} style={{ marginTop: 2 }} />
             </View>
           </Row>
         );

--- a/apps/mobile/src/components/Skeletons.tsx
+++ b/apps/mobile/src/components/Skeletons.tsx
@@ -179,9 +179,17 @@ export function ListScreenSkeleton({
 
 /**
  * The friends tab: the two balance sections — owed to you, and what you owe —
- * each a heading and a short list. Shaped like the real screen so the swap is a
- * fill, and shown in place of it rather than the "all square" empty state,
- * which is a verdict on somebody's money the query has not returned yet.
+ * each a heading and a short list.
+ *
+ * Shaped to `FriendsSection` down to the pixel so the swap to real content is a
+ * fill, not a jump. The loaded list is drawn as bare rows on the screen with a
+ * hairline between — *not* inside a Card — so this must be too: an earlier
+ * version wrapped the rows in `SkeletonList` (a Card with an `lg` inset and a
+ * shadow), and on load that surface, its rounded corners and the inset all
+ * vanished at once while every row slid left. The heading matches the real
+ * 19px `heading` and carries the same `marginBottom` the section header does,
+ * and the per-currency footnote holds its place at the foot. Shown in place of
+ * the "all square" empty state, which is a verdict the query has not returned.
  */
 export function PeopleSkeleton() {
   const theme = useTheme();
@@ -190,10 +198,32 @@ export function PeopleSkeleton() {
     <LoadingRegion style={{ gap: theme.spacing.xl }}>
       {[0, 1].map((section) => (
         <View key={section} style={{ gap: theme.spacing.md }}>
-          <Skeleton width="35%" height={16} animated={animated} />
-          <SkeletonList rows={2} />
+          {/* The section heading: the same 19px height as `SectionHeader`'s
+              `heading` text, and its `marginBottom` too, so the gap down to the
+              first row is identical and the list does not lift on load. */}
+          <Skeleton
+            width="35%"
+            height={19}
+            animated={animated}
+            style={{ marginBottom: theme.spacing.md }}
+          />
+          {/* Bare rows on the screen with a hairline between — exactly how
+              `FriendsSection` draws the loaded list. No Card. */}
+          <View>
+            {[0, 1].map((row, index, all) => (
+              <View key={row}>
+                <SkeletonRow />
+                {index < all.length - 1 ? (
+                  <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                ) : null}
+              </View>
+            ))}
+          </View>
         </View>
       ))}
+      {/* The per-currency footnote holds its spot so nothing shifts up under it
+          when the real note arrives. */}
+      <Skeleton width="70%" height={11} radius={theme.radius.sm} animated={animated} style={{ alignSelf: 'center' }} />
     </LoadingRegion>
   );
 }

--- a/apps/mobile/src/components/Skeletons.tsx
+++ b/apps/mobile/src/components/Skeletons.tsx
@@ -229,30 +229,68 @@ export function PeopleSkeleton() {
 }
 
 /**
- * The activity tab: a day heading and a few full-width entry cards, the shape
- * of the real feed. Shown in place of it while the first page loads, so the
- * cold screen is not the "nothing yet" empty state — which is a verdict the
- * query has not returned yet, not the answer.
+ * The activity tab: the vertical timeline — a tinted node on a connector line
+ * running down the left, the sentence and its amount beside it, the relative
+ * time beneath. Shaped to the real feed to the pixel so the swap is a fill, not
+ * a jump: an earlier version drew day headings over full-width rounded cards, a
+ * layout the feed no longer has, so the whole shape lurched when the timeline
+ * arrived. The rail node, the 2px connector, the `md` gap to the text and the
+ * `xl` drop between rows all match `ActivityScreen`'s timeline. Shown in place
+ * of the "nothing yet" empty state, which is a verdict the query has not
+ * returned yet.
  */
-export function FeedSkeleton() {
+export function FeedSkeleton({ rows = 5 }: { rows?: number }) {
   const theme = useTheme();
   const { animated } = useMotion();
   return (
-    <LoadingRegion style={{ gap: theme.spacing.xl }}>
-      {[0, 1].map((section) => (
-        <View key={section} style={{ gap: theme.spacing.md }}>
-          <Skeleton width="35%" height={16} animated={animated} />
-          {[0, 1, 2].map((card) => (
-            <Skeleton
-              key={card}
-              width="100%"
-              height={72}
-              radius={theme.radius.lg}
-              animated={animated}
-            />
-          ))}
-        </View>
-      ))}
+    <LoadingRegion>
+      {Array.from({ length: rows }, (_, index) => {
+        const isLast = index === rows - 1;
+        return (
+          <Row key={index} style={{ alignItems: 'stretch' }}>
+            {/* The rail: the node circle, then the connector running down to the
+                next node — dropped on the last row so it stops, not dangles. */}
+            <View style={{ width: 38, alignItems: 'center' }}>
+              <Skeleton width={38} height={38} radius={theme.radius.pill} animated={animated} />
+              {!isLast ? (
+                <View
+                  style={{
+                    flex: 1,
+                    width: 2,
+                    marginVertical: 2,
+                    backgroundColor: theme.color.border,
+                  }}
+                />
+              ) : null}
+            </View>
+
+            <View
+              style={{
+                flex: 1,
+                paddingStart: theme.spacing.md,
+                paddingBottom: isLast ? 0 : theme.spacing.xl,
+              }}
+            >
+              <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
+                {/* Two lines standing in for the wrapped sentence, and the
+                    amount that rides at its end. */}
+                <View style={{ flex: 1, gap: theme.spacing.sm }}>
+                  <Skeleton width="92%" height={15} animated={animated} />
+                  <Skeleton width="58%" height={15} animated={animated} />
+                </View>
+                <Skeleton width={56} height={16} animated={animated} />
+              </Row>
+              {/* The relative time, at its 11px height and the same 2px drop. */}
+              <Skeleton
+                width="26%"
+                height={11}
+                animated={animated}
+                style={{ marginTop: 2 }}
+              />
+            </View>
+          </Row>
+        );
+      })}
     </LoadingRegion>
   );
 }


### PR DESCRIPTION
Two loading skeletons didn't match their loaded screens, so data landing caused a visible **jump** instead of a seamless fill. Both reshaped to mirror the real layout to the pixel.

## Friends tab
`PeopleSkeleton` wrapped each section's rows in `SkeletonList` — a **Card** (surface bg, soft shadow, rounded corners, `lg` inset). The real `FriendsSection` draws rows **bare on the screen** with a hairline between, no Card. On load the surface, corners and inset all vanished while every row slid left.

Fix: bare rows + hairline, no Card; heading at the real 19px `heading` height with its `marginBottom`; a placeholder for the per-currency footnote.

## Activity tab
`FeedSkeleton` drew day headings over full-width rounded cards — a layout the feed no longer has. The real `ActivityScreen` is a **vertical timeline**: a tinted node on a connector line down the left, the sentence + amount beside it, the relative time beneath. The whole shape lurched on load.

Fix: mirror the timeline — 38px rail node + 2px connector between rows (dropped on the last), `md` gap to the text, two body lines (15px) with an amount at the end, relative time at 11px, `xl` drop between rows.

## Verification
- typecheck clean, lint clean
- skeletons are the transient in-flight frame on a cold query; structural match verified against `FriendsSection` and `ActivityScreen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the friends loading state to better match the final layout.
  * Added clearer section spacing, row dividers, and a centered footnote placeholder.
  * Replaced card-style loading rows with simpler list rows.
  * Redesigned feed loading placeholders as a vertical activity timeline with connectors, text, amounts, and timestamps.
  * Added support for displaying a configurable number of feed loading rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->