### PR TITLE
fix(mobile): OAuth callback no longer lands on "Unmatched Route"

### DIFF
--- a/apps/mobile/src/app/+native-intent.ts
+++ b/apps/mobile/src/app/+native-intent.ts
@@ -1,0 +1,36 @@
+/**
+ * Rewrite incoming native deep links before expo-router tries to match them.
+ *
+ * The one link that needs rewriting is the OAuth callback. Google and Apple
+ * sign-in redirect to `baaki://auth#access_token=…` — see
+ * `makeRedirectUri({ scheme: 'baaki', path: 'auth' })` in `lib/auth.tsx`. The
+ * token exchange is already done in-process: `WebBrowser.openAuthSessionAsync`
+ * hands that URL straight back to the caller, which calls `setSession`. So by
+ * the time the OS *also* delivers the link as an app intent, it carries nothing
+ * left to do — and there is no `/auth` screen, so letting the router match it
+ * lands on "Unmatched Route — page could not be found" right after a successful
+ * Google login. Send it to the root instead, where the session (now set)
+ * decides between the tabs and the sign-in screen.
+ *
+ * This runs outside the app context, so it cannot read auth state — it only
+ * rewrites the path. It must never throw: a crash here would take the cold
+ * launch down with it, so anything unexpected passes straight through.
+ *
+ * @param path the incoming link. Named `path` but it is the full URL (e.g.
+ *   `baaki://auth#…`), not just the path portion.
+ */
+export function redirectSystemPath({ path }: { path: string; initial: boolean }): string {
+  try {
+    // A base is required for the custom-scheme URL to parse. `baaki://auth`
+    // lands `auth` in the hostname; a `baaki:///auth` triple-slash form lands it
+    // in the pathname instead — cover both.
+    const url = new URL(path, 'baaki://app');
+    const firstSegment = url.pathname.replace(/^\/+/, '').split('/')[0];
+    if (url.hostname === 'auth' || firstSegment === 'auth') {
+      return '/';
+    }
+    return path;
+  } catch {
+    return path;
+  }
+}

--- a/scripts/check-filenames.sh
+++ b/scripts/check-filenames.sh
@@ -45,6 +45,11 @@ while IFS= read -r path; do
   if [[ $name =~ ^\(.+\)$ ]]; then continue; fi
   if [[ $name =~ ^\[\.{0,3}[A-Za-z0-9_-]+\](\.[A-Za-z0-9]+)?$ ]]; then continue; fi
 
+  # Expo Router's special files carry a leading `+` — `+native-intent.ts`,
+  # `+not-found.tsx`, `+html.tsx`. The `+` is the framework's; the rest is an
+  # ordinary name with a known extension.
+  if [[ $name =~ ^\+[A-Za-z0-9._-]+\.($EXTENSIONS)$ ]]; then continue; fi
+
   if [[ ! $name =~ ^[A-Za-z0-9._-]+$ ]] || [[ ! $name =~ \.($EXTENSIONS)$ ]]; then
     bad+="  $path"$'\n'
   fi


### PR DESCRIPTION
## Bug
After a successful **Google** (or Apple) sign-in, the app showed **"Unmatched Route — page could not be found"**. Login actually succeeded; the error came right after.

## Cause
The provider redirects to `baaki://auth#access_token=…` (`makeRedirectUri({ scheme: 'baaki', path: 'auth' })` in `lib/auth.tsx`). The token exchange is already done **in-process** — `WebBrowser.openAuthSessionAsync` hands that URL back to the caller, which calls `setSession`. But the OS **also** delivers the link as an app intent, and there is no `/auth` screen, so expo-router matches nothing and renders its Unmatched Route screen.

## Fix
Add `app/+native-intent.ts` with `redirectSystemPath`, which rewrites the redundant `baaki://auth` callback to `/` — where the now-set session routes on to the tabs or the sign-in screen. Non-auth deep links pass through untouched; the function never throws (a crash there would take the cold launch down).

Also teach `scripts/check-filenames.sh` about Expo Router's leading-`+` special files so the guard stops flagging `+native-intent.ts` as shell debris.

## Verification
- typecheck + lint + format clean
- JS-only (bundled), so a Metro reload picks it up — no native rebuild
- Manual: re-do Google login on device, confirm it lands on the dashboard, not Unmatched Route

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile OAuth callback handling by redirecting supported authentication links to the app’s home screen.
  * Preserved unrelated and malformed links without causing errors.
* **Chores**
  * Updated filename validation to allow approved Expo Router special files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->