### PR TITLE
feat(mobile): animated splash — native field hands off to a JS logo animation

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -2,10 +2,11 @@ import { useEffect } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import Constants from 'expo-constants';
 import * as Notifications from 'expo-notifications';
+import * as SplashScreen from 'expo-splash-screen';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { ActivityIndicator, useWindowDimensions, View } from 'react-native';
+import { ActivityIndicator, Platform, useWindowDimensions, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -19,6 +20,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { AnimatedSplash } from '@/components/AnimatedSplash';
 import { AppTabBar } from '@/components/AppTabBar';
 import { CampaignPopup } from '@/components/CampaignPopup';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
@@ -39,6 +41,14 @@ import { initObservability, withObservability } from '@/lib/observability';
 import { ensureAndroidChannel, pushSupported, routeForNotification } from '@/lib/push';
 import { applyStoredSessionReplayConsent } from '@/lib/sessionReplay';
 import { SyncProvider } from '@/sync';
+
+// Hold the native splash up past its auto-hide, so `AnimatedSplash` can take
+// over the field without a blank frame between them. Native only — there is no
+// native splash on web, where reaching into this is a no-op at best. It fails to
+// off: a rejection here must never keep the splash up forever.
+if (Platform.OS !== 'web') {
+  void SplashScreen.preventAutoHideAsync().catch(() => {});
+}
 
 // Before anything else renders, so a crash in the first frame is still caught.
 // Inert unless a DSN is configured.
@@ -158,6 +168,10 @@ function RootLayout() {
                               under it. */}
                                 <UpdateBanner />
                               </UpdateGate>
+                              {/* Topmost of all: the launch field, painting over
+                                  the whole app until it fades itself out. Native
+                                  only; renders nothing on web. */}
+                              <AnimatedSplash />
                             </ThemedRoot>
                           </ThemePreferenceProvider>
                         </UpdateProvider>

--- a/apps/mobile/src/components/AnimatedSplash.tsx
+++ b/apps/mobile/src/components/AnimatedSplash.tsx
@@ -1,0 +1,119 @@
+/**
+ * The animated splash — the bridge between the OS splash and the app.
+ *
+ * The launch has two splashes back to back, and the seam between them is meant
+ * to be invisible. First the native one (a solid `SPLASH_BG` field with the
+ * logo, configured in `app.json`'s `expo-splash-screen`) shows the instant the
+ * process starts, while the JS is still loading. Then this component mounts,
+ * hides the native splash, and paints an identical field on top — same colour,
+ * same logo, same place — so nothing flickers at the handoff. From there it
+ * plays: the logo settles in, holds a beat, and the whole field fades away to
+ * reveal the app underneath.
+ *
+ * Native only. On web there is no native splash to hand off from, and a
+ * full-screen overlay sitting over the app for a second would only get in the
+ * way of the layout checks the web build exists for — so it renders nothing.
+ *
+ * Motion is the app's own preference, not just the OS setting: someone who
+ * turned motion down inside Baaki gets a brief static hold and a fade, no
+ * logo animation.
+ *
+ * To rebrand: replace `assets/images/splash-icon.png` with the logo and set
+ * `SPLASH_BG` to the background — keep it identical to the `backgroundColor` in
+ * `app.json` so the native-to-JS handoff stays seamless. For full-bleed
+ * background art, drop an absolute-fill `<Image>` behind the logo below.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import * as SplashScreen from 'expo-splash-screen';
+import { Image } from 'expo-image';
+import { Platform, StyleSheet } from 'react-native';
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { useMotion } from '@/lib/motion';
+
+/** Kept identical to `expo-splash-screen`'s `backgroundColor` in `app.json` so
+    the native splash and this one are the same field — change both together. */
+const SPLASH_BG = '#7A5AF8';
+
+/** The logo drawn on the field. Swap this file to rebrand; a transparent PNG
+    reads best over the coloured background. */
+const LOGO = require('../../assets/images/splash-icon.png');
+
+export function AnimatedSplash() {
+  const { animated } = useMotion();
+  const [done, setDone] = useState(false);
+
+  // The whole field, and the logo riding on it.
+  const fieldOpacity = useSharedValue(1);
+  const logoOpacity = useSharedValue(animated ? 0 : 1);
+  const logoScale = useSharedValue(animated ? 0.82 : 1);
+
+  const finish = useCallback(() => setDone(true), []);
+
+  useEffect(() => {
+    if (Platform.OS === 'web') return;
+
+    // Hand off from the native splash to this one. This paints an identical
+    // field, so hiding the native splash reveals no gap.
+    SplashScreen.hideAsync().catch(() => {});
+
+    if (!animated) {
+      // Reduced motion: hold the field a moment, then fade it out. No logo move.
+      fieldOpacity.value = withDelay(
+        550,
+        withTiming(0, { duration: 220 }, (finished) => {
+          if (finished) runOnJS(finish)();
+        }),
+      );
+      return;
+    }
+
+    logoOpacity.value = withTiming(1, { duration: 460, easing: Easing.out(Easing.cubic) });
+    logoScale.value = withSequence(
+      withTiming(1.06, { duration: 460, easing: Easing.out(Easing.cubic) }),
+      withTiming(1, { duration: 160, easing: Easing.inOut(Easing.quad) }),
+    );
+    // Hold the settled logo, then lift the whole field to reveal the app.
+    fieldOpacity.value = withDelay(
+      920,
+      withTiming(0, { duration: 360, easing: Easing.in(Easing.cubic) }, (finished) => {
+        if (finished) runOnJS(finish)();
+      }),
+    );
+  }, [animated, finish, fieldOpacity, logoOpacity, logoScale]);
+
+  const fieldStyle = useAnimatedStyle(() => ({ opacity: fieldOpacity.value }));
+  const logoStyle = useAnimatedStyle(() => ({
+    opacity: logoOpacity.value,
+    transform: [{ scale: logoScale.value }],
+  }));
+
+  if (done || Platform.OS === 'web') return null;
+
+  return (
+    <Animated.View
+      // Eats touches while it is up, so a tap never reaches the app underneath
+      // mid-fade.
+      pointerEvents="auto"
+      style={[
+        StyleSheet.absoluteFill,
+        { backgroundColor: SPLASH_BG, alignItems: 'center', justifyContent: 'center' },
+        fieldStyle,
+      ]}
+    >
+      {/* Full-bleed background art, when there is any, goes here as an
+          absolute-fill <Image> behind the logo. */}
+      <Animated.View style={logoStyle}>
+        <Image source={LOGO} style={{ width: 100, height: 100 }} contentFit="contain" />
+      </Animated.View>
+    </Animated.View>
+  );
+}


### PR DESCRIPTION
Adds a two-stage animated launch (per the chosen "animated splash" approach).

## How it works
1. The **native** splash — the solid field + logo already configured in `app.json`'s `expo-splash-screen` — shows the instant the process starts, while JS loads.
2. `AnimatedSplash` mounts, **hides** the native splash, and paints an **identical** field on top (same colour, same logo, same place) so the handoff never flickers.
3. The logo settles in (fade + scale), holds a beat, and the whole field fades out to reveal the app.

## Details
- `_layout.tsx` calls `preventAutoHideAsync` so there's no blank frame before the JS field. Native only; fails to off so a rejection can never strand the splash up.
- Mounted **topmost** inside `ThemedRoot`, painting over the whole app until it fades itself out.
- **Native only** — renders nothing on web (no native splash to hand off from, and a full-screen overlay would flake the web layout checks).
- Honours the app's **motion preference** — reduced motion gets a brief static hold + fade, no logo move.

## Assets
Placeholder for now (the existing `splash-icon.png`). **To rebrand:** swap `assets/images/splash-icon.png` for the logo and set `SPLASH_BG` (keep it identical to `app.json`'s `backgroundColor`). Full-bleed background art drops in as an absolute-fill `<Image>` behind the logo — marked with a comment.

## Verification
- typecheck + lint + format clean
- native-only; visible in a standalone/release build (the dev client shows Expo's own splash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an animated splash screen for mobile app launches.
  * Added support for reduced-motion preferences with a simplified transition.
  * Prevented interaction with the app until the splash screen finishes.
  * Web experiences remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->