### PR TITLE
feat(mobile): every hero card carries a backdrop icon, not just the actions

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -671,6 +671,7 @@ function HeroBackdropIcon({ name }: { name: keyof typeof Ionicons.glyphMap }) {
       name={name}
       size={140}
       color={theme.color.onBrand}
+      accessible={false}
       style={{
         position: 'absolute',
         right: -20,

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -657,6 +657,31 @@ function HeroSkeleton() {
  * the reference design leans on, and a call to action beneath the copy. The whole
  * card is the tap target.
  */
+/**
+ * The faint oversized icon bled off a hero card's bottom-right corner — the
+ * "illustration" every slide in the deck carries, so the balance, trip and
+ * action cards all read as one family rather than some plain and some drawn on.
+ * The card's `Gradient` must set `overflow: 'hidden'` so the bleed clips to the
+ * rounded corner. `pointerEvents none` so it never eats the card's own tap.
+ */
+function HeroBackdropIcon({ name }: { name: keyof typeof Ionicons.glyphMap }) {
+  const theme = useTheme();
+  return (
+    <Ionicons
+      name={name}
+      size={140}
+      color={theme.color.onBrand}
+      style={{
+        position: 'absolute',
+        right: -20,
+        bottom: -28,
+        opacity: 0.16,
+        pointerEvents: 'none',
+      }}
+    />
+  );
+}
+
 function ActionSlide({
   icon,
   title,
@@ -686,21 +711,7 @@ function ActionSlide({
           overflow: 'hidden',
         }}
       >
-        {/* The illustration stand-in: an oversized, faint copy of the action's
-            own icon, bled off the bottom-right corner. `pointerEvents none` so it
-            never eats the card's own tap. */}
-        <Ionicons
-          name={icon}
-          size={140}
-          color={theme.color.onBrand}
-          style={{
-            position: 'absolute',
-            right: -20,
-            bottom: -28,
-            opacity: 0.16,
-            pointerEvents: 'none',
-          }}
-        />
+        <HeroBackdropIcon name={icon} />
         <View style={{ gap: theme.spacing.xs, paddingRight: 88 }}>
           <Text variant="subheading" tone="onBrand">
             {title}
@@ -743,8 +754,10 @@ function BalanceCard({ total, locale, t }: { total: CurrencyTotal; locale: strin
         gap: theme.spacing.lg,
         height: HERO_CARD_HEIGHT,
         justifyContent: 'space-between',
+        overflow: 'hidden',
       }}
     >
+      <HeroBackdropIcon name="wallet-outline" />
       <Row style={{ justifyContent: 'space-between' }}>
         <Text variant="caption" tone="onBrand">
           {t.yourBaaki}
@@ -817,8 +830,10 @@ function TripCard({ trip, locale, t }: { trip: TripSlide; locale: string; t: UiS
           gap: theme.spacing.lg,
           height: HERO_CARD_HEIGHT,
           justifyContent: 'space-between',
+          overflow: 'hidden',
         }}
       >
+        <HeroBackdropIcon name="airplane-outline" />
         <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
           <Row style={{ gap: theme.spacing.sm, alignItems: 'center', flex: 1 }}>
             <Text variant="subheading">{trip.coverEmoji ?? '🧳'}</Text>


### PR DESCRIPTION
The carousel was inconsistent — only the **action slides** (scan, invite) had the faint oversized backdrop icon; the **balance** and **trip** cards were plain, so the deck read as mismatched.

## Change
Pull the illustration into one `HeroBackdropIcon` helper and give **every** slide one:
- **Balance** card → `wallet-outline`
- **Trip** card → `airplane-outline`
- **Action** slides → their own icon (as before)

Each card's `Gradient` gets `overflow: 'hidden'` so the bled icon clips to the rounded corner.

## Verification
- typecheck + lint + format clean
- verified on device (trip card's airplane backdrop visible; same helper drives all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added subtle decorative background icons to action, balance, and trip cards.
  * Improved card visuals by clipping decorative elements within their boundaries.
  * Standardized icon presentation across hero cards for a more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->