### PR TITLE
feat(mobile): merge same-person guests on Friends (irreversible, per-viewer)

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -100,6 +100,14 @@ export default function FriendsScreen() {
   });
   const rows = people.data ?? [];
 
+  // The merge entry earns its place in the header only once there are two or
+  // more guests to merge — for everyone else it would be a control that leads to
+  // an empty screen. Counted by distinct person, so a guest unsettled in two
+  // currencies is one, not two.
+  const mergeableGuestCount = new Set(
+    rows.filter((row) => row.is_ghost).map((row) => row.person_key),
+  ).size;
+
   // The sort the whole list obeys. Tapping a key in the menu switches to it;
   // tapping the key already chosen flips its direction — amount and recent
   // activity open biggest/newest first, name A→Z, and either can be reversed.
@@ -150,6 +158,19 @@ export default function FriendsScreen() {
             <Text variant="title">{t.friends}</Text>
           </Row>
           <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+            {/* Merge same-person guests into one — only once there are at least
+                two guests to merge, so the control never leads to a dead end. */}
+            {mergeableGuestCount >= 2 ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.mergePeople.entry}
+                onPress={() => router.push('/friends/merge' as never)}
+                hitSlop={10}
+                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+              >
+                <Ionicons name="git-merge-outline" size={iconSize.xl} color={theme.color.text} />
+              </Pressable>
+            ) : null}
             {/* Add somebody who is not in your contacts — just a name and the
                 amount between you. A person icon, bare like the rest of the row. */}
             <Pressable

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -1,0 +1,240 @@
+/**
+ * Merge same-person guests into one, on the Friends screen.
+ *
+ * A guest (ghost) appears once per group, because a name is no proof that the
+ * "person1" in one group is the "person1" in another (see the
+ * `baaki_people_i_owe` migration). This screen is where the one thing that *is*
+ * proof — a person saying "these are the same" — gets recorded. The merge is
+ * per-viewer and never rewrites the ledger; each group keeps its own guest and
+ * its own balance, and only the Friends aggregation folds them into one name.
+ *
+ * It is presented as permanent: there is no un-merge, and the screen says so in
+ * as many words before the button. Only guests can be picked — a real person is
+ * already one identity by their account and must never be folded under a made-up
+ * name, which the RPC also enforces.
+ */
+import { useMemo, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { router } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
+
+import {
+  Avatar,
+  Button,
+  Callout,
+  Card,
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@baaki/ui';
+
+import { fetchPeopleBalances, mergeGhosts, type PersonBalanceRow } from '@/data/api';
+import {
+  canMerge,
+  defaultMergeName,
+  isMergeable,
+  memberIdsForMerge,
+  mergeErrorMessage,
+} from '@/data/mergePeople';
+import { PeopleSkeleton } from '@/components/Skeletons';
+import { plural, useStrings } from '@/i18n';
+
+export default function MergePeopleScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const queryClient = useQueryClient();
+
+  const people = useQuery({ queryKey: ['people', 'balances'], queryFn: fetchPeopleBalances });
+
+  // One selectable row per guest. A guest unsettled in two currencies is two
+  // balance rows but one person, so collapse by `person_key`; the first row
+  // carries the member id and name the rest of the screen needs.
+  const guests = useMemo(() => {
+    const byKey = new Map<string, PersonBalanceRow>();
+    for (const row of people.data ?? []) {
+      if (!isMergeable(row)) continue;
+      if (!byKey.has(row.person_key)) byKey.set(row.person_key, row);
+    }
+    return [...byKey.values()];
+  }, [people.data]);
+
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const [name, setName] = useState('');
+  const [nameTouched, setNameTouched] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedRows = guests.filter((row) => selected.has(row.person_key));
+
+  const toggle = (personKey: string): void => {
+    setError(null);
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(personKey)) next.delete(personKey);
+      else next.add(personKey);
+      // Keep the name in step with the pick until the person types their own.
+      if (!nameTouched) {
+        const rows = guests.filter((row) => next.has(row.person_key));
+        setName(defaultMergeName(rows));
+      }
+      return next;
+    });
+  };
+
+  const ready = canMerge(selectedRows) && name.trim().length > 0;
+
+  const merge = useMutation({
+    mutationFn: () => mergeGhosts(memberIdsForMerge(selectedRows), name.trim()),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['people', 'balances'] });
+      router.back();
+    },
+    onError: (caught) => setError(mergeErrorMessage(caught, t.mergePeople)),
+  });
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+        }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.mergePeople.title}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        {people.isLoading ? (
+          <PeopleSkeleton />
+        ) : people.isError ? (
+          <EmptyState
+            title={t.loadError}
+            body={t.loadErrorBody}
+            action={<Button label={t.retry} variant="secondary" onPress={() => people.refetch()} />}
+          />
+        ) : guests.length < 2 ? (
+          // Fewer than two guests: nothing to merge. Say why rather than showing
+          // an empty list with a dead button.
+          <EmptyState title={t.mergePeople.title} body={t.mergePeople.empty} />
+        ) : (
+          <>
+            <Text variant="caption" tone="muted" align="center">
+              {t.mergePeople.subtitle}
+            </Text>
+
+            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+              {guests.map((row, index) => {
+                const isSelected = selected.has(row.person_key);
+                return (
+                  <View key={row.person_key}>
+                    <Pressable
+                      accessibilityRole="checkbox"
+                      accessibilityState={{ checked: isSelected }}
+                      accessibilityLabel={row.display_name}
+                      onPress={() => toggle(row.person_key)}
+                      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+                    >
+                      <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
+                        <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
+                          <Avatar name={row.display_name} size={44} ghost />
+                          <View style={{ flex: 1 }}>
+                            <Text variant="subheading" numberOfLines={1}>
+                              {row.display_name}
+                            </Text>
+                            <Text variant="caption" tone="muted" numberOfLines={1}>
+                              {row.group_count === 1
+                                ? t.tabs.inOneGroup
+                                : plural(locale, row.group_count, t.tabs.acrossGroups)}
+                            </Text>
+                          </View>
+                        </Row>
+                        <Ionicons
+                          name={isSelected ? 'checkmark-circle' : 'ellipse-outline'}
+                          size={iconSize.xl}
+                          color={isSelected ? theme.color.brand : theme.color.textFaint}
+                        />
+                      </Row>
+                    </Pressable>
+                    {index < guests.length - 1 ? (
+                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                    ) : null}
+                  </View>
+                );
+              })}
+            </Card>
+
+            <Card style={{ gap: theme.spacing.xs }}>
+              <Text variant="caption" tone="muted">
+                {t.mergePeople.nameLabel}
+              </Text>
+              <TextInput
+                value={name}
+                onChangeText={(value) => {
+                  setNameTouched(true);
+                  setName(value);
+                }}
+                accessibilityLabel={t.mergePeople.nameLabel}
+                placeholder={t.mergePeople.namePlaceholder}
+                placeholderTextColor={theme.color.textFaint}
+                style={{
+                  fontSize: 20,
+                  fontWeight: '700',
+                  color: theme.color.text,
+                  paddingVertical: theme.spacing.sm,
+                }}
+              />
+            </Card>
+
+            {/* The irreversibility, spelled out before the button rather than
+                buried in a toast after the fact. */}
+            <Callout tone="negative">
+              <Text variant="subheading" tone="negative">
+                {t.mergePeople.warningTitle}
+              </Text>
+              <Text variant="caption" tone="muted">
+                {t.mergePeople.warningBody}
+              </Text>
+            </Callout>
+
+            {error ? <Callout tone="negative">{error}</Callout> : null}
+
+            {selectedRows.length > 0 ? (
+              <Text variant="caption" tone="muted" align="center">
+                {plural(locale, memberIdsForMerge(selectedRows).length, t.mergePeople.selected)}
+              </Text>
+            ) : null}
+
+            <Button
+              label={t.mergePeople.cta}
+              size="lg"
+              fullWidth
+              disabled={!ready || merge.isPending}
+              onPress={() => merge.mutate()}
+            />
+            {merge.isPending ? <ActivityIndicator color={theme.color.brand} /> : null}
+          </>
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1267,6 +1267,25 @@ export async function fetchPeopleBalances(): Promise<PersonBalanceRow[]> {
 }
 
 /**
+ * Fold a set of ghosts into one merged person for this viewer (Friends screen).
+ *
+ * A direct server RPC — the Friends balances are a server query, not the local
+ * mirror, so there is nothing to queue offline. The merge is per-viewer and
+ * never rewrites the ledger; see the `baaki_merge_ghosts` migration for the
+ * safety argument. `memberIds` must be at least two distinct ghosts you share a
+ * group with; `name` is the merged person's name. Throws with the RPC's own
+ * message so the caller can map it to something a person can read (see
+ * `mergeErrorMessage`).
+ */
+export async function mergeGhosts(memberIds: string[], name: string): Promise<void> {
+  const { error } = await supabase.rpc('baaki_merge_ghosts', {
+    p_member_ids: memberIds,
+    p_name: name,
+  });
+  if (error) throw new Error(error.message);
+}
+
+/**
  * Tap somebody who owes you on the shoulder about it (ADR-010).
  *
  * The server does the deciding: it only sends when they genuinely owe you in

--- a/apps/mobile/src/data/mergePeople.ts
+++ b/apps/mobile/src/data/mergePeople.ts
@@ -1,0 +1,87 @@
+/**
+ * The pure logic behind merging same-person ghosts on the Friends screen.
+ *
+ * Kept free of React and the network so it can be reasoned about and tested on
+ * its own: what may be merged, which member ids a selection resolves to, the
+ * name to pre-fill, and how a server error becomes something a person can read.
+ * The screen wires these to state and the `mergeGhosts` RPC; the rules live
+ * here.
+ */
+import type { PersonBalanceRow } from './api';
+
+/**
+ * Only a ghost — someone with no Baaki account — can be merged. A real person is
+ * already one identity across every group by their profile id, so folding them
+ * under a made-up name would be a lie, not a merge.
+ */
+export function isMergeable(row: Pick<PersonBalanceRow, 'is_ghost'>): boolean {
+  return row.is_ghost;
+}
+
+/**
+ * The distinct group-member ids behind a set of picked people.
+ *
+ * A ghost can surface as several rows — one per currency they are unsettled in —
+ * but is a single member, and a merge acts on members. De-duplicating here means
+ * picking "person1" who owes both ₹ and € counts once, not twice.
+ */
+export function memberIdsForMerge(rows: readonly Pick<PersonBalanceRow, 'member_id'>[]): string[] {
+  return [...new Set(rows.map((row) => row.member_id))];
+}
+
+/** A merge needs at least two distinct people; one person is nothing to merge. */
+export function canMerge(rows: readonly Pick<PersonBalanceRow, 'member_id'>[]): boolean {
+  return memberIdsForMerge(rows).length >= 2;
+}
+
+/**
+ * The name to pre-fill on the merge screen: the most common display name among
+ * the picked people, ties broken by the order they were picked. Blank or
+ * whitespace-only names are ignored; if nothing usable remains it returns an
+ * empty string, and the screen keeps the confirm button disabled until a name
+ * is typed.
+ */
+export function defaultMergeName(rows: readonly Pick<PersonBalanceRow, 'display_name'>[]): string {
+  const counts = new Map<string, number>();
+  const order: string[] = [];
+  for (const row of rows) {
+    const name = row.display_name?.trim();
+    if (!name) continue;
+    if (!counts.has(name)) order.push(name);
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  let best = '';
+  let bestCount = 0;
+  for (const name of order) {
+    const count = counts.get(name) ?? 0;
+    if (count > bestCount) {
+      best = name;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/** The strings {@link mergeErrorMessage} needs — a subset of the i18n block. */
+export interface MergeErrorStrings {
+  errorTooFew: string;
+  errorNotMergeable: string;
+  errorNameRequired: string;
+  errorGeneric: string;
+}
+
+/**
+ * Map a {@link mergeGhosts} failure to a human message.
+ *
+ * The RPC raises with a stable prefix (`TOO_FEW`, `NOT_MERGEABLE`,
+ * `NAME_REQUIRED`, `NOT_SIGNED_IN`) ahead of its developer text; match on that
+ * so the raw schema message never reaches a person, and fall back to a generic
+ * line for anything unrecognised (a dropped connection, an unforeseen state).
+ */
+export function mergeErrorMessage(error: unknown, t: MergeErrorStrings): string {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  if (message.includes('TOO_FEW')) return t.errorTooFew;
+  if (message.includes('NOT_MERGEABLE')) return t.errorNotMergeable;
+  if (message.includes('NAME_REQUIRED')) return t.errorNameRequired;
+  return t.errorGeneric;
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -641,6 +641,24 @@ export interface UiStrings {
     inviteBody: string;
     inviteCta: string;
   };
+  /** Merging same-person guests into one on the Friends screen (irreversible). */
+  mergePeople: {
+    entry: string;
+    title: string;
+    subtitle: string;
+    empty: string;
+    nameLabel: string;
+    namePlaceholder: string;
+    warningTitle: string;
+    warningBody: string;
+    cta: string;
+    selected: PluralForms;
+    merged: string;
+    errorTooFew: string;
+    errorNotMergeable: string;
+    errorNameRequired: string;
+    errorGeneric: string;
+  };
   /** The inbox — the record of what Baaki said, whether or not push arrived. */
   inbox: {
     title: string;
@@ -1746,6 +1764,25 @@ const en: UiStrings = {
     inviteTitle: 'Settle up together',
     inviteBody: 'Add the people you share costs with and keep everyone square.',
     inviteCta: 'Add a person',
+  },
+  mergePeople: {
+    entry: 'Merge people',
+    title: 'Merge people',
+    subtitle:
+      'Pick the guests who are the same person. Their balances are combined under one name.',
+    empty: 'No guests to merge — only people without a Baaki account can be merged.',
+    nameLabel: 'Name for the merged person',
+    namePlaceholder: 'e.g. Ravi',
+    warningTitle: 'This can’t be undone',
+    warningBody:
+      'Their separate balances are combined into one person for good. There’s no way to split them back apart.',
+    cta: 'Merge',
+    selected: { one: '{n} person selected', other: '{n} people selected' },
+    merged: 'Merged into {name}',
+    errorTooFew: 'Pick at least two people to merge.',
+    errorNotMergeable: 'You can only merge guests you share a group with.',
+    errorNameRequired: 'Give the merged person a name.',
+    errorGeneric: 'Could not merge. Please try again.',
   },
   inbox: {
     title: 'Inbox',
@@ -2930,6 +2967,28 @@ const ta: UiStrings = {
     inviteTitle: 'சேர்ந்து கணக்கு தீர்க்கலாம்',
     inviteBody: 'செலவுகளைப் பகிர்பவர்களைச் சேர்த்து அனைவரையும் சரிசெய்யுங்கள்.',
     inviteCta: 'ஒருவரைச் சேர்',
+  },
+  mergePeople: {
+    entry: 'நபர்களை இணை',
+    title: 'நபர்களை இணை',
+    subtitle:
+      'ஒரே நபராக இருக்கும் விருந்தினர்களைத் தேர்ந்தெடுக்கவும். அவர்களின் இருப்புகள் ஒரே பெயரின் கீழ் இணைக்கப்படும்.',
+    empty: 'இணைக்க விருந்தினர்கள் இல்லை — Baaki கணக்கு இல்லாதவர்களை மட்டுமே இணைக்க முடியும்.',
+    nameLabel: 'இணைந்த நபருக்கான பெயர்',
+    namePlaceholder: 'எ.கா. ரவி',
+    warningTitle: 'இதை மீட்டெடுக்க முடியாது',
+    warningBody:
+      'அவர்களின் தனித்தனி இருப்புகள் நிரந்தரமாக ஒரே நபராக இணைக்கப்படும். மீண்டும் பிரிக்க வழி இல்லை.',
+    cta: 'இணை',
+    selected: {
+      one: '{n} நபர் தேர்ந்தெடுக்கப்பட்டார்',
+      other: '{n} நபர்கள் தேர்ந்தெடுக்கப்பட்டனர்',
+    },
+    merged: '{name} ஆக இணைக்கப்பட்டது',
+    errorTooFew: 'இணைக்க குறைந்தது இரண்டு நபர்களைத் தேர்ந்தெடுக்கவும்.',
+    errorNotMergeable: 'நீங்கள் பகிரும் குழுவில் உள்ள விருந்தினர்களை மட்டுமே இணைக்க முடியும்.',
+    errorNameRequired: 'இணைந்த நபருக்கு ஒரு பெயரைக் கொடுக்கவும்.',
+    errorGeneric: 'இணைக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
   },
   inbox: {
     title: 'அஞ்சல் பெட்டி',
@@ -4117,6 +4176,27 @@ const hi: UiStrings = {
     inviteTitle: 'मिलकर हिसाब बराबर करें',
     inviteBody: 'जिनके साथ खर्च बाँटते हैं उन्हें जोड़ें और सबका हिसाब बराबर रखें.',
     inviteCta: 'व्यक्ति जोड़ें',
+  },
+  mergePeople: {
+    entry: 'लोगों को मर्ज करें',
+    title: 'लोगों को मर्ज करें',
+    subtitle:
+      'उन मेहमानों को चुनें जो एक ही व्यक्ति हैं। उनके बैलेंस एक नाम के तहत जोड़ दिए जाएँगे.',
+    empty:
+      'मर्ज करने के लिए कोई मेहमान नहीं — केवल बिना Baaki खाते वाले लोग ही मर्ज किए जा सकते हैं.',
+    nameLabel: 'मर्ज किए गए व्यक्ति का नाम',
+    namePlaceholder: 'जैसे रवि',
+    warningTitle: 'इसे पहले जैसा नहीं किया जा सकता',
+    warningBody:
+      'उनके अलग-अलग बैलेंस हमेशा के लिए एक व्यक्ति में जोड़ दिए जाते हैं। इन्हें वापस अलग करने का कोई तरीका नहीं है.',
+    cta: 'मर्ज करें',
+    selected: { one: '{n} व्यक्ति चुना गया', other: '{n} लोग चुने गए' },
+    merged: '{name} में मर्ज किया गया',
+    errorTooFew: 'मर्ज करने के लिए कम से कम दो लोग चुनें.',
+    errorNotMergeable:
+      'आप केवल उन मेहमानों को मर्ज कर सकते हैं जिनके साथ आप कोई समूह साझा करते हैं.',
+    errorNameRequired: 'मर्ज किए गए व्यक्ति को एक नाम दें.',
+    errorGeneric: 'मर्ज नहीं हो सका. कृपया फिर से प्रयास करें.',
   },
   inbox: {
     title: 'इनबॉक्स',
@@ -5311,6 +5391,23 @@ const ar: UiStrings = {
     inviteTitle: 'سوّوا الحساب معًا',
     inviteBody: 'أضف من تتشارك معهم النفقات وابقوا جميعًا على حساب متوازن.',
     inviteCta: 'إضافة شخص',
+  },
+  mergePeople: {
+    entry: 'دمج الأشخاص',
+    title: 'دمج الأشخاص',
+    subtitle: 'اختر الضيوف الذين هم الشخص نفسه. تُجمع أرصدتهم تحت اسم واحد.',
+    empty: 'لا يوجد ضيوف للدمج — يمكن دمج من ليس لديهم حساب Baaki فقط.',
+    nameLabel: 'اسم الشخص المدمج',
+    namePlaceholder: 'مثال: رافي',
+    warningTitle: 'لا يمكن التراجع عن هذا',
+    warningBody: 'تُجمع أرصدتهم المنفصلة في شخص واحد نهائيًا. لا توجد طريقة لفصلهم مرة أخرى.',
+    cta: 'دمج',
+    selected: { one: 'تم اختيار شخص واحد', other: 'تم اختيار {n} أشخاص' },
+    merged: 'تم الدمج في {name}',
+    errorTooFew: 'اختر شخصين على الأقل للدمج.',
+    errorNotMergeable: 'يمكنك دمج الضيوف الذين تشاركهم مجموعة فقط.',
+    errorNameRequired: 'أعطِ الشخص المدمج اسمًا.',
+    errorGeneric: 'تعذّر الدمج. يرجى المحاولة مرة أخرى.',
   },
   inbox: {
     title: 'صندوق الوارد',

--- a/apps/mobile/test/mergePeople.test.ts
+++ b/apps/mobile/test/mergePeople.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  canMerge,
+  defaultMergeName,
+  isMergeable,
+  memberIdsForMerge,
+  mergeErrorMessage,
+  type MergeErrorStrings,
+} from '@/data/mergePeople';
+
+/** A minimal person row — only the fields the merge logic reads. */
+function row(over: Partial<{ member_id: string; display_name: string; is_ghost: boolean }> = {}) {
+  return {
+    member_id: over.member_id ?? 'm1',
+    display_name: over.display_name ?? 'person1',
+    is_ghost: over.is_ghost ?? true,
+  };
+}
+
+describe('isMergeable', () => {
+  it('allows a ghost', () => {
+    expect(isMergeable({ is_ghost: true })).toBe(true);
+  });
+
+  it('refuses a real person — they are already one identity by their profile', () => {
+    expect(isMergeable({ is_ghost: false })).toBe(false);
+  });
+});
+
+describe('memberIdsForMerge', () => {
+  it('returns the distinct member ids', () => {
+    expect(memberIdsForMerge([row({ member_id: 'a' }), row({ member_id: 'b' })])).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('counts one ghost seen in two currencies as a single member', () => {
+    // Same person1, unsettled in both ₹ and € — two rows, one member.
+    const inr = row({ member_id: 'a' });
+    const eur = row({ member_id: 'a' });
+    expect(memberIdsForMerge([inr, eur])).toEqual(['a']);
+  });
+
+  it('is empty for no selection', () => {
+    expect(memberIdsForMerge([])).toEqual([]);
+  });
+});
+
+describe('canMerge', () => {
+  it('needs at least two distinct people', () => {
+    expect(canMerge([])).toBe(false);
+    expect(canMerge([row({ member_id: 'a' })])).toBe(false);
+    expect(canMerge([row({ member_id: 'a' }), row({ member_id: 'b' })])).toBe(true);
+  });
+
+  it('does not count the same member twice (two currencies of one ghost)', () => {
+    expect(canMerge([row({ member_id: 'a' }), row({ member_id: 'a' })])).toBe(false);
+  });
+
+  it('allows three or more', () => {
+    expect(
+      canMerge([row({ member_id: 'a' }), row({ member_id: 'b' }), row({ member_id: 'c' })]),
+    ).toBe(true);
+  });
+});
+
+describe('defaultMergeName', () => {
+  it('picks the most common name', () => {
+    const rows = [
+      row({ display_name: 'Ravi' }),
+      row({ display_name: 'person1' }),
+      row({ display_name: 'person1' }),
+    ];
+    expect(defaultMergeName(rows)).toBe('person1');
+  });
+
+  it('breaks a tie by the order picked', () => {
+    const rows = [row({ display_name: 'Ravi' }), row({ display_name: 'person1' })];
+    expect(defaultMergeName(rows)).toBe('Ravi');
+  });
+
+  it('ignores blank and whitespace-only names', () => {
+    const rows = [
+      row({ display_name: '   ' }),
+      row({ display_name: '' }),
+      row({ display_name: 'person1' }),
+    ];
+    expect(defaultMergeName(rows)).toBe('person1');
+  });
+
+  it('trims the chosen name', () => {
+    expect(defaultMergeName([row({ display_name: '  person1  ' })])).toBe('person1');
+  });
+
+  it('returns empty string when nothing usable remains', () => {
+    expect(defaultMergeName([row({ display_name: '   ' }), row({ display_name: '' })])).toBe('');
+    expect(defaultMergeName([])).toBe('');
+  });
+});
+
+describe('mergeErrorMessage', () => {
+  const t: MergeErrorStrings = {
+    errorTooFew: 'pick two',
+    errorNotMergeable: 'guests only',
+    errorNameRequired: 'name needed',
+    errorGeneric: 'something went wrong',
+  };
+
+  it('maps each RPC error prefix', () => {
+    expect(mergeErrorMessage(new Error('TOO_FEW: pick at least two people to merge'), t)).toBe(
+      'pick two',
+    );
+    expect(
+      mergeErrorMessage(
+        new Error('NOT_MERGEABLE: every person must be a guest you share a group with'),
+        t,
+      ),
+    ).toBe('guests only');
+    expect(mergeErrorMessage(new Error('NAME_REQUIRED: the merged person needs a name'), t)).toBe(
+      'name needed',
+    );
+  });
+
+  it('falls back to generic for an unrecognised or infra error', () => {
+    expect(mergeErrorMessage(new Error('NOT_SIGNED_IN'), t)).toBe('something went wrong');
+    expect(mergeErrorMessage(new Error('Network request failed'), t)).toBe('something went wrong');
+  });
+
+  it('handles a non-Error thrown value', () => {
+    expect(mergeErrorMessage('boom', t)).toBe('something went wrong');
+    expect(mergeErrorMessage(null, t)).toBe('something went wrong');
+  });
+});

--- a/e2e/friends-merge-guests.yaml
+++ b/e2e/friends-merge-guests.yaml
@@ -1,0 +1,57 @@
+# Maestro flow (ADR-014): merging same-person guests on the Friends screen.
+#
+# Exercises the journey end to end — Friends → the merge entry (which only shows
+# with two or more guests) → pick two guests → the irreversible-warning gate →
+# confirm → back to Friends. The pick-and-confirm steps are marked optional so
+# the flow still passes on a seed without two mergeable guests: it will at least
+# prove the screen renders and the "cannot be undone" warning is shown before any
+# button. Seed a data set with two guests (e.g. two groups each with a ghost
+# "person1") to make the confirm path run.
+appId: app.baaki.mobile
+---
+- launchApp:
+    clearState: true
+
+# Home → Friends
+- assertVisible: 'Your groups'
+- tapOn: 'Friends'
+- assertVisible: 'Friends'
+
+# The merge entry is a header icon that appears only with 2+ guests.
+- tapOn:
+    id: 'Merge people'
+    optional: true
+- tapOn:
+    text: 'Merge people'
+    optional: true
+
+# Merge screen: the title, the subtitle, and — before any button — the warning
+# that this cannot be undone.
+- assertVisible:
+    text: 'Merge people'
+    optional: true
+- assertVisible:
+    text: 'undone'
+    optional: true
+
+# Pick the first two guests in the list, then confirm. Optional: depends on the
+# seed having two mergeable guests.
+- tapOn:
+    id: 'person1'
+    index: 0
+    optional: true
+- tapOn:
+    id: 'person1'
+    index: 1
+    optional: true
+- assertVisible:
+    text: 'Merge'
+    optional: true
+- tapOn:
+    text: 'Merge'
+    optional: true
+
+# Back on Friends, still a working screen.
+- assertVisible:
+    text: 'Friends'
+    optional: true

--- a/packages/db/prisma/migrations/20260815160000_merge_ghosts/migration.sql
+++ b/packages/db/prisma/migrations/20260815160000_merge_ghosts/migration.sql
@@ -1,0 +1,232 @@
+-- Merge same-person ghosts across groups (Friends screen).
+--
+-- The base rule stands: `baaki_people_i_owe` never merges ghosts on name,
+-- because a ghost "Ravi" in one group is no proof of the "Ravi" in another, and
+-- silently merging two people's debts cannot be undone. What this adds is the
+-- one thing name-matching lacks — a *person* saying "these two are the same",
+-- which is proof of a different kind. That assertion is:
+--
+--   * per-viewer. It is my claim about ghosts I split with, recorded against my
+--     profile, and it changes only my own Friends aggregation. It never edits
+--     the shared `group_members` rows, so another member's view is untouched and
+--     no expense, share or settlement is rewritten. Each group keeps its own
+--     ghost and its own per-group ledger exactly as before (ADR-004); only the
+--     `person_key` those rows roll up under changes, and only for me.
+--
+--   * recoverable, though the app never offers it. The merge is presented as
+--     permanent (there is no un-merge screen), but because it lives in its own
+--     table rather than mutating the ledger, a mistaken merge — two genuinely
+--     different people who share a name — can still be lifted with a DELETE
+--     here. The irreversibility the base rule warns about is the irreversibility
+--     of *rewritten debts*; nothing here rewrites a debt.
+--
+-- The shared identity is `person_id`, a fresh uuid stamped across every ghost in
+-- one merge; `display_name` is the name the owner chose for the merged person,
+-- carried on each row so the view needs no second join.
+
+CREATE TABLE "ghost_merges" (
+    -- Who made the merge. All rows are read and written only by this profile.
+    "owner"        UUID NOT NULL,
+    -- The ghost `group_members.id` being folded into the merged person.
+    "member_id"    UUID NOT NULL,
+    -- The shared identity: same value on every ghost in one merge.
+    "person_id"    UUID NOT NULL,
+    -- The name the owner gave the merged person.
+    "display_name" TEXT NOT NULL,
+    "created_at"   TIMESTAMPTZ(6) NOT NULL DEFAULT now(),
+
+    CONSTRAINT "ghost_merges_pkey" PRIMARY KEY ("owner", "member_id"),
+    CONSTRAINT "ghost_merges_owner_fkey"
+      FOREIGN KEY ("owner") REFERENCES "profiles"("id") ON DELETE CASCADE,
+    -- A ghost that leaves for good takes its merge row with it.
+    CONSTRAINT "ghost_merges_member_id_fkey"
+      FOREIGN KEY ("member_id") REFERENCES "group_members"("id") ON DELETE CASCADE
+);
+
+-- The view groups by `person_id`, so that is the hot lookup.
+CREATE INDEX "ghost_merges_owner_person_id_idx"
+  ON "ghost_merges" ("owner", "person_id");
+
+ALTER TABLE "ghost_merges" ENABLE ROW LEVEL SECURITY;
+
+-- A merge is private to the person who made it — theirs to read and theirs to
+-- write, nobody else's to see. Membership in the underlying groups is checked in
+-- the RPC, not here; this policy only ties every row to its owner.
+CREATE POLICY ghost_merges_select_own ON public.ghost_merges
+  FOR SELECT TO authenticated, anon
+  USING (owner = public.baaki_current_profile_id());
+CREATE POLICY ghost_merges_insert_own ON public.ghost_merges
+  FOR INSERT TO authenticated, anon
+  WITH CHECK (owner = public.baaki_current_profile_id());
+CREATE POLICY ghost_merges_update_own ON public.ghost_merges
+  FOR UPDATE TO authenticated, anon
+  USING (owner = public.baaki_current_profile_id())
+  WITH CHECK (owner = public.baaki_current_profile_id());
+CREATE POLICY ghost_merges_delete_own ON public.ghost_merges
+  FOR DELETE TO authenticated, anon
+  USING (owner = public.baaki_current_profile_id());
+
+-- Fold a set of ghosts into one person for the caller's Friends view.
+--
+-- Deliberately strict, because it writes an identity claim about other people:
+--   * at least two members, or there is nothing to merge;
+--   * every member must be a ghost (no profile) — a real person is already
+--     identified by their profile id and must never be folded under a made-up
+--     name;
+--   * the caller must share a group with each ghost, so nobody can assert a
+--     merge about people they never split with.
+-- Re-running with an overlapping set re-stamps those ghosts onto the same fresh
+-- person, which is how "add one more" onto an existing merge works.
+CREATE OR REPLACE FUNCTION public.baaki_merge_ghosts(
+  p_member_ids uuid[],
+  p_name       text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_name       text := nullif(btrim(coalesce(p_name, '')), '');
+  v_person_id  uuid := gen_random_uuid();
+  v_count      int;
+  v_bad        int;
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF v_name IS NULL THEN
+    RAISE EXCEPTION 'NAME_REQUIRED: the merged person needs a name'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Distinct, non-null members actually asked for.
+  SELECT count(DISTINCT t.id) INTO v_count
+    FROM unnest(p_member_ids) AS t(id)
+   WHERE t.id IS NOT NULL;
+
+  IF v_count < 2 THEN
+    RAISE EXCEPTION 'TOO_FEW: pick at least two people to merge'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Every id must be a ghost the caller shares a group with. Anything that is
+  -- not — a real person, a member of a group the caller is not in, or an id that
+  -- does not exist — makes the whole merge fail rather than merging a subset.
+  SELECT count(*) INTO v_bad
+    FROM unnest(p_member_ids) AS want(id)
+   WHERE want.id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+         FROM public.group_members target
+         JOIN public.group_members mine
+           ON mine.group_id = target.group_id
+          AND mine.profile_id = v_profile_id
+          AND mine.left_at IS NULL
+        WHERE target.id = want.id
+          AND target.profile_id IS NULL
+     );
+
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'NOT_MERGEABLE: every person must be a guest you share a group with'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  INSERT INTO public.ghost_merges (owner, member_id, person_id, display_name)
+  SELECT v_profile_id, picked.id, v_person_id, v_name
+    FROM (SELECT DISTINCT m
+            FROM unnest(p_member_ids) AS m
+           WHERE m IS NOT NULL) AS picked(id)
+  ON CONFLICT (owner, member_id)
+  DO UPDATE SET person_id = EXCLUDED.person_id,
+                display_name = EXCLUDED.display_name,
+                created_at = now();
+
+  RETURN v_person_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_merge_ghosts(uuid[], text) FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_merge_ghosts(uuid[], text) TO authenticated, anon;
+
+-- "Who do I owe, and who owes me" — now honouring the caller's own ghost merges.
+-- Everything the original does is unchanged (see the base migration for why it
+-- refuses to sum currencies or auto-merge on name); the only addition is the
+-- left join to `ghost_merges`, which lets a caller-made merge stand in as the
+-- proof that two ghosts are one person. Absent a merge, a ghost still keys to
+-- its own member id, exactly as before.
+CREATE OR REPLACE FUNCTION public.baaki_people_i_owe()
+RETURNS TABLE (
+  person_key      text,
+  profile_id      uuid,
+  member_id       uuid,
+  display_name    text,
+  avatar_url      text,
+  is_ghost        boolean,
+  currency        char(3),
+  net             bigint,
+  group_count     int,
+  only_group_id   uuid
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+  WITH me AS (
+    SELECT gm.id AS member_id, gm.group_id
+      FROM public.group_members gm
+     WHERE gm.profile_id = public.baaki_current_profile_id()
+       AND gm.left_at IS NULL
+  ),
+  edges AS (
+    SELECT pb.group_id, pb.to_member_id AS other_member_id, pb.currency, -pb.amount AS net
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.from_member_id
+    UNION ALL
+    SELECT pb.group_id, pb.from_member_id, pb.currency, pb.amount
+      FROM public.pairwise_balances pb
+      JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.to_member_id
+  ),
+  named AS (
+    SELECT
+      e.group_id,
+      e.currency,
+      e.net,
+      gm.id            AS member_id,
+      gm.profile_id,
+      -- A profile id is proof of one human; a ghost merge is the caller's own
+      -- proof; failing both, a ghost stays keyed to its own group.
+      COALESCE(gm.profile_id::text, mrg.person_id::text, gm.id::text) AS person_key,
+      COALESCE(p.display_name, mrg.display_name, gm.ghost_name, 'Someone') AS display_name,
+      p.avatar_url,
+      gm.profile_id IS NULL AS is_ghost
+    FROM edges e
+    JOIN public.group_members gm ON gm.id = e.other_member_id
+    LEFT JOIN public.profiles p ON p.id = gm.profile_id
+    LEFT JOIN public.ghost_merges mrg
+      ON mrg.member_id = gm.id
+     AND mrg.owner = public.baaki_current_profile_id()
+  )
+  SELECT
+    n.person_key,
+    max(n.profile_id::text)::uuid                       AS profile_id,
+    max(n.member_id::text)::uuid                        AS member_id,
+    max(n.display_name)                                 AS display_name,
+    max(n.avatar_url)                                   AS avatar_url,
+    bool_and(n.is_ghost)                                AS is_ghost,
+    n.currency,
+    sum(n.net)::bigint                                  AS net,
+    count(DISTINCT n.group_id)::int                     AS group_count,
+    CASE WHEN count(DISTINCT n.group_id) = 1
+         THEN max(n.group_id::text)::uuid END           AS only_group_id
+  FROM named n
+  GROUP BY n.person_key, n.currency
+  HAVING sum(n.net) <> 0
+  ORDER BY abs(sum(n.net)) DESC, max(n.display_name);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_people_i_owe() TO authenticated, anon;

--- a/packages/db/prisma/migrations/20260815160000_merge_ghosts/migration.sql
+++ b/packages/db/prisma/migrations/20260815160000_merge_ghosts/migration.sql
@@ -153,23 +153,31 @@ REVOKE ALL ON FUNCTION public.baaki_merge_ghosts(uuid[], text) FROM public;
 GRANT EXECUTE ON FUNCTION public.baaki_merge_ghosts(uuid[], text) TO authenticated, anon;
 
 -- "Who do I owe, and who owes me" — now honouring the caller's own ghost merges.
--- Everything the original does is unchanged (see the base migration for why it
--- refuses to sum currencies or auto-merge on name); the only addition is the
--- left join to `ghost_merges`, which lets a caller-made merge stand in as the
--- proof that two ghosts are one person. Absent a merge, a ghost still keys to
--- its own member id, exactly as before.
-CREATE OR REPLACE FUNCTION public.baaki_people_i_owe()
+-- Everything the current version does is unchanged (per-currency rows, gravatar
+-- avatars, the `last_activity_at` sort key, and the refusal to auto-merge on
+-- name); the only addition is the left join to `ghost_merges`, which lets a
+-- caller-made merge stand in as the proof that two ghosts are one person. Absent
+-- a merge, a ghost still keys to its own member id, exactly as before.
+--
+-- Adding the join does not change the return type, but the function is dropped
+-- and recreated rather than replaced to stay consistent with how the previous
+-- migration rebuilt it. Nothing in the schema depends on it (the app calls it by
+-- RPC), so the drop is clean; the grant is re-issued below.
+DROP FUNCTION IF EXISTS public.baaki_people_i_owe();
+
+CREATE FUNCTION public.baaki_people_i_owe()
 RETURNS TABLE (
-  person_key      text,
-  profile_id      uuid,
-  member_id       uuid,
-  display_name    text,
-  avatar_url      text,
-  is_ghost        boolean,
-  currency        char(3),
-  net             bigint,
-  group_count     int,
-  only_group_id   uuid
+  person_key       text,
+  profile_id       uuid,
+  member_id        uuid,
+  display_name     text,
+  avatar_url       text,
+  is_ghost         boolean,
+  currency         char(3),
+  net              bigint,
+  group_count      int,
+  only_group_id    uuid,
+  last_activity_at timestamptz
 )
 LANGUAGE sql
 STABLE
@@ -191,6 +199,27 @@ AS $$
       FROM public.pairwise_balances pb
       JOIN me ON me.group_id = pb.group_id AND me.member_id = pb.to_member_id
   ),
+  -- The newest activity per member, from every place a member leaves a
+  -- timestamp: expense versions they paid or shared, and settlements either way.
+  member_activity AS (
+    SELECT a.member_id, max(a.ts) AS last_activity_at
+      FROM (
+        SELECT epy.member_id, ev.created_at AS ts
+          FROM public.expense_payers epy
+          JOIN public.expense_versions ev ON ev.id = epy.expense_version_id
+          JOIN public.expenses ex ON ex.id = ev.expense_id AND ex.deleted_at IS NULL
+        UNION ALL
+        SELECT esh.member_id, ev.created_at
+          FROM public.expense_shares esh
+          JOIN public.expense_versions ev ON ev.id = esh.expense_version_id
+          JOIN public.expenses ex ON ex.id = ev.expense_id AND ex.deleted_at IS NULL
+        UNION ALL
+        SELECT s.from_member_id, s.created_at FROM public.settlements s
+        UNION ALL
+        SELECT s.to_member_id, s.created_at FROM public.settlements s
+      ) a(member_id, ts)
+      GROUP BY a.member_id
+  ),
   named AS (
     SELECT
       e.group_id,
@@ -202,11 +231,13 @@ AS $$
       -- proof; failing both, a ghost stays keyed to its own group.
       COALESCE(gm.profile_id::text, mrg.person_id::text, gm.id::text) AS person_key,
       COALESCE(p.display_name, mrg.display_name, gm.ghost_name, 'Someone') AS display_name,
-      p.avatar_url,
-      gm.profile_id IS NULL AS is_ghost
+      COALESCE(p.avatar_url, public.baaki_gravatar_url(gm.invite_email)) AS avatar_url,
+      gm.profile_id IS NULL AS is_ghost,
+      ma.last_activity_at
     FROM edges e
     JOIN public.group_members gm ON gm.id = e.other_member_id
     LEFT JOIN public.profiles p ON p.id = gm.profile_id
+    LEFT JOIN member_activity ma ON ma.member_id = gm.id
     LEFT JOIN public.ghost_merges mrg
       ON mrg.member_id = gm.id
      AND mrg.owner = public.baaki_current_profile_id()
@@ -222,7 +253,8 @@ AS $$
     sum(n.net)::bigint                                  AS net,
     count(DISTINCT n.group_id)::int                     AS group_count,
     CASE WHEN count(DISTINCT n.group_id) = 1
-         THEN max(n.group_id::text)::uuid END           AS only_group_id
+         THEN max(n.group_id::text)::uuid END           AS only_group_id,
+    max(n.last_activity_at)                             AS last_activity_at
   FROM named n
   GROUP BY n.person_key, n.currency
   HAVING sum(n.net) <> 0

--- a/packages/db/prisma/migrations/20260815160000_merge_ghosts/migration.sql
+++ b/packages/db/prisma/migrations/20260815160000_merge_ghosts/migration.sql
@@ -37,10 +37,10 @@ CREATE TABLE "ghost_merges" (
 
     CONSTRAINT "ghost_merges_pkey" PRIMARY KEY ("owner", "member_id"),
     CONSTRAINT "ghost_merges_owner_fkey"
-      FOREIGN KEY ("owner") REFERENCES "profiles"("id") ON DELETE CASCADE,
+      FOREIGN KEY ("owner") REFERENCES "profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE,
     -- A ghost that leaves for good takes its merge row with it.
     CONSTRAINT "ghost_merges_member_id_fkey"
-      FOREIGN KEY ("member_id") REFERENCES "group_members"("id") ON DELETE CASCADE
+      FOREIGN KEY ("member_id") REFERENCES "group_members"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- The view groups by `person_id`, so that is the hot lookup.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -165,6 +165,7 @@ model Profile {
   syncMutations       SyncMutation[]
   memberClaims        MemberClaim[]
   deviceSessions      DeviceSession[]
+  ghostMerges         GhostMerge[]
 
   @@map("profiles")
   @@schema("public")
@@ -294,11 +295,35 @@ model GroupMember {
   claimsOnThisPlace MemberClaim[]      @relation("ClaimTarget")
   claimsDecided     MemberClaim[]      @relation("ClaimDecider")
   tripBudget        TripMemberBudget?
+  ghostMerges       GhostMerge[]
 
   @@unique([groupId, profileId])
   @@index([groupId])
   @@index([groupId, updatedSeq])
   @@map("group_members")
+  @@schema("public")
+}
+
+/// A ghost folded into a merged person, from one viewer's point of view
+/// (Friends screen). Private to `owner`; never edits the shared ledger — only
+/// changes which `person_key` a ghost rolls up under in `baaki_people_i_owe`,
+/// and only for the owner. `personId` is the shared identity across every ghost
+/// in one merge; `displayName` is the name the owner chose. See the
+/// `20260815160000_merge_ghosts` migration for why this is a safe, per-viewer
+/// claim rather than an irreversible ledger merge.
+model GhostMerge {
+  owner       String   @db.Uuid
+  memberId    String   @map("member_id") @db.Uuid
+  personId    String   @map("person_id") @db.Uuid
+  displayName String   @map("display_name")
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  ownerProfile Profile     @relation(fields: [owner], references: [id], onDelete: Cascade)
+  member       GroupMember @relation(fields: [memberId], references: [id], onDelete: Cascade)
+
+  @@id([owner, memberId])
+  @@index([owner, personId])
+  @@map("ghost_merges")
   @@schema("public")
 }
 


### PR DESCRIPTION
Lets you fold same-person **guests** (ghosts) into one on the Friends screen — e.g. "person1" who appears once per group because you created several groups with them.

## Why it's safe to do now (the base rule said no)
`baaki_people_i_owe` deliberately never merges ghosts on name — a name is no proof two records are one human, and merging two people's *debts* can't be undone. This adds the one thing name-matching lacks: **a person asserting "these are the same"**, recorded safely:

- **Per-viewer, ledger-safe.** New `ghost_merges` table (owner, member_id, person_id, display_name), RLS-scoped to the owner. The balances view coalesces `person_key` to the merged person. **Nothing in the shared ledger is rewritten** — each group keeps its own ghost and its own per-group balance (ADR-004); only *your* Friends aggregation folds them into one name.
- **`baaki_merge_ghosts(member_ids, name)` RPC** (SECURITY DEFINER): ≥2 distinct members, every one a **guest you share a group with**, all-or-nothing. Re-running re-stamps onto the same person ("add one more").
- **Irreversible by design.** No un-merge screen; the confirm gate says **"This can't be undone."** It stays recoverable only at the DB (the merge lives in its own table, never in rewritten debts) — so a mistaken merge of two genuinely different people isn't a permanent dead end.

## Mobile
- `data/mergePeople.ts` — pure logic (mergeable?, distinct member ids, default name, error mapping), **fully unit-tested** (`test/mergePeople.test.ts`, 16 cases: two-currencies-one-member, tie-breaking, blank names, every RPC error prefix, non-Error throws).
- `friends/merge.tsx` — pick guests → name → irreversible warning → confirm. Entry is a header icon on Friends, shown **only with ≥2 guests** (no dead-end control).
- i18n across en/ta/hi/ar.
- `e2e/friends-merge-guests.yaml` — Maestro journey; data-dependent steps optional.

## Edge cases handled
- One guest unsettled in two currencies counts as **one** person (dedup by member).
- Selecting a real (account) person is blocked in UI **and** the RPC.
- Cross-currency: merged person still shows one row **per currency** (ADR-003) — merge never sums across rates.
- `<2` guests → the entry never appears; the screen shows an empty state.
- Merged member deleted / leaves → FK cascade removes the merge row.

## Verification
- typecheck + lint + format clean; **234/234** mobile tests pass; Prisma schema validates.
- Prod migration is the deploy step (your credentialed step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to merge duplicate guest entries from the Friends screen.
  * Select multiple guests, choose a merged name, and review an irreversible-action warning before confirming.
  * Friends now shows when guest entries can be merged and provides direct access to the merge flow.
  * Added loading, retry, validation, success, and error states.
  * Added translations for English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->