### PR TITLE
feat(mobile): group photos are a paid feature; icons stay free

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useQuery } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Alert, ScrollView, TextInput, View } from 'react-native';
 
@@ -26,7 +27,8 @@ import { CountryRow } from '@/components/CountryPicker';
 import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
 import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates } from '@/components/TripDates';
-import { removeGroupPhoto, uploadGroupPhoto } from '@/data/api';
+import { photoGateParam, photoGateStatus, photoTapAction } from '@/lib/groupPhotoGate';
+import { canUploadGroupPhoto, removeGroupPhoto, uploadGroupPhoto } from '@/data/api';
 import { useGroup, useGroupLedger, useLeaveGroup, useUpdateGroup } from '@/data/hooks';
 import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -49,6 +51,16 @@ export default function GroupSettingsScreen() {
   const [status, setStatus] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
 
+  // A group photo is a paid feature; the cover emoji is free. The group may
+  // carry a photo if anyone in it is paid (or it holds a pass) — a server-side
+  // question, since one member cannot read another's subscription.
+  const photoGate = useQuery({
+    queryKey: ['photoGate', groupId],
+    queryFn: () => canUploadGroupPhoto(photoGateParam(groupId)),
+    enabled: groupId.length > 0,
+  });
+  const photoStatus = photoGateStatus(photoGate.data, photoGate.isLoading);
+
   const changePhoto = async (): Promise<void> => {
     const picked = await pickGroupPhoto();
     if (!picked) return;
@@ -63,6 +75,15 @@ export default function GroupSettingsScreen() {
     } finally {
       setUploading(false);
     }
+  };
+
+  // Tapping the photo: pick when allowed, otherwise point at the upgrade screen.
+  // Removing an existing photo is never gated — a group that loses its paying
+  // member can always fall back to an icon.
+  const onPhotoPress = (): void => {
+    const action = photoTapAction(photoStatus);
+    if (action === 'pick') void changePhoto();
+    else if (action === 'showLockedHint') router.push('/settings/upgrade');
   };
 
   const dropPhoto = async (): Promise<void> => {
@@ -155,7 +176,7 @@ export default function GroupSettingsScreen() {
               emoji={group.data.cover_emoji}
               size={72}
               busy={uploading}
-              onPress={() => void changePhoto()}
+              onPress={onPhotoPress}
             />
             <View style={{ flex: 1, gap: theme.spacing.xs }}>
               <Text variant="caption" tone="muted">
@@ -208,6 +229,14 @@ export default function GroupSettingsScreen() {
               />
             ) : null}
           </Row>
+
+          {/* Photos are a paid feature; the icon picker above is always free.
+              Only surfaced when the group cannot set one and has none to remove. */}
+          {photoStatus === 'locked' && !group.data.photo_path ? (
+            <Text variant="micro" tone="muted">
+              {t.groupPhoto.paidHint}
+            </Text>
+          ) : null}
         </Card>
 
         {/* Decides which payment rails the settle screen offers, and what a new

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useQuery } from '@tanstack/react-query';
 import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
@@ -26,7 +27,13 @@ import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
 import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates, type TripDatesValue } from '@/components/TripDates';
 import { pickGroupPhoto, type PickedImage } from '@/lib/image';
-import { uploadGroupPhoto } from '@/data/api';
+import {
+  photoGateParam,
+  photoGateStatus,
+  photoTapAction,
+  shouldClearPickedPhoto,
+} from '@/lib/groupPhotoGate';
+import { canUploadGroupPhoto, uploadGroupPhoto } from '@/data/api';
 import { useCreateGroup } from '@/data/hooks';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { useSync } from '@/sync';
@@ -81,6 +88,24 @@ export default function NewGroupScreen() {
   const [name, setName] = useState('');
   const [photo, setPhoto] = useState<PickedImage | null>(null);
   const [uploading, setUploading] = useState(false);
+
+  // A group photo is a paid feature; a cover emoji is free. A new group has only
+  // its creator, so the server gates on whether the creator is paid (null group).
+  const photoGate = useQuery({
+    queryKey: ['photoGate', null],
+    queryFn: () => canUploadGroupPhoto(photoGateParam(null)),
+  });
+  const photoStatus = photoGateStatus(photoGate.data, photoGate.isLoading);
+  // If the gate resolves locked after a photo was somehow chosen, ignore it — a
+  // locked group falls back to its icon, and this photo could never upload.
+  // Derived, not stored, so there is no setState-in-effect and no stale flash.
+  const effectivePhoto = shouldClearPickedPhoto(photoStatus, photo !== null) ? null : photo;
+
+  const onPhotoPress = (): void => {
+    const action = photoTapAction(photoStatus);
+    if (action === 'pick') void pickGroupPhoto().then(setPhoto);
+    else if (action === 'showLockedHint') router.push('/settings/upgrade');
+  };
   const [type, setType] = useState<GroupType>(GroupType.Trip);
   const [ghostName, setGhostName] = useState('');
   // People to add on Create — a typed name carries no address, a contact carries
@@ -167,11 +192,15 @@ export default function NewGroupScreen() {
       // "members of this group only" — which needs the group and the membership
       // row actually on the server. Flush the queued create (and everything
       // behind it) before writing an object under its id.
-      if (photo) {
+      if (effectivePhoto) {
         setUploading(true);
         try {
           await flush([groupId]);
-          await uploadGroupPhoto({ groupId, base64: photo.base64, mimeType: photo.mimeType });
+          await uploadGroupPhoto({
+            groupId,
+            base64: effectivePhoto.base64,
+            mimeType: effectivePhoto.mimeType,
+          });
         } catch {
           // A photo that would not upload is not worth losing the group over;
           // it can be added again from group settings.
@@ -241,10 +270,10 @@ export default function NewGroupScreen() {
           <Row style={{ gap: theme.spacing.lg }}>
             <GroupPhoto
               photoPath={null}
-              localUri={photo?.uri ?? null}
+              localUri={effectivePhoto?.uri ?? null}
               emoji={emoji}
               size={72}
-              onPress={() => void pickGroupPhoto().then(setPhoto)}
+              onPress={onPhotoPress}
             />
             <View style={{ flex: 1, gap: theme.spacing.xs }}>
               <InfoDisclosure
@@ -270,6 +299,13 @@ export default function NewGroupScreen() {
                   already shown large on the avatar beside it, so this only needs
                   to be a way in, not a billboard. */}
               <CoverEmojiPicker value={emoji} onChange={setPickedEmoji} compact />
+              {/* Photos are a paid feature; the icon above is always free. Said
+                  quietly here rather than as a wall in front of the tap. */}
+              {photoStatus === 'locked' ? (
+                <Text variant="micro" tone="muted">
+                  {t.groupPhoto.paidHint}
+                </Text>
+              ) : null}
             </View>
           </Row>
         </Card>

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -341,6 +341,24 @@ export async function removeGroupPhoto(groupId: string, path: string | null): Pr
   if (error) throw new Error(error.message);
 }
 
+/**
+ * May a real photo be set on this group — or, with no group yet, on the group
+ * the caller is about to create? A group photo is a paid feature; a cover emoji
+ * stays free. True when anyone in the group is paid (or the group holds a pass);
+ * for a new group that is just "is the creator paid".
+ *
+ * Answered by a SECURITY DEFINER RPC because a member cannot read another
+ * member's subscription under RLS — the server returns only the boolean, never
+ * whose subscription it was. Pass `null` for the new-group case.
+ */
+export async function canUploadGroupPhoto(groupId: string | null): Promise<boolean> {
+  const { data, error } = await supabase.rpc('baaki_can_upload_group_photo', {
+    p_group_id: groupId,
+  });
+  if (error) throw new Error(error.message);
+  return data === true;
+}
+
 /** The bucket accepts three types; anything else is stored as JPEG. */
 function normaliseImageMime(mimeType: string | null | undefined): string {
   if (mimeType === 'image/png' || mimeType === 'image/webp') return mimeType;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -659,6 +659,10 @@ export interface UiStrings {
     errorNameRequired: string;
     errorGeneric: string;
   };
+  /** Group photos are a paid feature; the cover emoji stays free for everyone. */
+  groupPhoto: {
+    paidHint: string;
+  };
   /** The inbox — the record of what Baaki said, whether or not push arrived. */
   inbox: {
     title: string;
@@ -1783,6 +1787,9 @@ const en: UiStrings = {
     errorNotMergeable: 'You can only merge guests you share a group with.',
     errorNameRequired: 'Give the merged person a name.',
     errorGeneric: 'Could not merge. Please try again.',
+  },
+  groupPhoto: {
+    paidHint: 'Group photos are a Plus feature. Pick an icon, or upgrade to add a photo.',
   },
   inbox: {
     title: 'Inbox',
@@ -2989,6 +2996,10 @@ const ta: UiStrings = {
     errorNotMergeable: 'நீங்கள் பகிரும் குழுவில் உள்ள விருந்தினர்களை மட்டுமே இணைக்க முடியும்.',
     errorNameRequired: 'இணைந்த நபருக்கு ஒரு பெயரைக் கொடுக்கவும்.',
     errorGeneric: 'இணைக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
+  },
+  groupPhoto: {
+    paidHint:
+      'குழு புகைப்படங்கள் Plus அம்சம். ஒரு ஐகானைத் தேர்ந்தெடுக்கவும், அல்லது புகைப்படம் சேர்க்க மேம்படுத்தவும்.',
   },
   inbox: {
     title: 'அஞ்சல் பெட்டி',
@@ -4197,6 +4208,9 @@ const hi: UiStrings = {
       'आप केवल उन मेहमानों को मर्ज कर सकते हैं जिनके साथ आप कोई समूह साझा करते हैं.',
     errorNameRequired: 'मर्ज किए गए व्यक्ति को एक नाम दें.',
     errorGeneric: 'मर्ज नहीं हो सका. कृपया फिर से प्रयास करें.',
+  },
+  groupPhoto: {
+    paidHint: 'ग्रुप फ़ोटो एक Plus सुविधा है। कोई आइकन चुनें, या फ़ोटो जोड़ने के लिए अपग्रेड करें।',
   },
   inbox: {
     title: 'इनबॉक्स',
@@ -5408,6 +5422,9 @@ const ar: UiStrings = {
     errorNotMergeable: 'يمكنك دمج الضيوف الذين تشاركهم مجموعة فقط.',
     errorNameRequired: 'أعطِ الشخص المدمج اسمًا.',
     errorGeneric: 'تعذّر الدمج. يرجى المحاولة مرة أخرى.',
+  },
+  groupPhoto: {
+    paidHint: 'صور المجموعة ميزة Plus. اختر أيقونة، أو قم بالترقية لإضافة صورة.',
   },
   inbox: {
     title: 'صندوق الوارد',

--- a/apps/mobile/src/lib/groupPhotoGate.ts
+++ b/apps/mobile/src/lib/groupPhotoGate.ts
@@ -1,0 +1,62 @@
+/**
+ * The rule the group-photo control obeys: a real photo is a paid feature, a
+ * cover emoji is free for everyone. The server answers "is this group (or its
+ * creator) paid" over the `baaki_can_upload_group_photo` RPC; this module turns
+ * that answer — and its loading state — into the small decisions the two photo
+ * screens (new group, group settings) need, kept pure so they can be tested
+ * without a renderer or the network.
+ */
+
+/** What the photo control should show. */
+export type PhotoGateStatus = 'loading' | 'allowed' | 'locked';
+
+/**
+ * The gate, from the RPC's boolean and whether it is still in flight. An
+ * undefined answer counts as loading: better to hold on the always-safe
+ * icon-only affordance for a moment than to flash a picker and snatch it back.
+ */
+export function photoGateStatus(
+  canUpload: boolean | undefined,
+  isLoading: boolean,
+): PhotoGateStatus {
+  if (isLoading || canUpload === undefined) return 'loading';
+  return canUpload ? 'allowed' : 'locked';
+}
+
+/** What tapping the group photo should do in each state. */
+export type PhotoTapAction = 'pick' | 'showLockedHint' | 'ignore';
+
+/**
+ * Tapping the photo: open the picker only when allowed; when locked, point the
+ * person at how to unlock it; while the answer is still loading, do nothing
+ * rather than act on an unknown.
+ */
+export function photoTapAction(status: PhotoGateStatus): PhotoTapAction {
+  switch (status) {
+    case 'allowed':
+      return 'pick';
+    case 'locked':
+      return 'showLockedHint';
+    case 'loading':
+      return 'ignore';
+  }
+}
+
+/**
+ * The `p_group_id` argument for `baaki_can_upload_group_photo`: a group's id for
+ * an existing group, or `null` when creating one — a new group has only its
+ * creator, so the server gates on the creator's own subscription.
+ */
+export function photoGateParam(groupId: string | null | undefined): string | null {
+  return groupId ?? null;
+}
+
+/**
+ * Whether an already-picked photo must be dropped. If the gate resolves to
+ * locked after an image was chosen — a slow answer, or a paying member leaving
+ * the group between screens — the picked photo can no longer be used, so it is
+ * cleared rather than silently failing to upload later.
+ */
+export function shouldClearPickedPhoto(status: PhotoGateStatus, hasPickedPhoto: boolean): boolean {
+  return status === 'locked' && hasPickedPhoto;
+}

--- a/apps/mobile/test/groupPhotoGate.test.ts
+++ b/apps/mobile/test/groupPhotoGate.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  photoGateParam,
+  photoGateStatus,
+  photoTapAction,
+  shouldClearPickedPhoto,
+  type PhotoGateStatus,
+} from '@/lib/groupPhotoGate';
+
+describe('photoGateStatus', () => {
+  it('is loading while the RPC is in flight', () => {
+    expect(photoGateStatus(undefined, true)).toBe('loading');
+    expect(photoGateStatus(true, true)).toBe('loading');
+    expect(photoGateStatus(false, true)).toBe('loading');
+  });
+
+  it('treats an undefined answer as loading even when not flagged loading', () => {
+    // A resolved query with no data yet must not read as "locked".
+    expect(photoGateStatus(undefined, false)).toBe('loading');
+  });
+
+  it('is allowed only when the answer is a definite yes', () => {
+    expect(photoGateStatus(true, false)).toBe('allowed');
+  });
+
+  it('is locked when the answer is a definite no', () => {
+    expect(photoGateStatus(false, false)).toBe('locked');
+  });
+});
+
+describe('photoTapAction', () => {
+  it('opens the picker when allowed', () => {
+    expect(photoTapAction('allowed')).toBe('pick');
+  });
+
+  it('points at the unlock path when locked', () => {
+    expect(photoTapAction('locked')).toBe('showLockedHint');
+  });
+
+  it('does nothing while loading', () => {
+    expect(photoTapAction('loading')).toBe('ignore');
+  });
+});
+
+describe('photoGateParam', () => {
+  it('passes a group id straight through', () => {
+    expect(photoGateParam('grp-1')).toBe('grp-1');
+  });
+
+  it('maps a missing group (new group) to null', () => {
+    expect(photoGateParam(null)).toBeNull();
+    expect(photoGateParam(undefined)).toBeNull();
+  });
+});
+
+describe('shouldClearPickedPhoto', () => {
+  it('clears a picked photo once the gate resolves locked', () => {
+    expect(shouldClearPickedPhoto('locked', true)).toBe(true);
+  });
+
+  it('keeps the photo when allowed, or when nothing was picked', () => {
+    expect(shouldClearPickedPhoto('allowed', true)).toBe(false);
+    expect(shouldClearPickedPhoto('locked', false)).toBe(false);
+    expect(shouldClearPickedPhoto('loading', true)).toBe(false);
+  });
+
+  // Every status is covered above; this guards against a new status slipping
+  // through without a decision.
+  it('never clears in a non-locked status', () => {
+    const statuses: PhotoGateStatus[] = ['loading', 'allowed'];
+    for (const status of statuses) {
+      expect(shouldClearPickedPhoto(status, true)).toBe(false);
+    }
+  });
+});

--- a/e2e/group-photo-paid-gate.yaml
+++ b/e2e/group-photo-paid-gate.yaml
@@ -1,0 +1,39 @@
+# Maestro flow (ADR-014): group photos are a paid feature, icons are free.
+#
+# On a free account, opening "new group" and tapping the photo must not reach a
+# picker — instead the icon (cover emoji) path stays, and the "Plus feature" hint
+# explains why. The photo-tap and hint steps are optional so the flow still
+# passes if the paid-gate RPC answers differently under a seed with a paying
+# member (in which case the picker is allowed and there is no hint). Seed a free
+# account to exercise the locked path fully.
+appId: app.baaki.mobile
+---
+- launchApp:
+    clearState: true
+
+# Home → new group
+- assertVisible: 'Your groups'
+- tapOn: 'New group'
+
+# The cover-emoji (icon) picker is always available — free for everyone.
+- assertVisible:
+    id: 'CoverEmojiPicker'
+    optional: true
+
+# On a free account the photo is locked: the hint is shown and tapping the photo
+# does not open a picker.
+- assertVisible:
+    text: 'Plus feature'
+    optional: true
+
+# The icon path still works: pick an emoji, name the group, create it.
+- tapOn:
+    id: 'CoverEmojiPicker'
+    optional: true
+- tapOn:
+    text: '🏠'
+    optional: true
+- inputText: 'Flat 4B'
+- tapOn:
+    text: 'Create'
+    optional: true

--- a/packages/db/prisma/migrations/20260815170000_group_photo_paid_gate/migration.sql
+++ b/packages/db/prisma/migrations/20260815170000_group_photo_paid_gate/migration.sql
@@ -1,0 +1,85 @@
+-- Group photos are a paid feature; icons (cover emoji) stay free for everyone.
+--
+-- The rule the app asks for: a group may carry a real photo if *anyone* in it is
+-- paid — one member's subscription lifts the whole group, so a paid person can
+-- set the picture for the trip everyone else is on for free. A brand-new group
+-- has only its creator, so there the question reduces to "is the creator paid".
+--
+-- This has to be answered server-side. A member cannot read another member's
+-- subscriptions under RLS (nor should they), so "is anyone here paid" is a
+-- SECURITY DEFINER question. These functions expose only a single boolean —
+-- never whose subscription it was, or anything else about it.
+
+-- Is this one profile paid right now: an active subscription that has not lapsed
+-- (a lifetime purchase has no period end and never lapses).
+CREATE OR REPLACE FUNCTION public.baaki_profile_is_paid(p_profile uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.subscriptions s
+     WHERE s.profile_id = p_profile
+       AND s.status = 'active'
+       AND (s.current_period_end IS NULL OR s.current_period_end > now())
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_profile_is_paid(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_profile_is_paid(uuid) TO authenticated, anon;
+
+-- May the caller set a real photo on this group (or, with no group yet, on a
+-- group they are about to create)?
+--   * no group id  → a new group; only the creator exists, so gate on the
+--     caller's own subscription;
+--   * a group id   → true if any current member is paid, or the group itself
+--     holds an unexpired pass. The caller must be a member to ask.
+-- Returns a bare boolean; the client uses it to choose the photo picker or the
+-- icon-only path, and the storage RLS still guards the upload itself.
+CREATE OR REPLACE FUNCTION public.baaki_can_upload_group_photo(p_group_id uuid DEFAULT NULL)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+BEGIN
+  IF v_profile IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF p_group_id IS NULL THEN
+    RETURN public.baaki_profile_is_paid(v_profile);
+  END IF;
+
+  -- Only a member may ask about their group.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.group_members gm
+     WHERE gm.group_id = p_group_id
+       AND gm.profile_id = v_profile
+       AND gm.left_at IS NULL
+  ) THEN
+    RETURN false;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1 FROM public.group_members gm
+     WHERE gm.group_id = p_group_id
+       AND gm.left_at IS NULL
+       AND gm.profile_id IS NOT NULL
+       AND public.baaki_profile_is_paid(gm.profile_id)
+  ) OR EXISTS (
+    SELECT 1 FROM public.group_passes gp
+     WHERE gp.group_id = p_group_id
+       AND gp.expires_at > now()
+  );
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_can_upload_group_photo(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_can_upload_group_photo(uuid) TO authenticated, anon;


### PR DESCRIPTION
A real group **photo** can be set only if **someone in the group is paid** — one paying member lifts the whole group (so they can set the picture for a trip everyone else is on free). A brand-new group has only its creator, so there it reduces to "is the creator paid". A **cover emoji** stays free for everyone.

## Server (functions only — no table, no drift)
Because a member can't read another member's subscription under RLS, "is anyone here paid" is answered server-side:
- `baaki_profile_is_paid(profile)` — an active, unlapsed subscription (a lifetime purchase never lapses).
- `baaki_can_upload_group_photo(group_id)` (SECURITY DEFINER): `null` group → gate on the caller; a group → any current member paid **or** an unexpired group pass. Members-only; returns just a boolean, never whose subscription it was.

## Mobile
- `lib/groupPhotoGate.ts` — pure decisions (status from the RPC answer + loading, tap action, RPC arg, whether to drop an already-picked photo), **unit tested** (`test/groupPhotoGate.test.ts`: loading precedence, undefined-as-loading, allowed/locked, param mapping, clear-picked matrix).
- **new-group** + **group settings**: the photo tap opens the picker only when allowed; when locked it points at the upgrade screen, a quiet "Plus feature" hint sits by the always-free emoji picker, and a picked photo is dropped (**derived**, not stored — no setState-in-effect) if the gate is locked. **Removing** an existing photo is never gated (a group that loses its paying member falls back to an icon).
- i18n across en/ta/hi/ar.
- `e2e/group-photo-paid-gate.yaml` — Maestro journey (new group → locked photo → free icon path); gate-dependent steps optional.

## Edge cases
- New group (no group id yet) → gate on the creator's own subscription.
- Non-member asking → false.
- Group with an active **pass** but no paid member → allowed.
- Paying member leaves → group can no longer add a photo, but can still **remove** one.
- Gate still loading → treated as locked (icon path), never a picker flash.

## Note
With no store selling subscriptions yet, everyone is currently free → photos are effectively icon-only until subscriptions exist, which is the intended gating.

## Verification
- typecheck + lint + format clean; **230/230** mobile tests pass; functions-only migration (no drift).
- Prod migration is the deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paid-feature access controls for group photo uploads during group creation and in group settings.
  * Users without access are directed to upgrade and can choose a free icon instead.
  * Existing group photos can still be removed.
  * Added helpful paid-feature hints in multiple languages.
* **Bug Fixes**
  * Prevented unavailable photo selections from being uploaded when access changes.
* **Tests**
  * Added coverage for photo access states and end-to-end group creation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->