### PR TITLE
fix(db): enforce group-photo paid gate server-side

### DIFF
--- a/packages/db/prisma/migrations/20260815180000_group_photo_gate_enforcement/migration.sql
+++ b/packages/db/prisma/migrations/20260815180000_group_photo_gate_enforcement/migration.sql
@@ -1,0 +1,102 @@
+-- Enforce the group-photo paid gate on the server, not only in the UI.
+--
+-- 20260815170000 added `baaki_can_upload_group_photo`, but the app used it only
+-- to choose the picker vs the icon path — the actual writes still went through
+-- RLS that checked *membership alone*:
+--   * the `group-photos` storage INSERT/UPDATE policies (20260805120000), and
+--   * the `groups` UPDATE path for `photo_path` (row-scoped by is_group_member,
+--     with a column guard that never mentioned photo_path).
+-- So any member could bypass the gate with a direct `PUT` of the object and a
+-- `PATCH /groups?id=eq.X {photo_path:...}` under their own JWT. The gate was a
+-- suggestion, not a boundary. This closes both write boundaries, and removes a
+-- side channel that let any client probe an arbitrary profile's paid status.
+
+-- 1. `baaki_profile_is_paid` was granted to authenticated/anon, which let any
+--    client call it on ANY profile id and learn whether that person pays — a
+--    definer function reading `subscriptions`, which RLS otherwise hides. No
+--    client needs it directly: the only legitimate caller is
+--    `baaki_can_upload_group_photo`, a SECURITY DEFINER function that runs as
+--    its owner and so keeps EXECUTE regardless of the client grant.
+REVOKE EXECUTE ON FUNCTION public.baaki_profile_is_paid(uuid) FROM authenticated, anon;
+
+-- 2. The `groups` column guard now also gates `photo_path`. Setting or changing
+--    it to a real path requires the paid gate; clearing it (removing the photo)
+--    is always allowed — a group that loses its paying member can still fall
+--    back to an icon, which is exactly what the app already does. Service-role,
+--    SECURITY DEFINER and migration paths stay exempt via the current_user
+--    check, unchanged from 20260815120000; only the photo_path block is added.
+CREATE OR REPLACE FUNCTION public.baaki_guard_group_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF current_user NOT IN ('anon', 'authenticated') THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.updated_seq IS DISTINCT FROM OLD.updated_seq THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: updated_seq is set by the server, not the client'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creator is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.id IS DISTINCT FROM OLD.id THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s id is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creation time is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- A group photo is a paid feature (ADR-011 addendum). Only gate setting one;
+  -- clearing it back to NULL is free and always allowed.
+  IF NEW.photo_path IS DISTINCT FROM OLD.photo_path
+     AND NEW.photo_path IS NOT NULL
+     AND NOT public.baaki_can_upload_group_photo(NEW.id) THEN
+    RAISE EXCEPTION 'PHOTO_GATE: a group photo is a paid feature'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN NEW;
+END
+$$;
+
+-- 3. The storage write boundaries. A member may still read and remove; setting
+--    a photo (INSERT a new object, or UPDATE-replace an existing one) now also
+--    requires the paid gate for the object's group. Guarded by the storage
+--    schema's presence so CI's bare Postgres skips it, exactly like the policies
+--    it supersedes (20260805120000).
+DO $$
+BEGIN
+  IF to_regclass('storage.buckets') IS NULL THEN
+    RAISE NOTICE 'storage schema absent (plain Postgres): skipping the photo policies';
+    RETURN;
+  END IF;
+
+  EXECUTE $policy$
+    DROP POLICY IF EXISTS "group photos are writable by members" ON storage.objects;
+    CREATE POLICY "group photos are writable by members" ON storage.objects
+      FOR INSERT TO authenticated, anon
+      WITH CHECK (
+        bucket_id = 'group-photos'
+        AND public.is_group_member(public.baaki_group_from_storage_path(name))
+        AND public.baaki_can_upload_group_photo(public.baaki_group_from_storage_path(name))
+      );
+
+    DROP POLICY IF EXISTS "group photos are replaceable by members" ON storage.objects;
+    CREATE POLICY "group photos are replaceable by members" ON storage.objects
+      FOR UPDATE TO authenticated, anon
+      USING (
+        bucket_id = 'group-photos'
+        AND public.is_group_member(public.baaki_group_from_storage_path(name))
+        AND public.baaki_can_upload_group_photo(public.baaki_group_from_storage_path(name))
+      );
+  $policy$;
+END
+$$;

--- a/packages/db/test/groups.test.ts
+++ b/packages/db/test/groups.test.ts
@@ -156,7 +156,7 @@ describe('the group-photo paid gate', () => {
     // A lifetime purchase — active with no period end, so it never lapses.
     await client.query(
       `INSERT INTO subscriptions (profile_id, period, status, store, current_period_end)
-       VALUES ($1, 'lifetime', 'active', 'test', NULL)`,
+       VALUES ($1, 'lifetime', 'active', 'promo', NULL)`,
       [profileId],
     );
   }

--- a/packages/db/test/groups.test.ts
+++ b/packages/db/test/groups.test.ts
@@ -144,3 +144,97 @@ describe('group photos', () => {
     }
   });
 });
+
+/**
+ * A group photo is a paid feature (ADR-011 addendum, TDR A39). The client asks
+ * `baaki_can_upload_group_photo` to pick the picker vs the icon, but the gate is
+ * enforced server-side (20260815180000) so a member cannot bypass the UI with a
+ * direct write. These pin the enforcement, not the suggestion.
+ */
+describe('the group-photo paid gate', () => {
+  async function makePaid(profileId: string): Promise<void> {
+    // A lifetime purchase — active with no period end, so it never lapses.
+    await client.query(
+      `INSERT INTO subscriptions (profile_id, period, status, store, current_period_end)
+       VALUES ($1, 'lifetime', 'active', 'test', NULL)`,
+      [profileId],
+    );
+  }
+
+  it('will not let a client read another profile’s paid status directly', async () => {
+    // baaki_profile_is_paid reads `subscriptions`, which RLS hides. It is a
+    // SECURITY DEFINER helper for the wrapper only; a client that could call it
+    // on any uuid would have an oracle for who pays.
+    const profileId = await createProfile('Asha');
+    const message = await asUser(profileId, () =>
+      expectDenied(client.query(`SELECT baaki_profile_is_paid($1)`, [profileId])),
+    );
+    expect(message).toMatch(/permission denied/i);
+  });
+
+  it('answers the new-group question from the caller’s own plan', async () => {
+    const free = await createProfile('Free');
+    const paid = await createProfile('Paid');
+    await makePaid(paid);
+
+    // p_group_id NULL = "a group I am about to create": gate on me alone.
+    expect(await asUser(free, async () => canUpload(null))).toBe(false);
+    expect(await asUser(paid, async () => canUpload(null))).toBe(true);
+  });
+
+  it('refuses a direct photo_path write when nobody in the group pays', async () => {
+    const profileId = await createProfile('Asha');
+    const groupId = await createGroup(profileId);
+
+    // The UI would never offer this, but a raw PATCH under the caller's JWT must
+    // still be refused — the gate is a boundary, not a hint.
+    const message = await asUser(profileId, () =>
+      expectDenied(
+        client.query(`UPDATE groups SET photo_path = $2 WHERE id = $1`, [
+          groupId,
+          `${groupId}/cover.jpg`,
+        ]),
+      ),
+    );
+    expect(message).toMatch(/PHOTO_GATE/);
+  });
+
+  it('allows the photo_path write once a member pays', async () => {
+    const profileId = await createProfile('Asha');
+    const groupId = await createGroup(profileId);
+    await makePaid(profileId);
+
+    await asUser(profileId, () =>
+      client.query(`UPDATE groups SET photo_path = $2 WHERE id = $1`, [
+        groupId,
+        `${groupId}/cover.jpg`,
+      ]),
+    );
+    expect((await readGroup(groupId)).photo_path).toBe(`${groupId}/cover.jpg`);
+  });
+
+  it('never gates clearing a photo — losing a paying member falls back to an icon', async () => {
+    const profileId = await createProfile('Asha');
+    const groupId = await createGroup(profileId);
+    // Seed a photo through the definer create path, then let an unpaid member
+    // remove it: clearing to NULL must always work.
+    await makePaid(profileId);
+    await asUser(profileId, () =>
+      client.query(`UPDATE groups SET photo_path = $2 WHERE id = $1`, [
+        groupId,
+        `${groupId}/cover.jpg`,
+      ]),
+    );
+    await client.query(`DELETE FROM subscriptions WHERE profile_id = $1`, [profileId]);
+
+    await asUser(profileId, () =>
+      client.query(`UPDATE groups SET photo_path = NULL WHERE id = $1`, [groupId]),
+    );
+    expect((await readGroup(groupId)).photo_path).toBeNull();
+  });
+});
+
+async function canUpload(groupId: string | null): Promise<boolean> {
+  const { rows } = await client.query(`SELECT baaki_can_upload_group_photo($1) AS ok`, [groupId]);
+  return rows[0]?.ok === true;
+}


### PR DESCRIPTION
Server-side enforcement of the group-photo paid gate. Addresses several review findings that the gate added in #209 was UI-only and bypassable.

## The hole
`baaki_can_upload_group_photo` (20260815170000) was consulted only by the client to pick the photo-picker vs the icon path. The real writes checked **membership alone**:
- `group-photos` storage INSERT/UPDATE policies → `is_group_member` only.
- `groups.photo_path` update → `groups_update` RLS + a column guard that never mentioned `photo_path`.

So any member could bypass it with a direct object `PUT` and `PATCH /groups?id=eq.X {photo_path}` under their own JWT. Plus `baaki_profile_is_paid(uuid)` was granted to `authenticated/anon`, an oracle for whether any profile pays.

## Fix (one migration, functions/policies/trigger only)
- **REVOKE** `EXECUTE` on `baaki_profile_is_paid(uuid)` from `authenticated, anon`. The wrapper is SECURITY DEFINER and keeps execute as its owner, so nothing legitimate breaks.
- **`baaki_guard_group_columns`** now gates `photo_path`: setting a real path requires `baaki_can_upload_group_photo(id)`; clearing to NULL is always free.
- **storage INSERT/UPDATE** policies AND-in the same check; membership still required; read/remove unchanged; emoji (a text column) untouched.

## Tests
`packages/db/test/groups.test.ts`: direct-read denial, new-group answer per caller plan, photo_path write refused-unpaid / allowed-once-paid, clearing never gated.

No `schema.prisma` change → no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
