### PR TITLE
fix(db): ghost merges union instead of overwrite

### DIFF
--- a/packages/db/prisma/migrations/20260815190000_merge_ghosts_union/migration.sql
+++ b/packages/db/prisma/migrations/20260815190000_merge_ghosts_union/migration.sql
@@ -83,12 +83,15 @@ BEGIN
       FROM unnest(p_member_ids) AS m
      WHERE m IS NOT NULL;
 
-  -- Any existing merge groups that overlap the selection: reusing the smallest
-  -- of their person_ids keeps a repeated merge stable rather than churning.
-  SELECT min(gm.person_id) INTO v_canonical
+  -- Any existing merge groups that overlap the selection: reusing the lowest of
+  -- their person_ids (uuid has no min() aggregate, so order and take one) keeps a
+  -- repeated merge stable rather than churning. No overlap leaves it NULL.
+  SELECT gm.person_id INTO v_canonical
     FROM public.ghost_merges gm
    WHERE gm.owner = v_profile_id
-     AND gm.member_id IN (SELECT member_id FROM _sel);
+     AND gm.member_id IN (SELECT member_id FROM _sel)
+   ORDER BY gm.person_id
+   LIMIT 1;
 
   -- No overlap with a prior merge: this is a brand-new person.
   IF v_canonical IS NULL THEN

--- a/packages/db/prisma/migrations/20260815190000_merge_ghosts_union/migration.sql
+++ b/packages/db/prisma/migrations/20260815190000_merge_ghosts_union/migration.sql
@@ -1,0 +1,122 @@
+-- Make ghost merges union instead of overwrite, so overlapping merges converge.
+--
+-- 20260815160000 minted a fresh person_id every call and upserted only the
+-- members passed in. That splits a prior merge the moment a new one shares a
+-- member with it: merge {A,B} → P1, then merge {B,C} → P2 leaves A on P1 while
+-- B and C move to P2 — A silently drops out of the person it was merged into,
+-- and the same set merged twice churns its person_id. A viewer's mental model
+-- is "these are all one human", which is a union, not a replace.
+--
+-- The fix pulls in every member already sharing a person_id with any selected
+-- member, and assigns the whole union ONE canonical person_id — reusing an
+-- existing one when present so a repeat is stable (idempotent grouping) and a
+-- transitive merge collapses to a single Friends total. baaki_people_i_owe is
+-- unchanged: it already keys on person_id, so a correct assignment is all it
+-- needs.
+--
+-- Note on cycles/self-reference: not representable here. member_id (a
+-- group_member) and person_id (a synthetic identity) are different namespaces,
+-- and person_id is server-minted, never a member_id — there is no member→member
+-- edge to close into a cycle, so there is nothing to reject.
+
+CREATE OR REPLACE FUNCTION public.baaki_merge_ghosts(
+  p_member_ids uuid[],
+  p_name       text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_name       text := nullif(btrim(coalesce(p_name, '')), '');
+  v_canonical  uuid;
+  v_count      int;
+  v_bad        int;
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_SIGNED_IN'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF v_name IS NULL THEN
+    RAISE EXCEPTION 'NAME_REQUIRED: the merged person needs a name'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Distinct, non-null members actually asked for.
+  SELECT count(DISTINCT t.id) INTO v_count
+    FROM unnest(p_member_ids) AS t(id)
+   WHERE t.id IS NOT NULL;
+
+  IF v_count < 2 THEN
+    RAISE EXCEPTION 'TOO_FEW: pick at least two people to merge'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Every id must be a ghost the caller shares a group with. Anything that is
+  -- not — a real person, a member of a group the caller is not in, or an id that
+  -- does not exist — makes the whole merge fail rather than merging a subset.
+  SELECT count(*) INTO v_bad
+    FROM unnest(p_member_ids) AS want(id)
+   WHERE want.id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+         FROM public.group_members target
+         JOIN public.group_members mine
+           ON mine.group_id = target.group_id
+          AND mine.profile_id = v_profile_id
+          AND mine.left_at IS NULL
+        WHERE target.id = want.id
+          AND target.profile_id IS NULL
+     );
+
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'NOT_MERGEABLE: every person must be a guest you share a group with'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- The members explicitly picked this time.
+  CREATE TEMP TABLE _sel ON COMMIT DROP AS
+    SELECT DISTINCT m AS member_id
+      FROM unnest(p_member_ids) AS m
+     WHERE m IS NOT NULL;
+
+  -- Any existing merge groups that overlap the selection: reusing the smallest
+  -- of their person_ids keeps a repeated merge stable rather than churning.
+  SELECT min(gm.person_id) INTO v_canonical
+    FROM public.ghost_merges gm
+   WHERE gm.owner = v_profile_id
+     AND gm.member_id IN (SELECT member_id FROM _sel);
+
+  -- No overlap with a prior merge: this is a brand-new person.
+  IF v_canonical IS NULL THEN
+    v_canonical := gen_random_uuid();
+  END IF;
+
+  -- The full union: the picked members plus every member already sharing a
+  -- person_id with any of them, so a transitive merge folds into one identity.
+  INSERT INTO public.ghost_merges (owner, member_id, person_id, display_name)
+  SELECT v_profile_id, u.member_id, v_canonical, v_name
+    FROM (
+      SELECT member_id FROM _sel
+      UNION
+      SELECT gm.member_id
+        FROM public.ghost_merges gm
+       WHERE gm.owner = v_profile_id
+         AND gm.person_id IN (
+           SELECT gm2.person_id
+             FROM public.ghost_merges gm2
+            WHERE gm2.owner = v_profile_id
+              AND gm2.member_id IN (SELECT member_id FROM _sel)
+         )
+    ) AS u(member_id)
+  ON CONFLICT (owner, member_id)
+  DO UPDATE SET person_id = EXCLUDED.person_id,
+                display_name = EXCLUDED.display_name,
+                created_at = now();
+
+  RETURN v_canonical;
+END
+$$;

--- a/packages/db/test/mergeGhosts.test.ts
+++ b/packages/db/test/mergeGhosts.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Merging same-person guests (TDR A38) is a union, not a replace.
+ *
+ * A viewer folds guests they know to be one human. When a later merge shares a
+ * member with an earlier one, the two must converge onto a single identity —
+ * otherwise a member silently drops out of the person it was merged into, and
+ * baaki_people_i_owe shows the same human as two Friends rows again. These pin
+ * the union and its idempotency at the database, where it is enforced.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+async function merge(profileId: string, memberIds: string[], name: string): Promise<string> {
+  return asUser(profileId, async () => {
+    const { rows } = await client.query(`SELECT baaki_merge_ghosts($1::uuid[], $2) AS person_id`, [
+      memberIds,
+      name,
+    ]);
+    return String(rows[0]?.person_id);
+  });
+}
+
+async function personIdOf(owner: string, memberId: string): Promise<string | null> {
+  const { rows } = await client.query(
+    `SELECT person_id FROM ghost_merges WHERE owner = $1 AND member_id = $2`,
+    [owner, memberId],
+  );
+  return rows[0]?.person_id ? String(rows[0].person_id) : null;
+}
+
+describe('merging guests unions overlapping groups', () => {
+  it('folds a transitive merge into one identity', async () => {
+    // One group, one real caller, three ghosts they share it with.
+    const { profileIds, memberIds } = await seedGroup(client, { memberCount: 1, ghostCount: 3 });
+    const caller = profileIds[0]!;
+    const [, ghostA, ghostB, ghostC] = memberIds;
+
+    await merge(caller, [ghostA!, ghostB!], 'Rahul');
+    // The second merge shares ghostB with the first — all three must converge,
+    // not split ghostA off onto its own person.
+    await merge(caller, [ghostB!, ghostC!], 'Rahul');
+
+    const pa = await personIdOf(caller, ghostA!);
+    const pb = await personIdOf(caller, ghostB!);
+    const pc = await personIdOf(caller, ghostC!);
+    expect(pa).not.toBeNull();
+    expect(pb).toBe(pa);
+    expect(pc).toBe(pa);
+  });
+
+  it('is idempotent — merging the same pair twice keeps one stable identity', async () => {
+    const { profileIds, memberIds } = await seedGroup(client, { memberCount: 1, ghostCount: 2 });
+    const caller = profileIds[0]!;
+    const [, ghostA, ghostB] = memberIds;
+
+    const first = await merge(caller, [ghostA!, ghostB!], 'Rahul');
+    const second = await merge(caller, [ghostA!, ghostB!], 'Rahul');
+    expect(second).toBe(first);
+
+    const { rows } = await client.query(
+      `SELECT count(DISTINCT person_id)::int AS people, count(*)::int AS rows
+         FROM ghost_merges WHERE owner = $1 AND member_id = ANY($2::uuid[])`,
+      [caller, [ghostA, ghostB]],
+    );
+    expect(rows[0]?.people).toBe(1);
+    expect(rows[0]?.rows).toBe(2);
+  });
+});


### PR DESCRIPTION
Makes ghost merges (#208) union instead of overwrite. Addresses a review finding that overlapping/transitive merges did not converge.

## The bug
`baaki_merge_ghosts` minted a fresh `person_id` every call and upserted only the passed members. So a merge sharing a member with an earlier one **split** the prior group:

- merge `{A,B}` → P1 (A,B → P1)
- merge `{B,C}` → P2 (B,C → P2), leaving **A stranded on P1**

A drops out of the person it was merged into, and `baaki_people_i_owe` shows one human as two Friends rows again. Reachable from the merge screen by re-merging an already-merged row.

## Fix
`baaki_merge_ghosts` now **unions**: pulls in every member already sharing a `person_id` with any selected member and assigns the whole set one canonical `person_id`, reusing an existing one when the selection overlaps a prior merge — so a repeat is stable (idempotent) and a transitive merge collapses to a single Friends total. `baaki_people_i_owe` is unchanged; it already keys on `person_id`.

**Cycles / self-reference:** not representable — `member_id` (a group_member) and the server-minted `person_id` are different namespaces, no member→member edge exists. Nothing to reject; noted in the migration.

## Tests
`packages/db/test/mergeGhosts.test.ts`: transitive merge converges to one identity; same pair twice → one stable `person_id`. Function-only, no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for merging duplicate guest identities into one canonical profile.
  * Automatically combines overlapping guest groups and preserves a stable identity for repeated merges.
  * Validates access permissions and selected guest details before completing a merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->