### PR TITLE
feat(ui): archive & leave group in red (ghostDanger variant)

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -361,8 +361,8 @@ export default function GroupSettingsScreen() {
         ) : null}
 
         <View style={{ gap: theme.spacing.md }}>
-          <Button label={t.group.archiveGroup} variant="ghost" fullWidth onPress={archive} />
-          <Button label={t.group.leaveGroup} variant="ghost" fullWidth onPress={leave} />
+          <Button label={t.group.archiveGroup} variant="ghostDanger" fullWidth onPress={archive} />
+          <Button label={t.group.leaveGroup} variant="ghostDanger" fullWidth onPress={leave} />
           {!settled ? (
             <Text variant="micro" tone="muted" align="center">
               {t.group.leaveWhenZero}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -14,9 +14,14 @@ import { Text } from './Text';
  * cannot be mistaken for the secondary button beside it, and it borrows the
  * semantic negative colour deliberately: in this app red already means money
  * leaving, and a destructive action is the same warning in a different place.
+ *
+ * `ghostDanger` is the quieter cousin: a chromeless button (like `ghost`) but
+ * with a red label, for the leave-and-archive kind of action that reads as a
+ * warning without shouting like a filled block — it sits at the foot of a
+ * settings screen, not in the main flow.
  */
 export type ButtonVariant =
-  'primary' | 'secondary' | 'ghost' | 'onBrand' | 'onBrandOutline' | 'danger';
+  'primary' | 'secondary' | 'ghost' | 'ghostDanger' | 'onBrand' | 'onBrandOutline' | 'danger';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 export interface ButtonProps extends Omit<PressableProps, 'style' | 'children'> {
@@ -93,7 +98,9 @@ export function Button({
         tone={
           variant === 'primary' || variant === 'onBrandOutline' || variant === 'danger'
             ? 'onBrand'
-            : 'brand'
+            : variant === 'ghostDanger'
+              ? 'negative'
+              : 'brand'
         }
       >
         {label}


### PR DESCRIPTION
Archive group and Leave group now read in red. Both sit at the foot of group settings and both undo something.

Adds a **ghostDanger** Button variant — chromeless like `ghost` but with a red label — quieter than the filled `danger` reserved for account erasure, so it warns without shouting. Applied to the two buttons; no other archive/leave call sites exist.

Typecheck + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)