### PR TITLE
fix(mobile): merge screen reaches its button with the keyboard open

### DIFF
--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -17,7 +17,15 @@ import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
-import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+} from 'react-native';
 
 import {
   Avatar,
@@ -101,140 +109,152 @@ export default function MergePeopleScreen() {
 
   return (
     <Screen>
-      <ScrollView
-        contentContainerStyle={{
-          paddingHorizontal: theme.spacing.xl,
-          paddingBottom: clearance,
-          gap: theme.spacing.xl,
-        }}
-        keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={false}
+      {/* On edge-to-edge Android the resize inset does not always lift the
+          content above the keyboard, so the name field's own button can end up
+          behind it and the screen reads as "won't scroll to the end". The
+          avoider (padding on iOS, resize on Android) keeps the button reachable
+          while the keyboard is open. */}
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={{ flex: 1 }}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.mergePeople.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
-        {people.isLoading ? (
-          <PeopleSkeleton />
-        ) : people.isError ? (
-          <EmptyState
-            title={t.loadError}
-            body={t.loadErrorBody}
-            action={<Button label={t.retry} variant="secondary" onPress={() => people.refetch()} />}
-          />
-        ) : guests.length < 2 ? (
-          // Fewer than two guests: nothing to merge. Say why rather than showing
-          // an empty list with a dead button.
-          <EmptyState title={t.mergePeople.title} body={t.mergePeople.empty} />
-        ) : (
-          <>
-            <Text variant="caption" tone="muted" align="center">
-              {t.mergePeople.subtitle}
-            </Text>
-
-            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-              {guests.map((row, index) => {
-                const isSelected = selected.has(row.person_key);
-                return (
-                  <View key={row.person_key}>
-                    <Pressable
-                      accessibilityRole="checkbox"
-                      accessibilityState={{ checked: isSelected }}
-                      accessibilityLabel={row.display_name}
-                      onPress={() => toggle(row.person_key)}
-                      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
-                    >
-                      <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
-                        <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
-                          <Avatar name={row.display_name} size={44} ghost />
-                          <View style={{ flex: 1 }}>
-                            <Text variant="subheading" numberOfLines={1}>
-                              {row.display_name}
-                            </Text>
-                            <Text variant="caption" tone="muted" numberOfLines={1}>
-                              {row.group_count === 1
-                                ? t.tabs.inOneGroup
-                                : plural(locale, row.group_count, t.tabs.acrossGroups)}
-                            </Text>
-                          </View>
-                        </Row>
-                        <Ionicons
-                          name={isSelected ? 'checkmark-circle' : 'ellipse-outline'}
-                          size={iconSize.xl}
-                          color={isSelected ? theme.color.brand : theme.color.textFaint}
-                        />
-                      </Row>
-                    </Pressable>
-                    {index < guests.length - 1 ? (
-                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                    ) : null}
-                  </View>
-                );
-              })}
-            </Card>
-
-            <Card style={{ gap: theme.spacing.xs }}>
-              <Text variant="caption" tone="muted">
-                {t.mergePeople.nameLabel}
-              </Text>
-              <TextInput
-                value={name}
-                onChangeText={(value) => {
-                  setNameTouched(true);
-                  setName(value);
-                }}
-                accessibilityLabel={t.mergePeople.nameLabel}
-                placeholder={t.mergePeople.namePlaceholder}
-                placeholderTextColor={theme.color.textFaint}
-                style={{
-                  fontSize: 20,
-                  fontWeight: '700',
-                  color: theme.color.text,
-                  paddingVertical: theme.spacing.sm,
-                }}
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: clearance,
+            gap: theme.spacing.xl,
+          }}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Row style={{ paddingTop: theme.spacing.md }}>
+            <IconButton label={t.common.back} onPress={() => router.back()}>
+              <Ionicons
+                name={directionalIcon('chevron-back')}
+                size={iconSize.lg}
+                color={theme.color.text}
               />
-            </Card>
+            </IconButton>
+            <View style={{ flex: 1, alignItems: 'center' }}>
+              <Text variant="heading">{t.mergePeople.title}</Text>
+            </View>
+            <View style={{ width: 44 }} />
+          </Row>
 
-            {/* The irreversibility, spelled out before the button rather than
-                buried in a toast after the fact. */}
-            <Callout tone="negative">
-              <Text variant="subheading" tone="negative">
-                {t.mergePeople.warningTitle}
-              </Text>
-              <Text variant="caption" tone="muted">
-                {t.mergePeople.warningBody}
-              </Text>
-            </Callout>
-
-            {error ? <Callout tone="negative">{error}</Callout> : null}
-
-            {selectedRows.length > 0 ? (
-              <Text variant="caption" tone="muted" align="center">
-                {plural(locale, memberIdsForMerge(selectedRows).length, t.mergePeople.selected)}
-              </Text>
-            ) : null}
-
-            <Button
-              label={t.mergePeople.cta}
-              size="lg"
-              fullWidth
-              disabled={!ready || merge.isPending}
-              onPress={() => merge.mutate()}
+          {people.isLoading ? (
+            <PeopleSkeleton />
+          ) : people.isError ? (
+            <EmptyState
+              title={t.loadError}
+              body={t.loadErrorBody}
+              action={
+                <Button label={t.retry} variant="secondary" onPress={() => people.refetch()} />
+              }
             />
-            {merge.isPending ? <ActivityIndicator color={theme.color.brand} /> : null}
-          </>
-        )}
-      </ScrollView>
+          ) : guests.length < 2 ? (
+            // Fewer than two guests: nothing to merge. Say why rather than showing
+            // an empty list with a dead button.
+            <EmptyState title={t.mergePeople.title} body={t.mergePeople.empty} />
+          ) : (
+            <>
+              <Text variant="caption" tone="muted" align="center">
+                {t.mergePeople.subtitle}
+              </Text>
+
+              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                {guests.map((row, index) => {
+                  const isSelected = selected.has(row.person_key);
+                  return (
+                    <View key={row.person_key}>
+                      <Pressable
+                        accessibilityRole="checkbox"
+                        accessibilityState={{ checked: isSelected }}
+                        accessibilityLabel={row.display_name}
+                        onPress={() => toggle(row.person_key)}
+                        style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+                      >
+                        <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
+                          <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
+                            <Avatar name={row.display_name} size={44} ghost />
+                            <View style={{ flex: 1 }}>
+                              <Text variant="subheading" numberOfLines={1}>
+                                {row.display_name}
+                              </Text>
+                              <Text variant="caption" tone="muted" numberOfLines={1}>
+                                {row.group_count === 1
+                                  ? t.tabs.inOneGroup
+                                  : plural(locale, row.group_count, t.tabs.acrossGroups)}
+                              </Text>
+                            </View>
+                          </Row>
+                          <Ionicons
+                            name={isSelected ? 'checkmark-circle' : 'ellipse-outline'}
+                            size={iconSize.xl}
+                            color={isSelected ? theme.color.brand : theme.color.textFaint}
+                          />
+                        </Row>
+                      </Pressable>
+                      {index < guests.length - 1 ? (
+                        <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                      ) : null}
+                    </View>
+                  );
+                })}
+              </Card>
+
+              <Card style={{ gap: theme.spacing.xs }}>
+                <Text variant="caption" tone="muted">
+                  {t.mergePeople.nameLabel}
+                </Text>
+                <TextInput
+                  value={name}
+                  onChangeText={(value) => {
+                    setNameTouched(true);
+                    setName(value);
+                  }}
+                  accessibilityLabel={t.mergePeople.nameLabel}
+                  placeholder={t.mergePeople.namePlaceholder}
+                  placeholderTextColor={theme.color.textFaint}
+                  style={{
+                    fontSize: 20,
+                    fontWeight: '700',
+                    color: theme.color.text,
+                    paddingVertical: theme.spacing.sm,
+                  }}
+                />
+              </Card>
+
+              {/* The irreversibility, spelled out before the button rather than
+                buried in a toast after the fact. */}
+              <Callout tone="negative">
+                <Text variant="subheading" tone="negative">
+                  {t.mergePeople.warningTitle}
+                </Text>
+                <Text variant="caption" tone="muted">
+                  {t.mergePeople.warningBody}
+                </Text>
+              </Callout>
+
+              {error ? <Callout tone="negative">{error}</Callout> : null}
+
+              {selectedRows.length > 0 ? (
+                <Text variant="caption" tone="muted" align="center">
+                  {plural(locale, memberIdsForMerge(selectedRows).length, t.mergePeople.selected)}
+                </Text>
+              ) : null}
+
+              <Button
+                label={t.mergePeople.cta}
+                size="lg"
+                fullWidth
+                disabled={!ready || merge.isPending}
+                onPress={() => merge.mutate()}
+              />
+              {merge.isPending ? <ActivityIndicator color={theme.color.brand} /> : null}
+            </>
+          )}
+        </ScrollView>
+      </KeyboardAvoidingView>
     </Screen>
   );
 }


### PR DESCRIPTION
The merge screen's Merge button sits just below the name field. On edge-to-edge Android the resize inset doesn't reliably lift content over the keyboard, so the button ends up behind it — reads as "won't scroll to the end".

Wraps the scroll view in a `KeyboardAvoidingView` (padding on iOS, resize on Android), the same pattern `sign-in.tsx` already uses. Static layout was already correct (stack route, `useScreenClearance()`), so this targets the keyboard-occlusion path specifically.

Typecheck + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)