### PR TITLE
feat(mobile): insights offline-first — spending computed from the mirror

### DIFF
--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -26,7 +26,6 @@ import { ScrollView, View } from 'react-native';
 import { categoryOf, format, type CategoryId } from '@baaki/core';
 import {
   BarList,
-  Callout,
   Card,
   ChipRow,
   ColumnChart,
@@ -48,7 +47,8 @@ import {
 import { CategoryBadge } from '@/components/Category';
 import { InsightsSkeleton } from '@/components/Skeletons';
 import type { SpendingRow } from '@/data/api';
-import { useGroup, useGroupSpending } from '@/data/hooks';
+import { computeSpendingRows } from '@/data/spending';
+import { useGroup } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
@@ -68,8 +68,12 @@ export default function InsightsScreen() {
   const groupId = id ?? '';
   const { profile } = useAuth();
 
-  const { group, members } = useGroup(groupId);
-  const spending = useGroupSpending(groupId);
+  const { group, members, expenses } = useGroup(groupId);
+
+  // Spending is a read of expenses the phone already mirrors, so it is computed
+  // on the device (ADR-005) rather than fetched — the local-first twin of the
+  // baaki_group_spending RPC, same rows, and it works with no connection.
+  const spendingRows = useMemo(() => computeSpendingRows(expenses.rows), [expenses.rows]);
 
   const [scope, setScope] = useState<Scope>(Scope.Group);
 
@@ -83,12 +87,11 @@ export default function InsightsScreen() {
   const groupCurrency = group.data?.default_currency ?? 'INR';
 
   const rows = useMemo(() => {
-    const all = spending.data ?? [];
     if (scope === Scope.Mine) {
-      return myMemberId ? all.filter((row) => row.member_id === myMemberId) : [];
+      return myMemberId ? spendingRows.filter((row) => row.member_id === myMemberId) : [];
     }
-    return all;
-  }, [spending.data, scope, myMemberId]);
+    return spendingRows;
+  }, [spendingRows, scope, myMemberId]);
 
   const currencies = useMemo(() => {
     const seen = [...new Set(rows.map((row) => row.currency))];
@@ -97,7 +100,7 @@ export default function InsightsScreen() {
     );
   }, [rows, groupCurrency]);
 
-  const loading = group.isLoading || members.isLoading || spending.isLoading;
+  const loading = group.isLoading || members.isLoading || expenses.isLoading;
 
   return (
     <Screen>
@@ -155,12 +158,6 @@ export default function InsightsScreen() {
             />
           ))
         )}
-
-        {spending.error ? (
-          <Callout tone="negative">
-            {spending.error instanceof Error ? spending.error.message : String(spending.error)}
-          </Callout>
-        ) : null}
 
         <Text variant="micro" tone="muted" align="center">
           {t.misc.insightsLiveNote}

--- a/apps/mobile/src/data/spending.ts
+++ b/apps/mobile/src/data/spending.ts
@@ -1,0 +1,104 @@
+/**
+ * Where the money went — computed on the device from the mirrored ledger.
+ *
+ * This is the local-first twin of the `baaki_group_spending` RPC (M5, TDR §8):
+ * the same per-member, per-currency, per-category, per-month share totals, but
+ * derived from the SQLite mirror the group screen already holds instead of a
+ * network round-trip (ADR-005). Insights is a read of expenses the phone
+ * already has, so it should work with no connection like every other read.
+ *
+ * It matches the server function exactly so the two are interchangeable:
+ *   * only the current version of a non-deleted expense counts;
+ *   * a category is lower-cased and trimmed, and anything empty or absent lands
+ *     in 'other';
+ *   * the month is the first day of the expense's month, taken by slicing the
+ *     'YYYY-MM-DD' string so no timezone can move it;
+ *   * nothing is converted between currencies and nothing is re-divided — the
+ *     shares are exactly what the ledger stored, odd paisa and all (ADR-003).
+ *
+ * Because it reads the group's overlaid rows, an expense still sitting in the
+ * mutation queue counts too — which is more current than the server-only RPC,
+ * and correct: it is money the group has spent.
+ */
+
+import type { SpendingRow } from './api';
+import type { ExpenseRow } from './types';
+
+/** Lower-case, trim, and fall back to 'other' — matches the SQL COALESCE. */
+function normaliseCategory(category: string | null | undefined): string {
+  const trimmed = (category ?? '').trim().toLowerCase();
+  return trimmed === '' ? 'other' : trimmed;
+}
+
+/**
+ * First day of the month as 'YYYY-MM-01', taken from the leading 'YYYY-MM' of
+ * the date string. Deliberately not `new Date(...)`: parsing would apply the
+ * phone's timezone and, east of UTC, file a 1st-of-month expense under the
+ * previous month.
+ */
+function firstOfMonth(expenseDate: string): string {
+  return `${expenseDate.slice(0, 7)}-01`;
+}
+
+interface Bucket {
+  member_id: string;
+  currency: string;
+  category: string;
+  month: string;
+  amount: bigint;
+  expenseIds: Set<string>;
+}
+
+// U+001F (unit separator) cannot appear in a uuid, currency, category or date,
+// so it is a safe delimiter for the composite bucket key.
+const KEY_SEP = String.fromCharCode(0x1f); // U+001F unit separator
+
+/**
+ * Aggregate a group's expenses into spending rows, one per
+ * (member, currency, category, month) — the finest grain the charts need, and
+ * the exact shape `fetchGroupSpending` returns, so `insights` can swap the RPC
+ * for this with no other change.
+ */
+export function computeSpendingRows(expenses: readonly ExpenseRow[]): SpendingRow[] {
+  const buckets = new Map<string, Bucket>();
+
+  for (const expense of expenses) {
+    // A deleted expense is not spending (matches `e.deleted_at IS NULL`).
+    if (expense.deleted_at) continue;
+    const version = expense.currentVersion;
+    if (!version) continue;
+
+    const currency = version.currency;
+    const category = normaliseCategory(version.category);
+    const month = firstOfMonth(version.expense_date);
+
+    for (const share of version.shares) {
+      const key = [share.member_id, currency, category, month].join(KEY_SEP);
+      let bucket = buckets.get(key);
+      if (!bucket) {
+        bucket = {
+          member_id: share.member_id,
+          currency,
+          category,
+          month,
+          amount: 0n,
+          expenseIds: new Set(),
+        };
+        buckets.set(key, bucket);
+      }
+      bucket.amount += BigInt(share.amount);
+      bucket.expenseIds.add(expense.id);
+    }
+  }
+
+  return [...buckets.values()].map((bucket) => ({
+    member_id: bucket.member_id,
+    currency: bucket.currency,
+    category: bucket.category,
+    month: bucket.month,
+    // BIGINT is a string across the wire; keep the same so callers `BigInt(...)`
+    // it exactly as they do the RPC's rows.
+    share_amount: bucket.amount.toString(),
+    expense_count: bucket.expenseIds.size,
+  }));
+}

--- a/apps/mobile/test/spending.test.ts
+++ b/apps/mobile/test/spending.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeSpendingRows } from '@/data/spending';
+import type { ExpenseRow } from '@/data/types';
+
+/**
+ * A minimal expense — only the fields the aggregation reads (deleted_at and the
+ * current version's currency, category, date and shares). The rest is filled so
+ * the shape is a real ExpenseRow.
+ */
+function expense(over: {
+  id?: string;
+  deleted?: boolean;
+  version?: null;
+  currency?: string;
+  category?: string | null;
+  date?: string;
+  shares?: { member_id: string; amount: string }[];
+}): ExpenseRow {
+  const version =
+    over.version === null
+      ? null
+      : {
+          id: `${over.id ?? 'e'}-v1`,
+          version_no: 1,
+          description: 'x',
+          category: over.category === undefined ? 'food' : over.category,
+          expense_date: over.date ?? '2026-03-15',
+          currency: over.currency ?? 'INR',
+          amount: '0',
+          split_type: 'equal',
+          split_params: { kind: 'equal', members: [] },
+          author_member_id: null,
+          notes: null,
+          created_at: '2026-03-15T00:00:00Z',
+          payers: [],
+          shares: over.shares ?? [{ member_id: 'm1', amount: '100' }],
+        };
+  return {
+    id: over.id ?? 'e1',
+    group_id: 'g1',
+    deleted_at: over.deleted ? '2026-03-16T00:00:00Z' : null,
+    created_at: '2026-03-15T00:00:00Z',
+    currentVersion: version,
+  } as unknown as ExpenseRow;
+}
+
+/** Find the single row for a (member, category, month, currency) key. */
+function find(
+  rows: ReturnType<typeof computeSpendingRows>,
+  member: string,
+  category: string,
+  month: string,
+  currency = 'INR',
+) {
+  return rows.find(
+    (r) =>
+      r.member_id === member &&
+      r.category === category &&
+      r.month === month &&
+      r.currency === currency,
+  );
+}
+
+describe('computeSpendingRows', () => {
+  it('sums a member’s shares within one category, currency and month', () => {
+    const rows = computeSpendingRows([
+      expense({
+        id: 'a',
+        category: 'food',
+        date: '2026-03-01',
+        shares: [{ member_id: 'm1', amount: '100' }],
+      }),
+      expense({
+        id: 'b',
+        category: 'food',
+        date: '2026-03-28',
+        shares: [{ member_id: 'm1', amount: '250' }],
+      }),
+    ]);
+    const row = find(rows, 'm1', 'food', '2026-03-01');
+    expect(row?.share_amount).toBe('350');
+    expect(row?.expense_count).toBe(2);
+  });
+
+  it('emits a row per member of the same expense', () => {
+    const rows = computeSpendingRows([
+      expense({
+        category: 'travel',
+        date: '2026-03-10',
+        shares: [
+          { member_id: 'm1', amount: '600' },
+          { member_id: 'm2', amount: '400' },
+        ],
+      }),
+    ]);
+    expect(find(rows, 'm1', 'travel', '2026-03-01')?.share_amount).toBe('600');
+    expect(find(rows, 'm2', 'travel', '2026-03-01')?.share_amount).toBe('400');
+  });
+
+  it('normalises the category: trims, lower-cases, and defaults to other', () => {
+    const rows = computeSpendingRows([
+      expense({ id: 'a', category: '  Food ', shares: [{ member_id: 'm1', amount: '10' }] }),
+      expense({ id: 'b', category: 'FOOD', shares: [{ member_id: 'm1', amount: '20' }] }),
+      expense({ id: 'c', category: null, shares: [{ member_id: 'm1', amount: '5' }] }),
+      expense({ id: 'd', category: '', shares: [{ member_id: 'm1', amount: '7' }] }),
+    ]);
+    // 'Food' and 'FOOD' collapse to one 'food' bucket.
+    expect(find(rows, 'm1', 'food', '2026-03-01')?.share_amount).toBe('30');
+    // null and '' both fall to 'other'.
+    expect(find(rows, 'm1', 'other', '2026-03-01')?.share_amount).toBe('12');
+  });
+
+  it('buckets by the first of the month without a timezone shift', () => {
+    const rows = computeSpendingRows([
+      expense({ date: '2026-01-01', shares: [{ member_id: 'm1', amount: '1' }] }),
+    ]);
+    // A 1st-of-month date must stay in January, never slip to December.
+    expect(rows[0]?.month).toBe('2026-01-01');
+  });
+
+  it('keeps currencies apart', () => {
+    const rows = computeSpendingRows([
+      expense({ id: 'a', currency: 'INR', shares: [{ member_id: 'm1', amount: '100' }] }),
+      expense({ id: 'b', currency: 'EUR', shares: [{ member_id: 'm1', amount: '200' }] }),
+    ]);
+    expect(find(rows, 'm1', 'food', '2026-03-01', 'INR')?.share_amount).toBe('100');
+    expect(find(rows, 'm1', 'food', '2026-03-01', 'EUR')?.share_amount).toBe('200');
+  });
+
+  it('excludes a deleted expense — a deleted one is not spending', () => {
+    const rows = computeSpendingRows([
+      expense({ id: 'a', deleted: true, shares: [{ member_id: 'm1', amount: '999' }] }),
+    ]);
+    expect(rows).toEqual([]);
+  });
+
+  it('skips an expense with no current version', () => {
+    const rows = computeSpendingRows([expense({ version: null })]);
+    expect(rows).toEqual([]);
+  });
+
+  it('counts distinct expenses, not shares', () => {
+    // Same member, category, month across three expenses → one row, count 3.
+    const rows = computeSpendingRows([
+      expense({ id: 'a', shares: [{ member_id: 'm1', amount: '1' }] }),
+      expense({ id: 'b', shares: [{ member_id: 'm1', amount: '1' }] }),
+      expense({ id: 'c', shares: [{ member_id: 'm1', amount: '1' }] }),
+    ]);
+    expect(find(rows, 'm1', 'food', '2026-03-01')?.expense_count).toBe(3);
+  });
+
+  it('sums large minor-unit amounts exactly, in bigint not float', () => {
+    const rows = computeSpendingRows([
+      expense({ id: 'a', shares: [{ member_id: 'm1', amount: '9007199254740993' }] }),
+      expense({ id: 'b', shares: [{ member_id: 'm1', amount: '2' }] }),
+    ]);
+    // 2^53 + 1 + 2 — a Number would lose the low bit; a bigint does not.
+    expect(find(rows, 'm1', 'food', '2026-03-01')?.share_amount).toBe('9007199254740995');
+  });
+
+  it('is empty for no expenses', () => {
+    expect(computeSpendingRows([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
First step of the offline-first program (per the audit). **Insights** no longer needs the network.

## Before
`insights.tsx` read `baaki_group_spending` over the wire — offline it spun, then showed nothing. But it's a read of expenses the phone already mirrors (ADR-005).

## After
New pure `data/spending.ts#computeSpendingRows` computes the same rows on-device from the group's mirrored ledger — the local-first twin of the RPC, matched exactly:
- current version of non-deleted expenses only;
- category lower-cased/trimmed, empty/absent → `other`;
- month sliced from the `YYYY-MM-DD` string (no timezone shift);
- shares summed in **bigint**, one row per (member, currency, category, month).

Reading the overlaid rows means a **queued** expense counts too — more current than the server-only RPC. `insights.tsx` now derives from `useGroup().expenses`; the network-error branch is removed (a mirror read doesn't fail). Charts unchanged.

## Tests
10 unit cases (`test/spending.test.ts`): aggregation, category normalisation, timezone-safe month bucketing, deleted/no-version exclusion, per-currency separation, distinct `expense_count`, exact bigint sums. All green; tsc + lint + prettier clean.

Next in the program: Friends read, then plan/budgets, then add-person→queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Insights now calculate spending locally from mirrored expense data.
  * Spending summaries support grouping by member, category, month, and currency.
  * Deleted or incomplete expenses are excluded from spending totals.

* **Bug Fixes**
  * Improved month and category handling for more accurate spending insights.
  * Preserved exact totals and distinct expense counts without currency conversion.

* **Tests**
  * Added coverage for aggregation, filtering, currencies, time zones, totals, and empty data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->