### PR TITLE
feat(mobile): Friends offline-first — pull-synced ghost_merges + local people-balances

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -16,7 +16,7 @@
 
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import {
   ActivityIndicator,
@@ -31,7 +31,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   Avatar,
   Badge,
-  Button,
   Card,
   EmptyState,
   iconSize,
@@ -44,7 +43,9 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { fetchPeopleBalances, nudgeToSettle, type PersonBalanceRow } from '@/data/api';
+import { nudgeToSettle, type PersonBalanceRow } from '@/data/api';
+import { usePeopleBalances } from '@/data/hooks';
+import { useAuth } from '@/lib/auth';
 import { PeopleSkeleton } from '@/components/Skeletons';
 import { plural, useStrings, type UiStrings } from '@/i18n';
 import { usePullRefresh } from '@/lib/pullRefresh';
@@ -94,11 +95,12 @@ export default function FriendsScreen() {
   const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
 
-  const people = useQuery({
-    queryKey: ['people', 'balances'],
-    queryFn: fetchPeopleBalances,
-  });
-  const rows = people.data ?? [];
+  const { profile } = useAuth();
+  // Local-first (ADR-005): who owes whom is computed from the mirror, so Friends
+  // works with no connection — the same rows the RPC returns, folded by the
+  // viewer's own ghost merges pulled into the mirror (A38).
+  const people = usePeopleBalances(profile?.id ?? null);
+  const rows = people.data;
 
   // The merge entry earns its place in the header only once there are two or
   // more guests to merge — for everyone else it would be a control that leads to
@@ -222,13 +224,6 @@ export default function FriendsScreen() {
 
         {people.isLoading ? (
           <PeopleSkeleton />
-        ) : people.isError ? (
-          // A failed fetch is not "all square" — say so, and give a way back.
-          <EmptyState
-            title={t.loadError}
-            body={t.loadErrorBody}
-            action={<Button label={t.retry} variant="secondary" onPress={() => people.refetch()} />}
-          />
         ) : rows.length === 0 ? (
           <EmptyState title={t.tabs.allSquare} body={t.tabs.allSquareBody} />
         ) : (

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -52,6 +52,7 @@ import {
   mergeErrorMessage,
 } from '@/data/mergePeople';
 import { PeopleSkeleton } from '@/components/Skeletons';
+import { useSync } from '@/sync';
 import { plural, useStrings } from '@/i18n';
 
 export default function MergePeopleScreen() {
@@ -59,6 +60,7 @@ export default function MergePeopleScreen() {
   const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const queryClient = useQueryClient();
+  const { flush } = useSync();
 
   const people = useQuery({ queryKey: ['people', 'balances'], queryFn: fetchPeopleBalances });
 
@@ -101,7 +103,11 @@ export default function MergePeopleScreen() {
   const merge = useMutation({
     mutationFn: () => mergeGhosts(memberIdsForMerge(selectedRows), name.trim()),
     onSuccess: async () => {
+      // The merge is written server-side by the RPC; pull it into the mirror so
+      // the now-local Friends list (ADR-005) folds it without waiting for the
+      // next background sync. The invalidate keeps this screen's own list fresh.
       await queryClient.invalidateQueries({ queryKey: ['people', 'balances'] });
+      void flush();
       router.back();
     },
     onError: (caught) => setError(mergeErrorMessage(caught, t.mergePeople)),

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -15,6 +15,7 @@ import { randomUUID } from 'expo-crypto';
 import {
   computeNetBalances,
   computePairwiseBalances,
+  ghostMerges,
   materialiseArchivedGroups,
   materialiseCaptures,
   materialiseExpenses,
@@ -62,8 +63,10 @@ import {
   updateMember,
   setMemberRole,
   withdrawDispute,
+  type PersonBalanceRow,
   type WriteExpenseInput,
 } from './api';
+import { aggregatePeopleBalances, type PersonContribution } from './peopleBalances';
 import { totalsByCurrency } from './totals';
 import { SettlementStatus } from './types';
 import type {
@@ -259,6 +262,116 @@ export function useHomeSummary(profileId: string | null) {
     isFetching: status === 'syncing',
     refetch: () => void flush(),
   };
+}
+
+/**
+ * Newest activity per member in one group, approximated from the mirror: the
+ * date of any expense they paid or shared, and the instant of any settlement
+ * either side of. The RPC uses expense-version `created_at`; offline the finest
+ * timestamp the mirror holds for an expense is its date, which is enough for the
+ * "recent activity" sort — it never feeds a balance.
+ */
+function lastActivityByMember(
+  snapshots: readonly ExpenseSnapshot[],
+  settlements: readonly SettlementSnapshot[],
+): Map<string, string> {
+  const latest = new Map<string, string>();
+  const bump = (memberId: string, ts: string): void => {
+    const current = latest.get(memberId);
+    if (current === undefined || ts > current) latest.set(memberId, ts);
+  };
+  for (const snapshot of snapshots) {
+    if (snapshot.deletedAt) continue;
+    for (const memberId of Object.keys(snapshot.payers)) bump(memberId, snapshot.date);
+    for (const memberId of Object.keys(snapshot.shares)) bump(memberId, snapshot.date);
+  }
+  for (const settlement of settlements) {
+    bump(settlement.from, settlement.at);
+    bump(settlement.to, settlement.at);
+  }
+  return latest;
+}
+
+/**
+ * Who owes you and who you owe, across every group — from the mirror (ADR-005).
+ *
+ * The local-first twin of `baaki_people_i_owe` (A11/A36/A38). For each group the
+ * viewer is in, the pairwise edge that touches them becomes one
+ * {@link PersonContribution}; a mirrored ghost merge (A38) supplies the
+ * `person_id` that folds a guest seen across groups; `aggregatePeopleBalances`
+ * sums it to the same rows the RPC returns. Reading the overlaid rows means a
+ * queued expense already counts. Gravatar is skipped offline (a hashed email the
+ * client does not hold) — a missing photo falls back to initials, as it already
+ * does.
+ */
+export function usePeopleBalances(profileId: string | null): LocalRead<PersonBalanceRow[]> {
+  const { mirror, queue } = useSync();
+
+  const rows = useMemo(() => {
+    if (!profileId) return [];
+
+    // member_id → the viewer's recorded merge for that ghost (A38).
+    const mergeByMember = new Map(ghostMerges(mirror).map((merge) => [merge.member_id, merge]));
+
+    const contributions: PersonContribution[] = [];
+    for (const group of materialiseGroups(mirror, queue) as unknown as GroupRow[]) {
+      const members = materialiseMembers(mirror, queue, {
+        groupId: group.id,
+      }) as unknown as MemberRow[];
+      const me = members.find(
+        (member) => member.profile_id === profileId && member.left_at === null,
+      );
+      if (!me) continue;
+      const byId = new Map(members.map((member) => [member.id, member] as const));
+
+      const snapshots = materialiseExpenses(mirror, queue, { groupId: group.id })
+        .map((expense) => toSnapshot(expense as unknown as ExpenseRow))
+        .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
+      const settlementSnapshots = (
+        materialiseSettlements(mirror, queue, { groupId: group.id }) as unknown as SettlementRow[]
+      ).map(toSettlementSnapshot);
+
+      const activity = lastActivityByMember(snapshots, settlementSnapshots);
+      const edges = computePairwiseBalances(snapshots, settlementSnapshots);
+
+      for (const edge of edges) {
+        // Keep only the edges I am on, oriented from my side: they owe me is
+        // positive, I owe them is negative — the RPC's sign.
+        let otherId: string;
+        let net: bigint;
+        if (edge.from === me.id) {
+          otherId = edge.to;
+          net = -edge.amount;
+        } else if (edge.to === me.id) {
+          otherId = edge.from;
+          net = edge.amount;
+        } else {
+          continue;
+        }
+
+        const other = byId.get(otherId);
+        if (!other) continue;
+        const merge = mergeByMember.get(other.id);
+        contributions.push({
+          groupId: group.id,
+          memberId: other.id,
+          profileId: other.profile_id,
+          displayName:
+            other.profile?.display_name ?? merge?.display_name ?? other.ghost_name ?? 'Someone',
+          avatarUrl: other.profile?.avatar_url ?? null,
+          isGhost: other.profile_id === null,
+          currency: edge.currency,
+          net,
+          lastActivityAt: activity.get(other.id) ?? null,
+          mergePersonId: merge?.person_id ?? null,
+        });
+      }
+    }
+
+    return aggregatePeopleBalances(contributions);
+  }, [mirror, queue, profileId]);
+
+  return useLocalRead(rows);
 }
 
 /**

--- a/apps/mobile/src/data/peopleBalances.ts
+++ b/apps/mobile/src/data/peopleBalances.ts
@@ -1,0 +1,134 @@
+/**
+ * Who owes you and who you owe, across every group — computed on the device.
+ *
+ * The local-first twin of the `baaki_people_i_owe` RPC (A11/A36/A38). The RPC
+ * takes the pairwise balance between you and each other member in every group
+ * you share (`pairwise_balances`), folds the rows that are really one person,
+ * and sums per currency. This does the same from the mirror: the caller feeds
+ * one {@link PersonContribution} per (group, other member, currency) — the
+ * pairwise edge that touches you — computed with the same `@baaki/core`
+ * function the group ledger uses, and this aggregates them.
+ *
+ * The identity rule matches the SQL exactly: a profile id is proof of one
+ * human; failing that, a ghost merge the viewer recorded stands in; failing
+ * both, a ghost stays keyed to its own group member and never folds by name
+ * (the rule A11 set and A38 only bends for an explicit merge).
+ */
+
+import type { PersonBalanceRow } from './api';
+
+export interface PersonContribution {
+  groupId: string;
+  /** The other member's group_member id (per-group). */
+  memberId: string;
+  /** Their profile id, or null for a ghost. */
+  profileId: string | null;
+  displayName: string;
+  avatarUrl: string | null;
+  isGhost: boolean;
+  currency: string;
+  /** This group's pairwise net: positive = they owe you, negative = you owe. */
+  net: bigint;
+  /** Newest activity touching them, or null. */
+  lastActivityAt: string | null;
+  /** The person id of a viewer-recorded ghost merge (A38), else null. */
+  mergePersonId: string | null;
+}
+
+/** COALESCE(profile_id, merge person_id, member_id) — the SQL's person_key. */
+function personKey(contribution: PersonContribution): string {
+  return contribution.profileId ?? contribution.mergePersonId ?? contribution.memberId;
+}
+
+/** Lexicographic max, ignoring null — mirrors the SQL `max(...)`. */
+function maxOrNull(current: string | null, next: string | null): string | null {
+  if (next === null) return current;
+  if (current === null) return next;
+  return next > current ? next : current;
+}
+
+interface Group {
+  person_key: string;
+  currency: string;
+  profile_id: string | null;
+  member_id: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+  /** bool_and: a person is a ghost only if every row of them is. */
+  is_ghost: boolean;
+  net: bigint;
+  groupIds: Set<string>;
+  last_activity_at: string | null;
+}
+
+/**
+ * Fold per-group contributions into one row per person and currency, exactly as
+ * `baaki_people_i_owe` returns them: summed net (a person square in a currency
+ * is dropped), a group count with the single group id when there is only one,
+ * and the newest activity. Ordered by the size of the balance, then name.
+ */
+export function aggregatePeopleBalances(
+  contributions: readonly PersonContribution[],
+): PersonBalanceRow[] {
+  const groups = new Map<string, Group>();
+
+  for (const c of contributions) {
+    const key = personKey(c);
+    const mapKey = `${key}|${c.currency}`;
+    let group = groups.get(mapKey);
+    if (!group) {
+      group = {
+        person_key: key,
+        currency: c.currency,
+        profile_id: null,
+        member_id: null,
+        display_name: null,
+        avatar_url: null,
+        is_ghost: true,
+        net: 0n,
+        groupIds: new Set(),
+        last_activity_at: null,
+      };
+      groups.set(mapKey, group);
+    }
+    group.net += c.net;
+    group.groupIds.add(c.groupId);
+    group.profile_id = maxOrNull(group.profile_id, c.profileId);
+    group.member_id = maxOrNull(group.member_id, c.memberId);
+    group.display_name = maxOrNull(group.display_name, c.displayName);
+    group.avatar_url = maxOrNull(group.avatar_url, c.avatarUrl);
+    group.is_ghost = group.is_ghost && c.isGhost;
+    group.last_activity_at = maxOrNull(group.last_activity_at, c.lastActivityAt);
+  }
+
+  const rows: PersonBalanceRow[] = [];
+  for (const group of groups.values()) {
+    // A person square in this currency is not a debt (SQL: HAVING sum <> 0).
+    if (group.net === 0n) continue;
+    rows.push({
+      person_key: group.person_key,
+      profile_id: group.profile_id,
+      member_id: group.member_id ?? group.person_key,
+      display_name: group.display_name ?? 'Someone',
+      avatar_url: group.avatar_url,
+      is_ghost: group.is_ghost,
+      currency: group.currency,
+      net: group.net.toString(),
+      group_count: group.groupIds.size,
+      only_group_id: group.groupIds.size === 1 ? [...group.groupIds][0]! : null,
+      last_activity_at: group.last_activity_at,
+    });
+  }
+
+  // abs(net) descending, then display name — the SQL's ORDER BY.
+  rows.sort((a, b) => {
+    const byAmount = absBig(BigInt(b.net)) - absBig(BigInt(a.net));
+    if (byAmount !== 0n) return byAmount > 0n ? 1 : -1;
+    return a.display_name.localeCompare(b.display_name);
+  });
+  return rows;
+}
+
+function absBig(value: bigint): bigint {
+  return value < 0n ? -value : value;
+}

--- a/apps/mobile/test/peopleBalances.test.ts
+++ b/apps/mobile/test/peopleBalances.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregatePeopleBalances, type PersonContribution } from '@/data/peopleBalances';
+
+function contribution(over: Partial<PersonContribution> = {}): PersonContribution {
+  return {
+    groupId: over.groupId ?? 'g1',
+    memberId: over.memberId ?? 'm1',
+    profileId: over.profileId ?? null,
+    displayName: over.displayName ?? 'Ravi',
+    avatarUrl: over.avatarUrl ?? null,
+    isGhost: over.isGhost ?? true,
+    currency: over.currency ?? 'INR',
+    net: over.net ?? 0n,
+    lastActivityAt: over.lastActivityAt ?? null,
+    mergePersonId: over.mergePersonId ?? null,
+  };
+}
+
+describe('aggregatePeopleBalances', () => {
+  it('keeps the sign: positive = they owe you, negative = you owe', () => {
+    const rows = aggregatePeopleBalances([
+      contribution({ memberId: 'a', net: 500n }),
+      contribution({ memberId: 'b', net: -300n }),
+    ]);
+    expect(rows.find((r) => r.member_id === 'a')?.net).toBe('500');
+    expect(rows.find((r) => r.member_id === 'b')?.net).toBe('-300');
+  });
+
+  it('sums one real person across groups into a single row', () => {
+    const rows = aggregatePeopleBalances([
+      contribution({ groupId: 'g1', memberId: 'm1', profileId: 'p1', net: 200n }),
+      contribution({ groupId: 'g2', memberId: 'm2', profileId: 'p1', net: 300n }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.person_key).toBe('p1');
+    expect(rows[0]?.net).toBe('500');
+    expect(rows[0]?.group_count).toBe(2);
+    expect(rows[0]?.only_group_id).toBeNull();
+  });
+
+  it('drops anyone who nets to zero across their groups', () => {
+    const rows = aggregatePeopleBalances([
+      contribution({ groupId: 'g1', profileId: 'p1', net: 400n }),
+      contribution({ groupId: 'g2', profileId: 'p1', net: -400n }),
+    ]);
+    expect(rows).toEqual([]);
+  });
+
+  it('folds two ghosts under one recorded merge', () => {
+    const rows = aggregatePeopleBalances([
+      contribution({ groupId: 'g1', memberId: 'm1', mergePersonId: 'person1', net: 100n }),
+      contribution({ groupId: 'g2', memberId: 'm2', mergePersonId: 'person1', net: 150n }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.person_key).toBe('person1');
+    expect(rows[0]?.net).toBe('250');
+    expect(rows[0]?.is_ghost).toBe(true);
+    expect(rows[0]?.group_count).toBe(2);
+  });
+
+  it('never folds two unmerged ghosts by name alone', () => {
+    const rows = aggregatePeopleBalances([
+      contribution({ groupId: 'g1', memberId: 'm1', displayName: 'person1', net: 100n }),
+      contribution({ groupId: 'g2', memberId: 'm2', displayName: 'person1', net: 150n }),
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.person_key))).toEqual(new Set(['m1', 'm2']));
+  });
+
+  it('is a ghost only when every contribution is (bool_and)', () => {
+    // A merge that includes one real-profile row is not a ghost overall.
+    const rows = aggregatePeopleBalances([
+      contribution({ memberId: 'm1', mergePersonId: 'person1', isGhost: true, net: 10n }),
+      contribution({
+        groupId: 'g2',
+        memberId: 'm2',
+        mergePersonId: 'person1',
+        isGhost: false,
+        profileId: null,
+        net: 20n,
+      }),
+    ]);
+    expect(rows[0]?.is_ghost).toBe(false);
+  });
+
+  it('keeps currencies as separate rows', () => {
+    const rows = aggregatePeopleBalances([
+      contribution({ profileId: 'p1', currency: 'INR', net: 100n }),
+      contribution({ profileId: 'p1', currency: 'EUR', net: 200n }),
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.currency === 'INR')?.net).toBe('100');
+    expect(rows.find((r) => r.currency === 'EUR')?.net).toBe('200');
+  });
+
+  it('sets only_group_id when the person is in exactly one group', () => {
+    const rows = aggregatePeopleBalances([
+      contribution({ groupId: 'g9', profileId: 'p1', net: 100n }),
+    ]);
+    expect(rows[0]?.only_group_id).toBe('g9');
+    expect(rows[0]?.group_count).toBe(1);
+  });
+
+  it('orders by the size of the balance, then name', () => {
+    const rows = aggregatePeopleBalances([
+      contribution({ memberId: 'small', displayName: 'B', net: 100n }),
+      contribution({ memberId: 'big', displayName: 'A', net: -900n }),
+      contribution({ memberId: 'mid', displayName: 'C', net: 400n }),
+    ]);
+    expect(rows.map((r) => r.member_id)).toEqual(['big', 'mid', 'small']);
+  });
+
+  it('carries the newest activity and picks a stable representative', () => {
+    const rows = aggregatePeopleBalances([
+      contribution({
+        groupId: 'g1',
+        memberId: 'm1',
+        profileId: 'p1',
+        displayName: 'Ravi',
+        lastActivityAt: '2026-01-01T00:00:00Z',
+        net: 100n,
+      }),
+      contribution({
+        groupId: 'g2',
+        memberId: 'm2',
+        profileId: 'p1',
+        displayName: 'Ravi',
+        lastActivityAt: '2026-03-01T00:00:00Z',
+        net: 50n,
+      }),
+    ]);
+    expect(rows[0]?.last_activity_at).toBe('2026-03-01T00:00:00Z');
+    expect(rows[0]?.profile_id).toBe('p1');
+  });
+
+  it('is empty for no contributions', () => {
+    expect(aggregatePeopleBalances([])).toEqual([]);
+  });
+});

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -52,6 +52,7 @@ const TABLES: readonly SyncTable[] = [
   SyncTable.SettlementAllocations,
   SyncTable.ActivityLog,
   SyncTable.Captures,
+  SyncTable.GhostMerges,
 ];
 
 export function emptyMirror(): MirrorState {
@@ -621,4 +622,23 @@ export function materialiseCaptures(
 /** The inbox: open, not deleted. What has been assigned or removed is gone from it. */
 export function openCaptures(captures: readonly MirrorCapture[]): MirrorCapture[] {
   return captures.filter((capture) => capture.status === 'open' && capture.deleted_at === null);
+}
+
+/**
+ * A viewer's ghost merge, as it lands in the mirror (A38). Pull-only — the
+ * client never writes these — so there is no pending overlay, unlike captures.
+ * `id` is the synthetic key the edge injects (the member_id), since the table's
+ * real key is the composite (owner, member_id).
+ */
+export interface MirrorGhostMerge extends MirrorRow {
+  readonly id: string;
+  readonly owner: string;
+  readonly member_id: string;
+  readonly person_id: string;
+  readonly display_name: string;
+}
+
+/** The viewer's ghost merges from the mirror; read-only, no overlay. */
+export function ghostMerges(state: MirrorState): MirrorGhostMerge[] {
+  return rowsFor(state, SyncTable.GhostMerges) as MirrorGhostMerge[];
 }

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -184,6 +184,19 @@ export enum SyncTable {
   ActivityLog = 'activity_log',
   /** Personal scope (TDR A34): captured expenses not yet assigned to a group. */
   Captures = 'captures',
+  /** Personal scope (A38): the viewer's ghost merges, pull-only, so Friends can
+   * fold merged guests offline. Never written through the queue. */
+  GhostMerges = 'ghost_merges',
+}
+
+/**
+ * The sync scope key for a viewer's ghost merges. Distinct from the plain
+ * profile id that captures uses, so the two personal-scope tables keep separate
+ * cursors instead of starving one another. The edge and the client must agree
+ * on this string, so it lives here.
+ */
+export function ghostMergesScope(profileId: string): string {
+  return `${profileId}:ghost_merges`;
 }
 
 /** bigint ↔ string at the wire boundary; JSON has no integers this size. */

--- a/packages/db/prisma/migrations/20260816120000_ghost_merges_sync/migration.sql
+++ b/packages/db/prisma/migrations/20260816120000_ghost_merges_sync/migration.sql
@@ -1,0 +1,61 @@
+-- Make ghost merges pull-syncable, so the Friends list can fold them offline.
+--
+-- baaki_people_i_owe folds a viewer's ghost merges (A38) server-side. To answer
+-- the same question from the device with no connection (ADR-005), the merges
+-- have to reach the mirror — otherwise an offline Friends read would un-fold
+-- people the viewer explicitly merged, a regression. ghost_merges is created
+-- only by the baaki_merge_ghosts RPC (online), so this is PULL-ONLY: the client
+-- never writes it through the queue; /sync just streams it down.
+--
+-- Same machinery as captures (A34, 20260814140000): a per-owner counter on
+-- profiles and an updated_seq the /sync pull walks with `.gt('updated_seq', N)`.
+-- Stamping is a trigger, so the RPC needs no change — its INSERT ... ON CONFLICT
+-- DO UPDATE fires it and re-stamps on every merge.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS ghost_merges_seq BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE public.ghost_merges
+  ADD COLUMN IF NOT EXISTS updated_seq BIGINT NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS ghost_merges_owner_updated_seq_idx
+  ON public.ghost_merges (owner, updated_seq);
+
+-- The per-owner high-water mark, advanced under the row lock the UPDATE takes so
+-- two concurrent merges cannot mint the same seq (the ordering the pull relies
+-- on). Mirror of baaki_next_capture_seq.
+CREATE OR REPLACE FUNCTION public.baaki_next_ghost_merge_seq(p_owner uuid)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_seq bigint;
+BEGIN
+  UPDATE public.profiles
+     SET ghost_merges_seq = ghost_merges_seq + 1
+   WHERE id = p_owner
+   RETURNING ghost_merges_seq INTO v_seq;
+  RETURN COALESCE(v_seq, 0);
+END
+$$;
+
+CREATE OR REPLACE FUNCTION public.baaki_stamp_ghost_merge_seq()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_seq := public.baaki_next_ghost_merge_seq(NEW.owner);
+  RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS ghost_merges_stamp_seq ON public.ghost_merges;
+CREATE TRIGGER ghost_merges_stamp_seq
+  BEFORE INSERT OR UPDATE ON public.ghost_merges
+  FOR EACH ROW EXECUTE FUNCTION public.baaki_stamp_ghost_merge_seq();
+
+-- Stamp rows that already exist so a first pull sees them rather than leaving
+-- them behind on updated_seq = 0. The no-op UPDATE fires the trigger above.
+UPDATE public.ghost_merges SET owner = owner;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -146,6 +146,7 @@ model Profile {
   /// captures equivalent of `groups.updated_seq`. Bumped under row lock by
   /// `baaki_next_capture_seq`.
   capturesSeq       BigInt   @default(0) @map("captures_seq")
+  ghostMergesSeq    BigInt   @default(0) @map("ghost_merges_seq")
   createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt         DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
@@ -317,12 +318,14 @@ model GhostMerge {
   personId    String   @map("person_id") @db.Uuid
   displayName String   @map("display_name")
   createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedSeq  BigInt   @default(0) @map("updated_seq")
 
   ownerProfile Profile     @relation(fields: [owner], references: [id], onDelete: Cascade)
   member       GroupMember @relation(fields: [memberId], references: [id], onDelete: Cascade)
 
   @@id([owner, memberId])
   @@index([owner, personId])
+  @@index([owner, updatedSeq])
   @@map("ghost_merges")
   @@schema("public")
 }

--- a/packages/db/test/mergeGhosts.test.ts
+++ b/packages/db/test/mergeGhosts.test.ts
@@ -91,4 +91,30 @@ describe('merging guests unions overlapping groups', () => {
     expect(rows[0]?.people).toBe(1);
     expect(rows[0]?.rows).toBe(2);
   });
+
+  it('stamps updated_seq so the merge can be pulled into the mirror', async () => {
+    // The sync trigger (20260816120000) advances a per-owner counter on every
+    // merge, so an offline Friends read can fold it (A38). Both members written
+    // by one merge get a positive, distinct seq, and the profile counter moves.
+    const { profileIds, memberIds } = await seedGroup(client, { memberCount: 1, ghostCount: 2 });
+    const caller = profileIds[0]!;
+    const [, ghostA, ghostB] = memberIds;
+
+    await merge(caller, [ghostA!, ghostB!], 'Rahul');
+
+    const { rows } = await client.query(
+      `SELECT member_id, updated_seq FROM ghost_merges
+        WHERE owner = $1 ORDER BY updated_seq`,
+      [caller],
+    );
+    expect(rows).toHaveLength(2);
+    const seqs = rows.map((row) => Number(row.updated_seq));
+    expect(seqs.every((seq) => seq > 0)).toBe(true);
+    expect(new Set(seqs).size).toBe(2); // distinct — the pull orders by it
+
+    const counter = await client.query(`SELECT ghost_merges_seq FROM profiles WHERE id = $1`, [
+      caller,
+    ]);
+    expect(Number(counter.rows[0]?.ghost_merges_seq)).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -671,6 +671,12 @@ async function pull(
   // group loop does not waste a `groups` lookup on it.
   groupIds.delete(profileId);
 
+  // Ghost merges (A38) ride a second personal scope, keyed distinctly so it does
+  // not share a cursor with captures. Must equal `ghostMergesScope(profileId)`
+  // in @baaki/core; inlined to keep the edge bundle free of that import.
+  const gmScope = `${profileId}:ghost_merges`;
+  groupIds.delete(gmScope);
+
   for (const groupId of groupIds) {
     const since = cursors[groupId] ?? 0;
 
@@ -737,6 +743,35 @@ async function pull(
     if (seq > capturesHighWater) capturesHighWater = seq;
   }
   nextCursors[profileId] = capturesHighWater;
+
+  // Personal scope (A38): the caller's own ghost merges, pull-only. Read as the
+  // caller so owner-only RLS (`ghost_merges_select_own`) already guarantees they
+  // are theirs. The mirror keys every row by a string `id`, but ghost_merges has
+  // a composite PK and no id column — so synthesise one from member_id, which is
+  // unique within an owner.
+  const gmSince = cursors[gmScope] ?? 0;
+  const { data: merges, error: mergesError } = await caller
+    .from('ghost_merges')
+    .select('*')
+    .eq('owner', profileId)
+    .gt('updated_seq', gmSince)
+    .order('updated_seq', { ascending: true })
+    .limit(MAX_ROWS_PER_TABLE);
+  if (mergesError) throw new HttpError(500, 'PULL_FAILED', `ghost_merges: ${mergesError.message}`);
+
+  let gmHighWater = gmSince;
+  for (const row of merges ?? []) {
+    const record = row as Record<string, unknown>;
+    const seq = Number(record.updated_seq ?? 0);
+    changes.push({
+      table: 'ghost_merges',
+      groupId: gmScope,
+      seq,
+      row: { ...record, id: record.member_id },
+    });
+    if (seq > gmHighWater) gmHighWater = seq;
+  }
+  nextCursors[gmScope] = gmHighWater;
 
   return { changes, cursors: nextCursors };
 }


### PR DESCRIPTION
Step 2 of the offline-first program. **Friends** no longer needs the network — and it took real infrastructure, so here's the shape.

## Why Friends needed more than insights
`baaki_people_i_owe` folds the viewer's ghost merges (A38). `ghost_merges` wasn't mirrored, so a local compute would **un-fold** merged guests even online — a regression. Fix: make `ghost_merges` a **pull-only synced table** (it's only ever written by the `baaki_merge_ghosts` RPC, online).

## Infrastructure (deploy-gated)
- **Migration `20260816120000`** — per-owner counter on `profiles` + `updated_seq` on `ghost_merges` + a stamping trigger, exactly like captures (A34). The merge RPC is unchanged; its upsert fires the trigger.
- **Protocol** — `SyncTable.GhostMerges` + `ghostMergesScope(profileId)` (distinct personal-scope cursor, so it doesn't starve captures).
- **Edge `/sync` pull** — streams the caller's merges since cursor, injecting a synthetic `id` (= `member_id`, since the table has a composite PK and the mirror keys by string `id`). Read as the caller → owner-only RLS applies.
- **Mirror** — `ghost_merges` joins the synced `TABLES` with a typed read-back.

## The read (pure client)
`usePeopleBalances` turns each group's pairwise edge touching me (`computePairwiseBalances` — the trusted core fn behind settle/balances) into a contribution, folds by the mirrored merge, and `aggregatePeopleBalances` (the pure, tested twin of the SQL) sums it. `friends.tsx` swaps the query for the hook; the merge screen flushes sync on success.

**Offline degradations — cosmetic, never money:** gravatar skipped (hashed email the client lacks) → initials; `last_activity_at` approximated from expense dates for the "recent" sort.

## Tests
- 11 unit cases for `aggregatePeopleBalances` (person_key folding, bool_and ghost, sums, ordering, currency split, only_group_id).
- DB test: the merge RPC stamps `updated_seq` (distinct, positive) + advances the profile counter.
- Full suite: 267 mobile tests green; core/mobile tsc + lint + prettier + `prisma validate` clean.

## Deploy (your credentialed step)
Migration → `supabase functions deploy sync`, together, before the client bundle relies on live pulls. The client half is pure JS (OTA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified friends view that calculates balances across groups and currencies.
  * Combined activity for the same person, including merged or guest identities.
  * Improved balance sorting and display with recent activity and group details.
  * Added synchronization support so merged identities remain consistent across devices.

* **Bug Fixes**
  * Refreshes local data after successfully merging people, keeping balances up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->