### PR TITLE
feat(mobile): add-person IOU offline-first via the queue (closes #194 deviation)

### DIFF
--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -16,7 +16,7 @@
 
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useQueryClient } from '@tanstack/react-query';
+import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
@@ -35,7 +35,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { addGhostMember, createGroup, fetchMembers, writeExpense } from '@/data/api';
+import { useAddGhostMember, useCreateGroup, useWriteExpense } from '@/data/hooks';
 import { GroupType } from '@/data/types';
 import { deviceDefaultCurrency, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -54,7 +54,16 @@ export default function AddPersonScreen() {
   const { t } = useStrings();
   const { profile } = useAuth();
   const guard = useGuestGuard();
-  const queryClient = useQueryClient();
+
+  // The 1:1 group and my own membership id, chosen once on the device so the
+  // whole IOU — group, ghost, expense — can be built and queued offline (ADR-005)
+  // and land under these exact ids when it syncs. Was a chain of direct RPCs
+  // (the add-person deviation); now it rides the queue like every other write.
+  const [groupId] = useState(() => randomUUID());
+  const [myMemberId] = useState(() => randomUUID());
+  const createGroup = useCreateGroup();
+  const addGhost = useAddGhostMember(groupId);
+  const writeExpense = useWriteExpense(groupId);
 
   const currency = deviceDefaultCurrency();
   const [name, setName] = useState('');
@@ -75,35 +84,37 @@ export default function AddPersonScreen() {
     setSaving(true);
     try {
       const personName = name.trim();
-      const groupId = await createGroup({ name: personName, type: GroupType.Other, currency });
-      const ghostId = await addGhostMember(groupId, personName);
-      const members = await fetchMembers(groupId);
-      const me = members.find((member) => member.profile_id === profile.id);
-      if (!me) throw new Error(t.addPerson.couldNotRecord);
+      // Create the 1:1 group with my membership under the id chosen above, so the
+      // expense two lines down can already name me as payer or debtor.
+      await createGroup.mutateAsync({
+        name: personName,
+        type: GroupType.Other,
+        currency,
+        groupId,
+        creatorMemberId: myMemberId,
+      });
+      const ghostId = await addGhost.mutateAsync(personName);
 
       // One expense that books the whole amount against the debtor: the payer
       // put the money in, the debtor's share is the lot, so the debtor owes the
       // payer exactly `amount`. "They owe me" makes me the payer; "I owe them"
       // makes the person the payer and the amount my share.
       const theyOwe = direction === 'theyOwe';
-      const payerId = theyOwe ? me.id : ghostId;
-      const debtorId = theyOwe ? ghostId : me.id;
-      await writeExpense({
-        groupId,
+      const payerId = theyOwe ? myMemberId : ghostId;
+      const debtorId = theyOwe ? ghostId : myMemberId;
+      await writeExpense.mutateAsync({
         description: note.trim() || personName,
         expenseDate: today(),
         currency,
         amount,
-        participants: [me.id, ghostId],
+        participants: [myMemberId, ghostId],
         payers: { [payerId]: amount },
         splitParams: { kind: 'exact', amounts: { [debtorId]: amount, [payerId]: 0n } },
       });
 
-      // These were direct writes, not the offline queue, so the local mirror
-      // does not know about them yet — the Friends list reads the server, so
-      // nudge it to refetch and the new person shows the moment we land back on
-      // it. The 1:1 group itself appears on the dashboard on the next sync pull.
-      await queryClient.invalidateQueries({ queryKey: ['people', 'balances'] });
+      // All three writes went through the offline queue, which updates the mirror
+      // synchronously — the now-local Friends list already shows the new person,
+      // and the whole IOU syncs when there is a connection. Nothing to refetch.
       router.back();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -278,6 +278,12 @@ export async function createGroup(input: {
    * which is a supported state, not a broken one.
    */
   country?: string | null;
+  /**
+   * The creator's own membership id, chosen by the client so an expense created
+   * in the same breath (an offline IOU) can name it before the server assigns
+   * one. Omitted, the server mints it as before.
+   */
+  creatorMemberId?: string;
 }): Promise<string> {
   const { data, error } = await supabase.rpc('baaki_create_group', {
     p_name: input.name?.trim() || null,
@@ -288,6 +294,7 @@ export async function createGroup(input: {
     p_group_id: input.groupId ?? null,
     p_photo_path: input.photoPath ?? null,
     p_country: input.country ?? null,
+    p_creator_member_id: input.creatorMemberId ?? null,
   });
   if (error) throw new Error(error.message);
   return data as string;

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -674,9 +674,14 @@ function serialiseExpense(input: Omit<WriteExpenseInput, 'groupId'>): Record<str
  */
 export function useCreateGroup() {
   const { mutate } = useSync();
+  const { profile } = useAuth();
   return useMutation({
     mutationFn: async (input: Parameters<typeof createGroup>[0]) => {
       const groupId = input.groupId ?? randomUUID();
+      // Always name the creator's membership id, even when the caller did not,
+      // so any expense made in this group offline references a member that will
+      // exist with this exact id once the create syncs (the server honours it).
+      const creatorMemberId = input.creatorMemberId ?? randomUUID();
       await mutate(MutationKind.GroupCreate, groupId, {
         name: input.name?.trim() || null,
         type: input.type,
@@ -685,6 +690,8 @@ export function useCreateGroup() {
         simplify: input.simplify ?? true,
         photoPath: input.photoPath ?? null,
         country: input.country ?? null,
+        creatorMemberId,
+        creatorProfileId: profile?.id ?? null,
       });
       return groupId;
     },

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -405,7 +405,36 @@ export function materialiseMembers(
   }
 
   for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
-    if (mutation.groupId !== options.groupId || mutation.kind !== 'member.add_ghost') continue;
+    if (mutation.groupId !== options.groupId) continue;
+
+    // A group created offline must show its creator as a member at once, with
+    // the id the client chose — so an expense queued behind it in the same
+    // breath can already name who paid, and matches once the server (which now
+    // honours the same id) has applied it. Without this the creator would be
+    // invisible until the create synced back.
+    if (mutation.kind === 'group.create') {
+      const payload = mutation.payload as {
+        creatorMemberId?: string | null;
+        creatorProfileId?: string | null;
+      };
+      const id = payload.creatorMemberId ?? `pending:${mutation.clientMutationId}`;
+      if (!byId.has(id)) {
+        byId.set(id, {
+          id,
+          group_id: mutation.groupId,
+          profile_id: payload.creatorProfileId ?? null,
+          ghost_name: null,
+          left_at: null,
+          invite_email: null,
+          invite_phone: null,
+          role: 'admin',
+          pending: true,
+        });
+      }
+      continue;
+    }
+
+    if (mutation.kind !== 'member.add_ghost') continue;
     const payload = mutation.payload as {
       memberId?: string;
       name: string;

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -163,6 +163,72 @@ describe('members', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.pending).toBeUndefined();
   });
+
+  it('shows the creator of a group started offline, under the id the client chose', () => {
+    // Without this a group made offline has no members until it syncs, so an
+    // expense queued behind it (an add-person IOU) has no "me" to name.
+    const queue = queued(
+      envelope('m-1', MutationKind.GroupCreate, {
+        name: 'Ravi',
+        currency: 'INR',
+        creatorMemberId: 'me-1',
+        creatorProfileId: 'profile-1',
+      }),
+    );
+    const rows = materialiseMembers(emptyMirror(), queue, { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'me-1',
+      profile_id: 'profile-1',
+      ghost_name: null,
+      role: 'admin',
+      pending: true,
+    });
+  });
+
+  it('shows both the creator and the ghost of an add-person IOU built offline', () => {
+    const queue = queued(
+      envelope('m-1', MutationKind.GroupCreate, {
+        name: 'Ravi',
+        currency: 'INR',
+        creatorMemberId: 'me-1',
+        creatorProfileId: 'profile-1',
+      }),
+      envelope('m-2', MutationKind.MemberAddGhost, { memberId: 'ghost-1', name: 'Ravi' }),
+    );
+    const rows = materialiseMembers(emptyMirror(), queue, { groupId: GROUP });
+    expect(rows.map((row) => row.id).sort()).toEqual(['ghost-1', 'me-1']);
+    expect(rows.find((row) => row.id === 'me-1')?.profile_id).toBe('profile-1');
+    expect(rows.find((row) => row.id === 'ghost-1')?.profile_id).toBeNull();
+  });
+
+  it('does not duplicate the creator once the server has confirmed it', () => {
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: SyncTable.GroupMembers,
+        groupId: GROUP,
+        seq: 1,
+        row: {
+          id: 'me-1',
+          group_id: GROUP,
+          profile_id: 'profile-1',
+          ghost_name: null,
+          left_at: null,
+        },
+      },
+    ]).state;
+    const queue = queued(
+      envelope('m-1', MutationKind.GroupCreate, {
+        name: 'Ravi',
+        currency: 'INR',
+        creatorMemberId: 'me-1',
+        creatorProfileId: 'profile-1',
+      }),
+    );
+    const rows = materialiseMembers(mirror, queue, { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.pending).toBeUndefined();
+  });
 });
 
 describe('groups', () => {

--- a/packages/db/prisma/migrations/20260816130000_group_create_creator_member_id/migration.sql
+++ b/packages/db/prisma/migrations/20260816130000_group_create_creator_member_id/migration.sql
@@ -1,0 +1,138 @@
+-- Let the client name the creator's membership id when it creates a group.
+--
+-- A group made offline needs its creator to be a member the moment it exists,
+-- with an id the client already knows — otherwise a queued expense in that group
+-- (an add-person IOU, TDR A34-style) cannot name who paid until the server has
+-- assigned the membership and it has synced back. Until now baaki_create_group
+-- minted the creator membership id itself, so those expenses had to be written
+-- online by direct RPC (the A11/add-person deviation). This adds an optional
+-- p_creator_member_id: when the client supplies it, the creator membership takes
+-- that id (which the /sync queue and the mirror overlay both use); when it does
+-- not, the server mints one exactly as before, so every existing caller — the
+-- direct createGroup RPC, Splitwise import — is unaffected.
+--
+-- Adding a parameter changes the signature, which would leave two overloads if
+-- done with CREATE OR REPLACE, so the old one is dropped first. Nothing depends
+-- on it but callers (it is invoked by RPC), so the drop is clean.
+
+DROP FUNCTION IF EXISTS public.baaki_create_group(
+  text, text, character, text, boolean, uuid, text, char
+);
+
+CREATE FUNCTION public.baaki_create_group(
+  p_name              text DEFAULT NULL::text,
+  p_type              text DEFAULT 'other'::text,
+  p_currency          character DEFAULT 'INR'::bpchar,
+  p_emoji             text DEFAULT NULL::text,
+  p_simplify          boolean DEFAULT true,
+  p_group_id          uuid DEFAULT NULL::uuid,
+  p_photo_path        text DEFAULT NULL::text,
+  p_country           char(2) DEFAULT NULL,
+  p_creator_member_id uuid DEFAULT NULL::uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_group_id   uuid;
+  v_member_id  uuid;
+  v_name       text := nullif(btrim(coalesce(p_name, '')), '');
+  v_country    char(2) := nullif(btrim(upper(coalesce(p_country, ''))), '');
+  v_is_guest   boolean;
+  v_created_at timestamptz;
+  v_group_count integer;
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED: a group needs an owner'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id = v_profile_id) THEN
+    RAISE EXCEPTION 'NO_PROFILE: profile % does not exist', v_profile_id
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  -- Replaying the create half of a queue must return the same group, not a
+  -- second one — and must not let somebody else's id be hijacked (ADR-005).
+  -- This runs before the guest check on purpose: replaying the create of the
+  -- one group a guest already has must not be mistaken for a second group.
+  IF p_group_id IS NOT NULL AND EXISTS (SELECT 1 FROM public.groups WHERE id = p_group_id) THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = p_group_id AND gm.profile_id = v_profile_id AND gm.left_at IS NULL
+    ) THEN
+      RAISE EXCEPTION 'GROUP_EXISTS: that group id is already taken'
+        USING ERRCODE = 'unique_violation';
+    END IF;
+    RETURN p_group_id;
+  END IF;
+
+  -- Guest ceilings (ADR-006 addendum). Mirrors GUEST_GROUP_LIMIT and
+  -- GUEST_TRIAL_DAYS in @baaki/core.
+  --
+  -- Guarded on the real auth.users *with* its `is_anonymous` column: CI runs
+  -- these migrations against a stub auth schema whose users table has no such
+  -- column, and calls this function to check ledger invariants. The column
+  -- reference inside the branch is only planned when the branch actually runs
+  -- (plpgsql plans statements lazily), so a false guard here means the missing
+  -- column is never touched. Absent an is_anonymous column there are no
+  -- anonymous users to limit anyway, so skipping the check is correct, not a
+  -- hole.
+  IF to_regclass('auth.users') IS NOT NULL
+     AND EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_schema = 'auth'
+         AND table_name = 'users'
+         AND column_name = 'is_anonymous'
+     ) THEN
+    SELECT u.is_anonymous, u.created_at
+      INTO v_is_guest, v_created_at
+      FROM auth.users u
+      WHERE u.id = v_profile_id;
+
+    IF coalesce(v_is_guest, false) THEN
+      IF now() >= v_created_at + interval '10 days' THEN
+        RAISE EXCEPTION 'GUEST_TRIAL_EXPIRED: sign up to keep using Baaki'
+          USING ERRCODE = 'insufficient_privilege';
+      END IF;
+
+      SELECT count(*) INTO v_group_count
+        FROM public.group_members
+        WHERE profile_id = v_profile_id AND left_at IS NULL;
+
+      IF v_group_count >= 1 THEN
+        RAISE EXCEPTION 'GUEST_GROUP_LIMIT: sign up to be in more than one group'
+          USING ERRCODE = 'insufficient_privilege';
+      END IF;
+    END IF;
+  END IF;
+
+  INSERT INTO public.groups
+    (id, name, type, default_currency, cover_emoji, simplify_debts, created_by, photo_path,
+     country_code)
+  VALUES
+    (COALESCE(p_group_id, gen_random_uuid()), v_name, p_type::"GroupType",
+     upper(p_currency), p_emoji, p_simplify, v_profile_id, p_photo_path,
+     COALESCE(v_country, (SELECT country_code FROM public.profiles WHERE id = v_profile_id)))
+  RETURNING id INTO v_group_id;
+
+  -- The creator's membership takes the client's id when one was given, so a
+  -- queued expense made in the same offline breath can already name it; else the
+  -- server mints one as before.
+  INSERT INTO public.group_members (id, group_id, profile_id, role, joined_via)
+  VALUES (COALESCE(p_creator_member_id, gen_random_uuid()), v_group_id, v_profile_id, 'admin', 'creator')
+  RETURNING id INTO v_member_id;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (v_group_id, v_member_id, 'created', 'group', v_group_id,
+          jsonb_build_object('name', v_name));
+
+  RETURN v_group_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_create_group(
+  text, text, character, text, boolean, uuid, text, char, uuid
+) TO authenticated, anon;

--- a/packages/db/test/groups.test.ts
+++ b/packages/db/test/groups.test.ts
@@ -238,3 +238,41 @@ async function canUpload(groupId: string | null): Promise<boolean> {
   const { rows } = await client.query(`SELECT baaki_can_upload_group_photo($1) AS ok`, [groupId]);
   return rows[0]?.ok === true;
 }
+
+describe('the creator membership id can be chosen by the client', () => {
+  it('uses the id the client passed, so an offline expense can name it', async () => {
+    // A group made offline needs its creator to be a member with the id the
+    // client already chose (20260816130000), so a queued IOU expense references
+    // a member that exists with exactly this id once it syncs.
+    const profileId = await createProfile('Asha');
+    const groupId = randomUUID();
+    const memberId = randomUUID();
+
+    await asUser(profileId, () =>
+      client.query(
+        `SELECT baaki_create_group($1, 'other', 'INR', NULL, true, $2, NULL, NULL, $3)`,
+        ['Ravi', groupId, memberId],
+      ),
+    );
+
+    const { rows } = await client.query(
+      `SELECT id, role FROM group_members WHERE group_id = $1 AND profile_id = $2`,
+      [groupId, profileId],
+    );
+    expect(rows[0]?.id).toBe(memberId);
+    expect(rows[0]?.role).toBe('admin');
+  });
+
+  it('still mints one when the client does not pass an id', async () => {
+    // The 7-arg call the rest of the suite uses omits it; the creator is still an
+    // admin member, just with a server id — backward compatible.
+    const profileId = await createProfile('Asha');
+    const groupId = await createGroup(profileId);
+    const { rows } = await client.query(
+      `SELECT id, role FROM group_members WHERE group_id = $1 AND profile_id = $2`,
+      [groupId, profileId],
+    );
+    expect(rows[0]?.id).toBeTruthy();
+    expect(rows[0]?.role).toBe('admin');
+  });
+});

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -352,6 +352,10 @@ class SyncSession {
           // The client already chose this id and its queued expenses reference it.
           p_group_id: mutation.groupId,
           p_photo_path: (mutation.payload.photoPath as string | undefined) ?? null,
+          // And the creator's membership id, so an IOU expense queued in the same
+          // breath names a member that will exist with this exact id (A34-style
+          // offline group creation). Absent, the RPC mints one as before.
+          p_creator_member_id: (mutation.payload.creatorMemberId as string | undefined) ?? null,
           // Which country the group is in decides which payment rails it is
           // offered (ADR-012). Dropped here, a group created offline came back
           // with no rails and no way to settle on one.


### PR DESCRIPTION
Step 4 of the offline-first program — and it closes the #194 direct-RPC deviation.

## Before
Adding "Ravi owes me ₹500" chained **four direct RPCs** (createGroup → addGhostMember → fetchMembers → writeExpense). It needed the server-assigned creator member id for the expense, so it couldn't be built offline.

## The missing piece
`group.create` minted the creator membership id server-side, and `materialiseMembers` overlaid **only ghosts** — so a group made offline had no members until it synced. Nothing an expense could name.

## Fix
- **Migration `20260816130000`** — `baaki_create_group` gains `p_creator_member_id` (`DEFAULT NULL`; direct RPC + Splitwise import unchanged). Client-supplied → the creator membership takes that id. DROP+CREATE (new param = new signature).
- **Mirror** — `materialiseMembers` synthesizes the creator of a pending `group.create` from `creatorMemberId` + `creatorProfileId`. **Fixes offline group creation generally**, not just add-person; de-dupes once the server confirms the same id.
- **Client** — `useCreateGroup` always chooses a `creatorMemberId` (+ carries `creatorProfileId`); the edge forwards `p_creator_member_id`.
- **add-person.tsx** — picks `groupId` + its member id up front, then `useCreateGroup` → `useAddGhostMember` → `useWriteExpense`, all queued. Mirror updates synchronously → the local Friends list shows the person at once; the IOU syncs when online. No refetch, no round-trip.

## Tests
- 4 overlay cases: creator synthesized under the client id, add-person's two members, no duplicate after sync.
- DB test: `baaki_create_group` honors the client id, and still mints one without it (backward compat).
- 536 core + 267 mobile green; tsc + lint + prettier clean; schema unchanged (functions-only migration → no drift).

## Deploy (your step)
Migration + `supabase functions deploy sync`, together. Client half is OTA.

Owed: a TDR amendment recording add-person now goes through the queue (was the #194 deviation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved offline group creation with stable member identities.
  * Newly created groups immediately show the creator as a pending administrator.
  * One-to-one groups, members, and expenses can be queued for synchronization while offline.
  * Group creation remains compatible with flows that do not provide a member ID.

* **Bug Fixes**
  * Prevented duplicate creator memberships when offline changes synchronize with the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->