### PR TITLE
feat(mobile): trip plan + budgets offline-first (final offline-first step)

### DIFF
--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -46,14 +46,17 @@ import {
 } from '@baaki/ui';
 
 import {
-  addPlanItem,
-  clearMyTripBudget,
-  removePlanItem,
-  setGroupBudget,
-  setMyTripBudget,
-  setPlanItemDone,
-} from '@/data/api';
-import { useGroup, useGroupBudget, useMemberBudgets, usePlanItems } from '@/data/hooks';
+  useAddPlanItem,
+  useClearMyTripBudget,
+  useGroup,
+  useGroupBudget,
+  useMemberBudgets,
+  usePlanItems,
+  useRemovePlanItem,
+  useSetGroupBudget,
+  useSetMyTripBudget,
+  useSetPlanItemDone,
+} from '@/data/hooks';
 import { displayName } from '@/data/types';
 import { useAuth } from '@/lib/auth';
 import { ListScreenSkeleton } from '@/components/Skeletons';
@@ -92,6 +95,15 @@ export default function PlanScreen() {
   const plan = usePlanItems(groupId);
   const budgets = useMemberBudgets(groupId);
   const groupBudget = useGroupBudget(groupId);
+
+  // Every write goes through the offline queue (A23), so the plan works with no
+  // connection and the mirror updates the moment a mutation is enqueued.
+  const addItem = useAddPlanItem(groupId);
+  const toggleItem = useSetPlanItemDone(groupId);
+  const removeItem = useRemovePlanItem(groupId);
+  const setMine = useSetMyTripBudget(groupId);
+  const clearMineBudget = useClearMyTripBudget(groupId);
+  const setOverall = useSetGroupBudget(groupId);
 
   const [addingTo, setAddingTo] = useState<string | null>(null);
   const [title, setTitle] = useState('');
@@ -225,14 +237,12 @@ export default function PlanScreen() {
   const saveMine = async (): Promise<void> => {
     setBusy(true);
     try {
-      await setMyTripBudget({
-        groupId,
+      await setMine.mutateAsync({
         amountMinor: myAmount,
         currency,
         visibility: myShare ? 'group' : 'private',
       });
       setEditingMine(false);
-      await budgets.refetch();
     } finally {
       setBusy(false);
     }
@@ -241,9 +251,8 @@ export default function PlanScreen() {
   const clearMine = async (): Promise<void> => {
     setBusy(true);
     try {
-      await clearMyTripBudget(groupId);
+      await clearMineBudget.mutateAsync();
       setEditingMine(false);
-      await budgets.refetch();
     } finally {
       setBusy(false);
     }
@@ -257,10 +266,8 @@ export default function PlanScreen() {
   const saveOverall = async (): Promise<void> => {
     setBusy(true);
     try {
-      await setGroupBudget({ groupId, amountMinor: overallAmount, currency });
+      await setOverall.mutateAsync({ amountMinor: overallAmount, currency });
       setEditingOverall(false);
-      await budgets.refetch();
-      await groupBudget.refetch();
     } finally {
       setBusy(false);
     }
@@ -269,9 +276,8 @@ export default function PlanScreen() {
   const clearOverall = async (): Promise<void> => {
     setBusy(true);
     try {
-      await setGroupBudget({ groupId, amountMinor: null });
+      await setOverall.mutateAsync({ amountMinor: null });
       setEditingOverall(false);
-      await groupBudget.refetch();
     } finally {
       setBusy(false);
     }
@@ -283,23 +289,20 @@ export default function PlanScreen() {
     if (!title.trim()) return;
     setBusy(true);
     try {
-      await addPlanItem({ groupId, day, title: title.trim(), currency });
+      await addItem.mutateAsync({ day, title: title.trim(), currency });
       setTitle('');
       setAddingTo(null);
-      await plan.refetch();
     } finally {
       setBusy(false);
     }
   };
 
   const toggle = async (item: PlanItem): Promise<void> => {
-    await setPlanItemDone(item.id, !item.done);
-    await plan.refetch();
+    await toggleItem.mutateAsync({ itemId: item.id, done: !item.done });
   };
 
   const remove = async (item: PlanItem): Promise<void> => {
-    await removePlanItem(item.id);
-    await plan.refetch();
+    await removeItem.mutateAsync(item.id);
   };
 
   if (group.isLoading || plan.isLoading) {

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -20,10 +20,13 @@ import {
   materialiseCaptures,
   materialiseExpenses,
   materialiseGroups,
+  materialiseMemberBudgets,
   materialiseMembers,
+  materialisePlanItems,
   materialiseSettlements,
   MutationKind,
   openCaptures,
+  openPlanItems,
   overlayPending,
   rowsFor,
   simplify,
@@ -52,9 +55,9 @@ import {
   fetchNotifications,
   fetchMemberClaims,
   decideMemberClaim,
-  fetchPlanItems,
-  fetchMemberBudgets,
-  fetchGroupBudget,
+  type PlanItemRow,
+  type MemberBudgetRow,
+  type GroupBudget,
   markNotificationsRead,
   recordSettlement,
   resolveDispute,
@@ -1026,35 +1029,137 @@ export function useLeaveGroup(groupId: string) {
   });
 }
 
-/** The trip's plan. Read-only here; writes go through the RPCs in api.ts. */
-export function usePlanItems(groupId: string) {
-  return useQuery({
-    queryKey: ['plan', groupId],
-    queryFn: () => fetchPlanItems(groupId),
-    enabled: groupId !== '',
-  });
+/** The trip's plan, read from the mirror so it opens with no connection (A23). */
+export function usePlanItems(groupId: string): LocalRead<PlanItemRow[]> {
+  const { mirror, queue } = useSync();
+  const items = useMemo(
+    () =>
+      openPlanItems(materialisePlanItems(mirror, queue, { groupId })) as unknown as PlanItemRow[],
+    [mirror, queue, groupId],
+  );
+  return useLocalRead(items);
 }
 
 /**
- * Personal trip budgets for the group. RLS decides what comes back: the
- * caller's own row always, plus anybody who shared theirs with the group. A
- * private budget belonging to somebody else is never in this list — the screen
- * cannot render, and cannot leak, what it never received.
+ * Personal trip budgets for the group, from the mirror. RLS already decided
+ * what the pull returned — the caller's own always, plus anybody who shared
+ * theirs — so a private budget belonging to somebody else was never mirrored
+ * and cannot leak. The caller's own pending set/clear is overlaid by member id.
  */
-export function useMemberBudgets(groupId: string) {
-  return useQuery({
-    queryKey: keys.memberBudgets(groupId),
-    queryFn: () => fetchMemberBudgets(groupId),
-    enabled: groupId !== '',
+export function useMemberBudgets(groupId: string): LocalRead<MemberBudgetRow[]> {
+  const { mirror, queue } = useSync();
+  const { profile } = useAuth();
+  const budgets = useMemo(() => {
+    const myMemberId =
+      (materialiseMembers(mirror, queue, { groupId }) as unknown as MemberRow[]).find(
+        (member) => member.profile_id === profile?.id && member.left_at === null,
+      )?.id ?? null;
+    return materialiseMemberBudgets(mirror, queue, {
+      groupId,
+      myMemberId,
+    }) as unknown as MemberBudgetRow[];
+  }, [mirror, queue, groupId, profile?.id]);
+  return useLocalRead(budgets);
+}
+
+/** The overall trip budget, read off the mirrored group row (ADR-005). */
+export function useGroupBudget(groupId: string): LocalRead<GroupBudget> {
+  const { mirror, queue } = useSync();
+  const budget = useMemo(() => {
+    const group = (materialiseGroups(mirror, queue) as unknown as GroupRow[]).find(
+      (row) => row.id === groupId,
+    );
+    const minor = group?.budget_minor;
+    return {
+      amountMinor: minor === null || minor === undefined ? null : BigInt(minor),
+      currency: group?.budget_currency ?? null,
+    } as GroupBudget;
+  }, [mirror, queue, groupId]);
+  return useLocalRead(budget);
+}
+
+/** Add a plan item, queued (A23). The client chooses the id so the overlay and
+ *  the RPC's replay guard both key on it. */
+export function useAddPlanItem(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: (input: {
+      day: string;
+      title: string;
+      startsAt?: string | null;
+      note?: string | null;
+      category?: string | null;
+      plannedMinor?: bigint | null;
+      currency?: string | null;
+    }) =>
+      mutate(MutationKind.PlanItemCreate, groupId, {
+        itemId: randomUUID(),
+        day: input.day,
+        title: input.title,
+        startsAt: input.startsAt ?? null,
+        note: input.note ?? null,
+        category: input.category ?? null,
+        plannedMinor:
+          input.plannedMinor === null || input.plannedMinor === undefined
+            ? null
+            : input.plannedMinor.toString(),
+        currency: input.currency ?? null,
+      }),
   });
 }
 
-/** The overall trip budget, read straight off the group row. */
-export function useGroupBudget(groupId: string) {
-  return useQuery({
-    queryKey: keys.groupBudget(groupId),
-    queryFn: () => fetchGroupBudget(groupId),
-    enabled: groupId !== '',
+/** Tick a plan item done or undone, queued. */
+export function useSetPlanItemDone(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: (input: { itemId: string; done: boolean }) =>
+      mutate(MutationKind.PlanItemUpdate, groupId, { itemId: input.itemId, done: input.done }),
+  });
+}
+
+/** Remove a plan item, queued (a soft delete server-side so it propagates). */
+export function useRemovePlanItem(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: (itemId: string) => mutate(MutationKind.PlanItemDelete, groupId, { itemId }),
+  });
+}
+
+/** Set the caller's own trip budget, queued. */
+export function useSetMyTripBudget(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: (input: {
+      amountMinor: bigint;
+      currency?: string | null;
+      visibility: 'private' | 'group';
+    }) =>
+      mutate(MutationKind.MemberBudgetSet, groupId, {
+        amountMinor: input.amountMinor.toString(),
+        currency: input.currency ?? null,
+        visibility: input.visibility,
+      }),
+  });
+}
+
+/** Clear the caller's own trip budget, queued (soft delete server-side). */
+export function useClearMyTripBudget(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: () => mutate(MutationKind.MemberBudgetClear, groupId, {}),
+  });
+}
+
+/** Set (or clear, with a null amount) the overall trip budget, queued. Admin-only,
+ *  enforced by the RPC the edge dispatches to. */
+export function useSetGroupBudget(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: (input: { amountMinor: bigint | null; currency?: string | null }) =>
+      mutate(MutationKind.GroupBudgetSet, groupId, {
+        amountMinor: input.amountMinor === null ? null : input.amountMinor.toString(),
+        currency: input.currency ?? null,
+      }),
   });
 }
 

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -48,6 +48,12 @@ export interface GroupRow {
   remind_evening_at: string;
   archived_at: string | null;
   created_at: string;
+  /** The overall trip budget, minor units, or null for "no cap". Set by an admin
+   *  and always group-visible; the private per-member caps live elsewhere.
+   *  Optional because the narrow contact/group REST selects omit it — the mirror
+   *  row (a full `*` pull) always carries it. */
+  budget_minor?: string | null;
+  budget_currency?: string | null;
   /** True while this row exists only in the local queue (ADR-005). */
   pending?: boolean;
 }

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -27,7 +27,11 @@ import type {
   CaptureDeletePayload,
   ExpenseCreatePayload,
   ExpenseDeletePayload,
+  MemberBudgetSetPayload,
   MutationEnvelope,
+  PlanItemCreatePayload,
+  PlanItemDeletePayload,
+  PlanItemUpdatePayload,
   SyncChange,
 } from './protocol';
 import type { QueuedMutation } from './queue';
@@ -53,6 +57,8 @@ const TABLES: readonly SyncTable[] = [
   SyncTable.ActivityLog,
   SyncTable.Captures,
   SyncTable.GhostMerges,
+  SyncTable.TripPlanItems,
+  SyncTable.TripMemberBudgets,
 ];
 
 export function emptyMirror(): MirrorState {
@@ -465,6 +471,8 @@ export interface MirrorGroup extends MirrorRow {
   readonly default_currency: string;
   readonly created_at: string;
   readonly archived_at: string | null;
+  readonly budget_minor?: string | null;
+  readonly budget_currency?: string | null;
   readonly pending?: boolean;
 }
 
@@ -506,6 +514,24 @@ function buildGroups(state: MirrorState, queue: readonly QueuedMutation[]): Mirr
           ...existing,
           ...(mutation.payload as Record<string, unknown>),
           id: existing.id,
+          pending: true,
+        });
+      }
+    }
+
+    // The overall trip budget is a column on the group row (A23), so an
+    // optimistic set shows on the group at once; a null amount clears it.
+    if (mutation.kind === 'group_budget.set') {
+      const existing = byId.get(mutation.groupId);
+      if (existing) {
+        const payload = mutation.payload as {
+          amountMinor: string | null;
+          currency?: string | null;
+        };
+        byId.set(mutation.groupId, {
+          ...existing,
+          budget_minor: payload.amountMinor,
+          budget_currency: payload.amountMinor === null ? null : (payload.currency ?? null),
           pending: true,
         });
       }
@@ -670,4 +696,179 @@ export interface MirrorGhostMerge extends MirrorRow {
 /** The viewer's ghost merges from the mirror; read-only, no overlay. */
 export function ghostMerges(state: MirrorState): MirrorGhostMerge[] {
   return rowsFor(state, SyncTable.GhostMerges) as MirrorGhostMerge[];
+}
+
+// ─────────────────────────────────────────────── trip plan + budgets (A23) ──
+//
+// The plan is a group's shared list, not money (no balance ever reads it), so
+// it gets the same server+pending overlay as everything else: an item added in
+// a dead zone is only in the queue until it syncs, and without the overlay it
+// would look lost. Delete is soft (a `deleted_at` the seq pull carries), so the
+// mirror filters it out rather than a hard removal a second device never sees.
+
+export interface MirrorPlanItem extends MirrorRow {
+  readonly id: string;
+  readonly group_id: string;
+  readonly day: string;
+  readonly starts_at: string | null;
+  readonly title: string;
+  readonly note: string | null;
+  readonly category: string | null;
+  readonly planned_minor: string | null;
+  readonly currency: string;
+  readonly done_at: string | null;
+  readonly expense_id: string | null;
+  readonly position: number;
+  readonly deleted_at: string | null;
+  readonly pending?: boolean;
+}
+
+/** The plan of one group: server rows with queued create/update/delete on top. */
+export function materialisePlanItems(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: { readonly groupId: string },
+): MirrorPlanItem[] {
+  const byId = new Map<string, MirrorPlanItem>();
+  for (const row of rowsFor(state, SyncTable.TripPlanItems, options.groupId) as MirrorPlanItem[]) {
+    byId.set(row.id, row);
+  }
+
+  for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (mutation.groupId !== options.groupId) continue;
+
+    switch (mutation.kind) {
+      case 'plan_item.create': {
+        const payload = mutation.payload as PlanItemCreatePayload;
+        if (byId.has(payload.itemId)) break;
+        byId.set(payload.itemId, {
+          id: payload.itemId,
+          group_id: mutation.groupId,
+          day: payload.day,
+          starts_at: payload.startsAt ?? null,
+          title: payload.title,
+          note: payload.note ?? null,
+          category: payload.category ?? null,
+          planned_minor: payload.plannedMinor ?? null,
+          currency: payload.currency ?? 'INR',
+          done_at: null,
+          expense_id: null,
+          // The server sets the real position (last within its day); until then
+          // sort a fresh item after the known ones, tie-broken by insertion.
+          position: Number.MAX_SAFE_INTEGER,
+          deleted_at: null,
+          pending: true,
+        });
+        break;
+      }
+      case 'plan_item.update': {
+        const payload = mutation.payload as PlanItemUpdatePayload;
+        const existing = byId.get(payload.itemId);
+        if (!existing) break;
+        const cleared = new Set(payload.clear ?? []);
+        byId.set(payload.itemId, {
+          ...existing,
+          day: payload.day ?? existing.day,
+          title: payload.title ?? existing.title,
+          starts_at: cleared.has('starts_at') ? null : (payload.startsAt ?? existing.starts_at),
+          note: cleared.has('note') ? null : (payload.note ?? existing.note),
+          category: cleared.has('category') ? null : (payload.category ?? existing.category),
+          planned_minor: cleared.has('planned_minor')
+            ? null
+            : (payload.plannedMinor ?? existing.planned_minor),
+          expense_id: cleared.has('expense_id') ? null : (payload.expenseId ?? existing.expense_id),
+          done_at:
+            payload.done === undefined
+              ? existing.done_at
+              : payload.done
+                ? (existing.done_at ?? mutation.clientCreatedAt)
+                : null,
+          pending: true,
+        });
+        break;
+      }
+      case 'plan_item.delete': {
+        const { itemId } = mutation.payload as PlanItemDeletePayload;
+        const existing = byId.get(itemId);
+        if (existing) {
+          byId.set(itemId, { ...existing, deleted_at: mutation.clientCreatedAt, pending: true });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return [...byId.values()].sort((a, b) => {
+    if (a.day !== b.day) return a.day.localeCompare(b.day);
+    if (a.position !== b.position) return a.position - b.position;
+    return String(a.id).localeCompare(String(b.id));
+  });
+}
+
+/** The plan to render: what has not been removed. */
+export function openPlanItems(items: readonly MirrorPlanItem[]): MirrorPlanItem[] {
+  return items.filter((item) => item.deleted_at === null);
+}
+
+export interface MirrorMemberBudget extends MirrorRow {
+  readonly id: string;
+  readonly group_id: string;
+  readonly member_id: string;
+  readonly amount_minor: string;
+  readonly currency: string;
+  readonly visibility: 'private' | 'group';
+  readonly deleted_at: string | null;
+  readonly pending?: boolean;
+}
+
+/**
+ * The personal budgets visible to the caller, server rows with the caller's own
+ * queued set/clear on top. The queue only ever writes the caller's own budget,
+ * so the pending row is keyed by their member id (`myMemberId`), which the
+ * payload does not carry — the RPC derives it server-side.
+ */
+export function materialiseMemberBudgets(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: { readonly groupId: string; readonly myMemberId: string | null },
+): MirrorMemberBudget[] {
+  const byMember = new Map<string, MirrorMemberBudget>();
+  for (const row of rowsFor(
+    state,
+    SyncTable.TripMemberBudgets,
+    options.groupId,
+  ) as MirrorMemberBudget[]) {
+    byMember.set(row.member_id, row);
+  }
+
+  const mine = options.myMemberId;
+  if (mine) {
+    for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+      if (mutation.groupId !== options.groupId) continue;
+
+      if (mutation.kind === 'member_budget.set') {
+        const payload = mutation.payload as MemberBudgetSetPayload;
+        const existing = byMember.get(mine);
+        byMember.set(mine, {
+          id: existing?.id ?? `pending:${mutation.clientMutationId}`,
+          group_id: mutation.groupId,
+          member_id: mine,
+          amount_minor: payload.amountMinor,
+          currency: payload.currency ?? existing?.currency ?? 'INR',
+          visibility: payload.visibility,
+          deleted_at: null,
+          pending: true,
+        });
+      } else if (mutation.kind === 'member_budget.clear') {
+        const existing = byMember.get(mine);
+        if (existing) {
+          byMember.set(mine, { ...existing, deleted_at: mutation.clientCreatedAt, pending: true });
+        }
+      }
+    }
+  }
+
+  return [...byMember.values()].filter((budget) => budget.deleted_at === null);
 }

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -34,6 +34,16 @@ export enum MutationKind {
   CaptureUpdate = 'capture.update',
   CaptureDelete = 'capture.delete',
   CaptureAssign = 'capture.assign',
+  // Trip plan + budgets (A23) — group-scoped, so unlike captures these carry a
+  // real group id in the envelope and are authorised by membership. Plan items
+  // get create/update/delete; a personal budget is a single upsert with an
+  // explicit clear; the overall budget stays admin-gated through its own kind.
+  PlanItemCreate = 'plan_item.create',
+  PlanItemUpdate = 'plan_item.update',
+  PlanItemDelete = 'plan_item.delete',
+  MemberBudgetSet = 'member_budget.set',
+  MemberBudgetClear = 'member_budget.clear',
+  GroupBudgetSet = 'group_budget.set',
 }
 
 export interface MutationEnvelope<K extends MutationKind = MutationKind, P = unknown> {
@@ -129,6 +139,55 @@ export interface CaptureAssignPayload {
   readonly expenseId: string;
 }
 
+/**
+ * Trip plan + budgets (A23). Amounts are minor-unit decimal strings, like every
+ * other money field on the wire. `itemId` is client-chosen and the idempotency
+ * key, so a replayed create returns the same row.
+ */
+export interface PlanItemCreatePayload {
+  readonly itemId: string;
+  readonly day: string;
+  readonly title: string;
+  readonly startsAt?: string | null;
+  readonly note?: string | null;
+  readonly category?: string | null;
+  readonly plannedMinor?: string | null;
+  readonly currency?: CurrencyCode | null;
+}
+
+export interface PlanItemUpdatePayload {
+  readonly itemId: string;
+  readonly day?: string;
+  readonly title?: string;
+  readonly startsAt?: string | null;
+  readonly note?: string | null;
+  readonly category?: string | null;
+  readonly plannedMinor?: string | null;
+  readonly done?: boolean;
+  readonly expenseId?: string | null;
+  /** Fields to clear to NULL — maps to the RPC's `p_clear text[]`. */
+  readonly clear?: readonly string[];
+}
+
+export interface PlanItemDeletePayload {
+  readonly itemId: string;
+}
+
+export interface MemberBudgetSetPayload {
+  readonly amountMinor: string;
+  readonly currency?: CurrencyCode | null;
+  readonly visibility: 'private' | 'group';
+}
+
+/** Clearing carries nothing — the scope (group) and the caller identify the row. */
+export type MemberBudgetClearPayload = Record<string, never>;
+
+/** The overall trip budget on the group row; null amount clears it. Admin-only. */
+export interface GroupBudgetSetPayload {
+  readonly amountMinor: string | null;
+  readonly currency?: CurrencyCode | null;
+}
+
 export interface SyncRequest {
   readonly deviceId: string;
   readonly mutations: readonly MutationEnvelope[];
@@ -187,6 +246,12 @@ export enum SyncTable {
   /** Personal scope (A38): the viewer's ghost merges, pull-only, so Friends can
    * fold merged guests offline. Never written through the queue. */
   GhostMerges = 'ghost_merges',
+  /** Group-scoped, read+write (A23). The trip plan is not money, so it never
+   * touches a balance — but it is a group's shared list and belongs offline. */
+  TripPlanItems = 'trip_plan_items',
+  /** Group-scoped, read+write. A member's personal spend ceiling for a trip;
+   * a `private` one is only ever pulled to its owner (RLS). */
+  TripMemberBudgets = 'trip_member_budgets',
 }
 
 /**

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -17,10 +17,13 @@ import {
   enqueue,
   materialiseCaptures,
   materialiseGroups,
+  materialiseMemberBudgets,
   materialiseMembers,
+  materialisePlanItems,
   materialiseSettlements,
   MutationKind,
   openCaptures,
+  openPlanItems,
   reconcile,
   SyncTable,
   type MutationEnvelope,
@@ -438,5 +441,205 @@ describe('captures', () => {
     const rows = materialiseCaptures(state, queued(edit), { ownerId: OWNER });
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ description: 'Petrol (edited)', pending: true });
+  });
+});
+
+describe('trip plan (A23)', () => {
+  const create = envelope('p-1', MutationKind.PlanItemCreate, {
+    itemId: 'item-1',
+    day: '2026-03-14',
+    title: 'Scuba dive',
+    currency: 'INR',
+  });
+
+  it('shows a plan item added with no network, marked pending', () => {
+    const rows = materialisePlanItems(emptyMirror(), queued(create), { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'item-1',
+      title: 'Scuba dive',
+      day: '2026-03-14',
+      done_at: null,
+      deleted_at: null,
+      pending: true,
+    });
+  });
+
+  it('ticks an item done, and back undone', () => {
+    const done = envelope('p-2', MutationKind.PlanItemUpdate, { itemId: 'item-1', done: true });
+    const [row] = materialisePlanItems(emptyMirror(), queued(create, done), { groupId: GROUP });
+    expect(row?.done_at).not.toBeNull();
+
+    const undone = envelope('p-3', MutationKind.PlanItemUpdate, { itemId: 'item-1', done: false });
+    const [row2] = materialisePlanItems(emptyMirror(), queued(create, done, undone), {
+      groupId: GROUP,
+    });
+    expect(row2?.done_at).toBeNull();
+  });
+
+  it('removes an item — soft-deleted, so openPlanItems drops it', () => {
+    const remove = envelope('p-4', MutationKind.PlanItemDelete, { itemId: 'item-1' });
+    const all = materialisePlanItems(emptyMirror(), queued(create, remove), { groupId: GROUP });
+    expect(all[0]?.deleted_at).not.toBeNull();
+    // The screen reads openPlanItems, so a removed item is simply gone from it.
+    expect(openPlanItems(all)).toHaveLength(0);
+  });
+
+  it('sorts by day then position, with a fresh offline item after the known ones', () => {
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: SyncTable.TripPlanItems,
+        groupId: GROUP,
+        seq: 1,
+        row: {
+          id: 'server-1',
+          group_id: GROUP,
+          day: '2026-03-14',
+          title: 'Breakfast',
+          position: 0,
+          currency: 'INR',
+          done_at: null,
+          deleted_at: null,
+        },
+      },
+    ]).state;
+    const rows = openPlanItems(materialisePlanItems(mirror, queued(create), { groupId: GROUP }));
+    // Same day: the server item (position 0) before the pending one (last).
+    expect(rows.map((r) => r.id)).toEqual(['server-1', 'item-1']);
+  });
+
+  it('does not duplicate an item the server has since confirmed', () => {
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: SyncTable.TripPlanItems,
+        groupId: GROUP,
+        seq: 1,
+        row: {
+          id: 'item-1',
+          group_id: GROUP,
+          day: '2026-03-14',
+          title: 'Scuba dive',
+          position: 0,
+          currency: 'INR',
+          done_at: null,
+          deleted_at: null,
+        },
+      },
+    ]).state;
+    const rows = materialisePlanItems(mirror, queued(create), { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.pending).toBeUndefined();
+  });
+
+  it('leaves another group’s plan alone', () => {
+    const elsewhere = envelope(
+      'p-9',
+      MutationKind.PlanItemCreate,
+      { itemId: 'item-2', day: '2026-03-14', title: 'X', currency: 'INR' },
+      'g-2',
+    );
+    expect(materialisePlanItems(emptyMirror(), queued(elsewhere), { groupId: GROUP })).toHaveLength(
+      0,
+    );
+  });
+});
+
+describe('trip member budgets (A23)', () => {
+  const ME = 'me-1';
+  const set = envelope('b-1', MutationKind.MemberBudgetSet, {
+    amountMinor: '500000',
+    currency: 'INR',
+    visibility: 'private',
+  });
+
+  it('shows my budget set offline, keyed to my member id', () => {
+    const rows = materialiseMemberBudgets(emptyMirror(), queued(set), {
+      groupId: GROUP,
+      myMemberId: ME,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      member_id: ME,
+      amount_minor: '500000',
+      visibility: 'private',
+      pending: true,
+    });
+  });
+
+  it('clears my budget — soft-deleted, so it drops out of the list', () => {
+    const clear = envelope('b-2', MutationKind.MemberBudgetClear, {});
+    const rows = materialiseMemberBudgets(emptyMirror(), queued(set, clear), {
+      groupId: GROUP,
+      myMemberId: ME,
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('overwrites my existing budget rather than adding a second', () => {
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: SyncTable.TripMemberBudgets,
+        groupId: GROUP,
+        seq: 1,
+        row: {
+          id: 'bud-1',
+          group_id: GROUP,
+          member_id: ME,
+          amount_minor: '100000',
+          currency: 'INR',
+          visibility: 'private',
+          deleted_at: null,
+        },
+      },
+    ]).state;
+    const rows = materialiseMemberBudgets(mirror, queued(set), { groupId: GROUP, myMemberId: ME });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.amount_minor).toBe('500000');
+    expect(rows[0]?.id).toBe('bud-1'); // same row, raised
+  });
+
+  it('does not overlay anything when the caller has no member id', () => {
+    const rows = materialiseMemberBudgets(emptyMirror(), queued(set), {
+      groupId: GROUP,
+      myMemberId: null,
+    });
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe('overall trip budget rides the group row', () => {
+  const base: SyncChange = {
+    table: SyncTable.Groups,
+    groupId: GROUP,
+    seq: 1,
+    row: {
+      id: GROUP,
+      name: 'Goa',
+      default_currency: 'INR',
+      created_at: AT,
+      archived_at: null,
+      budget_minor: null,
+      budget_currency: null,
+    },
+  };
+
+  it('sets the overall budget optimistically on the group', () => {
+    const mirror = reconcile(emptyMirror(), [base]).state;
+    const set = envelope('g-1', MutationKind.GroupBudgetSet, {
+      amountMinor: '2000000',
+      currency: 'INR',
+    });
+    const [row] = materialiseGroups(mirror, queued(set));
+    expect(row).toMatchObject({ budget_minor: '2000000', budget_currency: 'INR', pending: true });
+  });
+
+  it('clears the overall budget with a null amount', () => {
+    const withBudget = reconcile(emptyMirror(), [
+      { ...base, row: { ...base.row, budget_minor: '2000000', budget_currency: 'INR' } },
+    ]).state;
+    const clear = envelope('g-2', MutationKind.GroupBudgetSet, { amountMinor: null });
+    const [row] = materialiseGroups(withBudget, queued(clear));
+    expect(row?.budget_minor).toBeNull();
+    expect(row?.budget_currency).toBeNull();
   });
 });

--- a/packages/db/prisma/migrations/20260816140000_plan_budgets_sync/migration.sql
+++ b/packages/db/prisma/migrations/20260816140000_plan_budgets_sync/migration.sql
@@ -1,0 +1,148 @@
+-- Make the trip plan and per-member budgets offline-first (ADR-005).
+--
+-- Both were direct-RPC only, so the plan screen was blank with no connection.
+-- To ride the mirror they need what every group-scoped synced table has: an
+-- `updated_seq` the /sync pull walks with `.gt('updated_seq', N)`, stamped by
+-- the shared `baaki_stamp_seq` trigger (keyed on group_id, same as settlements
+-- and expenses).
+--
+-- The load-bearing change is delete. A seq-based pull can only carry rows that
+-- still exist, so a hard DELETE never reaches a second device — it would keep
+-- showing an item the first device removed. Captures solved this by making
+-- delete a soft `deleted_at` UPDATE that the pull carries as a tombstone; the
+-- client mirror filters it out. Both delete RPCs here become soft-deletes, and
+-- the per-member upsert clears the tombstone when a budget is set again.
+
+-- 1. Sync columns + indexes + the stamping trigger, on both tables.
+ALTER TABLE public.trip_plan_items
+  ADD COLUMN IF NOT EXISTS updated_seq bigint NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS deleted_at  timestamptz;
+
+CREATE INDEX IF NOT EXISTS trip_plan_items_group_id_updated_seq_idx
+  ON public.trip_plan_items (group_id, updated_seq);
+
+DROP TRIGGER IF EXISTS trip_plan_items_stamp_seq ON public.trip_plan_items;
+CREATE TRIGGER trip_plan_items_stamp_seq
+  BEFORE INSERT OR UPDATE ON public.trip_plan_items
+  FOR EACH ROW EXECUTE FUNCTION public.baaki_stamp_seq();
+
+ALTER TABLE public.trip_member_budgets
+  ADD COLUMN IF NOT EXISTS updated_seq bigint NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS deleted_at  timestamptz;
+
+CREATE INDEX IF NOT EXISTS trip_member_budgets_group_id_updated_seq_idx
+  ON public.trip_member_budgets (group_id, updated_seq);
+
+DROP TRIGGER IF EXISTS trip_member_budgets_stamp_seq ON public.trip_member_budgets;
+CREATE TRIGGER trip_member_budgets_stamp_seq
+  BEFORE INSERT OR UPDATE ON public.trip_member_budgets
+  FOR EACH ROW EXECUTE FUNCTION public.baaki_stamp_seq();
+
+-- Stamp the rows that already exist so a first pull carries them.
+UPDATE public.trip_plan_items SET group_id = group_id;
+UPDATE public.trip_member_budgets SET group_id = group_id;
+
+-- 2. Removing a plan item is now a soft delete, so the tombstone propagates.
+CREATE OR REPLACE FUNCTION public.baaki_remove_plan_item(p_item_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+BEGIN
+  SELECT group_id INTO v_group_id FROM public.trip_plan_items WHERE id = p_item_id;
+  IF v_group_id IS NULL THEN
+    RETURN; -- Never existed. Removing nothing is not an error.
+  END IF;
+  IF NOT public.is_group_member(v_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Soft delete, and only when still live, so removing twice does not re-stamp.
+  UPDATE public.trip_plan_items
+     SET deleted_at = now()
+   WHERE id = p_item_id AND deleted_at IS NULL;
+END
+$$;
+
+-- 3. Clearing a personal budget is a soft delete, keyed to the caller's member.
+CREATE OR REPLACE FUNCTION public.baaki_clear_my_trip_budget(p_group_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_member uuid;
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  v_member := public.baaki_my_member_id(p_group_id);
+  UPDATE public.trip_member_budgets
+     SET deleted_at = now()
+   WHERE group_id = p_group_id AND member_id = v_member AND deleted_at IS NULL;
+END
+$$;
+
+-- 4. Setting a personal budget clears any prior tombstone, so the one row per
+--    member (the UNIQUE key) comes back to life rather than colliding.
+CREATE OR REPLACE FUNCTION public.baaki_set_my_trip_budget(
+  p_group_id     uuid,
+  p_amount_minor bigint,
+  p_currency     char(3) DEFAULT NULL,
+  p_visibility   text DEFAULT 'private'
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_member   uuid;
+  v_currency char(3);
+  v_id       uuid;
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_member := public.baaki_my_member_id(p_group_id);
+  IF v_member IS NULL THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you have no membership here'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_amount_minor IS NULL OR p_amount_minor < 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: a budget is zero or more'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF p_visibility NOT IN ('private', 'group') THEN
+    RAISE EXCEPTION 'INVALID_VISIBILITY: private or group'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT COALESCE(p_currency, default_currency) INTO v_currency
+  FROM public.groups WHERE id = p_group_id;
+
+  INSERT INTO public.trip_member_budgets
+    (group_id, member_id, amount_minor, currency, visibility)
+  VALUES
+    (p_group_id, v_member, p_amount_minor, upper(v_currency), p_visibility)
+  ON CONFLICT (member_id) DO UPDATE
+    SET amount_minor = EXCLUDED.amount_minor,
+        currency     = EXCLUDED.currency,
+        visibility   = EXCLUDED.visibility,
+        deleted_at   = NULL,
+        updated_at   = now()
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1156,12 +1156,15 @@ model TripPlanItem {
   createdBy    String?   @map("created_by") @db.Uuid
   createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt    DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  updatedSeq   BigInt    @default(0) @map("updated_seq")
+  deletedAt    DateTime? @map("deleted_at") @db.Timestamptz(6)
 
   group   Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
   expense Expense?     @relation(fields: [expenseId], references: [id], onDelete: SetNull)
   author  GroupMember? @relation(fields: [createdBy], references: [id], onDelete: SetNull)
 
   @@index([groupId, day, position], map: "trip_plan_items_group_day_idx")
+  @@index([groupId, updatedSeq])
   @@map("trip_plan_items")
   @@schema("public")
 }
@@ -1176,21 +1179,24 @@ model TripPlanItem {
 /// private; it is the sum of their `ExpenseShare` rows, which the shared ledger
 /// already shows everyone. Only the target this cap sets is hidden.
 model TripMemberBudget {
-  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  groupId     String   @map("group_id") @db.Uuid
-  memberId    String   @unique @map("member_id") @db.Uuid
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  groupId     String    @map("group_id") @db.Uuid
+  memberId    String    @unique @map("member_id") @db.Uuid
   /// The ceiling, in minor units of `currency`. Zero is allowed; negative is not.
-  amountMinor BigInt   @map("amount_minor")
-  currency    String   @default("INR") @db.Char(3)
+  amountMinor BigInt    @map("amount_minor")
+  currency    String    @default("INR") @db.Char(3)
   /// 'private' (owner-only) | 'group' (whole group). CHECK in migration SQL.
-  visibility  String   @default("private")
-  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  visibility  String    @default("private")
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  updatedSeq  BigInt    @default(0) @map("updated_seq")
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz(6)
 
   group  Group       @relation(fields: [groupId], references: [id], onDelete: Cascade)
   member GroupMember @relation(fields: [memberId], references: [id], onDelete: Cascade)
 
   @@index([groupId])
+  @@index([groupId, updatedSeq])
   @@map("trip_member_budgets")
   @@schema("public")
 }

--- a/packages/db/test/trip-budgets.test.ts
+++ b/packages/db/test/trip-budgets.test.ts
@@ -160,3 +160,46 @@ describe('the overall budget is the admin’s', () => {
     });
   });
 });
+
+describe('clearing a personal budget is a soft delete (so it syncs)', () => {
+  it('marks the row deleted and bumps the seq rather than dropping it', async () => {
+    const member = group.profileIds[1] as string;
+    const memberId = group.memberIds[1] as string;
+    await as(member, async () => {
+      await client.query(`SELECT baaki_set_my_trip_budget($1, 500000, NULL, 'private')`, [
+        group.groupId,
+      ]);
+      await client.query(`SELECT baaki_clear_my_trip_budget($1)`, [group.groupId]);
+    });
+    const { rows } = await client.query(
+      `SELECT deleted_at, updated_seq FROM trip_member_budgets WHERE member_id = $1`,
+      [memberId],
+    );
+    // The tombstone stays so a second device learns the budget is gone.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].deleted_at).not.toBeNull();
+    expect(Number(rows[0].updated_seq)).toBeGreaterThan(0);
+  });
+
+  it('revives the one row when the budget is set again, not a second row', async () => {
+    const member = group.profileIds[1] as string;
+    const memberId = group.memberIds[1] as string;
+    await as(member, async () => {
+      await client.query(`SELECT baaki_set_my_trip_budget($1, 500000, NULL, 'private')`, [
+        group.groupId,
+      ]);
+      await client.query(`SELECT baaki_clear_my_trip_budget($1)`, [group.groupId]);
+      await client.query(`SELECT baaki_set_my_trip_budget($1, 700000, NULL, 'private')`, [
+        group.groupId,
+      ]);
+    });
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n, max(amount_minor)::text AS amount, bool_or(deleted_at IS NULL) AS live
+         FROM trip_member_budgets WHERE member_id = $1`,
+      [memberId],
+    );
+    expect(rows[0].n).toBe(1); // the UNIQUE(member_id) row, raised — not a collision
+    expect(rows[0].amount).toBe('700000');
+    expect(rows[0].live).toBe(true);
+  });
+});

--- a/packages/db/test/trip-plan.test.ts
+++ b/packages/db/test/trip-plan.test.ts
@@ -264,17 +264,21 @@ describe('changing the plan', () => {
     });
   });
 
-  it('removes, and removing twice is not an error', async () => {
+  it('removes as a soft delete so the tombstone can sync, and twice is fine', async () => {
     const id = await as(group.profileIds[0] as string, seedItem);
     await as(group.profileIds[0] as string, async () => {
       await client.query(`SELECT baaki_remove_plan_item($1)`, [id]);
       await client.query(`SELECT baaki_remove_plan_item($1)`, [id]);
     });
+    // The row stays, marked deleted, so a seq-based pull carries the removal to
+    // other devices; a live read (deleted_at IS NULL) sees nothing.
     const { rows } = await client.query(
-      `SELECT count(*)::int AS n FROM trip_plan_items WHERE id = $1`,
+      `SELECT deleted_at, updated_seq FROM trip_plan_items WHERE id = $1`,
       [id],
     );
-    expect(rows[0].n).toBe(0);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].deleted_at).not.toBeNull();
+    expect(Number(rows[0].updated_seq)).toBeGreaterThan(0);
   });
 });
 

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -60,7 +60,15 @@ type MutationKind =
   | 'capture.create'
   | 'capture.update'
   | 'capture.delete'
-  | 'capture.assign';
+  | 'capture.assign'
+  // Trip plan + budgets (A23) — group-scoped, authorised by membership, so NOT
+  // in isPersonalKind below.
+  | 'plan_item.create'
+  | 'plan_item.update'
+  | 'plan_item.delete'
+  | 'member_budget.set'
+  | 'member_budget.clear'
+  | 'group_budget.set';
 
 /** True for the kinds whose scope is a user, not a group. */
 function isPersonalKind(kind: MutationKind): boolean {
@@ -384,6 +392,56 @@ class SyncSession {
         return await this.deleteCapture(mutation);
       case 'capture.assign':
         return await this.assignCapture(mutation);
+      case 'plan_item.create':
+        return await this.rpcAsCaller('baaki_add_plan_item', {
+          p_group_id: mutation.groupId,
+          p_day: requireString(mutation.payload.day, 'day'),
+          p_title: requireString(mutation.payload.title, 'title'),
+          p_starts_at: (mutation.payload.startsAt as string | undefined) ?? null,
+          p_note: (mutation.payload.note as string | undefined) ?? null,
+          p_category: (mutation.payload.category as string | undefined) ?? null,
+          p_planned_minor: (mutation.payload.plannedMinor as string | undefined) ?? null,
+          p_currency: (mutation.payload.currency as string | undefined) ?? null,
+          // Client-chosen id: the RPC's replay guard dedupes on it.
+          p_item_id: requireString(mutation.payload.itemId, 'itemId'),
+        });
+      case 'plan_item.update':
+        return await this.rpcAsCaller('baaki_update_plan_item', {
+          p_item_id: requireString(mutation.payload.itemId, 'itemId'),
+          // NULL means "leave alone"; p_clear (below) is how a field is emptied.
+          p_day: (mutation.payload.day as string | undefined) ?? null,
+          p_starts_at: (mutation.payload.startsAt as string | undefined) ?? null,
+          p_title: (mutation.payload.title as string | undefined) ?? null,
+          p_note: (mutation.payload.note as string | undefined) ?? null,
+          p_category: (mutation.payload.category as string | undefined) ?? null,
+          p_planned_minor: (mutation.payload.plannedMinor as string | undefined) ?? null,
+          p_done: (mutation.payload.done as boolean | undefined) ?? null,
+          p_expense_id: (mutation.payload.expenseId as string | undefined) ?? null,
+          p_clear: (mutation.payload.clear as string[] | undefined) ?? [],
+        });
+      case 'plan_item.delete':
+        return await this.rpcAsCaller('baaki_remove_plan_item', {
+          p_item_id: requireString(mutation.payload.itemId, 'itemId'),
+        });
+      case 'member_budget.set':
+        return await this.rpcAsCaller('baaki_set_my_trip_budget', {
+          p_group_id: mutation.groupId,
+          p_amount_minor: requireString(mutation.payload.amountMinor, 'amountMinor'),
+          p_currency: (mutation.payload.currency as string | undefined) ?? null,
+          p_visibility: (mutation.payload.visibility as string | undefined) ?? 'private',
+        });
+      case 'member_budget.clear':
+        return await this.rpcAsCaller('baaki_clear_my_trip_budget', {
+          p_group_id: mutation.groupId,
+        });
+      case 'group_budget.set':
+        // Admin-gated inside the RPC — kept a distinct kind rather than widening
+        // group.update, so any member cannot move the overall ceiling.
+        return await this.rpcAsCaller('baaki_set_group_budget', {
+          p_group_id: mutation.groupId,
+          p_amount_minor: (mutation.payload.amountMinor as string | null) ?? null,
+          p_currency: (mutation.payload.currency as string | undefined) ?? null,
+        });
       default:
         throw new HttpError(
           400,
@@ -705,6 +763,10 @@ async function pull(
       ['expenses', EXPENSE_SELECT],
       ['settlements', SETTLEMENT_SELECT],
       ['activity_log', '*'],
+      // Trip plan + budgets (A23). Flat rows, no embeds. Read as the caller, so a
+      // co-member's private budget is filtered by RLS and simply not returned.
+      ['trip_plan_items', '*'],
+      ['trip_member_budgets', '*'],
     ] as const) {
       const { data, error } = await caller
         .from(table)


### PR DESCRIPTION
The last step of the offline-first program. The plan screen was direct-RPC only — blank with no connection. It now reads the mirror and writes the queue (ADR-005). Plan items are **not money** (A23), so no ledger risk.

## What
`trip_plan_items` + `trip_member_budgets` become group-scoped **read+write** synced tables (cloned from settlements).

**Migration `20260816140000`** — `updated_seq` + `deleted_at` + indexes + the shared `baaki_stamp_seq` trigger on both. The load-bearing change: a seq pull can only carry rows that still exist, so **delete becomes soft** (`baaki_remove_plan_item`, `baaki_clear_my_trip_budget` → `deleted_at` UPDATE the pull carries as a tombstone), and `baaki_set_my_trip_budget` clears the tombstone on its upsert so the UNIQUE(member_id) row revives rather than colliding.

**Protocol** — 2 tables + 6 kinds (plan_item.create/update/delete, member_budget.set/clear, group_budget.set kept distinct so the overall budget stays admin-gated).

**Edge** — 2 flat pull entries + dispatch via `rpcAsCaller` to existing RPCs.

**Mirror** — `materialisePlanItems` + `materialiseMemberBudgets` (create/update/soft-delete overlay); the overall budget rides the group row, patched optimistically.

**Client** — reads → mirror; new queued write hooks; `plan.tsx` drops direct RPCs + refetches.

## Tests (strong scenarios + edges, as asked)
- 12 overlay cases: add offline, done/undone, soft-delete hidden by `openPlanItems`, day+position sort with fresh item last, no-dup-after-sync, other-group isolation; budget set/clear/upsert-not-duplicate/no-member-id; overall budget set + clear.
- Existing plan-remove db test updated to assert the tombstone (was count=0); new budget soft-delete + revive db tests.
- **548 core + 267 mobile green**; tsc + lint + prettier + `prisma validate` clean; schema+migration in step (no drift).

## Deploy (your step)
Migration + `supabase functions deploy sync`. Client half is OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added offline support for trip plan items and personal or group budgets.
  - Plan items and budgets now update immediately and synchronize automatically when connectivity returns.
  - Added support for creating, editing, completing, and removing plan items.
  - Added support for setting and clearing personal trip budgets and setting group budgets.
  - Group details can now display overall budget and currency information.

- **Bug Fixes**
  - Improved synchronization reliability when changes are made offline or connectivity is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->