### PR TITLE
fix(plan): harden offline plan/budgets against review findings

### DIFF
--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -13,7 +13,7 @@
  * it.
  */
 
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Pressable, ScrollView, TextInput, View } from 'react-native';
@@ -285,14 +285,20 @@ export default function PlanScreen() {
 
   const isTrip = group.data?.type === 'trip';
 
+  // `busy` is async state, so a double-tap can fire two submits in the same tick
+  // before it re-renders — each mints a fresh itemId, so both post. A synchronous
+  // ref closes that window; the button still reflects `busy` for the UI.
+  const submitting = useRef(false);
   const submit = async (day: string): Promise<void> => {
-    if (!title.trim()) return;
+    if (!title.trim() || submitting.current) return;
+    submitting.current = true;
     setBusy(true);
     try {
       await addItem.mutateAsync({ day, title: title.trim(), currency });
       setTitle('');
       setAddingTo(null);
     } finally {
+      submitting.current = false;
       setBusy(false);
     }
   };

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1410,6 +1410,9 @@ export async function fetchPlanItems(groupId: string): Promise<PlanItemRow[]> {
       'id, group_id, day, starts_at, title, note, category, planned_minor, currency, done_at, expense_id, position',
     )
     .eq('group_id', groupId)
+    // Soft-deleted rows are tombstones for sync (ADR-005); a direct read wants
+    // only what is live. The pull query stays unfiltered so it can propagate them.
+    .is('deleted_at', null)
     .order('day', { ascending: true })
     .order('position', { ascending: true });
   if (error) throw new Error(error.message);
@@ -1476,7 +1479,9 @@ export async function fetchMemberBudgets(groupId: string): Promise<MemberBudgetR
   const { data, error } = await supabase
     .from('trip_member_budgets')
     .select('id, group_id, member_id, amount_minor, currency, visibility')
-    .eq('group_id', groupId);
+    .eq('group_id', groupId)
+    // Live budgets only; a cleared one is a soft-delete tombstone (ADR-005).
+    .is('deleted_at', null);
   if (error) throw new Error(error.message);
   return (data ?? []) as MemberBudgetRow[];
 }

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -19,6 +19,7 @@ import {
   materialiseArchivedGroups,
   materialiseCaptures,
   materialiseExpenses,
+  materialiseGroup,
   materialiseGroups,
   materialiseMemberBudgets,
   materialiseMembers,
@@ -1066,9 +1067,9 @@ export function useMemberBudgets(groupId: string): LocalRead<MemberBudgetRow[]> 
 export function useGroupBudget(groupId: string): LocalRead<GroupBudget> {
   const { mirror, queue } = useSync();
   const budget = useMemo(() => {
-    const group = (materialiseGroups(mirror, queue) as unknown as GroupRow[]).find(
-      (row) => row.id === groupId,
-    );
+    // materialiseGroup (not materialiseGroups) so an archived trip still shows
+    // its budget, and a queued group_budget.set on it is not filtered away.
+    const group = materialiseGroup(mirror, queue, groupId) as unknown as GroupRow | undefined;
     const minor = group?.budget_minor;
     return {
       amountMinor: minor === null || minor === undefined ? null : BigInt(minor),

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -556,6 +556,20 @@ export function materialiseGroups(
 }
 
 /**
+ * One group by id, archived or not. `materialiseGroups` hides archived groups so
+ * they leave the dashboard, but a per-group screen (the plan, its budget) still
+ * opens on an archived trip and must see its row — including a queued
+ * `group_budget.set` that has not synced yet.
+ */
+export function materialiseGroup(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  groupId: string,
+): MirrorGroup | undefined {
+  return buildGroups(state, queue).find((group) => group.id === groupId);
+}
+
+/**
  * The archived groups — the ones `materialiseGroups` hides — newest-archived
  * first, so the archive reads as a most-recent-on-top history. Unarchiving is
  * an ordinary group.update clearing `archived_at`, so the same queue overlay
@@ -721,6 +735,9 @@ export interface MirrorPlanItem extends MirrorRow {
   readonly position: number;
   readonly deleted_at: string | null;
   readonly pending?: boolean;
+  /** Queue order for a pending create the server has not positioned yet, so two
+   *  items added back-to-back sort in the order they were typed, not by UUID. */
+  readonly pending_rank?: number;
 }
 
 /** The plan of one group: server rows with queued create/update/delete on top. */
@@ -754,8 +771,9 @@ export function materialisePlanItems(
           done_at: null,
           expense_id: null,
           // The server sets the real position (last within its day); until then
-          // sort a fresh item after the known ones, tie-broken by insertion.
+          // sort a fresh item after the known ones, tie-broken by queue order.
           position: Number.MAX_SAFE_INTEGER,
+          pending_rank: mutation.seq,
           deleted_at: null,
           pending: true,
         });
@@ -803,6 +821,11 @@ export function materialisePlanItems(
   return [...byId.values()].sort((a, b) => {
     if (a.day !== b.day) return a.day.localeCompare(b.day);
     if (a.position !== b.position) return a.position - b.position;
+    // Same position means two not-yet-positioned pending creates; keep the order
+    // they were queued in before falling back to a (stable but arbitrary) id.
+    if (a.pending_rank !== undefined && b.pending_rank !== undefined) {
+      return a.pending_rank - b.pending_rank;
+    }
     return String(a.id).localeCompare(String(b.id));
   });
 }

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -165,9 +165,13 @@ export interface PlanItemUpdatePayload {
   readonly plannedMinor?: string | null;
   readonly done?: boolean;
   readonly expenseId?: string | null;
-  /** Fields to clear to NULL — maps to the RPC's `p_clear text[]`. */
-  readonly clear?: readonly string[];
+  /** Fields to clear to NULL — maps to the RPC's `p_clear text[]`. Only the
+   *  nullable plan-item columns; anything else the RPC would ignore anyway. */
+  readonly clear?: readonly PlanItemClearField[];
 }
+
+/** The nullable plan-item columns a {@link PlanItemUpdatePayload} may clear. */
+export type PlanItemClearField = 'starts_at' | 'note' | 'category' | 'planned_minor' | 'expense_id';
 
 export interface PlanItemDeletePayload {
   readonly itemId: string;

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -485,6 +485,50 @@ describe('trip plan (A23)', () => {
     expect(openPlanItems(all)).toHaveLength(0);
   });
 
+  it('drops a plan item the server pulled already tombstoned', () => {
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: SyncTable.TripPlanItems,
+        groupId: GROUP,
+        seq: 2,
+        row: {
+          id: 'server-gone',
+          group_id: GROUP,
+          day: '2026-03-14',
+          title: 'Cancelled',
+          position: 0,
+          currency: 'INR',
+          done_at: null,
+          deleted_at: AT,
+        },
+      },
+    ]).state;
+    const all = materialisePlanItems(mirror, queued(), { groupId: GROUP });
+    expect(all).toHaveLength(1); // kept for reconciliation
+    expect(openPlanItems(all)).toHaveLength(0); // but never rendered
+  });
+
+  it('keeps two offline items in the order they were added, not by id', () => {
+    // 'zzz' was queued before 'aaa'; a plain id tie-break would flip them, so
+    // this only passes if pending items sort by queue order (pending_rank).
+    const first = envelope('p-6', MutationKind.PlanItemCreate, {
+      itemId: 'zzz-item',
+      day: '2026-03-14',
+      title: 'First',
+      currency: 'INR',
+    });
+    const second = envelope('p-7', MutationKind.PlanItemCreate, {
+      itemId: 'aaa-item',
+      day: '2026-03-14',
+      title: 'Second',
+      currency: 'INR',
+    });
+    const rows = openPlanItems(
+      materialisePlanItems(emptyMirror(), queued(first, second), { groupId: GROUP }),
+    );
+    expect(rows.map((r) => r.id)).toEqual(['zzz-item', 'aaa-item']);
+  });
+
   it('sorts by day then position, with a fresh offline item after the known ones', () => {
     const mirror = reconcile(emptyMirror(), [
       {
@@ -603,6 +647,27 @@ describe('trip member budgets (A23)', () => {
       groupId: GROUP,
       myMemberId: null,
     });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('omits a budget the server pulled already tombstoned', () => {
+    const mirror = reconcile(emptyMirror(), [
+      {
+        table: SyncTable.TripMemberBudgets,
+        groupId: GROUP,
+        seq: 2,
+        row: {
+          id: 'bud-gone',
+          group_id: GROUP,
+          member_id: ME,
+          amount_minor: '100000',
+          currency: 'INR',
+          visibility: 'private',
+          deleted_at: AT,
+        },
+      },
+    ]).state;
+    const rows = materialiseMemberBudgets(mirror, queued(), { groupId: GROUP, myMemberId: ME });
     expect(rows).toHaveLength(0);
   });
 });

--- a/packages/db/test/trip-budgets.test.ts
+++ b/packages/db/test/trip-budgets.test.ts
@@ -165,20 +165,27 @@ describe('clearing a personal budget is a soft delete (so it syncs)', () => {
   it('marks the row deleted and bumps the seq rather than dropping it', async () => {
     const member = group.profileIds[1] as string;
     const memberId = group.memberIds[1] as string;
-    await as(member, async () => {
+    const seqAfterSet = await as(member, async () => {
       await client.query(`SELECT baaki_set_my_trip_budget($1, 500000, NULL, 'private')`, [
         group.groupId,
       ]);
+      const { rows } = await client.query(
+        `SELECT updated_seq FROM trip_member_budgets WHERE member_id = $1`,
+        [memberId],
+      );
       await client.query(`SELECT baaki_clear_my_trip_budget($1)`, [group.groupId]);
+      return Number(rows[0].updated_seq);
     });
     const { rows } = await client.query(
       `SELECT deleted_at, updated_seq FROM trip_member_budgets WHERE member_id = $1`,
       [memberId],
     );
-    // The tombstone stays so a second device learns the budget is gone.
+    // The tombstone stays so a second device learns the budget is gone, and the
+    // clear must bump the seq past the set so that pull actually carries it.
     expect(rows).toHaveLength(1);
     expect(rows[0].deleted_at).not.toBeNull();
-    expect(Number(rows[0].updated_seq)).toBeGreaterThan(0);
+    expect(seqAfterSet).toBeGreaterThan(0);
+    expect(Number(rows[0].updated_seq)).toBeGreaterThan(seqAfterSet);
   });
 
   it('revives the one row when the budget is set again, not a second row', async () => {

--- a/packages/db/test/trip-plan.test.ts
+++ b/packages/db/test/trip-plan.test.ts
@@ -266,9 +266,16 @@ describe('changing the plan', () => {
 
   it('removes as a soft delete so the tombstone can sync, and twice is fine', async () => {
     const id = await as(group.profileIds[0] as string, seedItem);
-    await as(group.profileIds[0] as string, async () => {
+    const seqAfterFirst = await as(group.profileIds[0] as string, async () => {
       await client.query(`SELECT baaki_remove_plan_item($1)`, [id]);
+      const { rows } = await client.query(`SELECT updated_seq FROM trip_plan_items WHERE id = $1`, [
+        id,
+      ]);
+      const seq = Number(rows[0].updated_seq);
+      // Removing again must be a no-op — the RPC guards on `deleted_at IS NULL`,
+      // so a second call cannot re-stamp the seq and churn every device's pull.
       await client.query(`SELECT baaki_remove_plan_item($1)`, [id]);
+      return seq;
     });
     // The row stays, marked deleted, so a seq-based pull carries the removal to
     // other devices; a live read (deleted_at IS NULL) sees nothing.
@@ -278,7 +285,8 @@ describe('changing the plan', () => {
     );
     expect(rows).toHaveLength(1);
     expect(rows[0].deleted_at).not.toBeNull();
-    expect(Number(rows[0].updated_seq)).toBeGreaterThan(0);
+    expect(seqAfterFirst).toBeGreaterThan(0);
+    expect(Number(rows[0].updated_seq)).toBe(seqAfterFirst); // unchanged by the 2nd remove
   });
 });
 


### PR DESCRIPTION
Follow-up on the plan/budgets offline PR (#220). Treated every CodeRabbit comment as untrusted, verified each against current code, fixed the still-valid ones, skipped the rest with a reason.

## Fixed
- **Same-tick double-submit (dup plan item).** `submit` guarded only by async `busy` state; a double-tap fired two calls before re-render and each `useAddPlanItem` mints a fresh `itemId`, so both posted. Added a synchronous `useRef` guard.
- **Pending item order.** Two not-yet-positioned offline creates tie-broke by UUID. Now they carry `pending_rank = mutation.seq` and sort by queue order — the order they were typed.
- **Archived-trip budget.** `useGroupBudget` read through `materialiseGroups`, which filters archived groups, hiding the budget (and any queued `group_budget.set`). New `materialiseGroup(state, queue, id)` returns one group archived-or-not.
- **Tombstones leaking into direct reads.** `fetchPlanItems` / `fetchMemberBudgets` now filter `deleted_at IS NULL`. Soft-deletes are sync tombstones; the pull query stays unfiltered so removals still propagate.
- **`clear` typing.** `PlanItemUpdatePayload.clear` is now a `PlanItemClearField` union of the five nullable columns, checked at compile time.

## Tests
- Pulled tombstone dropped from `openPlanItems` and `materialiseMemberBudgets`.
- Pending queue-order (ids chosen to defeat a plain id tie-break).
- DB: second `baaki_remove_plan_item` leaves `updated_seq` unchanged; `baaki_clear_my_trip_budget` bumps the seq past the set.
- Core **551 pass**; core + mobile typecheck clean; prettier clean.

## Skipped (with reason)
- ESLint import-resolver for `@/data/hooks` — alias already resolves, lint is green.
- `as unknown as` → declared type aliases — cosmetic, wide blast radius, no behaviour change.
- Tombstone-contract alignment (helper vs internal filter) — both paths already yield correct visible rows.
- `CREATE INDEX CONCURRENTLY` / batched backfill — incompatible with the migration transaction; tables are tiny.
- RPC-side `p_clear` rejection — unknown keys are harmless no-ops and the wire type now blocks them at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate plan items when submissions occur repeatedly in quick succession.
  * Removed deleted plan items and member budgets from displayed results.
  * Improved budget visibility for archived groups and recently updated group data.
  * Preserved the order of offline-added plan items for more predictable displays.

* **Reliability**
  * Improved handling of deleted records and offline changes during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->