### PR TITLE
fix+feat(mobile): Friends merge/add-person — warning text, nav clearance, pick from contacts

### DIFF
--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -31,7 +31,7 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -50,7 +50,9 @@ function today(): string {
 
 export default function AddPersonScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  // Under the persistent bottom nav (like friends/contacts and friends/merge),
+  // so pad for the bar, not just the system inset.
+  const clearance = useTabBarClearance();
   const { t } = useStrings();
   const { profile } = useAuth();
   const guard = useGuestGuard();

--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
-import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { ActivityIndicator, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
   AmountField,
@@ -35,6 +35,7 @@ import {
   useTheme,
 } from '@baaki/ui';
 
+import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
 import { useAddGhostMember, useCreateGroup, useWriteExpense } from '@/data/hooks';
 import { GroupType } from '@/data/types';
 import { deviceDefaultCurrency, useStrings } from '@/i18n';
@@ -74,6 +75,16 @@ export default function AddPersonScreen() {
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  // Pull the name straight off a contact instead of typing it. This is a 1:1
+  // IOU, so only the first ticked person is used; the address book never leaves
+  // the device (ContactPicker reads it locally).
+  const onPickContact = (chosen: readonly PickedContact[]): void => {
+    const first = chosen[0];
+    if (first) setName(first.name);
+    setPickerOpen(false);
+  };
 
   const canSave = name.trim().length > 0 && amount > 0n && direction !== null && !saving;
 
@@ -172,6 +183,24 @@ export default function AddPersonScreen() {
               paddingVertical: theme.spacing.sm,
             }}
           />
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.tabs.fromContacts}
+            onPress={() => setPickerOpen(true)}
+            style={({ pressed }) => ({
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: theme.spacing.xs,
+              alignSelf: 'flex-start',
+              paddingVertical: theme.spacing.xs,
+              opacity: pressed ? 0.6 : 1,
+            })}
+          >
+            <Ionicons name="person-add-outline" size={iconSize.sm} color={theme.color.brand} />
+            <Text variant="caption" style={{ color: theme.color.brand }}>
+              {t.tabs.fromContacts}
+            </Text>
+          </Pressable>
         </Card>
 
         <View style={{ gap: theme.spacing.sm }}>
@@ -247,6 +276,30 @@ export default function AddPersonScreen() {
         />
         {saving ? <ActivityIndicator color={theme.color.brand} /> : null}
       </ScrollView>
+
+      <Modal visible={pickerOpen} animationType="slide" onRequestClose={() => setPickerOpen(false)}>
+        <Screen edges={['top', 'bottom']}>
+          <View
+            style={{
+              flex: 1,
+              paddingHorizontal: theme.spacing.xl,
+              paddingBottom: theme.spacing.md,
+              gap: theme.spacing.lg,
+            }}
+          >
+            <Row style={{ paddingTop: theme.spacing.md }}>
+              <IconButton label={t.common.close} onPress={() => setPickerOpen(false)}>
+                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+              </IconButton>
+              <View style={{ flex: 1, alignItems: 'center' }}>
+                <Text variant="heading">{t.tabs.fromContacts}</Text>
+              </View>
+              <View style={{ width: 44 }} />
+            </Row>
+            <ContactPicker onConfirm={onPickContact} confirmVerb={t.misc.continueWith} />
+          </View>
+        </Screen>
+      </Modal>
     </Screen>
   );
 }

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -39,7 +39,7 @@ import {
   Row,
   Screen,
   Text,
-  useScreenClearance,
+  useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
@@ -57,7 +57,10 @@ import { plural, useStrings } from '@/i18n';
 
 export default function MergePeopleScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  // This screen renders under the persistent bottom nav (like friends/contacts),
+  // so it needs the tab-bar clearance — the plain screen inset left the Merge
+  // button hidden behind the bar, unreachable by scrolling.
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const queryClient = useQueryClient();
   const { flush } = useSync();

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -231,14 +231,11 @@ export default function MergePeopleScreen() {
               </Card>
 
               {/* The irreversibility, spelled out before the button rather than
-                buried in a toast after the fact. */}
-              <Callout tone="negative">
-                <Text variant="subheading" tone="negative">
-                  {t.mergePeople.warningTitle}
-                </Text>
-                <Text variant="caption" tone="muted">
-                  {t.mergePeople.warningBody}
-                </Text>
+                buried in a toast after the fact. Title + body go through Callout's
+                own props: it wraps children in a single Text, so passing two Text
+                nodes made the heading and body run together as inline spans. */}
+              <Callout tone="negative" title={t.mergePeople.warningTitle}>
+                {t.mergePeople.warningBody}
               </Callout>
 
               {error ? <Callout tone="negative">{error}</Callout> : null}


### PR DESCRIPTION
From a device screenshot + follow-up requests on the Friends flows.

## 1. Merge warning ran together (bug)
"This can't be undone**Their** separate balances…" — heading glued to body. `Callout` wraps `children` in one `<Text>`, so the two `<Text>` nodes passed as children rendered as inline spans. Used `Callout`'s existing `title` prop (stacks the bold line above the body).

## 2. Footer hidden behind the bottom nav (bug)
`friends/merge` and `friends/add-person` render under the persistent bottom nav (sibling `friends/contacts` already accounts for it) but padded the scroll foot with `useScreenClearance()` — system inset only, not the bar. So the **Merge button couldn't be scrolled into view**. Switched both to `useTabBarClearance()`.

## 3. Pick a name from contacts on add-a-person (feature)
The 1:1 IOU screen was type-the-name only. Added a "From contacts" affordance under the name field that opens the existing `ContactPicker` full-screen (in a Modal); the first ticked person fills the name. Address book stays on the device — only the chosen name is read into the field. Single-pick by intent (an IOU is between two people). Capturing the contact's email/phone to pre-fill an invite is a sensible follow-up, out of scope here.

Typecheck + prettier clean; no schema/RPC change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a contact picker to the Add Friend screen, allowing users to select a contact and automatically populate the name field.
  - Added the ability to close the contact picker after making a selection.

- **Bug Fixes**
  - Improved bottom spacing on friend-related screens to account for persistent navigation.
  - Prevented the merge action button from being obscured.
  - Improved presentation of the irreversible-action warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->