### PR TITLE
fix(mobile): reset contact picker between opens on add-person

### DIFF
--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -296,7 +296,15 @@ export default function AddPersonScreen() {
               </View>
               <View style={{ width: 44 }} />
             </Row>
-            <ContactPicker onConfirm={onPickContact} confirmVerb={t.misc.continueWith} />
+            {/* Mounted only while open. ContactPicker keeps the ticked set in
+                its own state, and a React Native Modal keeps its children mounted
+                across a close — so without this gate, reopening the picker shows
+                the last pick still ticked and confirming re-saves that stale
+                person (onPickContact takes the first of the set). Remounting on
+                each open starts it empty. */}
+            {pickerOpen ? (
+              <ContactPicker onConfirm={onPickContact} confirmVerb={t.misc.continueWith} />
+            ) : null}
           </View>
         </Screen>
       </Modal>


### PR DESCRIPTION
## What

The add-person contact picker retained its selection across closes. Pick a contact → confirm → close; reopen → the previous pick is still ticked, and confirming re-saves that stale person (`onPickContact` takes the first of the set).

Root cause: `ContactPicker` holds the ticked set in its own `picked` state, and a React Native `<Modal>` keeps its children mounted when `visible={false}` — so the state never reset.

## Fix

Gate the `ContactPicker` render on `pickerOpen`, so it unmounts on close and remounts with an empty selection on the next open. One-line structural change; typecheck + lint green.

## Review findings — disposition

- **Fixed:** stale-selection on reopen (this change).
- **Skipped — ESLint TS-resolver:** the `@/components/ContactPicker` alias already resolves; lint is green and `contacts.tsx` uses the identical import. No config change needed.
- **Skipped — iOS regression test:** `vitest.config.ts` deliberately scopes unit tests to pure modules ("anything that renders belongs in Maestro"). A reopen-modal render test needs an RN renderer the repo doesn't stand up; the Maestro flow is its correct home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reset contact selections each time the add-person modal is opened.
  * Prevented previously selected contacts from persisting unexpectedly between openings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->