### PR TITLE
perf(mobile): cross-fade tab scenes instead of shift

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -16,9 +16,13 @@ export default function TabsLayout() {
         headerShown: false,
         // The root bar draws the navigation; this one would be a second copy.
         tabBarStyle: { display: 'none' },
-        // Tabs hard-cut without this. Scenes shift-and-fade as you move between
-        // them, honouring the app's motion switch.
-        animation: animated ? 'shift' : 'none',
+        // Tabs hard-cut without this. A plain cross-fade rather than 'shift':
+        // shift slides each scene sideways as well as fading it, and that
+        // horizontal translate is the heaviest work in the tab path — on a busy
+        // tab (the dashboard) it drops frames and the switch reads as sluggish.
+        // Fade keeps a soft transition for the motion switch at a fraction of
+        // the cost; 'none' when motion is off.
+        animation: animated ? 'fade' : 'none',
       }}
     >
       <Tabs.Screen name="index" />


### PR DESCRIPTION
## Why

Tab switches felt sluggish. The bottom-tab scene animation was `shift`, which slides each scene sideways *and* fades it. The horizontal translate is the heaviest work in the tab-switch path; on a busy destination (the dashboard — hero carousel + queries mounting) it drops frames, so the switch reads as slow.

## Change

`(tabs)/_layout.tsx`: scene `animation` `shift` → `fade`. A soft cross-fade that still honours the motion switch at a fraction of the cost. `none` when motion is off, unchanged.

## Note on scope

Reported on a **dev apk + Metro** build, where dev-mode Hermes + Metro instrumentation inflate transition cost well beyond release. This trims the one JS-thread-heavy animation in the tab path, which helps both dev feel and real low-end devices — but the true measure is a release build.

typecheck + lint green. No test pinned `shift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)