### PR TITLE
perf(mobile): remove screen transition animation

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,24 +1,22 @@
 import { Tabs } from 'expo-router';
 
-import { useMotion } from '@/lib/motion';
-
 /**
  * The four tab screens. The bottom bar itself is rendered once at the root
  * (`AppTabBar`) so it stays on every screen, not just these — so this navigator
  * hides its own bar and only owns the scene switching between the tabs.
  */
 export default function TabsLayout() {
-  const { animated } = useMotion();
-
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
         // The root bar draws the navigation; this one would be a second copy.
         tabBarStyle: { display: 'none' },
-        // Tabs hard-cut without this. Scenes shift-and-fade as you move between
-        // them, honouring the app's motion switch.
-        animation: animated ? 'shift' : 'none',
+        // No scene animation: a tab switch cuts straight to the destination.
+        // The animated variants (shift, fade) translate/cross-fade the whole
+        // scene, and on a busy tab that dropped frames and read as slow — an
+        // instant switch is the fastest a tab can feel.
+        animation: 'none',
       }}
     >
       <Tabs.Screen name="index" />

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -333,12 +333,13 @@ function AuthGate() {
   const { animated } = useMotion();
 
   /**
-   * A push slides in from the right and a modal rises from the bottom, which is
-   * how the screen says whether you have gone somewhere or opened something on
-   * top. With motion off, both become `none` — not a faster slide, because a
-   * shortened animation is still animation to somebody who cannot watch one.
+   * Pushes cut straight to the destination — no slide. The slide-from-right was
+   * the most visible transition and the one that read as slow, so a push now
+   * lands instantly; "back" is still carried by the header and the swipe gesture.
+   * A modal still rises from the bottom, because that rise is what says "on top
+   * of" rather than "gone to", and it is cheap; with motion off it too is `none`.
    */
-  const push = animated ? ('slide_from_right' as const) : ('none' as const);
+  const push = 'none' as const;
   const sheet = animated ? ('slide_from_bottom' as const) : ('none' as const);
   const modal = { presentation: 'modal' as const, animation: sheet };
 


### PR DESCRIPTION
## Why

Screen-to-screen navigation felt slow. Two animations drove it:
- bottom-tab scene `shift` — slides each scene sideways as it fades
- push `slide_from_right`

Both animate the whole incoming screen; on a busy destination (the dashboard) that dropped frames and read as sluggish.

## Change

- `(tabs)/_layout.tsx`: scene `animation` → `none` (tab switches cut straight to the destination).
- `_layout.tsx`: `push` → `none` (pushes land instantly). "Back" still carried by the header + swipe gesture (`gestureEnabled` unchanged).

Modals still rise from the bottom — that rise signals "on top of" rather than "gone to", and it's cheap; the motion switch still turns it off.

typecheck + lint green.

## Note

Reported on dev apk + Metro; instant transitions help most there, and are the fastest a switch can feel on any build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)