### PR TITLE
fix(mobile): group realtime crash + leaving a group removes it from the dashboard

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -18,7 +18,7 @@ import {
   Text,
   Toggle,
   useTheme,
-  useScreenClearance,
+  useTabBarClearance,
 } from '@baaki/ui';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
@@ -36,7 +36,10 @@ import { groupLabel } from '@/data/types';
 
 export default function GroupSettingsScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  // This screen renders under the persistent bottom nav, so it must pad for the
+  // bar, not just the system inset — with the plain inset the last row (Leave
+  // group, below Archive) sat behind the bar and could not be reached.
+  const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -575,6 +575,20 @@ export function useGroupLedger(groupId: string, myProfileId: string | null): Gro
 }
 
 /**
+ * A monotonic suffix so each realtime subscription gets its own channel topic.
+ *
+ * `supabase.channel(topic)` returns an *existing* channel when one with that
+ * topic is still registered, and `removeChannel()` is async and fire-and-forget.
+ * So a fast unmount → remount — which is exactly what React does when it freezes
+ * a navigated-away screen and reconnects its effects on return — can hand the
+ * new effect back the previous, still-subscribed channel; adding a
+ * `postgres_changes` callback to an already-subscribed channel throws. A fresh
+ * suffix on every mount sidesteps the reuse: the old channel is torn down by its
+ * own cleanup while the new one is built clean and unsubscribed.
+ */
+let realtimeChannelSeq = 0;
+
+/**
  * Live group channel (TDR §1). Any change to the group's rows pulls the group,
  * so a second device sees an expense without a manual refresh.
  *
@@ -590,7 +604,7 @@ export function useGroupRealtime(groupId: string): void {
     if (!groupId) return;
 
     const channel = supabase
-      .channel(`group:${groupId}`)
+      .channel(`group:${groupId}:${++realtimeChannelSeq}`)
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'expenses', filter: `group_id=eq.${groupId}` },
@@ -1024,9 +1038,16 @@ export function useSetMemberRole(groupId: string) {
 
 export function useLeaveGroup(groupId: string) {
   const queryClient = useQueryClient();
+  const { forgetGroup } = useSync();
   return useMutation({
     mutationFn: leaveGroup,
-    onSuccess: () => invalidateGroup(queryClient, groupId),
+    // Leaving hides the group server-side (RLS), so it can never be pulled again
+    // to signal its removal — the client must forget it locally, or it lingers
+    // on the dashboard forever. Purge the mirror first, then refresh what is left.
+    onSuccess: async () => {
+      await forgetGroup(groupId);
+      invalidateGroup(queryClient, groupId);
+    },
   });
 }
 
@@ -1220,7 +1241,7 @@ export function useItemClaims(receiptId: string | null) {
   useEffect(() => {
     if (!receiptId) return;
     const channel = supabase
-      .channel(`receipt:${receiptId}`)
+      .channel(`receipt:${receiptId}:${++realtimeChannelSeq}`)
       .on(
         'postgres_changes',
         {

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -217,12 +217,22 @@ class SqliteStore implements LocalStore {
     });
   }
 
-  forgetGroup(groupId: string): Promise<void> {
+  forgetGroup(groupId: string, queue: readonly QueuedMutation[]): Promise<void> {
     return this.serial.run(async () => {
       const database = await this.db();
+      // All three in one transaction: the mirror rows, the cursor and the queue
+      // are one fact — "this group is gone" — so a kill between them must not
+      // leave the queue replaying against rows that no longer exist.
       await database.withTransactionAsync(async () => {
         await database.runAsync(`DELETE FROM mirror_rows WHERE group_id = ?`, [groupId]);
         await database.runAsync(`DELETE FROM sync_cursors WHERE group_id = ?`, [groupId]);
+        await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
+        for (const mutation of queue) {
+          await database.runAsync(
+            `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
+            [mutation.clientMutationId, mutation.seq, JSON.stringify(mutation)],
+          );
+        }
       });
     });
   }

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -217,6 +217,16 @@ class SqliteStore implements LocalStore {
     });
   }
 
+  forgetGroup(groupId: string): Promise<void> {
+    return this.serial.run(async () => {
+      const database = await this.db();
+      await database.withTransactionAsync(async () => {
+        await database.runAsync(`DELETE FROM mirror_rows WHERE group_id = ?`, [groupId]);
+        await database.runAsync(`DELETE FROM sync_cursors WHERE group_id = ?`, [groupId]);
+      });
+    });
+  }
+
   reset(): Promise<void> {
     return this.serial.run(async () => {
       const database = await this.db();

--- a/apps/mobile/src/sync/driver.web.ts
+++ b/apps/mobile/src/sync/driver.web.ts
@@ -107,8 +107,13 @@ class AsyncStorageStore implements LocalStore {
     });
   }
 
-  forgetGroup(groupId: string): Promise<void> {
+  forgetGroup(groupId: string, queue: readonly QueuedMutation[]): Promise<void> {
     return this.serial.run(async () => {
+      // AsyncStorage has no cross-key transaction, so web cannot make these three
+      // writes atomic the way SQLite does — but the web store is best-effort by
+      // design (a torn write is rebuilt by the next pull), so consolidating the
+      // three writes here is as far as it goes; a journal would be a new
+      // mechanism for a loss the next sync already heals.
       const rows = await this.read<StoredRow[]>(WEB_KEYS.rows, []);
       await AsyncStorage.setItem(
         WEB_KEYS.rows,
@@ -117,6 +122,7 @@ class AsyncStorageStore implements LocalStore {
       const cursors = await this.read<Record<string, number>>(WEB_KEYS.cursors, {});
       delete cursors[groupId];
       await AsyncStorage.setItem(WEB_KEYS.cursors, JSON.stringify(cursors));
+      await AsyncStorage.setItem(WEB_KEYS.queue, JSON.stringify(queue));
     });
   }
 

--- a/apps/mobile/src/sync/driver.web.ts
+++ b/apps/mobile/src/sync/driver.web.ts
@@ -107,6 +107,19 @@ class AsyncStorageStore implements LocalStore {
     });
   }
 
+  forgetGroup(groupId: string): Promise<void> {
+    return this.serial.run(async () => {
+      const rows = await this.read<StoredRow[]>(WEB_KEYS.rows, []);
+      await AsyncStorage.setItem(
+        WEB_KEYS.rows,
+        JSON.stringify(rows.filter((row) => row.groupId !== groupId)),
+      );
+      const cursors = await this.read<Record<string, number>>(WEB_KEYS.cursors, {});
+      delete cursors[groupId];
+      await AsyncStorage.setItem(WEB_KEYS.cursors, JSON.stringify(cursors));
+    });
+  }
+
   reset(): Promise<void> {
     return this.serial.run(() => AsyncStorage.removeMany(Object.values(WEB_KEYS)));
   }

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -163,8 +163,17 @@ export class SyncEngine {
    * membership, so a left group would sit on the dashboard forever. Leaving is
    * the one change the client applies itself: drop the group's rows, its cursor
    * and any of its still-unsent edits, in memory and on disk together.
+   *
+   * A flush already in flight was started before the leave and may carry this
+   * group's rows in its response; its `reconcile` runs against `this.state`
+   * *after* the network await, so purging first would let that late response
+   * re-add the group we just removed. Wait for it to land before removing, and
+   * because the leave has already committed server-side, any flush that starts
+   * afterwards can no longer see the group (RLS) and cannot bring it back.
    */
   async forgetGroup(groupId: string): Promise<void> {
+    await this.flushing;
+
     const tables = {} as Record<SyncTable, Record<string, MirrorRow>>;
     for (const table of Object.keys(this.state.mirror.tables) as SyncTable[]) {
       const kept: Record<string, MirrorRow> = {};
@@ -181,8 +190,10 @@ export class SyncEngine {
     const queue = this.state.queue.filter((mutation) => mutation.groupId !== groupId);
 
     this.set({ mirror: { tables, cursors }, queue });
-    await this.store.forgetGroup(groupId);
-    await this.store.writeQueue(queue);
+    // One durable step: the group's rows, its cursor and its unsent edits go
+    // together, so a crash cannot leave the queue replaying against a group the
+    // mirror has forgotten.
+    await this.store.forgetGroup(groupId, queue);
   }
 
   /**

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -20,13 +20,13 @@ import {
   markFailed,
   nextBatch,
   reconcile,
+  SyncTable,
   type MirrorRow,
   type MirrorState,
   type MutationEnvelope,
   type QueuedMutation,
   type SyncChange,
   type SyncRejectionCode,
-  type SyncTable,
 } from '@baaki/core';
 
 import { reportHandled } from '@/lib/observability';
@@ -151,6 +151,38 @@ export class SyncEngine {
       lastError: null,
       lastSyncedAt: null,
     });
+  }
+
+  /**
+   * Leaving a group (ADR-006): forget it locally, at once.
+   *
+   * Leaving flips `left_at`, and `is_group_member` gates the group's RLS — so
+   * the moment you leave, a pull can no longer see the group and can never send
+   * the "it is gone" that a soft-delete would. Nothing else would ever drop it
+   * from the mirror, and `materialiseGroups` keys off `archived_at`, not your
+   * membership, so a left group would sit on the dashboard forever. Leaving is
+   * the one change the client applies itself: drop the group's rows, its cursor
+   * and any of its still-unsent edits, in memory and on disk together.
+   */
+  async forgetGroup(groupId: string): Promise<void> {
+    const tables = {} as Record<SyncTable, Record<string, MirrorRow>>;
+    for (const table of Object.keys(this.state.mirror.tables) as SyncTable[]) {
+      const kept: Record<string, MirrorRow> = {};
+      for (const [id, row] of Object.entries(this.state.mirror.tables[table])) {
+        // The groups row is the group itself (keyed by its id); every other
+        // table's rows carry the group they belong to.
+        const belongs = table === SyncTable.Groups ? id === groupId : row.group_id === groupId;
+        if (!belongs) kept[id] = row;
+      }
+      tables[table] = kept;
+    }
+    const cursors = { ...this.state.mirror.cursors };
+    delete cursors[groupId];
+    const queue = this.state.queue.filter((mutation) => mutation.groupId !== groupId);
+
+    this.set({ mirror: { tables, cursors }, queue });
+    await this.store.forgetGroup(groupId);
+    await this.store.writeQueue(queue);
   }
 
   /**

--- a/apps/mobile/src/sync/provider.tsx
+++ b/apps/mobile/src/sync/provider.tsx
@@ -38,6 +38,8 @@ interface SyncContextValue extends SyncState {
   flush: (groupIds?: string[]) => Promise<void>;
   retry: (clientMutationId: string) => Promise<void>;
   discard: (clientMutationId: string) => Promise<void>;
+  /** Forget a group locally after leaving it — see `SyncEngine.forgetGroup`. */
+  forgetGroup: (groupId: string) => Promise<void>;
   /** True when there is unsent work — the UI says "syncing" rather than lying. */
   pendingCount: number;
 }
@@ -133,6 +135,7 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       flush: (groupIds?: string[]) => syncEngine.flush({ groupIds }),
       retry: (id: string) => syncEngine.retry(id),
       discard: (id: string) => syncEngine.discard(id),
+      forgetGroup: (groupId: string) => syncEngine.forgetGroup(groupId),
       pendingCount: state.queue.length,
     }),
     [state, mutate],

--- a/apps/mobile/src/sync/store.ts
+++ b/apps/mobile/src/sync/store.ts
@@ -37,11 +37,14 @@ export interface LocalStore {
   clearDraft(key: string): Promise<void>;
   listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]>;
   /**
-   * Drop every mirror row and cursor for one group. Leaving a group hides it
-   * server-side (RLS), so a pull can never again report it — the client has to
-   * forget it locally or it lingers on the dashboard forever.
+   * Drop every mirror row and cursor for one group, and replace the queue with
+   * `queue` (the group's still-unsent edits removed), as one durable step.
+   * Leaving a group hides it server-side (RLS), so a pull can never again report
+   * it — the client has to forget it locally or it lingers on the dashboard
+   * forever, and a half-applied purge would leave the queue replaying against a
+   * group the mirror no longer has.
    */
-  forgetGroup(groupId: string): Promise<void>;
+  forgetGroup(groupId: string, queue: readonly QueuedMutation[]): Promise<void>;
   /** Signing out must leave nothing of the previous account behind. */
   reset(): Promise<void>;
 }

--- a/apps/mobile/src/sync/store.ts
+++ b/apps/mobile/src/sync/store.ts
@@ -36,6 +36,12 @@ export interface LocalStore {
   writeDraft(key: string, value: unknown): Promise<void>;
   clearDraft(key: string): Promise<void>;
   listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]>;
+  /**
+   * Drop every mirror row and cursor for one group. Leaving a group hides it
+   * server-side (RLS), so a pull can never again report it — the client has to
+   * forget it locally or it lingers on the dashboard forever.
+   */
+  forgetGroup(groupId: string): Promise<void>;
   /** Signing out must leave nothing of the previous account behind. */
   reset(): Promise<void>;
 }

--- a/apps/mobile/test/syncEngine.test.ts
+++ b/apps/mobile/test/syncEngine.test.ts
@@ -69,11 +69,12 @@ vi.mock('../src/sync/store', () => ({
     writeDraft: async () => {},
     clearDraft: async () => {},
     listDrafts: async () => [],
-    forgetGroup: async (groupId: string) => {
+    forgetGroup: async (groupId: string, queue: QueuedMutation[]) => {
       for (const [key, row] of [...h.disk.rows]) {
         if (row.groupId === groupId) h.disk.rows.delete(key);
       }
       delete h.disk.cursors[groupId];
+      h.disk.queue = [...queue];
     },
     reset: async () => {
       h.disk.rows.clear();
@@ -285,5 +286,55 @@ describe('leaving a group forgets it locally', () => {
 
     expect(groupIds(relaunched.getState().mirror)).toEqual(['g-two']);
     expect(relaunched.getState().queue.map((m) => m.clientMutationId)).toEqual(['x-two']);
+
+    // Persisted, not just in memory: a third launch hydrates only x-two, so the
+    // departed group's unsent edit is gone from disk and never replays.
+    const thirdLaunch = new SyncEngine();
+    await thirdLaunch.hydrate();
+    expect(thirdLaunch.getState().queue.map((m) => m.clientMutationId)).toEqual(['x-two']);
+  });
+
+  it('is not undone by a flush that was already in flight when it ran', async () => {
+    online();
+    // The group is on disk and known before the leave.
+    h.disk.rows.set('groups:g-goa', {
+      table: 'groups',
+      id: 'g-goa',
+      groupId: 'g-goa',
+      seq: 1,
+      row: {
+        id: 'g-goa',
+        name: 'Goa Trip',
+        default_currency: 'INR',
+        created_at: '2026-08-01T00:00:00.000Z',
+        archived_at: null,
+      },
+    });
+    h.disk.cursors = { 'g-goa': 2 };
+    const engine = new SyncEngine();
+    await engine.hydrate();
+    expect(groupIds(engine.getState().mirror)).toEqual(['g-goa']);
+
+    // A flush is in flight, its response held open — it still carries the
+    // group's rows, the way a pull that raced the leave would.
+    let land: (value: unknown) => void = () => {};
+    h.invoke.mockReturnValueOnce(
+      new Promise((resolve) => {
+        land = resolve;
+      }),
+    );
+    const flushing = engine.flush();
+
+    // Leaving now: forgetGroup must wait for that flush rather than purge into
+    // its teeth. Kick it off, then let the flush land carrying g-goa.
+    const forgetting = engine.forgetGroup('g-goa');
+    land({ data: discoveryResponse(), error: null });
+    await Promise.all([flushing, forgetting]);
+
+    // The late response did not resurrect it — in memory or on disk.
+    expect(groupIds(engine.getState().mirror)).toEqual([]);
+    const relaunched = new SyncEngine();
+    await relaunched.hydrate();
+    expect(groupIds(relaunched.getState().mirror)).toEqual([]);
   });
 });

--- a/apps/mobile/test/syncEngine.test.ts
+++ b/apps/mobile/test/syncEngine.test.ts
@@ -69,6 +69,12 @@ vi.mock('../src/sync/store', () => ({
     writeDraft: async () => {},
     clearDraft: async () => {},
     listDrafts: async () => [],
+    forgetGroup: async (groupId: string) => {
+      for (const [key, row] of [...h.disk.rows]) {
+        if (row.groupId === groupId) h.disk.rows.delete(key);
+      }
+      delete h.disk.cursors[groupId];
+    },
     reset: async () => {
       h.disk.rows.clear();
       h.disk.cursors = {};
@@ -209,5 +215,75 @@ describe('runFlush once groups are already known', () => {
     expect(h.invoke).toHaveBeenCalledTimes(1);
     const [, options] = h.invoke.mock.calls[0] as [string, { body: Record<string, unknown> }];
     expect(options.body.cursors).toEqual({ 'g-goa': 2 });
+  });
+});
+
+describe('leaving a group forgets it locally', () => {
+  it('drops the group from the mirror and disk so it never comes back', async () => {
+    online();
+    h.invoke.mockResolvedValue({ data: discoveryResponse(), error: null });
+
+    const engine = new SyncEngine();
+    await engine.flush();
+    expect(groupIds(engine.getState().mirror)).toEqual(['g-goa']);
+
+    await engine.forgetGroup('g-goa');
+
+    // Gone from memory: the group row, its members, and its cursor.
+    expect(groupIds(engine.getState().mirror)).toEqual([]);
+    expect(engine.getState().mirror.tables.group_members['m-me']).toBeUndefined();
+    expect(engine.getState().mirror.cursors['g-goa']).toBeUndefined();
+
+    // And gone from disk, which is the whole point: leaving hides the group
+    // server-side (RLS), so a pull can never again report it — only forgetting
+    // it locally stops a relaunch from hydrating the stale group back onto Home.
+    const relaunched = new SyncEngine();
+    await relaunched.hydrate();
+    expect(groupIds(relaunched.getState().mirror)).toEqual([]);
+  });
+
+  it('discards that group’s still-unsent edits but keeps other groups', async () => {
+    online();
+    h.invoke.mockResolvedValue({ data: discoveryResponse(), error: null });
+    const engine = new SyncEngine();
+    await engine.flush();
+
+    // A second group on disk, and a queued edit for each — leaving g-goa must
+    // take only its own unsent work with it.
+    h.disk.rows.set('groups:g-two', {
+      table: 'groups',
+      id: 'g-two',
+      groupId: 'g-two',
+      seq: 1,
+      row: {
+        id: 'g-two',
+        name: 'Flat',
+        default_currency: 'INR',
+        created_at: '2026-08-02T00:00:00.000Z',
+        archived_at: null,
+      },
+    });
+    h.disk.cursors['g-two'] = 1;
+    const relaunched = new SyncEngine();
+    await relaunched.hydrate();
+    await relaunched.enqueue({
+      clientMutationId: 'x-goa',
+      kind: 'group.update' as never,
+      groupId: 'g-goa',
+      clientCreatedAt: '2026-08-09T00:00:00.000Z',
+      payload: { name: 'renamed' },
+    });
+    await relaunched.enqueue({
+      clientMutationId: 'x-two',
+      kind: 'group.update' as never,
+      groupId: 'g-two',
+      clientCreatedAt: '2026-08-09T00:00:00.000Z',
+      payload: { name: 'renamed too' },
+    });
+
+    await relaunched.forgetGroup('g-goa');
+
+    expect(groupIds(relaunched.getState().mirror)).toEqual(['g-two']);
+    expect(relaunched.getState().queue.map((m) => m.clientMutationId)).toEqual(['x-two']);
   });
 });

--- a/e2e/leave-group.yaml
+++ b/e2e/leave-group.yaml
@@ -1,0 +1,42 @@
+# Maestro flow (ADR-014): leaving a group removes it from the dashboard.
+#
+# Regression guard for the bug where a left group lingered on Home forever.
+# Leaving flips `left_at`, which `is_group_member` gates the group's RLS on, so
+# the server can never pull the group again to signal it is gone — the client
+# has to forget it locally (`SyncEngine.forgetGroup`, covered as a unit test in
+# apps/mobile/test/syncEngine.test.ts). This is the on-device half: leave, and
+# assert the group is no longer on Home even after a relaunch.
+#
+# Precondition: the seeded "Goa trip" is settled for the acting member (leaving
+# is refused while a balance is open — that guard has its own copy). If the seed
+# carries an open balance, settle it first with the settle flow.
+appId: app.baaki.mobile
+---
+- launchApp:
+    clearState: true
+
+# Home shows the group
+- assertVisible: 'Your groups'
+- assertVisible: 'Goa trip'
+
+# Into the group, then its settings
+- tapOn: 'Goa trip'
+- tapOn: 'Settings'
+- assertVisible: 'Members'
+
+# The Leave button sits below Archive at the very bottom, under the tab bar —
+# scroll it into reach (the clearance this flow also guards) and confirm.
+- scrollUntilVisible:
+    element: 'Leave group'
+    direction: DOWN
+- tapOn: 'Leave group'
+- tapOn: 'Leave'
+
+# Back on Home, the group is gone
+- assertVisible: 'Your groups'
+- assertNotVisible: 'Goa trip'
+
+# And it stays gone across a relaunch — the mirror forgot it, so hydrate cannot
+# bring the stale group back (the whole point of the fix).
+- launchApp
+- assertNotVisible: 'Goa trip'


### PR DESCRIPTION
Three group bugs hit while navigating and leaving a group.

## 1. Realtime render crash
`useGroupRealtime` / `useItemClaims` built a channel with a fixed topic (`group:<id>`). `supabase.channel(topic)` returns an **existing** channel when one is still registered, and `removeChannel()` is async and fire-and-forget — so when React freezes a navigated-away screen and reconnects its effects on return, the new effect is handed the previous, **still-subscribed** channel, and adding a `postgres_changes` callback to a subscribed channel throws:

> cannot add `postgres_changes` callbacks for realtime:group:… after `subscribe()`

Fix: a monotonic suffix per subscription — every mount gets its own topic, so the old channel is torn down by its own cleanup while the new one is built clean.

## 2. Leaving a group left it on the dashboard forever
Leaving flips `left_at`, and `is_group_member` gates the group's RLS — so the moment you leave, a pull can no longer see the group and can **never** send the "it is gone" a soft-delete would. Nothing removed it from the local mirror, and `materialiseGroups` filters on `archived_at`, not your membership.

Fix: `SyncEngine.forgetGroup` (backed by `LocalStore.forgetGroup` on both the SQLite and web drivers) drops the group's rows, its cursor, and any still-unsent edits — in memory and on disk. `useLeaveGroup` calls it on success.

_(Archiving already worked: it rides the queue overlay and is pulled back with `archived_at` set. Verified by inspection + a core unit check.)_

## 3. The Leave button was unreachable
Group settings renders under the persistent bottom nav but padded with `useScreenClearance` (system inset only), so the last row — Leave, below Archive — sat behind the bar (see the screenshot report). `useTabBarClearance` pads for the bar.

## Tests
- `SyncEngine.forgetGroup` unit tests: forgets in memory **and** on disk so a relaunch can't resurrect the group; discards only that group's unsent edits, keeps others.
- Maestro `e2e/leave-group.yaml`: leave → gone from Home → still gone after relaunch. (Maestro CI job is `if: false`, so this is an artifact, not a gate.)

Full mobile suite: 269 pass. typecheck + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Leaving a group now fully removes its local data and pending changes, so it does not reappear after restarting the app.
  * Realtime updates remain reliable when screens are revisited.
  * Group settings actions remain accessible above the persistent tab bar.

* **Tests**
  * Added coverage for group removal, app relaunch behavior, and preserving data from other groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->