### PR TITLE
fix(sync): disambiguate group_members→profiles embed after ghost_merges

### DIFF
--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -46,9 +46,12 @@ const GROUP_SELECT = `
   archived_at, created_at
 `;
 
+// profiles is embedded by its FK column (profile_id): ghost_merges references
+// both group_members and profiles, so PostgREST sees two group_members↔profiles
+// relationships and an unqualified embed fails ("more than one relationship").
 const MEMBER_SELECT = `
   id, group_id, profile_id, ghost_name, role, vpa, payment_rail, payment_handle, left_at,
-  profile:profiles ( id, display_name, avatar_url, default_vpa, payment_rail, payment_handle )
+  profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa, payment_rail, payment_handle )
 `;
 
 const EXPENSE_SELECT = `
@@ -128,7 +131,7 @@ export async function fetchActivity(groupId: string, limit = 50): Promise<Activi
       .select(
         `id, group_id, actor_member_id, verb, object_type, object_id, payload, created_at,
          actor:group_members!activity_log_actor_member_id_fkey (
-           id, profile_id, ghost_name, profile:profiles ( display_name )
+           id, profile_id, ghost_name, profile:profiles!profile_id ( display_name )
          )`,
       )
       .eq('group_id', groupId)
@@ -148,7 +151,7 @@ export async function fetchRecentActivity(
         `id, group_id, actor_member_id, verb, object_type, object_id, payload, created_at,
          group:groups ( id, name, cover_emoji ),
          actor:group_members!activity_log_actor_member_id_fkey (
-           id, profile_id, ghost_name, profile:profiles ( display_name )
+           id, profile_id, ghost_name, profile:profiles!profile_id ( display_name )
          )`,
       )
       .order('created_at', { ascending: false })
@@ -246,7 +249,7 @@ export async function fetchMembersByGroup(): Promise<Map<string, MemberRow[]>> {
     await supabase
       .from('group_members')
       .select(
-        'id, group_id, profile_id, ghost_name, role, vpa, left_at, invite_email, invite_phone, profile:profiles ( id, display_name, avatar_url, default_vpa )',
+        'id, group_id, profile_id, ghost_name, role, vpa, left_at, invite_email, invite_phone, profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa )',
       )
       .is('left_at', null)
       .order('created_at', { ascending: true }),

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -39,21 +39,24 @@ const GROUP_ROW_COLUMNS = `
   start_date, end_date, archived_at, created_at
 `;
 
+// profiles is embedded by its FK column (profile_id): ghost_merges references
+// both group_members and profiles, so PostgREST sees two group_members↔profiles
+// relationships and an unqualified embed fails ("more than one relationship").
 const MEMBER_ROW_COLUMNS = `
   id, group_id, profile_id, ghost_name, role, vpa, left_at,
-  profile:profiles ( id, display_name, avatar_url, default_vpa )
+  profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa )
 `;
 
 const ACTIVITY_COLUMNS = `
   id, group_id, actor_member_id, verb, object_type, object_id, payload, created_at,
   actor:group_members!activity_log_actor_member_id_fkey (
-    id, profile_id, ghost_name, profile:profiles ( display_name )
+    id, profile_id, ghost_name, profile:profiles!profile_id ( display_name )
   )
 `;
 
 const MEMBER_COLUMNS = `
   id, group_id, profile_id, ghost_name, left_at, role,
-  profile:profiles ( display_name )
+  profile:profiles!profile_id ( display_name )
 `;
 
 const EXPENSE_COLUMNS = `

--- a/supabase/functions/export-data/index.ts
+++ b/supabase/functions/export-data/index.ts
@@ -70,7 +70,9 @@ serveWithCors(async (request) => {
         service.from('groups').select('*').eq('id', groupId).single(),
         service
           .from('group_members')
-          .select('*, profile:profiles ( display_name )')
+          // Hint the FK column: ghost_merges bridges group_members and profiles,
+          // so an unqualified profiles embed is ambiguous.
+          .select('*, profile:profiles!profile_id ( display_name )')
           .eq('group_id', groupId),
         service
           .from('expenses')

--- a/supabase/functions/invite-accept/index.ts
+++ b/supabase/functions/invite-accept/index.ts
@@ -81,7 +81,9 @@ serveWithCors(async (request) => {
 
     const { data: members } = await service
       .from('group_members')
-      .select('id, ghost_name, profile_id, profiles ( display_name )')
+      // FK-hinted: ghost_merges bridges group_members and profiles, so the embed
+      // is ambiguous without naming the column.
+      .select('id, ghost_name, profile_id, profiles!profile_id ( display_name )')
       .eq('group_id', invite.group_id)
       .is('left_at', null);
 

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -759,7 +759,13 @@ async function pull(
     }
 
     for (const [table, select] of [
-      ['group_members', '*, profile:profiles ( id, display_name, avatar_url, default_vpa )'],
+      // profiles is embedded by the explicit FK column: ghost_merges references
+      // both group_members and profiles, so PostgREST otherwise sees two
+      // group_members↔profiles relationships and refuses to guess.
+      [
+        'group_members',
+        '*, profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa )',
+      ],
       ['expenses', EXPENSE_SELECT],
       ['settlements', SETTLEMENT_SELECT],
       ['activity_log', '*'],


### PR DESCRIPTION
## Regression

Deploying the merge migrations added the `ghost_merges` table, which has FKs to **both** `group_members` (member_id) and `profiles` (owner). PostgREST now resolves **two** `group_members↔profiles` relationships:

- direct: `group_members.profile_id → profiles`
- many-to-many via `ghost_merges`

So every unqualified `profiles` embed on `group_members` fails with `PGRST201` — *"more than one relationship was found for 'group_members' and 'profiles'"*. On device this showed as **`PULL_FAILED: group_members: Could not embed…`** — sync fully broken.

## Fix

Hint the FK column on all such embeds: `profile:profiles!profile_id ( … )`. PostgREST then uses the direct relationship.

**Verified against prod REST:**
- `select=id,profile:profiles!profile_id(display_name)` → resolves (`[]` under anon RLS)
- `select=id,profiles(display_name)` → `PGRST201` listing both the direct FK and the `ghost_merges` m2m

## Sites

- Edge (deployed to prod already): `sync`, `export-data`, `invite-accept`
- Mobile `api.ts`: `MEMBER_SELECT`, both activity queries, `fetchMembersByGroup`
- Shared `packages/api-client/client.ts`: member + activity columns

## Verification

- `pnpm -r typecheck` — clean
- `pnpm format:check` — clean
- Live prod REST probe (above)

The edge fixes are **live now** (sync unblocked on-device); the client fixes reach devices with the next OTA/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)