### PR TITLE
feat(mobile): add-person — single-pick contacts, identity-led card, note mic

### DIFF
--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -22,6 +22,7 @@ import { ActivityIndicator, Modal, Pressable, ScrollView, TextInput, View } from
 
 import {
   AmountField,
+  Avatar,
   Button,
   Callout,
   Card,
@@ -36,6 +37,7 @@ import {
 } from '@baaki/ui';
 
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
+import { DictateButton } from '@/components/DictateButton';
 import { useAddGhostMember, useCreateGroup, useWriteExpense } from '@/data/hooks';
 import { GroupType } from '@/data/types';
 import { deviceDefaultCurrency, useStrings } from '@/i18n';
@@ -168,42 +170,40 @@ export default function AddPersonScreen() {
           {t.addPerson.subtitle}
         </Text>
 
-        <Card style={{ gap: theme.spacing.xs }}>
-          <Text variant="caption" tone="muted">
-            {t.addPerson.nameLabel}
-          </Text>
-          <TextInput
-            value={name}
-            onChangeText={setName}
-            accessibilityLabel={t.addPerson.nameLabel}
-            placeholder={t.addPerson.namePlaceholder}
-            placeholderTextColor={theme.color.textFaint}
-            autoFocus
-            style={{
-              fontSize: 20,
-              fontWeight: '700',
-              color: theme.color.text,
-              paddingVertical: theme.spacing.sm,
-            }}
-          />
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.tabs.fromContacts}
+        {/* The person is the subject of this screen, so the card leads with
+            them: an avatar that fills in with the name's own colour and initial
+            as it is typed, the name as the field beside it, and picking from
+            contacts as a real button rather than a footnote link. */}
+        <Card style={{ gap: theme.spacing.lg }}>
+          <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+            <Avatar name={name.trim() || '?'} size={56} ghost />
+            <View style={{ flex: 1, gap: theme.spacing.xs }}>
+              <Text variant="caption" tone="muted">
+                {t.addPerson.nameLabel}
+              </Text>
+              <TextInput
+                value={name}
+                onChangeText={setName}
+                accessibilityLabel={t.addPerson.nameLabel}
+                placeholder={t.addPerson.namePlaceholder}
+                placeholderTextColor={theme.color.textFaint}
+                autoFocus
+                style={{
+                  fontSize: 20,
+                  fontWeight: '700',
+                  color: theme.color.text,
+                  paddingVertical: theme.spacing.xs,
+                }}
+              />
+            </View>
+          </Row>
+          <Button
+            label={t.tabs.fromContacts}
+            variant="secondary"
+            size="sm"
+            fullWidth
             onPress={() => setPickerOpen(true)}
-            style={({ pressed }) => ({
-              flexDirection: 'row',
-              alignItems: 'center',
-              gap: theme.spacing.xs,
-              alignSelf: 'flex-start',
-              paddingVertical: theme.spacing.xs,
-              opacity: pressed ? 0.6 : 1,
-            })}
-          >
-            <Ionicons name="person-add-outline" size={iconSize.sm} color={theme.color.brand} />
-            <Text variant="caption" style={{ color: theme.color.brand }}>
-              {t.tabs.fromContacts}
-            </Text>
-          </Pressable>
+          />
         </Card>
 
         <View style={{ gap: theme.spacing.sm }}>
@@ -258,14 +258,29 @@ export default function AddPersonScreen() {
           <Text variant="caption" tone="muted">
             {t.addPerson.noteLabel}
           </Text>
-          <TextInput
-            value={note}
-            onChangeText={setNote}
-            accessibilityLabel={t.addPerson.noteLabel}
-            placeholder={t.addPerson.notePlaceholder}
-            placeholderTextColor={theme.color.textFaint}
-            style={{ fontSize: 16, color: theme.color.text, paddingVertical: theme.spacing.sm }}
-          />
+          <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+            <TextInput
+              value={note}
+              onChangeText={setNote}
+              accessibilityLabel={t.addPerson.noteLabel}
+              placeholder={t.addPerson.notePlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              style={{
+                flex: 1,
+                fontSize: 16,
+                color: theme.color.text,
+                paddingVertical: theme.spacing.sm,
+              }}
+            />
+            {/* Speak the note instead of typing it — the same mic the expense
+                description has. The person's name is handed to the recogniser as
+                a hint, since a name is exactly what a general model mishears. */}
+            <DictateButton
+              value={note}
+              onChange={setNote}
+              hints={name.trim() ? [name.trim()] : undefined}
+            />
+          </Row>
         </Card>
 
         {error ? <Callout tone="negative">{error}</Callout> : null}
@@ -306,7 +321,9 @@ export default function AddPersonScreen() {
                 person (onPickContact takes the first of the set). Remounting on
                 each open starts it empty. */}
             {pickerOpen ? (
-              <ContactPicker onConfirm={onPickContact} confirmVerb={t.misc.continueWith} />
+              // Single-pick: a one-to-one IOU has room for exactly one name, so
+              // a tap chooses that person and closes the sheet.
+              <ContactPicker single onConfirm={onPickContact} confirmVerb={t.misc.continueWith} />
             ) : null}
           </View>
         </Screen>

--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -16,9 +16,12 @@
 
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { Image } from 'expo-image';
 import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
 import { ActivityIndicator, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
+
+import { parseReceiptText, type HeuristicReceipt } from '@baaki/core';
 
 import {
   AmountField,
@@ -42,7 +45,12 @@ import { useAddGhostMember, useCreateGroup, useWriteExpense } from '@/data/hooks
 import { GroupType } from '@/data/types';
 import { deviceDefaultCurrency, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { useBackup } from '@/lib/cloud/BackupProvider';
+import { captureReceipt, type PickedImage } from '@/lib/image';
 import { useGuestGuard } from '@/lib/guestGuard';
+import { recogniseReceipt } from '@/lib/ocr';
+import { markPending } from '@/lib/receiptIndex';
+import { saveReceipt } from '@/lib/receiptStore';
 
 type Direction = 'theyOwe' | 'iOwe';
 
@@ -72,6 +80,7 @@ export default function AddPersonScreen() {
   const createGroup = useCreateGroup();
   const addGhost = useAddGhostMember(groupId);
   const writeExpense = useWriteExpense(groupId);
+  const backup = useBackup();
 
   const currency = deviceDefaultCurrency();
   const [name, setName] = useState('');
@@ -81,6 +90,48 @@ export default function AddPersonScreen() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
+
+  // A receipt for the IOU. The photo is read on the phone (A5); the merchant
+  // prefills the note, and the image and its OCR text are kept in the device
+  // vault + your own cloud — never uploaded to Baaki (the receipt-scan privacy
+  // choice). Keyed by an id chosen up front so the vault path is stable.
+  const [receiptId] = useState(() => randomUUID());
+  const [photo, setPhoto] = useState<PickedImage | null>(null);
+  const [rawText, setRawText] = useState<string | null>(null);
+  const [parsed, setParsed] = useState<HeuristicReceipt | null>(null);
+  const [scanning, setScanning] = useState(false);
+
+  /**
+   * Photograph the bill and keep it. On-device OCR reads the text so it can
+   * travel with the expense; the heuristic parser pulls the merchant to prefill
+   * the note. The amount stays yours to type — reading a trustworthy total needs
+   * the metered server parser, which needs a group this screen has not made yet.
+   */
+  const addReceipt = async (): Promise<void> => {
+    setError(null);
+    let picked: PickedImage | null = null;
+    try {
+      picked = await captureReceipt();
+    } catch {
+      picked = null;
+    }
+    if (!picked) return;
+
+    setPhoto(picked);
+    setScanning(true);
+    try {
+      const recognised = await recogniseReceipt(picked.uri);
+      setRawText(recognised?.text ?? null);
+      const receipt = recognised ? parseReceiptText(recognised.text, { currency }) : null;
+      setParsed(receipt);
+      if (receipt?.merchant && note.trim().length === 0) setNote(receipt.merchant);
+    } catch {
+      setRawText(null);
+      setParsed(null);
+    } finally {
+      setScanning(false);
+    }
+  };
 
   // Pull the name straight off a contact instead of typing it. This is a 1:1
   // IOU, so only the first ticked person is used; the address book never leaves
@@ -129,6 +180,31 @@ export default function AddPersonScreen() {
         payers: { [payerId]: amount },
         splitParams: { kind: 'exact', amounts: { [debtorId]: amount, [payerId]: 0n } },
       });
+
+      // Keep the receipt image on the device and, if a personal cloud is
+      // connected, queue it there — it is never uploaded to Baaki. The photo and
+      // its OCR text stay in the vault sidecar; only the amount and note reached
+      // the expense (A5, receipt-scan privacy).
+      if (photo) {
+        const saved = saveReceipt(receiptId, {
+          base64: photo.base64,
+          sidecar: {
+            captureId: receiptId,
+            currency,
+            amountMinor: Number(amount),
+            itemCount: parsed?.items.length ?? 0,
+            items: (parsed?.items ?? []).map((item) => ({ label: item.label, total: item.total })),
+            date: today(),
+            category: null,
+            rawText,
+            createdAt: new Date().toISOString(),
+          },
+        });
+        if (saved) {
+          await markPending(receiptId, saved, new Date().toISOString());
+          void backup.kick();
+        }
+      }
 
       // All three writes went through the offline queue, which updates the mirror
       // synchronously — the now-local Friends list already shows the new person,
@@ -281,6 +357,35 @@ export default function AddPersonScreen() {
               hints={name.trim() ? [name.trim()] : undefined}
             />
           </Row>
+        </Card>
+
+        {/* The bill, for when pointing a camera beats typing. The photo is kept
+            on the device (and your own cloud), never on Baaki; its text is read
+            here and rides the expense, and the merchant prefills the note. */}
+        <Card style={{ gap: theme.spacing.md }}>
+          <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text variant="subheading">{t.captures.receipt}</Text>
+            <Button
+              label={t.captures.addReceipt}
+              variant="secondary"
+              size="sm"
+              disabled={scanning || saving}
+              onPress={() => void addReceipt()}
+              icon={<Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />}
+            />
+          </Row>
+          {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
+          {photo ? (
+            <Image
+              source={{ uri: photo.uri }}
+              style={{ width: '100%', height: 160, borderRadius: theme.radius.md }}
+              contentFit="cover"
+              transition={150}
+            />
+          ) : null}
+          {photo && parsed && parsed.items.length === 0 ? (
+            <Callout tone="info">{t.captures.couldNotRead}</Callout>
+          ) : null}
         </Card>
 
         {error ? <Callout tone="negative">{error}</Callout> : null}

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -385,6 +385,10 @@ export function ContactPicker({
                     contact={item}
                     already={already}
                     single={single}
+                    // Single-pick confirms on the tap, so `busy` has no button to
+                    // disable — it has to lock the rows themselves, or a second
+                    // tap fires a second confirm while the first is still writing.
+                    disabled={single && busy}
                     selected={single ? false : picked.has(key)}
                     onPress={() => (single ? onConfirm([item]) : toggle(key, item))}
                   />
@@ -470,31 +474,37 @@ function ContactRow({
   already,
   selected,
   single = false,
+  disabled = false,
   onPress,
 }: {
   contact: PickedContact;
   already: boolean;
   selected: boolean;
   single?: boolean;
+  /** Locked for a reason other than membership (a single-pick write in flight). */
+  disabled?: boolean;
   onPress: () => void;
 }): React.JSX.Element {
   const theme = useTheme();
   const { t } = useStrings();
   const inset = theme.spacing.lg + 40 + theme.spacing.md;
+  // `already` is one reason a row is inert (and the only one that renames the
+  // subtitle); `disabled` is the other. Both dim and deafen the row the same way.
+  const locked = already || disabled;
 
   return (
     <Pressable
-      onPress={already ? undefined : onPress}
-      disabled={already}
+      onPress={locked ? undefined : onPress}
+      disabled={locked}
       // Single-pick is a choose-one list, so each row is a radio button that
       // acts on the tap; multi keeps the checkbox it fills and unfills.
       accessibilityRole={single ? 'button' : 'checkbox'}
-      accessibilityState={single ? { disabled: already } : { checked: selected, disabled: already }}
+      accessibilityState={single ? { disabled: locked } : { checked: selected, disabled: locked }}
       accessibilityLabel={
         already ? t.pickers.alreadyAddedName.replace('{name}', contact.name) : contact.name
       }
       style={({ pressed }) => ({
-        opacity: already ? 0.45 : 1,
+        opacity: locked ? 0.45 : 1,
         backgroundColor: pressed ? theme.color.surfaceMuted : theme.color.surface,
       })}
     >

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -33,7 +33,17 @@ import {
   type LayoutChangeEvent,
 } from 'react-native';
 
-import { Avatar, Button, Card, EmptyState, iconSize, Row, Text, useTheme } from '@baaki/ui';
+import {
+  Avatar,
+  Button,
+  Card,
+  directionalIcon,
+  EmptyState,
+  iconSize,
+  Row,
+  Text,
+  useTheme,
+} from '@baaki/ui';
 
 import { plural, useStrings } from '@/i18n';
 import { SkeletonList } from '@/components/Skeletons';
@@ -56,6 +66,13 @@ interface ContactPickerProps {
   confirmVerb?: string;
   /** Disables confirming while the caller is still writing the last lot away. */
   busy?: boolean;
+  /**
+   * Pick exactly one. A tap confirms that person there and then — no ticking, no
+   * strip, no confirm button — because a one-to-one IOU has room for a single
+   * name and asking someone to tick one then press a button is a step invented
+   * for a list that only ever wanted one answer.
+   */
+  single?: boolean;
 }
 
 /**
@@ -105,6 +122,7 @@ export function ContactPicker({
   initialSelected,
   confirmVerb,
   busy = false,
+  single = false,
 }: ContactPickerProps): React.JSX.Element {
   const theme = useTheme();
   const { t, locale } = useStrings();
@@ -320,7 +338,7 @@ export function ContactPicker({
         ) : null}
       </View>
 
-      {chosen.length > 0 ? <PickedStrip chosen={chosen} onRemove={toggle} /> : null}
+      {!single && chosen.length > 0 ? <PickedStrip chosen={chosen} onRemove={toggle} /> : null}
 
       {matches.length === 0 ? (
         <EmptyState
@@ -366,8 +384,9 @@ export function ContactPicker({
                   <ContactRow
                     contact={item}
                     already={already}
-                    selected={picked.has(key)}
-                    onPress={() => toggle(key, item)}
+                    single={single}
+                    selected={single ? false : picked.has(key)}
+                    onPress={() => (single ? onConfirm([item]) : toggle(key, item))}
                   />
                 );
               }}
@@ -393,16 +412,20 @@ export function ContactPicker({
         {t.pickers.onlyPickedAreSent}
       </Text>
 
-      <Button
-        label={
-          chosen.length === 0
-            ? t.pickers.nobodyPickedYet
-            : `${confirmVerb ?? t.add} ${plural(locale, chosen.length, t.pickers.personCount)}`
-        }
-        fullWidth
-        disabled={chosen.length === 0 || busy}
-        onPress={() => onConfirm(chosen)}
-      />
+      {/* Single-pick confirms on the tap itself, so there is no set to send and
+          no button to send it — the row is the action. */}
+      {single ? null : (
+        <Button
+          label={
+            chosen.length === 0
+              ? t.pickers.nobodyPickedYet
+              : `${confirmVerb ?? t.add} ${plural(locale, chosen.length, t.pickers.personCount)}`
+          }
+          fullWidth
+          disabled={chosen.length === 0 || busy}
+          onPress={() => onConfirm(chosen)}
+        />
+      )}
     </View>
   );
 }
@@ -446,11 +469,13 @@ function ContactRow({
   contact,
   already,
   selected,
+  single = false,
   onPress,
 }: {
   contact: PickedContact;
   already: boolean;
   selected: boolean;
+  single?: boolean;
   onPress: () => void;
 }): React.JSX.Element {
   const theme = useTheme();
@@ -461,8 +486,10 @@ function ContactRow({
     <Pressable
       onPress={already ? undefined : onPress}
       disabled={already}
-      accessibilityRole="checkbox"
-      accessibilityState={{ checked: selected, disabled: already }}
+      // Single-pick is a choose-one list, so each row is a radio button that
+      // acts on the tap; multi keeps the checkbox it fills and unfills.
+      accessibilityRole={single ? 'button' : 'checkbox'}
+      accessibilityState={single ? { disabled: already } : { checked: selected, disabled: already }}
       accessibilityLabel={
         already ? t.pickers.alreadyAddedName.replace('{name}', contact.name) : contact.name
       }
@@ -487,11 +514,19 @@ function ContactRow({
             {already ? t.pickers.alreadyInGroup : (contact.email ?? contact.phone ?? '')}
           </Text>
         </View>
-        <Ionicons
-          name={selected ? 'checkmark-circle' : 'ellipse-outline'}
-          size={iconSize.xxl}
-          color={selected ? theme.color.brand : theme.color.border}
-        />
+        {single ? (
+          <Ionicons
+            name={directionalIcon('chevron-forward')}
+            size={iconSize.lg}
+            color={theme.color.textFaint}
+          />
+        ) : (
+          <Ionicons
+            name={selected ? 'checkmark-circle' : 'ellipse-outline'}
+            size={iconSize.xxl}
+            color={selected ? theme.color.brand : theme.color.border}
+          />
+        )}
       </Row>
       {/* Inset past the avatar, so the rule reads as separating names rather
           than boxing every row. */}


### PR DESCRIPTION
Device feedback on the **add-a-person** IOU screen — four refinements.

## Changes

**1. Single-pick from contacts.** `ContactPicker` gains a `single` mode (used here). A one-to-one IOU has room for exactly one name, so a tap chooses that person and closes the sheet — no ticking, no picked-strip, no confirm button. Because there's no button, `busy` locks the rows themselves. Multi-select is untouched.

**2. Identity-led first card.** An `Avatar` that fills in with the typed name's colour + initial, the name field beside it, and **From contacts** as a real secondary button instead of a footnote link.

**3. Note dictation mic.** The note gets the same `DictateButton` the expense description has, with the person's name as a recogniser hint.

**4. Receipts (scan + keep).** "Add receipt" photographs the bill, reads it on the phone (ML Kit OCR), and `parseReceiptText` pulls the merchant to prefill the note. On save the image + OCR text go to the device vault and, if a personal cloud is connected, are queued there — **never uploaded to Baaki**. The amount stays manual (a trustworthy total needs the metered, group-bound server parser). Reuses the capture-screen path.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- Client-only; ships with the next build. Receipt keep rides the own-cloud path, which is OAuth-gated and unproven live.