### PR TITLE
fix(mobile): hide Paid by section when editing an expense

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -202,7 +202,12 @@ export default function AddExpenseScreen() {
       setAmount(safeBigInt(draft.amount));
       setDescription(draft.description);
       setSplitKind(draft.splitKind);
-      setPayer(draft.payer ?? myMemberId);
+      // When editing, the payer is fixed on the saved expense and its picker is
+      // hidden — so a stale draft.payer from an earlier edit session must never
+      // override it. New expenses still take the draft's chosen payer.
+      setPayer(
+        editing ? (version?.payers[0]?.member_id ?? myMemberId) : (draft.payer ?? myMemberId),
+      );
       setParticipants(draft.participants);
       setWeights(draft.weights ?? {});
       setPercents(draft.percents ?? {});
@@ -626,7 +631,7 @@ export default function AddExpenseScreen() {
           />
         </View>
 
-        {!editing ? (
+        {!expenseId ? (
           <Card style={{ gap: theme.spacing.md }}>
             <Text variant="caption" tone="muted">
               {t.paidBy}

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -626,28 +626,30 @@ export default function AddExpenseScreen() {
           />
         </View>
 
-        <Card style={{ gap: theme.spacing.md }}>
-          <Text variant="caption" tone="muted">
-            {t.paidBy}
-          </Text>
-          <Row style={{ flexWrap: 'wrap', gap: theme.spacing.md }}>
-            {(members.data ?? []).map((member) => (
-              <Pressable
-                key={member.id}
-                accessibilityRole="radio"
-                accessibilityState={{ selected: payer === member.id }}
-                accessibilityLabel={`${t.paidBy}: ${displayName(member, profile?.id)}`}
-                onPress={() => setPayer(member.id)}
-                style={{ alignItems: 'center', gap: 4, opacity: payer === member.id ? 1 : 0.45 }}
-              >
-                <Avatar name={displayName(member)} ghost={isGhost(member)} />
-                <Text variant="micro" tone={payer === member.id ? 'brand' : 'muted'}>
-                  {displayName(member, profile?.id)}
-                </Text>
-              </Pressable>
-            ))}
-          </Row>
-        </Card>
+        {!editing ? (
+          <Card style={{ gap: theme.spacing.md }}>
+            <Text variant="caption" tone="muted">
+              {t.paidBy}
+            </Text>
+            <Row style={{ flexWrap: 'wrap', gap: theme.spacing.md }}>
+              {(members.data ?? []).map((member) => (
+                <Pressable
+                  key={member.id}
+                  accessibilityRole="radio"
+                  accessibilityState={{ selected: payer === member.id }}
+                  accessibilityLabel={`${t.paidBy}: ${displayName(member, profile?.id)}`}
+                  onPress={() => setPayer(member.id)}
+                  style={{ alignItems: 'center', gap: 4, opacity: payer === member.id ? 1 : 0.45 }}
+                >
+                  <Avatar name={displayName(member)} ghost={isGhost(member)} />
+                  <Text variant="micro" tone={payer === member.id ? 'brand' : 'muted'}>
+                    {displayName(member, profile?.id)}
+                  </Text>
+                </Pressable>
+              ))}
+            </Row>
+          </Card>
+        ) : null}
 
         <Card style={{ gap: theme.spacing.md }}>
           <Row style={{ justifyContent: 'space-between' }}>


### PR DESCRIPTION
The add-expense form doubles as the edit form. On a saved expense the payer is already fixed, so the **Paid by** picker only belongs in the create flow.

When editing (`expenseId` present), the Paid by `Card` is now hidden. The `payer` stays seeded from the current version, so save keeps the original payer unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The payer selection card is now shown only when creating a new expense and remains hidden while editing.
  * When editing an existing expense, the saved payer is preserved instead of being replaced by the draft payer.
  * New expenses continue to restore the payer selected in the draft.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->