### PR TITLE
fix(mobile): note field clips to a fragment beside the mic

### DIFF
--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -334,18 +334,21 @@ export default function AddPersonScreen() {
           <Text variant="caption" tone="muted">
             {t.addPerson.noteLabel}
           </Text>
-          <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+          <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
             <TextInput
               value={note}
               onChangeText={setNote}
               accessibilityLabel={t.addPerson.noteLabel}
               placeholder={t.addPerson.notePlaceholder}
               placeholderTextColor={theme.color.textFaint}
+              multiline
+              textAlignVertical="top"
               style={{
                 flex: 1,
                 fontSize: 16,
                 color: theme.color.text,
                 paddingVertical: theme.spacing.sm,
+                minHeight: 44,
               }}
             />
             {/* Speak the note instead of typing it — the same mic the expense

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -585,12 +585,15 @@ export default function AddExpenseScreen() {
               placeholder={t.expense.descriptionPlaceholder}
               placeholderTextColor={theme.color.textFaint}
               accessibilityLabel={t.description}
+              multiline
+              textAlignVertical="top"
               style={{
                 flex: 1,
                 fontSize: 17,
                 fontWeight: '600',
                 color: theme.color.text,
                 paddingVertical: theme.spacing.sm,
+                minHeight: 44,
               }}
             />
             {/* The member names are handed to the recogniser as hints. A


### PR DESCRIPTION
The **What was it for?** description input (and the add-person note) were single-line `TextInput`s. RN keeps a horizontal scroll offset on single-line inputs, so the text showed as a clipped fragment (e.g. `nat`) in a box that looked tiny next to the dictate mic.

Made both inputs `multiline` with `minHeight: 44` and `textAlignVertical: 'top'`, and set the add-person Row to `flex-start`, so the note wraps and the box holds its size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)