### PR TITLE
fix(mobile): preserve currency when editing an expense

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -58,6 +58,10 @@ interface ExpenseDraft {
   description: string;
   splitKind: SplitKind;
   payer: MemberId | null;
+  /** The currency this expense was paid in, when it differs from the group's. */
+  currency: string | null;
+  /** The stored conversion rate for a foreign-currency expense (ADR-003). */
+  fx: FxRecord | null;
   participants: MemberId[];
   /** Kept apart, because a weight of 1 is not one percent. */
   weights: SplitEntries;
@@ -208,6 +212,8 @@ export default function AddExpenseScreen() {
       setPayer(
         editing ? (version?.payers[0]?.member_id ?? myMemberId) : (draft.payer ?? myMemberId),
       );
+      setExpenseCurrency(draft.currency ?? null);
+      setFx(draft.fx ?? null);
       setParticipants(draft.participants);
       setWeights(draft.weights ?? {});
       setPercents(draft.percents ?? {});
@@ -220,6 +226,12 @@ export default function AddExpenseScreen() {
       // open would quietly rewrite their answer.
       setCategory((version.category as CategoryId | null) ?? null);
       setCategoryChosen(version.category !== null);
+      // The expense keeps the currency it was paid in — without this, editing a
+      // foreign-currency expense reopened on the group currency and quietly
+      // rewrote it. The stored rate is not in the read model, so a foreign
+      // expense asks for its rate again on save.
+      setExpenseCurrency(version.currency);
+      setFx(null);
       setPayer(version.payers[0]?.member_id ?? myMemberId);
       setParticipants(version.shares.map((share) => share.member_id));
       setSplitKind(
@@ -285,6 +297,8 @@ export default function AddExpenseScreen() {
       description,
       splitKind,
       payer,
+      currency: expenseCurrency,
+      fx,
       participants,
       weights,
       percents,

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -40,6 +40,7 @@ import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { handoverKey } from '@/lib/handover';
+import { resolveDraftCurrency, resolveDraftFx } from '@/lib/expenseDraft';
 import { captureReceipt } from '@/lib/image';
 import { recogniseReceipt } from '@/lib/ocr';
 import {
@@ -58,10 +59,14 @@ interface ExpenseDraft {
   description: string;
   splitKind: SplitKind;
   payer: MemberId | null;
-  /** The currency this expense was paid in, when it differs from the group's. */
-  currency: string | null;
+  /**
+   * The currency this expense was paid in, when it differs from the group's.
+   * Optional: drafts written before this field existed omit it, which is not
+   * the same as an explicit null — see resolveDraftCurrency.
+   */
+  currency?: string | null;
   /** The stored conversion rate for a foreign-currency expense (ADR-003). */
-  fx: FxRecord | null;
+  fx?: FxRecord | null;
   participants: MemberId[];
   /** Kept apart, because a weight of 1 is not one percent. */
   weights: SplitEntries;
@@ -212,8 +217,8 @@ export default function AddExpenseScreen() {
       setPayer(
         editing ? (version?.payers[0]?.member_id ?? myMemberId) : (draft.payer ?? myMemberId),
       );
-      setExpenseCurrency(draft.currency ?? null);
-      setFx(draft.fx ?? null);
+      setExpenseCurrency(resolveDraftCurrency(draft.currency, version?.currency ?? null));
+      setFx(resolveDraftFx(draft.fx));
       setParticipants(draft.participants);
       setWeights(draft.weights ?? {});
       setPercents(draft.percents ?? {});

--- a/apps/mobile/src/lib/expenseDraft.ts
+++ b/apps/mobile/src/lib/expenseDraft.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolving a crash-recovery draft's currency back onto the edit form.
+ *
+ * `currency` and `fx` were added to the draft after drafts already existed on
+ * devices, so a draft written by an older build has them `undefined`. That is
+ * not the same as an explicit `null`: `null` is "this expense is in the group's
+ * own currency", a real choice the user made, while `undefined` is "this draft
+ * predates the field and says nothing". A legacy draft must therefore fall back
+ * to the currency the saved expense was actually in, not silently become the
+ * group currency and rewrite a foreign expense on the next save.
+ */
+import type { FxRecord } from '@baaki/core';
+
+/**
+ * The currency to seed from a draft. `undefined` (legacy draft) defers to the
+ * saved version's currency; an explicit value — including `null` — is honoured.
+ */
+export function resolveDraftCurrency(
+  draftCurrency: string | null | undefined,
+  versionCurrency: string | null,
+): string | null {
+  return draftCurrency === undefined ? versionCurrency : draftCurrency;
+}
+
+/**
+ * The rate to seed from a draft. The saved read model carries no rate, so a
+ * legacy draft has none to recover; only an explicit value survives.
+ */
+export function resolveDraftFx(draftFx: FxRecord | null | undefined): FxRecord | null {
+  return draftFx === undefined ? null : draftFx;
+}

--- a/apps/mobile/test/expenseDraft.test.ts
+++ b/apps/mobile/test/expenseDraft.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Recovering a foreign-currency edit from a crash-recovery draft.
+ *
+ * `currency`/`fx` were added to the draft after drafts already existed on
+ * devices. The bug this pins is the legacy draft: one written by an older build
+ * has `currency` undefined, and the old code turned that into the group
+ * currency — silently rewriting a foreign expense the next time it saved. A
+ * draft that predates the field must defer to the currency the saved expense
+ * was actually in, while an explicit null (the user really chose the group
+ * currency) is left alone.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveDraftCurrency, resolveDraftFx } from '@/lib/expenseDraft';
+import type { FxRecord } from '@baaki/core';
+
+describe('resolveDraftCurrency', () => {
+  it('falls back to the saved expense currency for a legacy draft (undefined)', () => {
+    // A draft written before the field existed, on an expense paid in USD.
+    expect(resolveDraftCurrency(undefined, 'USD')).toBe('USD');
+  });
+
+  it('honours an explicit null as the intentional group currency', () => {
+    // The user chose the group currency and it was persisted; keep it.
+    expect(resolveDraftCurrency(null, 'USD')).toBeNull();
+  });
+
+  it('honours an explicit currency chosen in the draft', () => {
+    expect(resolveDraftCurrency('EUR', 'USD')).toBe('EUR');
+  });
+
+  it('defers to a null version currency for a new-expense legacy draft', () => {
+    // No saved version to fall back to → group currency (null) downstream.
+    expect(resolveDraftCurrency(undefined, null)).toBeNull();
+  });
+});
+
+describe('resolveDraftFx', () => {
+  const rate = { source: 'you' } as unknown as FxRecord;
+
+  it('recovers no rate from a legacy draft (undefined)', () => {
+    expect(resolveDraftFx(undefined)).toBeNull();
+  });
+
+  it('honours an explicit null', () => {
+    expect(resolveDraftFx(null)).toBeNull();
+  });
+
+  it('honours an explicit rate', () => {
+    expect(resolveDraftFx(rate)).toBe(rate);
+  });
+});


### PR DESCRIPTION
**Bug:** the edit seed restored amount, split, payer, category — but never the currency. Editing a foreign-currency expense reopened on the *group* currency, so the picker showed the wrong currency and saving silently rewrote it to the group's.

**Fix:**
- Seed `expenseCurrency` from `version.currency` on edit. (The stored FX rate isn't in the client read model, so a foreign expense shows the rate section again and re-asks for its rate on save — correct, versus the old silent corruption.)
- Carry `currency` + `fx` through the crash-recovery draft so a mid-edit currency change survives an app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expense drafts now retain and restore the selected currency and foreign-exchange details.
  * Editing an existing expense restores its original currency.
  * Foreign-exchange rates are cleared during editing and can be entered again when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->