### PR TITLE
feat(mobile): Mobbin-informed design pass on the money-reading screens

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -17,13 +17,30 @@ import {
   useTheme,
 } from '@baaki/ui';
 
-import { describeActivity, parseMoney, relativeTime, verbEmoji } from '@/data/activity';
+import { dayHeading, dayKey, describeActivity, parseMoney, verbEmoji } from '@/data/activity';
 import { fetchRecentActivity } from '@/data/api';
 import { FeedSkeleton } from '@/components/Skeletons';
 import { useNotifications } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { usePullRefresh } from '@/lib/pullRefresh';
+
+/**
+ * The feed cut into calendar days, newest first, order otherwise untouched — the
+ * query already returns it sorted, so this only draws the lines between days.
+ */
+function groupByDay<T extends { created_at: string }>(
+  entries: readonly T[],
+): { key: string; entries: T[] }[] {
+  const sections: { key: string; entries: T[] }[] = [];
+  for (const entry of entries) {
+    const key = dayKey(entry.created_at);
+    const last = sections[sections.length - 1];
+    if (last && last.key === key) last.entries.push(entry);
+    else sections.push({ key, entries: [entry] });
+  }
+  return sections;
+}
 
 export default function ActivityScreen() {
   const theme = useTheme();
@@ -96,86 +113,109 @@ export default function ActivityScreen() {
             }
           />
         ) : entries.length === 0 ? (
-          <EmptyState title={t.nothingYet} body={t.tabs.activityEmptyBody} />
+          <EmptyState
+            title={t.nothingYet}
+            body={t.tabs.activityEmptyBody}
+            icon={<Ionicons name="pulse" size={iconSize.xxl} color={theme.color.brand} />}
+          />
         ) : (
-          // A single vertical timeline: each event is a node on a connector line
-          // running down the left, its icon in a soft circle tinted by the group
-          // it belongs to, the sentence beside it and the relative time beneath.
-          <View>
-            {entries.map((entry, index) => {
-              const isLast = index === entries.length - 1;
-              const tint = tintForKey(entry.group_id);
-              return (
-                <Pressable
-                  key={entry.id}
-                  accessibilityRole="button"
-                  accessibilityLabel={describeActivity(entry, myProfileId)}
-                  onPress={() => router.push(`/group/${entry.group_id}`)}
-                  style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+          // A vertical timeline broken into days: each event is a node on a
+          // connector line running down the left, its icon in a soft circle
+          // tinted by the group it belongs to, the sentence beside it and the
+          // time beneath. The day headings are what make forty rows skimmable —
+          // without them every row had to be read to place it in time.
+          <View style={{ gap: theme.spacing.lg }}>
+            {groupByDay(entries).map((section) => (
+              <View key={section.key}>
+                <Text
+                  variant="micro"
+                  tone="muted"
+                  style={{ textTransform: 'uppercase', marginBottom: theme.spacing.md }}
                 >
-                  <Row style={{ alignItems: 'stretch' }}>
-                    {/* The rail: the node, then the line running down to the next
+                  {dayHeading(locale, section.entries[0]!.created_at)}
+                </Text>
+                {section.entries.map((entry, index) => {
+                  const isLast = index === section.entries.length - 1;
+                  const tint = tintForKey(entry.group_id);
+                  return (
+                    <Pressable
+                      key={entry.id}
+                      accessibilityRole="button"
+                      accessibilityLabel={describeActivity(entry, myProfileId)}
+                      onPress={() => router.push(`/group/${entry.group_id}`)}
+                      style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+                    >
+                      <Row style={{ alignItems: 'stretch' }}>
+                        {/* The rail: the node, then the line running down to the next
                         node — dropped for the last row so it stops, not dangles. */}
-                    <View style={{ width: 38, alignItems: 'center' }}>
-                      <View
-                        style={{
-                          width: 38,
-                          height: 38,
-                          borderRadius: 19,
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          backgroundColor: theme.tint[tint].bg,
-                        }}
-                      >
-                        <Text style={{ fontSize: 16 }}>{verbEmoji(entry.verb)}</Text>
-                      </View>
-                      {!isLast ? (
+                        <View style={{ width: 38, alignItems: 'center' }}>
+                          <View
+                            style={{
+                              width: 38,
+                              height: 38,
+                              borderRadius: 19,
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              backgroundColor: theme.tint[tint].bg,
+                            }}
+                          >
+                            <Text style={{ fontSize: 16 }}>{verbEmoji(entry.verb)}</Text>
+                          </View>
+                          {!isLast ? (
+                            <View
+                              style={{
+                                flex: 1,
+                                width: 2,
+                                marginVertical: 2,
+                                backgroundColor: theme.color.border,
+                              }}
+                            />
+                          ) : null}
+                        </View>
+
                         <View
                           style={{
                             flex: 1,
-                            width: 2,
-                            marginVertical: 2,
-                            backgroundColor: theme.color.border,
+                            paddingStart: theme.spacing.md,
+                            paddingBottom: isLast ? 0 : theme.spacing.xl,
                           }}
-                        />
-                      ) : null}
-                    </View>
-
-                    <View
-                      style={{
-                        flex: 1,
-                        paddingStart: theme.spacing.md,
-                        paddingBottom: isLast ? 0 : theme.spacing.xl,
-                      }}
-                    >
-                      <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
-                        <Text variant="body" numberOfLines={3} style={{ flex: 1 }}>
-                          {describeActivity(entry, myProfileId)}
-                        </Text>
-                        {/* `payload` is an untyped JSON blob, so a bad amount
+                        >
+                          <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
+                            <Text variant="body" numberOfLines={3} style={{ flex: 1 }}>
+                              {describeActivity(entry, myProfileId)}
+                            </Text>
+                            {/* `payload` is an untyped JSON blob, so a bad amount
                             must render as no amount, not as a crashed tab. */}
-                        {(() => {
-                          const money = parseMoney(entry.payload);
-                          if (!money) return null;
-                          return (
-                            <MoneyText
-                              amount={money.amount}
-                              currency={money.currency}
-                              locale={locale}
-                              variant="subheading"
-                              tone="default"
-                            />
-                          );
-                        })()}
+                            {(() => {
+                              const money = parseMoney(entry.payload);
+                              if (!money) return null;
+                              return (
+                                <MoneyText
+                                  amount={money.amount}
+                                  currency={money.currency}
+                                  locale={locale}
+                                  variant="subheading"
+                                  tone="default"
+                                />
+                              );
+                            })()}
+                          </Row>
+                          {/* The day is the heading's job now, so the row keeps only
+                          the clock — "yesterday" printed forty times under a
+                          heading that already said it was noise. */}
+                          <Text variant="micro" tone="muted" style={{ marginTop: 2 }}>
+                            {new Intl.DateTimeFormat(locale, {
+                              hour: 'numeric',
+                              minute: '2-digit',
+                            }).format(new Date(entry.created_at))}
+                          </Text>
+                        </View>
                       </Row>
-                      <Text variant="micro" tone="muted" style={{ marginTop: 2 }}>
-                        {relativeTime(locale, entry.created_at)}
-                      </Text>
-                    </View>
-                  </Row>
-                </Pressable>
-              );
-            })}
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ))}
           </View>
         )}
       </ScrollView>

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -278,12 +278,17 @@ export default function HomeScreen() {
         {summary.isLoading ? (
           <HeroSkeleton />
         ) : (
-          <HeroCarousel
-            trips={activeTrips}
-            totals={summary.totals.length > 0 ? summary.totals : [headline]}
-            locale={locale}
-            t={t}
-          />
+          <View style={{ gap: theme.spacing.lg }}>
+            {/* Where you stand, flat and always on screen. It used to be the
+                first slide of a swipeable deck, which meant the one number the
+                app exists to tell you could be a card-width away — and after a
+                swipe to the trip or the promo card, gone. No money app in the
+                category hides the balance behind a gesture. The deck survives
+                beneath it, smaller, for the things that genuinely are a shelf:
+                a running trip, a second currency, the two shortcuts. */}
+            <BalanceCard total={headline} locale={locale} t={t} />
+            <HeroDeck trips={activeTrips} totals={summary.totals.slice(1)} locale={locale} t={t} />
+          </View>
         )}
 
         {loading ? (
@@ -292,6 +297,7 @@ export default function HomeScreen() {
           <EmptyState
             title={t.tabs.noGroups}
             body={t.tabs.noGroupsBody}
+            icon={<Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.brand} />}
             action={<Button label={t.newGroup} onPress={openNewGroup} />}
           />
         ) : (
@@ -487,20 +493,25 @@ function todayIn(timeZone: string): string {
 export const HERO_CARD_HEIGHT = 196;
 
 /**
- * The dashboard hero: a swipeable deck of cards with a peek of the next one at
- * the right edge and a dot pager beneath (the live dot stretched into a pill),
- * modelled on the podcast-style featured carousel. Any trip running today rides
- * at the front — the most "now" thing on the dashboard — then one card per
- * currency (a total across currencies is a number that does not exist, ADR-004),
- * then the action slides (scan a receipt, add a person) that turn the empty
- * right of the deck into a shortcut instead of dead space.
- *
- * Unlike a bare card, the deck always shows its dots — the peek and the pager
- * are the two signals that say "swipe me", so they stay even when there is a
- * single slide (a fresh account with one currency and no trip). The peek is
- * dropped to zero in that lone case so a single card still fills the width.
+ * The height of a card in the deck beneath the balance. Shorter than the hero on
+ * purpose: the deck is the shelf of secondary things, and two cards of equal
+ * weight stacked would be two heroes and no hierarchy.
  */
-function HeroCarousel({
+const DECK_CARD_HEIGHT = 132;
+
+/**
+ * The shelf under the balance: a swipeable deck with a peek of the next card at
+ * the right edge and a dot pager beneath. Any trip running today rides at the
+ * front — the most "now" thing on the dashboard — then any further currency (a
+ * total across currencies is a number that does not exist, ADR-004), then the
+ * action slides (scan a receipt, add a person) that turn the empty right of the
+ * deck into a shortcut instead of dead space.
+ *
+ * The peek and the pager are the two signals that say "swipe me", so they stay
+ * even when there is a single slide. The peek is dropped to zero in that lone
+ * case so a single card still fills the width.
+ */
+function HeroDeck({
   trips,
   totals,
   locale,
@@ -522,7 +533,7 @@ function HeroCarousel({
     })),
     ...totals.map((total) => ({
       key: `cur:${total.currency}`,
-      node: <BalanceCard total={total} locale={locale} t={t} />,
+      node: <BalanceCard total={total} locale={locale} t={t} compact />,
     })),
     {
       key: 'act:scan',
@@ -608,10 +619,10 @@ function HeroCarousel({
 }
 
 /**
- * The hero while the balance is still loading — a card-shaped block at the exact
- * `HERO_CARD_HEIGHT` the real deck uses, with a sliver of the next card at the
- * right (the peek) and a three-dot pager beneath. Shaped so the swap to the real
- * carousel is a fill, not a jump: same height, same peek, same dots.
+ * The hero while the balance is still loading — the full-width balance block at
+ * its real height, then the deck beneath it with a sliver of the next card at
+ * the right (the peek) and a three-dot pager. Shaped so the swap to the real
+ * thing is a fill, not a jump: same heights, same peek, same dots.
  */
 function HeroSkeleton() {
   const theme = useTheme();
@@ -622,18 +633,24 @@ function HeroSkeleton() {
   const cardWidth = available - peek;
   return (
     <View style={{ gap: theme.spacing.md }}>
-      {/* The card and the peek sliver, clipped so the sliver never widens the
-          row past the gutter. */}
+      <Skeleton
+        width={available}
+        height={HERO_CARD_HEIGHT}
+        radius={theme.radius.lg}
+        animated={animated}
+      />
+      {/* The deck card and the peek sliver, clipped so the sliver never widens
+          the row past the gutter. */}
       <View style={{ flexDirection: 'row', gap: theme.spacing.md, overflow: 'hidden' }}>
         <Skeleton
           width={cardWidth}
-          height={HERO_CARD_HEIGHT}
+          height={DECK_CARD_HEIGHT}
           radius={theme.radius.lg}
           animated={animated}
         />
         <Skeleton
           width={peek}
-          height={HERO_CARD_HEIGHT}
+          height={DECK_CARD_HEIGHT}
           radius={theme.radius.lg}
           animated={animated}
         />
@@ -710,24 +727,24 @@ function ActionSlide({
         colors={colors}
         radius={theme.radius.lg}
         style={{
-          padding: theme.spacing.xl,
-          height: HERO_CARD_HEIGHT,
+          padding: theme.spacing.lg,
+          height: DECK_CARD_HEIGHT,
           justifyContent: 'space-between',
-          gap: theme.spacing.lg,
+          gap: theme.spacing.sm,
           overflow: 'hidden',
         }}
       >
         <HeroBackdropIcon name={icon} />
-        <View style={{ gap: theme.spacing.xs, paddingRight: 88 }}>
-          <Text variant="subheading" tone="onBrand">
+        <View style={{ gap: 2, paddingRight: 72 }}>
+          <Text variant="subheading" tone="onBrand" numberOfLines={1}>
             {title}
           </Text>
-          <Text variant="caption" tone="onBrand" style={{ opacity: 0.9 }}>
+          <Text variant="micro" tone="onBrand" numberOfLines={2} style={{ opacity: 0.9 }}>
             {body}
           </Text>
         </View>
         <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-          <Text variant="caption" tone="onBrand" style={{ fontWeight: '700' }}>
+          <Text variant="micro" tone="onBrand" style={{ fontWeight: '700' }}>
             {cta}
           </Text>
           <Ionicons name="arrow-forward" size={iconSize.base} color={theme.color.onBrand} />
@@ -743,7 +760,19 @@ function ActionSlide({
  * settled — so the card's colour, not just its number, tells you where you
  * stand at a glance. The net big, the owed/owe split beneath.
  */
-function BalanceCard({ total, locale, t }: { total: CurrencyTotal; locale: string; t: UiStrings }) {
+function BalanceCard({
+  total,
+  locale,
+  t,
+  compact = false,
+}: {
+  total: CurrencyTotal;
+  locale: string;
+  t: UiStrings;
+  /** A second currency riding in the deck: deck height, and the owed/owe split
+   *  dropped — at that size it is three numbers where one will do. */
+  compact?: boolean;
+}) {
   const theme = useTheme();
   const wash =
     total.net > 0n
@@ -757,8 +786,8 @@ function BalanceCard({ total, locale, t }: { total: CurrencyTotal; locale: strin
       radius={theme.radius.lg}
       style={{
         padding: theme.spacing.xl,
-        gap: theme.spacing.lg,
-        height: HERO_CARD_HEIGHT,
+        gap: compact ? theme.spacing.sm : theme.spacing.lg,
+        height: compact ? DECK_CARD_HEIGHT : HERO_CARD_HEIGHT,
         justifyContent: 'space-between',
         overflow: 'hidden',
       }}
@@ -779,37 +808,43 @@ function BalanceCard({ total, locale, t }: { total: CurrencyTotal; locale: strin
           currency={total.currency as never}
           locale={locale}
           tone="onBrand"
-          style={{ fontSize: 40, lineHeight: 46, fontWeight: '700' }}
+          style={
+            compact
+              ? { fontSize: 28, lineHeight: 34, fontWeight: '700' }
+              : { fontSize: 40, lineHeight: 46, fontWeight: '700' }
+          }
         />
         <Text variant="caption" tone="onBrand">
           {total.net === 0n ? t.allSettled : total.net > 0n ? t.overallOwed : t.overallOwe}
         </Text>
       </View>
 
-      <Row style={{ gap: theme.spacing.xxl }}>
-        <View>
-          <Text variant="micro" tone="onBrand">
-            {t.youAreOwed}
-          </Text>
-          <CountUpMoney
-            amount={total.owed}
-            currency={total.currency as never}
-            locale={locale}
-            tone="onBrand"
-          />
-        </View>
-        <View>
-          <Text variant="micro" tone="onBrand">
-            {t.youOwe}
-          </Text>
-          <CountUpMoney
-            amount={total.owing}
-            currency={total.currency as never}
-            locale={locale}
-            tone="onBrand"
-          />
-        </View>
-      </Row>
+      {compact ? null : (
+        <Row style={{ gap: theme.spacing.xxl }}>
+          <View>
+            <Text variant="micro" tone="onBrand">
+              {t.youAreOwed}
+            </Text>
+            <CountUpMoney
+              amount={total.owed}
+              currency={total.currency as never}
+              locale={locale}
+              tone="onBrand"
+            />
+          </View>
+          <View>
+            <Text variant="micro" tone="onBrand">
+              {t.youOwe}
+            </Text>
+            <CountUpMoney
+              amount={total.owing}
+              currency={total.currency as never}
+              locale={locale}
+              tone="onBrand"
+            />
+          </View>
+        </Row>
+      )}
     </Gradient>
   );
 }
@@ -832,9 +867,9 @@ function TripCard({ trip, locale, t }: { trip: TripSlide; locale: string; t: UiS
         colors={theme.gradient.accent}
         radius={theme.radius.lg}
         style={{
-          padding: theme.spacing.xl,
-          gap: theme.spacing.lg,
-          height: HERO_CARD_HEIGHT,
+          padding: theme.spacing.lg,
+          gap: theme.spacing.sm,
+          height: DECK_CARD_HEIGHT,
           justifyContent: 'space-between',
           overflow: 'hidden',
         }}
@@ -842,8 +877,8 @@ function TripCard({ trip, locale, t }: { trip: TripSlide; locale: string; t: UiS
         <HeroBackdropIcon name="airplane-outline" />
         <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
           <Row style={{ gap: theme.spacing.sm, alignItems: 'center', flex: 1 }}>
-            <Text variant="subheading">{trip.coverEmoji ?? '🧳'}</Text>
-            <Text variant="subheading" tone="onBrand" numberOfLines={1} style={{ flex: 1 }}>
+            <Text variant="caption">{trip.coverEmoji ?? '🧳'}</Text>
+            <Text variant="caption" tone="onBrand" numberOfLines={1} style={{ flex: 1 }}>
               {trip.title}
             </Text>
           </Row>
@@ -852,23 +887,24 @@ function TripCard({ trip, locale, t }: { trip: TripSlide; locale: string; t: UiS
           </Text>
         </Row>
 
-        <View>
-          <Text tone="onBrand" style={{ fontSize: 34, lineHeight: 40, fontWeight: '700' }}>
-            {t.tripDay.replace('{day}', String(trip.day)).replace('{total}', String(trip.total))}
-          </Text>
-          <Text variant="caption" tone="onBrand">
-            {net === 0n ? t.allSettled : net > 0n ? t.youAreOwed : t.youOwe}
-          </Text>
-        </View>
+        <Text tone="onBrand" style={{ fontSize: 24, lineHeight: 30, fontWeight: '700' }}>
+          {t.tripDay.replace('{day}', String(trip.day)).replace('{total}', String(trip.total))}
+        </Text>
 
         <Row style={{ justifyContent: 'space-between', alignItems: 'flex-end' }}>
-          <CountUpMoney
-            amount={net < 0n ? -net : net}
-            currency={trip.currency as never}
-            locale={locale}
-            tone="onBrand"
-          />
-          <Text variant="caption" tone="onBrand">
+          <View>
+            <Text variant="micro" tone="onBrand">
+              {net === 0n ? t.allSettled : net > 0n ? t.youAreOwed : t.youOwe}
+            </Text>
+            <CountUpMoney
+              amount={net < 0n ? -net : net}
+              currency={trip.currency as never}
+              locale={locale}
+              tone="onBrand"
+              variant="caption"
+            />
+          </View>
+          <Text variant="micro" tone="onBrand">
             {t.plan}
           </Text>
         </Row>

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -36,7 +36,7 @@ import { DictateButton } from '@/components/DictateButton';
 import { scanReceipt, scanReceiptText } from '@/data/api';
 import { useAssignCapture, useGroup } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
-import { plural, useStrings } from '@/i18n';
+import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { handoverKey } from '@/lib/handover';
@@ -288,6 +288,29 @@ export default function AddExpenseScreen() {
     else setPercents(update);
   };
   const splitIssue = splitProblem(splitKind, entries, participants);
+
+  /**
+   * The split, folded into one sentence until somebody wants to argue with it.
+   *
+   * Almost every expense is "I paid, split it equally with everyone" — and that
+   * case was costing three open sections (how to split, who paid, who is in) and
+   * a screenful of scroll between the amount and the save button. Collapsed, the
+   * sentence still says exactly what will be saved, which is the part that must
+   * never be hidden; expanded, nothing about the controls has changed.
+   *
+   * It opens itself whenever the configuration is not that default, and stays
+   * open while the numbers do not add up — a validation message under a fold is
+   * a validation message nobody reads.
+   */
+  const isDefaultSplit =
+    splitKind === SplitKind.Equal &&
+    payer !== null &&
+    payer === myMemberId &&
+    participants.length > 0 &&
+    participants.length === (members.data ?? []).length;
+  const [splitOpen, setSplitOpen] = useState(false);
+  const showSplit = splitOpen || !isDefaultSplit || splitIssue !== null;
+  const payerMember = (members.data ?? []).find((member) => member.id === payer) ?? null;
 
   const groupCurrency = group.data?.default_currency ?? 'INR';
   // The expense keeps the currency it was paid in; the group's is only the
@@ -638,10 +661,56 @@ export default function AddExpenseScreen() {
           />
         </View>
 
-        <View style={{ gap: theme.spacing.md }}>
-          <Text variant="caption" tone="muted">
-            {t.expense.howToSplit}
-          </Text>
+        {/* The one-line answer to "who pays what", tappable to open the three
+            controls that decide it. */}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ expanded: showSplit }}
+          accessibilityLabel={t.expense.howToSplit}
+          onPress={() => setSplitOpen((open) => !open)}
+          // Never fold a broken split away behind its own summary.
+          disabled={splitIssue !== null}
+        >
+          <Card style={{ gap: theme.spacing.xs }}>
+            <Row style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text variant="caption" tone="muted">
+                  {t.expense.howToSplit}
+                </Text>
+                <Text variant="subheading" numberOfLines={2}>
+                  {[
+                    payerMember
+                      ? fill(t.expense.paidByName, {
+                          name: displayName(payerMember, profile?.id),
+                        })
+                      : t.expense.chooseWhoPaid,
+                    splitKind === SplitKind.Equal
+                      ? t.expense.equally
+                      : splitKind === SplitKind.Shares
+                        ? t.expense.shares
+                        : t.expense.percent,
+                    plural(locale, participants.length, t.memberCount),
+                  ].join(' · ')}
+                </Text>
+              </View>
+              <Row style={{ gap: theme.spacing.xs, alignItems: 'center', flexShrink: 0 }}>
+                <Text variant="caption" tone="brand">
+                  {showSplit ? t.common.done : t.common.edit}
+                </Text>
+                <Ionicons
+                  name={showSplit ? 'chevron-up' : 'chevron-down'}
+                  size={iconSize.md}
+                  color={theme.color.brand}
+                />
+              </Row>
+            </Row>
+          </Card>
+        </Pressable>
+
+        {/* Kept mounted and hidden rather than unmounted: the weighted split's
+            fields hold text somebody is mid-way through typing, and a fold that
+            threw it away would be a worse trade than a taller tree. */}
+        <View style={{ gap: theme.spacing.md, display: showSplit ? 'flex' : 'none' }}>
           <ChipRow<SplitKind>
             value={splitKind}
             onChange={setSplitKind}
@@ -654,7 +723,7 @@ export default function AddExpenseScreen() {
         </View>
 
         {!expenseId ? (
-          <Card style={{ gap: theme.spacing.md }}>
+          <Card style={{ gap: theme.spacing.md, display: showSplit ? 'flex' : 'none' }}>
             <Text variant="caption" tone="muted">
               {t.paidBy}
             </Text>
@@ -678,7 +747,7 @@ export default function AddExpenseScreen() {
           </Card>
         ) : null}
 
-        <Card style={{ gap: theme.spacing.md }}>
+        <Card style={{ gap: theme.spacing.md, display: showSplit ? 'flex' : 'none' }}>
           <Row style={{ justifyContent: 'space-between' }}>
             <Text variant="caption" tone="muted">
               {t.expense.splitBetween}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -686,11 +686,16 @@ export default function GroupScreen() {
           ) : null}
         </ScrollView>
 
-        <Fab
-          label={t.addExpense}
-          onPress={() => router.push(`/group/${groupId}/add-expense`)}
-          icon={<Ionicons name="add" size={iconSize.xl} color={theme.color.onBrand} />}
-        />
+        {/* The empty state carries its own Add expense button, and two of the
+            same button on one screen is a screen that cannot decide. The FAB
+            stands down for exactly that case. */}
+        {tab === Tab.Expenses && visibleExpenses.length === 0 ? null : (
+          <Fab
+            label={t.addExpense}
+            onPress={() => router.push(`/group/${groupId}/add-expense`)}
+            icon={<Ionicons name="add" size={iconSize.xl} color={theme.color.onBrand} />}
+          />
+        )}
       </DetailEnter>
     </Screen>
   );

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useMutation } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
 
@@ -34,9 +35,11 @@ import {
   useOpenReceipts,
 } from '@/data/hooks';
 import { describeActivity, parseMoney, verbEmoji } from '@/data/activity';
+import { nudgeToSettle } from '@/data/api';
 import { expenseTitle } from '@/data/expenseTitle';
 import { GroupSkeleton } from '@/components/Skeletons';
-import { actorName, displayName, groupLabel, isGhost } from '@/data/types';
+import { formatParts, type MemberId } from '@baaki/core';
+import { actorName, displayName, groupLabel, isGhost, type ExpenseVersionRow } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { DetailEnter } from '@/lib/anim';
@@ -51,6 +54,76 @@ enum Tab {
   Expenses = 'expenses',
   Balances = 'balances',
   Activity = 'activity',
+}
+
+/**
+ * The nudge on a balances row, for somebody who owes this group money.
+ *
+ * The same one-a-day server rule the Friends tab leans on (ADR-010), and the
+ * same manner: once tapped it stops offering, and a rate limit reads as "already
+ * nudged today" rather than as an error. Nobody should be told off for asking.
+ */
+function RemindChip({
+  groupId,
+  memberId,
+  currency,
+}: {
+  groupId: string;
+  memberId: MemberId;
+  currency: string;
+}) {
+  const { t } = useStrings();
+  const [note, setNote] = useState<string | null>(null);
+
+  const nudge = useMutation({
+    mutationFn: () => nudgeToSettle({ groupId, toMemberId: memberId, currency }),
+    onSuccess: () => setNote(t.people.reminded),
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      setNote(message.includes('NUDGE_RATE_LIMIT') ? t.people.remindedToday : t.loadError);
+    },
+  });
+
+  if (note) {
+    return (
+      <Text variant="micro" tone="muted">
+        {note}
+      </Text>
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={() => nudge.mutate()}
+      disabled={nudge.isPending}
+      accessibilityRole="button"
+      accessibilityLabel={t.people.remind}
+      hitSlop={10}
+      style={({ pressed }) => ({ opacity: pressed || nudge.isPending ? 0.6 : 1 })}
+    >
+      <Badge label={t.people.remind} tone="brand" />
+    </Pressable>
+  );
+}
+
+/**
+ * What one expense did to one person's balance — what they put in beyond their
+ * own share (positive: they lent), or their share of what somebody else put in
+ * (negative: they borrowed).
+ *
+ * `null` means they are in neither column: an expense between other people in
+ * the group. That is a blank on the row, not a zero — a zero would read as "you
+ * are square on this one", which is a different sentence.
+ */
+function myStake(
+  version: ExpenseVersionRow | null | undefined,
+  memberId: MemberId | null,
+): bigint | null {
+  if (!version || !memberId) return null;
+  const paid = version.payers.find((row) => row.member_id === memberId)?.amount;
+  const share = version.shares.find((row) => row.member_id === memberId)?.amount;
+  if (paid === undefined && share === undefined) return null;
+  return BigInt(paid ?? 0) - BigInt(share ?? 0);
 }
 
 export default function GroupScreen() {
@@ -268,8 +341,15 @@ export default function GroupScreen() {
             }}
           >
             <Row style={{ justifyContent: 'space-between' }}>
+              {/* A zero is not "you are owed ₹0" — it is the good outcome, and
+                  it gets said as one. The label carried the sign for every
+                  balance except the one worth celebrating. */}
               <Text variant="caption" style={{ color: inkMuted }}>
-                {ledger.myBalance >= 0n ? t.youAreOwed : t.youOwe}
+                {ledger.myBalance === 0n
+                  ? t.allSettled
+                  : ledger.myBalance > 0n
+                    ? t.youAreOwed
+                    : t.youOwe}
               </Text>
               {ledger.pending !== 0n ? <Badge label={t.pendingConfirmation} tone="brand" /> : null}
             </Row>
@@ -364,12 +444,35 @@ export default function GroupScreen() {
 
           {tab === Tab.Expenses ? (
             visibleExpenses.length === 0 ? (
-              <EmptyState title={t.nothingYet} body={t.nothingYetBody} />
+              // An empty list that only describes itself leaves the one thing to
+              // do on the screen to a floating button in the corner. The way out
+              // of an empty state belongs inside it.
+              <EmptyState
+                title={t.nothingYet}
+                body={t.nothingYetBody}
+                icon={
+                  <Ionicons name="receipt-outline" size={iconSize.xxl} color={theme.color.brand} />
+                }
+                action={
+                  <Button
+                    label={t.addExpense}
+                    onPress={() => router.push(`/group/${groupId}/add-expense`)}
+                    icon={<Ionicons name="add" size={iconSize.md} color={theme.color.onBrand} />}
+                  />
+                }
+              />
             ) : (
               <View>
                 {visibleExpenses.map((expense, index) => {
                   const version = expense.currentVersion;
                   const payer = version?.payers[0]?.member_id ?? null;
+                  // What this one expense did to *your* balance: what you put in
+                  // beyond your share (you lent), or your share of what somebody
+                  // else put in (you borrowed). The row used to end in the
+                  // expense total, which is the group's number and never the
+                  // answer to the question somebody opens a ledger with. The
+                  // total keeps its place in the subtitle.
+                  const stake = myStake(version, ledger.myMemberId);
                   // Somebody disagreeing with an expense is worth seeing from the
                   // list. A disagreement you only find by opening the row is one
                   // that sits there unanswered.
@@ -411,7 +514,18 @@ export default function GroupScreen() {
                             </Row>
                             <Text variant="caption" tone="muted" numberOfLines={1}>
                               {[
-                                fill(t.expense.paidByName, { name: nameOf(payer) }),
+                                version
+                                  ? fill(t.expense.paidByNameAmount, {
+                                      name: nameOf(payer),
+                                      amount: formatParts(
+                                        {
+                                          minor: BigInt(version.amount),
+                                          currency: version.currency,
+                                        },
+                                        { locale },
+                                      ).text,
+                                    })
+                                  : fill(t.expense.paidByName, { name: nameOf(payer) }),
                                 version
                                   ? new Intl.DateTimeFormat(locale, {
                                       day: 'numeric',
@@ -430,13 +544,26 @@ export default function GroupScreen() {
                           </View>
                           {version ? (
                             <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
-                              <MoneyText
-                                amount={BigInt(version.amount)}
-                                currency={version.currency}
-                                locale={locale}
-                                tone="default"
-                                style={{ fontWeight: '700' }}
-                              />
+                              <View style={{ alignItems: 'flex-end' }}>
+                                <Text variant="micro" tone="muted">
+                                  {stake === null
+                                    ? t.expense.notInvolved
+                                    : stake > 0n
+                                      ? t.expense.youLent
+                                      : stake < 0n
+                                        ? t.expense.youBorrowed
+                                        : t.allSettled}
+                                </Text>
+                                {stake !== null && stake !== 0n ? (
+                                  <MoneyText
+                                    amount={stake}
+                                    currency={version.currency}
+                                    locale={locale}
+                                    mode="balance"
+                                    style={{ fontWeight: '700' }}
+                                  />
+                                ) : null}
+                              </View>
                               {expense.pending ? <PendingMark /> : null}
                             </Row>
                           ) : null}
@@ -484,6 +611,13 @@ export default function GroupScreen() {
                         </Text>
                       </View>
                       <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+                        {/* Somebody who owes the group money can be nudged from
+                            the row that says so, the way Friends already does —
+                            reading a debt and acting on it were two screens
+                            apart for no reason. Ghosts have nowhere to send it. */}
+                        {balance < 0n && !isGhost(member) && member.id !== ledger.myMemberId ? (
+                          <RemindChip groupId={groupId} memberId={member.id} currency={currency} />
+                        ) : null}
                         <MoneyText
                           amount={balance}
                           currency={currency}
@@ -504,7 +638,11 @@ export default function GroupScreen() {
 
           {tab === Tab.Activity ? (
             (activity.data ?? []).length === 0 ? (
-              <EmptyState title={t.nothingYet} body={t.group.activityEmptyBody} />
+              <EmptyState
+                title={t.nothingYet}
+                body={t.group.activityEmptyBody}
+                icon={<Ionicons name="pulse" size={iconSize.xxl} color={theme.color.brand} />}
+              />
             ) : (
               // Flat like the Expenses and Balances tabs — bare rows and
               // hairlines, not a boxed Card, so all three tabs read alike.

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -466,6 +466,32 @@ export default function GroupScreen() {
                 {visibleExpenses.map((expense, index) => {
                   const version = expense.currentVersion;
                   const payer = version?.payers[0]?.member_id ?? null;
+                  // An imported Splitwise expense can have several payers, so
+                  // "Asha paid ₹1,200" beside the expense total would put the
+                  // whole bill on whoever happens to sort first. One payer is
+                  // named and credited with what they actually put in; several
+                  // are counted, and the number beside them is the total they
+                  // put in between them.
+                  const payerCount = version?.payers.length ?? 0;
+                  const paidLine =
+                    version === null
+                      ? fill(t.expense.paidByName, { name: nameOf(payer) })
+                      : fill(t.expense.paidByNameAmount, {
+                          name:
+                            payerCount > 1
+                              ? plural(locale, payerCount, t.misc.peopleCount)
+                              : nameOf(payer),
+                          amount: formatParts(
+                            {
+                              minor:
+                                payerCount > 1
+                                  ? BigInt(version.amount)
+                                  : BigInt(version.payers[0]?.amount ?? version.amount),
+                              currency: version.currency,
+                            },
+                            { locale },
+                          ).text,
+                        });
                   // What this one expense did to *your* balance: what you put in
                   // beyond your share (you lent), or your share of what somebody
                   // else put in (you borrowed). The row used to end in the
@@ -514,18 +540,7 @@ export default function GroupScreen() {
                             </Row>
                             <Text variant="caption" tone="muted" numberOfLines={1}>
                               {[
-                                version
-                                  ? fill(t.expense.paidByNameAmount, {
-                                      name: nameOf(payer),
-                                      amount: formatParts(
-                                        {
-                                          minor: BigInt(version.amount),
-                                          currency: version.currency,
-                                        },
-                                        { locale },
-                                      ).text,
-                                    })
-                                  : fill(t.expense.paidByName, { name: nameOf(payer) }),
+                                paidLine,
                                 version
                                   ? new Intl.DateTimeFormat(locale, {
                                       day: 'numeric',

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useMutation } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Alert, Linking, Pressable, ScrollView, View } from 'react-native';
 
 import {
   allocateSettlement,
+  BalanceDirection,
   buildPaymentUri,
   defaultRailFor,
   railById,
@@ -34,6 +36,7 @@ import {
 } from '@baaki/ui';
 
 import { toSnapshot, useGroup, useGroupLedger, useRecordSettlement } from '@/data/hooks';
+import { nudgeToSettle } from '@/data/api';
 import { expenseTitle } from '@/data/expenseTitle';
 import { displayName, isGhost, payableAt, type MemberRow } from '@/data/types';
 import { fill, useStrings } from '@/i18n';
@@ -265,33 +268,55 @@ export default function SettleScreen() {
         </Row>
 
         {counterparties.length === 0 || !counterparty ? (
-          <EmptyState title={t.allSettled} body={t.group.nobodyOwes} />
+          <EmptyState
+            title={t.allSettled}
+            body={t.group.nobodyOwes}
+            icon={
+              <Ionicons name="checkmark-circle" size={iconSize.xxl} color={theme.color.positive} />
+            }
+          />
         ) : (
           <>
             <Card style={{ gap: theme.spacing.md }}>
               <Text variant="caption" tone="muted">
                 {t.misc.withLabel}
               </Text>
+              {/* Each face carries what settling with them is worth. The picker
+                  used to be names alone, so choosing between three people meant
+                  tapping each one to read the number that decides it. */}
               <Row style={{ flexWrap: 'wrap', gap: theme.spacing.lg }}>
-                {counterparties.map((member) => (
-                  <Pressable
-                    key={member.id}
-                    accessibilityRole="radio"
-                    accessibilityState={{ selected: counterparty.id === member.id }}
-                    accessibilityLabel={displayName(member)}
-                    onPress={() => setSelected(member.id)}
-                    style={{
-                      alignItems: 'center',
-                      gap: 4,
-                      opacity: counterparty.id === member.id ? 1 : 0.45,
-                    }}
-                  >
-                    <Avatar name={displayName(member)} ghost={isGhost(member)} size={52} />
-                    <Text variant="micro" tone={counterparty.id === member.id ? 'brand' : 'muted'}>
-                      {displayName(member)}
-                    </Text>
-                  </Pressable>
-                ))}
+                {counterparties.map((member) => {
+                  const theirs = ledger.balances.get(member.id) ?? 0n;
+                  const active = counterparty.id === member.id;
+                  return (
+                    <Pressable
+                      key={member.id}
+                      accessibilityRole="radio"
+                      accessibilityState={{ selected: active }}
+                      accessibilityLabel={displayName(member)}
+                      onPress={() => setSelected(member.id)}
+                      style={{ alignItems: 'center', gap: 4, opacity: active ? 1 : 0.45 }}
+                    >
+                      <Avatar name={displayName(member)} ghost={isGhost(member)} size={52} />
+                      <Text variant="micro" tone={active ? 'brand' : 'muted'}>
+                        {displayName(member)}
+                      </Text>
+                      {/* Their balance told from my side: they are on the other
+                          side of my ledger by construction, so a negative of
+                          theirs is money owed to me. */}
+                      <MoneyText
+                        amount={theirs < 0n ? -theirs : theirs}
+                        currency={currency}
+                        locale={locale}
+                        variant="micro"
+                        mode="balance"
+                        direction={
+                          theirs < 0n ? BalanceDirection.OwedToYou : BalanceDirection.YouOwe
+                        }
+                      />
+                    </Pressable>
+                  );
+                })}
               </Row>
             </Card>
 
@@ -372,6 +397,14 @@ export default function SettleScreen() {
               }
             />
 
+            {/* When the money is coming the other way, recording it is not the
+                only thing somebody came here to do — the other half of "settle
+                up" is asking. One tap, the server's one-a-day rule (ADR-010),
+                and no follow-up that reads like a collections notice. */}
+            {!iPay ? (
+              <RemindRow groupId={groupId} memberId={counterparty.id} currency={currency} />
+            ) : null}
+
             {recordSettlement.isPending ? <ActivityIndicator color={theme.color.brand} /> : null}
 
             <Text variant="micro" tone="muted" align="center">
@@ -388,4 +421,52 @@ export default function SettleScreen() {
 
 function min(a: bigint, b: bigint): bigint {
   return a < b ? a : b;
+}
+
+/**
+ * The nudge under the settle button, for the case where somebody else is the one
+ * who owes. Same rule and same manner as the Friends tab: it goes once, and the
+ * daily limit reads as "already nudged today" rather than as a failure.
+ */
+function RemindRow({
+  groupId,
+  memberId,
+  currency,
+}: {
+  groupId: string;
+  memberId: MemberId;
+  currency: string;
+}) {
+  const { t } = useStrings();
+  const [note, setNote] = useState<string | null>(null);
+
+  const nudge = useMutation({
+    mutationFn: () => nudgeToSettle({ groupId, toMemberId: memberId, currency }),
+    onSuccess: () => setNote(t.people.reminded),
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      setNote(message.includes('NUDGE_RATE_LIMIT') ? t.people.remindedToday : t.loadError);
+    },
+  });
+
+  if (note) {
+    return (
+      <Text variant="caption" tone="muted" align="center">
+        {note}
+      </Text>
+    );
+  }
+
+  return (
+    <Button
+      // The name is on the card above; gluing it to the verb here would be a
+      // sentence assembled in English word order and wrong in three locales.
+      label={t.people.remind}
+      variant="secondary"
+      size="lg"
+      fullWidth
+      disabled={nudge.isPending}
+      onPress={() => nudge.mutate()}
+    />
+  );
 }

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -147,6 +147,57 @@ export function verbEmoji(verb: string): string {
  *
  * `now` is injectable so the two branches are testable without a live clock.
  */
+/**
+ * The heading over a day's worth of entries — "Today", "Yesterday", "Saturday",
+ * then a plain date once the week is out.
+ *
+ * A feed of forty rows each stamped "3 days ago" is a list you have to read to
+ * navigate; the same rows under day headings are a list you can skim. The
+ * wording is `Intl`'s in every locale, and `RelativeTimeFormat` is
+ * feature-detected for the same reason `relativeTime` detects it — Hermes does
+ * not always ship it, and a missing constructor took this screen down once.
+ *
+ * The comparison is in calendar days in the phone's own timezone, not in
+ * elapsed hours: something logged at 23:50 last night is "yesterday" at 00:10,
+ * not "an hour ago" under today's heading.
+ */
+export function dayHeading(locale: string, iso: string, now: number = Date.now()): string {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return iso;
+  const when = new Date(parsed);
+  const midnight = (date: Date): number =>
+    new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+  const days = Math.round((midnight(new Date(now)) - midnight(when)) / 86_400_000);
+
+  const RTF = Intl.RelativeTimeFormat as typeof Intl.RelativeTimeFormat | undefined;
+  if ((days === 0 || days === 1) && typeof RTF === 'function') {
+    return capitalize(locale, new RTF(locale, { numeric: 'auto' }).format(-days, 'day'));
+  }
+  if (days > 1 && days < 7) {
+    return capitalize(locale, new Intl.DateTimeFormat(locale, { weekday: 'long' }).format(when));
+  }
+  const sameYear = when.getFullYear() === new Date(now).getFullYear();
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'long',
+    ...(sameYear ? {} : { year: 'numeric' }),
+  }).format(when);
+}
+
+/** "yesterday" → "Yesterday", in the locale's own casing rules. */
+function capitalize(locale: string, value: string): string {
+  const [first] = Array.from(value);
+  return first ? first.toLocaleUpperCase(locale) + value.slice(first.length) : value;
+}
+
+/** The calendar day an entry belongs to, as a grouping key in local time. */
+export function dayKey(iso: string): string {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return iso;
+  const when = new Date(parsed);
+  return `${when.getFullYear()}-${when.getMonth() + 1}-${when.getDate()}`;
+}
+
 export function relativeTime(locale: string, iso: string, now: number = Date.now()): string {
   const parsed = Date.parse(iso);
   if (!Number.isFinite(parsed)) return iso;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -887,6 +887,15 @@ export interface UiStrings {
     untitled: string;
     /** "Asha paid" under a row. The name comes first in English and may not elsewhere. */
     paidByName: string;
+    /** "Asha paid ₹1,200" — the row's subtitle, so the total is not lost when
+     *  the amount column switches to what the expense did to *your* balance. */
+    paidByNameAmount: string;
+    /** The label over an expense row's own effect on your balance: money you put
+     *  in beyond your share, and your share of money somebody else put in. */
+    youLent: string;
+    youBorrowed: string;
+    /** An expense you neither paid for nor have a share of. */
+    notInvolved: string;
     /** "edited twice" — the count is edits, so it starts at one. */
     editedTimes: PluralForms;
     /** "In 4 expenses" over the list on a member. */
@@ -2085,6 +2094,10 @@ const en: UiStrings = {
     disputed: 'Disputed',
     untitled: 'Untitled',
     paidByName: '{name} paid',
+    paidByNameAmount: '{name} paid {amount}',
+    youLent: 'you lent',
+    youBorrowed: 'you borrowed',
+    notInvolved: 'not involved',
     editedTimes: { one: 'edited once', other: 'edited {n} times' },
     inCount: { one: 'In {n} expense', other: 'In {n} expenses' },
     whoOwesWhat: 'Who owes what',
@@ -3370,6 +3383,10 @@ const ta: UiStrings = {
     disputed: 'மறுப்பு',
     untitled: 'பெயரிடப்படாதது',
     paidByName: '{name} கொடுத்தார்',
+    paidByNameAmount: '{name} {amount} கொடுத்தார்',
+    youLent: 'நீங்கள் கொடுத்தது',
+    youBorrowed: 'நீங்கள் வாங்கியது',
+    notInvolved: 'உங்களுக்கு தொடர்பில்லை',
     editedTimes: { one: 'ஒருமுறை திருத்தப்பட்டது', other: '{n} முறை திருத்தப்பட்டது' },
     inCount: { one: '{n} செலவில்', other: '{n} செலவுகளில்' },
     whoOwesWhat: 'யார் என்ன தர வேண்டும்',
@@ -4651,6 +4668,10 @@ const hi: UiStrings = {
     disputed: 'विवादित',
     untitled: 'बिना नाम',
     paidByName: '{name} ने भुगतान किया',
+    paidByNameAmount: '{name} ने {amount} दिए',
+    youLent: 'आपने दिए',
+    youBorrowed: 'आपने लिए',
+    notInvolved: 'आप इसमें नहीं',
     editedTimes: { one: 'एक बार संपादित', other: '{n} बार संपादित' },
     inCount: { one: '{n} खर्च में', other: '{n} खर्चों में' },
     whoOwesWhat: 'किस पर क्या बाकी',
@@ -5962,6 +5983,10 @@ const ar: UiStrings = {
     disputed: 'متنازع عليه',
     untitled: 'بلا عنوان',
     paidByName: 'دفع {name}',
+    paidByNameAmount: 'دفع {name} {amount}',
+    youLent: 'دفعت عنهم',
+    youBorrowed: 'حصتك',
+    notInvolved: 'لست ضمنها',
     editedTimes: {
       zero: 'لم يُعدّل',
       one: 'عُدّل مرة واحدة',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -5984,8 +5984,8 @@ const ar: UiStrings = {
     untitled: 'بلا عنوان',
     paidByName: 'دفع {name}',
     paidByNameAmount: 'دفع {name} {amount}',
-    youLent: 'دفعت عنهم',
-    youBorrowed: 'حصتك',
+    youLent: 'أقرضت',
+    youBorrowed: 'اقترضت',
     notInvolved: 'لست ضمنها',
     editedTimes: {
       zero: 'لم يُعدّل',

--- a/apps/mobile/test/activity.test.ts
+++ b/apps/mobile/test/activity.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { describeActivity, relativeTime, verbEmoji } from '@/data/activity';
+import { dayHeading, dayKey, describeActivity, relativeTime, verbEmoji } from '@/data/activity';
 import type { ActivityActor, ActivityRow } from '@/data/types';
 
 const RAVI: ActivityActor = {
@@ -233,5 +233,52 @@ describe('how long ago', () => {
     } finally {
       mutable.RelativeTimeFormat = original;
     }
+  });
+});
+
+/**
+ * The day headings over the feed.
+ *
+ * The heading is what makes a long feed skimmable, so the two cases that must
+ * not drift are the boundary ones: something logged just before midnight is
+ * "Yesterday" ten minutes later, not "an hour ago" filed under today, and a
+ * missing `Intl.RelativeTimeFormat` on Hermes degrades the wording rather than
+ * taking the screen down.
+ */
+describe('dayHeading', () => {
+  const now = Date.parse('2026-08-15T12:00:00');
+
+  it('names today and yesterday, capitalized', () => {
+    expect(dayHeading('en', new Date(now - 2 * 3600 * 1000).toISOString(), now)).toBe('Today');
+    expect(dayHeading('en', '2026-08-14T23:50:00', now)).toBe('Yesterday');
+  });
+
+  it('counts calendar days, not elapsed hours', () => {
+    // Ten minutes old, but on the other side of midnight.
+    const justAfterMidnight = Date.parse('2026-08-15T00:10:00');
+    expect(dayHeading('en', '2026-08-14T23:50:00', justAfterMidnight)).toBe('Yesterday');
+  });
+
+  it('uses the weekday inside the week and a date beyond it', () => {
+    expect(dayHeading('en', '2026-08-11T09:00:00', now)).toBe('Tuesday');
+    expect(dayHeading('en', '2026-07-04T09:00:00', now)).toContain('July');
+  });
+
+  it('does not throw when Intl.RelativeTimeFormat is missing (Android Hermes)', () => {
+    const mutable = Intl as unknown as { RelativeTimeFormat?: typeof Intl.RelativeTimeFormat };
+    const original = mutable.RelativeTimeFormat;
+    try {
+      delete mutable.RelativeTimeFormat;
+      const heading = dayHeading('en', new Date(now - 3600 * 1000).toISOString(), now);
+      expect(typeof heading).toBe('string');
+      expect(heading).not.toContain('undefined');
+    } finally {
+      mutable.RelativeTimeFormat = original;
+    }
+  });
+
+  it('keys entries by local calendar day', () => {
+    expect(dayKey('2026-08-15T00:10:00')).toBe(dayKey('2026-08-15T23:50:00'));
+    expect(dayKey('2026-08-14T23:50:00')).not.toBe(dayKey('2026-08-15T00:10:00'));
   });
 });

--- a/packages/ui/src/components/ListRow.tsx
+++ b/packages/ui/src/components/ListRow.tsx
@@ -71,16 +71,41 @@ export function EmptyState({
   title,
   body,
   action,
+  icon,
 }: {
   title: string;
   body: string;
   action?: ReactNode;
+  /**
+   * A glyph above the words, in a soft brand-tinted square. An empty screen is
+   * mostly air, and a page of two grey sentences in the middle of it reads as a
+   * screen that failed rather than one with nothing in it yet. The mark is
+   * decoration in the exact sense that matters here: it says "this is a state,
+   * not an error" before the sentence is read. Optional, because a short-lived
+   * empty inside a list (a filtered tab) does not want the ceremony.
+   */
+  icon?: ReactNode;
 }) {
   const theme = useTheme();
   return (
     <View
       style={{ alignItems: 'center', paddingVertical: theme.spacing.xxxl, gap: theme.spacing.sm }}
     >
+      {icon ? (
+        <View
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: theme.radius.lg,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.color.brandSoft,
+            marginBottom: theme.spacing.sm,
+          }}
+        >
+          {icon}
+        </View>
+      ) : null}
       <Text variant="heading" align="center">
         {title}
       </Text>


### PR DESCRIPTION
A design pass over the screens where money is read, with each change taken from how apps in the same category already solve the same problem. References are Mobbin screens, linked per item.

## What changed

**1. An expense row says what it did to *your* balance.**
It used to end in the expense total — the group's number, and never the question somebody opens a ledger with. Now the right rail reads `you lent` / `you borrowed` over your own delta (`paid − your share`), coloured by the app's one semantic money rule; the total moves into the subtitle next to who paid. An expense you are in neither column of reads "not involved" rather than a misleading ₹0.
Reference: [Splitwise group detail](https://mobbin.com/screens/1621a1d1-94a4-4c31-8f49-d99215bdfe02)

**2. The dashboard balance is flat and always visible.**
It was slide one of a swipeable deck, so the one number the app exists to tell you could be a card-width away — and after a swipe, off screen. The balance is now a full-width block; the deck survives beneath it at 132pt (down from 196) for what genuinely is a shelf: a running trip, any second currency, the two shortcut slides.
References: [Monzo](https://mobbin.com/screens/6c2bac17-2f8f-468d-bc8f-c77b4cf7ea5b), [Starling](https://mobbin.com/screens/9c57bdad-38f3-4e65-8374-960de4bfa3cc)

**3. Add-expense folds the split into one sentence.**
"You paid · Equally · 4 people", tappable to open. Almost every expense is that default, and it was costing three open sections and a screenful of scroll between the amount and Save. The section opens itself when the configuration is not the default, and stays open while the split does not add up — a validation message under a fold is one nobody reads. The controls are hidden, not unmounted, so half-typed share fields survive a fold.
Reference: [Splitwise add expense](https://mobbin.com/screens/639effbe-e37d-4613-bac3-3f34605e04ad)

**4. Settle up shows the amounts, and can ask.**
Each counterparty's face now carries what settling with them is worth, so choosing between three people no longer means tapping each one. When the money is coming the other way, a `Remind` button sits under the settle CTA — the existing `baaki_nudge_to_settle` RPC, so the one-a-day rule and ADR-010's tone are unchanged. The same nudge appears on the group's Balances rows.
References: [Revolut settle up](https://mobbin.com/screens/4a30eb35-3271-47a1-9f82-20e5aceb2479), [GoPay](https://mobbin.com/screens/005a4a08-fb29-4032-bd5d-e64864d0a81e)

**5. The activity feed is cut into days.**
`Today` / `Yesterday` / `Tuesday` / `4 July` headings, and each row keeps only its clock — "yesterday" printed forty times under a heading that already said it was noise. New `dayHeading`/`dayKey` helpers compare calendar days in local time, so 23:50 last night is Yesterday at 00:10, and `Intl.RelativeTimeFormat` is feature-detected the way `relativeTime` already is (Hermes).
References: [Monzo](https://mobbin.com/screens/8f921563-4da7-4e2b-98ea-e3e5e47b9229), [PayPal](https://mobbin.com/screens/5969e566-58ee-4417-bedc-be826d2a427a)

**6. Empty states have a mark and a way out.**
`EmptyState` takes an optional `icon` (soft brand square above the words). The group's expense list, the dashboard's no-groups state, the activity feed and the settled-up settle screen use it; the expense list also ends in an Add expense button rather than leaving the only action on the screen to a floating corner button.
References: [WhatsApp](https://mobbin.com/screens/e1b4d6ec-439d-4006-ae27-0324d09af995), [BFF](https://mobbin.com/screens/82352f5f-b68b-4a25-8284-90321f10afb9)

**Also:** a zero group balance says "all settled" instead of "you are owed ₹0".

## Notes

- New strings (`paidByNameAmount`, `youLent`, `youBorrowed`, `notInvolved`) are in all four locales.
- No schema, RPC or edge change; nothing to deploy beyond the app.
- `dayHeading` / `dayKey` are covered by 5 new tests.

## Gates

`pnpm typecheck` · `pnpm lint` · `pnpm test` (720 tests) · `prettier --check` — all green. Not yet run on a device.

## Deliberately not in this PR

- The group screen's own Activity tab still lists rows with a date+time subtitle; it could take the same day headings.
- Splitwise's cover-image group header, and a "you are all settled up in this group" sentence in place of the ₹0 hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pib1zHzfKvFyJtuRDyoHV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Activity entries are grouped by day with localized headings and clock times.
  - Added settlement reminders and nudges with success and error feedback.
  - Expense details now show paid amounts and whether you lent, borrowed, or were not involved.
  - Expense split settings can be collapsed for simpler setup.
  - Dashboard layout is more compact, keeping the primary balance prominent.
  - Empty states now include helpful icons and relevant actions.

- **Improvements**
  - Added expense messaging in English, Tamil, Hindi, and Arabic.
  - Settlement member selection shows balance direction and amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->