### PR TITLE
feat(mobile): lead the way in with real provider buttons

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -58,6 +58,7 @@
     "react-native-reanimated": "4.5.3",
     "react-native-safe-area-context": "~5.8.1",
     "react-native-screens": "~4.27.0",
+    "react-native-svg": "15.15.4",
     "react-native-url-polyfill": "^4.0.0",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.10.1"

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -1,10 +1,11 @@
 /**
  * Getting in.
  *
- * Four ways, ordered by how little they ask for: carry on as a guest, a code
- * to a phone, a password, Google. ADR-006 is that nobody is made to register
- * before they can split a bill, so the guest button is not tucked away at the
- * bottom in small type.
+ * Five ways: Apple, Google, a code to a phone, an email and a password, or
+ * nothing at all. They are ordered by how quickly they end — the two providers
+ * first, because they are one tap and no typing, then email, then the guest
+ * way. ADR-006 is that nobody is made to register before they can split a bill,
+ * so the guest button is not tucked away at the bottom in small type.
  *
  * Which Supabase call each of these makes is decided in @baaki/core, not here.
  * A guest who taps "Google" must have Google *added* to the account they
@@ -21,7 +22,7 @@
  * settings row they cannot read, is a door that only opens from the inside.
  */
 
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
@@ -54,7 +55,8 @@ import { dialingCodeForCountry } from '@baaki/core';
 import { CountryCodePicker } from '@/components/CountryCodePicker';
 import { LanguagePicker } from '@/components/LanguagePicker';
 import { Onboarding } from '@/components/Onboarding';
-import { deviceCountry, useStrings } from '@/i18n';
+import { SocialButton } from '@/components/SocialButton';
+import { deviceCountry, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { friendlyError } from '@/lib/errors';
 
@@ -127,6 +129,7 @@ export default function SignInScreen() {
   const [stage, setStage] = useState<'phone' | 'code'>('phone');
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
+  const [passwordShown, setPasswordShown] = useState(false);
   const [intent, setIntent] = useState<'sign_in' | 'sign_up'>('sign_in');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -162,10 +165,15 @@ export default function SignInScreen() {
 
   /**
    * The welcome: the wordmark on a coloured sweep, the language in the corner,
-   * and the three ways in — sign in, sign up, or carry on as a guest — with the
-   * social marks under them. ADR-006 says nobody registers before they can split
-   * a bill, so the guest way stays on this first screen rather than behind a
-   * form; it is only quieter than the two account buttons, not hidden.
+   * and the ways in beneath — the two providers first as full-width branded
+   * rows, then a hairline, then email, guest, and a line for somebody who
+   * already has an account.
+   *
+   * The providers moved above the fold and grew labels because a mark alone
+   * does not say which account it would use, and the order they arrive in is
+   * the platform's, not ours (see `SocialRow`). ADR-006 says nobody registers
+   * before they can split a bill, so the guest way stays on this first screen
+   * rather than behind a form; it is quieter than the email button, not hidden.
    */
   if (!showOptions) {
     return (
@@ -225,24 +233,39 @@ export default function SignInScreen() {
           keyboardShouldPersistTaps="handled"
         >
           <View style={{ gap: theme.spacing.xl }}>
+            {/* The fastest way in goes first. Somebody who has a Google or an
+                Apple account is one tap from being signed in, and every app
+                that does this well puts that tap above the form rather than
+                under it — the account buttons below are for the people those
+                two do not cover, not the other way round. */}
+            <View style={{ gap: theme.spacing.md }}>
+              <SocialRow
+                busy={busy}
+                onApple={() => void run(withApple)}
+                onGoogle={() => void run(withGoogle)}
+                t={t}
+              />
+            </View>
+
+            {/* A hairline either side of the label, not bare text — the seam
+                between "one tap" above and "an email and a password" below. */}
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}>
+              <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+              <Text variant="caption" tone="muted">
+                {t.signIn.or}
+              </Text>
+              <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+            </View>
+
             <View style={{ gap: theme.spacing.sm }}>
               <Button
-                label={t.signIn.signInAction}
+                label={t.signIn.continueEmail}
                 size="lg"
                 fullWidth
                 disabled={busy}
-                onPress={() => {
-                  setIntent('sign_in');
-                  setMode(Mode.Password);
-                  setShowOptions(true);
-                }}
-              />
-              <Button
-                label={t.signIn.createAccount}
-                variant="secondary"
-                size="lg"
-                fullWidth
-                disabled={busy}
+                icon={
+                  <Ionicons name="mail-outline" size={iconSize.md} color={theme.color.onBrand} />
+                }
                 onPress={() => {
                   setIntent('sign_up');
                   setMode(Mode.Password);
@@ -251,49 +274,28 @@ export default function SignInScreen() {
               />
               {/* ADR-006: nobody is made to register before splitting a bill, so
                   the guest way in stays on the first screen — quieter than the
-                  two account buttons, never hidden. */}
+                  account buttons, never hidden. */}
               <Button
                 label={t.signIn.continueGuest}
-                variant="ghost"
+                variant="secondary"
+                size="lg"
                 fullWidth
                 disabled={busy}
                 onPress={() => void run(continueAsGuest)}
               />
-            </View>
-
-            {/* A hairline either side of the label, not bare text — the seam
-                between "have an account" above and "one tap" below. */}
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}>
-              <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
-              <Text variant="caption" tone="muted">
-                {t.signIn.orSignInWith}
-              </Text>
-              <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
-            </View>
-
-            {/* The social marks up front, one tap in without a form — the same
-                providers the options screen offers. */}
-            <View
-              style={{
-                flexDirection: 'row',
-                justifyContent: 'center',
-                gap: theme.spacing.xl,
-              }}
-            >
-              <ProviderTile
-                label={t.signIn.signInApple}
+              {/* Coming back is a different errand from starting, and it is the
+                  rarer one on this screen: a line, not a third block. */}
+              <Button
+                label={t.signIn.haveAccount}
+                variant="ghost"
+                fullWidth
                 disabled={busy}
-                onPress={() => void run(withApple)}
-              >
-                <Ionicons name="logo-apple" size={iconSize.xxxl} color={theme.color.text} />
-              </ProviderTile>
-              <ProviderTile
-                label={t.signIn.signInGoogle}
-                disabled={busy}
-                onPress={() => void run(withGoogle)}
-              >
-                <Ionicons name="logo-google" size={iconSize.xxxl} color={theme.color.text} />
-              </ProviderTile>
+                onPress={() => {
+                  setIntent('sign_in');
+                  setMode(Mode.Password);
+                  setShowOptions(true);
+                }}
+              />
             </View>
 
             {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
@@ -358,6 +360,27 @@ export default function SignInScreen() {
                 here without passing the welcome, so this is their only sight of
                 the chips before they are asked to read a form. */}
             <LanguagePicker />
+
+            {/* The providers sit above the form here too. They were a row of
+                small squares under it, which put the one-tap way in below a
+                keyboard on every phone. */}
+            <View style={{ gap: theme.spacing.md }}>
+              <SocialRow
+                busy={busy}
+                guest={isGuest}
+                onApple={() => void run(withApple)}
+                onGoogle={() => void run(withGoogle)}
+                t={t}
+              />
+            </View>
+
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}>
+              <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+              <Text variant="caption" tone="muted">
+                {t.signIn.or}
+              </Text>
+              <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+            </View>
 
             <Card style={{ gap: theme.spacing.lg }}>
               {/* Two ways in, named for what they ask for. The password face
@@ -504,21 +527,43 @@ export default function SignInScreen() {
                   <Text variant="caption" tone="muted">
                     {t.signIn.password}
                   </Text>
-                  <TextInput
-                    value={password}
-                    onChangeText={setPassword}
-                    secureTextEntry
-                    autoCapitalize="none"
-                    autoComplete={intent === 'sign_up' ? 'new-password' : 'current-password'}
-                    accessibilityLabel={t.signIn.password}
-                    placeholderTextColor={theme.color.textFaint}
-                    style={{
-                      fontSize: 18,
-                      fontWeight: '500',
-                      color: theme.color.text,
-                      paddingVertical: theme.spacing.sm,
-                    }}
-                  />
+                  {/* The eye is not a nicety on this field: the app asks for
+                      eight characters, the keyboard is a phone keyboard, and a
+                      password typed blind is the most common reason a correct
+                      one is reported wrong. Every reference login has it. */}
+                  <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+                    <TextInput
+                      value={password}
+                      onChangeText={setPassword}
+                      secureTextEntry={!passwordShown}
+                      autoCapitalize="none"
+                      autoComplete={intent === 'sign_up' ? 'new-password' : 'current-password'}
+                      accessibilityLabel={t.signIn.password}
+                      placeholderTextColor={theme.color.textFaint}
+                      style={{
+                        flex: 1,
+                        fontSize: 18,
+                        fontWeight: '500',
+                        color: theme.color.text,
+                        paddingVertical: theme.spacing.sm,
+                      }}
+                    />
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={
+                        passwordShown ? t.signIn.hidePassword : t.signIn.showPassword
+                      }
+                      onPress={() => setPasswordShown((shown) => !shown)}
+                      hitSlop={12}
+                      style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+                    >
+                      <Ionicons
+                        name={passwordShown ? 'eye-off-outline' : 'eye-outline'}
+                        size={iconSize.lg}
+                        color={theme.color.textMuted}
+                      />
+                    </Pressable>
+                  </Row>
                   <Text variant="micro" tone="muted">
                     {t.signIn.passwordHint}
                   </Text>
@@ -541,43 +586,6 @@ export default function SignInScreen() {
               {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
               {error ? <Callout tone="negative">{error}</Callout> : null}
             </Card>
-
-            {/* Icon-only tiles rather than two stacked full-width buttons: the
-                provider is a small choice next to the account above, and a row
-                of marks reads as "one of these" in a glance where a stack of
-                labelled bars reads as two more things to do.
-
-                Apple's mark is a custom tile here, not its native button. The
-                native sheet is still what opens — `withApple` calls it directly
-                (see auth.tsx), the widget was only ever the surface — so on an
-                iPhone this tile brings up the same system sign-in. */}
-            <View style={{ gap: theme.spacing.md }}>
-              <Text variant="caption" tone="muted" align="center">
-                {t.signIn.orSignInWith}
-              </Text>
-              <View
-                style={{
-                  flexDirection: 'row',
-                  justifyContent: 'center',
-                  gap: theme.spacing.lg,
-                }}
-              >
-                <ProviderTile
-                  label={isGuest ? t.signIn.continueApple : t.signIn.signInApple}
-                  disabled={busy}
-                  onPress={() => void run(withApple)}
-                >
-                  <Ionicons name="logo-apple" size={iconSize.xxxl} color={theme.color.text} />
-                </ProviderTile>
-                <ProviderTile
-                  label={isGuest ? t.signIn.continueGoogle : t.signIn.signInGoogle}
-                  disabled={busy}
-                  onPress={() => void run(withGoogle)}
-                >
-                  <Ionicons name="logo-google" size={iconSize.xxxl} color={theme.color.text} />
-                </ProviderTile>
-              </View>
-            </View>
 
             {/* ADR-006: nobody is forced to register before they can use Baaki.
               Still here, one step back from the welcome, for somebody who came
@@ -604,44 +612,48 @@ export default function SignInScreen() {
 }
 
 /**
- * A square, icon-only social button — one mark in the row under "or sign in
- * with". Icon-only, so it carries the provider's name as its accessibility
- * label; a screen reader hears "Sign in with Google", not "button".
+ * The two providers, stacked, in the order this platform expects.
+ *
+ * Apple leads on iOS and Google on Android — not a style choice: on an iPhone
+ * the Apple sheet is the one that needs no browser and no typing, and on
+ * Android it is Google's. Putting the home platform's own account first is what
+ * every well-made sign-in on either store does, and it is the difference
+ * between one tap and one tap plus a web view.
+ *
+ * A guest sees "Continue with", not "Sign in with": they are adding a way back
+ * into an account they already have, and "sign in" would suggest they are about
+ * to arrive somewhere else — which, if it happened, would strand their groups.
  */
-function ProviderTile({
-  label,
-  disabled,
-  onPress,
-  children,
+function SocialRow({
+  busy,
+  guest = false,
+  onApple,
+  onGoogle,
+  t,
 }: {
-  label: string;
-  disabled?: boolean;
-  onPress: () => void;
-  children: ReactNode;
+  busy: boolean;
+  guest?: boolean;
+  onApple: () => void;
+  onGoogle: () => void;
+  t: UiStrings;
 }) {
-  const theme = useTheme();
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={label}
-      accessibilityState={{ disabled: Boolean(disabled) }}
-      disabled={disabled}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        width: 96,
-        height: 60,
-        borderRadius: theme.radius.lg,
-        borderWidth: 1,
-        borderColor: theme.color.border,
-        backgroundColor: theme.color.surface,
-        alignItems: 'center',
-        justifyContent: 'center',
-        opacity: disabled ? 0.5 : 1,
-        transform: [{ scale: pressed ? 0.97 : 1 }],
-        ...theme.shadow.soft,
-      })}
-    >
-      {children}
-    </Pressable>
+  const apple = (
+    <SocialButton
+      key="apple"
+      provider="apple"
+      label={guest ? t.signIn.continueApple : t.signIn.signInApple}
+      disabled={busy}
+      onPress={onApple}
+    />
   );
+  const google = (
+    <SocialButton
+      key="google"
+      provider="google"
+      label={guest ? t.signIn.continueGoogle : t.signIn.signInGoogle}
+      disabled={busy}
+      onPress={onGoogle}
+    />
+  );
+  return <>{Platform.OS === 'ios' ? [apple, google] : [google, apple]}</>;
 }

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -241,6 +241,7 @@ export default function SignInScreen() {
             <View style={{ gap: theme.spacing.md }}>
               <SocialRow
                 busy={busy}
+                wording="continue"
                 onApple={() => void run(withApple)}
                 onGoogle={() => void run(withGoogle)}
                 t={t}
@@ -367,7 +368,7 @@ export default function SignInScreen() {
             <View style={{ gap: theme.spacing.md }}>
               <SocialRow
                 busy={busy}
-                guest={isGuest}
+                wording={isGuest ? 'continue' : 'signIn'}
                 onApple={() => void run(withApple)}
                 onGoogle={() => void run(withGoogle)}
                 t={t}
@@ -530,7 +531,12 @@ export default function SignInScreen() {
                   {/* The eye is not a nicety on this field: the app asks for
                       eight characters, the keyboard is a phone keyboard, and a
                       password typed blind is the most common reason a correct
-                      one is reported wrong. Every reference login has it. */}
+                      one is reported wrong. Every reference login has it.
+
+                      The dots are the placeholder for the same reason: these
+                      fields carry no border, so an empty one with no
+                      placeholder reads as a gap rather than as somewhere to
+                      type. Dots need no translating. */}
                   <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
                     <TextInput
                       value={password}
@@ -539,6 +545,7 @@ export default function SignInScreen() {
                       autoCapitalize="none"
                       autoComplete={intent === 'sign_up' ? 'new-password' : 'current-password'}
                       accessibilityLabel={t.signIn.password}
+                      placeholder="••••••••"
                       placeholderTextColor={theme.color.textFaint}
                       style={{
                         flex: 1,
@@ -620,28 +627,32 @@ export default function SignInScreen() {
  * every well-made sign-in on either store does, and it is the difference
  * between one tap and one tap plus a web view.
  *
- * A guest sees "Continue with", not "Sign in with": they are adding a way back
- * into an account they already have, and "sign in" would suggest they are about
- * to arrive somewhere else — which, if it happened, would strand their groups.
+ * "Sign in with" is reserved for the one screen where it is true: somebody who
+ * tapped "I already have an account". Everywhere else the same button both makes
+ * an account and returns to one, and both Apple's and Google's own guidelines
+ * say to write "Continue with" when it does. It matters here beyond wording — a
+ * guest tapping it is attaching a way back into the groups already on this
+ * phone, and "sign in" would suggest they are about to land somewhere else.
  */
 function SocialRow({
   busy,
-  guest = false,
+  wording,
   onApple,
   onGoogle,
   t,
 }: {
   busy: boolean;
-  guest?: boolean;
+  wording: 'continue' | 'signIn';
   onApple: () => void;
   onGoogle: () => void;
   t: UiStrings;
 }) {
+  const carryOn = wording === 'continue';
   const apple = (
     <SocialButton
       key="apple"
       provider="apple"
-      label={guest ? t.signIn.continueApple : t.signIn.signInApple}
+      label={carryOn ? t.signIn.continueApple : t.signIn.signInApple}
       disabled={busy}
       onPress={onApple}
     />
@@ -650,7 +661,7 @@ function SocialRow({
     <SocialButton
       key="google"
       provider="google"
-      label={guest ? t.signIn.continueGoogle : t.signIn.signInGoogle}
+      label={carryOn ? t.signIn.continueGoogle : t.signIn.signInGoogle}
       disabled={busy}
       onPress={onGoogle}
     />

--- a/apps/mobile/src/components/SocialButton.tsx
+++ b/apps/mobile/src/components/SocialButton.tsx
@@ -1,0 +1,110 @@
+/**
+ * The provider buttons on the way in.
+ *
+ * These were icon-only tiles — two 96×60 squares under a hairline that said
+ * "or sign in with". That reads as a decoration until you have already decided
+ * to look for it, and it hides the one fact that makes somebody tap: *which*
+ * account they would be using. Every app that does this well (Duolingo, eBay,
+ * Canva, Speak, Recime, MyFitnessPal, Finimize) draws the same thing instead —
+ * a full-width row, the provider's own mark on the left, its own words on it.
+ *
+ * The marks are the real ones. Apple's is white on black (inverted in dark, as
+ * Apple's own guidance says), Google's is the four-colour G on white behind a
+ * hairline — a purple-tinted G or a monochrome one is off-brand for both, and
+ * on a screen whose whole job is trust, an approximated logo is the wrong place
+ * to save a dependency.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, View } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+
+import { Text, useTheme } from '@baaki/ui';
+
+export type SocialProvider = 'apple' | 'google';
+
+/**
+ * Google's G, drawn from its four brand colours at the official proportions.
+ * Left as fixed hex rather than theme colours on purpose: a brand mark that
+ * changed with the app's palette would no longer be the brand mark.
+ */
+function GoogleMark({ size = 20 }: { size?: number }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 48 48">
+      <Path
+        fill="#4285F4"
+        d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"
+      />
+      <Path
+        fill="#34A853"
+        d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"
+      />
+      <Path
+        fill="#FBBC05"
+        d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24s.85 6.91 2.34 9.88l7.35-5.7z"
+      />
+      <Path
+        fill="#EA4335"
+        d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"
+      />
+    </Svg>
+  );
+}
+
+/**
+ * One provider row: the mark pinned left, the label centred in the whole width.
+ *
+ * Centring the label in the button rather than beside the mark is what keeps a
+ * stack of these looking like a stack — "Continue with Apple" and "Continue
+ * with Google" are different lengths, and a row-centred pair puts their marks
+ * at two different x positions, which reads as two buttons that do not belong
+ * to each other. The mark is absolutely positioned so the label can own the
+ * centre without either one moving the other.
+ */
+export function SocialButton({
+  provider,
+  label,
+  onPress,
+  disabled = false,
+}: {
+  provider: SocialProvider;
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+}) {
+  const theme = useTheme();
+  const apple = provider === 'apple';
+  // Apple's mark inverts with the surface; Google's button is always the light
+  // one, which is the only variant Google's guidelines allow beside the
+  // four-colour G.
+  const background = apple ? theme.color.text : '#FFFFFF';
+  const ink = apple ? theme.color.bg : '#1F1F1F';
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        height: 56,
+        borderRadius: theme.radius.pill,
+        alignSelf: 'stretch',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: background,
+        borderWidth: apple ? 0 : 1,
+        borderColor: '#DADCE0',
+        opacity: disabled ? 0.45 : pressed ? 0.9 : 1,
+      })}
+    >
+      <View style={{ position: 'absolute', start: theme.spacing.xl }}>
+        {apple ? <Ionicons name="logo-apple" size={22} color={ink} /> : <GoogleMark />}
+      </View>
+      <Text variant="subheading" style={{ color: ink }}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -630,6 +630,14 @@ export interface UiStrings {
     continueApple: string;
     signInApple: string;
     orSignInWith: string;
+    /** The word on the hairline between the provider buttons and the form. */
+    or: string;
+    /** The email path, named beside "Continue with Apple/Google" so the three
+     *  ways in read as one list rather than a list and an exception. */
+    continueEmail: string;
+    /** Spoken labels for the reveal toggle on the password field. */
+    showPassword: string;
+    hidePassword: string;
     continueGuest: string;
     guestFootnote: string;
     memberFootnote: string;
@@ -1822,6 +1830,10 @@ const en: UiStrings = {
     continueApple: 'Continue with Apple',
     signInApple: 'Sign in with Apple',
     orSignInWith: 'or sign in with',
+    or: 'or',
+    continueEmail: 'Continue with email',
+    showPassword: 'Show password',
+    hidePassword: 'Hide password',
     continueGuest: 'Continue as guest',
     guestFootnote:
       'Everything you have already added stays exactly where it is. This only adds a way to sign back in.',
@@ -3098,6 +3110,10 @@ const ta: UiStrings = {
     continueApple: 'Apple மூலம் தொடர்',
     signInApple: 'Apple மூலம் உள்நுழை',
     orSignInWith: 'அல்லது இதன் மூலம் உள்நுழை',
+    or: 'அல்லது',
+    continueEmail: 'மின்னஞ்சலில் தொடர்க',
+    showPassword: 'கடவுச்சொல்லைக் காட்டு',
+    hidePassword: 'கடவுச்சொல்லை மறை',
     continueGuest: 'விருந்தினராகத் தொடர்',
     guestFootnote:
       'நீங்கள் ஏற்கனவே சேர்த்த அனைத்தும் அப்படியே இருக்கும். இது மீண்டும் உள்நுழைய ஒரு வழியை மட்டுமே சேர்க்கிறது.',
@@ -4394,6 +4410,10 @@ const hi: UiStrings = {
     continueApple: 'Apple से जारी रखें',
     signInApple: 'Apple से साइन इन करें',
     orSignInWith: 'या इसके ज़रिए साइन इन करें',
+    or: 'या',
+    continueEmail: 'ईमेल से जारी रखें',
+    showPassword: 'पासवर्ड दिखाएँ',
+    hidePassword: 'पासवर्ड छिपाएँ',
     continueGuest: 'मेहमान के तौर पर जारी रखें',
     guestFootnote:
       'आपने जो जोड़ा है वह जहाँ है वहीं रहेगा। इससे सिर्फ़ दोबारा साइन इन करने का रास्ता जुड़ता है।',
@@ -5688,6 +5708,10 @@ const ar: UiStrings = {
     continueApple: 'المتابعة عبر Apple',
     signInApple: 'تسجيل الدخول عبر Apple',
     orSignInWith: 'أو سجّل الدخول عبر',
+    or: 'أو',
+    continueEmail: 'المتابعة بالبريد الإلكتروني',
+    showPassword: 'إظهار كلمة المرور',
+    hidePassword: 'إخفاء كلمة المرور',
     continueGuest: 'المتابعة كضيف',
     guestFootnote: 'كل ما أضفته يبقى كما هو تمامًا. هذا يضيف فقط طريقة للعودة وتسجيل الدخول.',
     memberFootnote:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 15.1.1(expo-font@57.0.1)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       '@microsoft/react-native-clarity':
         specifier: ^4.6.3
-        version: 4.6.3(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+        version: 4.6.3(react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       '@react-native-async-storage/async-storage':
         specifier: 3.1.1
         version: 3.1.1(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -233,6 +233,9 @@ importers:
       react-native-screens:
         specifier: ~4.27.0
         version: 4.27.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native-svg:
+        specifier: 15.15.4
+        version: 15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       react-native-url-polyfill:
         specifier: ^4.0.0
         version: 4.0.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))
@@ -3347,6 +3350,9 @@ packages:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
 
@@ -3543,6 +3549,17 @@ packages:
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -3708,6 +3725,19 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -3762,6 +3792,10 @@ packages:
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
@@ -5130,6 +5164,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -5396,6 +5433,9 @@ packages:
   npm-package-arg@11.0.3:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -5779,6 +5819,12 @@ packages:
 
   react-native-screens@4.27.0:
     resolution: {integrity: sha512-IUukKYilhKhdJqGh59BmxrAjgIO84CaOkdowEY20+RmapOAFpqS//xOIcq2iqDQ4xVoxuwCHGWhY/Tbz6lTblA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-svg@15.15.4:
+    resolution: {integrity: sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -7951,10 +7997,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@microsoft/react-native-clarity@4.6.3(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+  '@microsoft/react-native-clarity@4.6.3(react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
     dependencies:
       react: 19.2.8
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+    optionalDependencies:
+      react-native-svg: 15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
@@ -9963,6 +10011,8 @@ snapshots:
 
   big-integer@1.6.52: {}
 
+  boolbase@1.0.0: {}
+
   bplist-creator@0.1.0:
     dependencies:
       stream-buffers: 2.2.0
@@ -10185,6 +10235,21 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+
+  css-what@6.2.2: {}
+
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
@@ -10327,6 +10392,24 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dotenv@16.6.1: {}
 
   dotenv@17.4.2: {}
@@ -10374,6 +10457,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@4.5.0: {}
 
   env-paths@3.0.0: {}
 
@@ -10536,7 +10621,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-expo: 1.1.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -10576,21 +10661,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
-      get-tsconfig: 4.14.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -10613,7 +10683,7 @@ snapshots:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11992,6 +12062,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdn-data@2.0.14: {}
+
   memoize-one@5.2.1: {}
 
   memoize-one@6.0.0: {}
@@ -12314,6 +12386,10 @@ snapshots:
       proc-log: 4.2.0
       semver: 7.8.5
       validate-npm-package-name: 5.0.1
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   nullthrows@1.1.1: {}
 
@@ -12707,6 +12783,14 @@ snapshots:
     dependencies:
       react: 19.2.8
       react-freeze: 1.0.4(react@19.2.8)
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+      warn-once: 0.1.1
+
+  react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 19.2.8
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
       warn-once: 0.1.1
 


### PR DESCRIPTION
Mobbin-benchmarked pass over the way into the app.

## What was wrong

Apple and Google were two 96×60 icon-only tiles sitting **below** the email form, under a hairline reading "or sign in with". Three problems, in order of how much they cost:

- On the options screen the one-tap path sat under the keyboard on every phone.
- The tiles never said which account was about to be used — the thing that actually decides whether somebody taps.
- Google's mark was a monochrome Ionicons glyph tinted with the app's purple. Off-brand for both vendors, on the one screen whose entire job is trust.

## What the references do

Every one of them leads with the providers, above the form, full-width, carrying the provider's own mark and its own words:

- [eBay](https://mobbin.com/screens/cecf445a-64ec-4b34-92d8-6f07ac082f0a)
- [Canva](https://mobbin.com/screens/525ca9f0-d2e1-41cc-9295-f86a72561c26)
- [Speak](https://mobbin.com/screens/3b88f3b6-0b11-48f1-85bf-ab1aebe3bf2e)
- [Recime](https://mobbin.com/screens/3181d469-6af3-45e5-a60e-84fb880f6b83)
- [Finimize](https://mobbin.com/screens/736b48bd-63d0-499e-a2de-8a7fea0e76f3)

Duolingo, MyFitnessPal and Vocabulary do the same thing; I no longer have their screen ids to hand, so they are named rather than linked.

## What changed

**Providers lead, on both screens.** Full-width rows above the form on the welcome screen and the options screen.

**Platform order.** Apple first on iOS, Google first on Android. Not cosmetic — on each platform the home account is the one that needs no browser round trip.

**The real marks.** New `SocialButton` component. Google is the official four-colour G drawn as SVG paths on a white button behind a `#DADCE0` hairline, the only variant Google's guidelines allow. Apple is white-on-black, inverting with the surface as Apple's guidance says. The mark is absolutely positioned left and the label owns the centre, so a stack of two rows keeps both marks at the same x — row-centring would put them at two different positions and read as two unrelated buttons.

**"Continue with" vs "Sign in with".** The welcome screen is where somebody with no account arrives; that button both registers and returns, and both vendors' guidelines say to write "Continue with" when it does. "Sign in with" now appears only on the screen reached through "I already have an account", where it is true. The prop reads `wording: 'continue' | 'signIn'` rather than a `guest` boolean that meant the right thing by accident.

**Password reveal.** The form asks for eight characters on a phone keyboard; typing that blind is the usual reason a correct password comes back rejected. Eye toggle with `showPassword` / `hidePassword` a11y labels, plus a `••••••••` placeholder — these fields carry no border, so an empty one with no placeholder rendered as blank space with an eye floating beside it.

Guest entry is untouched (ADR-006): "Continue as guest" still sits on the welcome screen, no account required.

## Deliberately not done

Both are real gaps; neither is a design fix, and inventing one would have made the screen worse:

- **No password reset.** Every reference has "Forgot password?". `AuthValue` has no reset call — that's Supabase `resetPasswordForEmail` plus a deep link, i.e. backend work.
- **No Terms or Privacy documents exist.** No URL for either anywhere in the app. The references all carry a legal footnote; one that links to nothing is worse than none.

## Notes for review

`react-native-svg` is new and is a **native** dependency — this needs a rebuild, not an OTA update.

## Verification

- `tsc --noEmit` clean, `pnpm -w run lint` clean, 230 mobile tests pass.
- Built locally (`gradlew assembleRelease`, `BUILD SUCCESSFUL`) and installed on an emulator. Both screens checked by eye: the four-colour G renders, marks align across the stack, wording is right on each screen, password field reads as a field.
- Strings added to all four locales (en, ta, hi, ar); `strings.test.ts` key parity passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-width Apple and Google sign-in buttons with branded visuals and accessible labels.
  * Reorganized sign-in options for clearer navigation between social sign-in, email/password, and guest access.
  * Added password visibility controls and an email continuation action.
* **Localization**
  * Added translated labels for sign-in separators, email continuation, and password visibility controls in English, Tamil, Hindi, and Arabic.
* **Style**
  * Improved button states, colors, spacing, and visual consistency across sign-in screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->