### PR TITLE
fix(mobile): keep the raw sync exception off the screen

### DIFF
--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -20,7 +20,7 @@ import { useSync } from '@/sync';
 export function SyncBanner({ groupId }: { groupId?: string }) {
   const theme = useTheme();
   const { t, locale } = useStrings();
-  const { status, queue, rejected, retry, discard, lastError } = useSync();
+  const { status, queue, rejected, retry, discard } = useSync();
   const { preference: syncNetwork } = useSyncNetwork();
 
   const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
@@ -103,7 +103,13 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
       : status === 'error'
         ? {
             icon: 'cloud-offline-outline' as const,
-            message: plural(locale, pending.length, t.misc.cantReachServer),
+            // With nothing queued there is no count to quote — a bare "0 changes
+            // saved here, waiting to send" is both wrong (nothing is waiting) and
+            // alarming on a phone that is plainly online.
+            message:
+              pending.length > 0
+                ? plural(locale, pending.length, t.misc.cantReachServer)
+                : t.misc.cantReachServerIdle,
           }
         : {
             icon: 'sync-outline' as const,
@@ -120,11 +126,13 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
           </Text>
         </View>
       </Row>
-      {status === 'error' && lastError ? (
-        <Text variant="micro" tone="muted">
-          {lastError}
-        </Text>
-      ) : null}
+      {/* The raw exception used to print here under the friendly line — things
+          like "NativeStatement.finalizeAsync ... database is locked". It is an
+          internal message, never translated and never actionable, and it made a
+          normal offline state read as a broken app. It still travels to Sentry
+          via reportHandled; it just no longer lands on the screen. The friendly
+          line above already says the one thing the user needs: saved here,
+          waiting to send. */}
     </Card>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -962,6 +962,8 @@ export interface UiStrings {
     notSentYet: string;
     offlineWithCount: PluralForms;
     cantReachServer: PluralForms;
+    /** Server unreachable but nothing is queued — no count to quote. */
+    cantReachServerIdle: string;
     syncingCount: PluralForms;
     notAnAmount: string;
     notARate: string;
@@ -2171,6 +2173,7 @@ const en: UiStrings = {
       one: "Can't reach the server — {n} change saved here, waiting to send",
       other: "Can't reach the server — {n} changes saved here, waiting to send",
     },
+    cantReachServerIdle: "Can't reach the server — everything here is saved",
     syncingCount: { one: 'Sending {n} change…', other: 'Sending {n} changes…' },
     offlineSaved: 'Offline — everything here is saved on this phone',
     notAnAmount: 'That does not look like an amount',
@@ -3469,6 +3472,7 @@ const ta: UiStrings = {
       one: 'சர்வரை அடைய முடியவில்லை — {n} மாற்றம் இங்கே சேமிக்கப்பட்டு காத்திருக்கிறது',
       other: 'சர்வரை அடைய முடியவில்லை — {n} மாற்றங்கள் இங்கே சேமிக்கப்பட்டு காத்திருக்கின்றன',
     },
+    cantReachServerIdle: 'சர்வரை அடைய முடியவில்லை — எல்லாம் இங்கே சேமிக்கப்பட்டுள்ளது',
     syncingCount: {
       one: '{n} மாற்றம் அனுப்பப்படுகிறது…',
       other: '{n} மாற்றங்கள் அனுப்பப்படுகின்றன…',
@@ -4760,6 +4764,7 @@ const hi: UiStrings = {
       one: 'सर्वर तक नहीं पहुँच पा रहे — {n} बदलाव यहीं सेव है, भेजने का इंतज़ार',
       other: 'सर्वर तक नहीं पहुँच पा रहे — {n} बदलाव यहीं सेव हैं, भेजने का इंतज़ार',
     },
+    cantReachServerIdle: 'सर्वर तक नहीं पहुँच पा रहे — सब कुछ यहीं सेव है',
     syncingCount: { one: '{n} बदलाव भेजा जा रहा है…', other: '{n} बदलाव भेजे जा रहे हैं…' },
     offlineSaved: 'ऑफ़लाइन — यहाँ का सब कुछ इसी फ़ोन पर सेव है',
     notAnAmount: 'यह रकम जैसा नहीं लगता',
@@ -6102,6 +6107,7 @@ const ar: UiStrings = {
       many: 'تعذّر الوصول إلى الخادم — {n} تغييرًا محفوظًا هنا في انتظار الإرسال',
       other: 'تعذّر الوصول إلى الخادم — {n} تغيير محفوظ هنا في انتظار الإرسال',
     },
+    cantReachServerIdle: 'تعذّر الوصول إلى الخادم — كل شيء هنا محفوظ',
     syncingCount: {
       zero: 'جارٍ الإرسال…',
       one: 'جارٍ إرسال تغيير واحد…',


### PR DESCRIPTION
## What was wrong

The app-wide offline banner (it rides on Home and inside every group) printed the raw caught exception beneath its friendly line:

> Can't reach the server — 0 changes saved here, waiting to send
> **Call to function 'NativeStatement.finalizeAsync' has been rejected.**
> **→ Caused by: Error code : database is locked**

That second part is an internal SQLite/flush message — never translated, never actionable — and it made a normal offline-first state read as a broken app. `lastError` is always just `caught.message` from the flush path; it is only ever technical.

A second, smaller wrong in the same banner: with an empty queue it still said "**0** changes saved here, waiting to send" — nothing was waiting, and the phone in the screenshot was plainly on 5G.

## What changed

- **The raw exception no longer renders.** Removed the `lastError` block from `SyncBanner`. It still goes to Sentry via `reportHandled` in the engine — it just leaves the screen. The friendly line already says the one thing the user needs: saved here, waiting to send.
- **Zero-queue wording.** When the server is unreachable but nothing is queued, the banner now reads "Can't reach the server — everything here is saved" (new `cantReachServerIdle`, all four locales) instead of quoting a count of zero.

## Scope

The `rejected` path in the same banner still shows `first.message` — that is the server's own per-change validation string (with a translated fallback), meant to be read, not an internal error. Left as is.

There are also ~20 form-level error Callouts across the app that render a caught `error` after an explicit failed action. Those usually carry a useful server reason and only appear on a deliberate submit, so they are out of scope here; happy to sweep them behind a friendly-error helper as a follow-up if you want.

## Verification

- `tsc --noEmit` clean, `pnpm expo lint` clean, `prettier --check` clean, 236 mobile tests pass, `strings.test.ts` parity passes.
- The exact failure (a DB lock during flush) is not reproducible on demand on the emulator; the change is a removal of the only raw-text render plus a zero-count wording branch, so nothing technical can print in that banner now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync status messaging when the server cannot be reached and no changes are pending.
  * Removed raw error details from the sync banner in favor of clearer status text.
  * Added localized messaging in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->