### PR TITLE
feat(mobile): dashboard polish, guest prompt, tips + consistent empty states

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -114,7 +114,11 @@ export default function ActivityScreen() {
               title={t.loadError}
               body={t.loadErrorBody}
               icon={
-                <Ionicons name="cloud-offline-outline" size={iconSize.xxl} color={theme.color.brand} />
+                <Ionicons
+                  name="cloud-offline-outline"
+                  size={iconSize.xxl}
+                  color={theme.color.brand}
+                />
               }
               action={
                 <Button label={t.retry} variant="secondary" onPress={() => activity.refetch()} />

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -66,6 +66,10 @@ export default function ActivityScreen() {
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
+          // So the empty and error states can take the room the feed is not using
+          // and sit centred, the same way the Friends screen does. With a feed
+          // present this changes nothing.
+          flexGrow: 1,
         }}
         showsVerticalScrollIndicator={false}
         refreshControl={
@@ -105,19 +109,27 @@ export default function ActivityScreen() {
         {activity.isLoading ? (
           <FeedSkeleton />
         ) : activity.isError ? (
-          <EmptyState
-            title={t.loadError}
-            body={t.loadErrorBody}
-            action={
-              <Button label={t.retry} variant="secondary" onPress={() => activity.refetch()} />
-            }
-          />
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <EmptyState
+              title={t.loadError}
+              body={t.loadErrorBody}
+              icon={
+                <Ionicons name="cloud-offline-outline" size={iconSize.xxl} color={theme.color.brand} />
+              }
+              action={
+                <Button label={t.retry} variant="secondary" onPress={() => activity.refetch()} />
+              }
+            />
+          </View>
         ) : entries.length === 0 ? (
-          <EmptyState
-            title={t.nothingYet}
-            body={t.tabs.activityEmptyBody}
-            icon={<Ionicons name="pulse" size={iconSize.xxl} color={theme.color.brand} />}
-          />
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <EmptyState
+              title={t.nothingYet}
+              body={t.tabs.activityEmptyBody}
+              icon={<Ionicons name="pulse" size={iconSize.xxl} color={theme.color.brand} />}
+              action={<Button label={t.newGroup} onPress={() => router.push('/new-group')} />}
+            />
+          </View>
         ) : (
           // A vertical timeline broken into days: each event is a node on a
           // connector line running down the left, its icon in a soft circle

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -31,6 +31,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   Avatar,
   Badge,
+  Button,
   Card,
   EmptyState,
   iconSize,
@@ -267,10 +268,13 @@ export default function FriendsScreen() {
  * are empty. So the first state names that and the second keeps the
  * congratulation for the people who earned it.
  *
- * No button: the two ways in — add from contacts, add a person — live as icons
- * in the header, present on this screen and every other Friends state, so the
- * empty state states the situation and points at them rather than duplicating
- * them in the middle of the page.
+ * The "no friends" state carries a primary "Add a person" button — the one way
+ * forward, in the middle of the empty page where a first-time person is looking,
+ * matching the Activity screen's empty (and the finance apps in the category,
+ * which all put a call to action in the empty state). The header icons stay for
+ * the return visitor; the button is for the person who has never added anyone.
+ * The "all square" state keeps no button — it is a small congratulation, not a
+ * dead end to escape.
  */
 function EmptyFriends({ hasPeople, t }: { hasPeople: boolean; t: UiStrings }): React.JSX.Element {
   const theme = useTheme();
@@ -286,6 +290,14 @@ function EmptyFriends({ hasPeople, t }: { hasPeople: boolean; t: UiStrings }): R
             size={iconSize.xxl}
             color={theme.color.brand}
           />
+        }
+        action={
+          hasPeople ? undefined : (
+            <Button
+              label={t.addPerson.title}
+              onPress={() => router.push('/friends/add-person' as never)}
+            />
+          )
         }
       />
     </View>

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { Pressable, RefreshControl, ScrollView, useWindowDimensions, View } from 'react-native';
 
-import { dayNumber, daysBetween } from '@baaki/core';
+import { dayNumber, daysBetween, GUEST_TRIAL_DAYS, type GuestGate } from '@baaki/core';
 import {
   Avatar,
   Button,
@@ -250,24 +251,7 @@ export default function HomeScreen() {
         ) : null}
 
         {isGuest ? (
-          <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.sm }}>
-            <Text variant="subheading" tone="brand">
-              {t.tabs.guestBanner}
-            </Text>
-            <Text variant="caption" tone="muted">
-              {guard.gate?.expired
-                ? t.tabs.guestReadOnly
-                : guard.gate
-                  ? t.tabs.guestDaysLeft.replace('{days}', String(guard.gate.daysLeft))
-                  : t.tabs.guestBannerBody}
-            </Text>
-            <Button
-              label={t.tabs.addYourDetails}
-              variant="secondary"
-              size="sm"
-              onPress={() => router.push('/settings/account')}
-            />
-          </Card>
+          <GuestPrompt gate={guard.gate} t={t} onPress={() => router.push('/settings/account')} />
         ) : null}
 
         {/* The balance, one card per currency — there is no total across them
@@ -348,6 +332,150 @@ export default function HomeScreen() {
         )}
       </ScrollView>
     </Screen>
+  );
+}
+
+/** The AsyncStorage key holding the day the guest last closed the prompt. */
+const GUEST_PROMPT_DISMISS_KEY = 'guestPrompt:dismissedOn';
+
+/** Today as `YYYY-MM-DD` in the device's own zone — the unit a daily nudge counts in. */
+function localToday(): string {
+  try {
+    return new Intl.DateTimeFormat('en-CA').format(new Date());
+  } catch {
+    return new Date().toISOString().slice(0, 10);
+  }
+}
+
+/**
+ * A dismissal that only lasts the day. The prompt can be closed, but the close
+ * is good until midnight: we store the day it was closed on and show the card
+ * again on any later day. So a guest is nudged once a day — not nagged on every
+ * open, and not silenced for good. `ready` gates the first paint so the card
+ * never flashes in and then vanishes when a same-day dismissal loads a beat later.
+ */
+function useDailyDismiss(key: string): { hidden: boolean; ready: boolean; dismiss: () => void } {
+  const [dismissedOn, setDismissedOn] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    AsyncStorage.getItem(key)
+      .then((value) => {
+        if (alive) setDismissedOn(value);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (alive) setReady(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [key]);
+  const dismiss = useCallback(() => {
+    const today = localToday();
+    setDismissedOn(today);
+    void AsyncStorage.setItem(key, today).catch(() => {});
+  }, [key]);
+  return { hidden: dismissedOn === localToday(), ready, dismiss };
+}
+
+/**
+ * The guest's standing prompt — a neutral welcome card, not a second brand block.
+ *
+ * The balance hero right below it wears the brand wash. The old banner sat in
+ * `brandSoft`, so the top of a guest's screen was two purple blocks with no
+ * hierarchy — the thing the user flagged. This sits quiet in `surface` behind a
+ * hairline with a brand icon chip, so the coloured balance reads as the hero and
+ * this reads as the aside: the colour-hero-then-neutral-prompt rhythm the finance
+ * references lean on (Starling's welcome card over its balance, Buddy's white
+ * setup card under its total).
+ *
+ * A progress bar draws the trial running down — filled for the time left, so a
+ * shrinking bar is the countdown you feel at a glance, not a number you have to
+ * read. It empties and turns to warning as the days run out, and once the trial
+ * is spent the whole card does (the chip, the bar), so "read-only" lands as a
+ * real state rather than decoration.
+ *
+ * The card carries a close: a guest can dismiss it, but only for the day — it
+ * returns tomorrow (see `useDailyDismiss`).
+ */
+function GuestPrompt({
+  gate,
+  t,
+  onPress,
+}: {
+  gate: GuestGate | null;
+  t: UiStrings;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  const { hidden, ready, dismiss } = useDailyDismiss(GUEST_PROMPT_DISMISS_KEY);
+  if (!ready || hidden) return null;
+
+  const expired = gate?.expired ?? false;
+  const body = expired
+    ? t.tabs.guestReadOnly
+    : gate
+      ? t.tabs.guestDaysLeft.replace('{days}', String(gate.daysLeft))
+      : t.tabs.guestBannerBody;
+  const accent = expired ? theme.color.warning : theme.color.brand;
+  // The fraction of the trial still left — the bar empties from the right as the
+  // days burn down. Clamped so a stale clock can't over- or under-fill it.
+  const remaining = gate ? Math.max(0, Math.min(1, gate.daysLeft / GUEST_TRIAL_DAYS)) : 1;
+
+  // One compact band: the whole card is the way to sign up (the chevron says so),
+  // so there is no separate button, no icon chip, no title line — just the status,
+  // a hairline countdown under it, and a close. The earlier card stacked a chip,
+  // a heading, a full-width button and the bar; that read as bloated for what is
+  // an aside above the balance.
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={t.tabs.addYourDetails}
+      onPress={onPress}
+      style={({ pressed }) => ({ opacity: pressed ? 0.85 : 1 })}
+    >
+      <Card style={{ gap: theme.spacing.sm }}>
+        <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+          <Text variant="caption" tone="muted" numberOfLines={2} style={{ flex: 1, minWidth: 0 }}>
+            {body}
+          </Text>
+          <Ionicons name="chevron-forward" size={iconSize.base} color={accent} />
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.common.close}
+            onPress={dismiss}
+            hitSlop={10}
+            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+          >
+            <Ionicons name="close" size={iconSize.md} color={theme.color.textFaint} />
+          </Pressable>
+        </Row>
+
+        {gate ? (
+          <View
+            accessible
+            accessibilityRole="progressbar"
+            accessibilityValue={{ min: 0, max: GUEST_TRIAL_DAYS, now: gate.daysLeft }}
+            style={{
+              height: 4,
+              borderRadius: 2,
+              backgroundColor: theme.color.border,
+              overflow: 'hidden',
+            }}
+          >
+            <View
+              style={{
+                width: `${remaining * 100}%`,
+                height: '100%',
+                borderRadius: 2,
+                backgroundColor: accent,
+              }}
+            />
+          </View>
+        ) : null}
+      </Card>
+    </Pressable>
   );
 }
 

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -254,25 +254,24 @@ export default function HomeScreen() {
           <GuestPrompt gate={guard.gate} t={t} onPress={() => router.push('/settings/account')} />
         ) : null}
 
-        {/* The balance, one card per currency — there is no total across them
-            (ADR-004), so several currencies read as several cards you swipe
-            rather than one sum that would be a lie. While the balance is still
-            loading a hero-shaped skeleton stands in, rather than a card of
-            confident zeros the query has not actually returned yet. */}
+        {/* One deck, one row of dots. The balance rides at the front as the first
+            slide — the number you see on load — then any second currency (no
+            total across them, ADR-004), any running trip, and the two shortcuts.
+            This used to be a flat balance card with a *second* swipeable deck
+            beneath it, which read as two carousels stacked; the finance apps in
+            the category (Cleo, Monzo, Wise) all keep balances as slides of a
+            single deck. While the balance loads a hero-shaped skeleton stands in
+            rather than a card of confident zeros the query has not returned. */}
         {summary.isLoading ? (
           <HeroSkeleton />
         ) : (
-          <View style={{ gap: theme.spacing.lg }}>
-            {/* Where you stand, flat and always on screen. It used to be the
-                first slide of a swipeable deck, which meant the one number the
-                app exists to tell you could be a card-width away — and after a
-                swipe to the trip or the promo card, gone. No money app in the
-                category hides the balance behind a gesture. The deck survives
-                beneath it, smaller, for the things that genuinely are a shelf:
-                a running trip, a second currency, the two shortcuts. */}
-            <BalanceCard total={headline} locale={locale} t={t} />
-            <HeroDeck trips={activeTrips} totals={summary.totals.slice(1)} locale={locale} t={t} />
-          </View>
+          <HeroDeck
+            primary={headline}
+            trips={activeTrips}
+            totals={summary.totals.slice(1)}
+            locale={locale}
+            t={t}
+          />
         )}
 
         {loading ? (
@@ -621,30 +620,28 @@ function todayIn(timeZone: string): string {
 export const HERO_CARD_HEIGHT = 196;
 
 /**
- * The height of a card in the deck beneath the balance. Shorter than the hero on
- * purpose: the deck is the shelf of secondary things, and two cards of equal
- * weight stacked would be two heroes and no hierarchy.
- */
-const DECK_CARD_HEIGHT = 132;
-
-/**
- * The shelf under the balance: a swipeable deck with a peek of the next card at
- * the right edge and a dot pager beneath. Any trip running today rides at the
- * front — the most "now" thing on the dashboard — then any further currency (a
- * total across currencies is a number that does not exist, ADR-004), then the
- * action slides (scan a receipt, add a person) that turn the empty right of the
- * deck into a shortcut instead of dead space.
+ * The one swipeable deck on the dashboard: a peek of the next card at the right
+ * edge and a dot pager beneath. The balance rides at the front as the first
+ * slide — the number you see on load, never behind a gesture on arrival — then
+ * any running trip (the most "now" thing), any second currency (a total across
+ * them is a number that does not exist, ADR-004), and the two shortcut slides
+ * (scan a receipt, add a person) that turn the empty right of the deck into a
+ * shortcut instead of dead space.
  *
- * The peek and the pager are the two signals that say "swipe me", so they stay
- * even when there is a single slide. The peek is dropped to zero in that lone
- * case so a single card still fills the width.
+ * Every slide is the same height (`HERO_CARD_HEIGHT`) so the deck never jumps as
+ * you swipe — the pattern Cleo and Wise use for a balance-card carousel. The peek
+ * and the pager are the two signals that say "swipe me", so they stay even for a
+ * single slide; the peek drops to zero in that lone case so one card fills the
+ * width.
  */
 function HeroDeck({
+  primary,
   trips,
   totals,
   locale,
   t,
 }: {
+  primary: CurrencyTotal;
   trips: readonly TripSlide[];
   totals: readonly CurrencyTotal[];
   locale: string;
@@ -655,13 +652,17 @@ function HeroDeck({
   const [page, setPage] = useState(0);
 
   const slides = [
+    {
+      key: `cur:${primary.currency}:primary`,
+      node: <BalanceCard total={primary} locale={locale} t={t} />,
+    },
     ...trips.map((trip) => ({
       key: `trip:${trip.id}`,
       node: <TripCard trip={trip} locale={locale} t={t} />,
     })),
     ...totals.map((total) => ({
       key: `cur:${total.currency}`,
-      node: <BalanceCard total={total} locale={locale} t={t} compact />,
+      node: <BalanceCard total={total} locale={locale} t={t} />,
     })),
     {
       key: 'act:scan',
@@ -747,10 +748,10 @@ function HeroDeck({
 }
 
 /**
- * The hero while the balance is still loading — the full-width balance block at
- * its real height, then the deck beneath it with a sliver of the next card at
- * the right (the peek) and a three-dot pager. Shaped so the swap to the real
- * thing is a fill, not a jump: same heights, same peek, same dots.
+ * The deck while the balance is still loading — the front card at its real height
+ * with a sliver of the next one at the right (the peek), and a three-dot pager
+ * beneath. Shaped so the swap to the real deck is a fill, not a jump: same
+ * height, same peek, same dots.
  */
 function HeroSkeleton() {
   const theme = useTheme();
@@ -761,24 +762,18 @@ function HeroSkeleton() {
   const cardWidth = available - peek;
   return (
     <View style={{ gap: theme.spacing.md }}>
-      <Skeleton
-        width={available}
-        height={HERO_CARD_HEIGHT}
-        radius={theme.radius.lg}
-        animated={animated}
-      />
-      {/* The deck card and the peek sliver, clipped so the sliver never widens
+      {/* The front card and the peek sliver, clipped so the sliver never widens
           the row past the gutter. */}
       <View style={{ flexDirection: 'row', gap: theme.spacing.md, overflow: 'hidden' }}>
         <Skeleton
           width={cardWidth}
-          height={DECK_CARD_HEIGHT}
+          height={HERO_CARD_HEIGHT}
           radius={theme.radius.lg}
           animated={animated}
         />
         <Skeleton
           width={peek}
-          height={DECK_CARD_HEIGHT}
+          height={HERO_CARD_HEIGHT}
           radius={theme.radius.lg}
           animated={animated}
         />
@@ -855,8 +850,8 @@ function ActionSlide({
         colors={colors}
         radius={theme.radius.lg}
         style={{
-          padding: theme.spacing.lg,
-          height: DECK_CARD_HEIGHT,
+          padding: theme.spacing.xl,
+          height: HERO_CARD_HEIGHT,
           justifyContent: 'space-between',
           gap: theme.spacing.sm,
           overflow: 'hidden',
@@ -888,19 +883,7 @@ function ActionSlide({
  * settled — so the card's colour, not just its number, tells you where you
  * stand at a glance. The net big, the owed/owe split beneath.
  */
-function BalanceCard({
-  total,
-  locale,
-  t,
-  compact = false,
-}: {
-  total: CurrencyTotal;
-  locale: string;
-  t: UiStrings;
-  /** A second currency riding in the deck: deck height, and the owed/owe split
-   *  dropped — at that size it is three numbers where one will do. */
-  compact?: boolean;
-}) {
+function BalanceCard({ total, locale, t }: { total: CurrencyTotal; locale: string; t: UiStrings }) {
   const theme = useTheme();
   const wash =
     total.net > 0n
@@ -914,8 +897,8 @@ function BalanceCard({
       radius={theme.radius.lg}
       style={{
         padding: theme.spacing.xl,
-        gap: compact ? theme.spacing.sm : theme.spacing.lg,
-        height: compact ? DECK_CARD_HEIGHT : HERO_CARD_HEIGHT,
+        gap: theme.spacing.lg,
+        height: HERO_CARD_HEIGHT,
         justifyContent: 'space-between',
         overflow: 'hidden',
       }}
@@ -936,43 +919,37 @@ function BalanceCard({
           currency={total.currency as never}
           locale={locale}
           tone="onBrand"
-          style={
-            compact
-              ? { fontSize: 28, lineHeight: 34, fontWeight: '700' }
-              : { fontSize: 40, lineHeight: 46, fontWeight: '700' }
-          }
+          style={{ fontSize: 40, lineHeight: 46, fontWeight: '700' }}
         />
         <Text variant="caption" tone="onBrand">
           {total.net === 0n ? t.allSettled : total.net > 0n ? t.overallOwed : t.overallOwe}
         </Text>
       </View>
 
-      {compact ? null : (
-        <Row style={{ gap: theme.spacing.xxl }}>
-          <View>
-            <Text variant="micro" tone="onBrand">
-              {t.youAreOwed}
-            </Text>
-            <CountUpMoney
-              amount={total.owed}
-              currency={total.currency as never}
-              locale={locale}
-              tone="onBrand"
-            />
-          </View>
-          <View>
-            <Text variant="micro" tone="onBrand">
-              {t.youOwe}
-            </Text>
-            <CountUpMoney
-              amount={total.owing}
-              currency={total.currency as never}
-              locale={locale}
-              tone="onBrand"
-            />
-          </View>
-        </Row>
-      )}
+      <Row style={{ gap: theme.spacing.xxl }}>
+        <View>
+          <Text variant="micro" tone="onBrand">
+            {t.youAreOwed}
+          </Text>
+          <CountUpMoney
+            amount={total.owed}
+            currency={total.currency as never}
+            locale={locale}
+            tone="onBrand"
+          />
+        </View>
+        <View>
+          <Text variant="micro" tone="onBrand">
+            {t.youOwe}
+          </Text>
+          <CountUpMoney
+            amount={total.owing}
+            currency={total.currency as never}
+            locale={locale}
+            tone="onBrand"
+          />
+        </View>
+      </Row>
     </Gradient>
   );
 }
@@ -995,9 +972,9 @@ function TripCard({ trip, locale, t }: { trip: TripSlide; locale: string; t: UiS
         colors={theme.gradient.accent}
         radius={theme.radius.lg}
         style={{
-          padding: theme.spacing.lg,
+          padding: theme.spacing.xl,
           gap: theme.spacing.sm,
-          height: DECK_CARD_HEIGHT,
+          height: HERO_CARD_HEIGHT,
           justifyContent: 'space-between',
           overflow: 'hidden',
         }}

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -27,6 +27,7 @@ import { useMotion } from '@/lib/motion';
 import { deviceDefaultCurrency, plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
+import { useDashboardTips, type Tip } from '@/lib/tips';
 import { SyncBanner } from '@/components/SyncBanner';
 import { SkeletonList } from '@/components/Skeletons';
 import { GroupCard } from '@/components/GroupCard';
@@ -51,6 +52,7 @@ export default function HomeScreen() {
   const summary = useHomeSummary(profile?.id ?? null);
   const captures = useCaptures();
   const guard = useGuestGuard();
+  const tips = useDashboardTips(t);
 
   // Captures waiting in the personal inbox (A34) — surfaced as a card and a
   // badged header entry so a caught expense is not forgotten before it lands in
@@ -274,6 +276,10 @@ export default function HomeScreen() {
           />
         )}
 
+        {/* One rotating, dismissible hint — a light way to teach the app's less
+            obvious moves without another shelf of cards. */}
+        {tips.tip ? <TipCard tip={tips.tip} t={t} onDismiss={tips.dismiss} /> : null}
+
         {loading ? (
           <SkeletonList rows={3} />
         ) : list.length === 0 ? (
@@ -475,6 +481,70 @@ function GuestPrompt({
         ) : null}
       </Card>
     </Pressable>
+  );
+}
+
+/**
+ * The dashboard tip card — a compact, dismissible hint in the lean house style:
+ * an icon chip, a small "TIP" kicker over a one-line title, a line of body, and
+ * a close. When the tip has a next step the whole card taps through to it (the
+ * chevron says so); otherwise it is a plain aside. The close retires this tip for
+ * good; the deck of tips rotates by the day (see `useDashboardTips`).
+ */
+function TipCard({ tip, t, onDismiss }: { tip: Tip; t: UiStrings; onDismiss: () => void }) {
+  const theme = useTheme();
+  const body = (
+    <Card style={{ gap: 0 }}>
+      <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+        <View
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 20,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.color.brandSoft,
+          }}
+        >
+          <Ionicons name={tip.icon} size={iconSize.lg} color={theme.color.brand} />
+        </View>
+        <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
+          <Text variant="micro" tone="brand" style={{ letterSpacing: 0.6 }}>
+            {t.tips.label.toUpperCase()}
+          </Text>
+          <Text variant="subheading" numberOfLines={1}>
+            {tip.title}
+          </Text>
+          <Text variant="caption" tone="muted" numberOfLines={2}>
+            {tip.body}
+          </Text>
+        </View>
+        {tip.route ? (
+          <Ionicons name="chevron-forward" size={iconSize.base} color={theme.color.brand} />
+        ) : null}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t.common.close}
+          onPress={onDismiss}
+          hitSlop={10}
+          style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+        >
+          <Ionicons name="close" size={iconSize.md} color={theme.color.textFaint} />
+        </Pressable>
+      </Row>
+    </Card>
+  );
+  return tip.route ? (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={tip.title}
+      onPress={() => router.push(tip.route as never)}
+      style={({ pressed }) => ({ opacity: pressed ? 0.85 : 1 })}
+    >
+      {body}
+    </Pressable>
+  ) : (
+    body
   );
 }
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -754,6 +754,21 @@ export interface UiStrings {
     inviteBody: string;
     inviteCta: string;
   };
+  /** The rotating "did you know" tips card on the dashboard — one useful,
+   *  app-specific hint at a time, dismissible for good. */
+  tips: {
+    label: string;
+    voiceTitle: string;
+    voiceBody: string;
+    splitTitle: string;
+    splitBody: string;
+    remindTitle: string;
+    remindBody: string;
+    offlineTitle: string;
+    offlineBody: string;
+    scanTitle: string;
+    scanBody: string;
+  };
   /** Merging same-person guests into one on the Friends screen (irreversible). */
   mergePeople: {
     entry: string;
@@ -2009,6 +2024,19 @@ const en: UiStrings = {
     inviteTitle: 'Settle up together',
     inviteBody: 'Add the people you share costs with and keep everyone square.',
     inviteCta: 'Add a person',
+  },
+  tips: {
+    label: 'Tip',
+    voiceTitle: 'Add by voice',
+    voiceBody: 'Tap the mic and just say it — “dinner 800, split with Ravi”.',
+    splitTitle: 'Split your way',
+    splitBody: 'Tap the split on any expense to change shares — it doesn’t have to be equal.',
+    remindTitle: 'A gentle nudge',
+    remindBody: 'Send a reminder to whoever owes you, straight from the balance.',
+    offlineTitle: 'Works offline',
+    offlineBody: 'Add expenses with no signal — they sync the moment you’re back.',
+    scanTitle: 'Scan a receipt',
+    scanBody: 'Snap a bill and Baaki fills in the items for you.',
   },
   mergePeople: {
     entry: 'Merge people',
@@ -3351,6 +3379,19 @@ const ta: UiStrings = {
     inviteTitle: 'சேர்ந்து கணக்கு தீர்க்கலாம்',
     inviteBody: 'செலவுகளைப் பகிர்பவர்களைச் சேர்த்து அனைவரையும் சரிசெய்யுங்கள்.',
     inviteCta: 'ஒருவரைச் சேர்',
+  },
+  tips: {
+    label: 'உதவிக்குறிப்பு',
+    voiceTitle: 'குரலால் சேர்',
+    voiceBody: 'மைக்கைத் தட்டி சொல்லுங்கள் — “டின்னர் 800, ரவியுடன் பங்கிடு”.',
+    splitTitle: 'உங்கள் விதத்தில் பங்கிடு',
+    splitBody: 'எந்தச் செலவின் பங்கையும் தட்டி மாற்றுங்கள் — எல்லாம் சமமாக இருக்க வேண்டியதில்லை.',
+    remindTitle: 'மெதுவான நினைவூட்டல்',
+    remindBody: 'உங்களுக்குக் கடன்பட்டவருக்கு பேலன்ஸிலிருந்தே நினைவூட்டல் அனுப்புங்கள்.',
+    offlineTitle: 'இணையம் இல்லாமலும் வேலை செய்யும்',
+    offlineBody: 'சிக்னல் இல்லாமலும் செலவுகளைச் சேருங்கள் — திரும்பியதும் ஒத்திசைந்து விடும்.',
+    scanTitle: 'ரசீதை ஸ்கேன் செய்',
+    scanBody: 'பில்லைப் படம் எடுங்கள், பாக்கி பொருட்களை நிரப்பும்.',
   },
   mergePeople: {
     entry: 'நபர்களை இணை',
@@ -4708,6 +4749,19 @@ const hi: UiStrings = {
     inviteTitle: 'मिलकर हिसाब बराबर करें',
     inviteBody: 'जिनके साथ खर्च बाँटते हैं उन्हें जोड़ें और सबका हिसाब बराबर रखें.',
     inviteCta: 'व्यक्ति जोड़ें',
+  },
+  tips: {
+    label: 'सुझाव',
+    voiceTitle: 'बोलकर जोड़ें',
+    voiceBody: 'माइक दबाएँ और बस बोलें — “डिनर 800, रवि के साथ बाँटो”.',
+    splitTitle: 'अपने तरीके से बाँटें',
+    splitBody: 'किसी भी खर्च के स्प्लिट पर टैप करके हिस्से बदलें — ज़रूरी नहीं कि बराबर हो.',
+    remindTitle: 'हल्की याद दिलाएँ',
+    remindBody: 'जो आपके पैसे देना है उसे बैलेंस से ही रिमाइंडर भेजें.',
+    offlineTitle: 'बिना इंटरनेट भी चलता है',
+    offlineBody: 'सिग्नल न हो तब भी खर्च जोड़ें — वापस आते ही सिंक हो जाते हैं.',
+    scanTitle: 'रसीद स्कैन करें',
+    scanBody: 'बिल की फ़ोटो लें और बाकी आइटम खुद भर देता है.',
   },
   mergePeople: {
     entry: 'लोगों को मर्ज करें',
@@ -6067,6 +6121,19 @@ const ar: UiStrings = {
     inviteTitle: 'سوّوا الحساب معًا',
     inviteBody: 'أضف من تتشارك معهم النفقات وابقوا جميعًا على حساب متوازن.',
     inviteCta: 'إضافة شخص',
+  },
+  tips: {
+    label: 'نصيحة',
+    voiceTitle: 'أضِف بصوتك',
+    voiceBody: 'اضغط الميكروفون وقل ما تريد — «عشاء 800، اقسمها مع رافي».',
+    splitTitle: 'اقسم بطريقتك',
+    splitBody: 'اضغط على القسمة في أي مصروف لتغيير الحصص — ليس بالضرورة أن تكون بالتساوي.',
+    remindTitle: 'تذكير لطيف',
+    remindBody: 'أرسل تذكيرًا لمن عليه دفعٌ لك، مباشرةً من الرصيد.',
+    offlineTitle: 'يعمل دون إنترنت',
+    offlineBody: 'أضِف المصاريف دون شبكة — تتزامن فور عودتك.',
+    scanTitle: 'امسح الإيصال',
+    scanBody: 'صوّر الفاتورة وباقي يملأ البنود نيابةً عنك.',
   },
   mergePeople: {
     entry: 'دمج الأشخاص',

--- a/apps/mobile/src/lib/tips.ts
+++ b/apps/mobile/src/lib/tips.ts
@@ -1,0 +1,118 @@
+/**
+ * The dashboard's rotating tips — one useful, Baaki-specific hint at a time.
+ *
+ * These are not generic money advice; each points at something the app can
+ * actually do that a new person would not find on their own (add by voice,
+ * reshape a split, nudge a debtor, work offline, scan a receipt). One shows at a
+ * time and it rotates by the day, so the surface never becomes a wall of cards —
+ * the same restraint the dashboard's single deck keeps. A tip can be dismissed
+ * for good with its close; once every tip is dismissed the card stops appearing.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import type { UiStrings } from '@/i18n';
+
+export interface Tip {
+  /** Stable id — the key a dismissal is remembered under, so the set survives copy edits. */
+  id: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  title: string;
+  body: string;
+  /** Where tapping the card goes, when the tip has a next step. */
+  route?: string;
+}
+
+/** The AsyncStorage key holding the ids the person has dismissed for good. */
+const DISMISS_KEY = 'dashboardTips:dismissed';
+const DAY_MS = 86_400_000;
+
+function buildTips(t: UiStrings): Tip[] {
+  return [
+    { id: 'voice', icon: 'mic-outline', title: t.tips.voiceTitle, body: t.tips.voiceBody },
+    { id: 'split', icon: 'pie-chart-outline', title: t.tips.splitTitle, body: t.tips.splitBody },
+    {
+      id: 'remind',
+      icon: 'notifications-outline',
+      title: t.tips.remindTitle,
+      body: t.tips.remindBody,
+    },
+    {
+      id: 'offline',
+      icon: 'cloud-offline-outline',
+      title: t.tips.offlineTitle,
+      body: t.tips.offlineBody,
+    },
+    {
+      id: 'scan',
+      icon: 'scan-outline',
+      title: t.tips.scanTitle,
+      body: t.tips.scanBody,
+      route: '/capture?scan=1',
+    },
+  ];
+}
+
+/**
+ * The tip to show right now, plus a way to retire it. Returns `null` while the
+ * dismissed set is still loading (so the card never flashes in then vanishes)
+ * and once nothing is left to show. The live tip is picked by the day so it
+ * changes daily, and skips anything already dismissed.
+ */
+export function useDashboardTips(t: UiStrings): { tip: Tip | null; dismiss: () => void } {
+  const [dismissed, setDismissed] = useState<readonly string[]>([]);
+  const [ready, setReady] = useState(false);
+  // The day index is read once, off the render path — `Date.now()` is impure, so
+  // calling it during render would make the picked tip unstable across re-renders.
+  const [day, setDay] = useState<number | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    AsyncStorage.getItem(DISMISS_KEY)
+      .then((raw) => {
+        if (!alive) return;
+        try {
+          setDismissed(raw ? (JSON.parse(raw) as string[]) : []);
+        } catch {
+          setDismissed([]);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        // Stamped here, inside the async callback rather than in the effect body,
+        // so `Date.now()` stays off the render path and no synchronous setState
+        // fires in the effect itself.
+        if (alive) {
+          setDay(Math.floor(Date.now() / DAY_MS));
+          setReady(true);
+        }
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const available = useMemo(
+    () => buildTips(t).filter((tip) => !dismissed.includes(tip.id)),
+    [t, dismissed],
+  );
+
+  const tip =
+    !ready || day === null || available.length === 0
+      ? null
+      : available[day % available.length];
+
+  const dismiss = useCallback(() => {
+    if (!tip) return;
+    setDismissed((prev) => {
+      if (prev.includes(tip.id)) return prev;
+      const next = [...prev, tip.id];
+      void AsyncStorage.setItem(DISMISS_KEY, JSON.stringify(next)).catch(() => {});
+      return next;
+    });
+  }, [tip]);
+
+  return { tip, dismiss };
+}

--- a/apps/mobile/src/lib/tips.ts
+++ b/apps/mobile/src/lib/tips.ts
@@ -100,9 +100,7 @@ export function useDashboardTips(t: UiStrings): { tip: Tip | null; dismiss: () =
   );
 
   const tip =
-    !ready || day === null || available.length === 0
-      ? null
-      : available[day % available.length];
+    !ready || day === null || available.length === 0 ? null : available[day % available.length];
 
   const dismiss = useCallback(() => {
     if (!tip) return;


### PR DESCRIPTION
Dashboard + Activity/Friends UI work in `apps/mobile`. Gates green (tsc + eslint), not device-tested. Design refs from Mobbin.

## Slim guest prompt (`4841fcb`)
Guest banner was `brandSoft` stacked on the brand-gradient balance — two purple blocks. Now a neutral compact band: status line + thin trial-countdown bar (`daysLeft / GUEST_TRIAL_DAYS`), whole card taps to sign-up, close X = daily dismissal (AsyncStorage).

## One balance deck (`2ed507f`)
Flat balance card + a second swipeable deck read as two carousels stacked. Balance is now slide 1 of a single deck (then trip / 2nd currency / scan / invite), one height, one dot row — the Cleo/Monzo/Wise pattern.

## Rotating dashboard tips (`1ab457a`)
One useful, Baaki-specific hint at a time (voice, split, remind, offline, scan). Compact card, rotates by day, dismiss retires a tip for good. Strings in all 4 locales.

## Consistent empty states (`9575ad6`)
Friends empty was centred with an icon; Activity's sat top-aligned with no CTA. Both now share one anatomy — tinted icon, title, body, one primary CTA (New group / Add a person) — centred the same way. Modeled on Splitwise/Discord/Swarm empties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the mobile dashboard with a unified hero card for balances, trips, currencies, and shortcuts.
  * Added localized daily tips covering voice entry, custom splitting, reminders, offline use, and receipt scanning.
  * Added a guest prompt with daily dismissal persistence.
  * Added “Add a person” and “new group” actions to relevant empty states.
* **Bug Fixes**
  * Improved activity feed layout so loading, error, and empty states center vertically.
  * Added clearer offline and empty-state icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->