### PR TITLE
feat(mobile): inbox + voice redesign, daily tip sheet, header sync glyph

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1,8 +1,15 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { Pressable, RefreshControl, ScrollView, useWindowDimensions, View } from 'react-native';
+import {
+  Modal,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 
 import { dayNumber, daysBetween, GUEST_TRIAL_DAYS, type GuestGate } from '@baaki/core';
 import {
@@ -27,8 +34,8 @@ import { useMotion } from '@/lib/motion';
 import { deviceDefaultCurrency, plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
-import { useDashboardTips, type Tip } from '@/lib/tips';
-import { SyncBanner } from '@/components/SyncBanner';
+import { useDashboardTips } from '@/lib/tips';
+import { SyncStatusIcon } from '@/components/SyncBanner';
 import { SkeletonList } from '@/components/Skeletons';
 import { GroupCard } from '@/components/GroupCard';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
@@ -52,7 +59,6 @@ export default function HomeScreen() {
   const summary = useHomeSummary(profile?.id ?? null);
   const captures = useCaptures();
   const guard = useGuestGuard();
-  const tips = useDashboardTips(t);
 
   // Captures waiting in the personal inbox (A34) — surfaced as a card and a
   // badged header entry so a caught expense is not forgotten before it lands in
@@ -185,6 +191,11 @@ export default function HomeScreen() {
               {profile?.display_name ?? t.account.you}
             </Text>
           </Pressable>
+          {/* The sync state as one glyph, to the left of the camera — a quiet
+              cloud when there are unsent changes or no connection, a turning
+              arrow mid-sync, a red mark for a refused change. Nothing when all is
+              well. It replaces the wide banner the dashboard used to carry. */}
+          <SyncStatusIcon />
           {/* Bare icons, no button chrome — the header reads as a title row, not
               a toolbar of pills. Straight to the camera: the icon is a scanner,
               so it opens one rather than a form to fill in first (the capture
@@ -212,8 +223,6 @@ export default function HomeScreen() {
         </Row>
 
         <OverflowMenu visible={menuOpen} onClose={() => setMenuOpen(false)} items={menuItems} />
-
-        <SyncBanner />
 
         {/* Expenses caught without a group yet (A34). Sits near the top so an
             inbox with something in it is the first thing after the balance, not
@@ -276,10 +285,6 @@ export default function HomeScreen() {
           />
         )}
 
-        {/* One rotating, dismissible hint — a light way to teach the app's less
-            obvious moves without another shelf of cards. */}
-        {tips.tip ? <TipCard tip={tips.tip} t={t} onDismiss={tips.dismiss} /> : null}
-
         {loading ? (
           <SkeletonList rows={3} />
         ) : list.length === 0 ? (
@@ -336,6 +341,12 @@ export default function HomeScreen() {
           </View>
         )}
       </ScrollView>
+
+      {/* The daily tip, surfaced as a sheet on the first Home open of the day —
+          one useful, Baaki-specific move at a time, then out of the way until
+          tomorrow. Replaces the inline card so a hint asks for a beat of
+          attention rather than sitting as furniture nobody reads. */}
+      <TipSheet t={t} />
     </Screen>
   );
 }
@@ -484,67 +495,156 @@ function GuestPrompt({
   );
 }
 
+/** The day the tip sheet was last shown, so it surfaces once a day and no more. */
+const TIP_SHEET_KEY = 'dashboardTips:shownOn';
+
 /**
- * The dashboard tip card — a compact, dismissible hint in the lean house style:
- * an icon chip, a small "TIP" kicker over a one-line title, a line of body, and
- * a close. When the tip has a next step the whole card taps through to it (the
- * chevron says so); otherwise it is a plain aside. The close retires this tip for
- * good; the deck of tips rotates by the day (see `useDashboardTips`).
+ * The daily tip, as a bottom sheet.
+ *
+ * It shows itself once on the first Home open of each day — the deck rotates by
+ * the day (see `useDashboardTips`), so a new move surfaces each time rather than
+ * the same card sitting inline forever. A big icon over the "TIP" kicker, the
+ * title and body, then the way out: a primary that walks to the feature when the
+ * tip points somewhere (only the receipt scan does today), and a plain "Got it"
+ * otherwise. Tapping the backdrop dismisses it too — a hint never traps.
+ *
+ * The show is stamped for the day the moment it opens, not on close, so a person
+ * who reads it and backgrounds the app is not shown it again on the next open.
  */
-function TipCard({ tip, t, onDismiss }: { tip: Tip; t: UiStrings; onDismiss: () => void }) {
+function TipSheet({ t }: { t: UiStrings }) {
   const theme = useTheme();
-  const body = (
-    <Card style={{ gap: 0 }}>
-      <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
-        <View
+  const { tip } = useDashboardTips(t);
+
+  // The day the sheet was last shown, read once on mount — the same shape the
+  // guest prompt's daily dismissal uses, and for the same reason: reading it in a
+  // plain mount effect (not one gated on the tip loading) is what actually runs.
+  // `ready` gates the first paint so the sheet never flashes before we know.
+  const [shownOn, setShownOn] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [closed, setClosed] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    AsyncStorage.getItem(TIP_SHEET_KEY)
+      .then((value) => {
+        if (alive) setShownOn(value);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (alive) setReady(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const open = ready && shownOn !== localToday() && !closed && Boolean(tip);
+
+  // Stamp the day the moment the sheet is shown — not on close — so someone who
+  // reads it and backgrounds the app is not shown it again on the next open. The
+  // write goes straight to storage and deliberately does not touch `shownOn`, so
+  // the sheet stays up this session until the person closes it.
+  const stamped = useRef(false);
+  useEffect(() => {
+    if (!open || stamped.current) return;
+    stamped.current = true;
+    void AsyncStorage.setItem(TIP_SHEET_KEY, localToday()).catch(() => {});
+  }, [open]);
+
+  const close = () => setClosed(true);
+  const act = () => {
+    if (tip?.route) router.push(tip.route as never);
+    close();
+  };
+
+  // The Modal stays mounted and is driven by `visible` — toggling a freshly
+  // mounted Modal's `visible` to true a beat after first render did not present
+  // reliably on Android, which is why an earlier version stamped the day but
+  // never appeared. With `tip` still loading there is nothing to show yet.
+  return (
+    <Modal transparent animationType="fade" visible={open} onRequestClose={close}>
+      {tip ? (
+      /* Tap outside to close — the same escape the campaign popup gives. */
+      <Pressable
+        onPress={close}
+        accessibilityLabel={t.common.close}
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(10, 10, 26, 0.55)',
+          justifyContent: 'flex-end',
+        }}
+      >
+        {/* Swallows the tap so pressing the sheet itself does not dismiss it. A
+            bottom sheet, not a centred dialog: it slides up from the bar the tip
+            is about, and leaves the balance above it in view. */}
+        <Pressable
+          onPress={() => {}}
           style={{
-            width: 40,
-            height: 40,
-            borderRadius: 20,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: theme.color.brandSoft,
+            backgroundColor: theme.color.surface,
+            borderTopLeftRadius: theme.radius.xxl,
+            borderTopRightRadius: theme.radius.xxl,
+            paddingHorizontal: theme.spacing.xxl,
+            paddingTop: theme.spacing.xl,
+            paddingBottom: theme.spacing.xxl,
+            gap: theme.spacing.lg,
+            ...theme.shadow.lifted,
           }}
         >
-          <Ionicons name={tip.icon} size={iconSize.lg} color={theme.color.brand} />
-        </View>
-        <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
-          <Text variant="micro" tone="brand" style={{ letterSpacing: 0.6 }}>
-            {t.tips.label.toUpperCase()}
-          </Text>
-          <Text variant="subheading" numberOfLines={1}>
-            {tip.title}
-          </Text>
-          <Text variant="caption" tone="muted" numberOfLines={2}>
-            {tip.body}
-          </Text>
-        </View>
-        {tip.route ? (
-          <Ionicons name="chevron-forward" size={iconSize.base} color={theme.color.brand} />
-        ) : null}
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t.common.close}
-          onPress={onDismiss}
-          hitSlop={10}
-          style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
-        >
-          <Ionicons name="close" size={iconSize.md} color={theme.color.textFaint} />
+          {/* A grab handle — the visual grammar of a sheet you can pull down. */}
+          <View
+            style={{
+              alignSelf: 'center',
+              width: 40,
+              height: 4,
+              borderRadius: 2,
+              backgroundColor: theme.color.border,
+            }}
+          />
+
+          <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
+            <View
+              style={{
+                width: 64,
+                height: 64,
+                borderRadius: 32,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.color.brandSoft,
+              }}
+            >
+              <Ionicons name={tip.icon} size={iconSize.xxl} color={theme.color.brand} />
+            </View>
+            <Text variant="micro" tone="brand" style={{ letterSpacing: 0.8 }}>
+              {t.tips.label.toUpperCase()}
+            </Text>
+            <Text variant="title" align="center">
+              {tip.title}
+            </Text>
+            <Text variant="body" tone="muted" align="center">
+              {tip.body}
+            </Text>
+          </View>
+
+          <View style={{ gap: theme.spacing.sm }}>
+            {tip.route ? (
+              <>
+                <Button label={t.tips.action} size="lg" fullWidth onPress={act} />
+                <Button
+                  label={t.misc.gotIt}
+                  variant="secondary"
+                  size="sm"
+                  fullWidth
+                  onPress={close}
+                />
+              </>
+            ) : (
+              <Button label={t.misc.gotIt} size="lg" fullWidth onPress={close} />
+            )}
+          </View>
         </Pressable>
-      </Row>
-    </Card>
-  );
-  return tip.route ? (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={tip.title}
-      onPress={() => router.push(tip.route as never)}
-      style={({ pressed }) => ({ opacity: pressed ? 0.85 : 1 })}
-    >
-      {body}
-    </Pressable>
-  ) : (
-    body
+      </Pressable>
+      ) : null}
+    </Modal>
   );
 }
 

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -26,18 +26,34 @@ import {
   iconSize,
   Row,
   Screen,
-  SectionHeader,
   Text,
   tintForKey,
   useTabBarClearance,
   useTheme,
 } from '@baaki/ui';
 
+import { dayHeading, dayKey } from '@/data/activity';
 import { useMarkNotificationsRead, useNotifications } from '@/data/hooks';
 import { SkeletonList } from '@/components/Skeletons';
 import type { NotificationRow } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { usePullRefresh } from '@/lib/pullRefresh';
+
+/**
+ * The inbox cut into calendar days, newest first — the same day-heading grouping
+ * the Activity feed uses, so the two screens that sit together read the same way.
+ * The query already returns rows sorted; this only draws the lines between days.
+ */
+function groupByDay(rows: readonly NotificationRow[]): { key: string; rows: NotificationRow[] }[] {
+  const sections: { key: string; rows: NotificationRow[] }[] = [];
+  for (const row of rows) {
+    const key = dayKey(row.created_at);
+    const last = sections[sections.length - 1];
+    if (last && last.key === key) last.rows.push(row);
+    else sections.push({ key, rows: [row] });
+  }
+  return sections;
+}
 
 const ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {
   settlement_confirmed: 'checkmark-circle',
@@ -103,7 +119,10 @@ export default function InboxScreen() {
           />
         }
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
+        {/* A big left-aligned title over its own back row — the modern inbox
+            header (Superlist, Linear): the screen name carries the weight, not a
+            small centred label squeezed between two chevrons. */}
+        <View style={{ paddingTop: theme.spacing.md, gap: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons
               name={directionalIcon('chevron-back')}
@@ -111,20 +130,14 @@ export default function InboxScreen() {
               color={theme.color.text}
             />
           </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.inbox.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
+          <Text variant="title">{t.inbox.title}</Text>
+        </View>
 
         {notifications.isLoading ? (
           // Until the fetch answers, `rows` is empty — which is not the same as
           // "you have no notifications". Showing the empty state here told people
           // their inbox was empty while it was still loading.
-          <View style={{ gap: theme.spacing.md }}>
-            <SectionHeader title={t.inbox.recent} />
-            <SkeletonList rows={5} trailing={false} />
-          </View>
+          <SkeletonList rows={6} trailing={false} />
         ) : notifications.isError ? (
           <EmptyState
             title={t.loadError}
@@ -136,21 +149,34 @@ export default function InboxScreen() {
         ) : rows.length === 0 ? (
           <EmptyState title={t.nothingYet} body={t.inbox.nothingYetBody} />
         ) : (
-          <View style={{ gap: theme.spacing.md }}>
-            <SectionHeader title={t.inbox.recent} />
-            <View>
-              {rows.map((row, index) => {
-                const { title, body } = renderNotification(row.kind, factsOf(row), locale, {
-                  title: row.title,
-                  body: row.body,
-                });
-                const unreadRow = row.read_at === null;
-                // Flat row: the kind's colour lives in the icon chip on the left,
-                // not the whole row. A read one is dimmed.
-                const tint = tintForKey(row.kind);
-                return (
-                  <View key={row.id}>
+          // Grouped by day, newest first. An unread row is a soft brand-tinted
+          // card, not a lone dot — the whole row carries the "new" signal, the
+          // way Luma and Superlist mark an unread update. A read one drops back
+          // to a flat transparent row, so the eye lands on what arrived since.
+          <View style={{ gap: theme.spacing.lg }}>
+            {groupByDay(rows).map((section) => (
+              <View key={section.key} style={{ gap: theme.spacing.xs }}>
+                <Text
+                  variant="micro"
+                  tone="muted"
+                  style={{
+                    textTransform: 'uppercase',
+                    marginBottom: theme.spacing.xs,
+                    paddingHorizontal: theme.spacing.sm,
+                  }}
+                >
+                  {dayHeading(locale, section.rows[0]!.created_at)}
+                </Text>
+                {section.rows.map((row) => {
+                  const { title, body } = renderNotification(row.kind, factsOf(row), locale, {
+                    title: row.title,
+                    body: row.body,
+                  });
+                  const unreadRow = row.read_at === null;
+                  const tint = tintForKey(row.kind);
+                  return (
                     <Pressable
+                      key={row.id}
                       accessibilityRole={row.group_id ? 'button' : undefined}
                       accessibilityLabel={title}
                       onPress={
@@ -159,16 +185,14 @@ export default function InboxScreen() {
                           : undefined
                       }
                       style={({ pressed }) => ({
-                        opacity: pressed ? 0.6 : unreadRow ? 1 : 0.7,
+                        opacity: pressed ? 0.6 : 1,
+                        borderRadius: theme.radius.lg,
+                        backgroundColor: unreadRow ? theme.color.brandSoft : 'transparent',
+                        paddingHorizontal: theme.spacing.sm,
+                        paddingVertical: theme.spacing.md,
                       })}
                     >
-                      <Row
-                        style={{
-                          gap: theme.spacing.md,
-                          alignItems: 'center',
-                          paddingVertical: theme.spacing.md,
-                        }}
-                      >
+                      <Row style={{ gap: theme.spacing.md, alignItems: 'flex-start' }}>
                         <View
                           style={{
                             width: 40,
@@ -185,7 +209,7 @@ export default function InboxScreen() {
                             color={theme.tint[tint].ink}
                           />
                         </View>
-                        <View style={{ flex: 1 }}>
+                        <View style={{ flex: 1, gap: 2 }}>
                           <Text variant="subheading" numberOfLines={2}>
                             {title}
                           </Text>
@@ -193,25 +217,32 @@ export default function InboxScreen() {
                             {body}
                           </Text>
                         </View>
-                        {unreadRow ? (
-                          <View
-                            style={{
-                              width: 8,
-                              height: 8,
-                              borderRadius: 4,
-                              backgroundColor: theme.color.brand,
-                            }}
-                          />
-                        ) : null}
+                        {/* The clock lives on the right, the day is the heading's
+                            job — the row says when within the day, not which day. */}
+                        <View style={{ alignItems: 'flex-end', gap: 6 }}>
+                          <Text variant="micro" tone="muted">
+                            {new Intl.DateTimeFormat(locale, {
+                              hour: 'numeric',
+                              minute: '2-digit',
+                            }).format(new Date(row.created_at))}
+                          </Text>
+                          {unreadRow ? (
+                            <View
+                              style={{
+                                width: 8,
+                                height: 8,
+                                borderRadius: 4,
+                                backgroundColor: theme.color.brand,
+                              }}
+                            />
+                          ) : null}
+                        </View>
                       </Row>
                     </Pressable>
-                    {index < rows.length - 1 ? (
-                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                    ) : null}
-                  </View>
-                );
-              })}
-            </View>
+                  );
+                })}
+              </View>
+            ))}
           </View>
         )}
 

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -7,15 +7,110 @@
  * is true: the entry is saved, it just hasn't left the phone yet.
  */
 
+import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Pressable, View } from 'react-native';
+import { Animated, Easing, Pressable, View } from 'react-native';
 
 import { Card, iconSize, Row, Text, useTheme } from '@baaki/ui';
 
 import { plural, useStrings } from '@/i18n';
 
+import { useMotion } from '@/lib/motion';
 import { SyncNetworkPreference, useSyncNetwork } from '@/lib/syncNetwork';
-import { useSync } from '@/sync';
+import { SyncStatus, useSync } from '@/sync';
+
+/**
+ * The sync state as a single header glyph, next to the camera on the dashboard.
+ *
+ * The full banner (below) is right on a screen that is about one group's ledger;
+ * on the dashboard it was a wide card carrying a sentence for a state that is
+ * normal and usually momentary. This says the same thing in the corner: a
+ * refused change is a red alert that needs a look, an unsent queue or a dropped
+ * connection is a quiet cloud, an in-flight sync is a turning arrow. When there
+ * is nothing to report — online, idle, nothing queued — it renders nothing, so
+ * the header is not carrying a permanent "all good" badge nobody asked for.
+ */
+export function SyncStatusIcon() {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const { animated } = useMotion();
+  const { status, queue, rejected } = useSync();
+
+  const spin = useState(() => new Animated.Value(0))[0];
+  const spinning = status === SyncStatus.Syncing && animated;
+  useEffect(() => {
+    if (!spinning) return;
+    const loop = Animated.loop(
+      Animated.timing(spin, {
+        toValue: 1,
+        duration: 1000,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+    );
+    loop.start();
+    return () => {
+      loop.stop();
+      spin.setValue(0);
+    };
+  }, [spinning, spin]);
+
+  // One neutral colour for every ordinary sync state — offline, waiting, in
+  // flight — so the glyph reads as one header control, the same weight as the
+  // camera beside it, not a different-coloured badge each time the network
+  // shifts. Red is reserved for the one state that needs a decision: a change
+  // the server refused (ADR-005 treats plain offline as normal, not an error).
+  const neutral = theme.color.text;
+  const state =
+    rejected.length > 0
+      ? { icon: 'alert-circle' as const, color: theme.color.negative, label: t.extras.oneChangeFailed }
+      : status === SyncStatus.Offline
+        ? { icon: 'cloud-offline-outline' as const, color: neutral, label: t.misc.offlineSaved }
+        : status === SyncStatus.Error
+          ? {
+              icon: 'cloud-offline-outline' as const,
+              color: neutral,
+              label: t.misc.cantReachServerIdle,
+            }
+          : status === SyncStatus.Metered
+            ? { icon: 'cloud-offline-outline' as const, color: neutral, label: t.sync.waitingWifi }
+            : status === SyncStatus.Syncing || queue.length > 0
+              ? {
+                  icon: 'sync-outline' as const,
+                  color: neutral,
+                  label: plural(locale, queue.length, t.misc.syncingCount),
+                }
+              : null;
+
+  // Online, idle, nothing queued — say nothing.
+  if (!state) return null;
+
+  const glyph = (
+    <Ionicons name={state.icon} size={iconSize.xl} color={state.color} />
+  );
+
+  return (
+    <View
+      accessibilityRole="image"
+      accessibilityLabel={state.label}
+      style={{ padding: theme.spacing.xs }}
+    >
+      {status === SyncStatus.Syncing ? (
+        <Animated.View
+          style={{
+            transform: [
+              { rotate: spin.interpolate({ inputRange: [0, 1], outputRange: ['0deg', '360deg'] }) },
+            ],
+          }}
+        >
+          {glyph}
+        </Animated.View>
+      ) : (
+        glyph
+      )}
+    </View>
+  );
+}
 
 export function SyncBanner({ groupId }: { groupId?: string }) {
   const theme = useTheme();

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -16,12 +16,131 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { ExpoSpeechRecognitionModule, useSpeechRecognitionEvent } from 'expo-speech-recognition';
-import { Linking, Pressable, View } from 'react-native';
+import { Animated, Easing, Linking, Pressable, View } from 'react-native';
 
-import { iconSize, Text, useTheme } from '@baaki/ui';
+import { iconSize, Text, useTheme, type Theme } from '@baaki/ui';
 
 import { useStrings } from '@/i18n';
 import { dictationError, speechLocale } from '@/lib/dictation';
+import { useMotion } from '@/lib/motion';
+
+const MIC_SIZE = 104;
+
+/**
+ * The rings breathing out from the mic while it listens — the near-universal
+ * "I am hearing you" of a voice screen (Roku, Meta AI, Todoist). Three staggered
+ * pulses expand and fade on a loop, so the surface is visibly live rather than a
+ * still button that may or may not be recording. With motion off they do not
+ * render at all: the reduced-motion setting is an input, not a hint (TDR §11).
+ */
+function PulseRings({ active, theme }: { active: boolean; theme: Theme }) {
+  const { animated } = useMotion();
+  // Held in state (not a ref) so the render below may read them — the values are
+  // created once by the lazy initialiser and never replaced, so this never
+  // re-renders on its own.
+  const [rings] = useState(() => [0, 1, 2].map(() => new Animated.Value(0)));
+
+  useEffect(() => {
+    if (!active || !animated) return;
+    const loops = rings.map((value, index) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(index * 600),
+          Animated.timing(value, {
+            toValue: 1,
+            duration: 1800,
+            easing: Easing.out(Easing.ease),
+            useNativeDriver: true,
+          }),
+        ]),
+      ),
+    );
+    loops.forEach((loop) => loop.start());
+    return () => {
+      loops.forEach((loop) => loop.stop());
+      rings.forEach((value) => value.setValue(0));
+    };
+  }, [active, animated, rings]);
+
+  if (!active || !animated) return null;
+  return (
+    <>
+      {rings.map((value, index) => (
+        <Animated.View
+          key={index}
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            width: MIC_SIZE,
+            height: MIC_SIZE,
+            borderRadius: MIC_SIZE / 2,
+            backgroundColor: theme.color.brand,
+            opacity: value.interpolate({ inputRange: [0, 1], outputRange: [0.28, 0] }),
+            transform: [
+              { scale: value.interpolate({ inputRange: [0, 1], outputRange: [1, 2.4] }) },
+            ],
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * A live sound bar under the status while listening — five bars rising and
+ * falling out of step, the shorthand for "audio is coming in" (Todoist, Shopee).
+ * With motion off it holds a still, uneven silhouette so the shape still reads as
+ * a waveform without anything moving.
+ */
+function Waveform({ active, theme }: { active: boolean; theme: Theme }) {
+  const { animated } = useMotion();
+  const [bars] = useState(() => [0, 1, 2, 3, 4].map(() => new Animated.Value(0.3)));
+
+  useEffect(() => {
+    if (!active || !animated) return;
+    const loops = bars.map((value, index) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(index * 120),
+          Animated.timing(value, {
+            toValue: 1,
+            duration: 380,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: false,
+          }),
+          Animated.timing(value, {
+            toValue: 0.3,
+            duration: 380,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: false,
+          }),
+        ]),
+      ),
+    );
+    loops.forEach((loop) => loop.start());
+    return () => loops.forEach((loop) => loop.stop());
+  }, [active, animated, bars]);
+
+  // Still but uneven when motion is off — a silhouette, not a flat line.
+  const resting = [0.5, 0.9, 0.4, 1, 0.6];
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, height: 32 }}>
+      {bars.map((value, index) => (
+        <Animated.View
+          key={index}
+          style={{
+            width: 4,
+            borderRadius: 2,
+            backgroundColor: theme.color.brand,
+            height: animated
+              ? value.interpolate({ inputRange: [0, 1], outputRange: [6, 30] })
+              : 6 + resting[index]! * 24,
+          }}
+        />
+      ))}
+    </View>
+  );
+}
 
 export interface VoiceCaptureProps {
   /** Called with the final sentence once the speaker stops. */
@@ -141,42 +260,62 @@ export function VoiceCapture({ onDone, hints }: VoiceCaptureProps) {
 
   return (
     <View style={{ alignItems: 'center', gap: theme.spacing.xl }}>
+      {/* The live transcript as it forms, or the prompt before a word is heard —
+          the sentence the person is building is the headline of the screen. */}
       <Text variant="title" align="center">
         {live || t.voice.prompt}
       </Text>
 
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel={listening ? t.misc.stopDictating : t.voice.tapToSpeak}
-        accessibilityState={{ busy: listening }}
-        onPress={() => (listening ? stop() : void start())}
-        hitSlop={8}
-        style={({ pressed }) => ({
-          width: 96,
-          height: 96,
-          borderRadius: 48,
+      {/* The mic sits inside a fixed square so the pulse rings expanding behind it
+          never shove the layout around as they grow. */}
+      <View
+        style={{
+          width: MIC_SIZE * 2.4,
+          height: MIC_SIZE * 2.4,
           alignItems: 'center',
           justifyContent: 'center',
-          backgroundColor: listening ? theme.color.brand : theme.color.brandSoft,
-          opacity: pressed ? 0.9 : 1,
-        })}
+        }}
       >
-        <Ionicons
-          name={listening ? 'stop' : 'mic'}
-          size={iconSize.xl}
-          color={listening ? theme.color.onBrand : theme.color.brand}
-        />
-      </Pressable>
+        <PulseRings active={listening} theme={theme} />
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={listening ? t.misc.stopDictating : t.voice.tapToSpeak}
+          accessibilityState={{ busy: listening }}
+          onPress={() => (listening ? stop() : void start())}
+          hitSlop={8}
+          style={({ pressed }) => ({
+            width: MIC_SIZE,
+            height: MIC_SIZE,
+            borderRadius: MIC_SIZE / 2,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: listening ? theme.color.brand : theme.color.brandSoft,
+            opacity: pressed ? 0.9 : 1,
+          })}
+        >
+          <Ionicons
+            name={listening ? 'stop' : 'mic'}
+            size={iconSize.xxl}
+            color={listening ? theme.color.onBrand : theme.color.brand}
+          />
+        </Pressable>
+      </View>
 
-      <Text tone={listening ? 'brand' : 'muted'}>
-        {listening ? t.misc.listening : t.voice.tapToSpeak}
-      </Text>
-
-      {!live && !listening ? (
-        <Text variant="caption" tone="faint" align="center">
-          {t.voice.example}
+      {/* Listening: the status word over a live waveform. Idle: the same status
+          line, with a worked example under it so a first-timer knows the shape of
+          a sentence the parser understands. */}
+      <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
+        <Text tone={listening ? 'brand' : 'muted'}>
+          {listening ? t.misc.listening : t.voice.tapToSpeak}
         </Text>
-      ) : null}
+        {listening ? (
+          <Waveform active={listening} theme={theme} />
+        ) : !live ? (
+          <Text variant="caption" tone="faint" align="center">
+            {t.voice.example}
+          </Text>
+        ) : null}
+      </View>
 
       {error ? (
         <Pressable onPress={() => void Linking.openSettings()} accessibilityRole="button">

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -758,6 +758,7 @@ export interface UiStrings {
    *  app-specific hint at a time, dismissible for good. */
   tips: {
     label: string;
+    action: string;
     voiceTitle: string;
     voiceBody: string;
     splitTitle: string;
@@ -2027,6 +2028,7 @@ const en: UiStrings = {
   },
   tips: {
     label: 'Tip',
+    action: 'Show me',
     voiceTitle: 'Add by voice',
     voiceBody: 'Tap the mic and just say it — “dinner 800, split with Ravi”.',
     splitTitle: 'Split your way',
@@ -3382,6 +3384,7 @@ const ta: UiStrings = {
   },
   tips: {
     label: 'உதவிக்குறிப்பு',
+    action: 'காட்டு',
     voiceTitle: 'குரலால் சேர்',
     voiceBody: 'மைக்கைத் தட்டி சொல்லுங்கள் — “டின்னர் 800, ரவியுடன் பங்கிடு”.',
     splitTitle: 'உங்கள் விதத்தில் பங்கிடு',
@@ -4752,6 +4755,7 @@ const hi: UiStrings = {
   },
   tips: {
     label: 'सुझाव',
+    action: 'दिखाओ',
     voiceTitle: 'बोलकर जोड़ें',
     voiceBody: 'माइक दबाएँ और बस बोलें — “डिनर 800, रवि के साथ बाँटो”.',
     splitTitle: 'अपने तरीके से बाँटें',
@@ -6124,6 +6128,7 @@ const ar: UiStrings = {
   },
   tips: {
     label: 'نصيحة',
+    action: 'أرِني',
     voiceTitle: 'أضِف بصوتك',
     voiceBody: 'اضغط الميكروفون وقل ما تريد — «عشاء 800، اقسمها مع رافي».',
     splitTitle: 'اقسم بطريقتك',


### PR DESCRIPTION
Mobbin-informed mobile UI pass, verified on-device (emulator + physical phone).

## Inbox (`inbox.tsx`)
Big left title, day-grouped sections (reuses the Activity feed's `dayHeading`), per-row timestamp, unread rows as soft brand cards instead of a lone dot, dividers dropped.

## Speak-an-expense (`VoiceCapture.tsx`)
Static mic → pulsing three-ring mic with a live waveform while listening and a "try saying" example when idle. All motion gated on the reduced-motion preference (`useMotion`).

## Tips → daily sheet (`(tabs)/index.tsx`)
Inline dashboard tip card → bottom sheet that surfaces once on the first Home open of the day, stamps the day on show (won't re-nag), rotates by day. Always-mounted Modal driven by `visible` (a post-mount `visible` toggle didn't present on Android). New i18n key `tips.action` across all four locales.

## Sync glyph (`SyncBanner.tsx`)
Wide `SyncBanner` dropped from the dashboard for a single header glyph beside the camera — neutral cloud when offline / changes queued, turning arrow mid-sync, red only for a refused change; nothing when idle. Banner kept on the group screen where retry/discard lives.

Gates: `tsc --noEmit` and `eslint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)