### PR TITLE
chore(mobile): app id app.waves.mobile + dual waves:// scheme (rename stage C)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
     "name": "Waves",
-    "slug": "baaki",
+    "slug": "waves",
     "version": "0.1.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "baaki",
+    "scheme": ["waves", "baaki"],
     "userInterfaceStyle": "automatic",
     "backgroundColor": "#F3F1FB",
     "runtimeVersion": {
@@ -17,11 +17,11 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "app.baaki.mobile",
+      "bundleIdentifier": "app.waves.mobile",
       "usesAppleSignIn": true
     },
     "android": {
-      "package": "app.baaki.mobile",
+      "package": "app.waves.mobile",
       "permissions": ["android.permission.READ_SMS"],
       "adaptiveIcon": {
         "backgroundColor": "#7A5AF8",

--- a/apps/mobile/src/app/+native-intent.ts
+++ b/apps/mobile/src/app/+native-intent.ts
@@ -21,10 +21,11 @@
  */
 export function redirectSystemPath({ path }: { path: string; initial: boolean }): string {
   try {
-    // A base is required for the custom-scheme URL to parse. `baaki://auth`
-    // lands `auth` in the hostname; a `baaki:///auth` triple-slash form lands it
-    // in the pathname instead — cover both.
-    const url = new URL(path, 'baaki://app');
+    // A base is required for the custom-scheme URL to parse. `waves://auth`
+    // lands `auth` in the hostname; a `waves:///auth` triple-slash form lands it
+    // in the pathname instead — cover both. The base only matters when `path`
+    // arrives schemeless; a full `waves://` or `baaki://` URL parses on its own.
+    const url = new URL(path, 'waves://app');
     const firstSegment = url.pathname.replace(/^\/+/, '').split('/')[0];
     if (url.hostname === 'auth' || firstSegment === 'auth') {
       return '/';

--- a/apps/mobile/src/lib/push.ts
+++ b/apps/mobile/src/lib/push.ts
@@ -143,7 +143,7 @@ export async function refreshPushToken(): Promise<PushResult> {
   } catch (caught) {
     // The usual one, on an Android build with no `google-services.json`:
     // "Default FirebaseApp is not initialized". Also a Firebase project whose
-    // package name is not `app.baaki.mobile`, and a device with no network.
+    // package name is not `app.waves.mobile`, and a device with no network.
     // None of them are anything the person can act on, and none of them are
     // worth taking the app down for.
     console.warn('push token unavailable:', (caught as Error).message);
@@ -193,7 +193,9 @@ export function routeForNotification(response: Notifications.NotificationRespons
   const data = response.notification.request.content.data as { url?: unknown } | undefined;
   const url = typeof data?.url === 'string' ? data.url : null;
   if (!url) return null;
-  // `baaki://group/<id>` → `/group/<id>`. The scheme is only there because a
-  // push has to survive being handed to the operating system.
-  return url.replace(/^baaki:\/\//, '/');
+  // `waves://group/<id>` (or a pre-rebrand `baaki://…` still in the queue) →
+  // `/group/<id>`. The scheme is only there because a push has to survive being
+  // handed to the operating system; either of the app's registered schemes maps
+  // to the same in-app path.
+  return url.replace(/^(?:baaki|waves):\/\//, '/');
 }

--- a/e2e/friends-merge-guests.yaml
+++ b/e2e/friends-merge-guests.yaml
@@ -7,7 +7,7 @@
 # prove the screen renders and the "cannot be undone" warning is shown before any
 # button. Seed a data set with two guests (e.g. two groups each with a ghost
 # "person1") to make the confirm path run.
-appId: app.baaki.mobile
+appId: app.waves.mobile
 ---
 - launchApp:
     clearState: true

--- a/e2e/group-photo-paid-gate.yaml
+++ b/e2e/group-photo-paid-gate.yaml
@@ -6,7 +6,7 @@
 # passes if the paid-gate RPC answers differently under a seed with a paying
 # member (in which case the picker is allowed and there is no hint). Seed a free
 # account to exercise the locked path fully.
-appId: app.baaki.mobile
+appId: app.waves.mobile
 ---
 - launchApp:
     clearState: true

--- a/e2e/home-to-add-expense.yaml
+++ b/e2e/home-to-add-expense.yaml
@@ -2,7 +2,7 @@
 # headline balance, open a group, reach the add-expense screen and use the
 # built-in calculator. The full happy path from TDR §10 — invite guest, scan
 # receipt, claim items, UPI settle, confirm — lands with M3–M5.
-appId: app.baaki.mobile
+appId: app.waves.mobile
 ---
 - launchApp:
     clearState: true

--- a/e2e/leave-group.yaml
+++ b/e2e/leave-group.yaml
@@ -10,7 +10,7 @@
 # Precondition: the seeded "Goa trip" is settled for the acting member (leaving
 # is refused while a balance is open — that guard has its own copy). If the seed
 # carries an open balance, settle it first with the settle flow.
-appId: app.baaki.mobile
+appId: app.waves.mobile
 ---
 - launchApp:
     clearState: true

--- a/packages/core/src/notifications/campaign.ts
+++ b/packages/core/src/notifications/campaign.ts
@@ -51,7 +51,7 @@ export interface CampaignEmailOptions {
   /**
    * Where the button lands. Web-lite has no redeem page, so with a web URL the
    * button opens web-lite and the code is typed in the app; with none it falls
-   * back to a `baaki://redeem` deep link, which works on the phone and does
+   * back to a `waves://redeem` deep link, which works on the phone and does
    * nothing in desktop webmail — where the visible code chip is the way in.
    */
   readonly webUrl?: string | null;
@@ -75,7 +75,7 @@ const RIGHT_TO_LEFT = new Set(['ar', 'he', 'fa', 'ur']);
 /**
  * The button's target.
  *
- * A configured web URL wins. Failing that, a promo code becomes a `baaki://`
+ * A configured web URL wins. Failing that, a promo code becomes a `waves://`
  * deep link so a phone can open straight into redeeming it. With neither there
  * is nothing to link to, and the mail is still worth sending for what it says.
  */
@@ -84,7 +84,7 @@ export function campaignCtaUrl(
   webUrl?: string | null,
 ): string | null {
   if (webUrl && /^https?:\/\//i.test(webUrl.trim())) return webUrl.trim().replace(/\/+$/, '');
-  if (promoCode) return `baaki://redeem?code=${encodeURIComponent(promoCode)}`;
+  if (promoCode) return `waves://redeem?code=${encodeURIComponent(promoCode)}`;
   return null;
 }
 

--- a/packages/core/src/notifications/email.ts
+++ b/packages/core/src/notifications/email.ts
@@ -130,7 +130,11 @@ export interface EmailOptions {
  * neither, there is no button — an email is still worth sending for what it
  * says.
  */
-const SAFE_LINK = /^(?:baaki:\/\/|https?:\/\/)/i;
+// Both app schemes are accepted: the store of notifications still holds
+// `baaki://` deep links written before the rebrand (and the DB functions still
+// emit them), while new links use `waves://`. The app registers both, so both
+// resolve; this rewriter has to recognise both too.
+const SAFE_LINK = /^(?:baaki:\/\/|waves:\/\/|https?:\/\/)/i;
 
 export function webLinkFor(
   deepLink: string | null | undefined,
@@ -157,7 +161,7 @@ export function webLinkFor(
   if (safeDeepLink.startsWith('http://') || safeDeepLink.startsWith('https://'))
     return safeDeepLink;
 
-  const group = /^baaki:\/\/group\/([0-9a-fA-F-]{36})/.exec(safeDeepLink);
+  const group = /^(?:baaki|waves):\/\/group\/([0-9a-fA-F-]{36})/.exec(safeDeepLink);
   return group ? `${base}/g/${group[1]}` : base;
 }
 

--- a/packages/core/test/campaignEmail.test.ts
+++ b/packages/core/test/campaignEmail.test.ts
@@ -84,7 +84,7 @@ describe('campaignCtaUrl', () => {
   });
 
   it('falls back to a redeem deep link when only a code is known', () => {
-    expect(campaignCtaUrl('DIWALI 26', null)).toBe('baaki://redeem?code=DIWALI%2026');
+    expect(campaignCtaUrl('DIWALI 26', null)).toBe('waves://redeem?code=DIWALI%2026');
   });
 
   it('has nothing to link to with neither', () => {

--- a/packages/core/test/scrub.test.ts
+++ b/packages/core/test/scrub.test.ts
@@ -95,7 +95,7 @@ describe('things that are the whole reason to send a report', () => {
               frames: [
                 {
                   filename: 'app:///index.android.bundle',
-                  abs_path: '/data/user/0/app.baaki.mobile/files/8f3aa91c4d5e6b7a8c9d0e1f2a3b4c5d',
+                  abs_path: '/data/user/0/app.waves.mobile/files/8f3aa91c4d5e6b7a8c9d0e1f2a3b4c5d',
                   function: 'computeShares',
                 },
               ],

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -47,7 +47,12 @@ site_url = "baaki://"
 # produces, and Supabase matches these exactly — `baaki://` on its own does not
 # cover it, so leaving it out sends every OAuth round trip to site_url instead
 # and the app never sees the tokens.
-additional_redirect_urls = ["baaki://", "baaki://auth", "http://localhost:3000"]
+#
+# The auth redirect deliberately stays on the `baaki` scheme through the rebrand:
+# the app now registers both `waves://` and `baaki://`, and the `waves://` entries
+# below are pre-allowed so the OAuth redirect can move to `waves://auth` in one
+# step once the prod Supabase + Google/Apple consoles also list it.
+additional_redirect_urls = ["baaki://", "baaki://auth", "waves://", "waves://auth", "http://localhost:3000"]
 jwt_expiry = 3600
 enable_signup = true
 # ADR-006. A guest opens a link and starts splitting; there is no account until


### PR DESCRIPTION
Stage C — native identity + deep-link scheme, done as a **transition** so nothing already deployed breaks. Merging this changes no running system; it takes effect on the **next native build**, which needs the ops runbook below.

## Code changes
- **app.json**: `bundleIdentifier` + `package` → `app.waves.mobile`, `slug` → `waves`, `scheme` → `["waves","baaki"]`.
- **Both schemes accepted** by consumers: `routeForNotification` (push) and `webLinkFor` (email) match `(?:baaki|waves)://`; `+native-intent` parses either. So every `baaki://…` link a prod DB function has already emitted still resolves.
- **Producers emit `waves://`**: `campaignCtaUrl` → `waves://redeem`.
- **OAuth redirect stays `baaki://auth`** on purpose — no Supabase/Google/Apple change needed to keep sign-in working. `waves://auth` is pre-allowed in `supabase/config.toml` for a one-step cutover later.
- e2e `appId` + Sentry-scrub fixture → `app.waves.mobile`.

## Gates
core + mobile `typecheck`, `lint`, tests (555 + 259) ✅

## ⚠️ Ops runbook — required before/at the next native build (only you can do these)
1. **Firebase**: add an Android app `app.waves.mobile` (+ iOS `app.waves.mobile`) to the Firebase project; download the new `google-services.json` / `GoogleService-Info.plist` and replace the ones in `apps/mobile/`. Until then FCM push fails on the new build. *(left unchanged in this PR on purpose)*
2. **Google OAuth**: new Android/iOS OAuth client(s) for `app.waves.mobile` (package + SHA-1 / bundle id); update the `EXPO_PUBLIC_*` client-id envs.
3. **Apple**: new App ID / bundle `app.waves.mobile`, Sign in with Apple enabled.
4. **Store**: `app.waves.mobile` is a **new app** — new Play/App Store listing; existing installs will not auto-update.
5. **EAS**: `slug` changed → confirm the EAS project link / `projectId` (`updates.url`) still points where you want, or re-init.
6. Then `expo prebuild --clean` + local build.

## Later (Stage D / follow-ups)
- Switch the OAuth redirect to `waves://auth` (flip `makeRedirectUri` scheme + add to **prod** Supabase redirect allowlist).
- Migration to make the `baaki_*` notification functions emit `waves://` deep links (safe once the app understands both — this PR makes it understand both).
- `baaki_*` Supabase function rename (Stage D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the mobile app identity and deep-link scheme to Waves.
  * Added support for both new `waves://` and legacy `baaki://` links.
  * Updated notification, campaign, email, and authentication links to route correctly.

* **Tests**
  * Updated end-to-end flows and link-related tests for the Waves app identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->