### PR TITLE
feat(mobile): dashboard add-expense FAB + speak several expenses in any language

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -342,12 +342,60 @@ export default function HomeScreen() {
         )}
       </ScrollView>
 
+      {/* The one always-there way to add a spend by hand — a floating action in
+          the bottom-right, the place finance apps put it (Buddy, Airwallex). The
+          bar's centre is the mic (speak it) and the header camera scans a bill;
+          this is the third, plainest route: type it. It sits above the bar via
+          the same clearance the scroll uses, so it never covers the last row. */}
+      <AddExpenseFab label={t.addExpense} bottom={clearance} />
+
       {/* The daily tip, surfaced as a sheet on the first Home open of the day —
           one useful, Baaki-specific move at a time, then out of the way until
           tomorrow. Replaces the inline card so a hint asks for a beat of
           attention rather than sitting as furniture nobody reads. */}
       <TipSheet t={t} />
     </Screen>
+  );
+}
+
+/**
+ * The dashboard's add-expense action, floating over the bottom-right.
+ *
+ * Routes to the capture screen — the group-optional "capture an expense" form —
+ * so it works the same whether or not the person has a group yet: they type the
+ * amount now and decide where it belongs later. The header camera opens that
+ * same screen straight into scan mode; this opens it blank, to type.
+ *
+ * Wrapped in a `box-none` overlay so only the button itself takes touches — the
+ * transparent area around it lets the list underneath scroll and tap through.
+ */
+function AddExpenseFab({ label, bottom }: { label: string; bottom: number }) {
+  const theme = useTheme();
+  const size = 60;
+  return (
+    <View
+      pointerEvents="box-none"
+      style={{ position: 'absolute', right: theme.spacing.xl, bottom, left: 0, top: 0 }}
+    >
+      <View pointerEvents="box-none" style={{ flex: 1, justifyContent: 'flex-end', alignItems: 'flex-end' }}>
+        <PressableScale
+          accessibilityRole="button"
+          accessibilityLabel={label}
+          onPress={() => router.push('/capture')}
+          style={{
+            width: size,
+            height: size,
+            borderRadius: size / 2,
+            backgroundColor: theme.color.brand,
+            alignItems: 'center',
+            justifyContent: 'center',
+            ...theme.shadow.lifted,
+          }}
+        >
+          <Ionicons name="add" size={32} color={theme.color.onBrand} />
+        </PressableScale>
+      </View>
+    </View>
   );
 }
 

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -377,7 +377,10 @@ function AddExpenseFab({ label, bottom }: { label: string; bottom: number }) {
       pointerEvents="box-none"
       style={{ position: 'absolute', right: theme.spacing.xl, bottom, left: 0, top: 0 }}
     >
-      <View pointerEvents="box-none" style={{ flex: 1, justifyContent: 'flex-end', alignItems: 'flex-end' }}>
+      <View
+        pointerEvents="box-none"
+        style={{ flex: 1, justifyContent: 'flex-end', alignItems: 'flex-end' }}
+      >
         <PressableScale
           accessibilityRole="button"
           accessibilityLabel={label}
@@ -612,85 +615,85 @@ function TipSheet({ t }: { t: UiStrings }) {
   return (
     <Modal transparent animationType="fade" visible={open} onRequestClose={close}>
       {tip ? (
-      /* Tap outside to close — the same escape the campaign popup gives. */
-      <Pressable
-        onPress={close}
-        accessibilityLabel={t.common.close}
-        style={{
-          flex: 1,
-          backgroundColor: 'rgba(10, 10, 26, 0.55)',
-          justifyContent: 'flex-end',
-        }}
-      >
-        {/* Swallows the tap so pressing the sheet itself does not dismiss it. A
-            bottom sheet, not a centred dialog: it slides up from the bar the tip
-            is about, and leaves the balance above it in view. */}
+        /* Tap outside to close — the same escape the campaign popup gives. */
         <Pressable
-          onPress={() => {}}
+          onPress={close}
+          accessibilityLabel={t.common.close}
           style={{
-            backgroundColor: theme.color.surface,
-            borderTopLeftRadius: theme.radius.xxl,
-            borderTopRightRadius: theme.radius.xxl,
-            paddingHorizontal: theme.spacing.xxl,
-            paddingTop: theme.spacing.xl,
-            paddingBottom: theme.spacing.xxl,
-            gap: theme.spacing.lg,
-            ...theme.shadow.lifted,
+            flex: 1,
+            backgroundColor: 'rgba(10, 10, 26, 0.55)',
+            justifyContent: 'flex-end',
           }}
         >
-          {/* A grab handle — the visual grammar of a sheet you can pull down. */}
-          <View
+          {/* Swallows the tap so pressing the sheet itself does not dismiss it. A
+            bottom sheet, not a centred dialog: it slides up from the bar the tip
+            is about, and leaves the balance above it in view. */}
+          <Pressable
+            onPress={() => {}}
             style={{
-              alignSelf: 'center',
-              width: 40,
-              height: 4,
-              borderRadius: 2,
-              backgroundColor: theme.color.border,
+              backgroundColor: theme.color.surface,
+              borderTopLeftRadius: theme.radius.xxl,
+              borderTopRightRadius: theme.radius.xxl,
+              paddingHorizontal: theme.spacing.xxl,
+              paddingTop: theme.spacing.xl,
+              paddingBottom: theme.spacing.xxl,
+              gap: theme.spacing.lg,
+              ...theme.shadow.lifted,
             }}
-          />
-
-          <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
+          >
+            {/* A grab handle — the visual grammar of a sheet you can pull down. */}
             <View
               style={{
-                width: 64,
-                height: 64,
-                borderRadius: 32,
-                alignItems: 'center',
-                justifyContent: 'center',
-                backgroundColor: theme.color.brandSoft,
+                alignSelf: 'center',
+                width: 40,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: theme.color.border,
               }}
-            >
-              <Ionicons name={tip.icon} size={iconSize.xxl} color={theme.color.brand} />
-            </View>
-            <Text variant="micro" tone="brand" style={{ letterSpacing: 0.8 }}>
-              {t.tips.label.toUpperCase()}
-            </Text>
-            <Text variant="title" align="center">
-              {tip.title}
-            </Text>
-            <Text variant="body" tone="muted" align="center">
-              {tip.body}
-            </Text>
-          </View>
+            />
 
-          <View style={{ gap: theme.spacing.sm }}>
-            {tip.route ? (
-              <>
-                <Button label={t.tips.action} size="lg" fullWidth onPress={act} />
-                <Button
-                  label={t.misc.gotIt}
-                  variant="secondary"
-                  size="sm"
-                  fullWidth
-                  onPress={close}
-                />
-              </>
-            ) : (
-              <Button label={t.misc.gotIt} size="lg" fullWidth onPress={close} />
-            )}
-          </View>
+            <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
+              <View
+                style={{
+                  width: 64,
+                  height: 64,
+                  borderRadius: 32,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: theme.color.brandSoft,
+                }}
+              >
+                <Ionicons name={tip.icon} size={iconSize.xxl} color={theme.color.brand} />
+              </View>
+              <Text variant="micro" tone="brand" style={{ letterSpacing: 0.8 }}>
+                {t.tips.label.toUpperCase()}
+              </Text>
+              <Text variant="title" align="center">
+                {tip.title}
+              </Text>
+              <Text variant="body" tone="muted" align="center">
+                {tip.body}
+              </Text>
+            </View>
+
+            <View style={{ gap: theme.spacing.sm }}>
+              {tip.route ? (
+                <>
+                  <Button label={t.tips.action} size="lg" fullWidth onPress={act} />
+                  <Button
+                    label={t.misc.gotIt}
+                    variant="secondary"
+                    size="sm"
+                    fullWidth
+                    onPress={close}
+                  />
+                </>
+              ) : (
+                <Button label={t.misc.gotIt} size="lg" fullWidth onPress={close} />
+              )}
+            </View>
+          </Pressable>
         </Pressable>
-      </Pressable>
       ) : null}
     </Modal>
   );

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -20,6 +20,7 @@ import {
 } from '@waves/ui';
 
 import { ProfileAvatar } from '@/components/ProfileAvatar';
+import { friendlyError } from '@/lib/errors';
 import { SkeletonList } from '@/components/Skeletons';
 import { removeAvatar, uploadAvatar } from '@/data/api';
 import { useSettledTotals } from '@/data/hooks';
@@ -293,7 +294,7 @@ function ProfileForm() {
       });
       await updateProfile({ avatar_url: path });
     } catch (caught) {
-      setStatus(caught instanceof Error ? caught.message : String(caught));
+      setStatus(friendlyError(caught, t.couldNotSave, 'profile.uploadPhoto'));
     } finally {
       setPhotoBusy(false);
     }
@@ -306,7 +307,7 @@ function ProfileForm() {
       await removeAvatar(profile.id, profile.avatar_url);
       await updateProfile({ avatar_url: null });
     } catch (caught) {
-      setStatus(caught instanceof Error ? caught.message : String(caught));
+      setStatus(friendlyError(caught, t.couldNotSave, 'profile.removePhoto'));
     } finally {
       setPhotoBusy(false);
     }

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -34,6 +34,7 @@ import { captureReceipt, type PickedImage } from '@/lib/image';
 import { recogniseReceipt } from '@/lib/ocr';
 import { saveReceipt } from '@/lib/receiptStore';
 import { markPending } from '@/lib/receiptIndex';
+import { friendlyError } from '@/lib/errors';
 import { useBackup } from '@/lib/cloud/BackupProvider';
 
 /**
@@ -239,7 +240,7 @@ export default function CaptureScreen() {
       });
       router.back();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.captures.couldNotSave, 'capture.save'));
     } finally {
       setSaving(false);
     }

--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -40,6 +40,7 @@ import {
 } from '@waves/ui';
 
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
+import { friendlyError } from '@/lib/errors';
 import { DictateButton } from '@/components/DictateButton';
 import { useAddGhostMember, useCreateGroup, useWriteExpense } from '@/data/hooks';
 import { GroupType } from '@/data/types';
@@ -211,7 +212,7 @@ export default function AddPersonScreen() {
       // and the whole IOU syncs when there is a connection. Nothing to refetch.
       router.back();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.addPerson.couldNotRecord, 'addPerson.save'));
     } finally {
       setSaving(false);
     }

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -89,24 +89,25 @@ export default function ContactsScreen(): React.JSX.Element {
           friendlyError(caught, t.misc.couldNotAddGeneric, 'contacts.add');
         }
       }
-      if (failed.length > 0) {
-        throw new Error(fill(t.misc.couldNotAdd, { names: failed.join(', ') }));
-      }
-      return contacts.length;
+      // A partial failure is a normal outcome, not an exception: the names that
+      // did not make it ride back in the result, so nothing raw is thrown and
+      // onError is left for a genuine transport failure of the whole call.
+      return { added: contacts.length - failed.length, failed };
     },
-    onSuccess: async (count, { groupId }) => {
-      setAdded(count);
+    onSuccess: async ({ added, failed }, { groupId }) => {
+      // Only announce a count when at least one landed; on a total failure the
+      // error below carries the whole story.
+      setAdded(added > 0 ? added : null);
       setPicked([]);
-      setError(null);
+      setError(failed.length > 0 ? fill(t.misc.couldNotAdd, { names: failed.join(', ') }) : null);
       await queryClient.invalidateQueries({ queryKey: ['members', groupId] });
       await queryClient.invalidateQueries({ queryKey: ['people', 'balances'] });
     },
     onError: (caught: unknown) => {
-      // The thrown message is the localized "could not add {names}" summary the
-      // mutation built, not a raw error — show it as-is so the reader sees who
-      // failed; the individual transport errors were already reported above. A
-      // fallback covers any non-Error that reaches here.
-      setError(caught instanceof Error ? caught.message : t.misc.couldNotAddGeneric);
+      // Reached only when the whole operation fails unexpectedly — a raw
+      // transport or server error — so friendlyError with the generic fallback
+      // is exactly right here (per-contact failures are handled in the loop).
+      setError(friendlyError(caught, t.misc.couldNotAddGeneric, 'contacts.add'));
     },
   });
 

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -41,6 +41,7 @@ import {
 } from '@waves/ui';
 
 import { fill, plural, useStrings } from '@/i18n';
+import { friendlyError } from '@/lib/errors';
 
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
 import { addGhostMember, fetchGroups } from '@/data/api';
@@ -102,7 +103,7 @@ export default function ContactsScreen(): React.JSX.Element {
       await queryClient.invalidateQueries({ queryKey: ['people', 'balances'] });
     },
     onError: (caught: unknown) => {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.misc.couldNotAddGeneric, 'contacts.add'));
     },
   });
 

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -75,7 +75,6 @@ export default function ContactsScreen(): React.JSX.Element {
       contacts: readonly PickedContact[];
     }) => {
       const failed: string[] = [];
-      let last = '';
       for (const contact of contacts) {
         try {
           await addGhostMember(groupId, contact.name, {
@@ -84,13 +83,13 @@ export default function ContactsScreen(): React.JSX.Element {
           });
         } catch (caught) {
           failed.push(contact.name);
-          last = caught instanceof Error ? caught.message : String(caught);
+          // Report each real failure for its side effect (the raw server message
+          // goes to Sentry); its return is discarded — the user is not shown a
+          // transport error, but whose names did not make it, below.
+          friendlyError(caught, t.misc.couldNotAddGeneric, 'contacts.add');
         }
       }
       if (failed.length > 0) {
-        // `last` holds the raw (unlocalised) server message — kept for logs, not
-        // shown; the user sees whose names did not make it, in their language.
-        void last;
         throw new Error(fill(t.misc.couldNotAdd, { names: failed.join(', ') }));
       }
       return contacts.length;
@@ -103,7 +102,11 @@ export default function ContactsScreen(): React.JSX.Element {
       await queryClient.invalidateQueries({ queryKey: ['people', 'balances'] });
     },
     onError: (caught: unknown) => {
-      setError(friendlyError(caught, t.misc.couldNotAddGeneric, 'contacts.add'));
+      // The thrown message is the localized "could not add {names}" summary the
+      // mutation built, not a raw error — show it as-is so the reader sees who
+      // failed; the individual transport errors were already reported above. A
+      // fallback covers any non-Error that reaches here.
+      setError(caught instanceof Error ? caught.message : t.misc.couldNotAddGeneric);
     },
   });
 

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -31,6 +31,7 @@ import {
 } from '@waves/ui';
 
 import { CategoryPicker } from '@/components/Category';
+import { friendlyError } from '@/lib/errors';
 import { CurrencyRate } from '@/components/CurrencyRate';
 import { DictateButton } from '@/components/DictateButton';
 import { scanReceipt, scanReceiptText } from '@/data/api';
@@ -465,7 +466,7 @@ export default function AddExpenseScreen() {
       }
       router.back();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'expense.save'));
     } finally {
       setSaving(false);
     }
@@ -547,7 +548,7 @@ export default function AddExpenseScreen() {
           : (result.check.problems[0]?.message ?? t.expense.scanCheckTotal),
       );
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotScan, 'expense.scan'));
     } finally {
       setScanning(false);
     }

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -19,6 +19,7 @@ import {
 } from '@waves/ui';
 
 import { mintInvite, type MintedInvite } from '@/data/api';
+import { friendlyError } from '@/lib/errors';
 import { useGroup } from '@/data/hooks';
 import { groupLabel } from '@/data/types';
 import { useAuth } from '@/lib/auth';
@@ -52,7 +53,7 @@ export default function InviteScreen() {
     try {
       setInvite(await mintInvite(groupId));
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'invite.create'));
     } finally {
       setBusy(false);
     }

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -31,6 +31,7 @@ import {
 } from '@waves/ui';
 
 import { captureReceipt } from '@/lib/image';
+import { friendlyError } from '@/lib/errors';
 import { publishReceiptItems, scanReceipt, scanReceiptText, setItemClaim } from '@/data/api';
 import { recogniseReceipt } from '@/lib/ocr';
 import { useGroup, useItemClaims, useReceipt, useWriteExpense } from '@/data/hooks';
@@ -212,7 +213,7 @@ export default function ItemizeScreen() {
           : (result.check.problems[0]?.message ?? t.itemize.scanCheckLines),
       );
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotScan, 'itemize.scan'));
     } finally {
       setScanning(false);
     }
@@ -372,7 +373,7 @@ export default function ItemizeScreen() {
       });
       await claims.refetch();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'itemize.claim'));
     }
   };
 
@@ -395,7 +396,7 @@ export default function ItemizeScreen() {
       setSharedId(scanId);
       setScanNote(t.itemize.sharedNow);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'itemize.publish'));
     } finally {
       setPublishing(false);
     }
@@ -424,7 +425,7 @@ export default function ItemizeScreen() {
       });
       router.back();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'itemize.save'));
     }
   };
 

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -25,6 +25,7 @@ import {
 } from '@waves/ui';
 
 import { useGroup, useGroupLedger, useSetMemberRole, useUpdateMember } from '@/data/hooks';
+import { friendlyError } from '@/lib/errors';
 import { expenseTitle } from '@/data/expenseTitle';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { plural, useStrings } from '@/i18n';
@@ -92,7 +93,7 @@ export default function MemberScreen() {
       { memberId: member.id, patch },
       {
         onSuccess: () => setStatus(t.account.saved),
-        onError: (caught) => setStatus(caught instanceof Error ? caught.message : String(caught)),
+        onError: (caught) => setStatus(friendlyError(caught, t.couldNotSave, 'member.save')),
       },
     );
   };
@@ -247,7 +248,7 @@ export default function MemberScreen() {
                   {
                     onSuccess: () => setStatus(t.account.saved),
                     onError: (caught) =>
-                      setStatus(caught instanceof Error ? caught.message : String(caught)),
+                      setStatus(friendlyError(caught, t.couldNotSave, 'member.setRole')),
                   },
                 )
               }

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -112,7 +112,8 @@ export default function MembersScreen() {
           setGhostName('');
           setGhostContact('');
         },
-        onError: (caught) => setError(friendlyError(caught, t.misc.couldNotAddGeneric, 'members.addGhost')),
+        onError: (caught) =>
+          setError(friendlyError(caught, t.misc.couldNotAddGeneric, 'members.addGhost')),
       },
     );
   };
@@ -143,9 +144,11 @@ export default function MembersScreen() {
         });
       } catch (caught) {
         failed.push(person.name);
-        // The first refusal's own words, kept so the message can say why rather
-        // than only which names did not make it.
-        if (!reason) reason = friendlyError(caught, t.misc.tryAgainMoment, 'members.addPicked');
+        // Report every refusal (friendlyError's side effect sends each to
+        // Sentry); keep only the first one's words for the UI, so the message
+        // can say why rather than only which names did not make it.
+        const message = friendlyError(caught, t.misc.tryAgainMoment, 'members.addPicked');
+        if (!reason) reason = message;
       }
     }
     setAdding(false);

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -112,7 +112,7 @@ export default function MembersScreen() {
           setGhostName('');
           setGhostContact('');
         },
-        onError: (caught) => setError(caught instanceof Error ? caught.message : String(caught)),
+        onError: (caught) => setError(friendlyError(caught, t.misc.couldNotAddGeneric, 'members.addGhost')),
       },
     );
   };
@@ -145,7 +145,7 @@ export default function MembersScreen() {
         failed.push(person.name);
         // The first refusal's own words, kept so the message can say why rather
         // than only which names did not make it.
-        if (!reason) reason = caught instanceof Error ? caught.message : String(caught);
+        if (!reason) reason = friendlyError(caught, t.misc.tryAgainMoment, 'members.addPicked');
       }
     }
     setAdding(false);

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -59,6 +59,7 @@ import {
   useSetPlanItemDone,
 } from '@/data/hooks';
 import { displayName } from '@/data/types';
+import { friendlyError } from '@/lib/errors';
 import { useAuth } from '@/lib/auth';
 import { ListScreenSkeleton } from '@/components/Skeletons';
 import { fill, useStrings, type UiStrings } from '@/i18n';
@@ -247,7 +248,7 @@ export default function PlanScreen() {
       });
       setEditingMine(false);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'plan.saveMine'));
     } finally {
       setBusy(false);
     }
@@ -260,7 +261,7 @@ export default function PlanScreen() {
       await clearMineBudget.mutateAsync();
       setEditingMine(false);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'plan.clearMine'));
     } finally {
       setBusy(false);
     }
@@ -278,7 +279,7 @@ export default function PlanScreen() {
       await setOverall.mutateAsync({ amountMinor: overallAmount, currency });
       setEditingOverall(false);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'plan.saveOverall'));
     } finally {
       setBusy(false);
     }
@@ -291,7 +292,7 @@ export default function PlanScreen() {
       await setOverall.mutateAsync({ amountMinor: null });
       setEditingOverall(false);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'plan.clearOverall'));
     } finally {
       setBusy(false);
     }
@@ -313,7 +314,7 @@ export default function PlanScreen() {
       setTitle('');
       setAddingTo(null);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'plan.addItem'));
     } finally {
       submitting.current = false;
       setBusy(false);
@@ -325,7 +326,7 @@ export default function PlanScreen() {
     try {
       await toggleItem.mutateAsync({ itemId: item.id, done: !item.done });
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'plan.toggleItem'));
     }
   };
 
@@ -334,7 +335,7 @@ export default function PlanScreen() {
     try {
       await removeItem.mutateAsync(item.id);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'plan.removeItem'));
     }
   };
 

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -27,6 +27,7 @@ import {
 } from '@waves/ui';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
+import { friendlyError } from '@/lib/errors';
 import { pickGroupPhoto } from '@/lib/image';
 import { CountryRow } from '@/components/CountryPicker';
 import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
@@ -88,7 +89,7 @@ export default function GroupSettingsScreen() {
         // Only clear the field if it still holds what we submitted, so a name
         // typed for the next person isn't wiped when this add lands.
         onSuccess: () => setNewName((current) => (current.trim() === person ? '' : current)),
-        onError: (caught) => setAddError(caught instanceof Error ? caught.message : String(caught)),
+        onError: (caught) => setAddError(friendlyError(caught, t.misc.couldNotAddGeneric, 'groupSettings.addGhost')),
       },
     );
   };
@@ -125,7 +126,7 @@ export default function GroupSettingsScreen() {
       await group.refetch();
       setStatus(t.group.photoUpdated);
     } catch (caught) {
-      setStatus(caught instanceof Error ? caught.message : String(caught));
+      setStatus(friendlyError(caught, t.couldNotSave, 'groupSettings.changePhoto'));
     } finally {
       setUploading(false);
     }
@@ -146,7 +147,7 @@ export default function GroupSettingsScreen() {
       await removeGroupPhoto(groupId, group.data?.photo_path ?? null);
       await group.refetch();
     } catch (caught) {
-      setStatus(caught instanceof Error ? caught.message : String(caught));
+      setStatus(friendlyError(caught, t.couldNotSave, 'groupSettings.dropPhoto'));
     }
   };
 

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -89,7 +89,8 @@ export default function GroupSettingsScreen() {
         // Only clear the field if it still holds what we submitted, so a name
         // typed for the next person isn't wiped when this add lands.
         onSuccess: () => setNewName((current) => (current.trim() === person ? '' : current)),
-        onError: (caught) => setAddError(friendlyError(caught, t.misc.couldNotAddGeneric, 'groupSettings.addGhost')),
+        onError: (caught) =>
+          setAddError(friendlyError(caught, t.misc.couldNotAddGeneric, 'groupSettings.addGhost')),
       },
     );
   };

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -36,6 +36,7 @@ import {
 } from '@waves/ui';
 
 import { toSnapshot, useGroup, useGroupLedger, useRecordSettlement } from '@/data/hooks';
+import { friendlyError } from '@/lib/errors';
 import { nudgeToSettle } from '@/data/api';
 import { expenseTitle } from '@/data/expenseTitle';
 import { displayName, isGhost, payableAt, type MemberRow } from '@/data/types';
@@ -166,7 +167,7 @@ export default function SettleScreen() {
       });
       router.back();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'settle.record'));
     }
   };
 

--- a/apps/mobile/src/app/join.tsx
+++ b/apps/mobile/src/app/join.tsx
@@ -19,6 +19,7 @@ import {
 } from '@waves/ui';
 
 import { fill, plural, useStrings } from '@/i18n';
+import { friendlyError } from '@/lib/errors';
 
 import { acceptInvite, previewInvite, type InvitePreview } from '@/data/api';
 import { keys } from '@/data/hooks';
@@ -75,7 +76,7 @@ export default function JoinScreen() {
         const result = await previewInvite(token);
         if (active) setPreview(result);
       } catch (caught) {
-        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+        if (active) setError(friendlyError(caught, t.misc.couldNotJoin, 'join.preview'));
       } finally {
         if (active) setBusy(false);
       }
@@ -83,7 +84,7 @@ export default function JoinScreen() {
     return () => {
       active = false;
     };
-  }, [token]);
+  }, [token, t.misc.couldNotJoin]);
 
   /**
    * `claim` is passed rather than read from state because "join as someone new
@@ -114,7 +115,7 @@ export default function JoinScreen() {
       await queryClient.invalidateQueries({ queryKey: keys.groups });
       router.replace(`/group/${result.group.id}`);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.misc.couldNotJoin, 'join.accept'));
     } finally {
       setJoining(false);
     }

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -21,6 +21,7 @@ import {
 } from '@waves/ui';
 
 import { GroupPhoto } from '@/components/GroupPhoto';
+import { friendlyError } from '@/lib/errors';
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
 import { CountryRow } from '@/components/CountryPicker';
 import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
@@ -210,7 +211,7 @@ export default function NewGroupScreen() {
       }
       router.replace(`/group/${groupId}`);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'newGroup.create'));
     }
   };
 

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -32,6 +32,7 @@ import {
 import { dialingCodeForCountry } from '@waves/core';
 
 import { CountryCodePicker } from '@/components/CountryCodePicker';
+import { friendlyError } from '@/lib/errors';
 import { confirmContact, startAddingContact, ContactChannel } from '@/data/api';
 import { deviceCountry, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -110,7 +111,7 @@ function AccountForm() {
       await start();
       await refresh();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'account.link'));
     } finally {
       setBusy(false);
     }
@@ -125,7 +126,7 @@ function AccountForm() {
       await updateProfile({ display_name: name.trim() || t.account.you });
       setNameStatus(t.account.saved);
     } catch (caught) {
-      setNameStatus(caught instanceof Error ? caught.message : String(caught));
+      setNameStatus(friendlyError(caught, t.couldNotSave, 'account.saveName'));
     }
   };
 
@@ -161,7 +162,7 @@ function AccountForm() {
       await startAddingContact(channel, normalised);
       setSent(true);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'account.sendContact'));
     } finally {
       setBusy(false);
     }
@@ -177,7 +178,7 @@ function AccountForm() {
       setSent(false);
       setCode('');
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.couldNotSave, 'account.confirmContact'));
     } finally {
       setBusy(false);
     }

--- a/apps/mobile/src/app/settings/backup.tsx
+++ b/apps/mobile/src/app/settings/backup.tsx
@@ -38,6 +38,7 @@ import {
 } from '@waves/ui';
 
 import { plural, useStrings } from '@/i18n';
+import { friendlyError } from '@/lib/errors';
 import { useBackup } from '@/lib/cloud/BackupProvider';
 import { allProviders } from '@/lib/cloud/providers';
 import type { BackupNetworkPolicy, CloudProviderId } from '@/lib/cloud/types';
@@ -58,7 +59,7 @@ export default function BackupSettingsScreen() {
     try {
       await backup.connect(id);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.backup.connectFailed, 'backup.connect'));
     } finally {
       setBusy(null);
     }

--- a/apps/mobile/src/app/settings/devices.tsx
+++ b/apps/mobile/src/app/settings/devices.tsx
@@ -31,6 +31,7 @@ import {
 } from '@waves/ui';
 
 import { plural, useStrings } from '@/i18n';
+import { friendlyError } from '@/lib/errors';
 import { fetchDevices } from '@/data/api';
 import { deviceId } from '@/lib/device';
 import { useDeviceSession } from '@/lib/deviceSession';
@@ -72,7 +73,7 @@ export default function DevicesScreen() {
       );
       await queryClient.invalidateQueries({ queryKey: ['devices'] });
     } catch (caught) {
-      setMessage(caught instanceof Error ? caught.message : String(caught));
+      setMessage(friendlyError(caught, t.devices.couldNotSignOut, 'devices.signOutOthers'));
     } finally {
       setBusy(false);
     }

--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -22,6 +22,7 @@ import {
 } from '@waves/ui';
 
 import { exportData } from '@/data/api';
+import { friendlyError } from '@/lib/errors';
 import { useGroups } from '@/data/hooks';
 import { groupLabel } from '@/data/types';
 import { useStrings } from '@/i18n';
@@ -73,7 +74,7 @@ export default function ExportScreen() {
       }
       setDone(`${result.filename} · ${Math.ceil(result.content.length / 1024)} KB`);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.exportData.exportFailed, 'export.run'));
     } finally {
       setBusy(false);
     }

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -160,30 +160,30 @@ export default function ImportScreen() {
   const choose = async (): Promise<void> => {
     setError(null);
     setDone(null);
-
-    const picked = await DocumentPicker.getDocumentAsync({
-      // Some Android file providers hand back `application/octet-stream` for a
-      // .csv, so text/* is allowed too rather than hiding the file the person
-      // came here to select.
-      type: [
-        'text/csv',
-        'text/comma-separated-values',
-        'text/plain',
-        'application/json',
-        'application/octet-stream',
-      ],
-      copyToCacheDirectory: true,
-    });
-    if (picked.canceled) return;
-
-    const asset = picked.assets[0];
-    if (!asset) return;
-
     setBusy(true);
-    setFileGroups([]);
-    setFileGroupIndex(0);
-    setParsed(null);
     try {
+      const picked = await DocumentPicker.getDocumentAsync({
+        // Some Android file providers hand back `application/octet-stream` for a
+        // .csv, so text/* is allowed too rather than hiding the file the person
+        // came here to select.
+        type: [
+          'text/csv',
+          'text/comma-separated-values',
+          'text/plain',
+          'application/json',
+          'application/octet-stream',
+        ],
+        copyToCacheDirectory: true,
+      });
+      if (picked.canceled) return;
+
+      const asset = picked.assets[0];
+      if (!asset) return;
+
+      setFileGroups([]);
+      setFileGroupIndex(0);
+      setParsed(null);
+
       const text = new FileSystem.File(asset.uri).textSync();
       setFile(asset.name);
 

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -54,6 +54,7 @@ import {
 } from '@waves/ui';
 
 import { createGroup, fetchMembers, importLedger, type ImportPerson } from '@/data/api';
+import { friendlyError } from '@/lib/errors';
 import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useGroups } from '@/data/hooks';
 import { displayName, groupLabel, GroupType, type MemberRow } from '@/data/types';
@@ -217,7 +218,7 @@ export default function ImportScreen() {
         problems: result.problems,
       });
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.importLedger.importFailed, 'import.readFile'));
     } finally {
       setBusy(false);
     }
@@ -341,7 +342,7 @@ export default function ImportScreen() {
       });
       void groups.refetch();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      setError(friendlyError(caught, t.importLedger.importFailed, 'import.commit'));
     } finally {
       setBusy(false);
     }

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -26,6 +26,7 @@ import {
   type NotificationPrefs,
 } from '@/data/api';
 import { useStrings, type UiStrings } from '@/i18n';
+import { friendlyError } from '@/lib/errors';
 import { useAuth } from '@/lib/auth';
 import { enablePush, PushFailure, PushPermission, pushPermission } from '@/lib/push';
 
@@ -151,7 +152,7 @@ export default function NotificationSettingsScreen() {
         // The switch goes back to what the server still holds, so the screen
         // never shows a preference that was not saved.
         setPrefs(previous);
-        setStatus(caught instanceof Error ? caught.message : String(caught));
+        setStatus(friendlyError(caught, t.notifications.failSaveFailed, 'notifications.savePrefs'));
       });
   };
 

--- a/apps/mobile/src/app/settings/paying.tsx
+++ b/apps/mobile/src/app/settings/paying.tsx
@@ -32,6 +32,7 @@ import {
 } from '@waves/ui';
 
 import { CountryRow } from '@/components/CountryPicker';
+import { friendlyError } from '@/lib/errors';
 import { deviceCountry, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
@@ -104,7 +105,7 @@ function PayingForm() {
       });
       setStatus(t.account.saved);
     } catch (caught) {
-      setStatus(caught instanceof Error ? caught.message : String(caught));
+      setStatus(friendlyError(caught, t.couldNotSave, 'paying.save'));
     }
   };
 

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -19,7 +19,7 @@
  * shows a message instead of crashing.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
@@ -38,18 +38,20 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { useCreateCapture, useCreateGroup, useGroup, useGroups, useWriteExpense } from '@/data/hooks';
+import {
+  useCreateCapture,
+  useCreateGroup,
+  useGroup,
+  useGroups,
+  useWriteExpense,
+} from '@/data/hooks';
 import { groupLabel, GroupType } from '@/data/types';
 import { deviceDefaultCurrency, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { aiEnabled, useAiAccess } from '@/lib/aiAccess';
 import { friendlyError } from '@/lib/errors';
 import { VoiceMicPanel } from '@/components/VoiceMicPanel';
-import {
-  parseVoiceExpenses,
-  type VoiceGroupRef,
-  type VoiceParseResult,
-} from '@/lib/voiceExpense';
+import { parseVoiceExpenses, type VoiceGroupRef, type VoiceParseResult } from '@/lib/voiceExpense';
 import { interpretVoiceExpenses } from '@/lib/voiceLlm';
 
 /** One editable line on the review screen. */
@@ -101,6 +103,17 @@ export default function VoiceScreen() {
   const [saving, setSaving] = useState(false);
   // Remounts the mic to start a fresh utterance after a miss.
   const [attempt, setAttempt] = useState(0);
+  // The "make a new group" the sentence asked for, kept apart from the current
+  // destination so its row stays selectable after the reader picks the inbox or
+  // an existing group instead.
+  const [requested, setRequested] = useState<{
+    groupId: string;
+    memberId: string;
+    name: string;
+  } | null>(null);
+  // A new group is created once, not again on a save retry after a partial
+  // failure. Flipped true after the create lands; reset when a fresh parse comes.
+  const groupCreated = useRef(false);
 
   const groupRows = groups.data ?? [];
   const groupRefs: VoiceGroupRef[] = groupRows.map((group) => ({ id: group.id, name: group.name }));
@@ -127,13 +140,19 @@ export default function VoiceScreen() {
         currency: item.currency,
       })),
     );
+    // A fresh parse is a fresh group to create.
+    groupCreated.current = false;
     // Default the destination to what was heard: a new group to make, an
     // existing group named, else the capture inbox.
     if (result.group?.kind === 'create') {
-      setDest({ kind: 'create', groupId: randomUUID(), memberId: randomUUID(), name: result.group.name });
+      const created = { groupId: randomUUID(), memberId: randomUUID(), name: result.group.name };
+      setRequested(created);
+      setDest({ kind: 'create', ...created });
     } else if (result.group?.kind === 'existing') {
+      setRequested(null);
       setDest({ kind: 'existing', groupId: result.group.groupId });
     } else {
+      setRequested(null);
       setDest({ kind: 'unassigned' });
     }
     setNoAmount(false);
@@ -161,12 +180,16 @@ export default function VoiceScreen() {
   const retry = (): void => {
     setNoAmount(false);
     setError(null);
+    setRequested(null);
+    groupCreated.current = false;
     setPhase('listening');
     setAttempt((current) => current + 1);
   };
 
   const editDraft = (key: string, patch: Partial<Draft>): void => {
-    setDrafts((current) => current.map((draft) => (draft.key === key ? { ...draft, ...patch } : draft)));
+    setDrafts((current) =>
+      current.map((draft) => (draft.key === key ? { ...draft, ...patch } : draft)),
+    );
   };
   const removeDraft = (key: string): void => {
     setDrafts((current) => current.filter((draft) => draft.key !== key));
@@ -183,7 +206,10 @@ export default function VoiceScreen() {
         for (const draft of drafts) {
           const amount = toMinor(draft.amount);
           if (amount === null) continue;
+          // The draft's own id is the capture id, so a save retried after a
+          // partial failure re-uses it rather than minting a second capture.
           await createCapture.mutateAsync({
+            captureId: draft.key,
             description: draft.note.trim() || fallback,
             expenseDate: date,
             currency: draft.currency ?? deviceDefaultCurrency(),
@@ -196,8 +222,9 @@ export default function VoiceScreen() {
 
       // A group destination. Make the group first if it is a new one — its id
       // and the reader's member id were chosen up front, so an expense can name
-      // them in the same breath (the offline-first pattern used elsewhere).
-      if (dest.kind === 'create') {
+      // them in the same breath (the offline-first pattern used elsewhere). The
+      // ref guards a second create on a retry: the group exists after the first.
+      if (dest.kind === 'create' && !groupCreated.current) {
         await createGroup.mutateAsync({
           groupId: dest.groupId,
           creatorMemberId: dest.memberId,
@@ -205,6 +232,7 @@ export default function VoiceScreen() {
           type: GroupType.Other,
           currency: deviceDefaultCurrency(),
         });
+        groupCreated.current = true;
       }
 
       const groupCurrency =
@@ -229,7 +257,9 @@ export default function VoiceScreen() {
         // Every spoken expense is "I paid, split it equally" — the group's own
         // currency, everyone in, me as payer. The reader can refine any of it on
         // the expense afterwards; this is the sane default, not a guess to hide.
-        const expenseId = randomUUID();
+        // The draft's stable id is the expense id (and the split seed), so a
+        // retry appends no duplicate.
+        const expenseId = draft.key;
         const shares = computeShares({
           amount,
           currency: groupCurrency,
@@ -259,7 +289,11 @@ export default function VoiceScreen() {
     }
   };
 
-  const canSave = drafts.length > 0 && !saving;
+  // Every draft must carry a real amount — an empty or non-numeric field would
+  // otherwise be silently skipped, and a screenful of them would "save" nothing
+  // while still navigating away.
+  const canSave =
+    drafts.length > 0 && !saving && drafts.every((draft) => toMinor(draft.amount) !== null);
 
   return (
     <Screen>
@@ -282,7 +316,9 @@ export default function VoiceScreen() {
         {error ? <Callout tone="negative">{error}</Callout> : null}
 
         {phase === 'thinking' ? (
-          <View style={{ alignItems: 'center', gap: theme.spacing.lg, paddingTop: theme.spacing.xxl }}>
+          <View
+            style={{ alignItems: 'center', gap: theme.spacing.lg, paddingTop: theme.spacing.xxl }}
+          >
             <ActivityIndicator color={theme.color.brand} />
             <Text tone="muted">{t.voice.thinking}</Text>
           </View>
@@ -290,6 +326,7 @@ export default function VoiceScreen() {
           <View style={{ gap: theme.spacing.xl }}>
             <DestinationPicker
               dest={dest}
+              requested={requested}
               onChoose={setDest}
               groups={groupRows}
               t={t}
@@ -304,6 +341,8 @@ export default function VoiceScreen() {
                   onEdit={editDraft}
                   onRemove={removeDraft}
                   removeLabel={t.captures.delete}
+                  amountLabel={t.captures.amount}
+                  noteLabel={t.captures.description}
                   notePlaceholder={t.captures.descriptionPlaceholder}
                   theme={theme}
                 />
@@ -311,10 +350,7 @@ export default function VoiceScreen() {
             </View>
 
             <Button
-              label={plural(locale, drafts.length, t.voice.save).replace(
-                '{n}',
-                String(drafts.length),
-              )}
+              label={plural(locale, drafts.length, t.voice.save)}
               onPress={() => void save()}
               disabled={!canSave}
             />
@@ -346,18 +382,19 @@ export default function VoiceScreen() {
  */
 function DestinationPicker({
   dest,
+  requested,
   onChoose,
   groups,
   t,
   theme,
 }: {
   dest: Dest;
+  requested: { groupId: string; memberId: string; name: string } | null;
   onChoose: (dest: Dest) => void;
   groups: { id: string; name: string | null }[];
   t: ReturnType<typeof useStrings>['t'];
   theme: ReturnType<typeof useTheme>;
 }) {
-  const create = dest.kind === 'create' ? dest : null;
   const rows: { key: string; label: string; selected: boolean; onPress: () => void }[] = [
     {
       key: 'unassigned',
@@ -366,12 +403,14 @@ function DestinationPicker({
       onPress: () => onChoose({ kind: 'unassigned' }),
     },
   ];
-  if (create) {
+  // Driven by the persisted request, not the current destination, so the "new
+  // group" row stays offered after the reader switches to the inbox or a group.
+  if (requested) {
     rows.push({
       key: 'create',
-      label: t.voice.newGroupNamed.replace('{name}', create.name),
-      selected: true,
-      onPress: () => onChoose(create),
+      label: t.voice.newGroupNamed.replace('{name}', requested.name),
+      selected: dest.kind === 'create',
+      onPress: () => onChoose({ kind: 'create', ...requested }),
     });
   }
   for (const group of groups) {
@@ -422,6 +461,8 @@ function DraftRow({
   onEdit,
   onRemove,
   removeLabel,
+  amountLabel,
+  noteLabel,
   notePlaceholder,
   theme,
 }: {
@@ -429,6 +470,8 @@ function DraftRow({
   onEdit: (key: string, patch: Partial<Draft>) => void;
   onRemove: (key: string) => void;
   removeLabel: string;
+  amountLabel: string;
+  noteLabel: string;
   notePlaceholder: string;
   theme: ReturnType<typeof useTheme>;
 }) {
@@ -454,6 +497,7 @@ function DraftRow({
             value={draft.amount}
             onChangeText={(value) => onEdit(draft.key, { amount: value })}
             keyboardType="decimal-pad"
+            accessibilityLabel={amountLabel}
             style={{
               flex: 1,
               fontSize: 20,
@@ -469,6 +513,7 @@ function DraftRow({
         onChangeText={(value) => onEdit(draft.key, { note: value })}
         placeholder={notePlaceholder}
         placeholderTextColor={theme.color.textFaint}
+        accessibilityLabel={noteLabel}
         style={{ flex: 1, fontSize: 16, color: theme.color.text, paddingVertical: 0 }}
       />
       <IconButton label={removeLabel} onPress={() => onRemove(draft.key)}>

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -1,30 +1,36 @@
 /**
- * Speak an expense.
+ * Speak an expense — one or several, in any language, with an optional new group.
  *
- * Reached from the raised mic in the bottom bar. The reader says something like
- * "add 500 to the Goa trip"; the phone turns it into text on-device (see
- * VoiceCapture), this parses out the amount and the group it names (see
- * voiceExpense), and hands off to the ordinary add-expense form with those
- * filled in — so the last step is always a glance and a Save, never a blind
- * write. When the sentence names no group, or names one ambiguously, it asks
- * which rather than guessing.
+ * Reached from the raised mic. The phone turns speech into text on-device (see
+ * VoiceMicPanel). What that text means is worked out in two tiers: when the
+ * reader has connected their own model key, {@link interpretVoiceExpenses} asks
+ * the model — which handles several expenses in a breath, other languages, and a
+ * spoken "make a group called X" far better than rules can; with no key, or if
+ * the call fails, the pure {@link parseVoiceExpenses} heuristic does the certain
+ * part (amounts, currencies, a named group) on its own.
  *
- * The route file imports nothing native: the microphone is reached through
- * VoiceMicPanel, which loads the native module inside a try (see the note
- * there), so an older binary shows a plain message instead of crashing.
+ * Either way the last step is a review, never a blind write: the heard expenses
+ * are listed, each editable, with a destination to choose — the capture inbox
+ * (unassigned, the default), an existing group, or a new group the sentence
+ * asked for. Only then does Save write them.
+ *
+ * The route imports nothing native directly: the microphone is reached through
+ * VoiceMicPanel, which loads the native module inside a try, so an older binary
+ * shows a message instead of crashing.
  */
 
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
-import { ScrollView, View } from 'react-native';
+import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
+import { computeShares, type SplitParams } from '@waves/core';
 import {
   Button,
   Callout,
   IconButton,
   iconSize,
-  ListRow,
   Row,
   Screen,
   Text,
@@ -32,67 +38,228 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { useGroups } from '@/data/hooks';
-import { groupLabel } from '@/data/types';
-import { useStrings } from '@/i18n';
+import { useCreateCapture, useCreateGroup, useGroup, useGroups, useWriteExpense } from '@/data/hooks';
+import { groupLabel, GroupType } from '@/data/types';
+import { deviceDefaultCurrency, plural, useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+import { aiEnabled, useAiAccess } from '@/lib/aiAccess';
+import { friendlyError } from '@/lib/errors';
 import { VoiceMicPanel } from '@/components/VoiceMicPanel';
-import { parseVoiceExpense, type ParsedVoiceExpense } from '@/lib/voiceExpense';
+import {
+  parseVoiceExpenses,
+  type VoiceGroupRef,
+  type VoiceParseResult,
+} from '@/lib/voiceExpense';
+import { interpretVoiceExpenses } from '@/lib/voiceLlm';
+
+/** One editable line on the review screen. */
+interface Draft {
+  key: string;
+  amount: string;
+  note: string;
+  currency: string | null;
+}
+
+/** Where the reviewed expenses will be written. */
+type Dest =
+  | { kind: 'unassigned' }
+  | { kind: 'existing'; groupId: string }
+  | { kind: 'create'; groupId: string; memberId: string; name: string };
+
+const EQUAL: SplitParams = { kind: 'equal' };
+
+/** Today as `YYYY-MM-DD` — the expense date a spoken expense is filed under. */
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** A major-unit amount string to minor units, or null when it is not a number. */
+function toMinor(amount: string): bigint | null {
+  const value = Number.parseFloat(amount.replace(/,/g, ''));
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return BigInt(Math.round(value * 100));
+}
 
 export default function VoiceScreen() {
   const theme = useTheme();
   const clearance = useScreenClearance();
-  const { t } = useStrings();
+  const { t, locale } = useStrings();
+  const { profile } = useAuth();
+  const access = useAiAccess();
   const groups = useGroups();
 
-  // Parsed result (with the raw sentence, for name matching) waiting on a group
-  // choice, or null while still listening.
-  const [pending, setPending] = useState<{ parsed: ParsedVoiceExpense; transcript: string } | null>(
-    null,
-  );
+  const createCapture = useCreateCapture();
+  const createGroup = useCreateGroup();
+
+  // 'listening' → the mic; 'thinking' → the model is reading; 'review' → the
+  // heard expenses, editable, awaiting a destination and a Save.
+  const [phase, setPhase] = useState<'listening' | 'thinking' | 'review'>('listening');
+  const [drafts, setDrafts] = useState<Draft[]>([]);
+  const [dest, setDest] = useState<Dest>({ kind: 'unassigned' });
   const [noAmount, setNoAmount] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
   // Remounts the mic to start a fresh utterance after a miss.
   const [attempt, setAttempt] = useState(0);
 
   const groupRows = groups.data ?? [];
-  const groupRefs = groupRows.map((group) => ({ id: group.id, name: group.name }));
+  const groupRefs: VoiceGroupRef[] = groupRows.map((group) => ({ id: group.id, name: group.name }));
   const hints = groupRows.map((group) => group.name ?? '').filter(Boolean);
 
-  const goToExpense = (groupId: string, parsed: ParsedVoiceExpense, transcript: string): void => {
-    // Swap this modal for the prefilled form, so Back from the form returns to
-    // where the reader was, not to the mic. The raw sentence rides along so the
-    // form can match spoken names ("split with Ravi and Priya") to its members.
-    router.replace({
-      pathname: '/group/[id]/add-expense',
-      params: {
-        id: groupId,
-        voice: '1',
-        amount: parsed.amountMinor === null ? '0' : String(parsed.amountMinor),
-        description: parsed.note,
-        people: transcript,
-      },
-    });
+  // Members and currency of the chosen group, read from the local mirror. Empty
+  // id (the unassigned/create cases) reads nothing, which is what we want.
+  const targetGroupId = dest.kind === 'existing' ? dest.groupId : '';
+  const target = useGroup(targetGroupId);
+  const writeExpense = useWriteExpense(dest.kind === 'unassigned' ? '' : dest.groupId);
+
+  const applyResult = (result: VoiceParseResult): void => {
+    if (result.items.length === 0) {
+      setNoAmount(true);
+      setAttempt((current) => current + 1);
+      setPhase('listening');
+      return;
+    }
+    setDrafts(
+      result.items.map((item) => ({
+        key: randomUUID(),
+        amount: String(item.amountMajor),
+        note: item.note,
+        currency: item.currency,
+      })),
+    );
+    // Default the destination to what was heard: a new group to make, an
+    // existing group named, else the capture inbox.
+    if (result.group?.kind === 'create') {
+      setDest({ kind: 'create', groupId: randomUUID(), memberId: randomUUID(), name: result.group.name });
+    } else if (result.group?.kind === 'existing') {
+      setDest({ kind: 'existing', groupId: result.group.groupId });
+    } else {
+      setDest({ kind: 'unassigned' });
+    }
+    setNoAmount(false);
+    setPhase('review');
   };
 
   const handleTranscript = (transcript: string): void => {
-    const parsed = parseVoiceExpense(transcript, groupRefs);
-    if (parsed.amountMinor === null) {
-      setNoAmount(true);
-      setAttempt((current) => current + 1);
-      return;
-    }
-    if (parsed.groupId) {
-      goToExpense(parsed.groupId, parsed, transcript);
-      return;
-    }
-    // Amount understood, group not — ask which.
-    setPending({ parsed, transcript });
+    setPhase('thinking');
+    void (async () => {
+      // With a key, let the model read it (several expenses, other languages, a
+      // spoken new group). It self-guards on the key and returns null when there
+      // is none or the call fails — then the pure heuristic takes over.
+      let result: VoiceParseResult | null = null;
+      if (aiEnabled(access)) {
+        result = await interpretVoiceExpenses(transcript, {
+          groups: groupRefs,
+          locale,
+          defaultCurrency: deviceDefaultCurrency(),
+        }).catch(() => null);
+      }
+      applyResult(result ?? parseVoiceExpenses(transcript, groupRefs));
+    })();
   };
 
   const retry = (): void => {
     setNoAmount(false);
-    setPending(null);
+    setError(null);
+    setPhase('listening');
     setAttempt((current) => current + 1);
   };
+
+  const editDraft = (key: string, patch: Partial<Draft>): void => {
+    setDrafts((current) => current.map((draft) => (draft.key === key ? { ...draft, ...patch } : draft)));
+  };
+  const removeDraft = (key: string): void => {
+    setDrafts((current) => current.filter((draft) => draft.key !== key));
+  };
+
+  const save = async (): Promise<void> => {
+    setError(null);
+    setSaving(true);
+    try {
+      const date = today();
+      const fallback = t.voice.anExpense;
+
+      if (dest.kind === 'unassigned') {
+        for (const draft of drafts) {
+          const amount = toMinor(draft.amount);
+          if (amount === null) continue;
+          await createCapture.mutateAsync({
+            description: draft.note.trim() || fallback,
+            expenseDate: date,
+            currency: draft.currency ?? deviceDefaultCurrency(),
+            amount,
+          });
+        }
+        router.replace('/captures');
+        return;
+      }
+
+      // A group destination. Make the group first if it is a new one — its id
+      // and the reader's member id were chosen up front, so an expense can name
+      // them in the same breath (the offline-first pattern used elsewhere).
+      if (dest.kind === 'create') {
+        await createGroup.mutateAsync({
+          groupId: dest.groupId,
+          creatorMemberId: dest.memberId,
+          name: dest.name,
+          type: GroupType.Other,
+          currency: deviceDefaultCurrency(),
+        });
+      }
+
+      const groupCurrency =
+        dest.kind === 'create'
+          ? deviceDefaultCurrency()
+          : (target.group.data?.default_currency ?? deviceDefaultCurrency());
+      const participants =
+        dest.kind === 'create'
+          ? [dest.memberId]
+          : (target.members.data ?? []).map((member) => member.id);
+      const payer =
+        dest.kind === 'create'
+          ? dest.memberId
+          : ((target.members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ??
+            participants[0]);
+
+      if (participants.length === 0 || !payer) throw new Error('no members to split among');
+
+      for (const draft of drafts) {
+        const amount = toMinor(draft.amount);
+        if (amount === null) continue;
+        // Every spoken expense is "I paid, split it equally" — the group's own
+        // currency, everyone in, me as payer. The reader can refine any of it on
+        // the expense afterwards; this is the sane default, not a guess to hide.
+        const expenseId = randomUUID();
+        const shares = computeShares({
+          amount,
+          currency: groupCurrency,
+          params: EQUAL,
+          participants,
+          seed: expenseId,
+        });
+        await writeExpense.mutateAsync({
+          expenseId,
+          description: draft.note.trim() || fallback,
+          category: null,
+          expenseDate: date,
+          currency: groupCurrency,
+          amount,
+          splitParams: EQUAL,
+          participants,
+          payers: { [payer]: amount },
+          // ShareMap is a Map; the write input wants a plain record.
+          expectedShares: Object.fromEntries(shares),
+        });
+      }
+      router.replace({ pathname: '/group/[id]', params: { id: dest.groupId } });
+    } catch (caught) {
+      setError(friendlyError(caught, t.couldNotSave, 'voice.save'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const canSave = drafts.length > 0 && !saving;
 
   return (
     <Screen>
@@ -106,38 +273,51 @@ export default function VoiceScreen() {
         showsVerticalScrollIndicator={false}
       >
         <Row style={{ paddingTop: theme.spacing.md, justifyContent: 'space-between' }}>
-          <Text variant="heading">{t.voice.title}</Text>
+          <Text variant="heading">{phase === 'review' ? t.voice.review : t.voice.title}</Text>
           <IconButton label={t.common.close} onPress={() => router.back()}>
             <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
         </Row>
 
-        {groupRows.length === 0 ? (
-          // Nothing to speak an expense into yet.
-          <View style={{ gap: theme.spacing.lg, paddingTop: theme.spacing.xxl }}>
-            <Text align="center" tone="muted">
-              {t.voice.noGroups}
-            </Text>
-            <View style={{ alignItems: 'center' }}>
-              <Button label={t.voice.makeGroup} onPress={() => router.replace('/new-group')} />
-            </View>
+        {error ? <Callout tone="negative">{error}</Callout> : null}
+
+        {phase === 'thinking' ? (
+          <View style={{ alignItems: 'center', gap: theme.spacing.lg, paddingTop: theme.spacing.xxl }}>
+            <ActivityIndicator color={theme.color.brand} />
+            <Text tone="muted">{t.voice.thinking}</Text>
           </View>
-        ) : pending ? (
-          // Amount understood; pick the group it belongs to.
-          <View style={{ gap: theme.spacing.lg }}>
-            <Callout tone="info">
-              {t.voice.heard.replace('{note}', pending.parsed.note || t.voice.anExpense)}
-            </Callout>
-            <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
-              {t.voice.chooseGroup.toUpperCase()}
-            </Text>
-            {groupRows.map((group) => (
-              <ListRow
-                key={group.id}
-                title={groupLabel(group)}
-                onPress={() => goToExpense(group.id, pending.parsed, pending.transcript)}
-              />
-            ))}
+        ) : phase === 'review' ? (
+          <View style={{ gap: theme.spacing.xl }}>
+            <DestinationPicker
+              dest={dest}
+              onChoose={setDest}
+              groups={groupRows}
+              t={t}
+              theme={theme}
+            />
+
+            <View style={{ gap: theme.spacing.md }}>
+              {drafts.map((draft) => (
+                <DraftRow
+                  key={draft.key}
+                  draft={draft}
+                  onEdit={editDraft}
+                  onRemove={removeDraft}
+                  removeLabel={t.captures.delete}
+                  notePlaceholder={t.captures.descriptionPlaceholder}
+                  theme={theme}
+                />
+              ))}
+            </View>
+
+            <Button
+              label={plural(locale, drafts.length, t.voice.save).replace(
+                '{n}',
+                String(drafts.length),
+              )}
+              onPress={() => void save()}
+              disabled={!canSave}
+            />
           </View>
         ) : (
           // Listening.
@@ -145,13 +325,155 @@ export default function VoiceScreen() {
             {noAmount ? <Callout tone="warning">{t.voice.noAmount}</Callout> : null}
             <VoiceMicPanel key={attempt} onDone={handleTranscript} hints={hints} />
             {noAmount ? (
-              <View style={{ alignItems: 'center' }}>
-                <Button label={t.voice.tryAgain} variant="secondary" onPress={retry} />
-              </View>
+              <Button
+                label={t.voice.tryAgain}
+                variant="secondary"
+                onPress={retry}
+                style={{ alignSelf: 'center' }}
+              />
             ) : null}
           </View>
         )}
       </ScrollView>
     </Screen>
+  );
+}
+
+/**
+ * The one choice a Save needs: where the expenses land. The capture inbox is
+ * always offered and is the default; a "new group" row appears when the sentence
+ * asked for one; then every existing group. The selected row carries a check.
+ */
+function DestinationPicker({
+  dest,
+  onChoose,
+  groups,
+  t,
+  theme,
+}: {
+  dest: Dest;
+  onChoose: (dest: Dest) => void;
+  groups: { id: string; name: string | null }[];
+  t: ReturnType<typeof useStrings>['t'];
+  theme: ReturnType<typeof useTheme>;
+}) {
+  const create = dest.kind === 'create' ? dest : null;
+  const rows: { key: string; label: string; selected: boolean; onPress: () => void }[] = [
+    {
+      key: 'unassigned',
+      label: t.captures.unassigned,
+      selected: dest.kind === 'unassigned',
+      onPress: () => onChoose({ kind: 'unassigned' }),
+    },
+  ];
+  if (create) {
+    rows.push({
+      key: 'create',
+      label: t.voice.newGroupNamed.replace('{name}', create.name),
+      selected: true,
+      onPress: () => onChoose(create),
+    });
+  }
+  for (const group of groups) {
+    rows.push({
+      key: group.id,
+      label: groupLabel(group),
+      selected: dest.kind === 'existing' && dest.groupId === group.id,
+      onPress: () => onChoose({ kind: 'existing', groupId: group.id }),
+    });
+  }
+
+  return (
+    <View style={{ gap: theme.spacing.sm }}>
+      <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
+        {t.voice.saveTo.toUpperCase()}
+      </Text>
+      {rows.map((row) => (
+        <Pressable
+          key={row.key}
+          onPress={row.onPress}
+          accessibilityRole="button"
+          accessibilityState={{ selected: row.selected }}
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+            borderRadius: theme.radius.lg,
+            backgroundColor: row.selected ? theme.color.brandSoft : theme.color.surface,
+          }}
+        >
+          <Text style={{ color: row.selected ? theme.color.brand : theme.color.text }}>
+            {row.label}
+          </Text>
+          {row.selected ? (
+            <Ionicons name="checkmark-circle" size={iconSize.md} color={theme.color.brand} />
+          ) : null}
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+/** One editable expense line: an amount, a note, and a way to drop it. */
+function DraftRow({
+  draft,
+  onEdit,
+  onRemove,
+  removeLabel,
+  notePlaceholder,
+  theme,
+}: {
+  draft: Draft;
+  onEdit: (key: string, patch: Partial<Draft>) => void;
+  onRemove: (key: string) => void;
+  removeLabel: string;
+  notePlaceholder: string;
+  theme: ReturnType<typeof useTheme>;
+}) {
+  return (
+    <Row
+      style={{
+        alignItems: 'center',
+        gap: theme.spacing.md,
+        paddingVertical: theme.spacing.md,
+        paddingHorizontal: theme.spacing.lg,
+        borderRadius: theme.radius.lg,
+        backgroundColor: theme.color.surface,
+      }}
+    >
+      <View style={{ minWidth: 88 }}>
+        <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+          {draft.currency ? (
+            <Text variant="micro" tone="muted">
+              {draft.currency}
+            </Text>
+          ) : null}
+          <TextInput
+            value={draft.amount}
+            onChangeText={(value) => onEdit(draft.key, { amount: value })}
+            keyboardType="decimal-pad"
+            style={{
+              flex: 1,
+              fontSize: 20,
+              fontWeight: '700',
+              color: theme.color.text,
+              paddingVertical: 0,
+            }}
+          />
+        </Row>
+      </View>
+      <TextInput
+        value={draft.note}
+        onChangeText={(value) => onEdit(draft.key, { note: value })}
+        placeholder={notePlaceholder}
+        placeholderTextColor={theme.color.textFaint}
+        style={{ flex: 1, fontSize: 16, color: theme.color.text, paddingVertical: 0 }}
+      />
+      <IconButton label={removeLabel} onPress={() => onRemove(draft.key)}>
+        <Ionicons name="close-circle" size={iconSize.md} color={theme.color.textFaint} />
+      </IconButton>
+    </Row>
   );
 }

--- a/apps/mobile/src/components/CurrencyRate.tsx
+++ b/apps/mobile/src/components/CurrencyRate.tsx
@@ -35,6 +35,7 @@ import {
 import { Button, Callout, Card, ChipRow, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
+import { friendlyError } from '@/lib/errors';
 
 import { fetchFxRate } from '@/data/api';
 
@@ -144,7 +145,7 @@ export function CurrencyRate({
     } catch (caught) {
       // Not a blocker: typing a rate works offline and is often more accurate.
       setError(
-        `${caught instanceof Error ? caught.message : String(caught)}${t.misc.rateFetchFailedSuffix}`,
+        `${friendlyError(caught, t.misc.rateFetchFailed, 'currencyRate.fetch')}${t.misc.rateFetchFailedSuffix}`,
       );
     } finally {
       setBusy(false);

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -63,7 +63,11 @@ export function SyncStatusIcon() {
   const neutral = theme.color.text;
   const state =
     rejected.length > 0
-      ? { icon: 'alert-circle' as const, color: theme.color.negative, label: t.extras.oneChangeFailed }
+      ? {
+          icon: 'alert-circle' as const,
+          color: theme.color.negative,
+          label: t.extras.oneChangeFailed,
+        }
       : status === SyncStatus.Offline
         ? { icon: 'cloud-offline-outline' as const, color: neutral, label: t.misc.offlineSaved }
         : status === SyncStatus.Error
@@ -85,9 +89,7 @@ export function SyncStatusIcon() {
   // Online, idle, nothing queued — say nothing.
   if (!state) return null;
 
-  const glyph = (
-    <Ionicons name={state.icon} size={iconSize.xl} color={state.color} />
-  );
+  const glyph = <Ionicons name={state.icon} size={iconSize.xl} color={state.color} />;
 
   return (
     <View

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -27,11 +27,69 @@ import { useMotion } from '@/lib/motion';
 const MIC_SIZE = 104;
 
 /**
+ * A soft halo that breathes behind the mic while it listens — a slow, low-opacity
+ * swell that makes the button read as a live orb rather than a flat disc. It is
+ * the calm base layer under the sharper expanding rings; the two together are the
+ * modern voice-assistant look (Siri, Google Assistant). With motion off it holds
+ * a single gentle glow so the depth is still there without anything moving.
+ */
+function Halo({ active, theme }: { active: boolean; theme: Theme }) {
+  const { animated } = useMotion();
+  const [pulse] = useState(() => new Animated.Value(0));
+
+  useEffect(() => {
+    if (!active || !animated) return;
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, {
+          toValue: 1,
+          duration: 1600,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulse, {
+          toValue: 0,
+          duration: 1600,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => {
+      loop.stop();
+      pulse.setValue(0);
+    };
+  }, [active, animated, pulse]);
+
+  if (!active) return null;
+  const size = MIC_SIZE * 1.7;
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={{
+        position: 'absolute',
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: theme.color.brand,
+        opacity: animated ? pulse.interpolate({ inputRange: [0, 1], outputRange: [0.1, 0.22] }) : 0.14,
+        transform: [
+          { scale: animated ? pulse.interpolate({ inputRange: [0, 1], outputRange: [1, 1.12] }) : 1.05 },
+        ],
+      }}
+    />
+  );
+}
+
+/**
  * The rings breathing out from the mic while it listens — the near-universal
- * "I am hearing you" of a voice screen (Roku, Meta AI, Todoist). Three staggered
- * pulses expand and fade on a loop, so the surface is visibly live rather than a
- * still button that may or may not be recording. With motion off they do not
- * render at all: the reduced-motion setting is an input, not a hint (TDR §11).
+ * "I am hearing you" of a voice screen (Siri, Google Assistant, Meta AI). Three
+ * staggered *outline* rings expand and fade on a loop: a thin stroke reads as
+ * cleaner and more modern than a filling disc, and layered over the halo it
+ * gives the surface real depth rather than a single blunt pulse. With motion off
+ * they do not render at all — the reduced-motion setting is an input, not a hint
+ * (TDR §11); the still halo alone carries the idle state.
  */
 function PulseRings({ active, theme }: { active: boolean; theme: Theme }) {
   const { animated } = useMotion();
@@ -45,10 +103,10 @@ function PulseRings({ active, theme }: { active: boolean; theme: Theme }) {
     const loops = rings.map((value, index) =>
       Animated.loop(
         Animated.sequence([
-          Animated.delay(index * 600),
+          Animated.delay(index * 700),
           Animated.timing(value, {
             toValue: 1,
-            duration: 1800,
+            duration: 2100,
             easing: Easing.out(Easing.ease),
             useNativeDriver: true,
           }),
@@ -74,10 +132,11 @@ function PulseRings({ active, theme }: { active: boolean; theme: Theme }) {
             width: MIC_SIZE,
             height: MIC_SIZE,
             borderRadius: MIC_SIZE / 2,
-            backgroundColor: theme.color.brand,
-            opacity: value.interpolate({ inputRange: [0, 1], outputRange: [0.28, 0] }),
+            borderWidth: 2,
+            borderColor: theme.color.brand,
+            opacity: value.interpolate({ inputRange: [0, 1], outputRange: [0.45, 0] }),
             transform: [
-              { scale: value.interpolate({ inputRange: [0, 1], outputRange: [1, 2.4] }) },
+              { scale: value.interpolate({ inputRange: [0, 1], outputRange: [1, 2.6] }) },
             ],
           }}
         />
@@ -86,31 +145,49 @@ function PulseRings({ active, theme }: { active: boolean; theme: Theme }) {
   );
 }
 
+/** How many bars in the waveform, and the tallest each may reach. */
+const WAVE_BARS = 9;
+const WAVE_MIN = 6;
+
 /**
- * A live sound bar under the status while listening — five bars rising and
- * falling out of step, the shorthand for "audio is coming in" (Todoist, Shopee).
- * With motion off it holds a still, uneven silhouette so the shape still reads as
- * a waveform without anything moving.
+ * The peak height a bar may reach, weighted toward the centre so the row reads as
+ * a rounded wave crest rather than a flat block — the centre bars tower, the
+ * edges stay short (the equaliser shape every voice UI settled on).
+ */
+function barPeak(index: number): number {
+  const middle = (WAVE_BARS - 1) / 2;
+  const distance = Math.abs(index - middle) / middle;
+  return 34 - distance * 18;
+}
+
+/**
+ * A live sound wave under the status while listening — nine bars rising and
+ * falling out of step, centre-weighted into a crest, the shorthand for "audio is
+ * coming in". Rounded and tinted a touch lighter at the edges for depth. With
+ * motion off it holds a still crest silhouette so the shape still reads as a
+ * waveform without anything moving.
  */
 function Waveform({ active, theme }: { active: boolean; theme: Theme }) {
   const { animated } = useMotion();
-  const [bars] = useState(() => [0, 1, 2, 3, 4].map(() => new Animated.Value(0.3)));
+  const [bars] = useState(() =>
+    Array.from({ length: WAVE_BARS }, () => new Animated.Value(0.3)),
+  );
 
   useEffect(() => {
     if (!active || !animated) return;
     const loops = bars.map((value, index) =>
       Animated.loop(
         Animated.sequence([
-          Animated.delay(index * 120),
+          Animated.delay(index * 70),
           Animated.timing(value, {
             toValue: 1,
-            duration: 380,
+            duration: 300 + (index % 3) * 60,
             easing: Easing.inOut(Easing.ease),
             useNativeDriver: false,
           }),
           Animated.timing(value, {
-            toValue: 0.3,
-            duration: 380,
+            toValue: 0.28,
+            duration: 300 + (index % 3) * 60,
             easing: Easing.inOut(Easing.ease),
             useNativeDriver: false,
           }),
@@ -121,23 +198,28 @@ function Waveform({ active, theme }: { active: boolean; theme: Theme }) {
     return () => loops.forEach((loop) => loop.stop());
   }, [active, animated, bars]);
 
-  // Still but uneven when motion is off — a silhouette, not a flat line.
-  const resting = [0.5, 0.9, 0.4, 1, 0.6];
   return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, height: 32 }}>
-      {bars.map((value, index) => (
-        <Animated.View
-          key={index}
-          style={{
-            width: 4,
-            borderRadius: 2,
-            backgroundColor: theme.color.brand,
-            height: animated
-              ? value.interpolate({ inputRange: [0, 1], outputRange: [6, 30] })
-              : 6 + resting[index]! * 24,
-          }}
-        />
-      ))}
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, height: 36 }}>
+      {bars.map((value, index) => {
+        const peak = barPeak(index);
+        // Edge bars a touch translucent so the crest has depth, not a flat wall.
+        const middle = (WAVE_BARS - 1) / 2;
+        const opacity = 1 - (Math.abs(index - middle) / middle) * 0.35;
+        return (
+          <Animated.View
+            key={index}
+            style={{
+              width: 4,
+              borderRadius: 2,
+              backgroundColor: theme.color.brand,
+              opacity,
+              height: animated
+                ? value.interpolate({ inputRange: [0, 1], outputRange: [WAVE_MIN, peak] })
+                : (WAVE_MIN + peak) / 2,
+            }}
+          />
+        );
+      })}
     </View>
   );
 }
@@ -276,6 +358,7 @@ export function VoiceCapture({ onDone, hints }: VoiceCaptureProps) {
           justifyContent: 'center',
         }}
       >
+        <Halo active={listening} theme={theme} />
         <PulseRings active={listening} theme={theme} />
         <Pressable
           accessibilityRole="button"
@@ -291,6 +374,16 @@ export function VoiceCapture({ onDone, hints }: VoiceCaptureProps) {
             justifyContent: 'center',
             backgroundColor: listening ? theme.color.brand : theme.color.brandSoft,
             opacity: pressed ? 0.9 : 1,
+            // A brand-tinted glow lifts the mic off the surface while it is live.
+            ...(listening
+              ? {
+                  shadowColor: theme.color.brand,
+                  shadowOpacity: 0.45,
+                  shadowRadius: 20,
+                  shadowOffset: { width: 0, height: 6 },
+                  elevation: 10,
+                }
+              : null),
           })}
         >
           <Ionicons

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -73,9 +73,15 @@ function Halo({ active, theme }: { active: boolean; theme: Theme }) {
         height: size,
         borderRadius: size / 2,
         backgroundColor: theme.color.brand,
-        opacity: animated ? pulse.interpolate({ inputRange: [0, 1], outputRange: [0.1, 0.22] }) : 0.14,
+        opacity: animated
+          ? pulse.interpolate({ inputRange: [0, 1], outputRange: [0.1, 0.22] })
+          : 0.14,
         transform: [
-          { scale: animated ? pulse.interpolate({ inputRange: [0, 1], outputRange: [1, 1.12] }) : 1.05 },
+          {
+            scale: animated
+              ? pulse.interpolate({ inputRange: [0, 1], outputRange: [1, 1.12] })
+              : 1.05,
+          },
         ],
       }}
     />
@@ -169,9 +175,7 @@ function barPeak(index: number): number {
  */
 function Waveform({ active, theme }: { active: boolean; theme: Theme }) {
   const { animated } = useMotion();
-  const [bars] = useState(() =>
-    Array.from({ length: WAVE_BARS }, () => new Animated.Value(0.3)),
-  );
+  const [bars] = useState(() => Array.from({ length: WAVE_BARS }, () => new Animated.Value(0.3)));
 
   useEffect(() => {
     if (!active || !animated) return;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -606,7 +606,7 @@ export interface UiStrings {
     newGroupNamed: string;
     thinking: string;
     /** '{n}' is how many expenses will be saved. */
-    save: { one: string; other: string };
+    save: PluralForms;
   };
   /** Notification preferences, and what the phone will and will not allow. */
   notifications: {
@@ -3508,7 +3508,7 @@ const ta: UiStrings = {
     },
     couldNotRead: 'இந்த ரசீதைப் படிக்க முடியவில்லை — தொகையை நீங்களே உள்ளிடவும்.',
     savedOnDevice: 'இந்தச் சாதனத்தில் சேமிக்கப்பட்டது',
-    couldNotSave: "இதைச் சேமிக்க முடியவில்லை — சிறிது நேரத்தில் மீண்டும் முயற்சிக்கவும்.",
+    couldNotSave: 'இதைச் சேமிக்க முடியவில்லை — சிறிது நேரத்தில் மீண்டும் முயற்சிக்கவும்.',
     save: 'சேமி',
   },
   backup: {
@@ -4892,7 +4892,7 @@ const hi: UiStrings = {
     },
     couldNotRead: 'यह रसीद पढ़ी नहीं जा सकी — राशि स्वयं दर्ज करें।',
     savedOnDevice: 'इस डिवाइस पर सहेजा गया',
-    couldNotSave: "इसे सहेजा नहीं जा सका — कृपया थोड़ी देर में फिर से कोशिश करें।",
+    couldNotSave: 'इसे सहेजा नहीं जा सका — कृपया थोड़ी देर में फिर से कोशिश करें।',
     save: 'सहेजें',
   },
   backup: {
@@ -6043,7 +6043,7 @@ const ar: UiStrings = {
     saveTo: 'الحفظ في',
     newGroupNamed: 'مجموعة جديدة «{name}»',
     thinking: 'جارٍ الفهم…',
-    save: { one: 'حفظ مصروف {n}', other: 'حفظ {n} مصاريف' },
+    save: { one: 'حفظ مصروف', other: 'حفظ {n} مصاريف' },
   },
   notifications: {
     title: 'الإشعارات',
@@ -6284,7 +6284,7 @@ const ar: UiStrings = {
     },
     couldNotRead: 'تعذّر قراءة هذا الإيصال — أدخل المبلغ بنفسك.',
     savedOnDevice: 'محفوظ على هذا الجهاز',
-    couldNotSave: "تعذّر حفظ هذا — يُرجى المحاولة مرة أخرى بعد قليل.",
+    couldNotSave: 'تعذّر حفظ هذا — يُرجى المحاولة مرة أخرى بعد قليل.',
     save: 'حفظ',
   },
   backup: {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -267,6 +267,8 @@ export interface UiStrings {
    *  error never reads as "you have nothing". */
   loadError: string;
   loadErrorBody: string;
+  couldNotSave: string;
+  couldNotScan: string;
   retry: string;
   whatFor: string;
   spending: string;
@@ -369,6 +371,7 @@ export interface UiStrings {
   };
   /** Getting the whole ledger out, in full and for free (ADR-012). */
   exportData: {
+    exportFailed: string;
     title: string;
     everythingFree: string;
     noPaywall: string;
@@ -454,6 +457,7 @@ export interface UiStrings {
   };
   /** The devices screen and the free-tier two-device cap. */
   devices: {
+    couldNotSignOut: string;
     title: string;
     intro: string;
     thisDevice: string;
@@ -827,10 +831,12 @@ export interface UiStrings {
     itemCount: PluralForms;
     couldNotRead: string;
     savedOnDevice: string;
+    couldNotSave: string;
     save: string;
   };
   /** Backing up scanned receipts to the user's own cloud drive (Drive/Dropbox/OneDrive). */
   backup: {
+    connectFailed: string;
     title: string;
     subtitle: string;
     primaryTitle: string;
@@ -1010,6 +1016,10 @@ export interface UiStrings {
   };
   /** Starting a group, joining one by link, and the odds and ends around both. */
   misc: {
+    couldNotAddGeneric: string;
+    tryAgainMoment: string;
+    couldNotJoin: string;
+    rateFetchFailed: string;
     newGroupPlaceholder: string;
     personName: string;
     createGroup: string;
@@ -1232,6 +1242,7 @@ export interface UiStrings {
   };
   /** Bringing a ledger in from Splitwise or from Waves's own export. */
   importLedger: {
+    importFailed: string;
     splitwiseTitle: string;
     ledgerTitle: string;
     splitwiseHowTo: string;
@@ -1560,6 +1571,8 @@ const en: UiStrings = {
   nothingYetBody: 'Add your first expense and the maths takes care of itself.',
   loadError: "Couldn't load this",
   loadErrorBody: 'Check your connection and pull to refresh, or try again.',
+  couldNotSave: 'Could not save this. Please try again.',
+  couldNotScan: 'Could not scan this bill. Enter the details yourself.',
   retry: 'Try again',
   whatFor: 'What kind of expense',
   spending: 'Spending',
@@ -1649,6 +1662,7 @@ const en: UiStrings = {
     },
   ],
   exportData: {
+    exportFailed: 'Could not export your data. Please try again.',
     title: 'Export your data',
     everythingFree: 'Everything, always free',
     noPaywall: 'no paywall',
@@ -1731,6 +1745,7 @@ const en: UiStrings = {
       'This guards the screen, not the data — your ledger is protected by row-level security on the server whether the lock is on or not.',
   },
   devices: {
+    couldNotSignOut: 'Could not sign out the other devices. Please try again.',
     title: 'Devices',
     intro:
       'The free plan covers two devices at a time. A device you have not opened in a while stops counting on its own.',
@@ -2103,9 +2118,11 @@ const en: UiStrings = {
     },
     couldNotRead: "Couldn't read this bill — enter the amount yourself.",
     savedOnDevice: 'Saved on this device',
+    couldNotSave: "Couldn't save this — please try again in a moment.",
     save: 'Save capture',
   },
   backup: {
+    connectFailed: 'Could not connect. Please try again.',
     title: 'Receipt backup',
     subtitle: 'Keep scanned receipts on your own cloud',
     primaryTitle: 'Back up receipts to',
@@ -2285,6 +2302,10 @@ const en: UiStrings = {
     itemized: 'Itemized',
   },
   misc: {
+    couldNotAddGeneric: 'Could not add everyone. Please try again.',
+    tryAgainMoment: 'Please try again in a moment.',
+    couldNotJoin: 'Could not open this invite. Please try again.',
+    rateFetchFailed: 'Could not fetch the rate',
     newGroupPlaceholder: 'Goa trip',
     personName: "Person's name",
     createGroup: 'Create group',
@@ -2541,6 +2562,7 @@ const en: UiStrings = {
     hadItem: '{name} had {label}',
   },
   importLedger: {
+    importFailed: 'Could not bring in that file. Please try again.',
     splitwiseTitle: 'Import a Splitwise export',
     ledgerTitle: 'Import a ledger',
     splitwiseHowTo:
@@ -2903,6 +2925,8 @@ const ta: UiStrings = {
   nothingYetBody: 'முதல் செலவைச் சேருங்கள் — கணக்கு தானே பார்த்துக்கொள்ளும்.',
   loadError: 'இதை ஏற்ற முடியவில்லை',
   loadErrorBody: 'இணைப்பைச் சரிபார்த்து இழுத்துப் புதுப்பிக்கவும், அல்லது மீண்டும் முயலவும்.',
+  couldNotSave: 'இதைச் சேமிக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
+  couldNotScan: 'இந்த ரசீதை ஸ்கேன் செய்ய முடியவில்லை. விவரங்களை நீங்களே உள்ளிடவும்.',
   retry: 'மீண்டும் முயற்சி',
   whatFor: 'எந்த வகைச் செலவு',
   spending: 'செலவு',
@@ -2989,6 +3013,7 @@ const ta: UiStrings = {
     },
   ],
   exportData: {
+    exportFailed: 'உங்கள் தரவை ஏற்றுமதி செய்ய முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
     title: 'உங்கள் தரவை ஏற்றுமதி செய்',
     everythingFree: 'எல்லாமே, எப்போதும் இலவசம்',
     noPaywall: 'கட்டணச் சுவர் இல்லை',
@@ -3076,6 +3101,7 @@ const ta: UiStrings = {
       'இது திரையைக் காக்கிறது, தரவை அல்ல — பூட்டு இருந்தாலும் இல்லாவிட்டாலும் உங்கள் கணக்கு சர்வரில் வரிசை அளவிலான பாதுகாப்பால் காக்கப்படுகிறது.',
   },
   devices: {
+    couldNotSignOut: 'மற்ற சாதனங்களை வெளியேற்ற முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
     title: 'சாதனங்கள்',
     intro:
       'இலவசத் திட்டத்தில் ஒரே நேரத்தில் இரண்டு சாதனங்கள். சிறிது காலம் திறக்காத சாதனம் தானாகவே கணக்கில் இருந்து விலகும்.',
@@ -3464,9 +3490,11 @@ const ta: UiStrings = {
     },
     couldNotRead: 'இந்த ரசீதைப் படிக்க முடியவில்லை — தொகையை நீங்களே உள்ளிடவும்.',
     savedOnDevice: 'இந்தச் சாதனத்தில் சேமிக்கப்பட்டது',
+    couldNotSave: "இதைச் சேமிக்க முடியவில்லை — சிறிது நேரத்தில் மீண்டும் முயற்சிக்கவும்.",
     save: 'சேமி',
   },
   backup: {
+    connectFailed: 'இணைக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
     title: 'ரசீது காப்புப்படி',
     subtitle: 'ஸ்கேன் செய்த ரசீதுகளை உங்கள் சொந்த கிளவுடில் வைத்திருங்கள்',
     primaryTitle: 'ரசீதுகளை காப்புப்பிடி',
@@ -3653,6 +3681,10 @@ const ta: UiStrings = {
     itemized: 'பொருள் வாரியாக',
   },
   misc: {
+    couldNotAddGeneric: 'எல்லாரையும் சேர்க்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
+    tryAgainMoment: 'சிறிது நேரத்தில் மீண்டும் முயற்சிக்கவும்.',
+    couldNotJoin: 'இந்த அழைப்பைத் திறக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
+    rateFetchFailed: 'மாற்று விகிதத்தைப் பெற முடியவில்லை',
     newGroupPlaceholder: 'கோவா பயணம்',
     personName: 'நபரின் பெயர்',
     createGroup: 'குழுவை உருவாக்கு',
@@ -3926,6 +3958,7 @@ const ta: UiStrings = {
     hadItem: '{name} {label} சாப்பிட்டார்',
   },
   importLedger: {
+    importFailed: 'அந்தக் கோப்பை இறக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
     splitwiseTitle: 'Splitwise ஏற்றுமதியை இறக்குமதி செய்',
     ledgerTitle: 'ஒரு கணக்கை இறக்குமதி செய்',
     splitwiseHowTo:
@@ -4290,6 +4323,8 @@ const hi: UiStrings = {
   nothingYetBody: 'पहला खर्च जोड़िए, हिसाब अपने आप संभल जाएगा।',
   loadError: 'यह लोड नहीं हो सका',
   loadErrorBody: 'कनेक्शन जाँचें और खींचकर रिफ़्रेश करें, या फिर कोशिश करें।',
+  couldNotSave: 'इसे सहेजा नहीं जा सका। कृपया फिर कोशिश करें।',
+  couldNotScan: 'यह रसीद स्कैन नहीं हो सकी। विवरण स्वयं दर्ज करें।',
   retry: 'फिर कोशिश करें',
   whatFor: 'किस तरह का खर्च',
   spending: 'खर्च',
@@ -4375,6 +4410,7 @@ const hi: UiStrings = {
     },
   ],
   exportData: {
+    exportFailed: 'आपका डेटा निर्यात नहीं हो सका। कृपया फिर कोशिश करें।',
     title: 'अपना डेटा निर्यात करें',
     everythingFree: 'सब कुछ, हमेशा मुफ़्त',
     noPaywall: 'कोई पेवॉल नहीं',
@@ -4458,6 +4494,7 @@ const hi: UiStrings = {
       'यह स्क्रीन की रक्षा करता है, डेटा की नहीं — लॉक चालू हो या बंद, आपका हिसाब सर्वर पर रो-लेवल सुरक्षा से सुरक्षित है।',
   },
   devices: {
+    couldNotSignOut: 'अन्य डिवाइस साइन आउट नहीं हो सके। कृपया फिर कोशिश करें।',
     title: 'डिवाइस',
     intro:
       'मुफ़्त प्लान में एक साथ दो डिवाइस चलते हैं। जो डिवाइस कुछ समय से नहीं खुला, वह अपने आप गिनती से हट जाता है।',
@@ -4832,9 +4869,11 @@ const hi: UiStrings = {
     },
     couldNotRead: 'यह रसीद पढ़ी नहीं जा सकी — राशि स्वयं दर्ज करें।',
     savedOnDevice: 'इस डिवाइस पर सहेजा गया',
+    couldNotSave: "इसे सहेजा नहीं जा सका — कृपया थोड़ी देर में फिर से कोशिश करें।",
     save: 'सहेजें',
   },
   backup: {
+    connectFailed: 'कनेक्ट नहीं हो सका। कृपया फिर कोशिश करें।',
     title: 'रसीद बैकअप',
     subtitle: 'स्कैन की गई रसीदें अपने क्लाउड पर रखें',
     primaryTitle: 'रसीदें यहाँ बैकअप करें',
@@ -5014,6 +5053,10 @@ const hi: UiStrings = {
     itemized: 'चीज़-वार',
   },
   misc: {
+    couldNotAddGeneric: 'सभी को नहीं जोड़ा जा सका। कृपया फिर कोशिश करें।',
+    tryAgainMoment: 'कृपया थोड़ी देर में फिर कोशिश करें।',
+    couldNotJoin: 'यह निमंत्रण नहीं खुल सका। कृपया फिर कोशिश करें।',
+    rateFetchFailed: 'दर प्राप्त नहीं हो सकी',
     newGroupPlaceholder: 'गोवा ट्रिप',
     personName: 'व्यक्ति का नाम',
     createGroup: 'समूह बनाएँ',
@@ -5272,6 +5315,7 @@ const hi: UiStrings = {
     hadItem: '{name} ने {label} लिया',
   },
   importLedger: {
+    importFailed: 'वह फ़ाइल नहीं लाई जा सकी। कृपया फिर कोशिश करें।',
     splitwiseTitle: 'Splitwise निर्यात आयात करें',
     ledgerTitle: 'हिसाब आयात करें',
     splitwiseHowTo:
@@ -5642,6 +5686,8 @@ const ar: UiStrings = {
   nothingYetBody: 'أضف أول مصروف والحساب يتكفل بنفسه.',
   loadError: 'تعذّر تحميل هذا',
   loadErrorBody: 'تحقّق من اتصالك واسحب للتحديث، أو أعد المحاولة.',
+  couldNotSave: 'تعذّر حفظ هذا. حاول مرة أخرى.',
+  couldNotScan: 'تعذّر مسح هذا الإيصال. أدخل التفاصيل بنفسك.',
   retry: 'حاول مرة أخرى',
   whatFor: 'نوع المصروف',
   spending: 'الإنفاق',
@@ -5727,6 +5773,7 @@ const ar: UiStrings = {
     },
   ],
   exportData: {
+    exportFailed: 'تعذّر تصدير بياناتك. حاول مرة أخرى.',
     title: 'تصدير بياناتك',
     everythingFree: 'كل شيء، مجانًا دائمًا',
     noPaywall: 'بلا جدار دفع',
@@ -5822,6 +5869,7 @@ const ar: UiStrings = {
       'هذا يحمي الشاشة لا البيانات — دفترك محمي على الخادم بأمان على مستوى الصفوف سواء كان القفل مفعّلًا أم لا.',
   },
   devices: {
+    couldNotSignOut: 'تعذّر تسجيل خروج الأجهزة الأخرى. حاول مرة أخرى.',
     title: 'الأجهزة',
     intro:
       'الخطة المجانية تشمل جهازين في وقت واحد. الجهاز الذي لم تفتحه منذ فترة يتوقف عن العدّ من تلقاء نفسه.',
@@ -6208,9 +6256,11 @@ const ar: UiStrings = {
     },
     couldNotRead: 'تعذّر قراءة هذا الإيصال — أدخل المبلغ بنفسك.',
     savedOnDevice: 'محفوظ على هذا الجهاز',
+    couldNotSave: "تعذّر حفظ هذا — يُرجى المحاولة مرة أخرى بعد قليل.",
     save: 'حفظ',
   },
   backup: {
+    connectFailed: 'تعذّر الاتصال. حاول مرة أخرى.',
     title: 'نسخ الإيصالات احتياطيًا',
     subtitle: 'احتفظ بالإيصالات الممسوحة على سحابتك الخاصة',
     primaryTitle: 'انسخ الإيصالات احتياطيًا إلى',
@@ -6417,6 +6467,10 @@ const ar: UiStrings = {
     itemized: 'حسب الأصناف',
   },
   misc: {
+    couldNotAddGeneric: 'تعذّرت إضافة الجميع. حاول مرة أخرى.',
+    tryAgainMoment: 'يُرجى المحاولة مرة أخرى بعد قليل.',
+    couldNotJoin: 'تعذّر فتح هذه الدعوة. حاول مرة أخرى.',
+    rateFetchFailed: 'تعذّر جلب سعر الصرف',
     newGroupPlaceholder: 'رحلة دبي',
     personName: 'اسم الشخص',
     createGroup: 'إنشاء مجموعة',
@@ -6734,6 +6788,7 @@ const ar: UiStrings = {
     hadItem: '{name} تناول {label}',
   },
   importLedger: {
+    importFailed: 'تعذّر إحضار ذلك الملف. حاول مرة أخرى.',
     splitwiseTitle: 'استيراد ملف Splitwise',
     ledgerTitle: 'استيراد دفتر',
     splitwiseHowTo: 'في Splitwise، افتح المجموعة واختر Export as spreadsheet، ثم اختر الملف هنا.',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -599,6 +599,14 @@ export interface UiStrings {
     noGroups: string;
     makeGroup: string;
     unavailable: string;
+    /** The review step for one or more heard expenses. */
+    review: string;
+    saveTo: string;
+    /** '{name}' is the spoken group name. */
+    newGroupNamed: string;
+    thinking: string;
+    /** '{n}' is how many expenses will be saved. */
+    save: { one: string; other: string };
   };
   /** Notification preferences, and what the phone will and will not allow. */
   notifications: {
@@ -1881,6 +1889,11 @@ const en: UiStrings = {
     noGroups: 'Make a group first, then speak an expense into it.',
     makeGroup: 'New group',
     unavailable: 'Speech isn’t available on this phone.',
+    review: 'Review',
+    saveTo: 'Save to',
+    newGroupNamed: 'New group “{name}”',
+    thinking: 'Making sense of that…',
+    save: { one: 'Save {n} expense', other: 'Save {n} expenses' },
   },
   notifications: {
     title: 'Notifications',
@@ -3242,6 +3255,11 @@ const ta: UiStrings = {
     noGroups: 'முதலில் ஒரு குழுவை உருவாக்கு, பிறகு செலவைப் பேசு.',
     makeGroup: 'புதிய குழு',
     unavailable: 'இந்த ஃபோனில் பேச்சு அங்கீகாரம் இல்லை.',
+    review: 'மறுபார்வை',
+    saveTo: 'இதில் சேமி',
+    newGroupNamed: 'புதிய குழு “{name}”',
+    thinking: 'புரிந்துகொள்கிறது…',
+    save: { one: '{n} செலவைச் சேமி', other: '{n} செலவுகளைச் சேமி' },
   },
   notifications: {
     title: 'அறிவிப்புகள்',
@@ -4632,6 +4650,11 @@ const hi: UiStrings = {
     noGroups: 'पहले एक ग्रुप बनाएँ, फिर उसमें खर्च बोलें।',
     makeGroup: 'नया ग्रुप',
     unavailable: 'इस फ़ोन पर वॉइस पहचान उपलब्ध नहीं है।',
+    review: 'समीक्षा',
+    saveTo: 'यहाँ सहेजें',
+    newGroupNamed: 'नया समूह “{name}”',
+    thinking: 'समझा जा रहा है…',
+    save: { one: '{n} खर्च सहेजें', other: '{n} खर्च सहेजें' },
   },
   notifications: {
     title: 'सूचनाएँ',
@@ -6016,6 +6039,11 @@ const ar: UiStrings = {
     noGroups: 'أنشئ مجموعة أولًا، ثم انطق مصروفًا فيها.',
     makeGroup: 'مجموعة جديدة',
     unavailable: 'التعرّف على الكلام غير متاح على هذا الهاتف.',
+    review: 'مراجعة',
+    saveTo: 'الحفظ في',
+    newGroupNamed: 'مجموعة جديدة «{name}»',
+    thinking: 'جارٍ الفهم…',
+    save: { one: 'حفظ مصروف {n}', other: 'حفظ {n} مصاريف' },
   },
   notifications: {
     title: 'الإشعارات',

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -285,3 +285,194 @@ export function stripMemberNames(
     .join(' ')
     .trim();
 }
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Several expenses in one breath, an optional "make a group", and a nudge
+ * toward other languages.
+ *
+ * The single-expense parser above is the certain core. This layer sits on top
+ * for the fuller request: "five rupees for snacks, ten for tea, shopping 1000"
+ * is four expenses, not one; "make a group called Goa and add 500" both creates
+ * a group and files an expense into it. None of it needs a model — but a model
+ * does all of it better across languages, so when a key is present the caller
+ * prefers {@link interpretVoiceExpenses} and falls back to this only when there
+ * is no key or the call fails.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/** One expense lifted out of a possibly-multi sentence. Always has an amount. */
+export interface VoiceExpenseItem {
+  amountMinor: bigint;
+  amountMajor: number;
+  currency: string | null;
+  note: string;
+}
+
+/**
+ * What the sentence says to do about a group: name an existing one, ask for a
+ * new one by name, or neither (the screen defaults such expenses to the capture
+ * inbox, unassigned).
+ */
+export type VoiceGroupTarget =
+  | { kind: 'existing'; groupId: string }
+  | { kind: 'create'; name: string }
+  | null;
+
+/** The whole of what a spoken sentence asked for. */
+export interface VoiceParseResult {
+  items: VoiceExpenseItem[];
+  group: VoiceGroupTarget;
+  /** A split count, when one was heard — carried through for the group case. */
+  splitCount: number | null;
+}
+
+/**
+ * Native numerals to ASCII, so "५०० रुपये" and "௫" and "٥" all read as numbers.
+ * Devanagari, Tamil, Arabic-Indic and Eastern-Arabic (Persian/Urdu) digits are
+ * the ones this app's four locales and their neighbours actually type or speak.
+ */
+const NATIVE_DIGIT_BLOCKS: readonly number[] = [0x0966, 0x0be6, 0x0660, 0x06f0];
+
+export function normalizeDigits(text: string): string {
+  return text.replace(/[०-९௦-௯٠-٩۰-۹]/g, (ch) => {
+    const code = ch.codePointAt(0) ?? 0;
+    for (const base of NATIVE_DIGIT_BLOCKS) {
+      if (code >= base && code <= base + 9) return String(code - base);
+    }
+    return ch;
+  });
+}
+
+/**
+ * A spoken "make a group" and the name it gives.
+ *
+ * Matches "create/make/start/new/open [a] [new] group [called/named/for] X",
+ * where X runs to the first joining word ("and", "then", ",", "with") or the
+ * end. Returns the trimmed name and the sentence with that whole clause cut out,
+ * so what remains can still be parsed for expenses ("make a group Goa and add
+ * 500 for lunch" leaves "add 500 for lunch"). Null when no such intent is heard.
+ */
+export function detectCreateGroup(transcript: string): { name: string; rest: string } | null {
+  const pattern =
+    /\b(?:create|make|start|open|add|new)\s+(?:a\s+)?(?:new\s+)?group\s+(?:called|named|for|titled|as|:)?\s*/i;
+  const head = transcript.match(pattern);
+  if (!head || head.index === undefined) return null;
+
+  const after = transcript.slice(head.index + head[0].length);
+  // The name is everything up to a joining word that starts the next clause, or
+  // the end. "and/then/with/plus" and a comma each end the name.
+  const nameMatch = after.match(/^(.*?)(?:\s+(?:and|then|with|plus|also)\b|\s*[,;]|$)/i);
+  const name = (nameMatch?.[1] ?? after).trim().replace(/[.\s]+$/, '');
+  if (!name) return null;
+
+  // Consume the whole name match — name *and* the joining word that ended it
+  // ("and", a comma) — so the joiner does not lead the leftover sentence.
+  const consumed = head[0].length + (nameMatch?.[0]?.length ?? after.length);
+  const rest = (transcript.slice(0, head.index) + ' ' + transcript.slice(head.index + consumed)).trim();
+  return { name, rest };
+}
+
+/**
+ * The sentence broken into one piece per expense.
+ *
+ * People list expenses with commas and "and" ("5 for snacks, 10 for tea and 20
+ * for the cab"), and also just by starting the next amount ("snacks 5 tea 10").
+ * We split on the explicit separators first; any piece that still holds more
+ * than one currency-adjacent amount is split again just before each amount, so
+ * a run with no commas still comes apart. Pieces with no amount are dropped by
+ * the caller.
+ */
+function segmentExpenses(text: string): string[] {
+  const bySeparator = text
+    .split(/\s*,\s*|\s+and\s+|\s*;\s*|\s+then\s+|\n+/i)
+    .map((piece) => piece.trim())
+    .filter(Boolean);
+
+  const pieces: string[] = [];
+  const amountRe = /\d[\d,]*(?:\.\d+)?/g;
+  for (const piece of bySeparator) {
+    // Where each amount starts. One or none leaves the piece whole; several
+    // means a run with no separators ("5 snacks 10 tea"), cut just before every
+    // amount after the first so each amount keeps the words that follow it. The
+    // text before the first amount stays with it (a label may lead: "snacks 5").
+    const starts: number[] = [];
+    amountRe.lastIndex = 0;
+    for (let m = amountRe.exec(piece); m !== null; m = amountRe.exec(piece)) starts.push(m.index);
+    if (starts.length <= 1) {
+      pieces.push(piece);
+      continue;
+    }
+    for (let i = 0; i < starts.length; i += 1) {
+      const from = i === 0 ? 0 : starts[i];
+      const to = i + 1 < starts.length ? starts[i + 1] : piece.length;
+      const chunk = piece.slice(from, to).trim();
+      if (chunk) pieces.push(chunk);
+    }
+  }
+  return pieces.filter(Boolean);
+}
+
+/**
+ * Parse a transcript into one or more expenses, plus any group instruction.
+ *
+ * Pure and model-free: the heuristic fallback for {@link interpretVoiceExpenses}.
+ * A create-group clause is lifted out first; the rest is segmented, each segment
+ * parsed for an amount/currency/note, and segments with no amount dropped. A
+ * currency named in one segment carries to later segments that name none, so
+ * "5 rupees snacks, 10 tea" makes both INR. When exactly one expense and no new
+ * group are found, the named existing group (if any) is attached.
+ */
+export function parseVoiceExpenses(
+  transcript: string,
+  groups: readonly VoiceGroupRef[],
+): VoiceParseResult {
+  const normalized = normalizeDigits(transcript);
+  const created = detectCreateGroup(normalized);
+  const body = created ? created.rest : normalized;
+
+  // The group is settled before the notes are built, so each note can have the
+  // named group's words taken out ("dinner on the Goa trip" → note "dinner").
+  let group: VoiceGroupTarget = null;
+  let matchedName: string | null = null;
+  if (created) {
+    group = { kind: 'create', name: created.name };
+  } else {
+    const groupId = matchGroup(tokenize(body), groups);
+    if (groupId) {
+      group = { kind: 'existing', groupId };
+      matchedName = groups.find((candidate) => candidate.id === groupId)?.name ?? null;
+    }
+  }
+
+  const segments = segmentExpenses(body);
+  const items: VoiceExpenseItem[] = [];
+  let carriedCurrency: string | null = null;
+
+  for (const segment of segments) {
+    const amountMajor = extractAmount(segment);
+    if (amountMajor === null) continue;
+    const currency: string | null = detectCurrency(segment) ?? carriedCurrency;
+    if (currency) carriedCurrency = currency;
+    items.push({
+      amountMajor,
+      amountMinor: BigInt(Math.round(amountMajor * 100)),
+      currency,
+      note: buildNote(segment, matchedName),
+    });
+  }
+
+  // Nothing segmented out but there is still a single amount — treat the whole
+  // sentence as one expense, matching the single-expense parser's reach.
+  if (items.length === 0) {
+    const one = parseVoiceExpense(body, groups);
+    if (one.amountMinor !== null && one.amountMajor !== null) {
+      items.push({
+        amountMinor: one.amountMinor,
+        amountMajor: one.amountMajor,
+        currency: one.currency,
+        note: one.note,
+      });
+    }
+  }
+
+  return { items, group, splitCount: extractSplitCount(body) };
+}

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -313,9 +313,7 @@ export interface VoiceExpenseItem {
  * inbox, unassigned).
  */
 export type VoiceGroupTarget =
-  | { kind: 'existing'; groupId: string }
-  | { kind: 'create'; name: string }
-  | null;
+  { kind: 'existing'; groupId: string } | { kind: 'create'; name: string } | null;
 
 /** The whole of what a spoken sentence asked for. */
 export interface VoiceParseResult {
@@ -363,11 +361,18 @@ export function detectCreateGroup(transcript: string): { name: string; rest: str
   const nameMatch = after.match(/^(.*?)(?:\s+(?:and|then|with|plus|also)\b|\s*[,;]|$)/i);
   const name = (nameMatch?.[1] ?? after).trim().replace(/[.\s]+$/, '');
   if (!name) return null;
+  // A name that opens with a joining word is not a name: "create a group and add
+  // 100" names nothing. Treat the clause as missing so the rest parses normally.
+  if (/^(?:and|then|with|plus|also)\b/i.test(name)) return null;
 
   // Consume the whole name match — name *and* the joining word that ended it
   // ("and", a comma) — so the joiner does not lead the leftover sentence.
   const consumed = head[0].length + (nameMatch?.[0]?.length ?? after.length);
-  const rest = (transcript.slice(0, head.index) + ' ' + transcript.slice(head.index + consumed)).trim();
+  const rest = (
+    transcript.slice(0, head.index) +
+    ' ' +
+    transcript.slice(head.index + consumed)
+  ).trim();
   return { name, rest };
 }
 
@@ -382,7 +387,11 @@ export function detectCreateGroup(transcript: string): { name: string; rest: str
  * the caller.
  */
 function segmentExpenses(text: string): string[] {
-  const bySeparator = text
+  // Take out "split among 4" / "4 people" first, so the count is never scanned
+  // as an amount and turned into a phantom expense. The caller keeps the count
+  // separately (extractSplitCount reads the untouched body), so nothing is lost.
+  const withoutCount = text.replace(new RegExp(SPLIT_COUNT.source, 'gi'), ' ');
+  const bySeparator = withoutCount
     .split(/\s*,\s*|\s+and\s+|\s*;\s*|\s+then\s+|\n+/i)
     .map((piece) => piece.trim())
     .filter(Boolean);

--- a/apps/mobile/src/lib/voiceLlm.ts
+++ b/apps/mobile/src/lib/voiceLlm.ts
@@ -127,7 +127,10 @@ const CHAT_URLS: Record<AiProviderId, string> = {
  */
 async function resolveModel(id: AiProviderId): Promise<string> {
   const settings = await getAiSettings();
-  return settings.model ?? defaultAiModel(id);
+  // An empty stored override is no override — fall back to the provider default
+  // rather than sending "" as the model and forcing the request to fail.
+  const override = settings.model?.trim();
+  return override ? override : defaultAiModel(id);
 }
 
 /**
@@ -263,10 +266,11 @@ function mapItems(rawItems: unknown): VoiceExpenseItem[] {
   for (const entry of rawItems as RawLlmItem[]) {
     const amountMajor = Number(entry?.amount);
     if (!Number.isFinite(amountMajor) || amountMajor <= 0) continue;
-    const currency =
-      typeof entry?.currency === 'string' && entry.currency.trim().length > 0
-        ? entry.currency.trim().toUpperCase()
-        : null;
+    // Only a three-letter code is a currency: the model sometimes answers with a
+    // word ("rupees", "Rs"), which is not one — take it as "no currency named"
+    // and let the screen fill the default rather than store a bad code.
+    const rawCurrency = typeof entry?.currency === 'string' ? entry.currency.trim() : '';
+    const currency = /^[a-z]{3}$/i.test(rawCurrency) ? rawCurrency.toUpperCase() : null;
     items.push({
       amountMajor,
       amountMinor: BigInt(Math.round(amountMajor * 100)),

--- a/apps/mobile/src/lib/voiceLlm.ts
+++ b/apps/mobile/src/lib/voiceLlm.ts
@@ -1,0 +1,385 @@
+/**
+ * The model tier of speak-an-expense — used only when the reader has brought a
+ * key (see aiKeys), and never otherwise.
+ *
+ * The heuristic parser in voiceExpense.ts is certain and free, but it reads with
+ * rules written for English-shaped sentences: a number, a currency word, a group
+ * name it can see. It cannot follow "பணம் ஐநூறு ரூபாய் மளிகைக்கு" the way a model
+ * can, and it hedges on anything it is not sure of. When a key is present the
+ * caller layers this on top — a model reads the whole transcript, in whatever
+ * language it was spoken, and hands back the same {@link VoiceParseResult} shape
+ * the heuristic does, so the screen downstream does not care which tier produced
+ * it.
+ *
+ * This is best-effort by construction: it is one network round-trip to somebody
+ * else's paid account, over a link that may be slow or down, returning free-form
+ * text that may or may not be the JSON we asked for. Every one of those failure
+ * modes — no key, no signal, a non-200, a truncated body, prose instead of JSON —
+ * comes back as `null`, which the caller reads as "the model could not help this
+ * time" and falls through to the heuristic. It never throws into the add-expense
+ * flow, and it never blocks it for longer than a few seconds.
+ *
+ * The credential goes straight from this device to the provider the reader chose,
+ * exactly as aiKeys promises — Baaki has no copy and this file adds no path to
+ * one. The transcript, likewise, is sent only to that provider; the raw error on
+ * a failure is reported to Sentry (scrubbed), but the key and the transcript are
+ * not.
+ */
+
+import { getActiveAiKey, aiProvider, defaultAiModel, type AiProviderId } from '@/lib/aiKeys';
+import { addAiTokensUsed, getAiSettings } from '@/lib/aiSettings';
+import { reportHandled } from '@/lib/observability';
+import type {
+  VoiceExpenseItem,
+  VoiceGroupRef,
+  VoiceGroupTarget,
+  VoiceParseResult,
+} from '@/lib/voiceExpense';
+
+/**
+ * What the model needs beyond the words: which groups exist so it can match one
+ * by name, the reader's locale so it leans into the right language, and the
+ * currency to assume when a line names none.
+ */
+export interface VoiceLlmContext {
+  /** The reader's groups; only those with a non-null name are offered to the model. */
+  groups: readonly VoiceGroupRef[];
+  /** The app's active locale — 'en' | 'ta' | 'hi' | 'ar' — a nudge, not a fence. */
+  locale: string;
+  /** The ISO currency to fill in when the speaker names none. */
+  defaultCurrency: string;
+}
+
+/** How long we will wait on the provider before giving up and falling back. */
+const REQUEST_TIMEOUT_MS = 8000;
+
+/** A ceiling on the answer — a handful of expenses is plenty; runaway output is a bug. */
+const MAX_TOKENS = 500;
+
+/**
+ * The JSON the model is asked to return, before we trust any of it. Every field
+ * is optional and `unknown`, because it comes from a language model and the whole
+ * point of the mapping below is to not believe it until it is checked.
+ */
+interface RawLlmItem {
+  amount?: unknown;
+  currency?: unknown;
+  note?: unknown;
+}
+
+interface RawLlmGroup {
+  type?: unknown;
+  name?: unknown;
+}
+
+interface RawLlmResult {
+  items?: unknown;
+  group?: unknown;
+}
+
+/**
+ * The instruction the model works to. Kept blunt and schema-first: the one thing
+ * that matters is that the reply is machine-readable JSON in the exact shape the
+ * mapping expects, so the prompt spends its words on that and on the couple of
+ * conventions (major units, null-for-default currency) the mapping relies on.
+ */
+function systemPrompt(ctx: VoiceLlmContext): string {
+  return [
+    'You are an expense parser for a bill-splitting app.',
+    'You are given a short spoken sentence, which may be in any language',
+    `(the speaker's app locale is "${ctx.locale}", but honour whatever language you actually hear:`,
+    'English, Tamil, Hindi, Arabic, or another).',
+    'Extract every expense the sentence describes and return STRICT JSON only — no prose,',
+    'no markdown, no code fences — matching exactly this schema:',
+    '{"items":[{"amount":<number in MAJOR units>,"currency":<ISO 4217 string or null>,"note":<short description string>}],',
+    '"group":{"type":"existing","name":<one of the provided group names>}|{"type":"create","name":<string>}|null}',
+    'Amounts are positive numbers in MAJOR units: "5 rupees" is amount 5 with currency "INR", not 500.',
+    `If a line names no currency, set its currency to null — the app fills the default (${ctx.defaultCurrency}).`,
+    'A note is a short human description of what the money was for, with the amount and currency words removed.',
+    'If the sentence asks to create a new group (e.g. "make a group called Goa"), set group to',
+    '{"type":"create","name":"Goa"}. If it names one of the existing groups listed below, set group to',
+    '{"type":"existing","name":"<that exact name>"}. Otherwise set group to null.',
+    'Never invent a group that is neither newly requested nor in the list.',
+  ].join(' ');
+}
+
+/** The user turn: the transcript, plus the existing group names to match against. */
+function userPrompt(transcript: string, ctx: VoiceLlmContext): string {
+  const names = ctx.groups
+    .map((group) => group.name)
+    .filter((name): name is string => typeof name === 'string' && name.trim().length > 0);
+  const groupList = names.length > 0 ? names.map((name) => `- ${name}`).join('\n') : '(none)';
+  return `Existing groups:\n${groupList}\n\nSentence:\n${transcript}`;
+}
+
+/** Where each provider's chat/messages endpoint lives. */
+const CHAT_URLS: Record<AiProviderId, string> = {
+  openai: 'https://api.openai.com/v1/chat/completions',
+  moonshot: 'https://api.moonshot.ai/v1/chat/completions',
+  anthropic: 'https://api.anthropic.com/v1/messages',
+};
+
+/**
+ * The model to run: the reader's chosen override when they set one, else the
+ * provider's default. A stale override that names a model this provider does not
+ * list is tolerated here — the provider will reject it and we fall back — but the
+ * common case is a live choice or no choice at all.
+ */
+async function resolveModel(id: AiProviderId): Promise<string> {
+  const settings = await getAiSettings();
+  return settings.model ?? defaultAiModel(id);
+}
+
+/**
+ * The response body, its raw text, and the token counts if the provider reported
+ * them. Split out so the OpenAI-shaped and Anthropic-shaped calls can share the
+ * same parse-and-map tail.
+ */
+interface ProviderReply {
+  /** The model's answer as text — the JSON we asked for, before parsing. */
+  text: string;
+  /** Total tokens the call spent, best-effort, for usage recording. Zero if unknown. */
+  totalTokens: number;
+}
+
+/**
+ * Ask an OpenAI-compatible provider (OpenAI, Moonshot). Both speak the same
+ * chat/completions dialect, so the request and the shape of the reply are one and
+ * the same; only the base URL and the model differ.
+ */
+async function callOpenAiCompatible(
+  url: string,
+  headers: Record<string, string>,
+  model: string,
+  ctx: VoiceLlmContext,
+  transcript: string,
+  signal: AbortSignal,
+): Promise<ProviderReply | null> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { ...headers, 'content-type': 'application/json' },
+    signal,
+    body: JSON.stringify({
+      model,
+      temperature: 0,
+      max_tokens: MAX_TOKENS,
+      // Force a JSON object back rather than hoping the prose is well-formed.
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: systemPrompt(ctx) },
+        { role: 'user', content: userPrompt(transcript, ctx) },
+      ],
+    }),
+  });
+  if (!response.ok) return null;
+
+  const json = (await response.json()) as {
+    choices?: { message?: { content?: unknown } }[];
+    usage?: { total_tokens?: unknown };
+  };
+  const content = json.choices?.[0]?.message?.content;
+  if (typeof content !== 'string') return null;
+
+  const total = json.usage?.total_tokens;
+  return { text: content, totalTokens: typeof total === 'number' ? total : 0 };
+}
+
+/**
+ * Ask Anthropic, whose Messages API takes a top-level `system` and returns a
+ * content-block array rather than a single string. The dangerous-direct-browser
+ * header is required because this runs inside a React Native / webview runtime
+ * that Anthropic treats as a browser origin.
+ */
+async function callAnthropic(
+  headers: Record<string, string>,
+  model: string,
+  ctx: VoiceLlmContext,
+  transcript: string,
+  signal: AbortSignal,
+): Promise<ProviderReply | null> {
+  const response = await fetch(CHAT_URLS.anthropic, {
+    method: 'POST',
+    headers: {
+      ...headers,
+      'content-type': 'application/json',
+      'anthropic-dangerous-direct-browser-access': 'true',
+    },
+    signal,
+    body: JSON.stringify({
+      model,
+      max_tokens: MAX_TOKENS,
+      temperature: 0,
+      system: systemPrompt(ctx),
+      messages: [{ role: 'user', content: userPrompt(transcript, ctx) }],
+    }),
+  });
+  if (!response.ok) return null;
+
+  const json = (await response.json()) as {
+    content?: { type?: string; text?: unknown }[];
+    usage?: { input_tokens?: unknown; output_tokens?: unknown };
+  };
+  // The first text block is the answer; Anthropic can interleave other block
+  // types, so we pick the text one rather than assuming index 0.
+  const block = json.content?.find((part) => part?.type === 'text');
+  if (!block || typeof block.text !== 'string') return null;
+
+  const input = json.usage?.input_tokens;
+  const output = json.usage?.output_tokens;
+  const totalTokens =
+    (typeof input === 'number' ? input : 0) + (typeof output === 'number' ? output : 0);
+  return { text: block.text, totalTokens };
+}
+
+/**
+ * Strip a ```json … ``` fence if the model wrapped its answer in one, then parse.
+ * We ask for bare JSON, but models fence it anyway often enough that not handling
+ * it would throw away otherwise-good answers. Returns null on anything unparseable.
+ */
+function parseJsonLoosely(text: string): RawLlmResult | null {
+  const trimmed = text.trim();
+  // Peel a leading/trailing code fence (```json … ``` or plain ``` … ```).
+  const unfenced = trimmed
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/i, '')
+    .trim();
+  try {
+    const parsed = JSON.parse(unfenced) as unknown;
+    if (parsed && typeof parsed === 'object') return parsed as RawLlmResult;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Turn the model's items into trusted {@link VoiceExpenseItem}s. Anything whose
+ * amount is not a finite number greater than zero is dropped rather than salvaged
+ * — a bad amount is worse than a missing row, because the screen would file it.
+ */
+function mapItems(rawItems: unknown): VoiceExpenseItem[] {
+  if (!Array.isArray(rawItems)) return [];
+  const items: VoiceExpenseItem[] = [];
+  for (const entry of rawItems as RawLlmItem[]) {
+    const amountMajor = Number(entry?.amount);
+    if (!Number.isFinite(amountMajor) || amountMajor <= 0) continue;
+    const currency =
+      typeof entry?.currency === 'string' && entry.currency.trim().length > 0
+        ? entry.currency.trim().toUpperCase()
+        : null;
+    items.push({
+      amountMajor,
+      amountMinor: BigInt(Math.round(amountMajor * 100)),
+      currency,
+      note: String(entry?.note ?? '').trim(),
+    });
+  }
+  return items;
+}
+
+/**
+ * Resolve the model's group instruction to the app's {@link VoiceGroupTarget}.
+ * An "existing" name is only honoured if it matches a real group by name,
+ * case-insensitively and exactly; a made-up name resolves to null so the expense
+ * lands in the capture inbox rather than in the wrong group. A "create" needs a
+ * non-empty trimmed name. Everything else is null.
+ */
+function mapGroup(rawGroup: unknown, groups: readonly VoiceGroupRef[]): VoiceGroupTarget {
+  if (!rawGroup || typeof rawGroup !== 'object') return null;
+  const group = rawGroup as RawLlmGroup;
+
+  if (group.type === 'existing' && typeof group.name === 'string') {
+    const wanted = group.name.trim().toLowerCase();
+    const match = groups.find(
+      (candidate) => candidate.name && candidate.name.trim().toLowerCase() === wanted,
+    );
+    return match ? { kind: 'existing', groupId: match.id } : null;
+  }
+
+  if (group.type === 'create' && typeof group.name === 'string') {
+    const name = group.name.trim();
+    return name.length > 0 ? { kind: 'create', name } : null;
+  }
+
+  return null;
+}
+
+/**
+ * Record what the call spent against the reader's usage counter, so the ceiling
+ * they may have set (see aiSettings) actually counts model-powered voice parses.
+ * Best-effort and self-contained: a storage hiccup here must not sink an
+ * otherwise-good parse, so it is swallowed.
+ */
+async function noteUsage(totalTokens: number): Promise<void> {
+  if (totalTokens <= 0) return;
+  try {
+    await addAiTokensUsed(totalTokens);
+  } catch {
+    // Usage accounting is a nicety, not a correctness requirement — never let it
+    // turn a successful parse into a failure.
+  }
+}
+
+/**
+ * Interpret a spoken transcript with the reader's own model, or return null.
+ *
+ * Null means "the model tier could not help" for any reason — there is no key, the
+ * key is a provider we do not recognise, the network failed, the provider said no,
+ * the reply was not JSON, or the JSON carried nothing usable — and the caller then
+ * falls back to the heuristic parser. It never throws.
+ */
+export async function interpretVoiceExpenses(
+  transcript: string,
+  ctx: VoiceLlmContext,
+): Promise<VoiceParseResult | null> {
+  const text = transcript.trim();
+  if (text.length === 0) return null;
+
+  const active = await getActiveAiKey();
+  // No key means this whole tier is off — the heuristic is the only parser.
+  if (!active) return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const provider = aiProvider(active.id);
+    const headers = provider.authHeaders(active.key);
+    const model = await resolveModel(active.id);
+
+    const reply =
+      active.id === 'anthropic'
+        ? await callAnthropic(headers, model, ctx, text, controller.signal)
+        : await callOpenAiCompatible(
+            CHAT_URLS[active.id],
+            headers,
+            model,
+            ctx,
+            text,
+            controller.signal,
+          );
+    if (!reply) return null;
+
+    const parsed = parseJsonLoosely(reply.text);
+    if (!parsed) return null;
+
+    const items = mapItems(parsed.items);
+    const group = mapGroup(parsed.group, ctx.groups);
+    // Nothing to file and no group to make — let the heuristic have a go instead.
+    if (items.length === 0 && group === null) return null;
+
+    // The call earned its cost only once we know it produced something usable.
+    await noteUsage(reply.totalTokens);
+
+    // The model schema carries no split count; the screen matches spoken names
+    // itself (see matchMemberNames), so null here is right, not a gap.
+    return { items, group, splitCount: null };
+  } catch (caught) {
+    // Network error, abort/timeout, malformed body — all of it is a fallback, not
+    // a crash. The raw error (scrubbed) goes to Sentry; the key and transcript do
+    // not travel with it.
+    reportHandled(caught, 'voice.llm');
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -18,6 +18,17 @@ import type { LocalStore, StoredRow } from './store';
 
 const SCHEMA = `
 PRAGMA journal_mode = WAL;
+-- Wait for a held lock instead of throwing SQLITE_BUSY the instant the file is
+-- busy. In a production build there is one JS instance, one connection to this
+-- file, and every write goes through Serial, so nothing in-process can contend.
+-- The contention this guards against is a second connection left open by the
+-- dev runtime: Fast Refresh / Reload builds a fresh SyncEngine and opens the
+-- file again without closing the previous instance's handle, and a write racing
+-- that orphan surfaced as "NativeStatement.finalizeAsync ... database is locked"
+-- on screen. Five seconds is far longer than any real write here takes and lets
+-- the loser wait out the lock rather than reject; it also hardens prod against a
+-- rare WAL checkpoint overlap. Set per connection, so it runs on every open.
+PRAGMA busy_timeout = 5000;
 
 CREATE TABLE IF NOT EXISTS mirror_rows (
   table_name TEXT NOT NULL,

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -17,7 +17,6 @@ import { Serial } from './serial';
 import type { LocalStore, StoredRow } from './store';
 
 const SCHEMA = `
-PRAGMA journal_mode = WAL;
 -- Wait for a held lock instead of throwing SQLITE_BUSY the instant the file is
 -- busy. In a production build there is one JS instance, one connection to this
 -- file, and every write goes through Serial, so nothing in-process can contend.
@@ -27,8 +26,10 @@ PRAGMA journal_mode = WAL;
 -- that orphan surfaced as "NativeStatement.finalizeAsync ... database is locked"
 -- on screen. Five seconds is far longer than any real write here takes and lets
 -- the loser wait out the lock rather than reject; it also hardens prod against a
--- rare WAL checkpoint overlap. Set per connection, so it runs on every open.
+-- rare WAL checkpoint overlap. Set FIRST, before the journal-mode change below,
+-- so the busy handler is already active if that statement itself meets a lock.
 PRAGMA busy_timeout = 5000;
+PRAGMA journal_mode = WAL;
 
 CREATE TABLE IF NOT EXISTS mirror_rows (
   table_name TEXT NOT NULL,

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -107,3 +107,68 @@ describe('matchMemberNames', () => {
     expect(matchMemberNames('add 500 for dinner', members)).toEqual([]);
   });
 });
+
+import { detectCreateGroup, normalizeDigits, parseVoiceExpenses } from '@/lib/voiceExpense';
+
+describe('parseVoiceExpenses (several in one breath)', () => {
+  it('splits a comma-and-and list into one expense each', () => {
+    const result = parseVoiceExpenses(
+      '5 rupees for snacks, 10 rupee for tea, shopping 1000, others 100',
+      groups,
+    );
+    expect(result.items.map((item) => item.amountMajor)).toEqual([5, 10, 1000, 100]);
+    expect(result.items.map((item) => item.note)).toEqual(['snacks', 'tea', 'shopping', 'others']);
+  });
+
+  it('carries a currency named once to the later items that name none', () => {
+    const result = parseVoiceExpenses('5 rupees snacks, 10 tea, 20 cab', groups);
+    expect(result.items.every((item) => item.currency === 'INR')).toBe(true);
+  });
+
+  it('keeps a lone expense working, with its named group', () => {
+    const result = parseVoiceExpenses('add 500 rupees for dinner on the Goa trip', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(500);
+    expect(result.items[0].note).toBe('dinner');
+    expect(result.group).toEqual({ kind: 'existing', groupId: 'g-goa' });
+  });
+
+  it('reads a create-group instruction and still files the expenses', () => {
+    const result = parseVoiceExpenses('make a group called Weekend and add 200 for lunch', groups);
+    expect(result.group).toEqual({ kind: 'create', name: 'Weekend' });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(200);
+    expect(result.items[0].note).toBe('lunch');
+  });
+
+  it('drops segments that carry no amount', () => {
+    const result = parseVoiceExpenses('hello, 50 for coffee, um', groups);
+    expect(result.items.map((item) => item.amountMajor)).toEqual([50]);
+  });
+});
+
+describe('detectCreateGroup', () => {
+  it('lifts the name and returns the rest', () => {
+    expect(detectCreateGroup('create a group named Goa Trip and add 100')).toEqual({
+      name: 'Goa Trip',
+      rest: 'add 100',
+    });
+  });
+
+  it('is null when no group is asked for', () => {
+    expect(detectCreateGroup('add 100 for lunch')).toBeNull();
+  });
+});
+
+describe('normalizeDigits', () => {
+  it('turns Devanagari, Tamil and Arabic-Indic numerals into ASCII', () => {
+    expect(normalizeDigits('५००')).toBe('500');
+    expect(normalizeDigits('௫')).toBe('5');
+    expect(normalizeDigits('٢٠')).toBe('20');
+  });
+
+  it('reads an amount written in native numerals', () => {
+    const result = parseVoiceExpenses('५०० rupees for dinner', groups);
+    expect(result.items[0]?.amountMajor).toBe(500);
+  });
+});

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -172,3 +172,19 @@ describe('normalizeDigits', () => {
     expect(result.items[0]?.amountMajor).toBe(500);
   });
 });
+
+describe('parseVoiceExpenses — split count and unnamed create-group', () => {
+  it('reads a split count without turning it into an extra expense', () => {
+    const result = parseVoiceExpenses('split 1000 among 4 people', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(1000);
+    expect(result.splitCount).toBe(4);
+  });
+
+  it('drops an unnamed create-group instruction but keeps the expense', () => {
+    const result = parseVoiceExpenses('create a group and add 500 for dinner', groups);
+    expect(result.group).toBeNull();
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(500);
+  });
+});

--- a/apps/mobile/test/voiceLlm.test.ts
+++ b/apps/mobile/test/voiceLlm.test.ts
@@ -120,7 +120,10 @@ describe('interpretVoiceExpenses', () => {
       items: [{ amount: 100, currency: 'INR', note: 'lunch' }],
       group: { type: 'create', name: '  Weekend  ' },
     });
-    vi.stubGlobal('fetch', vi.fn(async () => openAiReply(content)));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => openAiReply(content)),
+    );
 
     const result = await interpretVoiceExpenses('make a group weekend, 100 lunch', ctx);
     expect(result?.group).toEqual({ kind: 'create', name: 'Weekend' });
@@ -136,7 +139,10 @@ describe('interpretVoiceExpenses', () => {
       ],
       group: null,
     });
-    vi.stubGlobal('fetch', vi.fn(async () => openAiReply(content)));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => openAiReply(content)),
+    );
 
     const result = await interpretVoiceExpenses('snack 12.5 dollars', ctx);
     expect(result?.items).toEqual([
@@ -146,8 +152,12 @@ describe('interpretVoiceExpenses', () => {
 
   it('strips a code fence around the JSON before parsing', async () => {
     getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
-    const fenced = '```json\n' + JSON.stringify({ items: [{ amount: 5, note: 'chai' }], group: null }) + '\n```';
-    vi.stubGlobal('fetch', vi.fn(async () => openAiReply(fenced)));
+    const fenced =
+      '```json\n' + JSON.stringify({ items: [{ amount: 5, note: 'chai' }], group: null }) + '\n```';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => openAiReply(fenced)),
+    );
 
     const result = await interpretVoiceExpenses('chai 5', ctx);
     expect(result?.items).toEqual([
@@ -158,7 +168,10 @@ describe('interpretVoiceExpenses', () => {
   it('returns null when nothing usable comes back (no items, no group)', async () => {
     getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
     const content = JSON.stringify({ items: [], group: null });
-    vi.stubGlobal('fetch', vi.fn(async () => openAiReply(content)));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => openAiReply(content)),
+    );
 
     expect(await interpretVoiceExpenses('hello there', ctx)).toBeNull();
   });
@@ -167,7 +180,9 @@ describe('interpretVoiceExpenses', () => {
     getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response),
+      vi.fn(
+        async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response,
+      ),
     );
 
     expect(await interpretVoiceExpenses('add 500 for dinner', ctx)).toBeNull();
@@ -193,7 +208,12 @@ describe('interpretVoiceExpenses', () => {
           ok: true,
           status: 200,
           json: async () => ({
-            content: [{ type: 'text', text: JSON.stringify({ items: [{ amount: 9, note: 'bus' }], group: null }) }],
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ items: [{ amount: 9, note: 'bus' }], group: null }),
+              },
+            ],
             usage: { input_tokens: 30, output_tokens: 12 },
           }),
         }) as unknown as Response,
@@ -207,9 +227,9 @@ describe('interpretVoiceExpenses', () => {
     // The Messages endpoint, with the browser-access header the RN runtime needs.
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe('https://api.anthropic.com/v1/messages');
-    expect((init.headers as Record<string, string>)['anthropic-dangerous-direct-browser-access']).toBe(
-      'true',
-    );
+    expect(
+      (init.headers as Record<string, string>)['anthropic-dangerous-direct-browser-access'],
+    ).toBe('true');
     // input + output tokens summed for the usage counter.
     expect(addAiTokensUsedMock).toHaveBeenCalledWith(42);
   });

--- a/apps/mobile/test/voiceLlm.test.ts
+++ b/apps/mobile/test/voiceLlm.test.ts
@@ -1,0 +1,216 @@
+/**
+ * The model tier of speak-an-expense, minus the model and the keystore.
+ *
+ * The three things worth pinning down without a device, a key, or a network:
+ * that no key means no call at all (the heuristic owns that case), that a
+ * well-formed provider reply is mapped into the right items and group, and that
+ * every failure the network can hand back — a non-200, a thrown fetch — comes out
+ * as null rather than an exception into the add-expense flow.
+ *
+ * aiKeys pulls in expo-secure-store, aiSettings pulls in async-storage, and
+ * observability pulls in Sentry; none of that belongs in a pure unit test, so all
+ * three are stubbed and the provider call is exercised through a stubbed fetch.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted so the vi.mock factories below (which run before the imports) can close
+// over them — vitest only allows a factory to reference names it created via
+// vi.hoisted or names prefixed with "mock".
+const { getActiveAiKeyMock, getAiSettingsMock, addAiTokensUsedMock } = vi.hoisted(() => ({
+  getActiveAiKeyMock: vi.fn(),
+  getAiSettingsMock: vi.fn(async () => ({
+    enabled: true,
+    model: null,
+    tokenLimit: null,
+    tokensUsed: 0,
+  })),
+  addAiTokensUsedMock: vi.fn(async () => {}),
+}));
+
+vi.mock('@/lib/aiKeys', () => ({
+  getActiveAiKey: getActiveAiKeyMock,
+  // A minimal stand-in for the real provider record: the only surface voiceLlm
+  // touches is authHeaders (and, via defaultAiModel, models).
+  aiProvider: (id: string) => ({
+    id,
+    authHeaders: (key: string) => ({ Authorization: `Bearer ${key}` }),
+    models: ['gpt-4o-mini'],
+  }),
+  defaultAiModel: () => 'gpt-4o-mini',
+}));
+
+vi.mock('@/lib/aiSettings', () => ({
+  getAiSettings: getAiSettingsMock,
+  addAiTokensUsed: addAiTokensUsedMock,
+}));
+
+vi.mock('@/lib/observability', () => ({
+  reportHandled: vi.fn(),
+}));
+
+import { interpretVoiceExpenses, type VoiceLlmContext } from '@/lib/voiceLlm';
+
+const ctx: VoiceLlmContext = {
+  groups: [
+    { id: 'g-goa', name: 'Goa Trip' },
+    { id: 'g-flat', name: 'Flat 4B' },
+  ],
+  locale: 'en',
+  defaultCurrency: 'INR',
+};
+
+/** An OpenAI chat/completions reply whose message content is the given JSON string. */
+function openAiReply(content: string, usageTokens = 42): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content } }],
+      usage: { total_tokens: usageTokens },
+    }),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  getActiveAiKeyMock.mockReset();
+  addAiTokensUsedMock.mockClear();
+});
+
+describe('interpretVoiceExpenses', () => {
+  it('returns null when no key is connected, without calling the network', async () => {
+    getActiveAiKeyMock.mockResolvedValue(null);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await interpretVoiceExpenses('add 500 rupees to Goa trip', ctx)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('maps a well-formed OpenAI-style reply into items and the matched group', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const content = JSON.stringify({
+      items: [
+        { amount: 500, currency: 'INR', note: 'dinner' },
+        { amount: 20, currency: null, note: 'tea' },
+      ],
+      group: { type: 'existing', name: 'goa trip' }, // case-insensitive match
+    });
+    const fetchMock = vi.fn(async () => openAiReply(content, 128));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await interpretVoiceExpenses('500 dinner and 20 for tea, Goa trip', ctx);
+
+    expect(result).not.toBeNull();
+    expect(result?.items).toEqual([
+      { amountMajor: 500, amountMinor: 50000n, currency: 'INR', note: 'dinner' },
+      { amountMajor: 20, amountMinor: 2000n, currency: null, note: 'tea' },
+    ]);
+    expect(result?.group).toEqual({ kind: 'existing', groupId: 'g-goa' });
+    expect(result?.splitCount).toBeNull();
+    // The reported usage tokens are recorded against the reader's counter.
+    expect(addAiTokensUsedMock).toHaveBeenCalledWith(128);
+  });
+
+  it('reads a "create a new group" instruction', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const content = JSON.stringify({
+      items: [{ amount: 100, currency: 'INR', note: 'lunch' }],
+      group: { type: 'create', name: '  Weekend  ' },
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => openAiReply(content)));
+
+    const result = await interpretVoiceExpenses('make a group weekend, 100 lunch', ctx);
+    expect(result?.group).toEqual({ kind: 'create', name: 'Weekend' });
+  });
+
+  it('drops items with a non-positive or non-numeric amount', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const content = JSON.stringify({
+      items: [
+        { amount: 0, note: 'free' },
+        { amount: 'abc', note: 'junk' },
+        { amount: 12.5, currency: 'usd', note: 'snack' },
+      ],
+      group: null,
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => openAiReply(content)));
+
+    const result = await interpretVoiceExpenses('snack 12.5 dollars', ctx);
+    expect(result?.items).toEqual([
+      { amountMajor: 12.5, amountMinor: 1250n, currency: 'USD', note: 'snack' },
+    ]);
+  });
+
+  it('strips a code fence around the JSON before parsing', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const fenced = '```json\n' + JSON.stringify({ items: [{ amount: 5, note: 'chai' }], group: null }) + '\n```';
+    vi.stubGlobal('fetch', vi.fn(async () => openAiReply(fenced)));
+
+    const result = await interpretVoiceExpenses('chai 5', ctx);
+    expect(result?.items).toEqual([
+      { amountMajor: 5, amountMinor: 500n, currency: null, note: 'chai' },
+    ]);
+  });
+
+  it('returns null when nothing usable comes back (no items, no group)', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const content = JSON.stringify({ items: [], group: null });
+    vi.stubGlobal('fetch', vi.fn(async () => openAiReply(content)));
+
+    expect(await interpretVoiceExpenses('hello there', ctx)).toBeNull();
+  });
+
+  it('returns null on a non-200 response', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response),
+    );
+
+    expect(await interpretVoiceExpenses('add 500 for dinner', ctx)).toBeNull();
+  });
+
+  it('returns null (never throws) when fetch rejects', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    );
+
+    await expect(interpretVoiceExpenses('add 500 for dinner', ctx)).resolves.toBeNull();
+  });
+
+  it('sends an anthropic-shaped request for a Claude key and reads its content blocks', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'anthropic', key: 'sk-ant-test' });
+    const fetchMock = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            content: [{ type: 'text', text: JSON.stringify({ items: [{ amount: 9, note: 'bus' }], group: null }) }],
+            usage: { input_tokens: 30, output_tokens: 12 },
+          }),
+        }) as unknown as Response,
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await interpretVoiceExpenses('bus 9', ctx);
+    expect(result?.items).toEqual([
+      { amountMajor: 9, amountMinor: 900n, currency: null, note: 'bus' },
+    ]);
+    // The Messages endpoint, with the browser-access header the RN runtime needs.
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.anthropic.com/v1/messages');
+    expect((init.headers as Record<string, string>)['anthropic-dangerous-direct-browser-access']).toBe(
+      'true',
+    );
+    // input + output tokens summed for the usage counter.
+    expect(addAiTokensUsedMock).toHaveBeenCalledWith(42);
+  });
+});


### PR DESCRIPTION
## Dashboard "+" FAB

A floating **+** bottom-right of the dashboard — the plainest of three add routes beside the header camera (scan) and the bar's mic (speak). Opens the group-optional **capture** screen, so it works with or without a group. Placement follows [Buddy](https://mobbin.com/screens/af11c67a-b7e8-4ae8-a304-eaa2b2d5af13) / [Airwallex](https://mobbin.com/screens/453339d6-1383-442a-8f86-6b16a72c4a9c); clears the tab bar via the shared clearance so it never covers the last row. **Verified on-device.**

## Speak an expense — several, any language, optional new group

- **`parseVoiceExpenses`** (pure, tested): splits *"5 rupees for snacks, 10 for tea, shopping 1000, others 100"* into four expenses; a currency named once carries forward; native numerals (Devanagari / Tamil / Arabic-Indic) read as numbers; **`detectCreateGroup`** lifts *"make a group called X"* and still files the expenses after it.
- **`voiceLlm.interpretVoiceExpenses`** — the model tier. With the reader's own key connected (BYOK, A40) it asks the model, which handles multi-expense, other languages and a spoken new group far better than rules. Self-guards on the key, 8s timeout, reports failures to Sentry, returns `null` so the heuristic takes over — **never throws**. Token usage metered back.
- **Review, not blind write**: heard expenses listed + editable, with a destination — the capture inbox (unassigned, default), an existing group, or the new group the sentence asked for. Group saves write one expense each, equal split among members, me as payer.

## Animation + fix

Listening animation reworked to a modern assistant look — a **breathing halo**, expanding **ring outlines**, and a **9-bar centre-weighted waveform**, all reduced-motion gated. The "try again" button is now centred (`Button` defaults to `flex-start`; a passed `alignSelf` overrides).

## Gates
- `tsc --noEmit` → 0
- `expo lint` → 0 problems
- `vitest run` → **277 passed** (24 new parser cases + 9 LLM cases)

## Testing note
The capture FAB was verified on the emulator end-to-end. The **voice flow is unit-tested only** — the emulator has no speech-recognition engine (and the animation only plays while listening), so the live speak→review→save path needs a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a floating action button for quickly adding expenses.
  - Voice capture now supports multiple expenses, group creation, existing-group selection, editable review, and automatic split calculations.
  - Improved voice capture visuals with animated glow, waveform, and listening effects.

- **Bug Fixes**
  - Replaced raw error messages with localized, operation-specific guidance throughout the app.
  - SQLite now waits briefly for locked data, reducing temporary save failures.
  - Import cancellation and picker failures now reliably clear loading states.

- **Localization**
  - Added translations for voice workflows, import/export, backup, sharing, and common error messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->