### PR TITLE
feat(mobile): activate Microsoft Clarity with the project id

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -9,6 +9,7 @@
       "node": "24.18.0",
       "env": {
         "EXPO_PUBLIC_SUPABASE_URL": "https://xvjzbpgcmotoahtqcxve.supabase.co",
+        "EXPO_PUBLIC_CLARITY_PROJECT_ID": "y0l49bcxl4",
         "EXPO_PUBLIC_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inh2anpicGdjbW90b2FodHFjeHZlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ5OTgxODAsImV4cCI6MjA4MDU3NDE4MH0.mVAdmMk8gO_GoQS9TvVJNOwmVWNK-cSiO6InHKwoQoo"
       }
     },

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -564,85 +564,85 @@ function TipSheet({ t }: { t: UiStrings }) {
   return (
     <Modal transparent animationType="fade" visible={open} onRequestClose={close}>
       {tip ? (
-      /* Tap outside to close — the same escape the campaign popup gives. */
-      <Pressable
-        onPress={close}
-        accessibilityLabel={t.common.close}
-        style={{
-          flex: 1,
-          backgroundColor: 'rgba(10, 10, 26, 0.55)',
-          justifyContent: 'flex-end',
-        }}
-      >
-        {/* Swallows the tap so pressing the sheet itself does not dismiss it. A
-            bottom sheet, not a centred dialog: it slides up from the bar the tip
-            is about, and leaves the balance above it in view. */}
+        /* Tap outside to close — the same escape the campaign popup gives. */
         <Pressable
-          onPress={() => {}}
+          onPress={close}
+          accessibilityLabel={t.common.close}
           style={{
-            backgroundColor: theme.color.surface,
-            borderTopLeftRadius: theme.radius.xxl,
-            borderTopRightRadius: theme.radius.xxl,
-            paddingHorizontal: theme.spacing.xxl,
-            paddingTop: theme.spacing.xl,
-            paddingBottom: theme.spacing.xxl,
-            gap: theme.spacing.lg,
-            ...theme.shadow.lifted,
+            flex: 1,
+            backgroundColor: 'rgba(10, 10, 26, 0.55)',
+            justifyContent: 'flex-end',
           }}
         >
-          {/* A grab handle — the visual grammar of a sheet you can pull down. */}
-          <View
+          {/* Swallows the tap so pressing the sheet itself does not dismiss it. A
+            bottom sheet, not a centred dialog: it slides up from the bar the tip
+            is about, and leaves the balance above it in view. */}
+          <Pressable
+            onPress={() => {}}
             style={{
-              alignSelf: 'center',
-              width: 40,
-              height: 4,
-              borderRadius: 2,
-              backgroundColor: theme.color.border,
+              backgroundColor: theme.color.surface,
+              borderTopLeftRadius: theme.radius.xxl,
+              borderTopRightRadius: theme.radius.xxl,
+              paddingHorizontal: theme.spacing.xxl,
+              paddingTop: theme.spacing.xl,
+              paddingBottom: theme.spacing.xxl,
+              gap: theme.spacing.lg,
+              ...theme.shadow.lifted,
             }}
-          />
-
-          <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
+          >
+            {/* A grab handle — the visual grammar of a sheet you can pull down. */}
             <View
               style={{
-                width: 64,
-                height: 64,
-                borderRadius: 32,
-                alignItems: 'center',
-                justifyContent: 'center',
-                backgroundColor: theme.color.brandSoft,
+                alignSelf: 'center',
+                width: 40,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: theme.color.border,
               }}
-            >
-              <Ionicons name={tip.icon} size={iconSize.xxl} color={theme.color.brand} />
-            </View>
-            <Text variant="micro" tone="brand" style={{ letterSpacing: 0.8 }}>
-              {t.tips.label.toUpperCase()}
-            </Text>
-            <Text variant="title" align="center">
-              {tip.title}
-            </Text>
-            <Text variant="body" tone="muted" align="center">
-              {tip.body}
-            </Text>
-          </View>
+            />
 
-          <View style={{ gap: theme.spacing.sm }}>
-            {tip.route ? (
-              <>
-                <Button label={t.tips.action} size="lg" fullWidth onPress={act} />
-                <Button
-                  label={t.misc.gotIt}
-                  variant="secondary"
-                  size="sm"
-                  fullWidth
-                  onPress={close}
-                />
-              </>
-            ) : (
-              <Button label={t.misc.gotIt} size="lg" fullWidth onPress={close} />
-            )}
-          </View>
+            <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
+              <View
+                style={{
+                  width: 64,
+                  height: 64,
+                  borderRadius: 32,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: theme.color.brandSoft,
+                }}
+              >
+                <Ionicons name={tip.icon} size={iconSize.xxl} color={theme.color.brand} />
+              </View>
+              <Text variant="micro" tone="brand" style={{ letterSpacing: 0.8 }}>
+                {t.tips.label.toUpperCase()}
+              </Text>
+              <Text variant="title" align="center">
+                {tip.title}
+              </Text>
+              <Text variant="body" tone="muted" align="center">
+                {tip.body}
+              </Text>
+            </View>
+
+            <View style={{ gap: theme.spacing.sm }}>
+              {tip.route ? (
+                <>
+                  <Button label={t.tips.action} size="lg" fullWidth onPress={act} />
+                  <Button
+                    label={t.misc.gotIt}
+                    variant="secondary"
+                    size="sm"
+                    fullWidth
+                    onPress={close}
+                  />
+                </>
+              ) : (
+                <Button label={t.misc.gotIt} size="lg" fullWidth onPress={close} />
+              )}
+            </View>
+          </Pressable>
         </Pressable>
-      </Pressable>
       ) : null}
     </Modal>
   );

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -63,7 +63,11 @@ export function SyncStatusIcon() {
   const neutral = theme.color.text;
   const state =
     rejected.length > 0
-      ? { icon: 'alert-circle' as const, color: theme.color.negative, label: t.extras.oneChangeFailed }
+      ? {
+          icon: 'alert-circle' as const,
+          color: theme.color.negative,
+          label: t.extras.oneChangeFailed,
+        }
       : status === SyncStatus.Offline
         ? { icon: 'cloud-offline-outline' as const, color: neutral, label: t.misc.offlineSaved }
         : status === SyncStatus.Error
@@ -85,9 +89,7 @@ export function SyncStatusIcon() {
   // Online, idle, nothing queued — say nothing.
   if (!state) return null;
 
-  const glyph = (
-    <Ionicons name={state.icon} size={iconSize.xl} color={state.color} />
-  );
+  const glyph = <Ionicons name={state.icon} size={iconSize.xl} color={state.color} />;
 
   return (
     <View

--- a/apps/mobile/src/lib/clarity.ts
+++ b/apps/mobile/src/lib/clarity.ts
@@ -66,7 +66,10 @@ export function initClarity(): void {
   if (!sdk) return;
 
   try {
-    sdk.initialize(PROJECT_ID);
+    // `LogLevel.None` keeps the SDK's own console output quiet in every build;
+    // raise it to `Verbose` locally only when debugging why capture will not
+    // initialise. Capture itself is still held by the `pause()` below.
+    sdk.initialize(PROJECT_ID, { logLevel: sdk.LogLevel.None });
     void sdk.pause();
     started = true;
   } catch {


### PR DESCRIPTION
Sets **`EXPO_PUBLIC_CLARITY_PROJECT_ID` = `y0l49bcxl4`**, activating the existing Clarity integration (#143) that was wired but inert.

## What changes
- **`eas.json`** — the id added to the base build env (public — it ships in the client bundle — so it sits beside the Supabase values, not treated as a secret). Also set in the gitignored `.env` for local builds.
- **`clarity.ts`** — one line: `initialize` now passes `logLevel: None` to keep the SDK's own console output quiet.

Otherwise unchanged: the id was always read from this env var (never hardcoded), so a clone without an account behaves as before.

## Effect
- `clarityConfigured` becomes true → the analytics toggle appears on the privacy screen.
- `initClarity()` brings the SDK up at launch **paused, capturing nothing**.

## ⚠️ Two gates keep capture off until you act
1. The reader turns the privacy toggle **on** (`allowSessionReplay` resumes it).
2. **Dashboard step this PR cannot make:** set the Clarity project's masking to **Strict** (Settings → Masking) before enabling capture — the app puts expense amounts, descriptions, payment handles and members' names on screen.

## Gates
- `tsc --noEmit` → 0 · `expo lint` → 0 · `prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Configured the mobile app’s analytics setup for release builds.
  * Suppressed Clarity SDK messages from appearing in the app’s console while preserving existing capture behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->