### PR TITLE
feat(mobile): friendlier contacts picker (Mobbin pass)

### DIFF
--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -155,11 +155,14 @@ export default function ContactsScreen(): React.JSX.Element {
           <>
             {added !== null ? (
               <Card style={{ backgroundColor: theme.color.brandSoft }}>
-                <Text variant="caption" tone="brand">
-                  {fill(t.misc.contactsAdded, {
-                    count: plural(locale, added, t.misc.peopleCount),
-                  })}
-                </Text>
+                <Row style={{ gap: theme.spacing.sm }}>
+                  <Ionicons name="checkmark-circle" size={iconSize.lg} color={theme.color.brand} />
+                  <Text variant="caption" tone="brand" style={{ flex: 1 }}>
+                    {fill(t.misc.contactsAdded, {
+                      count: plural(locale, added, t.misc.peopleCount),
+                    })}
+                  </Text>
+                </Row>
               </Card>
             ) : null}
             <ContactPicker onConfirm={setPicked} confirmVerb={t.misc.continueWith} />

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -36,7 +36,6 @@ import {
 import {
   Avatar,
   Button,
-  Card,
   directionalIcon,
   EmptyState,
   iconSize,
@@ -270,31 +269,41 @@ export function ContactPicker({
   }
 
   if (access === Access.Denied) {
+    // A refusal is a state, not a dead end: a friendly medallion, what it means,
+    // and the one button that fixes it. `Linking.openSettings` opens the app's
+    // own settings page where the contacts switch lives — a prominent primary
+    // action, not a buried ghost link — and the AppState listener reloads on the
+    // way back. (`Contacts.presentFormAsync` used to sit here, which opens a
+    // *new-contact* form, not the permission screen the label promises.)
     return (
-      <Card style={{ gap: theme.spacing.sm }}>
-        <Text variant="caption" tone="muted">
-          {t.pickers.contactsDenied}
-        </Text>
-        {/* `Contacts.presentFormAsync` used to be here, which opens a form for
-            creating a *new* contact — not the permission screen the label
-            promises. This is the one that goes where it says. */}
-        <Button
-          label={t.pickers.openSettings}
-          variant="ghost"
-          onPress={() => void Linking.openSettings().catch(() => undefined)}
+      <View style={{ flex: 1, justifyContent: 'center' }}>
+        <EmptyState
+          icon={<Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.brand} />}
+          title={t.pickers.contactsDeniedTitle}
+          body={t.pickers.contactsDenied}
+          action={
+            <Button
+              label={t.pickers.openSettings}
+              onPress={() => void Linking.openSettings().catch(() => undefined)}
+            />
+          }
         />
-      </Card>
+      </View>
     );
   }
 
-  if (access === 'unavailable') {
+  if (access === Access.Unavailable) {
     return (
-      <Card style={{ gap: theme.spacing.sm }}>
-        <Text variant="caption" tone="muted">
-          {t.pickers.contactsUnavailable}
-        </Text>
-        <Button label={t.pickers.tryAgain} variant="ghost" onPress={() => void load()} />
-      </Card>
+      <View style={{ flex: 1, justifyContent: 'center' }}>
+        <EmptyState
+          icon={<Ionicons name="book-outline" size={iconSize.xxl} color={theme.color.brand} />}
+          title={t.pickers.contactsUnavailableTitle}
+          body={t.pickers.contactsUnavailable}
+          action={
+            <Button label={t.pickers.tryAgain} variant="secondary" onPress={() => void load()} />
+          }
+        />
+      </View>
     );
   }
 
@@ -342,6 +351,13 @@ export function ContactPicker({
 
       {matches.length === 0 ? (
         <EmptyState
+          icon={
+            <Ionicons
+              name={query ? 'search-outline' : 'people-outline'}
+              size={iconSize.xxl}
+              color={theme.color.brand}
+            />
+          }
           title={t.pickers.nobodyHere}
           body={query ? t.pickers.noContactMatches : t.pickers.noneHasEmailOrNumber}
         />

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1300,8 +1300,10 @@ export interface UiStrings {
   };
   /** Picking people, a country, and the dates a trip runs between. */
   pickers: {
+    contactsDeniedTitle: string;
     contactsDenied: string;
     openSettings: string;
+    contactsUnavailableTitle: string;
     contactsUnavailable: string;
     tryAgain: string;
     searchContacts: string;
@@ -2637,9 +2639,11 @@ const en: UiStrings = {
     couldNotFindYou: 'Could not find you in that group. Open it and try again.',
   },
   pickers: {
+    contactsDeniedTitle: 'Contacts are switched off',
     contactsDenied:
       'Waves cannot see your contacts. You can still add people by typing a name, an email or a number — nothing about a group needs your address book.',
     openSettings: 'Open settings',
+    contactsUnavailableTitle: 'Couldn’t open your contacts',
     contactsUnavailable:
       'Waves could not read the address book on this phone. Nothing is wrong with your permissions — add people by typing a name, an email or a number instead.',
     tryAgain: 'Try again',
@@ -4043,9 +4047,11 @@ const ta: UiStrings = {
       'அந்தக் குழுவில் உங்களைக் கண்டறிய முடியவில்லை. அதைத் திறந்து மீண்டும் முயற்சிக்கவும்.',
   },
   pickers: {
+    contactsDeniedTitle: 'தொடர்புகள் அணைக்கப்பட்டுள்ளன',
     contactsDenied:
       'பாக்கியால் உங்கள் தொடர்புகளைப் பார்க்க முடியாது. பெயர், மின்னஞ்சல் அல்லது எண்ணைத் தட்டச்சு செய்து இன்னும் நபர்களைச் சேர்க்கலாம் — ஒரு குழுவுக்கு உங்கள் முகவரிப் புத்தகம் தேவையில்லை.',
     openSettings: 'அமைப்புகளைத் திற',
+    contactsUnavailableTitle: 'தொடர்புகளைத் திறக்க முடியவில்லை',
     contactsUnavailable:
       'இந்த ஃபோனில் உள்ள முகவரிப் புத்தகத்தைப் பாக்கியால் படிக்க முடியவில்லை. உங்கள் அனுமதிகளில் எந்தத் தவறும் இல்லை — பெயர், மின்னஞ்சல் அல்லது எண்ணைத் தட்டச்சு செய்து நபர்களைச் சேருங்கள்.',
     tryAgain: 'மீண்டும் முயற்சி',
@@ -5402,9 +5408,11 @@ const hi: UiStrings = {
     couldNotFindYou: 'उस समूह में आप नहीं मिले। उसे खोलकर फिर कोशिश करें।',
   },
   pickers: {
+    contactsDeniedTitle: 'संपर्क बंद हैं',
     contactsDenied:
       'बाकी आपके संपर्क नहीं देख सकता। आप फिर भी नाम, ईमेल या नंबर टाइप करके लोग जोड़ सकते हैं — समूह के लिए आपकी संपर्क सूची ज़रूरी नहीं।',
     openSettings: 'सेटिंग्स खोलें',
+    contactsUnavailableTitle: 'आपके संपर्क नहीं खुल सके',
     contactsUnavailable:
       'बाकी इस फ़ोन की संपर्क सूची नहीं पढ़ सका। आपकी अनुमतियों में कोई गड़बड़ नहीं है — इसके बजाय नाम, ईमेल या नंबर टाइप करके लोग जोड़ें।',
     tryAgain: 'फिर कोशिश करें',
@@ -6926,9 +6934,11 @@ const ar: UiStrings = {
     couldNotFindYou: 'تعذّر العثور عليك في تلك المجموعة. افتحها وحاول مرة أخرى.',
   },
   pickers: {
+    contactsDeniedTitle: 'جهات الاتصال مُوقَفة',
     contactsDenied:
       'لا يستطيع باقي رؤية جهات اتصالك. ما زال بإمكانك إضافة أشخاص بكتابة اسم أو بريد أو رقم — لا شيء في المجموعة يحتاج دفتر عناوينك.',
     openSettings: 'افتح الإعدادات',
+    contactsUnavailableTitle: 'تعذّر فتح جهات اتصالك',
     contactsUnavailable:
       'تعذّر على باقي قراءة دفتر العناوين على هذا الهاتف. لا خلل في أذوناتك — أضف الأشخاص بكتابة اسم أو بريد أو رقم بدلًا من ذلك.',
     tryAgain: 'حاول مرة أخرى',


### PR DESCRIPTION
## What

A Mobbin-informed pass over the **From your contacts** flow (`friends/contacts.tsx` + `ContactPicker`) to make its edge states warmer and more on-standard, without touching the data path (permission flow, search, selection, and adding a contact as a ghost member all unchanged).

## Mobbin references

- Permission / pre-grant states — [Setel](https://mobbin.com/screens/2e2b9f09-830d-4118-b0b6-d2b68329c25b), [Corner](https://mobbin.com/screens/999f6a44-ab98-40ef-a634-bae490b1a84a), [Upside](https://mobbin.com/screens/96019917-4b41-44ca-be27-653d17390f02): a centred illustration/glyph + heading + a plain-language explanation + a **prominent primary** "Allow access" button — never a flat dead-end card.
- Contact list pickers — [WhatsApp](https://mobbin.com/screens/7484a21f-a674-4421-b796-8d3f4acd81f5), [Snapchat](https://mobbin.com/screens/7b24bb2a-20e7-4df6-b0e4-c08679d7c5c9), [Discord](https://mobbin.com/screens/58590b90-9c75-4cc7-a6ab-29dafd837f25), [LINE](https://mobbin.com/screens/cccad93f-73cd-4ac2-9b92-c887c02c15d7): search field, sticky A–Z sections, initial avatars, per-row select circle, index rail, primary action. The existing `ContactPicker` already matches this — confirmed on-standard, left intact.

## Improvements applied

1. **Permission-denied → friendly `EmptyState`** with a glyph medallion (people), the explanation as body, and a prominent primary **Open settings** button (was a flat muted card with a buried ghost link). Vertically centred; the existing AppState listener still reloads on return.
2. **Contacts-unavailable → `EmptyState`** with a book glyph + secondary **Try again**.
3. **No-results / empty book → `EmptyState` now leads with a glyph** — search when a query is active, people otherwise (every Mobbin empty state leads with a mark).
4. **"Added" confirmation** gains a checkmark-circle glyph for a warmer success cue.

## i18n

Added `contactsDeniedTitle` / `contactsUnavailableTitle` to the TS interface and all four locales (en, ta, hi, ar); reused every existing string otherwise.

## Validation

- `npx tsc --noEmit` — clean
- `npx eslint` on the three changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)