### PR TITLE
feat(mobile): payment method on add-a-person IOU

### DIFF
--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -21,7 +21,7 @@ import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
 import { ActivityIndicator, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
 
-import { parseReceiptText, type HeuristicReceipt } from '@waves/core';
+import { parseReceiptText, type HeuristicReceipt, type PaymentMethod } from '@waves/core';
 
 import {
   AmountField,
@@ -55,6 +55,36 @@ import { saveReceipt } from '@/lib/receiptStore';
 
 type Direction = 'theyOwe' | 'iOwe';
 
+/**
+ * How the money moved. A single-select row that mirrors the rest of the app:
+ * the same four ids and icons everywhere, so "credit" is one glyph the user
+ * learns once. It is optional — tapping the chosen chip again clears it.
+ */
+const PAYMENT_METHODS: readonly {
+  readonly id: PaymentMethod;
+  readonly icon: keyof typeof Ionicons.glyphMap;
+}[] = [
+  { id: 'cash', icon: 'cash-outline' },
+  { id: 'credit', icon: 'card-outline' },
+  { id: 'debit', icon: 'card' },
+  { id: 'forex', icon: 'swap-horizontal-outline' },
+];
+
+/** The i18n label for one method — kept beside the ids so a new method is a
+ * type error until it is translated in every locale. */
+function paymentMethodLabel(t: ReturnType<typeof useStrings>['t'], id: PaymentMethod): string {
+  switch (id) {
+    case 'cash':
+      return t.addPerson.payCash;
+    case 'credit':
+      return t.addPerson.payCredit;
+    case 'debit':
+      return t.addPerson.payDebit;
+    case 'forex':
+      return t.addPerson.payForex;
+  }
+}
+
 /** Today as `YYYY-MM-DD`, the format an expense date is stored in. */
 function today(): string {
   const now = new Date();
@@ -87,6 +117,7 @@ export default function AddPersonScreen() {
   const [name, setName] = useState('');
   const [amount, setAmount] = useState(0n);
   const [direction, setDirection] = useState<Direction | null>(null);
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(null);
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -180,6 +211,7 @@ export default function AddPersonScreen() {
         participants: [myMemberId, ghostId],
         payers: { [payerId]: amount },
         splitParams: { kind: 'exact', amounts: { [debtorId]: amount, [payerId]: 0n } },
+        paymentMethod,
       });
 
       // Keep the receipt image on the device and, if a personal cloud is
@@ -324,6 +356,55 @@ export default function AddPersonScreen() {
                     style={{ color: active ? theme.color.brand : theme.color.text }}
                   >
                     {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </Row>
+        </View>
+
+        {/* How the money moved — the same four methods, ids and icons the rest of
+            the app uses, so it reads as one app. Optional and single-select:
+            tapping the chosen chip again clears it. */}
+        <View style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            {t.addPerson.paidWith}
+          </Text>
+          <Row style={{ gap: theme.spacing.sm }}>
+            {PAYMENT_METHODS.map((method) => {
+              const active = paymentMethod === method.id;
+              const label = paymentMethodLabel(t, method.id);
+              return (
+                <Pressable
+                  key={method.id}
+                  accessibilityRole="radio"
+                  accessibilityState={{ selected: active, disabled: saving }}
+                  accessibilityLabel={label}
+                  disabled={saving}
+                  // Tap the selected one again to clear it — the field is optional.
+                  onPress={() => setPaymentMethod((current) => (current === method.id ? null : method.id))}
+                  style={{
+                    flex: 1,
+                    alignItems: 'center',
+                    gap: theme.spacing.xs,
+                    paddingVertical: theme.spacing.md,
+                    borderRadius: theme.radius.md,
+                    borderWidth: 1,
+                    borderColor: active ? theme.color.brand : theme.color.border,
+                    backgroundColor: active ? theme.color.brandSoft : theme.color.surface,
+                    opacity: saving ? 0.5 : 1,
+                  }}
+                >
+                  <Ionicons
+                    name={method.icon}
+                    size={iconSize.md}
+                    color={active ? theme.color.brand : theme.color.text}
+                  />
+                  <Text
+                    variant="caption"
+                    style={{ color: active ? theme.color.brand : theme.color.text }}
+                  >
+                    {label}
                   </Text>
                 </Pressable>
               );

--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -382,7 +382,9 @@ export default function AddPersonScreen() {
                   accessibilityLabel={label}
                   disabled={saving}
                   // Tap the selected one again to clear it — the field is optional.
-                  onPress={() => setPaymentMethod((current) => (current === method.id ? null : method.id))}
+                  onPress={() =>
+                    setPaymentMethod((current) => (current === method.id ? null : method.id))
+                  }
                   style={{
                     flex: 1,
                     alignItems: 'center',

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -19,6 +19,7 @@ import {
   type DeviceSession,
   type FxRecord,
   type ParsedReceipt,
+  type PaymentMethod,
   type ReceiptCheck,
   type SplitParams,
 } from '@waves/core';
@@ -58,7 +59,7 @@ const EXPENSE_SELECT = `
   id, group_id, deleted_at, created_at,
   currentVersion:expense_versions!expenses_current_version_id_fkey (
     id, version_no, description, category, expense_date, currency, amount,
-    split_type, split_params, author_member_id, notes, created_at,
+    split_type, split_params, author_member_id, notes, payment_method, created_at,
     payers:expense_payers ( member_id, amount ),
     shares:expense_shares ( member_id, amount )
   )
@@ -536,6 +537,8 @@ export interface WriteExpenseInput {
   /** Our local computation, sent so the server can contradict us if we differ. */
   expectedShares?: Record<string, bigint>;
   notes?: string | null;
+  /** How the money moved: cash | credit | debit | forex. Optional. */
+  paymentMethod?: PaymentMethod | null;
   /** The rate used, when this expense is not in the group's currency. */
   fx?: FxRecord | null;
   clientMutationId?: string;
@@ -572,6 +575,9 @@ export async function writeExpense(input: WriteExpenseInput): Promise<WriteExpen
           )
         : undefined,
       notes: input.notes ?? null,
+      // Full snapshot, not a patch: an append-only version always carries the
+      // field, so an omitted method and an explicit null both mean "none".
+      paymentMethod: input.paymentMethod ?? null,
       fx: input.fx ?? null,
       // Idempotency key: a retry after a flaky network must not double-post.
       clientMutationId: input.clientMutationId ?? randomUUID(),

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -709,6 +709,7 @@ function serialiseExpense(input: Omit<WriteExpenseInput, 'groupId'>): Record<str
         )
       : undefined,
     notes: input.notes ?? null,
+    paymentMethod: input.paymentMethod ?? null,
   };
 }
 

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -99,6 +99,7 @@ export interface ExpenseVersionRow {
   split_params: SplitParams;
   author_member_id: MemberId | null;
   notes: string | null;
+  payment_method: string | null;
   created_at: string;
   payers: { member_id: MemberId; amount: string }[];
   shares: { member_id: MemberId; amount: string }[];

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -211,6 +211,11 @@ export interface UiStrings {
     iOweThem: string;
     noteLabel: string;
     notePlaceholder: string;
+    paidWith: string;
+    payCash: string;
+    payCredit: string;
+    payDebit: string;
+    payForex: string;
     save: string;
     couldNotRecord: string;
   };
@@ -1532,6 +1537,11 @@ const en: UiStrings = {
     iOweThem: 'I owe them',
     noteLabel: 'Note (optional)',
     notePlaceholder: 'What is it for?',
+    paidWith: 'Paid with',
+    payCash: 'Cash',
+    payCredit: 'Credit',
+    payDebit: 'Debit',
+    payForex: 'Forex',
     save: 'Record it',
     couldNotRecord: 'Could not record this. Please try again.',
   },
@@ -2890,6 +2900,11 @@ const ta: UiStrings = {
     iOweThem: 'நான் அவருக்குத் தர வேண்டும்',
     noteLabel: 'குறிப்பு (விருப்பம்)',
     notePlaceholder: 'எதற்காக?',
+    paidWith: 'எதில் செலுத்தினீர்கள்',
+    payCash: 'பணம்',
+    payCredit: 'கிரெடிட்',
+    payDebit: 'டெபிட்',
+    payForex: 'அயல்நாணயம்',
     save: 'பதிவு செய்',
     couldNotRecord: 'இதைப் பதிவு செய்ய முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
   },
@@ -4294,6 +4309,11 @@ const hi: UiStrings = {
     iOweThem: 'मैं उन्हें दूँगा',
     noteLabel: 'नोट (वैकल्पिक)',
     notePlaceholder: 'किस लिए?',
+    paidWith: 'किससे चुकाया',
+    payCash: 'नकद',
+    payCredit: 'क्रेडिट',
+    payDebit: 'डेबिट',
+    payForex: 'विदेशी मुद्रा',
     save: 'दर्ज करें',
     couldNotRecord: 'यह दर्ज नहीं हो सका। कृपया फिर कोशिश करें।',
   },
@@ -5655,6 +5675,11 @@ const ar: UiStrings = {
     iOweThem: 'أدين له',
     noteLabel: 'ملاحظة (اختياري)',
     notePlaceholder: 'لأجل ماذا؟',
+    paidWith: 'دُفِع بـ',
+    payCash: 'نقدًا',
+    payCredit: 'بطاقة ائتمان',
+    payDebit: 'بطاقة خصم',
+    payForex: 'عملة أجنبية',
     save: 'سجّل',
     couldNotRecord: 'تعذّر تسجيل هذا. حاول مرة أخرى.',
   },

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -145,6 +145,7 @@ export interface MirrorExpense extends MirrorRow {
     readonly split_params: SplitParams;
     readonly author_member_id: string | null;
     readonly notes: string | null;
+    readonly payment_method: string | null;
     readonly created_at: string;
     readonly payers: readonly { member_id: string; amount: string }[];
     readonly shares: readonly { member_id: string; amount: string }[];
@@ -231,6 +232,7 @@ function applyPending(
           split_params: payload.splitParams,
           author_member_id: options.authorMemberId ?? null,
           notes: payload.notes ?? null,
+          payment_method: payload.paymentMethod ?? null,
           created_at: mutation.clientCreatedAt,
           payers: Object.entries(payload.payers).map(([member_id, amount]) => ({
             member_id,

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -70,7 +70,12 @@ export interface ExpenseCreatePayload {
   readonly payers: Readonly<Record<MemberId, string>>;
   readonly receiptId?: string | null;
   readonly notes?: string | null;
+  /** How the money moved: cash | credit | debit | forex. Optional. */
+  readonly paymentMethod?: PaymentMethod | null;
 }
+
+/** The four ways an expense is paid for; optional everywhere it appears. */
+export type PaymentMethod = 'cash' | 'credit' | 'debit' | 'forex';
 
 export interface ExpenseUpdatePayload extends ExpenseCreatePayload {
   /** Version the client edited, so the server can detect a concurrent edit. */

--- a/packages/db/prisma/migrations/20260818120000_add_person_payment/migration.sql
+++ b/packages/db/prisma/migrations/20260818120000_add_person_payment/migration.sql
@@ -1,0 +1,202 @@
+-- Add a "paid with" payment method to an expense version.
+--
+-- The add-a-person screen (and, later, the rest of the expense screens) lets you
+-- record how the money moved — cash, credit, debit or forex. It is a plain,
+-- optional label on the version, never part of the split or the ledger maths, so
+-- it is a nullable text column and nothing that reads a balance has to change.
+--
+-- `baaki_apply_expense` is the one writer of an expense version (M1, ADR-013), so
+-- the column can only be filled by teaching that function a new parameter. Adding
+-- an argument changes the signature, and CREATE OR REPLACE would then create a
+-- SECOND function rather than replacing the first — every existing call would go
+-- ambiguous — so the old 18-argument signature is dropped explicitly first, the
+-- pattern the fx and Splitwise-import migrations already established.
+
+ALTER TABLE public.expense_versions
+  ADD COLUMN IF NOT EXISTS payment_method text;
+
+DROP FUNCTION IF EXISTS public.baaki_apply_expense(
+  uuid, uuid, uuid, text, text, date, char(3), bigint, text, jsonb, jsonb, jsonb, uuid, text, uuid,
+  int, jsonb, text
+);
+
+CREATE OR REPLACE FUNCTION public.baaki_apply_expense(
+  p_group_id           uuid,
+  p_expense_id         uuid,
+  p_author_member_id   uuid,
+  p_description        text,
+  p_category           text,
+  p_expense_date       date,
+  p_currency           char(3),
+  p_amount             bigint,
+  p_split_type         text,
+  p_split_params       jsonb,
+  p_payers             jsonb,
+  p_shares             jsonb,
+  p_client_mutation_id uuid,
+  p_notes              text DEFAULT NULL,
+  p_receipt_id         uuid DEFAULT NULL,
+  p_base_version_no    int DEFAULT NULL,
+  p_fx                 jsonb DEFAULT NULL,
+  p_source             text DEFAULT 'manual',
+  p_payment_method     text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_existing        RECORD;
+  v_version_no      int;
+  v_version_id      uuid;
+  v_is_new          boolean := false;
+  v_row             jsonb;
+  v_unknown         int;
+  v_conflict        boolean := false;
+  v_superseded_no   int;
+  v_superseded_by   uuid;
+  v_superseded_desc text;
+  v_group_currency  char(3);
+BEGIN
+  -- This function is SECURITY DEFINER and callable by clients: verify the caller
+  -- is a live member of the group before it moves a balance (security hardening).
+  PERFORM public.baaki_assert_expense_caller(p_group_id, p_author_member_id);
+
+  -- Replay of a mutation we already applied (ADR-005).
+  IF p_client_mutation_id IS NOT NULL THEN
+    SELECT ev.id, ev.expense_id, ev.version_no INTO v_existing
+    FROM public.expense_versions ev
+    WHERE ev.client_mutation_id = p_client_mutation_id;
+    IF FOUND THEN
+      RETURN jsonb_build_object(
+        'expenseId', v_existing.expense_id,
+        'versionId', v_existing.id,
+        'versionNo', v_existing.version_no,
+        'replayed', true
+      );
+    END IF;
+  END IF;
+
+  -- A rate that converts the wrong way is worse than no rate: it converts
+  -- confidently and wrongly. Checked before a single row is written.
+  SELECT g.default_currency INTO v_group_currency FROM public.groups g WHERE g.id = p_group_id;
+  PERFORM public.baaki_assert_fx_valid(p_fx, upper(p_currency)::char(3), v_group_currency);
+
+  -- Every member referenced must belong to this group; a caller cannot smuggle
+  -- in somebody else's member id (ADR-013).
+  SELECT count(*) INTO v_unknown
+  FROM (
+    SELECT (value ->> 'memberId')::uuid AS member_id FROM jsonb_array_elements(p_payers)
+    UNION
+    SELECT (value ->> 'memberId')::uuid FROM jsonb_array_elements(p_shares)
+    UNION
+    SELECT p_author_member_id
+  ) referenced
+  WHERE referenced.member_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.id = referenced.member_id AND gm.group_id = p_group_id
+    );
+  IF v_unknown > 0 THEN
+    RAISE EXCEPTION 'UNKNOWN_MEMBER: % member(s) are not in this group', v_unknown
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  IF p_expense_id IS NULL OR NOT EXISTS (SELECT 1 FROM public.expenses WHERE id = p_expense_id) THEN
+    v_is_new := true;
+    INSERT INTO public.expenses (id, group_id, created_by)
+    VALUES (COALESCE(p_expense_id, gen_random_uuid()), p_group_id, p_author_member_id)
+    RETURNING id INTO p_expense_id;
+    v_version_no := 1;
+  ELSE
+    IF (SELECT group_id FROM public.expenses WHERE id = p_expense_id) <> p_group_id THEN
+      RAISE EXCEPTION 'WRONG_GROUP: that expense belongs to another group'
+        USING ERRCODE = 'check_violation';
+    END IF;
+    SELECT COALESCE(max(version_no), 0) + 1 INTO v_version_no
+    FROM public.expense_versions WHERE expense_id = p_expense_id;
+
+    -- Somebody else wrote a version after the one this client was looking at.
+    -- Append-only means both survive; the later receipt — this one — wins.
+    IF p_base_version_no IS NOT NULL AND p_base_version_no < v_version_no - 1 THEN
+      v_conflict := true;
+      SELECT ev.version_no, ev.author_member_id, ev.description
+        INTO v_superseded_no, v_superseded_by, v_superseded_desc
+        FROM public.expense_versions ev
+        JOIN public.expenses e ON e.id = ev.expense_id AND e.current_version_id = ev.id
+       WHERE ev.expense_id = p_expense_id;
+    END IF;
+  END IF;
+
+  INSERT INTO public.expense_versions
+    (expense_id, version_no, author_member_id, description, category, expense_date,
+     currency, amount, split_type, split_params, receipt_id, notes, payment_method,
+     client_mutation_id, fx, source)
+  VALUES
+    (p_expense_id, v_version_no, p_author_member_id, p_description, p_category, p_expense_date,
+     upper(p_currency), p_amount, p_split_type::"SplitType", p_split_params, p_receipt_id,
+     p_notes, p_payment_method, p_client_mutation_id, p_fx, COALESCE(p_source, 'manual')::"ExpenseSource")
+  RETURNING id INTO v_version_id;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_payers) LOOP
+    INSERT INTO public.expense_payers (expense_version_id, member_id, amount)
+    VALUES (v_version_id, (v_row ->> 'memberId')::uuid, (v_row ->> 'amount')::bigint);
+  END LOOP;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_shares) LOOP
+    INSERT INTO public.expense_shares (expense_version_id, member_id, amount)
+    VALUES (v_version_id, (v_row ->> 'memberId')::uuid, (v_row ->> 'amount')::bigint);
+  END LOOP;
+
+  -- Pointing at the new version is what makes the edit live.
+  UPDATE public.expenses SET current_version_id = v_version_id WHERE id = p_expense_id;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (
+    p_group_id, p_author_member_id,
+    CASE WHEN v_is_new THEN 'added' ELSE 'edited' END,
+    'expense', p_expense_id,
+    jsonb_build_object(
+      'description', p_description,
+      'amount', p_amount::text,
+      'currency', upper(p_currency),
+      'versionNo', v_version_no,
+      'source', COALESCE(p_source, 'manual')
+    )
+  );
+
+  -- A second entry, so the person whose edit lost can find it. Their version is
+  -- still in `expense_versions` and restoring it is just another edit.
+  IF v_conflict THEN
+    INSERT INTO public.activity_log
+      (group_id, actor_member_id, verb, object_type, object_id, payload)
+    VALUES (
+      p_group_id, p_author_member_id, 'superseded', 'expense', p_expense_id,
+      jsonb_build_object(
+        'supersededVersionNo', v_superseded_no,
+        'supersededAuthorMemberId', v_superseded_by,
+        'supersededDescription', v_superseded_desc,
+        'baseVersionNo', p_base_version_no,
+        'winningVersionNo', v_version_no
+      )
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'expenseId', p_expense_id,
+    'versionId', v_version_id,
+    'versionNo', v_version_no,
+    'replayed', false,
+    'superseded', v_conflict,
+    'supersededVersionNo', v_superseded_no
+  );
+END
+$$;
+
+-- SECURITY DEFINER and called by clients through /sync and expense-write; the
+-- grant is re-applied because DROP FUNCTION took the old one's grants with it.
+GRANT EXECUTE ON FUNCTION public.baaki_apply_expense(
+  uuid, uuid, uuid, text, text, date, char(3), bigint, text, jsonb, jsonb, jsonb, uuid, text, uuid,
+  int, jsonb, text, text
+) TO authenticated, anon;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -465,6 +465,9 @@ model ExpenseVersion {
   fx               Json?
   receiptId        String?       @map("receipt_id") @db.Uuid
   notes            String?
+  /// How the money moved: cash | credit | debit | forex. Optional, and never
+  /// part of the split or a balance — a plain label on the version.
+  paymentMethod    String?       @map("payment_method")
   /// Idempotency key from the offline mutation queue (ADR-005).
   clientMutationId String?       @unique @map("client_mutation_id") @db.Uuid
   source           ExpenseSource @default(manual)

--- a/supabase/functions/expense-write/index.ts
+++ b/supabase/functions/expense-write/index.ts
@@ -47,6 +47,8 @@ interface ExpenseWriteRequest {
   /** Client's own share computation, checked against ours when present. */
   expectedShares?: Record<string, string>;
   notes?: string | null;
+  /** How the money moved: cash | credit | debit | forex. Stored verbatim. */
+  paymentMethod?: string | null;
   receiptId?: string | null;
   /**
    * The rate used, when the expense is not in the group's currency (ADR-003).
@@ -160,6 +162,7 @@ serveWithCors(async (request) => {
       p_notes: body.notes ?? null,
       p_receipt_id: body.receiptId ?? null,
       p_fx: body.fx ?? null,
+      p_payment_method: body.paymentMethod ?? null,
     });
 
     if (applyError) {

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -141,7 +141,7 @@ const EXPENSE_SELECT = `
   id, group_id, deleted_at, created_at, updated_seq,
   currentVersion:expense_versions!expenses_current_version_id_fkey (
     id, version_no, description, category, expense_date, currency, amount,
-    split_type, split_params, author_member_id, notes, created_at,
+    split_type, split_params, author_member_id, notes, payment_method, created_at,
     payers:expense_payers ( member_id, amount ),
     shares:expense_shares ( member_id, amount )
   )
@@ -473,6 +473,7 @@ class SyncSession {
       expectedShares?: Record<string, string>;
       fx?: FxRecord | null;
       notes?: string | null;
+      paymentMethod?: string | null;
       receiptId?: string | null;
       baseVersionNo?: number;
     };
@@ -547,6 +548,7 @@ class SyncSession {
       // instead of a silent overwrite (TDR §4.4).
       p_base_version_no: payload.baseVersionNo ?? null,
       p_fx: payload.fx ?? null,
+      p_payment_method: payload.paymentMethod ?? null,
     });
     if (error) throw error;
     return data;


### PR DESCRIPTION
## What

The add-a-person screen records a plain 1:1 IOU but was missing the **"paid with"** payment-method option the rest of the app uses. This adds a single-select row of the four standard methods — **cash** (`cash-outline`), **credit** (`card-outline`), **debit** (`card`), **forex** (`swap-horizontal-outline`) — each an icon + i18n label. It is optional: tapping the selected chip again clears it. Inputs lock while a save is in flight, and each chip's `accessibilityState.selected` reflects the exact chosen method.

## Persistence path (there is a deploy step)

The add-person IOU rides the offline queue (`useWriteExpense` → `mutate` → the `sync` edge function), and the one writer of an expense version is the `baaki_apply_expense` RPC. To store the method end-to-end:

- **Migration** `packages/db/prisma/migrations/20260818120000_add_person_payment/migration.sql`
  - `ALTER TABLE expense_versions ADD COLUMN payment_method text` (nullable).
  - **RPC changed**: `baaki_apply_expense` gains a trailing `p_payment_method text DEFAULT NULL` and stores it. Adding an argument changes the signature, so the old 18-arg signature is `DROP FUNCTION`-ed first (the fx / Splitwise-import precedent) and `EXECUTE` re-granted to `authenticated, anon`.
- `schema.prisma`: `paymentMethod String? @map("payment_method")` on `ExpenseVersion`.
- **Edge functions** (both changed, both need redeploy): `sync` and `expense-write` pass `p_payment_method` through and select `payment_method` in the read embed so it round-trips.
- `@waves/core`: new `PaymentMethod` union (`cash | credit | debit | forex`) on `ExpenseCreatePayload`; carried in the mirror overlay.
- Mobile: `WriteExpenseInput`, `serialiseExpense`, `ExpenseVersionRow`, `EXPENSE_SELECT`, and the screen UI.
- i18n: `paidWith` / `payCash` / `payCredit` / `payDebit` / `payForex` added to the interface and all four locales (en, ta, hi, ar).

Field is a full-snapshot value on an append-only version, so an omitted method and an explicit null both mean "none" — no partial-update semantics to preserve.

## Deploy steps required
1. Apply the migration (`payment_method` column + `baaki_apply_expense` replacement).
2. Redeploy the `sync` and `expense-write` edge functions.

## Validation
- `apps/mobile`: `tsc --noEmit` clean, `eslint` on changed files clean.
- `packages/core`: `tsc --noEmit` clean, `vitest run` 555 passed.
- `packages/db`: `prisma validate` — schema is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
