### PR TITLE
feat(mobile): timeline activity feed; unify inbox + review-screen icons

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -157,38 +157,51 @@ export default function ActivityScreen() {
                       accessibilityRole="button"
                       accessibilityLabel={describeActivity(entry, myProfileId)}
                       onPress={() => router.push(`/group/${entry.group_id}`)}
-                      style={({ pressed }) => ({
-                        opacity: pressed ? 0.6 : 1,
-                        marginBottom: isLast ? 0 : theme.spacing.lg,
-                      })}
+                      style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
                     >
-                      <Row style={{ alignItems: 'center' }}>
-                        {/* The same node the dashboard draws: a line glyph in a
-                        soft-brand circle, one accent. The vertical connector is
-                        gone — it read as a stray border running past the text and
-                        the finance feeds this follows (Cash App, Zopa) skip it,
-                        letting the circles and the day headings carry the rhythm. */}
-                        <View
-                          style={{
-                            width: 42,
-                            height: 42,
-                            borderRadius: 21,
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            backgroundColor: theme.color.brandSoft,
-                          }}
-                        >
-                          <Ionicons
-                            name={verbIcon(entry.verb)}
-                            size={iconSize.xl}
-                            color={theme.color.brand}
-                          />
+                      <Row style={{ alignItems: 'stretch' }}>
+                        {/* The rail: the node — the dashboard's line glyph in a
+                        soft-brand circle — and a thin connector running from it
+                        down to the next node, so the day reads as one continuous
+                        timeline (Oura, Airwallex) rather than loose rows. The
+                        connector is a hairline in brandSoft, centred on the
+                        circle, and it stops at the last node so it ends, not
+                        dangles. */}
+                        <View style={{ width: 42, alignItems: 'center' }}>
+                          <View
+                            style={{
+                              width: 42,
+                              height: 42,
+                              borderRadius: 21,
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              backgroundColor: theme.color.brandSoft,
+                            }}
+                          >
+                            <Ionicons
+                              name={verbIcon(entry.verb)}
+                              size={iconSize.xl}
+                              color={theme.color.brand}
+                            />
+                          </View>
+                          {!isLast ? (
+                            <View
+                              style={{
+                                flex: 1,
+                                width: 2,
+                                marginTop: theme.spacing.xs,
+                                borderRadius: 1,
+                                backgroundColor: theme.color.brandSoft,
+                              }}
+                            />
+                          ) : null}
                         </View>
 
                         <View
                           style={{
                             flex: 1,
                             paddingStart: theme.spacing.md,
+                            paddingBottom: isLast ? 0 : theme.spacing.xl,
                           }}
                         >
                           <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -16,6 +16,7 @@ import {
   Avatar,
   Button,
   Card,
+  ChipRow,
   EmptyState,
   Gradient,
   iconSize,
@@ -29,7 +30,7 @@ import {
 } from '@waves/ui';
 
 import { useCaptures, useGroups, useHomeSummary } from '@/data/hooks';
-import { CountUpMoney, PressableScale, Stagger } from '@/lib/anim';
+import { CountUpMoney, PressableScale } from '@/lib/anim';
 import { useMotion } from '@/lib/motion';
 import { deviceDefaultCurrency, plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -316,7 +317,7 @@ export default function HomeScreen() {
                 const members = summary.membersFor(group.id);
                 const balance = summary.balanceFor(group.id);
                 return (
-                  <Stagger key={group.id} index={index}>
+                  <View key={group.id}>
                     <GroupCard
                       id={group.id}
                       title={groupLabel(group, members, profile?.id)}
@@ -334,7 +335,7 @@ export default function HomeScreen() {
                     {index < visible.length - 1 ? (
                       <View style={{ height: 1, backgroundColor: theme.color.border }} />
                     ) : null}
-                  </Stagger>
+                  </View>
                 );
               })}
             </View>
@@ -734,10 +735,15 @@ function categoryLabel(type: GroupType, t: UiStrings): string {
 }
 
 /**
- * The group filter as a strip of icon-over-label tiles — a leading "All" chip,
- * then one per group type the person actually has. The active tile wears the
- * brand fill with a soft shadow; the rest sit quiet in white behind a hairline
- * border. The strip scrolls sideways, so more types never crowd the row.
+ * The group filter as a row of compact pills — a leading "All", then one per
+ * group type the person actually has, each an inline icon + label. The active
+ * pill wears the brand fill; the rest sit quiet on the surface. It scrolls
+ * sideways, so more types never crowd the row.
+ *
+ * This was a strip of chunky 74px icon-over-label tiles; the finance apps in the
+ * category (Splitwise, PayPal, Monzo) filter with small pills, not tiles, so it
+ * now reuses the shared {@link ChipRow} — lighter to read and one fewer bespoke
+ * control to keep in step with the rest of the app.
  */
 function CategoryStrip({
   types,
@@ -750,61 +756,26 @@ function CategoryStrip({
   onSelect: (value: GroupType | 'all') => void;
   t: UiStrings;
 }) {
-  const theme = useTheme();
-
-  const chips: { key: GroupType | 'all'; icon: keyof typeof Ionicons.glyphMap; label: string }[] = [
-    { key: 'all', icon: 'apps', label: t.filterAll },
+  const options: {
+    value: GroupType | 'all';
+    label: string;
+    icon: (color: string) => React.ReactNode;
+  }[] = [
+    {
+      value: 'all',
+      label: t.filterAll,
+      icon: (color) => <Ionicons name="apps" size={iconSize.sm} color={color} />,
+    },
     ...types.map((type) => ({
-      key: type,
-      icon: CATEGORY_ICON[type],
+      value: type,
       label: categoryLabel(type, t),
+      icon: (color: string) => (
+        <Ionicons name={CATEGORY_ICON[type]} size={iconSize.sm} color={color} />
+      ),
     })),
   ];
 
-  return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      contentContainerStyle={{ gap: theme.spacing.sm, paddingVertical: theme.spacing.xs }}
-    >
-      {chips.map((chip) => {
-        const selected = chip.key === active;
-        const ink = selected ? theme.color.onBrand : theme.color.text;
-        return (
-          <PressableScale
-            key={chip.key}
-            onPress={() => onSelect(chip.key)}
-            accessibilityRole="button"
-            accessibilityState={{ selected }}
-            accessibilityLabel={chip.label}
-          >
-            <View
-              style={{
-                width: 74,
-                paddingVertical: theme.spacing.md,
-                borderRadius: theme.radius.lg,
-                alignItems: 'center',
-                gap: theme.spacing.xs,
-                backgroundColor: selected ? theme.color.brand : theme.color.surface,
-                borderWidth: 1,
-                borderColor: selected ? theme.color.brand : theme.color.border,
-                ...(selected ? theme.shadow.soft : null),
-              }}
-            >
-              <Ionicons
-                name={chip.icon}
-                size={iconSize.xl}
-                color={selected ? theme.color.onBrand : theme.color.textMuted}
-              />
-              <Text variant="micro" numberOfLines={1} style={{ color: ink }}>
-                {chip.label}
-              </Text>
-            </View>
-          </PressableScale>
-        );
-      })}
-    </ScrollView>
-  );
+  return <ChipRow options={options} value={active} onChange={onSelect} />;
 }
 
 /** One currency's standing: the net, and the two sides that make it up. */

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -27,7 +27,6 @@ import {
   Row,
   Screen,
   Text,
-  tintForKey,
   useTabBarClearance,
   useTheme,
 } from '@waves/ui';
@@ -55,16 +54,18 @@ function groupByDay(rows: readonly NotificationRow[]): { key: string; rows: Noti
   return sections;
 }
 
+// Outline glyphs, to speak the same icon language as the Activity feed and the
+// dashboard — the two screens sit together, so they carry one set of marks.
 const ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {
-  settlement_confirmed: 'checkmark-circle',
-  settlement_initiated: 'arrow-forward-circle',
-  settlement_confirm_request: 'help-circle',
-  trip_nudge_morning: 'sunny',
-  trip_nudge_evening: 'moon',
-  nudge: 'hand-left',
-  expense_added: 'receipt',
-  ghost_claimed: 'person-add',
-  group_invite_accepted: 'person-add',
+  settlement_confirmed: 'checkmark-circle-outline',
+  settlement_initiated: 'arrow-forward-circle-outline',
+  settlement_confirm_request: 'help-circle-outline',
+  trip_nudge_morning: 'sunny-outline',
+  trip_nudge_evening: 'moon-outline',
+  nudge: 'hand-left-outline',
+  expense_added: 'receipt-outline',
+  ghost_claimed: 'person-add-outline',
+  group_invite_accepted: 'person-add-outline',
 };
 
 function factsOf(row: NotificationRow): Record<string, string | undefined> {
@@ -209,7 +210,6 @@ export default function InboxScreen() {
                       body: row.body,
                     });
                     const unreadRow = row.read_at === null;
-                    const tint = tintForKey(row.kind);
                     return (
                       <Pressable
                         key={row.id}
@@ -236,13 +236,13 @@ export default function InboxScreen() {
                               borderRadius: theme.radius.pill,
                               alignItems: 'center',
                               justifyContent: 'center',
-                              backgroundColor: theme.tint[tint].bg,
+                              backgroundColor: theme.color.brandSoft,
                             }}
                           >
                             <Ionicons
-                              name={ICONS[row.kind] ?? 'notifications'}
-                              size={iconSize.md}
-                              color={theme.tint[tint].ink}
+                              name={ICONS[row.kind] ?? 'notifications-outline'}
+                              size={iconSize.lg}
+                              color={theme.color.brand}
                             />
                           </View>
                           <View style={{ flex: 1, gap: 2 }}>

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -29,6 +29,8 @@ import { computeShares, type SplitParams } from '@waves/core';
 import {
   Button,
   Callout,
+  Card,
+  Divider,
   IconButton,
   iconSize,
   Row,
@@ -395,10 +397,20 @@ function DestinationPicker({
   t: ReturnType<typeof useStrings>['t'];
   theme: ReturnType<typeof useTheme>;
 }) {
-  const rows: { key: string; label: string; selected: boolean; onPress: () => void }[] = [
+  type Row = {
+    key: string;
+    label: string;
+    icon: React.ComponentProps<typeof Ionicons>['name'];
+    selected: boolean;
+    onPress: () => void;
+  };
+  const rows: Row[] = [
     {
       key: 'unassigned',
       label: t.captures.unassigned,
+      // The inbox row wears the dashboard's captures glyph, so "Unassigned" here
+      // and the captures card on Home read as the same place.
+      icon: 'file-tray-full-outline',
       selected: dest.kind === 'unassigned',
       onPress: () => onChoose({ kind: 'unassigned' }),
     },
@@ -409,6 +421,7 @@ function DestinationPicker({
     rows.push({
       key: 'create',
       label: t.voice.newGroupNamed.replace('{name}', requested.name),
+      icon: 'add-circle-outline',
       selected: dest.kind === 'create',
       onPress: () => onChoose({ kind: 'create', ...requested }),
     });
@@ -417,6 +430,7 @@ function DestinationPicker({
     rows.push({
       key: group.id,
       label: groupLabel(group),
+      icon: 'people-outline',
       selected: dest.kind === 'existing' && dest.groupId === group.id,
       onPress: () => onChoose({ kind: 'existing', groupId: group.id }),
     });
@@ -427,30 +441,62 @@ function DestinationPicker({
       <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
         {t.voice.saveTo.toUpperCase()}
       </Text>
-      {rows.map((row) => (
-        <Pressable
-          key={row.key}
-          onPress={row.onPress}
-          accessibilityRole="button"
-          accessibilityState={{ selected: row.selected }}
-          style={{
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            paddingVertical: theme.spacing.md,
-            paddingHorizontal: theme.spacing.lg,
-            borderRadius: theme.radius.lg,
-            backgroundColor: row.selected ? theme.color.brandSoft : theme.color.surface,
-          }}
-        >
-          <Text style={{ color: row.selected ? theme.color.brand : theme.color.text }}>
-            {row.label}
-          </Text>
-          {row.selected ? (
-            <Ionicons name="checkmark-circle" size={iconSize.md} color={theme.color.brand} />
-          ) : null}
-        </Pressable>
-      ))}
+      {/* One grouped card, hairlines between rows — the destination is a single
+          choice, so it reads as a single control (Expensify "To", Monzo lists)
+          rather than a stack of floating pills. Selection is a leading glyph
+          that lights to brand plus a filled radio, not a full-width purple fill. */}
+      <Card padded={false} style={{ overflow: 'hidden' }}>
+        {rows.map((row, index) => (
+          <View key={row.key}>
+            <Pressable
+              onPress={row.onPress}
+              accessibilityRole="button"
+              accessibilityState={{ selected: row.selected }}
+              style={({ pressed }) => ({
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: theme.spacing.md,
+                paddingVertical: theme.spacing.md,
+                paddingHorizontal: theme.spacing.lg,
+                opacity: pressed ? 0.6 : 1,
+              })}
+            >
+              <View
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: 18,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: row.selected ? theme.color.brandSoft : theme.color.surfaceMuted,
+                }}
+              >
+                <Ionicons
+                  name={row.icon}
+                  size={iconSize.md}
+                  color={row.selected ? theme.color.brand : theme.color.textMuted}
+                />
+              </View>
+              <Text
+                numberOfLines={1}
+                style={{
+                  flex: 1,
+                  color: row.selected ? theme.color.brand : theme.color.text,
+                  fontWeight: row.selected ? '600' : '400',
+                }}
+              >
+                {row.label}
+              </Text>
+              <Ionicons
+                name={row.selected ? 'checkmark-circle' : 'ellipse-outline'}
+                size={iconSize.md}
+                color={row.selected ? theme.color.brand : theme.color.border}
+              />
+            </Pressable>
+            {index < rows.length - 1 ? <Divider /> : null}
+          </View>
+        ))}
+      </Card>
     </View>
   );
 }
@@ -476,49 +522,60 @@ function DraftRow({
   theme: ReturnType<typeof useTheme>;
 }) {
   return (
-    <Row
-      style={{
-        alignItems: 'center',
-        gap: theme.spacing.md,
-        paddingVertical: theme.spacing.md,
-        paddingHorizontal: theme.spacing.lg,
-        borderRadius: theme.radius.lg,
-        backgroundColor: theme.color.surface,
-      }}
-    >
-      <View style={{ minWidth: 88 }}>
-        <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-          {draft.currency ? (
-            <Text variant="micro" tone="muted">
-              {draft.currency}
-            </Text>
-          ) : null}
+    // A receipt-glyph node (the same one the feeds use), the amount as the hero
+    // with its currency, and the note on the line beneath — a card that reads as
+    // one expense at a glance (Copilot / Expensify review rows), editable in
+    // place. Remove is a quiet trailing control, not a heavy grey disc.
+    <Card>
+      <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+        <View
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 20,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.color.brandSoft,
+          }}
+        >
+          <Ionicons name="receipt-outline" size={iconSize.lg} color={theme.color.brand} />
+        </View>
+
+        <View style={{ flex: 1, gap: theme.spacing.xs }}>
+          <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            {draft.currency ? (
+              <Text variant="caption" tone="muted" style={{ fontWeight: '600' }}>
+                {draft.currency}
+              </Text>
+            ) : null}
+            <TextInput
+              value={draft.amount}
+              onChangeText={(value) => onEdit(draft.key, { amount: value })}
+              keyboardType="decimal-pad"
+              accessibilityLabel={amountLabel}
+              style={{
+                flex: 1,
+                fontSize: 24,
+                fontWeight: '700',
+                color: theme.color.text,
+                paddingVertical: 0,
+              }}
+            />
+          </Row>
           <TextInput
-            value={draft.amount}
-            onChangeText={(value) => onEdit(draft.key, { amount: value })}
-            keyboardType="decimal-pad"
-            accessibilityLabel={amountLabel}
-            style={{
-              flex: 1,
-              fontSize: 20,
-              fontWeight: '700',
-              color: theme.color.text,
-              paddingVertical: 0,
-            }}
+            value={draft.note}
+            onChangeText={(value) => onEdit(draft.key, { note: value })}
+            placeholder={notePlaceholder}
+            placeholderTextColor={theme.color.textFaint}
+            accessibilityLabel={noteLabel}
+            style={{ fontSize: 15, color: theme.color.textMuted, paddingVertical: 0 }}
           />
-        </Row>
-      </View>
-      <TextInput
-        value={draft.note}
-        onChangeText={(value) => onEdit(draft.key, { note: value })}
-        placeholder={notePlaceholder}
-        placeholderTextColor={theme.color.textFaint}
-        accessibilityLabel={noteLabel}
-        style={{ flex: 1, fontSize: 16, color: theme.color.text, paddingVertical: 0 }}
-      />
-      <IconButton label={removeLabel} onPress={() => onRemove(draft.key)}>
-        <Ionicons name="close-circle" size={iconSize.md} color={theme.color.textFaint} />
-      </IconButton>
-    </Row>
+        </View>
+
+        <IconButton label={removeLabel} onPress={() => onRemove(draft.key)}>
+          <Ionicons name="close" size={iconSize.md} color={theme.color.textFaint} />
+        </IconButton>
+      </Row>
+    </Card>
   );
 }

--- a/apps/mobile/src/components/GroupCard.tsx
+++ b/apps/mobile/src/components/GroupCard.tsx
@@ -10,7 +10,7 @@
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { View } from 'react-native';
+import { Pressable, View } from 'react-native';
 
 import type { CurrencyCode } from '@waves/core';
 import {
@@ -25,7 +25,6 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { PressableScale } from '@/lib/anim';
 
 export function GroupCard({
   id,
@@ -56,10 +55,14 @@ export function GroupCard({
   const theme = useTheme();
 
   return (
-    <PressableScale
+    // Flat opacity feedback, no scale. The list scrolls a lot and every row a
+    // Reanimated AnimatedPressable made the scroll heavy; a plain Pressable
+    // still says "I heard you" without the zoom.
+    <Pressable
       onPress={onPress}
       accessibilityRole="button"
       accessibilityLabel={`${title}, ${statusLabel}${pendingLabel ? `, ${pendingLabel}` : ''}`}
+      style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
     >
       <Row
         style={{ gap: theme.spacing.md, alignItems: 'center', paddingVertical: theme.spacing.md }}
@@ -107,6 +110,6 @@ export function GroupCard({
           color={theme.color.textFaint}
         />
       </Row>
-    </PressableScale>
+    </Pressable>
   );
 }


### PR DESCRIPTION
Stacked on #264 (base = `feat/activity-icon-consistency`) — the Activity timeline builds on the shared `verbIcon` from that PR. Retarget to `main` once #264 merges.

## What

### Activity → timeline
Proper vertical timeline (Oura / Airwallex): each day's events hang off a rail — the shared `verbIcon` node in a soft-brand circle + a **thin `brandSoft` connector** to the next node, stopping at the last. Tuned to read as a rail, not a hard border (the earlier connector complaint). Row spacing rides content padding so the rail stretches through the gap.

### Inbox → same icon language as Activity/dashboard
Was a per-notification **group-tinted circle + filled icon**. Now **soft-brand circle + brand outline glyph** — icon map switched to `-outline` variants (`receipt-outline`, `checkmark-circle-outline`, `person-add-outline`, `sunny-outline`…). Dropped unused `tintForKey`.

### Voice review screen (Mobbin redesign)
- **Destination picker**: one grouped card + hairline dividers; leading glyph (inbox / new-group / people) that lights to brand + a filled radio — instead of a stack of full-purple pills.
- **Draft expense**: a card with a receipt node, the **amount as hero** + note beneath, quiet trailing remove.

## Test
- `tsc --noEmit` exit 0
- `eslint` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)