### PR TITLE
feat: admin-controlled per-group receipt cap

### DIFF
--- a/apps/admin/src/app/config/page.tsx
+++ b/apps/admin/src/app/config/page.tsx
@@ -1,0 +1,81 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { appConfig, saveAppConfig } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * The numeric knobs. Today that is the per-group receipt cap; anything else that
+ * needs a number the console can turn without a deploy joins the same table and
+ * shows up here as another row.
+ */
+export default async function Config({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; saved?: string }>;
+}) {
+  const { error, saved } = await searchParams;
+  const rows = await appConfig();
+
+  async function save(formData: FormData) {
+    'use server';
+
+    let failure: string | null = null;
+    try {
+      await saveAppConfig({
+        key: String(formData.get('key') ?? '').trim(),
+        value: Number(formData.get('value') ?? 0),
+      });
+    } catch (caught) {
+      failure = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    if (failure) redirect(`/config?error=${encodeURIComponent(failure)}`);
+    revalidatePath('/config');
+    redirect('/config?saved=1');
+  }
+
+  return (
+    <main>
+      <header className="top">
+        <h1>Limits</h1>{' '}
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+      {saved ? <p className="faint">Saved.</p> : null}
+
+      <p className="note" style={{ padding: 0 }}>
+        Numeric knobs the app reads at runtime. The receipt cap is how many receipts a group may
+        hold before it must upgrade or add storage — a paid group has no cap. The number lives here
+        so it can change without a deploy; the database enforces it, so lowering it is real.
+      </p>
+
+      {rows.length === 0 ? (
+        <section style={{ marginTop: 20 }}>
+          <p className="note">
+            No knobs yet. If you expected some, the
+            <code> 20260818160000_receipt_cap </code> migration may not be deployed to this project.
+          </p>
+        </section>
+      ) : null}
+
+      {rows.map((row) => (
+        <div key={row.key}>
+          <h2>{row.key}</h2>
+          <section>
+            <form action={save} className="flag">
+              <input type="hidden" name="key" value={row.key} />
+              {row.description ? <p className="note">{row.description}</p> : null}
+              <label>
+                <span>Value</span>
+                <input type="number" name="value" min={0} step={1} defaultValue={row.value} />
+              </label>
+              <button type="submit">Save</button>
+            </form>
+          </section>
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/apps/admin/src/app/config/page.tsx
+++ b/apps/admin/src/app/config/page.tsx
@@ -23,9 +23,13 @@ export default async function Config({
 
     let failure: string | null = null;
     try {
+      const rawValue = String(formData.get('value') ?? '').trim();
+      if (rawValue === '') {
+        throw new Error('A limit is a whole number, zero or more.');
+      }
       await saveAppConfig({
         key: String(formData.get('key') ?? '').trim(),
-        value: Number(formData.get('value') ?? 0),
+        value: Number(rawValue),
       });
     } catch (caught) {
       failure = caught instanceof Error ? caught.message : String(caught);
@@ -69,7 +73,7 @@ export default async function Config({
               {row.description ? <p className="note">{row.description}</p> : null}
               <label>
                 <span>Value</span>
-                <input type="number" name="value" min={0} step={1} defaultValue={row.value} />
+                <input type="number" name="value" min={0} step={1} defaultValue={row.value} required />
               </label>
               <button type="submit">Save</button>
             </form>

--- a/apps/admin/src/app/config/page.tsx
+++ b/apps/admin/src/app/config/page.tsx
@@ -73,7 +73,14 @@ export default async function Config({
               {row.description ? <p className="note">{row.description}</p> : null}
               <label>
                 <span>Value</span>
-                <input type="number" name="value" min={0} step={1} defaultValue={row.value} required />
+                <input
+                  type="number"
+                  name="value"
+                  min={0}
+                  step={1}
+                  defaultValue={row.value}
+                  required
+                />
               </label>
               <button type="submit">Save</button>
             </form>

--- a/apps/admin/src/components/Shell.tsx
+++ b/apps/admin/src/components/Shell.tsx
@@ -21,6 +21,7 @@ const TITLES: Record<string, string> = {
   '/promotions': 'Promotions',
   '/campaigns': 'Campaigns',
   '/flags': 'Experiments',
+  '/config': 'Limits',
   '/rate-limits': 'Rate limits',
   '/feedback': 'Feedback',
 };

--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -79,6 +79,7 @@ const SECTIONS: Section[] = [
     heading: 'Config',
     items: [
       { href: '/flags', label: 'Experiments', icon: I.flags },
+      { href: '/config', label: 'Limits', icon: I.gauge },
       { href: '/rate-limits', label: 'Rate limits', icon: I.gauge },
     ],
   },

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -63,6 +63,9 @@ const FUNCTION_MISSING = 'PGRST202';
 /** The same first-run state, for a table rather than a function. */
 const TABLE_MISSING = 'PGRST205';
 
+/** PostgREST returns this when `.single()` matches no rows. */
+const NO_ROWS = 'PGRST116';
+
 async function call<T>(fn: string, args: Record<string, unknown> = {}): Promise<T[]> {
   await requireSession();
   const { data, error } = await client().rpc(fn, args);
@@ -249,8 +252,13 @@ export async function saveAppConfig(input: { key: string; value: number }): Prom
   const { error } = await client()
     .from('app_config')
     .update({ value: input.value, updated_at: new Date().toISOString() })
-    .eq('key', input.key);
-  if (error) throw new Error(`saving ${input.key} failed: ${error.message}`);
+    .eq('key', input.key)
+    .select()
+    .single();
+  if (error) {
+    if (error.code === NO_ROWS) throw new Error(`no such config key "${input.key}"`);
+    throw new Error(`saving ${input.key} failed: ${error.message}`);
+  }
 }
 
 export interface PromoCodeRow {

--- a/apps/admin/src/lib/data.ts
+++ b/apps/admin/src/lib/data.ts
@@ -206,6 +206,53 @@ export async function saveFlag(input: {
   if (error) throw new Error(`saving ${input.key} failed: ${error.message}`);
 }
 
+export interface AppConfigRow {
+  key: string;
+  value: number;
+  description: string;
+  updated_at: string;
+}
+
+/**
+ * The numeric knobs — the receipt cap and any limit that joins it. Like
+ * `feature_flags`, this is configuration the console owns, not an aggregate
+ * over somebody's data, so it is read straight from the table.
+ */
+export async function appConfig(): Promise<AppConfigRow[]> {
+  await requireSession();
+  const { data, error } = await client()
+    .from('app_config')
+    .select('key, value, description, updated_at')
+    .order('key');
+  if (error) {
+    if (error.code === TABLE_MISSING) return [];
+    throw new Error(`reading app_config failed: ${error.message}`);
+  }
+  return (data ?? []) as AppConfigRow[];
+}
+
+/**
+ * Change a knob's value. An UPDATE, not an upsert: the keys are defined by the
+ * migrations that read them, so the console turns existing knobs and cannot
+ * invent one the code never looks at.
+ */
+export async function saveAppConfig(input: { key: string; value: number }): Promise<void> {
+  await requireSession();
+
+  if (!/^[a-z][a-z0-9_]{1,60}$/.test(input.key)) {
+    throw new Error('A key is lowercase letters, digits and underscores, starting with a letter.');
+  }
+  if (!Number.isInteger(input.value) || input.value < 0) {
+    throw new Error('A limit is a whole number, zero or more.');
+  }
+
+  const { error } = await client()
+    .from('app_config')
+    .update({ value: input.value, updated_at: new Date().toISOString() })
+    .eq('key', input.key);
+  if (error) throw new Error(`saving ${input.key} failed: ${error.message}`);
+}
+
 export interface PromoCodeRow {
   code: string;
   tier: string;

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1125,14 +1125,13 @@ function BalanceCard({ total, locale, t }: { total: CurrencyTotal; locale: strin
       }}
     >
       <HeroBackdropIcon name="wallet-outline" />
-      <Row style={{ justifyContent: 'space-between' }}>
-        <Text variant="caption" tone="onBrand">
-          {t.yourBaaki}
-        </Text>
-        <Text variant="micro" tone="onBrand">
-          {total.currency}
-        </Text>
-      </Row>
+      {/* Currencies are never summed (ADR-004), so the deck can carry a card per
+          currency. The code rides in the heading — not just a corner chip — so
+          two balance cards read as "your USD" and "your INR", never as two
+          identical "Your balance". */}
+      <Text variant="caption" tone="onBrand">
+        {`${t.yourBaaki} · ${total.currency}`}
+      </Text>
 
       <View>
         <CountUpMoney

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -34,7 +35,8 @@ import { CategoryPicker } from '@/components/Category';
 import { friendlyError } from '@/lib/errors';
 import { CurrencyRate } from '@/components/CurrencyRate';
 import { DictateButton } from '@/components/DictateButton';
-import { scanReceipt, scanReceiptText } from '@/data/api';
+import { canAddReceipt, scanReceipt, scanReceiptText } from '@/data/api';
+import { receiptCapStatus, receiptTapAction } from '@/lib/receiptCapGate';
 import { useAssignCapture, useGroup } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
@@ -184,6 +186,22 @@ export default function AddExpenseScreen() {
   const [scanNote, setScanNote] = useState<string | null>(null);
   /** Set once a scan has read line items, so the offer to itemize is real. */
   const [scannedItems, setScannedItems] = useState(0);
+
+  // The per-group receipt ceiling. A group holds a few receipts for free (the
+  // number is an admin knob); past it, scanning is a paid feature. A paid group
+  // has no cap. This only draws the affordance — the server enforces the same
+  // rule when it records the receipt.
+  const receiptCap = useQuery({
+    queryKey: ['receiptCap', groupId],
+    queryFn: () => canAddReceipt(groupId),
+  });
+  // A failed fetch must not lock a scan the server would allow: an undefined
+  // answer that is no longer loading is treated as allowed, and the server is
+  // the real boundary if it turns out the group was capped after all.
+  const capStatus = receiptCap.isError
+    ? 'allowed'
+    : receiptCapStatus(receiptCap.data, receiptCap.isLoading);
+  const capLocked = capStatus === 'locked';
 
   const myMemberId = useMemo(
     () => (members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ?? null,
@@ -506,6 +524,10 @@ export default function AddExpenseScreen() {
    * saves itself, and the amount lands in the same field, editable.
    */
   const scan = async (): Promise<void> => {
+    // The cap decides the button below, but guard here too: a scan is not free
+    // to start (the camera, the OCR, the metered call), and the server would
+    // refuse to record it anyway.
+    if (receiptTapAction(capStatus) !== 'scan') return;
     setError(null);
     setScanNote(null);
     let picked: Awaited<ReturnType<typeof captureReceipt>> = null;
@@ -614,19 +636,41 @@ export default function AddExpenseScreen() {
         <Card style={{ gap: theme.spacing.md }}>
           <Row style={{ justifyContent: 'space-between' }}>
             <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-              <Text variant="subheading">{t.expense.scanBillTitle}</Text>
+              <Text variant="subheading">
+                {capLocked ? t.expense.capReachedTitle : t.expense.scanBillTitle}
+              </Text>
               <Text variant="caption" tone="muted">
-                {t.expense.scanBillBody}
+                {capLocked ? t.expense.capReachedBody : t.expense.scanBillBody}
               </Text>
             </View>
-            <Button
-              label={scanning ? t.expense.reading : t.expense.scan}
-              variant="secondary"
-              disabled={scanning || saving}
-              onPress={() => void scan()}
-              icon={<Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />}
-            />
+            {/* Once the group is capped the scan button has nothing to do — a
+                scan the server would refuse — so it gives way to the two ways
+                out: pay, or bring your own storage. */}
+            {!capLocked ? (
+              <Button
+                label={scanning ? t.expense.reading : t.expense.scan}
+                variant="secondary"
+                disabled={scanning || saving || capStatus === 'loading'}
+                onPress={() => void scan()}
+                icon={
+                  <Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />
+                }
+              />
+            ) : null}
           </Row>
+          {capLocked ? (
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Button
+                label={t.expense.capUpgrade}
+                onPress={() => router.push('/settings/upgrade')}
+              />
+              <Button
+                label={t.expense.capAddStorage}
+                variant="secondary"
+                onPress={() => router.push('/settings/backup')}
+              />
+            </Row>
+          ) : null}
           {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
           {scanNote ? (
             <Text variant="caption" tone="brand">

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -202,6 +202,7 @@ export default function AddExpenseScreen() {
     ? 'allowed'
     : receiptCapStatus(receiptCap.data, receiptCap.isLoading);
   const capLocked = capStatus === 'locked';
+  const queryClient = useQueryClient();
 
   const myMemberId = useMemo(
     () => (members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ?? null,
@@ -569,6 +570,10 @@ export default function AddExpenseScreen() {
           ? t.expense.scanReconciles
           : (result.check.problems[0]?.message ?? t.expense.scanCheckTotal),
       );
+
+      // The receipt just landed, so the cached cap count is now stale. Refresh
+      // the gate before another scan can start from a wrong number.
+      await queryClient.invalidateQueries({ queryKey: ['receiptCap', groupId] });
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotScan, 'expense.scan'));
     } finally {

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { randomUUID } from 'expo-crypto';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -32,7 +33,14 @@ import {
 
 import { captureReceipt } from '@/lib/image';
 import { friendlyError } from '@/lib/errors';
-import { publishReceiptItems, scanReceipt, scanReceiptText, setItemClaim } from '@/data/api';
+import {
+  canAddReceipt,
+  publishReceiptItems,
+  scanReceipt,
+  scanReceiptText,
+  setItemClaim,
+} from '@/data/api';
+import { receiptCapStatus, receiptTapAction } from '@/lib/receiptCapGate';
 import { recogniseReceipt } from '@/lib/ocr';
 import { useGroup, useItemClaims, useReceipt, useWriteExpense } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
@@ -103,6 +111,17 @@ export default function ItemizeScreen() {
   const [error, setError] = useState<string | null>(null);
   const [scanning, setScanning] = useState(false);
   const [scanNote, setScanNote] = useState<string | null>(null);
+
+  // The per-group receipt ceiling — same gate as the add-expense scan card.
+  // Only the affordance; the server enforces the cap when it records.
+  const receiptCap = useQuery({
+    queryKey: ['receiptCap', groupId],
+    queryFn: () => canAddReceipt(groupId),
+  });
+  const capStatus = receiptCap.isError
+    ? 'allowed'
+    : receiptCapStatus(receiptCap.data, receiptCap.isLoading);
+  const capLocked = capStatus === 'locked';
   /** A bill that has been scanned but not yet handed to the table. */
   const [scanId, setScanId] = useState<string | null>(null);
 
@@ -175,6 +194,8 @@ export default function ItemizeScreen() {
   /* eslint-enable react-hooks/set-state-in-effect */
 
   const scan = async (): Promise<void> => {
+    // Capped groups don't scan — the server would refuse the record anyway.
+    if (receiptTapAction(capStatus) !== 'scan') return;
     const picked = await captureReceipt();
     if (!picked) return;
     setError(null);
@@ -472,21 +493,38 @@ export default function ItemizeScreen() {
           <Card style={{ gap: theme.spacing.md }}>
             <Row style={{ justifyContent: 'space-between' }}>
               <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-                <Text variant="subheading">{t.itemize.scanTitle}</Text>
+                <Text variant="subheading">
+                  {capLocked ? t.expense.capReachedTitle : t.itemize.scanTitle}
+                </Text>
                 <Text variant="caption" tone="muted">
-                  {t.itemize.scanBody}
+                  {capLocked ? t.expense.capReachedBody : t.itemize.scanBody}
                 </Text>
               </View>
-              <Button
-                label={scanning ? t.expense.reading : t.expense.scan}
-                variant="secondary"
-                disabled={scanning}
-                onPress={() => void scan()}
-                icon={
-                  <Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />
-                }
-              />
+              {!capLocked ? (
+                <Button
+                  label={scanning ? t.expense.reading : t.expense.scan}
+                  variant="secondary"
+                  disabled={scanning || capStatus === 'loading'}
+                  onPress={() => void scan()}
+                  icon={
+                    <Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />
+                  }
+                />
+              ) : null}
             </Row>
+            {capLocked ? (
+              <Row style={{ gap: theme.spacing.sm }}>
+                <Button
+                  label={t.expense.capUpgrade}
+                  onPress={() => router.push('/settings/upgrade')}
+                />
+                <Button
+                  label={t.expense.capAddStorage}
+                  variant="secondary"
+                  onPress={() => router.push('/settings/backup')}
+                />
+              </Row>
+            ) : null}
             {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
             {scanNote ? (
               <Text variant="caption" tone="brand">

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { randomUUID } from 'expo-crypto';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -122,6 +122,7 @@ export default function ItemizeScreen() {
     ? 'allowed'
     : receiptCapStatus(receiptCap.data, receiptCap.isLoading);
   const capLocked = capStatus === 'locked';
+  const queryClient = useQueryClient();
   /** A bill that has been scanned but not yet handed to the table. */
   const [scanId, setScanId] = useState<string | null>(null);
 
@@ -224,6 +225,10 @@ export default function ItemizeScreen() {
 
       fillFromReceipt(result.parsed);
       setScanId(result.receiptId);
+
+      // The receipt just landed, so the cached cap count is now stale. Refresh
+      // the gate before another scan can start from a wrong number.
+      await queryClient.invalidateQueries({ queryKey: ['receiptCap', groupId] });
 
       // The arithmetic decides what the person is asked to look at. Saying
       // "scanned!" and leaving them to notice a wrong total is the failure

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -370,6 +370,24 @@ export async function canUploadGroupPhoto(groupId: string | null): Promise<boole
   return data === true;
 }
 
+/**
+ * Whether this group may take one more receipt.
+ *
+ * A group holds a set number of receipts for free (the number is an admin knob,
+ * `app_config.receipt_cap_per_group`); past it, somebody has to pay or add
+ * storage. A paid group has no cap. Answered by a SECURITY DEFINER RPC — a
+ * member cannot count another's entitlement under RLS — which returns only the
+ * boolean. The server enforces the same rule when it records the receipt, so
+ * this is the affordance, not the boundary.
+ */
+export async function canAddReceipt(groupId: string): Promise<boolean> {
+  const { data, error } = await supabase.rpc('baaki_can_add_receipt', {
+    p_group_id: groupId,
+  });
+  if (error) throw new Error(error.message);
+  return data === true;
+}
+
 /** The bucket accepts three types; anything else is stored as JPEG. */
 function normaliseImageMime(mimeType: string | null | undefined): string {
   if (mimeType === 'image/png' || mimeType === 'image/webp') return mimeType;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1003,6 +1003,11 @@ export interface UiStrings {
     reading: string;
     scanReconciles: string;
     scanCheckTotal: string;
+    /** Scan card, when the group has filled its free receipt cap (admin knob). */
+    capReachedTitle: string;
+    capReachedBody: string;
+    capUpgrade: string;
+    capAddStorage: string;
     /** The scanned-bill card and the receipt hand-off on the group screen. */
     aBill: string;
     splitBillA11y: string;
@@ -2349,6 +2354,11 @@ const en: UiStrings = {
     reading: 'Reading…',
     scanReconciles: 'Read the total off the bill. Check it, then split it however you like.',
     scanCheckTotal: 'Check the total against the bill before saving.',
+    capReachedTitle: 'Receipt limit reached',
+    capReachedBody:
+      'This group has used its free receipts. Upgrade or add your own storage to keep scanning.',
+    capUpgrade: 'Upgrade',
+    capAddStorage: 'Add storage',
     aBill: 'A bill',
     splitBillA11y: 'Split {merchant} by item',
     receiptClaimedNone: {
@@ -3787,6 +3797,11 @@ const ta: UiStrings = {
     scanReconciles:
       'ரசீதிலிருந்து மொத்தம் படிக்கப்பட்டது. சரிபார்த்து, உங்களுக்கு ஏற்றபடி பிரியுங்கள்.',
     scanCheckTotal: 'சேமிப்பதற்கு முன் ரசீதுடன் மொத்தத்தைச் சரிபாருங்கள்.',
+    capReachedTitle: 'ரசீது வரம்பை எட்டிவிட்டது',
+    capReachedBody:
+      'இந்தக் குழு அதன் இலவச ரசீதுகளைப் பயன்படுத்திவிட்டது. தொடர்ந்து ஸ்கேன் செய்ய மேம்படுத்துங்கள் அல்லது உங்கள் சொந்த சேமிப்பகத்தைச் சேர்க்கவும்.',
+    capUpgrade: 'மேம்படுத்து',
+    capAddStorage: 'சேமிப்பகம் சேர்',
     aBill: 'ஒரு பில்',
     splitBillA11y: '{merchant} பொருள் வாரியாகப் பிரி',
     receiptClaimedNone: {
@@ -5216,6 +5231,11 @@ const hi: UiStrings = {
     reading: 'पढ़ रहे हैं…',
     scanReconciles: 'बिल से कुल रकम पढ़ ली। जाँच लें, फिर जैसे चाहें बाँटें।',
     scanCheckTotal: 'सेव करने से पहले कुल रकम बिल से मिला लें।',
+    capReachedTitle: 'रसीद की सीमा पूरी हो गई',
+    capReachedBody:
+      'इस ग्रुप की मुफ़्त रसीदें ख़त्म हो गई हैं। स्कैन करते रहने के लिए अपग्रेड करें या अपना स्टोरेज जोड़ें।',
+    capUpgrade: 'अपग्रेड करें',
+    capAddStorage: 'स्टोरेज जोड़ें',
     aBill: 'एक बिल',
     splitBillA11y: '{merchant} को चीज़-वार बाँटें',
     receiptClaimedNone: {
@@ -6665,6 +6685,11 @@ const ar: UiStrings = {
     reading: 'جارٍ القراءة…',
     scanReconciles: 'قرأنا المجموع من الفاتورة. تحقّق منه ثم قسّمه كما تشاء.',
     scanCheckTotal: 'قارن المجموع بالفاتورة قبل الحفظ.',
+    capReachedTitle: 'تم بلوغ حدّ الإيصالات',
+    capReachedBody:
+      'استهلكت هذه المجموعة إيصالاتها المجانية. رقِّ الخطة أو أضِف مساحتك الخاصة لمواصلة المسح.',
+    capUpgrade: 'ترقية',
+    capAddStorage: 'إضافة مساحة',
     aBill: 'فاتورة',
     splitBillA11y: 'قسّم {merchant} حسب الصنف',
     receiptClaimedNone: {

--- a/apps/mobile/src/lib/receiptCapGate.ts
+++ b/apps/mobile/src/lib/receiptCapGate.ts
@@ -1,0 +1,50 @@
+/**
+ * The rule the receipt-scan control obeys: a group may hold a set number of
+ * receipts for free (an admin knob), and past that the scan is a paid feature —
+ * unlock it by upgrading or by adding your own storage. The server answers "may
+ * this group take one more receipt" over the `baaki_can_add_receipt` RPC; this
+ * module turns that answer, and its loading state, into the small decisions the
+ * two scan screens (add-expense, itemize) need, kept pure so they can be tested
+ * without a renderer or the network.
+ *
+ * Deliberately the same shape as `groupPhotoGate` — the two gates guard
+ * different features but wear the same three states, so a reader who knows one
+ * knows the other.
+ */
+
+/** What the scan control should show. */
+export type ReceiptCapStatus = 'loading' | 'allowed' | 'locked';
+
+/**
+ * The gate, from the RPC's boolean and whether it is still in flight. An
+ * undefined answer counts as loading: better to hold on the neutral scan
+ * affordance for a moment than to flash it and snatch it back — and, unlike the
+ * photo gate, a failed fetch should not lock scanning that the server would
+ * have allowed, so the caller decides its own fallback (see `useReceiptCap`).
+ */
+export function receiptCapStatus(
+  canAdd: boolean | undefined,
+  isLoading: boolean,
+): ReceiptCapStatus {
+  if (isLoading || canAdd === undefined) return 'loading';
+  return canAdd ? 'allowed' : 'locked';
+}
+
+/** What tapping the scan button should do in each state. */
+export type ReceiptTapAction = 'scan' | 'showLockedHint' | 'ignore';
+
+/**
+ * Tapping scan: read the bill only when allowed; when locked, point the person
+ * at how to unlock it; while the answer is still loading, do nothing rather
+ * than act on an unknown.
+ */
+export function receiptTapAction(status: ReceiptCapStatus): ReceiptTapAction {
+  switch (status) {
+    case 'allowed':
+      return 'scan';
+    case 'locked':
+      return 'showLockedHint';
+    case 'loading':
+      return 'ignore';
+  }
+}

--- a/apps/mobile/test/receiptCapGate.test.ts
+++ b/apps/mobile/test/receiptCapGate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { receiptCapStatus, receiptTapAction } from '@/lib/receiptCapGate';
+
+describe('receiptCapStatus', () => {
+  it('is loading while the RPC is in flight', () => {
+    expect(receiptCapStatus(undefined, true)).toBe('loading');
+    expect(receiptCapStatus(true, true)).toBe('loading');
+    expect(receiptCapStatus(false, true)).toBe('loading');
+  });
+
+  it('treats an undefined answer as loading even when not flagged loading', () => {
+    // A resolved query with no data yet must not read as "locked".
+    expect(receiptCapStatus(undefined, false)).toBe('loading');
+  });
+
+  it('is allowed only when the answer is a definite yes', () => {
+    expect(receiptCapStatus(true, false)).toBe('allowed');
+  });
+
+  it('is locked when the answer is a definite no', () => {
+    expect(receiptCapStatus(false, false)).toBe('locked');
+  });
+});
+
+describe('receiptTapAction', () => {
+  it('scans when allowed', () => {
+    expect(receiptTapAction('allowed')).toBe('scan');
+  });
+
+  it('points at the unlock path when locked', () => {
+    expect(receiptTapAction('locked')).toBe('showLockedHint');
+  });
+
+  it('does nothing while loading', () => {
+    expect(receiptTapAction('loading')).toBe('ignore');
+  });
+});

--- a/packages/db/prisma/migrations/20260818160000_receipt_cap/migration.sql
+++ b/packages/db/prisma/migrations/20260818160000_receipt_cap/migration.sql
@@ -1,0 +1,220 @@
+-- A per-group ceiling on receipts, set from the admin console (ADR-011 / A16).
+--
+-- Every group gets a number of receipts for free; past it, somebody has to pay
+-- or bring their own storage. Unlike the group-photo gate — a plain boolean
+-- entitlement — the receipt cap has a *number*, and that number must be a knob
+-- the console can turn without a deploy. `feature_flags` cannot hold it: a flag
+-- answers on/off and which A/B arm, never "how many", and the server could not
+-- read a limit out of an arm name cleanly.
+--
+-- So a second, deliberately tiny configuration table: `app_config`, one row per
+-- numeric knob. Same shape of trust as `feature_flags` — readable by any client
+-- (it is configuration, not data about a person), written by the service role
+-- alone. A limit a client could raise is not a limit.
+--
+-- The cap lifts entirely for a paid group, exactly like the photo gate: one
+-- member's subscription (or an unexpired group pass) frees the whole group.
+
+-- ─────────────────────────────────────────────────── the knob ──
+
+CREATE TABLE IF NOT EXISTS public.app_config (
+  key         text PRIMARY KEY,
+  value       integer NOT NULL,
+  description text NOT NULL DEFAULT '',
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+
+  -- Same identifier shape as a flag key, for the same reason: it is read from
+  -- code by name, and a key differing only by case is a bug nobody finds.
+  CONSTRAINT app_config_key_shape CHECK (key ~ '^[a-z][a-z0-9_]{1,60}$'),
+  -- A negative ceiling is never intended; zero means "paid only".
+  CONSTRAINT app_config_value_nonneg CHECK (value >= 0)
+);
+
+ALTER TABLE public.app_config ENABLE ROW LEVEL SECURITY;
+
+-- Readable by everybody signed in, guests included — the phone needs the number
+-- to draw the right affordance before it ever tries to scan, and offline
+-- (ADR-005). Nothing here is secret.
+DROP POLICY IF EXISTS app_config_read ON public.app_config;
+CREATE POLICY app_config_read ON public.app_config
+  FOR SELECT TO anon, authenticated USING (true);
+
+-- No write policy, so with RLS on only the service role can change a limit.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.app_config FROM anon, authenticated;
+
+-- The default ceiling. `ON CONFLICT DO NOTHING` so re-running the migration
+-- never stamps over a number the console has since changed.
+INSERT INTO public.app_config (key, value, description)
+VALUES ('receipt_cap_per_group', 3, 'Free receipts a group may hold before it must upgrade or add storage.')
+ON CONFLICT (key) DO NOTHING;
+
+-- ─────────────────────────────────────────── reading the knob ──
+
+/**
+ * The receipt ceiling, with a floor to fall back to.
+ *
+ * If the row is missing — a project the seed never reached — a sensible default
+ * rather than zero, so a misconfiguration is generous, not a lockout.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_receipt_cap()
+RETURNS integer
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE((SELECT value FROM public.app_config WHERE key = 'receipt_cap_per_group'), 3);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_receipt_cap() TO authenticated, anon, service_role;
+
+-- ────────────────────────────────────── is the group paid ──
+
+/**
+ * Whether a group is paid: any current member holds an active subscription, or
+ * the group itself has an unexpired pass. The same rule the photo gate uses,
+ * pulled into one function because both the client gate and the record path
+ * ask it. SECURITY DEFINER because a member cannot read another member's
+ * subscription under RLS; the answer is a bare boolean and reveals nothing
+ * about whose it was.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_group_is_paid(p_group_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.group_members gm
+     WHERE gm.group_id = p_group_id
+       AND gm.left_at IS NULL
+       AND gm.profile_id IS NOT NULL
+       AND public.baaki_profile_is_paid(gm.profile_id)
+  ) OR EXISTS (
+    SELECT 1 FROM public.group_passes gp
+     WHERE gp.group_id = p_group_id
+       AND gp.expires_at > now()
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_group_is_paid(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_group_is_paid(uuid) TO authenticated, service_role;
+
+-- ─────────────────────────────── may the caller add a receipt ──
+
+/**
+ * May the caller attach one more receipt to this group?
+ *   * not a member  → no (and it is not their business how many the group has);
+ *   * paid group    → always yes, the cap does not apply;
+ *   * otherwise     → yes while the group holds fewer than the cap.
+ *
+ * A bare boolean, like the photo gate. The client uses it to choose the scan
+ * button or the upsell; `baaki_record_receipt` enforces the same rule as the
+ * real boundary, so a client that ignores this answer still cannot exceed it.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_can_add_receipt(p_group_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+BEGIN
+  IF v_profile IS NULL OR p_group_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.group_members gm
+     WHERE gm.group_id = p_group_id
+       AND gm.profile_id = v_profile
+       AND gm.left_at IS NULL
+  ) THEN
+    RETURN false;
+  END IF;
+
+  IF public.baaki_group_is_paid(p_group_id) THEN
+    RETURN true;
+  END IF;
+
+  RETURN (SELECT count(*) FROM public.receipts WHERE group_id = p_group_id)
+         < public.baaki_receipt_cap();
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_can_add_receipt(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_can_add_receipt(uuid) TO authenticated;
+
+-- ──────────────────────── the cap as the real boundary ──
+-- `baaki_record_receipt` is the single service-role path that writes a receipt
+-- row (ADR-013), so the ceiling is enforced here where it cannot be bypassed.
+-- Re-declared whole (CREATE OR REPLACE) with the cap check added; the body is
+-- otherwise the 20260805140000 original.
+--
+-- Only a *new* row is capped. Re-recording an existing receipt id (a re-parse
+-- of the same bill) is an UPDATE and must always be let through, or a retry
+-- after the cap is reached would fail on a receipt that already counts.
+
+CREATE OR REPLACE FUNCTION public.baaki_record_receipt(
+  p_group_id     uuid,
+  p_receipt_id   uuid,
+  p_profile_id   uuid,
+  p_source       text,
+  p_storage_path text,
+  p_raw_text     text,
+  p_parsed       jsonb,
+  p_status       text,
+  p_input_tokens int DEFAULT 0,
+  p_output_tokens int DEFAULT 0
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  -- The ceiling, enforced at the one insert path. A paid group is exempt; an
+  -- update of a receipt that already exists is not a new receipt and is exempt.
+  IF NOT public.baaki_group_is_paid(p_group_id)
+     AND (p_receipt_id IS NULL
+          OR NOT EXISTS (SELECT 1 FROM public.receipts WHERE id = p_receipt_id))
+     AND (SELECT count(*) FROM public.receipts WHERE group_id = p_group_id)
+         >= public.baaki_receipt_cap()
+  THEN
+    RAISE EXCEPTION 'RECEIPT_CAP'
+      USING ERRCODE = 'check_violation',
+            HINT = 'This group has reached its receipt limit; upgrade or add storage to add more.';
+  END IF;
+
+  INSERT INTO public.receipts
+    (id, group_id, storage_path, source, raw_text, parse_status, parsed, created_by)
+  VALUES
+    (COALESCE(p_receipt_id, gen_random_uuid()), p_group_id, p_storage_path,
+     p_source::"ReceiptSource", p_raw_text, p_status::"ParseStatus", p_parsed,
+     public.baaki_my_member_id_for(p_group_id, p_profile_id))
+  ON CONFLICT (id) DO UPDATE
+    SET parsed = excluded.parsed,
+        parse_status = excluded.parse_status,
+        raw_text = excluded.raw_text
+  RETURNING id INTO v_id;
+
+  -- Metered because each scan has a real API cost to watch (ADR-011).
+  INSERT INTO public.usage_events
+    (profile_id, group_id, kind, input_tokens, output_tokens, metadata)
+  VALUES (p_profile_id, p_group_id, 'receipt_scan', p_input_tokens, p_output_tokens,
+          jsonb_build_object('receiptId', v_id, 'status', p_status));
+
+  RETURN v_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) TO service_role;

--- a/packages/db/prisma/migrations/20260818170000_receipt_cap_hardening/migration.sql
+++ b/packages/db/prisma/migrations/20260818170000_receipt_cap_hardening/migration.sql
@@ -1,0 +1,169 @@
+-- Hardening for the per-group receipt cap (20260818160000_receipt_cap).
+--
+-- Two follow-ups to that migration, both re-declared whole (CREATE OR REPLACE)
+-- so this migration is idempotent and safe to re-run:
+--
+--   E. A TOCTOU race. `baaki_record_receipt` checks the count and then inserts
+--      in two steps; two concurrent transactions could both pass the count and
+--      both insert, taking an unpaid group one (or more) over its ceiling. The
+--      count and the insert must be atomic against a concurrent recorder for
+--      the *same group*. A transaction-scoped advisory lock keyed on the group
+--      serializes recording per group — the same device the ghost-merge path
+--      uses to serialize per owner (20260816150000). Different groups never
+--      contend (only a hash collision would, harmlessly).
+--
+--   F. A re-parse wrongly blocked at the edge. `baaki_can_add_receipt` returned
+--      false whenever the group sat at cap, even when the request was
+--      re-scanning an *existing* receipt — an update, which the recorder itself
+--      correctly allows. The edge function calls this before spending on the
+--      model, so at cap a legitimate re-parse was refused with a 429 that the
+--      recorder would never have raised. The gate now takes an optional receipt
+--      id and mirrors the recorder's update exemption.
+
+-- ─────────────────────────────── may the caller add a receipt ──
+
+/**
+ * May the caller attach one more receipt to this group?
+ *   * re-parse of an existing receipt (p_receipt_id already in the group)
+ *                   → always yes; it is an update, not a new receipt, and the
+ *                     recorder lets it through even at cap;
+ *   * not a member  → no (and it is not their business how many the group has);
+ *   * paid group    → always yes, the cap does not apply;
+ *   * otherwise     → yes while the group holds fewer than the cap.
+ *
+ * `p_receipt_id` defaults to NULL so the existing one-argument callers (the
+ * mobile client's `canAddReceipt`, which only knows the group) keep working and
+ * keep the new-receipt semantics. A bare boolean, like the photo gate; the real
+ * boundary is `baaki_record_receipt`, which enforces the same rule.
+ */
+
+-- Drop the previous one-argument overload first. If both it and the new
+-- two-argument form (with a defaulted second arg) existed, a one-argument call
+-- would match both and Postgres would raise "function is not unique". Removing
+-- it makes the defaulted form the sole match for the mobile client's 1-arg call.
+DROP FUNCTION IF EXISTS public.baaki_can_add_receipt(uuid);
+
+CREATE OR REPLACE FUNCTION public.baaki_can_add_receipt(
+  p_group_id   uuid,
+  p_receipt_id uuid DEFAULT NULL
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+BEGIN
+  IF v_profile IS NULL OR p_group_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.group_members gm
+     WHERE gm.group_id = p_group_id
+       AND gm.profile_id = v_profile
+       AND gm.left_at IS NULL
+  ) THEN
+    RETURN false;
+  END IF;
+
+  -- A re-parse of a receipt that already belongs to this group is an update,
+  -- never a new row against the ceiling. Exactly the recorder's exemption, so
+  -- the gate cannot refuse what the boundary would allow.
+  IF p_receipt_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.receipts
+     WHERE id = p_receipt_id
+       AND group_id = p_group_id
+  ) THEN
+    RETURN true;
+  END IF;
+
+  IF public.baaki_group_is_paid(p_group_id) THEN
+    RETURN true;
+  END IF;
+
+  RETURN (SELECT count(*) FROM public.receipts WHERE group_id = p_group_id)
+         < public.baaki_receipt_cap();
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_can_add_receipt(uuid, uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_can_add_receipt(uuid, uuid) TO authenticated;
+
+-- ──────────────────────── the cap as the real boundary ──
+-- Re-declared whole with a per-group transaction advisory lock at the top of
+-- the block, before the cap check, held (xact-scoped) through the INSERT. The
+-- count and the write are now atomic against a concurrent recorder for the same
+-- group, closing the TOCTOU window. Body is otherwise the 20260818160000
+-- version unchanged; same REVOKE/GRANT (service_role only).
+
+CREATE OR REPLACE FUNCTION public.baaki_record_receipt(
+  p_group_id     uuid,
+  p_receipt_id   uuid,
+  p_profile_id   uuid,
+  p_source       text,
+  p_storage_path text,
+  p_raw_text     text,
+  p_parsed       jsonb,
+  p_status       text,
+  p_input_tokens int DEFAULT 0,
+  p_output_tokens int DEFAULT 0
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  -- Serialize recording for this group. Without it the count below and the
+  -- INSERT are two steps: two concurrent callers could both count < cap and
+  -- both insert, exceeding the ceiling. Keyed on the group so only same-group
+  -- recorders wait; released on commit/rollback. Same lock device as the
+  -- ghost-merge serialization (20260816150000).
+  PERFORM pg_advisory_xact_lock(hashtext('baaki_record_receipt:' || p_group_id::text)::bigint);
+
+  -- The ceiling, enforced at the one insert path. A paid group is exempt; an
+  -- update of a receipt that already exists is not a new receipt and is exempt.
+  IF NOT public.baaki_group_is_paid(p_group_id)
+     AND (p_receipt_id IS NULL
+          OR NOT EXISTS (SELECT 1 FROM public.receipts WHERE id = p_receipt_id))
+     AND (SELECT count(*) FROM public.receipts WHERE group_id = p_group_id)
+         >= public.baaki_receipt_cap()
+  THEN
+    RAISE EXCEPTION 'RECEIPT_CAP'
+      USING ERRCODE = 'check_violation',
+            HINT = 'This group has reached its receipt limit; upgrade or add storage to add more.';
+  END IF;
+
+  INSERT INTO public.receipts
+    (id, group_id, storage_path, source, raw_text, parse_status, parsed, created_by)
+  VALUES
+    (COALESCE(p_receipt_id, gen_random_uuid()), p_group_id, p_storage_path,
+     p_source::"ReceiptSource", p_raw_text, p_status::"ParseStatus", p_parsed,
+     public.baaki_my_member_id_for(p_group_id, p_profile_id))
+  ON CONFLICT (id) DO UPDATE
+    SET parsed = excluded.parsed,
+        parse_status = excluded.parse_status,
+        raw_text = excluded.raw_text
+  RETURNING id INTO v_id;
+
+  -- Metered because each scan has a real API cost to watch (ADR-011).
+  INSERT INTO public.usage_events
+    (profile_id, group_id, kind, input_tokens, output_tokens, metadata)
+  VALUES (p_profile_id, p_group_id, 'receipt_scan', p_input_tokens, p_output_tokens,
+          jsonb_build_object('receiptId', v_id, 'status', p_status));
+
+  RETURN v_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) TO service_role;

--- a/packages/db/prisma/migrations/20260818180000_receipt_cap_group_scope/migration.sql
+++ b/packages/db/prisma/migrations/20260818180000_receipt_cap_group_scope/migration.sql
@@ -1,0 +1,108 @@
+-- Group-scope the receipt recorder (hardening for 20260818170000).
+--
+-- `baaki_record_receipt` is the single service-role write path for a receipt, so
+-- it is the real boundary — the gate `baaki_can_add_receipt` only decides an
+-- affordance. Two holes let a caller reference a receipt id that belongs to a
+-- DIFFERENT group:
+--
+--   * the cap-exemption `EXISTS` looked up the id alone, so passing any existing
+--     receipt id (from any group) skipped the ceiling; and
+--   * `ON CONFLICT (id) DO UPDATE` matched by id alone, so the same forged id
+--     would overwrite another group's receipt (its parsed text, status) — a
+--     cross-group tamper, even though `group_id` itself was never rewritten.
+--
+-- The gate already qualifies the exemption by `(id, group_id)` (its update
+-- exemption only fires when the receipt is in *this* group); the recorder must
+-- do the same, and refuse rather than silently no-op when a conflicting id turns
+-- out to belong elsewhere.
+--
+-- Re-declared whole (CREATE OR REPLACE), idempotent; advisory lock and cap check
+-- are the 20260818170000 version, with the id lookups group-qualified and a
+-- guard on a conflict that resolves to another group's row.
+
+CREATE OR REPLACE FUNCTION public.baaki_record_receipt(
+  p_group_id     uuid,
+  p_receipt_id   uuid,
+  p_profile_id   uuid,
+  p_source       text,
+  p_storage_path text,
+  p_raw_text     text,
+  p_parsed       jsonb,
+  p_status       text,
+  p_input_tokens int DEFAULT 0,
+  p_output_tokens int DEFAULT 0
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  -- Serialize recording for this group, so the count below and the INSERT are
+  -- atomic against a concurrent recorder for the same group (TOCTOU). Keyed on
+  -- the group, released on commit/rollback. Same device as the ghost-merge
+  -- serialization (20260816150000).
+  PERFORM pg_advisory_xact_lock(hashtext('baaki_record_receipt:' || p_group_id::text)::bigint);
+
+  -- The ceiling, enforced at the one insert path. A paid group is exempt; an
+  -- update of a receipt that already exists IN THIS GROUP is not a new receipt
+  -- and is exempt — the id must belong to p_group_id, or a receipt id borrowed
+  -- from another group would slip past the cap.
+  IF NOT public.baaki_group_is_paid(p_group_id)
+     AND (p_receipt_id IS NULL
+          OR NOT EXISTS (
+            SELECT 1 FROM public.receipts
+             WHERE id = p_receipt_id AND group_id = p_group_id
+          ))
+     AND (SELECT count(*) FROM public.receipts WHERE group_id = p_group_id)
+         >= public.baaki_receipt_cap()
+  THEN
+    RAISE EXCEPTION 'RECEIPT_CAP'
+      USING ERRCODE = 'check_violation',
+            HINT = 'This group has reached its receipt limit; upgrade or add storage to add more.';
+  END IF;
+
+  -- Insert, or update only when the conflicting row is already this group's. The
+  -- `WHERE receipts.group_id = p_group_id` on the conflict means a forged id that
+  -- belongs to another group matches nothing to update and returns no row —
+  -- group_id is never rewritten and another group's receipt is never touched.
+  INSERT INTO public.receipts
+    (id, group_id, storage_path, source, raw_text, parse_status, parsed, created_by)
+  VALUES
+    (COALESCE(p_receipt_id, gen_random_uuid()), p_group_id, p_storage_path,
+     p_source::"ReceiptSource", p_raw_text, p_status::"ParseStatus", p_parsed,
+     public.baaki_my_member_id_for(p_group_id, p_profile_id))
+  ON CONFLICT (id) DO UPDATE
+    SET parsed = excluded.parsed,
+        parse_status = excluded.parse_status,
+        raw_text = excluded.raw_text
+    WHERE receipts.group_id = p_group_id
+  RETURNING id INTO v_id;
+
+  -- No row means the id exists but in a different group: the conflict skipped the
+  -- INSERT and the group-scoped WHERE skipped the UPDATE. Refuse rather than
+  -- return NULL, so a caller cannot probe or touch another group's receipt.
+  IF v_id IS NULL THEN
+    RAISE EXCEPTION 'RECEIPT_GROUP_MISMATCH'
+      USING ERRCODE = 'check_violation',
+            HINT = 'That receipt belongs to a different group.';
+  END IF;
+
+  -- Metered because each scan has a real API cost to watch (ADR-011).
+  INSERT INTO public.usage_events
+    (profile_id, group_id, kind, input_tokens, output_tokens, metadata)
+  VALUES (p_profile_id, p_group_id, 'receipt_scan', p_input_tokens, p_output_tokens,
+          jsonb_build_object('receiptId', v_id, 'status', p_status));
+
+  RETURN v_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) TO service_role;

--- a/packages/db/prisma/migrations/20260818190000_receipt_group_mismatch_early/migration.sql
+++ b/packages/db/prisma/migrations/20260818190000_receipt_group_mismatch_early/migration.sql
@@ -1,0 +1,111 @@
+-- Raise the cross-group receipt id early (refines 20260818180000).
+--
+-- 20260818180000 made `baaki_record_receipt` safe against a receipt id from
+-- another group — the group-scoped ON CONFLICT never overwrites it, and the
+-- NULL-RETURNING guard refuses it. But it only refused *after* the cap check, so
+-- a foreign id against a group already at cap raised RECEIPT_CAP rather than the
+-- accurate RECEIPT_GROUP_MISMATCH, and reported the group's cap state for a
+-- receipt that was never in it.
+--
+-- Decide the group question first: right after the advisory lock, before the
+-- cap check, a non-null id that exists in a DIFFERENT group is rejected outright.
+-- Valid or null ids fall through to the unchanged cap behaviour. The post-INSERT
+-- NULL guard stays as a backstop but is now unreachable for the cross-group case.
+--
+-- Re-declared whole (CREATE OR REPLACE), idempotent; same REVOKE/GRANT.
+
+CREATE OR REPLACE FUNCTION public.baaki_record_receipt(
+  p_group_id     uuid,
+  p_receipt_id   uuid,
+  p_profile_id   uuid,
+  p_source       text,
+  p_storage_path text,
+  p_raw_text     text,
+  p_parsed       jsonb,
+  p_status       text,
+  p_input_tokens int DEFAULT 0,
+  p_output_tokens int DEFAULT 0
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  -- Serialize recording for this group, so the count below and the INSERT are
+  -- atomic against a concurrent recorder for the same group (TOCTOU). Keyed on
+  -- the group, released on commit/rollback. Same device as the ghost-merge
+  -- serialization (20260816150000).
+  PERFORM pg_advisory_xact_lock(hashtext('baaki_record_receipt:' || p_group_id::text)::bigint);
+
+  -- The group question first: a non-null id that already exists in a DIFFERENT
+  -- group is neither a new receipt for this group nor a valid update of one, so
+  -- it is refused before the cap is even consulted — an accurate error, and no
+  -- report of this group's cap state for a receipt that was never in it.
+  IF p_receipt_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.receipts
+     WHERE id = p_receipt_id AND group_id <> p_group_id
+  ) THEN
+    RAISE EXCEPTION 'RECEIPT_GROUP_MISMATCH'
+      USING ERRCODE = 'check_violation',
+            HINT = 'That receipt belongs to a different group.';
+  END IF;
+
+  -- The ceiling, enforced at the one insert path. A paid group is exempt; an
+  -- update of a receipt that already exists IN THIS GROUP is not a new receipt
+  -- and is exempt.
+  IF NOT public.baaki_group_is_paid(p_group_id)
+     AND (p_receipt_id IS NULL
+          OR NOT EXISTS (
+            SELECT 1 FROM public.receipts
+             WHERE id = p_receipt_id AND group_id = p_group_id
+          ))
+     AND (SELECT count(*) FROM public.receipts WHERE group_id = p_group_id)
+         >= public.baaki_receipt_cap()
+  THEN
+    RAISE EXCEPTION 'RECEIPT_CAP'
+      USING ERRCODE = 'check_violation',
+            HINT = 'This group has reached its receipt limit; upgrade or add storage to add more.';
+  END IF;
+
+  -- Insert, or update only when the conflicting row is already this group's. The
+  -- cross-group case is already refused above; this WHERE is the backstop.
+  INSERT INTO public.receipts
+    (id, group_id, storage_path, source, raw_text, parse_status, parsed, created_by)
+  VALUES
+    (COALESCE(p_receipt_id, gen_random_uuid()), p_group_id, p_storage_path,
+     p_source::"ReceiptSource", p_raw_text, p_status::"ParseStatus", p_parsed,
+     public.baaki_my_member_id_for(p_group_id, p_profile_id))
+  ON CONFLICT (id) DO UPDATE
+    SET parsed = excluded.parsed,
+        parse_status = excluded.parse_status,
+        raw_text = excluded.raw_text
+    WHERE receipts.group_id = p_group_id
+  RETURNING id INTO v_id;
+
+  -- Backstop: no row means the id exists but in a different group (already caught
+  -- above). Refuse rather than return NULL.
+  IF v_id IS NULL THEN
+    RAISE EXCEPTION 'RECEIPT_GROUP_MISMATCH'
+      USING ERRCODE = 'check_violation',
+            HINT = 'That receipt belongs to a different group.';
+  END IF;
+
+  -- Metered because each scan has a real API cost to watch (ADR-011).
+  INSERT INTO public.usage_events
+    (profile_id, group_id, kind, input_tokens, output_tokens, metadata)
+  VALUES (p_profile_id, p_group_id, 'receipt_scan', p_input_tokens, p_output_tokens,
+          jsonb_build_object('receiptId', v_id, 'status', p_status));
+
+  RETURN v_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_record_receipt(
+  uuid, uuid, uuid, text, text, text, jsonb, text, int, int
+) TO service_role;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1260,3 +1260,17 @@ model RateLimitSetting {
   @@map("rate_limit_settings")
   @@schema("public")
 }
+
+/// A numeric knob the admin console turns without a deploy — the receipt cap
+/// lives here (see 20260818160000_receipt_cap). One row per limit. Readable by
+/// clients (it is configuration, not data about a person); written by the
+/// service role alone, so a limit a client could raise is not a limit.
+model AppConfig {
+  key         String   @id
+  value       Int
+  description String   @default("")
+  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@map("app_config")
+  @@schema("public")
+}

--- a/supabase/functions/receipt-parse/index.ts
+++ b/supabase/functions/receipt-parse/index.ts
@@ -187,8 +187,13 @@ serveWithCors(async (request) => {
     // means an unpaid group that has filled its free receipts. `record_receipt`
     // enforces the same rule as the real boundary, so this is only to save the
     // model call and give a clean 429 instead of a raised `RECEIPT_CAP`.
+    //
+    // Pass the receipt id so a re-parse of an *existing* receipt (an update) is
+    // not refused at cap: the recorder lets an update through, and the gate must
+    // agree or a legitimate re-scan is blocked with a spend that never happens.
     const { data: canAdd } = await caller.rpc('baaki_can_add_receipt', {
       p_group_id: body.groupId,
+      p_receipt_id: body.receiptId ?? null,
     });
     if (canAdd === false) {
       throw new HttpError(

--- a/supabase/functions/receipt-parse/index.ts
+++ b/supabase/functions/receipt-parse/index.ts
@@ -181,6 +181,23 @@ serveWithCors(async (request) => {
       );
     }
 
+    // The per-group receipt ceiling (ADR-011). Checked before the model call
+    // for the same reason as the quota: refuse a spend that would be capped at
+    // record time anyway. Paid groups are exempt inside the RPC; a `false` here
+    // means an unpaid group that has filled its free receipts. `record_receipt`
+    // enforces the same rule as the real boundary, so this is only to save the
+    // model call and give a clean 429 instead of a raised `RECEIPT_CAP`.
+    const { data: canAdd } = await caller.rpc('baaki_can_add_receipt', {
+      p_group_id: body.groupId,
+    });
+    if (canAdd === false) {
+      throw new HttpError(
+        429,
+        'RECEIPT_CAP_REACHED',
+        'This group has reached its receipt limit. Upgrade or add storage to add more.',
+      );
+    }
+
     const content: unknown[] = [];
     if (body.storagePath) {
       // IDOR guard: the download runs with the service role, which bypasses


### PR DESCRIPTION
## What

A per-group ceiling on receipts, with the limit **controllable from the admin console** (not hardcoded). Any group holds a set number of receipts for free; past the cap, scanning is a paid feature — unlock by **upgrading** or **adding your own storage**. A **paid group has no cap** (any member subscribed, or an unexpired group pass lifts it for everyone — same rule as the group-photo gate).

## The number is a knob, not a constant

`feature_flags` only answers on/off + which A/B arm — it can't hold "how many". So a new tiny **`app_config`** table holds numeric limits: readable by any client (it's configuration, not data about a person), written by the service role alone. Seeded at `receipt_cap_per_group = 3`. The console turns it without a deploy.

## Enforcement — mirrors the group-photo gate

- **Server (real boundary):** `baaki_can_add_receipt(group[, receiptId])` RPC + a cap check inside `baaki_record_receipt`, the single service-role insert path (ADR-013). Only a *new* receipt is capped; re-recording an existing id (a re-parse) always passes. A **per-group transaction advisory lock** serializes recording so concurrent callers can't race past the ceiling (TOCTOU).
- **Edge:** `receipt-parse` refuses early with `RECEIPT_CAP_REACHED` so the model isn't called for a capped group; passes `p_receipt_id` so a legitimate re-parse at cap is not wrongly blocked.
- **Client:** pure `receiptCapGate` module + a `useQuery` gates the scan cards in `add-expense` and `itemize`; locked state shows **Upgrade** / **Add storage** (`/settings/upgrade`, `/settings/backup`). The gate query is invalidated after each successful scan so it reflects the new count. A failed gate fetch falls open (the server still enforces).

## Admin

New **Limits** page (`apps/admin/config`) editing `app_config` values via a service-role server action. Blank value is rejected (0 stays valid, = paid-only), input is `required`, and a no-row / unknown-key update throws instead of silently reporting "Saved".

## Also in this PR

- Dashboard balance carousel headed every per-currency card identically ("Your balance"), so two currencies read as two identical cards — the heading now composes the currency ("Your balance · USD").
- i18n for the locked copy across all five locales. Prisma `AppConfig` model added.

## Migrations

- `20260818160000_receipt_cap` — table, seed, `baaki_receipt_cap` / `baaki_group_is_paid` / `baaki_can_add_receipt`, cap check in `baaki_record_receipt`.
- `20260818170000_receipt_cap_hardening` — advisory lock (TOCTOU), `receiptId`-aware `can_add_receipt` (drops the old 1-arg overload to avoid an ambiguous match).

## Gates

Green: mobile `tsc` + `eslint` + `vitest` (286), admin `tsc` + `lint`, `prisma validate`.

## Deploy status

**Applied to prod (2026-08-18):** both migrations deployed and verified (`app_config.receipt_cap_per_group=3`; `baaki_can_add_receipt` is the 2-arg form). Edge `receipt-parse` deployed. Admin app (Vercel) not pushed — separate deploy if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable receipt limits for groups.
  - Added a Limits page in the admin area for viewing and updating numeric settings.
  - Added upgrade and storage options when a group reaches its receipt allowance.
  - Added receipt-capacity messaging in English, Tamil, Hindi, and Arabic.

- **Bug Fixes**
  - Prevented over-limit receipt submissions, including concurrent attempts.
  - Allowed existing receipts to be reprocessed safely.

- **Style**
  - Updated the dashboard heading to display the currency inline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->