### PR TITLE
fix(mobile): dashboard polish — new-group in toolbar, teal balance, sync/camera fixes

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -85,6 +85,7 @@ export default function HomeScreen() {
       { icon: 'cloud-done-outline', label: t.backup.title, route: '/settings/backup' },
       { icon: 'language-outline', label: t.language, route: '/settings/language' },
       { icon: 'contrast-outline', label: t.account.themeRow, route: '/settings/theme' },
+      { icon: 'key-outline', label: t.account.aiKeysRow, route: '/settings/ai-keys' },
       { icon: 'settings-outline', label: t.account.faceSettings, route: '/profile' },
     ],
     [t],
@@ -198,9 +199,38 @@ export default function HomeScreen() {
               well. It replaces the wide banner the dashboard used to carry. */}
           <SyncStatusIcon />
           {/* Bare icons, no button chrome — the header reads as a title row, not
-              a toolbar of pills. Straight to the camera: the icon is a scanner,
-              so it opens one rather than a form to fill in first (the capture
-              screen reads the `scan` flag and launches the camera on mount). */}
+              a toolbar of pills. Create a group: the plainest way to start one,
+              sitting with the other top actions rather than inside the group
+              list where its button crowded the title row. */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.newGroup}
+            onPress={openNewGroup}
+            hitSlop={10}
+            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+          >
+            {/* People glyph with a small "+" badge, so the action reads as
+                "create a group" rather than "go to groups". The badge sits in a
+                page-coloured disc at the corner so the plus separates cleanly
+                from the people strokes underneath it. */}
+            <View>
+              <Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.text} />
+              <View
+                style={{
+                  position: 'absolute',
+                  right: -5,
+                  bottom: -5,
+                  borderRadius: 999,
+                  backgroundColor: theme.color.bg,
+                }}
+              >
+                <Ionicons name="add-circle" size={iconSize.base} color={theme.color.brand} />
+              </View>
+            </View>
+          </Pressable>
+          {/* Straight to the camera: the icon is a scanner, so it opens one
+              rather than a form to fill in first (the capture screen reads the
+              `scan` flag and launches the camera on mount). */}
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={t.captures.captureCta}
@@ -297,18 +327,9 @@ export default function HomeScreen() {
           />
         ) : (
           <View>
-            <SectionHeader
-              title={t.yourGroups}
-              action={
-                <Button
-                  label={t.newGroup}
-                  size="sm"
-                  icon={<Ionicons name="add" size={iconSize.base} color={theme.color.onBrand} />}
-                  onPress={openNewGroup}
-                  style={{ height: 32, paddingHorizontal: theme.spacing.md, gap: theme.spacing.xs }}
-                />
-              }
-            />
+            {/* No action here anymore — "new group" lives in the top toolbar
+                next to the camera, so the title row never crowds or clips. */}
+            <SectionHeader title={t.yourGroups} />
             {presentTypes.length > 1 ? (
               <CategoryStrip types={presentTypes} active={active} onSelect={setCategory} t={t} />
             ) : null}
@@ -1070,7 +1091,7 @@ function ActionSlide({
 }
 
 /**
- * One balance card, coloured by its verdict: a green wash when the net is owed
+ * One balance card, coloured by its verdict: a teal wash when the net is owed
  * to you, red when you owe, and the neutral brand wash once everything is
  * settled — so the card's colour, not just its number, tells you where you
  * stand at a glance. The net big, the owed/owe split beneath.

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -230,12 +230,18 @@ export default function CaptureScreen() {
 
   // "Straight to the camera": when opened from the dashboard scanner icon, fire
   // the capture once on mount rather than waiting for a tap on "Add receipt".
-  // The ref guards against the effect running twice (React 18 strict mode, or a
-  // re-render mid-scan).
+  //
+  // The ref guards a double-run within one mount (React 18 strict mode, or a
+  // re-render mid-scan). It does NOT survive a remount, and Android recreates
+  // the JS activity when it returns from the separate native camera activity —
+  // so after the user closes the camera the screen could remount, still see
+  // `scan=1`, and pop the camera open again, on a loop. Clearing the param the
+  // moment we fire means a remount sees no `scan` and leaves the form alone.
   const autoScanned = useRef(false);
   useEffect(() => {
     if (scan && !autoScanned.current) {
       autoScanned.current = true;
+      router.setParams({ scan: undefined });
       void addReceipt();
     }
     // addReceipt is stable enough for a one-shot; deps intentionally minimal.

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -283,7 +283,13 @@ export class SyncEngine {
     // happened to name one. The `!online` case already returned above, so the
     // one round trip this costs a brand-new guest is against their own empty
     // ledger, once, and tells them the truth either way.
-    this.set({ status: SyncStatus.Syncing });
+    //
+    // Only announce "syncing" when there is something the user actually queued
+    // to push. The 30s poll also runs this round trip to pull the mirror when
+    // nothing is queued, and flipping to Syncing for that made the header glyph
+    // blink and spin every interval for a routine background fetch nobody asked
+    // to watch. A silent pull leaves the status where it was (Idle).
+    if (batch.length > 0) this.set({ status: SyncStatus.Syncing });
 
     try {
       const { data, error } = await supabase.functions.invoke('sync', {

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -94,14 +94,14 @@ export const gradients = {
   // and off warning amber so it never reads as a status. Every stop holds white.
   accentLight: ['#0369A1', '#2563EB', '#4F46E5'],
   accentDark: ['#0C4A6E', '#1E40AF', '#3730A3'],
-  // The balance card wears its verdict: a green wash when the net is in your
+  // The balance card wears its verdict: a teal wash when the net is in your
   // favour, a red one when you owe. Both are the money hues (positive/negative)
   // deepened across three stops so the white balance and its small labels stay
   // legible on every corner — the same rule the brand wash follows above. The
   // neutral, all-settled state keeps the brand wash, so colour only ever
   // appears when there is a debt to point at.
-  positiveLight: ['#065F46', '#0A6E4E', '#0E9F6E'],
-  positiveDark: ['#053D2E', '#065F46', '#0A7E59'],
+  positiveLight: ['#0A5A5F', '#0A6E70', '#0E9F8E'],
+  positiveDark: ['#04403E', '#065F5C', '#0A7E76'],
   negativeLight: ['#8C1D3F', '#B01D50', '#D22C63'],
   negativeDark: ['#611228', '#8C1D3F', '#A81F4C'],
 } as const;


### PR DESCRIPTION
## What

Dashboard polish pass from live device testing.

- **New group** moved from the section-header pill (crowded/clipped the "Your groups" title, worse in Tamil/Hindi/Arabic) to a **toolbar icon next to the camera**, with a `+` badge so it reads as *create a group*, not *go to groups*.
- **Balance carousel** owed-wash retinted **green → teal** (`positive` gradient token). Owe stays red, settled purple — three verdicts stay distinct.
- **Sync header glyph** no longer blinks/spins every 30s: `Syncing` status is set only when there are queued mutations to push, not for a routine background mirror pull.
- **Capture camera reopen loop** fixed: clear the `scan` param the instant auto-scan fires, so an Android activity-recreation remount (returning from the native camera) does not re-pop the camera.

## Test

- `tsc --noEmit` clean (mobile + ui).
- Verified live on emulator: toolbar group icon + badge, teal reserved for owed, no spinner blink, camera opens once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an AI Keys destination to the dashboard overflow menu.
  - Moved the “New Group” action to the top toolbar for easier access.

- **Bug Fixes**
  - Prevented receipt capture from launching repeatedly after screen remounts.
  - Improved synchronization status handling so pull-only updates don’t display an unnecessary syncing state.

- **Style**
  - Updated positive balance gradients from green to teal across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->