### PR TITLE
fix(mobile): dashboard balance red-flash + voice review polish

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -304,7 +304,7 @@ export default function HomeScreen() {
             the category (Cleo, Monzo, Wise) all keep balances as slides of a
             single deck. While the balance loads a hero-shaped skeleton stands in
             rather than a card of confident zeros the query has not returned. */}
-        {summary.isLoading ? (
+        {summary.isLoading || summary.pendingFirstSync ? (
           <HeroSkeleton />
         ) : (
           <HeroDeck

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -47,7 +47,7 @@ import {
   useGroups,
   useWriteExpense,
 } from '@/data/hooks';
-import { groupLabel, GroupType } from '@/data/types';
+import { groupLabel, GroupType, type GroupRow } from '@/data/types';
 import { deviceDefaultCurrency, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { aiEnabled, useAiAccess } from '@/lib/aiAccess';
@@ -308,8 +308,20 @@ export default function VoiceScreen() {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md, justifyContent: 'space-between' }}>
-          <Text variant="heading">{phase === 'review' ? t.voice.review : t.voice.title}</Text>
+        <Row
+          style={{
+            paddingTop: theme.spacing.md,
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          {/* The heading wears the voice glyph so the screen reads as "the thing
+              you spoke", not a generic form — the same mic that started the
+              flow, carried through to the review. */}
+          <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+            <Ionicons name="mic" size={iconSize.lg} color={theme.color.brand} />
+            <Text variant="heading">{phase === 'review' ? t.voice.review : t.voice.title}</Text>
+          </Row>
           <IconButton label={t.common.close} onPress={() => router.back()}>
             <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
@@ -355,6 +367,7 @@ export default function VoiceScreen() {
               label={plural(locale, drafts.length, t.voice.save)}
               onPress={() => void save()}
               disabled={!canSave}
+              style={{ alignSelf: 'center' }}
             />
           </View>
         ) : (
@@ -377,6 +390,16 @@ export default function VoiceScreen() {
   );
 }
 
+/** One Ionicon per group type, the fallback when a group has no cover emoji —
+ * echoing the new-group picker and the dashboard's category glyphs. */
+const GROUP_TYPE_ICON: Record<GroupType, React.ComponentProps<typeof Ionicons>['name']> = {
+  [GroupType.Trip]: 'airplane',
+  [GroupType.Home]: 'home',
+  [GroupType.Couple]: 'heart',
+  [GroupType.Event]: 'sparkles',
+  [GroupType.Other]: 'people-outline',
+};
+
 /**
  * The one choice a Save needs: where the expenses land. The capture inbox is
  * always offered and is the default; a "new group" row appears when the sentence
@@ -393,14 +416,17 @@ function DestinationPicker({
   dest: Dest;
   requested: { groupId: string; memberId: string; name: string } | null;
   onChoose: (dest: Dest) => void;
-  groups: { id: string; name: string | null }[];
+  groups: GroupRow[];
   t: ReturnType<typeof useStrings>['t'];
   theme: ReturnType<typeof useTheme>;
 }) {
   type Row = {
     key: string;
     label: string;
+    // A row wears either the group's own cover emoji or, lacking one, an Ionicon
+    // — the inbox and "new group" rows only ever use an icon.
     icon: React.ComponentProps<typeof Ionicons>['name'];
+    emoji?: string | null;
     selected: boolean;
     onPress: () => void;
   };
@@ -426,11 +452,18 @@ function DestinationPicker({
       onPress: () => onChoose({ kind: 'create', ...requested }),
     });
   }
-  for (const group of groups) {
+  // Newest group first: the one you just made is the one you are most likely
+  // saving into, so it sits at the top of the list rather than lost in creation
+  // order. Every row carries its own cover emoji (or a type glyph as a fallback)
+  // so a trip, a home and an event are told apart at a glance instead of a
+  // column of identical people icons.
+  const sorted = [...groups].sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+  for (const group of sorted) {
     rows.push({
       key: group.id,
       label: groupLabel(group),
-      icon: 'people-outline',
+      icon: GROUP_TYPE_ICON[group.type] ?? 'people-outline',
+      emoji: group.cover_emoji,
       selected: dest.kind === 'existing' && dest.groupId === group.id,
       onPress: () => onChoose({ kind: 'existing', groupId: group.id }),
     });
@@ -471,11 +504,15 @@ function DestinationPicker({
                   backgroundColor: row.selected ? theme.color.brandSoft : theme.color.surfaceMuted,
                 }}
               >
-                <Ionicons
-                  name={row.icon}
-                  size={iconSize.md}
-                  color={row.selected ? theme.color.brand : theme.color.textMuted}
-                />
+                {row.emoji ? (
+                  <Text style={{ fontSize: 18 }}>{row.emoji}</Text>
+                ) : (
+                  <Ionicons
+                    name={row.icon}
+                    size={iconSize.md}
+                    color={row.selected ? theme.color.brand : theme.color.textMuted}
+                  />
+                )}
               </View>
               <Text
                 numberOfLines={1}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -213,7 +213,7 @@ export function useSettledTotals(profileId: string | null): LocalRead<Map<string
  * already in them, because `materialiseExpenses` replays the queue on top.
  */
 export function useHomeSummary(profileId: string | null) {
-  const { mirror, queue, hydrated, status, flush } = useSync();
+  const { mirror, queue, hydrated, status, lastSyncedAt, flush } = useSync();
 
   const summary = useMemo(() => {
     const membersByGroup = new Map<string, MemberRow[]>();
@@ -268,6 +268,22 @@ export function useHomeSummary(profileId: string | null) {
     totals: summary.totals,
     isLoading: !hydrated,
     isFetching: status === 'syncing',
+    // The mirror hydrates from disk instantly (ADR-005), but that snapshot can
+    // be behind the server — a settlement that cleared your debt may only exist
+    // server-side until the session's first pull lands. Painting a confident,
+    // colour-coded balance from stale local data means the card can read "you
+    // owe" (red) and then flip once the sync reconciles — the exact jump the
+    // hero skeleton exists to hide. So the balance is only trustworthy once the
+    // first sync of the session has settled. `lastSyncedAt` is in-memory and
+    // starts null each launch, so it marks *this session's* first success.
+    //
+    // Bounded, never a hang: the provider kicks one `flush` on mount, which
+    // resolves to either `lastSyncedAt` set (success) or a can't-sync status
+    // (offline/metered/error). In those states there is nothing better than the
+    // local snapshot, so fall through and show it at once rather than shimmer
+    // forever — local-first still wins whenever the network can't answer.
+    pendingFirstSync:
+      hydrated && lastSyncedAt === null && (status === 'idle' || status === 'syncing'),
     refetch: () => void flush(),
   };
 }

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -100,7 +100,7 @@ export const gradients = {
   // legible on every corner — the same rule the brand wash follows above. The
   // neutral, all-settled state keeps the brand wash, so colour only ever
   // appears when there is a debt to point at.
-  positiveLight: ['#0A5A5F', '#0A6E70', '#0E9F8E'],
+  positiveLight: ['#0A5A5F', '#0A6E70', '#0A7E76'],
   positiveDark: ['#04403E', '#065F5C', '#0A7E76'],
   negativeLight: ['#8C1D3F', '#B01D50', '#D22C63'],
   negativeDark: ['#611228', '#8C1D3F', '#A81F4C'],


### PR DESCRIPTION
Stacked on #267 (`fix/dashboard-polish`) — diff here is only this batch.

## Dashboard balance red-flash
The hero balance is computed local-first (ADR-005) from the on-disk mirror, which can be behind the server — a settlement that cleared your debt may live only server-side until the session's first pull lands. So the card painted a confident colour-coded balance ("you owe" = red), then flipped once sync reconciled.

- `useHomeSummary` now exposes `pendingFirstSync` (`hydrated && lastSyncedAt === null && status ∈ {idle, syncing}`). `lastSyncedAt` is in-memory, null each launch, so it marks *this session's* first successful sync.
- The hero shows `HeroSkeleton` while `isLoading || pendingFirstSync`, then swaps straight to the correct card — no wrong-colour flip.
- Bounded, never hangs: the provider kicks one `flush` on mount, which resolves to `lastSyncedAt` set or a can't-sync status (offline/metered/error) — those fall through to local data at once, so local-first still wins when the network can't answer.
- Scoped to the hero only; the group list keeps its instant local render.

## Voice review screen
- Header gains a brand `mic` glyph so the review reads as the thing you spoke.
- Save button centred (`alignSelf: 'center'`), matching the Try-Again button.
- Destination picker: each group row shows its **cover emoji** (or a **type glyph** fallback — trip/home/couple/event/other) instead of a column of identical people icons, and the list is sorted **newest-group-first** so a just-created group is easy to spot.

## Token
- Darkened `positiveLight` teal endpoint `#0E9F8E` → `#0A7E76` for white-on-teal legibility on the balance card's brightest corner.

Typecheck + lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pib1zHzfKvFyJtuRDyoHV