### PR TITLE
fix(db): RPC boundary hardening — service-role expense writes + scoped settlement parties

### DIFF
--- a/packages/db/prisma/migrations/20260819000000_rpc_boundary_hardening/migration.sql
+++ b/packages/db/prisma/migrations/20260819000000_rpc_boundary_hardening/migration.sql
@@ -29,17 +29,34 @@
 -- the owner-role paths that seed expenses in migrations and tests.
 
 -- ── SEC-1 + INT-1: the expense write RPC is service-role only again ───────────
-REVOKE EXECUTE ON FUNCTION public.baaki_apply_expense(
-  uuid, uuid, uuid, text, text, date, char(3), bigint, text, jsonb, jsonb, jsonb, uuid, text, uuid,
-  int, jsonb, text, text
-) FROM anon, authenticated;
-
--- Re-grant the door the edge functions use. The last DROP..CREATE dropped this
--- grant and never restored it; make the intent explicit and current.
-GRANT EXECUTE ON FUNCTION public.baaki_apply_expense(
-  uuid, uuid, uuid, text, text, date, char(3), bigint, text, jsonb, jsonb, jsonb, uuid, text, uuid,
-  int, jsonb, text, text
-) TO service_role;
+-- `baaki_apply_expense` accreted several signatures as parameters were appended
+-- (15 → 19 args). Each migration `DROP`ped the previous by an explicit type list
+-- and `CREATE`d the next — but a `DROP FUNCTION IF EXISTS` whose type list does
+-- not match exactly is a silent no-op, so at least one stale overload survived
+-- still carrying `GRANT ... TO authenticated, anon`. That is the overload a short
+-- positional call resolves to, which is how the anon/forged-share path stayed
+-- open. Revoking a single hand-written signature cannot catch what you cannot
+-- see, so loop over every overload by its real identity from the catalog.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'baaki_apply_expense'
+  LOOP
+    -- FROM PUBLIC too: a function created under Supabase's default privileges
+    -- carries an EXECUTE grant the client roles inherit, so revoking only anon
+    -- and authenticated by name leaves that inherited grant in place. This is
+    -- exactly what the original atomic-write migration did (REVOKE ALL FROM
+    -- PUBLIC, anon, authenticated) and what the later re-grants undid.
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon, authenticated', r.sig);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', r.sig);
+  END LOOP;
+END
+$$;
 
 -- ── INT-2: settlement parties must belong to the settlement's group ──────────
 CREATE OR REPLACE FUNCTION public.baaki_record_settlement(
@@ -146,10 +163,26 @@ $$;
 -- anon is already blocked by is_group_member (a null profile matches no row),
 -- but revoke it so the grant matches the intent; authenticated keeps it because
 -- the mobile client records settlements through this RPC directly (and /sync
--- calls it as the caller, not the service role).
-REVOKE EXECUTE ON FUNCTION public.baaki_record_settlement(
-  uuid, uuid, uuid, bigint, text, character, text, jsonb, uuid, text
-) FROM anon;
+-- calls it as the caller, not the service role). Loop over every overload for
+-- the same reason as above — this RPC also grew a parameter over its history.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'baaki_record_settlement'
+  LOOP
+    -- Revoke from PUBLIC and anon (see the note above about inherited grants),
+    -- then re-grant the roles that legitimately call it so removing the PUBLIC
+    -- grant does not lock them out.
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon', r.sig);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', r.sig);
+  END LOOP;
+END
+$$;
 
 -- PostgREST caches the schema; tell it the permissions/signatures changed.
 NOTIFY pgrst, 'reload schema';

--- a/packages/db/prisma/migrations/20260819000000_rpc_boundary_hardening/migration.sql
+++ b/packages/db/prisma/migrations/20260819000000_rpc_boundary_hardening/migration.sql
@@ -1,0 +1,155 @@
+-- RPC boundary hardening (audit P0)
+--
+-- Two SECURITY DEFINER money RPCs were reachable straight from PostgREST by
+-- client roles and trusted what the client sent.
+--
+--  SEC-1 (critical): `baaki_apply_expense` was created service-role only
+--    (20260804181500_atomic_expense_write: REVOKE ALL FROM PUBLIC, anon,
+--    authenticated; GRANT TO service_role) — correct. But every later migration
+--    that changed its signature re-granted it "TO authenticated, anon", and the
+--    last one (20260818120000_add_person_payment) DROP..CREATE'd it and re-added
+--    only that wrong grant, dropping the service_role grant on the way. So the
+--    anon key shipped in every app binary (a JWT with role=anon and no `sub`)
+--    could call it: `baaki_assert_expense_caller` returns without checking when
+--    `baaki_current_profile_id()` is null, which it is for anon.
+--  INT-1 (critical): the shares are stored verbatim; only Σpayers=Σshares=amount
+--    is checked (a deferred constraint trigger). The recompute that would catch a
+--    forged share vector lives in the Deno `sync`/`expense-write` edge functions
+--    (both recompute from the split params and verify the client's copy before
+--    calling this as the service role) — not in the DB. So a client reaching the
+--    RPC directly skipped it.
+--  INT-2 (critical): `baaki_record_settlement` never checked that the two parties
+--    belong to the settlement's group.
+--
+-- Fix: restore `baaki_apply_expense` to service-role only (closes SEC-1 and
+-- INT-1 together — the edge functions become the only door again), and constrain
+-- the settlement parties to the group. The caller assertion's null-profile branch
+-- is deliberately left as-is: post-revoke it is reachable only by the service
+-- role (edge functions / cron), which is trusted, and tightening it would break
+-- the owner-role paths that seed expenses in migrations and tests.
+
+-- ── SEC-1 + INT-1: the expense write RPC is service-role only again ───────────
+REVOKE EXECUTE ON FUNCTION public.baaki_apply_expense(
+  uuid, uuid, uuid, text, text, date, char(3), bigint, text, jsonb, jsonb, jsonb, uuid, text, uuid,
+  int, jsonb, text, text
+) FROM anon, authenticated;
+
+-- Re-grant the door the edge functions use. The last DROP..CREATE dropped this
+-- grant and never restored it; make the intent explicit and current.
+GRANT EXECUTE ON FUNCTION public.baaki_apply_expense(
+  uuid, uuid, uuid, text, text, date, char(3), bigint, text, jsonb, jsonb, jsonb, uuid, text, uuid,
+  int, jsonb, text, text
+) TO service_role;
+
+-- ── INT-2: settlement parties must belong to the settlement's group ──────────
+CREATE OR REPLACE FUNCTION public.baaki_record_settlement(
+  p_group_id           uuid,
+  p_from_member_id     uuid,
+  p_to_member_id       uuid,
+  p_amount             bigint,
+  p_method             text,
+  p_currency           char(3) DEFAULT NULL,
+  p_note               text DEFAULT NULL,
+  p_allocations        jsonb DEFAULT '[]'::jsonb,
+  p_client_mutation_id uuid DEFAULT NULL,
+  p_rail               text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_settlement_id uuid;
+  v_currency      char(3);
+  v_actor         uuid;
+  v_allocation    jsonb;
+  v_rail          text := COALESCE(NULLIF(btrim(p_rail), ''), p_method);
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in this group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Resolve the caller's own member id up front: it is both the authorization
+  -- check below and the actor on the activity entry further down.
+  v_actor := public.baaki_my_member_id(p_group_id);
+  IF v_actor IS NULL OR v_actor NOT IN (p_from_member_id, p_to_member_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: you can only record a settlement you are part of'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Both parties must be members of THIS group. The FKs only prove the ids are
+  -- real `group_members` rows, not that they belong here — without this a member
+  -- could name a party from another group, and auto-confirm would later write an
+  -- offsetting balance against a member nobody in this group can see, erasing
+  -- their own debt while the per-group sum still totals zero.
+  IF NOT EXISTS (
+        SELECT 1 FROM public.group_members gm
+        WHERE gm.id = p_from_member_id AND gm.group_id = p_group_id
+      )
+     OR NOT EXISTS (
+        SELECT 1 FROM public.group_members gm
+        WHERE gm.id = p_to_member_id AND gm.group_id = p_group_id
+      ) THEN
+    RAISE EXCEPTION 'UNKNOWN_MEMBER: both parties must be members of this group'
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  IF p_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: settle a positive amount' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying the same mutation must not create a second settlement (ADR-005).
+  IF p_client_mutation_id IS NOT NULL THEN
+    SELECT id INTO v_settlement_id
+    FROM public.settlements WHERE client_mutation_id = p_client_mutation_id;
+    IF v_settlement_id IS NOT NULL THEN
+      RETURN v_settlement_id;
+    END IF;
+  END IF;
+
+  SELECT COALESCE(p_currency, default_currency) INTO v_currency
+  FROM public.groups WHERE id = p_group_id;
+
+  INSERT INTO public.settlements
+    (group_id, from_member_id, to_member_id, currency, amount, method, rail, status, note,
+     client_mutation_id)
+  VALUES
+    (p_group_id, p_from_member_id, p_to_member_id, upper(v_currency), p_amount,
+     CASE WHEN p_method IN ('upi', 'cash', 'bank', 'other') THEN p_method ELSE 'other' END
+       ::"SettlementMethod",
+     v_rail, 'initiated', p_note, p_client_mutation_id)
+  RETURNING id INTO v_settlement_id;
+
+  FOR v_allocation IN SELECT * FROM jsonb_array_elements(COALESCE(p_allocations, '[]'::jsonb))
+  LOOP
+    INSERT INTO public.settlement_allocations (settlement_id, expense_id, amount)
+    VALUES (
+      v_settlement_id,
+      (v_allocation ->> 'expenseId')::uuid,
+      (v_allocation ->> 'amount')::bigint
+    )
+    ON CONFLICT (settlement_id, expense_id)
+    DO UPDATE SET amount = public.settlement_allocations.amount + EXCLUDED.amount;
+  END LOOP;
+
+  INSERT INTO public.activity_log (group_id, actor_member_id, verb, object_type, object_id, payload)
+  VALUES (p_group_id, v_actor, 'settled', 'settlement', v_settlement_id,
+          jsonb_build_object('amount', p_amount, 'currency', v_currency,
+                             'method', p_method, 'rail', v_rail));
+
+  RETURN v_settlement_id;
+END
+$$;
+
+-- anon is already blocked by is_group_member (a null profile matches no row),
+-- but revoke it so the grant matches the intent; authenticated keeps it because
+-- the mobile client records settlements through this RPC directly (and /sync
+-- calls it as the caller, not the service role).
+REVOKE EXECUTE ON FUNCTION public.baaki_record_settlement(
+  uuid, uuid, uuid, bigint, text, character, text, jsonb, uuid, text
+) FROM anon;
+
+-- PostgREST caches the schema; tell it the permissions/signatures changed.
+NOTIFY pgrst, 'reload schema';

--- a/packages/db/test/fx.test.ts
+++ b/packages/db/test/fx.test.ts
@@ -145,6 +145,11 @@ describe('the rate on the expense itself', () => {
     fx: unknown,
   ): Promise<string | null> {
     try {
+      // `baaki_apply_expense` is service-role only; seed on the owner connection
+      // (the trusted path the edge functions use). The JWT claim set by
+      // `seedGroup` stays, so the in-function member checks still resolve to the
+      // real member — this test is about the fx validation, not authorization.
+      await client.query(`RESET ROLE`);
       await client.query(
         `SELECT baaki_apply_expense($1::uuid, $2::uuid, $3::uuid, 'Dinner', NULL::text,
                                     '2026-08-05'::date, $4::char(3), 1000::bigint,

--- a/packages/db/test/m4-nudge-to-settle.test.ts
+++ b/packages/db/test/m4-nudge-to-settle.test.ts
@@ -94,25 +94,26 @@ async function expense(
 ): Promise<void> {
   const half = amount / 2n;
   const author = await myMember(groupId, owner);
-  await asUser(owner, () =>
-    client.query(
-      `SELECT baaki_apply_expense($1::uuid, $2::uuid, $3::uuid, 'Dinner', NULL::text,
-                                  '2026-08-06'::date, 'INR'::char(3), $4::bigint,
-                                  'equal'::text, '{"kind":"equal"}'::jsonb,
-                                  $5::jsonb, $6::jsonb, $7::uuid)`,
-      [
-        groupId,
-        randomUUID(),
-        author,
-        amount.toString(),
-        JSON.stringify([{ memberId: payer, amount: amount.toString() }]),
-        JSON.stringify([
-          { memberId: payer, amount: half.toString() },
-          { memberId: other, amount: (amount - half).toString() },
-        ]),
-        randomUUID(),
-      ],
-    ),
+  // Seeded on the owner connection: `baaki_apply_expense` is service-role only,
+  // so seeding it as `authenticated` would now be denied. The owner bypasses the
+  // grant and the null-profile branch treats it as a trusted (service) caller.
+  await client.query(
+    `SELECT baaki_apply_expense($1::uuid, $2::uuid, $3::uuid, 'Dinner', NULL::text,
+                                '2026-08-06'::date, 'INR'::char(3), $4::bigint,
+                                'equal'::text, '{"kind":"equal"}'::jsonb,
+                                $5::jsonb, $6::jsonb, $7::uuid)`,
+    [
+      groupId,
+      randomUUID(),
+      author,
+      amount.toString(),
+      JSON.stringify([{ memberId: payer, amount: amount.toString() }]),
+      JSON.stringify([
+        { memberId: payer, amount: half.toString() },
+        { memberId: other, amount: (amount - half).toString() },
+      ]),
+      randomUUID(),
+    ],
   );
 }
 

--- a/packages/db/test/people.test.ts
+++ b/packages/db/test/people.test.ts
@@ -94,26 +94,28 @@ async function expense(
 ): Promise<void> {
   const half = amount / 2n;
   const author = await myMember(groupId, owner);
-  await asUser(owner, () =>
-    client.query(
-      `SELECT baaki_apply_expense($1::uuid, $2::uuid, $3::uuid, 'Dinner', NULL::text,
-                                  '2026-08-06'::date, $4::char(3), $5::bigint,
-                                  'equal'::text, '{"kind":"equal"}'::jsonb,
-                                  $6::jsonb, $7::jsonb, $8::uuid)`,
-      [
-        groupId,
-        randomUUID(),
-        author,
-        currency,
-        amount.toString(),
-        JSON.stringify([{ memberId: payer, amount: amount.toString() }]),
-        JSON.stringify([
-          { memberId: payer, amount: half.toString() },
-          { memberId: other, amount: (amount - half).toString() },
-        ]),
-        randomUUID(),
-      ],
-    ),
+  // Seeded on the owner connection: `baaki_apply_expense` is service-role only,
+  // so seeding it as `authenticated` would now be denied. The owner bypasses the
+  // grant and the null-profile branch treats it as a trusted (service) caller —
+  // the same door the edge functions use.
+  await client.query(
+    `SELECT baaki_apply_expense($1::uuid, $2::uuid, $3::uuid, 'Dinner', NULL::text,
+                                '2026-08-06'::date, $4::char(3), $5::bigint,
+                                'equal'::text, '{"kind":"equal"}'::jsonb,
+                                $6::jsonb, $7::jsonb, $8::uuid)`,
+    [
+      groupId,
+      randomUUID(),
+      author,
+      currency,
+      amount.toString(),
+      JSON.stringify([{ memberId: payer, amount: amount.toString() }]),
+      JSON.stringify([
+        { memberId: payer, amount: half.toString() },
+        { memberId: other, amount: (amount - half).toString() },
+      ]),
+      randomUUID(),
+    ],
   );
 }
 

--- a/packages/db/test/rls.test.ts
+++ b/packages/db/test/rls.test.ts
@@ -109,7 +109,11 @@ describe('expenses and their money rows', () => {
     }
   });
 
-  it('a member adds an expense through the RPC, and an outsider cannot', async () => {
+  it('no client role calls the expense write RPC directly — not even a member', async () => {
+    // Hardened after the audit: `baaki_apply_expense` is service-role only, so
+    // the Deno edge functions (which recompute the shares) are the one door.
+    // Both a member and an outsider are refused at the grant — this closes the
+    // anon fail-open and the forged-share hole together.
     const payers = JSON.stringify([{ memberId: group.memberIds[0], amount: '9000' }]);
     const shares = JSON.stringify(
       (group.memberIds as string[]).slice(0, 3).map((memberId) => ({ memberId, amount: '3000' })),
@@ -117,46 +121,14 @@ describe('expenses and their money rows', () => {
     const call = `SELECT baaki_apply_expense($1, NULL, $2, 'Chai', NULL, current_date, 'INR',
       9000, 'equal', '{"kind":"equal"}'::jsonb, $3::jsonb, $4::jsonb, $5)`;
 
-    await asRole(client, 'authenticated', memberClaims(group.profileIds[0] as string), async () => {
-      const result = await client.query(call, [
-        group.groupId,
-        group.memberIds[0],
-        payers,
-        shares,
-        randomUUID(),
-      ]);
-      expect(result.rowCount).toBe(1);
-    });
-
-    await asRole(client, 'authenticated', memberClaims(outsiderProfileId), async () => {
-      const message = await expectDenied(
-        client.query(call, [group.groupId, group.memberIds[0], payers, shares, randomUUID()]),
-      );
-      expect(message).toMatch(/NOT_A_MEMBER/);
-    });
-  });
-
-  it('a member cannot record an expense as written by somebody else', async () => {
-    // The version rows are append-only, so a wrong author is permanent.
-    await asRole(client, 'authenticated', memberClaims(group.profileIds[0] as string), async () => {
-      const message = await expectDenied(
-        client.query(
-          `SELECT baaki_apply_expense($1, NULL, $2, 'Not mine', NULL, current_date, 'INR',
-             6000, 'equal', '{"kind":"equal"}'::jsonb, $3::jsonb, $4::jsonb, $5)`,
-          [
-            group.groupId,
-            group.memberIds[1], // somebody else
-            JSON.stringify([{ memberId: group.memberIds[1], amount: '6000' }]),
-            JSON.stringify([
-              { memberId: group.memberIds[0], amount: '3000' },
-              { memberId: group.memberIds[1], amount: '3000' },
-            ]),
-            randomUUID(),
-          ],
-        ),
-      );
-      expect(message).toMatch(/NOT_THE_AUTHOR/);
-    });
+    for (const profileId of [group.profileIds[0] as string, outsiderProfileId]) {
+      await asRole(client, 'authenticated', memberClaims(profileId), async () => {
+        const message = await expectDenied(
+          client.query(call, [group.groupId, group.memberIds[0], payers, shares, randomUUID()]),
+        );
+        expect(message).toMatch(/permission denied/i);
+      });
+    }
   });
 });
 

--- a/packages/db/test/rpc-boundary.test.ts
+++ b/packages/db/test/rpc-boundary.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for the RPC boundary hardening (audit P0).
+ *
+ * These exercise the two gaps the existing suite never covered, and which is
+ * exactly why they survived: it only ever called the RPCs as an authenticated
+ * member or straight off the owner connection — never as `anon`, and never with
+ * a settlement party from another group.
+ *
+ *   SEC-1: the anon key (role=anon, no `sub`) fell through the caller check and
+ *          could write expenses in any group.
+ *   INT-1: client-supplied shares were stored verbatim; only the sum was checked.
+ *          Both are closed by revoking `baaki_apply_expense` from the client
+ *          roles — the edge functions, as the service role, are the only door.
+ *   INT-2: `baaki_record_settlement` never checked that the two parties belong
+ *          to the settlement's group.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, expectDenied } from './helpers';
+
+let client: Client;
+
+interface Scene {
+  groupA: string;
+  groupB: string;
+  attackerProfile: string;
+  attackerMemberA: string; // attacker's member id in group A
+  victimMemberA: string; // another member of group A
+  outsiderMemberB: string; // a member of group B — not in A
+}
+
+let scene: Scene;
+
+/** Run `fn` as an authenticated user (a JWT with role + sub), rolled back. */
+async function asAuthenticated<T>(profileId: string, fn: () => Promise<T>): Promise<T> {
+  await client.query('BEGIN');
+  try {
+    await client.query(`SELECT set_config('request.jwt.claims', $1, true)`, [
+      JSON.stringify({ sub: profileId, role: 'authenticated' }),
+    ]);
+    await client.query('SET LOCAL ROLE authenticated');
+    return await fn();
+  } finally {
+    await client.query('ROLLBACK');
+  }
+}
+
+/** Run `fn` as the anonymous key: role=anon, no `sub`. */
+async function asAnon<T>(fn: () => Promise<T>): Promise<T> {
+  await client.query('BEGIN');
+  try {
+    await client.query(`SELECT set_config('request.jwt.claims', $1, true)`, [
+      JSON.stringify({ role: 'anon' }),
+    ]);
+    await client.query('SET LOCAL ROLE anon');
+    return await fn();
+  } finally {
+    await client.query('ROLLBACK');
+  }
+}
+
+beforeAll(async () => {
+  client = await connect();
+
+  const attackerProfile = randomUUID();
+  const victimProfile = randomUUID();
+  const outsiderProfile = randomUUID();
+  const groupA = randomUUID();
+  const groupB = randomUUID();
+  const attackerMemberA = randomUUID();
+  const victimMemberA = randomUUID();
+  const outsiderMemberB = randomUUID();
+
+  for (const [id, name] of [
+    [attackerProfile, 'Attacker'],
+    [victimProfile, 'Victim'],
+    [outsiderProfile, 'Outsider'],
+  ] as const) {
+    await client.query(
+      `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, $2, 'INR')`,
+      [id, name],
+    );
+  }
+  await client.query(
+    `INSERT INTO groups (id, name, type, default_currency, created_by) VALUES ($1, 'A', 'trip', 'INR', $2)`,
+    [groupA, attackerProfile],
+  );
+  await client.query(
+    `INSERT INTO groups (id, name, type, default_currency, created_by) VALUES ($1, 'B', 'trip', 'INR', $2)`,
+    [groupB, outsiderProfile],
+  );
+  await client.query(
+    `INSERT INTO group_members (id, group_id, profile_id, role, joined_via) VALUES
+       ($1, $2, $3, 'member', 'created'),
+       ($4, $2, $5, 'member', 'created')`,
+    [attackerMemberA, groupA, attackerProfile, victimMemberA, victimProfile],
+  );
+  await client.query(
+    `INSERT INTO group_members (id, group_id, profile_id, role, joined_via) VALUES ($1, $2, $3, 'member', 'created')`,
+    [outsiderMemberB, groupB, outsiderProfile],
+  );
+
+  scene = { groupA, groupB, attackerProfile, attackerMemberA, victimMemberA, outsiderMemberB };
+});
+
+afterAll(async () => {
+  // Clean up the two groups (cascades to members); expenses were never written.
+  await client.query(`DELETE FROM group_members WHERE group_id = ANY($1)`, [
+    [scene.groupA, scene.groupB],
+  ]);
+  await client.query(`DELETE FROM groups WHERE id = ANY($1)`, [[scene.groupA, scene.groupB]]);
+  await client.query(`DELETE FROM profiles WHERE id = ANY($1)`, [[scene.attackerProfile]]);
+  await client.end();
+});
+
+describe('SEC-1 / INT-1 — baaki_apply_expense is service-role only', () => {
+  const call = (role: 'anon' | 'authenticated') => {
+    const run = () =>
+      client.query(
+        `SELECT baaki_apply_expense($1, NULL, $2, 'x', NULL, current_date, 'INR', 1000,
+           'equal', '{"kind":"equal"}'::jsonb, $3::jsonb, $4::jsonb, $5)`,
+        [
+          scene.groupA,
+          scene.attackerMemberA,
+          JSON.stringify([{ memberId: scene.attackerMemberA, amount: '1000' }]),
+          JSON.stringify([{ memberId: scene.attackerMemberA, amount: '1000' }]),
+          randomUUID(),
+        ],
+      );
+    return role === 'anon' ? asAnon(run) : asAuthenticated(scene.attackerProfile, run);
+  };
+
+  it('refuses the anon key (the SEC-1 fail-open)', async () => {
+    expect(await expectDenied(call('anon'))).toMatch(/permission denied/i);
+  });
+
+  it('refuses an authenticated member calling directly (the INT-1 forged-share door)', async () => {
+    expect(await expectDenied(call('authenticated'))).toMatch(/permission denied/i);
+  });
+});
+
+describe('INT-2 — settlement parties must belong to the group', () => {
+  it('refuses a settlement whose counterparty is a member of another group', async () => {
+    await asAuthenticated(scene.attackerProfile, async () => {
+      const message = await expectDenied(
+        client.query(
+          `SELECT baaki_record_settlement($1, $2, $3, 5000, 'cash', 'INR', NULL, '[]'::jsonb, $4) AS id`,
+          [scene.groupA, scene.attackerMemberA, scene.outsiderMemberB, randomUUID()],
+        ),
+      );
+      expect(message).toMatch(/UNKNOWN_MEMBER/);
+    });
+  });
+
+  it('still records a settlement between two members of the same group', async () => {
+    await asAuthenticated(scene.attackerProfile, async () => {
+      const { rows } = await client.query(
+        `SELECT baaki_record_settlement($1, $2, $3, 5000, 'cash', 'INR', NULL, '[]'::jsonb, $4) AS id`,
+        [scene.groupA, scene.attackerMemberA, scene.victimMemberA, randomUUID()],
+      );
+      expect(rows[0].id).toBeTruthy();
+    });
+  });
+
+  it('refuses the anon key outright', async () => {
+    await asAnon(async () => {
+      const message = await expectDenied(
+        client.query(
+          `SELECT baaki_record_settlement($1, $2, $3, 5000, 'cash', 'INR', NULL, '[]'::jsonb, $4) AS id`,
+          [scene.groupA, scene.attackerMemberA, scene.victimMemberA, randomUUID()],
+        ),
+      );
+      expect(message).toMatch(/permission denied/i);
+    });
+  });
+});

--- a/packages/db/test/rpc-boundary.test.ts
+++ b/packages/db/test/rpc-boundary.test.ts
@@ -28,6 +28,8 @@ interface Scene {
   groupA: string;
   groupB: string;
   attackerProfile: string;
+  victimProfile: string;
+  outsiderProfile: string;
   attackerMemberA: string; // attacker's member id in group A
   victimMemberA: string; // another member of group A
   outsiderMemberB: string; // a member of group B — not in A
@@ -104,7 +106,16 @@ beforeAll(async () => {
     [outsiderMemberB, groupB, outsiderProfile],
   );
 
-  scene = { groupA, groupB, attackerProfile, attackerMemberA, victimMemberA, outsiderMemberB };
+  scene = {
+    groupA,
+    groupB,
+    attackerProfile,
+    victimProfile,
+    outsiderProfile,
+    attackerMemberA,
+    victimMemberA,
+    outsiderMemberB,
+  };
 });
 
 afterAll(async () => {
@@ -113,7 +124,9 @@ afterAll(async () => {
     [scene.groupA, scene.groupB],
   ]);
   await client.query(`DELETE FROM groups WHERE id = ANY($1)`, [[scene.groupA, scene.groupB]]);
-  await client.query(`DELETE FROM profiles WHERE id = ANY($1)`, [[scene.attackerProfile]]);
+  await client.query(`DELETE FROM profiles WHERE id = ANY($1)`, [
+    [scene.attackerProfile, scene.victimProfile, scene.outsiderProfile],
+  ]);
   await client.end();
 });
 

--- a/packages/db/test/security-hardening.test.ts
+++ b/packages/db/test/security-hardening.test.ts
@@ -178,7 +178,14 @@ describe('a member cannot pay a debt by saying they did', () => {
   });
 });
 
-describe('a stranger cannot write into a group', () => {
+describe('the expense write RPC is not client-callable', () => {
+  // Hardened after the audit: `baaki_apply_expense` is revoked from anon and
+  // authenticated, so no client role reaches the function body at all — the
+  // Deno edge functions (sync / expense-write) recompute the shares and call it
+  // as the service role, and they are the only door. This closes the anon
+  // fail-open in `baaki_assert_expense_caller` and the forged-share hole (which
+  // only the SUM was ever checked against) in one move. Every client below is
+  // refused at the grant, before a row is touched.
   const write = (groupId: string, authorMemberId: string, payerMemberId: string) =>
     client.query(
       `SELECT baaki_apply_expense($1, NULL, $2, 'Injected', NULL, current_date, 'INR', 60000,
@@ -193,36 +200,32 @@ describe('a stranger cannot write into a group', () => {
     );
 
   it('refuses somebody who has never been a member', async () => {
-    // `baaki_apply_expense` is SECURITY DEFINER and checked that the member ids
-    // it was handed belonged to the group — never that the caller did. This
-    // committed a ₹600 expense into a stranger's group and moved every balance.
     await asClient(scene.outsider, async () => {
       const message = await expectDenied(
         write(scene.groupId, scene.members[0] as string, scene.members[0] as string),
       );
-      expect(message).toMatch(/NOT_A_MEMBER/);
+      expect(message).toMatch(/permission denied/i);
     });
   });
 
   it('refuses a member who has left', async () => {
-    // The easy case: no leaked id needed, only their own. `left_at` stops
-    // `is_group_member`, and this function never asked it.
     await asClient(scene.exProfile, async () => {
       const message = await expectDenied(
         write(scene.groupId, scene.exMember, scene.members[0] as string),
       );
-      expect(message).toMatch(/NOT_A_MEMBER/);
+      expect(message).toMatch(/permission denied/i);
     });
   });
 
-  it('lets a member write, as themselves', async () => {
+  it('refuses even a current member calling directly, not just strangers', async () => {
+    // The forged-share hole was reachable by any member, not only outsiders, so
+    // the fix has to shut the door on members too — they write through the edge
+    // functions, never straight into this RPC.
     await asClient(scene.profiles[0] as string, async () => {
-      const result = await write(
-        scene.groupId,
-        scene.members[0] as string,
-        scene.members[0] as string,
+      const message = await expectDenied(
+        write(scene.groupId, scene.members[0] as string, scene.members[0] as string),
       );
-      expect(result.rowCount).toBe(1);
+      expect(message).toMatch(/permission denied/i);
     });
   });
 });
@@ -258,6 +261,9 @@ describe('nobody writes history in somebody else’s name', () => {
   });
 
   it('refuses an expense recorded as written by somebody else', async () => {
+    // Forging authorship through the RPC is now refused at the grant (the RPC is
+    // service-role only); the direct-INSERT forgery above is still caught by the
+    // append-only column guard.
     await asClient(scene.profiles[1] as string, async () => {
       const message = await expectDenied(
         client.query(
@@ -272,7 +278,7 @@ describe('nobody writes history in somebody else’s name', () => {
           ],
         ),
       );
-      expect(message).toMatch(/NOT_THE_AUTHOR/);
+      expect(message).toMatch(/permission denied/i);
     });
   });
 });


### PR DESCRIPTION
**Security P0.** Closes three verified audit findings that share one root cause: the `SECURITY DEFINER` money RPCs were reachable straight from PostgREST by client roles and trusted what the client sent. **Not deployed — needs a prod migration once reviewed.**

## Findings closed
- **SEC-1 (critical):** `baaki_apply_expense` was *created* service-role only, but later signature changes re-granted it `TO authenticated, anon`, and the last `DROP..CREATE` (`add_person_payment`) restored **only** that wrong grant — dropping the `service_role` grant. The anon key shipped in every app binary (JWT `role=anon`, no `sub`) fell through `baaki_assert_expense_caller`'s null-profile branch and could write/edit expenses in any group, as any author, on append-only rows.
- **INT-1 (critical):** shares stored verbatim; only Σpayers=Σshares=amount checked. The recompute that catches a forged share vector lives in the `sync`/`expense-write` edge functions, not the DB — a direct caller skipped it.
- **INT-2 (critical):** `baaki_record_settlement` never checked the two parties belong to the settlement's group → a member could erase their own debt via a counterparty from another group; auto-confirm laundered it; per-group Σ stayed zero so CI couldn't see it.

## Fix
- `REVOKE baaki_apply_expense FROM anon, authenticated` + restore `GRANT ... TO service_role`. The edge functions (which recompute shares from the split params and verify the client's copy) are the only door again — closing SEC-1 **and** INT-1 together. Confirmed the only callers are `sync/index.ts` and `expense-write/index.ts`, both as the service role.
- `baaki_record_settlement`: add the from/to group-membership check (INT-2); `REVOKE ... FROM anon` (authenticated stays — the mobile client records settlements directly, and `/sync` calls it as the caller).
- The `assert_expense_caller` null-profile branch is deliberately left as-is: post-revoke it's reachable only by the service role / owner (edge functions, cron, migrations, test seeds), all trusted; tightening it would break those paths.

## Tests
- New `rpc-boundary.test.ts` exercises the exact gaps that hid these: the `anon` role, and a settlement party from another group.
- Existing suites updated for the stronger guard — client-role calls are now refused at the grant (`permission denied`), and the two seed helpers (`people`, `m4-nudge`) that wrote expenses as `authenticated` now seed on the owner connection (the trusted path).

Typecheck + prettier clean. The DB test suite needs a live Postgres — the **migrations / RLS / ledger-invariants CI job** runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pib1zHzfKvFyJtuRDyoHV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Restricted expense creation to trusted service operations.
  - Prevented anonymous and direct member access to expense-writing actions.
  - Strengthened settlement validation to ensure both parties belong to the same group.
  - Blocked anonymous settlement requests.

- **Bug Fixes**
  - Improved protection against cross-group settlements and forged expense authorship.
  - Preserved valid same-group settlement processing.

- **Tests**
  - Added regression coverage for RPC access controls, membership validation, and settlement authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->