### PR TITLE
fix(mobile): hide unsupported voice languages; outline Simplify pill

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -448,12 +448,13 @@ export default function GroupScreen() {
               style={{ color: ink }}
             />
 
-            {/* Two equal-width pills on the tinted hero. Settle up stays the
-                filled brand CTA; the simplify toggle uses the on-panel white
-                treatment (white pill, brand label) so it reads on any tint
-                instead of the muddy soft-purple secondary. A soft shadow lifts
-                the white pill off the pastel. Reduced side padding keeps longer
-                labels ("Who pays whom?") on one line at half width. */}
+            {/* Two equal-width pills on the tinted hero. Settle up is the one
+                filled brand CTA; Simplify is a secondary, so it reads as an
+                outline — transparent with a brand border and brand label. On a
+                pale tint a solid-white pill turned out brighter than the CTA and
+                stole the eye; the outline recedes behind the primary the way a
+                secondary should. Reduced side padding keeps the longer toggle
+                label ("Who pays whom?") on one line at half width. */}
             <Row style={{ gap: theme.spacing.md }}>
               <Button
                 label={t.settleUp}
@@ -465,9 +466,14 @@ export default function GroupScreen() {
               />
               <Button
                 label={group.data.simplify_debts ? t.simplify : t.whoPaysWhom}
-                variant="onBrand"
+                variant="ghost"
                 onPress={() => router.push(`/group/${groupId}/simplify`)}
-                style={{ flex: 1, paddingHorizontal: theme.spacing.md, ...theme.shadow.soft }}
+                style={{
+                  flex: 1,
+                  paddingHorizontal: theme.spacing.md,
+                  borderWidth: 1,
+                  borderColor: theme.color.brand,
+                }}
               />
             </Row>
           </TintCard>

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -243,6 +243,41 @@ function recognitionAvailable(): boolean {
   }
 }
 
+/**
+ * The subset of the app's languages this phone's recogniser can actually listen
+ * in. A chip for a language the device cannot recognise only leads to a red "not
+ * supported" after the tap, so a language that is not supported is not shown.
+ *
+ * `getSupportedLocales` returns an empty list on Android 12 and below (and can
+ * throw when the service package is missing): there we cannot tell what is
+ * supported, so we return `null` and every chip is shown rather than hiding them
+ * all. A non-empty device list that matched none of ours is treated the same
+ * way — more likely a normalisation miss than a phone that speaks nothing we
+ * offer.
+ */
+async function loadSupportedLanguages(): Promise<Language[] | null> {
+  try {
+    let androidRecognitionServicePackage: string | undefined;
+    try {
+      const pkg = ExpoSpeechRecognitionModule.getDefaultRecognitionService?.().packageName;
+      if (pkg) androidRecognitionServicePackage = pkg;
+    } catch {
+      // iOS / older builds have no Android service concept — query without one.
+    }
+    const { locales } = await ExpoSpeechRecognitionModule.getSupportedLocales(
+      androidRecognitionServicePackage ? { androidRecognitionServicePackage } : {},
+    );
+    if (!locales || locales.length === 0) return null;
+    const base = new Set(
+      locales.map((tag) => tag.trim().split(/[-_]/)[0]?.toLowerCase()).filter(Boolean),
+    );
+    const supported = LANGUAGES.filter((lang) => base.has(lang));
+    return supported.length > 0 ? supported : null;
+  } catch {
+    return null;
+  }
+}
+
 export function VoiceCapture({ onDone, hints }: VoiceCaptureProps) {
   const theme = useTheme();
   const { t, language, locale } = useStrings();
@@ -253,6 +288,8 @@ export function VoiceCapture({ onDone, hints }: VoiceCaptureProps) {
   // can switch it here without changing the whole app — on-device recognition
   // targets one locale per session, so this is a per-utterance choice.
   const [spokenLang, setSpokenLang] = useState<Language | null>(null);
+  // Which languages this phone can recognise (null until asked / when unknown).
+  const [supportedLangs, setSupportedLangs] = useState<Language[] | null>(null);
   const [listening, setListening] = useState(false);
   const [live, setLive] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -342,6 +379,19 @@ export function VoiceCapture({ onDone, hints }: VoiceCaptureProps) {
   const stop = useCallback((): void => {
     ExpoSpeechRecognitionModule.stop();
   }, []);
+
+  // Ask the recogniser which languages it can hear, once, so the chips only
+  // offer the ones that will actually work on this phone.
+  useEffect(() => {
+    if (!available) return;
+    let alive = true;
+    void loadSupportedLanguages().then((langs) => {
+      if (alive) setSupportedLangs(langs);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [available]);
 
   // Open the mic as the screen appears — the reader tapped a mic to get here, so
   // making them tap a second one to start would be a step too many.
@@ -441,47 +491,51 @@ export function VoiceCapture({ onDone, hints }: VoiceCaptureProps) {
       {/* Which language to listen in — the recogniser targets one locale per
           session, so a speaker whose phone is in one language and mouth in
           another picks it here. The chip shows each language in its own script,
-          so it is found by the name its speaker knows. */}
-      <View
-        style={{
-          flexDirection: 'row',
-          flexWrap: 'wrap',
-          justifyContent: 'center',
-          alignItems: 'center',
-          gap: theme.spacing.sm,
-        }}
-      >
-        <Ionicons name="globe-outline" size={iconSize.sm} color={theme.color.textMuted} />
-        {LANGUAGES.map((lang) => {
-          const selected = (spokenLang ?? language) === lang;
-          return (
-            <Pressable
-              key={lang}
-              onPress={() => chooseLang(lang)}
-              accessibilityRole="button"
-              accessibilityState={{ selected }}
-              accessibilityLabel={LANGUAGE_NAMES[lang].english}
-              style={({ pressed }) => ({
-                paddingVertical: theme.spacing.xs,
-                paddingHorizontal: theme.spacing.md,
-                borderRadius: theme.radius.pill,
-                backgroundColor: selected ? theme.color.brandSoft : theme.color.surfaceMuted,
-                opacity: pressed ? 0.6 : 1,
-              })}
-            >
-              <Text
-                variant="caption"
-                style={{
-                  color: selected ? theme.color.brand : theme.color.textMuted,
-                  fontWeight: selected ? '600' : '400',
-                }}
+          so it is found by the name its speaker knows. Only languages this phone
+          can actually recognise are offered; with just one, there is nothing to
+          choose and the row is hidden. */}
+      {(supportedLangs ?? LANGUAGES).length > 1 ? (
+        <View
+          style={{
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+          }}
+        >
+          <Ionicons name="globe-outline" size={iconSize.sm} color={theme.color.textMuted} />
+          {(supportedLangs ?? LANGUAGES).map((lang) => {
+            const selected = (spokenLang ?? language) === lang;
+            return (
+              <Pressable
+                key={lang}
+                onPress={() => chooseLang(lang)}
+                accessibilityRole="button"
+                accessibilityState={{ selected }}
+                accessibilityLabel={LANGUAGE_NAMES[lang].english}
+                style={({ pressed }) => ({
+                  paddingVertical: theme.spacing.xs,
+                  paddingHorizontal: theme.spacing.md,
+                  borderRadius: theme.radius.pill,
+                  backgroundColor: selected ? theme.color.brandSoft : theme.color.surfaceMuted,
+                  opacity: pressed ? 0.6 : 1,
+                })}
               >
-                {LANGUAGE_NAMES[lang].own}
-              </Text>
-            </Pressable>
-          );
-        })}
-      </View>
+                <Text
+                  variant="caption"
+                  style={{
+                    color: selected ? theme.color.brand : theme.color.textMuted,
+                    fontWeight: selected ? '600' : '400',
+                  }}
+                >
+                  {LANGUAGE_NAMES[lang].own}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
 
       {error ? (
         <Pressable onPress={() => void Linking.openSettings()} accessibilityRole="button">


### PR DESCRIPTION
## What

Two mobile UI fixes.

### Voice quick-add — hide languages the phone can't recognise
The language chips offered Tamil / Hindi / Arabic even on phones whose recogniser can't hear them. Tapping one only surfaced a red *"this phone cannot recognise that language yet"* **after** the tap.

- Query `getSupportedLocales()` once (via the default recognition service) and only render chips for languages the device can actually recognise.
- **Fallback:** Android 12 and below returns an empty list, and the call can throw — in that case show every chip rather than hiding them all.
- The whole picker row is hidden when only one language remains (nothing to choose).

### Group hero — outline Simplify pill
The `Settle up` / `Simplify` pair used a solid-white pill for Simplify. On the pale-lilac tint the white pill out-shouted the filled brand CTA next to it. Simplify is now a secondary **outline** pill (transparent, brand border + label) so it recedes behind the primary — the standard filled-primary / outline-secondary hierarchy.

## Test
- `tsc --noEmit` clean
- `expo lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pib1zHzfKvFyJtuRDyoHV