### PR TITLE
fix(mobile): give the captures inbox an activity-style loading skeleton and layout

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -16,30 +16,13 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { dayHeading, dayKey, describeActivity, parseMoney, verbIcon } from '@/data/activity';
+import { dayHeading, describeActivity, groupByDay, parseMoney, verbIcon } from '@/data/activity';
 import { fetchRecentActivity } from '@/data/api';
 import { FeedSkeleton } from '@/components/Skeletons';
 import { useNotifications } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { usePullRefresh } from '@/lib/pullRefresh';
-
-/**
- * The feed cut into calendar days, newest first, order otherwise untouched — the
- * query already returns it sorted, so this only draws the lines between days.
- */
-function groupByDay<T extends { created_at: string }>(
-  entries: readonly T[],
-): { key: string; entries: T[] }[] {
-  const sections: { key: string; entries: T[] }[] = [];
-  for (const entry of entries) {
-    const key = dayKey(entry.created_at);
-    const last = sections[sections.length - 1];
-    if (last && last.key === key) last.entries.push(entry);
-    else sections.push({ key, entries: [entry] });
-  }
-  return sections;
-}
 
 export default function ActivityScreen() {
   const theme = useTheme();

--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -31,7 +31,9 @@ import {
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
+import { InboxSkeleton } from '@/components/Skeletons';
 import { capturePhotoUrl } from '@/data/api';
+import { dayHeading, groupByDay } from '@/data/activity';
 import { useCaptures, useDeleteCapture, useGroups, useHomeSummary } from '@/data/hooks';
 import { groupLabel, type CaptureRow, type GroupRow } from '@/data/types';
 import { useStrings } from '@/i18n';
@@ -144,86 +146,108 @@ export default function CapturesScreen() {
         </IconButton>
       </Row>
 
-      {rows.length === 0 ? (
-        <View style={{ flex: 1, justifyContent: 'center', paddingHorizontal: theme.spacing.xl }}>
-          <EmptyState
-            title={t.captures.emptyTitle}
-            body={t.captures.emptyBody}
-            action={
-              <Button label={t.captures.captureCta} onPress={() => router.push('/capture')} />
-            }
+      {/* One scroll region for every state, the way `ActivityScreen` does it —
+          so pull-to-refresh still works while the mirror is loading or the
+          inbox is genuinely empty, not only once cards are on screen. */}
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+          flexGrow: 1,
+        }}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={pull.refreshing}
+            onRefresh={pull.onRefresh}
+            tintColor={theme.color.brand}
           />
-        </View>
-      ) : (
-        <ScrollView
-          contentContainerStyle={{
-            paddingHorizontal: theme.spacing.xl,
-            paddingBottom: clearance,
-            gap: theme.spacing.md,
-          }}
-          showsVerticalScrollIndicator={false}
-          refreshControl={
-            <RefreshControl
-              refreshing={pull.refreshing}
-              onRefresh={pull.onRefresh}
-              tintColor={theme.color.brand}
+        }
+      >
+        {captures.isLoading ? (
+          <InboxSkeleton />
+        ) : rows.length === 0 ? (
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <EmptyState
+              title={t.captures.emptyTitle}
+              body={t.captures.emptyBody}
+              action={
+                <Button label={t.captures.captureCta} onPress={() => router.push('/capture')} />
+              }
             />
-          }
-        >
-          {rows.map((capture) => (
-            <Card key={capture.id} style={{ gap: theme.spacing.md }}>
-              <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-                {capture.photo_path ? (
-                  <CaptureThumb path={capture.photo_path} size={46} />
-                ) : (
-                  <CategoryBadge category={capture.category} size={46} />
-                )}
-                <View style={{ flex: 1, minWidth: 0 }}>
-                  <MoneyText
-                    amount={BigInt(capture.amount)}
-                    currency={capture.currency}
-                    locale={locale}
-                    variant="subheading"
-                  />
-                  {capture.description ? (
-                    <Text variant="caption" tone="muted" numberOfLines={1}>
-                      {capture.description}
-                    </Text>
-                  ) : null}
-                  <Text variant="micro" tone="muted">
-                    {shortDate(capture.expense_date, locale)}
-                    {capture.pending ? ` · ${t.captures.notSynced}` : ''}
-                  </Text>
-                </View>
-              </Row>
+          </View>
+        ) : (
+          // Day-grouped, same as the activity feed: a heading per calendar day
+          // then that day's cards, so the inbox reads as one system with the
+          // activity tab rather than a flat pile of receipts.
+          <View style={{ gap: theme.spacing.lg }}>
+            {groupByDay(rows).map((section) => (
+              <View key={section.key} style={{ gap: theme.spacing.md }}>
+                <Text variant="micro" tone="muted" style={{ textTransform: 'uppercase' }}>
+                  {dayHeading(locale, section.entries[0]!.created_at)}
+                </Text>
+                {section.entries.map((capture) => (
+                  <Card key={capture.id} style={{ gap: theme.spacing.md }}>
+                    <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                      {capture.photo_path ? (
+                        <CaptureThumb path={capture.photo_path} size={46} />
+                      ) : (
+                        <CategoryBadge category={capture.category} size={46} />
+                      )}
+                      <View style={{ flex: 1, minWidth: 0 }}>
+                        <MoneyText
+                          amount={BigInt(capture.amount)}
+                          currency={capture.currency}
+                          locale={locale}
+                          variant="subheading"
+                        />
+                        {capture.description ? (
+                          <Text variant="caption" tone="muted" numberOfLines={1}>
+                            {capture.description}
+                          </Text>
+                        ) : null}
+                        <Text variant="micro" tone="muted">
+                          {shortDate(capture.expense_date, locale)}
+                          {capture.pending ? ` · ${t.captures.notSynced}` : ''}
+                        </Text>
+                      </View>
+                    </Row>
 
-              <Row style={{ gap: theme.spacing.md }}>
-                <Button
-                  label={t.captures.assign}
-                  size="sm"
-                  onPress={() => setAssigning(capture)}
-                  style={{ flex: 1 }}
-                />
-                <IconButton
-                  label={t.captures.delete}
-                  onPress={() =>
-                    Alert.alert(t.captures.delete, t.captures.deleteConfirm, [
-                      { text: t.common.cancel, style: 'cancel' },
-                      {
-                        text: t.captures.delete,
-                        style: 'destructive',
-                        onPress: () => void deleteCapture.mutateAsync(capture.id),
-                      },
-                    ])
-                  }
-                >
-                  <Ionicons name="trash-outline" size={iconSize.lg} color={theme.color.textMuted} />
-                </IconButton>
-              </Row>
-            </Card>
-          ))}
-        </ScrollView>
-      )}
+                    <Row style={{ gap: theme.spacing.md }}>
+                      <Button
+                        label={t.captures.assign}
+                        size="sm"
+                        onPress={() => setAssigning(capture)}
+                        style={{ flex: 1 }}
+                      />
+                      <IconButton
+                        label={t.captures.delete}
+                        onPress={() =>
+                          Alert.alert(t.captures.delete, t.captures.deleteConfirm, [
+                            { text: t.common.cancel, style: 'cancel' },
+                            {
+                              text: t.captures.delete,
+                              style: 'destructive',
+                              onPress: () => void deleteCapture.mutateAsync(capture.id),
+                            },
+                          ])
+                        }
+                      >
+                        <Ionicons
+                          name="trash-outline"
+                          size={iconSize.lg}
+                          color={theme.color.textMuted}
+                        />
+                      </IconButton>
+                    </Row>
+                  </Card>
+                ))}
+              </View>
+            ))}
+          </View>
+        )}
+      </ScrollView>
 
       {/* The group picker, as a sheet over the list rather than a screen away —
           assigning is one tap and one choice, and a whole route for it would be

--- a/apps/mobile/src/components/Skeletons.tsx
+++ b/apps/mobile/src/components/Skeletons.tsx
@@ -296,6 +296,67 @@ export function FeedSkeleton({ rows = 5 }: { rows?: number }) {
   );
 }
 
+/**
+ * The captures inbox: day headings over a stack of capture cards, each a
+ * thumbnail beside an amount, a description line and a date, then an
+ * assign/delete action row underneath. Shaped to `CapturesScreen`'s real
+ * `Card` down to the pixel — same `xl` card padding and `md` internal gap,
+ * the same 46px thumbnail corner (`radius.sm`, not a pill: a receipt photo is
+ * a small rectangle, not an avatar), the same three text lines at their real
+ * variants (`subheading` for the amount, `caption` for the description,
+ * `micro` for the date) — so the swap to real cards is a fill, not a jump.
+ * The action row stands in for the `sm` Assign button (38px, pill radius) and
+ * the 44px delete `IconButton`, whose icon is the only thing skeletoned since
+ * the button chrome itself is invisible until pressed. Two day sections of
+ * two cards each is enough to read as "a short list", the same restraint
+ * `PeopleSkeleton` uses. Shown in place of the "nothing yet" empty state,
+ * which is a verdict the local mirror has not hydrated yet (ADR-005).
+ */
+export function InboxSkeleton() {
+  const theme = useTheme();
+  const { animated } = useMotion();
+  return (
+    <LoadingRegion style={{ gap: theme.spacing.lg }}>
+      {[0, 1].map((section) => (
+        <View key={section} style={{ gap: theme.spacing.md }}>
+          <Skeleton
+            width="28%"
+            height={11}
+            animated={animated}
+            style={{ marginBottom: theme.spacing.xs }}
+          />
+          {[0, 1].map((card) => (
+            <Card key={card} style={{ gap: theme.spacing.md }}>
+              <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                <Skeleton width={46} height={46} radius={theme.radius.sm} animated={animated} />
+                <View style={{ flex: 1, gap: theme.spacing.sm }}>
+                  <Skeleton width="45%" height={16} animated={animated} />
+                  <Skeleton width="65%" height={13} animated={animated} />
+                  <Skeleton width="30%" height={11} animated={animated} />
+                </View>
+              </Row>
+              <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                <Skeleton
+                  width="100%"
+                  height={38}
+                  radius={theme.radius.pill}
+                  animated={animated}
+                  style={{ flex: 1 }}
+                />
+                <View
+                  style={{ width: 44, height: 44, alignItems: 'center', justifyContent: 'center' }}
+                >
+                  <Skeleton width={22} height={22} radius={theme.radius.sm} animated={animated} />
+                </View>
+              </Row>
+            </Card>
+          ))}
+        </View>
+      ))}
+    </LoadingRegion>
+  );
+}
+
 /** Insights: a heading and a couple of chart-sized blocks. */
 export function InsightsSkeleton() {
   const theme = useTheme();

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -207,6 +207,26 @@ export function dayKey(iso: string): string {
   return `${when.getFullYear()}-${when.getMonth() + 1}-${when.getDate()}`;
 }
 
+/**
+ * Any feed cut into calendar days, newest first, order otherwise untouched —
+ * the caller's own query already sorts it, so this only draws the lines
+ * between days. Shared by the activity feed and the captures inbox, which
+ * both read as "a list of things that happened" and both want the same day
+ * headings rather than each inventing its own.
+ */
+export function groupByDay<T extends { created_at: string }>(
+  entries: readonly T[],
+): { key: string; entries: T[] }[] {
+  const sections: { key: string; entries: T[] }[] = [];
+  for (const entry of entries) {
+    const key = dayKey(entry.created_at);
+    const last = sections[sections.length - 1];
+    if (last && last.key === key) last.entries.push(entry);
+    else sections.push({ key, entries: [entry] });
+  }
+  return sections;
+}
+
 export function relativeTime(locale: string, iso: string, now: number = Date.now()): string {
   const parsed = Date.parse(iso);
   if (!Number.isFinite(parsed)) return iso;


### PR DESCRIPTION
## Summary
- The captures inbox rendered `rows = captures.data ?? []` and only checked `rows.length === 0`, so while `captures.isLoading` was true it showed the "nothing yet" empty state instead of a loading placeholder, then popped in cards once the local mirror hydrated.
- Fixed by mirroring `ActivityScreen`'s pattern exactly: one persistent `ScrollView` (with pull-to-refresh) wraps all three states — `isLoading` → skeleton, loaded-and-empty → `EmptyState`, loaded-with-rows → content — instead of a separate `View`/`ScrollView` per branch (which also meant pull-to-refresh didn't work in the old empty state).
- Added a new `InboxSkeleton` to `Skeletons.tsx`, shaped to the real capture `Card` down to the pixel (46px thumbnail, subheading/caption/micro text lines, the `sm` Assign button and delete `IconButton` footprint) — same philosophy as the existing `FeedSkeleton`/`PeopleSkeleton`.
- Brought the inbox's layout closer to the activity feed by day-grouping capture cards under the same `dayHeading` headings the activity tab uses. Lifted `groupByDay` out of `activity.tsx` into `data/activity.ts` so both feeds share one implementation.
- Kept cards (not the activity timeline) since captures carry photo thumbnails, category badges, and per-row assign/delete actions that a timeline row can't hold — the skeleton and day-grouping now do the "one system" work instead.
- All existing inbox behavior (assign-to-group sheet, delete confirm, capture CTA, offline "not synced yet" hint) is unchanged.

## Test plan
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm --filter @waves/mobile typecheck` (full `pnpm typecheck` fails only in `packages/db`, a pre-existing environment gap in this worktree — missing `packages/db/.env` with `DIRECT_URL` — unrelated to this change)
- [ ] Manual: open the inbox cold and confirm the skeleton shows before cards, and that a truly empty inbox shows the empty state (not skeleton) once hydrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)