### PR TITLE
feat(mobile): let merge people target a device contact

### DIFF
--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -158,7 +158,18 @@ export default function MergePeopleScreen() {
 
   const removeContactTarget = (memberId: string): void => {
     setError(null);
-    setContactTargets((prev) => prev.filter((row) => row.member_id !== memberId));
+    setContactTargets((prev) => {
+      const next = prev.filter((row) => row.member_id !== memberId);
+      // Keep the auto-name in step with the selection the same way toggle and
+      // onPickContact do — the removed contact is no longer in it — until the
+      // person types their own. The ghost addGhostMember created is left alone;
+      // this only drops it from this merge's selection.
+      if (!nameTouched) {
+        const rows = guests.filter((row) => selected.has(row.person_key));
+        setName(defaultMergeName([...rows, ...next]));
+      }
+      return next;
+    });
   };
 
   const closeContactFlow = (): void => {
@@ -190,6 +201,16 @@ export default function MergePeopleScreen() {
         }
         return next;
       });
+      closeContactFlow();
+      return;
+    }
+    // Already added as a contact target on this list — it is in the selection
+    // and the name already reflects it, so re-picking it must not run through
+    // chooseGroup again and create a second ghost. Just close.
+    const alreadyAdded = contactTargets.some(
+      (row) => row.display_name.trim().toLowerCase() === needle,
+    );
+    if (alreadyAdded) {
       closeContactFlow();
       return;
     }
@@ -371,7 +392,7 @@ export default function MergePeopleScreen() {
                           </View>
                         </Row>
                         <IconButton
-                          label={t.pickers.removeName.replace('{name}', row.display_name)}
+                          label={fill(t.pickers.removeName, { name: row.display_name })}
                           onPress={() => removeContactTarget(row.member_id)}
                         >
                           <Ionicons
@@ -570,7 +591,12 @@ function ChooseGroupForContact({
           <Button
             label={t.misc.startAGroup}
             variant="secondary"
-            onPress={() => router.push('/new-group')}
+            onPress={() => {
+              // Dismiss the contact modal before leaving, so it is not left
+              // stacked under the new-group screen.
+              onCancel();
+              router.push('/new-group');
+            }}
           />
         </Card>
       ) : (

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -12,6 +12,15 @@
  * as many words before the button. Only guests can be picked — a real person is
  * already one identity by their account and must never be folded under a made-up
  * name, which the RPC also enforces.
+ *
+ * A merge target does not have to already be on this screen's list. Picking a
+ * phone contact resolves it the same way a person reading names would: if it
+ * matches an existing guest by name, that guest is ticked; if it does not, the
+ * contact is not yet anyone in Waves, so it is added as a guest of one of your
+ * groups first — through the very same `addGhostMember` path `contacts.tsx` and
+ * `add-person.tsx` use — and then folded into the selection. Either way the
+ * merge itself still goes through `mergeGhosts` and its ledger-safety rules;
+ * nothing here writes to a balance.
  */
 import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -20,6 +29,7 @@ import { router } from 'expo-router';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
+  Modal,
   Platform,
   Pressable,
   ScrollView,
@@ -33,9 +43,11 @@ import {
   Callout,
   Card,
   directionalIcon,
+  Divider,
   EmptyState,
   IconButton,
   iconSize,
+  ListRow,
   Row,
   Screen,
   Text,
@@ -43,7 +55,13 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { fetchPeopleBalances, mergeGhosts, type PersonBalanceRow } from '@/data/api';
+import {
+  addGhostMember,
+  fetchGroups,
+  fetchPeopleBalances,
+  mergeGhosts,
+  type PersonBalanceRow,
+} from '@/data/api';
 import {
   canMerge,
   defaultMergeName,
@@ -51,9 +69,28 @@ import {
   memberIdsForMerge,
   mergeErrorMessage,
 } from '@/data/mergePeople';
+import { groupLabel, type GroupRow } from '@/data/types';
+import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
 import { PeopleSkeleton } from '@/components/Skeletons';
+import { friendlyError } from '@/lib/errors';
 import { useSync } from '@/sync';
-import { plural, useStrings } from '@/i18n';
+import { fill, plural, useStrings } from '@/i18n';
+
+/**
+ * A merge candidate that did not come from the balances list — a ghost just
+ * created (or about to be) from a device contact. Shaped like the subset of
+ * {@link PersonBalanceRow} the merge logic actually reads, so it can sit
+ * alongside guest rows in the same selection without either side knowing about
+ * the other's origin.
+ */
+interface ContactMergeTarget {
+  readonly member_id: string;
+  readonly display_name: string;
+}
+
+/** Where the "add a contact" flow is: closed, picking a contact, or — once a
+ * contact turns out to be new to the app — picking which group to add them to. */
+type ContactStep = 'closed' | 'pick' | 'chooseGroup';
 
 export default function MergePeopleScreen() {
   const theme = useTheme();
@@ -80,11 +117,29 @@ export default function MergePeopleScreen() {
   }, [people.data]);
 
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  // Guests materialised from a device contact that was new to the app. They
+  // never had a balance to appear in `guests`, so they live beside it rather
+  // than in it — always part of the selection once added (removable, not
+  // untickable, since there is no unmerged state to go back to).
+  const [contactTargets, setContactTargets] = useState<readonly ContactMergeTarget[]>([]);
   const [name, setName] = useState('');
   const [nameTouched, setNameTouched] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const selectedRows = guests.filter((row) => selected.has(row.person_key));
+  const [contactStep, setContactStep] = useState<ContactStep>('closed');
+  const [pendingContact, setPendingContact] = useState<PickedContact | null>(null);
+  const [contactBusy, setContactBusy] = useState(false);
+  const [contactError, setContactError] = useState<string | null>(null);
+
+  // Only fetched once the contact flow actually needs somewhere to put a new
+  // ghost — most visits to this screen never open it.
+  const groups = useQuery({
+    queryKey: ['groups'],
+    queryFn: fetchGroups,
+    enabled: contactStep !== 'closed',
+  });
+
+  const selectedRows = [...guests.filter((row) => selected.has(row.person_key)), ...contactTargets];
 
   const toggle = (personKey: string): void => {
     setError(null);
@@ -95,13 +150,91 @@ export default function MergePeopleScreen() {
       // Keep the name in step with the pick until the person types their own.
       if (!nameTouched) {
         const rows = guests.filter((row) => next.has(row.person_key));
-        setName(defaultMergeName(rows));
+        setName(defaultMergeName([...rows, ...contactTargets]));
       }
       return next;
     });
   };
 
+  const removeContactTarget = (memberId: string): void => {
+    setError(null);
+    setContactTargets((prev) => prev.filter((row) => row.member_id !== memberId));
+  };
+
+  const closeContactFlow = (): void => {
+    setContactStep('closed');
+    setPendingContact(null);
+    setContactError(null);
+  };
+
+  /**
+   * A contact was picked. If its name matches somebody already on this list,
+   * that is exactly the recognition this screen is built on — tick them, the
+   * same as tapping their row would. Only when nothing matches is the contact
+   * genuinely new, and the flow moves on to asking which group to add them to.
+   */
+  const onPickContact = (chosen: readonly PickedContact[]): void => {
+    const contact = chosen[0];
+    if (!contact) return;
+    setContactError(null);
+    const needle = contact.name.trim().toLowerCase();
+    const matches = guests.filter((row) => row.display_name.trim().toLowerCase() === needle);
+    if (matches.length > 0) {
+      setError(null);
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const row of matches) next.add(row.person_key);
+        if (!nameTouched) {
+          const rows = guests.filter((row) => next.has(row.person_key));
+          setName(defaultMergeName([...rows, ...contactTargets]));
+        }
+        return next;
+      });
+      closeContactFlow();
+      return;
+    }
+    setPendingContact(contact);
+    setContactStep('chooseGroup');
+  };
+
+  /**
+   * The contact is new to the app: add them as a guest of the chosen group —
+   * through the same `addGhostMember` RPC `contacts.tsx` and `add-person.tsx`
+   * use, so there is exactly one path that creates a ghost — then fold the new
+   * member straight into this merge's selection.
+   */
+  const attachContact = async (groupId: string): Promise<void> => {
+    if (!pendingContact) return;
+    setContactBusy(true);
+    setContactError(null);
+    try {
+      const memberId = await addGhostMember(groupId, pendingContact.name, {
+        email: pendingContact.email,
+        phone: pendingContact.phone,
+      });
+      const newTarget: ContactMergeTarget = {
+        member_id: memberId,
+        display_name: pendingContact.name,
+      };
+      setContactTargets((prev) => [...prev, newTarget]);
+      if (!nameTouched) setName(defaultMergeName([...selectedRows, newTarget]));
+      setError(null);
+      closeContactFlow();
+    } catch (caught) {
+      setContactError(
+        friendlyError(
+          caught,
+          fill(t.mergePeople.errorContactAdd, { name: pendingContact.name }),
+          'merge.attachContact',
+        ),
+      );
+    } finally {
+      setContactBusy(false);
+    }
+  };
+
   const ready = canMerge(selectedRows) && name.trim().length > 0;
+  const nothingToMergeYet = guests.length === 0 && contactTargets.length === 0;
 
   const merge = useMutation({
     mutationFn: () => mergeGhosts(memberIdsForMerge(selectedRows), name.trim()),
@@ -160,10 +293,21 @@ export default function MergePeopleScreen() {
                 <Button label={t.retry} variant="secondary" onPress={() => people.refetch()} />
               }
             />
-          ) : guests.length < 2 ? (
-            // Fewer than two guests: nothing to merge. Say why rather than showing
-            // an empty list with a dead button.
-            <EmptyState title={t.mergePeople.title} body={t.mergePeople.empty} />
+          ) : nothingToMergeYet ? (
+            // Nothing on the balances list yet — but a device contact can still
+            // start a merge (see the module doc), so the empty state offers that
+            // rather than being a dead end.
+            <EmptyState
+              title={t.mergePeople.title}
+              body={t.mergePeople.empty}
+              action={
+                <Button
+                  label={t.tabs.fromContacts}
+                  variant="secondary"
+                  onPress={() => setContactStep('pick')}
+                />
+              }
+            />
           ) : (
             <>
               <Text variant="caption" tone="muted" align="center">
@@ -173,6 +317,7 @@ export default function MergePeopleScreen() {
               <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
                 {guests.map((row, index) => {
                   const isSelected = selected.has(row.person_key);
+                  const isLastRow = index === guests.length - 1 && contactTargets.length === 0;
                   return (
                     <View key={row.person_key}>
                       <Pressable
@@ -203,13 +348,62 @@ export default function MergePeopleScreen() {
                           />
                         </Row>
                       </Pressable>
-                      {index < guests.length - 1 ? (
+                      {!isLastRow ? (
+                        <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                      ) : null}
+                    </View>
+                  );
+                })}
+                {contactTargets.map((row, index) => {
+                  const isLastRow = index === contactTargets.length - 1;
+                  return (
+                    <View key={row.member_id}>
+                      <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
+                        <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
+                          <Avatar name={row.display_name} size={44} ghost />
+                          <View style={{ flex: 1 }}>
+                            <Text variant="subheading" numberOfLines={1}>
+                              {row.display_name}
+                            </Text>
+                            <Text variant="caption" tone="muted" numberOfLines={1}>
+                              {t.mergePeople.fromContactsTag}
+                            </Text>
+                          </View>
+                        </Row>
+                        <IconButton
+                          label={t.pickers.removeName.replace('{name}', row.display_name)}
+                          onPress={() => removeContactTarget(row.member_id)}
+                        >
+                          <Ionicons
+                            name="close-circle"
+                            size={iconSize.xl}
+                            color={theme.color.textFaint}
+                          />
+                        </IconButton>
+                      </Row>
+                      {!isLastRow ? (
                         <View style={{ height: 1, backgroundColor: theme.color.border }} />
                       ) : null}
                     </View>
                   );
                 })}
               </Card>
+
+              <Button
+                label={t.tabs.fromContacts}
+                variant="secondary"
+                size="sm"
+                fullWidth
+                disabled={merge.isPending}
+                onPress={() => setContactStep('pick')}
+                icon={
+                  <Ionicons
+                    name="person-add-outline"
+                    size={iconSize.md}
+                    color={theme.color.brand}
+                  />
+                }
+              />
 
               <Card style={{ gap: theme.spacing.xs }}>
                 <Text variant="caption" tone="muted">
@@ -261,6 +455,156 @@ export default function MergePeopleScreen() {
           )}
         </ScrollView>
       </KeyboardAvoidingView>
+
+      {/* Picking a device contact as a merge target: step one is the contact
+          itself, step two (only when the contact is new to the app) is which
+          group to add them to. Mounted only while open, for the same reason
+          add-person's own contact modal is — a React Native Modal keeps its
+          children mounted across a close, so without this gate the picker would
+          reopen showing the last pick still ticked. */}
+      <Modal
+        visible={contactStep !== 'closed'}
+        animationType="slide"
+        onRequestClose={closeContactFlow}
+      >
+        <Screen edges={['top', 'bottom']}>
+          <View
+            style={{
+              flex: 1,
+              paddingHorizontal: theme.spacing.xl,
+              paddingBottom: theme.spacing.md,
+              gap: theme.spacing.lg,
+            }}
+          >
+            <Row style={{ paddingTop: theme.spacing.md }}>
+              <IconButton label={t.common.close} onPress={closeContactFlow}>
+                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+              </IconButton>
+              <View style={{ flex: 1, alignItems: 'center' }}>
+                <Text variant="heading">
+                  {contactStep === 'pick' ? t.tabs.fromContacts : t.misc.addToWhichGroup}
+                </Text>
+              </View>
+              <View style={{ width: 44 }} />
+            </Row>
+            {contactStep === 'pick' ? (
+              <ContactPicker single onConfirm={onPickContact} confirmVerb={t.misc.continueWith} />
+            ) : pendingContact ? (
+              <ChooseGroupForContact
+                contact={pendingContact}
+                groups={groups.data ?? []}
+                loading={groups.isLoading}
+                busy={contactBusy}
+                error={contactError}
+                onChoose={(groupId) => void attachContact(groupId)}
+                onCancel={closeContactFlow}
+              />
+            ) : null}
+          </View>
+        </Screen>
+      </Modal>
     </Screen>
+  );
+}
+
+/**
+ * Which of my groups a brand-new contact-ghost joins, once merge.tsx has
+ * established they are not already anyone in `guests`.
+ *
+ * Deliberately the smaller sibling of `contacts.tsx`'s own `ChooseGroup`: one
+ * contact rather than a batch, and the destination is a merge selection rather
+ * than a fresh membership, but the list itself — and the "no groups yet, start
+ * one" fallback — is the same shape on purpose.
+ */
+function ChooseGroupForContact({
+  contact,
+  groups,
+  loading,
+  busy,
+  error,
+  onChoose,
+  onCancel,
+}: {
+  contact: PickedContact;
+  groups: readonly GroupRow[];
+  loading: boolean;
+  busy: boolean;
+  error: string | null;
+  onChoose: (groupId: string) => void;
+  onCancel: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const clearance = useTabBarClearance();
+  const { t } = useStrings();
+
+  return (
+    <ScrollView
+      contentContainerStyle={{ paddingBottom: clearance, gap: theme.spacing.lg }}
+      showsVerticalScrollIndicator={false}
+    >
+      <Card style={{ gap: theme.spacing.xs }}>
+        <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+          <Avatar name={contact.name} size={44} ghost />
+          <View style={{ flex: 1 }}>
+            <Text variant="subheading" numberOfLines={1}>
+              {contact.name}
+            </Text>
+            <Text variant="micro" tone="muted" numberOfLines={1}>
+              {contact.email ?? contact.phone ?? t.misc.noAddress}
+            </Text>
+          </View>
+        </Row>
+      </Card>
+
+      <Text variant="caption" tone="muted">
+        {fill(t.mergePeople.newContactBody, { name: contact.name })}
+      </Text>
+
+      {loading ? (
+        <ActivityIndicator color={theme.color.brand} />
+      ) : groups.length === 0 ? (
+        <Card style={{ gap: theme.spacing.md }}>
+          <Text variant="caption" tone="muted">
+            {t.extras.noGroupsYet}
+          </Text>
+          <Button
+            label={t.misc.startAGroup}
+            variant="secondary"
+            onPress={() => router.push('/new-group')}
+          />
+        </Card>
+      ) : (
+        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+          {groups.map((group, index) => (
+            <View key={group.id}>
+              <ListRow
+                title={groupLabel(group)}
+                leading={
+                  <Avatar
+                    name={groupLabel(group)}
+                    emoji={group.cover_emoji ?? undefined}
+                    size={40}
+                  />
+                }
+                onPress={busy ? undefined : () => onChoose(group.id)}
+                trailing={
+                  <Ionicons
+                    name={directionalIcon('chevron-forward')}
+                    size={iconSize.md}
+                    color={theme.color.textFaint}
+                  />
+                }
+              />
+              {index < groups.length - 1 ? <Divider /> : null}
+            </View>
+          ))}
+        </Card>
+      )}
+
+      {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
+      {error ? <Callout tone="negative">{error}</Callout> : null}
+
+      <Button label={t.common.cancel} variant="ghost" onPress={onCancel} />
+    </ScrollView>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -805,6 +805,15 @@ export interface UiStrings {
     errorNameRequired: string;
     errorNotSignedIn: string;
     errorGeneric: string;
+    /** Caption on a merge-list row added from a device contact rather than picked
+     *  off the balances list. */
+    fromContactsTag: string;
+    /** Shown while choosing a group for a contact that is new to the app.
+     *  `{name}` is the contact's name. */
+    newContactBody: string;
+    /** Fallback when adding a contact as a new guest fails. `{name}` is the
+     *  contact's name. */
+    errorContactAdd: string;
   };
   /** Group photos are a paid feature; the cover emoji stays free for everyone. */
   groupPhoto: {
@@ -2150,6 +2159,10 @@ const en: UiStrings = {
     errorNameRequired: 'Give the merged person a name.',
     errorNotSignedIn: 'You’re signed out. Sign in and try the merge again.',
     errorGeneric: 'Could not merge. Please try again.',
+    fromContactsTag: 'Added from contacts',
+    newContactBody:
+      '{name} isn’t on Waves yet. Add them to a group first, then merge them in below.',
+    errorContactAdd: 'Could not add {name}. Please try again.',
   },
   groupPhoto: {
     paidHint: 'Group photos are a Plus feature. Pick an icon, or upgrade to add a photo.',
@@ -3581,6 +3594,10 @@ const ta: UiStrings = {
     errorNameRequired: 'இணைந்த நபருக்கு ஒரு பெயரைக் கொடுக்கவும்.',
     errorNotSignedIn: 'நீங்கள் வெளியேறிவிட்டீர்கள். உள்நுழைந்து மீண்டும் இணைக்க முயற்சிக்கவும்.',
     errorGeneric: 'இணைக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
+    fromContactsTag: 'தொடர்புகளிலிருந்து சேர்க்கப்பட்டது',
+    newContactBody:
+      '{name} இன்னும் Waves-இல் இல்லை. முதலில் அவர்களை ஒரு குழுவில் சேர்க்கவும், பிறகு கீழே இணைக்கவும்.',
+    errorContactAdd: '{name} ஐச் சேர்க்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
   },
   groupPhoto: {
     paidHint:
@@ -5027,6 +5044,10 @@ const hi: UiStrings = {
     errorNameRequired: 'मर्ज किए गए व्यक्ति को एक नाम दें.',
     errorNotSignedIn: 'आप साइन आउट हैं. साइन इन करके फिर से मर्ज करें.',
     errorGeneric: 'मर्ज नहीं हो सका. कृपया फिर से प्रयास करें.',
+    fromContactsTag: 'संपर्कों से जोड़ा गया',
+    newContactBody:
+      '{name} अभी Waves पर नहीं है. पहले उन्हें किसी समूह में जोड़ें, फिर नीचे मर्ज करें.',
+    errorContactAdd: '{name} को नहीं जोड़ा जा सका. कृपया फिर कोशिश करें.',
   },
   groupPhoto: {
     paidHint: 'ग्रुप फ़ोटो एक Plus सुविधा है। कोई आइकन चुनें, या फ़ोटो जोड़ने के लिए अपग्रेड करें।',
@@ -6468,6 +6489,9 @@ const ar: UiStrings = {
     errorNameRequired: 'أعطِ الشخص المدمج اسمًا.',
     errorNotSignedIn: 'أنت مسجّل الخروج. سجّل الدخول وحاول الدمج مرة أخرى.',
     errorGeneric: 'تعذّر الدمج. يرجى المحاولة مرة أخرى.',
+    fromContactsTag: 'أُضيف من جهات الاتصال',
+    newContactBody: '{name} ليس على Waves بعد. أضفه إلى مجموعة أولاً، ثم ادمجه أدناه.',
+    errorContactAdd: 'تعذّرت إضافة {name}. يرجى المحاولة مرة أخرى.',
   },
   groupPhoto: {
     paidHint: 'صور المجموعة ميزة Plus. اختر أيقونة، أو قم بالترقية لإضافة صورة.',


### PR DESCRIPTION
## Summary
- The merge-people screen (`friends/merge.tsx`) could only fold together guests already shown on the balances list — there was no way to pick a device contact as a merge target.
- Added a "From contacts" entry point that opens the existing `ContactPicker` (single-select, same lazy/non-throwing permission handling it already has).
- If the picked contact's name matches an existing guest, that guest is ticked — the same name-recognition the screen already relies on for regular merges.
- If the contact is new to the app, the flow asks which group to add them to (reusing the same group-list UI shape as `contacts.tsx`) and materializes them via the existing `addGhostMember` RPC — the exact path `contacts.tsx` and `add-person.tsx` already use — then folds the new member into the selection.
- The merge itself is untouched: it still goes through `mergeGhosts`/`memberIdsForMerge`/`canMerge`, so the advisory-locked, union-not-overwrite ledger safety from the earlier merge-race work applies identically to contact-sourced targets. No new DB writes or migrations.
- Added `fromContactsTag`, `newContactBody`, `errorContactAdd` to `mergePeople` in all four locales (en/ta/hi/ar).

## Which hook/RPC the merge goes through
- Matching an existing guest: no RPC call, just local selection state (same as ticking a row today).
- Materializing a new contact: `addGhostMember(groupId, name, { email, phone })` → `baaki_add_ghost_member` RPC (group-scoped, idempotent on email/phone).
- The merge: `mergeGhosts(memberIds, name)` → `baaki_merge_ghosts` RPC, unchanged.

## Follow-up flagged
- `baaki_add_ghost_member`'s phone/email dedup is scoped to a single group (`WHERE gm.group_id = p_group_id`), not cross-group. So a device contact is matched to an existing merge target by **name** only (case-insensitive), same signal the rest of this screen already uses — `PersonBalanceRow` doesn't currently expose phone/email to the client. If cross-group phone/email matching is wanted later, `baaki_people_i_owe` would need to return contact fields, which is a server change outside this task's scope.

## Test plan
- [x] `pnpm format` / `pnpm lint` / `pnpm typecheck` clean for mobile, ui, core, web, admin (packages/db typecheck fails in this worktree only due to a pre-existing missing `DIRECT_URL` env var, unrelated to this change — no files under `packages/db` were touched)
- [x] `pnpm --filter @waves/mobile run test` — 286/286 passing, including `mergePeople.test.ts` (pure logic unchanged)
- [ ] Manual device test of the contact picker + group-choose flow (not run — no device/emulator in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contact-based selection when merging people.
  * Added support for adding contacts who are not yet on Waves to a selected group.
  * Added options to remove contact targets and identify contacts in merge results.
  * Added contact picker and group selection flows, including contact-only empty states.

* **Bug Fixes**
  * Improved loading and error handling when adding contacts.

* **Localization**
  * Added English, Tamil, Hindi, and Arabic translations for the new contact merge experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->