### PR TITLE
feat(mobile): attach, keep and view receipts on expenses (E1/E2)

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -410,6 +410,7 @@ function AuthGate() {
         <Stack.Screen name="group/[id]/expense/[expenseId]" />
         <Stack.Screen name="group/[id]/invite" options={modal} />
         <Stack.Screen name="group/[id]/itemize" options={modal} />
+        <Stack.Screen name="receipt/[id]" options={modal} />
         <Stack.Screen name="friends/contacts" />
         <Stack.Screen name="settings/backup" />
         <Stack.Screen name="settings/notifications" />

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
+import { Image } from 'expo-image';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
@@ -21,6 +22,7 @@ import {
   Callout,
   Card,
   ChipRow,
+  directionalIcon,
   EmptyState,
   IconButton,
   iconSize,
@@ -28,6 +30,7 @@ import {
   Row,
   Screen,
   Text,
+  Toggle,
   useTheme,
 } from '@waves/ui';
 
@@ -44,8 +47,13 @@ import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { handoverKey } from '@/lib/handover';
 import { resolveDraftCurrency, resolveDraftFx } from '@/lib/expenseDraft';
-import { captureReceipt } from '@/lib/image';
+import { captureReceipt, pickReceiptImage, type PickedImage } from '@/lib/image';
 import { recogniseReceipt } from '@/lib/ocr';
+import { receiptFiles, saveReceipt } from '@/lib/receiptStore';
+import { entryFor, markPending } from '@/lib/receiptIndex';
+import { useBackup } from '@/lib/cloud/BackupProvider';
+import { providerFor } from '@/lib/cloud/providers';
+import { loadTokens, saveTokens } from '@/lib/cloud/tokens';
 import { matchMemberNames, stripMemberNames } from '@/lib/voiceExpense';
 import {
   entryValues,
@@ -136,6 +144,7 @@ export default function AddExpenseScreen() {
   const { mutate } = useSync();
   const assignCapture = useAssignCapture();
   const guard = useGuestGuard();
+  const backup = useBackup();
 
   const editing = expenses.rows.find((expense) => expense.id === expenseId);
 
@@ -186,6 +195,23 @@ export default function AddExpenseScreen() {
   const [scanNote, setScanNote] = useState<string | null>(null);
   /** Set once a scan has read line items, so the offer to itemize is real. */
   const [scannedItems, setScannedItems] = useState(0);
+  // The kept bill for this expense (E2): its local image URI once a scan or an
+  // attach has written it to the device vault, keyed by the expense id. Null
+  // means no receipt on this device — the thumbnail and the "view" affordance
+  // hide themselves. Seeded straight from disk (a synchronous file check) so a
+  // receipt kept on an earlier edit shows the moment the screen reopens, without
+  // an effect that would flash it in a frame late.
+  const [receiptUri, setReceiptUri] = useState<string | null>(
+    () => receiptFiles(targetExpenseId)?.imageUri ?? null,
+  );
+  // E3: share the kept bill with the group, off by default. Only meaningful
+  // once the receipt is backed up to a share-capable personal cloud (Drive) —
+  // `shareEligible` says whether that is true yet, so the toggle is never a
+  // promise the plumbing can't keep. `shareUrl` is the link, either loaded from
+  // an existing expense or minted on save.
+  const [shareWithGroup, setShareWithGroup] = useState(false);
+  const [shareEligible, setShareEligible] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
 
   // The per-group receipt ceiling. A group holds a few receipts for free (the
   // number is an admin knob); past it, scanning is a paid feature. A paid group
@@ -208,6 +234,21 @@ export default function AddExpenseScreen() {
     () => (members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ?? null,
     [members.data, profile?.id],
   );
+
+  // Whether the kept bill has reached a share-capable cloud yet (E3). Read from
+  // the backup index, which is async — so it lives in an effect, re-run when a
+  // fresh save changes `receiptUri`. This is what keeps the group-share toggle
+  // honest: it can only be turned on once there is actually something to serve.
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const entry = await entryFor(targetExpenseId);
+      if (active) setShareEligible(entry?.state === 'synced' && entry.provider === 'gdrive');
+    })();
+    return () => {
+      active = false;
+    };
+  }, [targetExpenseId, receiptUri]);
 
   // Seed the form once the group has loaded: I paid, everyone splits — or the
   // current version's values when editing. Done during render (React's
@@ -294,6 +335,10 @@ export default function AddExpenseScreen() {
       // expense asks for its rate again on save.
       setExpenseCurrency(version.currency);
       setFx(null);
+      // A bill already opened to the group carries its link on the version (E3);
+      // reopen the toggle on so an edit does not silently un-share it.
+      setShareUrl(version.receipt_share_url ?? null);
+      setShareWithGroup(Boolean(version.receipt_share_url));
       setPayer(version.payers[0]?.member_id ?? myMemberId);
       setParticipants(version.shares.map((share) => share.member_id));
       setSplitKind(
@@ -438,6 +483,33 @@ export default function AddExpenseScreen() {
     );
   }
 
+  /**
+   * The group-share link to store on the expense (E3), or null.
+   *
+   * Off, or an already-known link, are settled without a network call. Turning
+   * it on mints the link from the owner's OWN Drive — but only when the bill has
+   * actually reached Drive (a synced backup with a file id). If it has not, this
+   * returns null rather than a broken promise: the toggle's own gate means the
+   * user was told to back it up first, and a save must never claim a share it
+   * cannot serve. The image never passes through Waves at any step.
+   */
+  const resolveShareUrl = async (): Promise<string | null> => {
+    if (!shareWithGroup) return null;
+    if (shareUrl) return shareUrl;
+    const entry = await entryFor(targetExpenseId);
+    if (!entry || entry.state !== 'synced' || entry.provider !== 'gdrive' || !entry.remoteId) {
+      return null;
+    }
+    const stored = await loadTokens('gdrive');
+    if (!stored) return null;
+    const provider = providerFor('gdrive');
+    if (!provider.share) return null;
+    const tokens = await provider.ensureValid(stored);
+    await saveTokens('gdrive', tokens);
+    const result = await provider.share(tokens, { remoteId: entry.remoteId });
+    return 'url' in result ? result.url : null;
+  };
+
   const submit = async (): Promise<void> => {
     // Read-only once the guest trial is up (ADR-006 addendum): the group and its
     // history stay visible, but a new or edited expense sends them to sign up.
@@ -449,10 +521,23 @@ export default function AddExpenseScreen() {
     }
     setSaving(true);
     try {
+      // Mint the group-share link before the write, so it rides the same
+      // mutation and reaches other members with the expense. A Drive hiccup here
+      // must not block saving the expense itself — on any trouble it stays null,
+      // never a half-shared receipt.
+      let receiptShareUrl: string | null = null;
+      try {
+        receiptShareUrl = await resolveShareUrl();
+      } catch {
+        receiptShareUrl = null;
+      }
+      if (receiptShareUrl) setShareUrl(receiptShareUrl);
+
       // Straight into the durable queue: this returns as soon as the mutation
       // is on disk, so the expense is saved whether or not there is a network.
       await mutate(expenseId ? MutationKind.ExpenseUpdate : MutationKind.ExpenseCreate, groupId, {
         expenseId: targetExpenseId,
+        receiptShareUrl,
         // Blank stays blank. Writing the English word "Expense" here made every
         // undescribed row identical in the list, and put a word nobody typed
         // into an append-only ledger, the CSV export and the notification text —
@@ -512,6 +597,74 @@ export default function AddExpenseScreen() {
   };
 
   /**
+   * Keep the bill (E2): write it to the on-device vault under the expense id,
+   * and queue a personal-cloud backup if one is connected — exactly what the
+   * capture screen does, and for the same privacy reason. The image is never
+   * uploaded to Waves; only the parsed fields ride the expense sync.
+   *
+   * Best-effort by design: the vault returns null on web or a build without a
+   * document dir, and a failed keep must never cost the scan or the attach that
+   * produced it. So it swallows its own trouble and leaves the amount typed.
+   */
+  const persistReceipt = (
+    picked: PickedImage,
+    extra?: {
+      amountMinor?: number;
+      items?: { label: string; total: number }[];
+      rawText?: string | null;
+      date?: string | null;
+    },
+  ): void => {
+    try {
+      const saved = saveReceipt(targetExpenseId, {
+        base64: picked.base64,
+        sidecar: {
+          captureId: targetExpenseId,
+          currency,
+          amountMinor: extra?.amountMinor ?? Number(amount),
+          itemCount: extra?.items?.length ?? 0,
+          items: extra?.items ?? [],
+          date: extra?.date ?? new Date().toISOString().slice(0, 10),
+          category,
+          rawText: extra?.rawText ?? null,
+          createdAt: new Date().toISOString(),
+        },
+      });
+      if (!saved) return;
+      setReceiptUri(saved.imageUri);
+      // Remember it needs backup before any network is involved, then nudge the
+      // queue; both no-op cleanly when there is no provider or no signal.
+      void markPending(targetExpenseId, saved, new Date().toISOString()).then(() => backup.kick());
+    } catch {
+      // A vault that would not write is not a reason to lose the expense.
+    }
+  };
+
+  /**
+   * Attach a bill the person already has (E1).
+   *
+   * The escape hatch for when scanning is the wrong tool: the bill is a
+   * screenshot of a delivery order, a PDF photographed earlier, or a scan that
+   * failed and they would rather attach the picture in their gallery. Unlike a
+   * scan it never hits the metered `receipt-parse` path — nothing is recorded
+   * server-side, so it does not count against the group's receipt cap and is
+   * offered even when the cap is reached. The image is kept and the amount stays
+   * theirs to type.
+   */
+  const attach = async (): Promise<void> => {
+    setError(null);
+    setScanNote(null);
+    let picked: PickedImage | null = null;
+    try {
+      picked = await pickReceiptImage();
+    } catch {
+      picked = null;
+    }
+    if (!picked) return;
+    persistReceipt(picked);
+  };
+
+  /**
    * Photograph the bill, fill in the two fields somebody was about to type.
    *
    * This screen deliberately does not become an itemizing screen. Most bills
@@ -556,6 +709,17 @@ export default function AddExpenseScreen() {
       if (result.parsed.grandTotal > 0) setAmount(BigInt(result.parsed.grandTotal));
       if (result.parsed.merchant && !description.trim()) setDescription(result.parsed.merchant);
       setScannedItems(result.parsed.items.length);
+
+      // Keep the photographed bill too (E2), with what the parser recovered as
+      // its sidecar so the on-device archive reads as a record, not a folder of
+      // JPEGs. The scan's own server receipt is a separate thing (the metered
+      // parse); this is the copy the owner keeps and can view later.
+      persistReceipt(picked, {
+        amountMinor: result.parsed.grandTotal > 0 ? result.parsed.grandTotal : undefined,
+        items: result.parsed.items.map((item) => ({ label: item.label, total: item.total })),
+        rawText: recognised?.text ?? null,
+        date: result.parsed.date,
+      });
 
       // Kept for the itemize screen in case they want it. Nobody should have to
       // photograph the same bill twice, and a scan is metered (ADR-011).
@@ -637,20 +801,22 @@ export default function AddExpenseScreen() {
 
         {/* Below the amount, not above it. Typing a number is the fast path and
             stays the first thing on the screen; the camera is for the bill that
-            is easier to point at than to read. */}
+            is easier to point at than to read. Attach sits beside Scan for the
+            bill that is already a picture, or the scan that would not read. */}
         <Card style={{ gap: theme.spacing.md }}>
-          <Row style={{ justifyContent: 'space-between' }}>
-            <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-              <Text variant="subheading">
-                {capLocked ? t.expense.capReachedTitle : t.expense.scanBillTitle}
-              </Text>
-              <Text variant="caption" tone="muted">
-                {capLocked ? t.expense.capReachedBody : t.expense.scanBillBody}
-              </Text>
-            </View>
-            {/* Once the group is capped the scan button has nothing to do — a
-                scan the server would refuse — so it gives way to the two ways
-                out: pay, or bring your own storage. */}
+          <View>
+            <Text variant="subheading">
+              {capLocked ? t.expense.capReachedTitle : t.expense.scanBillTitle}
+            </Text>
+            <Text variant="caption" tone="muted">
+              {capLocked ? t.expense.capReachedBody : t.expense.scanBillBody}
+            </Text>
+          </View>
+
+          {/* Scan is metered and gives way when the group is capped; Attach is
+              not — it keeps a photo on the device and never records a receipt
+              server-side, so it is offered even at the cap. */}
+          <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
             {!capLocked ? (
               <Button
                 label={scanning ? t.expense.reading : t.expense.scan}
@@ -662,6 +828,13 @@ export default function AddExpenseScreen() {
                 }
               />
             ) : null}
+            <Button
+              label={t.expense.attach}
+              variant="secondary"
+              disabled={scanning || saving}
+              onPress={() => void attach()}
+              icon={<Ionicons name="image-outline" size={iconSize.md} color={theme.color.brand} />}
+            />
           </Row>
           {capLocked ? (
             <Row style={{ gap: theme.spacing.sm }}>
@@ -682,6 +855,69 @@ export default function AddExpenseScreen() {
               {scanNote}
             </Text>
           ) : null}
+
+          {/* The kept bill (E2): a thumbnail that opens the full-screen viewer,
+              and below it the explicit, off-by-default choice to open it to the
+              group from your own Drive (E3). Both hide themselves until there is
+              a bill on the device. */}
+          {receiptUri ? (
+            <>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.expense.viewReceipt}
+                onPress={() =>
+                  router.push(
+                    `/receipt/${targetExpenseId}${
+                      shareUrl ? `?shareUrl=${encodeURIComponent(shareUrl)}` : ''
+                    }`,
+                  )
+                }
+              >
+                <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                  <Image
+                    source={{ uri: receiptUri }}
+                    style={{ width: 52, height: 52, borderRadius: theme.radius.md }}
+                    contentFit="cover"
+                    transition={150}
+                  />
+                  <View style={{ flex: 1, minWidth: 0 }}>
+                    <Text variant="subheading" numberOfLines={1}>
+                      {t.expense.viewReceipt}
+                    </Text>
+                    <Text variant="micro" tone="muted" numberOfLines={1}>
+                      {t.expense.receiptAttached}
+                    </Text>
+                  </View>
+                  <Ionicons
+                    name={directionalIcon('chevron-forward')}
+                    size={iconSize.md}
+                    color={theme.color.textFaint}
+                  />
+                </Row>
+              </Pressable>
+
+              <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text variant="caption">{t.expense.shareReceiptTitle}</Text>
+                  <Text variant="micro" tone="muted">
+                    {shareEligible
+                      ? t.expense.shareReceiptBody
+                      : t.expense.shareReceiptNeedsStorage}
+                  </Text>
+                </View>
+                <Toggle
+                  value={shareWithGroup}
+                  onValueChange={setShareWithGroup}
+                  // Off means off; on can always be turned back off. On can only
+                  // be turned on once the bill is on a share-capable cloud, so a
+                  // toggle can never claim to share what nothing can serve.
+                  disabled={!shareEligible && !shareWithGroup}
+                  accessibilityLabel={t.expense.shareReceiptTitle}
+                />
+              </Row>
+            </>
+          ) : null}
+
           {scannedItems > 0 && !editing ? (
             <Pressable
               accessibilityRole="button"

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -1,6 +1,7 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { Image } from 'expo-image';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, Alert, ScrollView, View } from 'react-native';
+import { ActivityIndicator, Alert, Linking, Pressable, ScrollView, View } from 'react-native';
 
 import { categoryOf } from '@waves/core';
 import {
@@ -35,6 +36,7 @@ import { expenseTitle } from '@/data/expenseTitle';
 import { displayName, groupLabel, isGhost } from '@/data/types';
 import { fill, plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { receiptFiles } from '@/lib/receiptStore';
 
 function splitLabels(t: UiStrings): Record<string, string> {
   return {
@@ -100,6 +102,25 @@ export default function ExpenseDetailScreen() {
 
   const currency = version.currency;
   const deleted = Boolean(expense.deleted_at);
+
+  // The bill (E2/E3). The owner has it in the device vault; a member who is not
+  // the owner has no local copy, but may have the owner's Drive link if they
+  // opened it to the group. Either is a way to see the receipt — the local one
+  // opens the in-app zoom viewer, the link opens the owner's own Drive.
+  const localReceipt = receiptFiles(expense.id);
+  const receiptShareUrl = version.receipt_share_url;
+  const hasReceipt = Boolean(localReceipt) || Boolean(receiptShareUrl);
+  const openReceipt = (): void => {
+    if (localReceipt) {
+      router.push(
+        `/receipt/${expense.id}${
+          receiptShareUrl ? `?shareUrl=${encodeURIComponent(receiptShareUrl)}` : ''
+        }`,
+      );
+    } else if (receiptShareUrl) {
+      void Linking.openURL(receiptShareUrl).catch(() => undefined);
+    }
+  };
   // The hero wears the expense's category colour, not a money colour: this
   // amount is a total that belongs to nobody, shown neutral. Ink from the same
   // pair keeps it legible on the tint.
@@ -189,6 +210,56 @@ export default function ExpenseDetailScreen() {
             {deleted ? <Badge label={t.expense.deleted} tone="negative" /> : null}
           </Row>
         </TintCard>
+
+        {/* The bill, when there is one to see (E2/E3). A local thumbnail opens
+            the pinch-zoom viewer; a member with only the owner's share link gets
+            a row that opens it. Absent entirely when neither exists. */}
+        {hasReceipt ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.expense.viewReceipt}
+            onPress={openReceipt}
+          >
+            <Card style={{ paddingVertical: theme.spacing.md }}>
+              <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                {localReceipt ? (
+                  <Image
+                    source={{ uri: localReceipt.imageUri }}
+                    style={{ width: 52, height: 52, borderRadius: theme.radius.md }}
+                    contentFit="cover"
+                    transition={150}
+                  />
+                ) : (
+                  <View
+                    style={{
+                      width: 52,
+                      height: 52,
+                      borderRadius: theme.radius.md,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: theme.color.bg,
+                    }}
+                  >
+                    <Ionicons name="receipt-outline" size={iconSize.lg} color={theme.color.brand} />
+                  </View>
+                )}
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text variant="subheading" numberOfLines={1}>
+                    {t.expense.viewReceipt}
+                  </Text>
+                  <Text variant="micro" tone="muted" numberOfLines={1}>
+                    {t.expense.receiptTitle}
+                  </Text>
+                </View>
+                <Ionicons
+                  name={directionalIcon('chevron-forward')}
+                  size={iconSize.md}
+                  color={theme.color.textFaint}
+                />
+              </Row>
+            </Card>
+          </Pressable>
+        ) : null}
 
         {version.payers.length > 1 ? (
           <View>

--- a/apps/mobile/src/app/receipt/[id].tsx
+++ b/apps/mobile/src/app/receipt/[id].tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Image } from 'expo-image';
+import { Linking, useWindowDimensions, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { router, useLocalSearchParams } from 'expo-router';
+
+import { Button, EmptyState, IconButton, iconSize, Screen, useTheme } from '@waves/ui';
+
+import { fill, useStrings } from '@/i18n';
+import { providerFor } from '@/lib/cloud/providers';
+import { entryFor } from '@/lib/receiptIndex';
+import { receiptFiles } from '@/lib/receiptStore';
+
+/**
+ * See the bill, any time after it was kept (E2).
+ *
+ * The receipt lives in the on-device vault, keyed by the expense id — never on
+ * Waves. This screen reads it from there and shows it full-bleed, pinch to zoom.
+ * When the local file is gone (a reinstall, a cleared vault) it does not simply
+ * fail: if the receipt was backed up to a personal cloud, it says which one and,
+ * when a share link is known, offers to open it; otherwise it explains the bill
+ * is on the device it was added from. A missing receipt is a calm message, never
+ * a crash.
+ */
+export default function ReceiptViewerScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const { id, shareUrl } = useLocalSearchParams<{ id: string; shareUrl?: string }>();
+  const receiptId = id ?? '';
+
+  // Device-only and synchronous — the vault is a file lookup. Null on web, and
+  // null once the file is gone, which is the fallback path below.
+  const files = receiptFiles(receiptId);
+
+  // Only consulted when the local image is missing, to tell the person where it
+  // went. A backed-up receipt names its provider; anything else is "other
+  // device". Read once on mount.
+  const [cloudLabel, setCloudLabel] = useState<string | null>(null);
+  useEffect(() => {
+    if (files) return;
+    let active = true;
+    void (async () => {
+      const entry = await entryFor(receiptId);
+      if (!active) return;
+      setCloudLabel(
+        entry?.state === 'synced' && entry.provider ? providerFor(entry.provider).label : null,
+      );
+    })();
+    return () => {
+      active = false;
+    };
+  }, [files, receiptId]);
+
+  return (
+    <Screen edges={['top', 'bottom']}>
+      <View style={{ flex: 1, backgroundColor: theme.color.bg }}>
+        <View style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.close} onPress={() => router.back()}>
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+          </IconButton>
+        </View>
+
+        {files ? (
+          <ZoomableImage uri={files.imageUri} />
+        ) : (
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <EmptyState
+              title={t.expense.receiptMissingTitle}
+              body={
+                cloudLabel
+                  ? fill(t.expense.receiptMissingCloud, { provider: cloudLabel })
+                  : t.expense.receiptMissingOtherDevice
+              }
+              action={
+                // A share link means the owner opened the bill to the group from
+                // their own Drive (E3) — anyone can open it, even without the
+                // local file.
+                shareUrl ? (
+                  <Button
+                    label={t.expense.viewReceipt}
+                    onPress={() => void Linking.openURL(shareUrl).catch(() => undefined)}
+                  />
+                ) : undefined
+              }
+            />
+          </View>
+        )}
+      </View>
+    </Screen>
+  );
+}
+
+const AnimatedImage = Animated.createAnimatedComponent(Image);
+
+/**
+ * The bill, pinch to zoom and drag to pan, double-tap to reset.
+ *
+ * Deliberately self-contained: the gestures live on shared values so the pan and
+ * zoom stay on the UI thread, and the whole thing resets to fit on a double tap
+ * so a person who zoomed in can always get back out. Clamped to a sane range so
+ * the image can neither shrink to a dot nor fly off screen.
+ */
+function ZoomableImage({ uri }: { uri: string }): React.JSX.Element {
+  const { width, height } = useWindowDimensions();
+
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const savedX = useSharedValue(0);
+  const savedY = useSharedValue(0);
+
+  const pinch = Gesture.Pinch()
+    .onUpdate((event) => {
+      // Clamp between fit (1) and 5×, so it can neither vanish nor over-magnify.
+      const next = Math.min(Math.max(savedScale.get() * event.scale, 1), 5);
+      scale.set(next);
+    })
+    .onEnd(() => {
+      savedScale.set(scale.get());
+      if (scale.get() <= 1) {
+        translateX.set(withTiming(0));
+        translateY.set(withTiming(0));
+        savedX.set(0);
+        savedY.set(0);
+      }
+    });
+
+  const pan = Gesture.Pan()
+    .onUpdate((event) => {
+      // Panning only makes sense once zoomed in; at fit it stays put.
+      if (scale.get() <= 1) return;
+      translateX.set(savedX.get() + event.translationX);
+      translateY.set(savedY.get() + event.translationY);
+    })
+    .onEnd(() => {
+      savedX.set(translateX.get());
+      savedY.set(translateY.get());
+    });
+
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onEnd(() => {
+      scale.set(withTiming(1));
+      savedScale.set(1);
+      translateX.set(withTiming(0));
+      translateY.set(withTiming(0));
+      savedX.set(0);
+      savedY.set(0);
+    });
+
+  const composed = Gesture.Simultaneous(pinch, pan, doubleTap);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.get() },
+      { translateY: translateY.get() },
+      { scale: scale.get() },
+    ],
+  }));
+
+  return (
+    <GestureDetector gesture={composed}>
+      <Animated.View style={{ flex: 1, justifyContent: 'center' }} collapsable={false}>
+        <AnimatedImage
+          source={{ uri }}
+          style={[{ width, height: height * 0.8 }, animatedStyle]}
+          contentFit="contain"
+          transition={150}
+        />
+      </Animated.View>
+    </GestureDetector>
+  );
+}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -59,7 +59,7 @@ const EXPENSE_SELECT = `
   id, group_id, deleted_at, created_at,
   currentVersion:expense_versions!expenses_current_version_id_fkey (
     id, version_no, description, category, expense_date, currency, amount,
-    split_type, split_params, author_member_id, notes, payment_method, created_at,
+    split_type, split_params, author_member_id, notes, payment_method, receipt_share_url, created_at,
     payers:expense_payers ( member_id, amount ),
     shares:expense_shares ( member_id, amount )
   )
@@ -557,6 +557,8 @@ export interface WriteExpenseInput {
   notes?: string | null;
   /** How the money moved: cash | credit | debit | forex. Optional. */
   paymentMethod?: PaymentMethod | null;
+  /** A view-only link to the owner's own cloud copy of the receipt (E3). */
+  receiptShareUrl?: string | null;
   /** The rate used, when this expense is not in the group's currency. */
   fx?: FxRecord | null;
   clientMutationId?: string;
@@ -596,6 +598,9 @@ export async function writeExpense(input: WriteExpenseInput): Promise<WriteExpen
       // Full snapshot, not a patch: an append-only version always carries the
       // field, so an omitted method and an explicit null both mean "none".
       paymentMethod: input.paymentMethod ?? null,
+      // A view-only link to the owner's own cloud copy of the receipt (E3); the
+      // image itself never reaches the server, only this optional URL.
+      receiptShareUrl: input.receiptShareUrl ?? null,
       fx: input.fx ?? null,
       // Idempotency key: a retry after a flaky network must not double-post.
       clientMutationId: input.clientMutationId ?? randomUUID(),

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -726,6 +726,7 @@ function serialiseExpense(input: Omit<WriteExpenseInput, 'groupId'>): Record<str
       : undefined,
     notes: input.notes ?? null,
     paymentMethod: input.paymentMethod ?? null,
+    receiptShareUrl: input.receiptShareUrl ?? null,
   };
 }
 

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -100,6 +100,8 @@ export interface ExpenseVersionRow {
   author_member_id: MemberId | null;
   notes: string | null;
   payment_method: string | null;
+  /** A view-only link to the owner's own cloud copy of the receipt (E3), or null. */
+  receipt_share_url: string | null;
   created_at: string;
   payers: { member_id: MemberId; amount: string }[];
   shares: { member_id: MemberId; amount: string }[];

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1025,6 +1025,21 @@ export interface UiStrings {
     capReachedBody: string;
     capUpgrade: string;
     capAddStorage: string;
+    /** Attaching a bill from the gallery, and viewing a kept one (E1/E2). */
+    attach: string;
+    attachReceiptA11y: string;
+    viewReceipt: string;
+    receiptAttached: string;
+    receiptTitle: string;
+    /** Viewer states when the local file is gone but a backup may exist. */
+    receiptMissingTitle: string;
+    receiptMissingOtherDevice: string;
+    /** Has a {provider} placeholder — the personal cloud it was backed up to. */
+    receiptMissingCloud: string;
+    /** Sharing a Drive-stored bill with the group, explicit opt-in (E3). */
+    shareReceiptTitle: string;
+    shareReceiptBody: string;
+    shareReceiptNeedsStorage: string;
     /** The scanned-bill card and the receipt hand-off on the group screen. */
     aBill: string;
     splitBillA11y: string;
@@ -2386,6 +2401,20 @@ const en: UiStrings = {
       'This group has used its free receipts. Upgrade or add your own storage to keep scanning.',
     capUpgrade: 'Upgrade',
     capAddStorage: 'Add storage',
+    attach: 'Attach',
+    attachReceiptA11y: 'Attach a photo of the bill from your gallery',
+    viewReceipt: 'View receipt',
+    receiptAttached: 'Bill kept — tap to view',
+    receiptTitle: 'Receipt',
+    receiptMissingTitle: 'Receipt not on this device',
+    receiptMissingOtherDevice:
+      'This bill is saved on the device it was added from. Open the app there to see it.',
+    receiptMissingCloud: 'This bill is backed up to your {provider}, not on this device.',
+    shareReceiptTitle: 'Share receipt with group',
+    shareReceiptBody:
+      'Let everyone in the group open the bill from your own Drive. The image never touches Waves. Off by default.',
+    shareReceiptNeedsStorage:
+      'Back this receipt up to Google Drive first to share it with the group.',
     aBill: 'A bill',
     splitBillA11y: 'Split {merchant} by item',
     receiptClaimedNone: {
@@ -3839,6 +3868,21 @@ const ta: UiStrings = {
       'இந்தக் குழு அதன் இலவச ரசீதுகளைப் பயன்படுத்திவிட்டது. தொடர்ந்து ஸ்கேன் செய்ய மேம்படுத்துங்கள் அல்லது உங்கள் சொந்த சேமிப்பகத்தைச் சேர்க்கவும்.',
     capUpgrade: 'மேம்படுத்து',
     capAddStorage: 'சேமிப்பகம் சேர்',
+    attach: 'இணை',
+    attachReceiptA11y: 'கேலரியில் இருந்து பில் புகைப்படத்தை இணை',
+    viewReceipt: 'ரசீதைப் பார்',
+    receiptAttached: 'பில் சேமிக்கப்பட்டது — பார்க்க தட்டவும்',
+    receiptTitle: 'ரசீது',
+    receiptMissingTitle: 'இந்தச் சாதனத்தில் ரசீது இல்லை',
+    receiptMissingOtherDevice:
+      'இந்த பில் அது சேர்க்கப்பட்ட சாதனத்தில் சேமிக்கப்பட்டுள்ளது. அதைப் பார்க்க அங்கே ஆப்பைத் திறக்கவும்.',
+    receiptMissingCloud:
+      'இந்த பில் உங்கள் {provider}-இல் காப்பு எடுக்கப்பட்டுள்ளது, இந்தச் சாதனத்தில் இல்லை.',
+    shareReceiptTitle: 'ரசீதைக் குழுவுடன் பகிர்',
+    shareReceiptBody:
+      'குழுவில் உள்ள அனைவரும் உங்கள் Drive-இல் இருந்து பில்லைத் திறக்கலாம். படம் Waves-ஐ ஒருபோதும் தொடாது. இயல்பாக அணைக்கப்பட்டுள்ளது.',
+    shareReceiptNeedsStorage:
+      'குழுவுடன் பகிர இந்த ரசீதை முதலில் Google Drive-இல் காப்பு எடுக்கவும்.',
     aBill: 'ஒரு பில்',
     splitBillA11y: '{merchant} பொருள் வாரியாகப் பிரி',
     receiptClaimedNone: {
@@ -5283,6 +5327,20 @@ const hi: UiStrings = {
       'इस ग्रुप की मुफ़्त रसीदें ख़त्म हो गई हैं। स्कैन करते रहने के लिए अपग्रेड करें या अपना स्टोरेज जोड़ें।',
     capUpgrade: 'अपग्रेड करें',
     capAddStorage: 'स्टोरेज जोड़ें',
+    attach: 'जोड़ें',
+    attachReceiptA11y: 'गैलरी से बिल की फ़ोटो जोड़ें',
+    viewReceipt: 'रसीद देखें',
+    receiptAttached: 'बिल सहेजा गया — देखने के लिए टैप करें',
+    receiptTitle: 'रसीद',
+    receiptMissingTitle: 'इस डिवाइस पर रसीद नहीं है',
+    receiptMissingOtherDevice:
+      'यह बिल उसी डिवाइस पर सहेजा गया है जहाँ से इसे जोड़ा गया था। इसे देखने के लिए वहाँ ऐप खोलें।',
+    receiptMissingCloud: 'यह बिल आपके {provider} पर बैकअप है, इस डिवाइस पर नहीं।',
+    shareReceiptTitle: 'रसीद ग्रुप के साथ साझा करें',
+    shareReceiptBody:
+      'ग्रुप के सभी लोग आपके Drive से बिल खोल सकते हैं। छवि कभी Waves तक नहीं पहुँचती। डिफ़ॉल्ट रूप से बंद।',
+    shareReceiptNeedsStorage:
+      'ग्रुप के साथ साझा करने के लिए पहले इस रसीद का Google Drive पर बैकअप लें।',
     aBill: 'एक बिल',
     splitBillA11y: '{merchant} को चीज़-वार बाँटें',
     receiptClaimedNone: {
@@ -6746,6 +6804,20 @@ const ar: UiStrings = {
       'استهلكت هذه المجموعة إيصالاتها المجانية. رقِّ الخطة أو أضِف مساحتك الخاصة لمواصلة المسح.',
     capUpgrade: 'ترقية',
     capAddStorage: 'إضافة مساحة',
+    attach: 'إرفاق',
+    attachReceiptA11y: 'أرفق صورة الفاتورة من معرض الصور',
+    viewReceipt: 'عرض الإيصال',
+    receiptAttached: 'تم حفظ الفاتورة — اضغط للعرض',
+    receiptTitle: 'الإيصال',
+    receiptMissingTitle: 'الإيصال غير موجود على هذا الجهاز',
+    receiptMissingOtherDevice:
+      'هذه الفاتورة محفوظة على الجهاز الذي أُضيفت منه. افتح التطبيق هناك لعرضها.',
+    receiptMissingCloud: 'تم نسخ هذه الفاتورة احتياطيًا إلى {provider}، وليست على هذا الجهاز.',
+    shareReceiptTitle: 'مشاركة الإيصال مع المجموعة',
+    shareReceiptBody:
+      'اسمح لكل أفراد المجموعة بفتح الفاتورة من Drive الخاص بك. الصورة لا تصل إلى Waves أبدًا. مُعطَّل افتراضيًا.',
+    shareReceiptNeedsStorage:
+      'انسخ هذا الإيصال احتياطيًا إلى Google Drive أولًا لمشاركته مع المجموعة.',
     aBill: 'فاتورة',
     splitBillA11y: 'قسّم {merchant} حسب الصنف',
     receiptClaimedNone: {

--- a/apps/mobile/src/lib/cloud/googleDrive.ts
+++ b/apps/mobile/src/lib/cloud/googleDrive.ts
@@ -14,7 +14,14 @@
 import { authorize, isExpired, refresh, type OAuthConfig } from './oauth';
 import { requestJson, uploadFile } from './http';
 import { BACKUP_FOLDER, clientId, isConfigured as clientConfigured } from './config';
-import type { CloudProvider, CloudTokens, CloudUploadInput, CloudUploadResult } from './types';
+import type {
+  CloudProvider,
+  CloudShareRef,
+  CloudShareResult,
+  CloudTokens,
+  CloudUploadInput,
+  CloudUploadResult,
+} from './types';
 
 const DISCOVERY = {
   authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
@@ -101,5 +108,28 @@ export const googleDrive: CloudProvider = {
     );
     await putFile(tokens, folderId, input.jsonUri, `${input.captureId}.json`, 'application/json');
     return { remoteId };
+  },
+  /**
+   * Open the receipt to anyone with the link, view-only, and hand back that link
+   * (E3). Two calls: grant a `reader`/`anyone` permission on the file, then read
+   * its `webViewLink`.
+   *
+   * The `drive.file` scope this provider already holds is enough — it grants
+   * full control of files the app itself created, permission changes included,
+   * without widening access to the rest of the user's Drive. The image never
+   * passes through Waves; the link points straight at the owner's own Drive.
+   */
+  async share(tokens: CloudTokens, ref: CloudShareRef): Promise<CloudShareResult> {
+    await requestJson(`https://www.googleapis.com/drive/v3/files/${ref.remoteId}/permissions`, {
+      method: 'POST',
+      headers: authHeader(tokens),
+      body: { role: 'reader', type: 'anyone' },
+    });
+    const meta = await requestJson(
+      `https://www.googleapis.com/drive/v3/files/${ref.remoteId}?fields=webViewLink`,
+      { headers: authHeader(tokens) },
+    );
+    const url = meta.webViewLink as string | undefined;
+    return url ? { url } : { unsupported: true };
   },
 };

--- a/apps/mobile/src/lib/cloud/types.ts
+++ b/apps/mobile/src/lib/cloud/types.ts
@@ -43,6 +43,23 @@ export interface CloudUploadResult {
   readonly remoteId: string;
 }
 
+/** Which already-uploaded file to open a link to. */
+export interface CloudShareRef {
+  /** The provider's id for the uploaded image (the `remoteId` from upload). */
+  readonly remoteId: string;
+}
+
+/**
+ * An "anyone with the link, view-only" URL, or an honest refusal.
+ *
+ * Sharing bends the privacy model on purpose (E3): a receipt normally lives only
+ * on the owner's device and their own cloud, never on Waves. This opens the
+ * owner's OWN cloud copy to a link so group members can see it — the image still
+ * never touches Waves. Not every provider can do it, and a provider that can't
+ * says so rather than returning a broken URL.
+ */
+export type CloudShareResult = { readonly url: string } | { readonly unsupported: true };
+
 export interface CloudProvider {
   readonly id: CloudProviderId;
   readonly label: string;
@@ -54,6 +71,13 @@ export interface CloudProvider {
   ensureValid(tokens: CloudTokens): Promise<CloudTokens>;
   /** Upload the image and its sidecar; resolve with the image's remote id. */
   upload(tokens: CloudTokens, input: CloudUploadInput): Promise<CloudUploadResult>;
+  /**
+   * Open an anyone-with-link view of an already-uploaded file (E3). Optional:
+   * a provider that omits it, or returns `{ unsupported }`, cannot share, and
+   * the caller must never present a share as done. Only Google Drive implements
+   * it today.
+   */
+  share?(tokens: CloudTokens, ref: CloudShareRef): Promise<CloudShareResult>;
 }
 
 /** Wi‑Fi only, or Wi‑Fi and mobile data. Defaults to Wi‑Fi to protect data plans. */

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -218,6 +218,46 @@ export async function pickReceiptPhoto(): Promise<PickedImage | null> {
 }
 
 /**
+ * A receipt the person already has — pick it from the photo library.
+ *
+ * The counterpart to {@link captureReceipt} for the times there is nothing to
+ * point a camera at: the bill is a screenshot of a food-delivery order, a PDF
+ * someone photographed earlier, or a scan that failed and the person would
+ * rather attach the picture they already took. It goes straight to the library
+ * rather than the camera, and it is deliberately not gated behind OCR — an
+ * attached image is worth keeping whether or not a model can read a total off
+ * it (E1/E2).
+ *
+ * Sized and compressed exactly like a camera receipt so the vault and any
+ * personal-cloud backup carry the same bytes either way. Returns null when the
+ * person cancels or declines access — both ordinary answers, not errors.
+ */
+export async function pickReceiptImage(): Promise<PickedImage | null> {
+  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (!permission.granted) return null;
+
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images'],
+    quality: 1,
+    base64: false,
+  });
+  if (result.canceled) return null;
+
+  const asset = result.assets[0];
+  if (!asset) return null;
+
+  const shrunk =
+    (await shrink({
+      uri: asset.uri,
+      width: asset.width,
+      height: asset.height,
+      maxEdge: RECEIPT_MAX_EDGE,
+      compress: 0.9,
+    })) ?? (await readUnshrunk(asset.uri));
+  return { base64: shrunk.base64, mimeType: 'image/jpeg', uri: shrunk.uri };
+}
+
+/**
  * A receipt, however this phone can best get one.
  *
  * The document scanner is tried first: it finds the page edges and flattens the

--- a/apps/mobile/src/lib/receiptIndex.ts
+++ b/apps/mobile/src/lib/receiptIndex.ts
@@ -78,6 +78,16 @@ export async function pendingEntries(): Promise<ReceiptIndexEntry[]> {
 }
 
 /**
+ * The backup record for one receipt, or null when it was never indexed. Lets a
+ * viewer whose local file is gone (a reinstall, a cleared vault) tell the person
+ * *where* the receipt went — "backed up to your Drive" reads very differently
+ * from "on your other device" — rather than a bare "not found".
+ */
+export async function entryFor(captureId: string): Promise<ReceiptIndexEntry | null> {
+  return (await readMap())[captureId] ?? null;
+}
+
+/**
  * Record a freshly saved receipt as needing backup. Called the moment the
  * capture screen writes the files, before any network is involved, so a receipt
  * caught offline is remembered and uploaded later rather than lost.

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -146,6 +146,7 @@ export interface MirrorExpense extends MirrorRow {
     readonly author_member_id: string | null;
     readonly notes: string | null;
     readonly payment_method: string | null;
+    readonly receipt_share_url: string | null;
     readonly created_at: string;
     readonly payers: readonly { member_id: string; amount: string }[];
     readonly shares: readonly { member_id: string; amount: string }[];
@@ -233,6 +234,7 @@ function applyPending(
           author_member_id: options.authorMemberId ?? null,
           notes: payload.notes ?? null,
           payment_method: payload.paymentMethod ?? null,
+          receipt_share_url: payload.receiptShareUrl ?? null,
           created_at: mutation.clientCreatedAt,
           payers: Object.entries(payload.payers).map(([member_id, amount]) => ({
             member_id,

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -72,6 +72,12 @@ export interface ExpenseCreatePayload {
   readonly notes?: string | null;
   /** How the money moved: cash | credit | debit | forex. Optional. */
   readonly paymentMethod?: PaymentMethod | null;
+  /**
+   * An anyone-with-link view of the owner's OWN cloud copy of the receipt, so
+   * group members can see the bill (E3). Optional and null unless the owner
+   * explicitly opted in; the image itself never touches Waves.
+   */
+  readonly receiptShareUrl?: string | null;
 }
 
 /** The four ways an expense is paid for; optional everywhere it appears. */


### PR DESCRIPTION
Client-only half of the receipt work, split out of #279 so it can land ahead of the E3 server deploy.

## E1 — attach a bill
- `pickReceiptImage()` in `lib/image.ts`; "Attach" button beside "Scan" on edit-expense. Attach isn't metered, so it doesn't count against the group receipt cap.

## E2 — see the bill anytime
- Scanned + attached images persisted to the on-device vault keyed by expense id (+ own-cloud backup queue); image never touches Waves.
- Full-screen pinch-zoom viewer at `app/receipt/[id].tsx`; thumbnail on edit + row on expense detail; missing local file → friendly "on your cloud / other device" state, never a crash.

## Note
Carries the inert E3 *client* threading (share toggle default-OFF, optional `receipt_share_url` read field, `CloudProvider.share()`). It stays dormant — the privacy-posture change only takes effect with the E3 **server** half (migration + edge), which remains in #279 to deploy together later (needs ADR-008/TDR amendment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Attach receipt images from the camera or photo gallery when adding expenses.
  - View receipts from expense details with full-screen zoom and pan controls.
  - Store receipts locally and optionally share cloud-backed, view-only links.
  - Added Google Drive receipt sharing after backup synchronization.
  - Added localized receipt attachment and sharing messages in English, Tamil, Hindi, and Arabic.

- **Bug Fixes**
  - Receipt sharing failures no longer prevent expenses from being saved.
  - Added clear messaging when receipts are unavailable on the device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->