### PR TITLE
fix(mobile): drop the subtitle blurb atop merge people

### DIFF
--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -331,10 +331,6 @@ export default function MergePeopleScreen() {
             />
           ) : (
             <>
-              <Text variant="caption" tone="muted" align="center">
-                {t.mergePeople.subtitle}
-              </Text>
-
               <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
                 {guests.map((row, index) => {
                   const isSelected = selected.has(row.person_key);


### PR DESCRIPTION
Removes the intro caption (`mergePeople.subtitle`) above the people list on the merge screen, per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)