### PR TITLE
feat(mobile): UPI payment method on add-person (region-gated) + default cash

### DIFF
--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -44,7 +44,7 @@ import { friendlyError } from '@/lib/errors';
 import { DictateButton } from '@/components/DictateButton';
 import { useAddGhostMember, useCreateGroup, useWriteExpense } from '@/data/hooks';
 import { GroupType } from '@/data/types';
-import { deviceDefaultCurrency, useStrings } from '@/i18n';
+import { deviceDefaultCurrency, deviceSupportsUpi, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useBackup } from '@/lib/cloud/BackupProvider';
 import { captureReceipt, type PickedImage } from '@/lib/image';
@@ -63,8 +63,11 @@ type Direction = 'theyOwe' | 'iOwe';
 const PAYMENT_METHODS: readonly {
   readonly id: PaymentMethod;
   readonly icon: keyof typeof Ionicons.glyphMap;
+  /** Offered only where the rail exists (deviceSupportsUpi); filtered below. */
+  readonly regional?: boolean;
 }[] = [
   { id: 'cash', icon: 'cash-outline' },
+  { id: 'upi', icon: 'phone-portrait-outline', regional: true },
   { id: 'credit', icon: 'card-outline' },
   { id: 'debit', icon: 'card' },
   { id: 'forex', icon: 'swap-horizontal-outline' },
@@ -76,6 +79,8 @@ function paymentMethodLabel(t: ReturnType<typeof useStrings>['t'], id: PaymentMe
   switch (id) {
     case 'cash':
       return t.addPerson.payCash;
+    case 'upi':
+      return t.captures.payUpi;
     case 'credit':
       return t.addPerson.payCredit;
     case 'debit':
@@ -114,10 +119,14 @@ export default function AddPersonScreen() {
   const backup = useBackup();
 
   const currency = deviceDefaultCurrency();
+  // UPI only where the region has the rail; every other method is universal.
+  const paymentMethods = PAYMENT_METHODS.filter(
+    (method) => !method.regional || deviceSupportsUpi(),
+  );
   const [name, setName] = useState('');
   const [amount, setAmount] = useState(0n);
   const [direction, setDirection] = useState<Direction | null>(null);
-  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(null);
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>('cash');
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -371,7 +380,7 @@ export default function AddPersonScreen() {
             {t.addPerson.paidWith}
           </Text>
           <Row style={{ gap: theme.spacing.sm }}>
-            {PAYMENT_METHODS.map((method) => {
+            {paymentMethods.map((method) => {
               const active = paymentMethod === method.id;
               const label = paymentMethodLabel(t, method.id);
               return (

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -81,7 +81,7 @@ export interface ExpenseCreatePayload {
 }
 
 /** The four ways an expense is paid for; optional everywhere it appears. */
-export type PaymentMethod = 'cash' | 'credit' | 'debit' | 'forex';
+export type PaymentMethod = 'cash' | 'upi' | 'credit' | 'debit' | 'forex';
 
 export interface ExpenseUpdatePayload extends ExpenseCreatePayload {
   /** Version the client edited, so the server can detect a concurrent edit. */


### PR DESCRIPTION
## What
- **UPI in "paid with"** on the add-a-person screen, shown only where the device region supports the rail — via the existing `deviceSupportsUpi()` helper (derives from device locale/region, i.e. the phone's own settings). Same gating the capture screen uses.
- **Default payment = cash** (was unselected), matching the capture screen.
- **Currency** already follows the device (`deviceDefaultCurrency()`) — no change needed; confirmed nothing hardcodes it.

## Cross-package
- `@waves/core`: `'upi'` added to the `PaymentMethod` union. `payment_method` is a free-text `String?` column (no CHECK) and the edge writer passes it through, so **no DB migration** is required.
- Reuses `captures.payUpi` (already present in en/ta/hi/ar) — no new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)