### PR TITLE
fix(mobile): activity shows group name + modal headings clear the status bar

### DIFF
--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -497,7 +497,7 @@ export default function AddPersonScreen() {
       </ScrollView>
 
       <Modal visible={pickerOpen} animationType="slide" onRequestClose={() => setPickerOpen(false)}>
-        <Screen edges={['top', 'bottom']}>
+        <Screen edges={['top', 'bottom']} inModal>
           <View
             style={{
               flex: 1,

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -484,7 +484,7 @@ export default function MergePeopleScreen() {
         animationType="slide"
         onRequestClose={closeContactFlow}
       >
-        <Screen edges={['top', 'bottom']}>
+        <Screen edges={['top', 'bottom']} inModal>
           <View
             style={{
               flex: 1,

--- a/apps/mobile/src/components/CountryCodePicker.tsx
+++ b/apps/mobile/src/components/CountryCodePicker.tsx
@@ -81,7 +81,7 @@ export function CountryCodePicker({
       </Pressable>
 
       <Modal visible={open} animationType="slide" onRequestClose={close}>
-        <Screen edges={['top', 'bottom']}>
+        <Screen edges={['top', 'bottom']} inModal>
           <View
             style={{
               paddingHorizontal: theme.spacing.xl,

--- a/apps/mobile/src/components/CountryPicker.tsx
+++ b/apps/mobile/src/components/CountryPicker.tsx
@@ -57,7 +57,7 @@ export function CountryRow({
       </Card>
 
       <Modal visible={open} animationType="slide" onRequestClose={() => setOpen(false)}>
-        <Screen edges={['top', 'bottom']}>
+        <Screen edges={['top', 'bottom']} inModal>
           <View
             style={{
               paddingHorizontal: theme.spacing.xl,

--- a/apps/mobile/src/components/CoverEmojiPicker.tsx
+++ b/apps/mobile/src/components/CoverEmojiPicker.tsx
@@ -75,7 +75,7 @@ export function CoverEmojiPicker({
       )}
 
       <Modal visible={open} animationType="slide" onRequestClose={() => setOpen(false)}>
-        <Screen edges={['top', 'bottom']}>
+        <Screen edges={['top', 'bottom']} inModal>
           <View style={{ paddingHorizontal: theme.spacing.xl, paddingBottom: theme.spacing.md }}>
             <Text variant="heading">{t.group.chooseIcon}</Text>
           </View>

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -92,8 +92,13 @@ export function describeActivity(entry: ActivityRow, myProfileId: string | null)
       return `${who} confirmed a settlement`;
     case 'joined':
       return `${who} joined`;
-    case 'created':
-      return `${who} created the group`;
+    case 'created': {
+      // The group's name at creation, carried on the payload. Nameless groups
+      // (ADR: nameless_groups) leave it null, so those still read "the group".
+      const name =
+        typeof payload.name === 'string' && payload.name.trim() ? payload.name.trim() : null;
+      return name ? `${who} created ${name}` : `${who} created the group`;
+    }
     default:
       // An unknown verb is a row written by a newer build than this one. Say
       // what is known rather than dropping it — a feed with holes in it is

--- a/apps/mobile/test/activity.test.ts
+++ b/apps/mobile/test/activity.test.ts
@@ -133,6 +133,12 @@ describe('what happened', () => {
     expect(describeActivity(row({ verb }), 'me')).toBe(expected);
   });
 
+  it('names the group when the create payload carries one', () => {
+    expect(describeActivity(row({ verb: 'created', payload: { name: 'Goa Trip' } }), 'me')).toBe(
+      'Ravi created Goa Trip',
+    );
+  });
+
   it('shows a verb it does not know rather than nothing', () => {
     // Written by a newer build than this one — an offline queue can replay
     // months late (ADR-005), so this is reachable in a released app.

--- a/apps/web/src/lib/activity.ts
+++ b/apps/web/src/lib/activity.ts
@@ -43,8 +43,13 @@ export function describeActivity(entry: ActivityRow, myProfileId: string | null)
       return `${who} confirmed a settlement`;
     case 'joined':
       return `${who} joined`;
-    case 'created':
-      return `${who} created the group`;
+    case 'created': {
+      // The group's name at creation, carried on the payload. Nameless groups
+      // leave it null, so those still read "the group".
+      const name =
+        typeof payload?.name === 'string' && payload.name.trim() ? payload.name.trim() : null;
+      return name ? `${who} created ${name}` : `${who} created the group`;
+    }
     default:
       return `${who} ${entry.verb} ${entry.object_type}`;
   }

--- a/packages/ui/src/components/Surfaces.tsx
+++ b/packages/ui/src/components/Surfaces.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { View, type ViewProps, type ViewStyle } from 'react-native';
-import { SafeAreaView, type Edge } from 'react-native-safe-area-context';
+import { SafeAreaProvider, SafeAreaView, type Edge } from 'react-native-safe-area-context';
 
 import { useTheme } from '../theme';
 import type { TintName } from '../tokens';
@@ -10,17 +10,27 @@ export function Screen({
   children,
   edges = ['top'],
   style,
+  inModal = false,
 }: {
   children: ReactNode;
   edges?: readonly Edge[];
   style?: ViewStyle;
+  /**
+   * Set when this Screen is the root of a React Native `Modal`. A Modal renders
+   * in its own native window that the app's SafeAreaProvider can't reach, so on
+   * edge-to-edge Android the insets read as zero and the content slides under
+   * the status bar. Wrapping the modal's Screen in its own provider makes the
+   * safe-area inside it re-measure against the modal window.
+   */
+  inModal?: boolean;
 }) {
   const theme = useTheme();
-  return (
+  const screen = (
     <SafeAreaView edges={edges} style={[{ flex: 1, backgroundColor: theme.color.bg }, style]}>
       {children}
     </SafeAreaView>
   );
+  return inModal ? <SafeAreaProvider>{screen}</SafeAreaProvider> : screen;
 }
 
 export interface CardProps extends ViewProps {


### PR DESCRIPTION
## What

Two UI fixes from device testing.

### Activity feed names the group
"Ravi created the group" → **"Ravi created Goa Trip"**, read off the create payload's `name`. Nameless groups leave it null, so those still read "created the group". Fixed in both the mobile (`data/activity.ts`) and web (`lib/activity.ts`) feeds so the phone and browser word the event identically.

### Modal headings no longer overlap the status bar
The settlement region picker (and its siblings) rendered their heading **under** the status-bar clock/icons. A React Native `Modal` opens its own native window the app's `SafeAreaProvider` can't reach, so on edge-to-edge Android the top inset read as **zero**.

`Screen` gains an `inModal` prop that wraps it in a fresh `SafeAreaProvider`, re-measuring the safe area against the modal window. Applied to the five slide-up `Screen`-in-`Modal` pickers: CountryPicker, CountryCodePicker, CoverEmojiPicker, add-person contact picker, merge contact flow.

## Test
- `apps/mobile` activity tests: 35 pass (added a case asserting the group name shows).
- typecheck (ui/mobile/web) + lint + format all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added UPI as a payment option when supported and available in the user’s region.
  - Cash is now selected by default when adding a person.

- **Bug Fixes**
  - Improved safe-area handling across mobile modal screens.
  - Group creation activity messages now display the group name when available.
  - Removed the unnecessary subtitle from the merge screen.

- **Tests**
  - Added coverage for named group creation activity descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->