### PR TITLE
feat(mobile): streamline add-person defaults + header icon

### DIFF
--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -10,8 +10,9 @@
  * of record; it is the ordinary primitives (create a group, add a ghost, write
  * one expense) wired to one screen so the common case takes one save.
  *
- * The direction is asked, never assumed: "they owe me" and "I owe them" are
- * opposite ledger entries, and defaulting one would quietly book the wrong one.
+ * The direction defaults to "they owe me" — the case people open this screen
+ * for — but it stays a visible, selected choice, not a hidden one: both options
+ * are on screen and picking "I owe them" is a single tap before saving.
  */
 
 import { useState } from 'react';
@@ -125,7 +126,9 @@ export default function AddPersonScreen() {
   );
   const [name, setName] = useState('');
   const [amount, setAmount] = useState(0n);
-  const [direction, setDirection] = useState<Direction | null>(null);
+  // Defaults to the common case — they owe you — but stays a visible, selected
+  // choice with "I owe them" one tap away, not a hidden assumption.
+  const [direction, setDirection] = useState<Direction | null>('theyOwe');
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>('cash');
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
@@ -279,14 +282,13 @@ export default function AddPersonScreen() {
             />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.addPerson.title}</Text>
+            <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+              <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.brand} />
+              <Text variant="heading">{t.addPerson.title}</Text>
+            </Row>
           </View>
           <View style={{ width: 44 }} />
         </Row>
-
-        <Text variant="caption" tone="muted" align="center">
-          {t.addPerson.subtitle}
-        </Text>
 
         {/* The person is the subject of this screen, so the card leads with
             them: an avatar that fills in with the name's own colour and initial


### PR DESCRIPTION
## What
Add-a-person screen polish. Opens straight into the common case instead of a blank form.

- **Removed** the "Track what someone owes you…" subtitle — title + fields already say it.
- **Header icon**: person-add glyph beside the title.
- **Default Cash** payment method (still tap to change/clear).
- **Default "They owe me"** direction — the case people open this for — kept as a visible selected choice with "I owe them" one tap away.

## Stacked on #283
Based on `fix/activity-groupname-modal-safearea` so `add-person.tsx` carries its `inModal` safe-area fix. Merge #283 first, then this retargets to `main` cleanly.

## Test
typecheck + lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)