### PR TITLE
feat(mobile): show unassigned captures in the Inbox too

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -30,7 +30,7 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { useCaptures, useGroups, useHomeSummary } from '@/data/hooks';
+import { useGroups, useHomeSummary } from '@/data/hooks';
 import { CountUpMoney, PressableScale } from '@/lib/anim';
 import { useMotion } from '@/lib/motion';
 import { deviceDefaultCurrency, plural, useStrings, type UiStrings } from '@/i18n';
@@ -40,6 +40,7 @@ import { useDashboardTips } from '@/lib/tips';
 import { SyncStatusIcon } from '@/components/SyncBanner';
 import { SkeletonList } from '@/components/Skeletons';
 import { GroupCard } from '@/components/GroupCard';
+import { UnassignedCapturesCard } from '@/components/UnassignedCapturesCard';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
 import { useAvatarUrl } from '@/components/ProfileAvatar';
 import { groupLabel, GroupType } from '@/data/types';
@@ -59,13 +60,7 @@ export default function HomeScreen() {
 
   const groups = useGroups();
   const summary = useHomeSummary(profile?.id ?? null);
-  const captures = useCaptures();
   const guard = useGuestGuard();
-
-  // Captures waiting in the personal inbox (A34) — surfaced as a card and a
-  // badged header entry so a caught expense is not forgotten before it lands in
-  // a group.
-  const captureCount = captures.data?.length ?? 0;
 
   const list = groups.data ?? [];
   const loading = groups.isLoading || summary.isLoading;
@@ -262,40 +257,8 @@ export default function HomeScreen() {
 
         {/* Expenses caught without a group yet (A34). Sits near the top so an
             inbox with something in it is the first thing after the balance, not
-            a screen nobody remembers to open. */}
-        {captureCount > 0 ? (
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.captures.unassigned}
-            onPress={() => router.push('/captures')}
-          >
-            <Card style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}>
-              <View
-                style={{
-                  width: 42,
-                  height: 42,
-                  borderRadius: 21,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  backgroundColor: theme.color.brandSoft,
-                }}
-              >
-                <Ionicons
-                  name="file-tray-full-outline"
-                  size={iconSize.xl}
-                  color={theme.color.brand}
-                />
-              </View>
-              <View style={{ flex: 1, minWidth: 0 }}>
-                <Text variant="subheading">{t.captures.unassigned}</Text>
-                <Text variant="caption" tone="muted">
-                  {plural(locale, captureCount, t.captures.unassignedBody)}
-                </Text>
-              </View>
-              <Ionicons name="chevron-forward" size={iconSize.lg} color={theme.color.textFaint} />
-            </Card>
-          </Pressable>
-        ) : null}
+            a screen nobody remembers to open. The same card is in the Inbox. */}
+        <UnassignedCapturesCard />
 
         {isGuest ? (
           <GuestPrompt gate={guard.gate} t={t} onPress={() => router.push('/settings/account')} />

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -32,8 +32,9 @@ import {
 } from '@waves/ui';
 
 import { dayHeading, dayKey } from '@/data/activity';
-import { useMarkNotificationsRead, useNotifications } from '@/data/hooks';
+import { useCaptures, useMarkNotificationsRead, useNotifications } from '@/data/hooks';
 import { SkeletonList } from '@/components/Skeletons';
+import { UnassignedCapturesCard } from '@/components/UnassignedCapturesCard';
 import type { NotificationRow } from '@/data/types';
 import { useStrings } from '@/i18n';
 import { usePullRefresh } from '@/lib/pullRefresh';
@@ -89,6 +90,10 @@ export default function InboxScreen() {
   const { t, locale } = useStrings();
   const notifications = useNotifications();
   const markRead = useMarkNotificationsRead();
+  // Unassigned captures show as their own card above the list; the count also
+  // decides whether an empty notification list is really "nothing yet" or just
+  // "nothing but the capture waiting above".
+  const captureCount = useCaptures().data?.length ?? 0;
 
   const rows = notifications.data ?? [];
   const unread = rows.filter((row) => row.read_at === null);
@@ -142,6 +147,11 @@ export default function InboxScreen() {
           <View style={{ width: 44 }} />
         </Row>
 
+        {/* A capture with no group yet is something waiting for you, so it
+            belongs here as much as on the dashboard — the two "anything for me?"
+            screens. It renders nothing when there is none. */}
+        <UnassignedCapturesCard />
+
         {notifications.isLoading ? (
           // Until the fetch answers, `rows` is empty — which is not the same as
           // "you have no notifications". Showing the empty state here told people
@@ -168,9 +178,11 @@ export default function InboxScreen() {
               }
             />
           </View>
-        ) : rows.length === 0 ? (
+        ) : rows.length === 0 && captureCount === 0 ? (
           // Centred, with a glyph — the "all square" treatment Friends uses, so an
           // empty inbox reads as a state and not a screen that failed to load.
+          // A waiting capture counts as content, so the empty state stands down
+          // when the card above is showing.
           <View style={{ flex: 1, justifyContent: 'center' }}>
             <EmptyState
               title={t.nothingYet}

--- a/apps/mobile/src/components/UnassignedCapturesCard.tsx
+++ b/apps/mobile/src/components/UnassignedCapturesCard.tsx
@@ -29,7 +29,9 @@ export function UnassignedCapturesCard() {
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={t.captures.unassigned}
+      // Both halves the card shows, so the spoken name carries the count a
+      // sighted reader gets from the body line, not just "Unassigned".
+      accessibilityLabel={`${t.captures.unassigned}. ${plural(locale, count, t.captures.unassignedBody)}`}
       onPress={() => router.push('/captures')}
     >
       <Card style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}>

--- a/apps/mobile/src/components/UnassignedCapturesCard.tsx
+++ b/apps/mobile/src/components/UnassignedCapturesCard.tsx
@@ -1,0 +1,58 @@
+/**
+ * The "expenses caught without a group yet" card (A34).
+ *
+ * A capture with no home is easy to forget, so the one place it must never be
+ * is out of sight. It shows on the dashboard, near the top, and in the inbox —
+ * the two screens a person opens to answer "is there anything for me?" — so a
+ * waiting capture is found from either. Self-contained: it reads the count
+ * itself and renders nothing when there is none, so a caller drops it in without
+ * a guard of its own.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, View } from 'react-native';
+
+import { Card, iconSize, Text, useTheme } from '@waves/ui';
+
+import { useCaptures } from '@/data/hooks';
+import { plural, useStrings } from '@/i18n';
+
+export function UnassignedCapturesCard() {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const captures = useCaptures();
+  const count = captures.data?.length ?? 0;
+
+  if (count === 0) return null;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={t.captures.unassigned}
+      onPress={() => router.push('/captures')}
+    >
+      <Card style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}>
+        <View
+          style={{
+            width: 42,
+            height: 42,
+            borderRadius: 21,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.color.brandSoft,
+          }}
+        >
+          <Ionicons name="file-tray-full-outline" size={iconSize.xl} color={theme.color.brand} />
+        </View>
+        <View style={{ flex: 1, minWidth: 0 }}>
+          <Text variant="subheading">{t.captures.unassigned}</Text>
+          <Text variant="caption" tone="muted">
+            {plural(locale, count, t.captures.unassignedBody)}
+          </Text>
+        </View>
+        <Ionicons name="chevron-forward" size={iconSize.lg} color={theme.color.textFaint} />
+      </Card>
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## What
The "Unassigned — N captures waiting for a group" card (A34) now appears in the **Inbox**, not just the dashboard. Both are the "is there anything for me?" screens, so a captured expense without a home is found from either. Tapping opens the captures list, same as before.

## How
- Extracted the card into a shared `components/UnassignedCapturesCard.tsx` — it reads the capture count itself and renders `null` when there is none, so both screens drop it in without their own guard.
- Dashboard now uses the shared component (removed the inline block + its now-unused `useCaptures`/`captureCount`).
- Inbox: card sits above the notification list; the empty "nothing yet" state stands down when a capture is waiting, so the screen never claims to be empty while showing a card.

## Test
typecheck + lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an unassigned captures card that displays the number of pending captures.
  * Selecting the card opens the captures view for review and organization.
  * Unassigned captures now appear at the top of the inbox alongside notifications.
* **Bug Fixes**
  * The inbox now shows an empty state only when there are no notifications or unassigned captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->