### PR TITLE
feat(mobile): show trip-dates section only for trip groups

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -329,13 +329,19 @@ export default function GroupSettingsScreen() {
           }
         />
 
-        <TripDates
-          group={group.data}
-          locale={locale}
-          onChange={(patch) =>
-            updateGroup.mutate(patch, { onSuccess: () => setStatus(t.account.saved) })
-          }
-        />
+        {/* Trip dates and their nudges only mean anything on a trip, so the
+            section appears only for that type and disappears the moment the
+            group is changed to another kind. Nothing recorded is touched — the
+            stored dates simply stop being shown until it is a trip again. */}
+        {(group.data.type ?? GroupType.Other) === GroupType.Trip ? (
+          <TripDates
+            group={group.data}
+            locale={locale}
+            onChange={(patch) =>
+              updateGroup.mutate(patch, { onSuccess: () => setStatus(t.account.saved) })
+            }
+          />
+        ) : null}
 
         {/* ADR-009: simplification is presentation only — the pairwise ledger
             underneath is untouched, so this is safe to toggle at any time. */}


### PR DESCRIPTION
## What
In group settings, the trip-dates section (dates + morning/evening nudges) now shows **only when the group type is Trip**. Changing the type away from Trip hides it immediately; changing back shows it again.

Nothing recorded is touched — the stored `start_date`/`end_date` are simply not shown while the group is another kind.

## Test
typecheck + lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trip date settings are now shown only for groups classified as trips.
  * Non-trip groups no longer display irrelevant trip date options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->