### PR TITLE
feat(mobile): QR icon in the group header to join the group

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -344,6 +344,18 @@ export default function GroupScreen() {
               when all is well. It replaces the wide banner this screen used to
               stack under the header. */}
             <SyncStatusIcon />
+            {/* A code to hand the group across the table. The whole invite
+              surface — link, share sheet and the QR to point a camera at — lives
+              one tap behind this, so it is the fast way to get somebody in
+              without typing a thing. */}
+            <Pressable
+              onPress={() => router.push(`/group/${groupId}/invite`)}
+              accessibilityRole="button"
+              accessibilityLabel={t.people.inviteTitle}
+              hitSlop={10}
+            >
+              <Ionicons name="qr-code-outline" size={iconSize.xl} color={theme.color.text} />
+            </Pressable>
             {/* Planner, spending and settings live behind this one menu; planner
               only shows for a trip. Bare icon, no chip, to match the back
               arrow. */}


### PR DESCRIPTION
## What
Adds a **QR icon** to the group detail header. Tapping it opens the group's invite screen — link, share sheet, and the QR code to point a camera at (added in #286) — so someone can join without typing anything.

Sits between the sync glyph and the overflow menu, a bare icon matching the back arrow. Reuses the existing invite route and `inviteTitle` string — no new strings.

## Test
typecheck + lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a QR-code invite button to group headers.
  * Added navigation to the group invite screen.
  * Improved accessibility with an invite label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->