### PR TITLE
fix(mobile): sync on any network by default (fixes the always-on offline glyph)

### DIFF
--- a/apps/mobile/src/lib/syncNetwork.tsx
+++ b/apps/mobile/src/lib/syncNetwork.tsx
@@ -1,9 +1,10 @@
 /**
  * Which networks sync is allowed to use, and the switch for it.
  *
- * Three choices — Wi‑Fi only, mobile data only, or both — with Wi‑Fi the
- * default, because the safe assumption is that somebody would rather their
- * ledger wait for Wi‑Fi than spend a metered megabyte they did not choose to.
+ * Three choices — Wi‑Fi only, mobile data only, or both — with both the
+ * default, so a shared ledger stays live wherever the phone is. Wi‑Fi-only used
+ * to be the default, but it left a cellular-only phone permanently on the
+ * "waiting for Wi‑Fi" glyph, which read as the app being offline.
  *
  * This is a device-local preference (ADR-005 keeps the queue on the phone), so
  * it lives in AsyncStorage like theme and motion, not on the server. Two
@@ -99,8 +100,8 @@ export function SyncNetworkProvider({ children }: { children: ReactNode }) {
     setStored(value);
     const run = chainRef.current.then(async () => {
       try {
-        // Wi‑Fi is the default, so storing it is the same as storing nothing —
-        // and clearing the key keeps a fresh install and a reset-to-default
+        // The default (Both) storing it is the same as storing nothing — so
+        // clearing the key keeps a fresh install and a reset-to-default
         // identical.
         if (value === DEFAULT) await AsyncStorage.removeItem(KEY);
         else await AsyncStorage.setItem(KEY, value);

--- a/apps/mobile/src/lib/syncNetwork.tsx
+++ b/apps/mobile/src/lib/syncNetwork.tsx
@@ -27,15 +27,20 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 const KEY = 'baaki.sync_network';
 
 export enum SyncNetworkPreference {
-  /** Sync only on Wi‑Fi. The default: never spend mobile data unasked. */
+  /** Sync only on Wi‑Fi — never spend mobile data unasked. */
   Wifi = 'wifi',
   /** Sync only on mobile data, never Wi‑Fi. The deliberate, unusual choice. */
   Cellular = 'cellular',
-  /** Sync on whatever connection is up. */
+  /** Sync on whatever connection is up. The default. */
   Both = 'both',
 }
 
-const DEFAULT = SyncNetworkPreference.Wifi;
+// Sync on any connection by default. A ledger people share is expected to be
+// live wherever the phone is, and the payloads are tiny; Wi‑Fi-only used to be
+// the default and made every cellular-only phone sit permanently on the
+// "waiting for Wi‑Fi" glyph, which read as the app being offline or broken.
+// Anyone who wants to hold data for Wi‑Fi can still choose it in settings.
+const DEFAULT = SyncNetworkPreference.Both;
 
 function parse(raw: string | null): SyncNetworkPreference {
   return raw === 'wifi' || raw === 'cellular' || raw === 'both'

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -290,8 +290,9 @@ export class SyncEngine {
     }
 
     // Online, but maybe not over a connection the user has agreed to spend.
-    // Wi‑Fi is the default, so a phone on mobile data holds its queue rather
-    // than syncing until Wi‑Fi returns — the change is already safe on disk.
+    // The default is to sync on any connection; only if someone has chosen
+    // Wi‑Fi-only does a phone on mobile data hold its queue until Wi‑Fi returns
+    // — and the change is already safe on disk either way.
     if (!(await networkAllowed())) {
       this.set({ status: SyncStatus.Metered });
       return;


### PR DESCRIPTION
## What
The header sync glyph looked permanently "offline" on a fully online phone.

**Cause:** the default sync-network preference was **Wi-Fi only** (`DEFAULT = SyncNetworkPreference.Wifi`). On mobile data, every flush stops at the `Metered` state — and `SyncStatusIcon` draws `Metered` with the **same `cloud-offline-outline` icon** as true offline. So a phone on 5G showed a stuck offline-looking badge on the dashboard and group screens, and held changes off the server until Wi-Fi appeared.

**Fix:** default is now **Both** — sync on whatever connection is up. A shared ledger should be live wherever the phone is, and payloads are tiny. Wi-Fi-only is still available in Settings → Sync; an explicit stored preference is untouched, so only users who never chose one change behaviour.

## Note
This doesn't change that `Metered` and true `Offline` share one glyph — a separate polish if we want to keep Wi-Fi-only legible. Out of scope here.

## Test
typecheck + lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)