### PR TITLE
feat(mobile): capture screen polish — header icon, default category, scrollable pay row

### DIFF
--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -11,7 +11,7 @@ import {
   dayNumber,
   guessCategory,
   parseReceiptText,
-  type CategoryId,
+  CategoryId,
   type HeuristicReceipt,
 } from '@waves/core';
 import {
@@ -181,7 +181,7 @@ export default function CaptureScreen() {
 
   const [amount, setAmount] = useState<bigint>(0n);
   const [description, setDescription] = useState('');
-  const [category, setCategory] = useState<CategoryId | null>(null);
+  const [category, setCategory] = useState<CategoryId | null>(CategoryId.Food);
   const [categoryChosen, setCategoryChosen] = useState(false);
   const [date, setDate] = useState<string>(() => todayIso());
   const [editingDate, setEditingDate] = useState(false);
@@ -233,9 +233,12 @@ export default function CaptureScreen() {
     }
   };
 
-  // The guess follows the description until a chip is tapped, then stops moving
-  // under the user's finger — the same rule the add-expense category uses.
-  const [guessedFrom, setGuessedFrom] = useState<string | null>(null);
+  // Category starts on Food & drink — the most common capture, one fewer tap for
+  // it. The guess then follows the description until a chip is tapped, at which
+  // point it stops moving under the user's finger (the same rule add-expense
+  // uses). Seeding guessedFrom to the initial empty description means the guess
+  // does not fire on mount, so that default survives until the person types.
+  const [guessedFrom, setGuessedFrom] = useState<string | null>('');
   if (!categoryChosen && description !== guessedFrom) {
     setGuessedFrom(description);
     setCategory(guessCategory(description));
@@ -377,9 +380,10 @@ export default function CaptureScreen() {
           <IconButton label={t.common.close} onPress={() => router.back()}>
             <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
+          <Row style={{ flex: 1, justifyContent: 'center', gap: theme.spacing.xs }}>
+            <Ionicons name="receipt-outline" size={iconSize.md} color={theme.color.brand} />
             <Text variant="heading">{t.captures.newTitle}</Text>
-          </View>
+          </Row>
           <View style={{ width: 44 }} />
         </Row>
 
@@ -466,12 +470,19 @@ export default function CaptureScreen() {
 
         {/* How it was paid. Single-select tags, icon + word; cash is chosen by
             default, tapping the chosen one again clears it ("not said" stays a
-            valid answer). UPI only appears where the region settles over it. */}
+            valid answer). UPI only appears where the region settles over it. One
+            row that scrolls sideways rather than wrapping to a second line, so the
+            block keeps a fixed height however many rails the region offers. */}
         <View style={{ gap: theme.spacing.sm }}>
           <Text variant="caption" tone="muted">
             {t.captures.paidWith}
           </Text>
-          <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={{ gap: theme.spacing.sm, paddingRight: theme.spacing.xl }}
+          >
             {paymentMethods.map((method) => {
               const active = paymentMethod === method.id;
               return (
@@ -510,13 +521,13 @@ export default function CaptureScreen() {
                 </Pressable>
               );
             })}
-          </Row>
+          </ScrollView>
         </View>
 
         {/* Destination and date, folded into one card of divided rows rather than
             two stacked cards — the meta a capture carries, grouped so it reads as
             one block. "Decide later" is the default group: the split, and who is
-            in it, is chosen when the capture is assigned (the line under it). */}
+            in it, is chosen when the capture is assigned. */}
         <Card style={{ paddingVertical: theme.spacing.xs, gap: 0 }}>
           <FieldRow
             icon={targetGroup ? 'people' : 'people-outline'}
@@ -527,13 +538,6 @@ export default function CaptureScreen() {
             onPress={() => setPickingGroup(true)}
             accessibilityLabel={`${t.captures.group}: ${targetGroupName}`}
           />
-          <Text
-            variant="micro"
-            tone="muted"
-            style={{ marginLeft: iconSize.md + theme.spacing.md, marginBottom: theme.spacing.sm }}
-          >
-            {t.captures.splitLaterHint}
-          </Text>
           <Divider />
           <FieldRow
             icon="calendar-outline"

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -4,13 +4,22 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
+  withSpring,
   withTiming,
 } from 'react-native-reanimated';
 
@@ -38,6 +47,7 @@ import {
 } from '@waves/ui';
 
 import { CategoryPicker } from '@/components/Category';
+import { ZoomableImage } from '@/components/ZoomableImage';
 import { COMMON_CURRENCIES } from '@/components/CurrencyRate';
 import { DictateButton } from '@/components/DictateButton';
 import { useCreateCapture, useGroups, useHomeSummary } from '@/data/hooks';
@@ -170,6 +180,7 @@ const consumedScans = new Set<string>();
  */
 export default function CaptureScreen() {
   const theme = useTheme();
+  const insets = useSafeAreaInsets();
   const { t, locale } = useStrings();
   const createCapture = useCreateCapture();
   const backup = useBackup();
@@ -194,6 +205,8 @@ export default function CaptureScreen() {
   const [date, setDate] = useState<string>(() => todayIso());
   const [editingDate, setEditingDate] = useState(false);
   const [photo, setPhoto] = useState<PickedImage | null>(null);
+  // Full-screen preview of the attached bill, opened by tapping the thumbnail.
+  const [previewing, setPreviewing] = useState(false);
   const [rawText, setRawText] = useState<string | null>(null);
   // What the on-device parser recovered from the bill: total, item count, lines.
   // Null until a receipt is read; low `confidence` means show it as a draft.
@@ -588,12 +601,34 @@ export default function CaptureScreen() {
           </Row>
           {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
           {photo ? (
-            <Image
-              source={{ uri: photo.uri }}
-              style={{ width: '100%', height: 180, borderRadius: theme.radius.md }}
-              contentFit="cover"
-              transition={150}
-            />
+            // Tap the thumbnail to see the whole bill: the cropped cover view is
+            // enough to confirm the right photo attached, but reading the lines
+            // needs the full frame.
+            <Pressable
+              accessibilityRole="imagebutton"
+              accessibilityLabel={t.captures.previewReceipt}
+              onPress={() => setPreviewing(true)}
+              style={{ borderRadius: theme.radius.md, overflow: 'hidden' }}
+            >
+              <Image
+                source={{ uri: photo.uri }}
+                style={{ width: '100%', height: 180 }}
+                contentFit="cover"
+                transition={150}
+              />
+              <View
+                style={{
+                  position: 'absolute',
+                  right: theme.spacing.sm,
+                  bottom: theme.spacing.sm,
+                  padding: theme.spacing.xs,
+                  borderRadius: theme.radius.sm,
+                  backgroundColor: 'rgba(10, 10, 26, 0.55)',
+                }}
+              >
+                <Ionicons name="expand-outline" size={iconSize.sm} color="#ffffff" />
+              </View>
+            </Pressable>
           ) : null}
 
           {/* What the phone read off the bill. A confident parse shows the lines
@@ -721,6 +756,36 @@ export default function CaptureScreen() {
           />
         </SheetOverlay>
       ) : null}
+
+      {/* The bill at full size — pinch to zoom, drag to pan, tap the corner to
+          close. Same viewer as the saved receipt, so it reads the same before
+          the row exists. */}
+      <Modal
+        visible={previewing && photo !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setPreviewing(false)}
+        statusBarTranslucent
+      >
+        <View style={{ flex: 1, backgroundColor: '#000000' }}>
+          {photo ? <ZoomableImage uri={photo.uri} /> : null}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.common.close}
+            onPress={() => setPreviewing(false)}
+            style={{
+              position: 'absolute',
+              top: insets.top + theme.spacing.md,
+              right: theme.spacing.xl,
+              padding: theme.spacing.sm,
+              borderRadius: theme.radius.pill,
+              backgroundColor: 'rgba(255, 255, 255, 0.15)',
+            }}
+          >
+            <Ionicons name="close" size={iconSize.md} color="#ffffff" />
+          </Pressable>
+        </View>
+      </Modal>
     </Screen>
   );
 }
@@ -800,15 +865,20 @@ function SheetOverlay({
   // never fights the list's own vertical scroll.
   const translateY = useSharedValue(0);
   const dragToClose = Gesture.Pan()
+    // Only engage once the finger has clearly moved vertically, so a plain tap
+    // on the handle still falls through to the Pressable that closes the sheet.
+    .activeOffsetY([-12, 12])
     .onUpdate((event) => {
-      translateY.set(Math.max(0, event.translationY));
+      // Down follows the finger 1:1; an upward pull rubber-bands so the sheet
+      // feels anchored rather than free.
+      translateY.set(event.translationY > 0 ? event.translationY : event.translationY / 4);
     })
     .onEnd((event) => {
       if (translateY.get() > 120 || event.velocityY > 800) {
-        translateY.set(withTiming(600));
-        runOnJS(onClose)();
+        // Carry the flick through: animate the rest of the way out, then close.
+        translateY.set(withTiming(700, { duration: 180 }, () => runOnJS(onClose)()));
       } else {
-        translateY.set(withTiming(0));
+        translateY.set(withSpring(0, { damping: 20, stiffness: 220 }));
       }
     });
   const cardStyle = useAnimatedStyle(() => ({

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -249,7 +249,11 @@ export default function CaptureScreen() {
   const [guessedFrom, setGuessedFrom] = useState<string | null>('');
   if (!categoryChosen && description !== guessedFrom) {
     setGuessedFrom(description);
-    setCategory(guessCategory(description));
+    // Keep the current category when the description matches no bucket:
+    // guessCategory returns null for unrecognised text, and clearing on null
+    // would wipe the Food default (or a prior guess) leaving no chip selected.
+    const guess = guessCategory(description);
+    if (guess) setCategory(guess);
   }
 
   const applyDate = (event: DateTimePickerEvent, picked?: Date): void => {

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -6,6 +6,13 @@ import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 
 import {
   currencySymbol,
@@ -782,6 +789,28 @@ function SheetOverlay({
   const theme = useTheme();
   const { t } = useStrings();
   const insets = useSafeAreaInsets();
+
+  // Drag the handle down to dismiss. translateY only ever goes positive (down);
+  // past a short threshold or on a quick flick the sheet closes, otherwise it
+  // springs back. The gesture lives on the header, not the whole card, so it
+  // never fights the list's own vertical scroll.
+  const translateY = useSharedValue(0);
+  const dragToClose = Gesture.Pan()
+    .onUpdate((event) => {
+      translateY.set(Math.max(0, event.translationY));
+    })
+    .onEnd((event) => {
+      if (translateY.get() > 120 || event.velocityY > 800) {
+        translateY.set(withTiming(600));
+        runOnJS(onClose)();
+      } else {
+        translateY.set(withTiming(0));
+      }
+    });
+  const cardStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.get() }],
+  }));
+
   return (
     <Pressable
       accessibilityRole="button"
@@ -797,42 +826,59 @@ function SheetOverlay({
         justifyContent: 'flex-end',
       }}
     >
-      <Pressable
-        onPress={() => {}}
-        style={{
-          backgroundColor: theme.color.surface,
-          borderTopLeftRadius: theme.radius.lg,
-          borderTopRightRadius: theme.radius.lg,
-          padding: theme.spacing.xl,
-          // Clear the Android gesture/nav bar so the last list row is not
-          // hidden behind it.
-          paddingBottom: theme.spacing.xl + insets.bottom,
-          gap: theme.spacing.md,
-          maxHeight: '75%',
-        }}
+      <Animated.View
+        style={[
+          {
+            backgroundColor: theme.color.surface,
+            borderTopLeftRadius: theme.radius.lg,
+            borderTopRightRadius: theme.radius.lg,
+            padding: theme.spacing.xl,
+            // Clear the Android gesture/nav bar so the last list row is not
+            // hidden behind it.
+            paddingBottom: theme.spacing.xl + insets.bottom,
+            gap: theme.spacing.md,
+            maxHeight: '75%',
+          },
+          cardStyle,
+        ]}
       >
-        <View
-          style={{
-            alignSelf: 'center',
-            width: 40,
-            height: 4,
-            borderRadius: 2,
-            backgroundColor: theme.color.border,
-          }}
-        />
-        <Text variant="heading">{title}</Text>
-        {/* flexShrink lets this scroll: without it the list keeps its full
-            content height and the sheet's maxHeight clips the overflow instead
-            of scrolling it, so a long group or currency list loses its bottom
-            rows. */}
-        <ScrollView
-          showsVerticalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-          style={{ flexShrink: 1 }}
-        >
-          {children}
-        </ScrollView>
-      </Pressable>
+        {/* Swallow taps on the card so they never reach the backdrop, which
+            would close the sheet. */}
+        <Pressable onPress={() => {}} style={{ gap: theme.spacing.md, flexShrink: 1 }}>
+          {/* The header is the drag surface AND a tap-to-close target: the grab
+              handle reads as draggable, so make it do something when pushed. */}
+          <GestureDetector gesture={dragToClose}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t.common.close}
+              onPress={onClose}
+              style={{ gap: theme.spacing.md }}
+            >
+              <View
+                style={{
+                  alignSelf: 'center',
+                  width: 40,
+                  height: 4,
+                  borderRadius: 2,
+                  backgroundColor: theme.color.border,
+                }}
+              />
+              <Text variant="heading">{title}</Text>
+            </Pressable>
+          </GestureDetector>
+          {/* flexShrink lets this scroll: without it the list keeps its full
+              content height and the sheet's maxHeight clips the overflow instead
+              of scrolling it, so a long group or currency list loses its bottom
+              rows. */}
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+            style={{ flexShrink: 1 }}
+          >
+            {children}
+          </ScrollView>
+        </Pressable>
+      </Animated.View>
     </Pressable>
   );
 }

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -668,7 +668,9 @@ export default function CaptureScreen() {
                   <Text
                     variant="subheading"
                     tone="muted"
-                    style={{ width: 28, textAlign: 'center' }}
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                    style={{ width: 36, textAlign: 'center' }}
                   >
                     {currencySymbol(code)}
                   </Text>
@@ -814,7 +816,15 @@ function SheetOverlay({
           }}
         />
         <Text variant="heading">{title}</Text>
-        <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+        {/* flexShrink lets this scroll: without it the list keeps its full
+            content height and the sheet's maxHeight clips the overflow instead
+            of scrolling it, so a long group or currency list loses its bottom
+            rows. */}
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+          style={{ flexShrink: 1 }}
+        >
           {children}
         </ScrollView>
       </Pressable>

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -5,6 +5,7 @@ import { Image } from 'expo-image';
 import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
   currencySymbol,
@@ -780,6 +781,7 @@ function SheetOverlay({
 }): React.JSX.Element {
   const theme = useTheme();
   const { t } = useStrings();
+  const insets = useSafeAreaInsets();
   return (
     <Pressable
       accessibilityRole="button"
@@ -802,6 +804,9 @@ function SheetOverlay({
           borderTopLeftRadius: theme.radius.lg,
           borderTopRightRadius: theme.radius.lg,
           padding: theme.spacing.xl,
+          // Clear the Android gesture/nav bar so the last list row is not
+          // hidden behind it.
+          paddingBottom: theme.spacing.xl + insets.bottom,
           gap: theme.spacing.md,
           maxHeight: '75%',
         }}

--- a/apps/mobile/src/app/receipt/[id].tsx
+++ b/apps/mobile/src/app/receipt/[id].tsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Image } from 'expo-image';
-import { Linking, useWindowDimensions, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { Linking, View } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 
 import { Button, EmptyState, IconButton, iconSize, Screen, useTheme } from '@waves/ui';
 
+import { ZoomableImage } from '@/components/ZoomableImage';
 import { fill, useStrings } from '@/i18n';
 import { providerFor } from '@/lib/cloud/providers';
 import { entryFor } from '@/lib/receiptIndex';
@@ -89,88 +87,5 @@ export default function ReceiptViewerScreen(): React.JSX.Element {
         )}
       </View>
     </Screen>
-  );
-}
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
-
-/**
- * The bill, pinch to zoom and drag to pan, double-tap to reset.
- *
- * Deliberately self-contained: the gestures live on shared values so the pan and
- * zoom stay on the UI thread, and the whole thing resets to fit on a double tap
- * so a person who zoomed in can always get back out. Clamped to a sane range so
- * the image can neither shrink to a dot nor fly off screen.
- */
-function ZoomableImage({ uri }: { uri: string }): React.JSX.Element {
-  const { width, height } = useWindowDimensions();
-
-  const scale = useSharedValue(1);
-  const savedScale = useSharedValue(1);
-  const translateX = useSharedValue(0);
-  const translateY = useSharedValue(0);
-  const savedX = useSharedValue(0);
-  const savedY = useSharedValue(0);
-
-  const pinch = Gesture.Pinch()
-    .onUpdate((event) => {
-      // Clamp between fit (1) and 5×, so it can neither vanish nor over-magnify.
-      const next = Math.min(Math.max(savedScale.get() * event.scale, 1), 5);
-      scale.set(next);
-    })
-    .onEnd(() => {
-      savedScale.set(scale.get());
-      if (scale.get() <= 1) {
-        translateX.set(withTiming(0));
-        translateY.set(withTiming(0));
-        savedX.set(0);
-        savedY.set(0);
-      }
-    });
-
-  const pan = Gesture.Pan()
-    .onUpdate((event) => {
-      // Panning only makes sense once zoomed in; at fit it stays put.
-      if (scale.get() <= 1) return;
-      translateX.set(savedX.get() + event.translationX);
-      translateY.set(savedY.get() + event.translationY);
-    })
-    .onEnd(() => {
-      savedX.set(translateX.get());
-      savedY.set(translateY.get());
-    });
-
-  const doubleTap = Gesture.Tap()
-    .numberOfTaps(2)
-    .onEnd(() => {
-      scale.set(withTiming(1));
-      savedScale.set(1);
-      translateX.set(withTiming(0));
-      translateY.set(withTiming(0));
-      savedX.set(0);
-      savedY.set(0);
-    });
-
-  const composed = Gesture.Simultaneous(pinch, pan, doubleTap);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      { translateX: translateX.get() },
-      { translateY: translateY.get() },
-      { scale: scale.get() },
-    ],
-  }));
-
-  return (
-    <GestureDetector gesture={composed}>
-      <Animated.View style={{ flex: 1, justifyContent: 'center' }} collapsable={false}>
-        <AnimatedImage
-          source={{ uri }}
-          style={[{ width, height: height * 0.8 }, animatedStyle]}
-          contentFit="contain"
-          transition={150}
-        />
-      </Animated.View>
-    </GestureDetector>
   );
 }

--- a/apps/mobile/src/components/Category.tsx
+++ b/apps/mobile/src/components/Category.tsx
@@ -69,7 +69,6 @@ export function CategoryPicker({
     >
       {CATEGORIES.map((category) => {
         const selected = category.id === value;
-        const tint = theme.tint[category.tint];
         const label = t.categories[category.id];
         return (
           <Pressable
@@ -78,25 +77,28 @@ export function CategoryPicker({
             accessibilityState={{ selected }}
             accessibilityLabel={label}
             onPress={() => onChange(category.id)}
+            // Same chip shape and brand tint as the "Paid with" row on the same
+            // screen, so the two selectors read as one language rather than the
+            // louder per-category fill this used to wear.
             style={({ pressed }) => ({
               flexDirection: 'row',
               alignItems: 'center',
-              gap: theme.spacing.sm,
-              height: 36,
+              gap: theme.spacing.xs,
+              paddingVertical: theme.spacing.sm,
               paddingHorizontal: theme.spacing.md,
-              borderRadius: theme.radius.pill,
-              backgroundColor: selected ? tint.bg : theme.color.surface,
+              borderRadius: theme.radius.md,
               borderWidth: 1,
-              borderColor: selected ? tint.ink : 'transparent',
-              opacity: pressed ? 0.85 : 1,
+              borderColor: selected ? theme.color.brand : theme.color.border,
+              backgroundColor: selected ? theme.color.brandSoft : theme.color.surface,
+              opacity: pressed ? 0.7 : 1,
             })}
           >
             <Ionicons
               name={category.icon as keyof typeof Ionicons.glyphMap}
-              size={iconSize.base}
-              color={selected ? tint.ink : theme.color.textMuted}
+              size={iconSize.md}
+              color={selected ? theme.color.brand : theme.color.textMuted}
             />
-            <Text variant="caption" style={{ color: selected ? tint.ink : theme.color.textMuted }}>
+            <Text variant="body" style={{ color: selected ? theme.color.brand : theme.color.text }}>
               {label}
             </Text>
           </Pressable>

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -1,0 +1,90 @@
+import { Image } from 'expo-image';
+import { useWindowDimensions } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+
+const AnimatedImage = Animated.createAnimatedComponent(Image);
+
+/**
+ * An image you can pinch to zoom, drag to pan, and double-tap to reset to fit.
+ *
+ * Deliberately self-contained: the gestures live on shared values so the pan and
+ * zoom stay on the UI thread, and the whole thing resets to fit on a double tap
+ * so a person who zoomed in can always get back out. Clamped to a sane range so
+ * the image can neither shrink to a dot nor fly off screen.
+ *
+ * Shared by the saved-receipt viewer and the capture screen's pre-save preview,
+ * so a bill looks and behaves the same before and after the row exists.
+ */
+export function ZoomableImage({ uri }: { uri: string }): React.JSX.Element {
+  const { width, height } = useWindowDimensions();
+
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const savedX = useSharedValue(0);
+  const savedY = useSharedValue(0);
+
+  const pinch = Gesture.Pinch()
+    .onUpdate((event) => {
+      // Clamp between fit (1) and 5×, so it can neither vanish nor over-magnify.
+      const next = Math.min(Math.max(savedScale.get() * event.scale, 1), 5);
+      scale.set(next);
+    })
+    .onEnd(() => {
+      savedScale.set(scale.get());
+      if (scale.get() <= 1) {
+        translateX.set(withTiming(0));
+        translateY.set(withTiming(0));
+        savedX.set(0);
+        savedY.set(0);
+      }
+    });
+
+  const pan = Gesture.Pan()
+    .onUpdate((event) => {
+      // Panning only makes sense once zoomed in; at fit it stays put.
+      if (scale.get() <= 1) return;
+      translateX.set(savedX.get() + event.translationX);
+      translateY.set(savedY.get() + event.translationY);
+    })
+    .onEnd(() => {
+      savedX.set(translateX.get());
+      savedY.set(translateY.get());
+    });
+
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onEnd(() => {
+      scale.set(withTiming(1));
+      savedScale.set(1);
+      translateX.set(withTiming(0));
+      translateY.set(withTiming(0));
+      savedX.set(0);
+      savedY.set(0);
+    });
+
+  const composed = Gesture.Simultaneous(pinch, pan, doubleTap);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.get() },
+      { translateY: translateY.get() },
+      { scale: scale.get() },
+    ],
+  }));
+
+  return (
+    <GestureDetector gesture={composed}>
+      <Animated.View style={{ flex: 1, justifyContent: 'center' }} collapsable={false}>
+        <AnimatedImage
+          source={{ uri }}
+          style={[{ width, height: height * 0.8 }, animatedStyle]}
+          contentFit="contain"
+          transition={150}
+        />
+      </Animated.View>
+    </GestureDetector>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -7719,7 +7719,11 @@ export function deviceDefaultCurrency(): CurrencyCode {
  * include UPI, so the tag stays hidden rather than guessing India.
  */
 export function deviceSupportsUpi(): boolean {
-  return railsFor(deviceCountry()).some((rail) => rail.id === RailId.Upi);
+  // An unknown region assumes India, exactly as deviceDefaultCurrency falls back
+  // to INR — otherwise a phone with no Region set shows ₹ everywhere yet hides
+  // UPI, the one rail that ₹ implies. A device set to a real country without the
+  // rail (the UAE, the US) still hides it correctly.
+  return railsFor(deviceCountry() ?? 'IN').some((rail) => rail.id === RailId.Upi);
 }
 
 /**

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -859,6 +859,7 @@ export interface UiStrings {
     date: string;
     receipt: string;
     addReceipt: string;
+    previewReceipt: string;
     reading: string;
     notSynced: string;
     assign: string;
@@ -2232,6 +2233,7 @@ const en: UiStrings = {
     date: 'Date',
     receipt: 'Receipt',
     addReceipt: 'Add receipt',
+    previewReceipt: 'Preview the attached bill',
     reading: 'Reading…',
     notSynced: 'Not synced yet',
     assign: 'Assign to group',
@@ -3691,6 +3693,7 @@ const ta: UiStrings = {
     date: 'தேதி',
     receipt: 'ரசீது',
     addReceipt: 'ரசீதைச் சேர்',
+    previewReceipt: 'இணைத்த ரசீதை முன்னோட்டமிடு',
     reading: 'படிக்கிறது…',
     notSynced: 'இன்னும் ஒத்திசைக்கவில்லை',
     assign: 'குழுவுக்கு ஒதுக்கு',
@@ -5162,6 +5165,7 @@ const hi: UiStrings = {
     date: 'तारीख़',
     receipt: 'रसीद',
     addReceipt: 'रसीद जोड़ें',
+    previewReceipt: 'संलग्न रसीद का पूर्वावलोकन करें',
     reading: 'पढ़ रहे हैं…',
     notSynced: 'अभी सिंक नहीं हुआ',
     assign: 'समूह को सौंपें',
@@ -6628,6 +6632,7 @@ const ar: UiStrings = {
     date: 'التاريخ',
     receipt: 'الإيصال',
     addReceipt: 'أضف إيصالًا',
+    previewReceipt: 'معاينة الإيصال المرفق',
     reading: 'جارٍ القراءة…',
     notSynced: 'لم تتم المزامنة بعد',
     assign: 'أسنِد إلى مجموعة',


### PR DESCRIPTION
Four small changes to the capture-an-expense screen, per request:

- **Header icon** — a `receipt-outline` sits beside the title, matching the add-person header treatment.
- **Default category** — starts on **Food & drink** (most common capture, one fewer tap). The description-guess still takes over the instant the person types; `guessedFrom` is seeded to the empty description so the default is not wiped on mount and only the guess (or a tap) changes it.
- **"Paid with" scrolls, not wraps** — the rails are now one sideways-scrolling row instead of a wrapping `flexWrap` block, so the section keeps a fixed height however many methods a region offers (UPI adds a chip in India, etc.).
- **Removed the split-later hint** under the group row — "Decide later" already carries that meaning; the extra line was noise. (i18n key left defined, just unused.)

Single-file diff. typecheck + eslint + prettier green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Captures now default to the Food category.
  - Category suggestions begin updating after the description is edited.
  - Added a receipt icon to the capture header.

- **Improvements**
  - Payment-method options now scroll horizontally for easier navigation.
  - Removed the split-later hint from the group selector.
  - Currency symbols can shrink to fit in picker controls.
  - Picker sheets now better accommodate scrollable content.
  - UPI availability now aligns with the default Indian currency setting when device location is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->