### PR TITLE
feat(mobile): group the dashboard overflow menu with dividers

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -71,18 +71,52 @@ export default function HomeScreen() {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuItems: OverflowMenuItem[] = useMemo(
     () => [
-      { icon: 'person-circle-outline', label: t.account.yourAccount, route: '/settings/account' },
+      // The `section` keys are internal grouping only (not user-visible): they
+      // cluster the rows into account / data / app / settings, and OverflowMenu
+      // draws a divider wherever two adjacent rows fall in different sections.
+      {
+        icon: 'person-circle-outline',
+        label: t.account.yourAccount,
+        route: '/settings/account',
+        section: 'account',
+      },
       {
         icon: 'notifications-outline',
         label: t.account.notifications,
         route: '/settings/notifications',
+        section: 'account',
       },
-      { icon: 'archive-outline', label: t.group.archivedTitle, route: '/settings/archived' },
-      { icon: 'cloud-done-outline', label: t.backup.title, route: '/settings/backup' },
-      { icon: 'language-outline', label: t.language, route: '/settings/language' },
-      { icon: 'contrast-outline', label: t.account.themeRow, route: '/settings/theme' },
-      { icon: 'key-outline', label: t.account.aiKeysRow, route: '/settings/ai-keys' },
-      { icon: 'settings-outline', label: t.account.faceSettings, route: '/profile' },
+      {
+        icon: 'archive-outline',
+        label: t.group.archivedTitle,
+        route: '/settings/archived',
+        section: 'data',
+      },
+      {
+        icon: 'cloud-done-outline',
+        label: t.backup.title,
+        route: '/settings/backup',
+        section: 'data',
+      },
+      { icon: 'language-outline', label: t.language, route: '/settings/language', section: 'app' },
+      {
+        icon: 'contrast-outline',
+        label: t.account.themeRow,
+        route: '/settings/theme',
+        section: 'app',
+      },
+      {
+        icon: 'key-outline',
+        label: t.account.aiKeysRow,
+        route: '/settings/ai-keys',
+        section: 'app',
+      },
+      {
+        icon: 'settings-outline',
+        label: t.account.faceSettings,
+        route: '/profile',
+        section: 'settings',
+      },
     ],
     [t],
   );

--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -9,7 +9,7 @@
 
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, type Href } from 'expo-router';
-import { Modal, Pressable, View } from 'react-native';
+import { Modal, Pressable, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { iconSize, Text, useTheme } from '@waves/ui';
@@ -18,6 +18,10 @@ export interface OverflowMenuItem {
   icon: keyof typeof Ionicons.glyphMap;
   label: string;
   route: Href;
+  // Optional grouping key. A divider is drawn between two consecutive items
+  // whose `section` differs; items with no `section` never draw one, so a menu
+  // that omits it (the group header) stays a flat, undivided list.
+  section?: string;
 }
 
 export function OverflowMenu({
@@ -72,25 +76,47 @@ export function OverflowMenu({
               overflow: 'hidden',
             }}
           >
-            {items.map((item) => (
-              <Pressable
-                key={item.label}
-                onPress={() => go(item.route)}
-                accessibilityRole="button"
-                accessibilityLabel={item.label}
-                style={({ pressed }) => ({
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: theme.spacing.md,
-                  paddingHorizontal: theme.spacing.lg,
-                  paddingVertical: theme.spacing.md,
-                  backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',
-                })}
-              >
-                <Ionicons name={item.icon} size={iconSize.lg} color={theme.color.textMuted} />
-                <Text variant="body">{item.label}</Text>
-              </Pressable>
-            ))}
+            {items.map((item, index) => {
+              // A divider sits at a section boundary only: both this row and the
+              // one above it name a section, and the two differ. That rules out
+              // a divider before the first row (no row above) and any menu that
+              // leaves `section` unset (the group header), which stays flat.
+              const previous = items[index - 1];
+              const dividerAbove =
+                previous !== undefined &&
+                previous.section !== undefined &&
+                item.section !== undefined &&
+                previous.section !== item.section;
+              return (
+                <View key={item.label}>
+                  {dividerAbove && (
+                    <View
+                      style={{
+                        height: StyleSheet.hairlineWidth,
+                        backgroundColor: theme.color.border,
+                        marginVertical: theme.spacing.xs,
+                      }}
+                    />
+                  )}
+                  <Pressable
+                    onPress={() => go(item.route)}
+                    accessibilityRole="button"
+                    accessibilityLabel={item.label}
+                    style={({ pressed }) => ({
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      gap: theme.spacing.md,
+                      paddingHorizontal: theme.spacing.lg,
+                      paddingVertical: theme.spacing.md,
+                      backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',
+                    })}
+                  >
+                    <Ionicons name={item.icon} size={iconSize.lg} color={theme.color.textMuted} />
+                    <Text variant="body">{item.label}</Text>
+                  </Pressable>
+                </View>
+              );
+            })}
           </View>
         </View>
       </Pressable>


### PR DESCRIPTION
Groups the dashboard's three-dot overflow menu into clusters separated by thin hairline dividers.

## What changed
- `OverflowMenuItem` gains an optional `section?: string` key.
- `OverflowMenu` draws a hairline divider (`StyleSheet.hairlineWidth`, `theme.color.border`, small `theme.spacing.xs` vertical margin) between two consecutive rows whose `section` differs. No divider is drawn before the first row, after the last, or when either adjacent row has no section.
- The dashboard's 8 items are assigned to 4 clusters, in their existing order:
  - **account** — Your account, Notifications
  - **data** — Archived groups, Backup
  - **app** — Language, Theme, AI keys
  - **settings** — Settings

The `section` keys are internal grouping only (not user-visible), so no i18n.

## Unaffected
The group-header menu (`group/[id]/index.tsx`) sets no `section` on its items, so it produces zero dividers and stays visually identical.

## Validation
`tsc --noEmit`, `eslint`, and `vitest run` (287 tests) all pass; both files prettier-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)