### PR TITLE
perf(mobile): shell-first rendering on the group subroutes

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -17,6 +17,11 @@ export default function TabsLayout() {
         // scene, and on a busy tab that dropped frames and read as slow — an
         // instant switch is the fastest a tab can feel.
         animation: 'none',
+        // Suspend an off-screen tab's rendering while it is blurred, so its
+        // queries and realtime subscriptions stop competing for the JS thread
+        // with the foreground tab's paint. It re-renders from cache on return,
+        // which is instant.
+        freezeOnBlur: true,
       }}
     >
       <Tabs.Screen name="index" />

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -466,10 +466,24 @@ export default function AddExpenseScreen() {
   }, [amount, currency, splitParams, participants, targetExpenseId]);
 
   if (group.isLoading || members.isLoading || restored.loading) {
+    // Shell first: the back button and title paint instantly on navigation, and
+    // only the form body waits on the mirror read (a few ms at launch). A bare
+    // full-screen spinner used to leave a headerless blank while it loaded.
     return (
-      <Screen>
-        <View style={{ padding: theme.spacing.xl }}>
-          <ActivityIndicator color={theme.color.brand} />
+      <Screen edges={['top', 'bottom']}>
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>
+          <Row style={{ paddingTop: theme.spacing.md }}>
+            <IconButton label={t.common.close} onPress={() => router.back()}>
+              <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+            </IconButton>
+            <View style={{ flex: 1, alignItems: 'center' }}>
+              <Text variant="heading">{editing ? t.expense.edit : t.addExpense}</Text>
+            </View>
+            <View style={{ width: 44 }} />
+          </Row>
+          <View style={{ paddingTop: theme.spacing.xxxl, alignItems: 'center' }}>
+            <ActivityIndicator color={theme.color.brand} />
+          </View>
         </View>
       </Screen>
     );

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -79,10 +79,25 @@ export default function ExpenseDetailScreen() {
   };
 
   if (expenses.isLoading) {
+    // Shell first: the back button paints instantly on navigation; the title
+    // and body fill in once the mirror read lands (a few ms at launch).
     return (
       <Screen>
-        <View style={{ padding: theme.spacing.xl }}>
-          <ActivityIndicator color={theme.color.brand} />
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>
+          <Row style={{ paddingTop: theme.spacing.md }}>
+            <IconButton label={t.common.back} onPress={() => router.back()}>
+              <Ionicons
+                name={directionalIcon('chevron-back')}
+                size={iconSize.lg}
+                color={theme.color.text}
+              />
+            </IconButton>
+            <View style={{ flex: 1 }} />
+            <View style={{ width: 44 }} />
+          </Row>
+          <View style={{ paddingTop: theme.spacing.xxxl, alignItems: 'center' }}>
+            <ActivityIndicator color={theme.color.brand} />
+          </View>
         </View>
       </Screen>
     );

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -319,10 +319,23 @@ export default function ItemizeScreen() {
   }, [shown, unclaimed.length, participants, grandTotal, currency, splitParams]);
 
   if (group.isLoading || members.isLoading) {
+    // Shell first: the header paints instantly on navigation; only the items
+    // region waits on the mirror read.
     return (
       <Screen>
-        <View style={{ padding: theme.spacing.xl }}>
-          <ActivityIndicator color={theme.color.brand} />
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>
+          <Row style={{ paddingTop: theme.spacing.md }}>
+            <IconButton label={t.common.close} onPress={() => router.back()}>
+              <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+            </IconButton>
+            <View style={{ flex: 1, alignItems: 'center' }}>
+              <Text variant="heading">{t.itemize.title}</Text>
+            </View>
+            <View style={{ width: 44 }} />
+          </Row>
+          <View style={{ paddingTop: theme.spacing.xxxl, alignItems: 'center' }}>
+            <ActivityIndicator color={theme.color.brand} />
+          </View>
         </View>
       </Screen>
     );

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -61,7 +61,7 @@ import {
 import { displayName } from '@/data/types';
 import { friendlyError } from '@/lib/errors';
 import { useAuth } from '@/lib/auth';
-import { ListScreenSkeleton } from '@/components/Skeletons';
+import { SkeletonList } from '@/components/Skeletons';
 import { fill, useStrings, type UiStrings } from '@/i18n';
 
 /** Today where the trip is, not where the server is. */
@@ -340,7 +340,28 @@ export default function PlanScreen() {
   };
 
   if (group.isLoading || plan.isLoading) {
-    return <ListScreenSkeleton rows={5} trailing={false} />;
+    // Shell first: the real header (back + title) paints instantly on
+    // navigation; only the list below stands in as a skeleton while the mirror
+    // read lands.
+    return (
+      <Screen>
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>
+          <Row style={{ paddingTop: theme.spacing.md, gap: theme.spacing.sm }}>
+            <IconButton label={t.common.back} onPress={() => router.back()}>
+              <Ionicons
+                name={directionalIcon('chevron-back')}
+                size={iconSize.lg}
+                color={theme.color.text}
+              />
+            </IconButton>
+            <Text variant="heading">{t.plan}</Text>
+          </Row>
+        </View>
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>
+          <SkeletonList rows={5} trailing={false} />
+        </View>
+      </Screen>
+    );
   }
 
   return (

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -236,10 +236,23 @@ export default function SettleScreen() {
   };
 
   if (group.isLoading || members.isLoading) {
+    // Shell first: the header paints instantly on navigation; only the payee
+    // list waits on the mirror read.
     return (
       <Screen>
-        <View style={{ padding: theme.spacing.xl }}>
-          <ActivityIndicator color={theme.color.brand} />
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>
+          <Row style={{ paddingTop: theme.spacing.md }}>
+            <IconButton label={t.common.close} onPress={() => router.back()}>
+              <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+            </IconButton>
+            <View style={{ flex: 1, alignItems: 'center' }}>
+              <Text variant="heading">{t.settleUp}</Text>
+            </View>
+            <View style={{ width: 44 }} />
+          </Row>
+          <View style={{ paddingTop: theme.spacing.xxxl, alignItems: 'center' }}>
+            <ActivityIndicator color={theme.color.brand} />
+          </View>
         </View>
       </Screen>
     );


### PR DESCRIPTION
Navigation to the group subroutes felt slow because each withheld its whole shell behind a loading gate. Now the header (back + title) paints instantly and only the data region waits on the local mirror read.

**Shell-first on 5 screens:**
- `add-expense` — back + "Add expense"/"Edit" title immediately; form body skeletons
- `expense/[expenseId]` — back button immediately; title fills in with the version
- `settle` — back + "Settle up" immediately
- `itemize` — back + title immediately
- `plan` — real header immediately; list stands in as a `SkeletonList` (was a full-screen skeleton that replaced the header too)

**Also:** `freezeOnBlur` on the tabs so a blurred tab's queries/subscriptions stop competing with the foreground tab's paint.

Deferred: the group-detail `index.tsx` (already a shaped skeleton) — hoisting its header must be paired with guarding `group.data` and memoizing the after-gate feed compute; separate follow-up.

Gates: tsc + eslint clean, vitest 287/287 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading states across expense, itemization, planning, and settlement screens.
  - Screen headers, navigation controls, titles, and layout structure now appear immediately while content loads.
  - Added more appropriate loading placeholders, including skeleton list content.
  - Improved tab performance by preserving off-screen tab state and suspending unnecessary rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->