### PR TITLE
perf(mobile): cut redundant compute on the hottest screens

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -14,7 +14,7 @@
  * account are followed across groups, because a profile id is proof.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useMutation } from '@tanstack/react-query';
 import { router } from 'expo-router';
@@ -130,15 +130,27 @@ export default function FriendsScreen() {
     }
   };
 
-  const owedToYou = sortPeople(
-    rows.filter((row) => BigInt(row.net) > 0n),
-    sortKey,
-    sortDir,
+  // The two lists are a filter plus an O(n log n) sort each, and every render —
+  // opening or closing the sort menu, a pull-to-refresh tick — used to run both
+  // again and hand back freshly allocated arrays. They only actually change when
+  // the rows or the chosen sort change, so memoise on exactly those.
+  const owedToYou = useMemo(
+    () =>
+      sortPeople(
+        rows.filter((row) => BigInt(row.net) > 0n),
+        sortKey,
+        sortDir,
+      ),
+    [rows, sortKey, sortDir],
   );
-  const youOwe = sortPeople(
-    rows.filter((row) => BigInt(row.net) < 0n),
-    sortKey,
-    sortDir,
+  const youOwe = useMemo(
+    () =>
+      sortPeople(
+        rows.filter((row) => BigInt(row.net) < 0n),
+        sortKey,
+        sortDir,
+      ),
+    [rows, sortKey, sortDir],
   );
 
   return (

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -456,9 +456,12 @@ export function useGroup(groupId: string) {
   const { mirror, queue } = useSync();
 
   const rows = useMemo(() => {
-    const group =
-      (materialiseGroups(mirror, queue).find((row) => row.id === groupId) as unknown as
-        GroupRow | undefined) ?? null;
+    // Build the one group we want instead of materialising, archived-filtering
+    // and sorting every group only to `.find` a single row. `materialiseGroups`
+    // hides archived trips, so preserve that: an archived group resolves to null
+    // here exactly as the old `.find` over the active list did.
+    const built = materialiseGroup(mirror, queue, groupId) as unknown as GroupRow | undefined;
+    const group = built && !built.archived_at ? built : null;
     const members = materialiseMembers(mirror, queue, { groupId }) as unknown as MemberRow[];
     const settlements = materialiseSettlements(mirror, queue, {
       groupId,

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -107,6 +107,23 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
   });
 }
 
+/** Shallow-equal two cursor maps: same keys, same values. */
+function sameCursors(a: Record<string, number>, b: Record<string, number>): boolean {
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  for (const key of keys) if (a[key] !== b[key]) return false;
+  return true;
+}
+
+/** Same queue contents in the same order — by item identity, which
+ * `applyOutcomes` preserves when it drops nothing. */
+function sameQueue(a: readonly QueuedMutation[], b: readonly QueuedMutation[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) if (a[i] !== b[i]) return false;
+  return true;
+}
+
 export class SyncEngine {
   private store: LocalStore = createLocalStore();
   private state: SyncState = {
@@ -366,20 +383,42 @@ export class SyncEngine {
         message: entry.message,
       }));
 
-      const merged = reconcile(this.state.mirror, response.changes ?? []);
-      const mirror: MirrorState = {
-        // The server's cursors are authoritative: they also advance past rows
-        // this client is not allowed to see, which stops the cursor stalling.
-        cursors: { ...merged.state.cursors, ...(response.cursors ?? {}) },
-        tables: merged.state.tables,
-      };
+      const changes = response.changes ?? [];
+      const merged = reconcile(this.state.mirror, changes);
+      // The server's cursors are authoritative: they also advance past rows
+      // this client is not allowed to see, which stops the cursor stalling.
+      const nextCursors = { ...merged.state.cursors, ...(response.cursors ?? {}) };
 
-      await this.persist(response.changes ?? [], mirror, folded.queue);
+      // Hold the old references when this flush folded in nothing.
+      //
+      // The 30s poll (POLL_INTERVAL_MS) runs this round trip on a loop, and the
+      // common answer is "nothing new": no rows to apply and the cursors already
+      // where they are. reconcile still allocates a fresh tables/cursors object
+      // and applyOutcomes a fresh queue array, so assigning them would hand the
+      // mounted screens a new `mirror`/`queue` identity every interval — and
+      // every useMemo keyed on [mirror, queue, …] (the home summary, people
+      // balances, the group ledger) would recompute for a background fetch that
+      // changed nothing: periodic jank nobody asked to watch. When nothing was
+      // applied, keep the existing references so referential equality holds and
+      // those memos stay put. When changes did land — or the cursors or queue
+      // actually moved — this is exactly the old path: a new mirror, the folded
+      // queue.
+      const nothingApplied = changes.length === 0;
+      const mirror: MirrorState =
+        nothingApplied && sameCursors(this.state.mirror.cursors, nextCursors)
+          ? this.state.mirror
+          : { cursors: nextCursors, tables: merged.state.tables };
+      const queue =
+        folded.rejected.length === 0 && sameQueue(this.state.queue, folded.queue)
+          ? this.state.queue
+          : folded.queue;
+
+      await this.persist(changes, mirror, queue);
 
       this.set({
         status: SyncStatus.Idle,
         mirror,
-        queue: folded.queue,
+        queue,
         rejected: [...this.state.rejected, ...rejected],
         lastSyncedAt: response.serverTime ?? new Date().toISOString(),
         lastError: null,


### PR DESCRIPTION
Three precise, verified cuts to synchronous JS-thread work on the mounted screens. Behavior and rendered output are unchanged.

## Fix 1 — Stop churning the `mirror`/`queue` references on empty polls (biggest win)
`apps/mobile/src/sync/engine.ts` — the 30s background poll (`POLL_INTERVAL_MS`) runs the sync round trip on a loop, and the usual answer is "nothing new". `reconcile` still allocates a fresh tables/cursors object and `applyOutcomes` a fresh queue array, so `runFlush` handed every mounted screen a new `mirror`/`queue` identity every interval — and every `useMemo` keyed on `[mirror, queue, …]` (home summary, people balances, the group ledger) recomputed for a fetch that changed nothing. When nothing was applied (empty change set with unmoved cursors, and a queue with nothing dropped) the existing references are kept, so referential equality holds and those memos stay put. When changes do land, the old path runs exactly as before.

Note: the fix preserves the `queue` reference as well as `mirror`, because every hot memo keys on both and `applyOutcomes` reallocates the queue array each poll — preserving only `mirror` would not have stopped the recompute.

## Fix 2 — `useGroup` builds one group instead of all of them
`apps/mobile/src/data/hooks.ts` — `useGroup` resolved its row with `materialiseGroups(mirror, queue).find(...)`, materialising every group + archived-filter + full sort just to pick one id. Swapped to the existing single-row `materialiseGroup(...)`. Archived-visibility semantics are preserved exactly: `materialiseGroups` hides archived trips, so an archived group still resolves to `null` here as the old `.find` over the active list did.

## Fix 4 — Memoise the Friends sorts
`apps/mobile/src/app/(tabs)/friends.tsx` — `owedToYou`/`youOwe` (a filter + O(n log n) sort each) recomputed on every render and returned fresh arrays. Wrapped both in `useMemo` keyed on `[rows, sortKey, sortDir]`. Output is identical.

Fix 3 (group-detail memoisation) was dropped from this PR to avoid a file collision with a parallel PR that owns `group/[id]/index.tsx`.

## Gates
- `tsc --noEmit` (apps/mobile) — clean
- `eslint` on the three changed files — clean
- `prettier --write` — applied
- `vitest run` — **25 files / 287 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved responsiveness on the Friends screen by avoiding unnecessary list recalculations.
  * Made group loading more efficient while continuing to exclude archived groups.
  * Reduced unnecessary sync and persistence updates when no effective changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->