### PR TITLE
feat(mobile): rounded-dot invite QR with centered app glyph

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -55,6 +55,7 @@
     "react-native-document-scanner-plugin": "^2.0.4",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-get-sms-android": "^2.1.0",
+    "react-native-qrcode-styled": "^0.4.0",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-reanimated": "4.5.3",
     "react-native-safe-area-context": "~5.8.1",
@@ -65,6 +66,7 @@
     "react-native-worklets": "0.10.1"
   },
   "devDependencies": {
+    "@types/qrcode": "^1.5.6",
     "@types/react": "~19.2.2",
     "eslint": "^9.39.5",
     "eslint-config-expo": "~57.0.1",

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -14,7 +14,7 @@ import {
   Share,
   View,
 } from 'react-native';
-import QRCode from 'react-native-qrcode-svg';
+import QRCodeStyled from 'react-native-qrcode-styled';
 
 import {
   Badge,
@@ -228,25 +228,45 @@ export default function InviteScreen() {
                   borderRadius: theme.radius.md,
                 }}
               >
-                <QRCode
-                  getRef={(c) => (qrRef.current = c)}
-                  value={link}
+                <QRCodeStyled
+                  // The ref forwards to the underlying react-native-svg <Svg>,
+                  // whose toDataURL(cb) captureQr calls to share the code as a
+                  // PNG — same contract the old library's getRef gave us, so no
+                  // native screenshot module is needed.
+                  ref={(c) => {
+                    qrRef.current = c;
+                  }}
+                  data={link}
+                  // 200pt of modules plus a white quiet border, so it stays
+                  // crisp inside the card and scans without crowding the edge.
                   size={200}
-                  backgroundColor="#ffffff"
-                  // The brand wash instead of flat black — the same purple ramp
-                  // the balance card wears, swept corner to corner. Both stops
-                  // are dark enough on white to stay well within scanning
-                  // contrast, and level-H error correction plus the padded
-                  // centre logo keep it readable with the app mark punched out.
-                  enableLinearGradient
-                  linearGradient={[theme.gradient.brand[0]!, theme.gradient.brand[2]!]}
-                  gradientDirection={['0', '0', '1', '1']}
-                  ecl="H"
-                  logo={require('../../../../assets/images/icon.png')}
-                  logoSize={44}
-                  logoBackgroundColor="#ffffff"
-                  logoBorderRadius={10}
-                  logoMargin={4}
+                  padding={16}
+                  style={{ backgroundColor: '#ffffff' }}
+                  // A fixed near-black rather than a theme token: the code lives
+                  // on a permanently white tile in both light and dark, so the
+                  // ink must not follow the theme or it would vanish in dark mode.
+                  color="#0A0A1A"
+                  // Level-H error correction leaves ~30% redundancy, enough that
+                  // the punched-out centre logo and the rounded dots never cost a
+                  // scan.
+                  errorCorrectionLevel="H"
+                  // Each module a rounded dot with a hair of a gap between them —
+                  // the "scan with phone" wallet look — instead of a solid grid.
+                  pieceBorderRadius="50%"
+                  pieceScale={0.92}
+                  // The three corner finders as rounded squares with a rounded
+                  // pupil, matching the dot treatment.
+                  outerEyesOptions={{ borderRadius: '28%', color: '#0A0A1A' }}
+                  innerEyesOptions={{ borderRadius: '35%', color: '#0A0A1A' }}
+                  // The Waves glyph on its rounded tile, centred with a quiet
+                  // margin; hidePieces clears the modules behind it so it sits in
+                  // a clean gap rather than on top of the code.
+                  logo={{
+                    href: require('../../../../assets/images/icon.png'),
+                    scale: 0.85,
+                    padding: 6,
+                    hidePieces: true,
+                  }}
                 />
               </View>
             </Card>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       react-native-get-sms-android:
         specifier: ^2.1.0
         version: 2.1.0(patch_hash=e72c594803865c47c2f801d4365965e702516c309f10d38bfe3a48a8c2c1f05d)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))
+      react-native-qrcode-styled:
+        specifier: ^0.4.0
+        version: 0.4.0(react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       react-native-qrcode-svg:
         specifier: ^6.3.21
         version: 6.3.21(react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -249,6 +252,9 @@ importers:
         specifier: 0.10.1
         version: 0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)
     devDependencies:
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@types/react':
         specifier: ~19.2.2
         version: 19.2.18
@@ -2726,6 +2732,9 @@ packages:
   '@types/pg@8.21.0':
     resolution: {integrity: sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/react-dom@19.2.4':
     resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
     peerDependencies:
@@ -4416,6 +4425,9 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
+  fast-text-encoding@1.0.6:
+    resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
+
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
@@ -5849,6 +5861,14 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-qrcode-styled@0.4.0:
+    resolution: {integrity: sha512-j5C5LFOr9KdAqm1snQX8UQH9RFRSH4FY1/7Ts/UvtR/5A9rmb61ZzIIW5d0RteY1D+DWVfnXDMhLmTJXXRgKpg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+      react-native-svg: '*'
 
   react-native-qrcode-svg@6.3.21:
     resolution: {integrity: sha512-6vcj4rcdpWedvphDR+NSJcudJykNuLgNGFwm2p4xYjR8RdyTzlrELKI5LkO4ANS9cQUbqsfkpippPv64Q2tUtA==}
@@ -9328,6 +9348,10 @@ snapshots:
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 26.2.0
+
   '@types/react-dom@19.2.4(@types/react@19.2.18)':
     dependencies:
       '@types/react': 19.2.18
@@ -11451,6 +11475,8 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
+  fast-text-encoding@1.0.6: {}
+
   fast-uri@3.1.5: {}
 
   fastq@1.20.1:
@@ -12885,6 +12911,15 @@ snapshots:
     dependencies:
       react: 19.2.8
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+
+  react-native-qrcode-styled@0.4.0(react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+    dependencies:
+      fast-text-encoding: 1.0.6
+      qrcode: 1.5.4
+      react: 19.2.8
+      react-fast-compare: 3.2.2
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+      react-native-svg: 15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
 
   react-native-qrcode-svg@6.3.21(react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## What

Restyles the group invite QR code to match the WalletConnect / "scan with phone" modal aesthetic:

- **Rounded dot modules** — each module is a rounded dot (`pieceBorderRadius="50%"`) with a small gap (`pieceScale={0.92}`), not a solid square grid.
- **Rounded finder eyes** — the three corner markers render as rounded squares with rounded pupils (`outerEyesOptions` / `innerEyesOptions` with `borderRadius`).
- **Centered app-logo tile** — the Waves glyph (`assets/images/icon.png`) on its rounded tile, centered in a clean quiet gap (`hidePieces` + logo `padding`).
- **Dark-on-white, theme-independent** — a fixed near-black `#0A0A1A` on a permanently white tile, so the code never inverts in dark mode.
- **High error correction** — `errorCorrectionLevel="H"` (~30% redundancy) keeps it scannable with the logo punched out.

## Dependency

The old `react-native-qrcode-svg` can only draw square modules, so this swaps in **`react-native-qrcode-styled` (0.4.0)** — a **pure-JS** library built on `react-native-svg`, which is already installed. It pulls **no native code** and needs **no config plugin**, so the managed Expo build is unaffected. `@types/qrcode` is added as a dev-only dependency so the library's `QRCodeOptions` props type-check.

## Share-as-image preserved (native path)

The new component forwards its `ref` to the underlying `<Svg>`, whose `toDataURL(cb)` returns the same base64 PNG the old `getRef` did. `captureQr` / `shareQr` and the link-only fallback keep working unchanged — **no screenshot module** (`react-native-view-shot`) needed.

## Validation

- `tsc --noEmit`: clean
- `eslint` on invite.tsx: clean
- `vitest run`: 25 files / 287 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated group invitation QR codes with a more polished, branded appearance.
  - Added rounded QR elements, customized finder patterns, improved error correction, and a centered app logo.
  - Preserved the ability to capture QR codes as PNG images for sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->