### PR TITLE
feat(mobile): add-expense polish — payment method, category default, add-person, heading icon

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -7,12 +7,13 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
+  CategoryId,
   computeShares,
   guessCategory,
   MutationKind,
-  type CategoryId,
   type FxRecord,
   type MemberId,
+  type PaymentMethod,
   type SplitParams,
 } from '@waves/core';
 import {
@@ -35,6 +36,7 @@ import {
 } from '@waves/ui';
 
 import { CategoryPicker } from '@/components/Category';
+import { PaymentMethodPicker } from '@/components/PaymentMethodPicker';
 import { friendlyError } from '@/lib/errors';
 import { CurrencyRate } from '@/components/CurrencyRate';
 import { DictateButton } from '@/components/DictateButton';
@@ -42,7 +44,7 @@ import { canAddReceipt, scanReceipt, scanReceiptText } from '@/data/api';
 import { receiptCapStatus, receiptTapAction } from '@/lib/receiptCapGate';
 import { useAssignCapture, useGroup } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
-import { fill, plural, useStrings } from '@/i18n';
+import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { handoverKey } from '@/lib/handover';
@@ -164,6 +166,9 @@ export default function AddExpenseScreen() {
   const [description, setDescription] = useState('');
   const [splitKind, setSplitKind] = useState<SplitKind>(SplitKind.Equal);
   const [payer, setPayer] = useState<MemberId | null>(null);
+  // How it was paid — a free-text tag on the expense. Defaults to cash; the
+  // picker offers UPI only where the region settles over it.
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cash');
   const [participants, setParticipants] = useState<MemberId[]>([]);
   // What was typed into each member's field, as text. Two maps, not one: the
   // same person is "2 shares" and "40%", and switching between the two must not
@@ -172,7 +177,7 @@ export default function AddExpenseScreen() {
   const [percents, setPercents] = useState<SplitEntries>({});
   // Guessed from the description until somebody picks one themselves, at which
   // point the guess must stop moving it — see `categoryChosen`.
-  const [category, setCategory] = useState<CategoryId | null>(null);
+  const [category, setCategory] = useState<CategoryId | null>(CategoryId.Food);
   const [categoryChosen, setCategoryChosen] = useState(false);
   /**
    * Names to bias the recogniser towards. "You" and "Someone" are placeholders
@@ -340,6 +345,7 @@ export default function AddExpenseScreen() {
       setShareUrl(version.receipt_share_url ?? null);
       setShareWithGroup(Boolean(version.receipt_share_url));
       setPayer(version.payers[0]?.member_id ?? myMemberId);
+      setPaymentMethod((version.payment_method as PaymentMethod | null) ?? 'cash');
       setParticipants(version.shares.map((share) => share.member_id));
       setSplitKind(
         version.split_type === 'percent'
@@ -369,7 +375,11 @@ export default function AddExpenseScreen() {
   const [guessedFrom, setGuessedFrom] = useState<string | null>(null);
   if (seededFor !== null && !categoryChosen && description !== guessedFrom) {
     setGuessedFrom(description);
-    setCategory(guessCategory(description));
+    // Keep the current category when the text matches no bucket: guessCategory
+    // returns null for unrecognised descriptions, and clearing on null would
+    // wipe the Food & drink default (or an earlier guess).
+    const guess = guessCategory(description);
+    if (guess) setCategory(guess);
   }
 
   // Everybody in a weighted split needs a number to start from, and the set
@@ -412,7 +422,6 @@ export default function AddExpenseScreen() {
     participants.length === (members.data ?? []).length;
   const [splitOpen, setSplitOpen] = useState(false);
   const showSplit = splitOpen || !isDefaultSplit || splitIssue !== null;
-  const payerMember = (members.data ?? []).find((member) => member.id === payer) ?? null;
 
   const groupCurrency = group.data?.default_currency ?? 'INR';
   // The expense keeps the currency it was paid in; the group's is only the
@@ -477,7 +486,10 @@ export default function AddExpenseScreen() {
               <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
             </IconButton>
             <View style={{ flex: 1, alignItems: 'center' }}>
-              <Text variant="heading">{editing ? t.expense.edit : t.addExpense}</Text>
+              <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+                <Ionicons name="receipt-outline" size={iconSize.md} color={theme.color.brand} />
+                <Text variant="heading">{editing ? t.expense.edit : t.addExpense}</Text>
+              </Row>
             </View>
             <View style={{ width: 44 }} />
           </Row>
@@ -569,6 +581,7 @@ export default function AddExpenseScreen() {
         splitParams,
         participants,
         payers: { [payer]: amount.toString() },
+        paymentMethod,
         expectedShares: preview
           ? Object.fromEntries([...preview].map(([id, share]) => [id, share.toString()]))
           : undefined,
@@ -784,7 +797,10 @@ export default function AddExpenseScreen() {
             <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{editing ? t.expense.edit : t.addExpense}</Text>
+            <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+              <Ionicons name="receipt-outline" size={iconSize.md} color={theme.color.brand} />
+              <Text variant="heading">{editing ? t.expense.edit : t.addExpense}</Text>
+            </Row>
             <Text variant="micro" tone="muted">
               {groupLabel(group.data, members.data ?? [], profile?.id)}
             </Text>
@@ -998,6 +1014,14 @@ export default function AddExpenseScreen() {
           />
         </View>
 
+        {/* How it was paid — a tag on the expense, defaulting to cash. */}
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="caption" tone="muted">
+            {t.captures.paidWith}
+          </Text>
+          <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} />
+        </View>
+
         {/* The one-line answer to "who pays what", tappable to open the three
             controls that decide it. */}
         <Pressable
@@ -1016,11 +1040,6 @@ export default function AddExpenseScreen() {
                 </Text>
                 <Text variant="subheading" numberOfLines={2}>
                   {[
-                    payerMember
-                      ? fill(t.expense.paidByName, {
-                          name: displayName(payerMember, profile?.id),
-                        })
-                      : t.expense.chooseWhoPaid,
                     splitKind === SplitKind.Equal
                       ? t.expense.equally
                       : splitKind === SplitKind.Shares
@@ -1191,6 +1210,18 @@ export default function AddExpenseScreen() {
               {splitIssue}
             </Text>
           ) : null}
+
+          {/* Someone missing from the roster is added on the group's own members
+              screen, then they appear here to be split with. */}
+          <Button
+            label={t.people.addSomeone}
+            variant="secondary"
+            size="sm"
+            onPress={() => router.push(`/group/${groupId}/members`)}
+            icon={
+              <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.brand} />
+            }
+          />
         </Card>
       </ScrollView>
 

--- a/apps/mobile/src/components/PaymentMethodPicker.tsx
+++ b/apps/mobile/src/components/PaymentMethodPicker.tsx
@@ -1,0 +1,107 @@
+/**
+ * How a spend was paid — a horizontal row of chips (cash, UPI, card, …).
+ *
+ * The id is what persists to the free-text `payment_method` column, so any of
+ * these is safe to store; the icon and label are UI. Debit wears the filled
+ * card so it reads apart from credit's outline at chip size. `upi` is offered
+ * only where the rail exists (see `deviceSupportsUpi`); everywhere else the row
+ * is the region rails a person would recognise. One row that scrolls sideways
+ * rather than wrapping, so the block keeps a fixed height however many rails a
+ * region offers.
+ *
+ * Shared so the capture screen, add-expense, and add-person all speak the same
+ * language for the same field.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, ScrollView } from 'react-native';
+
+import { type PaymentMethod } from '@waves/core';
+import { iconSize, Text, useTheme } from '@waves/ui';
+
+import { deviceSupportsUpi, useStrings } from '@/i18n';
+
+const PAYMENT_METHODS: readonly {
+  id: PaymentMethod;
+  icon: keyof typeof Ionicons.glyphMap;
+  /** True for a rail that only some regions have — filtered by device support. */
+  regional?: boolean;
+}[] = [
+  { id: 'cash', icon: 'cash-outline' },
+  { id: 'upi', icon: 'phone-portrait-outline', regional: true },
+  { id: 'credit', icon: 'card-outline' },
+  { id: 'debit', icon: 'card' },
+  { id: 'forex', icon: 'swap-horizontal-outline' },
+];
+
+export function PaymentMethodPicker({
+  value,
+  onChange,
+}: {
+  value: PaymentMethod | null;
+  onChange: (value: PaymentMethod) => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  const label = (id: PaymentMethod): string => {
+    switch (id) {
+      case 'cash':
+        return t.captures.payCash;
+      case 'upi':
+        return t.captures.payUpi;
+      case 'credit':
+        return t.captures.payCredit;
+      case 'debit':
+        return t.captures.payDebit;
+      case 'forex':
+        return t.captures.payForex;
+    }
+  };
+
+  const upiSupported = deviceSupportsUpi();
+  const methods = PAYMENT_METHODS.filter((method) => !method.regional || upiSupported);
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={{ gap: theme.spacing.sm, paddingRight: theme.spacing.xl }}
+    >
+      {methods.map((method) => {
+        const active = value === method.id;
+        return (
+          <Pressable
+            key={method.id}
+            accessibilityRole="radio"
+            accessibilityState={{ selected: active }}
+            accessibilityLabel={label(method.id)}
+            onPress={() => onChange(method.id)}
+            style={({ pressed }) => ({
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: theme.spacing.xs,
+              paddingVertical: theme.spacing.sm,
+              paddingHorizontal: theme.spacing.md,
+              borderRadius: theme.radius.md,
+              borderWidth: 1,
+              borderColor: active ? theme.color.brand : theme.color.border,
+              backgroundColor: active ? theme.color.brandSoft : theme.color.surface,
+              opacity: pressed ? 0.7 : 1,
+            })}
+          >
+            <Ionicons
+              name={method.icon}
+              size={iconSize.md}
+              color={active ? theme.color.brand : theme.color.textMuted}
+            />
+            <Text variant="body" style={{ color: active ? theme.color.brand : theme.color.text }}>
+              {label(method.id)}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}


### PR DESCRIPTION
Five changes to the add-expense screen (from direct request):

- **Payment method** — new "Paid with" picker, default **cash**, UPI where supported; persists to the existing `payment_method` column (protocol/mirror already carried it), reloads from the version on edit. Extracted a shared `PaymentMethodPicker` (canonical `PaymentMethod` type + `t.captures.pay*` labels).
- **Category** defaults to **Food & drink**; a no-match description keeps the default rather than clearing it.
- **Add someone** button under the roster → group members screen.
- **Paid-by** — removed only the redundant summary line; payer picker unchanged.
- **Heading icon** — receipt glyph beside the title.

Gates: tsc + eslint clean, vitest 287/287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)