### PR TITLE
fix(mobile): neutral the dashboard add-group plus badge

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -254,7 +254,7 @@ export default function HomeScreen() {
                   backgroundColor: theme.color.bg,
                 }}
               >
-                <Ionicons name="add-circle" size={iconSize.base} color={theme.color.brand} />
+                <Ionicons name="add-circle" size={iconSize.base} color={theme.color.text} />
               </View>
             </View>
           </Pressable>


### PR DESCRIPTION
The add-group "+" badge in the top toolbar was the only brand-coloured glyph among neutral header icons. Draw it in the text colour so the toolbar reads as one plain title row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)