### PR TITLE
feat(mobile): gate the AI-keys entry points behind a feature flag

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -33,6 +33,7 @@ import {
 import { useGroups, useHomeSummary } from '@/data/hooks';
 import { CountUpMoney, PressableScale } from '@/lib/anim';
 import { useMotion } from '@/lib/motion';
+import { useFlagEnabled } from '@/lib/flags';
 import { deviceDefaultCurrency, plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
@@ -69,6 +70,9 @@ export default function HomeScreen() {
   // less-used destinations, surfaced from the dashboard rather than only from
   // the profile tab.
   const [menuOpen, setMenuOpen] = useState(false);
+  // The bring-your-own AI-key vault is gated behind a flag until it ships: off
+  // for everyone with no flag row, on only where the console turns it on.
+  const aiKeysEnabled = useFlagEnabled('ai_keys');
   const menuItems: OverflowMenuItem[] = useMemo(
     () => [
       // The `section` keys are internal grouping only (not user-visible): they
@@ -105,12 +109,16 @@ export default function HomeScreen() {
         route: '/settings/theme',
         section: 'app',
       },
-      {
-        icon: 'key-outline',
-        label: t.account.aiKeysRow,
-        route: '/settings/ai-keys',
-        section: 'app',
-      },
+      ...(aiKeysEnabled
+        ? [
+            {
+              icon: 'key-outline' as const,
+              label: t.account.aiKeysRow,
+              route: '/settings/ai-keys' as const,
+              section: 'app',
+            },
+          ]
+        : []),
       {
         icon: 'settings-outline',
         label: t.account.faceSettings,
@@ -118,7 +126,7 @@ export default function HomeScreen() {
         section: 'settings',
       },
     ],
-    [t],
+    [t, aiKeysEnabled],
   );
 
   // The group list gets a category filter strip — but only worth showing once

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -30,6 +30,7 @@ import { useAuth } from '@/lib/auth';
 import { pickAvatarPhoto } from '@/lib/image';
 import { describeGrace, useLock } from '@/lib/lock';
 import { useMotion } from '@/lib/motion';
+import { useFlagEnabled } from '@/lib/flags';
 import { SyncNetworkPreference, useSyncNetwork } from '@/lib/syncNetwork';
 import { useThemePreference } from '@/lib/theme';
 
@@ -263,6 +264,8 @@ function ProfileForm() {
   const theme = useTheme();
   const clearance = useTabBarClearance();
   const { t, locale } = useStrings();
+  // Gate the bring-your-own AI-key vault behind a flag until it ships.
+  const aiKeysEnabled = useFlagEnabled('ai_keys');
   const { profile, isGuest, updateProfile, signOut } = useAuth();
 
   const { enabled: lockEnabled, supported: lockSupported, graceSeconds } = useLock();
@@ -468,17 +471,19 @@ function ProfileForm() {
             preference nor a Baaki purchase — it is a credential the reader
             supplies, held on the device, to run the model-powered features on
             their own account. */}
-        <SettingsSection
-          title={t.account.sectionAi}
-          rows={[
-            {
-              icon: 'key-outline',
-              label: t.account.aiKeysRow,
-              hint: t.account.aiKeysHint,
-              route: '/settings/ai-keys',
-            },
-          ]}
-        />
+        {aiKeysEnabled ? (
+          <SettingsSection
+            title={t.account.sectionAi}
+            rows={[
+              {
+                icon: 'key-outline',
+                label: t.account.aiKeysRow,
+                hint: t.account.aiKeysHint,
+                route: '/settings/ai-keys',
+              },
+            ]}
+          />
+        ) : null}
 
         {/* Language leads. It was fifth, under Import, and it is the one setting
             somebody may have to reach *before* they can read the four above it —


### PR DESCRIPTION
Hide the bring-your-own AI-key vault's two entry points — the "Your AI keys" row in the dashboard overflow menu (`index.tsx`) and the AI section on the profile/settings screen (`profile.tsx`) — behind the `ai_keys` feature flag.

The flag fails off (`useFlagEnabled`): with no flag row (the default) both entry points are hidden; they surface only where the console enables the flag for a rollout. The `/settings/ai-keys` route itself is untouched (deep-link reachable), so no in-progress setup breaks.

Gates: tsc + eslint clean, vitest 287/287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)