### PR TITLE
feat(mobile): redesign add-expense to match capture + share the expense-form components

### DIFF
--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -1,27 +1,11 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { randomUUID } from 'expo-crypto';
 import { router, useLocalSearchParams } from 'expo-router';
-import {
-  ActivityIndicator,
-  Modal,
-  Platform,
-  Pressable,
-  ScrollView,
-  TextInput,
-  View,
-} from 'react-native';
+import { ActivityIndicator, Modal, Platform, Pressable, ScrollView, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-  withTiming,
-} from 'react-native-reanimated';
 
 import {
   currencySymbol,
@@ -30,14 +14,13 @@ import {
   parseReceiptText,
   CategoryId,
   type HeuristicReceipt,
+  type PaymentMethod,
 } from '@waves/core';
 import {
-  AmountField,
   Button,
   Callout,
   Card,
   Divider,
-  IconButton,
   iconSize,
   MoneyText,
   Row,
@@ -47,19 +30,17 @@ import {
 } from '@waves/ui';
 
 import { CategoryPicker } from '@/components/Category';
+import { PaymentMethodPicker } from '@/components/PaymentMethodPicker';
 import { ZoomableImage } from '@/components/ZoomableImage';
 import { COMMON_CURRENCIES } from '@/components/CurrencyRate';
-import { DictateButton } from '@/components/DictateButton';
+import { AmountHeader } from '@/components/expense/AmountHeader';
+import { DescriptionField } from '@/components/expense/DescriptionField';
+import { ExpenseHeader } from '@/components/expense/ExpenseHeader';
+import { ChoiceRow, FieldRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import { useCreateCapture, useGroups, useHomeSummary } from '@/data/hooks';
 import { groupLabel, GroupType, type GroupRow, type MemberRow } from '@/data/types';
 import { useAuth } from '@/lib/auth';
-import {
-  deviceDefaultCurrency,
-  deviceSupportsUpi,
-  plural,
-  useStrings,
-  type UiStrings,
-} from '@/i18n';
+import { deviceDefaultCurrency, plural, useStrings, type UiStrings } from '@/i18n';
 import { captureReceipt, type PickedImage } from '@/lib/image';
 import { recogniseReceipt } from '@/lib/ocr';
 import { saveReceipt } from '@/lib/receiptStore';
@@ -131,29 +112,6 @@ function showDate(iso: string, locale: string): string {
 }
 
 /**
- * How the spend was paid — a tag, not a commitment. The id is what persists (a
- * free-text `payment_method` column, so any of these ids is safe to store); the
- * icon and label are UI. Debit wears the filled card so it reads apart from
- * credit's outline at chip size. `upi` is offered only where the rail exists
- * (see `deviceSupportsUpi`); everywhere else the row is region rails a person
- * would recognise.
- */
-const PAYMENT_METHODS: readonly {
-  id: 'cash' | 'upi' | 'credit' | 'debit' | 'forex';
-  icon: keyof typeof Ionicons.glyphMap;
-  /** True for a rail that only some regions have — filtered by device support. */
-  regional?: boolean;
-}[] = [
-  { id: 'cash', icon: 'cash-outline' },
-  { id: 'upi', icon: 'phone-portrait-outline', regional: true },
-  { id: 'credit', icon: 'card-outline' },
-  { id: 'debit', icon: 'card' },
-  { id: 'forex', icon: 'swap-horizontal-outline' },
-];
-
-type PaymentMethodId = (typeof PAYMENT_METHODS)[number]['id'];
-
-/**
  * The scan nonces already consumed, at module scope so the set survives a
  * remount.
  *
@@ -219,7 +177,7 @@ export default function CaptureScreen() {
   // capture and survive until it is assigned. Payment defaults to cash (the most
   // common answer, and one fewer tap for it); the group defaults to "decide
   // later" (null), which keeps the capture in the inbox.
-  const [paymentMethod, setPaymentMethod] = useState<PaymentMethodId | null>('cash');
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>('cash');
   const [targetGroupId, setTargetGroupId] = useState<string | null>(null);
   const [pickingGroup, setPickingGroup] = useState(false);
 
@@ -232,27 +190,6 @@ export default function CaptureScreen() {
   const targetGroupName = targetGroup
     ? groupLabel(targetGroup, summary.membersFor(targetGroup.id), profile?.id)
     : t.captures.decideLater;
-
-  // Only the rails this region actually offers. UPI is dropped everywhere the
-  // device does not settle over it, so nobody outside its reach sees a tag that
-  // means nothing to them.
-  const upiSupported = deviceSupportsUpi();
-  const paymentMethods = PAYMENT_METHODS.filter((method) => !method.regional || upiSupported);
-
-  const paymentLabel = (id: PaymentMethodId): string => {
-    switch (id) {
-      case 'cash':
-        return t.captures.payCash;
-      case 'upi':
-        return t.captures.payUpi;
-      case 'credit':
-        return t.captures.payCredit;
-      case 'debit':
-        return t.captures.payDebit;
-      case 'forex':
-        return t.captures.payForex;
-    }
-  };
 
   // Category starts on Food & drink — the most common capture, one fewer tap for
   // it. The guess then follows the description until a chip is tapped, at which
@@ -401,82 +338,32 @@ export default function CaptureScreen() {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-          <Row style={{ flex: 1, justifyContent: 'center', gap: theme.spacing.xs }}>
-            <Ionicons name="receipt-outline" size={iconSize.md} color={theme.color.brand} />
-            <Text variant="heading">{t.captures.newTitle}</Text>
-          </Row>
-          <View style={{ width: 44 }} />
-        </Row>
+        <ExpenseHeader title={t.captures.newTitle} />
 
         {/* Amount-forward hero: the number is the point of this screen, so it
             leads — big and centred, with the currency it is counted in a tap
-            below it (the Splitwise/PayPal amount-first pattern). No card around
-            it; the whitespace is the frame. */}
-        <View style={{ alignItems: 'center', gap: theme.spacing.md, paddingTop: theme.spacing.md }}>
-          <AmountField currency={currency} value={amount} onChange={setAmount} />
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={`${t.captures.currencyLabel}: ${currency}`}
-            onPress={() => setPickingCurrency(true)}
-            style={({ pressed }) => ({
-              flexDirection: 'row',
-              alignItems: 'center',
-              gap: theme.spacing.xs,
-              paddingVertical: theme.spacing.xs,
-              paddingHorizontal: theme.spacing.md,
-              borderRadius: theme.radius.pill,
-              backgroundColor: theme.color.surfaceMuted,
-              opacity: pressed ? 0.7 : 1,
-            })}
-          >
-            <Text variant="caption" tone="muted">
-              {currencySymbol(currency)}
-            </Text>
-            <Text variant="caption" style={{ fontWeight: '700', color: theme.color.text }}>
-              {currency}
-            </Text>
-            <Ionicons name="chevron-down" size={iconSize.sm} color={theme.color.textMuted} />
-          </Pressable>
-        </View>
+            below it (the Splitwise/PayPal amount-first pattern). Shared with
+            add-expense. */}
+        <AmountHeader
+          currency={currency}
+          amount={amount}
+          onAmountChange={setAmount}
+          onPressCurrency={() => setPickingCurrency(true)}
+        />
 
         {/* Description, as a single underlined field rather than a boxed card —
             it sits right under the amount so the two things a person always fills
-            in are together, with the mic to speak it instead of type (A5). */}
-        <View style={{ gap: theme.spacing.xs }}>
-          <Row
-            style={{
-              alignItems: 'center',
-              gap: theme.spacing.sm,
-              borderBottomWidth: 1,
-              borderBottomColor: theme.color.border,
-              paddingBottom: theme.spacing.xs,
-            }}
-          >
-            <Ionicons name="receipt-outline" size={iconSize.md} color={theme.color.textMuted} />
-            <TextInput
-              value={description}
-              onChangeText={setDescription}
-              placeholder={t.captures.descriptionPlaceholder}
-              placeholderTextColor={theme.color.textFaint}
-              accessibilityLabel={t.captures.description}
-              style={{
-                flex: 1,
-                fontSize: 17,
-                fontWeight: '600',
-                color: theme.color.text,
-                paddingVertical: theme.spacing.sm,
-              }}
-            />
-            {/* Group names are handed to the recogniser as hints — a general
-                model mangles Indian names, and a note like "dinner with Ravi" is
-                exactly where they turn up. */}
-            <DictateButton value={description} onChange={setDescription} hints={groupNameHints} />
-          </Row>
-        </View>
+            in are together, with the mic to speak it instead of type (A5). Group
+            names are handed to the recogniser as hints — a general model mangles
+            Indian names, and a note like "dinner with Ravi" is exactly where they
+            turn up. */}
+        <DescriptionField
+          value={description}
+          onChange={setDescription}
+          placeholder={t.captures.descriptionPlaceholder}
+          accessibilityLabel={t.captures.description}
+          hints={groupNameHints}
+        />
 
         {/* What it was for. The guess follows the description until a chip is
             tapped; the chips are the picker, unchanged. */}
@@ -502,51 +389,9 @@ export default function CaptureScreen() {
           <Text variant="caption" tone="muted">
             {t.captures.paidWith}
           </Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
-            contentContainerStyle={{ gap: theme.spacing.sm, paddingRight: theme.spacing.xl }}
-          >
-            {paymentMethods.map((method) => {
-              const active = paymentMethod === method.id;
-              return (
-                <Pressable
-                  key={method.id}
-                  accessibilityRole="button"
-                  accessibilityLabel={paymentLabel(method.id)}
-                  accessibilityState={{ selected: active }}
-                  onPress={() =>
-                    setPaymentMethod((current) => (current === method.id ? null : method.id))
-                  }
-                  style={({ pressed }) => ({
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    gap: theme.spacing.xs,
-                    paddingVertical: theme.spacing.sm,
-                    paddingHorizontal: theme.spacing.md,
-                    borderRadius: theme.radius.md,
-                    borderWidth: 1,
-                    borderColor: active ? theme.color.brand : theme.color.border,
-                    backgroundColor: active ? theme.color.brandSoft : theme.color.surface,
-                    opacity: pressed ? 0.7 : 1,
-                  })}
-                >
-                  <Ionicons
-                    name={method.icon}
-                    size={iconSize.md}
-                    color={active ? theme.color.brand : theme.color.textMuted}
-                  />
-                  <Text
-                    variant="body"
-                    style={{ color: active ? theme.color.brand : theme.color.text }}
-                  >
-                    {paymentLabel(method.id)}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
+          {/* Shared with add-expense; capture lets "not said" stand, so a tap on
+              the chosen chip clears it (allowDeselect). */}
+          <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} allowDeselect />
         </View>
 
         {/* Destination and date, folded into one card of divided rows rather than
@@ -791,173 +636,6 @@ export default function CaptureScreen() {
 }
 
 /**
- * A labelled tap-row: a leading icon, the field name over its value, a chevron.
- * The rows a capture's meta (group, date) share, so they read as one block
- * inside a single card rather than a stack of near-identical cards.
- */
-function FieldRow({
-  icon,
-  iconColor,
-  label,
-  value,
-  valueMuted = false,
-  onPress,
-  accessibilityLabel,
-}: {
-  icon: keyof typeof Ionicons.glyphMap;
-  iconColor?: string;
-  label: string;
-  value: string;
-  valueMuted?: boolean;
-  onPress: () => void;
-  accessibilityLabel: string;
-}): React.JSX.Element {
-  const theme = useTheme();
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: theme.spacing.md,
-        paddingVertical: theme.spacing.md,
-        opacity: pressed ? 0.6 : 1,
-      })}
-    >
-      <Ionicons name={icon} size={iconSize.md} color={iconColor ?? theme.color.textMuted} />
-      <View style={{ flex: 1, gap: 2 }}>
-        <Text variant="caption" tone="muted">
-          {label}
-        </Text>
-        <Text variant="subheading" numberOfLines={1} tone={valueMuted ? 'muted' : undefined}>
-          {value}
-        </Text>
-      </View>
-      <Ionicons name="chevron-forward" size={iconSize.md} color={theme.color.textFaint} />
-    </Pressable>
-  );
-}
-
-/**
- * A bottom sheet over the form: a dimmed backdrop that closes on tap, a rounded
- * card that swallows its own taps, a grab handle and a title. The two pickers on
- * this screen (currency, group) share it so they present and dismiss the same
- * way.
- */
-function SheetOverlay({
-  title,
-  onClose,
-  children,
-}: {
-  title: string;
-  onClose: () => void;
-  children: ReactNode;
-}): React.JSX.Element {
-  const theme = useTheme();
-  const { t } = useStrings();
-  const insets = useSafeAreaInsets();
-
-  // Drag the handle down to dismiss. translateY only ever goes positive (down);
-  // past a short threshold or on a quick flick the sheet closes, otherwise it
-  // springs back. The gesture lives on the header, not the whole card, so it
-  // never fights the list's own vertical scroll.
-  const translateY = useSharedValue(0);
-  const dragToClose = Gesture.Pan()
-    // Only engage once the finger has clearly moved vertically, so a plain tap
-    // on the handle still falls through to the Pressable that closes the sheet.
-    .activeOffsetY([-12, 12])
-    .onUpdate((event) => {
-      // Down follows the finger 1:1; an upward pull rubber-bands so the sheet
-      // feels anchored rather than free.
-      translateY.set(event.translationY > 0 ? event.translationY : event.translationY / 4);
-    })
-    .onEnd((event) => {
-      if (translateY.get() > 120 || event.velocityY > 800) {
-        // Carry the flick through: animate the rest of the way out, then close.
-        translateY.set(withTiming(700, { duration: 180 }, () => runOnJS(onClose)()));
-      } else {
-        translateY.set(withSpring(0, { damping: 20, stiffness: 220 }));
-      }
-    });
-  const cardStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: translateY.get() }],
-  }));
-
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={t.common.close}
-      onPress={onClose}
-      style={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(10, 10, 26, 0.55)',
-        justifyContent: 'flex-end',
-      }}
-    >
-      <Animated.View
-        style={[
-          {
-            backgroundColor: theme.color.surface,
-            borderTopLeftRadius: theme.radius.lg,
-            borderTopRightRadius: theme.radius.lg,
-            padding: theme.spacing.xl,
-            // Clear the Android gesture/nav bar so the last list row is not
-            // hidden behind it.
-            paddingBottom: theme.spacing.xl + insets.bottom,
-            gap: theme.spacing.md,
-            maxHeight: '75%',
-          },
-          cardStyle,
-        ]}
-      >
-        {/* Swallow taps on the card so they never reach the backdrop, which
-            would close the sheet. */}
-        <Pressable onPress={() => {}} style={{ gap: theme.spacing.md, flexShrink: 1 }}>
-          {/* The header is the drag surface AND a tap-to-close target: the grab
-              handle reads as draggable, so make it do something when pushed. */}
-          <GestureDetector gesture={dragToClose}>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t.common.close}
-              onPress={onClose}
-              style={{ gap: theme.spacing.md }}
-            >
-              <View
-                style={{
-                  alignSelf: 'center',
-                  width: 40,
-                  height: 4,
-                  borderRadius: 2,
-                  backgroundColor: theme.color.border,
-                }}
-              />
-              <Text variant="heading">{title}</Text>
-            </Pressable>
-          </GestureDetector>
-          {/* flexShrink lets this scroll: without it the list keeps its full
-              content height and the sheet's maxHeight clips the overflow instead
-              of scrolling it, so a long group or currency list loses its bottom
-              rows. */}
-          <ScrollView
-            showsVerticalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
-            style={{ flexShrink: 1 }}
-          >
-            {children}
-          </ScrollView>
-        </Pressable>
-      </Animated.View>
-    </Pressable>
-  );
-}
-
-/**
  * The group destinations, grouped so the one you mean is near the top:
  *
  *   1. "Decide later" — pinned, the default that keeps the capture in the inbox.
@@ -1043,45 +721,5 @@ function GroupPicker({
         </View>
       ))}
     </View>
-  );
-}
-
-/** One row in a picker sheet — a leading glyph, a label, a check when chosen. */
-function ChoiceRow({
-  leading,
-  label,
-  selected,
-  onPress,
-}: {
-  leading: ReactNode;
-  label: string;
-  selected: boolean;
-  onPress: () => void;
-}): React.JSX.Element {
-  const theme = useTheme();
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={label}
-      accessibilityState={{ selected }}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: theme.spacing.md,
-        paddingVertical: theme.spacing.md,
-        opacity: pressed ? 0.6 : 1,
-      })}
-    >
-      {leading}
-      <Text
-        variant="body"
-        numberOfLines={1}
-        style={{ flex: 1, color: selected ? theme.color.brand : theme.color.text }}
-      >
-        {label}
-      </Text>
-      {selected ? <Ionicons name="checkmark" size={iconSize.md} color={theme.color.brand} /> : null}
-    </Pressable>
   );
 }

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -9,6 +9,7 @@ import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react
 import {
   CategoryId,
   computeShares,
+  currencySymbol,
   guessCategory,
   MutationKind,
   type FxRecord,
@@ -17,7 +18,6 @@ import {
   type SplitParams,
 } from '@waves/core';
 import {
-  AmountField,
   Avatar,
   Button,
   Callout,
@@ -38,8 +38,11 @@ import {
 import { CategoryPicker } from '@/components/Category';
 import { PaymentMethodPicker } from '@/components/PaymentMethodPicker';
 import { friendlyError } from '@/lib/errors';
-import { CurrencyRate } from '@/components/CurrencyRate';
-import { DictateButton } from '@/components/DictateButton';
+import { COMMON_CURRENCIES, CurrencyRate } from '@/components/CurrencyRate';
+import { AmountHeader } from '@/components/expense/AmountHeader';
+import { DescriptionField } from '@/components/expense/DescriptionField';
+import { ExpenseHeader } from '@/components/expense/ExpenseHeader';
+import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import { canAddReceipt, scanReceipt, scanReceiptText } from '@/data/api';
 import { receiptCapStatus, receiptTapAction } from '@/lib/receiptCapGate';
 import { useAssignCapture, useGroup } from '@/data/hooks';
@@ -194,6 +197,10 @@ export default function AddExpenseScreen() {
 
   const [expenseCurrency, setExpenseCurrency] = useState<string | null>(null);
   const [fx, setFx] = useState<FxRecord | null>(null);
+  // The currency is chosen from the header pill's sheet, the same shortlist the
+  // capture screen offers. Picking one clears any rate typed for the old
+  // currency, exactly as the old in-card chips did (see CurrencyRate.choose).
+  const [pickingCurrency, setPickingCurrency] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [scanning, setScanning] = useState(false);
@@ -428,6 +435,15 @@ export default function AddExpenseScreen() {
   // default and what a converted total would be shown in (ADR-003).
   const currency = expenseCurrency ?? groupCurrency;
 
+  // Picking from the header pill: a rate typed for the previous currency would
+  // convert the wrong thing (and the server rejects it), so clear it — the same
+  // reset the old in-card currency chips did.
+  const chooseCurrency = (code: string): void => {
+    setExpenseCurrency(code);
+    setFx(null);
+    setPickingCurrency(false);
+  };
+
   // Every keystroke, debounced just enough to avoid one write per character.
   useDraft<ExpenseDraft>(
     draftKey,
@@ -481,18 +497,7 @@ export default function AddExpenseScreen() {
     return (
       <Screen edges={['top', 'bottom']}>
         <View style={{ paddingHorizontal: theme.spacing.xl }}>
-          <Row style={{ paddingTop: theme.spacing.md }}>
-            <IconButton label={t.common.close} onPress={() => router.back()}>
-              <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-            </IconButton>
-            <View style={{ flex: 1, alignItems: 'center' }}>
-              <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
-                <Ionicons name="receipt-outline" size={iconSize.md} color={theme.color.brand} />
-                <Text variant="heading">{editing ? t.expense.edit : t.addExpense}</Text>
-              </Row>
-            </View>
-            <View style={{ width: 44 }} />
-          </Row>
+          <ExpenseHeader title={editing ? t.expense.edit : t.addExpense} />
           <View style={{ paddingTop: theme.spacing.xxxl, alignItems: 'center' }}>
             <ActivityIndicator color={theme.color.brand} />
           </View>
@@ -792,30 +797,20 @@ export default function AddExpenseScreen() {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
-              <Ionicons name="receipt-outline" size={iconSize.md} color={theme.color.brand} />
-              <Text variant="heading">{editing ? t.expense.edit : t.addExpense}</Text>
-            </Row>
-            <Text variant="micro" tone="muted">
-              {groupLabel(group.data, members.data ?? [], profile?.id)}
-            </Text>
-          </View>
-          {editing ? (
-            <View style={{ width: 44 }} />
-          ) : (
-            <IconButton
-              label={t.expense.splitByItem}
-              onPress={() => router.replace(`/group/${groupId}/itemize`)}
-            >
-              <Ionicons name="list-outline" size={iconSize.lg} color={theme.color.brand} />
-            </IconButton>
-          )}
-        </Row>
+        <ExpenseHeader
+          title={editing ? t.expense.edit : t.addExpense}
+          subtitle={groupLabel(group.data, members.data ?? [], profile?.id)}
+          right={
+            editing ? undefined : (
+              <IconButton
+                label={t.expense.splitByItem}
+                onPress={() => router.replace(`/group/${groupId}/itemize`)}
+              >
+                <Ionicons name="list-outline" size={iconSize.lg} color={theme.color.brand} />
+              </IconButton>
+            )
+          }
+        />
 
         {editing ? (
           <Card style={{ backgroundColor: theme.color.brandSoft }}>
@@ -825,9 +820,14 @@ export default function AddExpenseScreen() {
           </Card>
         ) : null}
 
-        <Card>
-          <AmountField currency={currency} value={amount} onChange={setAmount} />
-        </Card>
+        {/* Amount-forward hero shared with the capture screen: big centred
+            number, the currency it is counted in a tap below it. */}
+        <AmountHeader
+          currency={currency}
+          amount={amount}
+          onAmountChange={setAmount}
+          onPressCurrency={() => setPickingCurrency(true)}
+        />
 
         {/* Below the amount, not above it. Typing a number is the fast path and
             stays the first thing on the screen; the camera is for the bill that
@@ -960,6 +960,9 @@ export default function AddExpenseScreen() {
           ) : null}
         </Card>
 
+        {/* Currency is chosen from the header pill; this now collapses to the FX
+            rate alone — nothing while the expense is in the group's currency,
+            the rate methods once it is foreign (ADR-003). */}
         <CurrencyRate
           groupCurrency={groupCurrency}
           currency={currency}
@@ -967,36 +970,21 @@ export default function AddExpenseScreen() {
           amount={amount}
           fx={fx}
           onFxChange={setFx}
+          showCurrencyPicker={false}
         />
 
-        <Card style={{ gap: theme.spacing.md }}>
-          <Text variant="caption" tone="muted">
-            {t.description}
-          </Text>
-          <Row style={{ gap: theme.spacing.md, alignItems: 'flex-start' }}>
-            <TextInput
-              value={description}
-              onChangeText={setDescription}
-              placeholder={t.expense.descriptionPlaceholder}
-              placeholderTextColor={theme.color.textFaint}
-              accessibilityLabel={t.description}
-              multiline
-              textAlignVertical="top"
-              style={{
-                flex: 1,
-                fontSize: 17,
-                fontWeight: '600',
-                color: theme.color.text,
-                paddingVertical: theme.spacing.sm,
-                minHeight: 44,
-              }}
-            />
-            {/* The member names are handed to the recogniser as hints. A
-                general model guesses at Indian names and gets them wrong, and
-                the note is exactly where they turn up. */}
-            <DictateButton value={description} onChange={setDescription} hints={nameHints} />
-          </Row>
-        </Card>
+        {/* Description field shared with capture. Kept multiline here for the
+            longer notes a group expense sometimes carries. The member names are
+            handed to the recogniser as hints — a general model guesses at Indian
+            names and gets them wrong, and the note is where they turn up. */}
+        <DescriptionField
+          value={description}
+          onChange={setDescription}
+          placeholder={t.expense.descriptionPlaceholder}
+          accessibilityLabel={t.description}
+          hints={nameHints}
+          multiline
+        />
 
         {/* Pre-picked from the description, because a menu between somebody and
             saving a dinner is how a column ends up empty — and an empty column
@@ -1264,6 +1252,39 @@ export default function AddExpenseScreen() {
           </Row>
         </Row>
       </View>
+
+      {/* Currency picker, as a sheet over the form — the same shortlist and the
+          same sheet the capture screen uses, so a person meets the same
+          currencies in both places. Picking a foreign one reveals the rate card
+          below the amount (CurrencyRate). */}
+      {pickingCurrency ? (
+        <SheetOverlay
+          title={t.captures.currencyPickerTitle}
+          onClose={() => setPickingCurrency(false)}
+        >
+          <View style={{ gap: theme.spacing.xs }}>
+            {COMMON_CURRENCIES.map((code) => (
+              <ChoiceRow
+                key={code}
+                leading={
+                  <Text
+                    variant="subheading"
+                    tone="muted"
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                    style={{ width: 36, textAlign: 'center' }}
+                  >
+                    {currencySymbol(code)}
+                  </Text>
+                }
+                label={code}
+                selected={currency === code}
+                onPress={() => chooseCurrency(code)}
+              />
+            ))}
+          </View>
+        </SheetOverlay>
+      ) : null}
     </Screen>
   );
 }

--- a/apps/mobile/src/components/CurrencyRate.tsx
+++ b/apps/mobile/src/components/CurrencyRate.tsx
@@ -72,6 +72,17 @@ export interface CurrencyRateProps {
   amount: bigint;
   fx: FxRecord | null;
   onFxChange: (fx: FxRecord | null) => void;
+  /**
+   * Whether this component owns picking the currency, too.
+   *
+   * True (the default) keeps the historical shape: a "Paid in another currency"
+   * ghost button that opens a card carrying both the currency chips and, once a
+   * foreign currency is chosen, the rate. False means the currency is chosen
+   * elsewhere — the add-expense header pill — so this collapses to the rate
+   * alone: nothing at all while the expense is in the group's currency, and only
+   * the rate methods once it is foreign.
+   */
+  showCurrencyPicker?: boolean;
 }
 
 export function CurrencyRate({
@@ -81,7 +92,8 @@ export function CurrencyRate({
   amount,
   fx,
   onFxChange,
-}: CurrencyRateProps): React.JSX.Element {
+  showCurrencyPicker = true,
+}: CurrencyRateProps): React.JSX.Element | null {
   const theme = useTheme();
   const { t } = useStrings();
   const [open, setOpen] = useState(false);
@@ -134,6 +146,20 @@ export function CurrencyRate({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [amount, method, chargedText, currency, groupCurrency]);
 
+  // When the currency is chosen elsewhere (the header pill), a change to it must
+  // clear a rate typed for the previous currency — the same reset `choose` does
+  // on the legacy in-card chips. Done during render (React's "adjust state when
+  // the input changes" pattern) rather than in an effect, so it never lags a
+  // frame behind the new currency. Guarded to the pill-driven path; the legacy
+  // chips already clear through `choose`.
+  const [ratedFor, setRatedFor] = useState(currency);
+  if (!showCurrencyPicker && ratedFor !== currency) {
+    setRatedFor(currency);
+    setChargedText('');
+    setRateText('');
+    setError(null);
+  }
+
   const applyTyped = (text: string): void => {
     setRateText(text);
     setError(null);
@@ -168,7 +194,11 @@ export function CurrencyRate({
 
   const converted = fx && amount > 0n ? convertWithRecord(money(amount, currency), fx) : null;
 
-  if (!open && !foreign) {
+  // The currency lives in the header pill: nothing to show until the expense is
+  // foreign, and then only the rate — never the in-card currency chips.
+  if (!showCurrencyPicker) {
+    if (!foreign) return null;
+  } else if (!open && !foreign) {
     return (
       <Button
         label={t.misc.paidAnotherCurrency}
@@ -184,11 +214,13 @@ export function CurrencyRate({
       <Text variant="caption" tone="muted">
         {t.extras.paidIn}
       </Text>
-      <ChipRow<string>
-        value={currency}
-        onChange={choose}
-        options={COMMON_CURRENCIES.map((code) => ({ value: code, label: code }))}
-      />
+      {showCurrencyPicker ? (
+        <ChipRow<string>
+          value={currency}
+          onChange={choose}
+          options={COMMON_CURRENCIES.map((code) => ({ value: code, label: code }))}
+        />
+      ) : null}
 
       {foreign ? (
         <>

--- a/apps/mobile/src/components/CurrencyRate.tsx
+++ b/apps/mobile/src/components/CurrencyRate.tsx
@@ -17,7 +17,7 @@
  * is most often the least accurate.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { TextInput, View } from 'react-native';
 
 import {
@@ -102,6 +102,15 @@ export function CurrencyRate({
   const [rateText, setRateText] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The pair the component is showing right now. `fetchToday` captures the pair
+  // it launched for and, on return, applies its result only if this still
+  // matches — otherwise a rate fetched for a currency the user has since changed
+  // away from would land on the new pair. Kept in a ref so the async closure
+  // reads the latest value, not the one it closed over.
+  const latestPair = useRef(`${currency}|${groupCurrency}`);
+  useEffect(() => {
+    latestPair.current = `${currency}|${groupCurrency}`;
+  }, [currency, groupCurrency]);
 
   const foreign = currency !== groupCurrency;
 
@@ -176,19 +185,24 @@ export function CurrencyRate({
   };
 
   const fetchToday = async (): Promise<void> => {
+    // The pair this request is for; a change away from it before the response
+    // lands makes the response stale, and stale rates must not be applied.
+    const pair = `${currency}|${groupCurrency}`;
     setError(null);
     setBusy(true);
     try {
       const record = await fetchFxRate(currency, groupCurrency);
+      if (latestPair.current !== pair) return;
       onFxChange(record);
       setRateText(rateToDecimal(fromFxRecord(record), 4));
     } catch (caught) {
+      if (latestPair.current !== pair) return;
       // Not a blocker: typing a rate works offline and is often more accurate.
       setError(
         `${friendlyError(caught, t.misc.rateFetchFailed, 'currencyRate.fetch')}${t.misc.rateFetchFailedSuffix}`,
       );
     } finally {
-      setBusy(false);
+      if (latestPair.current === pair) setBusy(false);
     }
   };
 

--- a/apps/mobile/src/components/PaymentMethodPicker.tsx
+++ b/apps/mobile/src/components/PaymentMethodPicker.tsx
@@ -34,13 +34,24 @@ const PAYMENT_METHODS: readonly {
   { id: 'forex', icon: 'swap-horizontal-outline' },
 ];
 
-export function PaymentMethodPicker({
-  value,
-  onChange,
-}: {
-  value: PaymentMethod | null;
-  onChange: (value: PaymentMethod) => void;
-}) {
+/**
+ * Two shapes, one picker. The group add-expense screen always has a method
+ * chosen (cash by default) and only ever swaps it, so its `onChange` never sees
+ * null. The capture screen lets "not said" be a valid answer — tapping the
+ * chosen chip again clears it — so under `allowDeselect` the same tap can hand
+ * back null. The discriminated union keeps each caller's `onChange` honest about
+ * which it will receive.
+ */
+type PaymentMethodPickerProps =
+  | { value: PaymentMethod | null; onChange: (value: PaymentMethod) => void; allowDeselect?: false }
+  | {
+      value: PaymentMethod | null;
+      onChange: (value: PaymentMethod | null) => void;
+      allowDeselect: true;
+    };
+
+export function PaymentMethodPicker(props: PaymentMethodPickerProps) {
+  const { value } = props;
   const theme = useTheme();
   const { t } = useStrings();
 
@@ -77,7 +88,13 @@ export function PaymentMethodPicker({
             accessibilityRole="radio"
             accessibilityState={{ selected: active }}
             accessibilityLabel={label(method.id)}
-            onPress={() => onChange(method.id)}
+            onPress={() => {
+              if (props.allowDeselect) {
+                props.onChange(active ? null : method.id);
+              } else {
+                props.onChange(method.id);
+              }
+            }}
             style={({ pressed }) => ({
               flexDirection: 'row',
               alignItems: 'center',

--- a/apps/mobile/src/components/expense/AmountHeader.tsx
+++ b/apps/mobile/src/components/expense/AmountHeader.tsx
@@ -1,0 +1,59 @@
+/**
+ * The amount-forward hero the expense forms share.
+ *
+ * The number is the point of these screens, so it leads — big and centred, with
+ * the currency it is counted in a tap below it (the Splitwise/PayPal amount-
+ * first pattern). No card around it; the whitespace is the frame. The pill shows
+ * the current currency and opens the screen's own currency picker on tap.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, View } from 'react-native';
+
+import { currencySymbol } from '@waves/core';
+import { AmountField, iconSize, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+
+export function AmountHeader({
+  currency,
+  amount,
+  onAmountChange,
+  onPressCurrency,
+}: {
+  currency: string;
+  amount: bigint;
+  onAmountChange: (value: bigint) => void;
+  onPressCurrency: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  return (
+    <View style={{ alignItems: 'center', gap: theme.spacing.md, paddingTop: theme.spacing.md }}>
+      <AmountField currency={currency} value={amount} onChange={onAmountChange} />
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${t.captures.currencyLabel}: ${currency}`}
+        onPress={onPressCurrency}
+        style={({ pressed }) => ({
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: theme.spacing.xs,
+          paddingVertical: theme.spacing.xs,
+          paddingHorizontal: theme.spacing.md,
+          borderRadius: theme.radius.pill,
+          backgroundColor: theme.color.surfaceMuted,
+          opacity: pressed ? 0.7 : 1,
+        })}
+      >
+        <Text variant="caption" tone="muted">
+          {currencySymbol(currency)}
+        </Text>
+        <Text variant="caption" style={{ fontWeight: '700', color: theme.color.text }}>
+          {currency}
+        </Text>
+        <Ionicons name="chevron-down" size={iconSize.sm} color={theme.color.textMuted} />
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/expense/DescriptionField.tsx
+++ b/apps/mobile/src/components/expense/DescriptionField.tsx
@@ -1,0 +1,76 @@
+/**
+ * The description field the expense forms share.
+ *
+ * A single underlined field rather than a boxed card — it sits right under the
+ * amount so the two things a person always fills in are together, with a leading
+ * receipt glyph and the mic to speak it instead of type (A5). Group or member
+ * names are handed to the recogniser as hints — a general model mangles Indian
+ * names, and a note like "dinner with Ravi" is exactly where they turn up.
+ *
+ * `multiline` lets the group form keep its taller note while capture stays a
+ * single line; the underline styling is the same either way.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { TextInput, View } from 'react-native';
+
+import { iconSize, Row, useTheme } from '@waves/ui';
+
+import { DictateButton } from '@/components/DictateButton';
+
+export function DescriptionField({
+  value,
+  onChange,
+  placeholder,
+  accessibilityLabel,
+  hints,
+  multiline = false,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  accessibilityLabel: string;
+  /** Names to bias the recogniser towards (group names, or member names). */
+  hints?: readonly string[];
+  multiline?: boolean;
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Row
+      style={{
+        alignItems: multiline ? 'flex-start' : 'center',
+        gap: theme.spacing.sm,
+        borderBottomWidth: 1,
+        borderBottomColor: theme.color.border,
+        paddingBottom: theme.spacing.xs,
+      }}
+    >
+      <Ionicons
+        name="receipt-outline"
+        size={iconSize.md}
+        color={theme.color.textMuted}
+        style={multiline ? { paddingTop: theme.spacing.sm } : undefined}
+      />
+      <TextInput
+        value={value}
+        onChangeText={onChange}
+        placeholder={placeholder}
+        placeholderTextColor={theme.color.textFaint}
+        accessibilityLabel={accessibilityLabel}
+        multiline={multiline}
+        textAlignVertical={multiline ? 'top' : undefined}
+        style={{
+          flex: 1,
+          fontSize: 17,
+          fontWeight: '600',
+          color: theme.color.text,
+          paddingVertical: theme.spacing.sm,
+          ...(multiline ? { minHeight: 44 } : null),
+        }}
+      />
+      <View style={multiline ? { paddingTop: theme.spacing.xs } : undefined}>
+        <DictateButton value={value} onChange={onChange} hints={hints} />
+      </View>
+    </Row>
+  );
+}

--- a/apps/mobile/src/components/expense/ExpenseHeader.tsx
+++ b/apps/mobile/src/components/expense/ExpenseHeader.tsx
@@ -1,0 +1,53 @@
+/**
+ * The top bar the expense forms share: a close button, a centred receipt icon
+ * and title, and a trailing slot.
+ *
+ * Capture and group add-expense both open with the same header — the only
+ * differences are the title, an optional subtitle (the group an expense is
+ * being added to), and an optional trailing action (add-expense's "split by
+ * item"). Everything else — the close affordance, the brand receipt glyph, the
+ * centring, the 44pt spacer that keeps the title optically centred when there is
+ * no trailing action — is identical, so it lives here once.
+ */
+
+import { type ReactNode } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { View } from 'react-native';
+
+import { IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+
+export function ExpenseHeader({
+  title,
+  subtitle,
+  right,
+}: {
+  title: string;
+  subtitle?: string;
+  /** A trailing action; a 44pt spacer keeps the title centred when omitted. */
+  right?: ReactNode;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  return (
+    <Row style={{ paddingTop: theme.spacing.md }}>
+      <IconButton label={t.common.close} onPress={() => router.back()}>
+        <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+      </IconButton>
+      <View style={{ flex: 1, alignItems: 'center' }}>
+        <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+          <Ionicons name="receipt-outline" size={iconSize.md} color={theme.color.brand} />
+          <Text variant="heading">{title}</Text>
+        </Row>
+        {subtitle ? (
+          <Text variant="micro" tone="muted">
+            {subtitle}
+          </Text>
+        ) : null}
+      </View>
+      {right ?? <View style={{ width: 44 }} />}
+    </Row>
+  );
+}

--- a/apps/mobile/src/components/expense/SheetOverlay.tsx
+++ b/apps/mobile/src/components/expense/SheetOverlay.tsx
@@ -1,0 +1,233 @@
+/**
+ * The sheet and row primitives the expense forms share.
+ *
+ * Both the capture screen and the group add-expense screen present their
+ * pickers (currency, destination) as a bottom sheet over the form, and list
+ * their choices as a leading glyph + label + check. Pulling them here means the
+ * two screens present, dismiss, and read the same rather than each carrying its
+ * own copy that could drift apart.
+ */
+
+import { type ReactNode } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, ScrollView, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { iconSize, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+
+/**
+ * A labelled tap-row: a leading icon, the field name over its value, a chevron.
+ * The rows an expense's meta (group, date) share, so they read as one block
+ * inside a single card rather than a stack of near-identical cards.
+ */
+export function FieldRow({
+  icon,
+  iconColor,
+  label,
+  value,
+  valueMuted = false,
+  onPress,
+  accessibilityLabel,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  iconColor?: string;
+  label: string;
+  value: string;
+  valueMuted?: boolean;
+  onPress: () => void;
+  accessibilityLabel: string;
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: theme.spacing.md,
+        paddingVertical: theme.spacing.md,
+        opacity: pressed ? 0.6 : 1,
+      })}
+    >
+      <Ionicons name={icon} size={iconSize.md} color={iconColor ?? theme.color.textMuted} />
+      <View style={{ flex: 1, gap: 2 }}>
+        <Text variant="caption" tone="muted">
+          {label}
+        </Text>
+        <Text variant="subheading" numberOfLines={1} tone={valueMuted ? 'muted' : undefined}>
+          {value}
+        </Text>
+      </View>
+      <Ionicons name="chevron-forward" size={iconSize.md} color={theme.color.textFaint} />
+    </Pressable>
+  );
+}
+
+/**
+ * A bottom sheet over the form: a dimmed backdrop that closes on tap, a rounded
+ * card that swallows its own taps, a grab handle and a title. The pickers on the
+ * expense screens (currency, group) share it so they present and dismiss the
+ * same way.
+ */
+export function SheetOverlay({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const insets = useSafeAreaInsets();
+
+  // Drag the handle down to dismiss. translateY only ever goes positive (down);
+  // past a short threshold or on a quick flick the sheet closes, otherwise it
+  // springs back. The gesture lives on the header, not the whole card, so it
+  // never fights the list's own vertical scroll.
+  const translateY = useSharedValue(0);
+  const dragToClose = Gesture.Pan()
+    // Only engage once the finger has clearly moved vertically, so a plain tap
+    // on the handle still falls through to the Pressable that closes the sheet.
+    .activeOffsetY([-12, 12])
+    .onUpdate((event) => {
+      // Down follows the finger 1:1; an upward pull rubber-bands so the sheet
+      // feels anchored rather than free.
+      translateY.set(event.translationY > 0 ? event.translationY : event.translationY / 4);
+    })
+    .onEnd((event) => {
+      if (translateY.get() > 120 || event.velocityY > 800) {
+        // Carry the flick through: animate the rest of the way out, then close.
+        translateY.set(withTiming(700, { duration: 180 }, () => runOnJS(onClose)()));
+      } else {
+        translateY.set(withSpring(0, { damping: 20, stiffness: 220 }));
+      }
+    });
+  const cardStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.get() }],
+  }));
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={t.common.close}
+      onPress={onClose}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(10, 10, 26, 0.55)',
+        justifyContent: 'flex-end',
+      }}
+    >
+      <Animated.View
+        style={[
+          {
+            backgroundColor: theme.color.surface,
+            borderTopLeftRadius: theme.radius.lg,
+            borderTopRightRadius: theme.radius.lg,
+            padding: theme.spacing.xl,
+            // Clear the Android gesture/nav bar so the last list row is not
+            // hidden behind it.
+            paddingBottom: theme.spacing.xl + insets.bottom,
+            gap: theme.spacing.md,
+            maxHeight: '75%',
+          },
+          cardStyle,
+        ]}
+      >
+        {/* Swallow taps on the card so they never reach the backdrop, which
+            would close the sheet. */}
+        <Pressable onPress={() => {}} style={{ gap: theme.spacing.md, flexShrink: 1 }}>
+          {/* The header is the drag surface AND a tap-to-close target: the grab
+              handle reads as draggable, so make it do something when pushed. */}
+          <GestureDetector gesture={dragToClose}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t.common.close}
+              onPress={onClose}
+              style={{ gap: theme.spacing.md }}
+            >
+              <View
+                style={{
+                  alignSelf: 'center',
+                  width: 40,
+                  height: 4,
+                  borderRadius: 2,
+                  backgroundColor: theme.color.border,
+                }}
+              />
+              <Text variant="heading">{title}</Text>
+            </Pressable>
+          </GestureDetector>
+          {/* flexShrink lets this scroll: without it the list keeps its full
+              content height and the sheet's maxHeight clips the overflow instead
+              of scrolling it, so a long group or currency list loses its bottom
+              rows. */}
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+            style={{ flexShrink: 1 }}
+          >
+            {children}
+          </ScrollView>
+        </Pressable>
+      </Animated.View>
+    </Pressable>
+  );
+}
+
+/** One row in a picker sheet — a leading glyph, a label, a check when chosen. */
+export function ChoiceRow({
+  leading,
+  label,
+  selected,
+  onPress,
+}: {
+  leading: ReactNode;
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ selected }}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: theme.spacing.md,
+        paddingVertical: theme.spacing.md,
+        opacity: pressed ? 0.6 : 1,
+      })}
+    >
+      {leading}
+      <Text
+        variant="body"
+        numberOfLines={1}
+        style={{ flex: 1, color: selected ? theme.color.brand : theme.color.text }}
+      >
+        {label}
+      </Text>
+      {selected ? <Ionicons name="checkmark" size={iconSize.md} color={theme.color.brand} /> : null}
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## What changed

The group **add-expense** screen was restyled to match the **capture** screen's design language, and the UI both screens duplicated is now extracted into shared components under `components/expense/` and reused by both.

### Visual redesign (add-expense: before → after)
- **Amount:** a boxed `Card` around `AmountField` → the same **amount-forward hero** capture uses: a big centred number with a tappable **currency pill** below it.
- **Currency:** the in-card currency chips inside `CurrencyRate` → the header pill opens a currency sheet (the same shortlist + the same bottom sheet capture uses). Picking a foreign currency still reveals the FX rate methods (charged / typed / today's) below the amount — `CurrencyRate` now collapses to the rate alone.
- **Description:** a boxed `Card` with a label → the same **underlined field** with a leading receipt glyph and the dictate mic (kept `multiline` for longer group notes).
- **Header:** shared `ExpenseHeader` (close + centred receipt icon/title, optional subtitle = the group, optional trailing split-by-item action).
- Category and "paid with" chip rows unchanged (already the shared pickers).

### Shared components extracted (`components/expense/`)
- **`AmountHeader`** — centred `AmountField` + currency pill. Used by capture **and** add-expense.
- **`DescriptionField`** — underlined `TextInput` + `DictateButton` with recogniser hints; `multiline` prop. Both screens.
- **`ExpenseHeader`** — close + icon/title + optional subtitle/trailing action. Both screens (and add-expense's loading shell).
- **`SheetOverlay` / `ChoiceRow` / `FieldRow`** — the drag-to-dismiss sheet and picker rows, promoted out of capture. Both screens' currency sheets now share them.

### Reused, not re-created
- `CategoryPicker` and `PaymentMethodPicker` are reused. `PaymentMethodPicker` gained a typed `allowDeselect` prop (discriminated union) so **capture** keeps its "tap the chosen chip to clear it" behaviour while **add-expense** always keeps a method selected.
- Capture was refactored onto the shared components (its inline amount hero, description, header, payment chips, and sheet/row helpers deleted) and stays **visually and behaviourally identical**.

### Preserved on add-expense
Scan/attach receipt + share-with-group toggle, the collapsible split section (payer picker, Equal/Shares/Percent, participants roster with per-member weight/percent inputs), add-someone, the pinned Save bar with running total, editing mode, and draft save/restore.

### i18n & validation
- No new strings — reuses existing keys.
- `tsc --noEmit` clean, `eslint` clean on all touched files, `vitest run` green (25 files / 287 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed expense-entry experience with consistent headers, amount and currency controls, description fields, payment selection, and bottom-sheet pickers.
  * Added common-currency options for faster currency selection.
  * Added optional voice input support for expense descriptions.
  * Payment methods can now be cleared when deselection is enabled.

* **Bug Fixes**
  * Changing currency now clears the exchange rate and prevents outdated rate results from being applied.
  * Improved accessibility and interaction behavior across expense form controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->