### PR TITLE
feat(mobile): block users and render them as ghosts

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -18,6 +18,7 @@ import {
 
 import { dayHeading, describeActivity, groupByDay, parseMoney, verbIcon } from '@/data/activity';
 import { fetchRecentActivity } from '@/data/api';
+import { useBlockedUsers } from '@/data/blocked';
 import { FeedSkeleton } from '@/components/Skeletons';
 import { useNotifications } from '@/data/hooks';
 import { useStrings } from '@/i18n';
@@ -31,6 +32,7 @@ export default function ActivityScreen() {
   const { t, locale } = useStrings();
   const { session } = useAuth();
   const myProfileId = session?.user.id ?? null;
+  const { blockedIds } = useBlockedUsers();
 
   const activity = useQuery({
     queryKey: ['activity', 'recent'],
@@ -138,7 +140,7 @@ export default function ActivityScreen() {
                     <Pressable
                       key={entry.id}
                       accessibilityRole="button"
-                      accessibilityLabel={describeActivity(entry, myProfileId)}
+                      accessibilityLabel={describeActivity(entry, myProfileId, blockedIds)}
                       onPress={() => router.push(`/group/${entry.group_id}`)}
                       style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
                     >
@@ -189,7 +191,7 @@ export default function ActivityScreen() {
                         >
                           <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
                             <Text variant="body" numberOfLines={3} style={{ flex: 1 }}>
-                              {describeActivity(entry, myProfileId)}
+                              {describeActivity(entry, myProfileId, blockedIds)}
                             </Text>
                             {/* `payload` is an untyped JSON blob, so a bad amount
                             must render as no amount, not as a crashed tab. */}

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -45,6 +45,7 @@ import {
 } from '@waves/ui';
 
 import { nudgeToSettle, type PersonBalanceRow } from '@/data/api';
+import { useBlockedUsers } from '@/data/blocked';
 import { useKnownPeopleCount, usePeopleBalances } from '@/data/hooks';
 import { useAuth } from '@/lib/auth';
 import { PeopleSkeleton } from '@/components/Skeletons';
@@ -494,6 +495,12 @@ function FriendCard({
   t: ReturnType<typeof useStrings>['t'];
 }): React.JSX.Element {
   const theme = useTheme();
+  const { isBlocked } = useBlockedUsers();
+  // A blocked person is hidden behind the ghost name and the ghost avatar here
+  // too, so their identity never surfaces on the Friends list — the amount and
+  // everything the row does with it are unchanged; only who it names is.
+  const blocked = isBlocked(row.profile_id);
+  const shownName = blocked ? t.misc.someone : row.display_name;
   // Flat WhatsApp row: the money colour is gone from the background, the amount
   // reads in ordinary ink, and the owed/owe meaning is carried by the sign and
   // the section this row sits under. The avatar keeps the person's own colour.
@@ -508,17 +515,17 @@ function FriendCard({
           // The route is typed once expo regenerates its route map; `as never`
           // matches how the other friends/* pushes bridge that gap.
           `/friends/person/${encodeURIComponent(row.person_key)}?name=${encodeURIComponent(
-            row.display_name,
+            shownName,
           )}` as never,
         );
 
   const body = (
     <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
       <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
-        <Avatar name={row.display_name} size={44} ghost={row.is_ghost} />
+        <Avatar name={shownName} size={44} ghost={row.is_ghost || blocked} />
         <View style={{ flex: 1 }}>
           <Text variant="subheading" numberOfLines={1}>
-            {row.display_name}
+            {shownName}
           </Text>
           <Text variant="caption" tone="muted" numberOfLines={1}>
             {row.group_count === 1
@@ -572,7 +579,7 @@ function FriendCard({
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={row.display_name}
+      accessibilityLabel={shownName}
       style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
     >
       {body}

--- a/apps/mobile/src/app/friends/person/[key].tsx
+++ b/apps/mobile/src/app/friends/person/[key].tsx
@@ -15,7 +15,7 @@ import { useMemo } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useQuery } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
-import { Pressable, ScrollView, View } from 'react-native';
+import { Alert, Pressable, ScrollView, View } from 'react-native';
 
 import {
   Button,
@@ -34,8 +34,9 @@ import {
 } from '@waves/ui';
 
 import { fetchPersonGroupBalances, type PersonGroupBalanceRow } from '@/data/api';
+import { useBlockedUsers } from '@/data/blocked';
 import { PeopleSkeleton } from '@/components/Skeletons';
-import { useStrings } from '@/i18n';
+import { fill, useStrings } from '@/i18n';
 
 /** A person's balance in one group: the group, and one net per currency in it. */
 interface GroupBlock {
@@ -58,7 +59,27 @@ export default function PersonDetailScreen() {
   });
 
   const rows = useMemo(() => person.data ?? [], [person.data]);
-  const title = name ?? rows[0]?.display_name ?? '';
+
+  // Only a person with an account can be blocked, and for one the `person_key`
+  // in the route *is* their profile id (the list keys them on it), so `key` is
+  // the block key. A ghost or a merged-ghost person_key is not a profile id and
+  // nothing elsewhere keys off it, so those are left un-blockable.
+  const { isBlocked, block, unblock } = useBlockedUsers();
+  const isRealPerson = rows.some((row) => !row.is_ghost);
+  const blocked = isRealPerson && isBlocked(key);
+  const realName = rows.find((row) => !row.is_ghost)?.display_name ?? name ?? t.misc.someone;
+  const title = blocked ? t.misc.someone : (name ?? rows[0]?.display_name ?? '');
+
+  const confirmBlock = (): void => {
+    Alert.alert(fill(t.blocked.confirmTitle, { name: realName }), t.blocked.confirmBody, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.blocked.action,
+        style: 'destructive',
+        onPress: () => block({ id: key, name: realName, avatarUrl: null }),
+      },
+    ]);
+  };
 
   // One block per group (a group can carry two currencies), and the per-currency
   // total across all of them — the figure the Friends list showed, restated here
@@ -103,7 +124,20 @@ export default function PersonDetailScreen() {
               {title}
             </Text>
           </View>
-          <View style={{ width: 44 }} />
+          {isRealPerson ? (
+            <IconButton
+              label={blocked ? t.blocked.unblock : t.blocked.action}
+              onPress={blocked ? () => unblock(key) : confirmBlock}
+            >
+              <Ionicons
+                name={blocked ? 'person-add-outline' : 'person-remove-outline'}
+                size={iconSize.md}
+                color={blocked ? theme.color.brand : theme.color.negative}
+              />
+            </IconButton>
+          ) : (
+            <View style={{ width: 44 }} />
+          )}
         </Row>
 
         {person.isLoading ? (

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -33,7 +33,8 @@ import {
   useRestoreExpense,
 } from '@/data/hooks';
 import { expenseTitle } from '@/data/expenseTitle';
-import { displayName, groupLabel, isGhost } from '@/data/types';
+import { useBlockedUsers } from '@/data/blocked';
+import { displayName, groupLabel, isBlockedMember, isGhost } from '@/data/types';
 import { fill, plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { receiptFiles } from '@/lib/receiptStore';
@@ -64,10 +65,11 @@ export default function ExpenseDetailScreen() {
 
   const expense = expenses.rows.find((row) => row.id === expenseId);
   const version = expense?.currentVersion;
+  const { blockedIds } = useBlockedUsers();
   const lookup = memberLookup(members.data);
   const nameOf = (memberId: string | null): string => {
     const member = memberId ? lookup.get(memberId) : undefined;
-    return member ? displayName(member, profile?.id) : t.misc.someone;
+    return member ? displayName(member, profile?.id, blockedIds, t.misc.someone) : t.misc.someone;
   };
   // The label reads "You"; the avatar keeps the real name so the current user's
   // circle is the same initial and colour here as on every other screen — a
@@ -75,7 +77,7 @@ export default function ExpenseDetailScreen() {
   // avatar made it a lone pink "Y" next to a blue "G" elsewhere for one person.
   const avatarNameOf = (memberId: string | null): string => {
     const member = memberId ? lookup.get(memberId) : undefined;
-    return member ? displayName(member) : t.misc.someone;
+    return member ? displayName(member, null, blockedIds, t.misc.someone) : t.misc.someone;
   };
 
   if (expenses.isLoading) {
@@ -316,7 +318,9 @@ export default function ExpenseDetailScreen() {
                     leading={
                       <Avatar
                         name={avatarNameOf(share.member_id)}
-                        ghost={member ? isGhost(member) : false}
+                        ghost={
+                          member ? isGhost(member) || isBlockedMember(member, blockedIds) : false
+                        }
                         size={38}
                       />
                     }

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -39,7 +39,14 @@ import { nudgeToSettle } from '@/data/api';
 import { expenseTitle } from '@/data/expenseTitle';
 import { GroupSkeleton } from '@/components/Skeletons';
 import { formatParts, type MemberId } from '@waves/core';
-import { displayName, groupLabel, isGhost, type ExpenseVersionRow } from '@/data/types';
+import { useBlockedUsers } from '@/data/blocked';
+import {
+  displayName,
+  groupLabel,
+  isBlockedMember,
+  isGhost,
+  type ExpenseVersionRow,
+} from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { DetailEnter } from '@/lib/anim';
@@ -217,10 +224,11 @@ export default function GroupScreen() {
   );
   const confirmSettlement = useConfirmSettlement(groupId);
 
+  const { blockedIds } = useBlockedUsers();
   const lookup = memberLookup(members.data);
   const nameOf = (memberId: string | null): string => {
     const member = memberId ? lookup.get(memberId) : undefined;
-    return member ? displayName(member, profile?.id) : t.misc.someone;
+    return member ? displayName(member, profile?.id, blockedIds, t.misc.someone) : t.misc.someone;
   };
 
   if (group.isLoading) {
@@ -736,11 +744,15 @@ export default function GroupScreen() {
                         paddingVertical: theme.spacing.md,
                       }}
                     >
-                      <Avatar name={displayName(member)} ghost={isGhost(member)} size={40} />
+                      <Avatar
+                        name={displayName(member, null, blockedIds, t.misc.someone)}
+                        ghost={isGhost(member) || isBlockedMember(member, blockedIds)}
+                        size={40}
+                      />
                       <View style={{ flex: 1 }}>
                         <Row style={{ gap: theme.spacing.sm }}>
                           <Text variant="subheading" numberOfLines={1} style={{ flexShrink: 1 }}>
-                            {displayName(member, profile?.id)}
+                            {displayName(member, profile?.id, blockedIds, t.misc.someone)}
                           </Text>
                           {member.role === 'admin' && !isGhost(member) ? (
                             <Badge label={t.people.admin} tone="brand" />
@@ -792,7 +804,7 @@ export default function GroupScreen() {
                 {(activity.data ?? []).map((entry, index) => (
                   <View key={entry.id}>
                     <ListRow
-                      title={describeActivity(entry, profile?.id ?? null)}
+                      title={describeActivity(entry, profile?.id ?? null, blockedIds)}
                       subtitle={new Intl.DateTimeFormat(locale, {
                         day: 'numeric',
                         month: 'short',

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ScrollView, TextInput, View } from 'react-native';
+import { Alert, ScrollView, TextInput, View } from 'react-native';
 
 import { isValidVpa } from '@waves/core';
 import {
@@ -27,8 +27,9 @@ import {
 import { useGroup, useGroupLedger, useSetMemberRole, useUpdateMember } from '@/data/hooks';
 import { friendlyError } from '@/lib/errors';
 import { expenseTitle } from '@/data/expenseTitle';
-import { displayName, groupLabel, isGhost } from '@/data/types';
-import { plural, useStrings } from '@/i18n';
+import { useBlockedUsers } from '@/data/blocked';
+import { displayName, groupLabel, isBlockedMember, isGhost } from '@/data/types';
+import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 
 export default function MemberScreen() {
@@ -43,6 +44,7 @@ export default function MemberScreen() {
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
   const updateMember = useUpdateMember(groupId);
   const setRole = useSetMemberRole(groupId);
+  const { blockedIds, block, unblock } = useBlockedUsers();
 
   const member = members.data?.find((row) => row.id === memberId);
   const isMe = member?.profile_id === profile?.id;
@@ -73,7 +75,27 @@ export default function MemberScreen() {
   }
 
   const ghost = isGhost(member);
+  const blocked = isBlockedMember(member, blockedIds);
+  // A blocked person wears the ghost look and the ghost name here too — the one
+  // exception is the block card below, which needs their real name to name the
+  // action. Blocking is display-only; it never touches the balance shown here.
+  const shownName = displayName(member, profile?.id, blockedIds, t.misc.someone);
+  const realName = member.profile?.display_name ?? member.ghost_name ?? t.misc.someone;
   const vpaValid = vpa.trim() === '' || isValidVpa(vpa.trim());
+
+  const confirmBlock = (): void => {
+    if (!member.profile_id) return;
+    const profileId = member.profile_id;
+    Alert.alert(fill(t.blocked.confirmTitle, { name: realName }), t.blocked.confirmBody, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.blocked.action,
+        style: 'destructive',
+        onPress: () =>
+          block({ id: profileId, name: realName, avatarUrl: member.profile?.avatar_url ?? null }),
+      },
+    ]);
+  };
   const balance = ledger.balances.get(member.id) ?? 0n;
   // The hero wears the money colour for its meaning — mint when this person is
   // owed, pink when they owe — and a neutral lilac when they are square, so a
@@ -118,7 +140,7 @@ export default function MemberScreen() {
             />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{displayName(member, profile?.id)}</Text>
+            <Text variant="heading">{shownName}</Text>
             <Text variant="micro" tone="muted">
               {groupLabel(group.data, members.data ?? [])}
             </Text>
@@ -135,7 +157,7 @@ export default function MemberScreen() {
             padding: theme.spacing.xl,
           }}
         >
-          <Avatar name={displayName(member)} ghost={ghost} size={78} />
+          <Avatar name={shownName} ghost={ghost || blocked} size={78} />
           <MoneyText
             amount={balance}
             currency={currency}
@@ -147,6 +169,7 @@ export default function MemberScreen() {
           />
           <Row style={{ gap: theme.spacing.sm }}>
             {ghost ? <Badge label={t.notJoinedYet} /> : null}
+            {blocked ? <Badge label={t.blocked.badge} /> : null}
             {member.role === 'admin' ? <Badge label={t.people.admin} tone="brand" /> : null}
             {isMe ? <Badge label={t.people.you} tone="positive" /> : null}
           </Row>
@@ -255,6 +278,27 @@ export default function MemberScreen() {
             />
             <Text variant="micro" tone="muted">
               {ghost ? t.people.adminNeedsAccount : t.people.adminNote}
+            </Text>
+          </Card>
+        ) : null}
+
+        {/* Block or unblock this person. Only offered for a real account that is
+            not you: a ghost has no cross-group identity to block, and blocking
+            yourself is meaningless. It only changes how they are shown — the
+            balance above is untouched — so it lives here as a quiet control
+            rather than a destructive headline. */}
+        {!isMe && !ghost && member.profile_id ? (
+          <Card style={{ gap: theme.spacing.sm }}>
+            <Text variant="caption" tone="muted">
+              {t.blocked.title}
+            </Text>
+            <Button
+              label={blocked ? t.blocked.unblock : t.blocked.action}
+              variant={blocked ? 'secondary' : 'ghostDanger'}
+              onPress={blocked ? () => unblock(member.profile_id!) : confirmBlock}
+            />
+            <Text variant="micro" tone="muted">
+              {t.blocked.note}
             </Text>
           </Card>
         ) : null}

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -29,7 +29,8 @@ import {
   useGroupLedger,
   useMemberClaims,
 } from '@/data/hooks';
-import { displayName, groupLabel, isGhost, vpaOf } from '@/data/types';
+import { useBlockedUsers } from '@/data/blocked';
+import { displayName, groupLabel, isBlockedMember, isGhost, vpaOf } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { friendlyError } from '@/lib/errors';
@@ -44,6 +45,7 @@ export default function MembersScreen() {
 
   const { group, members } = useGroup(groupId);
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
+  const { blockedIds } = useBlockedUsers();
   const addGhost = useAddGhostMember(groupId);
   const claims = useMemberClaims(groupId);
   const decide = useDecideMemberClaim(groupId);
@@ -243,9 +245,14 @@ export default function MembersScreen() {
           {(members.data ?? []).map((member, index) => (
             <View key={member.id}>
               <ListRow
-                title={displayName(member, profile?.id)}
+                title={displayName(member, profile?.id, blockedIds, t.misc.someone)}
                 subtitle={isGhost(member) ? t.notJoinedYet : (vpaOf(member) ?? t.misc.noUpiYet)}
-                leading={<Avatar name={displayName(member)} ghost={isGhost(member)} />}
+                leading={
+                  <Avatar
+                    name={displayName(member, null, blockedIds, t.misc.someone)}
+                    ghost={isGhost(member) || isBlockedMember(member, blockedIds)}
+                  />
+                }
                 onPress={() => router.push(`/group/${groupId}/member/${member.id}`)}
                 trailing={
                   <Row style={{ gap: theme.spacing.sm }}>

--- a/apps/mobile/src/app/settings/blocked.tsx
+++ b/apps/mobile/src/app/settings/blocked.tsx
@@ -1,0 +1,122 @@
+/**
+ * The people you have blocked, and the one screen that still shows them by name.
+ *
+ * Everywhere else a blocked person is rendered as the anonymous ghost — that is
+ * the whole point of blocking. Here they keep their real name and face, because
+ * this is where you decide to let them back: you cannot unblock a row of
+ * identical ghosts. Blocking is device-local and display-only (see
+ * `data/blocked`); the note says so plainly, so nobody mistakes it for the kind
+ * of block that hides you from them or splits a balance.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { ScrollView, View } from 'react-native';
+
+import {
+  Avatar,
+  Button,
+  Card,
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  useTabBarClearance,
+  useTheme,
+} from '@waves/ui';
+
+import type { BlockedUser } from '@/data/blocked';
+import { useBlockedUsers } from '@/data/blocked';
+import { useAvatarUrl } from '@/components/ProfileAvatar';
+import { useStrings, type UiStrings } from '@/i18n';
+
+export default function BlockedScreen() {
+  const theme = useTheme();
+  const clearance = useTabBarClearance();
+  const { t } = useStrings();
+  const { blocked, unblock } = useBlockedUsers();
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.blocked.title}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        <Text variant="caption" tone="muted">
+          {t.blocked.note}
+        </Text>
+
+        {blocked.length === 0 ? (
+          <EmptyState
+            title={t.blocked.emptyTitle}
+            body={t.blocked.emptyBody}
+            icon={
+              <Ionicons
+                name="person-remove-outline"
+                size={iconSize.xxl}
+                color={theme.color.brand}
+              />
+            }
+          />
+        ) : (
+          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            {blocked.map((user, index) => (
+              <View key={user.id}>
+                <BlockedRow user={user} onUnblock={() => unblock(user.id)} t={t} />
+                {index < blocked.length - 1 ? (
+                  <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                ) : null}
+              </View>
+            ))}
+          </Card>
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}
+
+/** One blocked person: their real name and face, and the way back in. */
+function BlockedRow({
+  user,
+  onUnblock,
+  t,
+}: {
+  user: BlockedUser;
+  onUnblock: () => void;
+  t: UiStrings;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const url = useAvatarUrl(user.avatarUrl);
+  const name = user.name.trim() || t.misc.someone;
+
+  return (
+    <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center', gap: theme.spacing.md }}>
+      <Avatar name={name} size={44} photoUrl={url} />
+      <Text variant="subheading" numberOfLines={1} style={{ flex: 1 }}>
+        {name}
+      </Text>
+      <Button label={t.blocked.unblock} size="sm" variant="secondary" onPress={onUnblock} />
+    </Row>
+  );
+}

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -152,6 +152,26 @@ export default function PrivacyScreen() {
           <SectionHeader title={t.privacy.dataControlsSection} />
           <Card style={{ paddingVertical: theme.spacing.xs }}>
             <ListRow
+              title={t.blocked.row}
+              subtitle={t.blocked.rowHint}
+              onPress={() => router.push('/settings/blocked')}
+              leading={
+                <Ionicons
+                  name="person-remove-outline"
+                  size={iconSize.md}
+                  color={theme.color.brand}
+                />
+              }
+              trailing={
+                <Ionicons
+                  name={directionalIcon('chevron-forward')}
+                  size={iconSize.md}
+                  color={theme.color.textFaint}
+                />
+              }
+            />
+            <View style={{ height: 1, backgroundColor: theme.color.border }} />
+            <ListRow
               title={t.privacy.exportRow}
               subtitle={t.privacy.exportRowHint}
               onPress={() => router.push('/settings/export')}

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -45,10 +45,14 @@ export function parseMoney(
   }
 }
 
-export function describeActivity(entry: ActivityRow, myProfileId: string | null): string {
+export function describeActivity(
+  entry: ActivityRow,
+  myProfileId: string | null,
+  blocked?: ReadonlySet<string> | null,
+): string {
   const { payload } = entry;
   const description = typeof payload.description === 'string' ? payload.description : null;
-  const who = actorName(entry.actor, myProfileId);
+  const who = actorName(entry.actor, myProfileId, blocked);
 
   switch (entry.verb) {
     case 'added':

--- a/apps/mobile/src/data/blocked.ts
+++ b/apps/mobile/src/data/blocked.ts
@@ -1,0 +1,161 @@
+/**
+ * People you have blocked, and the single question every screen asks about them.
+ *
+ * Blocking here is a display-level act, not a server-enforced one: it hides a
+ * person's identity on this device by rendering them as the app's existing
+ * anonymous ghost (the "Someone" name and the dashed ghost avatar) wherever they
+ * would otherwise appear. It never touches a balance, a share or a settlement —
+ * you can still owe or be owed by somebody you have blocked, you just stop seeing
+ * who they are. Because it is a per-device privacy preference and nothing the
+ * other person should learn about, it lives in AsyncStorage, keyed on the blocked
+ * person's profile id (their one identity across every group) — no table, no
+ * migration, no sync. Server-enforced blocking (refusing shared groups, hiding
+ * you from them) is a deliberate follow-up, called out in the PR.
+ *
+ * The set is a module-level store with subscribers rather than per-hook state:
+ * many screens render a person at once, and blocking on one must ghost them on
+ * all of them immediately, without a reload. A snapshot of the name and avatar is
+ * kept alongside the id so the "Blocked users" list can still name each person —
+ * the one screen that intentionally shows their real identity, so you know who
+ * you are unblocking.
+ */
+
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/** The AsyncStorage key. `v1` leaves room to change the shape without a clash. */
+const STORAGE_KEY = 'blockedUsers:v1';
+
+export interface BlockedUser {
+  /** The blocked person's profile (user) id — their identity across all groups. */
+  id: string;
+  /** Their name at the moment they were blocked, so the unblock list can name
+   *  them even though every other surface now shows them as a ghost. */
+  name: string;
+  /** Avatar storage path or URL snapshot, or null — resolved like any avatar. */
+  avatarUrl: string | null;
+}
+
+/** Parse the stored blob defensively — a corrupt value is an empty list, not a crash. */
+export function parseBlocked(raw: string | null): BlockedUser[] {
+  if (!raw) return [];
+  try {
+    const data: unknown = JSON.parse(raw);
+    if (!Array.isArray(data)) return [];
+    return data
+      .filter(
+        (item): item is { id: string; name?: unknown; avatarUrl?: unknown } =>
+          typeof item === 'object' &&
+          item !== null &&
+          typeof (item as { id?: unknown }).id === 'string',
+      )
+      .map((item) => ({
+        id: item.id,
+        name: typeof item.name === 'string' ? item.name : '',
+        avatarUrl: typeof item.avatarUrl === 'string' ? item.avatarUrl : null,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+/** Next list after blocking `user`: newest first, one entry per id (a re-block
+ *  refreshes the snapshot rather than duplicating). Pure, so it is unit-tested. */
+export function upsertBlocked(list: readonly BlockedUser[], user: BlockedUser): BlockedUser[] {
+  return [user, ...list.filter((entry) => entry.id !== user.id)];
+}
+
+/** Next list after unblocking `id`. Pure. */
+export function removeBlocked(list: readonly BlockedUser[], id: string): BlockedUser[] {
+  return list.filter((entry) => entry.id !== id);
+}
+
+// --- module store -----------------------------------------------------------
+
+let blocked: readonly BlockedUser[] = [];
+let ready = false;
+let hydration: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+/** Load once, lazily, on first subscribe. Failures leave an empty list, ready. */
+function hydrate(): Promise<void> {
+  if (hydration) return hydration;
+  hydration = AsyncStorage.getItem(STORAGE_KEY)
+    .then((raw) => {
+      blocked = parseBlocked(raw);
+    })
+    .catch(() => {
+      blocked = [];
+    })
+    .finally(() => {
+      ready = true;
+      emit();
+    });
+  return hydration;
+}
+
+function persist(next: readonly BlockedUser[]): void {
+  blocked = next;
+  emit();
+  void AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {});
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  void hydrate();
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+function snapshotList(): readonly BlockedUser[] {
+  return blocked;
+}
+
+function snapshotReady(): boolean {
+  return ready;
+}
+
+export interface UseBlockedUsers {
+  /** The blocked people, newest first, with their name/avatar snapshots. */
+  blocked: readonly BlockedUser[];
+  /** Just the ids — the set every render site checks a person against. */
+  blockedIds: ReadonlySet<string>;
+  /** False until the stored list has loaded, so nothing flashes real-then-ghost. */
+  ready: boolean;
+  isBlocked: (profileId: string | null | undefined) => boolean;
+  block: (user: BlockedUser) => void;
+  unblock: (id: string) => void;
+}
+
+/**
+ * The single source of truth for who is blocked. Every screen that renders a
+ * person reads `blockedIds` from here and asks the same question, so a block
+ * takes effect everywhere at once.
+ */
+export function useBlockedUsers(): UseBlockedUsers {
+  const list = useSyncExternalStore(subscribe, snapshotList, snapshotList);
+  const isReady = useSyncExternalStore(subscribe, snapshotReady, snapshotReady);
+
+  const blockedIds = useMemo(() => new Set(list.map((entry) => entry.id)), [list]);
+
+  const isBlocked = useCallback(
+    (profileId: string | null | undefined): boolean =>
+      Boolean(profileId && blockedIds.has(profileId)),
+    [blockedIds],
+  );
+
+  const block = useCallback((user: BlockedUser) => {
+    persist(upsertBlocked(blocked, user));
+  }, []);
+
+  const unblock = useCallback((id: string) => {
+    persist(removeBlocked(blocked, id));
+  }, []);
+
+  return { blocked: list, blockedIds, ready: isReady, isBlocked, block, unblock };
+}

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -254,9 +254,13 @@ export interface NotificationRow {
 export function actorName(
   actor: ActivityActor | null | undefined,
   myProfileId: string | null,
+  blocked?: ReadonlySet<string> | null,
 ): string {
   if (!actor) return 'Someone';
   if (myProfileId && actor.profile_id === myProfileId) return 'You';
+  // A blocked person is shown as the anonymous ghost everywhere they surface —
+  // the feed included — never their real name. Never applied to yourself.
+  if (actor.profile_id && blocked?.has(actor.profile_id)) return 'Someone';
   return actor.profile?.display_name ?? actor.ghost_name ?? 'Someone';
 }
 
@@ -267,10 +271,38 @@ export interface BalanceRow {
   balance: string;
 }
 
-/** Display name for a member, real or ghost. */
-export function displayName(member: MemberRow, myProfileId?: string | null): string {
+/**
+ * Display name for a member, real or ghost.
+ *
+ * `blocked` is the set of profile ids the viewer has blocked (device-local, see
+ * `data/blocked`). A blocked person is never shown by their real name — they
+ * read as the anonymous ghost (`someoneLabel`, the localized `t.misc.someone`)
+ * so the block is a genuine change in how they appear, not a cosmetic tag. The
+ * viewer is never blocked against themselves, so "You" always wins first. This
+ * only touches the label; nothing here reads or moves a balance.
+ */
+export function displayName(
+  member: MemberRow,
+  myProfileId?: string | null,
+  blocked?: ReadonlySet<string> | null,
+  someoneLabel = 'Someone',
+): string {
   if (member.profile_id && member.profile_id === myProfileId) return 'You';
+  if (member.profile_id && blocked?.has(member.profile_id)) return someoneLabel;
   return member.profile?.display_name ?? member.ghost_name ?? 'Someone';
+}
+
+/**
+ * Whether this member is a person the viewer has blocked — used to give them the
+ * ghost look (dashed avatar) alongside the ghost name. Only real people (with a
+ * profile id) can be blocked; a plain ghost has no cross-group identity to key
+ * a block on.
+ */
+export function isBlockedMember(
+  member: Pick<MemberRow, 'profile_id'>,
+  blocked?: ReadonlySet<string> | null,
+): boolean {
+  return Boolean(member.profile_id && blocked?.has(member.profile_id));
 }
 
 /**

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1486,6 +1486,19 @@ export interface UiStrings {
    * is worse than an untranslated one, and saying which version is
    * authoritative is the ordinary way to carry that.
    */
+  blocked: {
+    row: string;
+    rowHint: string;
+    title: string;
+    emptyTitle: string;
+    emptyBody: string;
+    note: string;
+    action: string;
+    unblock: string;
+    confirmTitle: string;
+    confirmBody: string;
+    badge: string;
+  };
   privacy: {
     row: string;
     rowHint: string;
@@ -2888,6 +2901,20 @@ const en: UiStrings = {
     alreadyDecided: 'Somebody has already answered this one.',
     placeTaken: 'That place belongs to somebody now.',
     theyAreAlreadyIn: 'They are already in this group.',
+  },
+  blocked: {
+    row: 'Blocked people',
+    rowHint: 'Names and faces you have hidden',
+    title: 'Blocked people',
+    emptyTitle: 'Nobody is blocked',
+    emptyBody: 'Block someone and they show up here as a ghost — you can unblock them any time.',
+    note: 'Blocking only hides how a person looks to you. It never changes what you owe or are owed.',
+    action: 'Block',
+    unblock: 'Unblock',
+    confirmTitle: 'Block {name}?',
+    confirmBody:
+      'They will appear as an anonymous ghost everywhere in the app. Your balances with them do not change, and they are not told.',
+    badge: 'Blocked',
   },
   privacy: {
     row: 'Privacy & security',
@@ -4386,6 +4413,21 @@ const ta: UiStrings = {
     placeTaken: 'அந்த இடம் இப்போது வேறு ஒருவருக்கு உரியது.',
     theyAreAlreadyIn: 'அவர் ஏற்கனவே இந்தக் குழுவில் இருக்கிறார்.',
   },
+  blocked: {
+    row: 'தடுக்கப்பட்டவர்கள்',
+    rowHint: 'நீங்கள் மறைத்த பெயர்களும் முகங்களும்',
+    title: 'தடுக்கப்பட்டவர்கள்',
+    emptyTitle: 'யாரும் தடுக்கப்படவில்லை',
+    emptyBody:
+      'ஒருவரைத் தடுத்தால் அவர் இங்கே பேயாகத் தோன்றுவார் — எப்போது வேண்டுமானாலும் தடையை நீக்கலாம்.',
+    note: 'தடுப்பது ஒருவர் உங்களுக்குத் தோன்றும் விதத்தை மட்டுமே மறைக்கிறது. நீங்கள் தர வேண்டியதோ பெற வேண்டியதோ மாறாது.',
+    action: 'தடு',
+    unblock: 'தடையை நீக்கு',
+    confirmTitle: '{name} ஐத் தடுக்கவா?',
+    confirmBody:
+      'செயலி முழுவதும் அவர் அடையாளம் தெரியாத பேயாகத் தோன்றுவார். அவருடனான உங்கள் இருப்புகள் மாறாது, அவருக்கு அறிவிக்கப்படாது.',
+    badge: 'தடுக்கப்பட்டது',
+  },
   privacy: {
     row: 'தனியுரிமை & பாதுகாப்பு',
     rowHint: 'என்ன சேமிக்கப்படுகிறது, எப்படி பாதுகாக்கப்படுகிறது',
@@ -5824,6 +5866,21 @@ const hi: UiStrings = {
     alreadyDecided: 'इसका जवाब कोई पहले ही दे चुका है।',
     placeTaken: 'वह जगह अब किसी और की है।',
     theyAreAlreadyIn: 'वे पहले से इस समूह में हैं।',
+  },
+  blocked: {
+    row: 'अवरोधित लोग',
+    rowHint: 'जिन नाम और चेहरों को आपने छिपाया है',
+    title: 'अवरोधित लोग',
+    emptyTitle: 'कोई अवरोधित नहीं है',
+    emptyBody:
+      'किसी को अवरोधित करें और वे यहाँ भूत के रूप में दिखेंगे — आप कभी भी अवरोध हटा सकते हैं।',
+    note: 'अवरोधित करना केवल यह छिपाता है कि कोई व्यक्ति आपको कैसा दिखता है। इससे आपका लेन-देन कभी नहीं बदलता।',
+    action: 'अवरोधित करें',
+    unblock: 'अवरोध हटाएँ',
+    confirmTitle: '{name} को अवरोधित करें?',
+    confirmBody:
+      'वे पूरे ऐप में एक गुमनाम भूत के रूप में दिखेंगे। उनके साथ आपका हिसाब नहीं बदलता, और उन्हें बताया नहीं जाता।',
+    badge: 'अवरोधित',
   },
   privacy: {
     row: 'निजता और सुरक्षा',
@@ -7443,6 +7500,19 @@ const ar: UiStrings = {
     alreadyDecided: 'ردّ أحدهم على هذا من قبل.',
     placeTaken: 'صار ذلك المكان لشخص آخر.',
     theyAreAlreadyIn: 'هو بالفعل في هذه المجموعة.',
+  },
+  blocked: {
+    row: 'الأشخاص المحظورون',
+    rowHint: 'الأسماء والوجوه التي أخفيتها',
+    title: 'الأشخاص المحظورون',
+    emptyTitle: 'لا أحد محظور',
+    emptyBody: 'احظر شخصًا وسيظهر هنا كشبح — يمكنك رفع الحظر عنه في أي وقت.',
+    note: 'الحظر يخفي فقط كيف يظهر لك الشخص. ولا يغيّر أبدًا ما لك أو ما عليك.',
+    action: 'حظر',
+    unblock: 'رفع الحظر',
+    confirmTitle: 'حظر {name}؟',
+    confirmBody: 'سيظهر كشبح مجهول في كل مكان في التطبيق. أرصدتك معه لا تتغيّر، ولا يتم إخباره.',
+    badge: 'محظور',
   },
   privacy: {
     row: 'الخصوصية والأمان',

--- a/apps/mobile/test/blocked.test.ts
+++ b/apps/mobile/test/blocked.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The block set, and the two pure questions every render site asks of it.
+ *
+ * Blocking is display-only: it must change the *name and face* a blocked person
+ * shows under, and it must never be mistaken for the viewer themselves. These
+ * check exactly that, plus the storage reducers that keep the set one-entry-per
+ * -person and survive a corrupt stored value.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseBlocked, removeBlocked, upsertBlocked, type BlockedUser } from '../src/data/blocked';
+import { displayName, isBlockedMember } from '../src/data/types';
+import type { MemberRow } from '../src/data/types';
+
+const user = (id: string, name = id): BlockedUser => ({ id, name, avatarUrl: null });
+
+const member = (over: Partial<MemberRow>): MemberRow =>
+  ({
+    id: 'm1',
+    group_id: 'g1',
+    profile_id: null,
+    ghost_name: null,
+    role: 'member',
+    vpa: null,
+    left_at: null,
+    ...over,
+  }) as MemberRow;
+
+describe('the block reducers', () => {
+  it('adds newest first', () => {
+    const list = upsertBlocked(upsertBlocked([], user('a')), user('b'));
+    expect(list.map((entry) => entry.id)).toEqual(['b', 'a']);
+  });
+
+  it('never lists the same person twice, and refreshes their snapshot', () => {
+    const list = upsertBlocked([user('a', 'Old')], user('a', 'New'));
+    expect(list).toHaveLength(1);
+    expect(list[0]!.name).toBe('New');
+  });
+
+  it('removes by id and leaves the rest', () => {
+    expect(removeBlocked([user('a'), user('b')], 'a').map((entry) => entry.id)).toEqual(['b']);
+  });
+
+  it('reads back what was written', () => {
+    const list = [user('a', 'Ada'), user('b', 'Bo')];
+    expect(parseBlocked(JSON.stringify(list))).toEqual(list);
+  });
+
+  it('treats a missing or corrupt store as nobody blocked', () => {
+    expect(parseBlocked(null)).toEqual([]);
+    expect(parseBlocked('not json')).toEqual([]);
+    expect(parseBlocked('{"not":"an array"}')).toEqual([]);
+  });
+
+  it('drops entries with no id and fills a missing name', () => {
+    const raw = JSON.stringify([{ id: 'a' }, { name: 'no id' }, { id: 'b', name: 'Bo' }]);
+    expect(parseBlocked(raw)).toEqual([
+      { id: 'a', name: '', avatarUrl: null },
+      { id: 'b', name: 'Bo', avatarUrl: null },
+    ]);
+  });
+});
+
+describe('ghosting a blocked person', () => {
+  const blocked = new Set(['p-blocked']);
+  const real = member({ profile_id: 'p-blocked', profile: { display_name: 'Ravi' } as never });
+
+  it('shows a blocked person by the anonymous name, not their real one', () => {
+    expect(displayName(real, 'me', blocked, 'Someone')).toBe('Someone');
+    expect(isBlockedMember(real, blocked)).toBe(true);
+  });
+
+  it('shows an unblocked person normally', () => {
+    const other = member({ profile_id: 'p-ok', profile: { display_name: 'Priya' } as never });
+    expect(displayName(other, 'me', blocked, 'Someone')).toBe('Priya');
+    expect(isBlockedMember(other, blocked)).toBe(false);
+  });
+
+  it('never blocks the viewer against themselves', () => {
+    const me = member({ profile_id: 'p-blocked', profile: { display_name: 'Ravi' } as never });
+    // Even though this id is in the block set, it is the viewer's own id: "You"
+    // wins, so you never see yourself as a ghost.
+    expect(displayName(me, 'p-blocked', blocked, 'Someone')).toBe('You');
+  });
+
+  it('leaves a plain ghost (no profile) un-blockable', () => {
+    const ghost = member({ profile_id: null, ghost_name: 'Sam' });
+    expect(isBlockedMember(ghost, blocked)).toBe(false);
+    expect(displayName(ghost, 'me', blocked, 'Someone')).toBe('Sam');
+  });
+});


### PR DESCRIPTION
## What

Lets a user **block another person** and renders that person as the app's existing **anonymous "ghost"** everywhere they would otherwise appear — real name → the localized `t.misc.someone` ("Someone"), avatar → the dashed ghost circle. Plus block/unblock actions and a **Blocked people** list to review and undo.

Blocking here is a **display-level / identity-ghosting** change. It never touches the ledger — no balance, share, or settlement moves; you can still owe or be owed by someone you've blocked, and they are not told.

## Investigation findings

**The ghost look already exists.** `Avatar` (`packages/ui`) has a `ghost` prop that draws a dashed border; a not-yet-joined member with no name resolves to `"Someone"`. Blocking reuses exactly this — no parallel ghost visual.

**The choke points are two pure helpers.** Nearly every person surface renders a name via `displayName(member, myProfileId)` and a ghost avatar via `isGhost(member)` (both in `data/types.ts`); the activity feeds go through `actorName()`. Ghosting a blocked person is therefore centralised: these helpers gained an optional `blocked` set (+ localized "someone" label), and a new `isBlockedMember()` pairs the ghost avatar with the ghost name. The amounts never read the block set.

**Person identity across groups is `profile_id`.** That's the block key. Plain ghosts (no profile) have no cross-group identity, so they aren't blockable; the friends list/detail key on the same `person_key` which equals `profile_id` for a real person.

## Persistence decision (no migration)

The block set is **device-local in AsyncStorage** (`blockedUsers:v1`), keyed on `profile_id`, behind a module-level store + `useBlockedUsers()` hook that is the single source of truth — so a block ghosts a person on all mounted screens at once. A name/avatar **snapshot** is stored alongside each id so the Blocked-people list can still name each person (the one screen that intentionally shows real identity). **No Postgres migration, RLS, or edge function** — it ships in this PR.

## Display-block vs server-block

This is a **display-level block** (hide identity locally, per device). It is **not** server-enforced: it does not refuse shared groups, hide you from the other person, or change any balance. Server-enforced blocking is called out as a follow-up below.

## Render choke points ghosted

- Group **members list** and **member detail** (name, avatar, a `Blocked` badge)
- **Friends list** and **friend detail** (name, avatar, route title)
- **Group feed**: member rows + payer/actor names
- **Expense detail**: payer + participant rows
- Both **activity feeds** (`describeActivity` → `actorName`)

## Entry points added

- **Block / Unblock**: confirmed action on the **member-detail** screen; and a header toggle on the **friend-detail** screen.
- **Blocked people** screen (`app/settings/blocked.tsx`) with unblock, reached from a new row in the **Privacy** section.
- i18n: new `blocked.*` category added in **all four locales** (En/Ta/Hi/Ar).

## Deferred

- **Server-enforced blocking** (shared-group refusal, mutual invisibility) — a real backend change, intentionally out of this display-only PR.
- Ghosting the remaining **action screens** (settle, add-expense, itemize, plan, simplify, month), now a mechanical reuse of the same block-set parameter.

## Validation

- `tsc --noEmit` — clean
- `eslint` (touched files) — clean
- `vitest run` — **Test Files 26 passed (26) / Tests 297 passed (297)** (adds `test/blocked.test.ts`: block reducers + ghosting helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile blocking and unblocking for eligible people and group members.
  * Added Privacy settings access to a blocked-people list with empty states and unblock actions.
  * Blocked people are anonymized and shown with ghost-style avatars across activity, friends, groups, expenses, and member screens.
  * Added localized blocked-user messaging in English, Tamil, Hindi, and Arabic.
* **Tests**
  * Added coverage for blocking data handling, anonymized display names, and parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->