### PR TITLE
feat(db): auto-archive groups untouched for eighteen months

### DIFF
--- a/packages/db/prisma/migrations/20260820120000_auto_archive_stale_groups/migration.sql
+++ b/packages/db/prisma/migrations/20260820120000_auto_archive_stale_groups/migration.sql
@@ -1,0 +1,99 @@
+-- Auto-archive long-untouched groups (the privacy note's retention promise).
+--
+-- The privacy screen tells people a group they close and leave untouched for a
+-- year and a half is moved to their archive automatically, with nothing deleted
+-- and reopening always available. This is the job that makes that true.
+--
+-- "Untouched" is measured from the last real activity, not `updated_at`: that
+-- column is a Prisma `@updatedAt` and is not stamped by the raw SQL the sync
+-- cursor uses, so it lies about inactivity. The honest signal is the newest of
+-- the group's own creation and the last expense, settlement, or activity-log
+-- entry it carries — the things a person actually does in a group.
+--
+-- Archiving is a plain `archived_at` write, exactly what the manual archive
+-- action does. Two triggers already do the rest for free:
+--   * `groups_stamp_seq` bumps `updated_seq`, so the archive syncs to every
+--     member's device like any other change (TDR §4).
+--   * `groups_guard_columns` forbids `anon`/`authenticated` from touching these
+--     columns but exempts owner-run code, and this function is SECURITY DEFINER,
+--     so it writes freely while a signed-in client still cannot.
+--
+-- Nothing is deleted and nothing is notified: an archive is quiet and
+-- reversible, and a member who wants the group back just unarchives it. The
+-- `archived_at IS NULL` predicate makes the job idempotent — a second run, or an
+-- overlapping one, finds the row already archived and skips it.
+
+CREATE OR REPLACE FUNCTION public.baaki_auto_archive_stale_groups(
+  p_now timestamptz DEFAULT now(),
+  p_age interval    DEFAULT interval '18 months'
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_row   record;
+  v_count integer := 0;
+BEGIN
+  FOR v_row IN
+    SELECT g.id
+      FROM public.groups g
+     WHERE g.archived_at IS NULL
+       -- The last thing anyone did here. GREATEST ignores NULL arguments, so a
+       -- group with no expenses/settlements/activity falls back to its own
+       -- creation time — which correctly leaves a brand-new empty group alone.
+       AND GREATEST(
+             g.created_at,
+             (SELECT max(e.created_at) FROM public.expenses e     WHERE e.group_id = g.id),
+             (SELECT max(s.created_at) FROM public.settlements s  WHERE s.group_id = g.id),
+             (SELECT max(a.created_at) FROM public.activity_log a WHERE a.group_id = g.id)
+           ) <= p_now - p_age
+     -- Locked so two overlapping runs cannot both claim the same group; the
+     -- second simply finds nothing to do.
+     FOR UPDATE OF g SKIP LOCKED
+  LOOP
+    UPDATE public.groups
+       SET archived_at = p_now
+     WHERE id = v_row.id;
+
+    -- A line in the feed so the archive is explained rather than mysterious.
+    -- actor NULL = "the system did this", the same convention the auto-confirm
+    -- job uses.
+    INSERT INTO public.activity_log
+      (group_id, actor_member_id, verb, object_type, object_id, payload)
+    VALUES
+      (v_row.id, NULL, 'auto_archived', 'group', v_row.id,
+       jsonb_build_object('reason', 'inactive', 'after', p_age::text));
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END
+$$;
+
+-- The job runs from cron or the service role. Handing it to `authenticated`
+-- would let any signed-in person archive every group in the database.
+REVOKE ALL ON FUNCTION public.baaki_auto_archive_stale_groups(timestamptz, interval) FROM PUBLIC;
+
+-- pg_cron exists on Supabase and not in a bare Postgres container, so this is
+-- guarded rather than assumed. Once a day is plenty for an 18-month threshold:
+-- being archived on the day after eighteen months rather than the minute after
+-- is a difference no one will feel.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron') THEN
+    CREATE EXTENSION IF NOT EXISTS pg_cron;
+    PERFORM cron.unschedule('baaki-auto-archive')
+      WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'baaki-auto-archive');
+    PERFORM cron.schedule(
+      'baaki-auto-archive', '30 3 * * *',
+      'SELECT public.baaki_auto_archive_stale_groups()'
+    );
+  END IF;
+EXCEPTION WHEN OTHERS THEN
+  -- A database without permission to create extensions must still migrate.
+  RAISE NOTICE 'pg_cron not scheduled: %', SQLERRM;
+END
+$$;

--- a/packages/db/test/auto-archive.test.ts
+++ b/packages/db/test/auto-archive.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Auto-archiving long-untouched groups (the privacy note's retention promise).
+ *
+ * The privacy screen tells people a group left closed and untouched for a year
+ * and a half moves to their archive automatically, nothing deleted. This is the
+ * job behind that sentence, so the sentence is tested rather than assumed.
+ *
+ * "Untouched" is the newest of the group's creation and its last expense,
+ * settlement, or activity-log entry — never `updated_at`, which the raw SQL of
+ * the sync cursor does not stamp. The clock is an argument to the function, and
+ * the fixtures backdate `created_at` instead of waiting eighteen months, so the
+ * boundary can actually be exercised.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, connect, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+/** Push a group's creation — and any activity it carries — into the past. */
+async function ageGroup(groupId: string, ageText: string): Promise<void> {
+  await client.query(`UPDATE groups SET created_at = now() - $2::interval WHERE id = $1`, [
+    groupId,
+    ageText,
+  ]);
+  await client.query(
+    `UPDATE activity_log SET created_at = now() - $2::interval WHERE group_id = $1`,
+    [groupId, ageText],
+  );
+}
+
+const archivedAtOf = async (groupId: string): Promise<Date | null> => {
+  const { rows } = await client.query(`SELECT archived_at FROM groups WHERE id = $1`, [groupId]);
+  return rows[0]?.archived_at ?? null;
+};
+
+const runJob = async (): Promise<number> => {
+  const { rows } = await client.query(`SELECT public.baaki_auto_archive_stale_groups() AS n`);
+  return Number(rows[0]?.n ?? 0);
+};
+
+describe('baaki_auto_archive_stale_groups', () => {
+  it('archives a group that has sat untouched past the window', async () => {
+    const { groupId } = await seedGroup(client, { memberCount: 2 });
+    await ageGroup(groupId, '2 years');
+
+    await runJob();
+
+    expect(await archivedAtOf(groupId)).not.toBeNull();
+  });
+
+  it('leaves a group alone while it still has recent activity', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    // Old group, but a bill was added just now — that is a touch inside the
+    // window, so it must not be archived.
+    await ageGroup(groupId, '2 years');
+    await addEqualSplitExpense(client, {
+      groupId,
+      payers: { [memberIds[0] ?? '']: 42000n },
+      participants: [memberIds[0] ?? '', memberIds[1] ?? ''],
+      amount: 42000n,
+    });
+
+    await runJob();
+
+    expect(await archivedAtOf(groupId)).toBeNull();
+  });
+
+  it('leaves a freshly created group alone', async () => {
+    const { groupId } = await seedGroup(client, { memberCount: 2 });
+
+    await runJob();
+
+    expect(await archivedAtOf(groupId)).toBeNull();
+  });
+
+  it('does not re-touch an already-archived group and is idempotent', async () => {
+    const { groupId } = await seedGroup(client, { memberCount: 2 });
+    await ageGroup(groupId, '2 years');
+
+    await runJob();
+    const firstArchivedAt = await archivedAtOf(groupId);
+    expect(firstArchivedAt).not.toBeNull();
+
+    // A second sweep must not find it again, nor move its archive time.
+    await runJob();
+    const secondArchivedAt = await archivedAtOf(groupId);
+    expect(secondArchivedAt?.getTime()).toBe(firstArchivedAt?.getTime());
+  });
+
+  it('writes an auto_archived line to the group feed', async () => {
+    const { groupId } = await seedGroup(client, { memberCount: 2 });
+    await ageGroup(groupId, '2 years');
+
+    await runJob();
+
+    const { rows } = await client.query(
+      `SELECT verb, object_type FROM activity_log
+        WHERE group_id = $1 AND verb = 'auto_archived'`,
+      [groupId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.object_type).toBe('group');
+  });
+});


### PR DESCRIPTION
Makes the privacy note (#302) true: a daily `pg_cron` job (`baaki_auto_archive_stale_groups`) sets `archived_at` on any group whose **last touch** — the greatest of its creation and its last expense / settlement / activity-log entry — is older than 18 months and isn't already archived.

- **Last-touch is computed, not `updated_at`** — that column is a Prisma `@updatedAt` the sync cursor's raw SQL never stamps, so it under-reports inactivity.
- **Syncs for free**: a plain `archived_at` write; `groups_stamp_seq` bumps `updated_seq`, and `groups_guard_columns` exempts the SECURITY DEFINER job while still blocking clients.
- **Quiet & reversible**: nothing deleted, nothing notified, unarchive to reopen; `archived_at IS NULL` makes it idempotent; a feed line records the sweep.
- **Guarded pg_cron** so a bare Postgres (CI) still migrates.

Tests: archive-past-window, leave-with-recent-activity, leave-when-fresh, idempotency, feed line. tsc clean; the CI **database** job applies the migration to a fresh Postgres 17 and runs these tests.

⚠️ **Deploy-gated**: needs `pnpm db:migrate` against prod to create the function + schedule the cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically archives groups that have been inactive for 18 months.
  * Runs once daily when scheduled database jobs are available.
  * Records an activity entry when a group is automatically archived.

* **Bug Fixes**
  * Prevents recently active or newly created groups from being archived.
  * Ensures repeated archive runs do not create duplicate activity records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->