### PR TITLE
fix(mobile): close CodeRabbit block-privacy + FX stale-request gaps

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -140,7 +140,12 @@ export default function ActivityScreen() {
                     <Pressable
                       key={entry.id}
                       accessibilityRole="button"
-                      accessibilityLabel={describeActivity(entry, myProfileId, blockedIds)}
+                      accessibilityLabel={describeActivity(
+                        entry,
+                        myProfileId,
+                        blockedIds,
+                        t.misc.someone,
+                      )}
                       onPress={() => router.push(`/group/${entry.group_id}`)}
                       style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
                     >
@@ -191,7 +196,7 @@ export default function ActivityScreen() {
                         >
                           <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
                             <Text variant="body" numberOfLines={3} style={{ flex: 1 }}>
-                              {describeActivity(entry, myProfileId, blockedIds)}
+                              {describeActivity(entry, myProfileId, blockedIds, t.misc.someone)}
                             </Text>
                             {/* `payload` is an untyped JSON blob, so a bad amount
                             must render as no amount, not as a crashed tab. */}

--- a/apps/mobile/src/app/friends/person/[key].tsx
+++ b/apps/mobile/src/app/friends/person/[key].tsx
@@ -64,11 +64,17 @@ export default function PersonDetailScreen() {
   // in the route *is* their profile id (the list keys them on it), so `key` is
   // the block key. A ghost or a merged-ghost person_key is not a profile id and
   // nothing elsewhere keys off it, so those are left un-blockable.
-  const { isBlocked, block, unblock } = useBlockedUsers();
+  const { isBlocked, block, unblock, ready } = useBlockedUsers();
   const isRealPerson = rows.some((row) => !row.is_ghost);
-  const blocked = isRealPerson && isBlocked(key);
+  // Independent of `isRealPerson`: a ghost's key is never in the block set, so
+  // this stays false for one regardless — and asking directly means a block is
+  // honoured before the group rows have loaded, not only after.
+  const blocked = isBlocked(key);
   const realName = rows.find((row) => !row.is_ghost)?.display_name ?? name ?? t.misc.someone;
-  const title = blocked ? t.misc.someone : (name ?? rows[0]?.display_name ?? '');
+  // Until the block store has hydrated we cannot know whether this person is
+  // blocked, so show the generic label rather than risk flashing a real name
+  // that a block would have masked.
+  const title = !ready || blocked ? t.misc.someone : (name ?? rows[0]?.display_name ?? '');
 
   const confirmBlock = (): void => {
     Alert.alert(fill(t.blocked.confirmTitle, { name: realName }), t.blocked.confirmBody, [

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -282,25 +282,38 @@ export default function ExpenseDetailScreen() {
           <View>
             <SectionHeader title={t.paidBy} />
             <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-              {version.payers.map((payer, index) => (
-                <View key={payer.member_id}>
-                  <ListRow
-                    title={nameOf(payer.member_id)}
-                    leading={<Avatar name={avatarNameOf(payer.member_id)} size={38} />}
-                    trailing={
-                      <MoneyText
-                        amount={BigInt(payer.amount)}
-                        currency={currency}
-                        locale={locale}
-                        variant="caption"
-                      />
-                    }
-                  />
-                  {index < version.payers.length - 1 ? (
-                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                  ) : null}
-                </View>
-              ))}
+              {version.payers.map((payer, index) => {
+                const payerMember = lookup.get(payer.member_id);
+                return (
+                  <View key={payer.member_id}>
+                    <ListRow
+                      title={nameOf(payer.member_id)}
+                      leading={
+                        <Avatar
+                          name={avatarNameOf(payer.member_id)}
+                          ghost={
+                            payerMember
+                              ? isGhost(payerMember) || isBlockedMember(payerMember, blockedIds)
+                              : false
+                          }
+                          size={38}
+                        />
+                      }
+                      trailing={
+                        <MoneyText
+                          amount={BigInt(payer.amount)}
+                          currency={currency}
+                          locale={locale}
+                          variant="caption"
+                        />
+                      }
+                    />
+                    {index < version.payers.length - 1 ? (
+                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                    ) : null}
+                  </View>
+                );
+              })}
             </Card>
           </View>
         ) : null}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -761,7 +761,10 @@ export default function GroupScreen() {
                         <Text variant="caption" tone="muted" numberOfLines={1}>
                           {isGhost(member)
                             ? t.notJoinedYet
-                            : (member.vpa ?? member.profile?.default_vpa ?? '—')}
+                            : isBlockedMember(member, blockedIds)
+                              ? // A VPA carries a name or phone — masked for a blocked person.
+                                '—'
+                              : (member.vpa ?? member.profile?.default_vpa ?? '—')}
                         </Text>
                       </View>
                       <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
@@ -804,7 +807,12 @@ export default function GroupScreen() {
                 {(activity.data ?? []).map((entry, index) => (
                   <View key={entry.id}>
                     <ListRow
-                      title={describeActivity(entry, profile?.id ?? null, blockedIds)}
+                      title={describeActivity(
+                        entry,
+                        profile?.id ?? null,
+                        blockedIds,
+                        t.misc.someone,
+                      )}
                       subtitle={new Intl.DateTimeFormat(locale, {
                         day: 'numeric',
                         month: 'short',

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -246,7 +246,14 @@ export default function MembersScreen() {
             <View key={member.id}>
               <ListRow
                 title={displayName(member, profile?.id, blockedIds, t.misc.someone)}
-                subtitle={isGhost(member) ? t.notJoinedYet : (vpaOf(member) ?? t.misc.noUpiYet)}
+                subtitle={
+                  isGhost(member)
+                    ? t.notJoinedYet
+                    : isBlockedMember(member, blockedIds)
+                      ? // A VPA carries a name or phone — masked for a blocked person.
+                        t.misc.noUpiYet
+                      : (vpaOf(member) ?? t.misc.noUpiYet)
+                }
                 leading={
                   <Avatar
                     name={displayName(member, null, blockedIds, t.misc.someone)}

--- a/apps/mobile/src/components/CurrencyRate.tsx
+++ b/apps/mobile/src/components/CurrencyRate.tsx
@@ -115,6 +115,12 @@ export function CurrencyRate({
   const foreign = currency !== groupCurrency;
 
   const choose = (next: string): void => {
+    // Invalidate any in-flight fetch synchronously: point `latestPair` at the
+    // pair we are switching to so a response for the old pair is dropped the
+    // moment it returns, and clear the spinner now — the stale fetch's `finally`
+    // is guarded on the pair and would otherwise never release `busy`.
+    latestPair.current = `${next}|${groupCurrency}`;
+    setBusy(false);
     onCurrencyChange(next);
     // A rate for the old currency would convert the wrong thing, and the server
     // rejects it anyway — clearing it here just makes that visible sooner.

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -49,10 +49,11 @@ export function describeActivity(
   entry: ActivityRow,
   myProfileId: string | null,
   blocked?: ReadonlySet<string> | null,
+  someoneLabel = 'Someone',
 ): string {
   const { payload } = entry;
   const description = typeof payload.description === 'string' ? payload.description : null;
-  const who = actorName(entry.actor, myProfileId, blocked);
+  const who = actorName(entry.actor, myProfileId, blocked, someoneLabel);
 
   switch (entry.verb) {
     case 'added':

--- a/apps/mobile/src/data/blocked.ts
+++ b/apps/mobile/src/data/blocked.ts
@@ -81,15 +81,19 @@ function emit(): void {
   for (const listener of listeners) listener();
 }
 
+// Set once a block/unblock has run. If one lands while the initial read is
+// still pending, the read's older snapshot must not overwrite the live list.
+let mutated = false;
+
 /** Load once, lazily, on first subscribe. Failures leave an empty list, ready. */
 function hydrate(): Promise<void> {
   if (hydration) return hydration;
   hydration = AsyncStorage.getItem(STORAGE_KEY)
     .then((raw) => {
-      blocked = parseBlocked(raw);
+      if (!mutated) blocked = parseBlocked(raw);
     })
     .catch(() => {
-      blocked = [];
+      if (!mutated) blocked = [];
     })
     .finally(() => {
       ready = true;
@@ -99,6 +103,7 @@ function hydrate(): Promise<void> {
 }
 
 function persist(next: readonly BlockedUser[]): void {
+  mutated = true;
   blocked = next;
   emit();
   void AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {});

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -255,13 +255,14 @@ export function actorName(
   actor: ActivityActor | null | undefined,
   myProfileId: string | null,
   blocked?: ReadonlySet<string> | null,
+  someoneLabel = 'Someone',
 ): string {
-  if (!actor) return 'Someone';
+  if (!actor) return someoneLabel;
   if (myProfileId && actor.profile_id === myProfileId) return 'You';
   // A blocked person is shown as the anonymous ghost everywhere they surface —
   // the feed included — never their real name. Never applied to yourself.
-  if (actor.profile_id && blocked?.has(actor.profile_id)) return 'Someone';
-  return actor.profile?.display_name ?? actor.ghost_name ?? 'Someone';
+  if (actor.profile_id && blocked?.has(actor.profile_id)) return someoneLabel;
+  return actor.profile?.display_name ?? actor.ghost_name ?? someoneLabel;
 }
 
 export interface BalanceRow {

--- a/apps/mobile/test/blocked.test.ts
+++ b/apps/mobile/test/blocked.test.ts
@@ -13,7 +13,11 @@ import { parseBlocked, removeBlocked, upsertBlocked, type BlockedUser } from '..
 import { displayName, isBlockedMember } from '../src/data/types';
 import type { MemberRow } from '../src/data/types';
 
-const user = (id: string, name = id): BlockedUser => ({ id, name, avatarUrl: null });
+const user = (id: string, name = id, avatarUrl: string | null = null): BlockedUser => ({
+  id,
+  name,
+  avatarUrl,
+});
 
 const member = (over: Partial<MemberRow>): MemberRow =>
   ({
@@ -43,9 +47,15 @@ describe('the block reducers', () => {
     expect(removeBlocked([user('a'), user('b')], 'a').map((entry) => entry.id)).toEqual(['b']);
   });
 
-  it('reads back what was written', () => {
-    const list = [user('a', 'Ada'), user('b', 'Bo')];
+  it('reads back what was written, avatar and all', () => {
+    const list = [user('a', 'Ada', 'https://cdn/a.png'), user('b', 'Bo')];
     expect(parseBlocked(JSON.stringify(list))).toEqual(list);
+  });
+
+  it('keeps a refreshed avatar on re-block', () => {
+    const list = upsertBlocked([user('a', 'Ada', null)], user('a', 'Ada', 'https://cdn/a2.png'));
+    expect(list).toHaveLength(1);
+    expect(list[0]!.avatarUrl).toBe('https://cdn/a2.png');
   });
 
   it('treats a missing or corrupt store as nobody blocked', () => {
@@ -55,10 +65,16 @@ describe('the block reducers', () => {
   });
 
   it('drops entries with no id and fills a missing name', () => {
-    const raw = JSON.stringify([{ id: 'a' }, { name: 'no id' }, { id: 'b', name: 'Bo' }]);
+    const raw = JSON.stringify([
+      { id: 'a' },
+      { name: 'no id' },
+      { id: 'b', name: 'Bo' },
+      { id: 'c', name: 'Cy', avatarUrl: 123 },
+    ]);
     expect(parseBlocked(raw)).toEqual([
       { id: 'a', name: '', avatarUrl: null },
       { id: 'b', name: 'Bo', avatarUrl: null },
+      { id: 'c', name: 'Cy', avatarUrl: null },
     ]);
   });
 });


### PR DESCRIPTION
Follow-up CodeRabbit findings on the block-users feature, plus one FX lifecycle bug. Each verified against current code; still-valid ones fixed, kept minimal.

## Block privacy
- **Friends person screen** — block honoured independent of `isRealPerson` (ghost keys are never in the set anyway), and the generic label shows until the block store has hydrated, so a real name can't flash before the block is known.
- **Expense detail** — multi-payer avatars now ghost a blocked member, matching the existing share-avatar predicate.
- **Member VPA** — a UPI handle carries a name/phone, so it's masked for blocked members in the members list and the group header (each uses its own neutral fallback).
- **Block store hydration race** — a block/unblock during the pending initial `getItem` is no longer overwritten by the older stored snapshot.
- **Localized anonymous label** — `actorName`/`describeActivity` take a `someoneLabel`; activity screens pass `t.misc.someone` instead of the hardcoded `"Someone"`.
- **Test** — `blocked.test.ts` now exercises `avatarUrl` string preservation, refresh-on-re-block, and non-string → `null` normalization.

## Currency rate
- Switching currency mid-fetch invalidates the in-flight request **synchronously** (points `latestPair` at the new pair and clears `busy` in `choose`). Previously a stale response for the old pair skipped the pair-guarded `finally`, leaving the spinner stuck `true`.

### Skipped
- No render regression test for the deferred FX response: the mobile suite is pure-logic `.ts` only (no `@testing-library/react-native`). The fix makes invalidation synchronous, which is what the guard needed.

Validated: `tsc --noEmit` clean, `expo lint` clean, `blocked.test.ts` 11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Privacy & Safety**
  - Blocked members’ VPAs are hidden in balances and member lists.
  - Blocked or ghost members now appear with masked names and ghost avatars where appropriate.
  - Person details remain concealed until blocking status is confirmed.

- **Accessibility & Localization**
  - Activity descriptions support localized fallback text for unknown actors.

- **Bug Fixes**
  - Blocking status changes are preserved reliably during app startup and storage recovery.
  - Changing currency pairs now clears stale loading states and cancels outdated rate requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->