### PR TITLE
fix(mobile): hide left groups from the capture-inbox assign picker

### DIFF
--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -9,7 +9,7 @@
  * than hiding until the server has seen it (ADR-005).
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
@@ -107,6 +107,20 @@ export default function CapturesScreen() {
 
   // Which capture is being assigned, if any — drives the group-picker sheet.
   const [assigning, setAssigning] = useState<CaptureRow | null>(null);
+
+  // Only groups the viewer still belongs to belong in the picker. Leaving a
+  // group sets `left_at`; it does not remove the group row, so a left (or
+  // owner-removed) group lingers in the local mirror and `useGroups` still
+  // returns it. `membersFor` lists active members only, so a group where the
+  // viewer is no longer among them is one they left — never an assignment
+  // target for a new expense.
+  const assignableGroups = useMemo(
+    () =>
+      (groups.data ?? []).filter((group) =>
+        summary.membersFor(group.id).some((member) => member.profile_id === profile?.id),
+      ),
+    [groups.data, summary, profile?.id],
+  );
 
   const rows = captures.data ?? [];
 
@@ -284,14 +298,14 @@ export default function CapturesScreen() {
               {t.captures.assignBody}
             </Text>
 
-            {(groups.data ?? []).length === 0 ? (
+            {assignableGroups.length === 0 ? (
               <Text variant="caption" tone="muted" style={{ paddingVertical: theme.spacing.md }}>
                 {t.captures.noGroups}
               </Text>
             ) : (
               <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
                 <View style={{ gap: theme.spacing.xs }}>
-                  {(groups.data ?? []).map((group) => (
+                  {assignableGroups.map((group) => (
                     <Pressable
                       key={group.id}
                       accessibilityRole="button"


### PR DESCRIPTION
**Bug:** In the capture inbox, the "assign to a group" picker showed groups the user had already left — a capture could be assigned to a group they're no longer in.

**Cause:** Leaving a group sets `group_members.left_at`; the group row itself isn't removed (no group delete exists — only archive + leave), so it lingers in the local mirror and `useGroups()` still returns it. The dashboard summary already scopes to active membership; the picker used raw `useGroups()`.

**Fix:** Filter the picker to groups where the viewer is still an active member (`membersFor` returns non-left members only). A freshly created offline group seeds its creator into `membersFor`, so new groups stay assignable — no regression.

Validated: `tsc --noEmit` clean, `expo lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group selection now shows only groups where you’re still an active member.
  * Displays an appropriate empty state when no eligible groups are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->