### PR TITLE
fix(mobile): group-detail recovery-button size + overflow-menu a11y

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -540,13 +540,25 @@ export default function GroupScreen() {
 
           {tab === Tab.Expenses && hasDeleted ? (
             <Row style={{ justifyContent: 'flex-end', marginTop: -theme.spacing.md }}>
-              <Text
-                variant="caption"
-                tone="muted"
+              {/* A real button, not a text with an onPress: a screen reader now
+                  hears a control, and the 44pt floor plus hitSlop makes the
+                  caption a tap target rather than a hairline of text. */}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityState={{ expanded: showDeleted }}
+                accessibilityLabel={showDeleted ? t.group.hideDeleted : t.group.showDeleted}
                 onPress={() => setShowDeleted((current) => !current)}
+                hitSlop={8}
+                style={({ pressed }) => ({
+                  minHeight: 44,
+                  justifyContent: 'center',
+                  opacity: pressed ? 0.6 : 1,
+                })}
               >
-                {showDeleted ? t.group.hideDeleted : t.group.showDeleted}
-              </Text>
+                <Text variant="caption" tone="muted">
+                  {showDeleted ? t.group.hideDeleted : t.group.showDeleted}
+                </Text>
+              </Pressable>
             </Row>
           ) : null}
 

--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -14,6 +14,9 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { iconSize, Text, useTheme } from '@waves/ui';
 
+import { useStrings } from '@/i18n';
+import { useMotion } from '@/lib/motion';
+
 export interface OverflowMenuItem {
   icon: keyof typeof Ionicons.glyphMap;
   label: string;
@@ -35,6 +38,10 @@ export function OverflowMenu({
 }) {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
+  const { t } = useStrings();
+  // The fade is decoration, not meaning — reduced motion drops it to an instant
+  // present/dismiss (TDR §11 treats the setting as an input, not a hint).
+  const { animated } = useMotion();
 
   const go = (route: Href): void => {
     onClose();
@@ -42,15 +49,27 @@ export function OverflowMenu({
   };
 
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+    <Modal
+      visible={visible}
+      transparent
+      animationType={animated ? 'fade' : 'none'}
+      onRequestClose={onClose}
+    >
       {/* The scrim: a full-screen catcher so a tap anywhere off the card closes
-          the menu. Kept barely tinted — the point is to dismiss, not to dim. */}
+          the menu. Kept barely tinted — the point is to dismiss, not to dim. It
+          carries a label so a screen reader announces "Close" rather than a bare
+          unnamed button covering the whole screen. */}
       <Pressable
         onPress={onClose}
         style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.12)' }}
         accessibilityRole="button"
+        accessibilityLabel={t.common.close}
       >
         <View
+          // Marks the dropdown as the modal layer so a screen reader confines
+          // itself to the menu while it is open, instead of reading the screen
+          // behind the scrim.
+          accessibilityViewIsModal
           // Dropped from the top-right, clear of the status bar and roughly
           // where the header's three-dot sits. The shadow and the radius live on
           // this outer layer; the inner one clips the rows so a pressed row's
@@ -106,6 +125,9 @@ export function OverflowMenu({
                       flexDirection: 'row',
                       alignItems: 'center',
                       gap: theme.spacing.md,
+                      // A 44pt floor rather than trusting the padding+text sum to
+                      // clear it — a menu row is a primary tap target.
+                      minHeight: 44,
                       paddingHorizontal: theme.spacing.lg,
                       paddingVertical: theme.spacing.md,
                       backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -136,10 +136,22 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
         <Text variant="caption" tone="muted">
           {first?.message ?? t.misc.serverRefused}
         </Text>
+        {/* The two recovery actions for a refused change — the buttons a person
+            most needs to hit. A caption Text alone left the tap area ~18pt tall;
+            a 44pt floor plus hitSlop makes each a real target, and an explicit
+            label names the action for a screen reader rather than leaning on the
+            child text. */}
         <Row style={{ gap: theme.spacing.lg }}>
           <Pressable
             onPress={() => first && void retry(first.clientMutationId)}
             accessibilityRole="button"
+            accessibilityLabel={t.extras.tryAgain}
+            hitSlop={8}
+            style={({ pressed }) => ({
+              minHeight: 44,
+              justifyContent: 'center',
+              opacity: pressed ? 0.6 : 1,
+            })}
           >
             <Text variant="caption" tone="brand">
               {t.extras.tryAgain}
@@ -148,6 +160,13 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
           <Pressable
             onPress={() => first && void discard(first.clientMutationId)}
             accessibilityRole="button"
+            accessibilityLabel={t.extras.discardIt}
+            hitSlop={8}
+            style={({ pressed }) => ({
+              minHeight: 44,
+              justifyContent: 'center',
+              opacity: pressed ? 0.6 : 1,
+            })}
           >
             <Text variant="caption" tone="muted">
               {t.extras.discardIt}


### PR DESCRIPTION
From a UI/UX pass on **group detail**. The screen itself was in good shape (dense a11y on every header control, busy-locked actions, empty states with CTAs, `DetailEnter` reduced-motion gated, lists reading the local mirror so "empty" is honest). The gaps were in the shared pieces it pulls in.

### High — refused-sync recovery buttons ~18pt
`SyncBanner.tsx` — "Try again" / "Discard it" (shown inline on group detail when a change is refused) were a bare `Pressable` around a `caption` Text, no padding → ~18pt tall. The two buttons a person most needs to hit were the smallest on screen. Now: `minHeight:44` + `hitSlop` + explicit `accessibilityLabel`.

### Med — "Show deleted" was a text link, not a button
`index.tsx` expenses tab — was `<Text onPress>` (SR announces as text, ~18pt target). Now a real `Pressable`: `role=button`, `accessibilityState={{ expanded }}`, `minHeight:44`, `hitSlop`.

### Med — overflow menu accessibility (also fixes the dashboard)
`OverflowMenu.tsx`:
- `accessibilityViewIsModal` so a screen reader stays inside the menu instead of reading the screen behind the scrim.
- Dismiss scrim gained a `Close` label (was `role=button` with no label — an unnamed full-screen button).
- Fade gated on reduced-motion (instant present/dismiss when on).
- Each row carries an explicit `minHeight:44` rather than trusting padding+text to clear it.

---
Not addressed (would need caller changes / are Low): focus-restore to the ••• trigger on menu close; balances/activity rows non-tappable vs the members list; settings-tap label dropping the group name. Left for a follow-up.

Scope: `SyncBanner`, `OverflowMenu` (both shared), `group/[id]/index.tsx`. No data/route/ledger change. `tsc` / `eslint` / `prettier` clean. Not device-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved accessibility semantics for expense toggles, overflow menus, and sync recovery actions.
  * Increased touch target sizes and added expanded touch areas for easier interaction.
  * Added pressed-state feedback to interactive controls.
  * Added support for reduced-motion preferences in overflow menu transitions.
  * Localized accessibility labels for menu controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->