### PR TITLE
fix(mobile): voice-screen language chip touch target + reduced-motion picker

### DIFF
--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -52,6 +52,7 @@ import {
 import { groupLabel, GroupType, type GroupRow } from '@/data/types';
 import { deviceDefaultCurrency, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { useMotion } from '@/lib/motion';
 import { aiEnabled, useAiAccess } from '@/lib/aiAccess';
 import { friendlyError } from '@/lib/errors';
 import { VoiceMicPanel } from '@/components/VoiceMicPanel';
@@ -91,6 +92,7 @@ export default function VoiceScreen() {
   const clearance = useScreenClearance();
   const insets = useSafeAreaInsets();
   const { t, locale } = useStrings();
+  const { animated } = useMotion();
   const { profile } = useAuth();
   const access = useAiAccess();
   const groups = useGroups();
@@ -491,11 +493,14 @@ export default function VoiceScreen() {
         </View>
       ) : null}
 
-      {/* The destination picker, as a dismissible bottom sheet. */}
+      {/* The destination picker, as a dismissible bottom sheet. The fade is
+          decoration, not meaning — reduced motion drops it to an instant
+          present/dismiss (TDR §11 treats the setting as an input, not a hint),
+          matching the overflow menu. */}
       <Modal
         transparent
         visible={pickerOpen}
-        animationType="fade"
+        animationType={animated ? 'fade' : 'none'}
         onRequestClose={() => setPickerOpen(false)}
       >
         <Pressable

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -514,7 +514,14 @@ export function VoiceCapture({ onDone, hints }: VoiceCaptureProps) {
                 accessibilityRole="button"
                 accessibilityState={{ selected }}
                 accessibilityLabel={LANGUAGE_NAMES[lang].english}
+                hitSlop={8}
                 style={({ pressed }) => ({
+                  // A 44pt floor plus hitSlop: on `xs` padding alone the chip was
+                  // ~26pt, the smallest target on the screen and the one that
+                  // switches the recognition language. Centre the label so the
+                  // taller box does not push it off-centre.
+                  minHeight: 44,
+                  justifyContent: 'center',
                   paddingVertical: theme.spacing.xs,
                   paddingHorizontal: theme.spacing.md,
                   borderRadius: theme.radius.pill,


### PR DESCRIPTION
Audit of the **speak-an-expense** flow (`app/voice.tsx` + `VoiceCapture.tsx`). Two mechanical fixes, mobile-only.

## Touch target
The recognition-language chips (`VoiceCapture.tsx`) were **~26pt tall** — `xs` vertical padding over a 13/18 caption, no `hitSlop`. Smallest target on the screen, and the one that switches which language the mic listens in. Now a **44pt floor + `hitSlop={8}`**, label centred in the taller box. Same class as the currency-pill / category-chip fixes already shipped.

## Reduced-motion
The destination-picker bottom sheet used `animationType="fade"` unconditionally. Now gated behind `useMotion()` → `'none'` under reduced motion, matching `OverflowMenu`. TDR §11 treats reduce-motion as an input, not a hint.

Mic (104pt), review rows (~60pt), and the remove `IconButton` (44pt) were already in spec. The pulse/halo/waveform animations were already reduced-motion gated. The error→open-settings line is a separate behavior decision, deferred.

Gates: prettier ✓, tsc ✓, eslint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved reduced-motion support in the voice destination picker by disabling animations when requested.
  * Increased language-selection chip tap targets and vertically centered their labels for easier interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->