### PR TITLE
a11y(ui): mark SectionHeader as a screen-reader heading

### DIFF
--- a/packages/ui/src/components/Surfaces.tsx
+++ b/packages/ui/src/components/Surfaces.tsx
@@ -99,7 +99,13 @@ export function SectionHeader({ title, action }: { title: string; action?: React
         marginBottom: theme.spacing.md,
       }}
     >
-      <Text variant="heading">{title}</Text>
+      {/* Marked as a header so a screen reader's heading navigation (the iOS
+          rotor, TalkBack's heading swipe) can jump between sections — a long
+          settings or group screen is a wall of rows otherwise. Purely semantic;
+          nothing about the look changes. */}
+      <Text variant="heading" accessibilityRole="header">
+        {title}
+      </Text>
       {action}
     </View>
   );


### PR DESCRIPTION
Surfaced auditing the **settings hub** (`(tabs)/profile.tsx`), but the fix is one shared component.

## Gap
No heading anywhere in the app was tagged `accessibilityRole="header"` — verified across `SectionHeader` and every screen title. So a screen reader's heading navigation (iOS rotor, TalkBack heading-swipe) has nothing to land on. Settings alone has **5 sections**; the only way through them for a VoiceOver/TalkBack user is swiping past every row.

## Fix
Tag the `Text` inside the shared `SectionHeader` as a header. Every section title in the app routes through this one component, so heading navigation lights up app-wide from a single change. `Text` forwards a11y props via `{...rest}`, confirmed.

**Purely semantic — no visual or behavior change.**

The per-screen inline page title (e.g. the settings header row) is a separate concern that rides the deferred `ScreenHeader` extract; not in scope here.

Gates: prettier ✓, tsc (mobile + `@waves/ui`) ✓. `packages/ui` has no independent eslint config; the file is trivial (one prop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader navigation by identifying section headings as headers, with no visual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->