### PR TITLE
fix(mobile): login Back-button touch target + reduced-motion language picker

### DIFF
--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -243,6 +243,9 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
               label={t.common.back}
               variant="ghost"
               size="sm"
+              // A small corner ghost by design, but 38pt is under the 44 floor —
+              // hitSlop grows the target without inflating the visible pill.
+              hitSlop={8}
               onPress={() => (router.canGoBack() ? router.back() : router.replace('/sign-in'))}
             />
           </View>

--- a/apps/mobile/src/components/LanguagePicker.tsx
+++ b/apps/mobile/src/components/LanguagePicker.tsx
@@ -26,11 +26,15 @@ import { iconSize, Text, useTheme } from '@waves/ui';
 
 import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES, useStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
+import { useMotion } from '@/lib/motion';
 
 export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-start' }) {
   const theme = useTheme();
   const { t } = useStrings();
   const { language, setLanguage, restartNeeded } = useLanguage();
+  // The fade is decoration — reduced motion drops it to an instant present, the
+  // same gate the overflow menu and the voice picker use (TDR §11).
+  const { animated } = useMotion();
   const [open, setOpen] = useState(false);
 
   const current = LANGUAGE_NAMES[language].own;
@@ -71,7 +75,12 @@ export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-
         </Text>
       ) : null}
 
-      <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+      <Modal
+        visible={open}
+        transparent
+        animationType={animated ? 'fade' : 'none'}
+        onRequestClose={() => setOpen(false)}
+      >
         {/* Backdrop closes; the card swallows its own taps so a miss inside the
             menu does not dismiss it. */}
         <Pressable


### PR DESCRIPTION
Two mechanical fixes from the **login** audit (`AuthFlow` + `LanguagePicker`). Mobile-only.

## Touch target
The corner **Back** on the sign-up hero was `size="sm"` = **38pt**, under the 44 floor — and its mirror control (the language picker) is a proper 44. `Button` forwards `hitSlop` (extends `PressableProps`), so `hitSlop={8}` grows the target to ~54 without changing the visible pill.

## Reduced motion
`LanguagePicker`'s menu used `animationType="fade"` unconditionally. Now gated behind `useMotion()` → `'none'` under reduced motion, matching `OverflowMenu` and the voice picker (#312). TDR §11 treats reduce-motion as an input, not a hint.

Provider/phone/email buttons (56/48pt), the picker trigger + rows (44pt), and the password show/hide (`hitSlop=12`) were already in spec. Fields carry labels + `autoComplete`.

Gates: prettier ✓, tsc ✓, eslint ✓.

> Separate PR incoming for the front-door wordmark (`பாக்கி` → `Waves`) — a brand change across splash/onboarding/login, kept out of this a11y PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enlarged the sign-up welcome screen’s back button touch target without changing its appearance.
  * Improved support for reduced-motion preferences in the language picker.

* **User Experience**
  * The language picker modal now opens instantly when reduced motion is enabled and animates normally otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->