### PR TITLE
fix(mobile): front-door wordmark to Waves (was பாக்கி)

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -289,7 +289,7 @@ function LockGate({ children }: { children: React.ReactNode }) {
           <Text
             style={{ fontSize: 56, lineHeight: 72, fontWeight: '700', color: theme.color.onBrand }}
           >
-            பாக்கி
+            Waves
           </Text>
           <Ionicons name="lock-closed" size={iconSize.xl} color={theme.color.onBrand} />
         </View>

--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -206,7 +206,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                 color: theme.color.onBrand,
               }}
             >
-              பாக்கி
+              Waves
             </Text>
             <Text variant="caption" tone="onBrand" align="center">
               {isSignup ? t.signIn.splitAnything.replace('\n', ' ') : t.signIn.tagline}
@@ -392,7 +392,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                   color: theme.color.onBrand,
                 }}
               >
-                பாக்கி
+                Waves
               </Text>
               <Text variant="caption" tone="onBrand" align="center">
                 {isGuest

--- a/apps/mobile/src/components/Onboarding.tsx
+++ b/apps/mobile/src/components/Onboarding.tsx
@@ -132,7 +132,7 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
             }}
           >
             <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-              <Text style={{ fontSize: 20, fontWeight: '700', color: ink }}>பாக்கி</Text>
+              <Text style={{ fontSize: 20, fontWeight: '700', color: ink }}>Waves</Text>
               <Pressable
                 onPress={onDone}
                 accessibilityRole="button"


### PR DESCRIPTION
Surfaced in the **login** audit: the hero wordmark is a hardcoded `பாக்கி` — the **old** name (baaki), and not locale-aware, so every user in every language sees Tamil script. On the login screen it sits directly above the English tagline **"Waves · what is left over"** — two names on one screen. The footer/version already read "Waves".

## Fix
A wordmark is the brand's name, not translated copy, so it reads **"Waves"** in one script for everyone. Four render sites, text-only:
- `app/_layout.tsx` (splash), `AuthFlow.tsx` ×2 (welcome + form hero), `Onboarding.tsx`.

Type sizing (56/34/20pt) carries the Latin word without change. The `baaki.onboarding_seen` storage key is left alone — renaming it would re-trigger the tour for existing users.

## Out of scope
The ta/hi/ar **taglines** still carry the old name in their own scripts (`பாக்கி`/`बाकी`/`باقي`) — that's the wider native-script rebrand content sweep, tracked separately, not the wordmark.

Gates: prettier ✓, tsc ✓, eslint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the mobile app’s branding text to “Waves” across the lock screen, authentication screens, and onboarding experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->