### PR TITLE
fix(mobile): account verification code autofill + link-button touch target

### DIFF
--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -347,6 +347,11 @@ function AccountForm() {
                   editable={!busy}
                   keyboardType="number-pad"
                   maxLength={6}
+                  // The code has just arrived by SMS or email — let the OS offer
+                  // the one-tap fill rather than making it be retyped by hand.
+                  // `sms-otp` is Android's autofill hint; `oneTimeCode` is iOS's.
+                  autoComplete="sms-otp"
+                  textContentType="oneTimeCode"
                   accessibilityLabel={t.contact.verificationCode}
                   placeholder="123456"
                   placeholderTextColor={theme.color.textFaint}
@@ -458,7 +463,16 @@ function ProviderRow({
       {linked ? (
         <Badge label={linkedLabel} tone="positive" />
       ) : (
-        <Button label={linkLabel} size="sm" variant="secondary" disabled={busy} onPress={onLink} />
+        <Button
+          label={linkLabel}
+          size="sm"
+          variant="secondary"
+          disabled={busy}
+          // 38pt on its own — hitSlop lifts the target over the 44 floor
+          // without enlarging the small trailing pill.
+          hitSlop={8}
+          onPress={onLink}
+        />
       )}
     </Row>
   );


### PR DESCRIPTION
Two fixes from the **account / contact** screen audit (`settings/account.tsx`). Mobile-only, one file.

## Autofill
The verification-code field had `number-pad` + `maxLength=6` + a label, but **no autofill hint** — so a code that just arrived by SMS/email had to be retyped by hand. The sign-in OTP field already does this (`autoComplete="sms-otp"`); this one was missed. Added `autoComplete="sms-otp"` (Android) + `textContentType="oneTimeCode"` (iOS) so the OS offers one-tap fill.

## Touch target
`ProviderRow`'s **Link** button (Google/Apple) was `size="sm"` = **38pt**, under 44. `hitSlop={8}` lifts the target over the floor without enlarging the trailing pill — same fix as the login Back button (#314).

Already in spec: Back `IconButton` (44), Send/Confirm (`lg` 56), all fields labeled with `autoComplete`, both `SectionHeader`s now announce as headings (#313), channel/country switches guarded mid-request.

Gates: prettier ✓, tsc ✓, eslint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Verification-code fields now support automatic OTP suggestions on Android and iOS.
  * Provider-link buttons are easier to tap while preserving their existing appearance and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->