### PR TITLE
fix(mobile): lock-screen version label to Waves (was Baaki)

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -320,7 +320,7 @@ function LockGate({ children }: { children: React.ReactNode }) {
         align="center"
         style={{ paddingBottom: theme.spacing.xxxl }}
       >
-        Baaki {Constants.expoConfig?.version ?? ''}
+        Waves {Constants.expoConfig?.version ?? ''}
       </Text>
     </View>
   );


### PR DESCRIPTION
Follow-up to the wordmark rebrand (#315). Review flagged a remaining "Baaki" on the lock screen.

The hero glyph was changed in #315 but the **version label at the foot of the lock screen** (`_layout.tsx`) still read `Baaki {version}`. The sign-in screen already shows `Waves {version}` — this matches it. The `baaki.onboarding_seen` storage key is left untouched (renaming it would re-trigger the tour).

## On the other two review comments (not applied)
The eslint `@/` import-resolver findings on `LanguagePicker.tsx` and `voice.tsx` are **not valid**: eslint runs clean on both files (`import/no-unresolved` does not fire), and the `@/*` alias already resolves repo-wide — every app file uses it. No resolver change is needed; adding one would be a fix for a non-existent failure.

Gates: prettier ✓, tsc ✓, eslint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the lock screen footer branding from “Baaki” to “Waves.”
  * The app version remains visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->