### PR TITLE
refactor(mobile): wordmark from i18n (t.common.appName)

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -289,7 +289,7 @@ function LockGate({ children }: { children: React.ReactNode }) {
           <Text
             style={{ fontSize: 56, lineHeight: 72, fontWeight: '700', color: theme.color.onBrand }}
           >
-            Waves
+            {t.common.appName}
           </Text>
           <Ionicons name="lock-closed" size={iconSize.xl} color={theme.color.onBrand} />
         </View>
@@ -320,7 +320,7 @@ function LockGate({ children }: { children: React.ReactNode }) {
         align="center"
         style={{ paddingBottom: theme.spacing.xxxl }}
       >
-        Baaki {Constants.expoConfig?.version ?? ''}
+        {t.common.appName} {Constants.expoConfig?.version ?? ''}
       </Text>
     </View>
   );

--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -206,7 +206,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                 color: theme.color.onBrand,
               }}
             >
-              Waves
+              {t.common.appName}
             </Text>
             <Text variant="caption" tone="onBrand" align="center">
               {isSignup ? t.signIn.splitAnything.replace('\n', ' ') : t.signIn.tagline}
@@ -359,7 +359,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
               align="center"
               style={{ paddingTop: theme.spacing.xs }}
             >
-              Waves {Constants.expoConfig?.version ?? ''}
+              {t.common.appName} {Constants.expoConfig?.version ?? ''}
             </Text>
           </View>
         </ScrollView>
@@ -395,7 +395,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                   color: theme.color.onBrand,
                 }}
               >
-                Waves
+                {t.common.appName}
               </Text>
               <Text variant="caption" tone="onBrand" align="center">
                 {isGuest

--- a/apps/mobile/src/components/Onboarding.tsx
+++ b/apps/mobile/src/components/Onboarding.tsx
@@ -132,7 +132,9 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
             }}
           >
             <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-              <Text style={{ fontSize: 20, fontWeight: '700', color: ink }}>Waves</Text>
+              <Text style={{ fontSize: 20, fontWeight: '700', color: ink }}>
+                {t.common.appName}
+              </Text>
               <Pressable
                 onPress={onDone}
                 accessibilityRole="button"

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -343,6 +343,8 @@ export interface UiStrings {
    * labels, and sharing it is how translations go subtly wrong.
    */
   common: {
+    /** The app's name — a wordmark, the same in every locale (not translated). */
+    appName: string;
     back: string;
     /** Generic 'Loading…' — the spoken label a skeleton screen carries. */
     loading: string;
@@ -1747,6 +1749,7 @@ const en: UiStrings = {
   language: 'Language',
   upgrade: 'Upgrade',
   common: {
+    appName: 'Waves',
     back: 'Back',
     loading: 'Loading…',
     close: 'Close',
@@ -3206,6 +3209,7 @@ const ta: UiStrings = {
   language: 'மொழி',
   upgrade: 'மேம்படுத்தல்',
   common: {
+    appName: 'Waves',
     back: 'பின்',
     loading: 'ஏற்றுகிறது…',
     close: 'மூடு',
@@ -4713,6 +4717,7 @@ const hi: UiStrings = {
   language: 'भाषा',
   upgrade: 'अपग्रेड',
   common: {
+    appName: 'Waves',
     back: 'वापस',
     loading: 'लोड हो रहा है…',
     close: 'बंद करें',
@@ -6181,6 +6186,7 @@ const ar: UiStrings = {
   language: 'اللغة',
   upgrade: 'الترقية',
   common: {
+    appName: 'Waves',
     back: 'رجوع',
     loading: 'جارٍ التحميل…',
     close: 'إغلاق',


### PR DESCRIPTION
The brand name was hardcoded — `"Waves"` across the splash, onboarding, login and sign-up heroes plus two `{version}` footers, and the lock-screen footer was *still* `"Baaki"`. That drift is exactly what a single source of truth prevents.

## Change
- Added `common.appName` = `'Waves'` to the type interface + all four locales (same value everywhere — a wordmark is not translated; tsc enforces the key across locales).
- Pointed all **six** render sites at `t.common.appName`: `_layout.tsx` (hero + version footer), `AuthFlow.tsx` (welcome hero, form hero, version footer), `Onboarding.tsx` (header).

The next rename is one string.

**Supersedes #317** (which patched only the lock-screen footer) — please close it in favor of this. The `baaki.onboarding_seen` storage key is untouched.

Gates: prettier ✓, tsc ✓ (locale key parity), eslint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized application name support across the mobile app.
  - The app name now appears consistently in the lock screen, authentication flow, and onboarding screens.
  - Added translations for English, Tamil, Hindi, and Arabic locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->