### PR TITLE
fix(mobile): inbox header matches Activity (glyph + big title, keeps back chevron)

### DIFF
--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -129,11 +129,11 @@ export default function InboxScreen() {
           />
         }
       >
-        {/* The app's standard pushed-screen header — back chevron, centred
-            title, a matching spacer — the same one Settings, Privacy and
-            Feedback wear, so this screen reads as one of them rather than a
-            bespoke page. */}
-        <Row style={{ paddingTop: theme.spacing.md }}>
+        {/* Back chevron because you drilled in here from the Activity bell,
+            then the same glyph-plus-big-title mark the Activity feed wears — the
+            two screens sit together, so the inbox reads as the sibling it is
+            rather than a generic settings page. */}
+        <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center', gap: theme.spacing.sm }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
             <Ionicons
               name={directionalIcon('chevron-back')}
@@ -141,10 +141,8 @@ export default function InboxScreen() {
               color={theme.color.text}
             />
           </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.inbox.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
+          <Ionicons name="notifications-outline" size={iconSize.xl} color={theme.color.brand} />
+          <Text variant="title">{t.inbox.title}</Text>
         </Row>
 
         {/* A capture with no group yet is something waiting for you, so it


### PR DESCRIPTION
## What

Inbox screen wore the generic pushed-screen header (back chevron + centred `heading` + 44pt spacer — same as Settings / Privacy / Contact). But the inbox is opened from the Activity feed's bell and sits directly beside it, so beside its sibling the two read as unrelated screens.

New header is a hybrid:
- **Keeps** the back chevron — you drilled in here from Activity.
- **Drops** the centred heading + spacer for Activity's own mark: `notifications-outline` glyph in brand + left-aligned `variant="title"`.

Before → after:
```
[‹]        Inbox            [  ]     (was: centred heading, generic)
[‹] 🔔 Inbox                        (now: glyph + big title, like Activity)
```

## Why

The feed and the inbox are a pair (feed = what happened in groups; inbox = what Waves told you). They should look like a pair.

## Scope

One file, `apps/mobile/src/app/inbox.tsx`, header block only. No behaviour change. tsc + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the inbox header layout with a left-aligned back button, notification icon, and larger title.
  * Replaced the previous centered header presentation with a more streamlined design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->