### PR TITLE
feat(mobile): redesign the group-not-found screen

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -246,8 +246,11 @@ export default function GroupScreen() {
       <Screen edges={['top', 'bottom']}>
         <View style={{ flex: 1, paddingHorizontal: theme.spacing.xl }}>
           <Row style={{ paddingTop: theme.spacing.md }}>
+            {/* Never a dead control: a cold open from a notification or a stale
+                invite link has no history to pop, so the chevron falls back to
+                home rather than silently doing nothing. */}
             <Pressable
-              onPress={() => router.back()}
+              onPress={() => (router.canGoBack() ? router.back() : router.replace('/'))}
               accessibilityRole="button"
               accessibilityLabel={t.common.back}
               hitSlop={10}
@@ -294,9 +297,12 @@ export default function GroupScreen() {
             </Text>
           </View>
 
+          {/* The reliable way out. This state is most often reached by following
+              a link to a group that has gone, where there is no back stack — so
+              the primary action goes home for certain, the way join.tsx does. */}
           <Button
-            label={t.common.back}
-            onPress={() => router.back()}
+            label={t.misc.goToBaaki}
+            onPress={() => router.replace('/')}
             fullWidth
             style={{ marginBottom: theme.spacing.xl }}
           />

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -236,13 +236,71 @@ export default function GroupScreen() {
   }
 
   if (group.isError || !group.data) {
+    // A group can vanish for ordinary reasons — archived, left, a link that has
+    // gone stale — so this is a place to step back from, not a crash. It wears
+    // the shape the category's own not-found screens use: an escape at the top,
+    // a soft-tinted tile so the state looks like the app rather than a failure,
+    // and the one way out as a full-width bar under the thumb rather than a pill
+    // adrift in the middle of the page.
     return (
-      <Screen>
-        <EmptyState
-          title={t.group.notFound}
-          body={t.group.notFoundBody}
-          action={<Button label={t.common.back} onPress={() => router.back()} />}
-        />
+      <Screen edges={['top', 'bottom']}>
+        <View style={{ flex: 1, paddingHorizontal: theme.spacing.xl }}>
+          <Row style={{ paddingTop: theme.spacing.md }}>
+            <Pressable
+              onPress={() => router.back()}
+              accessibilityRole="button"
+              accessibilityLabel={t.common.back}
+              hitSlop={10}
+            >
+              <Ionicons
+                name={directionalIcon('chevron-back')}
+                size={iconSize.xxl}
+                color={theme.color.text}
+              />
+            </Pressable>
+          </Row>
+
+          <View
+            style={{
+              flex: 1,
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: theme.spacing.md,
+            }}
+          >
+            {/* Decorative: the title carries the meaning. A tile the size of a
+                group cover, in the soft brand tint the app uses for its empty
+                states. */}
+            <View
+              accessibilityElementsHidden
+              importantForAccessibility="no"
+              style={{
+                width: 96,
+                height: 96,
+                borderRadius: theme.radius.xl,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.color.brandSoft,
+                marginBottom: theme.spacing.sm,
+              }}
+            >
+              <Ionicons name="compass-outline" size={48} color={theme.color.brand} />
+            </View>
+            <Text variant="title" align="center" accessibilityRole="header">
+              {t.group.notFound}
+            </Text>
+            <Text variant="body" tone="muted" align="center">
+              {t.group.notFoundBody}
+            </Text>
+          </View>
+
+          <Button
+            label={t.common.back}
+            onPress={() => router.back()}
+            fullWidth
+            style={{ marginBottom: theme.spacing.xl }}
+          />
+        </View>
       </Screen>
     );
   }


### PR DESCRIPTION
## What

The group-detail screen's **not-found** state (`group.isError || !group.data`) was a bare centred `EmptyState` with a pill floating mid-screen — it read more like a crash than a place you can leave.

Redesigned it, Mobbin-informed (KOHO "Unable to accept invitation", MS Teams "couldn't find a meeting", Tonal "Not Found" all share the shape):

- **Escape chevron** top-left — a group going missing (archived / left / stale link) is a screen you step back from, not a dead end.
- **Soft-tinted cover-sized tile** (96pt, `brandSoft`, `compass-outline`) — the state looks like the app, not a failure. Same tint idiom as the app's other empty states.
- **Bold title + muted body**, centred.
- **Full-width CTA bar at the foot** (`fullWidth`, above the safe-area), thumb-reachable — replaces the mid-screen pill.

## Before → after

```
     [ small icon ]                 [‹]
     Group not found                       ⌷ 96pt tinted tile (compass)
     body text                          Group not found
     ( Back )  ← pill, mid-screen        body text

                                     [      Back      ]  ← full-width, foot
```

## Notes

- **No new strings** — reuses `t.group.notFound`, `notFoundBody`, `common.back`.
- a11y: tile decorative + hidden; title carries `header` role; back control labelled.
- `Screen edges={['top','bottom']}` so the foot bar clears the home indicator.
- tsc + eslint + prettier clean.
- Touches the same file as #320 (group feed) but a **different region** (early-return block) — no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned the missing or unavailable group screen with a full-screen layout.
  * Added branded visual treatment, clearer not-found messaging, and improved spacing.
  * Added a back arrow and full-width navigation button.

* **Bug Fixes**
  * Improved navigation from missing group pages by returning to the previous screen when possible, or safely redirecting to Home.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->