### PR TITLE
feat(mobile): drop the "Your groups" heading on the dashboard

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -26,7 +26,6 @@ import {
   iconSize,
   Row,
   Screen,
-  SectionHeader,
   Skeleton,
   Text,
   useTabBarClearance,
@@ -375,9 +374,6 @@ export default function HomeScreen() {
           />
         ) : (
           <View>
-            {/* No action here anymore — "new group" lives in the top toolbar
-                next to the camera, so the title row never crowds or clips. */}
-            <SectionHeader title={t.yourGroups} />
             {presentTypes.length > 1 ? (
               <CategoryStrip types={presentTypes} active={active} onSelect={setCategory} t={t} />
             ) : null}


### PR DESCRIPTION
The group list is the bulk of the dashboard and already reads as the groups — the "Your groups" heading only added a row of chrome above cards that say what they are. Remove the `SectionHeader` and its now-unused import; the category strip and list follow directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the unused “Your groups” section header from the group list for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->