### PR TITLE
fix(mobile): compact, consistent add-FAB on dashboard and group

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -461,7 +461,7 @@ function AddExpenseFab({ label, bottom }: { label: string; bottom: number }) {
             ...theme.shadow.lifted,
           }}
         >
-          <Ionicons name="add" size={32} color={theme.color.onBrand} />
+          <Ionicons name="add" size={iconSize.xxl} color={theme.color.onBrand} />
         </PressableScale>
       </View>
     </View>

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -437,7 +437,7 @@ export default function HomeScreen() {
  */
 function AddExpenseFab({ label, bottom }: { label: string; bottom: number }) {
   const theme = useTheme();
-  const size = 60;
+  const size = 52;
   return (
     <View
       pointerEvents="box-none"
@@ -461,7 +461,7 @@ function AddExpenseFab({ label, bottom }: { label: string; bottom: number }) {
             ...theme.shadow.lifted,
           }}
         >
-          <Ionicons name="add" size={iconSize.xxl} color={theme.color.onBrand} />
+          <Ionicons name="add" size={iconSize.lg} color={theme.color.onBrand} />
         </PressableScale>
       </View>
     </View>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -985,7 +985,7 @@ export default function GroupScreen() {
           <Fab
             label={t.addExpense}
             onPress={() => router.push(`/group/${groupId}/add-expense`)}
-            icon={<Ionicons name="add" size={iconSize.xl} color={theme.color.onBrand} />}
+            icon={<Ionicons name="add" size={iconSize.lg} color={theme.color.onBrand} />}
           />
         )}
       </DetailEnter>

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -163,6 +163,12 @@ export function IconButton({
   );
 }
 
+/**
+ * A round icon-only floating action button. `label` is not drawn — it is the
+ * accessibility name, so the control still announces what it does. The circle
+ * matches the dashboard's add button (52pt) so the two primary "+" controls
+ * read as the same affordance across screens.
+ */
 export function Fab({
   onPress,
   label,
@@ -173,6 +179,7 @@ export function Fab({
   icon: ReactNode;
 }) {
   const theme = useTheme();
+  const size = 52;
   return (
     <Pressable
       accessibilityRole="button"
@@ -183,21 +190,17 @@ export function Fab({
           position: 'absolute',
           right: theme.spacing.xl,
           bottom: 108,
-          height: 56,
-          paddingHorizontal: theme.spacing.xl,
-          borderRadius: theme.radius.pill,
-          flexDirection: 'row',
+          width: size,
+          height: size,
+          borderRadius: size / 2,
           alignItems: 'center',
-          gap: theme.spacing.sm,
+          justifyContent: 'center',
           backgroundColor: pressed ? theme.color.brandPressed : theme.color.brand,
         },
         theme.shadow.lifted,
       ]}
     >
       {icon}
-      <Text variant="subheading" tone="onBrand">
-        {label}
-      </Text>
     </Pressable>
   );
 }


### PR DESCRIPTION
Make the two primary "+" add buttons compact and consistent.

- **Dashboard FAB**: circle 60→52pt, glyph 32→20pt (`iconSize.lg`) — the earlier "+" was oversized in its circle.
- **Group FAB**: was an extended pill with an "Add expense" label; now a round 52pt "+" matching the dashboard. Label lives on as the accessibility name, so it still announces "Add expense".

Only the group screen uses the shared `Fab`, so no other caller is affected. Both circles clear the 44pt minimum touch target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Reduced the Add Expense floating action button and icon sizes for a more compact, consistent appearance.
  - Updated the floating action button to use a circular 52×52 layout with centered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->