### PR TITLE
fix(mobile): hide the bottom bar on the sign-up screen

### DIFF
--- a/apps/mobile/src/lib/tabBar.ts
+++ b/apps/mobile/src/lib/tabBar.ts
@@ -14,6 +14,7 @@
  */
 export const TAB_BAR_HIDDEN_ROUTES: ReadonlySet<string> = new Set([
   'sign-in',
+  'sign-up',
   'join',
   'capture',
   'new-group',

--- a/apps/mobile/test/tabBar.test.ts
+++ b/apps/mobile/test/tabBar.test.ts
@@ -34,6 +34,7 @@ describe('resolveTabBar', () => {
   it('hides on the full-screen camera and the signed-out screens', () => {
     expect(resolveTabBar(['capture']).hidden).toBe(true);
     expect(resolveTabBar(['sign-in']).hidden).toBe(true);
+    expect(resolveTabBar(['sign-up']).hidden).toBe(true);
     expect(resolveTabBar(['join']).hidden).toBe(true);
     expect(resolveTabBar(['new-group']).hidden).toBe(true);
   });


### PR DESCRIPTION
The root bottom bar hid itself on `sign-in` but not on `sign-up`, so the create-account / guest page reached from the login screen showed the app's tab bar over a signed-out screen. Add `sign-up` to `TAB_BAR_HIDDEN_ROUTES` alongside `sign-in`, with a matching assertion in the tabBar test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden the mobile tab bar on the sign-up screen for a cleaner onboarding experience.

* **Tests**
  * Added coverage to verify the tab bar remains hidden during sign-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->