### PR TITLE
fix(mobile): address CodeRabbit warnings in tour and country picker

### DIFF
--- a/apps/mobile/src/components/CountryCodePicker.tsx
+++ b/apps/mobile/src/components/CountryCodePicker.tsx
@@ -13,7 +13,7 @@
  * guess back from the code.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
 
@@ -56,11 +56,19 @@ export function CountryCodePicker({
   useEffect(() => {
     if (disabledCache) return;
     let cancelled = false;
-    void disabledCountries().then((codes) => {
-      const set = new Set(codes.map((entry) => entry.toUpperCase()));
-      disabledCache = set;
-      if (!cancelled) setDisabled(set);
-    });
+    void disabledCountries()
+      .then((codes) => {
+        const set = new Set(codes.map((entry) => entry.toUpperCase()));
+        disabledCache = set;
+        if (!cancelled) setDisabled(set);
+      })
+      .catch(() => {
+        // A failure or an offline phone leaves the set empty, so every market
+        // stays offered rather than none — and the void call cannot reject
+        // unhandled.
+        disabledCache = new Set();
+        if (!cancelled) setDisabled(new Set());
+      });
     return () => {
       cancelled = true;
     };
@@ -73,15 +81,23 @@ export function CountryCodePicker({
     [disabled],
   );
 
+  // Held in a ref so an inline `onChange` (a fresh identity each parent render)
+  // does not re-fire the correction effect below every render — which, while
+  // the guessed country stays switched off, would loop.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
   // If the guessed country turns out to be switched off, move the selection to
   // the first market that is still offered — otherwise the chip would show a
   // dial code the list will not let the person change.
   useEffect(() => {
     if (available.length === 0) return;
     if (!available.some((country) => country.code === code)) {
-      onChange(available[0].code);
+      onChangeRef.current(available[0].code);
     }
-  }, [available, code, onChange]);
+  }, [available, code]);
 
   const results = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/apps/mobile/src/lib/tour.tsx
+++ b/apps/mobile/src/lib/tour.tsx
@@ -171,15 +171,16 @@ export function TourProvider({ children }: { children: ReactNode }) {
   }, [remember]);
 
   const next = useCallback(() => {
-    setStep((current) => {
-      if (current >= TOUR_STEPS.length - 1) {
-        setActive(false);
-        remember();
-        return current;
-      }
-      return current + 1;
-    });
-  }, [remember]);
+    // Decide the terminal step before touching state so the setStep updater
+    // stays pure — no setActive/remember side effects inside it, which React
+    // may run more than once.
+    if (step >= TOUR_STEPS.length - 1) {
+      setActive(false);
+      remember();
+      return;
+    }
+    setStep((current) => Math.min(current + 1, TOUR_STEPS.length - 1));
+  }, [step, remember]);
 
   const prev = useCallback(() => setStep((current) => Math.max(0, current - 1)), []);
 


### PR DESCRIPTION
Addresses the CodeRabbit warning-level findings from the review of the auth/splash/paywall branch.

## Fixed

- **tour**: `next()` computed the terminal-step decision *inside* the `setStep` updater and ran `setActive(false)` / `remember()` there. State updaters must be pure — React (and the React Compiler) may run them more than once. The decision now happens before `setStep`, with the side effects outside it.
- **CountryCodePicker**: the `void disabledCountries()` fetch had no rejection handler, so a failure produced an unhandled promise rejection. It now catches and falls back to an empty denylist (every market offered), matching the documented intent.
- **CountryCodePicker**: the country-correction effect depended on `onChange`. With an inline `onChange` (a new identity each parent render) it re-fired every render, and could loop while the guessed country stayed disabled. `onChange` is now held in a ref and dropped from the deps.

## Skipped (with reason)

- **brand/token contrast recolor** — white-on-green is the established gateway aesthetic; a global brand recolor is a design decision, not a code defect.
- **restore Apple sign-in** — Apple was deliberately removed earlier; not reversing it.
- **guest gating on phone/verify-email** — no flow routes a live session onto those screens; upgrade happens in-app via `updateUser`/`linkIdentity`. The redirect is the intended guard.
- **PasswordOutcome verifyPhone** — no UI path performs a phone+password signUp (phone entry is OTP-only); `verifyEmail` already covers the confirm-needed case.
- **country_settings GRANT SELECT** — reads rely on Supabase's default table grants (feature works in prod, CI RLS check passes); an explicit grant would need a new migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved country code selection reliability when disabled-country data cannot be loaded.
  * Prevented unintended repeated fallback selections during component updates.
  * Completing the final tour step now immediately exits the tour and records it as completed.
  * Preserved safe step progression for non-final tour steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->