### PR TITLE
chore(mcp): add project-scoped Supabase MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--read-only",
+        "--project-ref=xvjzbpgcmotoahtqcxve"
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a committed `.mcp.json` so everyone on the repo gets the Supabase MCP server, pointed at the prod project (`xvjzbpgcmotoahtqcxve`).

## What
- `.mcp.json` at repo root declaring one server, `supabase`, run via `npx @supabase/mcp-server-supabase@latest`.

## Safety
- **`--read-only`** — the server may query and inspect, never mutate the database. A shared config cannot be used to write to prod.
- **No secret committed** — `SUPABASE_ACCESS_TOKEN` is read from the environment via `${SUPABASE_ACCESS_TOKEN}`. Each person supplies their own Supabase personal access token (`sbp_...`).

## Using it
Set a personal access token in your environment before starting Claude Code:
\`\`\`
export SUPABASE_ACCESS_TOKEN=sbp_xxx   # PowerShell: $env:SUPABASE_ACCESS_TOKEN='sbp_xxx'
\`\`\`
Claude Code will prompt to approve the project MCP server on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added read-only database integration configuration for development and inspection workflows.
  * Uses environment-based authentication to help keep access credentials secure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->