### PR TITLE
feat(agent-mcp): MCP server for agent actions as a signed-in user

### DIFF
--- a/apps/agent-mcp/README.md
+++ b/apps/agent-mcp/README.md
@@ -1,0 +1,96 @@
+# @waves/agent-mcp
+
+An MCP server that lets an AI agent act **inside Waves as a specific signed-in
+user** — list groups, add expenses, and record settlements — through the app's
+own authorized RPCs and edge functions. It never runs raw SQL and never moves
+money.
+
+## Why this instead of a database MCP
+
+A generic Supabase/Postgres MCP talks raw SQL with a management or service
+token. That bypasses Row-Level Security **and** the app's RPC boundary
+(ADR-013, #274), so it can write malformed ledger rows that skip split maths and
+integrity checks. This server does the opposite: it authenticates as a real user
+(their Supabase session) and calls the exact operations the mobile app calls, so
+RLS and the business rules apply to the agent identically to the human.
+
+## Safety model
+
+- **Acts as one user.** Built with the public anon key + the user's JWT — same
+  as `apps/mobile/src/lib/supabase.ts`. No service-role key is read. The agent
+  can do what that person can do, nothing more.
+- **No raw SQL.** There is no query tool. Every write is one named, validated
+  operation.
+- **No money movement.** `record_settlement` writes a settlement row (status
+  `initiated`); the actual transfer is a UPI/PayPal handoff link (`payment_link`)
+  a human opens and confirms in their own bank app.
+- **Read-only switch.** `WAVES_MCP_READONLY=1` registers only the read tools.
+
+## Tools
+
+| Tool | Kind | Path |
+| --- | --- | --- |
+| `whoami` | read | `auth.getUser` |
+| `list_groups` | read | `groups` (RLS) |
+| `list_members` | read | `group_members` (RLS) |
+| `get_balances` | read | `group_balances` (RLS) |
+| `create_group` | write | `rpc('baaki_create_group')` |
+| `add_expense` | write | `functions.invoke('expense-write')` → recomputes split, then `baaki_apply_expense` |
+| `record_settlement` | write | `rpc('baaki_record_settlement')` — records only |
+| `payment_link` | pure | builds a `upi://` or `paypal.me` link |
+
+All amounts are **integer minor units** (paise/cents) as strings — money is
+never a float.
+
+## Configuration
+
+The server needs the user's Supabase session (get it from a signed-in device or
+a login flow):
+
+| Env var | Required | Notes |
+| --- | --- | --- |
+| `WAVES_SUPABASE_URL` | yes | falls back to `EXPO_PUBLIC_SUPABASE_URL` |
+| `WAVES_SUPABASE_ANON_KEY` | yes | falls back to `EXPO_PUBLIC_SUPABASE_ANON_KEY` |
+| `WAVES_SUPABASE_ACCESS_TOKEN` | yes | the user's JWT |
+| `WAVES_SUPABASE_REFRESH_TOKEN` | no | supply it so long sessions auto-refresh |
+| `WAVES_MCP_READONLY` | no | `1` to expose read tools only |
+
+## Run
+
+```bash
+pnpm --filter @waves/agent-mcp build
+node apps/agent-mcp/dist/index.js
+# or, without building:
+pnpm --filter @waves/agent-mcp dev
+```
+
+MCP host config (stdio):
+
+```json
+{
+  "mcpServers": {
+    "waves-agent": {
+      "command": "node",
+      "args": ["apps/agent-mcp/dist/index.js"],
+      "env": {
+        "WAVES_SUPABASE_URL": "https://<ref>.supabase.co",
+        "WAVES_SUPABASE_ANON_KEY": "<anon key>",
+        "WAVES_SUPABASE_ACCESS_TOKEN": "<user jwt>",
+        "WAVES_SUPABASE_REFRESH_TOKEN": "<user refresh token>"
+      }
+    }
+  }
+}
+```
+
+Inspect it locally:
+
+```bash
+npx @modelcontextprotocol/inspector node apps/agent-mcp/dist/index.js
+```
+
+## Status
+
+First cut. Not yet wired into CI, and the write tools have been type-checked but
+not run end-to-end against a live project. Verify against a throwaway group
+before pointing it at anything real.

--- a/apps/agent-mcp/README.md
+++ b/apps/agent-mcp/README.md
@@ -28,16 +28,16 @@ RLS and the business rules apply to the agent identically to the human.
 
 ## Tools
 
-| Tool | Kind | Path |
-| --- | --- | --- |
-| `whoami` | read | `auth.getUser` |
-| `list_groups` | read | `groups` (RLS) |
-| `list_members` | read | `group_members` (RLS) |
-| `get_balances` | read | `group_balances` (RLS) |
-| `create_group` | write | `rpc('baaki_create_group')` |
-| `add_expense` | write | `functions.invoke('expense-write')` → recomputes split, then `baaki_apply_expense` |
-| `record_settlement` | write | `rpc('baaki_record_settlement')` — records only |
-| `payment_link` | pure | builds a `upi://` or `paypal.me` link |
+| Tool                | Kind  | Path                                                                               |
+| ------------------- | ----- | ---------------------------------------------------------------------------------- |
+| `whoami`            | read  | `auth.getUser`                                                                     |
+| `list_groups`       | read  | `groups` (RLS)                                                                     |
+| `list_members`      | read  | `group_members` (RLS)                                                              |
+| `get_balances`      | read  | `group_balances` (RLS)                                                             |
+| `create_group`      | write | `rpc('baaki_create_group')`                                                        |
+| `add_expense`       | write | `functions.invoke('expense-write')` → recomputes split, then `baaki_apply_expense` |
+| `record_settlement` | write | `rpc('baaki_record_settlement')` — records only                                    |
+| `payment_link`      | pure  | builds a `upi://` or `paypal.me` link                                              |
 
 All amounts are **integer minor units** (paise/cents) as strings — money is
 never a float.
@@ -47,13 +47,13 @@ never a float.
 The server needs the user's Supabase session (get it from a signed-in device or
 a login flow):
 
-| Env var | Required | Notes |
-| --- | --- | --- |
-| `WAVES_SUPABASE_URL` | yes | falls back to `EXPO_PUBLIC_SUPABASE_URL` |
-| `WAVES_SUPABASE_ANON_KEY` | yes | falls back to `EXPO_PUBLIC_SUPABASE_ANON_KEY` |
-| `WAVES_SUPABASE_ACCESS_TOKEN` | yes | the user's JWT |
-| `WAVES_SUPABASE_REFRESH_TOKEN` | no | supply it so long sessions auto-refresh |
-| `WAVES_MCP_READONLY` | no | `1` to expose read tools only |
+| Env var                        | Required | Notes                                         |
+| ------------------------------ | -------- | --------------------------------------------- |
+| `WAVES_SUPABASE_URL`           | yes      | falls back to `EXPO_PUBLIC_SUPABASE_URL`      |
+| `WAVES_SUPABASE_ANON_KEY`      | yes      | falls back to `EXPO_PUBLIC_SUPABASE_ANON_KEY` |
+| `WAVES_SUPABASE_ACCESS_TOKEN`  | yes      | the user's JWT                                |
+| `WAVES_SUPABASE_REFRESH_TOKEN` | no       | supply it so long sessions auto-refresh       |
+| `WAVES_MCP_READONLY`           | no       | `1` to expose read tools only                 |
 
 ## Run
 

--- a/apps/agent-mcp/package.json
+++ b/apps/agent-mcp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@waves/agent-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "An MCP server that lets an AI agent act inside Waves as a specific signed-in user — create groups, add expenses, and record settlements through the app's own authorized RPCs and edge functions, never raw SQL.",
+  "bin": {
+    "waves-agent-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@supabase/supabase-js": "^2.45.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/apps/agent-mcp/src/index.ts
+++ b/apps/agent-mcp/src/index.ts
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+/**
+ * Waves agent MCP server.
+ *
+ * Exposes the app's *operations* — not the database — as MCP tools, so an AI
+ * agent can create a group, add an expense, and record a settlement on behalf
+ * of a signed-in person. Every write goes through the same authorized path the
+ * mobile app uses:
+ *
+ *   - create_group      → rpc('baaki_create_group')          (user JWT)
+ *   - add_expense        → functions.invoke('expense-write')  (user JWT; the
+ *                          edge function recomputes the split and calls the
+ *                          service-role-only baaki_apply_expense for us — #274)
+ *   - record_settlement  → rpc('baaki_record_settlement')     (user JWT)
+ *
+ * Two things this server deliberately does NOT do:
+ *   - It never runs raw SQL. There is no query tool. Every write is one named,
+ *     validated operation, so business rules (split maths, ledger integrity,
+ *     the RPC boundary) can never be bypassed.
+ *   - It never moves money. `record_settlement` writes a settlement row saying
+ *     "X paid Y"; the actual transfer is a UPI/PayPal handoff link a human
+ *     opens and confirms in their own bank app. `payment_link` builds that
+ *     link; nothing here debits an account.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+
+import { currentUserId, makeClient, readEnv } from './supabase.js';
+
+type ToolResult = {
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+};
+
+const ok = (data: unknown): ToolResult => ({
+  content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+});
+const fail = (message: string): ToolResult => ({
+  content: [{ type: 'text', text: message }],
+  isError: true,
+});
+
+/** Integer minor units (paise/cents) as a decimal string — money is never a float. */
+const MinorUnits = z
+  .string()
+  .regex(/^\d+$/, 'Amount must be integer minor units (paise/cents) as a string, e.g. "12500".')
+  .describe('Integer minor units as a string, e.g. "12500" for ₹125.00');
+
+const MemberId = z.string().uuid().describe('A group_members.id from list_members');
+const GroupId = z.string().uuid().describe('A group id from list_groups');
+const Currency = z
+  .string()
+  .length(3)
+  .transform((c) => c.toUpperCase())
+  .describe('ISO-4217, e.g. INR, USD');
+
+const todayIso = (): string => new Date().toISOString().slice(0, 10);
+
+/** Read the app-defined error code out of a wrapped edge-function failure. */
+async function edgeError(error: unknown): Promise<string> {
+  const context = (error as { context?: Response }).context;
+  if (context && typeof context.json === 'function') {
+    try {
+      const body = (await context.json()) as { code?: string; message?: string };
+      if (body?.message) return body.code ? `${body.code}: ${body.message}` : body.message;
+      if (body?.code) return body.code;
+    } catch {
+      /* fall through */
+    }
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function main(): Promise<void> {
+  const env = readEnv();
+  const supabase = await makeClient(env);
+  const meId = await currentUserId(supabase);
+
+  const server = new McpServer({ name: 'waves-agent', version: '0.1.0' });
+
+  // ── reads ──────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'whoami',
+    {
+      description:
+        'The identity this server is acting as. Every write is performed as this user, under the same permissions they have in the app.',
+      inputSchema: {},
+    },
+    async (): Promise<ToolResult> => {
+      const { data } = await supabase.auth.getUser();
+      return ok({ userId: meId, email: data.user?.email ?? null, readOnly: env.readOnly });
+    },
+  );
+
+  server.registerTool(
+    'list_groups',
+    {
+      description:
+        "List the groups the signed-in user belongs to (RLS scopes this to them). Use it to find a group id before adding an expense or a settlement.",
+      inputSchema: {
+        includeArchived: z
+          .boolean()
+          .optional()
+          .describe('Include archived groups (default false).'),
+      },
+    },
+    async ({ includeArchived }): Promise<ToolResult> => {
+      let query = supabase
+        .from('groups')
+        .select('id, name, type, default_currency, cover_emoji, archived_at, start_date, end_date')
+        .order('created_at', { ascending: false });
+      if (!includeArchived) query = query.is('archived_at', null);
+      const { data, error } = await query;
+      if (error) return fail(error.message);
+      return ok(
+        (data ?? []).map((g) => ({
+          id: g.id,
+          name: g.name,
+          type: g.type,
+          currency: g.default_currency,
+          emoji: g.cover_emoji,
+          archived: Boolean(g.archived_at),
+          startDate: g.start_date,
+          endDate: g.end_date,
+        })),
+      );
+    },
+  );
+
+  server.registerTool(
+    'list_members',
+    {
+      description:
+        'The members of a group, with their member ids. Expenses and settlements are addressed by member id, not by person, so resolve names here first. "isYou" marks the signed-in user, who must be a party to any settlement.',
+      inputSchema: { groupId: GroupId },
+    },
+    async ({ groupId }): Promise<ToolResult> => {
+      const { data, error } = await supabase
+        .from('group_members')
+        .select(
+          'id, group_id, profile_id, ghost_name, vpa, role, profile:profiles!profile_id ( display_name, default_vpa )',
+        )
+        .eq('group_id', groupId)
+        .is('left_at', null)
+        .order('created_at', { ascending: true });
+      if (error) return fail(error.message);
+      return ok(
+        (data ?? []).map((m) => {
+          const profile = m.profile as { display_name?: string; default_vpa?: string } | null;
+          return {
+            memberId: m.id,
+            name: profile?.display_name ?? m.ghost_name ?? 'Unnamed',
+            isYou: m.profile_id === meId,
+            isGhost: !m.profile_id,
+            role: m.role,
+            vpa: m.vpa ?? profile?.default_vpa ?? null,
+          };
+        }),
+      );
+    },
+  );
+
+  server.registerTool(
+    'get_balances',
+    {
+      description:
+        'Who owes what in a group, per member and currency, in minor units. A positive balance is owed to that member; a negative balance is owed by them. Use this to know a settlement amount before recording one.',
+      inputSchema: { groupId: GroupId },
+    },
+    async ({ groupId }): Promise<ToolResult> => {
+      const { data, error } = await supabase
+        .from('group_balances')
+        .select('member_id, currency, balance')
+        .eq('group_id', groupId);
+      if (error) return fail(error.message);
+      return ok(data ?? []);
+    },
+  );
+
+  // ── writes ─────────────────────────────────────────────────────────────
+  // Registered only when the server is not in read-only mode.
+
+  if (!env.readOnly) {
+    registerWriteTools(server, supabase);
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // A stdio server must not print to stdout (that is the protocol channel).
+  process.stderr.write(
+    `waves-agent MCP up as ${meId}${env.readOnly ? ' (read-only)' : ''}\n`,
+  );
+}
+
+function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
+  server.registerTool(
+    'create_group',
+    {
+      description:
+        'Create a new group. The signed-in user is added as its first (admin) member automatically. Returns the new group id.',
+      inputSchema: {
+        name: z.string().min(1).optional().describe('Optional; an unnamed group is labelled by its members.'),
+        type: z
+          .enum(['trip', 'home', 'couple', 'event', 'other'])
+          .default('other')
+          .describe('What kind of group this is.'),
+        currency: Currency.default('INR'),
+        country: z
+          .string()
+          .length(2)
+          .optional()
+          .describe('ISO-3166 alpha-2, e.g. IN. Decides which payment rails the group offers.'),
+        emoji: z.string().optional().describe('A cover emoji.'),
+        simplify: z
+          .boolean()
+          .default(true)
+          .describe('Simplify debts in the presentation (ledger is untouched).'),
+      },
+    },
+    async ({ name, type, currency, country, emoji, simplify }): Promise<ToolResult> => {
+      const { data, error } = await supabase.rpc('baaki_create_group', {
+        p_name: name?.trim() || null,
+        p_type: type,
+        p_currency: currency,
+        p_emoji: emoji ?? null,
+        p_simplify: simplify,
+        p_group_id: null,
+        p_photo_path: null,
+        p_country: country ? country.toUpperCase() : null,
+        p_creator_member_id: null,
+      });
+      if (error) return fail(error.message);
+      return ok({ groupId: data });
+    },
+  );
+
+  server.registerTool(
+    'add_expense',
+    {
+      description:
+        "Add an expense to a group. The server does NOT trust a client-computed split — it sends the split intent to the app's expense-write edge function, which recomputes every share and writes the ledger. Amounts are integer minor units as strings. Resolve member ids with list_members first.",
+      inputSchema: {
+        groupId: GroupId,
+        description: z.string().min(1).describe('What the expense was for.'),
+        amount: MinorUnits.describe('Total of the expense, in minor units.'),
+        currency: Currency.optional().describe("Defaults to the group's currency if omitted."),
+        paidBy: MemberId.describe('The member who paid (single payer).'),
+        participants: z
+          .array(MemberId)
+          .min(1)
+          .describe('The members the expense is split across.'),
+        split: z
+          .discriminatedUnion('kind', [
+            z.object({ kind: z.literal('equal') }),
+            z.object({
+              kind: z.literal('exact'),
+              amounts: z
+                .record(MinorUnits)
+                .describe('memberId → minor units; must sum to the total.'),
+            }),
+            z.object({
+              kind: z.literal('shares'),
+              weights: z
+                .record(z.number().int().positive())
+                .describe('memberId → weight, e.g. {"a":2,"b":1}.'),
+            }),
+          ])
+          .optional()
+          .describe('How to split. Defaults to an equal split across participants.'),
+        expenseDate: z
+          .string()
+          .regex(/^\d{4}-\d{2}-\d{2}$/)
+          .optional()
+          .describe('YYYY-MM-DD; defaults to today.'),
+        category: z.string().optional(),
+        notes: z.string().optional(),
+      },
+    },
+    async (input): Promise<ToolResult> => {
+      const splitParams =
+        !input.split || input.split.kind === 'equal'
+          ? { kind: 'equal' }
+          : input.split.kind === 'exact'
+            ? { kind: 'exact', amounts: input.split.amounts }
+            : { kind: 'shares', weights: input.split.weights };
+
+      const expenseId = randomUUID();
+      const { data, error } = await supabase.functions.invoke('expense-write', {
+        body: {
+          groupId: input.groupId,
+          expenseId,
+          description: input.description,
+          category: input.category ?? null,
+          expenseDate: input.expenseDate ?? todayIso(),
+          currency: input.currency ?? undefined,
+          amount: input.amount,
+          splitParams,
+          participants: input.participants,
+          payers: { [input.paidBy]: input.amount },
+          // expectedShares omitted on purpose: the edge function is the source
+          // of truth for the split, and sending nothing lets it compute freely.
+          notes: input.notes ?? null,
+          paymentMethod: null,
+          receiptShareUrl: null,
+          fx: null,
+          clientMutationId: randomUUID(),
+        },
+      });
+      if (error) return fail(await edgeError(error));
+      return ok({ ...(data as object), expenseId });
+    },
+  );
+
+  server.registerTool(
+    'record_settlement',
+    {
+      description:
+        'Record that one member paid another to settle up. This writes a settlement row only — it does NOT move any money. The signed-in user (isYou in list_members) must be one of the two parties. Use payment_link to get the handoff URL a human opens to actually pay.',
+      inputSchema: {
+        groupId: GroupId,
+        fromMemberId: MemberId.describe('Who paid.'),
+        toMemberId: MemberId.describe('Who received.'),
+        amount: MinorUnits,
+        rail: z
+          .string()
+          .default('upi')
+          .describe('The payment rail id, e.g. upi, cash, bank, paypal.'),
+        currency: Currency.optional(),
+        note: z.string().optional(),
+      },
+    },
+    async ({ groupId, fromMemberId, toMemberId, amount, rail, currency, note }): Promise<ToolResult> => {
+      const method = (['upi', 'cash', 'bank', 'other'] as const).includes(
+        rail as 'upi' | 'cash' | 'bank' | 'other',
+      )
+        ? rail
+        : 'other';
+      const { data, error } = await supabase.rpc('baaki_record_settlement', {
+        p_group_id: groupId,
+        p_from_member_id: fromMemberId,
+        p_to_member_id: toMemberId,
+        p_amount: amount,
+        p_method: method,
+        p_rail: rail,
+        p_currency: currency ?? null,
+        p_note: note ?? null,
+        p_allocations: [],
+        p_client_mutation_id: randomUUID(),
+      });
+      if (error) return fail(error.message);
+      return ok({
+        settlementId: data,
+        status: 'initiated',
+        note: 'Recorded only — no money moved. Use payment_link for the payer to complete the transfer.',
+      });
+    },
+  );
+
+  server.registerTool(
+    'payment_link',
+    {
+      description:
+        'Build a payment handoff link (UPI or PayPal) for a payer to open in their own app and complete a transfer. This does not move money; it is a deep link a human taps and confirms.',
+      inputSchema: {
+        rail: z.enum(['upi', 'paypal']).default('upi'),
+        payeeVpa: z
+          .string()
+          .optional()
+          .describe('The payee UPI id (vpa), e.g. name@bank — from list_members. Required for upi.'),
+        payeeHandle: z
+          .string()
+          .optional()
+          .describe('The payee PayPal.me handle. Required for paypal.'),
+        payeeName: z.string().optional(),
+        amount: MinorUnits,
+        currency: Currency.default('INR'),
+      },
+    },
+    async ({ rail, payeeVpa, payeeHandle, payeeName, amount, currency }): Promise<ToolResult> => {
+      // Minor → major with two decimals. Every currency this app settles in is
+      // two-decimal; a decimal string keeps the exact value without a float.
+      const major = `${(BigInt(amount) / 100n).toString()}.${(BigInt(amount) % 100n)
+        .toString()
+        .padStart(2, '0')}`;
+
+      if (rail === 'upi') {
+        if (!payeeVpa) return fail('A UPI link needs payeeVpa (the payee\'s UPI id).');
+        const params = new URLSearchParams({
+          pa: payeeVpa,
+          ...(payeeName ? { pn: payeeName } : {}),
+          am: major,
+          cu: currency,
+        });
+        return ok({ rail, uri: `upi://pay?${params.toString()}`, amountMajor: major, currency });
+      }
+
+      if (!payeeHandle) return fail('A PayPal link needs payeeHandle (the PayPal.me handle).');
+      return ok({
+        rail,
+        uri: `https://paypal.me/${encodeURIComponent(payeeHandle)}/${major}${currency}`,
+        amountMajor: major,
+        currency,
+      });
+    },
+  );
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`waves-agent MCP failed to start: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/apps/agent-mcp/src/index.ts
+++ b/apps/agent-mcp/src/index.ts
@@ -102,7 +102,7 @@ async function main(): Promise<void> {
     'list_groups',
     {
       description:
-        "List the groups the signed-in user belongs to (RLS scopes this to them). Use it to find a group id before adding an expense or a settlement.",
+        'List the groups the signed-in user belongs to (RLS scopes this to them). Use it to find a group id before adding an expense or a settlement.',
       inputSchema: {
         includeArchived: z
           .boolean()
@@ -193,9 +193,7 @@ async function main(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // A stdio server must not print to stdout (that is the protocol channel).
-  process.stderr.write(
-    `waves-agent MCP up as ${meId}${env.readOnly ? ' (read-only)' : ''}\n`,
-  );
+  process.stderr.write(`waves-agent MCP up as ${meId}${env.readOnly ? ' (read-only)' : ''}\n`);
 }
 
 function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
@@ -205,7 +203,11 @@ function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
       description:
         'Create a new group. The signed-in user is added as its first (admin) member automatically. Returns the new group id.',
       inputSchema: {
-        name: z.string().min(1).optional().describe('Optional; an unnamed group is labelled by its members.'),
+        name: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Optional; an unnamed group is labelled by its members.'),
         type: z
           .enum(['trip', 'home', 'couple', 'event', 'other'])
           .default('other')
@@ -251,10 +253,7 @@ function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
         amount: MinorUnits.describe('Total of the expense, in minor units.'),
         currency: Currency.optional().describe("Defaults to the group's currency if omitted."),
         paidBy: MemberId.describe('The member who paid (single payer).'),
-        participants: z
-          .array(MemberId)
-          .min(1)
-          .describe('The members the expense is split across.'),
+        participants: z.array(MemberId).min(1).describe('The members the expense is split across.'),
         split: z
           .discriminatedUnion('kind', [
             z.object({ kind: z.literal('equal') }),
@@ -335,7 +334,15 @@ function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
         note: z.string().optional(),
       },
     },
-    async ({ groupId, fromMemberId, toMemberId, amount, rail, currency, note }): Promise<ToolResult> => {
+    async ({
+      groupId,
+      fromMemberId,
+      toMemberId,
+      amount,
+      rail,
+      currency,
+      note,
+    }): Promise<ToolResult> => {
       const method = (['upi', 'cash', 'bank', 'other'] as const).includes(
         rail as 'upi' | 'cash' | 'bank' | 'other',
       )
@@ -372,7 +379,9 @@ function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
         payeeVpa: z
           .string()
           .optional()
-          .describe('The payee UPI id (vpa), e.g. name@bank — from list_members. Required for upi.'),
+          .describe(
+            'The payee UPI id (vpa), e.g. name@bank — from list_members. Required for upi.',
+          ),
         payeeHandle: z
           .string()
           .optional()
@@ -390,7 +399,7 @@ function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
         .padStart(2, '0')}`;
 
       if (rail === 'upi') {
-        if (!payeeVpa) return fail('A UPI link needs payeeVpa (the payee\'s UPI id).');
+        if (!payeeVpa) return fail("A UPI link needs payeeVpa (the payee's UPI id).");
         const params = new URLSearchParams({
           pa: payeeVpa,
           ...(payeeName ? { pn: payeeName } : {}),
@@ -412,6 +421,8 @@ function registerWriteTools(server: McpServer, supabase: SupabaseClient): void {
 }
 
 main().catch((error: unknown) => {
-  process.stderr.write(`waves-agent MCP failed to start: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.stderr.write(
+    `waves-agent MCP failed to start: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
   process.exit(1);
 });

--- a/apps/agent-mcp/src/supabase.ts
+++ b/apps/agent-mcp/src/supabase.ts
@@ -1,0 +1,90 @@
+/**
+ * The Supabase client the tools act through — always as a real signed-in user.
+ *
+ * This is the whole safety argument of the server. It is built with the public
+ * anon key and the user's own session (an access token, optionally with a
+ * refresh token), exactly the way the mobile app builds its client
+ * (`apps/mobile/src/lib/supabase.ts`). Every call therefore carries that user's
+ * JWT, so Row-Level Security and the RPC boundary (ADR-013, #274) apply to the
+ * agent identically to the human: it can do what that person can do, and
+ * nothing more. No service-role key is read here on purpose — a service key
+ * would bypass RLS and turn a helpful agent into a way to forge another
+ * person's ledger.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+export interface WavesEnv {
+  url: string;
+  anonKey: string;
+  accessToken: string;
+  refreshToken?: string;
+  /** When true, the write tools are not registered at all. */
+  readOnly: boolean;
+}
+
+export function readEnv(): WavesEnv {
+  const url = process.env.WAVES_SUPABASE_URL ?? process.env.EXPO_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.WAVES_SUPABASE_ANON_KEY ?? process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+  const accessToken = process.env.WAVES_SUPABASE_ACCESS_TOKEN;
+  const refreshToken = process.env.WAVES_SUPABASE_REFRESH_TOKEN;
+  const readOnly = ['1', 'true', 'yes'].includes(
+    (process.env.WAVES_MCP_READONLY ?? '').toLowerCase(),
+  );
+
+  const missing: string[] = [];
+  if (!url) missing.push('WAVES_SUPABASE_URL');
+  if (!anonKey) missing.push('WAVES_SUPABASE_ANON_KEY');
+  if (!accessToken) missing.push('WAVES_SUPABASE_ACCESS_TOKEN');
+  if (missing.length) {
+    throw new Error(
+      `Missing required environment: ${missing.join(', ')}. ` +
+        'The server acts as a signed-in user, so it needs that user\'s Supabase ' +
+        'session (a WAVES_SUPABASE_ACCESS_TOKEN, and ideally a ' +
+        'WAVES_SUPABASE_REFRESH_TOKEN so long sessions keep working).',
+    );
+  }
+
+  return { url: url!, anonKey: anonKey!, accessToken: accessToken!, refreshToken, readOnly };
+}
+
+/**
+ * Build the client and attach the user's session. With a refresh token the
+ * client is told to keep the access token fresh itself, so a long-running agent
+ * does not fall over an hour in; with only an access token it works until that
+ * token expires and then every call returns an auth error — which is the honest
+ * failure, not a silent one.
+ */
+export async function makeClient(env: WavesEnv): Promise<SupabaseClient> {
+  const client = createClient(env.url, env.anonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: Boolean(env.refreshToken),
+      detectSessionInUrl: false,
+    },
+    global: {
+      // Set the header too, so the very first call (before setSession resolves)
+      // already carries the user's JWT rather than the bare anon key.
+      headers: { Authorization: `Bearer ${env.accessToken}` },
+    },
+  });
+
+  if (env.refreshToken) {
+    const { error } = await client.auth.setSession({
+      access_token: env.accessToken,
+      refresh_token: env.refreshToken,
+    });
+    if (error) throw new Error(`Could not establish the user session: ${error.message}`);
+  }
+
+  return client;
+}
+
+/** The signed-in user's own id — used to find "me" among a group's members. */
+export async function currentUserId(client: SupabaseClient): Promise<string> {
+  const { data, error } = await client.auth.getUser();
+  if (error || !data.user) {
+    throw new Error(`Not signed in (the session may have expired): ${error?.message ?? 'no user'}`);
+  }
+  return data.user.id;
+}

--- a/apps/agent-mcp/src/supabase.ts
+++ b/apps/agent-mcp/src/supabase.ts
@@ -39,7 +39,7 @@ export function readEnv(): WavesEnv {
   if (missing.length) {
     throw new Error(
       `Missing required environment: ${missing.join(', ')}. ` +
-        'The server acts as a signed-in user, so it needs that user\'s Supabase ' +
+        "The server acts as a signed-in user, so it needs that user's Supabase " +
         'session (a WAVES_SUPABASE_ACCESS_TOKEN, and ideally a ' +
         'WAVES_SUPABASE_REFRESH_TOKEN so long sessions keep working).',
     );

--- a/apps/agent-mcp/tsconfig.json
+++ b/apps/agent-mcp/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "declaration": false,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,28 @@ importers:
         specifier: ~5.9.2
         version: 5.9.3
 
+  apps/agent-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.30.0(supports-color@8.1.1)(zod@3.25.76)
+      '@supabase/supabase-js':
+        specifier: ^2.45.0
+        version: 2.112.3(@opentelemetry/api@1.9.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.12
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
   apps/mobile:
     dependencies:
       '@expo/ui':
@@ -269,7 +291,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/web:
     dependencies:
@@ -324,7 +346,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   e2e:
     dependencies:
@@ -349,7 +371,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/core:
     devDependencies:
@@ -364,7 +386,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/db:
     dependencies:
@@ -395,7 +417,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -1308,6 +1330,12 @@ packages:
     resolution: {integrity: sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==}
     hasBin: true
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1530,6 +1558,16 @@ packages:
       react-native-svg: '>=14.0.0'
     peerDependenciesMeta:
       react-native-svg:
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
         optional: true
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
@@ -2799,6 +2837,9 @@ packages:
   '@types/lodash@4.17.25':
     resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
@@ -3237,6 +3278,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
@@ -3437,6 +3486,10 @@ packages:
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -3639,11 +3692,35 @@ packages:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -4145,6 +4222,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -4487,6 +4572,16 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   exsolve@1.1.1:
     resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
 
@@ -4568,6 +4663,10 @@ packages:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.7.0:
     resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
@@ -4601,9 +4700,17 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -4777,6 +4884,10 @@ packages:
   hermes-parser@0.36.1:
     resolution: {integrity: sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==}
 
+  hono@4.13.3:
+    resolution: {integrity: sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -4859,6 +4970,14 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -4943,6 +5062,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
@@ -5026,6 +5148,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.9:
+    resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5049,6 +5174,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -5312,11 +5440,19 @@ packages:
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -5726,6 +5862,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -5779,6 +5918,10 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
@@ -5894,6 +6037,10 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -5915,6 +6062,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
@@ -5932,6 +6083,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
@@ -6216,6 +6371,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rtl-detect@1.1.2:
     resolution: {integrity: sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==}
 
@@ -6271,6 +6430,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
 
@@ -6281,6 +6444,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -6601,6 +6768,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -6612,6 +6784,10 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -6657,6 +6833,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -7010,6 +7189,11 @@ packages:
 
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -8138,6 +8322,10 @@ snapshots:
       chalk: 4.1.2
       js-yaml: 4.3.1
 
+  '@hono/node-server@2.1.1(hono@4.13.3)':
+    dependencies:
+      hono: 4.13.3
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -8306,6 +8494,28 @@ snapshots:
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
     optionalDependencies:
       react-native-svg: 15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.3)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
+      hono: 4.13.3
+      jose: 6.2.9
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
@@ -9557,6 +9767,10 @@ snapshots:
 
   '@types/lodash@4.17.25': {}
 
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
@@ -9933,13 +10147,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -10080,6 +10294,10 @@ snapshots:
   agent-cli-detector@0.1.4: {}
 
   ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
 
@@ -10339,6 +10557,20 @@ snapshots:
 
   big-integer@1.6.52: {}
 
+  body-parser@2.3.0(supports-color@8.1.1):
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3(supports-color@8.1.1)
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   bplist-creator@0.1.0:
@@ -10565,11 +10797,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.7
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-fetch@3.2.0:
     dependencies:
@@ -11287,6 +11534,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   expect-type@1.4.0: {}
 
   expo-application@57.0.2(expo@57.0.12):
@@ -11703,6 +11956,47 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  express-rate-limit@8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      express: 5.2.1(supports-color@8.1.1)
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1(supports-color@8.1.1):
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0(supports-color@8.1.1)
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3(supports-color@8.1.1)
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1(supports-color@8.1.1)
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   exsolve@1.1.1: {}
 
   fast-check@3.23.2:
@@ -11789,6 +12083,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -11825,7 +12130,11 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forwarded@0.2.0: {}
+
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fsevents@2.3.2:
     optional: true
@@ -11996,6 +12305,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.36.1
 
+  hono@4.13.3: {}
+
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -12080,6 +12391,10 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  ip-address@10.5.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.9
@@ -12162,6 +12477,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-promise@4.0.0: {}
 
   is-property@1.0.2: {}
 
@@ -12262,6 +12579,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.9: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.3.1:
@@ -12277,6 +12596,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -12473,9 +12794,13 @@ snapshots:
 
   mdn-data@2.0.14: {}
 
+  media-typer@1.1.1: {}
+
   memoize-one@5.2.1: {}
 
   memoize-one@6.0.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -12947,6 +13272,8 @@ snapshots:
       lru-cache: 11.5.2
       minipass: 7.1.3
 
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   perfect-debounce@2.1.0: {}
@@ -12993,6 +13320,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@2.3.1:
     dependencies:
@@ -13108,6 +13437,11 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   pump@3.0.4:
@@ -13127,6 +13461,11 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   query-string@7.1.3:
     dependencies:
       decode-uri-component: 0.2.2
@@ -13143,6 +13482,13 @@ snapshots:
   quick-lru@5.1.1: {}
 
   range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc9@3.0.1:
     dependencies:
@@ -13512,6 +13858,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
+  router@2.2.0(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rtl-detect@1.1.2: {}
 
   run-parallel@1.2.0:
@@ -13580,6 +13936,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   seq-queue@0.0.5: {}
 
   serialize-error@2.1.0: {}
@@ -13590,6 +13962,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1(supports-color@8.1.1):
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13930,6 +14311,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -13937,6 +14324,12 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@0.7.1: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -13996,6 +14389,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@6.21.0: {}
 
   undici-types@8.3.0: {}
 
@@ -14093,7 +14488,7 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0):
+  vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.5)
@@ -14107,12 +14502,13 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.33.0
       terser: 5.49.0
+      tsx: 4.23.12
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -14129,7 +14525,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -14337,6 +14733,10 @@ snapshots:
     dependencies:
       grammex: 3.1.13
       graphmatch: 1.1.1
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
Adds `apps/agent-mcp`, an MCP server that lets an AI agent **create groups, add expenses, and record settlements inside Waves — as a specific signed-in user**, through the app's own authorized RPCs and edge functions.

## Why not a database MCP
A generic Supabase/Postgres MCP runs raw SQL with a service/management token, which bypasses RLS **and** the RPC boundary (ADR-013, #274) and can write malformed ledger rows (skipping split maths and integrity checks). This server does the opposite: it builds its client with the anon key + the user's own JWT — exactly like `apps/mobile/src/lib/supabase.ts` — so RLS and every business rule apply to the agent identically to the human. **No service-role key is read.**

## Tools
| Tool | Kind | Path |
| --- | --- | --- |
| `whoami`, `list_groups`, `list_members`, `get_balances` | read | under RLS |
| `create_group` | write | `rpc('baaki_create_group')` |
| `add_expense` | write | `functions.invoke('expense-write')` → recomputes split → service-role-only `baaki_apply_expense` |
| `record_settlement` | write | `rpc('baaki_record_settlement')` — **records a row only** |
| `payment_link` | pure | builds a `upi://` / `paypal.me` handoff link |

## Safety
- **Acts as one user** (anon key + their JWT); no service key.
- **No raw-SQL tool** — every write is one named, validated operation.
- **No money movement** — `record_settlement` writes a settlement row (`initiated`); the transfer is a UPI/PayPal link a human opens and confirms. `payment_link` builds it.
- Amounts are **integer minor units** as strings — never a float.
- `WAVES_MCP_READONLY=1` registers only the read tools.
- Session from env: `WAVES_SUPABASE_ACCESS_TOKEN` (+ optional refresh token), URL/anon fall back to `EXPO_PUBLIC_*`.

## Status
Type-checked and boots cleanly (fails loudly on a missing token). **The write tools have NOT been run end-to-end against a live project yet** — verify on a throwaway group before pointing it at anything real. Not yet wired into CI.

## Lockfile note
The committed `pnpm-lock.yaml` delta is agent-mcp deps only. The unrelated `@expo/ngrok` devDep from the tunnel work was temporarily removed while regenerating the lockfile so a frozen install stays consistent with the committed manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server for authenticated Waves operations, including identity, groups, members, and balances.
  * Added optional write operations for creating groups, recording expenses, settling balances, and generating payment links.
  * Added read-only mode to prevent changes when enabled.
  * Added input validation, authentication checks, and clear error handling for tool requests.
  * Added secure configuration through environment variables and session support.

* **Documentation**
  * Added setup, configuration, usage, available tools, safety guidance, and validation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->