### PR TITLE
feat(mobile): onboarding tour after sign-in, tips priority queue, auth polish

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -35,6 +35,7 @@ import { useFlagEnabled } from '@/lib/flags';
 import { deviceDefaultCurrency, plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
+import { usePromptSlot } from '@/lib/promptQueue';
 import { useDashboardTips } from '@/lib/tips';
 import { TourTarget, useTour } from '@/lib/tour';
 import { SyncStatusIcon } from '@/components/SyncBanner';
@@ -66,21 +67,31 @@ export default function HomeScreen() {
   const guard = useGuestGuard();
   const tour = useTour();
 
-  // First time on Home, once the "seen" flag has been read, run the tour. The
-  // ref makes this fire exactly once — without it the effect would re-run each
-  // time the tour advances (its value changes) and snap back to step one. It
-  // remembers itself when finished; "Take the tour again" in the menu replays.
+  const list = groups.data ?? [];
+  const loading = groups.isLoading || summary.isLoading;
+
+  // First time on Home, once the "seen" flag has been read *and the data has
+  // loaded*, run the tour. Waiting on the data matters: the coach-marks anchor
+  // on the hero and the add buttons, and starting over skeletons spotlights the
+  // wrong rectangle until the real content reflows in under the hole.
+  //
+  // The ref makes this fire exactly once — without it the effect would re-run
+  // each time the tour advances (its value changes) and snap back to step one.
+  // It remembers itself when finished; "Take the tour again" in the menu replays.
   const tourStarted = useRef(false);
   useEffect(() => {
     if (tourStarted.current) return;
-    if (tour.ready && !tour.seen) {
+    if (tour.ready && !tour.seen && !loading) {
       tourStarted.current = true;
       tour.start();
     }
-  }, [tour.ready, tour.seen, tour]);
+  }, [tour.ready, tour.seen, tour, loading]);
 
-  const list = groups.data ?? [];
-  const loading = groups.isLoading || summary.isLoading;
+  // The tour holds the top of the prompt queue for the whole of a first run —
+  // from the moment we know it is owed (ready, not seen), through the wait for
+  // data and the tour itself, until it finishes and marks itself seen. While it
+  // holds the slot the daily tip stands down; see `TipSheet`.
+  usePromptSlot({ id: 'tour', priority: 100, active: tour.active || (tour.ready && !tour.seen) });
 
   // The header overflow menu (the three-dot dropdown): the settings and the
   // less-used destinations, surfaced from the dashboard rather than only from
@@ -657,6 +668,13 @@ function GuestPopup({
 const TIP_SHEET_KEY = 'dashboardTips:shownOn';
 
 /**
+ * How long the tip waits once it is cleared to show. On a first run this is the
+ * beat after the tour finishes before the hint lands; on any other day it is a
+ * small settle so the tip does not race the dashboard in. See `usePromptSlot`.
+ */
+const TIP_DELAY_MS = 1400;
+
+/**
  * The daily tip, as a bottom sheet.
  *
  * It shows itself once on the first Home open of each day — the deck rotates by
@@ -700,7 +718,17 @@ function TipSheet({ t }: { t: UiStrings }) {
     };
   }, []);
 
-  const open = ready && shownOn !== localToday() && !closed && Boolean(tip);
+  // Wants to show, on the merits: read, unshown today, not closed, has a tip.
+  const wants = ready && shownOn !== localToday() && !closed && Boolean(tip);
+  // But it only actually opens once the prompt queue clears it — behind the
+  // tour on a first run, and after a short delay either way (see TIP_DELAY_MS).
+  const granted = usePromptSlot({
+    id: 'dashboardTip',
+    priority: 10,
+    active: wants,
+    delayMs: TIP_DELAY_MS,
+  });
+  const open = wants && granted;
 
   // Stamp the day the moment the sheet is shown — not on close — so someone who
   // reads it and backgrounds the app is not shown it again on the next open. The

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import Constants from 'expo-constants';
 import * as Notifications from 'expo-notifications';
@@ -20,6 +21,7 @@ import {
   useTheme,
 } from '@waves/ui';
 
+import { Onboarding } from '@/components/Onboarding';
 import { AnimatedSplash } from '@/components/AnimatedSplash';
 import { AppTabBar } from '@/components/AppTabBar';
 import { CampaignPopup } from '@/components/CampaignPopup';
@@ -36,6 +38,7 @@ import { LocaleSync } from '@/i18n/localeSync';
 import { LockProvider, useLock } from '@/lib/lock';
 import { MotionProvider, TRANSITION_MS, useMotion } from '@/lib/motion';
 import { TourProvider } from '@/lib/tour';
+import { PromptQueueProvider } from '@/lib/promptQueue';
 import { SyncNetworkProvider } from '@/lib/syncNetwork';
 import { BackupProvider } from '@/lib/cloud/BackupProvider';
 import { ThemePreferenceProvider, useThemePreference } from '@/lib/theme';
@@ -80,6 +83,11 @@ if (pushSupported) {
     }),
   });
 }
+
+// The device-local flag that the intro tour has been seen. Shared verbatim with
+// the value AuthFlow wrote before the tour moved here, so anybody who already
+// saw it pre-move is not shown it again.
+const TOUR_KEY = 'baaki.onboarding_seen';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -150,42 +158,44 @@ function RootLayout() {
                         <UpdateProvider>
                           <ThemePreferenceProvider>
                             <TourProvider>
-                              <ThemedRoot>
-                                <ThemedStatusBar />
-                                {/* Outside the lock and the auth gate on purpose: a build
+                              <PromptQueueProvider>
+                                <ThemedRoot>
+                                  <ThemedStatusBar />
+                                  {/* Outside the lock and the auth gate on purpose: a build
                             we have stopped trusting should not be unlocking a
                             ledger or signing anybody in either. */}
-                                <UpdateGate>
-                                  <PushRouting />
-                                  <LockGate>
-                                    {/* Inside the lock so the two-device gate never
+                                  <UpdateGate>
+                                    <PushRouting />
+                                    <LockGate>
+                                      {/* Inside the lock so the two-device gate never
                                 paints over the lock screen, and past auth so it
                                 only ever asks a signed-in account. */}
-                                    <DeviceSessionProvider>
-                                      <AuthGate />
-                                      {/* Inside the lock on purpose: a promotion is not a
+                                      <DeviceSessionProvider>
+                                        <AuthGate />
+                                        {/* Inside the lock on purpose: a promotion is not a
                                   reason to show somebody's phone anything before
                                   they have unlocked it. */}
-                                      <CampaignPopup />
-                                      {/* The soft ask for push, once, to a
+                                        <CampaignPopup />
+                                        {/* The soft ask for push, once, to a
                                         signed-in person whose permission is
                                         still undetermined. */}
-                                      <NotificationPrompt />
-                                    </DeviceSessionProvider>
-                                  </LockGate>
-                                  {/* The coach-mark tour, over the whole app but
+                                        <NotificationPrompt />
+                                      </DeviceSessionProvider>
+                                    </LockGate>
+                                    {/* The coach-mark tour, over the whole app but
                                     only ever started from Home. Above the gate
                                     so its scrim covers the screen. */}
-                                  <TourOverlay />
-                                  {/* Last, so it paints over the screen rather than
+                                    <TourOverlay />
+                                    {/* Last, so it paints over the screen rather than
                               under it. */}
-                                  <UpdateBanner />
-                                </UpdateGate>
-                                {/* Topmost of all: the launch field, painting over
+                                    <UpdateBanner />
+                                  </UpdateGate>
+                                  {/* Topmost of all: the launch field, painting over
                                   the whole app until it fades itself out. Native
                                   only; renders nothing on web. */}
-                                <AnimatedSplash />
-                              </ThemedRoot>
+                                  <AnimatedSplash />
+                                </ThemedRoot>
+                              </PromptQueueProvider>
                             </TourProvider>
                           </ThemePreferenceProvider>
                         </UpdateProvider>
@@ -409,6 +419,27 @@ function AuthGate() {
     else if (session && onAuth) router.replace('/');
   }, [session, loading, onAuth, onPublicRoute, router]);
 
+  // The intro tour now comes *after* sign-in, not in front of it: the first
+  // authenticated launch on this device shows the three cards once, over the
+  // app, then never again. `null` until storage answers, so it neither flashes
+  // for a returning account nor holds a first-timer at a blank screen.
+  const [tourSeen, setTourSeen] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void AsyncStorage.getItem(TOUR_KEY)
+      .then((value) => {
+        if (!cancelled) setTourSeen(value === 'yes');
+      })
+      // Storage failing is not a reason to trap somebody on the tour forever;
+      // worst case they miss it, which costs nothing they cannot find later.
+      .catch(() => {
+        if (!cancelled) setTourSeen(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   if (loading || needsRedirect) {
     return (
       <View
@@ -421,6 +452,36 @@ function AuthGate() {
       >
         <ActivityIndicator color={theme.color.brand} />
       </View>
+    );
+  }
+
+  // A signed-in person who has not seen the tour meets it here, once, before
+  // the app proper. Held while storage is still answering so the app tree does
+  // not paint under it for a frame.
+  if (session && tourSeen !== true) {
+    if (tourSeen === null) {
+      return (
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.color.bg,
+          }}
+        >
+          <ActivityIndicator color={theme.color.brand} />
+        </View>
+      );
+    }
+    return (
+      <Onboarding
+        onDone={() => {
+          setTourSeen(true);
+          // Not awaited: the tour is over the moment they say so, and a write
+          // that fails costs them one repeat, not a stuck screen.
+          void AsyncStorage.setItem(TOUR_KEY, 'yes').catch(() => {});
+        }}
+      />
     );
   }
 

--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -19,18 +19,22 @@ import { router, useSegments } from 'expo-router';
 import { iconSize, PillTabBar, type PillTabItem } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
 import { useMotion } from '@/lib/motion';
 import { resolveTabBar } from '@/lib/tabBar';
 
 export function AppTabBar() {
   const { t } = useStrings();
   const { animated } = useMotion();
+  const { session } = useAuth();
   // `useSegments` is typed as a union of fixed-length route tuples, so indexing
   // past the first element trips the tuple bounds check under the CI tsconfig.
   // We only ever read positions generically, so widen to a plain string array.
   const segments = useSegments() as readonly string[];
 
-  const { hidden, activeKey } = resolveTabBar(segments);
+  // No session means no bar anywhere — the privacy page opened from the login
+  // legal line is the one place it used to leak onto a signed-out screen.
+  const { hidden, activeKey } = resolveTabBar(segments, !session);
   if (hidden) return null;
 
   const items: PillTabItem[] = [

--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -28,9 +28,8 @@
  * and set their phone up in English.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
@@ -62,7 +61,6 @@ import {
 import { dialingCodeForCountry } from '@waves/core';
 
 import { CountryCodePicker } from '@/components/CountryCodePicker';
-import { Onboarding } from '@/components/Onboarding';
 import { SocialButton } from '@/components/SocialButton';
 import { deviceCountry, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -74,8 +72,6 @@ enum Mode {
   Otp = 'otp',
   Password = 'password',
 }
-
-const TOUR_KEY = 'baaki.onboarding_seen';
 
 export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
   const theme = useTheme();
@@ -90,34 +86,6 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
    * be asking a question they answered a week ago.
    */
   const [showOptions, setShowOptions] = useState(isGuest);
-
-  /**
-   * `null` until storage answers. Rendering the welcome while we find out would
-   * show it for one frame and then yank it away, which reads as a glitch on the
-   * very first screen of the app.
-   *
-   * The tour belongs to the login entry alone: the sign-up page is somewhere a
-   * person navigates to on purpose, never the first thing the app shows, so it
-   * never owes them the tour. A guest is not a first-time user either.
-   */
-  const [tourSeen, setTourSeen] = useState<boolean | null>(isGuest || isSignup ? true : null);
-
-  useEffect(() => {
-    if (tourSeen !== null) return;
-    let cancelled = false;
-    void AsyncStorage.getItem(TOUR_KEY)
-      .then((value) => {
-        if (!cancelled) setTourSeen(value === 'yes');
-      })
-      // Storage failing is not a reason to hold somebody at a blank screen.
-      // Worst case they see the tour once more than they should.
-      .catch(() => {
-        if (!cancelled) setTourSeen(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [tourSeen]);
 
   // The dial code is a tappable country, not a prefix typed into the field. It
   // starts on the country this handset is set to — +971 in the UAE, +44 in the
@@ -161,27 +129,10 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
     }
   };
 
-  if (tourSeen === null) {
-    return <View style={{ flex: 1, backgroundColor: theme.color.brand }} />;
-  }
-
-  if (!tourSeen) {
-    return (
-      <Onboarding
-        onDone={() => {
-          setTourSeen(true);
-          // Not awaited: the tour is over the moment they say so, and a write
-          // that fails costs them one repeat, not a stuck screen.
-          void AsyncStorage.setItem(TOUR_KEY, 'yes').catch(() => {});
-        }}
-      />
-    );
-  }
-
   /**
    * The welcome: a round photo hero with a scribble, the value line in heavy
    * ink, the language in the corner, and the ways in beneath — Google first,
-   * then "continue with phone", then a hairline and the email path, and last the
+   * then "continue with email", then a hairline and the phone path, and last the
    * line to the other door. On the sign-up page the guest way sits among them; on
    * the login screen it does not.
    */
@@ -293,18 +244,22 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                 onGoogle={() => void run(withGoogle)}
                 t={t}
               />
-              {/* Phone as its own top-level way in, like the reference concept:
-                  a tap that drops straight into the code form rather than a tab
-                  the person has to find inside a card about passwords. */}
+              {/* Email as its own top-level way in: a tap that drops straight
+                  into the email-and-password form rather than a tab the person
+                  has to find inside a card. */}
               <Button
-                label={t.signIn.continuePhone}
+                label={t.signIn.continueEmail}
+                variant="primary"
                 size="lg"
                 fullWidth
                 disabled={busy}
                 icon={
-                  <Ionicons name="call-outline" size={iconSize.md} color={theme.color.onBrand} />
+                  <Ionicons name="mail-outline" size={iconSize.md} color={theme.color.onBrand} />
                 }
-                onPress={() => router.push('/phone')}
+                onPress={() => {
+                  setMode(Mode.Password);
+                  setShowOptions(true);
+                }}
               />
             </View>
 
@@ -319,21 +274,17 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
             </View>
 
             <View style={{ gap: theme.spacing.sm }}>
-              {/* Same ink as the phone button above — the two email/phone ways
-                  in read as one pair. */}
+              {/* The phone way in, below the seam — the two email/phone ways in
+                  read as one pair. */}
               <Button
-                label={t.signIn.continueEmail}
-                variant="primary"
+                label={t.signIn.continuePhone}
                 size="lg"
                 fullWidth
                 disabled={busy}
                 icon={
-                  <Ionicons name="mail-outline" size={iconSize.md} color={theme.color.onBrand} />
+                  <Ionicons name="call-outline" size={iconSize.md} color={theme.color.onBrand} />
                 }
-                onPress={() => {
-                  setMode(Mode.Password);
-                  setShowOptions(true);
-                }}
+                onPress={() => router.push('/phone')}
               />
               {/* ADR-006 addendum: the guest way in lives on the sign-up page,
                   not the login screen — quieter than the account buttons, still

--- a/apps/mobile/src/components/LegalLine.tsx
+++ b/apps/mobile/src/components/LegalLine.tsx
@@ -1,12 +1,13 @@
 /**
  * The "by continuing you agree to our Terms and Privacy Policy" line, with only
- * the two named documents underlined and tappable.
+ * Privacy Policy underlined and tappable.
  *
  * The sentence carries `{terms}` and `{privacy}` placeholders (see
- * `t.entry.agreeTerms`) so word order survives translation; those two are
- * rendered as underlined spans that open the privacy screen, and everything
- * else stays plain. Nested `Text` with `onPress` keeps the links inline rather
- * than wrapping the whole line in one control.
+ * `t.entry.agreeTerms`) so word order survives translation. Only `{privacy}`
+ * opens the privacy screen — the one document that exists; `{terms}` is plain
+ * words for now, since there is no separate terms page to point it at. Nested
+ * `Text` with `onPress` keeps the link inline rather than wrapping the whole
+ * line in one control.
  */
 
 import { router } from 'expo-router';
@@ -20,20 +21,22 @@ export function LegalLine({ textStyle }: { textStyle?: TextStyle }) {
 
   return (
     <Text style={[{ textAlign: 'center' }, textStyle]}>
-      {parts.map((part, index) =>
-        part === '{terms}' || part === '{privacy}' ? (
-          <Text
-            key={index}
-            accessibilityRole="link"
-            onPress={() => router.push('/settings/privacy')}
-            style={{ textDecorationLine: 'underline', fontWeight: '700' }}
-          >
-            {part === '{terms}' ? t.entry.termsWord : t.entry.privacyWord}
-          </Text>
-        ) : (
-          part
-        ),
-      )}
+      {parts.map((part, index) => {
+        if (part === '{privacy}') {
+          return (
+            <Text
+              key={index}
+              accessibilityRole="link"
+              onPress={() => router.push('/settings/privacy')}
+              style={{ textDecorationLine: 'underline', fontWeight: '700' }}
+            >
+              {t.entry.privacyWord}
+            </Text>
+          );
+        }
+        if (part === '{terms}') return t.entry.termsWord;
+        return part;
+      })}
     </Text>
   );
 }

--- a/apps/mobile/src/components/Onboarding.tsx
+++ b/apps/mobile/src/components/Onboarding.tsx
@@ -13,7 +13,7 @@
  * dots are there for anyone who wants to count.
  */
 
-import { useRef, useState } from 'react';
+import { memo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import {
   Pressable,
@@ -91,132 +91,199 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
     scroller.current?.scrollTo({ x: pageForSlide(0, SLIDES.length, rtl) * width, animated: false });
   };
 
+  const isLast = index === SLIDES.length - 1;
+  // The dots take the ink of the card they sit over — that is the current one.
+  const activeInk = theme.tint[SLIDES[index]!.tint].ink;
+
   return (
-    <ScrollView
-      ref={scroller}
-      horizontal
-      pagingEnabled
-      showsHorizontalScrollIndicator={false}
-      onScroll={onScroll}
-      onContentSizeChange={onContentSizeChange}
-      scrollEventThrottle={16}
-      // Pinned left-to-right on purpose: see `@/lib/carousel`. The reversal is
-      // arithmetic there rather than three platforms' disagreeing opinions
-      // about what `contentOffset.x` means in a mirrored scroll view.
-      style={{ flex: 1, direction: 'ltr' }}
-    >
-      {pageOrder(SLIDES, rtl).map(({ slide, index: slideIndex }) => {
-        // The words live in the string table; this file only knows the look.
-        const copy = t.onboarding[slideIndex] ?? t.onboarding[0]!;
-        const { bg, ink, inkMuted } = theme.tint[slide.tint];
-        const last = slideIndex === SLIDES.length - 1;
+    <View style={{ flex: 1 }}>
+      <ScrollView
+        ref={scroller}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onScroll={onScroll}
+        onContentSizeChange={onContentSizeChange}
+        scrollEventThrottle={16}
+        // Pinned left-to-right on purpose: see `@/lib/carousel`. The reversal is
+        // arithmetic there rather than three platforms' disagreeing opinions
+        // about what `contentOffset.x` means in a mirrored scroll view.
+        style={{ flex: 1, direction: 'ltr' }}
+      >
+        {pageOrder(SLIDES, rtl).map(({ slide, index: slideIndex }) => {
+          // The words live in the string table; this file only knows the look.
+          const copy = t.onboarding[slideIndex] ?? t.onboarding[0]!;
+          return (
+            <SlideCard
+              key={slide.tint}
+              emoji={slide.emoji}
+              tint={slide.tint}
+              title={copy.title}
+              body={copy.body}
+              appName={t.common.appName}
+              skipLabel={t.skip}
+              width={width}
+              height={height}
+              rtl={rtl}
+              topInset={insets.top}
+              bottomInset={insets.bottom}
+              onSkip={onDone}
+            />
+          );
+        })}
+      </ScrollView>
 
-        return (
-          <View
-            key={slide.tint}
-            style={{
-              width,
-              // Stated rather than stretched: a horizontal ScrollView sizes
-              // itself to its content, so a card left to find its own height
-              // is only as tall as its paragraph and the colour stops in the
-              // middle of the screen.
-              height,
-              // The card mirrors even though the pager holding it does not, so
-              // the wordmark, the dots and the arrow all sit where an Arabic
-              // reader expects them.
-              direction: rtl ? 'rtl' : 'ltr',
-              backgroundColor: bg,
-              paddingTop: insets.top + theme.spacing.md,
-              paddingBottom: insets.bottom + theme.spacing.xxl,
-              paddingHorizontal: theme.spacing.xxxl,
-            }}
-          >
-            <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-              <Text style={{ fontSize: 20, fontWeight: '700', color: ink }}>
-                {t.common.appName}
-              </Text>
-              <Pressable
-                onPress={onDone}
-                accessibilityRole="button"
-                accessibilityLabel={t.skip}
-                hitSlop={12}
-              >
-                <Text variant="caption" style={{ color: inkMuted }}>
-                  {t.skip}
-                </Text>
-              </Pressable>
-            </View>
-
-            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-              {/* Decorative: the sentence below says the same thing, and a
-                  screen reader announcing "receipt" adds nothing. */}
-              <Text
-                accessibilityElementsHidden
-                importantForAccessibility="no"
-                style={{ fontSize: 120 }}
-              >
-                {slide.emoji}
-              </Text>
-            </View>
-
-            <View style={{ gap: theme.spacing.md }}>
-              <Text style={{ fontSize: 36, fontWeight: '700', color: ink }}>{copy.title}</Text>
-              <Text variant="body" style={{ color: inkMuted }}>
-                {copy.body}
-              </Text>
-            </View>
-
+      {/* The dots and the next arrow are the only things that track which card
+          is showing, so they live here as one overlay rather than a copy baked
+          into every card. A swipe now recolours a few pixels of dot instead of
+          re-rendering three full-screen cards mid-gesture — which is what made
+          the tour drag. Placed to land exactly where the in-card row sat; the
+          cards reserve its room with a matching spacer. `box-none` so the empty
+          gaps still pass the drag through to the pager underneath. */}
+      <View
+        pointerEvents="box-none"
+        style={{
+          position: 'absolute',
+          left: theme.spacing.xxxl,
+          right: theme.spacing.xxxl,
+          bottom: insets.bottom + theme.spacing.xxl,
+          height: 56,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          // Mirrors like the card did: dots at the start, arrow at the end.
+          direction: rtl ? 'rtl' : 'ltr',
+        }}
+      >
+        <View style={{ flexDirection: 'row', gap: theme.spacing.sm }}>
+          {SLIDES.map((dot, dotIndex) => (
             <View
+              key={dot.tint}
               style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                paddingTop: theme.spacing.xxl,
+                height: 8,
+                width: dotIndex === index ? 24 : 8,
+                borderRadius: theme.radius.pill,
+                backgroundColor: activeInk,
+                opacity: dotIndex === index ? 1 : 0.3,
               }}
-            >
-              <View style={{ flexDirection: 'row', gap: theme.spacing.sm }}>
-                {SLIDES.map((dot, dotIndex) => (
-                  <View
-                    key={dot.tint}
-                    style={{
-                      height: 8,
-                      width: dotIndex === index ? 24 : 8,
-                      borderRadius: theme.radius.pill,
-                      backgroundColor: ink,
-                      opacity: dotIndex === index ? 1 : 0.3,
-                    }}
-                  />
-                ))}
-              </View>
+            />
+          ))}
+        </View>
 
-              <Pressable
-                onPress={() => goTo(slideIndex + 1)}
-                accessibilityRole="button"
-                accessibilityLabel={last ? t.getStarted : t.next}
-                style={({ pressed }) => ({
-                  height: 56,
-                  width: 56,
-                  borderRadius: theme.radius.pill,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  backgroundColor: theme.color.surface,
-                  opacity: pressed ? 0.85 : 1,
-                  ...theme.shadow.soft,
-                })}
-              >
-                <Ionicons
-                  // A tick means the same in both directions; an arrow does
-                  // not, and this one kept pointing right in a mirrored screen
-                  // — "next" pointing backwards, on the very first screen.
-                  name={last ? 'checkmark' : directionalIcon('arrow-forward')}
-                  size={iconSize.xxl}
-                  color={theme.color.text}
-                />
-              </Pressable>
-            </View>
-          </View>
-        );
-      })}
-    </ScrollView>
+        <Pressable
+          onPress={() => goTo(index + 1)}
+          accessibilityRole="button"
+          accessibilityLabel={isLast ? t.getStarted : t.next}
+          style={({ pressed }) => ({
+            height: 56,
+            width: 56,
+            borderRadius: theme.radius.pill,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.color.buttonPrimary,
+            opacity: pressed ? 0.85 : 1,
+            ...theme.shadow.soft,
+          })}
+        >
+          <Ionicons
+            // A tick means the same in both directions; an arrow does not, and
+            // this one kept pointing right in a mirrored screen — "next"
+            // pointing backwards, on the very first screen.
+            name={isLast ? 'checkmark' : directionalIcon('arrow-forward')}
+            size={iconSize.xxl}
+            color={theme.color.onButtonPrimary}
+          />
+        </Pressable>
+      </View>
+    </View>
   );
 }
+
+/**
+ * One card — index-free on purpose, and memoised, so the current-card state
+ * changing (which drives the dots) never re-renders the three cards. Only the
+ * overlay above tracks the index; a card is a fixed painting the pager slides.
+ */
+const SlideCard = memo(function SlideCard({
+  emoji,
+  tint,
+  title,
+  body,
+  appName,
+  skipLabel,
+  width,
+  height,
+  rtl,
+  topInset,
+  bottomInset,
+  onSkip,
+}: {
+  emoji: string;
+  tint: TintName;
+  title: string;
+  body: string;
+  appName: string;
+  skipLabel: string;
+  width: number;
+  height: number;
+  rtl: boolean;
+  topInset: number;
+  bottomInset: number;
+  onSkip: () => void;
+}) {
+  const theme = useTheme();
+  const { bg, ink, inkMuted } = theme.tint[tint];
+
+  return (
+    <View
+      style={{
+        width,
+        // Stated rather than stretched: a horizontal ScrollView sizes itself to
+        // its content, so a card left to find its own height is only as tall as
+        // its paragraph and the colour stops in the middle of the screen.
+        height,
+        // The card mirrors even though the pager holding it does not, so the
+        // wordmark and skip sit where an Arabic reader expects them.
+        direction: rtl ? 'rtl' : 'ltr',
+        backgroundColor: bg,
+        paddingTop: topInset + theme.spacing.md,
+        paddingBottom: bottomInset + theme.spacing.xxl,
+        paddingHorizontal: theme.spacing.xxxl,
+      }}
+    >
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+        <Text style={{ fontSize: 20, fontWeight: '700', color: ink }}>{appName}</Text>
+        <Pressable
+          onPress={onSkip}
+          accessibilityRole="button"
+          accessibilityLabel={skipLabel}
+          hitSlop={12}
+        >
+          <Text variant="caption" style={{ color: theme.color.buttonPrimary }}>
+            {skipLabel}
+          </Text>
+        </Pressable>
+      </View>
+
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        {/* Decorative: the sentence below says the same thing, and a screen
+            reader announcing "receipt" adds nothing. */}
+        <Text accessibilityElementsHidden importantForAccessibility="no" style={{ fontSize: 120 }}>
+          {emoji}
+        </Text>
+      </View>
+
+      <View style={{ gap: theme.spacing.md }}>
+        <Text style={{ fontSize: 36, fontWeight: '700', color: ink }}>{title}</Text>
+        <Text variant="body" style={{ color: inkMuted }}>
+          {body}
+        </Text>
+      </View>
+
+      {/* The room the dots and arrow used to take. They are one overlay now (see
+          Onboarding), so the card only reserves their space to keep the
+          paragraph at the height it has always sat at. */}
+      <View style={{ marginTop: theme.spacing.xxl, height: 56 }} />
+    </View>
+  );
+});

--- a/apps/mobile/src/lib/promptQueue.tsx
+++ b/apps/mobile/src/lib/promptQueue.tsx
@@ -1,0 +1,126 @@
+/**
+ * A priority queue for the one-at-a-time prompts that fight over the first-run
+ * screen — the coach-mark tour and the daily tip sheet today, more later.
+ *
+ * The problem it solves: on the very first Home open both the tour and the tip
+ * sheet want the screen at once, and stacking a hint on top of a coach-mark is
+ * noise. So each overlay claims a slot with a priority while it wants to show,
+ * and only the highest-priority live claim is *granted*. When that one releases
+ * (the tour finishes), the next in line is granted — after its own delay, so a
+ * hint lands a beat after the tour clears rather than the same frame.
+ *
+ * Kept deliberately small: a claim is just an id and a number, the winner is the
+ * live claim with the largest number, and a slot's `granted` is "am I the winner
+ * (once my delay has passed)". No timers or ordering live in the provider; the
+ * delay is the waiting slot's own concern.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+interface PromptQueueValue {
+  /** Register or update a claim; higher priority wins the screen. */
+  claim: (id: string, priority: number) => void;
+  /** Drop a claim — the next-highest live claim becomes the winner. */
+  release: (id: string) => void;
+  /** The id of the live claim with the highest priority, or `null` if none. */
+  winnerId: string | null;
+}
+
+const PromptQueueContext = createContext<PromptQueueValue | null>(null);
+
+export function PromptQueueProvider({ children }: { children: ReactNode }) {
+  const [claims, setClaims] = useState<Record<string, number>>({});
+
+  const claim = useCallback((id: string, priority: number) => {
+    setClaims((prev) => (prev[id] === priority ? prev : { ...prev, [id]: priority }));
+  }, []);
+
+  const release = useCallback((id: string) => {
+    setClaims((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
+  // The winner is the highest-priority live claim. `>` keeps the first-inserted
+  // on a tie, but priorities are meant to be distinct, so ties should not arise.
+  const winnerId = useMemo(() => {
+    let best: string | null = null;
+    let bestPriority = -Infinity;
+    for (const [id, priority] of Object.entries(claims)) {
+      if (priority > bestPriority) {
+        bestPriority = priority;
+        best = id;
+      }
+    }
+    return best;
+  }, [claims]);
+
+  const value = useMemo<PromptQueueValue>(
+    () => ({ claim, release, winnerId }),
+    [claim, release, winnerId],
+  );
+
+  return <PromptQueueContext.Provider value={value}>{children}</PromptQueueContext.Provider>;
+}
+
+/**
+ * Claim a slot in the prompt queue while `active`, and learn whether this slot
+ * is cleared to show right now.
+ *
+ * `granted` is true only when this slot is the queue's winner *and* its
+ * `delayMs` has elapsed since it became the winner. A higher-priority claim
+ * appearing pulls `granted` straight back to false and cancels the wait, so a
+ * tip that was a beat from showing steps aside the instant the tour starts.
+ */
+export function usePromptSlot({
+  id,
+  priority,
+  active,
+  delayMs = 0,
+}: {
+  id: string;
+  priority: number;
+  active: boolean;
+  delayMs?: number;
+}): boolean {
+  const ctx = useContext(PromptQueueContext);
+  if (!ctx) throw new Error('usePromptSlot must be used within a PromptQueueProvider');
+  const { claim, release, winnerId } = ctx;
+
+  useEffect(() => {
+    if (active) claim(id, priority);
+    else release(id);
+    return () => release(id);
+  }, [id, priority, active, claim, release]);
+
+  const isWinner = active && winnerId === id;
+  const [granted, setGranted] = useState(false);
+
+  // Grant from the timer callback and revoke in the cleanup, never in the effect
+  // body: a synchronous setState there cascades renders (and trips the lint). A
+  // zero delay still routes through the timer, one tick later — cheap and lets
+  // the two paths share one shape. Losing the winner (or a delay change) runs
+  // the cleanup, which clears any pending grant and pulls `granted` back down, so
+  // a higher-priority claim taking over stands this slot straight back down.
+  useEffect(() => {
+    if (!isWinner) return undefined;
+    const timer = setTimeout(() => setGranted(true), Math.max(0, delayMs));
+    return () => {
+      clearTimeout(timer);
+      setGranted(false);
+    };
+  }, [isWinner, delayMs]);
+
+  return granted;
+}

--- a/apps/mobile/src/lib/tabBar.ts
+++ b/apps/mobile/src/lib/tabBar.ts
@@ -44,11 +44,21 @@ export interface TabBarState {
 /**
  * Resolve the bar's state from the current route segments.
  *
- * `hidden` wins first: a modal or the camera or a signed-out screen shows no
- * bar. Otherwise the active destination is the tab inside the `(tabs)` group,
- * or the pushed inbox, or nothing when you are deeper in the app.
+ * `signedOut` wins first: the bar belongs to the app proper, which needs a
+ * session, so a person with no account never sees it — not on the auth screens,
+ * and not on the one public page they can still reach signed-out (the privacy
+ * policy, opened from the login legal line). Once they are in, that same privacy
+ * page — now reached from Settings — keeps the bar like any other settings page.
+ *
+ * Then `hidden`: a modal or the camera or a signed-out screen shows no bar.
+ * Otherwise the active destination is the tab inside the `(tabs)` group, or the
+ * pushed inbox, or nothing when you are deeper in the app.
  */
-export function resolveTabBar(segments: readonly string[]): TabBarState {
+export function resolveTabBar(segments: readonly string[], signedOut = false): TabBarState {
+  if (signedOut) {
+    return { hidden: true, activeKey: '' };
+  }
+
   const root = segments[0] ?? '';
   const leaf = segments[segments.length - 1] ?? '';
 


### PR DESCRIPTION
Moves the intro tour behind authentication and coordinates the first-run prompts so they no longer collide, plus a set of onboarding/auth fixes.

## Onboarding tour
- The three-card intro now runs on the **first authenticated launch** (gated in `AuthGate`) rather than in front of the login screen. Same device flag (`baaki.onboarding_seen`), so anyone who already saw it is not shown it again. Removed the tour branch and its dead imports from `AuthFlow`.
- The pager no longer re-renders all three full-screen cards on every index change: cards are memoised and index-free, and the dots + next arrow are one overlay that is the sole index subscriber. Kills the mid-swipe/mid-glide stutter. Layout unchanged (each card reserves the control-row space with a spacer).
- Next button and skip use the primary ink (`#181818` via `buttonPrimary`), arrow in `onButtonPrimary`.

## Prompt priority queue
- New `promptQueue`: overlays claim a slot with a priority; only the highest live claim is granted. The coach-mark tour holds the top for the whole first run, so the daily tip stands down while it is up and lands a beat after it clears (`TIP_DELAY_MS`).
- The coach-mark tour now **waits for the dashboard data to load** before it starts, so spotlights anchor on real content rather than skeletons.

## Auth
- Legal line links only **Privacy Policy**; "Terms" is plain words (no separate terms page to point at).
- The bottom tab bar no longer leaks onto signed-out screens: **no session → no bar** anywhere, including the privacy page opened from the login legal line. Signed in, that page keeps the bar.
- Swapped the auth hero's phone/email order: email joins Google above the seam, phone below it — on both the login and sign-up doors.

All changed files pass tsc + eslint + prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a first-run onboarding tour for signed-in users, shown once per device.
  * Improved onboarding slides, navigation, accessibility labels, and RTL support.
  * Added coordinated handling for overlapping prompts, prioritizing onboarding over daily tips.
  * Email and phone sign-in options now follow a clearer layout and routing.

* **Bug Fixes**
  * Hidden the tab bar for signed-out users, including on privacy and legal pages.
  * Updated legal text so only the Privacy Policy is tappable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->