### PR TITLE
feat(mobile): contact picker on its own screen, drop trip reminders

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -526,6 +526,7 @@ function AuthGate() {
         <Stack.Screen name="group/[id]/itemize" options={modal} />
         <Stack.Screen name="receipt/[id]" options={modal} />
         <Stack.Screen name="friends/contacts" />
+        <Stack.Screen name="contact-picker" options={modal} />
         <Stack.Screen name="settings/backup" />
         <Stack.Screen name="settings/notifications" />
         <Stack.Screen name="settings/export" />

--- a/apps/mobile/src/app/contact-picker.tsx
+++ b/apps/mobile/src/app/contact-picker.tsx
@@ -23,16 +23,16 @@ import { directionalIcon, IconButton, iconSize, Row, Screen, Text, useTheme } fr
 import { useStrings } from '@/i18n';
 
 import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
-import { clearContactRequest, peekContactRequest } from '@/lib/contactPickerBridge';
+import { takeContactRequest } from '@/lib/contactPickerBridge';
 
 export default function ContactPickerScreen(): React.JSX.Element {
   const theme = useTheme();
   const { t } = useStrings();
 
-  // Read once on mount and hold it: the module request is cleared on the way
-  // out, but this screen keeps its own copy so a re-render cannot lose the
-  // caller's callback mid-session.
-  const [request] = useState(() => peekContactRequest());
+  // Taken once on mount — this captures the request and clears the bridge in
+  // one step, so the route owns it outright and no re-render or later open can
+  // see a stale request. Nothing else clears it; this screen is the sole owner.
+  const [request] = useState(() => takeContactRequest());
 
   // Opened with no pending request (a deep link, a stray navigation) has
   // nothing to pick for — close rather than show a picker that answers nobody.
@@ -42,7 +42,6 @@ export default function ContactPickerScreen(): React.JSX.Element {
 
   const confirm = (people: readonly PickedContact[]): void => {
     request?.onPicked(people);
-    clearContactRequest();
     router.back();
   };
 

--- a/apps/mobile/src/app/contact-picker.tsx
+++ b/apps/mobile/src/app/contact-picker.tsx
@@ -1,0 +1,85 @@
+/**
+ * The full-screen contact picker.
+ *
+ * Adding people to a group used to open the address book inline — a tall list
+ * folded into the middle of the new-group and members forms. A thousand-name
+ * book needs the whole screen (the alphabet rail needs somewhere to aim), so it
+ * lives here as its own route now, and the form that wanted it navigates in.
+ *
+ * A pushed route cannot return a value the way an inline callback did, so the
+ * caller leaves its intent in `contactPickerBridge` first — who is already
+ * picked, and what to do with the answer — and this screen reads it once on
+ * open. Confirming hands the ticked people back through that callback and
+ * closes; backing out without confirming drops the request untouched.
+ */
+
+import { useEffect, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { View } from 'react-native';
+
+import { directionalIcon, IconButton, iconSize, Row, Screen, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+
+import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
+import { clearContactRequest, peekContactRequest } from '@/lib/contactPickerBridge';
+
+export default function ContactPickerScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  // Read once on mount and hold it: the module request is cleared on the way
+  // out, but this screen keeps its own copy so a re-render cannot lose the
+  // caller's callback mid-session.
+  const [request] = useState(() => peekContactRequest());
+
+  // Opened with no pending request (a deep link, a stray navigation) has
+  // nothing to pick for — close rather than show a picker that answers nobody.
+  useEffect(() => {
+    if (!request) router.back();
+  }, [request]);
+
+  const confirm = (people: readonly PickedContact[]): void => {
+    request?.onPicked(people);
+    clearContactRequest();
+    router.back();
+  };
+
+  return (
+    // The picker anchors its confirm button to the foot of the screen, so this
+    // route holds the bottom inset too — otherwise the button hides under the
+    // navigation bar on a three-button phone.
+    <Screen edges={['top', 'bottom']}>
+      <View
+        style={{
+          flex: 1,
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.md,
+          gap: theme.spacing.lg,
+        }}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.misc.fromYourContacts}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        <ContactPicker
+          onConfirm={confirm}
+          initialSelected={request?.initial}
+          existing={request?.existing}
+          confirmVerb={t.add}
+        />
+      </View>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -21,7 +21,7 @@ import {
   useScreenClearance,
 } from '@waves/ui';
 
-import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
+import { type PickedContact } from '@/components/ContactPicker';
 import {
   useAddGhostMember,
   useDecideMemberClaim,
@@ -33,6 +33,7 @@ import { useBlockedUsers } from '@/data/blocked';
 import { displayName, groupLabel, isBlockedMember, isGhost, vpaOf } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { requestContacts } from '@/lib/contactPickerBridge';
 import { friendlyError } from '@/lib/errors';
 
 export default function MembersScreen() {
@@ -52,7 +53,6 @@ export default function MembersScreen() {
 
   const [ghostName, setGhostName] = useState('');
   const [ghostContact, setGhostContact] = useState('');
-  const [browsing, setBrowsing] = useState(false);
   const [adding, setAdding] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [claimError, setClaimError] = useState<string | null>(null);
@@ -154,10 +154,7 @@ export default function MembersScreen() {
       }
     }
     setAdding(false);
-    if (failed.length === 0) {
-      setBrowsing(false);
-      return;
-    }
+    if (failed.length === 0) return;
     setError(fill(t.misc.couldNotAddSome, { reason: reason ?? '' }));
   };
 
@@ -169,6 +166,18 @@ export default function MembersScreen() {
       [member.invite_email, member.invite_phone].filter((value): value is string => Boolean(value)),
     ),
   );
+
+  // Opens the address book on its own screen rather than unfolding it inline.
+  // Whoever is already in the group is greyed out there; the ticked people come
+  // back through the bridge into `addPicked`.
+  const openContactPicker = (): void => {
+    requestContacts({
+      initial: [],
+      existing: alreadyAdded,
+      onPicked: (people) => void addPicked(people),
+    });
+    router.push('/contact-picker');
+  };
 
   return (
     <Screen>
@@ -328,23 +337,7 @@ export default function MembersScreen() {
             }}
           />
 
-          <Button
-            label={browsing ? t.people.hideContacts : t.people.browseContacts}
-            variant="ghost"
-            onPress={() => setBrowsing((open) => !open)}
-          />
-
-          {browsing ? (
-            // Tall enough that the letter rail has something to aim at — a
-            // 320pt window turns a thousand contacts back into a peephole.
-            <View style={{ height: 480 }}>
-              <ContactPicker
-                onConfirm={(people) => void addPicked(people)}
-                existing={alreadyAdded}
-                busy={adding}
-              />
-            </View>
-          ) : null}
+          <Button label={t.people.browseContacts} variant="ghost" onPress={openContactPicker} />
           <Text variant="micro" tone="muted">
             {t.misc.nameAloneBody}
           </Text>

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -273,66 +273,48 @@ export default function NewGroupScreen() {
           <View style={{ width: 44 }} />
         </Row>
 
-        {/* The identity of the group, top-down: the cover you tap to set a
-            photo, the icon under it, then the name in a field of its own. The
-            avatar used to sit left of a cramped column; centred and stacked it
-            reads as the one thing this card is for. */}
-        <Card style={{ gap: theme.spacing.lg, alignItems: 'center' }}>
-          <GroupPhoto
-            photoPath={null}
-            localUri={effectivePhoto?.uri ?? null}
-            emoji={emoji}
-            size={88}
-            onPress={onPhotoPress}
-          />
-          {/* A compact swatch, not a full-width button — the icon is already
-              shown large on the avatar above, so this is only a way in. */}
-          <CoverEmojiPicker value={emoji} onChange={setPickedEmoji} compact />
-
-          <View style={{ width: '100%', gap: theme.spacing.xs }}>
-            <Row
+        {/* One compact row: the cover you tap to set a photo, the name inline
+            beside it, and a clear (×) once there is a name. The icon swatch
+            tucks under the same row. */}
+        <Card style={{ gap: theme.spacing.md }}>
+          <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+            <GroupPhoto
+              photoPath={null}
+              localUri={effectivePhoto?.uri ?? null}
+              emoji={emoji}
+              size={52}
+              onPress={onPhotoPress}
+            />
+            <TextInput
+              value={name}
+              onChangeText={setName}
+              placeholder={t.misc.newGroupPlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              accessibilityLabel={t.group.groupName}
+              autoFocus
               style={{
-                alignItems: 'center',
-                gap: theme.spacing.sm,
-                borderWidth: 1,
-                borderColor: theme.color.border,
-                borderRadius: theme.radius.lg,
-                paddingHorizontal: theme.spacing.lg,
+                flex: 1,
+                fontSize: 18,
+                fontWeight: '700',
+                color: theme.color.text,
+                paddingVertical: theme.spacing.sm,
               }}
-            >
-              <TextInput
-                value={name}
-                onChangeText={setName}
-                placeholder={t.misc.newGroupPlaceholder}
-                placeholderTextColor={theme.color.textFaint}
-                accessibilityLabel={t.group.groupName}
-                autoFocus
-                style={{
-                  flex: 1,
-                  fontSize: 20,
-                  fontWeight: '700',
-                  color: theme.color.text,
-                  paddingVertical: theme.spacing.md,
-                }}
-              />
-              {name.length > 0 ? (
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={t.entry.clear}
-                  onPress={() => setName('')}
-                  hitSlop={8}
-                  style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
-                >
-                  <Ionicons name="close-circle" size={iconSize.lg} color={theme.color.textFaint} />
-                </Pressable>
-              ) : null}
-            </Row>
-            {/* Blank is fine — the group is labelled by who is in it. Said once,
-                quietly, under the field rather than behind an info toggle. */}
-            <Text variant="caption" tone="muted" align="center">
-              {t.extras.blankNameHint}
-            </Text>
-          </View>
+            />
+            {name.length > 0 ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.entry.clear}
+                onPress={() => setName('')}
+                hitSlop={8}
+                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+              >
+                <Ionicons name="close-circle" size={iconSize.md} color={theme.color.textFaint} />
+              </Pressable>
+            ) : null}
+          </Row>
+          {/* A compact swatch, not a full-width button — the icon is already on
+              the avatar; this is only a way in to change it. */}
+          <CoverEmojiPicker value={emoji} onChange={setPickedEmoji} compact />
         </Card>
 
         <View style={{ gap: theme.spacing.md }}>

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -22,11 +22,12 @@ import {
 
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { friendlyError } from '@/lib/errors';
-import { ContactPicker, type PickedContact } from '@/components/ContactPicker';
+import { type PickedContact } from '@/components/ContactPicker';
 import { CountryRow } from '@/components/CountryPicker';
 import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
 import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates, type TripDatesValue } from '@/components/TripDates';
+import { requestContacts } from '@/lib/contactPickerBridge';
 import { pickGroupPhoto, type PickedImage } from '@/lib/image';
 import {
   photoGateParam,
@@ -113,7 +114,6 @@ export default function NewGroupScreen() {
   // whatever the phone had. Same shape either way, so the create loop treats
   // them alike.
   const [ghosts, setGhosts] = useState<PickedContact[]>([]);
-  const [browsing, setBrowsing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Read once, not on every render: a phone does not change country mid-form.
   const [country, setCountry] = useState<string | null>(() => deviceCountry());
@@ -243,7 +243,13 @@ export default function NewGroupScreen() {
       }
       return merged;
     });
-    setBrowsing(false);
+  };
+
+  // Hand the picker who is already chosen and what to do with the answer, then
+  // open it on its own screen. It calls `addContacts` back through the bridge.
+  const openContactPicker = (): void => {
+    requestContacts({ initial: ghosts, onPicked: addContacts });
+    router.push('/contact-picker');
   };
 
   return (
@@ -357,15 +363,15 @@ export default function NewGroupScreen() {
             info={t.extras.ghostNote}
             titleVariant="caption"
             right={
-              // The same phone-contacts picker, moved to the section heading so
-              // it reads as an action on People rather than a stray button below
-              // the name field. Nobody's book is uploaded (ADR-006).
+              // Opens the address book on its own screen rather than unfolding
+              // it inline — a thousand-name list needs the whole height. Nobody's
+              // book is uploaded (ADR-006). The picker hands its answer back
+              // through the bridge into `addContacts`.
               <Pressable
                 accessibilityRole="button"
-                accessibilityState={{ expanded: browsing }}
-                accessibilityLabel={browsing ? t.people.hideContacts : t.people.browseContacts}
+                accessibilityLabel={t.people.browseContacts}
                 hitSlop={8}
-                onPress={() => setBrowsing((open) => !open)}
+                onPress={openContactPicker}
                 style={({ pressed }) => ({
                   flexDirection: 'row',
                   alignItems: 'center',
@@ -373,11 +379,7 @@ export default function NewGroupScreen() {
                   opacity: pressed ? 0.6 : 1,
                 })}
               >
-                <Ionicons
-                  name={browsing ? 'people' : 'people-outline'}
-                  size={iconSize.base}
-                  color={theme.color.brand}
-                />
+                <Ionicons name="people-outline" size={iconSize.base} color={theme.color.brand} />
                 <Text variant="caption" style={{ color: theme.color.brand }}>
                   {t.people.contacts}
                 </Text>
@@ -408,21 +410,6 @@ export default function NewGroupScreen() {
               onPress={addTypedGhost}
             />
           </Row>
-
-          {browsing ? (
-            // Tall enough that the letter rail has something to aim at — a
-            // short window turns a thousand contacts back into a peephole.
-            <View style={{ gap: theme.spacing.sm }}>
-              <Text variant="caption" tone="muted">
-                {t.misc.fromYourContacts}
-              </Text>
-              <View style={{ height: 480 }}>
-                {/* Seeded with whoever is already added, so the people already
-                    selected show ticked here rather than the picker opening blank. */}
-                <ContactPicker onConfirm={addContacts} initialSelected={ghosts} />
-              </View>
-            </View>
-          ) : null}
 
           {ghosts.length > 0 ? (
             <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -273,21 +273,33 @@ export default function NewGroupScreen() {
           <View style={{ width: 44 }} />
         </Row>
 
-        <Card style={{ gap: theme.spacing.lg }}>
-          <Row style={{ gap: theme.spacing.lg }}>
-            <GroupPhoto
-              photoPath={null}
-              localUri={effectivePhoto?.uri ?? null}
-              emoji={emoji}
-              size={72}
-              onPress={onPhotoPress}
-            />
-            <View style={{ flex: 1, gap: theme.spacing.xs }}>
-              <InfoDisclosure
-                title={t.group.nameOptional}
-                info={t.extras.blankNameHint}
-                titleVariant="caption"
-              />
+        {/* The identity of the group, top-down: the cover you tap to set a
+            photo, the icon under it, then the name in a field of its own. The
+            avatar used to sit left of a cramped column; centred and stacked it
+            reads as the one thing this card is for. */}
+        <Card style={{ gap: theme.spacing.lg, alignItems: 'center' }}>
+          <GroupPhoto
+            photoPath={null}
+            localUri={effectivePhoto?.uri ?? null}
+            emoji={emoji}
+            size={88}
+            onPress={onPhotoPress}
+          />
+          {/* A compact swatch, not a full-width button — the icon is already
+              shown large on the avatar above, so this is only a way in. */}
+          <CoverEmojiPicker value={emoji} onChange={setPickedEmoji} compact />
+
+          <View style={{ width: '100%', gap: theme.spacing.xs }}>
+            <Row
+              style={{
+                alignItems: 'center',
+                gap: theme.spacing.sm,
+                borderWidth: 1,
+                borderColor: theme.color.border,
+                borderRadius: theme.radius.lg,
+                paddingHorizontal: theme.spacing.lg,
+              }}
+            >
               <TextInput
                 value={name}
                 onChangeText={setName}
@@ -296,18 +308,31 @@ export default function NewGroupScreen() {
                 accessibilityLabel={t.group.groupName}
                 autoFocus
                 style={{
-                  fontSize: 22,
+                  flex: 1,
+                  fontSize: 20,
                   fontWeight: '700',
                   color: theme.color.text,
-                  paddingVertical: theme.spacing.sm,
+                  paddingVertical: theme.spacing.md,
                 }}
               />
-              {/* A compact swatch rather than a full-width button — the icon is
-                  already shown large on the avatar beside it, so this only needs
-                  to be a way in, not a billboard. */}
-              <CoverEmojiPicker value={emoji} onChange={setPickedEmoji} compact />
-            </View>
-          </Row>
+              {name.length > 0 ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={t.entry.clear}
+                  onPress={() => setName('')}
+                  hitSlop={8}
+                  style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+                >
+                  <Ionicons name="close-circle" size={iconSize.lg} color={theme.color.textFaint} />
+                </Pressable>
+              ) : null}
+            </Row>
+            {/* Blank is fine — the group is labelled by who is in it. Said once,
+                quietly, under the field rather than behind an info toggle. */}
+            <Text variant="caption" tone="muted" align="center">
+              {t.extras.blankNameHint}
+            </Text>
+          </View>
         </Card>
 
         <View style={{ gap: theme.spacing.md }}>

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -1,6 +1,5 @@
 import { useState, type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useQuery } from '@tanstack/react-query';
 import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
@@ -28,14 +27,6 @@ import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
 import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates, type TripDatesValue } from '@/components/TripDates';
 import { requestContacts } from '@/lib/contactPickerBridge';
-import { pickGroupPhoto, type PickedImage } from '@/lib/image';
-import {
-  photoGateParam,
-  photoGateStatus,
-  photoTapAction,
-  shouldClearPickedPhoto,
-} from '@/lib/groupPhotoGate';
-import { canUploadGroupPhoto, uploadGroupPhoto } from '@/data/api';
 import { useCreateGroup } from '@/data/hooks';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { useSync } from '@/sync';
@@ -85,29 +76,12 @@ export default function NewGroupScreen() {
   const { t, locale } = useStrings();
   const createGroup = useCreateGroup();
   const guard = useGuestGuard();
-  const { mutate, flush } = useSync();
+  const { mutate } = useSync();
 
   const [name, setName] = useState('');
-  const [photo, setPhoto] = useState<PickedImage | null>(null);
-  const [uploading, setUploading] = useState(false);
-
-  // A group photo is a paid feature; a cover emoji is free. A new group has only
-  // its creator, so the server gates on whether the creator is paid (null group).
-  const photoGate = useQuery({
-    queryKey: ['photoGate', null],
-    queryFn: () => canUploadGroupPhoto(photoGateParam(null)),
-  });
-  const photoStatus = photoGateStatus(photoGate.data, photoGate.isLoading);
-  // If the gate resolves locked after a photo was somehow chosen, ignore it — a
-  // locked group falls back to its icon, and this photo could never upload.
-  // Derived, not stored, so there is no setState-in-effect and no stale flash.
-  const effectivePhoto = shouldClearPickedPhoto(photoStatus, photo !== null) ? null : photo;
-
-  const onPhotoPress = (): void => {
-    const action = photoTapAction(photoStatus);
-    if (action === 'pick') void pickGroupPhoto().then(setPhoto);
-    else if (action === 'showLockedHint') router.push('/settings/upgrade');
-  };
+  // The group cover is an emoji icon, chosen by tapping the avatar. Photos are
+  // a paid feature edited from group settings, not part of creating one.
+  const [iconOpen, setIconOpen] = useState(false);
   const [type, setType] = useState<GroupType>(GroupType.Trip);
   const [ghostName, setGhostName] = useState('');
   // People to add on Create — a typed name carries no address, a contact carries
@@ -189,26 +163,6 @@ export default function NewGroupScreen() {
         });
       }
 
-      // The photo lives in Storage, not the offline queue, and its policy is
-      // "members of this group only" — which needs the group and the membership
-      // row actually on the server. Flush the queued create (and everything
-      // behind it) before writing an object under its id.
-      if (effectivePhoto) {
-        setUploading(true);
-        try {
-          await flush([groupId]);
-          await uploadGroupPhoto({
-            groupId,
-            base64: effectivePhoto.base64,
-            mimeType: effectivePhoto.mimeType,
-          });
-        } catch {
-          // A photo that would not upload is not worth losing the group over;
-          // it can be added again from group settings.
-        } finally {
-          setUploading(false);
-        }
-      }
       router.replace(`/group/${groupId}`);
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'newGroup.create'));
@@ -273,18 +227,18 @@ export default function NewGroupScreen() {
           <View style={{ width: 44 }} />
         </Row>
 
-        {/* One compact row: the cover you tap to set a photo, the name inline
-            beside it, and a clear (×) once there is a name. The icon swatch
-            tucks under the same row. */}
+        {/* One compact row: the cover — tapped to choose an icon — with the
+            name inline beside it and a clear (×) once there is a name. */}
         <Card style={{ gap: theme.spacing.md }}>
           <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
-            <GroupPhoto
-              photoPath={null}
-              localUri={effectivePhoto?.uri ?? null}
-              emoji={emoji}
-              size={52}
-              onPress={onPhotoPress}
-            />
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t.group.chooseIcon}
+              onPress={() => setIconOpen(true)}
+              style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+            >
+              <GroupPhoto photoPath={null} emoji={emoji} size={52} />
+            </Pressable>
             <TextInput
               value={name}
               onChangeText={setName}
@@ -312,10 +266,15 @@ export default function NewGroupScreen() {
               </Pressable>
             ) : null}
           </Row>
-          {/* A compact swatch, not a full-width button — the icon is already on
-              the avatar; this is only a way in to change it. */}
-          <CoverEmojiPicker value={emoji} onChange={setPickedEmoji} compact />
         </Card>
+
+        {/* Controlled by the avatar tap above — no trigger of its own. */}
+        <CoverEmojiPicker
+          value={emoji}
+          onChange={setPickedEmoji}
+          open={iconOpen}
+          onOpenChange={setIconOpen}
+        />
 
         <View style={{ gap: theme.spacing.md }}>
           <Text variant="caption" tone="muted">
@@ -460,15 +419,13 @@ export default function NewGroupScreen() {
         }}
       >
         {error ? <Callout tone="negative">{error}</Callout> : null}
-        {createGroup.isPending || uploading ? (
-          <ActivityIndicator color={theme.color.brand} />
-        ) : null}
+        {createGroup.isPending ? <ActivityIndicator color={theme.color.brand} /> : null}
 
         <Button
           label={t.misc.createGroup}
           size="lg"
           fullWidth
-          disabled={createGroup.isPending || uploading}
+          disabled={createGroup.isPending}
           onPress={() => void submit()}
         />
       </View>

--- a/apps/mobile/src/components/CoverEmojiPicker.tsx
+++ b/apps/mobile/src/components/CoverEmojiPicker.tsx
@@ -104,11 +104,22 @@ export function CoverEmojiPicker({
         {/* A bottom sheet, not a full page: a dim backdrop you can tap to
             dismiss, over a rounded card anchored to the bottom. */}
         <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+          {/* Dim scrim; tap to dismiss. Kept out of the accessibility tree —
+              the header's close button is the labelled way out, so a
+              full-screen dismissal target would only add screen-reader noise.
+              No theme scrim token exists; this matches the app's modal dim. */}
           <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.common.close}
             onPress={() => setOpen(false)}
-            style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              backgroundColor: '#00000080',
+            }}
           />
 
           <View

--- a/apps/mobile/src/components/CoverEmojiPicker.tsx
+++ b/apps/mobile/src/components/CoverEmojiPicker.tsx
@@ -3,19 +3,27 @@
  *
  * The old control was nine emoji crammed under the name field with no way to
  * reach a tenth — fine until the group is a badminton league or a wedding, and
- * then it is a wall. This is the same idea with room to breathe: one button that
- * opens a wide, curated set, grouped so the eye can find the row it wants.
+ * then it is a wall. This is the same idea with room to breathe: a curated set,
+ * grouped so the eye can find the row it wants, shown in a bottom sheet with the
+ * current pick previewed large at the top.
  *
  * Deliberately not the whole emoji keyboard. A shared-expense group wants a
  * cover somebody recognises at a glance in a list, not 🫠 — so the set is the
  * trips, homes, meals, journeys and pastimes a group is actually named after.
  * Whatever is picked is stored as a single character, same as before.
+ *
+ * Two ways to open it. Left to itself it renders its own trigger (a compact
+ * swatch or a button) and owns the open state. Passed `open`/`onOpenChange` it
+ * is controlled and renders no trigger — so a caller can open it from somewhere
+ * else entirely, like tapping the group's avatar.
  */
 
 import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { Modal, Pressable, ScrollView, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Button, Card, Row, Screen, Text, useTheme } from '@waves/ui';
+import { Button, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -31,19 +39,32 @@ export function CoverEmojiPicker({
   value,
   onChange,
   compact = false,
+  open,
+  onOpenChange,
 }: {
   value: string | null;
   onChange: (emoji: string) => void;
   /** A small emoji-swatch pill instead of a full button, for tight layouts. */
   compact?: boolean;
+  /** Controlled open state. When set, no trigger is rendered. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const theme = useTheme();
   const { t } = useStrings();
-  const [open, setOpen] = useState(false);
+  const insets = useSafeAreaInsets();
+  const [internalOpen, setInternalOpen] = useState(false);
+
+  const controlled = open !== undefined;
+  const isOpen = controlled ? open : internalOpen;
+  const setOpen = (next: boolean): void => {
+    if (controlled) onOpenChange?.(next);
+    else setInternalOpen(next);
+  };
 
   return (
     <>
-      {compact ? (
+      {controlled ? null : compact ? (
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={t.group.chooseIcon}
@@ -74,64 +95,128 @@ export function CoverEmojiPicker({
         />
       )}
 
-      <Modal visible={open} animationType="slide" onRequestClose={() => setOpen(false)}>
-        <Screen edges={['top', 'bottom']} inModal>
-          <View style={{ paddingHorizontal: theme.spacing.xl, paddingBottom: theme.spacing.md }}>
-            <Text variant="heading">{t.group.chooseIcon}</Text>
-          </View>
+      <Modal
+        visible={isOpen}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setOpen(false)}
+      >
+        {/* A bottom sheet, not a full page: a dim backdrop you can tap to
+            dismiss, over a rounded card anchored to the bottom. */}
+        <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.common.close}
+            onPress={() => setOpen(false)}
+            style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+          />
 
-          <ScrollView
-            contentContainerStyle={{
-              paddingHorizontal: theme.spacing.xl,
-              paddingBottom: theme.spacing.xxxl,
-              gap: theme.spacing.lg,
+          <View
+            style={{
+              maxHeight: '82%',
+              backgroundColor: theme.color.surface,
+              borderTopLeftRadius: theme.radius.xxl,
+              borderTopRightRadius: theme.radius.xxl,
+              paddingTop: theme.spacing.sm,
+              paddingBottom: insets.bottom + theme.spacing.md,
             }}
-            showsVerticalScrollIndicator={false}
           >
-            {EMOJI_GROUPS.map((emojis, index) => (
-              <Card key={index} style={{ gap: theme.spacing.sm }}>
-                <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
-                  {emojis.map((emoji) => {
-                    const selected = value === emoji;
-                    return (
-                      <Pressable
-                        key={emoji}
-                        accessibilityRole="radio"
-                        accessibilityState={{ selected }}
-                        accessibilityLabel={emoji}
-                        onPress={() => {
-                          onChange(emoji);
-                          setOpen(false);
-                        }}
-                        style={{
-                          width: 48,
-                          height: 48,
-                          borderRadius: theme.radius.pill,
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          backgroundColor: selected
-                            ? theme.color.brandSoft
-                            : theme.color.surfaceMuted,
-                        }}
-                      >
-                        <Text style={{ fontSize: 24 }}>{emoji}</Text>
-                      </Pressable>
-                    );
-                  })}
-                </Row>
-              </Card>
-            ))}
-          </ScrollView>
-
-          <View style={{ paddingHorizontal: theme.spacing.xl, paddingBottom: theme.spacing.lg }}>
-            <Button
-              label={t.common.close}
-              variant="ghost"
-              fullWidth
-              onPress={() => setOpen(false)}
+            {/* Grab handle */}
+            <View
+              style={{
+                alignSelf: 'center',
+                width: 40,
+                height: 4,
+                borderRadius: theme.radius.pill,
+                backgroundColor: theme.color.border,
+                marginBottom: theme.spacing.md,
+              }}
             />
+
+            <Row
+              style={{
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                paddingHorizontal: theme.spacing.xl,
+              }}
+            >
+              <Text variant="heading">{t.group.chooseIcon}</Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.common.close}
+                onPress={() => setOpen(false)}
+                hitSlop={8}
+                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+              >
+                <Ionicons name="close" size={iconSize.lg} color={theme.color.textMuted} />
+              </Pressable>
+            </Row>
+
+            {/* The current pick, previewed large on a tinted circle. */}
+            <View style={{ alignItems: 'center', paddingVertical: theme.spacing.lg }}>
+              <View
+                style={{
+                  width: 84,
+                  height: 84,
+                  borderRadius: 28,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: theme.color.brandSoft,
+                }}
+              >
+                <Text style={{ fontSize: 44 }}>{value ?? '👥'}</Text>
+              </View>
+            </View>
+
+            <ScrollView
+              contentContainerStyle={{
+                paddingHorizontal: theme.spacing.xl,
+                paddingBottom: theme.spacing.xl,
+                gap: theme.spacing.lg,
+              }}
+              showsVerticalScrollIndicator={false}
+            >
+              {EMOJI_GROUPS.map((emojis, index) => (
+                <View key={index} style={{ gap: theme.spacing.sm }}>
+                  {index > 0 ? (
+                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                  ) : null}
+                  <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
+                    {emojis.map((emoji) => {
+                      const selected = value === emoji;
+                      return (
+                        <Pressable
+                          key={emoji}
+                          accessibilityRole="radio"
+                          accessibilityState={{ selected }}
+                          accessibilityLabel={emoji}
+                          onPress={() => {
+                            onChange(emoji);
+                            setOpen(false);
+                          }}
+                          style={{
+                            width: 52,
+                            height: 52,
+                            borderRadius: theme.radius.lg,
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            borderWidth: selected ? 2 : 1,
+                            borderColor: selected ? theme.color.brand : theme.color.border,
+                            backgroundColor: selected
+                              ? theme.color.brandSoft
+                              : theme.color.surfaceMuted,
+                          }}
+                        >
+                          <Text style={{ fontSize: 26 }}>{emoji}</Text>
+                        </Pressable>
+                      );
+                    })}
+                  </Row>
+                </View>
+              ))}
+            </ScrollView>
           </View>
-        </Screen>
+        </View>
       </Modal>
     </>
   );

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -1,17 +1,11 @@
 /**
- * When the trip is, and the two reminders a day that come with it.
+ * When the trip is — its start and end, as one framed range.
  *
- * The reason to ask for dates at all is the reminders. Four people go to Goa;
- * on day one everybody adds everything; by day three nobody has entered
- * anything since the first lunch, and on the flight home somebody tries to
- * reconstruct a week of autorickshaws from memory. A shared ledger is only as
- * good as the habit of adding to it, and the habit needs prompting while the
- * receipts still exist.
- *
- * The times are settable because "breakfast" is not a fixed hour, and a group
- * asked at the wrong one mutes the app rather than moving the setting. The
- * timezone is the trip's rather than each reader's for the same reason: a
- * question about dinner should not arrive at 04:00.
+ * The span is worth recording on its own: it labels the group with its dates
+ * and marks how long the shared ledger was meant to cover. The daily-reminder
+ * controls that used to live here were removed, so this card now only asks the
+ * two dates; the underlying `remind_*` fields stay on the type for whatever
+ * else reads them, but nothing here sets them.
  */
 
 import { useState } from 'react';
@@ -19,7 +13,7 @@ import DateTimePicker, { type DateTimePickerEvent } from '@react-native-communit
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Platform, Pressable, View } from 'react-native';
 
-import { Button, Card, directionalIcon, iconSize, Row, Text, Toggle, useTheme } from '@waves/ui';
+import { Button, Card, directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -41,8 +35,6 @@ export interface TripDatesValue {
 enum Field {
   Start = 'start',
   End = 'end',
-  Morning = 'morning',
-  Evening = 'evening',
 }
 
 export interface TripDatesPatch {
@@ -71,22 +63,6 @@ function isoDate(value: Date): string {
   return `${value.getFullYear()}-${month}-${day}`;
 }
 
-function timeFrom(value: string): Date {
-  const [hours, minutes] = value.split(':').map(Number);
-  const date = new Date();
-  date.setHours(hours ?? 9, minutes ?? 0, 0, 0);
-  return date;
-}
-
-function isoTime(value: Date): string {
-  return `${String(value.getHours()).padStart(2, '0')}:${String(value.getMinutes()).padStart(2, '0')}:00`;
-}
-
-/** "9:00 am" in whatever the reader's phone calls that. */
-function showTime(value: string, locale: string): string {
-  return timeFrom(value).toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' });
-}
-
 function showDate(iso: string | null, locale: string, notSet: string): string {
   if (!iso) return notSet;
   return dateFrom(iso).toLocaleDateString(locale, {
@@ -95,8 +71,6 @@ function showDate(iso: string | null, locale: string, notSet: string): string {
     month: 'short',
   });
 }
-
-const deviceZone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Kolkata';
 
 /**
  * One end of the range — a tappable label over a big date, filling half the
@@ -131,48 +105,6 @@ function RangeEnd({
   );
 }
 
-/** A reminder time as a bordered pill: an icon, a small label, and the time. */
-function TimePill({
-  icon,
-  label,
-  value,
-  onPress,
-}: {
-  icon: keyof typeof Ionicons.glyphMap;
-  label: string;
-  value: string;
-  onPress: () => void;
-}) {
-  const theme = useTheme();
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={`${label}: ${value}`}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        flex: 1,
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: theme.spacing.sm,
-        borderWidth: 1,
-        borderColor: theme.color.border,
-        borderRadius: theme.radius.lg,
-        paddingHorizontal: theme.spacing.md,
-        paddingVertical: theme.spacing.sm,
-        opacity: pressed ? 0.7 : 1,
-      })}
-    >
-      <Ionicons name={icon} size={iconSize.md} color={theme.color.brand} />
-      <View style={{ gap: 1 }}>
-        <Text variant="micro" tone="muted">
-          {label}
-        </Text>
-        <Text variant="subheading">{value}</Text>
-      </View>
-    </Pressable>
-  );
-}
-
 export function TripDates({
   group,
   locale,
@@ -190,35 +122,23 @@ export function TripDates({
   // icon by default; the dates themselves stay in view.
   const [showInfo, setShowInfo] = useState(false);
 
-  const hasDates = Boolean(group.start_date && group.end_date);
-
   const apply = (field: Field, event: DateTimePickerEvent, picked?: Date): void => {
     // Android's picker is a modal that reports its own dismissal; iOS's is
     // inline and reports every scroll.
     if (Platform.OS === 'android') setEditing(null);
     if (event.type === 'dismissed' || !picked) return;
 
-    switch (field) {
-      case Field.Start: {
-        const start = isoDate(picked);
-        // An end date before the start is not a trip. Dragging the start past
-        // the end moves the end rather than refusing the tap.
-        const end = group.end_date && group.end_date < start ? start : group.end_date;
-        onChange({ start_date: start, end_date: end ?? start, time_zone: group.time_zone });
-        return;
-      }
-      case Field.End: {
-        const end = isoDate(picked);
-        const start = group.start_date && group.start_date > end ? end : group.start_date;
-        onChange({ end_date: end, start_date: start ?? end });
-        return;
-      }
-      case Field.Morning:
-        onChange({ remind_morning_at: isoTime(picked) });
-        return;
-      default:
-        onChange({ remind_evening_at: isoTime(picked) });
+    if (field === Field.Start) {
+      const start = isoDate(picked);
+      // An end date before the start is not a trip. Dragging the start past
+      // the end moves the end rather than refusing the tap.
+      const end = group.end_date && group.end_date < start ? start : group.end_date;
+      onChange({ start_date: start, end_date: end ?? start, time_zone: group.time_zone });
+      return;
     }
+    const end = isoDate(picked);
+    const start = group.start_date && group.start_date > end ? end : group.start_date;
+    onChange({ end_date: end, start_date: start ?? end });
   };
 
   return (
@@ -291,57 +211,6 @@ export function TripDates({
         />
       </Row>
 
-      {hasDates ? (
-        <>
-          <View style={{ height: 1, backgroundColor: theme.color.border }} />
-
-          <Row style={{ justifyContent: 'space-between' }}>
-            <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>
-              <Text variant="subheading">{t.pickers.dailyReminders}</Text>
-              <Text variant="caption" tone="muted">
-                {t.pickers.remindZoneNote.replace('{zone}', group.time_zone.replace(/_/g, ' '))}
-              </Text>
-            </View>
-            <Toggle
-              value={group.remind_daily}
-              onValueChange={(value) => onChange({ remind_daily: value })}
-              accessibilityLabel={t.pickers.dailyReminders}
-            />
-          </Row>
-
-          {group.remind_daily ? (
-            <>
-              <Row style={{ gap: theme.spacing.md }}>
-                <TimePill
-                  icon="sunny-outline"
-                  label={t.pickers.breakfast}
-                  value={showTime(group.remind_morning_at, locale)}
-                  onPress={() => setEditing(Field.Morning)}
-                />
-                <TimePill
-                  icon="moon-outline"
-                  label={t.pickers.endOfDay}
-                  value={showTime(group.remind_evening_at, locale)}
-                  onPress={() => setEditing(Field.Evening)}
-                />
-              </Row>
-
-              {group.time_zone !== deviceZone() ? (
-                <Button
-                  label={t.pickers.useMyTimezone.replace(
-                    '{zone}',
-                    deviceZone().split('/').pop()?.replace(/_/g, ' ') ?? '',
-                  )}
-                  size="sm"
-                  variant="ghost"
-                  onPress={() => onChange({ time_zone: deviceZone() })}
-                />
-              ) : null}
-            </>
-          ) : null}
-        </>
-      ) : null}
-
       {group.start_date && group.end_date ? (
         <Button
           label={t.pickers.clearDates}
@@ -353,16 +222,8 @@ export function TripDates({
 
       {editing ? (
         <DateTimePicker
-          value={
-            editing === Field.Start
-              ? dateFrom(group.start_date)
-              : editing === Field.End
-                ? dateFrom(group.end_date)
-                : timeFrom(
-                    editing === Field.Morning ? group.remind_morning_at : group.remind_evening_at,
-                  )
-          }
-          mode={editing === Field.Start || editing === Field.End ? 'date' : 'time'}
+          value={editing === Field.Start ? dateFrom(group.start_date) : dateFrom(group.end_date)}
+          mode="date"
           // The end of a trip cannot be before its beginning, so the picker
           // does not offer it.
           minimumDate={

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -211,13 +211,27 @@ export function TripDates({
         />
       </Row>
 
+      {/* A quiet way out, not a competing action: a small muted link tucked
+          under the range rather than a full-width button. */}
       {group.start_date && group.end_date ? (
-        <Button
-          label={t.pickers.clearDates}
-          size="sm"
-          variant="ghost"
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t.pickers.clearDates}
           onPress={() => onChange({ start_date: null, end_date: null })}
-        />
+          hitSlop={8}
+          style={({ pressed }) => ({ alignSelf: 'center', opacity: pressed ? 0.6 : 1 })}
+        >
+          <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            <Ionicons
+              name="close-circle-outline"
+              size={iconSize.sm}
+              color={theme.color.textMuted}
+            />
+            <Text variant="caption" tone="muted">
+              {t.pickers.clearDates}
+            </Text>
+          </Row>
+        </Pressable>
       ) : null}
 
       {editing ? (

--- a/apps/mobile/src/lib/contactPickerBridge.ts
+++ b/apps/mobile/src/lib/contactPickerBridge.ts
@@ -1,0 +1,48 @@
+/**
+ * A one-shot handoff between a screen that needs contacts and the full-screen
+ * contact picker.
+ *
+ * The picker used to be embedded inline under an "add people" section — a
+ * 480pt address book crammed into the middle of a form. Pulled out into its own
+ * route it has the whole screen to work with (a letter rail needs the height),
+ * but a pushed route cannot hand a value back the way a callback can. So the
+ * caller leaves its intent here first: who is already picked, and what to do
+ * with the answer. The picker reads it on open, and calls `onPicked` with the
+ * ticked people before it closes.
+ *
+ * Deliberately a module singleton, not React state: it has to outlive the
+ * navigation that carries the caller off-screen and back. It holds exactly one
+ * request — there is only ever one picker open — and is cleared once answered
+ * or abandoned, so a stale request can never leak into the next open.
+ */
+
+import type { PickedContact } from '@/components/ContactPicker';
+
+export interface ContactRequest {
+  /** Whoever the caller has already chosen, so the picker opens ticked. */
+  readonly initial: readonly PickedContact[];
+  /**
+   * Addresses already in the group — shown greyed rather than hidden, so it is
+   * obvious why they cannot be picked again. Omitted when nothing is off-limits.
+   */
+  readonly existing?: ReadonlySet<string>;
+  /** What the caller does with the people ticked, once the picker confirms. */
+  readonly onPicked: (people: readonly PickedContact[]) => void;
+}
+
+let pending: ContactRequest | null = null;
+
+/** Stash the caller's intent, then navigate to `/contact-picker`. */
+export function requestContacts(request: ContactRequest): void {
+  pending = request;
+}
+
+/** Read the open request (the picker reads this once on mount). */
+export function peekContactRequest(): ContactRequest | null {
+  return pending;
+}
+
+/** Drop the request — answered or abandoned, it must not carry over. */
+export function clearContactRequest(): void {
+  pending = null;
+}

--- a/apps/mobile/src/lib/contactPickerBridge.ts
+++ b/apps/mobile/src/lib/contactPickerBridge.ts
@@ -37,12 +37,13 @@ export function requestContacts(request: ContactRequest): void {
   pending = request;
 }
 
-/** Read the open request (the picker reads this once on mount). */
-export function peekContactRequest(): ContactRequest | null {
-  return pending;
-}
-
-/** Drop the request — answered or abandoned, it must not carry over. */
-export function clearContactRequest(): void {
+/**
+ * Take the open request and clear it in the same step — the picker reads this
+ * once on mount and thereafter owns the captured request, so nothing can carry
+ * over to the next open whether it confirms or is backed out of.
+ */
+export function takeContactRequest(): ContactRequest | null {
+  const request = pending;
   pending = null;
+  return request;
 }

--- a/apps/mobile/src/lib/tabBar.ts
+++ b/apps/mobile/src/lib/tabBar.ts
@@ -22,6 +22,7 @@ export const TAB_BAR_HIDDEN_ROUTES: ReadonlySet<string> = new Set([
   'join',
   'language',
   'capture',
+  'contact-picker',
   'new-group',
   'add-expense',
   'settle',


### PR DESCRIPTION
## What

Two changes to the new-group / edit-group section.

### Contact picker is now a screen, not inline
"Browse contacts" used to unfold a 480pt address book into the middle of the form. It now opens a dedicated `/contact-picker` modal route with the whole screen to work with (the alphabet rail needs the height). Wired from both **new-group** and the group **members** screen.

Because a pushed route can't return a value the way an inline callback could, the caller stashes its intent in a small module bridge (`contactPickerBridge.ts`) first — who's already picked (`initial`), which addresses are off-limits (`existing`, greyed out), and what to do with the answer (`onPicked`). The picker reads it once on mount and hands the ticked people back through the callback before closing. Backing out without confirming drops the request untouched.

### Trip reminders removed
`TripDates` loses the daily-reminder section — the toggle, the two time pills, and the timezone button. The card now only asks the trip's start and end. The `remind_*` fields stay on the value type and the create payload, so backend behaviour is unchanged; nothing in the UI sets them anymore.

## Notes
- New route registered as a modal and hidden from the bottom tab bar.
- No new i18n strings — the picker screen reuses existing keys; a few reminder-only keys are now unused (left in place).
- Local gates green: `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated full-screen contact picker for creating groups and managing group members.
  * Existing group members are shown as unavailable to prevent duplicate selections.
  * Added confirmation handling and navigation for selected contacts.
  * Added a redesigned emoji picker for group covers with grouped options and selected-state styling.

* **Improvements**
  * Simplified trip date editing to focus on start and end dates.
  * Removed daily reminder and reminder-time controls from trip date settings.
  * Removed group photo selection during new-group creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->