### PR TITLE
fix(mobile): drop body line under dashboard "no groups"

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -344,7 +344,6 @@ export default function HomeScreen() {
         ) : list.length === 0 ? (
           <EmptyState
             title={t.tabs.noGroups}
-            body={t.tabs.noGroupsBody}
             icon={<Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.brand} />}
           />
         ) : (

--- a/packages/ui/src/components/ListRow.tsx
+++ b/packages/ui/src/components/ListRow.tsx
@@ -81,7 +81,8 @@ export function EmptyState({
   icon,
 }: {
   title: string;
-  body: string;
+  /** The line under the title. Omit for a title-only empty state. */
+  body?: string;
   action?: ReactNode;
   /**
    * A glyph above the words, in a soft brand-tinted square. An empty screen is
@@ -116,9 +117,11 @@ export function EmptyState({
       <Text variant="heading" align="center">
         {title}
       </Text>
-      <Text variant="caption" tone="muted" align="center">
-        {body}
-      </Text>
+      {body ? (
+        <Text variant="caption" tone="muted" align="center">
+          {body}
+        </Text>
+      ) : null}
       {action ? <View style={{ marginTop: theme.spacing.md }}>{action}</View> : null}
     </View>
   );


### PR DESCRIPTION
Removes the sentence under the dashboard **no-groups** empty state — keeps the title and icon only.

`EmptyState`'s `body` prop is now optional and renders only when present, so every other empty state (friends owe/owed, etc.) is untouched.

Local gates green: `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty states by hiding unused caption areas when no supporting message is provided.
  * Simplified the Home screen’s no-groups empty state to show only its title and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->