### PR TITLE
feat(mobile): identity hero on the account screen (Mobbin)

### DIFF
--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -13,6 +13,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 
 import {
+  Avatar,
   Badge,
   Button,
   Callout,
@@ -94,6 +95,15 @@ function AccountForm() {
     channel === ContactChannel.Email
       ? (session?.user.email ?? null)
       : (session?.user.phone ?? null);
+
+  // A stable subtitle for the identity header: the account's own contact,
+  // independent of which channel the form below is currently pointed at, so it
+  // does not flip as the chips are toggled. Purely a label.
+  const accountContact = session?.user.email ?? session?.user.phone ?? null;
+
+  // The name shown in the header portrait, never blank — the same "You"
+  // fallback the save path already uses, so the header agrees with the row.
+  const displayName = name.trim() || t.account.you;
 
   // Which providers already sign this account in, so a linked one shows as done
   // rather than offering to link what is already linked. Adding one goes through
@@ -207,6 +217,29 @@ function AccountForm() {
           </View>
           <View style={{ width: 44 }} />
         </Row>
+
+        {/* A calm identity header: the avatar and name give the screen a focal
+            point that names whose account this is (Mobbin — Todoist, TheFork).
+            It is a portrait, not a control — the name is edited in the field
+            just below, and the initials fall back cleanly when there is no
+            display name yet. */}
+        <View
+          style={{
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+            paddingTop: theme.spacing.sm,
+          }}
+        >
+          <Avatar name={displayName} size={88} />
+          <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            <Text variant="title">{displayName}</Text>
+            {accountContact ? (
+              <Text variant="caption" tone="muted">
+                {accountContact}
+              </Text>
+            ) : null}
+          </View>
+        </View>
 
         {/* Your name, and how you appear to everyone else. Folded in from the
             old "You" screen so the whole account lives on one page. Save appears


### PR DESCRIPTION
Adds a centered **identity header** to the account screen — an initials `Avatar` (88) + display name + the account's own email/phone as a muted subtitle — giving a label-heavy page a focal point that names whose account it is.

- Name reuses the existing `t.account.you` fallback, so it never reads blank and agrees with the editable name field below.
- Subtitle derives from the account's own contact, independent of the email/phone chips (won't flip as they toggle).
- Purely presentational — no handler, mutation, query, navigation, or a11y label touched. No new strings.

Mobbin cues: [Todoist](https://mobbin.com/screens/0777766d-a21c-4f32-a6a2-e5c36bed2e5a), [TheFork](https://mobbin.com/screens/8c7f83c0-4795-4769-bd8b-3816a111a0a9).

Local gates green: `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an account identity header to Settings displaying the account avatar, display name, and primary contact.
  * Added a fallback name when no display name is entered.
  * Account identity details remain consistent regardless of the selected contact channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->