### PR TITLE
feat(mobile): tighten new-group name card + drop the country row

### DIFF
--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -22,7 +22,6 @@ import {
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { friendlyError } from '@/lib/errors';
 import { type PickedContact } from '@/components/ContactPicker';
-import { CountryRow } from '@/components/CountryPicker';
 import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
 import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates, type TripDatesValue } from '@/components/TripDates';
@@ -89,8 +88,10 @@ export default function NewGroupScreen() {
   // them alike.
   const [ghosts, setGhosts] = useState<PickedContact[]>([]);
   const [error, setError] = useState<string | null>(null);
-  // Read once, not on every render: a phone does not change country mid-form.
-  const [country, setCountry] = useState<string | null>(() => deviceCountry());
+  // Not asked on this screen anymore — derived silently from the phone's locale
+  // so the group still gets a sensible currency and settle rails (both changeable
+  // later in group settings, which keeps the country row).
+  const country: string | null = deviceCountry();
   // Null until somebody picks: the icon is otherwise read from the name, so an
   // untouched group still gets a sensible cover.
   const [pickedEmoji, setPickedEmoji] = useState<string | null>(null);
@@ -292,10 +293,6 @@ export default function NewGroupScreen() {
             ]}
           />
         </View>
-
-        {/* Decides which payment rails the settle screen offers, and what a new
-            expense starts in. The same flagged row the settings screen uses. */}
-        <CountryRow countryCode={country} onChange={setCountry} />
 
         {/* Dates and their daily nudges only mean anything for a trip — a
             flatshare or a couple has no start and end. Shown only for trips. */}

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -229,7 +229,7 @@ export default function NewGroupScreen() {
 
         {/* One compact row: the cover — tapped to choose an icon — with the
             name inline beside it and a clear (×) once there is a name. */}
-        <Card style={{ gap: theme.spacing.md }}>
+        <Card style={{ paddingVertical: theme.spacing.md }}>
           <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
             <Pressable
               accessibilityRole="button"
@@ -237,7 +237,7 @@ export default function NewGroupScreen() {
               onPress={() => setIconOpen(true)}
               style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
             >
-              <GroupPhoto photoPath={null} emoji={emoji} size={52} />
+              <GroupPhoto photoPath={null} emoji={emoji} size={44} />
             </Pressable>
             <TextInput
               value={name}
@@ -251,7 +251,7 @@ export default function NewGroupScreen() {
                 fontSize: 18,
                 fontWeight: '700',
                 color: theme.color.text,
-                paddingVertical: theme.spacing.sm,
+                paddingVertical: 0,
               }}
             />
             {name.length > 0 ? (


### PR DESCRIPTION
Two new-group tweaks from device testing:

**1. Tighten the name card** — it looked airy (default `xl` card padding + the input's own vertical padding around a 52pt avatar). Card vertical padding `xl`→`md`, avatar `52`→`44`, input `paddingVertical`→`0` so the row hugs its content.

**2. Drop the country row** — creating a group no longer asks for country. It's derived silently from the phone's locale so the group still gets a sensible default currency and settle rails, both changeable later in group settings (which keeps the country row). One less field before Create.

Presentation/UX only; `country`/`currency` still flow to create. Local gates green: `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Removed the editable country selector from the new-group form; the country is now set automatically based on the device locale.
  * Reduced spacing around the header card.
  * Adjusted the group image size and group-name input padding for a more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->