### PR TITLE
feat: add "Friends" as a kind of group

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -307,6 +307,11 @@ export default function GroupSettingsScreen() {
               { value: GroupType.Home, label: t.extras.typeHome, icon: iconFor('home') },
               { value: GroupType.Couple, label: t.extras.typeCouple, icon: iconFor('heart') },
               { value: GroupType.Event, label: t.extras.typeEvent, icon: iconFor('sparkles') },
+              {
+                value: GroupType.Friends,
+                label: t.extras.typeFriends,
+                icon: iconFor('people-circle'),
+              },
               { value: GroupType.Other, label: t.extras.typeOther, icon: iconFor('people') },
             ]}
           />

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -43,6 +43,7 @@ const EMOJI_FOR_TYPE: Record<GroupType, string> = {
   [GroupType.Home]: '🏠',
   [GroupType.Couple]: '💜',
   [GroupType.Event]: '🎉',
+  [GroupType.Friends]: '🧑‍🤝‍🧑',
   [GroupType.Other]: '👥',
 };
 
@@ -289,6 +290,11 @@ export default function NewGroupScreen() {
               { value: GroupType.Home, label: t.extras.typeHome, icon: iconFor('home') },
               { value: GroupType.Couple, label: t.extras.typeCouple, icon: iconFor('heart') },
               { value: GroupType.Event, label: t.extras.typeEvent, icon: iconFor('sparkles') },
+              {
+                value: GroupType.Friends,
+                label: t.extras.typeFriends,
+                icon: iconFor('people-circle'),
+              },
               { value: GroupType.Other, label: t.extras.typeOther, icon: iconFor('people') },
             ]}
           />

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -588,6 +588,7 @@ const GROUP_TYPE_ICON: Record<GroupType, React.ComponentProps<typeof Ionicons>['
   [GroupType.Home]: 'home',
   [GroupType.Couple]: 'heart',
   [GroupType.Event]: 'sparkles',
+  [GroupType.Friends]: 'people-circle',
   [GroupType.Other]: 'people-outline',
 };
 

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -5,6 +5,7 @@ export enum GroupType {
   Home = 'home',
   Couple = 'couple',
   Event = 'event',
+  Friends = 'friends',
   Other = 'other',
 }
 export enum SettlementMethod {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1632,6 +1632,7 @@ export interface UiStrings {
     typeHome: string;
     typeCouple: string;
     typeEvent: string;
+    typeFriends: string;
     typeOther: string;
     addPeopleByName: string;
     ghostNote: string;
@@ -3125,6 +3126,7 @@ const en: UiStrings = {
     typeHome: 'Home',
     typeCouple: 'Couple',
     typeEvent: 'Event',
+    typeFriends: 'Friends',
     typeOther: 'Other',
     addPeopleByName: 'Add friends',
     ghostNote: 'They do not need the app. Add them now and they can claim their history later.',
@@ -4700,6 +4702,7 @@ const ta: UiStrings = {
     typeHome: 'வீடு',
     typeCouple: 'தம்பதி',
     typeEvent: 'நிகழ்வு',
+    typeFriends: 'நண்பர்கள்',
     typeOther: 'மற்றவை',
     addPeopleByName: 'நண்பர்களைச் சேர்',
     ghostNote:
@@ -6206,6 +6209,7 @@ const hi: UiStrings = {
     typeHome: 'घर',
     typeCouple: 'जोड़ा',
     typeEvent: 'आयोजन',
+    typeFriends: 'दोस्त',
     typeOther: 'अन्य',
     addPeopleByName: 'दोस्त जोड़ें',
     ghostNote: 'उन्हें ऐप की ज़रूरत नहीं। अभी जोड़ दें, बाद में वे अपना इतिहास ले सकते हैं।',
@@ -7907,6 +7911,7 @@ const ar: UiStrings = {
     typeHome: 'المنزل',
     typeCouple: 'ثنائي',
     typeEvent: 'مناسبة',
+    typeFriends: 'الأصدقاء',
     typeOther: 'أخرى',
     addPeopleByName: 'أضف أصدقاء',
     ghostNote: 'لا يحتاجون التطبيق. أضفهم الآن ويمكنهم المطالبة بسجلّهم لاحقًا.',

--- a/packages/db/prisma/migrations/20260822000000_group_type_friends/migration.sql
+++ b/packages/db/prisma/migrations/20260822000000_group_type_friends/migration.sql
@@ -1,0 +1,8 @@
+-- Add a "friends" kind of group alongside trip/home/couple/event/other.
+--
+-- Additive and idempotent: ALTER TYPE ... ADD VALUE only extends the enum, so
+-- existing rows and the create RPC (which casts its text p_type to "GroupType"
+-- on insert) keep working unchanged. IF NOT EXISTS makes a re-run a no-op.
+-- Postgres keeps enum values for good; there is nothing to roll back, and an
+-- unused value costs nothing.
+ALTER TYPE "GroupType" ADD VALUE IF NOT EXISTS 'friends' AFTER 'event';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -28,6 +28,7 @@ enum GroupType {
   home
   couple
   event
+  friends
   other
 
   @@schema("public")


### PR DESCRIPTION
Adds a **Friends** option to the kind-of-group selector on the new-group and group-settings screens, alongside Trip/Home/Couple/Event/Other.

### End-to-end
- **Postgres enum** — additive, idempotent migration: `ALTER TYPE "GroupType" ADD VALUE IF NOT EXISTS 'friends' AFTER 'event'`.
- **Prisma schema** enum + the mobile **TS `GroupType`** enum.
- Both **ChipRows**, the new-group cover-emoji map, and the voice group-icon map (the two exhaustive `Record<GroupType>` maps tsc enforces).
- **i18n** `typeFriends` across en/ta/hi/ar.

The create RPC (`baaki_create_group`) casts its `text` `p_type` to `"GroupType"` on insert, so no RPC signature change — only the enum value.

### ⚠️ Deploy-gated
The migration must run on **prod** before the Friends chip can create a group there — otherwise the enum cast rejects `'friends'`. The enum add is irreversible (Postgres keeps enum values) but additive and safe.

Local gates green: `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`, `prisma validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Friends group type when creating and configuring groups.
  * Added Friends labels in English, Tamil, Hindi, and Arabic.
  * Added matching icons and fallback visuals for Friends groups.
  * Friends groups are now supported throughout the app.
  * Group creation now detects the country from the device locale.
  * Updated group creation layout and replaced trip-specific placeholder text with a generic prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->