### PR TITLE
feat(mobile): optional trip budget in new group

### DIFF
--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -6,6 +6,7 @@ import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react
 
 import { currencyForCountry, guessGroupEmoji, MutationKind } from '@waves/core';
 import {
+  AmountField,
   Button,
   Callout,
   Card,
@@ -98,6 +99,8 @@ export default function NewGroupScreen() {
   const [pickedEmoji, setPickedEmoji] = useState<string | null>(null);
   // Null until toggled, so it can follow the group type's default until then.
   const [simplify, setSimplify] = useState<boolean | null>(null);
+  // Optional starting budget for a trip, minor units. Zero is "not set".
+  const [budget, setBudget] = useState<bigint>(0n);
   const [tripDates, setTripDates] = useState<TripDatesValue>(() => ({
     start_date: null,
     end_date: null,
@@ -162,6 +165,16 @@ export default function NewGroupScreen() {
           remind_daily: tripDates.remind_daily,
           remind_morning_at: tripDates.remind_morning_at,
           remind_evening_at: tripDates.remind_evening_at,
+        });
+      }
+
+      // A starting budget, if one was typed. Same ordered queue behind the
+      // create, so it lands once the group exists (like the dates). Zero means
+      // "not set" — the planner shows no cap rather than a ₹0 ceiling.
+      if (type === GroupType.Trip && budget > 0n) {
+        await mutate(MutationKind.GroupBudgetSet, groupId, {
+          amountMinor: budget.toString(),
+          currency,
         });
       }
 
@@ -303,11 +316,23 @@ export default function NewGroupScreen() {
         {/* Dates and their daily nudges only mean anything for a trip — a
             flatshare or a couple has no start and end. Shown only for trips. */}
         {type === GroupType.Trip ? (
-          <TripDates
-            group={tripDates}
-            locale={locale}
-            onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
-          />
+          <>
+            <TripDates
+              group={tripDates}
+              locale={locale}
+              onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
+            />
+
+            {/* An optional starting budget for the trip. Left at zero it sets
+                nothing; entered, it seeds the planner's overall cap on create,
+                so the Plan screen opens with the number already in it. */}
+            <Card style={{ gap: theme.spacing.sm }}>
+              <Text variant="caption" tone="muted">
+                {t.extras.tripBudgetOptional}
+              </Text>
+              <AmountField currency={currency} value={budget} onChange={setBudget} />
+            </Card>
+          </>
         ) : null}
 
         {/* ADR-009: simplification is presentation only — the pairwise ledger

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1627,6 +1627,7 @@ export interface UiStrings {
   };
   extras: {
     blankNameHint: string;
+    tripBudgetOptional: string;
     whatKindOfGroup: string;
     typeTrip: string;
     typeHome: string;
@@ -3121,6 +3122,7 @@ const en: UiStrings = {
   },
   extras: {
     blankNameHint: 'Leave it blank and the group is named after whoever is in it.',
+    tripBudgetOptional: 'Trip budget (optional)',
     whatKindOfGroup: 'What kind of group?',
     typeTrip: 'Trip',
     typeHome: 'Home',
@@ -4697,6 +4699,7 @@ const ta: UiStrings = {
   },
   extras: {
     blankNameHint: 'காலியாக விட்டால், குழுவில் உள்ளவர்களின் பெயரில் குழு அமையும்.',
+    tripBudgetOptional: 'பயண பட்ஜெட் (விருப்பம்)',
     whatKindOfGroup: 'என்ன வகைக் குழு?',
     typeTrip: 'பயணம்',
     typeHome: 'வீடு',
@@ -6204,6 +6207,7 @@ const hi: UiStrings = {
   },
   extras: {
     blankNameHint: 'खाली छोड़ दें तो समूह का नाम उसमें शामिल लोगों पर रख दिया जाएगा।',
+    tripBudgetOptional: 'ट्रिप बजट (वैकल्पिक)',
     whatKindOfGroup: 'किस तरह का समूह?',
     typeTrip: 'यात्रा',
     typeHome: 'घर',
@@ -7906,6 +7910,7 @@ const ar: UiStrings = {
   },
   extras: {
     blankNameHint: 'اتركه فارغًا فتُسمّى المجموعة بأسماء من فيها.',
+    tripBudgetOptional: 'ميزانية الرحلة (اختياري)',
     whatKindOfGroup: 'أي نوع من المجموعات؟',
     typeTrip: 'رحلة',
     typeHome: 'المنزل',


### PR DESCRIPTION
When **Trip** is the kind of group, the create screen now offers an optional **Trip budget** field under the dates.

- Entered, it seeds the planner's overall cap on create — queued behind the create on the same ordered mirror queue as the trip dates (`MutationKind.GroupBudgetSet`), so the **Plan** screen opens with the number already in it.
- Left at zero it sets nothing (the planner shows no cap, not a ₹0 ceiling).

Reuses the existing `AmountField` (bigint minor units, ADR-003) and the group's derived currency. **No migration** — `budget_minor` and the budget-set mutation already exist in prod, so this ships with a normal OTA.

Local gates green: `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating Friends groups with a default emoji.
  * Added an optional, currency-aware budget field when creating trip groups.
  * Positive budgets are saved after group creation; zero budgets are not saved.
  * Added localized text for Friends groups and optional trip budgets in English, Tamil, Hindi, and Arabic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->