### PR TITLE
feat(mobile): Mobbin-style trip dates, budget and simplify in new group

### DIFF
--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -243,7 +243,7 @@ export default function NewGroupScreen() {
   };
   const dateSummary =
     tripDates.start_date && tripDates.end_date
-      ? `${shortDate(tripDates.start_date)} – ${shortDate(tripDates.end_date)}`
+      ? `${shortDate(tripDates.start_date)} - ${shortDate(tripDates.end_date)}`
       : t.add;
 
   // The budget for its pill, minor units back to a plain major string with the

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -11,6 +11,7 @@ import {
   Callout,
   Card,
   ChipRow,
+  Divider,
   IconButton,
   iconSize,
   Row,
@@ -60,6 +61,57 @@ const iconFor =
   (name: keyof typeof Ionicons.glyphMap) =>
   // eslint-disable-next-line react/display-name
   (color: string): ReactNode => <Ionicons name={name} size={iconSize.base} color={color} />;
+
+/** The soft brand-tinted square that leads a settings row. */
+function IconChip({ name }: { name: keyof typeof Ionicons.glyphMap }) {
+  const theme = useTheme();
+  return (
+    <View
+      style={{
+        width: 36,
+        height: 36,
+        borderRadius: theme.radius.md,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: theme.color.brandSoft,
+      }}
+    >
+      <Ionicons name={name} size={iconSize.base} color={theme.color.brand} />
+    </View>
+  );
+}
+
+/**
+ * One line of a grouped settings card: a leading icon, a title over an optional
+ * one-line hint, and the control it toggles or fills sitting at the far right.
+ */
+function SettingRow({
+  icon,
+  title,
+  subtitle,
+  trailing,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  title: string;
+  subtitle?: string;
+  trailing: ReactNode;
+}) {
+  const theme = useTheme();
+  return (
+    <Row style={{ alignItems: 'center', gap: theme.spacing.md, paddingVertical: theme.spacing.sm }}>
+      <IconChip name={icon} />
+      <View style={{ flex: 1, gap: 2 }}>
+        <Text variant="subheading">{title}</Text>
+        {subtitle ? (
+          <Text variant="caption" tone="muted">
+            {subtitle}
+          </Text>
+        ) : null}
+      </View>
+      {trailing}
+    </Row>
+  );
+}
 
 /**
  * Making a group, wearing the same clothes as the settings that edit one.
@@ -313,35 +365,46 @@ export default function NewGroupScreen() {
           />
         </View>
 
-        {/* Dates and their daily nudges only mean anything for a trip — a
-            flatshare or a couple has no start and end. Shown only for trips. */}
+        {/* Dates only mean anything for a trip — a flatshare or a couple has no
+            start and end. Shown only for trips. */}
         {type === GroupType.Trip ? (
-          <>
-            <TripDates
-              group={tripDates}
-              locale={locale}
-              onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
-            />
-
-            {/* An optional starting budget for the trip. Left at zero it sets
-                nothing; entered, it seeds the planner's overall cap on create,
-                so the Plan screen opens with the number already in it. */}
-            <Card style={{ gap: theme.spacing.sm }}>
-              <Text variant="caption" tone="muted">
-                {t.extras.tripBudgetOptional}
-              </Text>
-              <AmountField currency={currency} value={budget} onChange={setBudget} />
-            </Card>
-          </>
+          <TripDates
+            group={tripDates}
+            locale={locale}
+            onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
+          />
         ) : null}
 
-        {/* ADR-009: simplification is presentation only — the pairwise ledger
-            underneath is untouched. */}
-        <Card>
-          <InfoDisclosure
+        {/* Trip budget (trips only) and simplify debts as one grouped card of
+            icon-led rows — a label with its control at the far right.
+
+            The budget, left at zero, sets nothing; entered, it seeds the
+            planner's overall cap on create so the Plan screen opens with the
+            number already in it. ADR-009: simplification is presentation only —
+            the pairwise ledger underneath is untouched. */}
+        <Card style={{ gap: 0 }}>
+          {type === GroupType.Trip ? (
+            <>
+              <SettingRow
+                icon="wallet-outline"
+                title={t.extras.tripBudgetOptional}
+                trailing={
+                  <AmountField
+                    currency={currency}
+                    value={budget}
+                    onChange={setBudget}
+                    size="compact"
+                  />
+                }
+              />
+              <Divider />
+            </>
+          ) : null}
+          <SettingRow
+            icon="flash-outline"
             title={t.group.simplifyDebts}
-            info={t.group.simplifyDebtsBody}
-            right={
+            subtitle={t.group.simplifyDebtsHint}
+            trailing={
               <Toggle
                 value={effectiveSimplify}
                 onValueChange={setSimplify}

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -24,6 +24,7 @@ import {
   Row,
   Screen,
   Text,
+  type TintName,
   Toggle,
   useTheme,
 } from '@waves/ui';
@@ -69,16 +70,42 @@ const iconFor =
   // eslint-disable-next-line react/display-name
   (color: string): ReactNode => <Ionicons name={name} size={iconSize.base} color={color} />;
 
+/** The leading colour tile of a grouped row — a pastel square with an inked
+ *  glyph, the way each Apple Wallet row is led by its own coloured icon. */
+const TILE = 38;
+function IconTile({ tint, icon }: { tint: TintName; icon: keyof typeof Ionicons.glyphMap }) {
+  const theme = useTheme();
+  const pair = theme.tint[tint];
+  return (
+    <View
+      style={{
+        width: TILE,
+        height: TILE,
+        borderRadius: theme.radius.md,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: pair.bg,
+      }}
+    >
+      <Ionicons name={icon} size={iconSize.md} color={pair.ink} />
+    </View>
+  );
+}
+
 /**
- * One line of the combined attributes card: a label (with an optional one-line
- * hint under it) on the left, and its control — a value pill or a toggle — at
- * the far right, the way a task-details sheet stacks time, date and repeat.
+ * One row of the grouped attributes card, Apple-Wallet style: a leading colour
+ * tile, a bold label (with an optional one-line hint under it), and its control
+ * — a value pill or a toggle — at the far right.
  */
 function AttrRow({
+  tint,
+  icon,
   label,
   subtitle,
   children,
 }: {
+  tint: TintName;
+  icon: keyof typeof Ionicons.glyphMap;
   label: string;
   subtitle?: string;
   children: ReactNode;
@@ -88,12 +115,13 @@ function AttrRow({
     <Row
       style={{
         alignItems: 'center',
-        justifyContent: 'space-between',
         gap: theme.spacing.md,
+        paddingHorizontal: theme.spacing.lg,
         paddingVertical: theme.spacing.md,
       }}
     >
-      <View style={{ flexShrink: 1, gap: 2 }}>
+      <IconTile tint={tint} icon={icon} />
+      <View style={{ flex: 1, gap: 2 }}>
         <Text variant="subheading" style={{ fontWeight: '600' }}>
           {label}
         </Text>
@@ -108,20 +136,29 @@ function AttrRow({
   );
 }
 
+/** The hairline between grouped rows, inset past the colour tile so it starts
+ *  under the label the way a native grouped list draws it. */
+function InsetDivider() {
+  const theme = useTheme();
+  return (
+    <View style={{ paddingLeft: theme.spacing.lg + TILE + theme.spacing.md }}>
+      <Divider />
+    </View>
+  );
+}
+
 /**
- * The tappable value on the right of an AttrRow: an icon and its current value
- * on a soft pill. It lights up in the brand tint while its editor is unfolded
- * below, so the open row is obvious.
+ * The tappable value at the right of an AttrRow: the current value and a chevron
+ * that flips while its editor is unfolded below. It sits on a solid chip so it
+ * reads against the tinted group fill, and lights up in the brand tint open.
  */
 function Pill({
-  icon,
   label,
   placeholder = false,
   expanded,
   onPress,
   accessibilityLabel,
 }: {
-  icon: keyof typeof Ionicons.glyphMap;
   label: string;
   placeholder?: boolean;
   expanded: boolean;
@@ -140,17 +177,20 @@ function Pill({
         flexDirection: 'row',
         alignItems: 'center',
         gap: theme.spacing.xs,
-        paddingHorizontal: theme.spacing.md,
-        height: 38,
+        paddingLeft: theme.spacing.md,
+        paddingRight: theme.spacing.sm,
+        height: 36,
         borderRadius: theme.radius.pill,
-        backgroundColor: expanded ? theme.color.brandSoft : theme.color.surfaceMuted,
+        backgroundColor: expanded ? theme.color.brandSoft : theme.color.surface,
+        borderWidth: 1,
+        borderColor: expanded ? theme.color.brand : theme.color.border,
         opacity: pressed ? 0.7 : 1,
       })}
     >
-      <Ionicons name={icon} size={iconSize.base} color={ink} />
       <Text variant="subheading" style={{ fontWeight: '600', color: ink }}>
         {label}
       </Text>
+      <Ionicons name={expanded ? 'chevron-up' : 'chevron-down'} size={iconSize.sm} color={ink} />
     </Pressable>
   );
 }
@@ -439,10 +479,13 @@ export default function NewGroupScreen() {
             planner's overall cap on create so the Plan screen opens with the
             number already in it. ADR-009: simplification is presentation only —
             the pairwise ledger underneath is untouched. */}
-        <Card style={{ gap: 0 }}>
-          <AttrRow label={t.extras.groupKind}>
+        <Card
+          flat
+          padded={false}
+          style={{ backgroundColor: theme.color.surfaceMuted, overflow: 'hidden' }}
+        >
+          <AttrRow tint="lilac" icon={currentType.icon} label={t.extras.groupKind}>
             <Pill
-              icon={currentType.icon}
               label={currentType.label}
               expanded={openAttr === 'kind'}
               accessibilityLabel={t.extras.whatKindOfGroup}
@@ -450,7 +493,7 @@ export default function NewGroupScreen() {
             />
           </AttrRow>
           {openAttr === 'kind' ? (
-            <View style={{ paddingBottom: theme.spacing.md }}>
+            <View style={{ paddingHorizontal: theme.spacing.lg, paddingBottom: theme.spacing.md }}>
               <ChipRow<GroupType>
                 value={type}
                 onChange={(next) => {
@@ -468,10 +511,9 @@ export default function NewGroupScreen() {
 
           {type === GroupType.Trip ? (
             <>
-              <Divider />
-              <AttrRow label={t.misc.tripDatesTitle}>
+              <InsetDivider />
+              <AttrRow tint="sky" icon="calendar-outline" label={t.misc.tripDatesTitle}>
                 <Pill
-                  icon="calendar-outline"
                   label={dateSummary}
                   placeholder={!tripDates.start_date || !tripDates.end_date}
                   expanded={openAttr === 'dates'}
@@ -480,7 +522,9 @@ export default function NewGroupScreen() {
                 />
               </AttrRow>
               {openAttr === 'dates' ? (
-                <View style={{ paddingBottom: theme.spacing.md }}>
+                <View
+                  style={{ paddingHorizontal: theme.spacing.lg, paddingBottom: theme.spacing.md }}
+                >
                   <TripDates
                     group={tripDates}
                     locale={locale}
@@ -490,10 +534,9 @@ export default function NewGroupScreen() {
                 </View>
               ) : null}
 
-              <Divider />
-              <AttrRow label={t.extras.tripBudget}>
+              <InsetDivider />
+              <AttrRow tint="mint" icon="wallet-outline" label={t.extras.tripBudget}>
                 <Pill
-                  icon="wallet-outline"
                   label={budgetSummary}
                   placeholder={budget <= 0n}
                   expanded={openAttr === 'budget'}
@@ -502,15 +545,22 @@ export default function NewGroupScreen() {
                 />
               </AttrRow>
               {openAttr === 'budget' ? (
-                <View style={{ paddingBottom: theme.spacing.md }}>
+                <View
+                  style={{ paddingHorizontal: theme.spacing.lg, paddingBottom: theme.spacing.md }}
+                >
                   <AmountField currency={currency} value={budget} onChange={setBudget} />
                 </View>
               ) : null}
             </>
           ) : null}
 
-          <Divider />
-          <AttrRow label={t.group.simplifyDebts} subtitle={t.group.simplifyDebtsHint}>
+          <InsetDivider />
+          <AttrRow
+            tint="peach"
+            icon="flash-outline"
+            label={t.group.simplifyDebts}
+            subtitle={t.group.simplifyDebtsHint}
+          >
             <Toggle
               value={effectiveSimplify}
               onValueChange={setSimplify}

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -4,7 +4,14 @@ import { randomUUID } from 'expo-crypto';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
-import { currencyForCountry, guessGroupEmoji, MutationKind } from '@waves/core';
+import {
+  currencyForCountry,
+  currencySymbol,
+  guessGroupEmoji,
+  minorUnitExponent,
+  minorUnitScale,
+  MutationKind,
+} from '@waves/core';
 import {
   AmountField,
   Button,
@@ -62,54 +69,89 @@ const iconFor =
   // eslint-disable-next-line react/display-name
   (color: string): ReactNode => <Ionicons name={name} size={iconSize.base} color={color} />;
 
-/** The soft brand-tinted square that leads a settings row. */
-function IconChip({ name }: { name: keyof typeof Ionicons.glyphMap }) {
-  const theme = useTheme();
-  return (
-    <View
-      style={{
-        width: 36,
-        height: 36,
-        borderRadius: theme.radius.md,
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: theme.color.brandSoft,
-      }}
-    >
-      <Ionicons name={name} size={iconSize.base} color={theme.color.brand} />
-    </View>
-  );
-}
-
 /**
- * One line of a grouped settings card: a leading icon, a title over an optional
- * one-line hint, and the control it toggles or fills sitting at the far right.
+ * One line of the combined attributes card: a label (with an optional one-line
+ * hint under it) on the left, and its control — a value pill or a toggle — at
+ * the far right, the way a task-details sheet stacks time, date and repeat.
  */
-function SettingRow({
-  icon,
-  title,
+function AttrRow({
+  label,
   subtitle,
-  trailing,
+  children,
 }: {
-  icon: keyof typeof Ionicons.glyphMap;
-  title: string;
+  label: string;
   subtitle?: string;
-  trailing: ReactNode;
+  children: ReactNode;
 }) {
   const theme = useTheme();
   return (
-    <Row style={{ alignItems: 'center', gap: theme.spacing.md, paddingVertical: theme.spacing.sm }}>
-      <IconChip name={icon} />
-      <View style={{ flex: 1, gap: 2 }}>
-        <Text variant="subheading">{title}</Text>
+    <Row
+      style={{
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: theme.spacing.md,
+        paddingVertical: theme.spacing.md,
+      }}
+    >
+      <View style={{ flexShrink: 1, gap: 2 }}>
+        <Text variant="subheading" style={{ fontWeight: '600' }}>
+          {label}
+        </Text>
         {subtitle ? (
           <Text variant="caption" tone="muted">
             {subtitle}
           </Text>
         ) : null}
       </View>
-      {trailing}
+      {children}
     </Row>
+  );
+}
+
+/**
+ * The tappable value on the right of an AttrRow: an icon and its current value
+ * on a soft pill. It lights up in the brand tint while its editor is unfolded
+ * below, so the open row is obvious.
+ */
+function Pill({
+  icon,
+  label,
+  placeholder = false,
+  expanded,
+  onPress,
+  accessibilityLabel,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  placeholder?: boolean;
+  expanded: boolean;
+  onPress: () => void;
+  accessibilityLabel: string;
+}) {
+  const theme = useTheme();
+  const ink = expanded ? theme.color.brand : placeholder ? theme.color.textMuted : theme.color.text;
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ expanded }}
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: theme.spacing.xs,
+        paddingHorizontal: theme.spacing.md,
+        height: 38,
+        borderRadius: theme.radius.pill,
+        backgroundColor: expanded ? theme.color.brandSoft : theme.color.surfaceMuted,
+        opacity: pressed ? 0.7 : 1,
+      })}
+    >
+      <Ionicons name={icon} size={iconSize.base} color={ink} />
+      <Text variant="subheading" style={{ fontWeight: '600', color: ink }}>
+        {label}
+      </Text>
+    </Pressable>
   );
 }
 
@@ -136,6 +178,9 @@ export default function NewGroupScreen() {
   // a paid feature edited from group settings, not part of creating one.
   const [iconOpen, setIconOpen] = useState(false);
   const [type, setType] = useState<GroupType>(GroupType.Trip);
+  // Which attribute row of the combined card is unfolded, if any — one at a
+  // time, so the card stays a short list until you open the one you want.
+  const [openAttr, setOpenAttr] = useState<'kind' | 'dates' | 'budget' | null>(null);
   const [ghostName, setGhostName] = useState('');
   // People to add on Create — a typed name carries no address, a contact carries
   // whatever the phone had. Same shape either way, so the create loop treats
@@ -170,6 +215,48 @@ export default function NewGroupScreen() {
   // not. Follows the type until somebody says otherwise.
   const effectiveSimplify = simplify ?? (type === GroupType.Trip || type === GroupType.Event);
   const currency = currencyForCountry(country) ?? 'INR';
+
+  // The kinds of group, one place — the chips inside the picker and the icon on
+  // the collapsed pill both read from this.
+  const typeOptions: { value: GroupType; label: string; icon: keyof typeof Ionicons.glyphMap }[] = [
+    { value: GroupType.Trip, label: t.extras.typeTrip, icon: 'airplane' },
+    { value: GroupType.Home, label: t.extras.typeHome, icon: 'home' },
+    { value: GroupType.Couple, label: t.extras.typeCouple, icon: 'heart' },
+    { value: GroupType.Event, label: t.extras.typeEvent, icon: 'sparkles' },
+    { value: GroupType.Friends, label: t.extras.typeFriends, icon: 'people-circle' },
+    { value: GroupType.Other, label: t.extras.typeOther, icon: 'people' },
+  ];
+  const currentType = typeOptions.find((option) => option.value === type) ?? {
+    value: type,
+    label: t.extras.typeOther,
+    icon: 'people' as const,
+  };
+
+  // A short "9 Jan" for the date pill; the full weekday form lives inside the
+  // picker. Parsed at local noon so a date-only string never slips a day.
+  const shortDate = (iso: string): string => {
+    const [year, month, day] = iso.split('-').map(Number);
+    return new Date(year ?? 2026, (month ?? 1) - 1, day ?? 1, 12).toLocaleDateString(locale, {
+      day: 'numeric',
+      month: 'short',
+    });
+  };
+  const dateSummary =
+    tripDates.start_date && tripDates.end_date
+      ? `${shortDate(tripDates.start_date)} – ${shortDate(tripDates.end_date)}`
+      : t.add;
+
+  // The budget for its pill, minor units back to a plain major string with the
+  // currency symbol — the same maths AmountField does, just for display.
+  const budgetSummary = ((): string => {
+    if (budget <= 0n) return t.add;
+    const scale = minorUnitScale(currency);
+    const exponent = minorUnitExponent(currency);
+    const whole = (budget / scale).toString();
+    const major =
+      exponent === 0 ? whole : `${whole}.${(budget % scale).toString().padStart(exponent, '0')}`;
+    return `${currencySymbol(currency)}${major}`;
+  })();
 
   const submit = async (): Promise<void> => {
     // A guest gets one group and ten days (ADR-006 addendum). Past either, this
@@ -343,75 +430,93 @@ export default function NewGroupScreen() {
           onOpenChange={setIconOpen}
         />
 
-        <View style={{ gap: theme.spacing.md }}>
-          <Text variant="caption" tone="muted">
-            {t.extras.whatKindOfGroup}
-          </Text>
-          <ChipRow<GroupType>
-            value={type}
-            onChange={setType}
-            options={[
-              { value: GroupType.Trip, label: t.extras.typeTrip, icon: iconFor('airplane') },
-              { value: GroupType.Home, label: t.extras.typeHome, icon: iconFor('home') },
-              { value: GroupType.Couple, label: t.extras.typeCouple, icon: iconFor('heart') },
-              { value: GroupType.Event, label: t.extras.typeEvent, icon: iconFor('sparkles') },
-              {
-                value: GroupType.Friends,
-                label: t.extras.typeFriends,
-                icon: iconFor('people-circle'),
-              },
-              { value: GroupType.Other, label: t.extras.typeOther, icon: iconFor('people') },
-            ]}
-          />
-        </View>
-
-        {/* Dates only mean anything for a trip — a flatshare or a couple has no
-            start and end. Shown only for trips. */}
-        {type === GroupType.Trip ? (
-          <TripDates
-            group={tripDates}
-            locale={locale}
-            onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
-          />
-        ) : null}
-
-        {/* Trip budget (trips only) and simplify debts as one grouped card of
-            icon-led rows — a label with its control at the far right.
+        {/* Kind, dates, budget and simplify as one card of attribute rows —
+            each a label with a value pill that unfolds its editor beneath, so
+            the whole shape of a group is set from one short list rather than
+            four stacked cards. Dates and budget are trip-only.
 
             The budget, left at zero, sets nothing; entered, it seeds the
             planner's overall cap on create so the Plan screen opens with the
             number already in it. ADR-009: simplification is presentation only —
             the pairwise ledger underneath is untouched. */}
         <Card style={{ gap: 0 }}>
+          <AttrRow label={t.extras.groupKind}>
+            <Pill
+              icon={currentType.icon}
+              label={currentType.label}
+              expanded={openAttr === 'kind'}
+              accessibilityLabel={t.extras.whatKindOfGroup}
+              onPress={() => setOpenAttr((current) => (current === 'kind' ? null : 'kind'))}
+            />
+          </AttrRow>
+          {openAttr === 'kind' ? (
+            <View style={{ paddingBottom: theme.spacing.md }}>
+              <ChipRow<GroupType>
+                value={type}
+                onChange={(next) => {
+                  setType(next);
+                  setOpenAttr(null);
+                }}
+                options={typeOptions.map((option) => ({
+                  value: option.value,
+                  label: option.label,
+                  icon: iconFor(option.icon),
+                }))}
+              />
+            </View>
+          ) : null}
+
           {type === GroupType.Trip ? (
             <>
-              <SettingRow
-                icon="wallet-outline"
-                title={t.extras.tripBudgetOptional}
-                trailing={
-                  <AmountField
-                    currency={currency}
-                    value={budget}
-                    onChange={setBudget}
-                    size="compact"
-                  />
-                }
-              />
               <Divider />
+              <AttrRow label={t.misc.tripDatesTitle}>
+                <Pill
+                  icon="calendar-outline"
+                  label={dateSummary}
+                  placeholder={!tripDates.start_date || !tripDates.end_date}
+                  expanded={openAttr === 'dates'}
+                  accessibilityLabel={t.misc.tripDatesTitle}
+                  onPress={() => setOpenAttr((current) => (current === 'dates' ? null : 'dates'))}
+                />
+              </AttrRow>
+              {openAttr === 'dates' ? (
+                <View style={{ paddingBottom: theme.spacing.md }}>
+                  <TripDates
+                    group={tripDates}
+                    locale={locale}
+                    embedded
+                    onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
+                  />
+                </View>
+              ) : null}
+
+              <Divider />
+              <AttrRow label={t.extras.tripBudget}>
+                <Pill
+                  icon="wallet-outline"
+                  label={budgetSummary}
+                  placeholder={budget <= 0n}
+                  expanded={openAttr === 'budget'}
+                  accessibilityLabel={t.extras.tripBudgetOptional}
+                  onPress={() => setOpenAttr((current) => (current === 'budget' ? null : 'budget'))}
+                />
+              </AttrRow>
+              {openAttr === 'budget' ? (
+                <View style={{ paddingBottom: theme.spacing.md }}>
+                  <AmountField currency={currency} value={budget} onChange={setBudget} />
+                </View>
+              ) : null}
             </>
           ) : null}
-          <SettingRow
-            icon="flash-outline"
-            title={t.group.simplifyDebts}
-            subtitle={t.group.simplifyDebtsHint}
-            trailing={
-              <Toggle
-                value={effectiveSimplify}
-                onValueChange={setSimplify}
-                accessibilityLabel={t.group.simplifyDebts}
-              />
-            }
-          />
+
+          <Divider />
+          <AttrRow label={t.group.simplifyDebts} subtitle={t.group.simplifyDebtsHint}>
+            <Toggle
+              value={effectiveSimplify}
+              onValueChange={setSimplify}
+              accessibilityLabel={t.group.simplifyDebts}
+            />
+          </AttrRow>
         </Card>
 
         <Card style={{ gap: theme.spacing.md }}>

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -13,7 +13,7 @@ import DateTimePicker, { type DateTimePickerEvent } from '@react-native-communit
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Platform, Pressable, View } from 'react-native';
 
-import { Button, Card, directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { Button, Card, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -73,34 +73,53 @@ function showDate(iso: string | null, locale: string, notSet: string): string {
 }
 
 /**
- * One end of the range — a tappable label over a big date, filling half the
- * framed sweep. `align` hugs the start date to the outer left and the end date
- * to the outer right, so the arrow between them reads as the span of the trip.
+ * One end of the range — its own bordered field, a small label over the date
+ * with a calendar glyph. `set` lights the field in the brand tint so a chosen
+ * end reads as filled and an untouched one reads as waiting, and the two boxes
+ * sit side by side like the from/to of a date-range picker.
  */
 function RangeEnd({
   label,
   value,
+  set,
   onPress,
-  align,
 }: {
   label: string;
   value: string;
+  set: boolean;
   onPress: () => void;
-  align: 'flex-start' | 'flex-end';
 }) {
+  const theme = useTheme();
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={`${label}: ${value}`}
       onPress={onPress}
-      style={{ flex: 1, gap: 2, alignItems: align }}
+      style={({ pressed }) => ({
+        flex: 1,
+        gap: 4,
+        paddingVertical: theme.spacing.md,
+        paddingHorizontal: theme.spacing.md,
+        borderRadius: theme.radius.lg,
+        borderWidth: 1,
+        borderColor: set ? theme.color.brand : theme.color.border,
+        backgroundColor: set ? theme.color.brandSoft : theme.color.surface,
+        opacity: pressed ? 0.7 : 1,
+      })}
     >
       <Text variant="caption" tone="muted">
         {label}
       </Text>
-      <Text variant="subheading" style={{ fontWeight: '700' }}>
-        {value}
-      </Text>
+      <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+        <Ionicons
+          name="calendar-outline"
+          size={iconSize.sm}
+          color={set ? theme.color.brand : theme.color.textMuted}
+        />
+        <Text variant="subheading" style={{ fontWeight: '700' }}>
+          {value}
+        </Text>
+      </Row>
     </Pressable>
   );
 }
@@ -168,46 +187,21 @@ export function TripDates({
         ) : null}
       </View>
 
-      {/* The range as one framed Start → End sweep — the dates hug the outer
-          edges and a chip-borne arrow spans them, so it reads as a trip's
-          length rather than two unrelated fields. */}
-      <Row
-        style={{
-          alignItems: 'center',
-          gap: theme.spacing.md,
-          backgroundColor: theme.color.surfaceMuted,
-          borderRadius: theme.radius.lg,
-          paddingVertical: theme.spacing.md,
-          paddingHorizontal: theme.spacing.lg,
-        }}
-      >
+      {/* Start and end as two side-by-side fields — each its own bordered box
+          that lights up once picked, the way a from/to date-range picker reads,
+          rather than two labels sharing one strip. */}
+      <Row style={{ alignItems: 'stretch', gap: theme.spacing.sm }}>
         <RangeEnd
           label={t.pickers.starts}
           value={showDate(group.start_date, locale, t.pickers.notSet)}
+          set={Boolean(group.start_date)}
           onPress={() => setEditing(Field.Start)}
-          align="flex-start"
         />
-        <View
-          style={{
-            width: 28,
-            height: 28,
-            borderRadius: 14,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: theme.color.surface,
-          }}
-        >
-          <Ionicons
-            name={directionalIcon('arrow-forward')}
-            size={iconSize.sm}
-            color={theme.color.textMuted}
-          />
-        </View>
         <RangeEnd
           label={t.pickers.ends}
           value={showDate(group.end_date, locale, t.pickers.notSet)}
+          set={Boolean(group.end_date)}
           onPress={() => setEditing(Field.End)}
-          align="flex-end"
         />
       </Row>
 

--- a/apps/mobile/src/components/TripDates.tsx
+++ b/apps/mobile/src/components/TripDates.tsx
@@ -128,10 +128,17 @@ export function TripDates({
   group,
   locale,
   onChange,
+  embedded = false,
 }: {
   group: TripDatesValue;
   locale: string;
   onChange: (patch: TripDatesPatch) => void;
+  /**
+   * Drop the outer card and the title/info header, leaving just the two date
+   * fields, the clear link and the picker — for when this editor is unfolded
+   * inside a row of a bigger card that already carries the "Dates" label.
+   */
+  embedded?: boolean;
 }) {
   const theme = useTheme();
   const { t } = useStrings();
@@ -160,32 +167,34 @@ export function TripDates({
     onChange({ end_date: end, start_date: start ?? end });
   };
 
-  return (
-    <Card style={{ gap: theme.spacing.lg }}>
-      <View style={{ gap: theme.spacing.xs }}>
-        <Row style={{ justifyContent: 'space-between', gap: theme.spacing.sm }}>
-          <Text variant="subheading">{t.misc.tripDatesTitle}</Text>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityState={{ expanded: showInfo }}
-            accessibilityLabel={t.misc.aboutTripDates}
-            hitSlop={8}
-            onPress={() => setShowInfo((open) => !open)}
-            style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-          >
-            <Ionicons
-              name={showInfo ? 'information-circle' : 'information-circle-outline'}
-              size={iconSize.lg}
-              color={showInfo ? theme.color.brand : theme.color.textFaint}
-            />
-          </Pressable>
-        </Row>
-        {showInfo ? (
-          <Text variant="caption" tone="muted">
-            {t.misc.tripDatesBody}
-          </Text>
-        ) : null}
-      </View>
+  const body = (
+    <>
+      {embedded ? null : (
+        <View style={{ gap: theme.spacing.xs }}>
+          <Row style={{ justifyContent: 'space-between', gap: theme.spacing.sm }}>
+            <Text variant="subheading">{t.misc.tripDatesTitle}</Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityState={{ expanded: showInfo }}
+              accessibilityLabel={t.misc.aboutTripDates}
+              hitSlop={8}
+              onPress={() => setShowInfo((open) => !open)}
+              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+            >
+              <Ionicons
+                name={showInfo ? 'information-circle' : 'information-circle-outline'}
+                size={iconSize.lg}
+                color={showInfo ? theme.color.brand : theme.color.textFaint}
+              />
+            </Pressable>
+          </Row>
+          {showInfo ? (
+            <Text variant="caption" tone="muted">
+              {t.misc.tripDatesBody}
+            </Text>
+          ) : null}
+        </View>
+      )}
 
       {/* Start and end as two side-by-side fields — each its own bordered box
           that lights up once picked, the way a from/to date-range picker reads,
@@ -249,6 +258,9 @@ export function TripDates({
           onPress={() => setEditing(null)}
         />
       ) : null}
-    </Card>
+    </>
   );
+
+  if (embedded) return <View style={{ gap: theme.spacing.lg }}>{body}</View>;
+  return <Card style={{ gap: theme.spacing.lg }}>{body}</Card>;
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -992,6 +992,7 @@ export interface UiStrings {
     removePhoto: string;
     simplifyDebts: string;
     simplifyDebtsBody: string;
+    simplifyDebtsHint: string;
     membersHint: string;
     invitePeople: string;
     invitePeopleHint: string;
@@ -2442,6 +2443,7 @@ const en: UiStrings = {
     simplifyDebts: 'Simplify debts',
     simplifyDebtsBody:
       'Suggest the fewest payments that settle the group. The real who-owes-whom ledger is never rewritten.',
+    simplifyDebtsHint: 'Fewest payments to settle up',
     membersHint: 'Add people, rename, set UPI IDs',
     invitePeople: 'Invite people',
     invitePeopleHint: 'Share a link — no install needed to join',
@@ -3982,6 +3984,7 @@ const ta: UiStrings = {
     simplifyDebts: 'கடன்களை எளிமையாக்கு',
     simplifyDebtsBody:
       'குழுவைத் தீர்க்கும் மிகக் குறைந்த பணப்பரிமாற்றங்களைப் பரிந்துரைக்கும். யார் யாருக்குத் தர வேண்டும் என்ற உண்மையான கணக்கு மாற்றப்படுவதே இல்லை.',
+    simplifyDebtsHint: 'தீர்க குறைந்தபட்ச பணம் செலுத்தல்கள்',
     membersHint: 'ஆட்களைச் சேர், பெயர் மாற்று, UPI ID அமை',
     invitePeople: 'ஆட்களை அழை',
     invitePeopleHint: 'ஒரு இணைப்பைப் பகிருங்கள் — சேர ஆப் நிறுவத் தேவையில்லை',
@@ -5524,6 +5527,7 @@ const hi: UiStrings = {
     simplifyDebts: 'हिसाब सरल करें',
     simplifyDebtsBody:
       'समूह को निपटाने के सबसे कम भुगतान सुझाता है। किस पर किसका बाकी है, वह असली हिसाब कभी नहीं बदला जाता।',
+    simplifyDebtsHint: 'सेटल करने के लिए कम से कम भुगतान',
     membersHint: 'लोग जोड़ें, नाम बदलें, UPI ID सेट करें',
     invitePeople: 'लोगों को बुलाएँ',
     invitePeopleHint: 'एक लिंक साझा करें — जुड़ने के लिए कुछ इंस्टॉल करने की ज़रूरत नहीं',
@@ -7070,6 +7074,7 @@ const ar: UiStrings = {
     simplifyDebts: 'تبسيط الديون',
     simplifyDebtsBody:
       'يقترح أقل عدد من الدفعات لتسوية المجموعة. أما دفتر من يدين لمن فلا يُعاد كتابته أبدًا.',
+    simplifyDebtsHint: 'أقل عدد من المدفوعات للتسوية',
     membersHint: 'أضف أشخاصًا، غيّر الأسماء، اضبط معرّفات الدفع',
     invitePeople: 'ادعُ أشخاصًا',
     invitePeopleHint: 'شارك رابطًا — لا حاجة لتثبيت شيء للانضمام',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1629,6 +1629,8 @@ export interface UiStrings {
   extras: {
     blankNameHint: string;
     tripBudgetOptional: string;
+    groupKind: string;
+    tripBudget: string;
     whatKindOfGroup: string;
     typeTrip: string;
     typeHome: string;
@@ -3125,6 +3127,8 @@ const en: UiStrings = {
   extras: {
     blankNameHint: 'Leave it blank and the group is named after whoever is in it.',
     tripBudgetOptional: 'Trip budget (optional)',
+    groupKind: 'Kind',
+    tripBudget: 'Budget',
     whatKindOfGroup: 'What kind of group?',
     typeTrip: 'Trip',
     typeHome: 'Home',
@@ -4703,6 +4707,8 @@ const ta: UiStrings = {
   extras: {
     blankNameHint: 'காலியாக விட்டால், குழுவில் உள்ளவர்களின் பெயரில் குழு அமையும்.',
     tripBudgetOptional: 'பயண பட்ஜெட் (விருப்பம்)',
+    groupKind: 'வகை',
+    tripBudget: 'பட்ஜெட்',
     whatKindOfGroup: 'என்ன வகைக் குழு?',
     typeTrip: 'பயணம்',
     typeHome: 'வீடு',
@@ -6212,6 +6218,8 @@ const hi: UiStrings = {
   extras: {
     blankNameHint: 'खाली छोड़ दें तो समूह का नाम उसमें शामिल लोगों पर रख दिया जाएगा।',
     tripBudgetOptional: 'ट्रिप बजट (वैकल्पिक)',
+    groupKind: 'प्रकार',
+    tripBudget: 'बजट',
     whatKindOfGroup: 'किस तरह का समूह?',
     typeTrip: 'यात्रा',
     typeHome: 'घर',
@@ -7916,6 +7924,8 @@ const ar: UiStrings = {
   extras: {
     blankNameHint: 'اتركه فارغًا فتُسمّى المجموعة بأسماء من فيها.',
     tripBudgetOptional: 'ميزانية الرحلة (اختياري)',
+    groupKind: 'النوع',
+    tripBudget: 'الميزانية',
     whatKindOfGroup: 'أي نوع من المجموعات؟',
     typeTrip: 'رحلة',
     typeHome: 'المنزل',

--- a/packages/ui/src/components/AmountField.tsx
+++ b/packages/ui/src/components/AmountField.tsx
@@ -16,12 +16,21 @@ export function AmountField({
   currency,
   value,
   onChange,
+  size = 'display',
 }: {
   currency: CurrencyCode;
   value: bigint;
   onChange: (amount: bigint) => void;
+  /**
+   * 'display' is the hero amount — big and centred, for the expense entry
+   * screen. 'compact' is the right-aligned inline value that sits at the end of
+   * a settings row (a trip budget beside its label), sized to read as a field
+   * value rather than the point of the screen.
+   */
+  size?: 'display' | 'compact';
 }) {
   const theme = useTheme();
+  const compact = size === 'compact';
   const exponent = minorUnitExponent(currency);
   const scale = minorUnitScale(currency);
 
@@ -83,14 +92,15 @@ export function AmountField({
       style={{
         flexDirection: 'row',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: compact ? 'flex-end' : 'center',
         gap: theme.spacing.xs,
+        flexShrink: 0,
       }}
     >
       <Text
         style={{
-          fontSize: 30,
-          lineHeight: 44,
+          fontSize: compact ? 18 : 30,
+          lineHeight: compact ? 24 : 44,
           fontWeight: '700',
           color: theme.color.textMuted,
         }}
@@ -107,14 +117,14 @@ export function AmountField({
         accessibilityLabel={`Amount ${format(value) || '0'} ${currency}`}
         maxFontSizeMultiplier={1.4}
         style={{
-          minWidth: 28,
+          minWidth: compact ? 40 : 28,
           padding: 0,
-          fontSize: 44,
-          lineHeight: 50,
+          fontSize: compact ? 18 : 44,
+          lineHeight: compact ? 24 : 50,
           fontWeight: '700',
           color: theme.color.text,
           fontVariant: ['tabular-nums'],
-          textAlign: 'left',
+          textAlign: compact ? 'right' : 'left',
         }}
       />
     </View>


### PR DESCRIPTION
Redesigns the three trip/settings sections of **New group** against Mobbin references.

## What changed
- **Trip dates** — the merged `start → end` strip becomes two side-by-side bordered date fields (Skyscanner/Mozi range pattern), each with a calendar glyph, lighting up in the brand tint once picked. `TripDates` is shared, so group settings inherits the same look.
- **Trip budget + Simplify debts** — folded into **one grouped card** of icon-led rows (Revolut "Smart settle" style): leading icon chip, title over a one-line hint, control at the far right. Simplify now shows a short permanent hint instead of the info-fold.
- **AmountField** gains a backward-compatible `size="compact"` variant (right-aligned, field-sized) so the budget row reuses the same minor-unit parsing instead of duplicating money logic.

## i18n
New key `simplifyDebtsHint` in en/ta/hi/ar.

## Notes
- No migration, no data changes — UI only.
- Gates green locally: tsc (mobile + ui), mobile eslint, prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned group setup with expandable cards for group type, trip dates, budget, and debt simplification.
  * Added themed date fields with calendar icons, clear actions, and selected-state styling.
  * Added localized date and currency summaries, plus compact budget entry.
  * Added localized group setup guidance in English, Tamil, Hindi, and Arabic.
  * Improved amount fields with display and compact presentation options.
  * Refined spacing, dividers, card styling, and screen header layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->