### PR TITLE
fix(mobile): plain glyphs for dashboard add buttons

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -302,8 +302,8 @@ export default function HomeScreen() {
           )}
         </TourTarget>
 
-        {/* The two things you start on this screen, as round black icon
-            buttons under the deck: make a group, or add a spend by hand. */}
+        {/* The things you start on this screen, as plain icon buttons under the
+            deck: scan, add a spend, make a group, open the inbox. */}
         <Row
           style={{
             justifyContent: 'space-evenly',
@@ -403,10 +403,10 @@ export default function HomeScreen() {
 }
 
 /**
- * One round quick-add button under the deck: a black circle with a white icon
- * and its label beneath. The pair (group / expense) is the same two actions the
- * FAB and the new-group flow reach, surfaced where the eye lands after the
- * balance.
+ * One quick-add button under the deck: a plain inked glyph with its label
+ * beneath — no filled disc, the way a services row reads. The actions are the
+ * same ones the FAB and the new-group flow reach, surfaced where the eye lands
+ * after the balance.
  */
 function AddAction({
   icon,
@@ -433,13 +433,11 @@ function AddAction({
       style={{
         width: 48,
         height: 48,
-        borderRadius: 24,
-        backgroundColor: theme.color.buttonPrimary,
         alignItems: 'center',
         justifyContent: 'center',
       }}
     >
-      <Ionicons name={icon} size={22} color={theme.color.onBrand} />
+      <Ionicons name={icon} size={28} color={theme.color.text} />
       {badge ? (
         <View
           style={{

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -419,16 +419,16 @@ function AddAction({
   icon: keyof typeof Ionicons.glyphMap;
   label: string;
   onPress: () => void;
-  /** An optional count on the circle — e.g. how many captures are waiting. */
+  /** An optional count on the glyph — e.g. how many captures are waiting. */
   badge?: number;
   /** Keep the button in place but dim and unpressable — e.g. an empty inbox. */
   disabled?: boolean;
-  /** When set, the round icon (only) is a tour target, so a coach-mark's hole
-      hugs the circle rather than the circle plus its caption. */
+  /** When set, the glyph (only) is a tour target, so a coach-mark's hole hugs
+      the icon rather than the icon plus its caption. */
   tourId?: string;
 }) {
   const theme = useTheme();
-  const circle = (
+  const iconTarget = (
     <View
       style={{
         width: 48,
@@ -480,7 +480,7 @@ function AddAction({
         opacity: disabled ? 0.4 : pressed ? 0.6 : 1,
       })}
     >
-      {tourId ? <TourTarget id={tourId}>{circle}</TourTarget> : circle}
+      {tourId ? <TourTarget id={tourId}>{iconTarget}</TourTarget> : iconTarget}
       <Text variant="caption" tone="muted" numberOfLines={1} style={{ textAlign: 'center' }}>
         {label}
       </Text>


### PR DESCRIPTION
The quick-add row under the balance deck (Scan, Add expense, New group, Inbox) rendered each action as a filled **black circle** with a white icon. This drops the disc so the icons sit as **plain inked glyphs** over their labels, LINE-services style, sized up (22→28) to hold presence without the circle.

Badge (captures count) and disabled/dim states unchanged.

UI only, no data change. Gates green locally (tsc, eslint, prettier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded dashboard quick actions to include scanning, adding an expense, creating a group, and opening captures, making these common tasks easier to access.

* **Style**
  * Updated quick-action buttons with a transparent layout and larger icons while preserving existing badges, disabled states, accessibility, and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->