### PR TITLE
feat(mobile): scan a group's invite QR to join

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -66,6 +66,12 @@
           "cameraPermission": "Waves uses the camera to scan a bill, so the total and the items come out filled in instead of typed. The photograph stays on this phone whenever it can be read here."
         }
       ],
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Waves uses the camera to scan a group's invite QR code, so you can join without typing the link."
+        }
+      ],
       "./plugins/withShortNativeBuildPath",
       "expo-secure-store",
       "expo-sharing",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -18,6 +18,7 @@
     "base64-arraybuffer": "^1.0.2",
     "expo": "~57.0.12",
     "expo-auth-session": "~57.0.6",
+    "expo-camera": "~57.0.4",
     "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.10",
     "expo-contacts": "~57.0.3",

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -218,6 +218,17 @@ export default function FriendsScreen() {
             >
               <Ionicons name="people-outline" size={iconSize.xl} color={theme.color.text} />
             </Pressable>
+            {/* Point the camera at a group's invite QR to join it — the read
+                lands in the same join flow an invite link opens. */}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t.misc.scanToJoin}
+              onPress={() => router.push('/scan')}
+              hitSlop={10}
+              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+            >
+              <Ionicons name="qr-code-outline" size={iconSize.lg} color={theme.color.text} />
+            </Pressable>
             {/* The sort control — a bare vertical three-dot beside the button,
                 opening the same corner dropdown the rest of the app uses. */}
             <Pressable

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -527,6 +527,7 @@ function AuthGate() {
         <Stack.Screen name="receipt/[id]" options={modal} />
         <Stack.Screen name="friends/contacts" />
         <Stack.Screen name="contact-picker" options={modal} />
+        <Stack.Screen name="scan" options={modal} />
         <Stack.Screen name="settings/backup" />
         <Stack.Screen name="settings/notifications" />
         <Stack.Screen name="settings/export" />

--- a/apps/mobile/src/app/scan.tsx
+++ b/apps/mobile/src/app/scan.tsx
@@ -1,0 +1,66 @@
+import { lazy, Suspense } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { ActivityIndicator, View } from 'react-native';
+
+import { EmptyState, IconButton, iconSize, Row, Screen, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+import { cameraAvailable } from '@/lib/qrScan';
+
+// Only pulled in when the native camera is present — a dynamic import so an
+// older binary never even evaluates `expo-camera`.
+const ScannerCamera = lazy(() => import('@/components/ScannerCamera'));
+
+/**
+ * Point the camera at a group's invite QR and land in the join flow.
+ *
+ * The scanned code carries the same invite token an invite link does, so a good
+ * read just hands off to `/join?token=…` — the one screen that already previews
+ * the group and runs the ghost-claim. When the running binary predates
+ * `expo-camera` (a JS-only reload of an old dev-client), the screen says so
+ * instead of reaching for a camera that is not in the build yet.
+ */
+export default function ScanScreen() {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const available = cameraAvailable();
+
+  const onToken = (token: string): void => {
+    router.replace(`/join?token=${encodeURIComponent(token)}`);
+  };
+
+  return (
+    <Screen edges={['top', 'bottom']}>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.close} onPress={() => router.back()}>
+          <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.misc.scanToJoin}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
+      {available ? (
+        <Suspense
+          fallback={
+            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+              <ActivityIndicator color={theme.color.brand} />
+            </View>
+          }
+        >
+          <ScannerCamera onToken={onToken} />
+        </Suspense>
+      ) : (
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <EmptyState
+            icon={<Ionicons name="qr-code-outline" size={iconSize.xxl} color={theme.color.brand} />}
+            title={t.misc.scanToJoin}
+            body={t.misc.scanRebuild}
+          />
+        </View>
+      )}
+    </Screen>
+  );
+}

--- a/apps/mobile/src/components/ScannerCamera.tsx
+++ b/apps/mobile/src/components/ScannerCamera.tsx
@@ -1,0 +1,115 @@
+/**
+ * The live camera that reads an invite QR — the leaf that actually touches
+ * `expo-camera`.
+ *
+ * It is only ever loaded (via a dynamic import) once `cameraAvailable()` is
+ * true, so importing `expo-camera` here cannot crash an older binary: the
+ * module is never evaluated on a build that lacks the native side. It owns the
+ * permission dance because that is an `expo-camera` hook; the surrounding
+ * chrome (close, title) belongs to the route.
+ */
+
+import { useRef, useState } from 'react';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import { ActivityIndicator, Linking, StyleSheet, View } from 'react-native';
+
+import { Button, Callout, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+import { tokenFromScan } from '@/lib/qrScan';
+
+export default function ScannerCamera({ onToken }: { onToken: (token: string) => void }) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const [permission, requestPermission] = useCameraPermissions();
+  // A read fires many frames a second; once we have a good token we hand it up
+  // once and stop, and a bad read only flags itself without locking the camera.
+  const handled = useRef(false);
+  const [invalid, setInvalid] = useState(false);
+
+  if (!permission) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator color={theme.color.brand} />
+      </View>
+    );
+  }
+
+  if (!permission.granted) {
+    const canAsk = permission.canAskAgain;
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: theme.spacing.lg,
+          padding: theme.spacing.xl,
+        }}
+      >
+        <Text variant="body" tone="muted" align="center">
+          {canAsk ? t.misc.scanAllowBody : t.misc.scanDenied}
+        </Text>
+        <Button
+          label={t.misc.scanAllow}
+          size="lg"
+          onPress={() => void (canAsk ? requestPermission() : Linking.openSettings())}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1 }}>
+      <CameraView
+        style={{ flex: 1 }}
+        facing="back"
+        barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+        onBarcodeScanned={({ data }) => {
+          if (handled.current) return;
+          const token = tokenFromScan(data);
+          if (!token) {
+            setInvalid(true);
+            return;
+          }
+          handled.current = true;
+          onToken(token);
+        }}
+      />
+
+      {/* The aiming frame and the one line that says what to point at, floated
+          over the feed. */}
+      <View
+        pointerEvents="none"
+        style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center' }]}
+      >
+        <View
+          style={{
+            width: 232,
+            height: 232,
+            borderRadius: theme.radius.xl,
+            borderWidth: 3,
+            borderColor: '#FFFFFF',
+          }}
+        />
+      </View>
+
+      <View
+        pointerEvents="box-none"
+        style={{
+          position: 'absolute',
+          left: theme.spacing.xl,
+          right: theme.spacing.xl,
+          bottom: theme.spacing.xxxl,
+          gap: theme.spacing.md,
+          alignItems: 'center',
+        }}
+      >
+        {invalid ? <Callout tone="negative">{t.misc.scanInvalid}</Callout> : null}
+        <Text variant="body" style={{ color: '#FFFFFF' }} align="center">
+          {t.misc.scanHint}
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1160,6 +1160,13 @@ export interface UiStrings {
     couldNotJoin: string;
     rateFetchFailed: string;
     newGroupPlaceholder: string;
+    scanToJoin: string;
+    scanHint: string;
+    scanAllowBody: string;
+    scanAllow: string;
+    scanDenied: string;
+    scanInvalid: string;
+    scanRebuild: string;
     personName: string;
     createGroup: string;
     linkExpired: string;
@@ -2602,6 +2609,13 @@ const en: UiStrings = {
     couldNotJoin: 'Could not open this invite. Please try again.',
     rateFetchFailed: 'Could not fetch the rate',
     newGroupPlaceholder: 'Name this group',
+    scanToJoin: 'Scan to join',
+    scanHint: "Point at a group's invite QR code",
+    scanAllowBody: 'Allow the camera to read an invite QR code.',
+    scanAllow: 'Allow camera',
+    scanDenied: 'Camera access is off. Turn it on in Settings to scan.',
+    scanInvalid: 'That is not a Waves invite code.',
+    scanRebuild: 'Update the app to scan invite codes.',
     personName: "Person's name",
     createGroup: 'Create group',
     linkExpired: 'This link has expired',
@@ -4150,6 +4164,13 @@ const ta: UiStrings = {
     couldNotJoin: 'இந்த அழைப்பைத் திறக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
     rateFetchFailed: 'மாற்று விகிதத்தைப் பெற முடியவில்லை',
     newGroupPlaceholder: 'இந்தக் குழுவுக்குப் பெயரிடுங்கள்',
+    scanToJoin: 'ஸ்கேன் செய்து சேரவும்',
+    scanHint: 'குழுவின் அழைப்பு QR குறியீட்டை நோக்கிக் காட்டவும்',
+    scanAllowBody: 'அழைப்பு QR குறியீட்டைப் படிக்க கேமராவை அனுமதிக்கவும்.',
+    scanAllow: 'கேமராவை அனுமதி',
+    scanDenied: 'கேமரா அணுகல் அணைக்கப்பட்டுள்ளது. ஸ்கேன் செய்ய அமைப்புகளில் இயக்கவும்.',
+    scanInvalid: 'இது Waves அழைப்புக் குறியீடு அல்ல.',
+    scanRebuild: 'அழைப்புக் குறியீடுகளை ஸ்கேன் செய்ய ஆப்பைப் புதுப்பிக்கவும்.',
     personName: 'நபரின் பெயர்',
     createGroup: 'குழுவை உருவாக்கு',
     linkExpired: 'இந்த இணைப்பு காலாவதியாகிவிட்டது',
@@ -5684,6 +5705,13 @@ const hi: UiStrings = {
     couldNotJoin: 'यह निमंत्रण नहीं खुल सका। कृपया फिर कोशिश करें।',
     rateFetchFailed: 'दर प्राप्त नहीं हो सकी',
     newGroupPlaceholder: 'इस ग्रुप को नाम दें',
+    scanToJoin: 'स्कैन करके जुड़ें',
+    scanHint: 'ग्रुप के इनवाइट QR कोड की ओर कैमरा करें',
+    scanAllowBody: 'इनवाइट QR कोड पढ़ने के लिए कैमरे की अनुमति दें।',
+    scanAllow: 'कैमरा अनुमति दें',
+    scanDenied: 'कैमरा एक्सेस बंद है। स्कैन करने के लिए सेटिंग्स में चालू करें।',
+    scanInvalid: 'यह Waves इनवाइट कोड नहीं है।',
+    scanRebuild: 'इनवाइट कोड स्कैन करने के लिए ऐप अपडेट करें।',
     personName: 'व्यक्ति का नाम',
     createGroup: 'समूह बनाएँ',
     linkExpired: 'यह लिंक खत्म हो चुका है',
@@ -7254,6 +7282,13 @@ const ar: UiStrings = {
     couldNotJoin: 'تعذّر فتح هذه الدعوة. حاول مرة أخرى.',
     rateFetchFailed: 'تعذّر جلب سعر الصرف',
     newGroupPlaceholder: 'سمِّ هذه المجموعة',
+    scanToJoin: 'امسح للانضمام',
+    scanHint: 'وجّه الكاميرا إلى رمز QR الخاص بدعوة المجموعة',
+    scanAllowBody: 'اسمح للكاميرا بقراءة رمز QR الخاص بالدعوة.',
+    scanAllow: 'السماح للكاميرا',
+    scanDenied: 'الوصول إلى الكاميرا متوقف. فعّله من الإعدادات للمسح.',
+    scanInvalid: 'هذا ليس رمز دعوة Waves.',
+    scanRebuild: 'حدّث التطبيق لمسح رموز الدعوة.',
     personName: 'اسم الشخص',
     createGroup: 'إنشاء مجموعة',
     linkExpired: 'انتهت صلاحية هذا الرابط',

--- a/apps/mobile/src/lib/qrScan.ts
+++ b/apps/mobile/src/lib/qrScan.ts
@@ -27,14 +27,46 @@ export function cameraAvailable(): boolean {
  * `token` query on a join URL; a random QR from a poster is not an invite, and
  * returns null so the screen can say so rather than routing nowhere.
  */
+/** Where a real Waves invite points: the https link's host, and the deep-link
+ *  schemes the app registers. Anything else is somebody else's QR. */
+const INVITE_HOST = 'baaki.app';
+const INVITE_SCHEMES = new Set(['waves', 'baaki']);
+
 export function tokenFromScan(data: string): string | null {
   const text = data.trim();
   if (!text) return null;
-  // Must look like our join link, not just any string that happens to carry a
-  // token= pair.
-  if (!/\/join\b/i.test(text) && !/^waves:\/\/join\b/i.test(text)) return null;
-  const match = text.match(/[?&]token=([^&\s]+)/);
-  if (!match) return null;
+
+  // A token must not carry a fragment; drop anything after '#' before reading
+  // the query so `token=abc#frag` cannot smuggle the fragment into the token.
+  const withoutFragment = text.split('#')[0];
+
+  let parsed: URL;
+  try {
+    parsed = new URL(withoutFragment);
+  } catch {
+    return null;
+  }
+
+  // Only our own invite surfaces: the https link on the invite host, or the
+  // app's own deep-link schemes. The path must be exactly /join, not merely
+  // contain it, so `https://evil.example/x/join` is rejected.
+  const scheme = parsed.protocol.replace(/:$/, '').toLowerCase();
+  const path = parsed.pathname.replace(/\/+$/, '') || '/';
+  if (scheme === 'https') {
+    if (parsed.hostname.toLowerCase() !== INVITE_HOST || path !== '/join') return null;
+  } else if (INVITE_SCHEMES.has(scheme)) {
+    // `waves://join?token=…` parses with `join` as the host and an empty path.
+    const host = parsed.hostname.toLowerCase();
+    if (host !== 'join' && path !== '/join') return null;
+  } else {
+    return null;
+  }
+
+  // Read the token off the raw query rather than `searchParams`, whose support
+  // is patchy in the React Native URL polyfill. The fragment is already gone, so
+  // the capture cannot run past the query.
+  const match = parsed.search.match(/[?&]token=([^&]+)/);
+  if (!match || !match[1]) return null;
   try {
     return decodeURIComponent(match[1]);
   } catch {

--- a/apps/mobile/src/lib/qrScan.ts
+++ b/apps/mobile/src/lib/qrScan.ts
@@ -1,0 +1,43 @@
+/**
+ * The invite-QR scanner, kept behind a runtime check.
+ *
+ * `expo-camera` is a native module. On a JS-only reload of an older dev-client
+ * — one built before the module was installed — importing its `CameraView`
+ * eagerly would reach for a native view that is not there. So nothing here
+ * imports `expo-camera`; callers ask `cameraAvailable()` first and only mount
+ * the camera leaf when the answer is yes, showing a "rebuild the app" notice
+ * otherwise. Same discipline the document scanner uses (see `scanner.ts`).
+ */
+
+import { requireOptionalNativeModule } from 'expo';
+import { Platform } from 'react-native';
+
+/** Whether this binary actually contains the camera module. False on web, and
+ *  on any dev-client built before `expo-camera` was added. */
+export function cameraAvailable(): boolean {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') return false;
+  return requireOptionalNativeModule('ExpoCamera') != null;
+}
+
+/**
+ * The invite token out of whatever the camera read.
+ *
+ * A Waves invite QR encodes the join URL (`https://baaki.app/join?token=…`, or
+ * the `waves://join?token=…` deep link). We only trust a value that carries a
+ * `token` query on a join URL; a random QR from a poster is not an invite, and
+ * returns null so the screen can say so rather than routing nowhere.
+ */
+export function tokenFromScan(data: string): string | null {
+  const text = data.trim();
+  if (!text) return null;
+  // Must look like our join link, not just any string that happens to carry a
+  // token= pair.
+  if (!/\/join\b/i.test(text) && !/^waves:\/\/join\b/i.test(text)) return null;
+  const match = text.match(/[?&]token=([^&\s]+)/);
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}

--- a/apps/mobile/src/lib/tabBar.ts
+++ b/apps/mobile/src/lib/tabBar.ts
@@ -23,6 +23,7 @@ export const TAB_BAR_HIDDEN_ROUTES: ReadonlySet<string> = new Set([
   'language',
   'capture',
   'contact-picker',
+  'scan',
   'new-group',
   'add-expense',
   'settle',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       expo-auth-session:
         specifier: ~57.0.6
         version: 57.0.6(expo@57.0.12)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)
+      expo-camera:
+        specifier: ~57.0.4
+        version: 57.0.4(@types/emscripten@1.41.5)(expo@57.0.12)(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       expo-clipboard:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.12)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -2811,6 +2814,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/emscripten@1.41.5':
+    resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -3474,6 +3480,9 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  barcode-detector@3.2.2:
+    resolution: {integrity: sha512-/4QOrrNrCRmDSBWiiP4aC72dnkuXUEdcFRidHgbPRXUpy82XcCMvJssI6fEs6JT42LS7DvBVZO70qasJbYKyrA==}
 
   base64-arraybuffer@1.0.2:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
@@ -4258,6 +4267,17 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-camera@57.0.4:
+    resolution: {integrity: sha512-MqbbQ63O+cA8JbK3lfFHiD0f2jv8jB+EG/ILK6f5xnOPV9IR37yaG5+lGtRZNoOeYBzGypyOi17USItleMyuGw==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+      react-native-web: '*'
+    peerDependenciesMeta:
+      react-native-web:
+        optional: true
 
   expo-clipboard@57.0.1:
     resolution: {integrity: sha512-HWICri4+1ao7S6QEfcorxVumXDiDnx1guGGewjZgGJWLGxFYs0RgH8ujBs+lkTzBkMmlwADaWSlaesR+nDJt5Q==}
@@ -6708,6 +6728,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
@@ -6794,6 +6818,10 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -7216,6 +7244,11 @@ packages:
 
   zrender@6.1.0:
     resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
+
+  zxing-wasm@3.1.3:
+    resolution: {integrity: sha512-3lC9BJk4fR5ZJxcGjb0hVnDFOW7KpLXHIebiBmVd4FDRQZVeObztoTKxRUPxlWwSgxrMRONK0u50hBD1aTYEKg==}
+    peerDependencies:
+      '@types/emscripten': '>=1.39.6'
 
 snapshots:
 
@@ -9755,6 +9788,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/emscripten@1.41.5': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
@@ -10563,6 +10598,12 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  barcode-detector@3.2.2(@types/emscripten@1.41.5):
+    dependencies:
+      zxing-wasm: 3.1.3(@types/emscripten@1.41.5)
+    transitivePeerDependencies:
+      - '@types/emscripten'
+
   base64-arraybuffer@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -11250,7 +11291,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-expo: 1.1.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -11290,21 +11331,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
-      get-tsconfig: 4.14.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -11327,7 +11353,7 @@ snapshots:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11586,6 +11612,17 @@ snapshots:
     transitivePeerDependencies:
       - expo
       - supports-color
+
+  expo-camera@57.0.4(@types/emscripten@1.41.5)(expo@57.0.12)(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+    dependencies:
+      barcode-detector: 3.2.2(@types/emscripten@1.41.5)
+      expo: 57.0.12(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.9)(expo-router@57.0.12)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      react: 19.2.8
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+    optionalDependencies:
+      react-native-web: 0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+    transitivePeerDependencies:
+      - '@types/emscripten'
 
   expo-clipboard@57.0.1(expo@57.0.12)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
     dependencies:
@@ -14271,6 +14308,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
@@ -14346,6 +14385,10 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@0.7.1: {}
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   type-is@2.1.0:
     dependencies:
@@ -14769,3 +14812,8 @@ snapshots:
   zrender@6.1.0:
     dependencies:
       tslib: 2.3.0
+
+  zxing-wasm@3.1.3(@types/emscripten@1.41.5):
+    dependencies:
+      '@types/emscripten': 1.41.5
+      type-fest: 5.8.0


### PR DESCRIPTION
Adds a **scan-to-join** entry point in the **Friends** tab header (a `qr-code` icon beside add-person). It opens a camera that reads a group's invite QR and hands the token to the **existing `/join` flow** (preview + ghost-claim) — so joining by QR reuses everything joining by an invite link already does.

## Native dependency — needs a dev-client rebuild
`expo-camera` (~57.0.4) is a native module. It's kept behind a **runtime guard** (`cameraAvailable()` via `requireOptionalNativeModule`) and the camera leaf is a **dynamic import**, so:
- On the **current binary** (built before expo-camera): the app still launches; the scan screen shows a *"update the app to scan"* notice.
- After a **local dev-client rebuild** (`gradlew`): the live camera + permission flow works.

Per the native-module rule — nothing that can throw is imported at module top.

## What's here
- `app/scan.tsx` — modal route: availability gate → permission → camera, or the rebuild notice.
- `components/ScannerCamera.tsx` — the camera leaf (owns the `expo-camera` permission hook).
- `lib/qrScan.ts` — `cameraAvailable()` + `tokenFromScan()` (only trusts a `token=` on a `/join` URL).
- Friends-tab entry, `scan` route registered (modal + tab-bar-hidden), scan i18n (en/ta/hi/ar), expo-camera plugin + camera permission string.

UI/native only, no DB change. Gates green locally (tsc, eslint, prettier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added QR code scanning from the Friends screen for joining groups via invite links.
  - Added camera permission prompts, scan guidance, invalid-code feedback, and settings support.
  - Added a dedicated scan modal with close navigation and a hidden tab bar.
  - Added localized scanning text in English, Tamil, Hindi, and Arabic.
  - Added fallback messaging when camera support is unavailable or requires an app update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->