### PR TITLE
feat(mobile): LINE-style group rows, long-press quick-add, centred empty state

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -30,7 +30,7 @@ import { useNotifications, useRecentActivity } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { usePullRefresh } from '@/lib/pullRefresh';
-import { useSync } from '@/sync';
+import { SyncStatus, useSync } from '@/sync';
 
 // How many rows the feed shows at first, and how many more each time the scroll
 // nears the bottom. The whole history is already on the phone (the mirror), so
@@ -51,8 +51,10 @@ export default function ActivityScreen() {
 
   // The feed is read straight from the mirror, so it is here offline and the
   // moment the screen opens; `hydrated` is the one wait — the first read of the
-  // on-disk mirror at cold start, not a network call.
-  const { hydrated } = useSync();
+  // on-disk mirror at cold start, not a network call. If that read itself fails
+  // (`status` goes to Error while still unhydrated), a retry re-runs it via
+  // `flush`, so the screen offers a way out rather than a skeleton forever.
+  const { hydrated, status, flush } = useSync();
   const allEntries = useRecentActivity();
 
   // Infinite scroll over the local list: show `visible` rows, grow the window as
@@ -122,10 +124,29 @@ export default function ActivityScreen() {
         </Row>
 
         {!hydrated && allEntries.length === 0 ? (
-          // The only wait is the first read of the on-disk mirror. There is no
-          // error branch: a mirror read cannot fail the way a network call can,
-          // and an empty feed after hydration is "nothing yet", not "failed".
-          <FeedSkeleton />
+          status === SyncStatus.Error ? (
+            // The mirror read itself failed (a corrupt or unreadable local DB).
+            // Rare, but without this branch the skeleton would sit forever — so
+            // offer a retry, which re-runs hydration through a flush.
+            <View style={{ flex: 1, justifyContent: 'center' }}>
+              <EmptyState
+                title={t.loadError}
+                body={t.loadErrorBody}
+                icon={
+                  <Ionicons
+                    name="cloud-offline-outline"
+                    size={iconSize.xxl}
+                    color={theme.color.brand}
+                  />
+                }
+                action={<Button label={t.retry} variant="secondary" onPress={() => void flush()} />}
+              />
+            </View>
+          ) : (
+            // The ordinary wait: the first read of the on-disk mirror at cold
+            // start. An empty feed after it lands is "nothing yet", not "failed".
+            <FeedSkeleton />
+          )
         ) : allEntries.length === 0 ? (
           <View style={{ flex: 1, justifyContent: 'center' }}>
             <EmptyState

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -165,13 +165,13 @@ export default function ActivityScreen() {
                               borderRadius: 21,
                               alignItems: 'center',
                               justifyContent: 'center',
-                              backgroundColor: theme.color.brandSoft,
+                              backgroundColor: theme.color.buttonPrimary,
                             }}
                           >
                             <Ionicons
                               name={verbIcon(entry.verb)}
                               size={iconSize.xl}
-                              color={theme.color.brand}
+                              color={theme.color.onBrand}
                             />
                           </View>
                           {!isLast ? (

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -181,7 +181,7 @@ export default function ActivityScreen() {
                                 width: 2,
                                 marginTop: theme.spacing.xs,
                                 borderRadius: 1,
-                                backgroundColor: theme.color.brandSoft,
+                                backgroundColor: theme.color.buttonPrimary,
                               }}
                             />
                           ) : null}

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -1,7 +1,14 @@
+import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useQuery } from '@tanstack/react-query';
 import { router } from 'expo-router';
-import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
+import {
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  View,
+} from 'react-native';
 
 import {
   Button,
@@ -17,13 +24,21 @@ import {
 } from '@waves/ui';
 
 import { dayHeading, describeActivity, groupByDay, parseMoney, verbIcon } from '@/data/activity';
-import { fetchRecentActivity } from '@/data/api';
 import { useBlockedUsers } from '@/data/blocked';
 import { FeedSkeleton } from '@/components/Skeletons';
-import { useNotifications } from '@/data/hooks';
+import { useNotifications, useRecentActivity } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { usePullRefresh } from '@/lib/pullRefresh';
+import { useSync } from '@/sync';
+
+// How many rows the feed shows at first, and how many more each time the scroll
+// nears the bottom. The whole history is already on the phone (the mirror), so
+// this only bounds how much is mounted at once — a cheap window, not a fetch.
+const PAGE = 25;
+// Grow the window a little before the very end scrolls into view, so more rows
+// are already there rather than appearing under the thumb.
+const LOAD_AHEAD_PX = 600;
 
 export default function ActivityScreen() {
   const theme = useTheme();
@@ -34,11 +49,25 @@ export default function ActivityScreen() {
   const myProfileId = session?.user.id ?? null;
   const { blockedIds } = useBlockedUsers();
 
-  const activity = useQuery({
-    queryKey: ['activity', 'recent'],
-    queryFn: () => fetchRecentActivity(),
-  });
-  const entries = activity.data ?? [];
+  // The feed is read straight from the mirror, so it is here offline and the
+  // moment the screen opens; `hydrated` is the one wait — the first read of the
+  // on-disk mirror at cold start, not a network call.
+  const { hydrated } = useSync();
+  const allEntries = useRecentActivity();
+
+  // Infinite scroll over the local list: show `visible` rows, grow the window as
+  // the scroll nears the bottom. No page is ever fetched — the rows are already
+  // on the phone.
+  const [visible, setVisible] = useState(PAGE);
+  const entries = allEntries.slice(0, visible);
+  const onScroll = (event: NativeSyntheticEvent<NativeScrollEvent>): void => {
+    const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
+    const nearBottom =
+      layoutMeasurement.height + contentOffset.y >= contentSize.height - LOAD_AHEAD_PX;
+    if (nearBottom && visible < allEntries.length) {
+      setVisible((current) => Math.min(current + PAGE, allEntries.length));
+    }
+  };
 
   const notifications = useNotifications();
   const unread = (notifications.data ?? []).filter((row) => row.read_at === null).length;
@@ -56,6 +85,8 @@ export default function ActivityScreen() {
           flexGrow: 1,
         }}
         showsVerticalScrollIndicator={false}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
         refreshControl={
           <RefreshControl
             refreshing={pull.refreshing}
@@ -90,26 +121,12 @@ export default function ActivityScreen() {
           </IconButton>
         </Row>
 
-        {activity.isLoading ? (
+        {!hydrated && allEntries.length === 0 ? (
+          // The only wait is the first read of the on-disk mirror. There is no
+          // error branch: a mirror read cannot fail the way a network call can,
+          // and an empty feed after hydration is "nothing yet", not "failed".
           <FeedSkeleton />
-        ) : activity.isError ? (
-          <View style={{ flex: 1, justifyContent: 'center' }}>
-            <EmptyState
-              title={t.loadError}
-              body={t.loadErrorBody}
-              icon={
-                <Ionicons
-                  name="cloud-offline-outline"
-                  size={iconSize.xxl}
-                  color={theme.color.brand}
-                />
-              }
-              action={
-                <Button label={t.retry} variant="secondary" onPress={() => activity.refetch()} />
-              }
-            />
-          </View>
-        ) : entries.length === 0 ? (
+        ) : allEntries.length === 0 ? (
           <View style={{ flex: 1, justifyContent: 'center' }}>
             <EmptyState
               title={t.nothingYet}
@@ -165,13 +182,12 @@ export default function ActivityScreen() {
                               borderRadius: 21,
                               alignItems: 'center',
                               justifyContent: 'center',
-                              backgroundColor: theme.color.buttonPrimary,
                             }}
                           >
                             <Ionicons
                               name={verbIcon(entry.verb)}
                               size={iconSize.xl}
-                              color={theme.color.onBrand}
+                              color={theme.color.brand}
                             />
                           </View>
                           {!isLast ? (
@@ -181,7 +197,7 @@ export default function ActivityScreen() {
                                 width: 2,
                                 marginTop: theme.spacing.xs,
                                 borderRadius: 1,
-                                backgroundColor: theme.color.buttonPrimary,
+                                backgroundColor: theme.color.border,
                               }}
                             />
                           ) : null}

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -443,10 +443,10 @@ function FriendsSection({
                 borderRadius: 22,
                 alignItems: 'center',
                 justifyContent: 'center',
-                backgroundColor: theme.color.brandSoft,
+                backgroundColor: theme.color.buttonPrimary,
               }}
             >
-              <Ionicons name={emptyIcon} size={22} color={theme.color.brand} />
+              <Ionicons name={emptyIcon} size={22} color={theme.color.onBrand} />
             </View>
             <Text variant="caption" tone="muted" align="center">
               {emptyBody}

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -352,7 +352,7 @@ function NoFriendsHero({ t }: { t: UiStrings }): React.JSX.Element {
             width: 30,
             height: 30,
             borderRadius: 15,
-            backgroundColor: theme.color.brand,
+            backgroundColor: theme.color.buttonPrimary,
             borderWidth: 3,
             borderColor: theme.color.surface,
             alignItems: 'center',

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -359,7 +359,7 @@ function NoFriendsHero({ t }: { t: UiStrings }): React.JSX.Element {
             justifyContent: 'center',
           }}
         >
-          <Ionicons name="add" size={iconSize.lg} color={theme.color.onBrand} />
+          <Ionicons name="add" size={iconSize.lg} color={theme.color.onButtonPrimary} />
         </View>
       </View>
 

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -41,6 +41,7 @@ import { TourTarget, useTour } from '@/lib/tour';
 import { SyncStatusIcon } from '@/components/SyncBanner';
 import { SkeletonList } from '@/components/Skeletons';
 import { GroupCard } from '@/components/GroupCard';
+import { QuickAddSheet, useQuickAddActions } from '@/components/QuickAddSheet';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
 import { useAvatarUrl } from '@/components/ProfileAvatar';
 import { groupLabel, GroupType } from '@/data/types';
@@ -66,6 +67,11 @@ export default function HomeScreen() {
   const captureCount = captures.data?.length ?? 0;
   const guard = useGuestGuard();
   const tour = useTour();
+
+  // A press-and-hold on any add icon raises the same quick-add sheet — type,
+  // scan, or speak an expense — the phone-home-screen quick-actions gesture.
+  const [quickAddOpen, setQuickAddOpen] = useState(false);
+  const quickAddActions = useQuickAddActions();
 
   const list = groups.data ?? [];
   const loading = groups.isLoading || summary.isLoading;
@@ -222,6 +228,9 @@ export default function HomeScreen() {
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
+          // Fill the viewport so the no-groups empty state can centre itself in
+          // whatever height is left under the deck rather than hugging it.
+          flexGrow: 1,
         }}
         showsVerticalScrollIndicator={false}
         refreshControl={
@@ -319,12 +328,14 @@ export default function HomeScreen() {
             icon="camera-outline"
             label={t.scanBill}
             onPress={() => router.push(`/capture?scan=${Date.now()}`)}
+            onLongPress={() => setQuickAddOpen(true)}
           />
           <AddAction
             icon="add"
             label={t.addExpense}
             tourId="addExpense"
             onPress={() => router.push('/capture')}
+            onLongPress={() => setQuickAddOpen(true)}
           />
           <AddAction icon="people" label={t.newGroup} tourId="addGroup" onPress={openNewGroup} />
           {/* The captures inbox always holds its place in the row. It carries a
@@ -342,14 +353,18 @@ export default function HomeScreen() {
         {loading ? (
           <SkeletonList rows={3} />
         ) : list.length === 0 ? (
-          <EmptyState
-            title={t.tabs.noGroups}
-            icon={<Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.brand} />}
-          />
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <EmptyState
+              title={t.tabs.noGroups}
+              icon={
+                <Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.brand} />
+              }
+            />
+          </View>
         ) : (
           <View>
             <View>
-              {list.map((group, index) => {
+              {list.map((group) => {
                 const members = summary.membersFor(group.id);
                 const balance = summary.balanceFor(group.id);
                 // A running trip earns a live "on trip" tag; failing that, a
@@ -358,27 +373,23 @@ export default function HomeScreen() {
                 const isNew = nowMs - Date.parse(group.created_at) < NEW_GROUP_WINDOW_MS;
                 const tag = onTrip ? t.tagOnTrip : isNew ? t.tagNew : null;
                 return (
-                  <View key={group.id}>
-                    <GroupCard
-                      id={group.id}
-                      title={groupLabel(group, members, profile?.id)}
-                      memberLabel={plural(locale, summary.memberCountFor(group.id), t.memberCount)}
-                      coverEmoji={group.cover_emoji}
-                      balance={balance}
-                      currency={group.default_currency}
-                      locale={locale}
-                      statusLabel={
-                        balance === 0n ? t.allSettled : balance > 0n ? t.youAreOwed : t.youOwe
-                      }
-                      pendingLabel={summary.hasPending(group.id) ? t.pendingConfirmation : null}
-                      tag={tag}
-                      tagTone={onTrip ? 'positive' : 'brand'}
-                      onPress={() => router.push(`/group/${group.id}`)}
-                    />
-                    {index < list.length - 1 ? (
-                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                    ) : null}
-                  </View>
+                  <GroupCard
+                    key={group.id}
+                    id={group.id}
+                    title={groupLabel(group, members, profile?.id)}
+                    memberLabel={plural(locale, summary.memberCountFor(group.id), t.memberCount)}
+                    coverEmoji={group.cover_emoji}
+                    balance={balance}
+                    currency={group.default_currency}
+                    locale={locale}
+                    statusLabel={
+                      balance === 0n ? t.allSettled : balance > 0n ? t.youAreOwed : t.youOwe
+                    }
+                    pendingLabel={summary.hasPending(group.id) ? t.pendingConfirmation : null}
+                    tag={tag}
+                    tagTone={onTrip ? 'positive' : 'brand'}
+                    onPress={() => router.push(`/group/${group.id}`)}
+                  />
                 );
               })}
             </View>
@@ -398,6 +409,12 @@ export default function HomeScreen() {
           tomorrow. Replaces the inline card so a hint asks for a beat of
           attention rather than sitting as furniture nobody reads. */}
       <TipSheet t={t} />
+
+      <QuickAddSheet
+        visible={quickAddOpen}
+        onClose={() => setQuickAddOpen(false)}
+        actions={quickAddActions}
+      />
     </Screen>
   );
 }
@@ -412,6 +429,7 @@ function AddAction({
   icon,
   label,
   onPress,
+  onLongPress,
   badge,
   disabled,
   tourId,
@@ -419,6 +437,9 @@ function AddAction({
   icon: keyof typeof Ionicons.glyphMap;
   label: string;
   onPress: () => void;
+  /** A press-and-hold on the glyph — raises the quick-add sheet. Optional; the
+      icons that only do one thing (the inbox) leave it off. */
+  onLongPress?: () => void;
   /** An optional count on the glyph — e.g. how many captures are waiting. */
   badge?: number;
   /** Keep the button in place but dim and unpressable — e.g. an empty inbox. */
@@ -432,7 +453,7 @@ function AddAction({
     <View
       style={{
         width: 48,
-        height: 48,
+        height: 34,
         alignItems: 'center',
         justifyContent: 'center',
       }}
@@ -472,11 +493,13 @@ function AddAction({
       accessibilityState={{ disabled: Boolean(disabled) }}
       disabled={disabled}
       onPress={onPress}
+      onLongPress={onLongPress}
+      delayLongPress={250}
       style={({ pressed }) => ({
         flex: 1,
         minWidth: 0,
         alignItems: 'center',
-        gap: theme.spacing.xs,
+        gap: 2,
         opacity: disabled ? 0.4 : pressed ? 0.6 : 1,
       })}
     >

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -32,7 +32,7 @@ import { useCaptures, useGroups, useHomeSummary } from '@/data/hooks';
 import { CountUpMoney, PressableScale } from '@/lib/anim';
 import { useMotion } from '@/lib/motion';
 import { useFlagEnabled } from '@/lib/flags';
-import { deviceDefaultCurrency, plural, useStrings, type UiStrings } from '@/i18n';
+import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { usePromptSlot } from '@/lib/promptQueue';
@@ -41,6 +41,7 @@ import { TourTarget, useTour } from '@/lib/tour';
 import { SyncStatusIcon } from '@/components/SyncBanner';
 import { SkeletonList } from '@/components/Skeletons';
 import { GroupCard } from '@/components/GroupCard';
+import { useDefaultCurrency } from '@/lib/currency';
 import { QuickAddSheet, useQuickAddActions } from '@/components/QuickAddSheet';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
 import { useAvatarUrl } from '@/components/ProfileAvatar';
@@ -72,6 +73,7 @@ export default function HomeScreen() {
   // scan, or speak an expense — the phone-home-screen quick-actions gesture.
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const quickAddActions = useQuickAddActions();
+  const defaultCurrency = useDefaultCurrency();
 
   const list = groups.data ?? [];
   const loading = groups.isLoading || summary.isLoading;
@@ -186,7 +188,7 @@ export default function HomeScreen() {
    * empty state reads ₹0 and the first group then counts in dollars.
    */
   const headline = summary.totals[0] ?? {
-    currency: deviceDefaultCurrency(),
+    currency: defaultCurrency,
     net: 0n,
     owed: 0n,
     owing: 0n,

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -614,7 +614,6 @@ function GuestPopup({
     : gate
       ? t.tabs.guestDaysLeft.replace('{days}', String(gate.daysLeft))
       : t.tabs.guestBannerBody;
-  const accent = expired ? theme.color.warning : theme.color.brand;
 
   return (
     <Modal visible transparent animationType={animated ? 'fade' : 'none'} onRequestClose={dismiss}>
@@ -647,7 +646,7 @@ function GuestPopup({
               width: 72,
               height: 72,
               borderRadius: 36,
-              backgroundColor: theme.color.brandSoft,
+              backgroundColor: theme.color.buttonPrimary,
               alignItems: 'center',
               justifyContent: 'center',
             }}
@@ -655,7 +654,7 @@ function GuestPopup({
             <Ionicons
               name={expired ? 'lock-closed' : 'shield-checkmark'}
               size={38}
-              color={accent}
+              color={expired ? theme.color.warning : theme.color.onBrand}
             />
           </View>
 
@@ -825,10 +824,10 @@ function TipSheet({ t }: { t: UiStrings }) {
                   borderRadius: 32,
                   alignItems: 'center',
                   justifyContent: 'center',
-                  backgroundColor: theme.color.brandSoft,
+                  backgroundColor: theme.color.buttonPrimary,
                 }}
               >
-                <Ionicons name={tip.icon} size={iconSize.xxl} color={theme.color.brand} />
+                <Ionicons name={tip.icon} size={iconSize.xxl} color={theme.color.onBrand} />
               </View>
               <Text variant="micro" tone="brand" style={{ letterSpacing: 0.8 }}>
                 {t.tips.label.toUpperCase()}

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -218,19 +218,19 @@ function SettledPill({ profileId, locale }: { profileId: string | null; locale: 
           paddingHorizontal: theme.spacing.lg,
           paddingVertical: theme.spacing.sm,
           borderRadius: theme.radius.pill,
-          backgroundColor: theme.color.brandSoft,
+          backgroundColor: theme.color.buttonPrimary,
         }}
       >
-        <Ionicons name="checkmark-done" size={iconSize.base} color={theme.color.brand} />
+        <Ionicons name="checkmark-done" size={iconSize.base} color={theme.color.onBrand} />
         <Row style={{ gap: 4 }}>
           <MoneyText
             amount={top[1]}
             currency={top[0] as never}
             locale={locale}
             variant="subheading"
-            tone="brand"
+            tone="onBrand"
           />
-          <Text variant="caption" tone="brand">
+          <Text variant="caption" tone="onBrand">
             {t.account.settled}
           </Text>
         </Row>

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -155,7 +155,13 @@ export default function CaptureScreen() {
   // amount opens the picker. A traveller paying in a currency their phone's
   // region does not use should not have to leave and reopen the group form.
   const defaultCurrency = useDefaultCurrency();
-  const [currency, setCurrency] = useState<string>(() => defaultCurrency);
+  // Until the person picks a currency by hand, it follows the account default —
+  // which can arrive a beat after this screen mounts, once the profile loads, so
+  // an untouched capture is never saved in the device currency when the account
+  // says something else. Their pick then wins and sticks. Derived, not synced in
+  // an effect, so there is no setState-in-effect and no first-render snapshot.
+  const [pickedCurrency, setPickedCurrency] = useState<string | null>(null);
+  const currency = pickedCurrency ?? defaultCurrency;
   const [pickingCurrency, setPickingCurrency] = useState(false);
 
   const [amount, setAmount] = useState<bigint>(0n);
@@ -572,7 +578,7 @@ export default function CaptureScreen() {
                 label={code}
                 selected={currency === code}
                 onPress={() => {
-                  setCurrency(code);
+                  setPickedCurrency(code);
                   setPickingCurrency(false);
                 }}
               />

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -40,7 +40,8 @@ import { ChoiceRow, FieldRow, SheetOverlay } from '@/components/expense/SheetOve
 import { useCreateCapture, useGroups, useHomeSummary } from '@/data/hooks';
 import { groupLabel, GroupType, type GroupRow, type MemberRow } from '@/data/types';
 import { useAuth } from '@/lib/auth';
-import { deviceDefaultCurrency, plural, useStrings, type UiStrings } from '@/i18n';
+import { useDefaultCurrency } from '@/lib/currency';
+import { plural, useStrings, type UiStrings } from '@/i18n';
 import { captureReceipt, type PickedImage } from '@/lib/image';
 import { recogniseReceipt } from '@/lib/ocr';
 import { saveReceipt } from '@/lib/receiptStore';
@@ -153,7 +154,8 @@ export default function CaptureScreen() {
   // US default) but is the person's to change here — the currency pill under the
   // amount opens the picker. A traveller paying in a currency their phone's
   // region does not use should not have to leave and reopen the group form.
-  const [currency, setCurrency] = useState<string>(() => deviceDefaultCurrency());
+  const defaultCurrency = useDefaultCurrency();
+  const [currency, setCurrency] = useState<string>(() => defaultCurrency);
   const [pickingCurrency, setPickingCurrency] = useState(false);
 
   const [amount, setAmount] = useState<bigint>(0n);

--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -45,8 +45,9 @@ import { friendlyError } from '@/lib/errors';
 import { DictateButton } from '@/components/DictateButton';
 import { useAddGhostMember, useCreateGroup, useWriteExpense } from '@/data/hooks';
 import { GroupType } from '@/data/types';
-import { deviceDefaultCurrency, deviceSupportsUpi, useStrings } from '@/i18n';
+import { deviceSupportsUpi, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { useDefaultCurrency } from '@/lib/currency';
 import { useBackup } from '@/lib/cloud/BackupProvider';
 import { captureReceipt, type PickedImage } from '@/lib/image';
 import { useGuestGuard } from '@/lib/guestGuard';
@@ -119,7 +120,7 @@ export default function AddPersonScreen() {
   const writeExpense = useWriteExpense(groupId);
   const backup = useBackup();
 
-  const currency = deviceDefaultCurrency();
+  const currency = useDefaultCurrency();
   // UPI only where the region has the rail; every other method is universal.
   const paymentMethods = PAYMENT_METHODS.filter(
     (method) => !method.regional || deviceSupportsUpi(),

--- a/apps/mobile/src/app/friends/contacts.tsx
+++ b/apps/mobile/src/app/friends/contacts.tsx
@@ -154,10 +154,14 @@ export default function ContactsScreen(): React.JSX.Element {
         ) : (
           <>
             {added !== null ? (
-              <Card style={{ backgroundColor: theme.color.brandSoft }}>
+              <Card style={{ backgroundColor: theme.color.buttonPrimary }}>
                 <Row style={{ gap: theme.spacing.sm }}>
-                  <Ionicons name="checkmark-circle" size={iconSize.lg} color={theme.color.brand} />
-                  <Text variant="caption" tone="brand" style={{ flex: 1 }}>
+                  <Ionicons
+                    name="checkmark-circle"
+                    size={iconSize.lg}
+                    color={theme.color.onBrand}
+                  />
+                  <Text variant="caption" tone="onBrand" style={{ flex: 1 }}>
                     {fill(t.misc.contactsAdded, {
                       count: plural(locale, added, t.misc.peopleCount),
                     })}

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -844,8 +844,8 @@ export default function AddExpenseScreen() {
           />
 
           {editing ? (
-            <Card style={{ backgroundColor: theme.color.brandSoft }}>
-              <Text variant="caption" tone="brand">
+            <Card style={{ backgroundColor: theme.color.buttonPrimary }}>
+              <Text variant="caption" tone="onBrand">
                 {t.expense.editingKeepsVersion}
               </Text>
             </Card>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -301,11 +301,11 @@ export default function GroupScreen() {
                 borderRadius: theme.radius.xl,
                 alignItems: 'center',
                 justifyContent: 'center',
-                backgroundColor: theme.color.brandSoft,
+                backgroundColor: theme.color.buttonPrimary,
                 marginBottom: theme.spacing.sm,
               }}
             >
-              <Ionicons name="compass-outline" size={48} color={theme.color.brand} />
+              <Ionicons name="compass-outline" size={48} color={theme.color.onBrand} />
             </View>
             <Text variant="title" align="center" accessibilityRole="header">
               {t.group.notFound}
@@ -946,13 +946,13 @@ export default function GroupScreen() {
                             borderRadius: 19,
                             alignItems: 'center',
                             justifyContent: 'center',
-                            backgroundColor: theme.color.brandSoft,
+                            backgroundColor: theme.color.buttonPrimary,
                           }}
                         >
                           <Ionicons
                             name={verbIcon(entry.verb)}
                             size={iconSize.lg}
-                            color={theme.color.brand}
+                            color={theme.color.onBrand}
                           />
                         </View>
                       }

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -305,10 +305,10 @@ export default function InviteScreen() {
                       borderRadius: 28,
                       alignItems: 'center',
                       justifyContent: 'center',
-                      backgroundColor: theme.color.brandSoft,
+                      backgroundColor: theme.color.buttonPrimary,
                     }}
                   >
-                    <Ionicons name={option.icon} size={iconSize.lg} color={theme.color.brand} />
+                    <Ionicons name={option.icon} size={iconSize.lg} color={theme.color.onBrand} />
                   </View>
                   <Text variant="caption" tone="muted">
                     {option.label}

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -20,9 +20,7 @@ import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
 import { renderNotification } from '@waves/core';
 import {
   Button,
-  directionalIcon,
   EmptyState,
-  IconButton,
   iconSize,
   Row,
   Screen,
@@ -129,18 +127,11 @@ export default function InboxScreen() {
           />
         }
       >
-        {/* Back chevron because you drilled in here from the Activity bell,
-            then the same glyph-plus-big-title mark the Activity feed wears — the
-            two screens sit together, so the inbox reads as the sibling it is
-            rather than a generic settings page. */}
+        {/* The same glyph-plus-big-title mark the Activity feed wears — the two
+            screens sit together, so the inbox reads as the sibling it is. No
+            back chevron: the title sits at the left edge exactly like Activity,
+            and the bottom bar carries the way back. */}
         <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center', gap: theme.spacing.sm }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
           <Ionicons name="notifications-outline" size={iconSize.xl} color={theme.color.brand} />
           <Text variant="title">{t.inbox.title}</Text>
         </Row>

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -246,13 +246,13 @@ export default function InboxScreen() {
                               borderRadius: theme.radius.pill,
                               alignItems: 'center',
                               justifyContent: 'center',
-                              backgroundColor: theme.color.brandSoft,
+                              backgroundColor: theme.color.buttonPrimary,
                             }}
                           >
                             <Ionicons
                               name={ICONS[row.kind] ?? 'notifications-outline'}
                               size={iconSize.lg}
-                              color={theme.color.brand}
+                              color={theme.color.onBrand}
                             />
                           </View>
                           <View style={{ flex: 1, gap: 2 }}>

--- a/apps/mobile/src/app/language.tsx
+++ b/apps/mobile/src/app/language.tsx
@@ -98,14 +98,14 @@ export default function LanguageScreen() {
         {/* Choosing Arabic mirrors the layout only after a restart, so the note
             sits above the list, where the eyes already are. */}
         {restartNeeded ? (
-          <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.sm }}>
+          <Card style={{ backgroundColor: theme.color.buttonPrimary, gap: theme.spacing.sm }}>
             <Row style={{ gap: theme.spacing.sm }}>
-              <Ionicons name="refresh" size={iconSize.md} color={theme.color.brand} />
-              <Text variant="subheading" tone="brand">
+              <Ionicons name="refresh" size={iconSize.md} color={theme.color.onBrand} />
+              <Text variant="subheading" tone="onBrand">
                 {t.account.restartTitle}
               </Text>
             </Row>
-            <Text variant="caption" tone="muted">
+            <Text variant="caption" tone="onBrand">
               {isRtlLanguage(language)
                 ? t.account.restartBannerMirror
                 : t.account.restartBannerUnmirror}

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -37,6 +37,7 @@ import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates, type TripDatesValue } from '@/components/TripDates';
 import { requestContacts } from '@/lib/contactPickerBridge';
 import { useCreateGroup } from '@/data/hooks';
+import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { useSync } from '@/sync';
 import { GroupType } from '@/data/types';
@@ -210,6 +211,7 @@ export default function NewGroupScreen() {
   const theme = useTheme();
   const { t, locale } = useStrings();
   const createGroup = useCreateGroup();
+  const { profile } = useAuth();
   const guard = useGuestGuard();
   const { mutate } = useSync();
 
@@ -227,10 +229,10 @@ export default function NewGroupScreen() {
   // them alike.
   const [ghosts, setGhosts] = useState<PickedContact[]>([]);
   const [error, setError] = useState<string | null>(null);
-  // Not asked on this screen anymore — derived silently from the phone's locale
-  // so the group still gets a sensible currency and settle rails (both changeable
-  // later in group settings, which keeps the country row).
-  const country: string | null = deviceCountry();
+  // Not asked on this screen — taken from the account country (which the user
+  // sets on "Your account"), falling back to the phone's region. Decides the
+  // group's currency and settle rails, both changeable later in group settings.
+  const country: string | null = profile?.country_code ?? deviceCountry();
   // Null until somebody picks: the icon is otherwise read from the name, so an
   // untouched group still gets a sensible cover.
   const [pickedEmoji, setPickedEmoji] = useState<string | null>(null);

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -5,7 +5,6 @@ import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
-  currencyForCountry,
   currencySymbol,
   guessGroupEmoji,
   minorUnitExponent,
@@ -38,6 +37,7 @@ import { TripDates, type TripDatesValue } from '@/components/TripDates';
 import { requestContacts } from '@/lib/contactPickerBridge';
 import { useCreateGroup } from '@/data/hooks';
 import { useAuth } from '@/lib/auth';
+import { useDefaultCurrency } from '@/lib/currency';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { useSync } from '@/sync';
 import { GroupType } from '@/data/types';
@@ -212,6 +212,7 @@ export default function NewGroupScreen() {
   const { t, locale } = useStrings();
   const createGroup = useCreateGroup();
   const { profile } = useAuth();
+  const currency = useDefaultCurrency();
   const guard = useGuestGuard();
   const { mutate } = useSync();
 
@@ -256,7 +257,6 @@ export default function NewGroupScreen() {
   // Trips and events benefit most from simplification; a two-person group does
   // not. Follows the type until somebody says otherwise.
   const effectiveSimplify = simplify ?? (type === GroupType.Trip || type === GroupType.Event);
-  const currency = currencyForCountry(country) ?? 'INR';
 
   // The kinds of group, one place — the chips inside the picker and the icon on
   // the collapsed pill both read from this.

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -7,7 +7,7 @@
  * a new one, so everything entered as a guest comes with them.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
@@ -154,8 +154,15 @@ function AccountForm() {
   };
 
   // Picking a country saves it and, with it, the currency it implies — the one
-  // decision the field exists to make.
+  // decision the field exists to make. Serialised: a save in flight blocks a
+  // second pick, so a slow first response can never land after and overwrite a
+  // newer choice, and a failed save puts the row back to the country that is
+  // actually stored rather than leaving an unsaved one selected.
+  const countrySaving = useRef(false);
   const saveCountry = async (next: string | null): Promise<void> => {
+    if (countrySaving.current) return;
+    const prior = country;
+    countrySaving.current = true;
     setCountry(next);
     setRegionStatus(null);
     try {
@@ -165,7 +172,10 @@ function AccountForm() {
       });
       setRegionStatus(t.account.saved);
     } catch (caught) {
+      setCountry(prior);
       setRegionStatus(friendlyError(caught, t.couldNotSave, 'account.saveCountry'));
+    } finally {
+      countrySaving.current = false;
     }
   };
 

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -30,9 +30,10 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { dialingCodeForCountry } from '@waves/core';
+import { currencyForCountry, currencySymbol, dialingCodeForCountry } from '@waves/core';
 
 import { CountryCodePicker } from '@/components/CountryCodePicker';
+import { CountryRow } from '@/components/CountryPicker';
 import { friendlyError } from '@/lib/errors';
 import { confirmContact, startAddingContact, ContactChannel } from '@/data/api';
 import { deviceCountry, useStrings } from '@/i18n';
@@ -76,6 +77,18 @@ function AccountForm() {
   // profile; the key on this screen's owner keeps it honest across a swap.
   const [name, setName] = useState(profile?.display_name ?? '');
   const [nameStatus, setNameStatus] = useState<string | null>(null);
+
+  // Region: the country decides the default currency (and settle rails) and,
+  // optionally, a postal address. Seeded from the profile, falling back to the
+  // phone's region so the field is rarely empty on first open.
+  const [country, setCountry] = useState<string | null>(
+    profile?.country_code ?? deviceCountry() ?? null,
+  );
+  const [regionStatus, setRegionStatus] = useState<string | null>(null);
+  const [address, setAddress] = useState(profile?.address ?? '');
+  const [addressStatus, setAddressStatus] = useState<string | null>(null);
+  // The country drives this: it is what every new group and expense starts on.
+  const currency = currencyForCountry(country) ?? profile?.default_currency ?? 'INR';
 
   const [channel, setChannel] = useState<ContactChannel>(ContactChannel.Email);
   const [value, setValue] = useState('');
@@ -137,6 +150,34 @@ function AccountForm() {
       setNameStatus(t.account.saved);
     } catch (caught) {
       setNameStatus(friendlyError(caught, t.couldNotSave, 'account.saveName'));
+    }
+  };
+
+  // Picking a country saves it and, with it, the currency it implies — the one
+  // decision the field exists to make.
+  const saveCountry = async (next: string | null): Promise<void> => {
+    setCountry(next);
+    setRegionStatus(null);
+    try {
+      await updateProfile({
+        country_code: next,
+        default_currency: currencyForCountry(next) ?? profile?.default_currency ?? 'INR',
+      });
+      setRegionStatus(t.account.saved);
+    } catch (caught) {
+      setRegionStatus(friendlyError(caught, t.couldNotSave, 'account.saveCountry'));
+    }
+  };
+
+  const addressDirty = address.trim() !== (profile?.address ?? '');
+  const saveAddress = async (): Promise<void> => {
+    setAddressStatus(null);
+    try {
+      // Empty clears it to null rather than storing a blank string.
+      await updateProfile({ address: address.trim() || null });
+      setAddressStatus(t.account.saved);
+    } catch (caught) {
+      setAddressStatus(friendlyError(caught, t.couldNotSave, 'account.saveAddress'));
     }
   };
 
@@ -266,6 +307,74 @@ function AccountForm() {
                 {nameStatus}
               </Text>
             ) : null}
+          </Card>
+        </View>
+
+        {/* Where you are: the country sets the currency every new group and
+            expense starts on, and the settle rails you are offered. Required —
+            an address may follow, but it never has to. */}
+        <View style={{ gap: theme.spacing.md }}>
+          <SectionHeader title={t.account.regionTitle} />
+          <Card style={{ gap: theme.spacing.lg }}>
+            <CountryRow countryCode={country} onChange={(next) => void saveCountry(next)} />
+
+            {country ? (
+              <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                <View>
+                  <Text variant="caption" tone="muted">
+                    {t.account.currencyLabel}
+                  </Text>
+                  <Text variant="caption" tone="muted">
+                    {t.account.currencyFromCountry}
+                  </Text>
+                </View>
+                <Text variant="subheading">{`${currencySymbol(currency)} ${currency}`}</Text>
+              </Row>
+            ) : (
+              <Text variant="caption" tone="negative">
+                {t.account.countryRequired}
+              </Text>
+            )}
+
+            {regionStatus ? (
+              <Text
+                variant="caption"
+                tone={regionStatus === t.account.saved ? 'positive' : 'negative'}
+              >
+                {regionStatus}
+              </Text>
+            ) : null}
+
+            <View style={{ gap: theme.spacing.xs }}>
+              <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+                <Text variant="caption" tone="muted">
+                  {t.account.addressTitle}
+                </Text>
+                <Text variant="caption" tone="faint">
+                  {`· ${t.account.addressOptional}`}
+                </Text>
+              </Row>
+              <TextInput
+                value={address}
+                onChangeText={setAddress}
+                multiline
+                accessibilityLabel={t.account.addressTitle}
+                placeholder={t.account.addressPlaceholder}
+                placeholderTextColor={theme.color.textFaint}
+                style={[fieldStyle, { minHeight: 72, textAlignVertical: 'top' }]}
+              />
+              {addressDirty ? (
+                <Button label={t.common.save} fullWidth onPress={() => void saveAddress()} />
+              ) : null}
+              {addressStatus ? (
+                <Text
+                  variant="caption"
+                  tone={addressStatus === t.account.saved ? 'positive' : 'negative'}
+                >
+                  {addressStatus}
+                </Text>
+              ) : null}
+            </View>
           </Card>
         </View>
 

--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -85,14 +85,14 @@ export default function LanguageSettingsScreen() {
             is looking at a screen that did not mirror needs the explanation
             where their eyes already are. */}
         {restartNeeded ? (
-          <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.sm }}>
+          <Card style={{ backgroundColor: theme.color.buttonPrimary, gap: theme.spacing.sm }}>
             <Row style={{ gap: theme.spacing.sm }}>
-              <Ionicons name="refresh" size={iconSize.md} color={theme.color.brand} />
-              <Text variant="subheading" tone="brand">
+              <Ionicons name="refresh" size={iconSize.md} color={theme.color.onBrand} />
+              <Text variant="subheading" tone="onBrand">
                 {t.account.restartTitle}
               </Text>
             </Row>
-            <Text variant="caption" tone="muted">
+            <Text variant="caption" tone="onBrand">
               {isRtlLanguage(language)
                 ? t.account.restartBannerMirror
                 : t.account.restartBannerUnmirror}

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -195,15 +195,15 @@ export default function NotificationSettingsScreen() {
             defaults are the fix, and they are all off-switchable. */}
         <Card
           flat
-          style={{ backgroundColor: theme.color.brandSoft, paddingVertical: theme.spacing.lg }}
+          style={{ backgroundColor: theme.color.buttonPrimary, paddingVertical: theme.spacing.lg }}
         >
           <Row gap={theme.spacing.md}>
             <Ionicons
               name="shield-checkmark-outline"
               size={iconSize.xl}
-              color={theme.color.brand}
+              color={theme.color.onBrand}
             />
-            <Text variant="caption" tone="brand" style={{ flex: 1 }}>
+            <Text variant="caption" tone="onBrand" style={{ flex: 1 }}>
               {t.notifications.neverSpam}
             </Text>
           </Row>
@@ -288,12 +288,12 @@ function IconChip({ icon }: { icon: IconName }) {
         width: 40,
         height: 40,
         borderRadius: theme.radius.pill,
-        backgroundColor: theme.color.brandSoft,
+        backgroundColor: theme.color.buttonPrimary,
         alignItems: 'center',
         justifyContent: 'center',
       }}
     >
-      <Ionicons name={icon} size={iconSize.lg} color={theme.color.brand} />
+      <Ionicons name={icon} size={iconSize.lg} color={theme.color.onBrand} />
     </View>
   );
 }

--- a/apps/mobile/src/app/settings/upgrade.tsx
+++ b/apps/mobile/src/app/settings/upgrade.tsx
@@ -79,14 +79,14 @@ export default function UpgradeScreen() {
           <View style={{ width: 44 }} />
         </Row>
 
-        <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.md }}>
+        <Card style={{ backgroundColor: theme.color.buttonPrimary, gap: theme.spacing.md }}>
           {/* No badge saying "coming later". A brand badge on a brand-soft card
               is text with an invisible pill behind it, and the heading is
               already the whole announcement. */}
-          <Text variant="subheading" tone="brand">
+          <Text variant="subheading" tone="onBrand">
             {t.upgradeScreen.nothingToBuy}
           </Text>
-          <Text variant="caption" tone="muted">
+          <Text variant="caption" tone="onBrand">
             {t.upgradeScreen.nothingToBuyBody}
           </Text>
         </Card>

--- a/apps/mobile/src/app/verify-email.tsx
+++ b/apps/mobile/src/app/verify-email.tsx
@@ -151,10 +151,10 @@ export default function VerifyEmailScreen() {
               borderRadius: 48,
               alignItems: 'center',
               justifyContent: 'center',
-              backgroundColor: theme.color.brandSoft,
+              backgroundColor: theme.color.buttonPrimary,
             }}
           >
-            <Ionicons name="mail-unread-outline" size={44} color={theme.color.brand} />
+            <Ionicons name="mail-unread-outline" size={44} color={theme.color.onBrand} />
           </View>
           <Text
             align="center"

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -50,8 +50,9 @@ import {
   useWriteExpense,
 } from '@/data/hooks';
 import { groupLabel, GroupType, type GroupRow } from '@/data/types';
-import { deviceDefaultCurrency, plural, useStrings } from '@/i18n';
+import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { useDefaultCurrency } from '@/lib/currency';
 import { useMotion } from '@/lib/motion';
 import { aiEnabled, useAiAccess } from '@/lib/aiAccess';
 import { friendlyError } from '@/lib/errors';
@@ -94,6 +95,7 @@ export default function VoiceScreen() {
   const { t, locale } = useStrings();
   const { animated } = useMotion();
   const { profile } = useAuth();
+  const dc = useDefaultCurrency();
   const access = useAiAccess();
   const groups = useGroups();
 
@@ -180,7 +182,7 @@ export default function VoiceScreen() {
         result = await interpretVoiceExpenses(transcript, {
           groups: groupRefs,
           locale,
-          defaultCurrency: deviceDefaultCurrency(),
+          defaultCurrency: dc,
         }).catch(() => null);
       }
       applyResult(result ?? parseVoiceExpenses(transcript, groupRefs));
@@ -222,7 +224,7 @@ export default function VoiceScreen() {
             captureId: draft.key,
             description: draft.note.trim() || fallback,
             expenseDate: date,
-            currency: draft.currency ?? deviceDefaultCurrency(),
+            currency: draft.currency ?? dc,
             amount,
           });
         }
@@ -240,15 +242,13 @@ export default function VoiceScreen() {
           creatorMemberId: dest.memberId,
           name: dest.name,
           type: GroupType.Other,
-          currency: deviceDefaultCurrency(),
+          currency: dc,
         });
         groupCreated.current = true;
       }
 
       const groupCurrency =
-        dest.kind === 'create'
-          ? deviceDefaultCurrency()
-          : (target.group.data?.default_currency ?? deviceDefaultCurrency());
+        dest.kind === 'create' ? dc : (target.group.data?.default_currency ?? dc);
       const participants =
         dest.kind === 'create'
           ? [dest.memberId]
@@ -315,13 +315,13 @@ export default function VoiceScreen() {
     dest.kind === 'unassigned'
       ? null
       : dest.kind === 'create'
-        ? deviceDefaultCurrency()
-        : (target.group.data?.default_currency ?? deviceDefaultCurrency());
+        ? dc
+        : (target.group.data?.default_currency ?? dc);
   const draftTotals = new Map<string, bigint>();
   for (const draft of drafts) {
     const minor = toMinor(draft.amount);
     if (minor === null) continue;
-    const currency = destCurrency ?? draft.currency ?? deviceDefaultCurrency();
+    const currency = destCurrency ?? draft.currency ?? dc;
     draftTotals.set(currency, (draftTotals.get(currency) ?? 0n) + minor);
   }
   const singleTotal = draftTotals.size === 1 ? [...draftTotals.entries()][0] : null;

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -416,13 +416,17 @@ export default function VoiceScreen() {
                       borderRadius: 18,
                       alignItems: 'center',
                       justifyContent: 'center',
-                      backgroundColor: theme.color.brandSoft,
+                      backgroundColor: theme.color.buttonPrimary,
                     }}
                   >
                     {current.emoji ? (
                       <Text style={{ fontSize: 18 }}>{current.emoji}</Text>
                     ) : (
-                      <Ionicons name={current.icon} size={iconSize.md} color={theme.color.brand} />
+                      <Ionicons
+                        name={current.icon}
+                        size={iconSize.md}
+                        color={theme.color.onBrand}
+                      />
                     )}
                   </View>
                   <Text numberOfLines={1} style={{ flex: 1, color: theme.color.text }}>
@@ -770,10 +774,10 @@ function DraftRow({
             borderRadius: 20,
             alignItems: 'center',
             justifyContent: 'center',
-            backgroundColor: theme.color.brandSoft,
+            backgroundColor: theme.color.buttonPrimary,
           }}
         >
-          <Ionicons name="receipt-outline" size={iconSize.lg} color={theme.color.brand} />
+          <Ionicons name="receipt-outline" size={iconSize.lg} color={theme.color.onBrand} />
         </View>
 
         <View style={{ flex: 1, gap: theme.spacing.xs }}>

--- a/apps/mobile/src/components/CampaignPopup.tsx
+++ b/apps/mobile/src/components/CampaignPopup.tsx
@@ -130,16 +130,16 @@ export function CampaignPopup() {
               accessibilityRole="button"
               accessibilityLabel={t.misc.tapToCopy}
               style={{
-                backgroundColor: theme.color.brandSoft,
+                backgroundColor: theme.color.buttonPrimary,
                 borderRadius: theme.radius.md,
                 paddingVertical: theme.spacing.md,
                 alignItems: 'center',
               }}
             >
-              <Text variant="heading" tone="brand">
+              <Text variant="heading" tone="onBrand">
                 {campaign.promo_code}
               </Text>
-              <Text variant="micro" tone="muted">
+              <Text variant="micro" tone="onBrand">
                 {copied ? t.misc.copied : t.misc.tapToCopy}
               </Text>
             </Pressable>

--- a/apps/mobile/src/components/CoverEmojiPicker.tsx
+++ b/apps/mobile/src/components/CoverEmojiPicker.tsx
@@ -172,7 +172,7 @@ export function CoverEmojiPicker({
                   borderRadius: 28,
                   alignItems: 'center',
                   justifyContent: 'center',
-                  backgroundColor: theme.color.brandSoft,
+                  backgroundColor: theme.color.buttonPrimary,
                 }}
               >
                 <Text style={{ fontSize: 44 }}>{value ?? '👥'}</Text>

--- a/apps/mobile/src/components/GroupCard.tsx
+++ b/apps/mobile/src/components/GroupCard.tsx
@@ -9,21 +9,10 @@
  * amount and the amount's sign, not the row's background.
  */
 
-import Ionicons from '@expo/vector-icons/Ionicons';
 import { Pressable, View } from 'react-native';
 
 import type { CurrencyCode } from '@waves/core';
-import {
-  Avatar,
-  Badge,
-  directionalIcon,
-  iconSize,
-  MoneyText,
-  Row,
-  Text,
-  tintForKey,
-  useTheme,
-} from '@waves/ui';
+import { Avatar, Badge, MoneyText, Row, Text, tintForKey, useTheme } from '@waves/ui';
 
 export function GroupCard({
   id,
@@ -70,15 +59,16 @@ export function GroupCard({
       style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
     >
       <Row
-        style={{ gap: theme.spacing.md, alignItems: 'center', paddingVertical: theme.spacing.md }}
+        style={{ gap: theme.spacing.md, alignItems: 'center', paddingVertical: theme.spacing.lg }}
       >
-        {/* The avatar keeps the group's colour and initial — WhatsApp rows are
-            flat, but the face on the left still tells one row from the next. */}
-        <Avatar name={title} emoji={coverEmoji ?? undefined} size={46} tint={tintForKey(id)} />
+        {/* A bigger circular avatar carries the group's colour and initial. The
+            LINE-services look: solid round icon, bold name, muted line beneath,
+            airy rows with no hairline between them. */}
+        <Avatar name={title} emoji={coverEmoji ?? undefined} size={52} tint={tintForKey(id)} />
 
         <View style={{ flex: 1, minWidth: 0 }}>
           <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
-            <Text variant="subheading" numberOfLines={1} style={{ flexShrink: 1 }}>
+            <Text variant="heading" numberOfLines={1} style={{ flexShrink: 1 }}>
               {title}
             </Text>
             {tag ? <Badge label={tag} tone={tagTone} /> : null}
@@ -111,12 +101,6 @@ export function GroupCard({
             </Text>
           )}
         </View>
-
-        <Ionicons
-          name={directionalIcon('chevron-forward')}
-          size={iconSize.md}
-          color={theme.color.textFaint}
-        />
       </Row>
     </Pressable>
   );

--- a/apps/mobile/src/components/GroupPhoto.tsx
+++ b/apps/mobile/src/components/GroupPhoto.tsx
@@ -84,7 +84,7 @@ export function GroupPhoto({
             backgroundColor: theme.color.buttonPrimary,
           }}
         >
-          <Ionicons name="camera" size={size * 0.18} color={theme.color.onBrand} />
+          <Ionicons name="camera" size={size * 0.18} color={theme.color.onButtonPrimary} />
         </View>
       ) : null}
     </View>

--- a/apps/mobile/src/components/GroupPhoto.tsx
+++ b/apps/mobile/src/components/GroupPhoto.tsx
@@ -81,7 +81,7 @@ export function GroupPhoto({
             borderRadius: size,
             alignItems: 'center',
             justifyContent: 'center',
-            backgroundColor: theme.color.brand,
+            backgroundColor: theme.color.buttonPrimary,
           }}
         >
           <Ionicons name="camera" size={size * 0.18} color={theme.color.onBrand} />

--- a/apps/mobile/src/components/ProfileAvatar.tsx
+++ b/apps/mobile/src/components/ProfileAvatar.tsx
@@ -100,7 +100,7 @@ export function ProfileAvatar({
             borderColor: theme.color.surface,
           }}
         >
-          <Ionicons name="camera" size={size * 0.17} color={theme.color.onBrand} />
+          <Ionicons name="camera" size={size * 0.17} color={theme.color.onButtonPrimary} />
         </View>
       ) : null}
     </View>

--- a/apps/mobile/src/components/ProfileAvatar.tsx
+++ b/apps/mobile/src/components/ProfileAvatar.tsx
@@ -95,7 +95,7 @@ export function ProfileAvatar({
             borderRadius: size,
             alignItems: 'center',
             justifyContent: 'center',
-            backgroundColor: theme.color.brand,
+            backgroundColor: theme.color.buttonPrimary,
             borderWidth: 2,
             borderColor: theme.color.surface,
           }}

--- a/apps/mobile/src/components/QuickAddSheet.tsx
+++ b/apps/mobile/src/components/QuickAddSheet.tsx
@@ -1,0 +1,161 @@
+/**
+ * The long-press quick-add menu behind the dashboard's add icons.
+ *
+ * A short press on an add icon does the one obvious thing (scan a bill, open the
+ * expense form). A long press instead raises this sheet — the whole family of
+ * ways to start an expense in one place: type it, scan it, or speak it. It is
+ * the phone-home-screen "quick actions" gesture, brought to the icons that add.
+ *
+ * A bottom sheet, not an anchored popover: it slides up from the bar the icons
+ * sit on, matches the tip sheet's grammar, and sidesteps measuring an icon's
+ * on-screen position to float a card beside it.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Modal, Pressable, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { iconSize, Text, tintForKey, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+import { useMotion } from '@/lib/motion';
+
+export interface QuickAddAction {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  /** A stable key for the row's icon tint, so each action keeps its colour. */
+  tintKey: string;
+  /** Run on tap — the sheet closes first, then this fires. */
+  onPress: () => void;
+}
+
+/**
+ * Build the three standard ways to add an expense. Kept here so every add icon
+ * that opens the sheet offers the same set, and a fresh scan nonce is minted at
+ * press time (never in render) so the capture screen's consume-once guard holds.
+ */
+export function useQuickAddActions(): QuickAddAction[] {
+  const { t } = useStrings();
+  return [
+    {
+      icon: 'add',
+      label: t.addExpense,
+      tintKey: 'add',
+      onPress: () => router.push('/capture'),
+    },
+    {
+      icon: 'camera-outline',
+      label: t.scanBill,
+      tintKey: 'scan',
+      onPress: () => router.push(`/capture?scan=${Date.now()}`),
+    },
+    {
+      icon: 'mic-outline',
+      label: t.voice.speakExpense,
+      tintKey: 'voice',
+      onPress: () => router.push('/voice'),
+    },
+  ];
+}
+
+export function QuickAddSheet({
+  visible,
+  onClose,
+  actions,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  actions: readonly QuickAddAction[];
+}) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useStrings();
+  const { animated } = useMotion();
+
+  const activate = (action: QuickAddAction): void => {
+    onClose();
+    action.onPress();
+  };
+
+  return (
+    <Modal
+      transparent
+      visible={visible}
+      animationType={animated ? 'fade' : 'none'}
+      onRequestClose={onClose}
+    >
+      {/* Tap the scrim to dismiss; the inner press is swallowed so tapping the
+          sheet itself does not close it. */}
+      <Pressable
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel={t.common.close}
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(10, 10, 26, 0.55)',
+          justifyContent: 'flex-end',
+        }}
+      >
+        <Pressable
+          onPress={() => {}}
+          accessibilityViewIsModal
+          style={{
+            backgroundColor: theme.color.surface,
+            borderTopLeftRadius: theme.radius.xxl,
+            borderTopRightRadius: theme.radius.xxl,
+            paddingHorizontal: theme.spacing.lg,
+            paddingTop: theme.spacing.md,
+            paddingBottom: theme.spacing.md + insets.bottom,
+            ...theme.shadow.lifted,
+          }}
+        >
+          {/* The grab handle — the visual grammar of a sheet you can pull down. */}
+          <View
+            style={{
+              alignSelf: 'center',
+              width: 40,
+              height: 4,
+              borderRadius: 2,
+              backgroundColor: theme.color.border,
+              marginBottom: theme.spacing.sm,
+            }}
+          />
+
+          {actions.map((action) => {
+            const tint = theme.tint[tintForKey(action.tintKey)];
+            return (
+              <Pressable
+                key={action.label}
+                onPress={() => activate(action)}
+                accessibilityRole="button"
+                accessibilityLabel={action.label}
+                style={({ pressed }) => ({
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: theme.spacing.md,
+                  paddingVertical: theme.spacing.md,
+                  opacity: pressed ? 0.6 : 1,
+                })}
+              >
+                <View
+                  style={{
+                    width: 44,
+                    height: 44,
+                    borderRadius: 22,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: tint.bg,
+                  }}
+                >
+                  <Ionicons name={action.icon} size={iconSize.lg} color={tint.ink} />
+                </View>
+                <Text variant="subheading">{action.label}</Text>
+              </Pressable>
+            );
+          })}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -184,11 +184,11 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
   // the phone is not offline, it is being polite about data.
   if (status === 'metered') {
     return (
-      <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.xs }}>
+      <Card style={{ backgroundColor: theme.color.buttonPrimary, gap: theme.spacing.xs }}>
         <Row style={{ gap: theme.spacing.sm }}>
-          <Ionicons name="cloud-offline-outline" size={iconSize.md} color={theme.color.brand} />
+          <Ionicons name="cloud-offline-outline" size={iconSize.md} color={theme.color.onBrand} />
           <View style={{ flex: 1 }}>
-            <Text variant="caption" tone="brand">
+            <Text variant="caption" tone="onBrand">
               {syncNetwork === SyncNetworkPreference.Cellular
                 ? t.sync.waitingCellular
                 : t.sync.waitingWifi}
@@ -233,11 +233,11 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
           };
 
   return (
-    <Card style={{ backgroundColor: theme.color.brandSoft, gap: theme.spacing.xs }}>
+    <Card style={{ backgroundColor: theme.color.buttonPrimary, gap: theme.spacing.xs }}>
       <Row style={{ gap: theme.spacing.sm }}>
-        <Ionicons name={icon} size={iconSize.md} color={theme.color.brand} />
+        <Ionicons name={icon} size={iconSize.md} color={theme.color.onBrand} />
         <View style={{ flex: 1 }}>
-          <Text variant="caption" tone="brand">
+          <Text variant="caption" tone="onBrand">
             {message}
           </Text>
         </View>

--- a/apps/mobile/src/components/UnassignedCapturesCard.tsx
+++ b/apps/mobile/src/components/UnassignedCapturesCard.tsx
@@ -42,10 +42,10 @@ export function UnassignedCapturesCard() {
             borderRadius: 21,
             alignItems: 'center',
             justifyContent: 'center',
-            backgroundColor: theme.color.brandSoft,
+            backgroundColor: theme.color.buttonPrimary,
           }}
         >
-          <Ionicons name="file-tray-full-outline" size={iconSize.xl} color={theme.color.brand} />
+          <Ionicons name="file-tray-full-outline" size={iconSize.xl} color={theme.color.onBrand} />
         </View>
         <View style={{ flex: 1, minWidth: 0 }}>
           <Text variant="subheading">{t.captures.unassigned}</Text>

--- a/apps/mobile/src/components/UpdateGate.tsx
+++ b/apps/mobile/src/components/UpdateGate.tsx
@@ -49,10 +49,10 @@ function BlockingScreen(): React.JSX.Element {
           borderRadius: theme.radius.pill,
           alignItems: 'center',
           justifyContent: 'center',
-          backgroundColor: theme.color.brandSoft,
+          backgroundColor: theme.color.buttonPrimary,
         }}
       >
-        <Ionicons name="arrow-up-circle" size={iconSize.huge} color={theme.color.brand} />
+        <Ionicons name="arrow-up-circle" size={iconSize.huge} color={theme.color.onBrand} />
       </View>
 
       <Text variant="heading" align="center">

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -78,6 +78,8 @@ import {
 import { totalsByCurrency } from './totals';
 import { SettlementStatus } from './types';
 import type {
+  ActivityActor,
+  ActivityGroup,
   ActivityRow,
   CaptureRow,
   ExpenseRow,
@@ -443,6 +445,56 @@ export function usePendingAware(groupId: string, expenses: ExpenseRow[]): Expens
       }) as unknown as ExpenseRow[],
     [expenses, queue, groupId],
   );
+}
+
+export type RecentActivityRow = ActivityRow & { group: ActivityGroup | null };
+
+/**
+ * The recent-activity feed, entirely from the mirror — offline-first (ADR-005).
+ *
+ * `activity_log` is already pulled into the mirror per group, so the global feed
+ * is a read over what is on the phone rather than a network call: it shows the
+ * moment the app opens, works with no connection, and never empties because a
+ * request failed. The rows are stored raw (no embeds), so the group and the
+ * actor are joined back on from the mirrored `groups` and `group_members` — a
+ * member row carries its own `profile.display_name`, so a name needs no fetch.
+ *
+ * Newest-first across every group the phone knows about; the screen paginates
+ * this local list rather than asking the server for the next page.
+ */
+export function useRecentActivity(): RecentActivityRow[] {
+  const { mirror } = useSync();
+  return useMemo(() => {
+    const groups = new Map<string, ActivityGroup>();
+    for (const row of rowsFor(mirror, SyncTable.Groups)) {
+      const g = row as unknown as { id: string; name: string | null; cover_emoji: string | null };
+      groups.set(g.id, { id: g.id, name: g.name, cover_emoji: g.cover_emoji });
+    }
+
+    const actors = new Map<string, ActivityActor>();
+    for (const row of rowsFor(mirror, SyncTable.GroupMembers)) {
+      const m = row as unknown as {
+        id: string;
+        profile_id: string | null;
+        ghost_name: string | null;
+        profile?: { display_name: string | null } | null;
+      };
+      actors.set(m.id, {
+        id: m.id,
+        profile_id: m.profile_id,
+        ghost_name: m.ghost_name,
+        profile: m.profile ? { display_name: m.profile.display_name } : null,
+      });
+    }
+
+    return (rowsFor(mirror, SyncTable.ActivityLog) as unknown as ActivityRow[])
+      .map((row) => ({
+        ...row,
+        group: groups.get(row.group_id) ?? null,
+        actor: row.actor_member_id ? (actors.get(row.actor_member_id) ?? null) : null,
+      }))
+      .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
+  }, [mirror]);
 }
 
 /**

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -499,6 +499,13 @@ export interface UiStrings {
     otherCurrencies: PluralForms;
     saved: string;
     displayName: string;
+    regionTitle: string;
+    currencyLabel: string;
+    currencyFromCountry: string;
+    countryRequired: string;
+    addressTitle: string;
+    addressOptional: string;
+    addressPlaceholder: string;
     you: string;
     guestAccount: string;
     guestAccountBody: string;
@@ -1971,6 +1978,13 @@ const en: UiStrings = {
     otherCurrencies: { one: 'and {n} other currency', other: 'and {n} other currencies' },
     saved: 'Saved',
     displayName: 'Display name',
+    regionTitle: 'Region',
+    currencyLabel: 'Currency',
+    currencyFromCountry: 'Set from your country',
+    countryRequired: 'Pick your country to set your currency and payment options.',
+    addressTitle: 'Address',
+    addressOptional: 'Optional',
+    addressPlaceholder: 'Street, city, postal code',
     you: 'You',
     guestAccount: 'Guest account',
     guestAccountBody:
@@ -3497,6 +3511,14 @@ const ta: UiStrings = {
     otherCurrencies: { one: 'மேலும் {n} நாணயம்', other: 'மேலும் {n} நாணயங்கள்' },
     saved: 'சேமிக்கப்பட்டது',
     displayName: 'காட்டப்படும் பெயர்',
+    regionTitle: 'பகுதி',
+    currencyLabel: 'நாணயம்',
+    currencyFromCountry: 'உங்கள் நாட்டிலிருந்து அமைக்கப்படுகிறது',
+    countryRequired:
+      'நாணயத்தையும் பணச் செலுத்தல் விருப்பங்களையும் அமைக்க உங்கள் நாட்டைத் தேர்ந்தெடுக்கவும்.',
+    addressTitle: 'முகவரி',
+    addressOptional: 'விருப்பம்',
+    addressPlaceholder: 'தெரு, நகரம், அஞ்சல் குறியீடு',
     you: 'நீங்கள்',
     guestAccount: 'விருந்தினர் கணக்கு',
     guestAccountBody:
@@ -5070,6 +5092,13 @@ const hi: UiStrings = {
     otherCurrencies: { one: 'और {n} अन्य मुद्रा', other: 'और {n} अन्य मुद्राएँ' },
     saved: 'सेव हो गया',
     displayName: 'दिखने वाला नाम',
+    regionTitle: 'क्षेत्र',
+    currencyLabel: 'मुद्रा',
+    currencyFromCountry: 'आपके देश से सेट',
+    countryRequired: 'मुद्रा और भुगतान विकल्प सेट करने के लिए अपना देश चुनें।',
+    addressTitle: 'पता',
+    addressOptional: 'वैकल्पिक',
+    addressPlaceholder: 'गली, शहर, पिन कोड',
     you: 'आप',
     guestAccount: 'मेहमान खाता',
     guestAccountBody:
@@ -6627,6 +6656,13 @@ const ar: UiStrings = {
     },
     saved: 'تم الحفظ',
     displayName: 'الاسم الظاهر',
+    regionTitle: 'المنطقة',
+    currencyLabel: 'العملة',
+    currencyFromCountry: 'يُضبط حسب بلدك',
+    countryRequired: 'اختر بلدك لضبط العملة وخيارات الدفع.',
+    addressTitle: 'العنوان',
+    addressOptional: 'اختياري',
+    addressPlaceholder: 'الشارع، المدينة، الرمز البريدي',
     you: 'أنت',
     guestAccount: 'حساب ضيف',
     guestAccountBody:

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -3071,7 +3071,7 @@ const en: UiStrings = {
       'Waves holds as little about you as it can and still work. This describes what that is, in plain terms.',
     storeTitle: 'What is stored',
     storeBody:
-      'Your display name, and whichever of a phone number, email or sign-in identity you used. Optionally a payment handle, so somebody can pay you back, and a country, which decides which payment rails you are offered. The groups you are in, the expenses in them, and who owes whom. Nothing else: no contacts are uploaded, and there is no advertising identifier.',
+      'Your display name, and whichever of a phone number, email or sign-in identity you used. Optionally a payment handle, so somebody can pay you back, and a country, which decides which payment rails you are offered, and an optional postal address if you add one. The groups you are in, the expenses in them, and who owes whom. Nothing else: no contacts are uploaded, and there is no advertising identifier.',
     protectTitle: 'How it is kept',
     protectBody:
       'Every table is behind row-level security in the database, so a request can only ever read rows your own account is entitled to — not a filter applied by the app, but a rule the database enforces. Receipt images sit in a private bucket reached through short-lived signed links. Crash reports are scrubbed of addresses, phone numbers, payment handles and keys before they leave the phone. You can require your fingerprint or face to open the app.',
@@ -4663,7 +4663,7 @@ const ta: UiStrings = {
       'பாக்கி வேலை செய்ய எவ்வளவு தேவையோ அவ்வளவு மட்டுமே உங்களைப் பற்றி வைத்திருக்கிறது. அது என்ன என்பது இங்கே.',
     storeTitle: 'என்ன சேமிக்கப்படுகிறது',
     storeBody:
-      'உங்கள் பெயர், நீங்கள் பயன்படுத்திய தொலைபேசி எண், மின்னஞ்சல் அல்லது உள்நுழைவு அடையாளம். விருப்பப்படி ஒரு பணப் பரிமாற்ற முகவரி, மற்றும் ஒரு நாடு. நீங்கள் இருக்கும் குழுக்கள், அவற்றின் செலவுகள், யார் யாருக்குக் கடன்பட்டவர். வேறு எதுவும் இல்லை: தொடர்புகள் பதிவேற்றப்படுவதில்லை, விளம்பர அடையாளம் இல்லை.',
+      'உங்கள் பெயர், நீங்கள் பயன்படுத்திய தொலைபேசி எண், மின்னஞ்சல் அல்லது உள்நுழைவு அடையாளம். விருப்பப்படி ஒரு பணப் பரிமாற்ற முகவரி, ஒரு நாடு, மற்றும் நீங்கள் சேர்த்தால் ஒரு அஞ்சல் முகவரி. நீங்கள் இருக்கும் குழுக்கள், அவற்றின் செலவுகள், யார் யாருக்குக் கடன்பட்டவர். வேறு எதுவும் இல்லை: தொடர்புகள் பதிவேற்றப்படுவதில்லை, விளம்பர அடையாளம் இல்லை.',
     protectTitle: 'எப்படி பாதுகாக்கப்படுகிறது',
     protectBody:
       'ஒவ்வொரு அட்டவணையும் தரவுத்தளத்தில் வரிசை-நிலை பாதுகாப்பின் பின்னால் உள்ளது — செயலி வடிகட்டுவதல்ல, தரவுத்தளமே அமல்படுத்தும் விதி. ரசீது படங்கள் தனிப்பட்ட இடத்தில், குறுகிய கால இணைப்புகள் வழியாக மட்டுமே. செயலி முறிவு அறிக்கைகளிலிருந்து முகவரிகள், எண்கள், பணமுகவரிகள் தொலைபேசியை விட்டு வெளியேறும் முன்பே நீக்கப்படுகின்றன.',
@@ -6192,7 +6192,7 @@ const hi: UiStrings = {
       'बाकी आपके बारे में उतना ही रखता है जितना काम करने के लिए ज़रूरी है। वह क्या है, सीधे शब्दों में।',
     storeTitle: 'क्या रखा जाता है',
     storeBody:
-      'आपका नाम, और फ़ोन नंबर, ईमेल या साइन-इन पहचान में से जो आपने इस्तेमाल किया। वैकल्पिक रूप से एक भुगतान पता, ताकि कोई आपको लौटा सके, और एक देश। आप जिन समूहों में हैं, उनके ख़र्चे, और कौन किसका देनदार है। और कुछ नहीं: कोई संपर्क अपलोड नहीं होते, कोई विज्ञापन पहचानकर्ता नहीं।',
+      'आपका नाम, और फ़ोन नंबर, ईमेल या साइन-इन पहचान में से जो आपने इस्तेमाल किया। वैकल्पिक रूप से एक भुगतान पता, ताकि कोई आपको लौटा सके, एक देश, और यदि आप जोड़ें तो एक डाक पता। आप जिन समूहों में हैं, उनके ख़र्चे, और कौन किसका देनदार है। और कुछ नहीं: कोई संपर्क अपलोड नहीं होते, कोई विज्ञापन पहचानकर्ता नहीं।',
     protectTitle: 'कैसे सुरक्षित रहता है',
     protectBody:
       'हर तालिका डेटाबेस में row-level security के पीछे है — ऐप का लगाया फ़िल्टर नहीं, बल्कि डेटाबेस का लागू किया नियम। रसीद की तस्वीरें एक निजी जगह में, छोटी अवधि के लिंक से ही पहुँच में। क्रैश रिपोर्ट से पते, नंबर और भुगतान पते फ़ोन छोड़ने से पहले ही हटा दिए जाते हैं।',
@@ -7894,7 +7894,7 @@ const ar: UiStrings = {
     intro: 'يحتفظ باقي بأقل قدر ممكن عنك مع بقائه صالحًا للعمل. وهذا بيان بما يحتفظ به.',
     storeTitle: 'ما الذي يُحفظ',
     storeBody:
-      'اسمك، وما استخدمته من رقم هاتف أو بريد أو هوية دخول. واختياريًا عنوان دفع كي يتمكن أحدهم من ردّ المال إليك، وبلد. المجموعات التي تشارك فيها ومصروفاتها ومن يدين لمن. لا شيء غير ذلك: لا تُرفع جهات الاتصال، ولا يوجد معرّف إعلاني.',
+      'اسمك، وما استخدمته من رقم هاتف أو بريد أو هوية دخول. واختياريًا عنوان دفع كي يتمكن أحدهم من ردّ المال إليك، وبلد، وعنوان بريدي اختياري إن أضفته. المجموعات التي تشارك فيها ومصروفاتها ومن يدين لمن. لا شيء غير ذلك: لا تُرفع جهات الاتصال، ولا يوجد معرّف إعلاني.',
     protectTitle: 'كيف يُحمى',
     protectBody:
       'كل جدول محميّ بأمان على مستوى الصف داخل قاعدة البيانات — ليس ترشيحًا يجريه التطبيق، بل قاعدة تفرضها قاعدة البيانات نفسها. صور الإيصالات في مكان خاص لا يُوصل إليه إلا بروابط قصيرة الأجل. وتُنقّى تقارير الأعطال من العناوين والأرقام وعناوين الدفع قبل مغادرتها الهاتف.',

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -91,8 +91,10 @@ export interface Profile {
   /** How this person is paid: a `RailId` from `@waves/core`, and a handle on it. */
   payment_rail: string | null;
   payment_handle: string | null;
-  /** ISO-3166 alpha-2 — seeds a new group's country when they make one. */
+  /** ISO-3166 alpha-2 — seeds a new group's country and the default currency. */
   country_code: string | null;
+  /** Optional postal address, one free-text field. Null until they type one. */
+  address: string | null;
   default_currency: string;
   locale: string;
 }
@@ -211,7 +213,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const { data } = await supabase
           .from('profiles')
           .select(
-            'id, display_name, avatar_url, default_vpa, payment_rail, payment_handle, country_code, default_currency, locale',
+            'id, display_name, avatar_url, default_vpa, payment_rail, payment_handle, country_code, address, default_currency, locale',
           )
           .eq('id', session.user.id)
           .maybeSingle();
@@ -296,7 +298,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           .update(patch)
           .eq('id', session.user.id)
           .select(
-            'id, display_name, avatar_url, default_vpa, payment_rail, payment_handle, country_code, default_currency, locale',
+            'id, display_name, avatar_url, default_vpa, payment_rail, payment_handle, country_code, address, default_currency, locale',
           )
           .single();
         if (error) throw error;

--- a/apps/mobile/src/lib/currency.ts
+++ b/apps/mobile/src/lib/currency.ts
@@ -1,0 +1,35 @@
+/**
+ * The currency a new expense, group or IOU should start on for the person
+ * holding the phone.
+ *
+ * Signed in, this is their account currency — `profiles.default_currency`, set
+ * from the country they chose on "Your account" (see `currencyForCountry`). So
+ * a user in Dubai gets AED everywhere without setting it per group, and one who
+ * moves and changes their country moves the default with them. Before there is
+ * a profile (a guest, or the split second before it loads) it falls back to the
+ * phone's own region — the same guess `deviceDefaultCurrency` has always made.
+ *
+ * Always a default, never a lock: every group and every expense can still be
+ * counted in something else.
+ */
+
+import type { CurrencyCode } from '@waves/core';
+import { currencyForCountry } from '@waves/core';
+
+import { deviceDefaultCurrency } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+
+export function useDefaultCurrency(): CurrencyCode {
+  const { profile } = useAuth();
+  if (profile) {
+    // `default_currency` is set from the country and always present, but guard
+    // an unexpected empty string, and cross-check the country in case an older
+    // row never had its currency written.
+    return (
+      (profile.default_currency as CurrencyCode) ||
+      currencyForCountry(profile.country_code) ||
+      deviceDefaultCurrency()
+    );
+  }
+  return deviceDefaultCurrency();
+}

--- a/packages/db/prisma/migrations/20260822010000_profile_address/migration.sql
+++ b/packages/db/prisma/migrations/20260822010000_profile_address/migration.sql
@@ -1,0 +1,14 @@
+-- An optional postal address on the profile.
+--
+-- "Your account" now asks for a country (which decides the default currency and
+-- settle rails) and, optionally, a postal address. The country already had a
+-- column (`profiles.country_code`); the address is new. One free-text field,
+-- deliberately unstructured: address formats differ by country and Waves never
+-- posts anything to it, so there is nothing here that needs parsing into lines.
+--
+-- Nullable with no default: an existing profile simply has no address until its
+-- owner types one, and clearing the field stores NULL rather than an empty
+-- string. No RLS change — a profile's own row is already self-updatable under
+-- the policy that governs `display_name` and `country_code`.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS address text;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -138,8 +138,12 @@ model Profile {
   /// number or a Zelle number, and only the rail says which.
   paymentRail       String?  @map("payment_rail")
   paymentHandle     String?  @map("payment_handle")
-  /// ISO-3166 alpha-2. Decides which rails they are offered.
+  /// ISO-3166 alpha-2. Decides which rails they are offered and the default
+  /// currency (see `currencyForCountry`).
   countryCode       String?  @map("country_code") @db.Char(2)
+  /// Optional postal address, one free-text field — Waves never posts to it, so
+  /// it is never parsed into lines. Null until the owner types one.
+  address           String?  @map("address")
   defaultCurrency   String   @default("INR") @map("default_currency") @db.Char(3)
   locale            String   @default("en")
   notificationPrefs Json     @default("{}") @map("notification_prefs")

--- a/supabase/functions/export-data/index.ts
+++ b/supabase/functions/export-data/index.ts
@@ -64,6 +64,25 @@ serveWithCors(async (request) => {
       throw new HttpError(404, 'NOTHING_TO_EXPORT', 'You are not in any groups yet');
     }
 
+    // The caller's own profile row — the account data they gave us, including the
+    // optional postal address (ADR-012 portability, and the privacy screen's
+    // promise that everything stored is exportable). Read as the service so it
+    // is the whole row, not the RLS-narrowed view.
+    const { data: me, error: meError } = await service
+      .from('profiles')
+      .select(
+        'id, display_name, country_code, address, default_currency, default_vpa, payment_rail, payment_handle, locale, created_at',
+      )
+      .eq('id', user.user.id)
+      .single();
+    if (meError) {
+      throw new HttpError(
+        500,
+        'EXPORT_INCOMPLETE',
+        `Could not read your profile: ${meError.message}`,
+      );
+    }
+
     const exported = [];
     for (const groupId of groupIds) {
       const [group, members, expenses, settlements, activity] = await Promise.all([
@@ -130,6 +149,7 @@ serveWithCors(async (request) => {
             // Amounts stay in minor units, as strings: re-importing this file
             // must reproduce the ledger exactly (ADR-003).
             amountUnit: 'minor',
+            profile: me,
             groups: exported,
           },
           null,


### PR DESCRIPTION
Dashboard polish:

- Group rows adopt the LINE-services list look: a bigger 52px round avatar,
  a bold heading-weight name, a muted member line beneath, airy rows with no
  hairline between them, and no trailing chevron. The balance and owed/owe
  word stay at the trailing edge.
- Add icons gain a press-and-hold quick-add sheet (the phone home-screen
  quick-actions gesture): type, scan, or speak an expense from one place.
  New reusable QuickAddSheet + useQuickAddActions; the scan nonce is minted
  at press time, never in render.
- The add-action glyphs lose the dead space under them (icon box 48->34) and
  tighten the icon-to-label gap.
- The no-groups empty state centres itself in the height left under the deck
  instead of hugging it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013pib1zHzfKvFyJtuRDyoHV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a quick-add sheet for expenses, bill scanning, and voice entry, including long-press access.
  * Added country, currency, and optional address settings to account preferences.
  * New groups use the account’s country when available.
  * Activity updates now appear from locally available data.

* **UI Improvements**
  * Improved quick-add accessibility, feedback, dismissal, and safe-area support.
  * Refined group cards, navigation, spacing, and accent colors across the app.

* **Bug Fixes**
  * Expense capture and voice entry now consistently use the configured default currency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->