### PR TITLE
feat(mobile): configurable quick shortcut — two-finger double-tap + app-icon action

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -38,6 +38,7 @@
       "expo-router",
       "expo-localization",
       "expo-sqlite",
+      "expo-quick-actions",
       [
         "expo-splash-screen",
         {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -38,6 +38,7 @@
     "expo-localization": "~57.0.1",
     "expo-network": "~57.0.1",
     "expo-notifications": "~57.0.10",
+    "expo-quick-actions": "^6.0.2",
     "expo-router": "~57.0.12",
     "expo-secure-store": "~57.0.1",
     "expo-sharing": "~57.0.11",

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -37,7 +37,7 @@ import { useThemePreference } from '@/lib/theme';
 interface SettingsRow {
   icon: keyof typeof Ionicons.glyphMap;
   label: string;
-  hint: string;
+  hint?: string;
   route?: string;
   onPress?: () => void;
   /** Ends something. Red title, red icon. */
@@ -510,6 +510,11 @@ function ProfileForm() {
               label: t.account.motionRow,
               hint: motionSummary,
               route: '/settings/motion',
+            },
+            {
+              icon: 'flash-outline',
+              label: t.shortcut.title,
+              route: '/settings/shortcut',
             },
             {
               icon: 'cloud-outline',

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -37,6 +37,8 @@ import { LanguageProvider, useLanguage } from '@/i18n/language';
 import { LocaleSync } from '@/i18n/localeSync';
 import { LockProvider, useLock } from '@/lib/lock';
 import { MotionProvider, TRANSITION_MS, useMotion } from '@/lib/motion';
+import { ShortcutProvider } from '@/lib/shortcut';
+import { ShortcutGesture } from '@/components/ShortcutGesture';
 import { TourProvider } from '@/lib/tour';
 import { PromptQueueProvider } from '@/lib/promptQueue';
 import { SyncNetworkProvider } from '@/lib/syncNetwork';
@@ -159,42 +161,44 @@ function RootLayout() {
                           <ThemePreferenceProvider>
                             <TourProvider>
                               <PromptQueueProvider>
-                                <ThemedRoot>
-                                  <ThemedStatusBar />
-                                  {/* Outside the lock and the auth gate on purpose: a build
+                                <ShortcutProvider>
+                                  <ThemedRoot>
+                                    <ThemedStatusBar />
+                                    {/* Outside the lock and the auth gate on purpose: a build
                             we have stopped trusting should not be unlocking a
                             ledger or signing anybody in either. */}
-                                  <UpdateGate>
-                                    <PushRouting />
-                                    <LockGate>
-                                      {/* Inside the lock so the two-device gate never
+                                    <UpdateGate>
+                                      <PushRouting />
+                                      <LockGate>
+                                        {/* Inside the lock so the two-device gate never
                                 paints over the lock screen, and past auth so it
                                 only ever asks a signed-in account. */}
-                                      <DeviceSessionProvider>
-                                        <AuthGate />
-                                        {/* Inside the lock on purpose: a promotion is not a
+                                        <DeviceSessionProvider>
+                                          <AuthGate />
+                                          {/* Inside the lock on purpose: a promotion is not a
                                   reason to show somebody's phone anything before
                                   they have unlocked it. */}
-                                        <CampaignPopup />
-                                        {/* The soft ask for push, once, to a
+                                          <CampaignPopup />
+                                          {/* The soft ask for push, once, to a
                                         signed-in person whose permission is
                                         still undetermined. */}
-                                        <NotificationPrompt />
-                                      </DeviceSessionProvider>
-                                    </LockGate>
-                                    {/* The coach-mark tour, over the whole app but
+                                          <NotificationPrompt />
+                                        </DeviceSessionProvider>
+                                      </LockGate>
+                                      {/* The coach-mark tour, over the whole app but
                                     only ever started from Home. Above the gate
                                     so its scrim covers the screen. */}
-                                    <TourOverlay />
-                                    {/* Last, so it paints over the screen rather than
+                                      <TourOverlay />
+                                      {/* Last, so it paints over the screen rather than
                               under it. */}
-                                    <UpdateBanner />
-                                  </UpdateGate>
-                                  {/* Topmost of all: the launch field, painting over
+                                      <UpdateBanner />
+                                    </UpdateGate>
+                                    {/* Topmost of all: the launch field, painting over
                                   the whole app until it fades itself out. Native
                                   only; renders nothing on web. */}
-                                  <AnimatedSplash />
-                                </ThemedRoot>
+                                    <AnimatedSplash />
+                                  </ThemedRoot>
+                                </ShortcutProvider>
                               </PromptQueueProvider>
                             </TourProvider>
                           </ThemePreferenceProvider>
@@ -486,71 +490,74 @@ function AuthGate() {
   }
 
   return (
-    <View style={{ flex: 1 }}>
-      <Stack
-        screenOptions={{
-          headerShown: false,
-          contentStyle: { backgroundColor: 'transparent' },
-          animation: push,
-          animationDuration: TRANSITION_MS,
-          // Swiping back is the same journey as the animation, so it belongs to
-          // the same switch: with motion off there is nothing to drag.
-          gestureEnabled: animated,
-        }}
-      >
-        {/* Signing in and out replaces the whole tree; sliding it would suggest a
+    <ShortcutGesture>
+      <View style={{ flex: 1 }}>
+        <Stack
+          screenOptions={{
+            headerShown: false,
+            contentStyle: { backgroundColor: 'transparent' },
+            animation: push,
+            animationDuration: TRANSITION_MS,
+            // Swiping back is the same journey as the animation, so it belongs to
+            // the same switch: with motion off there is nothing to drag.
+            gestureEnabled: animated,
+          }}
+        >
+          {/* Signing in and out replaces the whole tree; sliding it would suggest a
           place to go back to, and there is not one. */}
-        <Stack.Screen name="welcome" options={{ animation: 'none' }} />
-        <Stack.Screen name="language" />
-        <Stack.Screen name="sign-in" options={{ animation: 'none' }} />
-        {/* The sign-up page slides in from the login screen and back out, so it
+          <Stack.Screen name="welcome" options={{ animation: 'none' }} />
+          <Stack.Screen name="language" />
+          <Stack.Screen name="sign-in" options={{ animation: 'none' }} />
+          {/* The sign-up page slides in from the login screen and back out, so it
             keeps a normal push — unlike sign-in, which replaces the whole tree. */}
-        <Stack.Screen name="sign-up" />
-        <Stack.Screen name="phone" />
-        <Stack.Screen name="verify-email" />
-        <Stack.Screen name="guest-welcome" />
-        <Stack.Screen name="(tabs)" options={{ animation: 'none' }} />
-        <Stack.Screen name="new-group" options={modal} />
-        {paywallEnabled ? <Stack.Screen name="paywall" options={modal} /> : null}
-        <Stack.Screen name="capture" options={modal} />
-        <Stack.Screen name="captures" />
-        <Stack.Screen name="group/[id]/index" />
-        <Stack.Screen name="group/[id]/add-expense" options={modal} />
-        <Stack.Screen name="group/[id]/settle" options={modal} />
-        <Stack.Screen name="group/[id]/simplify" />
-        <Stack.Screen name="group/[id]/settings" />
-        <Stack.Screen name="group/[id]/members" />
-        <Stack.Screen name="group/[id]/member/[memberId]" />
-        <Stack.Screen name="group/[id]/expense/[expenseId]" />
-        <Stack.Screen name="group/[id]/invite" options={modal} />
-        <Stack.Screen name="group/[id]/itemize" options={modal} />
-        <Stack.Screen name="receipt/[id]" options={modal} />
-        <Stack.Screen name="friends/contacts" />
-        <Stack.Screen name="contact-picker" options={modal} />
-        <Stack.Screen name="scan" options={modal} />
-        <Stack.Screen name="settings/backup" />
-        <Stack.Screen name="settings/notifications" />
-        <Stack.Screen name="settings/export" />
-        <Stack.Screen name="settings/import" />
-        <Stack.Screen name="settings/lock" />
-        <Stack.Screen name="settings/devices" />
-        <Stack.Screen name="settings/motion" />
-        <Stack.Screen name="settings/sync" />
-        <Stack.Screen name="settings/theme" />
-        <Stack.Screen name="settings/language" />
-        <Stack.Screen name="settings/upgrade" />
-        <Stack.Screen name="settings/redeem" />
-        <Stack.Screen name="settings/account" />
-        <Stack.Screen name="settings/feedback" />
-        <Stack.Screen name="settings/privacy" />
-        <Stack.Screen name="settings/delete-account" />
-        <Stack.Screen name="join" />
-        <Stack.Screen name="inbox" />
-        <Stack.Screen name="voice" options={modal} />
-      </Stack>
-      {/* One bar over the whole stack, so every screen keeps it — it hides
+          <Stack.Screen name="sign-up" />
+          <Stack.Screen name="phone" />
+          <Stack.Screen name="verify-email" />
+          <Stack.Screen name="guest-welcome" />
+          <Stack.Screen name="(tabs)" options={{ animation: 'none' }} />
+          <Stack.Screen name="new-group" options={modal} />
+          {paywallEnabled ? <Stack.Screen name="paywall" options={modal} /> : null}
+          <Stack.Screen name="capture" options={modal} />
+          <Stack.Screen name="captures" />
+          <Stack.Screen name="group/[id]/index" />
+          <Stack.Screen name="group/[id]/add-expense" options={modal} />
+          <Stack.Screen name="group/[id]/settle" options={modal} />
+          <Stack.Screen name="group/[id]/simplify" />
+          <Stack.Screen name="group/[id]/settings" />
+          <Stack.Screen name="group/[id]/members" />
+          <Stack.Screen name="group/[id]/member/[memberId]" />
+          <Stack.Screen name="group/[id]/expense/[expenseId]" />
+          <Stack.Screen name="group/[id]/invite" options={modal} />
+          <Stack.Screen name="group/[id]/itemize" options={modal} />
+          <Stack.Screen name="receipt/[id]" options={modal} />
+          <Stack.Screen name="friends/contacts" />
+          <Stack.Screen name="contact-picker" options={modal} />
+          <Stack.Screen name="scan" options={modal} />
+          <Stack.Screen name="settings/backup" />
+          <Stack.Screen name="settings/notifications" />
+          <Stack.Screen name="settings/export" />
+          <Stack.Screen name="settings/import" />
+          <Stack.Screen name="settings/lock" />
+          <Stack.Screen name="settings/devices" />
+          <Stack.Screen name="settings/motion" />
+          <Stack.Screen name="settings/shortcut" />
+          <Stack.Screen name="settings/sync" />
+          <Stack.Screen name="settings/theme" />
+          <Stack.Screen name="settings/language" />
+          <Stack.Screen name="settings/upgrade" />
+          <Stack.Screen name="settings/redeem" />
+          <Stack.Screen name="settings/account" />
+          <Stack.Screen name="settings/feedback" />
+          <Stack.Screen name="settings/privacy" />
+          <Stack.Screen name="settings/delete-account" />
+          <Stack.Screen name="join" />
+          <Stack.Screen name="inbox" />
+          <Stack.Screen name="voice" options={modal} />
+        </Stack>
+        {/* One bar over the whole stack, so every screen keeps it — it hides
           itself on the modals and the camera. */}
-      <AppTabBar />
-    </View>
+        <AppTabBar />
+      </View>
+    </ShortcutGesture>
   );
 }

--- a/apps/mobile/src/app/settings/shortcut.tsx
+++ b/apps/mobile/src/app/settings/shortcut.tsx
@@ -1,0 +1,138 @@
+/**
+ * The quick-shortcut settings — one action, two ways to fire it.
+ *
+ * The person picks what the shortcut does (or turns it off), and whether the
+ * two-finger double-tap is armed. The app-icon menu follows the same choice.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, ScrollView, View } from 'react-native';
+
+import {
+  Card,
+  Divider,
+  IconButton,
+  Row,
+  Screen,
+  Text,
+  Toggle,
+  directionalIcon,
+  iconSize,
+  useTabBarClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+import { useShortcut, type ShortcutAction } from '@/lib/shortcut';
+
+export default function ShortcutSettingsScreen() {
+  const theme = useTheme();
+  const clearance = useTabBarClearance();
+  const { t } = useStrings();
+  const { action, doubleTap, setAction, setDoubleTap } = useShortcut();
+
+  const options: { value: ShortcutAction; icon: keyof typeof Ionicons.glyphMap; label: string }[] =
+    [
+      { value: 'scan', icon: 'camera-outline', label: t.shortcut.optionScan },
+      { value: 'voice', icon: 'mic-outline', label: t.shortcut.optionVoice },
+      { value: 'add', icon: 'add-circle-outline', label: t.shortcut.optionAdd },
+      { value: 'off', icon: 'remove-circle-outline', label: t.shortcut.optionOff },
+    ];
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.shortcut.title}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        <Text variant="body" tone="muted">
+          {t.shortcut.intro}
+        </Text>
+
+        {/* The action the shortcut performs. */}
+        <View style={{ gap: theme.spacing.md }}>
+          <Text variant="caption" tone="muted">
+            {t.shortcut.actionLabel}
+          </Text>
+          <Card padded={false} style={{ overflow: 'hidden' }}>
+            {options.map((option, index) => {
+              const selected = action === option.value;
+              return (
+                <View key={option.value}>
+                  {index > 0 ? <Divider /> : null}
+                  <Pressable
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected }}
+                    accessibilityLabel={option.label}
+                    onPress={() => void setAction(option.value)}
+                    style={({ pressed }) => ({
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      gap: theme.spacing.md,
+                      paddingHorizontal: theme.spacing.lg,
+                      paddingVertical: theme.spacing.lg,
+                      opacity: pressed ? 0.6 : 1,
+                    })}
+                  >
+                    <Ionicons
+                      name={option.icon}
+                      size={iconSize.lg}
+                      color={selected ? theme.color.brand : theme.color.textMuted}
+                    />
+                    <Text variant="subheading" style={{ flex: 1 }}>
+                      {option.label}
+                    </Text>
+                    {selected ? (
+                      <Ionicons name="checkmark" size={iconSize.lg} color={theme.color.brand} />
+                    ) : null}
+                  </Pressable>
+                </View>
+              );
+            })}
+          </Card>
+        </View>
+
+        {/* The two-finger double-tap trigger. */}
+        <Card style={{ gap: theme.spacing.sm }}>
+          <Row style={{ justifyContent: 'space-between', gap: theme.spacing.lg }}>
+            <View style={{ flex: 1, gap: 2 }}>
+              <Text variant="subheading">{t.shortcut.doubleTapTitle}</Text>
+              <Text variant="caption" tone="muted">
+                {t.shortcut.doubleTapExplain}
+              </Text>
+            </View>
+            <Toggle
+              value={doubleTap}
+              onValueChange={(value) => void setDoubleTap(value)}
+              accessibilityLabel={t.shortcut.doubleTapTitle}
+              disabled={action === 'off'}
+            />
+          </Row>
+        </Card>
+
+        <Text variant="micro" tone="faint" align="center">
+          {t.shortcut.iconHint}
+        </Text>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/components/ShortcutGesture.tsx
+++ b/apps/mobile/src/components/ShortcutGesture.tsx
@@ -1,0 +1,44 @@
+/**
+ * Arms the quick shortcut's two triggers around the app it wraps:
+ *
+ *  - a two-finger double-tap anywhere (the iOS "Magic Tap" gesture) — two
+ *    fingers, so it never fires on an ordinary tap on a button or a list row;
+ *  - the app-icon shortcut — both a cold launch from it and a tap on it while
+ *    the app is already open.
+ *
+ * Both call the same `run()` from the shortcut store, which performs whatever
+ * action the user chose. The gesture is only armed when the setting is on and an
+ * action is chosen, so the wrapper is inert by default and costs nothing.
+ */
+
+import { useEffect } from 'react';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+
+import { useShortcut } from '@/lib/shortcut';
+import { initialQuickAction, onQuickAction, QUICK_ACTION_ID } from '@/lib/quickActions';
+
+export function ShortcutGesture({ children }: { children: React.ReactNode }) {
+  const { run, action, doubleTap } = useShortcut();
+  const armed = doubleTap && action !== 'off';
+
+  // The app-icon shortcut: a cold launch from it, and taps on it while running.
+  // Independent of the gesture toggle — choosing an action is opting into the
+  // icon menu, and turning the double-tap off should not silence the icon.
+  useEffect(() => {
+    if (action === 'off') return;
+    if (initialQuickAction() === QUICK_ACTION_ID) run();
+    return onQuickAction((id) => {
+      if (id === QUICK_ACTION_ID) run();
+    });
+  }, [action, run]);
+
+  const tap = Gesture.Tap()
+    .enabled(armed)
+    .minPointers(2)
+    .numberOfTaps(2)
+    // Callbacks on the JS thread so `run()` can navigate directly.
+    .runOnJS(true)
+    .onEnd(() => run());
+
+  return <GestureDetector gesture={tap}>{children}</GestureDetector>;
+}

--- a/apps/mobile/src/components/ShortcutGesture.tsx
+++ b/apps/mobile/src/components/ShortcutGesture.tsx
@@ -11,26 +11,39 @@
  * action is chosen, so the wrapper is inert by default and costs nothing.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import { useShortcut } from '@/lib/shortcut';
 import { initialQuickAction, onQuickAction, QUICK_ACTION_ID } from '@/lib/quickActions';
 
 export function ShortcutGesture({ children }: { children: React.ReactNode }) {
-  const { run, action, doubleTap } = useShortcut();
+  const { run, action, doubleTap, loading } = useShortcut();
   const armed = doubleTap && action !== 'off';
 
-  // The app-icon shortcut: a cold launch from it, and taps on it while running.
-  // Independent of the gesture toggle — choosing an action is opting into the
-  // icon menu, and turning the double-tap off should not silence the icon.
+  // The cold-launch icon shortcut, consumed exactly once and only after the
+  // stored action has loaded (so `run` reads the right action, not the default).
+  // `initialQuickAction()` stays set for the process, so without this guard
+  // changing the action in Settings — which used to re-run this effect — would
+  // fire it again.
+  const consumedInitial = useRef(false);
   useEffect(() => {
-    if (action === 'off') return;
-    if (initialQuickAction() === QUICK_ACTION_ID) run();
-    return onQuickAction((id) => {
-      if (id === QUICK_ACTION_ID) run();
-    });
-  }, [action, run]);
+    if (loading || consumedInitial.current) return;
+    if (initialQuickAction() === QUICK_ACTION_ID) {
+      consumedInitial.current = true;
+      run();
+    }
+  }, [loading, run]);
+
+  // Taps on the icon shortcut while the app is already open — registered once
+  // (run is stable), independent of the cold-launch guard above.
+  useEffect(
+    () =>
+      onQuickAction((id) => {
+        if (id === QUICK_ACTION_ID) run();
+      }),
+    [run],
+  );
 
   const tap = Gesture.Tap()
     .enabled(armed)

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -404,6 +404,18 @@ export interface UiStrings {
     importInstead: string;
   };
   /** The motion switch, and the phone setting it defers to. */
+  shortcut: {
+    title: string;
+    intro: string;
+    actionLabel: string;
+    optionScan: string;
+    optionVoice: string;
+    optionAdd: string;
+    optionOff: string;
+    doubleTapTitle: string;
+    doubleTapExplain: string;
+    iconHint: string;
+  };
   motion: {
     title: string;
     animateBetweenScreens: string;
@@ -1881,6 +1893,19 @@ const en: UiStrings = {
     webNote: 'On web the file is written to the app cache; use a device to share it onward.',
     shareTitle: 'Your Waves export',
     importInstead: 'Import from Splitwise',
+  },
+  shortcut: {
+    title: 'Quick shortcut',
+    intro:
+      'Pick one thing the shortcut does, and reach it fast — a two-finger double-tap anywhere in the app, or a long-press on the Waves icon on your home screen.',
+    actionLabel: 'The shortcut opens',
+    optionScan: 'Scan a receipt',
+    optionVoice: 'Speak an expense',
+    optionAdd: 'Add an expense',
+    optionOff: 'Off',
+    doubleTapTitle: 'Two-finger double-tap',
+    doubleTapExplain: 'Double-tap anywhere with two fingers to fire the shortcut.',
+    iconHint: 'Long-press the Waves icon on your home screen for the same shortcut.',
   },
   motion: {
     title: 'Motion',
@@ -3409,6 +3434,19 @@ const ta: UiStrings = {
       'வலையில் கோப்பு ஆப்பின் தற்காலிக இடத்தில் எழுதப்படுகிறது; மேலும் பகிர ஒரு சாதனத்தைப் பயன்படுத்துங்கள்.',
     shareTitle: 'உங்கள் பாக்கி ஏற்றுமதி',
     importInstead: 'Splitwise இலிருந்து இறக்குமதி',
+  },
+  shortcut: {
+    title: 'விரைவு குறுக்குவழி',
+    intro:
+      'குறுக்குவழி செய்யும் ஒரு செயலைத் தேர்ந்தெடுங்கள் — செயலியில் எங்கும் இரு விரல் இரட்டைத் தட்டு, அல்லது முகப்புத் திரையில் Waves சின்னத்தை நீண்ட நேரம் அழுத்துதல்.',
+    actionLabel: 'குறுக்குவழி திறப்பது',
+    optionScan: 'ரசீதை ஸ்கேன் செய்',
+    optionVoice: 'செலவைப் பேசு',
+    optionAdd: 'செலவைச் சேர்',
+    optionOff: 'அணை',
+    doubleTapTitle: 'இரு விரல் இரட்டைத் தட்டு',
+    doubleTapExplain: 'குறுக்குவழியைத் தூண்ட எங்கும் இரு விரல்களால் இரட்டைத் தட்டவும்.',
+    iconHint: 'அதே குறுக்குவழிக்கு முகப்புத் திரையில் Waves சின்னத்தை நீண்ட நேரம் அழுத்தவும்.',
   },
   motion: {
     title: 'அசைவு',
@@ -4995,6 +5033,19 @@ const hi: UiStrings = {
     shareTitle: 'आपका बाकी निर्यात',
     importInstead: 'Splitwise से आयात करें',
   },
+  shortcut: {
+    title: 'क्विक शॉर्टकट',
+    intro:
+      'शॉर्टकट जो एक काम करे उसे चुनें — ऐप में कहीं भी दो उँगलियों से डबल-टैप, या होम स्क्रीन पर Waves आइकन को देर तक दबाना।',
+    actionLabel: 'शॉर्टकट खोलता है',
+    optionScan: 'रसीद स्कैन करें',
+    optionVoice: 'खर्च बोलें',
+    optionAdd: 'खर्च जोड़ें',
+    optionOff: 'बंद',
+    doubleTapTitle: 'दो उँगलियों से डबल-टैप',
+    doubleTapExplain: 'शॉर्टकट चलाने के लिए कहीं भी दो उँगलियों से डबल-टैप करें।',
+    iconHint: 'वही शॉर्टकट पाने के लिए होम स्क्रीन पर Waves आइकन को देर तक दबाएँ।',
+  },
   motion: {
     title: 'गति',
     animateBetweenScreens: 'स्क्रीनों के बीच एनिमेशन',
@@ -6534,6 +6585,19 @@ const ar: UiStrings = {
     webNote: 'على الويب يُكتب الملف في ذاكرة التطبيق المؤقتة؛ استخدم جهازًا لمشاركته.',
     shareTitle: 'تصدير باقي الخاص بك',
     importInstead: 'استيراد من Splitwise',
+  },
+  shortcut: {
+    title: 'اختصار سريع',
+    intro:
+      'اختر ما يفعله الاختصار، وشغّله بسرعة — نقرة مزدوجة بإصبعين في أي مكان بالتطبيق، أو ضغطة مطوّلة على أيقونة Waves في الشاشة الرئيسية.',
+    actionLabel: 'يفتح الاختصار',
+    optionScan: 'مسح إيصال',
+    optionVoice: 'انطق مصروفًا',
+    optionAdd: 'أضف مصروفًا',
+    optionOff: 'إيقاف',
+    doubleTapTitle: 'نقرة مزدوجة بإصبعين',
+    doubleTapExplain: 'انقر نقرة مزدوجة بإصبعين في أي مكان لتشغيل الاختصار.',
+    iconHint: 'اضغط مطوّلًا على أيقونة Waves في الشاشة الرئيسية للاختصار نفسه.',
   },
   motion: {
     title: 'الحركة',

--- a/apps/mobile/src/lib/quickActions.ts
+++ b/apps/mobile/src/lib/quickActions.ts
@@ -1,0 +1,84 @@
+/**
+ * The OS app-icon shortcut (iOS Home-Screen Quick Actions / Android App
+ * Shortcuts), kept behind a runtime check.
+ *
+ * `expo-quick-actions` is a native module. On a JS-only reload of an older
+ * dev-client — one built before the module was installed — reaching for it would
+ * throw at launch. So nothing here imports it at module scope; every entry point
+ * loads it lazily inside a try/catch and no-ops when it is not in the binary
+ * (the same discipline the camera and scanner use). The in-app double-tap works
+ * regardless; only the icon menu waits on a rebuild.
+ */
+
+import { Platform } from 'react-native';
+
+import type { ShortcutAction } from './shortcut';
+
+/** The dynamic-quick-action id we route on when the app is launched from one. */
+export const QUICK_ACTION_ID = 'waves.shortcut';
+
+type QuickActionsModule = {
+  setItems: (items: unknown[]) => Promise<void> | void;
+  isSupported?: () => Promise<boolean> | boolean;
+  initial?: { id?: string } | null;
+  addListener?: (fn: (item: { id?: string }) => void) => { remove: () => void };
+};
+
+function load(): QuickActionsModule | null {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') return null;
+  try {
+    // Lazy, guarded require: absent on a dev-client built before the module was
+    // added, and we must not throw there.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('expo-quick-actions') as {
+      default?: QuickActionsModule;
+    } & QuickActionsModule;
+    return (mod.default ?? mod) as QuickActionsModule;
+  } catch {
+    return null;
+  }
+}
+
+const ICON: Record<Exclude<ShortcutAction, 'off'>, string> = {
+  // Symbol names resolve on iOS; Android falls back to no icon, which is fine.
+  scan: 'symbol:camera',
+  voice: 'symbol:mic',
+  add: 'symbol:plus',
+};
+
+/**
+ * Publish (or clear) the single icon shortcut for the chosen action. Called
+ * whenever the setting changes, and once on start. A no-op without the module.
+ */
+export async function syncQuickAction(action: ShortcutAction, title: string): Promise<void> {
+  const mod = load();
+  if (!mod) return;
+  try {
+    if (action === 'off') {
+      await mod.setItems([]);
+      return;
+    }
+    await mod.setItems([{ id: QUICK_ACTION_ID, title, icon: ICON[action], params: { action } }]);
+  } catch {
+    // A device that cannot set shortcuts (an old OS, a launcher without support)
+    // is not an error worth surfacing — the in-app gesture still works.
+  }
+}
+
+/** The action id the app was cold-launched with, if it was launched from the
+ *  icon shortcut. Null otherwise (or without the module). */
+export function initialQuickAction(): string | null {
+  const mod = load();
+  return mod?.initial?.id ?? null;
+}
+
+/** Subscribe to icon-shortcut taps while the app is already running. Returns a
+ *  no-op unsubscribe when the module is absent. */
+export function onQuickAction(fn: (id: string) => void): () => void {
+  const mod = load();
+  if (!mod?.addListener) return () => undefined;
+  const sub = mod.addListener((item) => {
+    if (item?.id) fn(item.id);
+  });
+  return () => sub.remove();
+}

--- a/apps/mobile/src/lib/shortcut.tsx
+++ b/apps/mobile/src/lib/shortcut.tsx
@@ -67,6 +67,10 @@ export function ShortcutProvider({ children }: { children: ReactNode }) {
     actionRef.current = action;
   }, [action]);
 
+  // If the user changes a setting during the (brief) storage read, the hydrated
+  // value must not land afterwards and reverse it. `dirty` is set by either
+  // setter and tells the load to leave that already-chosen value alone.
+  const dirty = useRef(false);
   useEffect(() => {
     let active = true;
     void (async () => {
@@ -75,9 +79,11 @@ export function ShortcutProvider({ children }: { children: ReactNode }) {
         AsyncStorage.getItem(DOUBLE_TAP_KEY).catch(() => null),
       ]);
       if (!active) return;
-      if (isAction(savedAction)) setActionState(savedAction);
-      // Default on: an armed gesture is the point of setting an action at all.
-      setDoubleTapState(savedTap === null ? true : savedTap === 'true');
+      if (!dirty.current) {
+        if (isAction(savedAction)) setActionState(savedAction);
+        // Default on: an armed gesture is the point of setting an action at all.
+        setDoubleTapState(savedTap === null ? true : savedTap === 'true');
+      }
       setLoading(false);
     })();
     return () => {
@@ -105,11 +111,13 @@ export function ShortcutProvider({ children }: { children: ReactNode }) {
   }, [action, loading, titleFor]);
 
   const setAction = useCallback(async (next: ShortcutAction) => {
+    dirty.current = true;
     setActionState(next);
     await AsyncStorage.setItem(ACTION_KEY, next).catch(() => undefined);
   }, []);
 
   const setDoubleTap = useCallback(async (on: boolean) => {
+    dirty.current = true;
     setDoubleTapState(on);
     await AsyncStorage.setItem(DOUBLE_TAP_KEY, String(on)).catch(() => undefined);
   }, []);

--- a/apps/mobile/src/lib/shortcut.tsx
+++ b/apps/mobile/src/lib/shortcut.tsx
@@ -1,0 +1,147 @@
+/**
+ * The quick shortcut — one action the user can fire two ways: a two-finger
+ * double-tap anywhere in the app (the iOS "Magic Tap" convention), and the
+ * app-icon long-press menu on the home screen. Both do the same thing, chosen
+ * on the Shortcut settings screen: scan a receipt, speak an expense, or open the
+ * add-expense form. "Off" disables both.
+ *
+ * The choice lives in AsyncStorage (a preference, not ledger data), loaded once
+ * on start. `run()` is stable and reads the latest choice through a ref, so the
+ * gesture and the icon listener never need re-binding when the setting changes.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { router } from 'expo-router';
+
+import { useStrings } from '@/i18n';
+import { syncQuickAction } from './quickActions';
+
+/** What the shortcut does. `off` disables both triggers. */
+export type ShortcutAction = 'off' | 'scan' | 'voice' | 'add';
+
+const ACTION_KEY = 'shortcut.action';
+const DOUBLE_TAP_KEY = 'shortcut.doubleTap';
+
+const ACTIONS: readonly ShortcutAction[] = ['off', 'scan', 'voice', 'add'];
+
+function isAction(value: string | null): value is ShortcutAction {
+  return value !== null && (ACTIONS as readonly string[]).includes(value);
+}
+
+interface ShortcutValue {
+  /** The chosen action; `off` until loaded, so nothing fires before the
+   *  preference is read. */
+  action: ShortcutAction;
+  /** Whether the two-finger double-tap gesture is armed. */
+  doubleTap: boolean;
+  loading: boolean;
+  setAction: (action: ShortcutAction) => Promise<void>;
+  setDoubleTap: (on: boolean) => Promise<void>;
+  /** Perform the current action now (no-op when `off`). Stable identity. */
+  run: () => void;
+}
+
+const ShortcutContext = createContext<ShortcutValue | null>(null);
+
+export function ShortcutProvider({ children }: { children: ReactNode }) {
+  const { t } = useStrings();
+  const [action, setActionState] = useState<ShortcutAction>('off');
+  const [doubleTap, setDoubleTapState] = useState(true);
+  const [loading, setLoading] = useState(true);
+
+  // `run` reads the live action through this, so it never needs re-creating.
+  // Written in an effect (not during render) and read only later, from a
+  // gesture or the icon listener — long after this has committed.
+  const actionRef = useRef<ShortcutAction>('off');
+  useEffect(() => {
+    actionRef.current = action;
+  }, [action]);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const [savedAction, savedTap] = await Promise.all([
+        AsyncStorage.getItem(ACTION_KEY).catch(() => null),
+        AsyncStorage.getItem(DOUBLE_TAP_KEY).catch(() => null),
+      ]);
+      if (!active) return;
+      if (isAction(savedAction)) setActionState(savedAction);
+      // Default on: an armed gesture is the point of setting an action at all.
+      setDoubleTapState(savedTap === null ? true : savedTap === 'true');
+      setLoading(false);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const titleFor = useCallback(
+    (value: ShortcutAction): string =>
+      value === 'scan'
+        ? t.shortcut.optionScan
+        : value === 'voice'
+          ? t.shortcut.optionVoice
+          : value === 'add'
+            ? t.shortcut.optionAdd
+            : t.shortcut.optionOff,
+    [t],
+  );
+
+  // Keep the OS icon shortcut in step with the choice (a no-op without the
+  // native module — see quickActions). Runs on load and on every change.
+  useEffect(() => {
+    if (loading) return;
+    void syncQuickAction(action, titleFor(action));
+  }, [action, loading, titleFor]);
+
+  const setAction = useCallback(async (next: ShortcutAction) => {
+    setActionState(next);
+    await AsyncStorage.setItem(ACTION_KEY, next).catch(() => undefined);
+  }, []);
+
+  const setDoubleTap = useCallback(async (on: boolean) => {
+    setDoubleTapState(on);
+    await AsyncStorage.setItem(DOUBLE_TAP_KEY, String(on)).catch(() => undefined);
+  }, []);
+
+  const run = useCallback(() => {
+    switch (actionRef.current) {
+      case 'scan':
+        // A fresh nonce so the capture screen's consume-once scan guard survives
+        // Android recreating it (same as the dashboard scan button).
+        router.push(`/capture?scan=${Date.now()}`);
+        break;
+      case 'voice':
+        router.push('/voice');
+        break;
+      case 'add':
+        router.push('/capture');
+        break;
+      default:
+        break;
+    }
+  }, []);
+
+  const value = useMemo<ShortcutValue>(
+    () => ({ action, doubleTap, loading, setAction, setDoubleTap, run }),
+    [action, doubleTap, loading, setAction, setDoubleTap, run],
+  );
+
+  return <ShortcutContext.Provider value={value}>{children}</ShortcutContext.Provider>;
+}
+
+export function useShortcut(): ShortcutValue {
+  const value = useContext(ShortcutContext);
+  if (!value) throw new Error('useShortcut must be used inside ShortcutProvider');
+  return value;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       expo-notifications:
         specifier: ~57.0.10
         version: 57.0.10(expo@57.0.12)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      expo-quick-actions:
+        specifier: ^6.0.2
+        version: 6.0.2(expo@57.0.12)(supports-color@8.1.1)(typescript@6.0.3)
       expo-router:
         specifier: ~57.0.12
         version: 57.0.12(ce1c40a51843c96e04481c2d9a4a82f8)
@@ -1142,6 +1145,9 @@ packages:
   '@expo/image-utils@0.11.4':
     resolution: {integrity: sha512-pn/4770DIEOcYZr484uazuwg20FX/qaDkeMRF6J+oxejynDmEmO8wLsCudaNShFE0BhyKGQTYrs2rsRhqrqESw==}
 
+  '@expo/image-utils@0.8.16':
+    resolution: {integrity: sha512-43j9zfSDau82f2u0Wu8mi12FtTlHNvZT84WYwXuFEXputDHFk3kyebYhkjMg8ESNtWqhLGy+ppAh4SN7IcPcFg==}
+
   '@expo/inline-modules@0.1.5':
     resolution: {integrity: sha512-LC+kWeIwnvsGIvDaFBd8uzleWzWZiZTCG7CmtfxBLjW/Gify596X67ZqTi76iHzm5KToAfwwX0nppAKPDA9vQw==}
 
@@ -1260,6 +1266,14 @@ packages:
 
   '@expo/prebuild-config@57.0.11':
     resolution: {integrity: sha512-GcBX2xQ6l4VrkxmlAXm6lVUeHhnURe0Jh86hNVQqoYYIFflUx4IFmMm9B9bN0mbp/Jb+j+CGjkSPQcIYq9NM/Q==}
+
+  '@expo/require-utils@55.0.7':
+    resolution: {integrity: sha512-nkgOCNeWIVfLy3B+THeuqMGNKo0x6jBit9ofE09pHL7XHSkWcEnIYRCLgks8E3wj9q3ylcF1BQLrTxGhPja7iA==}
+    peerDependencies:
+      typescript: ^5.0.0 || ^5.0.0-0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@expo/require-utils@57.0.4':
     resolution: {integrity: sha512-e7xbg/9BTQcsZE/oErafZXtI7kh5IgfasLJ97J5sFSzX2cA74pDvdlhW1KHVSaDkQyQv6h1LSLhsY7dEeOk7hw==}
@@ -4454,6 +4468,11 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-quick-actions@6.0.2:
+    resolution: {integrity: sha512-IVoTMCx55MjSnPqUEb5jhePpOAUdOTonifY3QXM/DBFxc6qMzBy5iJWEkfDZcFAzFzahK1ZW9tFaNv4pi2AAvQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-router@57.0.12:
     resolution: {integrity: sha512-vA+RUSzMwHmWa/pQpoYqJoTbhIQaX/OzvMvOlWVBeMflF1RC40zCzqLiXMKimWfEUh/G6ITnz31EtpNKUghxQw==}
@@ -8107,6 +8126,19 @@ snapshots:
       - supports-color
       - typescript
 
+  '@expo/image-utils@0.8.16(supports-color@8.1.1)(typescript@6.0.3)':
+    dependencies:
+      '@expo/require-utils': 55.0.7(supports-color@8.1.1)(typescript@6.0.3)
+      '@expo/spawn-async': 1.8.0
+      chalk: 4.1.2
+      getenv: 2.0.0
+      jimp-compact: 0.16.1
+      parse-png: 2.1.0
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@expo/inline-modules@0.1.5(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@expo/config-plugins': 57.0.7(supports-color@8.1.1)(typescript@6.0.3)
@@ -8302,6 +8334,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@expo/require-utils@55.0.7(supports-color@8.1.1)(typescript@6.0.3)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@expo/require-utils@57.0.4(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
@@ -11807,6 +11849,16 @@ snapshots:
       expo-constants: 57.0.9(expo@57.0.12)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(supports-color@8.1.1)
       react: 19.2.8
       react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  expo-quick-actions@6.0.2(expo@57.0.12)(supports-color@8.1.1)(typescript@6.0.3):
+    dependencies:
+      '@expo/image-utils': 0.8.16(supports-color@8.1.1)(typescript@6.0.3)
+      expo: 57.0.12(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.9)(expo-router@57.0.12)(react-dom@19.2.8(react@19.2.8))(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      schema-utils: 4.3.3
+      sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
A new Shortcut settings screen (Profile → Settings → Quick shortcut) lets the
user pick one action — scan a receipt, speak an expense, add an expense, or off
— and reach it two ways:

- A two-finger double-tap anywhere in the app (the iOS "Magic Tap" convention).
  Two fingers so it never fires on an ordinary tap on a button or a row; armed
  only when an action is chosen and the toggle is on, inert otherwise.
- The OS app-icon shortcut (Home-Screen Quick Actions / App Shortcuts):
  long-press the Waves icon to launch straight into the chosen action, and a tap
  while the app is open does the same.

Volume-button triggers were considered and left out: iOS gives no public API to
repurpose them and Android only sees them foregrounded, so a reliable
launch-from-volume is not buildable.

Implementation:
- lib/shortcut: AsyncStorage-backed provider (action + double-tap flag), a stable
  run() that routes by the live choice through a ref, and it keeps the icon
  shortcut in step.
- lib/quickActions: expo-quick-actions behind a guarded lazy require (the module
  self-guards too), so a JS-only reload of an older dev-client cannot crash — the
  icon menu simply waits for a native rebuild while the in-app gesture works now.
- components/ShortcutGesture wraps the app: the RNGH two-finger double-tap and the
  cold-launch / running icon-shortcut handling.
- Strings added in all four locales; a Shortcut row in the settings list.

Needs a native rebuild for the app-icon half (expo-quick-actions is native +
config plugin); the double-tap and settings work over Metro immediately.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013pib1zHzfKvFyJtuRDyoHV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable mobile shortcuts for scanning, voice entry, or adding an expense.
  * Shortcuts can be triggered from the app icon or with a two-finger double-tap gesture.
  * Added a Shortcut settings screen with enable/disable controls and action selection.
  * Shortcut preferences are saved and restored automatically.
  * Added localized shortcut guidance in English, Tamil, Hindi, and Arabic.
* **Bug Fixes**
  * Improved shortcut handling during app launch and prevented duplicate shortcut activation.
  * Added safer behavior on devices that do not support shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->