### PR TITLE
perf(mobile): show the dashboard carousel instantly from cache, neutral until synced

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -300,7 +300,7 @@ export default function HomeScreen() {
             single deck. While the balance loads a hero-shaped skeleton stands in
             rather than a card of confident zeros the query has not returned. */}
         <TourTarget id="hero">
-          {summary.isLoading || summary.pendingFirstSync ? (
+          {summary.isLoading ? (
             <HeroSkeleton />
           ) : (
             <HeroDeck
@@ -309,6 +309,11 @@ export default function HomeScreen() {
               totals={summary.totals.slice(1)}
               locale={locale}
               t={t}
+              // The mirror hydrates instantly, so the deck shows at once. Until
+              // this session's first sync settles the balance is provisional —
+              // shown in a neutral wash without the owe/owed colour, so it never
+              // flips red↔green when the sync reconciles (see BalanceCard).
+              provisional={summary.pendingFirstSync}
             />
           )}
         </TourTarget>
@@ -919,12 +924,16 @@ function HeroDeck({
   totals,
   locale,
   t,
+  provisional,
 }: {
   primary: CurrencyTotal;
   trips: readonly TripSlide[];
   totals: readonly CurrencyTotal[];
   locale: string;
   t: UiStrings;
+  /** True until this session's first sync settles: the balance is shown from the
+   *  local snapshot, neutral (no owe/owed colour) so it never flips on reconcile. */
+  provisional: boolean;
 }) {
   const theme = useTheme();
   const { width } = useWindowDimensions();
@@ -936,7 +945,7 @@ function HeroDeck({
   const slides = [
     {
       key: `cur:${primary.currency}:primary`,
-      node: <BalanceCard total={primary} locale={locale} t={t} />,
+      node: <BalanceCard total={primary} locale={locale} t={t} provisional={provisional} />,
     },
     ...trips.map((trip) => ({
       key: `trip:${trip.id}`,
@@ -944,7 +953,7 @@ function HeroDeck({
     })),
     ...totals.map((total) => ({
       key: `cur:${total.currency}`,
-      node: <BalanceCard total={total} locale={locale} t={t} />,
+      node: <BalanceCard total={total} locale={locale} t={t} provisional={provisional} />,
     })),
     {
       key: 'act:scan',
@@ -1171,10 +1180,26 @@ function ActionSlide({
  * settled — so the card's colour, not just its number, tells you where you
  * stand at a glance. The net big, the owed/owe split beneath.
  */
-function BalanceCard({ total, locale, t }: { total: CurrencyTotal; locale: string; t: UiStrings }) {
+function BalanceCard({
+  total,
+  locale,
+  t,
+  provisional,
+}: {
+  total: CurrencyTotal;
+  locale: string;
+  t: UiStrings;
+  /** Before the session's first sync: keep the wash neutral and say "updating"
+   *  rather than owe/owed, so the card never flips colour when the sync lands. */
+  provisional?: boolean;
+}) {
   const theme = useTheme();
-  const wash =
-    total.net > 0n
+  // Neutral (brand) wash while provisional: the owe/owed colour is exactly what
+  // must not appear from a stale snapshot and then flip. It firms up in place the
+  // moment the first sync settles.
+  const wash = provisional
+    ? theme.gradient.brand
+    : total.net > 0n
       ? theme.gradient.positive
       : total.net < 0n
         ? theme.gradient.negative
@@ -1208,8 +1233,14 @@ function BalanceCard({ total, locale, t }: { total: CurrencyTotal; locale: strin
           tone="onBrand"
           style={{ fontSize: 40, lineHeight: 46, fontWeight: '700' }}
         />
-        <Text variant="caption" tone="onBrand">
-          {total.net === 0n ? t.allSettled : total.net > 0n ? t.overallOwed : t.overallOwe}
+        <Text variant="caption" tone="onBrand" style={provisional ? { opacity: 0.8 } : undefined}>
+          {provisional
+            ? t.dashHero.updating
+            : total.net === 0n
+              ? t.allSettled
+              : total.net > 0n
+                ? t.overallOwed
+                : t.overallOwe}
         </Text>
       </View>
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -829,6 +829,7 @@ export interface UiStrings {
   /** The dashboard hero carousel's action slides — the promo-style cards that
       sit in the swipe deck after the balance (scan a receipt, add a person). */
   dashHero: {
+    updating: string;
     scanTitle: string;
     scanBody: string;
     scanCta: string;
@@ -2298,6 +2299,7 @@ const en: UiStrings = {
     group: 'Group',
   },
   dashHero: {
+    updating: 'Updating…',
     scanTitle: 'Snap a receipt',
     scanBody: 'Scan a bill and the items fill themselves in — split it in seconds.',
     scanCta: 'Scan',
@@ -3847,6 +3849,7 @@ const ta: UiStrings = {
     group: 'குழு',
   },
   dashHero: {
+    updating: 'புதுப்பிக்கிறது…',
     scanTitle: 'ரசீதைப் படம் எடுங்கள்',
     scanBody: 'பில்லை ஸ்கேன் செய்தால் பொருட்கள் தானாக நிரம்பும் — நொடிகளில் பங்கிடுங்கள்.',
     scanCta: 'ஸ்கேன்',
@@ -5412,6 +5415,7 @@ const hi: UiStrings = {
     group: 'समूह',
   },
   dashHero: {
+    updating: 'अपडेट हो रहा है…',
     scanTitle: 'रसीद स्कैन करें',
     scanBody: 'बिल स्कैन करें और आइटम अपने आप भर जाते हैं — कुछ ही पलों में बाँटें.',
     scanCta: 'स्कैन',
@@ -6970,6 +6974,7 @@ const ar: UiStrings = {
     group: 'مجموعة',
   },
   dashHero: {
+    updating: 'يُحدَّث…',
     scanTitle: 'صوّر الإيصال',
     scanBody: 'امسح الفاتورة وتُملأ البنود تلقائيًا — قسّمها في ثوانٍ.',
     scanCta: 'مسح',


### PR DESCRIPTION
The hero carousel sat on its skeleton until this session's first network sync
landed — even though the balance is already in the local mirror. On a slow
connection that read as a slow-loading carousel.

It now renders from the mirror the moment the screen hydrates. Until the first
sync settles the balance is *provisional*: a neutral (brand) wash instead of the
owe/owed red/green, and an "Updating…" line in place of the owe/owed word. That
was the whole reason for the wait — a stale snapshot could show "you owe" (red)
and flip to green on reconcile; keeping it colourless until synced removes the
wait without the misleading flip. The colour firms up in place when the first
sync completes. Offline/metered/error still fall through to the local snapshot.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013pib1zHzfKvFyJtuRDyoHV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard balance cards now appear immediately while summary data loads.
  * Loading balances use a neutral visual style and display a localized “Updating…” status.
  * The updating state is supported across primary and additional currency cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->