### PR TITLE
test(core): stop the monkey stress flake — give fuzzed rows group-unique ids

### DIFF
--- a/packages/core/test/monkey.stress.test.ts
+++ b/packages/core/test/monkey.stress.test.ts
@@ -271,6 +271,12 @@ const syncBatch = (): fc.Arbitrary<SyncChange[]> =>
       fc.record({
         table: fc.constantFrom(SyncTable.TripPlanItems, SyncTable.Settlements),
         groupId: fc.constantFrom(GROUP, OTHER),
+        // The bare row number; the group is prefixed below so the id is unique
+        // across groups. Production ids are UUIDs (globally unique), so a `row-5`
+        // in one group and a `row-5` in another cannot be the same row — and the
+        // mirror stores a table's rows by id, so letting the fuzzer collide two
+        // groups on one id models a state the protocol never produces and makes
+        // the order-independence assertion spuriously order-dependent.
         id: fc.integer({ min: 0, max: 200 }).map((n) => `row-${n}`),
         // A random positive step, accumulated per group below, so each group's
         // seqs are strictly increasing and unique — the protocol baaki_next_group_seq
@@ -285,18 +291,21 @@ const syncBatch = (): fc.Arbitrary<SyncChange[]> =>
       const nextSeq: Record<string, number> = {};
       return rows.map((r) => {
         nextSeq[r.groupId] = (nextSeq[r.groupId] ?? 0) + r.step;
+        // Group-namespaced id, matching production's globally-unique UUIDs, so no
+        // two groups ever share a storage key in a table.
+        const rowId = `${r.groupId}:${r.id}`;
         return {
           table: r.table,
           groupId: r.groupId,
           seq: nextSeq[r.groupId] as number,
           row: {
-            id: r.id,
+            id: rowId,
             group_id: r.groupId,
             day: '2026-05-01',
             currency: INR,
             deleted_at: null,
             position: 0,
-            title: r.id,
+            title: rowId,
           },
           deleted: r.deleted,
         };


### PR DESCRIPTION
The idempotency stress test picked a group and a row id independently, so the
same `row-5` could be generated for two different groups. The mirror stores a
table's rows keyed by id alone, so those two rows shared one storage slot and
the "applying in any order lands on the same state" assertion became genuinely
order-dependent — a ~1-in-3 failure on an unlucky seed, unrelated to any change
under test.

Production ids are UUIDs, globally unique, so two groups never share a row id;
the fuzzer now models that by prefixing the id with its group. Ran the file
5×/5× green after the change (it failed intermittently before). No production
code touched — this is the test modelling reality, not papering over a bug.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013pib1zHzfKvFyJtuRDyoHV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reconciliation stress-test coverage by ensuring generated row identifiers remain unique across groups.
  * Stabilized reverse-order reconciliation results by preventing input-order-dependent ID collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->