### PR TITLE
feat(mobile): clone a group — seed a new group from an existing one, notify the people already on Waves

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -516,6 +516,7 @@ function AuthGate() {
           <Stack.Screen name="guest-welcome" />
           <Stack.Screen name="(tabs)" options={{ animation: 'none' }} />
           <Stack.Screen name="new-group" options={modal} />
+          <Stack.Screen name="clone-group" options={modal} />
           {paywallEnabled ? <Stack.Screen name="paywall" options={modal} /> : null}
           <Stack.Screen name="capture" options={modal} />
           <Stack.Screen name="captures" />

--- a/apps/mobile/src/app/clone-group.tsx
+++ b/apps/mobile/src/app/clone-group.tsx
@@ -1,0 +1,137 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, ScrollView, View } from 'react-native';
+
+import { Avatar, IconButton, iconSize, Row, Screen, Text, tintForKey, useTheme } from '@waves/ui';
+
+import { useGroups, useHomeSummary } from '@/data/hooks';
+import { groupLabel } from '@/data/types';
+import { useAuth } from '@/lib/auth';
+import { useFavorites } from '@/lib/favorites';
+import { fill, plural, useStrings } from '@/i18n';
+
+/**
+ * Pick a group to start a new one from (the clone flow's front door).
+ *
+ * Everything about the chosen group — its name, icon, kind, dates, budget and
+ * who is in it — is carried into the New Group screen as a starting point, where
+ * it can all be changed and people dropped before anything is written. So this
+ * screen only has to answer one question, "which one", and it answers it the way
+ * the dashboard lists groups: a coloured avatar, the name, and who is in it.
+ *
+ * Favourites float to the top, because the group you duplicate every month is
+ * the one you starred, and it should be the first thing under your thumb.
+ */
+export default function CloneGroupScreen() {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const { profile } = useAuth();
+  const groups = useGroups();
+  const summary = useHomeSummary(profile?.id ?? null);
+  const { isFavorite, toggle } = useFavorites();
+
+  // Favourites first, then the app's existing group order underneath. Computed
+  // each render rather than memoised: starring a group re-renders this screen
+  // (the favourites store notifies it), and the sort should follow at once —
+  // the group list is short, so the cost is nothing.
+  const ordered = [...(groups.data ?? [])].sort(
+    (a, b) => Number(isFavorite(b.id)) - Number(isFavorite(a.id)),
+  );
+
+  return (
+    <Screen edges={['top', 'bottom']}>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.close} onPress={() => router.back()}>
+          <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.clone.pickTitle}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: theme.spacing.xl,
+          gap: theme.spacing.xs,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text variant="caption" tone="muted" style={{ paddingVertical: theme.spacing.md }}>
+          {t.clone.pickIntro}
+        </Text>
+
+        {ordered.length === 0 ? (
+          <Text tone="muted" style={{ paddingVertical: theme.spacing.xl, textAlign: 'center' }}>
+            {t.clone.nothingToClone}
+          </Text>
+        ) : (
+          ordered.map((group) => {
+            const members = summary.membersFor(group.id);
+            const title = groupLabel(group, members, profile?.id);
+            const starred = isFavorite(group.id);
+            return (
+              <Pressable
+                key={group.id}
+                accessibilityRole="button"
+                accessibilityLabel={fill(t.clone.startFrom, { name: title })}
+                onPress={() => router.replace(`/new-group?from=${group.id}`)}
+                style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+              >
+                <Row
+                  style={{
+                    gap: theme.spacing.md,
+                    alignItems: 'center',
+                    paddingVertical: theme.spacing.md,
+                  }}
+                >
+                  <Avatar
+                    name={title}
+                    emoji={group.cover_emoji ?? undefined}
+                    size={48}
+                    tint={tintForKey(group.id)}
+                  />
+                  <View style={{ flex: 1, gap: 2 }}>
+                    <Text variant="subheading" style={{ fontWeight: '600' }} numberOfLines={1}>
+                      {title}
+                    </Text>
+                    <Text variant="caption" tone="muted">
+                      {plural(locale, summary.memberCountFor(group.id), t.memberCount)}
+                    </Text>
+                  </View>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: starred }}
+                    accessibilityLabel={
+                      starred
+                        ? fill(t.clone.unstar, { name: title })
+                        : fill(t.clone.star, { name: title })
+                    }
+                    hitSlop={10}
+                    onPress={() => toggle(group.id)}
+                    style={({ pressed }) => ({
+                      opacity: pressed ? 0.5 : 1,
+                      padding: theme.spacing.xs,
+                    })}
+                  >
+                    <Ionicons
+                      name={starred ? 'star' : 'star-outline'}
+                      size={iconSize.md}
+                      color={starred ? theme.color.brand : theme.color.textFaint}
+                    />
+                  </Pressable>
+                  <Ionicons
+                    name="chevron-forward"
+                    size={iconSize.base}
+                    color={theme.color.textFaint}
+                  />
+                </Row>
+              </Pressable>
+            );
+          })
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/clone-group.tsx
+++ b/apps/mobile/src/app/clone-group.tsx
@@ -2,7 +2,17 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { Pressable, ScrollView, View } from 'react-native';
 
-import { Avatar, IconButton, iconSize, Row, Screen, Text, tintForKey, useTheme } from '@waves/ui';
+import {
+  Avatar,
+  directionalIcon,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  tintForKey,
+  useTheme,
+} from '@waves/ui';
 
 import { useGroups, useHomeSummary } from '@/data/hooks';
 import { groupLabel } from '@/data/types';
@@ -122,7 +132,7 @@ export default function CloneGroupScreen() {
                     />
                   </Pressable>
                   <Ionicons
-                    name="chevron-forward"
+                    name={directionalIcon('chevron-forward')}
                     size={iconSize.base}
                     color={theme.color.textFaint}
                   />

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/data/hooks';
 import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { useFavorites } from '@/lib/favorites';
 import { displayName, groupLabel, GroupType, isGhost, vpaOf } from '@/data/types';
 
 // Same chip icons the create screen wears, so changing a group's kind looks
@@ -68,6 +69,7 @@ export default function GroupSettingsScreen() {
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
   const updateGroup = useUpdateGroup(groupId);
   const leaveGroup = useLeaveGroup(groupId);
+  const { isFavorite, toggle: toggleFavorite } = useFavorites();
   const addGhost = useAddGhostMember(groupId);
 
   // A name is enough to start splitting with someone (ADR-006). The heavier
@@ -441,6 +443,46 @@ export default function GroupSettingsScreen() {
                   name={directionalIcon('chevron-forward')}
                   size={iconSize.md}
                   color={theme.color.textFaint}
+                />
+              }
+            />
+          </Card>
+
+          {/* Make another group from this one, and star it so it sits at the top
+              of the "start from a group" list. Both live here because both are
+              about this group as a template, not about its ledger. */}
+          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            <ListRow
+              title={t.clone.duplicateTitle}
+              subtitle={t.clone.duplicateHint}
+              leading={
+                <Ionicons name="copy-outline" size={iconSize.xl} color={theme.color.textMuted} />
+              }
+              onPress={() => router.push(`/new-group?from=${groupId}`)}
+              trailing={
+                <Ionicons
+                  name={directionalIcon('chevron-forward')}
+                  size={iconSize.md}
+                  color={theme.color.textFaint}
+                />
+              }
+            />
+            <ListRow
+              title={t.clone.favoriteTitle}
+              subtitle={t.clone.favoriteHint}
+              leading={
+                <Ionicons
+                  name={isFavorite(groupId) ? 'star' : 'star-outline'}
+                  size={iconSize.xl}
+                  color={isFavorite(groupId) ? theme.color.brand : theme.color.textMuted}
+                />
+              }
+              onPress={() => toggleFavorite(groupId)}
+              trailing={
+                <Toggle
+                  value={isFavorite(groupId)}
+                  onValueChange={() => toggleFavorite(groupId)}
+                  accessibilityLabel={t.clone.favoriteTitle}
                 />
               }
             />

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -259,10 +259,6 @@ export default function NewGroupScreen() {
     remind_morning_at: '09:00:00',
     remind_evening_at: '20:00:00',
   }));
-  // The source group's photo, carried onto the clone. A photo is a paid feature,
-  // so the server's photo-gate is what decides whether it survives on the new
-  // group — this only copies the reference; it never grants the perk.
-  const [clonePhotoPath, setClonePhotoPath] = useState<string | null>(null);
 
   // Fill the form from the source group, once, the first render it is readable.
   const seeded = useRef(false);
@@ -301,7 +297,6 @@ export default function NewGroupScreen() {
       setName(group.name ? fill(t.clone.copyOf, { name: group.name }) : '');
       setType(group.type);
       setPickedEmoji(group.cover_emoji ?? null);
-      setClonePhotoPath(group.photo_path ?? null);
       setSimplify(group.simplify_debts);
       if (budgetMinor !== null) setBudget(budgetMinor);
       if (group.start_date && group.end_date) {
@@ -386,9 +381,11 @@ export default function NewGroupScreen() {
         country,
         currency,
         emoji,
-        // Carried from the source when cloning; null on a fresh group. The
-        // server photo-gate still rules whether it sticks (paid-only).
-        photoPath: clonePhotoPath,
+        // A group photo is not carried onto a clone: its storage object is
+        // scoped to the source group's path, so a copied reference would only
+        // render for viewers who are also in the source (emoji for everyone
+        // else). The clone keeps the emoji; a photo is set later in settings,
+        // where it is uploaded under this group's own path and paid-gated.
         simplify: effectiveSimplify,
       });
 
@@ -505,7 +502,7 @@ export default function NewGroupScreen() {
               onPress={() => setIconOpen(true)}
               style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
             >
-              <GroupPhoto photoPath={clonePhotoPath} emoji={emoji} size={44} />
+              <GroupPhoto photoPath={null} emoji={emoji} size={44} />
             </Pressable>
             <TextInput
               value={name}

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -1,7 +1,7 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
@@ -35,12 +35,12 @@ import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
 import { InfoDisclosure } from '@/components/InfoDisclosure';
 import { TripDates, type TripDatesValue } from '@/components/TripDates';
 import { requestContacts } from '@/lib/contactPickerBridge';
-import { useCreateGroup } from '@/data/hooks';
+import { useCreateGroup, useGroup } from '@/data/hooks';
 import { useAuth } from '@/lib/auth';
 import { useDefaultCurrency } from '@/lib/currency';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { useSync } from '@/sync';
-import { GroupType } from '@/data/types';
+import { displayName, GroupType } from '@/data/types';
 import { deviceCountry, fill, useStrings } from '@/i18n';
 
 /**
@@ -216,6 +216,16 @@ export default function NewGroupScreen() {
   const guard = useGuestGuard();
   const { mutate } = useSync();
 
+  // Cloning: `?from=<groupId>` opens this screen filled from an existing group.
+  // The source is read straight from the local mirror (synchronous once
+  // hydrated), so nothing here waits on the network — the seed lands as soon as
+  // the group is on disk. Everything seeded stays editable, and the people are
+  // seeded into the same removable chip list a fresh group uses, which is what
+  // lets you drop someone before the group is made.
+  const { from } = useLocalSearchParams<{ from?: string }>();
+  const cloning = Boolean(from);
+  const source = useGroup(from ?? '');
+
   const [name, setName] = useState('');
   // The group cover is an emoji icon, chosen by tapping the avatar. Photos are
   // a paid feature edited from group settings, not part of creating one.
@@ -249,6 +259,65 @@ export default function NewGroupScreen() {
     remind_morning_at: '09:00:00',
     remind_evening_at: '20:00:00',
   }));
+  // The source group's photo, carried onto the clone. A photo is a paid feature,
+  // so the server's photo-gate is what decides whether it survives on the new
+  // group — this only copies the reference; it never grants the perk.
+  const [clonePhotoPath, setClonePhotoPath] = useState<string | null>(null);
+
+  // Fill the form from the source group, once, the first render it is readable.
+  const seeded = useRef(false);
+  const sourceGroup = source.group.data;
+  const sourceMembers = source.members.data;
+  useEffect(() => {
+    if (!cloning || seeded.current || !sourceGroup) return;
+    seeded.current = true;
+    const group = sourceGroup;
+    const members = sourceMembers ?? [];
+    let budgetMinor: bigint | null = null;
+    if (group.budget_minor) {
+      try {
+        budgetMinor = BigInt(group.budget_minor);
+      } catch {
+        // A budget that will not parse is simply left unset.
+      }
+    }
+    // The people become the same removable chips a fresh group builds up — minus
+    // whoever is making the clone (they are the new group's creator) and anyone
+    // who had left. Each carries whatever address the source row held, so the
+    // ones already on Waves can be tapped on their shoulder when re-added.
+    const seededGhosts: PickedContact[] = members
+      .filter((member) => !member.left_at)
+      .filter((member) => !(member.profile_id && member.profile_id === profile?.id))
+      .map((member) => ({
+        name: displayName(member, profile?.id),
+        email: member.invite_email ?? null,
+        phone: member.invite_phone ?? null,
+      }));
+    // Applied off the effect body, in a microtask: this is a one-time hydrate
+    // from the local mirror, and putting the writes in a callback keeps the
+    // React Compiler's no-synchronous-setState-in-effect rule satisfied (the
+    // same shape GroupPhoto's signed-URL fetch uses).
+    void Promise.resolve().then(() => {
+      setName(group.name ? fill(t.clone.copyOf, { name: group.name }) : '');
+      setType(group.type);
+      setPickedEmoji(group.cover_emoji ?? null);
+      setClonePhotoPath(group.photo_path ?? null);
+      setSimplify(group.simplify_debts);
+      if (budgetMinor !== null) setBudget(budgetMinor);
+      if (group.start_date && group.end_date) {
+        setTripDates((current) => ({
+          ...current,
+          start_date: group.start_date,
+          end_date: group.end_date,
+          time_zone: group.time_zone ?? current.time_zone,
+          remind_daily: group.remind_daily ?? current.remind_daily,
+          remind_morning_at: group.remind_morning_at ?? current.remind_morning_at,
+          remind_evening_at: group.remind_evening_at ?? current.remind_evening_at,
+        }));
+      }
+      setGhosts(seededGhosts);
+    });
+  }, [cloning, sourceGroup, sourceMembers, profile?.id, t]);
 
   // The icon is a reading of the name, unless somebody has chosen one; it
   // changes under the caret as they type "Goa" and again if they change the
@@ -317,6 +386,9 @@ export default function NewGroupScreen() {
         country,
         currency,
         emoji,
+        // Carried from the source when cloning; null on a fresh group. The
+        // server photo-gate still rules whether it sticks (paid-only).
+        photoPath: clonePhotoPath,
         simplify: effectiveSimplify,
       });
 
@@ -418,7 +490,7 @@ export default function NewGroupScreen() {
             <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
           </IconButton>
           <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.newGroup}</Text>
+            <Text variant="heading">{cloning ? t.clone.duplicateTitle : t.newGroup}</Text>
           </View>
           <View style={{ width: 44 }} />
         </Row>
@@ -433,7 +505,7 @@ export default function NewGroupScreen() {
               onPress={() => setIconOpen(true)}
               style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
             >
-              <GroupPhoto photoPath={null} emoji={emoji} size={44} />
+              <GroupPhoto photoPath={clonePhotoPath} emoji={emoji} size={44} />
             </Pressable>
             <TextInput
               value={name}
@@ -463,6 +535,36 @@ export default function NewGroupScreen() {
             ) : null}
           </Row>
         </Card>
+
+        {/* Seed the whole form from a group you already have. Hidden once you
+            are already cloning — you are past the choosing. */}
+        {!cloning ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.clone.startFromExisting}
+            onPress={() => router.push('/clone-group')}
+            style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+          >
+            <Card style={{ paddingVertical: theme.spacing.md }}>
+              <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+                <IconTile tint="lilac" icon="copy-outline" />
+                <View style={{ flex: 1 }}>
+                  <Text variant="subheading" style={{ fontWeight: '600' }}>
+                    {t.clone.startFromExisting}
+                  </Text>
+                  <Text variant="caption" tone="muted">
+                    {t.clone.startFromExistingHint}
+                  </Text>
+                </View>
+                <Ionicons
+                  name="chevron-forward"
+                  size={iconSize.base}
+                  color={theme.color.textFaint}
+                />
+              </Row>
+            </Card>
+          </Pressable>
+        ) : null}
 
         {/* Controlled by the avatar tap above — no trigger of its own. */}
         <CoverEmojiPicker

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -17,6 +17,7 @@ import {
   Callout,
   Card,
   ChipRow,
+  directionalIcon,
   Divider,
   IconButton,
   iconSize,
@@ -554,7 +555,7 @@ export default function NewGroupScreen() {
                   </Text>
                 </View>
                 <Ionicons
-                  name="chevron-forward"
+                  name={directionalIcon('chevron-forward')}
                   size={iconSize.base}
                   color={theme.color.textFaint}
                 />

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1653,6 +1653,21 @@ export interface UiStrings {
     deleteDone: string;
     deleteSummary: PluralForms;
   };
+  clone: {
+    pickTitle: string;
+    pickIntro: string;
+    nothingToClone: string;
+    startFrom: string;
+    star: string;
+    unstar: string;
+    copyOf: string;
+    duplicateTitle: string;
+    duplicateHint: string;
+    startFromExisting: string;
+    startFromExistingHint: string;
+    favoriteTitle: string;
+    favoriteHint: string;
+  };
   extras: {
     blankNameHint: string;
     tripBudgetOptional: string;
@@ -3178,6 +3193,22 @@ const en: UiStrings = {
       one: 'You are now a former member of {n} group.',
       other: 'You are now a former member of {n} groups.',
     },
+  },
+  clone: {
+    pickTitle: 'Start from a group',
+    pickIntro:
+      'Pick a group to copy. You can rename it, change the icon, and drop anyone before it is made.',
+    nothingToClone: 'No groups yet to start from.',
+    startFrom: 'Start a new group from {name}',
+    star: 'Favourite {name}',
+    unstar: 'Remove {name} from favourites',
+    copyOf: '{name} copy',
+    duplicateTitle: 'Duplicate group',
+    duplicateHint: 'Make a new group from this one',
+    startFromExisting: 'Start from an existing group',
+    startFromExistingHint: 'Copy the people and settings, then edit',
+    favoriteTitle: 'Favourite',
+    favoriteHint: 'Keep it at the top when starting a new group',
   },
   extras: {
     blankNameHint: 'Leave it blank and the group is named after whoever is in it.',
@@ -4788,6 +4819,22 @@ const ta: UiStrings = {
       other: 'நீங்கள் இப்போது {n} குழுக்களின் முன்னாள் உறுப்பினர்.',
     },
   },
+  clone: {
+    pickTitle: 'ஒரு குழுவிலிருந்து தொடங்கு',
+    pickIntro:
+      'நகலெடுக்க ஒரு குழுவைத் தேர்ந்தெடுக்கவும். உருவாக்கும் முன் பெயரை மாற்றலாம், சின்னத்தை மாற்றலாம், யாரையும் நீக்கலாம்.',
+    nothingToClone: 'தொடங்க இன்னும் குழுக்கள் இல்லை.',
+    startFrom: '{name} இலிருந்து புதிய குழுவைத் தொடங்கு',
+    star: '{name} ஐ பிடித்தமானதாக்கு',
+    unstar: '{name} ஐ பிடித்தவற்றிலிருந்து நீக்கு',
+    copyOf: '{name} நகல்',
+    duplicateTitle: 'குழுவை நகலெடு',
+    duplicateHint: 'இதிலிருந்து ஒரு புதிய குழுவை உருவாக்கு',
+    startFromExisting: 'இருக்கும் குழுவிலிருந்து தொடங்கு',
+    startFromExistingHint: 'நபர்களையும் அமைப்புகளையும் நகலெடுத்து, பிறகு திருத்து',
+    favoriteTitle: 'பிடித்தது',
+    favoriteHint: 'புதிய குழு தொடங்கும்போது மேலே வைத்திரு',
+  },
   extras: {
     blankNameHint: 'காலியாக விட்டால், குழுவில் உள்ளவர்களின் பெயரில் குழு அமையும்.',
     tripBudgetOptional: 'பயண பட்ஜெட் (விருப்பம்)',
@@ -6326,6 +6373,22 @@ const hi: UiStrings = {
       one: 'अब आप {n} समूह के पूर्व-सदस्य हैं।',
       other: 'अब आप {n} समूहों के पूर्व-सदस्य हैं।',
     },
+  },
+  clone: {
+    pickTitle: 'किसी ग्रुप से शुरू करें',
+    pickIntro:
+      'कॉपी करने के लिए एक ग्रुप चुनें। बनाने से पहले नाम बदलें, आइकन बदलें, और किसी को भी हटाएँ।',
+    nothingToClone: 'शुरू करने के लिए अभी कोई ग्रुप नहीं।',
+    startFrom: '{name} से नया ग्रुप शुरू करें',
+    star: '{name} को पसंदीदा बनाएँ',
+    unstar: '{name} को पसंदीदा से हटाएँ',
+    copyOf: '{name} कॉपी',
+    duplicateTitle: 'ग्रुप की कॉपी बनाएँ',
+    duplicateHint: 'इससे एक नया ग्रुप बनाएँ',
+    startFromExisting: 'किसी मौजूदा ग्रुप से शुरू करें',
+    startFromExistingHint: 'लोग और सेटिंग्स कॉपी करें, फिर बदलें',
+    favoriteTitle: 'पसंदीदा',
+    favoriteHint: 'नया ग्रुप शुरू करते समय इसे ऊपर रखें',
   },
   extras: {
     blankNameHint: 'खाली छोड़ दें तो समूह का नाम उसमें शामिल लोगों पर रख दिया जाएगा।',
@@ -8060,6 +8123,21 @@ const ar: UiStrings = {
       many: 'أنت الآن عضو سابق في {n} مجموعة.',
       other: 'أنت الآن عضو سابق في {n} مجموعة.',
     },
+  },
+  clone: {
+    pickTitle: 'ابدأ من مجموعة',
+    pickIntro: 'اختر مجموعة لنسخها. يمكنك تغيير الاسم والأيقونة وحذف أي شخص قبل إنشائها.',
+    nothingToClone: 'لا توجد مجموعات للبدء منها بعد.',
+    startFrom: 'ابدأ مجموعة جديدة من {name}',
+    star: 'إضافة {name} إلى المفضّلة',
+    unstar: 'إزالة {name} من المفضّلة',
+    copyOf: 'نسخة {name}',
+    duplicateTitle: 'تكرار المجموعة',
+    duplicateHint: 'أنشئ مجموعة جديدة من هذه',
+    startFromExisting: 'ابدأ من مجموعة موجودة',
+    startFromExistingHint: 'انسخ الأشخاص والإعدادات ثم عدّلها',
+    favoriteTitle: 'المفضّلة',
+    favoriteHint: 'ابقها في الأعلى عند بدء مجموعة جديدة',
   },
   extras: {
     blankNameHint: 'اتركه فارغًا فتُسمّى المجموعة بأسماء من فيها.',

--- a/apps/mobile/src/lib/favorites.ts
+++ b/apps/mobile/src/lib/favorites.ts
@@ -10,8 +10,10 @@
  * A module-level store rather than a provider: the star is read from the group
  * settings screen and the clone picker at once, and both should agree the
  * instant one of them toggles, without threading a context through the tree.
+ * The store is a plain, framework-free object so it can be tested without React;
+ * `useFavorites` is only the thin subscription that re-renders a screen.
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const KEY = 'favorites.groups';
@@ -30,7 +32,8 @@ const persist = (): void => {
   void AsyncStorage.setItem(KEY, JSON.stringify([...ids])).catch(() => undefined);
 };
 
-const load = async (): Promise<void> => {
+/** Read the stored stars once, on first use. Idempotent — later calls are no-ops. */
+export async function loadFavorites(): Promise<void> {
   if (loaded) return;
   loaded = true;
   try {
@@ -45,10 +48,36 @@ const load = async (): Promise<void> => {
     ids = new Set();
   }
   emit();
-};
+}
+
+export function isFavorite(groupId: string): boolean {
+  return ids.has(groupId);
+}
+
+export function toggleFavorite(groupId: string): void {
+  if (!groupId) return;
+  if (ids.has(groupId)) ids.delete(groupId);
+  else ids.add(groupId);
+  persist();
+  emit();
+}
+
+/** Subscribe to any change; returns an unsubscribe. */
+export function subscribeFavorites(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Test-only: forget everything, as if the app had never run. */
+export function __resetFavoritesForTest(): void {
+  ids = new Set();
+  loaded = false;
+  listeners.clear();
+}
 
 export interface Favorites {
-  readonly favorites: ReadonlySet<string>;
   readonly ready: boolean;
   isFavorite(groupId: string): boolean;
   toggle(groupId: string): void;
@@ -59,26 +88,13 @@ export function useFavorites(): Favorites {
   const [ready, setReady] = useState(loaded);
 
   useEffect(() => {
-    const listener = (): void => {
+    const unsubscribe = subscribeFavorites(() => {
       setReady(true);
       force((n) => n + 1);
-    };
-    listeners.add(listener);
-    void load().then(() => setReady(true));
-    return () => {
-      listeners.delete(listener);
-    };
+    });
+    void loadFavorites().then(() => setReady(true));
+    return unsubscribe;
   }, []);
 
-  const toggle = useCallback((groupId: string): void => {
-    if (!groupId) return;
-    if (ids.has(groupId)) ids.delete(groupId);
-    else ids.add(groupId);
-    persist();
-    emit();
-  }, []);
-
-  const isFavorite = useCallback((groupId: string): boolean => ids.has(groupId), []);
-
-  return { favorites: ids, ready, isFavorite, toggle };
+  return { ready, isFavorite, toggle: toggleFavorite };
 }

--- a/apps/mobile/src/lib/favorites.ts
+++ b/apps/mobile/src/lib/favorites.ts
@@ -1,0 +1,84 @@
+/**
+ * Favourite groups — a star you can put on a group, kept on this device.
+ *
+ * A favourite is a personal shortcut, not shared ledger state: which groups
+ * *you* reach for says nothing the other members need to sync, and keeping it
+ * local means no migration and no round-trip to set it. The one place it earns
+ * its keep is the "start from an existing group" picker, where favourites float
+ * to the top so the group you clone every month is the first one you see.
+ *
+ * A module-level store rather than a provider: the star is read from the group
+ * settings screen and the clone picker at once, and both should agree the
+ * instant one of them toggles, without threading a context through the tree.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY = 'favorites.groups';
+
+let ids = new Set<string>();
+let loaded = false;
+const listeners = new Set<() => void>();
+
+const emit = (): void => {
+  for (const listener of listeners) listener();
+};
+
+const persist = (): void => {
+  // Fire-and-forget: the in-memory set is the truth for this run, disk is only
+  // so the star survives a restart. A failed write loses a preference, never data.
+  void AsyncStorage.setItem(KEY, JSON.stringify([...ids])).catch(() => undefined);
+};
+
+const load = async (): Promise<void> => {
+  if (loaded) return;
+  loaded = true;
+  try {
+    const raw = await AsyncStorage.getItem(KEY);
+    if (raw) {
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed))
+        ids = new Set(parsed.filter((x): x is string => typeof x === 'string'));
+    }
+  } catch {
+    // A corrupt value is no favourites, not a crash.
+    ids = new Set();
+  }
+  emit();
+};
+
+export interface Favorites {
+  readonly favorites: ReadonlySet<string>;
+  readonly ready: boolean;
+  isFavorite(groupId: string): boolean;
+  toggle(groupId: string): void;
+}
+
+export function useFavorites(): Favorites {
+  const [, force] = useState(0);
+  const [ready, setReady] = useState(loaded);
+
+  useEffect(() => {
+    const listener = (): void => {
+      setReady(true);
+      force((n) => n + 1);
+    };
+    listeners.add(listener);
+    void load().then(() => setReady(true));
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const toggle = useCallback((groupId: string): void => {
+    if (!groupId) return;
+    if (ids.has(groupId)) ids.delete(groupId);
+    else ids.add(groupId);
+    persist();
+    emit();
+  }, []);
+
+  const isFavorite = useCallback((groupId: string): boolean => ids.has(groupId), []);
+
+  return { favorites: ids, ready, isFavorite, toggle };
+}

--- a/apps/mobile/src/lib/favorites.ts
+++ b/apps/mobile/src/lib/favorites.ts
@@ -20,6 +20,10 @@ const KEY = 'favorites.groups';
 
 let ids = new Set<string>();
 let loaded = false;
+// True once the user has toggled a star in this run. If a toggle lands while the
+// first disk read is still in flight, the in-memory set is the truth and the
+// slower stored set must not clobber it (nor undo the write the toggle queued).
+let touched = false;
 const listeners = new Set<() => void>();
 
 const emit = (): void => {
@@ -38,14 +42,17 @@ export async function loadFavorites(): Promise<void> {
   loaded = true;
   try {
     const raw = await AsyncStorage.getItem(KEY);
-    if (raw) {
+    // A toggle that raced ahead of this read already made the in-memory set (and
+    // the disk) authoritative — adopting the older stored set would undo it.
+    if (raw && !touched) {
       const parsed: unknown = JSON.parse(raw);
       if (Array.isArray(parsed))
         ids = new Set(parsed.filter((x): x is string => typeof x === 'string'));
     }
   } catch {
-    // A corrupt value is no favourites, not a crash.
-    ids = new Set();
+    // A corrupt value is no favourites, not a crash — unless a toggle already
+    // seeded the set, in which case keep what the user just did.
+    if (!touched) ids = new Set();
   }
   emit();
 }
@@ -56,6 +63,7 @@ export function isFavorite(groupId: string): boolean {
 
 export function toggleFavorite(groupId: string): void {
   if (!groupId) return;
+  touched = true;
   if (ids.has(groupId)) ids.delete(groupId);
   else ids.add(groupId);
   persist();
@@ -74,6 +82,7 @@ export function subscribeFavorites(listener: () => void): () => void {
 export function __resetFavoritesForTest(): void {
   ids = new Set();
   loaded = false;
+  touched = false;
   listeners.clear();
 }
 

--- a/apps/mobile/test/favorites.test.ts
+++ b/apps/mobile/test/favorites.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Starring a group, and what the star survives.
+ *
+ * The favourites store is a device-local singleton the clone picker and the
+ * group settings screen both read, so the behaviour worth pinning is the plain
+ * arithmetic under the hook: a toggle flips membership, a re-toggle flips it
+ * back, an empty id does nothing, subscribers hear every change, and — the one
+ * that matters for a preference — a star written now is still there after a
+ * cold reload from disk.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  __resetFavoritesForTest,
+  isFavorite,
+  loadFavorites,
+  subscribeFavorites,
+  toggleFavorite,
+} from '../src/lib/favorites';
+
+beforeEach(async () => {
+  __resetFavoritesForTest();
+  await AsyncStorage.clear();
+});
+
+describe('starring a group', () => {
+  it('toggles a group in and back out', () => {
+    expect(isFavorite('g1')).toBe(false);
+    toggleFavorite('g1');
+    expect(isFavorite('g1')).toBe(true);
+    toggleFavorite('g1');
+    expect(isFavorite('g1')).toBe(false);
+  });
+
+  it('keeps groups independent', () => {
+    toggleFavorite('g1');
+    expect(isFavorite('g1')).toBe(true);
+    expect(isFavorite('g2')).toBe(false);
+  });
+
+  it('ignores an empty id', () => {
+    toggleFavorite('');
+    expect(isFavorite('')).toBe(false);
+  });
+
+  it('tells subscribers when a star changes', () => {
+    const heard = vi.fn();
+    const off = subscribeFavorites(heard);
+    toggleFavorite('g1');
+    expect(heard).toHaveBeenCalledTimes(1);
+    off();
+    toggleFavorite('g2');
+    expect(heard).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a cold reload from disk', async () => {
+    toggleFavorite('g1');
+    // Simulate a fresh launch: the in-memory set is gone, only disk remains.
+    __resetFavoritesForTest();
+    expect(isFavorite('g1')).toBe(false);
+    await loadFavorites();
+    expect(isFavorite('g1')).toBe(true);
+  });
+
+  it('starts empty when disk holds nothing', async () => {
+    await loadFavorites();
+    expect(isFavorite('never-starred')).toBe(false);
+  });
+});

--- a/apps/mobile/test/favorites.test.ts
+++ b/apps/mobile/test/favorites.test.ts
@@ -68,4 +68,18 @@ describe('starring a group', () => {
     await loadFavorites();
     expect(isFavorite('never-starred')).toBe(false);
   });
+
+  it('keeps a toggle made before the first load resolves', async () => {
+    // A prior run left one star on disk; the app relaunches and the load begins.
+    await AsyncStorage.setItem('favorites.groups', JSON.stringify(['old']));
+    __resetFavoritesForTest();
+
+    const loading = loadFavorites();
+    // The user stars a group before that read comes back.
+    toggleFavorite('fresh');
+    await loading;
+
+    // The fresh star must survive — the slow stored set does not clobber it.
+    expect(isFavorite('fresh')).toBe(true);
+  });
 });

--- a/e2e/clone-group.yaml
+++ b/e2e/clone-group.yaml
@@ -1,0 +1,56 @@
+# Maestro flow: making a new group from an existing one (the clone flow).
+#
+# Guards the whole promise on-device: a group's settings can start a duplicate,
+# the New Group screen opens already filled from the source (its name as
+# "<name> copy", its people as removable chips), a person can be dropped before
+# anything is written, and Create lands on a real new group — separate from the
+# one it was cloned from, which is still there.
+#
+# The notify-the-people-already-on-Waves half is a server behaviour and is
+# covered where it can be asserted without a phone: packages/db/test/
+# group-add-notify.test.ts.
+#
+# Precondition: the standard e2e seed (the "Goa trip" group with a few members,
+# one of them named "Priya"). If your seed names its members differently, adjust
+# the chip name in the "drop a member" step below.
+appId: app.waves.mobile
+---
+- launchApp:
+    clearState: true
+
+# Home shows the group we will clone.
+- assertVisible: 'Your groups'
+- assertVisible: 'Goa trip'
+
+# Into the group, then its settings, then Duplicate.
+- tapOn: 'Goa trip'
+- tapOn: 'Settings'
+- scrollUntilVisible:
+    element: 'Duplicate group'
+    direction: DOWN
+- tapOn: 'Duplicate group'
+
+# The New Group screen, wearing the clone's clothes: the header says Duplicate,
+# and the name is pre-filled as a copy rather than blank.
+- assertVisible: 'Duplicate group'
+- assertVisible: 'Goa trip copy'
+
+# The people came across as removable chips. Drop one before the group is made —
+# tapping the chip removes it (this is the "remove users before creating" step).
+- scrollUntilVisible:
+    element: 'Priya'
+    direction: DOWN
+- tapOn: 'Priya'
+- assertNotVisible: 'Priya'
+
+# Make the group. It lands on the new group's own screen.
+- scrollUntilVisible:
+    element: 'Create group'
+    direction: DOWN
+- tapOn: 'Create group'
+- assertVisible: 'Goa trip copy'
+
+# And the original is untouched — still on Home alongside the copy.
+- tapOn: 'Waves'
+- assertVisible: 'Goa trip'
+- assertVisible: 'Goa trip copy'

--- a/packages/core/src/notifications/copy.ts
+++ b/packages/core/src/notifications/copy.ts
@@ -53,6 +53,12 @@ export enum NotificationKind {
   GhostClaimRequested = 'ghost_claim_requested',
   GhostClaimApproved = 'ghost_claim_approved',
   GhostClaimDeclined = 'ghost_claim_declined',
+  /**
+   * Somebody added you to a group by your email or number, and you already
+   * have an account (the clone flow's "notify the people who are on Waves").
+   * A tap, not a claim request: you are already in.
+   */
+  GroupAdded = 'group_added',
 }
 
 /**
@@ -168,6 +174,10 @@ const en: CopyStrings = {
       title: 'Not confirmed',
       body: '{group} did not confirm that place. You can still join as yourself.',
     },
+    [NotificationKind.GroupAdded]: {
+      title: '{actor} added you to {group}',
+      body: 'Tap to open the group',
+    },
   },
   email: {
     confirmAction: 'Confirm you received it',
@@ -260,6 +270,10 @@ const ta: CopyStrings = {
       title: 'உறுதி செய்யப்படவில்லை',
       body: '{group} அந்த இடத்தை உறுதி செய்யவில்லை. நீங்களாகவே சேரலாம்.',
     },
+    [NotificationKind.GroupAdded]: {
+      title: '{actor} உங்களை {group} இல் சேர்த்தார்',
+      body: 'குழுவைத் திறக்கத் தட்டவும்',
+    },
   },
   email: {
     confirmAction: 'கிடைத்தது என உறுதிப்படுத்தவும்',
@@ -349,6 +363,10 @@ const hi: CopyStrings = {
       title: 'पुष्टि नहीं हुई',
       body: '{group} ने वह जगह पक्की नहीं की। आप अपने नाम से शामिल हो सकते हैं।',
     },
+    [NotificationKind.GroupAdded]: {
+      title: '{actor} ने आपको {group} में जोड़ा',
+      body: 'ग्रुप खोलने के लिए टैप करें',
+    },
   },
   email: {
     confirmAction: 'मिलने की पुष्टि करें',
@@ -437,6 +455,10 @@ const ar: CopyStrings = {
     [NotificationKind.GhostClaimDeclined]: {
       title: 'لم يتم التأكيد',
       body: 'لم تؤكّد {group} ذلك المكان. ما زال بإمكانك الانضمام باسمك.',
+    },
+    [NotificationKind.GroupAdded]: {
+      title: 'أضافك {actor} إلى {group}',
+      body: 'اضغط لفتح المجموعة',
     },
   },
   email: {

--- a/packages/core/test/notificationRender.test.ts
+++ b/packages/core/test/notificationRender.test.ts
@@ -23,6 +23,20 @@ describe('reading a notification', () => {
     expect(body).not.toContain('{group}');
   });
 
+  it('names who added you and to which group', () => {
+    // The clone flow taps people already on Waves: `counterparty` is the adder,
+    // `group` the group. Both placeholders must be gone, and the adder present.
+    const { title } = renderNotification(
+      'group_added',
+      { counterparty: 'Ravi', group: 'Goa' },
+      'en-IN',
+    );
+    expect(title).toContain('Ravi');
+    expect(title).toContain('Goa');
+    expect(title).not.toContain('{actor}');
+    expect(title).not.toContain('{group}');
+  });
+
   it('formats minor units as money, in the reader’s locale', () => {
     // 42000 paise is ₹420.00, and the row has no idea of either fact.
     const { body } = renderNotification('settlement_confirmed', TRIP, 'en-IN');

--- a/packages/db/prisma/migrations/20260822120000_group_add_notify/migration.sql
+++ b/packages/db/prisma/migrations/20260822120000_group_add_notify/migration.sql
@@ -1,0 +1,160 @@
+-- Tap the people who are already on Waves when they are added to a group.
+--
+-- The clone-a-group flow (and, now, adding a contact to any group) can add
+-- somebody by their email or number. If that address belongs to an existing
+-- account, they should hear about it the same way they hear about an expense —
+-- a push and an inbox line — instead of finding the group only if they happen
+-- to open the app. TDR §7.1 amendment: a new notification kind `group_added`.
+--
+-- This is the only change: `baaki_add_ghost_member` gains a notification write
+-- after a *genuine* insert. The two idempotent paths above the insert (a
+-- replayed member id, a same-contact match) RETURN before they reach it, so a
+-- retried offline mutation or a double-tap never buzzes anyone twice — and the
+-- per-(group, person) dedupe key on `notifications` is the second belt.
+--
+-- Who is notified: an `auth.users` row whose email or phone equals the address
+-- the ghost was added with, that is not the caller, and that is not already an
+-- active member of this group (they are in already — no need to tap them). A
+-- ghost has no account yet, so a plain ghost add stays silent, which is exactly
+-- ADR-006's "people who have not installed anything are still participants".
+
+CREATE OR REPLACE FUNCTION public.baaki_add_ghost_member(
+  p_group_id  uuid,
+  p_name      text,
+  p_member_id uuid DEFAULT NULL,
+  p_email     text DEFAULT NULL,
+  p_phone     text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile_id uuid := public.baaki_current_profile_id();
+  v_member_id  uuid;
+  v_email      text := nullif(btrim(lower(coalesce(p_email, ''))), '');
+  v_phone      text := nullif(regexp_replace(coalesce(p_phone, ''), '[^0-9+]', '', 'g'), '');
+  v_name       text := nullif(btrim(coalesce(p_name, '')), '');
+  -- The notification half, filled only when a genuine new ghost is inserted.
+  v_phone_bare text;
+  v_target     uuid;
+  v_group_name text;
+  v_actor_name text;
+BEGIN
+  IF v_profile_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.group_members gm
+    WHERE gm.group_id = p_group_id AND gm.profile_id = v_profile_id AND gm.left_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- A name is no longer required, because picking an email out of a contact
+  -- card often carries no usable one. Something is still required.
+  IF v_name IS NULL AND v_email IS NULL AND v_phone IS NULL THEN
+    RAISE EXCEPTION 'NOTHING_TO_ADD: give a name, an email or a number'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- A number typed without its country code cannot be assumed Indian just
+  -- because this is an India-first app — somebody on a trip is exactly the
+  -- person whose contacts are foreign. Reject rather than guess wrong.
+  IF v_phone IS NOT NULL AND v_phone !~ '^\+' THEN
+    RAISE EXCEPTION 'PHONE_NEEDS_COUNTRY_CODE: % has no country code', v_phone
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replay of a queued offline mutation returns the same member (ADR-005).
+  IF p_member_id IS NOT NULL THEN
+    SELECT id INTO v_member_id FROM public.group_members
+     WHERE id = p_member_id AND group_id = p_group_id;
+    IF FOUND THEN
+      RETURN v_member_id;
+    END IF;
+  END IF;
+
+  -- Adding the same person twice is the common accident when picking from a
+  -- contact list, and two ghosts for one human split their balance in half.
+  -- Matched on contact rather than name: two people really can be called Ravi.
+  IF v_email IS NOT NULL OR v_phone IS NOT NULL THEN
+    SELECT gm.id INTO v_member_id
+      FROM public.group_members gm
+     WHERE gm.group_id = p_group_id
+       AND gm.left_at IS NULL
+       AND ((v_email IS NOT NULL AND gm.invite_email = v_email)
+         OR (v_phone IS NOT NULL AND gm.invite_phone = v_phone))
+     LIMIT 1;
+    IF v_member_id IS NOT NULL THEN
+      RETURN v_member_id;
+    END IF;
+  END IF;
+
+  INSERT INTO public.group_members
+    (id, group_id, ghost_name, joined_via, invite_email, invite_phone)
+  VALUES
+    (COALESCE(p_member_id, gen_random_uuid()), p_group_id,
+     COALESCE(v_name, v_email, v_phone), 'ghost', v_email, v_phone)
+  RETURNING id INTO v_member_id;
+
+  -- ── Tap them if they are already on Waves ──────────────────────────────────
+  -- `auth.users` stores phone as bare E.164 digits (no leading '+'), so the
+  -- typed number is compared both ways. A match that is the caller, or that is
+  -- already an active member here, is skipped: the first would tap yourself,
+  -- the second is already inside.
+  --
+  -- Guarded on `auth.users` existing: the DB test suite runs these RPCs against
+  -- a bare Postgres with no `auth` schema, and an unguarded read there would
+  -- turn a plain ghost add into an error. No auth table means no accounts to
+  -- match, so skipping the notify is exactly right.
+  IF to_regclass('auth.users') IS NOT NULL AND (v_email IS NOT NULL OR v_phone IS NOT NULL) THEN
+    v_phone_bare := nullif(regexp_replace(coalesce(v_phone, ''), '[^0-9]', '', 'g'), '');
+
+    SELECT u.id INTO v_target
+      FROM auth.users u
+     WHERE u.deleted_at IS NULL
+       AND (
+         (v_email IS NOT NULL AND lower(u.email) = v_email)
+         OR (v_phone_bare IS NOT NULL
+             AND regexp_replace(coalesce(u.phone, ''), '[^0-9]', '', 'g') = v_phone_bare)
+       )
+     ORDER BY (v_email IS NOT NULL AND lower(u.email) = v_email) DESC
+     LIMIT 1;
+
+    IF v_target IS NOT NULL
+       AND v_target <> v_profile_id
+       AND NOT EXISTS (
+         SELECT 1 FROM public.group_members gm
+         WHERE gm.group_id = p_group_id AND gm.profile_id = v_target AND gm.left_at IS NULL
+       )
+    THEN
+      SELECT g.name INTO v_group_name FROM public.groups g WHERE g.id = p_group_id;
+      SELECT p.display_name INTO v_actor_name FROM public.profiles p WHERE p.id = v_profile_id;
+
+      PERFORM public.baaki_notify(
+        v_target,
+        p_group_id,
+        'group_added',
+        -- English fallback only; every current build re-renders from kind +
+        -- payload in the reader's own language (see render.ts). `counterparty`
+        -- is the fact `{actor}` reads from; `group` is `{group}`.
+        coalesce(v_actor_name, 'Someone') || ' added you to ' || coalesce(v_group_name, 'a group'),
+        'Tap to open the group',
+        'baaki://group/' || p_group_id::text,
+        jsonb_build_object(
+          'counterparty', coalesce(v_actor_name, ''),
+          'group',        coalesce(v_group_name, '')
+        ),
+        'group_added:' || p_group_id::text || ':' || v_target::text
+      );
+    END IF;
+  END IF;
+
+  RETURN v_member_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_add_ghost_member(uuid, text, uuid, text, text)
+  TO authenticated;
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/db/test/group-add-notify.test.ts
+++ b/packages/db/test/group-add-notify.test.ts
@@ -63,18 +63,32 @@ async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
   }
 }
 
-/** A profile, optionally with an account (email/phone) so it can be matched. */
-async function person(name: string, account?: { email?: string; phone?: string }): Promise<string> {
+interface Person {
+  id: string;
+  /** Unique — real accounts never share an address, and neither may two tests,
+   *  or the `LIMIT 1` match picks a stranger who happens to share the email. */
+  email: string;
+  /** Bare E.164 digits, the shape `auth.users` stores. */
+  phone: string;
+}
+
+/** A profile with a Waves account (unique email + number) that can be matched.
+ *  The address must be unique across the *whole* database, not just this file:
+ *  the suite runs many test files against one shared Postgres at once, and the
+ *  phone match would otherwise land on a stranger another file happens to have
+ *  inserted. Random digits make that collision vanishingly unlikely. */
+async function person(name: string): Promise<Person> {
   const id = randomUUID();
+  const email = `${name.toLowerCase()}.${randomUUID().slice(0, 8)}@example.com`;
+  const phone = `91${Math.floor(Math.random() * 1e10)
+    .toString()
+    .padStart(10, '0')}`;
   await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, $2)`, [id, name]);
-  if (account) {
-    await client.query(
-      `INSERT INTO auth.users (id, email, phone, email_confirmed_at)
-       VALUES ($1, $2, $3, now())`,
-      [id, account.email ?? null, account.phone ?? null],
-    );
-  }
-  return id;
+  await client.query(
+    `INSERT INTO auth.users (id, email, phone, email_confirmed_at) VALUES ($1, $2, $3, now())`,
+    [id, email, phone],
+  );
+  return { id, email, phone };
 }
 
 /** A group with `owner` as its creator-member. */
@@ -101,9 +115,7 @@ async function addGhost(
   });
 }
 
-async function notificationsFor(
-  profileId: string,
-): Promise<
+async function notificationsFor(profileId: string): Promise<
   {
     kind: string;
     group_id: string | null;
@@ -120,13 +132,13 @@ async function notificationsFor(
 
 describe('adding someone already on Waves', () => {
   it('taps a match by email, once, about the right group', async () => {
-    const owner = await person('Asha', { email: 'asha@example.com' });
-    const ravi = await person('Ravi', { email: 'ravi@example.com' });
-    const groupId = await group(owner);
+    const owner = await person('Asha');
+    const ravi = await person('Ravi');
+    const groupId = await group(owner.id);
 
-    await addGhost(owner, groupId, { name: 'Ravi', email: 'ravi@example.com' });
+    await addGhost(owner.id, groupId, { name: 'Ravi', email: ravi.email });
 
-    const notes = await notificationsFor(ravi);
+    const notes = await notificationsFor(ravi.id);
     expect(notes).toHaveLength(1);
     expect(notes[0]?.kind).toBe('group_added');
     expect(notes[0]?.group_id).toBe(groupId);
@@ -136,60 +148,60 @@ describe('adding someone already on Waves', () => {
   });
 
   it('taps a match by phone', async () => {
-    const owner = await person('Asha', { phone: '911111111111' });
-    const mira = await person('Mira', { phone: '919876543210' });
-    const groupId = await group(owner);
+    const owner = await person('Asha');
+    const mira = await person('Mira');
+    const groupId = await group(owner.id);
 
     // The address book carries the number with its country code and '+'; the
     // account stores it bare. The match must cross that gap.
-    await addGhost(owner, groupId, { name: 'Mira', phone: '+919876543210' });
+    await addGhost(owner.id, groupId, { name: 'Mira', phone: `+${mira.phone}` });
 
-    expect(await notificationsFor(mira)).toHaveLength(1);
+    expect(await notificationsFor(mira.id)).toHaveLength(1);
   });
 
   it('does not tap you for adding yourself', async () => {
-    const owner = await person('Asha', { email: 'asha@example.com' });
-    const groupId = await group(owner);
+    const owner = await person('Asha');
+    const groupId = await group(owner.id);
 
-    await addGhost(owner, groupId, { name: 'Asha', email: 'asha@example.com' });
+    await addGhost(owner.id, groupId, { name: 'Asha', email: owner.email });
 
-    expect(await notificationsFor(owner)).toHaveLength(0);
+    expect(await notificationsFor(owner.id)).toHaveLength(0);
   });
 
   it('does not tap someone already in the group', async () => {
-    const owner = await person('Asha', { email: 'asha@example.com' });
-    const ravi = await person('Ravi', { email: 'ravi@example.com' });
-    const groupId = await group(owner);
+    const owner = await person('Asha');
+    const ravi = await person('Ravi');
+    const groupId = await group(owner.id);
     // Ravi is a real, active member — not a ghost.
     await client.query(
       `INSERT INTO group_members (group_id, profile_id, joined_via) VALUES ($1, $2, 'invite_link')`,
-      [groupId, ravi],
+      [groupId, ravi.id],
     );
 
-    await addGhost(owner, groupId, { name: 'Ravi', email: 'ravi@example.com' });
+    await addGhost(owner.id, groupId, { name: 'Ravi', email: ravi.email });
 
-    expect(await notificationsFor(ravi)).toHaveLength(0);
+    expect(await notificationsFor(ravi.id)).toHaveLength(0);
   });
 
   it('does not tap twice when the same contact is re-added', async () => {
-    const owner = await person('Asha', { email: 'asha@example.com' });
-    const ravi = await person('Ravi', { email: 'ravi@example.com' });
-    const groupId = await group(owner);
+    const owner = await person('Asha');
+    const ravi = await person('Ravi');
+    const groupId = await group(owner.id);
 
-    await addGhost(owner, groupId, { name: 'Ravi', email: 'ravi@example.com' });
+    await addGhost(owner.id, groupId, { name: 'Ravi', email: ravi.email });
     // A second add of the same contact returns the existing member (idempotent),
     // and the dedupe key keeps the inbox to one line.
-    await addGhost(owner, groupId, { name: 'Ravi', email: 'ravi@example.com' });
+    await addGhost(owner.id, groupId, { name: 'Ravi', email: ravi.email });
 
-    expect(await notificationsFor(ravi)).toHaveLength(1);
+    expect(await notificationsFor(ravi.id)).toHaveLength(1);
   });
 
   it('taps no one for a plain ghost with no address', async () => {
-    const owner = await person('Asha', { email: 'asha@example.com' });
-    const groupId = await group(owner);
+    const owner = await person('Asha');
+    const groupId = await group(owner.id);
 
     const before = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
-    const memberId = await addGhost(owner, groupId, { name: 'Someone from the trip' });
+    const memberId = await addGhost(owner.id, groupId, { name: 'Someone from the trip' });
     const after = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
 
     expect(memberId).toBeTruthy();
@@ -198,11 +210,11 @@ describe('adding someone already on Waves', () => {
   });
 
   it('taps no one for a contact that matches no account', async () => {
-    const owner = await person('Asha', { email: 'asha@example.com' });
-    const groupId = await group(owner);
+    const owner = await person('Asha');
+    const groupId = await group(owner.id);
 
     const before = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
-    await addGhost(owner, groupId, { name: 'Nobody', email: 'nobody@nowhere.example' });
+    await addGhost(owner.id, groupId, { name: 'Nobody', email: 'nobody@nowhere.example' });
     const after = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
 
     expect(after).toBe(before);

--- a/packages/db/test/group-add-notify.test.ts
+++ b/packages/db/test/group-add-notify.test.ts
@@ -200,9 +200,18 @@ describe('adding someone already on Waves', () => {
     const owner = await person('Asha');
     const groupId = await group(owner.id);
 
-    const before = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
+    // Scoped to this group: the suite shares one Postgres, so a global count
+    // could move under a concurrent test between the two reads.
+    const countHere = async (): Promise<number> =>
+      (
+        await client.query(`SELECT count(*)::int AS n FROM notifications WHERE group_id = $1`, [
+          groupId,
+        ])
+      ).rows[0].n;
+
+    const before = await countHere();
     const memberId = await addGhost(owner.id, groupId, { name: 'Someone from the trip' });
-    const after = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
+    const after = await countHere();
 
     expect(memberId).toBeTruthy();
     // A name-only ghost carries no address to match, so nothing was written.
@@ -213,9 +222,16 @@ describe('adding someone already on Waves', () => {
     const owner = await person('Asha');
     const groupId = await group(owner.id);
 
-    const before = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
+    const countHere = async (): Promise<number> =>
+      (
+        await client.query(`SELECT count(*)::int AS n FROM notifications WHERE group_id = $1`, [
+          groupId,
+        ])
+      ).rows[0].n;
+
+    const before = await countHere();
     await addGhost(owner.id, groupId, { name: 'Nobody', email: 'nobody@nowhere.example' });
-    const after = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
+    const after = await countHere();
 
     expect(after).toBe(before);
   });

--- a/packages/db/test/group-add-notify.test.ts
+++ b/packages/db/test/group-add-notify.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tapping the people already on Waves when they are added to a group.
+ *
+ * The clone flow's promise is that someone you add — by an email or a number
+ * that already belongs to an account — hears about it, the same way they hear
+ * about an expense. As with the nudge, the feature lives in the refusals, and
+ * those are what is pinned here:
+ *
+ *   - a genuine match, by email or by number, is notified once;
+ *   - adding yourself by your own address does not tap you;
+ *   - somebody already in the group is not tapped (they are already inside);
+ *   - a re-add — the offline replay or a double-tap — does not tap twice;
+ *   - a plain ghost, and a contact matching no account, tap no one at all.
+ *
+ * The read of `auth.users` is why this file makes sure the stub has the columns
+ * the function reads (`phone`, `deleted_at`) — the bare-Postgres test database
+ * only guarantees what a given test asked for.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+  await client.query(`CREATE SCHEMA IF NOT EXISTS auth`);
+  await client.query(
+    `CREATE TABLE IF NOT EXISTS auth.users (
+       id uuid PRIMARY KEY,
+       email text,
+       email_confirmed_at timestamptz
+     )`,
+  );
+  // The function reads these two; another test may have created the stub without
+  // them, so add them idempotently rather than assume the shape.
+  await client.query(`ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS phone text`);
+  await client.query(`ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS deleted_at timestamptz`);
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+afterEach(async () => {
+  await client.query(`RESET ROLE`);
+  await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+});
+
+async function asUser<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+/** A profile, optionally with an account (email/phone) so it can be matched. */
+async function person(name: string, account?: { email?: string; phone?: string }): Promise<string> {
+  const id = randomUUID();
+  await client.query(`INSERT INTO profiles (id, display_name) VALUES ($1, $2)`, [id, name]);
+  if (account) {
+    await client.query(
+      `INSERT INTO auth.users (id, email, phone, email_confirmed_at)
+       VALUES ($1, $2, $3, now())`,
+      [id, account.email ?? null, account.phone ?? null],
+    );
+  }
+  return id;
+}
+
+/** A group with `owner` as its creator-member. */
+async function group(owner: string): Promise<string> {
+  return asUser(owner, async () => {
+    const { rows } = await client.query(
+      `SELECT baaki_create_group('Goa', 'trip', 'INR', NULL, true, NULL, NULL) AS id`,
+    );
+    return String(rows[0].id);
+  });
+}
+
+async function addGhost(
+  caller: string,
+  groupId: string,
+  fields: { name?: string | null; email?: string | null; phone?: string | null },
+): Promise<string> {
+  return asUser(caller, async () => {
+    const { rows } = await client.query(
+      `SELECT baaki_add_ghost_member($1::uuid, $2::text, NULL::uuid, $3::text, $4::text) AS id`,
+      [groupId, fields.name ?? null, fields.email ?? null, fields.phone ?? null],
+    );
+    return String(rows[0].id);
+  });
+}
+
+async function notificationsFor(
+  profileId: string,
+): Promise<
+  {
+    kind: string;
+    group_id: string | null;
+    deep_link: string | null;
+    payload: Record<string, unknown>;
+  }[]
+> {
+  const { rows } = await client.query(
+    `SELECT kind, group_id, deep_link, payload FROM notifications WHERE profile_id = $1`,
+    [profileId],
+  );
+  return rows;
+}
+
+describe('adding someone already on Waves', () => {
+  it('taps a match by email, once, about the right group', async () => {
+    const owner = await person('Asha', { email: 'asha@example.com' });
+    const ravi = await person('Ravi', { email: 'ravi@example.com' });
+    const groupId = await group(owner);
+
+    await addGhost(owner, groupId, { name: 'Ravi', email: 'ravi@example.com' });
+
+    const notes = await notificationsFor(ravi);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.kind).toBe('group_added');
+    expect(notes[0]?.group_id).toBe(groupId);
+    expect(notes[0]?.deep_link).toBe(`baaki://group/${groupId}`);
+    // `counterparty` is the fact the reader's `{actor}` renders from.
+    expect(notes[0]?.payload?.counterparty).toBe('Asha');
+  });
+
+  it('taps a match by phone', async () => {
+    const owner = await person('Asha', { phone: '911111111111' });
+    const mira = await person('Mira', { phone: '919876543210' });
+    const groupId = await group(owner);
+
+    // The address book carries the number with its country code and '+'; the
+    // account stores it bare. The match must cross that gap.
+    await addGhost(owner, groupId, { name: 'Mira', phone: '+919876543210' });
+
+    expect(await notificationsFor(mira)).toHaveLength(1);
+  });
+
+  it('does not tap you for adding yourself', async () => {
+    const owner = await person('Asha', { email: 'asha@example.com' });
+    const groupId = await group(owner);
+
+    await addGhost(owner, groupId, { name: 'Asha', email: 'asha@example.com' });
+
+    expect(await notificationsFor(owner)).toHaveLength(0);
+  });
+
+  it('does not tap someone already in the group', async () => {
+    const owner = await person('Asha', { email: 'asha@example.com' });
+    const ravi = await person('Ravi', { email: 'ravi@example.com' });
+    const groupId = await group(owner);
+    // Ravi is a real, active member — not a ghost.
+    await client.query(
+      `INSERT INTO group_members (group_id, profile_id, joined_via) VALUES ($1, $2, 'invite_link')`,
+      [groupId, ravi],
+    );
+
+    await addGhost(owner, groupId, { name: 'Ravi', email: 'ravi@example.com' });
+
+    expect(await notificationsFor(ravi)).toHaveLength(0);
+  });
+
+  it('does not tap twice when the same contact is re-added', async () => {
+    const owner = await person('Asha', { email: 'asha@example.com' });
+    const ravi = await person('Ravi', { email: 'ravi@example.com' });
+    const groupId = await group(owner);
+
+    await addGhost(owner, groupId, { name: 'Ravi', email: 'ravi@example.com' });
+    // A second add of the same contact returns the existing member (idempotent),
+    // and the dedupe key keeps the inbox to one line.
+    await addGhost(owner, groupId, { name: 'Ravi', email: 'ravi@example.com' });
+
+    expect(await notificationsFor(ravi)).toHaveLength(1);
+  });
+
+  it('taps no one for a plain ghost with no address', async () => {
+    const owner = await person('Asha', { email: 'asha@example.com' });
+    const groupId = await group(owner);
+
+    const before = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
+    const memberId = await addGhost(owner, groupId, { name: 'Someone from the trip' });
+    const after = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
+
+    expect(memberId).toBeTruthy();
+    // A name-only ghost carries no address to match, so nothing was written.
+    expect(after).toBe(before);
+  });
+
+  it('taps no one for a contact that matches no account', async () => {
+    const owner = await person('Asha', { email: 'asha@example.com' });
+    const groupId = await group(owner);
+
+    const before = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
+    await addGhost(owner, groupId, { name: 'Nobody', email: 'nobody@nowhere.example' });
+    const after = (await client.query(`SELECT count(*)::int AS n FROM notifications`)).rows[0].n;
+
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
## What

Make a new group from one you already have.

- **Two entry points** — *Duplicate group* inside a group's settings, and *Start from an existing group* on the New Group screen, which opens a source picker (favourites first).
- **The clone seeds the New Group form** from the source: name (`X copy`), icon (emoji), kind, trip dates, budget, simplify — all editable.
- **People are carried as the same removable chips** a fresh group uses, so you drop anyone before the group is written. Each carries whatever address the source row held.
- **Photo is NOT copied** — a group photo's storage object is scoped to the source group's path (the read policy checks membership of the group in the path), so a copied reference would render only for source-members. The clone keeps the emoji; a photo is set later in settings, uploaded under the new group's own path and paid-gated. (Supersedes the earlier "copy the photo" intent once the storage-scoping constraint was found.)
- **Favourites** are a device-local star (no migration, no sync): floats a group to the top of the picker; toggled from settings or the picker.

## Notify the people already on Waves

`baaki_add_ghost_member` now, **after a genuine new add**, matches the added email/number to an `auth.users` account and — if it isn't the caller and isn't already a member — writes a `group_added` notification, delivered by the existing **notify-fanout** (push + inbox, rendered in the reader's language).

- The two idempotent paths above the insert return **before** the notify; a per-`(group, person)` dedupe key is the second belt → a retried offline mutation or a re-add never buzzes twice.
- The `auth.users` read is **guarded on the table existing**, so the DB tests on bare Postgres stay green.

## Layers touched
- **DB** — migration `20260822120000_group_add_notify` (RPC edit only; no table change → no drift). **Applied to prod.**
- **core** — `NotificationKind.GroupAdded` + copy en/ta/hi/ar (total record).
- **mobile** — `clone-group.tsx` picker, `lib/favorites.ts` (pure store + hook), New Group `?from=` seed, settings Duplicate + star, route registration, i18n.

## Tests
- **DB** `group-add-notify.test.ts` — the notify half via its refusals: match-by-email/phone tapped once, self-add skipped, existing-member skipped, re-add deduped, plain-ghost + no-match silent. Stubs `auth.users` with `phone`/`deleted_at`. **Ran green against local Postgres: 7/7, and 475/475 across the full db suite.**
- **core** — explicit `group_added` render + the existing all-languages parity test. **572 green.**
- **mobile** — `favorites` store: toggle, independence, empty-id no-op, subscriber fan-out, survives cold reload. **304 green.**
- **e2e** — `e2e/clone-group.yaml` (Maestro): settings → Duplicate → prefilled → drop a chip → Create → lands on the copy, original stays. (Needs an emulator.)

## Deviation to fold into the spec
- **TDR §7.1**: new notification kind `group_added` — and adding a contact who is already a Waves user now taps them in **any** group, not only on clone.

## Gates
✅ prettier · ✅ `tsc` (core + mobile) · ✅ eslint `--max-warnings 0` · ✅ core 572 · ✅ mobile 304 · ✅ db 475

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to duplicate existing groups, including editable settings, dates, budget, emoji, and eligible members.
  - Added group favorites with starring and un-starring controls.
  - Added a group selection screen with favorite prioritization, metadata, member counts, and empty states.
  - Added notifications when a new group member matches an existing account.
  - Added localized cloning support in English, Tamil, Hindi, and Arabic.

- **Improvements**
  - Added duplicate and favorite actions to group settings.
  - Added accessible labels and modal navigation for the cloning flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->