### PR TITLE
ci(e2e): un-disable the Maestro job — deterministic seed + gated pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,16 +230,18 @@ jobs:
           printf 'EXPO_PUBLIC_SUPABASE_URL=%s\nEXPO_PUBLIC_SUPABASE_ANON_KEY=%s\n' \
             "${{ secrets.E2E_SUPABASE_URL }}" "${{ secrets.E2E_SUPABASE_ANON_KEY }}" \
             > apps/mobile/.env
+      # Prebuild regenerates android/ from app config; --clean wipes it, so the
+      # Firebase file must land AFTER prebuild and before the Gradle build.
+      - name: Prebuild the Android project
+        working-directory: apps/mobile
+        run: npx expo prebuild --platform android --clean
       - name: Restore Waves google-services.json
         run: |
-          mkdir -p apps/mobile/android/app
           echo "${{ secrets.GOOGLE_SERVICES_JSON_B64 }}" | base64 -d \
             > apps/mobile/android/app/google-services.json
-      - name: Prebuild + assemble debug APK
-        working-directory: apps/mobile
-        run: |
-          npx expo prebuild --platform android --clean
-          cd android && ./gradlew :app:assembleDebug --no-daemon
+      - name: Assemble debug APK
+        working-directory: apps/mobile/android
+        run: ./gradlew :app:assembleDebug --no-daemon
 
       # Boot an emulator, install Maestro, install the APK, run the flows.
       - name: Run Maestro flows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,86 @@ jobs:
   e2e:
     name: e2e (Maestro)
     runs-on: ubuntu-latest
-    # Enabled once a build profile exists; the flow itself is committed so the
-    # happy path is reviewed alongside the code that implements it.
-    if: false
+    # Real mobile E2E: seed a known account, build the app against a staging
+    # project, boot an emulator, drive the flows in e2e/. It is gated on the
+    # repo variable E2E_ENABLED so it stays a clean skip (not a red X) until the
+    # prerequisites are provisioned — see e2e/README-e2e.md. Prerequisites:
+    #   • repo VARIABLE  E2E_ENABLED = true
+    #   • repo SECRETS   E2E_SUPABASE_URL, E2E_SUPABASE_ANON_KEY, E2E_SERVICE_KEY,
+    #                    E2E_EMAIL, E2E_PASSWORD, and GOOGLE_SERVICES_JSON_B64
+    #                    (android/app/google-services.json for app.waves.mobile,
+    #                    base64) — the Waves build profile the old stub waited on.
+    if: ${{ vars.E2E_ENABLED == 'true' }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
-      - run: echo "maestro test e2e/"
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - run: pnpm install --frozen-lockfile
+
+      # Seed the deterministic fixture the flows assert (Goa trip, Beach shack
+      # dinner, the ghost Priya) into the staging project.
+      - name: Seed the E2E backend
+        env:
+          E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          E2E_SERVICE_KEY: ${{ secrets.E2E_SERVICE_KEY }}
+          E2E_EMAIL: ${{ secrets.E2E_EMAIL }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+        run: node e2e/seed-e2e.mjs
+
+      # Build the app against the SAME staging project. The public keys are baked
+      # at bundle time from the env below; app.config reads them via .env.
+      - name: Point the build at staging
+        run: |
+          printf 'EXPO_PUBLIC_SUPABASE_URL=%s\nEXPO_PUBLIC_SUPABASE_ANON_KEY=%s\n' \
+            "${{ secrets.E2E_SUPABASE_URL }}" "${{ secrets.E2E_SUPABASE_ANON_KEY }}" \
+            > apps/mobile/.env
+      - name: Restore Waves google-services.json
+        run: |
+          mkdir -p apps/mobile/android/app
+          echo "${{ secrets.GOOGLE_SERVICES_JSON_B64 }}" | base64 -d \
+            > apps/mobile/android/app/google-services.json
+      - name: Prebuild + assemble debug APK
+        working-directory: apps/mobile
+        run: |
+          npx expo prebuild --platform android --clean
+          cd android && ./gradlew :app:assembleDebug --no-daemon
+
+      # Boot an emulator, install Maestro, install the APK, run the flows.
+      - name: Run Maestro flows
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          script: |
+            curl -Ls "https://get.maestro.mobile.dev" | bash
+            export PATH="$PATH:$HOME/.maestro/bin"
+            adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
+            # Explicit list so the login.yaml sub-flow is not run standalone.
+            maestro test \
+              --env E2E_EMAIL="${{ secrets.E2E_EMAIL }}" \
+              --env E2E_PASSWORD="${{ secrets.E2E_PASSWORD }}" \
+              --format junit --output maestro-report.xml \
+              e2e/home-to-add-expense.yaml \
+              e2e/clone-group.yaml \
+              e2e/group-photo-paid-gate.yaml \
+              e2e/friends-merge-guests.yaml \
+              e2e/leave-group.yaml
+      - name: Upload Maestro report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-report
+          path: |
+            maestro-report.xml
+            ~/.maestro/tests/**
+          if-no-files-found: ignore

--- a/e2e/README-e2e.md
+++ b/e2e/README-e2e.md
@@ -1,0 +1,80 @@
+# Mobile end-to-end tests (Maestro)
+
+The flows in this directory drive the real app on a device/emulator. They are
+the only tests that exercise rendering, navigation and the offline mirror end to
+end. The CI job that runs them (`e2e (Maestro)` in `.github/workflows/ci.yml`)
+is **gated off by default** and turns on once the prerequisites below exist —
+until then it is a clean skip, not a failure.
+
+## What the flows expect
+
+Each flow signs into a **known, seeded account** (`e2e/login.yaml`) and then
+asserts against a **deterministic fixture** created by `e2e/seed-e2e.mjs`:
+
+- a group named **Goa trip** (a trip, 🏖️),
+- one expense **Beach shack dinner** (₹1200), paid by the ghost **Priya**,
+  split among the ghosts **Priya / Sam / Dev** — so the login user's balance is
+  **zero** (which is why `leave-group` can leave without settling first).
+
+Because the fixture is fixed, the flow assertions are real (`assertVisible: 'Goa
+trip'`), not `optional` "screen renders" stubs.
+
+## Enabling it in CI
+
+1. **Create a staging Supabase project** (never point this at production — the
+   seeder refuses the prod ref and rewrites data freely). Apply the same
+   migrations to it (`pnpm --filter @waves/db migrate:deploy` with its
+   `DIRECT_URL`).
+
+2. **Add the Waves Android build profile.** The flows use `appId:
+app.waves.mobile`; the build needs `android/app/google-services.json`
+   registered for that package (the Stage-C Firebase step). Base64 it into a
+   secret.
+
+3. **Set the repo variable and secrets** (Settings → Secrets and variables →
+   Actions):
+
+   | kind     | name                       | value                                   |
+   | -------- | -------------------------- | --------------------------------------- |
+   | variable | `E2E_ENABLED`              | `true`                                  |
+   | secret   | `E2E_SUPABASE_URL`         | staging project URL                     |
+   | secret   | `E2E_SUPABASE_ANON_KEY`    | staging anon key (baked into the build) |
+   | secret   | `E2E_SERVICE_KEY`          | staging service_role key (seeder only)  |
+   | secret   | `E2E_EMAIL`                | e.g. `e2e@waves.test`                   |
+   | secret   | `E2E_PASSWORD`             | the login password                      |
+   | secret   | `GOOGLE_SERVICES_JSON_B64` | `base64 -w0 google-services.json`       |
+
+Once those are present, the job seeds the fixture, builds the APK against
+staging, boots an API-34 emulator, installs Maestro, and runs the flows.
+
+## Running locally
+
+```bash
+# 1. Seed a staging (or local-Supabase) project:
+export E2E_SUPABASE_URL="https://<ref>.supabase.co"
+export E2E_SERVICE_KEY="<service_role key>"
+export E2E_EMAIL="e2e@waves.test"
+export E2E_PASSWORD="<password>"
+node e2e/seed-e2e.mjs
+
+# 2. Build + install the app against the same project (see apps/mobile), then:
+maestro test --env E2E_EMAIL="$E2E_EMAIL" --env E2E_PASSWORD="$E2E_PASSWORD" \
+  e2e/home-to-add-expense.yaml e2e/clone-group.yaml \
+  e2e/group-photo-paid-gate.yaml e2e/friends-merge-guests.yaml e2e/leave-group.yaml
+```
+
+`login.yaml` is a sub-flow (`runFlow`) — run the five flows explicitly rather
+than `maestro test e2e/`, so it is not executed on its own.
+
+## The flows
+
+| Flow                         | Guards                                                                              |
+| ---------------------------- | ----------------------------------------------------------------------------------- |
+| `home-to-add-expense.yaml`   | launch → balance → open group → see expense + ghost → add-expense calculator        |
+| `leave-group.yaml`           | leave a settled group → gone from Home and stays gone after relaunch                |
+| `clone-group.yaml`           | Duplicate → prefilled New Group → drop a member → Create → copy made, original kept |
+| `group-photo-paid-gate.yaml` | group photo is paid, cover emoji is free                                            |
+| `friends-merge-guests.yaml`  | merge same-person ghosts, with the irreversible-warning gate                        |
+
+The `.mjs` scripts in this directory are a separate concern: manual integration
+checks against a **deployed** stack (see each file's header).

--- a/e2e/clone-group.yaml
+++ b/e2e/clone-group.yaml
@@ -15,8 +15,7 @@
 # the chip name in the "drop a member" step below.
 appId: app.waves.mobile
 ---
-- launchApp:
-    clearState: true
+- runFlow: login.yaml
 
 # Home shows the group we will clone.
 - assertVisible: 'Your groups'

--- a/e2e/friends-merge-guests.yaml
+++ b/e2e/friends-merge-guests.yaml
@@ -1,12 +1,10 @@
 # Maestro flow (ADR-014): merging same-person guests on the Friends screen.
 #
-# Exercises the journey end to end — Friends → the merge entry (which only shows
-# with two or more guests) → pick two guests → the irreversible-warning gate →
-# confirm → back to Friends. The pick-and-confirm steps are marked optional so
-# the flow still passes on a seed without two mergeable guests: it will at least
-# prove the screen renders and the "cannot be undone" warning is shown before any
-# button. Seed a data set with two guests (e.g. two groups each with a ghost
-# "person1") to make the confirm path run.
+# The seed (e2e/seed-e2e.mjs) puts the same ghost "Reeya" in two groups, each
+# with an unsettled balance, so she appears twice on Friends and the merge entry
+# (which only shows with two or more mergeable guests) is present. This drives
+# the whole journey: open the merge screen, see the irreversible-warning before
+# any button, pick both Reeya rows, and confirm.
 appId: app.waves.mobile
 ---
 - runFlow: login.yaml
@@ -16,41 +14,26 @@ appId: app.waves.mobile
 - tapOn: 'Friends'
 - assertVisible: 'Friends'
 
-# The merge entry is a header icon that appears only with 2+ guests.
-- tapOn:
-    id: 'Merge people'
-    optional: true
-- tapOn:
-    text: 'Merge people'
-    optional: true
+# The merge entry — a header action present because there are two mergeable guests.
+- tapOn: 'Merge people'
 
-# Merge screen: the title, the subtitle, and — before any button — the warning
-# that this cannot be undone.
-- assertVisible:
-    text: 'Merge people'
-    optional: true
-- assertVisible:
-    text: 'undone'
-    optional: true
+# Merge screen: its title, and — before any button — the "can't be undone" warning.
+- assertVisible: 'Merge people'
+- assertVisible: 'undone'
 
-# Pick the first two guests in the list, then confirm. Optional: depends on the
-# seed having two mergeable guests.
+# Pick both Reeya rows. The merged name pre-fills to "Reeya", so the button arms.
 - tapOn:
-    id: 'person1'
+    text: 'Reeya'
     index: 0
-    optional: true
 - tapOn:
-    id: 'person1'
+    text: 'Reeya'
     index: 1
-    optional: true
+
+# Confirm. Exact-match the button so it isn't the "Merge people" title.
 - assertVisible:
-    text: 'Merge'
-    optional: true
+    text: '^Merge$'
 - tapOn:
-    text: 'Merge'
-    optional: true
+    text: '^Merge$'
 
 # Back on Friends, still a working screen.
-- assertVisible:
-    text: 'Friends'
-    optional: true
+- assertVisible: 'Friends'

--- a/e2e/friends-merge-guests.yaml
+++ b/e2e/friends-merge-guests.yaml
@@ -9,8 +9,7 @@
 # "person1") to make the confirm path run.
 appId: app.waves.mobile
 ---
-- launchApp:
-    clearState: true
+- runFlow: login.yaml
 
 # Home → Friends
 - assertVisible: 'Your groups'

--- a/e2e/group-photo-paid-gate.yaml
+++ b/e2e/group-photo-paid-gate.yaml
@@ -8,8 +8,7 @@
 # account to exercise the locked path fully.
 appId: app.waves.mobile
 ---
-- launchApp:
-    clearState: true
+- runFlow: login.yaml
 
 # Home → new group
 - assertVisible: 'Your groups'

--- a/e2e/home-to-add-expense.yaml
+++ b/e2e/home-to-add-expense.yaml
@@ -1,23 +1,21 @@
-# Maestro flow (ADR-014). M0 covers only what exists today: launch, read the
-# headline balance, open a group, reach the add-expense screen and use the
-# built-in calculator. The full happy path from TDR §10 — invite guest, scan
-# receipt, claim items, UPI settle, confirm — lands with M3–M5.
+# The M0 happy path, now against a seeded, signed-in account: read the headline
+# balance, open the seeded group, see its expense and its ghost member, and use
+# the calculator on the add-expense screen. Fixture: e2e/seed-e2e.mjs.
 appId: app.waves.mobile
 ---
-- launchApp:
-    clearState: true
+- runFlow: login.yaml
 
-# Home
-- assertVisible: 'Your baaki'
+# Home — the headline and the seeded group
+- assertVisible: 'Your balance'
 - assertVisible: 'Your groups'
 - assertVisible: 'Goa trip'
 
-# Group
+# Group — the seeded expense and the Settle action
 - tapOn: 'Goa trip'
 - assertVisible: 'Settle up'
 - assertVisible: 'Beach shack dinner'
 
-# Balances tab shows every member, including the unclaimed ghost
+# Balances tab shows the seeded, unclaimed ghost
 - tapOn: 'Balances'
 - assertVisible: 'Priya'
 - assertVisible: 'not joined yet'
@@ -31,7 +29,4 @@ appId: app.waves.mobile
 - tapOn: '0'
 - tapOn: '0'
 - assertVisible: '1200.00'
-- tapOn:
-    id: 'Split between'
-    optional: true
 - tapOn: 'Save expense'

--- a/e2e/leave-group.yaml
+++ b/e2e/leave-group.yaml
@@ -12,8 +12,9 @@
 # carries an open balance, settle it first with the settle flow.
 appId: app.waves.mobile
 ---
-- launchApp:
-    clearState: true
+# Sign into the seeded account. The fixture leaves the focus user's balance at
+# zero in "Goa trip", so leaving is allowed without settling first.
+- runFlow: login.yaml
 
 # Home shows the group
 - assertVisible: 'Your groups'

--- a/e2e/login.yaml
+++ b/e2e/login.yaml
@@ -1,0 +1,32 @@
+# Reusable sign-in preamble.
+#
+# The other flows `runFlow: login.yaml` first so they open on a real, seeded,
+# signed-in dashboard rather than the sign-in wall. Without this, `clearState`
+# lands on `/welcome` and every "assertVisible: Goa trip" fails — which is why
+# the flows never actually passed.
+#
+# Credentials come from the Maestro env, matching the account e2e/seed-e2e.mjs
+# creates:  maestro test --env E2E_EMAIL=… --env E2E_PASSWORD=… e2e/
+appId: app.waves.mobile
+---
+- launchApp:
+    clearState: true
+
+# /welcome → /sign-in → the email form
+- tapOn: 'Sign in'
+- tapOn: 'Continue with email'
+- tapOn: 'Email or phone number'
+- inputText: '${E2E_EMAIL}'
+- tapOn: 'Password'
+- inputText: '${E2E_PASSWORD}'
+- hideKeyboard
+- tapOn: 'Sign in'
+
+# The dashboard appears once the first sync has pulled the seeded group. Give it
+# room — a cold sign-in does an auth round-trip and a full cursor pull.
+- extendedWaitUntilVisible:
+    element: 'Your groups'
+    timeout: 40000
+- extendedWaitUntilVisible:
+    element: 'Goa trip'
+    timeout: 40000

--- a/e2e/seed-e2e.mjs
+++ b/e2e/seed-e2e.mjs
@@ -122,6 +122,94 @@ async function insert(table, row) {
   if (error) die(`insert into ${table} failed`, error);
 }
 
+// One expense: `payer` paid `amount`, split equally among `shareMembers`.
+async function insertExpense({
+  groupId,
+  payer,
+  amount,
+  shareMembers,
+  description,
+  category,
+  date,
+}) {
+  const expenseId = randomUUID();
+  const versionId = randomUUID();
+  await insert('expenses', { id: expenseId, group_id: groupId, created_by: payer });
+  await insert('expense_versions', {
+    id: versionId,
+    expense_id: expenseId,
+    version_no: 1,
+    author_member_id: payer,
+    description,
+    category,
+    expense_date: date,
+    currency: 'INR',
+    amount: amount.toString(),
+    split_type: 'equal',
+    split_params: { kind: 'equal' },
+    source: 'manual',
+  });
+  await insert('expense_payers', {
+    id: randomUUID(),
+    expense_version_id: versionId,
+    member_id: payer,
+    amount: amount.toString(),
+  });
+  const shares = equalShares(amount, shareMembers.length);
+  for (let i = 0; i < shareMembers.length; i += 1) {
+    await insert('expense_shares', {
+      id: randomUUID(),
+      expense_version_id: versionId,
+      member_id: shareMembers[i],
+      amount: shares[i].toString(),
+    });
+  }
+  const { error } = await db
+    .from('expenses')
+    .update({ current_version_id: versionId })
+    .eq('id', expenseId);
+  if (error) die('setting current_version_id failed', error);
+}
+
+// A small group where the focus user shares an unsettled balance with one named
+// ghost — so that ghost shows up on the Friends screen. Two of these, with the
+// SAME ghost name, give `friends-merge-guests.yaml` two mergeable rows to fold
+// together. The focus user pays and both split equally, so the ghost owes them.
+async function seedMergeGroup(userId, groupName, ghostName) {
+  const groupId = randomUUID();
+  await insert('groups', {
+    id: groupId,
+    name: groupName,
+    type: 'other',
+    default_currency: 'INR',
+    created_by: userId,
+  });
+  const focusMemberId = randomUUID();
+  const ghostMemberId = randomUUID();
+  await insert('group_members', {
+    id: focusMemberId,
+    group_id: groupId,
+    profile_id: userId,
+    role: 'admin',
+    joined_via: 'creator',
+  });
+  await insert('group_members', {
+    id: ghostMemberId,
+    group_id: groupId,
+    ghost_name: ghostName,
+    joined_via: 'ghost',
+  });
+  await insertExpense({
+    groupId,
+    payer: focusMemberId,
+    amount: 60000n, // ₹600, split 50/50 → the ghost owes the focus user ₹300
+    shareMembers: [focusMemberId, ghostMemberId],
+    description: `${groupName} split`,
+    category: 'other',
+    date: '2026-08-05',
+  });
+}
+
 async function seed() {
   // The login user + its profile.
   const { data: created, error: userErr } = await db.auth.admin.createUser({
@@ -208,8 +296,14 @@ async function seed() {
     .eq('id', expenseId);
   if (curErr) die('setting current_version_id failed', curErr);
 
+  // The mergeable pair for friends-merge-guests: the same ghost "Reeya" in two
+  // groups, each with a balance so she appears twice on Friends and can be
+  // merged. Kept separate from Goa trip, whose focus balance stays zero.
+  await seedMergeGroup(userId, 'Weekend hike', 'Reeya');
+  await seedMergeGroup(userId, 'Diwali dinner', 'Reeya');
+
   console.log(
-    `✓ seeded ${EMAIL}: "${GROUP_NAME}" with ${GHOSTS.length} ghosts and "${EXPENSE_DESC}" (₹1200)`,
+    `✓ seeded ${EMAIL}: "${GROUP_NAME}" (${GHOSTS.length} ghosts, "${EXPENSE_DESC}" ₹1200) + a mergeable "Reeya" in two groups`,
   );
 }
 

--- a/e2e/seed-e2e.mjs
+++ b/e2e/seed-e2e.mjs
@@ -1,0 +1,219 @@
+// @ts-nocheck
+/**
+ * Deterministic E2E fixture — the exact, known state the Maestro flows assert.
+ *
+ * Unlike `seed-demo` (a randomised dashboard to look at), this writes ONE fixed
+ * account and ONE fixed group so `e2e/*.yaml` can assert real strings — "Goa
+ * trip", "Beach shack dinner", the ghost "Priya" — instead of degrading to
+ * `optional` "screen renders" proofs. It is the other half of un-disabling the
+ * Maestro job in CI: the app signs into this account, syncs, and finds this
+ * state.
+ *
+ * It talks to a Supabase project over the service key (bypassing RLS) plus the
+ * admin API (to mint the login user). It NEVER touches the local Postgres or a
+ * production project — it refuses to run against the known prod ref and requires
+ * an explicit `E2E_SUPABASE_URL`.
+ *
+ * Required env:
+ *   E2E_SUPABASE_URL   staging project URL      (e.g. https://abc.supabase.co)
+ *   E2E_SERVICE_KEY    that project's service_role key
+ *   E2E_EMAIL          the login the flows use   (e.g. e2e@waves.test)
+ *   E2E_PASSWORD       its password
+ *
+ * Run:  node e2e/seed-e2e.mjs
+ *
+ * It is idempotent: it deletes any prior fixture (the group, then the user) and
+ * rebuilds it, so a re-run always lands the same known state.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { createClient } from '@supabase/supabase-js';
+
+// ── config ──────────────────────────────────────────────────────────────────
+
+const URL = process.env.E2E_SUPABASE_URL;
+const SERVICE_KEY = process.env.E2E_SERVICE_KEY;
+const EMAIL = process.env.E2E_EMAIL ?? 'e2e@waves.test';
+const PASSWORD = process.env.E2E_PASSWORD;
+
+// The production project ref. This seeder deletes and rewrites freely, so it
+// must never point at it, the way `seed-demo` refuses DATABASE_URL/DIRECT_URL.
+const PROD_REF = 'xvjzbpgcmotoahtqcxve';
+
+if (!URL || !SERVICE_KEY || !PASSWORD) {
+  console.error(
+    'Missing env. Set E2E_SUPABASE_URL, E2E_SERVICE_KEY and E2E_PASSWORD (E2E_EMAIL optional).',
+  );
+  process.exit(1);
+}
+if (URL.includes(PROD_REF)) {
+  console.error(
+    `Refusing to seed the production project (${PROD_REF}). Point at a staging project.`,
+  );
+  process.exit(1);
+}
+
+const db = createClient(URL, SERVICE_KEY, { auth: { persistSession: false } });
+
+// The fixture. These strings are the contract the Maestro flows assert.
+const GROUP_NAME = 'Goa trip';
+const EXPENSE_DESC = 'Beach shack dinner';
+const AMOUNT_MINOR = 120000n; // ₹1200.00 in paise
+const GHOSTS = ['Priya', 'Sam', 'Dev'];
+
+const die = (msg, error) => {
+  console.error(msg, error?.message ?? error ?? '');
+  process.exit(1);
+};
+
+// Split `total` minor units equally across `n` members, giving the earliest
+// members the extra paise so the shares sum to the total exactly.
+function equalShares(total, n) {
+  const base = total / BigInt(n);
+  let remainder = total - base * BigInt(n);
+  const out = [];
+  for (let i = 0; i < n; i += 1) {
+    let share = base;
+    if (remainder > 0n) {
+      share += 1n;
+      remainder -= 1n;
+    }
+    out.push(share);
+  }
+  return out;
+}
+
+// ── 1. reset any prior fixture ────────────────────────────────────────────────
+
+async function findUserByEmail(email) {
+  // The admin API has no get-by-email, so page through until we find it. A
+  // staging project stays small, so one or two pages is plenty.
+  for (let page = 1; page <= 20; page += 1) {
+    const { data, error } = await db.auth.admin.listUsers({ page, perPage: 200 });
+    if (error) die('listUsers failed', error);
+    const hit = data.users.find((u) => (u.email ?? '').toLowerCase() === email.toLowerCase());
+    if (hit) return hit;
+    if (data.users.length < 200) return null;
+  }
+  return null;
+}
+
+async function reset() {
+  const existing = await findUserByEmail(EMAIL);
+  if (existing) {
+    // Delete any groups this user created first (cascades to members, expenses,
+    // versions, payers, shares, settlements), then the user (cascades profile).
+    const { data: groups } = await db.from('groups').select('id').eq('created_by', existing.id);
+    for (const g of groups ?? []) {
+      const { error } = await db.from('groups').delete().eq('id', g.id);
+      if (error) die(`deleting group ${g.id} failed`, error);
+    }
+    const { error } = await db.auth.admin.deleteUser(existing.id);
+    if (error) die('deleteUser failed', error);
+    console.log(`· reset: removed prior fixture user ${EMAIL}`);
+  }
+}
+
+// ── 2. build the fixture ──────────────────────────────────────────────────────
+
+async function insert(table, row) {
+  const { error } = await db.from(table).insert(row);
+  if (error) die(`insert into ${table} failed`, error);
+}
+
+async function seed() {
+  // The login user + its profile.
+  const { data: created, error: userErr } = await db.auth.admin.createUser({
+    email: EMAIL,
+    password: PASSWORD,
+    email_confirm: true,
+  });
+  if (userErr) die('createUser failed', userErr);
+  const userId = created.user.id;
+  await insert('profiles', { id: userId, display_name: 'You', default_currency: 'INR' });
+
+  // The group.
+  const groupId = randomUUID();
+  await insert('groups', {
+    id: groupId,
+    name: GROUP_NAME,
+    type: 'trip',
+    default_currency: 'INR',
+    cover_emoji: '🏖️',
+    created_by: userId,
+  });
+
+  // Members: the focus user (admin) plus the ghosts the flows name.
+  const focusMemberId = randomUUID();
+  await insert('group_members', {
+    id: focusMemberId,
+    group_id: groupId,
+    profile_id: userId,
+    role: 'admin',
+    joined_via: 'creator',
+  });
+  const ghostIds = {};
+  for (const name of GHOSTS) {
+    const id = randomUUID();
+    ghostIds[name] = id;
+    await insert('group_members', {
+      id,
+      group_id: groupId,
+      ghost_name: name,
+      joined_via: 'ghost',
+    });
+  }
+
+  // One expense: paid by Priya, split equally across the three ghosts and NOT
+  // the focus user — so the focus user's net balance is zero and `leave-group`
+  // can leave without settling first, while `home-to-add-expense` still sees
+  // the expense and the ghost.
+  const participants = GHOSTS.map((n) => ghostIds[n]);
+  const shares = equalShares(AMOUNT_MINOR, participants.length);
+  const expenseId = randomUUID();
+  const versionId = randomUUID();
+  await insert('expenses', { id: expenseId, group_id: groupId, created_by: ghostIds.Priya });
+  await insert('expense_versions', {
+    id: versionId,
+    expense_id: expenseId,
+    version_no: 1,
+    author_member_id: ghostIds.Priya,
+    description: EXPENSE_DESC,
+    category: 'food',
+    expense_date: '2026-08-01',
+    currency: 'INR',
+    amount: AMOUNT_MINOR.toString(),
+    split_type: 'equal',
+    split_params: { kind: 'equal' },
+    source: 'manual',
+  });
+  await insert('expense_payers', {
+    id: randomUUID(),
+    expense_version_id: versionId,
+    member_id: ghostIds.Priya,
+    amount: AMOUNT_MINOR.toString(),
+  });
+  for (let i = 0; i < participants.length; i += 1) {
+    await insert('expense_shares', {
+      id: randomUUID(),
+      expense_version_id: versionId,
+      member_id: participants[i],
+      amount: shares[i].toString(),
+    });
+  }
+  const { error: curErr } = await db
+    .from('expenses')
+    .update({ current_version_id: versionId })
+    .eq('id', expenseId);
+  if (curErr) die('setting current_version_id failed', curErr);
+
+  console.log(
+    `✓ seeded ${EMAIL}: "${GROUP_NAME}" with ${GHOSTS.length} ghosts and "${EXPENSE_DESC}" (₹1200)`,
+  );
+}
+
+// ── run ───────────────────────────────────────────────────────────────────────
+
+await reset();
+await seed();


### PR DESCRIPTION
## Phase 1 of the E2E coverage plan

Turns the committed-but-never-run Maestro flows into a **real, runnable** mobile E2E suite.

### Why they never passed
Each flow did `clearState` then asserted `Goa trip` — which lands on `/welcome` (no session, no data). The home flow also asserted the **stale** `Your baaki` (the headline now reads `Your balance`). So the suite was aspirational, not executable.

### What this adds
- **`e2e/seed-e2e.mjs`** — a deterministic fixture via the Supabase admin API + service key: one known login account, **Goa trip** with ghosts **Priya/Sam/Dev** and the expense **Beach shack dinner (₹1200)**, split so the login user's balance is **zero** (so `leave-group` can leave without settling). Idempotent; **refuses the prod ref**.
- **`e2e/login.yaml`** — a reusable sign-in sub-flow (creds from the Maestro `--env`) that waits for the seeded group to sync in.
- **The five flows** now `runFlow: login.yaml` first, assert **real strings** instead of `optional` stubs, and use current copy.
- **CI `e2e` job** replaces the `if:false` echo with a real pipeline: seed → build the APK against a staging project → boot an API-34 emulator → run Maestro. **Gated on the repo variable `E2E_ENABLED`**, so it's a clean skip (not a red X) until the prerequisites exist.
- **`e2e/README-e2e.md`** — the exact variable + secrets that turn it on.

### To actually enable it (owner steps)
Set repo var `E2E_ENABLED=true` and the secrets in the README: `E2E_SUPABASE_URL`, `E2E_SUPABASE_ANON_KEY`, `E2E_SERVICE_KEY`, `E2E_EMAIL`, `E2E_PASSWORD`, `GOOGLE_SERVICES_JSON_B64`. The build needs the **Waves `app.waves.mobile` google-services profile** — the Stage-C Firebase step this job was originally waiting on.

### Validation
YAML parses (all flows + workflow), `node --check` on the seed, prettier clean. The **green run itself** needs the staging project + secrets provisioned — it can't run against production by design, and can't run here (no emulator/staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated mobile end-to-end coverage for sign-in, group management, guest merging, photo access, and expense creation.
  - Added deterministic test data for repeatable validation of seeded accounts, groups, members, and expenses.
  - Updated flows to use shared sign-in and verify dashboard and balance information.
  - Enabled optional CI execution with test reporting.

- **Documentation**
  - Added setup requirements, local execution instructions, covered scenarios, and test-data guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->