### PR TITLE
test(e2e): Phase 2 — expense CRUD, rename/archive & sign-out flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,11 @@ jobs:
       # Boot an emulator, install Maestro, install the APK, run the flows.
       - name: Run Maestro flows
         uses: reactivecircus/android-emulator-runner@v2
+        env:
+          E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          E2E_SERVICE_KEY: ${{ secrets.E2E_SERVICE_KEY }}
+          E2E_EMAIL: ${{ secrets.E2E_EMAIL }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
         with:
           api-level: 34
           arch: x86_64
@@ -255,16 +260,26 @@ jobs:
             curl -Ls "https://get.maestro.mobile.dev" | bash
             export PATH="$PATH:$HOME/.maestro/bin"
             adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
-            # Explicit list so the login.yaml sub-flow is not run standalone.
-            maestro test \
-              --env E2E_EMAIL="${{ secrets.E2E_EMAIL }}" \
-              --env E2E_PASSWORD="${{ secrets.E2E_PASSWORD }}" \
-              --format junit --output maestro-report.xml \
-              e2e/home-to-add-expense.yaml \
-              e2e/clone-group.yaml \
-              e2e/group-photo-paid-gate.yaml \
-              e2e/friends-merge-guests.yaml \
-              e2e/leave-group.yaml
+            # Each flow mutates the shared staging backend (archive, leave,
+            # rename, delete), so reseed the deterministic fixture before every
+            # flow for isolation. The seed is idempotent (reset + rebuild), and
+            # each flow's login.yaml does clearState, so no state leaks across.
+            # Run flows one at a time (not `maestro test e2e/`) so the login.yaml
+            # sub-flow is never executed standalone.
+            status=0
+            for flow in \
+              home-to-add-expense edit-expense delete-restore-expense \
+              rename-archive-group sign-out-privacy clone-group \
+              group-photo-paid-gate friends-merge-guests leave-group; do
+              echo "::group::seed + $flow"
+              node e2e/seed-e2e.mjs
+              maestro test \
+                --env E2E_EMAIL="$E2E_EMAIL" \
+                --env E2E_PASSWORD="$E2E_PASSWORD" \
+                "e2e/$flow.yaml" || status=1
+              echo "::endgroup::"
+            done
+            exit $status
       - name: Upload Maestro report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,30 +256,10 @@ jobs:
           arch: x86_64
           profile: pixel_6
           disable-animations: true
-          script: |
-            curl -Ls "https://get.maestro.mobile.dev" | bash
-            export PATH="$PATH:$HOME/.maestro/bin"
-            adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
-            # Each flow mutates the shared staging backend (archive, leave,
-            # rename, delete), so reseed the deterministic fixture before every
-            # flow for isolation. The seed is idempotent (reset + rebuild), and
-            # each flow's login.yaml does clearState, so no state leaks across.
-            # Run flows one at a time (not `maestro test e2e/`) so the login.yaml
-            # sub-flow is never executed standalone.
-            status=0
-            for flow in \
-              home-to-add-expense edit-expense delete-restore-expense \
-              rename-archive-group sign-out-privacy clone-group \
-              group-photo-paid-gate friends-merge-guests leave-group; do
-              echo "::group::seed + $flow"
-              node e2e/seed-e2e.mjs
-              maestro test \
-                --env E2E_EMAIL="$E2E_EMAIL" \
-                --env E2E_PASSWORD="$E2E_PASSWORD" \
-                "e2e/$flow.yaml" || status=1
-              echo "::endgroup::"
-            done
-            exit $status
+          # A single line: android-emulator-runner parses `script` line-by-line,
+          # so the loop + reseed logic lives in a committed shell script that
+          # runs as one command. See e2e/run-maestro.sh.
+          script: bash e2e/run-maestro.sh
       - name: Upload Maestro report
         if: always()
         uses: actions/upload-artifact@v4

--- a/e2e/README-e2e.md
+++ b/e2e/README-e2e.md
@@ -68,13 +68,21 @@ than `maestro test e2e/`, so it is not executed on its own.
 
 ## The flows
 
-| Flow                         | Guards                                                                              |
-| ---------------------------- | ----------------------------------------------------------------------------------- |
-| `home-to-add-expense.yaml`   | launch → balance → open group → see expense + ghost → add-expense calculator        |
-| `leave-group.yaml`           | leave a settled group → gone from Home and stays gone after relaunch                |
-| `clone-group.yaml`           | Duplicate → prefilled New Group → drop a member → Create → copy made, original kept |
-| `group-photo-paid-gate.yaml` | group photo is paid, cover emoji is free                                            |
-| `friends-merge-guests.yaml`  | merge same-person ghosts, with the irreversible-warning gate                        |
+| Flow                          | Guards                                                                              |
+| ----------------------------- | ----------------------------------------------------------------------------------- |
+| `home-to-add-expense.yaml`    | launch → balance → open group → see expense + ghost → add-expense calculator        |
+| `edit-expense.yaml`           | edit the seeded expense → the ledger reflects the new value                         |
+| `delete-restore-expense.yaml` | delete → gone from the default view → Show deleted → Restore → back                 |
+| `rename-archive-group.yaml`   | rename a group (persists) → archive → gone from Home                                |
+| `sign-out-privacy.yaml`       | sign out → back at the gateway, the ledger off screen                               |
+| `clone-group.yaml`            | Duplicate → prefilled New Group → drop a member → Create → copy made, original kept |
+| `group-photo-paid-gate.yaml`  | group photo is paid, cover emoji is free                                            |
+| `friends-merge-guests.yaml`   | merge the two seeded "Reeya" ghosts, with the irreversible-warning gate             |
+| `leave-group.yaml`            | leave a settled group → gone from Home and stays gone after relaunch                |
+
+Each flow mutates the shared staging backend, so CI **reseeds the fixture before
+every flow** (the seed is idempotent). Locally, run one flow at a time and
+reseed between them.
 
 The `.mjs` scripts in this directory are a separate concern: manual integration
 checks against a **deployed** stack (see each file's header).

--- a/e2e/README-e2e.md
+++ b/e2e/README-e2e.md
@@ -57,14 +57,19 @@ export E2E_EMAIL="e2e@waves.test"
 export E2E_PASSWORD="<password>"
 node e2e/seed-e2e.mjs
 
-# 2. Build + install the app against the same project (see apps/mobile), then:
-maestro test --env E2E_EMAIL="$E2E_EMAIL" --env E2E_PASSWORD="$E2E_PASSWORD" \
-  e2e/home-to-add-expense.yaml e2e/clone-group.yaml \
-  e2e/group-photo-paid-gate.yaml e2e/friends-merge-guests.yaml e2e/leave-group.yaml
+# 2. Build + install the app against the same project (see apps/mobile). Then run
+#    each flow on its own, reseeding first, because the flows mutate the backend:
+for flow in home-to-add-expense edit-expense delete-restore-expense \
+            rename-archive-group sign-out-privacy clone-group \
+            group-photo-paid-gate friends-merge-guests leave-group; do
+  node e2e/seed-e2e.mjs
+  maestro test --env E2E_EMAIL="$E2E_EMAIL" --env E2E_PASSWORD="$E2E_PASSWORD" "e2e/$flow.yaml"
+done
 ```
 
-`login.yaml` is a sub-flow (`runFlow`) — run the five flows explicitly rather
-than `maestro test e2e/`, so it is not executed on its own.
+`login.yaml` is a sub-flow (`runFlow`) — run the flows explicitly (one per
+invocation) rather than `maestro test e2e/`, so it is not executed on its own.
+In CI this loop lives in `e2e/run-maestro.sh`.
 
 ## The flows
 

--- a/e2e/delete-restore-expense.yaml
+++ b/e2e/delete-restore-expense.yaml
@@ -1,0 +1,24 @@
+# Deleting an expense removes it from balances and the default view; Restore
+# brings it back (F-EXP-03). Uses the seeded "Beach shack dinner".
+appId: app.waves.mobile
+---
+- runFlow: login.yaml
+
+- tapOn: 'Goa trip'
+- tapOn: 'Beach shack dinner'
+
+# Delete, confirming the alert (exact-match so it isn't "Delete expense").
+- assertVisible: 'Delete expense'
+- tapOn: 'Delete expense'
+- assertVisible: 'Delete this expense?'
+- tapOn:
+    text: '^Delete$'
+
+# Back on the ledger it is gone from the default view.
+- assertNotVisible: 'Beach shack dinner'
+
+# Reveal deleted, reopen it, restore it.
+- tapOn: 'Show deleted'
+- tapOn: 'Beach shack dinner'
+- tapOn: 'Restore this expense'
+- assertVisible: 'Beach shack dinner'

--- a/e2e/edit-expense.yaml
+++ b/e2e/edit-expense.yaml
@@ -1,0 +1,22 @@
+# Editing an expense keeps a version history and shows the new value (F-EXP-02).
+# Opens the seeded "Beach shack dinner", renames it, saves, and confirms the
+# ledger reflects the edit.
+appId: app.waves.mobile
+---
+- runFlow: login.yaml
+
+- tapOn: 'Goa trip'
+- tapOn: 'Beach shack dinner'
+- assertVisible: 'Beach shack dinner'
+
+# Into the editor (the pencil), change the description, save.
+- tapOn: 'Edit'
+- assertVisible: 'What was it for?'
+- tapOn: 'Beach shack dinner'
+- eraseText: 40
+- inputText: 'Beach shack lunch'
+- hideKeyboard
+- tapOn: 'Save expense'
+
+# The edit is reflected.
+- assertVisible: 'Beach shack lunch'

--- a/e2e/rename-archive-group.yaml
+++ b/e2e/rename-archive-group.yaml
@@ -1,0 +1,28 @@
+# Renaming a group persists, and archiving removes it from Home (F-CFG-01 /
+# F-CFG-04). Uses the seeded "Goa trip".
+appId: app.waves.mobile
+---
+- runFlow: login.yaml
+
+- tapOn: 'Goa trip'
+- tapOn: 'Settings'
+- assertVisible: 'Save name'
+
+# Rename: the name field holds "Goa trip".
+- tapOn: 'Goa trip'
+- eraseText: 30
+- inputText: 'Goa 2026'
+- hideKeyboard
+- tapOn: 'Save name'
+
+# Archive it — the button sits below, past the roster.
+- scrollUntilVisible:
+    element: 'Archive group'
+    direction: DOWN
+- tapOn: 'Archive group'
+- assertVisible: 'Archive this group?'
+- tapOn: 'Archive'
+
+# Back on Home, the renamed group is gone from the list.
+- assertVisible: 'Your groups'
+- assertNotVisible: 'Goa 2026'

--- a/e2e/rename-archive-group.yaml
+++ b/e2e/rename-archive-group.yaml
@@ -15,7 +15,15 @@ appId: app.waves.mobile
 - hideKeyboard
 - tapOn: 'Save name'
 
-# Archive it — the button sits below, past the roster.
+# Prove the rename persisted before archiving: back on the group screen the new
+# name shows (it is re-read from the mirror, not the input we typed into). Without
+# this, a failed rename would leave "Goa 2026" nonexistent and the final
+# assertNotVisible would pass for the wrong reason.
+- tapOn: 'Back'
+- assertVisible: 'Goa 2026'
+
+# Archive it from settings — the button sits below, past the roster.
+- tapOn: 'Settings'
 - scrollUntilVisible:
     element: 'Archive group'
     direction: DOWN

--- a/e2e/run-maestro.sh
+++ b/e2e/run-maestro.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Drives the Maestro flows inside the CI emulator. This lives in a file, invoked
+# as a single line from the workflow, because android-emulator-runner parses its
+# inline `script:` line-by-line — a multi-line `for` loop or a persisted `export`
+# in the inline block would not survive that. One `bash e2e/run-maestro.sh` runs
+# as one command, so the loop and PATH behave normally.
+#
+# Each flow mutates the shared staging backend (archive, leave, rename, delete),
+# so the deterministic fixture is reseeded before every flow. The seed is
+# idempotent (reset + rebuild) and each flow's login.yaml does clearState, so no
+# state leaks across. Flows run one at a time so login.yaml is never standalone.
+#
+# Requires in the environment: E2E_SUPABASE_URL, E2E_SERVICE_KEY, E2E_EMAIL,
+# E2E_PASSWORD (the seeder + Maestro read these).
+set -uo pipefail
+
+curl -Ls "https://get.maestro.mobile.dev" | bash
+export PATH="$PATH:$HOME/.maestro/bin"
+
+adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
+
+FLOWS=(
+  home-to-add-expense
+  edit-expense
+  delete-restore-expense
+  rename-archive-group
+  sign-out-privacy
+  clone-group
+  group-photo-paid-gate
+  friends-merge-guests
+  leave-group
+)
+
+status=0
+for flow in "${FLOWS[@]}"; do
+  echo "::group::seed + ${flow}"
+  node e2e/seed-e2e.mjs
+  maestro test \
+    --env E2E_EMAIL="${E2E_EMAIL}" \
+    --env E2E_PASSWORD="${E2E_PASSWORD}" \
+    "e2e/${flow}.yaml" || status=1
+  echo "::endgroup::"
+done
+
+exit "${status}"

--- a/e2e/sign-out-privacy.yaml
+++ b/e2e/sign-out-privacy.yaml
@@ -1,0 +1,22 @@
+# Signing out returns to the signed-out gateway — the ledger is no longer on
+# screen (F-AUTH-05). The deeper privacy guard (the mirror is wiped) is a
+# reliability check in the audit; here we prove the session ends.
+appId: app.waves.mobile
+---
+- runFlow: login.yaml
+
+# Account → Sign out (the row sits at the foot of the settings list).
+- tapOn: 'Account'
+- scrollUntilVisible:
+    element: 'Sign out'
+    direction: DOWN
+- tapOn: 'Sign out'
+
+# Confirm the alert (exact-match so it isn't the row behind it).
+- assertVisible: 'Sign out?'
+- tapOn:
+    text: '^Sign out$'
+
+# Back at the signed-out gateway; the account and its groups are off screen.
+- assertVisible: 'Create account'
+- assertNotVisible: 'Goa trip'


### PR DESCRIPTION
## Phase 2 of the E2E coverage plan

Five new Maestro flows covering the **P0 functional gaps** the [audit](https://claude.ai/code/artifact/081996c1-2eb0-493c-97ec-1e08f052e2ef) flagged, each running against the seeded fixture via `login.yaml`:

| Flow | Covers |
|------|--------|
| `edit-expense.yaml` | F-EXP-02 — edit the seeded expense, assert the ledger reflects it |
| `delete-restore-expense.yaml` | F-EXP-03 — delete → gone from default view → Show deleted → Restore |
| `rename-archive-group.yaml` | F-CFG-01/04 — rename (persists) → archive → gone from Home |
| `sign-out-privacy.yaml` | F-AUTH-05 — sign out → back at the gateway, ledger off screen |

### Isolation fix (important)
The flows mutate **one shared staging backend** (archive, leave, rename, delete), so a single seed would corrupt later flows. The CI job now **reseeds the deterministic fixture before every flow** (the seed is idempotent) and runs them one at a time, so `login.yaml` is never executed standalone.

### Still gated
`E2E_ENABLED` keeps the whole job a clean skip until the staging project + secrets are provisioned (see `e2e/README-e2e.md`). Selectors are authored against the current i18n strings and will be confirmed on the first real device run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for editing, deleting and restoring expenses.
  * Added coverage for renaming and archiving groups.
  * Added sign-out and privacy verification scenarios.

* **Tests**
  * Expanded automated coverage for key expense, group, and account journeys.
  * Improved test reliability by resetting test data before each scenario.
  * Updated local and continuous integration test execution to run scenarios independently and report all failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->