### PR TITLE
fix(mobile): three release blockers from the E2E audit (D-01/02/03)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -21,7 +21,7 @@
     },
     "android": {
       "package": "app.waves.mobile",
-      "permissions": ["android.permission.READ_SMS"],
+      "permissions": [],
       "adaptiveIcon": {
         "backgroundColor": "#7A5AF8",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -7,7 +7,13 @@ import * as SplashScreen from 'expo-splash-screen';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { ActivityIndicator, Platform, useWindowDimensions, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Platform,
+  Text as RNText,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -30,6 +36,7 @@ import { TourOverlay } from '@/components/TourOverlay';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { UpdateBanner, UpdateGate } from '@/components/UpdateGate';
 import { AuthProvider, useAuth } from '@/lib/auth';
+import { supabaseConfigured } from '@/lib/supabase';
 import { DeviceSessionProvider } from '@/lib/deviceSession';
 import { useFlagEnabled } from '@/lib/flags';
 import { isRtl, isRtlLanguage, useStrings } from '@/i18n';
@@ -139,7 +146,43 @@ function DirectionRoot({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * The screen a misconfigured build shows instead of crashing.
+ *
+ * Deliberately self-contained — plain `react-native`, no theme, no i18n, no
+ * providers — because the reason it renders is that the app's foundations are
+ * not set up (see `supabaseConfigured`). Its copy is in English because there is
+ * no working string table to translate it, and the only audience is whoever
+ * installed a build whose keys were never baked in.
+ */
+function MisconfiguredBuild() {
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: '#0e1211',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 32,
+      }}
+    >
+      <RNText style={{ color: '#e7ece9', fontSize: 20, fontWeight: '700', marginBottom: 10 }}>
+        This build isn’t configured
+      </RNText>
+      <RNText style={{ color: '#9aa4a0', fontSize: 15, lineHeight: 22, textAlign: 'center' }}>
+        Waves is missing the keys it needs to reach its servers. Please reinstall the app from the
+        store, or contact support if this keeps happening.
+      </RNText>
+    </View>
+  );
+}
+
 function RootLayout() {
+  // A build shipped without its Supabase keys can do nothing useful, and must
+  // not mount the auth/sync tree below — that tree would poke an unreachable
+  // client. Show a plain notice instead of the crash the module-load throw used
+  // to cause (see supabase.ts).
+  if (!supabaseConfigured) return <MisconfiguredBuild />;
   return (
     // Outermost, above even the gesture root: every string in the app below it
     // reads from here, and the root view's own direction is one of them.

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -8,11 +8,23 @@ import { secureAuthStorage } from './secureStorage';
 const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const anonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
-if (!url || !anonKey) {
-  // Fail loudly at start-up rather than with a confusing network error later.
-  throw new Error(
-    'EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY must be set. ' +
-      'Copy .env.example to .env at the repo root and run `pnpm supabase:start`.',
+/**
+ * Whether this build actually shipped its Supabase keys.
+ *
+ * A build with the wrong or empty `EXPO_PUBLIC_*` env — a misconfigured EAS
+ * profile — used to `throw` right here, at module load. This module is imported
+ * by the root layout, *above* every error boundary, so that threw before React
+ * mounted and the app died on the first frame with no recoverable screen for
+ * 100% of users. Now the miss is a flag the root reads (see `_layout`) to paint
+ * a plain "this build is misconfigured" screen instead of crashing. The client
+ * is still constructed below — with an unreachable placeholder so `createClient`
+ * cannot throw on import — and the root never lets it be *used* when this is
+ * false, so no request is ever made to the placeholder.
+ */
+export const supabaseConfigured = Boolean(url && anonKey);
+if (!supabaseConfigured) {
+  console.error(
+    'Waves is misconfigured: EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY are not set in this build.',
   );
 }
 
@@ -25,20 +37,25 @@ if (!url || !anonKey) {
 // window; the client must construct there without touching either.
 const isServer = typeof window === 'undefined';
 
-export const supabase = createClient(url, anonKey, {
-  auth: {
-    // Native keeps the session (incl. the long-lived refresh token) in the OS
-    // keystore, not plaintext AsyncStorage; web falls back inside the adapter.
-    storage: isServer ? undefined : secureAuthStorage,
-    autoRefreshToken: !isServer,
-    persistSession: !isServer,
-    // No URL-based session handoff on native; deep links are handled explicitly.
-    detectSessionInUrl: !isServer && Platform.OS === 'web',
+export const supabase = createClient(
+  url ?? 'https://unconfigured.invalid',
+  anonKey ?? 'unconfigured',
+  {
+    auth: {
+      // Native keeps the session (incl. the long-lived refresh token) in the OS
+      // keystore, not plaintext AsyncStorage; web falls back inside the adapter.
+      storage: isServer ? undefined : secureAuthStorage,
+      autoRefreshToken: !isServer,
+      persistSession: !isServer,
+      // No URL-based session handoff on native; deep links are handled explicitly.
+      detectSessionInUrl: !isServer && Platform.OS === 'web',
+    },
   },
-});
+);
 
-// Refresh tokens only while the app is in front of the user.
-if (!isServer) {
+// Refresh tokens only while the app is in front of the user. Skipped entirely
+// on a misconfigured build so the placeholder client is never poked.
+if (!isServer && supabaseConfigured) {
   AppState.addEventListener('change', (state) => {
     if (state === 'active') void supabase.auth.startAutoRefresh();
     else void supabase.auth.stopAutoRefresh();

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -38,8 +38,12 @@ if (!supabaseConfigured) {
 const isServer = typeof window === 'undefined';
 
 export const supabase = createClient(
-  url ?? 'https://unconfigured.invalid',
-  anonKey ?? 'unconfigured',
+  // A well-formed, never-contacted placeholder when the build is unconfigured:
+  // it only exists so `createClient` constructs without throwing on import (the
+  // root gates on `supabaseConfigured`, so no request is ever made to it). Shaped
+  // like a real project URL so even a stricter future URL validation accepts it.
+  url ?? 'https://placeholder.supabase.co',
+  anonKey ?? 'placeholder-anon-key',
   {
     auth: {
       // Native keeps the session (incl. the long-lived refresh token) in the OS

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -255,12 +255,18 @@ class SqliteStore implements LocalStore {
   reset(): Promise<void> {
     return this.serial.run(async () => {
       const database = await this.db();
-      await database.execAsync(`
-        DELETE FROM mirror_rows WHERE 1 = 1;
-        DELETE FROM pending_mutations WHERE 1 = 1;
-        DELETE FROM sync_cursors WHERE 1 = 1;
-        DELETE FROM drafts WHERE 1 = 1;
-      `);
+      // The sign-out wipe is one fact — "this account's local data is gone" —
+      // and it is a privacy promise, so it runs in a transaction like
+      // `forgetGroup`. As a multi-statement `execAsync` (its previous form) a
+      // process kill between the four DELETEs left a partial wipe, and the next
+      // account on a shared phone could inherit the previous user's rows or
+      // drafts. All four now commit together or not at all.
+      await database.withTransactionAsync(async () => {
+        await database.runAsync(`DELETE FROM mirror_rows WHERE 1 = 1`);
+        await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
+        await database.runAsync(`DELETE FROM sync_cursors WHERE 1 = 1`);
+        await database.runAsync(`DELETE FROM drafts WHERE 1 = 1`);
+      });
     });
   }
 }


### PR DESCRIPTION
Fixes the three release-blocking defects the [E2E audit](https://claude.ai/code/artifact/081996c1-2eb0-493c-97ec-1e08f052e2ef) surfaced (Phase 0). All three were hiding behind green checks.

### D-01 — cold-start crash on a misconfigured build
`lib/supabase.ts` `throw`s at **module load** when `EXPO_PUBLIC_SUPABASE_URL/ANON_KEY` are missing. That module is imported by the root layout **above** every error boundary, so a mis-set EAS profile killed the app on the first frame for 100% of users with no recoverable UI.
- No longer throws. `supabaseConfigured` is a flag the root reads to render a plain **"This build isn't configured"** notice.
- The client is constructed with an unreachable placeholder so `createClient` can't throw on import; the auth/sync tree and the token-refresh listener never mount or poke it when unconfigured.

### D-02 — `READ_SMS` permission with no feature behind it
Removed `android.permission.READ_SMS` from the manifest — no code reads SMS (OTP is manual entry; the SMS-import parser works on pasted text). A restricted permission with nothing behind it is a Play Store review-hold / rejection risk.

### D-03 — sign-out wipe was not transactional (privacy)
The mirror wipe ran four `DELETE`s as a multi-statement `execAsync`. A process kill mid-wipe left a **partial wipe**, so the next account on a shared phone could inherit the previous user's rows/drafts. Now wrapped in `withTransactionAsync` exactly like `forgetGroup` — all four commit together or not at all.

### Gates
✅ `tsc` (mobile) · ✅ eslint `--max-warnings 0` · ✅ prettier. The `app.json` change needs a native rebuild to take effect (manifest), which is the local-build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear fallback screen for builds missing required backend configuration.
  * The app now starts safely when backend credentials are unavailable.

* **Bug Fixes**
  * Removed Android SMS read permission.
  * Improved data reset reliability by processing local sync data atomically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->