### PR TITLE
test(e2e): Phase 2 tail — change-logo, capture→assign & locale flows

### DIFF
--- a/e2e/README-e2e.md
+++ b/e2e/README-e2e.md
@@ -60,6 +60,7 @@ node e2e/seed-e2e.mjs
 # 2. Build + install the app against the same project (see apps/mobile). Then run
 #    each flow on its own, reseeding first, because the flows mutate the backend:
 for flow in home-to-add-expense edit-expense delete-restore-expense \
+            change-logo capture-assign locale-switch \
             rename-archive-group sign-out-privacy clone-group \
             group-photo-paid-gate friends-merge-guests leave-group; do
   node e2e/seed-e2e.mjs
@@ -79,6 +80,9 @@ In CI this loop lives in `e2e/run-maestro.sh`.
 | `edit-expense.yaml`           | edit the seeded expense → the ledger reflects the new value                         |
 | `delete-restore-expense.yaml` | delete → gone from the default view → Show deleted → Restore → back                 |
 | `rename-archive-group.yaml`   | rename a group (persists) → archive → gone from Home                                |
+| `change-logo.yaml`            | open Group settings → cover-emoji picker → pick a new icon → applies, sheet closes  |
+| `capture-assign.yaml`         | capture with no group → find it in the inbox → assign → add-expense prefilled       |
+| `locale-switch.yaml`          | Account → Language → switch to Hindi → strings re-render live (no restart)          |
 | `sign-out-privacy.yaml`       | sign out → back at the gateway, the ledger off screen                               |
 | `clone-group.yaml`            | Duplicate → prefilled New Group → drop a member → Create → copy made, original kept |
 | `group-photo-paid-gate.yaml`  | group photo is paid, cover emoji is free                                            |

--- a/e2e/capture-assign.yaml
+++ b/e2e/capture-assign.yaml
@@ -38,5 +38,8 @@ appId: app.waves.mobile
 - tapOn: 'Assign to group'
 - tapOn: 'Goa trip'
 
-# Assigning opens add-expense prefilled with the captured note.
+# Assigning opens add-expense — its description prompt ("What was it for?")
+# differs from the capture form's, so it proves we navigated off the inbox
+# before we check the captured note carried over as the prefill.
+- assertVisible: 'What was it for?'
 - assertVisible: 'Auto to airport'

--- a/e2e/capture-assign.yaml
+++ b/e2e/capture-assign.yaml
@@ -1,0 +1,42 @@
+# Capture an expense with no group, then assign it to one later (F-CAP-01, A34).
+# Adds a capture from the dashboard with the group left as "Decide later", finds
+# it waiting in the captures inbox, and assigns it to the seeded group — which
+# opens add-expense prefilled with the captured note.
+appId: app.waves.mobile
+---
+- runFlow: login.yaml
+- assertVisible: 'Your groups'
+
+# Dashboard add row → the short capture form.
+- tapOn: 'Add expense'
+- assertVisible: 'Capture an expense'
+
+# Amount via the shared calculator keypad: 250.00.
+- tapOn: '2'
+- tapOn: '5'
+- tapOn: '0'
+- tapOn: '0'
+
+# A note to recognise it by.
+- tapOn: 'What was it?'
+- inputText: 'Auto to airport'
+- hideKeyboard
+
+# Group left unset — the capture stays in the inbox rather than landing anywhere.
+- assertVisible: 'Decide later'
+- tapOn: 'Save capture'
+
+# Back on the dashboard the captures action now carries a count (local-first, no
+# server round-trip). Wait for it, then open the inbox.
+- extendedWaitUntilVisible:
+    text: 'Captures. 1'
+    timeout: 20000
+- tapOn: 'Captures. 1'
+
+# The waiting capture is listed; assign it to the seeded group.
+- assertVisible: 'Auto to airport'
+- tapOn: 'Assign to group'
+- tapOn: 'Goa trip'
+
+# Assigning opens add-expense prefilled with the captured note.
+- assertVisible: 'Auto to airport'

--- a/e2e/change-logo.yaml
+++ b/e2e/change-logo.yaml
@@ -20,7 +20,8 @@ appId: app.waves.mobile
 - assertVisible: 'Close'
 - tapOn: '🏕️'
 
-# Back on the settings form: the sheet is gone (change accepted), the trigger
-# remains for the next change.
+# Back on the settings form: the sheet is gone and the settings header now
+# renders the chosen icon — proof the update applied, not just that the picker
+# dismissed (which would also happen if the write failed).
 - assertNotVisible: 'Close'
-- assertVisible: 'Choose an icon'
+- assertVisible: '🏕️'

--- a/e2e/change-logo.yaml
+++ b/e2e/change-logo.yaml
@@ -1,0 +1,26 @@
+# Changing a group's icon (its "logo") applies live from Group settings
+# (F-CFG-02). Opens the seeded group, opens its cover-emoji picker, picks a new
+# icon, and confirms the sheet dismisses with the change accepted. The photo path
+# is a separate paid-gated flow (group-photo-paid-gate.yaml); this covers the
+# free icon path every account has.
+appId: app.waves.mobile
+---
+- runFlow: login.yaml
+
+# Home → the seeded group → its settings (the photo-and-name cluster opens it).
+- tapOn: 'Goa trip'
+- tapOn: 'Group settings'
+
+# The cover-emoji picker trigger is always present on the settings form.
+- assertVisible: 'Choose an icon'
+- tapOn: 'Choose an icon'
+
+# The bottom sheet is up (its close control is the labelled way out); pick a new
+# icon. Selecting fires the update and dismisses the sheet in one tap.
+- assertVisible: 'Close'
+- tapOn: '🏕️'
+
+# Back on the settings form: the sheet is gone (change accepted), the trigger
+# remains for the next change.
+- assertNotVisible: 'Close'
+- assertVisible: 'Choose an icon'

--- a/e2e/locale-switch.yaml
+++ b/e2e/locale-switch.yaml
@@ -1,0 +1,22 @@
+# Switching the app language applies live for a left-to-right locale (N-16).
+# Goes to Account → Language, switches to Hindi by its own name, and confirms the
+# screen re-renders in Hindi without a restart. (Arabic mirrors the layout and so
+# needs a native restart — out of scope for a single-session flow.)
+appId: app.waves.mobile
+---
+- runFlow: login.yaml
+- assertVisible: 'Your groups'
+
+# Account → Language (the row sits in the settings section, may be below fold).
+- tapOn: 'Account'
+- scrollUntilVisible:
+    element: 'Language'
+    direction: DOWN
+- tapOn: 'Language'
+- assertVisible: 'Language'
+
+# Pick Hindi by its endonym; the change applies to the live tree at once.
+- tapOn: 'हिन्दी'
+
+# The header is now Hindi — proof the strings switched without a relaunch.
+- assertVisible: 'भाषा'

--- a/e2e/run-maestro.sh
+++ b/e2e/run-maestro.sh
@@ -24,6 +24,9 @@ FLOWS=(
   edit-expense
   delete-restore-expense
   rename-archive-group
+  change-logo
+  capture-assign
+  locale-switch
   sign-out-privacy
   clone-group
   group-photo-paid-gate


### PR DESCRIPTION
Continues the E2E audit's Phase 2 with three more P0-gap flows. Each signs into the seeded fixture (`e2e/seed-e2e.mjs`) via `login.yaml` and asserts against known data.

## Flows

| Flow | Guards |
|------|--------|
| `change-logo.yaml` (F-CFG-02) | open Group settings → cover-emoji picker → pick a new icon → change applies, sheet closes |
| `capture-assign.yaml` (F-CAP-01, A34) | capture with no group → find it waiting in the inbox → assign → add-expense opens prefilled |
| `locale-switch.yaml` (N-16) | Account → Language → switch to Hindi → strings re-render live, no restart |

All three are wired into `run-maestro.sh` (reseeded before each, like the rest) and the README flow table.

## Not included
`voice→expense` (F-CAP-02) needs a real microphone; the CI emulator can't supply one, so it stays a manual check. Arabic is excluded from the locale flow because it mirrors the layout and needs a native restart — out of scope for a single-session flow.

## CI
The `e2e (Maestro)` job stays gated on `vars.E2E_ENABLED == 'true'` (still unprovisioned), so these are additive and don't change the green/red of the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for changing a group icon.
  * Added coverage for assigning captured expenses to a group and prefilling expense details.
  * Added coverage for switching the app language to Hindi without restarting.
  * Included the new scenarios in the local end-to-end test run and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->