### PR TITLE
fix(mobile): refresh signed image URLs before they expire (D-04)

### DIFF
--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -9,7 +9,7 @@
  * than hiding until the server has seen it (ADR-005).
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
@@ -33,6 +33,7 @@ import {
 import { CategoryBadge } from '@/components/Category';
 import { InboxSkeleton } from '@/components/Skeletons';
 import { capturePhotoUrl } from '@/data/api';
+import { useSignedUrl } from '@/lib/useSignedUrl';
 import { dayHeading, groupByDay } from '@/data/activity';
 import { useCaptures, useDeleteCapture, useGroups, useHomeSummary } from '@/data/hooks';
 import { groupLabel, type CaptureRow, type GroupRow } from '@/data/types';
@@ -53,24 +54,11 @@ function shortDate(iso: string, locale: string): string {
   });
 }
 
-/** A short-lived signed URL for a capture's receipt, re-resolved when it changes. */
+/** A signed URL for a capture's receipt, re-resolved on change and kept fresh
+ *  past the signed-URL expiry (see `useSignedUrl`). */
 function CaptureThumb({ path, size }: { path: string; size: number }) {
   const theme = useTheme();
-  const [url, setUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    let active = true;
-    void capturePhotoUrl(path)
-      .then((resolved) => {
-        if (active) setUrl(resolved);
-      })
-      .catch(() => {
-        if (active) setUrl(null);
-      });
-    return () => {
-      active = false;
-    };
-  }, [path]);
+  const url = useSignedUrl(path, capturePhotoUrl);
 
   return (
     <View

--- a/apps/mobile/src/components/GroupPhoto.tsx
+++ b/apps/mobile/src/components/GroupPhoto.tsx
@@ -11,7 +11,6 @@
  * the app goes through.
  */
 
-import { useEffect, useState } from 'react';
 import { Image } from 'expo-image';
 import { ActivityIndicator, Pressable, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -21,6 +20,7 @@ import { Text, useTheme } from '@waves/ui';
 import { useStrings } from '@/i18n';
 
 import { groupPhotoUrl } from '@/data/api';
+import { useSignedUrl } from '@/lib/useSignedUrl';
 
 interface GroupPhotoProps {
   photoPath?: string | null;
@@ -102,33 +102,10 @@ export function GroupPhoto({
   );
 }
 
-/** Resolves a storage path to a signed URL, and re-resolves when it changes. */
+/**
+ * Resolves a storage path to a signed URL, re-resolving when it changes and
+ * re-minting before the URL can expire (see `useSignedUrl`).
+ */
 export function useGroupPhotoUrl(photoPath: string | null | undefined): string | null {
-  const path = photoPath ?? null;
-  const [resolved, setResolved] = useState<{ path: string | null; url: string | null }>({
-    path: null,
-    url: null,
-  });
-
-  // Adjusted during render rather than in an effect: clearing a stale URL is
-  // derived from the new path, and doing it in an effect would show the old
-  // group's photo for a frame first.
-  if (resolved.path !== path) setResolved({ path, url: null });
-
-  useEffect(() => {
-    if (!path) return;
-    let active = true;
-    void groupPhotoUrl(path)
-      .then((url) => {
-        if (active) setResolved({ path, url });
-      })
-      .catch(() => {
-        if (active) setResolved({ path, url: null });
-      });
-    return () => {
-      active = false;
-    };
-  }, [path]);
-
-  return resolved.path === path ? resolved.url : null;
+  return useSignedUrl(photoPath, groupPhotoUrl);
 }

--- a/apps/mobile/src/components/ProfileAvatar.tsx
+++ b/apps/mobile/src/components/ProfileAvatar.tsx
@@ -7,7 +7,6 @@
  * resolves both, and this component only ever deals in the resolved value.
  */
 
-import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { ActivityIndicator, Pressable, View } from 'react-native';
 
@@ -16,36 +15,16 @@ import { Avatar, useTheme } from '@waves/ui';
 import { useStrings } from '@/i18n';
 
 import { avatarPhotoUrl } from '@/data/api';
+import { useSignedUrl } from '@/lib/useSignedUrl';
 
-/** Resolves whatever is in `avatar_url` to a displayable URL, and re-resolves on change. */
+/**
+ * Resolves whatever is in `avatar_url` to a displayable URL, re-resolving on
+ * change and re-minting before a signed URL can expire (see `useSignedUrl`).
+ * `avatarPhotoUrl` passes an https OAuth avatar straight through, so those never
+ * expire and the extra re-mints are cheap no-ops.
+ */
 export function useAvatarUrl(value: string | null | undefined): string | null {
-  const stored = value ?? null;
-  const [resolved, setResolved] = useState<{ stored: string | null; url: string | null }>({
-    stored: null,
-    url: null,
-  });
-
-  // Adjusted during render rather than in an effect: clearing a stale URL is
-  // derived from the new value, and doing it in an effect would show the
-  // previous person's face for a frame first.
-  if (resolved.stored !== stored) setResolved({ stored, url: null });
-
-  useEffect(() => {
-    if (!stored) return;
-    let active = true;
-    void avatarPhotoUrl(stored)
-      .then((url) => {
-        if (active) setResolved({ stored, url });
-      })
-      .catch(() => {
-        if (active) setResolved({ stored, url: null });
-      });
-    return () => {
-      active = false;
-    };
-  }, [stored]);
-
-  return resolved.stored === stored ? resolved.url : null;
+  return useSignedUrl(value, avatarPhotoUrl);
 }
 
 export function ProfileAvatar({

--- a/apps/mobile/src/lib/useSignedUrl.ts
+++ b/apps/mobile/src/lib/useSignedUrl.ts
@@ -40,11 +40,18 @@ export function useSignedUrl(
     if (!path) return;
     let active = true;
     let lastMintAt = 0;
+    // mint() fires from three places — the initial call, the timer and the
+    // foreground listener — so several can be in flight at once. A slower older
+    // request must not resolve after a newer one and overwrite the fresh URL
+    // (or push `lastMintAt` forward), so each mint takes a ticket and only the
+    // latest one is allowed to apply its result.
+    let latest = 0;
 
     const mint = (): void => {
+      const ticket = (latest += 1);
       void resolve(path)
         .then((url) => {
-          if (!active) return;
+          if (!active || ticket !== latest) return;
           // Advance the clock only on a real URL, so a failed mint (a null from
           // the resolver, or a rejection) leaves `lastMintAt` where it was —
           // then the next foreground retries at once instead of the broken image
@@ -53,7 +60,7 @@ export function useSignedUrl(
           setResolved({ key: path, url });
         })
         .catch(() => {
-          if (active) setResolved({ key: path, url: null });
+          if (active && ticket === latest) setResolved({ key: path, url: null });
         });
     };
 

--- a/apps/mobile/src/lib/useSignedUrl.ts
+++ b/apps/mobile/src/lib/useSignedUrl.ts
@@ -42,10 +42,15 @@ export function useSignedUrl(
     let lastMintAt = 0;
 
     const mint = (): void => {
-      lastMintAt = Date.now();
       void resolve(path)
         .then((url) => {
-          if (active) setResolved({ key: path, url });
+          if (!active) return;
+          // Advance the clock only on a real URL, so a failed mint (a null from
+          // the resolver, or a rejection) leaves `lastMintAt` where it was —
+          // then the next foreground retries at once instead of the broken image
+          // sitting for the full refresh window before another attempt.
+          if (url) lastMintAt = Date.now();
+          setResolved({ key: path, url });
         })
         .catch(() => {
           if (active) setResolved({ key: path, url: null });

--- a/apps/mobile/src/lib/useSignedUrl.ts
+++ b/apps/mobile/src/lib/useSignedUrl.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { AppState } from 'react-native';
+
+/**
+ * Resolve a private-Storage path to a signed URL, and keep it fresh.
+ *
+ * Every signed URL the app mints for a private bucket (group photos, avatars,
+ * capture receipts) expires after 60 minutes (see `data/api.ts`). Minted once
+ * into state, it would go stale in place: a screen left open past the hour, or
+ * an app resumed after longer, would show a broken image with nothing to
+ * re-mint it. This re-resolves on two triggers that cover both cases — a timer
+ * set safely inside the lifetime, and a return to the foreground when the last
+ * mint is old enough to be worth spending a request on — so a URL that is
+ * actually on screen never rots to a 401.
+ *
+ * The stale URL is cleared during render on a key change (not in an effect), so
+ * the previous path's image never flashes for a frame under a new key.
+ */
+const LIFETIME_MS = 60 * 60 * 1000;
+// Comfortably inside the hour, so the replacement is minted and loaded before
+// the one on screen can expire.
+const REFRESH_MS = 50 * 60 * 1000;
+
+export function useSignedUrl(
+  key: string | null | undefined,
+  resolve: (key: string) => Promise<string | null>,
+): string | null {
+  const path = key ?? null;
+  const [resolved, setResolved] = useState<{ key: string | null; url: string | null }>({
+    key: null,
+    url: null,
+  });
+
+  if (resolved.key !== path) setResolved({ key: path, url: null });
+
+  // The three callers pass a module-level resolver (`groupPhotoUrl`,
+  // `avatarPhotoUrl`, `capturePhotoUrl`) — stable identities — so `resolve` is
+  // an honest dependency here and does not churn the effect.
+  useEffect(() => {
+    if (!path) return;
+    let active = true;
+    let lastMintAt = 0;
+
+    const mint = (): void => {
+      lastMintAt = Date.now();
+      void resolve(path)
+        .then((url) => {
+          if (active) setResolved({ key: path, url });
+        })
+        .catch(() => {
+          if (active) setResolved({ key: path, url: null });
+        });
+    };
+
+    mint();
+    const timer = setInterval(mint, REFRESH_MS);
+    const subscription = AppState.addEventListener('change', (state) => {
+      // Only spend a request on resume if the URL on screen is old enough to be
+      // near or past expiry — a quick app switch should not re-mint everything.
+      if (state === 'active' && Date.now() - lastMintAt >= REFRESH_MS) mint();
+    });
+
+    return () => {
+      active = false;
+      clearInterval(timer);
+      subscription.remove();
+    };
+  }, [path, resolve]);
+
+  return resolved.key === path ? resolved.url : null;
+}
+
+export const SIGNED_URL_LIFETIME_MS = LIFETIME_MS;


### PR DESCRIPTION
Audit defect **D-04** (P1). Group photos, avatars and capture receipts are served from private Storage buckets via a signed URL minted for **60 minutes**. Each was resolved once into component state and never re-minted — a screen left open past the hour, or an app resumed after longer, showed a broken image with no recovery.

## Fix
A shared `useSignedUrl(key, resolve)` hook (`apps/mobile/src/lib/useSignedUrl.ts`) replaces the three hand-rolled resolvers:
- `useGroupPhotoUrl` (GroupPhoto)
- `useAvatarUrl` (ProfileAvatar)
- the `CaptureThumb` inline effect (captures)

It preserves the prior behaviour (mint on key change; clear the stale URL during render so no previous image flashes) and adds two refresh triggers **inside** the URL's lifetime:
- a **50-minute timer**, and
- a **re-mint on foreground** when the on-screen URL is old enough to be worth a request (a quick app-switch does not re-mint everything).

An https OAuth avatar is passed straight through by `avatarPhotoUrl`, so those re-mints are cheap no-ops.

## Testing
No new render-harness test: the mobile suite tests pure logic, not React rendering, and these hooks were previously untested for the same reason. Verified by `tsc` + `eslint --max-warnings 0` and the full unit suite (**309 pass**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of receipt thumbnails, group photos, and profile avatars.
  * Private images now refresh automatically to remain available over time, including after returning to the app.
  * Stale image links are cleared when content changes, preventing outdated images from appearing.
  * Improved handling of image-loading failures so unavailable images do not disrupt the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->