### PR TITLE
perf(mobile): chunk the cold-start mirror parse so it yields the thread (D-07)

### DIFF
--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -13,6 +13,7 @@ import * as SQLite from 'expo-sqlite';
 
 import type { MirrorRow, QueuedMutation, SyncTable } from '@waves/core';
 
+import { mapYielding } from './hydrateChunk';
 import { Serial } from './serial';
 import type { LocalStore, StoredRow } from './store';
 
@@ -123,7 +124,11 @@ class SqliteStore implements LocalStore {
         seq: number;
         json: string;
       }>(`SELECT table_name, id, group_id, seq, json FROM mirror_rows`);
-      return rows.map((row) => ({
+      // Parse in chunks that yield to the event loop between them. This read is
+      // the cold-start hydration path (see `hydrateChunk`): a heavy account's
+      // whole mirror is `JSON.parse`d here before `hydrated` flips, and doing it
+      // in one synchronous burst froze the loading skeleton and the first frame.
+      return mapYielding(rows, (row) => ({
         table: row.table_name as SyncTable,
         id: row.id,
         groupId: row.group_id,

--- a/apps/mobile/src/sync/hydrateChunk.ts
+++ b/apps/mobile/src/sync/hydrateChunk.ts
@@ -1,0 +1,40 @@
+/**
+ * Chunked, yielding map — used to parse the mirror at cold start without freezing
+ * the JS thread.
+ *
+ * Hydration reads every mirror row off disk and `JSON.parse`s it into memory
+ * before `hydrated` flips and the first real frame can render. On a heavy
+ * account that is O(all rows) of synchronous CPU in one burst: the loading
+ * skeleton stops animating and the first interaction is held hostage until it
+ * finishes — the single biggest device-perf risk in the app. Mapping the rows
+ * through this instead breaks the work into chunks and yields to the event loop
+ * between them, so React Native can paint and the skeleton keeps moving; the
+ * total parse cost is the same, but it no longer monopolises the thread.
+ */
+
+/** Rows per chunk before yielding. Big enough that the yields are few, small
+ *  enough that no single chunk blocks a frame. */
+export const HYDRATE_CHUNK = 512;
+
+/** A macrotask yield: `setTimeout(0)` lets RN commit a frame between chunks,
+ *  which a microtask (`Promise.resolve()`) would not. */
+export const yieldToEventLoop = (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+export async function mapYielding<T, U>(
+  items: readonly T[],
+  map: (item: T, index: number) => U,
+  chunk: number = HYDRATE_CHUNK,
+  onYield: () => Promise<void> = yieldToEventLoop,
+): Promise<U[]> {
+  const out: U[] = new Array<U>(items.length);
+  for (let index = 0; index < items.length; index += 1) {
+    out[index] = map(items[index] as T, index);
+    // Yield after a full chunk, but never after the last item — the caller is
+    // about to get the array, so a trailing yield is pure latency.
+    if (index + 1 < items.length && (index + 1) % chunk === 0) await onYield();
+  }
+  return out;
+}

--- a/apps/mobile/src/sync/hydrateChunk.ts
+++ b/apps/mobile/src/sync/hydrateChunk.ts
@@ -29,12 +29,16 @@ export async function mapYielding<T, U>(
   chunk: number = HYDRATE_CHUNK,
   onYield: () => Promise<void> = yieldToEventLoop,
 ): Promise<U[]> {
+  // Guard the step: a zero, negative, fractional or non-finite `chunk` would
+  // make the modulo below never (or nonsensically) fire — fall back to the
+  // default rather than silently parsing the whole mirror in one burst again.
+  const step = Number.isInteger(chunk) && chunk > 0 ? chunk : HYDRATE_CHUNK;
   const out: U[] = new Array<U>(items.length);
   for (let index = 0; index < items.length; index += 1) {
     out[index] = map(items[index] as T, index);
     // Yield after a full chunk, but never after the last item — the caller is
     // about to get the array, so a trailing yield is pure latency.
-    if (index + 1 < items.length && (index + 1) % chunk === 0) await onYield();
+    if (index + 1 < items.length && (index + 1) % step === 0) await onYield();
   }
   return out;
 }

--- a/apps/mobile/test/hydrateChunk.test.ts
+++ b/apps/mobile/test/hydrateChunk.test.ts
@@ -35,6 +35,19 @@ describe('mapYielding', () => {
     expect(onYield).not.toHaveBeenCalled();
   });
 
+  it('falls back to the default step for a non-positive-integer chunk', async () => {
+    const onYield = vi.fn(async () => {});
+    // chunk 0 would make the modulo NaN and never yield; the guard falls back to
+    // the 512 default, so a short list still maps correctly and simply doesn't
+    // reach a chunk boundary.
+    for (const bad of [0, -4, 2.5, Number.NaN]) {
+      onYield.mockClear();
+      const out = await mapYielding([1, 2, 3], (n) => n, bad, onYield);
+      expect(out).toEqual([1, 2, 3]);
+      expect(onYield).not.toHaveBeenCalled();
+    }
+  });
+
   it('handles an empty list without mapping or yielding', async () => {
     const map = vi.fn((n: number) => n);
     const onYield = vi.fn(async () => {});

--- a/apps/mobile/test/hydrateChunk.test.ts
+++ b/apps/mobile/test/hydrateChunk.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { mapYielding } from '../src/sync/hydrateChunk';
+import { HYDRATE_CHUNK, mapYielding } from '../src/sync/hydrateChunk';
 
 describe('mapYielding', () => {
   it('maps every item in order, like a plain map', async () => {
@@ -37,14 +37,16 @@ describe('mapYielding', () => {
 
   it('falls back to the default step for a non-positive-integer chunk', async () => {
     const onYield = vi.fn(async () => {});
-    // chunk 0 would make the modulo NaN and never yield; the guard falls back to
-    // the 512 default, so a short list still maps correctly and simply doesn't
-    // reach a chunk boundary.
+    // A bad chunk (0 makes the modulo NaN and never yields) must fall back to the
+    // HYDRATE_CHUNK default — not to "never yield". Prove it lands on the default
+    // boundary: HYDRATE_CHUNK + 1 items yield exactly once (after the first full
+    // default chunk, not after the final item).
+    const items = Array.from({ length: HYDRATE_CHUNK + 1 }, (_, i) => i);
     for (const bad of [0, -4, 2.5, Number.NaN]) {
       onYield.mockClear();
-      const out = await mapYielding([1, 2, 3], (n) => n, bad, onYield);
-      expect(out).toEqual([1, 2, 3]);
-      expect(onYield).not.toHaveBeenCalled();
+      const out = await mapYielding(items, (n) => n, bad, onYield);
+      expect(out).toEqual(items);
+      expect(onYield).toHaveBeenCalledTimes(1);
     }
   });
 

--- a/apps/mobile/test/hydrateChunk.test.ts
+++ b/apps/mobile/test/hydrateChunk.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { mapYielding } from '../src/sync/hydrateChunk';
+
+describe('mapYielding', () => {
+  it('maps every item in order, like a plain map', async () => {
+    const out = await mapYielding(
+      [1, 2, 3, 4, 5],
+      (n, i) => `${i}:${n * 2}`,
+      2,
+      async () => {},
+    );
+    expect(out).toEqual(['0:2', '1:4', '2:6', '3:8', '4:10']);
+  });
+
+  it('yields once per completed chunk, but never after the last item', async () => {
+    const onYield = vi.fn(async () => {});
+    // 5 items, chunk 2 → yields after index 1 and index 3 (multiples of 2 that
+    // are not the final item). Index 4 is last, so no trailing yield.
+    await mapYielding([1, 2, 3, 4, 5], (n) => n, 2, onYield);
+    expect(onYield).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not yield when a whole chunk boundary is the final item', async () => {
+    const onYield = vi.fn(async () => {});
+    // 4 items, chunk 2 → boundary at index 1 (yield) and index 3 (last, no yield).
+    await mapYielding([1, 2, 3, 4], (n) => n, 2, onYield);
+    expect(onYield).toHaveBeenCalledTimes(1);
+  });
+
+  it('never yields when the chunk is at least the length', async () => {
+    const onYield = vi.fn(async () => {});
+    const out = await mapYielding([1, 2, 3], (n) => n, 512, onYield);
+    expect(out).toEqual([1, 2, 3]);
+    expect(onYield).not.toHaveBeenCalled();
+  });
+
+  it('handles an empty list without mapping or yielding', async () => {
+    const map = vi.fn((n: number) => n);
+    const onYield = vi.fn(async () => {});
+    const out = await mapYielding([], map, 2, onYield);
+    expect(out).toEqual([]);
+    expect(map).not.toHaveBeenCalled();
+    expect(onYield).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Audit defect **D-07** (P1). At cold start the sync engine reads every mirror row off disk and `JSON.parse`s it into memory **before `hydrated` flips** and the first real frame renders. On a heavy account that is O(all rows) of synchronous CPU in one burst on the JS thread — the loading skeleton stops animating and the first interaction is held until it finishes. The audit calls this the single biggest device-perf risk.

## Fix
The native store's `readRows` now maps rows through a small chunked helper (`mapYielding`, in `apps/mobile/src/sync/hydrateChunk.ts`): it parses in chunks of **512** and **yields to the event loop** (`setTimeout(0)` — a real macrotask, so RN can commit a frame — not a microtask) between them. Same total parse cost, but it no longer monopolises the thread: the skeleton keeps moving and the first frame is not held hostage to the whole mirror.

## Testing
`mapYielding` is pure and unit-tested (`test/hydrateChunk.test.ts`): order preserved and map applied; yields once per completed chunk and **never** after the last item; no yield when the chunk covers the list; empty-list no-op. `tsc` clean, `eslint --max-warnings 0` clean, full suite **314 pass**.

## Scope
The web driver is left as-is — it is not the device-perf path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved mobile data synchronization by processing large datasets in smaller chunks.
  * The app remains more responsive during data hydration by periodically yielding to the event loop.
  * Added safeguards for invalid chunk settings while avoiding unnecessary delays after processing completes.

* **Tests**
  * Added coverage for ordered processing, chunk boundaries, empty inputs, fallback behavior, and avoiding unnecessary delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->