### PR TITLE
ci: per-app test jobs (mobile / web / api-client)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
-# ADR-014: merges are blocked on all four suites. A money app with offline sync
-# has two catastrophic failure modes — wrong balances and lost data — and both
-# are testable, so they are tested on every push.
+# ADR-014: merges are blocked on every suite below. A money app with offline
+# sync has two catastrophic failure modes — wrong balances and lost data — and
+# both are testable, so they are tested on every push. The app suites are split
+# one-per-app (mobile / web / api-client) so a red check names the app that broke.
 
 on:
   push:
@@ -58,8 +59,13 @@ jobs:
       # every net position, FX is reproducible.
       - run: pnpm test:core
 
-  app:
-    name: what the app tells people
+  # Each app (and the browser client it shares) is its own test job, so a
+  # failure names the app that broke and one app's suite never hides another's.
+  # All run on every push regardless of which files changed: a change in a shared
+  # package (packages/core, @waves/api-client) can break an app whose own files
+  # were untouched, so ADR-014's "all suites block a merge" stays true.
+  mobile:
+    name: mobile app tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -73,14 +79,38 @@ jobs:
       # anything else that decides what a person is told about their money.
       # Rendering is covered by the Maestro flows in e2e/, not here.
       - run: pnpm test:app
-      # The browser client: turning wire strings into balances. A Number
-      # slipping in here produces figures that look right and quietly differ
-      # from the app's.
-      - run: pnpm test:api
+
+  web:
+    name: web app tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
       # What a crash report is allowed to say. This one starts the real SDK and
       # reads the envelope, so a beforeSend wired to the wrong option fails here
-      # and nowhere else.
+      # and nowhere else. (The browser E2E is the separate web-e2e job.)
       - run: pnpm test:web
+
+  api-client:
+    name: api-client tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # The browser client the web app builds on: turning wire strings into
+      # balances. A Number slipping in here produces figures that look right and
+      # quietly differ from the app's.
+      - run: pnpm test:api
 
   database:
     name: migrations, RLS policies and ledger invariants


### PR DESCRIPTION
## What
Splits the monolithic `app` CI job — which ran mobile + web + api-client tests in sequence under one check named "what the app tells people" — into **three independent, parallel jobs**:

| job | runs | was |
| --- | --- | --- |
| `mobile app tests` | `pnpm test:app` (@waves/mobile) | bundled in `app` |
| `web app tests` | `pnpm test:web` (@waves/web) | bundled in `app` |
| `api-client tests` | `pnpm test:api` (@waves/api-client) | bundled in `app` |

## Why
A red check now names the app that broke, and one app's failure can't mask another's.

## Preserved
- **All three run on every push**, unconditionally — a shared-package change (packages/core, api-client) can break an app whose own files didn't change, so ADR-014's "every suite blocks a merge" holds. No path filters.
- `web-e2e` (Playwright), `static`, `money`, `database`, `security`, `e2e (Maestro)` unchanged.

Decisions confirmed with the maintainer: separate **jobs** (not separate workflow files), **always-run** (not path-filtered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated quality checks by separating validation for mobile, web, and API client components.
  - Each app area now runs its own dedicated test suite, making build results more targeted and reliable.
  - Updated CI documentation to reflect the expanded test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->