### PR TITLE
fix(sync): include receipt_share_url in the expense pull select

### DIFF
--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -156,7 +156,8 @@ const EXPENSE_SELECT = `
   id, group_id, deleted_at, created_at, updated_seq,
   currentVersion:expense_versions!expenses_current_version_id_fkey (
     id, version_no, description, category, category_meta, expense_date, currency, amount,
-    split_type, split_params, author_member_id, notes, payment_method, location, created_at,
+    split_type, split_params, author_member_id, notes, payment_method, receipt_share_url,
+    location, created_at,
     payers:expense_payers ( member_id, amount ),
     shares:expense_shares ( member_id, amount )
   )


### PR DESCRIPTION
## Bug

The E3 group-share receipt link (`receipt_share_url`, #279) is written by `baaki_apply_expense` and read by the expense detail UI — but it was **never listed in `EXPENSE_SELECT`** in `supabase/functions/sync/index.ts`, so the sync pull never returned the column.

Effect: the author saw the link through their own local pending overlay, but every **other** member's mirror had it undefined. The bill they explicitly shared with the group silently never reached the group.

Found while adding `location` to the same select in #370.

## Fix

One column added to the pull select. The mirror read shape (`MirrorExpense.currentVersion`) and the mobile `ExpenseVersionRow` already carry `receipt_share_url`, so nothing else changes.

## Base
Stacked on `feat/expense-location` (#370), since that PR already edits the same `EXPENSE_SELECT` line. Re-targets `main` once #370 merges.

## Not deployed
Edge deploy is gated. Code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)