### PR TITLE
feat(capture): carry a capture's location onto the assigned expense (A43)

### DIFF
--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -233,6 +233,8 @@ export default function CapturesScreen() {
         // A custom tag rides along as JSON so the assigned expense keeps it,
         // rather than dropping to a built-in (extends TDR §8).
         ...(capture.category_meta ? { categoryMeta: JSON.stringify(capture.category_meta) } : {}),
+        // The place the capture recorded, so the assigned expense keeps it (A43).
+        ...(capture.location ? { location: JSON.stringify(capture.location) } : {}),
         expenseDate: capture.expense_date,
       },
     });

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -151,6 +151,27 @@ function parseCategoryMetaParam(value: string | undefined): CategoryMeta | null 
   return null;
 }
 
+/**
+ * A capture's location arrives as a JSON route param (A43), the same handoff
+ * `categoryMeta` uses. A malformed or out-of-range value is simply no location —
+ * a prefill is never worth a crash — so the point is validated to Earth's ranges
+ * exactly as the server does before it seeds the form.
+ */
+function parseLocationParam(value: string | undefined): ExpenseLocation | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<ExpenseLocation>;
+    const lat = typeof parsed?.lat === 'number' ? parsed.lat : NaN;
+    const lng = typeof parsed?.lng === 'number' ? parsed.lng : NaN;
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+    const name = typeof parsed.name === 'string' ? parsed.name : null;
+    return { lat, lng, name };
+  } catch {
+    return null;
+  }
+}
+
 export default function AddExpenseScreen() {
   const theme = useTheme();
   const { t, locale } = useStrings();
@@ -167,6 +188,7 @@ export default function AddExpenseScreen() {
     description: captureDescription,
     category: captureCategory,
     categoryMeta: captureCategoryMeta,
+    location: captureLocation,
     expenseDate: captureExpenseDate,
   } = useLocalSearchParams<{
     id: string;
@@ -182,6 +204,9 @@ export default function AddExpenseScreen() {
     /** A custom tag's {label,icon,tint} snapshot, JSON-encoded, when a capture
      *  tagged with one is being assigned (extends TDR §8). */
     categoryMeta?: string;
+    /** The capture's {lat,lng,name} place, JSON-encoded, carried onto the
+     *  assigned expense (A43). Absent when the capture had no location. */
+    location?: string;
     expenseDate?: string;
   }>();
   const groupId = id ?? '';
@@ -370,6 +395,8 @@ export default function AddExpenseScreen() {
       // built-in. A malformed param is simply no meta (a built-in).
       setCategoryMeta(parseCategoryMetaParam(captureCategoryMeta));
       setCategoryChosen(Boolean(captureCategory));
+      // Carry the capture's place onto the expense it becomes (A43).
+      setLocation(parseLocationParam(captureLocation));
       setPayer(myMemberId);
     } else if (draft) {
       // A draft outranks the saved version: it is what the user was in the

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -159,6 +159,8 @@ export interface CaptureRow {
   payment_method: string | null;
   /** Intended destination group, chosen up front; null means decide later. */
   target_group_id: string | null;
+  /** Where the spend happened (A43): a {lat, lng, name} snapshot, or null. */
+  location: ExpenseLocation | null;
   status: CaptureStatus;
   assigned_expense_id: string | null;
   assigned_group_id: string | null;


### PR DESCRIPTION
## What

Assigning a **located capture** from the inbox now prefills the new expense with the place it recorded — the same JSON-route-param handoff `categoryMeta` already uses.

Before: the capture stored its location, but the expense it became silently started with none.

## Changes
- `CaptureRow` exposes `location` (the mirror already carries it).
- `captures.tsx` `assignTo` passes `location` as a JSON param when the capture has one.
- `add-expense.tsx` parses it via `parseLocationParam` — validated to Earth's ranges, because a prefill is never worth a crash — and seeds the form in the capture branch.

## Base
Stacked on `feat/expense-location` (#370), which added the `location` groundwork. Re-targets `main` once #370 merges.

## Gates
Mobile typecheck · lint clean · 336 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)