### PR TITLE
feat(web): optional opt-in location on the web add-expense form (A43)

### DIFF
--- a/apps/web/src/app/g/[groupId]/expense/[expenseId]/page.tsx
+++ b/apps/web/src/app/g/[groupId]/expense/[expenseId]/page.tsx
@@ -27,6 +27,7 @@ import { Section } from '@/components/Shell';
 import { SkeletonRows } from '@/components/Skeleton';
 import { baaki } from '@/lib/baaki';
 import { money } from '@/lib/money';
+import { coordLabel, mapsUrl } from '@/lib/geo';
 import { fill } from '@/i18n';
 import { useStrings } from '@/i18n-context';
 
@@ -166,6 +167,31 @@ function ExpenseDetail({ profileId }: { profileId: string }) {
             {money(BigInt(version.amount), currency, locale)}
           </div>
         </div>
+
+        {/* Where it happened (A43), when the author attached one — a link to
+            the point in maps. Absent otherwise. */}
+        {version.location ? (
+          <section className="panel">
+            <div className="panel-head">
+              <h2>{t.location.label}</h2>
+            </div>
+            <a
+              className="item"
+              href={mapsUrl(version.location)}
+              target="_blank"
+              rel="noreferrer"
+              style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+            >
+              <span aria-hidden>📍</span>
+              <span className="grow">
+                <span className="title">
+                  {version.location.name?.trim() || coordLabel(version.location)}
+                </span>
+              </span>
+              <span className="muted">{t.location.openMap}</span>
+            </a>
+          </section>
+        ) : null}
 
         <section className="panel">
           <div className="panel-head">

--- a/apps/web/src/components/ExpenseForm.tsx
+++ b/apps/web/src/components/ExpenseForm.tsx
@@ -12,7 +12,7 @@
  * written (TDR §4). The server still recomputes and owns the answer.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { useRouter } from 'next/navigation';
 
 import {
@@ -23,12 +23,14 @@ import {
   serialiseSplitParams,
   toMajorString,
   type CurrencyCode,
+  type ExpenseLocation,
   type SplitParams,
 } from '@waves/core';
 import { nameOf, type Group, type Member } from '@waves/api-client';
 
 import { baaki } from '@/lib/baaki';
 import { money as fmtMoney } from '@/lib/money';
+import { captureLocation, coordLabel, geolocationSupported, LocationFailure } from '@/lib/geo';
 import { fill } from '@/i18n';
 import { useStrings } from '@/i18n-context';
 
@@ -72,6 +74,36 @@ export function ExpenseForm({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Where the spend happened (A43). Optional and opt-in: null until the person
+  // clicks "Add location" and the browser grants it. Coordinates only on the web
+  // (no on-device reverse-geocode — see lib/geo).
+  const [location, setLocation] = useState<ExpenseLocation | null>(null);
+  const [locBusy, setLocBusy] = useState(false);
+  const [locFailure, setLocFailure] = useState<LocationFailure | null>(null);
+  // `navigator` does not exist during SSR, so reading it at render would make the
+  // server (no panel) and the first client render (panel) disagree — a hydration
+  // mismatch. useSyncExternalStore gives React a distinct server snapshot
+  // (false) and client snapshot, so hydration matches and the panel appears
+  // afterward on a browser that can locate. Support does not change at runtime,
+  // so the subscription is a no-op.
+  const canGeo = useSyncExternalStore(
+    () => () => {},
+    () => geolocationSupported,
+    () => false,
+  );
+
+  const addLocation = useCallback(async () => {
+    setLocFailure(null);
+    setLocBusy(true);
+    try {
+      const result = await captureLocation();
+      if (result.ok) setLocation(result.location);
+      else if (result.why !== LocationFailure.Unsupported) setLocFailure(result.why);
+    } finally {
+      setLocBusy(false);
+    }
+  }, []);
+
   useEffect(() => {
     let active = true;
     void (async () => {
@@ -100,6 +132,7 @@ export function ExpenseForm({
           setExpenseDate(version.expense_date);
           setPayer(version.payers[0]?.member_id ?? null);
           setParticipants(version.shares.map((s) => s.member_id));
+          setLocation(version.location ?? null);
           try {
             // Deserialise the stored split back into the editor. Anything the web
             // cannot express (adjustment, itemised) drops to a read-only note.
@@ -248,6 +281,7 @@ export function ExpenseForm({
         participants,
         payers: { [payer]: amount },
         expectedShares: Object.fromEntries(preview),
+        location,
         clientMutationId: crypto.randomUUID(),
       });
       router.replace(`/g/${groupId}`);
@@ -266,6 +300,7 @@ export function ExpenseForm({
     expenseDate,
     currency,
     participants,
+    location,
     router,
     t.add.defaultDescription,
   ]);
@@ -333,6 +368,49 @@ export function ExpenseForm({
             <p className="error">{t.add.notAnAmount}</p>
           ) : null}
         </section>
+
+        {/* Where it happened (A43) — optional, opt-in, coordinates only on the
+            web (no on-device reverse-geocode). Absent when the browser has no
+            geolocation at all. */}
+        {canGeo ? (
+          <section className="panel">
+            <div className="panel-head">
+              <h2>{t.location.label}</h2>
+            </div>
+            {location ? (
+              <div className="row" style={{ alignItems: 'center', gap: 8 }}>
+                <span aria-hidden>📍</span>
+                <span style={{ flex: 1 }}>{location.name?.trim() || coordLabel(location)}</span>
+                <button
+                  type="button"
+                  className="btn soft"
+                  onClick={() => setLocation(null)}
+                  aria-label={t.location.remove}
+                >
+                  {t.location.remove}
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="btn soft"
+                onClick={() => void addLocation()}
+                disabled={locBusy}
+              >
+                {locBusy ? t.location.adding : t.location.add}
+              </button>
+            )}
+            {locFailure === LocationFailure.Denied ? (
+              <p className="muted" style={{ marginTop: 6 }}>
+                {t.location.blocked}
+              </p>
+            ) : locFailure === LocationFailure.Unavailable ? (
+              <p className="muted" style={{ marginTop: 6 }}>
+                {t.location.unavailable}
+              </p>
+            ) : null}
+          </section>
+        ) : null}
 
         <section className="panel">
           <div className="panel-head">

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -159,6 +159,17 @@ export interface WebStrings {
     runningSum: string;
     cannotEditSplit: string;
   };
+  /** Attaching where a spend happened (A43). Coordinates only on the web — the
+   *  browser has no on-device reverse-geocoder. */
+  location: {
+    label: string;
+    add: string;
+    adding: string;
+    remove: string;
+    blocked: string;
+    unavailable: string;
+    openMap: string;
+  };
   /** The signed-in web client: shell, sign-in and the overview dashboard. */
   dash: {
     nav: {
@@ -367,6 +378,15 @@ const en: WebStrings = {
     runningSum: '{sum} of {total}',
     cannotEditSplit: 'This bill was split in a way the web cannot edit yet — open it in the app.',
   },
+  location: {
+    label: 'Location',
+    add: 'Add location',
+    adding: 'Getting location…',
+    remove: 'Remove',
+    blocked: 'Location is blocked in your browser. Allow it to add a place.',
+    unavailable: "Couldn't get your location — please try again.",
+    openMap: 'Open in maps',
+  },
   dash: {
     nav: {
       overview: 'Overview',
@@ -572,6 +592,15 @@ const ta: WebStrings = {
     runningSum: '{total} இல் {sum}',
     cannotEditSplit:
       'இந்த பில் இணையம் இன்னும் திருத்த முடியாத வகையில் பிரிக்கப்பட்டது — செயலியில் திறக்கவும்.',
+  },
+  location: {
+    label: 'இடம்',
+    add: 'இடத்தைச் சேர்',
+    adding: 'இடத்தைப் பெறுகிறது…',
+    remove: 'அகற்று',
+    blocked: 'உங்கள் உலாவியில் இடம் தடுக்கப்பட்டுள்ளது. இடத்தைச் சேர்க்க அனுமதிக்கவும்.',
+    unavailable: 'உங்கள் இடத்தைப் பெற முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
+    openMap: 'வரைபடத்தில் திற',
   },
   dash: {
     nav: {
@@ -779,6 +808,15 @@ const hi: WebStrings = {
     invalidSplit: 'ये हिस्से अभी पूरे नहीं जुड़ते।',
     runningSum: '{total} में से {sum}',
     cannotEditSplit: 'यह बिल ऐसे बाँटा गया जिसे वेब अभी संपादित नहीं कर सकता — इसे ऐप में खोलें।',
+  },
+  location: {
+    label: 'स्थान',
+    add: 'स्थान जोड़ें',
+    adding: 'स्थान लिया जा रहा है…',
+    remove: 'हटाएँ',
+    blocked: 'आपके ब्राउज़र में स्थान अवरुद्ध है. स्थान जोड़ने के लिए इसे अनुमति दें.',
+    unavailable: 'आपका स्थान नहीं मिल सका — कृपया फिर से कोशिश करें.',
+    openMap: 'मैप में खोलें',
   },
   dash: {
     nav: {
@@ -997,6 +1035,15 @@ const ar: WebStrings = {
     invalidSplit: 'هذه الحصص لا تتوافق بعد.',
     runningSum: '{sum} من {total}',
     cannotEditSplit: 'قُسّمت هذه الفاتورة بطريقة لا يمكن للويب تعديلها بعد — افتحها في التطبيق.',
+  },
+  location: {
+    label: 'الموقع',
+    add: 'إضافة موقع',
+    adding: 'جارٍ تحديد الموقع…',
+    remove: 'إزالة',
+    blocked: 'الموقع محظور في متصفحك. اسمح به لإضافة مكان.',
+    unavailable: 'تعذّر تحديد موقعك — يُرجى المحاولة مرة أخرى.',
+    openMap: 'فتح في الخرائط',
   },
   dash: {
     nav: {

--- a/apps/web/src/lib/geo.ts
+++ b/apps/web/src/lib/geo.ts
@@ -1,0 +1,71 @@
+/**
+ * Reading where a spend happened, in the browser (A43).
+ *
+ * Unlike the phone, the web has no on-device reverse-geocoder, and calling an
+ * external one would send the point to a third party — against the on-device
+ * privacy stance the mobile app holds. So the web stores coordinates only
+ * (`name: null`); the expense detail shows the point and a maps link, and if the
+ * same expense is opened on the phone its name can be filled there. Permission is
+ * the browser's own just-in-time prompt, asked only when the person clicks.
+ */
+
+import type { ExpenseLocation } from '@waves/core';
+
+export const geolocationSupported = typeof navigator !== 'undefined' && 'geolocation' in navigator;
+
+export enum LocationFailure {
+  /** No Geolocation API — an old browser, or an insecure (non-HTTPS) origin. */
+  Unsupported = 'unsupported',
+  /** They said no, which is an answer. */
+  Denied = 'denied',
+  /** Permission is there but no fix came back — no signal, a desktop with none. */
+  Unavailable = 'unavailable',
+}
+
+export type LocationResult =
+  | { readonly ok: true; readonly location: ExpenseLocation }
+  | { readonly ok: false; readonly why: LocationFailure };
+
+/**
+ * Ask (once, just-in-time via the browser) and read the current fix. Never
+ * throws: a refusal comes back as `denied`, any other trouble as `unavailable`,
+ * so the caller shows a message rather than catching. Coordinates only — the
+ * name is left null (see the module note).
+ */
+export function captureLocation(): Promise<LocationResult> {
+  if (!geolocationSupported) {
+    return Promise.resolve({ ok: false, why: LocationFailure.Unsupported });
+  }
+  return new Promise((resolve) => {
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+          resolve({ ok: false, why: LocationFailure.Unavailable });
+          return;
+        }
+        resolve({ ok: true, location: { lat: latitude, lng: longitude, name: null } });
+      },
+      (error) => {
+        resolve({
+          ok: false,
+          why:
+            error.code === error.PERMISSION_DENIED
+              ? LocationFailure.Denied
+              : LocationFailure.Unavailable,
+        });
+      },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 },
+    );
+  });
+}
+
+/** A link that opens the point in Google Maps in a new tab. */
+export function mapsUrl(location: ExpenseLocation): string {
+  return `https://www.google.com/maps/search/?api=1&query=${location.lat},${location.lng}`;
+}
+
+/** What to show for a coordinate pair with no name: a trimmed lat/lng. */
+export function coordLabel(location: ExpenseLocation): string {
+  return `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)}`;
+}

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -18,7 +18,14 @@
 
 import type { Session, SupabaseClient } from '@supabase/supabase-js';
 
-import { AuthMethod, checkPassword, planAuth, readIdentifier, type Viewer } from '@waves/core';
+import {
+  AuthMethod,
+  checkPassword,
+  planAuth,
+  readIdentifier,
+  type ExpenseLocation,
+  type Viewer,
+} from '@waves/core';
 
 import type { AcceptedInvite, Expense, Group, InvitePreview, Member, Settlement } from './types';
 import {
@@ -63,7 +70,7 @@ const EXPENSE_COLUMNS = `
   id, group_id, deleted_at, created_at,
   currentVersion:expense_versions!expenses_current_version_id_fkey (
     id, version_no, description, category, expense_date, currency, amount,
-    split_type, split_params,
+    split_type, split_params, location,
     payers:expense_payers ( member_id, amount ),
     shares:expense_shares ( member_id, amount )
   )
@@ -569,6 +576,8 @@ export function createBaakiClient({ supabase }: BaakiClientOptions) {
             )
           : undefined,
         notes: input.notes ?? null,
+        // Where the spend happened (A43); null unless the person opted in.
+        location: input.location ?? null,
         // The idempotency key. A guest on a flaky phone browser is exactly who
         // double-taps Save, and this is what makes the second one harmless.
         clientMutationId: input.clientMutationId,
@@ -593,6 +602,9 @@ export interface WriteExpenseInput {
   payers: Record<string, bigint>;
   expectedShares?: Record<string, bigint>;
   notes?: string | null;
+  /** Where the spend happened (A43); null unless the person opted in. The edge
+   *  function validates it to Earth's ranges before it is stored. */
+  location?: ExpenseLocation | null;
   clientMutationId: string;
 }
 

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -6,7 +6,7 @@
  * columns nobody renders is asking RLS to prove more than it has to.
  */
 
-import type { SplitParams } from '@waves/core';
+import type { ExpenseLocation, SplitParams } from '@waves/core';
 
 export type MemberId = string;
 
@@ -40,6 +40,8 @@ export interface ExpenseVersion {
   amount: string;
   split_type: string;
   split_params: SplitParams;
+  /** Where the spend happened (A43): a {lat, lng, name} snapshot, or null. */
+  location?: ExpenseLocation | null;
   payers: { member_id: MemberId; amount: string }[];
   shares: { member_id: MemberId; amount: string }[];
 }


### PR DESCRIPTION
## What

The **web** add-expense form gets the same opt-in location control the mobile app has.

**Coords-only on web.** The browser has no on-device reverse-geocoder, and calling an external one would send the point to a third party — against the on-device privacy stance the mobile feature holds. So the web stores coordinates only (`name: null`); the detail shows the point and a Google Maps link, and the name gets filled if the same expense is opened on the phone.

## Changes
- **api-client** — `WriteExpenseInput.location` threaded to `expense-write` (which already validates to Earth's ranges); `ExpenseVersion.location` + the read select carry it back so the web detail can render it.
- **`lib/geo.ts`** — `navigator.geolocation`, just-in-time browser prompt, never throws (denial → a message, not a catch).
- **`ExpenseForm`** — an opt-in panel; the geolocation-support check rides `useSyncExternalStore` so SSR and hydration agree (`navigator` is absent on the server — avoids a hydration mismatch).
- **Expense detail** — a maps link when a location is set.
- **i18n** — en/ta/hi/ar.

## Base
Stacked on `feat/expense-location` (#370). Re-targets `main` once #370 merges.

## Gates
Workspace typecheck 9/9 · web + api-client lint clean · api-client (12) + web (24) tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)