### PR TITLE
fix(voice): hear "five hundred rupees", not just "500"

### DIFF
--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -344,12 +344,35 @@ export function normalizeDigits(text: string): string {
 
 /** Words for numbers, and the Indian/Western multipliers that scale them. */
 const NUMBER_WORDS: ReadonlyMap<string, number> = new Map([
-  ['zero', 0], ['one', 1], ['two', 2], ['three', 3], ['four', 4], ['five', 5],
-  ['six', 6], ['seven', 7], ['eight', 8], ['nine', 9], ['ten', 10],
-  ['eleven', 11], ['twelve', 12], ['thirteen', 13], ['fourteen', 14],
-  ['fifteen', 15], ['sixteen', 16], ['seventeen', 17], ['eighteen', 18],
-  ['nineteen', 19], ['twenty', 20], ['thirty', 30], ['forty', 40], ['fourty', 40],
-  ['fifty', 50], ['sixty', 60], ['seventy', 70], ['eighty', 80], ['ninety', 90],
+  ['zero', 0],
+  ['one', 1],
+  ['two', 2],
+  ['three', 3],
+  ['four', 4],
+  ['five', 5],
+  ['six', 6],
+  ['seven', 7],
+  ['eight', 8],
+  ['nine', 9],
+  ['ten', 10],
+  ['eleven', 11],
+  ['twelve', 12],
+  ['thirteen', 13],
+  ['fourteen', 14],
+  ['fifteen', 15],
+  ['sixteen', 16],
+  ['seventeen', 17],
+  ['eighteen', 18],
+  ['nineteen', 19],
+  ['twenty', 20],
+  ['thirty', 30],
+  ['forty', 40],
+  ['fourty', 40],
+  ['fifty', 50],
+  ['sixty', 60],
+  ['seventy', 70],
+  ['eighty', 80],
+  ['ninety', 90],
 ]);
 
 /** Scaling words. `group` ones close off a chunk ("two thousand five hundred"). */
@@ -375,9 +398,19 @@ const SPOKEN_NUMBER = new RegExp(
   'gi',
 );
 
-/** A currency word or symbol — the signal that a nearby number is money. */
+/**
+ * A currency word or symbol — the signal that a nearby number is money.
+ *
+ * The alphabetic words carry word boundaries so a short token like "rs" cannot
+ * match inside an ordinary word ("person" → "pe-rs-on"): without them "one
+ * person paid" would read "rs" as currency and mint a false amount.
+ */
 const CURRENCY_TOKEN =
-  /(?:₹|\$|€|£|rupees?|rupaye|rs|inr|dollars?|usd|bucks?|euros?|eur|pounds?|quid|gbp|dirhams?|aed)/i;
+  /(?:₹|\$|€|£|\b(?:rupees?|rupaye|rs|inr|dollars?|usd|bucks?|euros?|eur|pounds?|quid|gbp|dirhams?|aed)\b)/i;
+
+/** Split-phrase context — a number here is a people count, still worth digitising. */
+const SPLIT_BEFORE_WORD = /^(?:among|amongst|between)$/i;
+const SPLIT_AFTER_WORD = /^(?:people|persons?|ppl|ways?|folks?|heads?)\b/i;
 
 /** Add up one run of number words: "five hundred and fifty" → 550. */
 function spokenRunToNumber(run: string): number | null {
@@ -415,20 +448,27 @@ function spokenRunToNumber(run: string): number | null {
  * silently dropped.
  *
  * Deliberately conservative: a run is only rewritten when it carries a
- * multiplier ("five hundred") or sits against a currency word ("twenty rupees").
- * A bare small number is left alone, because "one of us" and "table for two" are
- * ordinary speech, and turning them into digits would invent an amount out of a
- * sentence that never named one.
+ * multiplier ("five hundred"), sits against a currency word ("twenty rupees"),
+ * or sits in a split-count phrase ("split among five", "five people") — where
+ * the number is a people count that extractSplitCount, being digit-only, would
+ * otherwise miss. A bare small number in any other context is left alone,
+ * because "one of us" and "table for two" are ordinary speech, and turning them
+ * into digits would invent an amount out of a sentence that never named one.
  */
 export function normalizeSpokenNumbers(text: string): string {
   return text.replace(SPOKEN_NUMBER, (run, offset: number, whole: string) => {
-    const words = run.toLowerCase().split(/[\s-]+/).filter((w: string) => w && w !== 'and');
+    const words = run
+      .toLowerCase()
+      .split(/[\s-]+/)
+      .filter((w: string) => w && w !== 'and');
     const hasMultiplier = words.some((w: string) => NUMBER_MULTIPLIERS.has(w));
     const after = whole.slice(offset + run.length).trimStart();
     const before = whole.slice(0, offset).trimEnd();
+    const prevWord = before.split(/\s+/).pop() ?? '';
     const nextIsCurrency = CURRENCY_TOKEN.test(after.split(/\s+/)[0] ?? '');
-    const prevIsCurrency = CURRENCY_TOKEN.test(before.split(/\s+/).pop() ?? '');
-    if (!hasMultiplier && !nextIsCurrency && !prevIsCurrency) return run;
+    const prevIsCurrency = CURRENCY_TOKEN.test(prevWord);
+    const splitContext = SPLIT_BEFORE_WORD.test(prevWord) || SPLIT_AFTER_WORD.test(after);
+    if (!hasMultiplier && !nextIsCurrency && !prevIsCurrency && !splitContext) return run;
     const value = spokenRunToNumber(run);
     return value === null ? run : String(value);
   });

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -218,8 +218,10 @@ export function parseVoiceExpense(
   transcript: string,
   groups: readonly VoiceGroupRef[],
 ): ParsedVoiceExpense {
-  const tokens = tokenize(transcript);
-  const amountMajor = extractAmount(transcript);
+  // Spoken numbers become digits first; every pattern below is digit-based.
+  const said = normalizeSpokenNumbers(normalizeDigits(transcript));
+  const tokens = tokenize(said);
+  const amountMajor = extractAmount(said);
   const amountMinor = amountMajor === null ? null : BigInt(Math.round(amountMajor * 100));
   const groupId = matchGroup(tokens, groups);
   const matchedName = groupId ? (groups.find((group) => group.id === groupId)?.name ?? null) : null;
@@ -227,10 +229,10 @@ export function parseVoiceExpense(
   return {
     amountMinor,
     amountMajor,
-    currency: detectCurrency(transcript),
-    note: buildNote(transcript, matchedName),
+    currency: detectCurrency(said),
+    note: buildNote(said, matchedName),
     groupId,
-    splitCount: extractSplitCount(transcript),
+    splitCount: extractSplitCount(said),
   };
 }
 
@@ -340,6 +342,98 @@ export function normalizeDigits(text: string): string {
   });
 }
 
+/** Words for numbers, and the Indian/Western multipliers that scale them. */
+const NUMBER_WORDS: ReadonlyMap<string, number> = new Map([
+  ['zero', 0], ['one', 1], ['two', 2], ['three', 3], ['four', 4], ['five', 5],
+  ['six', 6], ['seven', 7], ['eight', 8], ['nine', 9], ['ten', 10],
+  ['eleven', 11], ['twelve', 12], ['thirteen', 13], ['fourteen', 14],
+  ['fifteen', 15], ['sixteen', 16], ['seventeen', 17], ['eighteen', 18],
+  ['nineteen', 19], ['twenty', 20], ['thirty', 30], ['forty', 40], ['fourty', 40],
+  ['fifty', 50], ['sixty', 60], ['seventy', 70], ['eighty', 80], ['ninety', 90],
+]);
+
+/** Scaling words. `group` ones close off a chunk ("two thousand five hundred"). */
+const NUMBER_MULTIPLIERS: ReadonlyMap<string, { factor: number; group: boolean }> = new Map([
+  ['hundred', { factor: 100, group: false }],
+  ['thousand', { factor: 1_000, group: true }],
+  ['lakh', { factor: 100_000, group: true }],
+  ['lakhs', { factor: 100_000, group: true }],
+  ['lac', { factor: 100_000, group: true }],
+  ['lacs', { factor: 100_000, group: true }],
+  ['crore', { factor: 10_000_000, group: true }],
+  ['crores', { factor: 10_000_000, group: true }],
+  ['million', { factor: 1_000_000, group: true }],
+  ['billion', { factor: 1_000_000_000, group: true }],
+]);
+
+/** Any single word that can appear inside a spoken number. */
+const NUMBER_WORD_RE = [...NUMBER_WORDS.keys(), ...NUMBER_MULTIPLIERS.keys()].join('|');
+
+/** A run of number words, joined by spaces, hyphens or a linking "and". */
+const SPOKEN_NUMBER = new RegExp(
+  `\\b(?:${NUMBER_WORD_RE})(?:[\\s-]+(?:and[\\s-]+)?(?:${NUMBER_WORD_RE}))*\\b`,
+  'gi',
+);
+
+/** A currency word or symbol — the signal that a nearby number is money. */
+const CURRENCY_TOKEN =
+  /(?:₹|\$|€|£|rupees?|rupaye|rs|inr|dollars?|usd|bucks?|euros?|eur|pounds?|quid|gbp|dirhams?|aed)/i;
+
+/** Add up one run of number words: "five hundred and fifty" → 550. */
+function spokenRunToNumber(run: string): number | null {
+  let total = 0;
+  let current = 0;
+  let seen = false;
+  for (const word of run.toLowerCase().split(/[\s-]+/)) {
+    if (!word || word === 'and') continue;
+    const unit = NUMBER_WORDS.get(word);
+    if (unit !== undefined) {
+      current += unit;
+      seen = true;
+      continue;
+    }
+    const mult = NUMBER_MULTIPLIERS.get(word);
+    if (!mult) return null;
+    // A bare "hundred"/"thousand" means one of them.
+    current = (current === 0 ? 1 : current) * mult.factor;
+    if (mult.group) {
+      total += current;
+      current = 0;
+    }
+    seen = true;
+  }
+  const value = total + current;
+  return seen && value > 0 ? value : null;
+}
+
+/**
+ * Rewrite spoken numbers as digits, so the digit-based patterns above see them.
+ *
+ * Dictation hands back what was said, and what people say is "five hundred
+ * rupees", not "500 rupees" — every amount pattern here is `\d`-based, so
+ * without this the sentence parses to no amount at all and the expense is
+ * silently dropped.
+ *
+ * Deliberately conservative: a run is only rewritten when it carries a
+ * multiplier ("five hundred") or sits against a currency word ("twenty rupees").
+ * A bare small number is left alone, because "one of us" and "table for two" are
+ * ordinary speech, and turning them into digits would invent an amount out of a
+ * sentence that never named one.
+ */
+export function normalizeSpokenNumbers(text: string): string {
+  return text.replace(SPOKEN_NUMBER, (run, offset: number, whole: string) => {
+    const words = run.toLowerCase().split(/[\s-]+/).filter((w: string) => w && w !== 'and');
+    const hasMultiplier = words.some((w: string) => NUMBER_MULTIPLIERS.has(w));
+    const after = whole.slice(offset + run.length).trimStart();
+    const before = whole.slice(0, offset).trimEnd();
+    const nextIsCurrency = CURRENCY_TOKEN.test(after.split(/\s+/)[0] ?? '');
+    const prevIsCurrency = CURRENCY_TOKEN.test(before.split(/\s+/).pop() ?? '');
+    if (!hasMultiplier && !nextIsCurrency && !prevIsCurrency) return run;
+    const value = spokenRunToNumber(run);
+    return value === null ? run : String(value);
+  });
+}
+
 /**
  * A spoken "make a group" and the name it gives.
  *
@@ -434,7 +528,7 @@ export function parseVoiceExpenses(
   transcript: string,
   groups: readonly VoiceGroupRef[],
 ): VoiceParseResult {
-  const normalized = normalizeDigits(transcript);
+  const normalized = normalizeSpokenNumbers(normalizeDigits(transcript));
   const created = detectCreateGroup(normalized);
   const body = created ? created.rest : normalized;
 

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -79,6 +79,18 @@ describe('parseVoiceExpense', () => {
     expect(parseVoiceExpense('300 split 3 ways', groups).amountMajor).toBe(300);
   });
 
+  it('reads a spoken split count ("split among five")', () => {
+    const parsed = parseVoiceExpense('five hundred rupees dinner split among five', groups);
+    expect(parsed.amountMajor).toBe(500);
+    expect(parsed.splitCount).toBe(5);
+  });
+
+  it('reads a spoken "five people" count', () => {
+    const parsed = parseVoiceExpense('five hundred rupees dinner for five people', groups);
+    expect(parsed.amountMajor).toBe(500);
+    expect(parsed.splitCount).toBe(5);
+  });
+
   it('leaves the count null when no split is said', () => {
     expect(parseVoiceExpense('add 500 for dinner', groups).splitCount).toBeNull();
   });

--- a/apps/mobile/test/watchVoiceExpense.test.ts
+++ b/apps/mobile/test/watchVoiceExpense.test.ts
@@ -120,13 +120,16 @@ describe('speaking an expense into the watch', () => {
   });
 
   it('refuses a malformed intent before it can reach the queue', () => {
-    expect(bridgeVoiceAdd({ t: 'voiceAdd', id: '', transcript: 'five hundred rupees' }, noGroups).ack)
-      .toBe(false);
+    expect(
+      bridgeVoiceAdd({ t: 'voiceAdd', id: '', transcript: 'five hundred rupees' }, noGroups).ack,
+    ).toBe(false);
     expect(bridgeVoiceAdd({ t: 'voiceAdd', id: 'x', transcript: '   ' }, noGroups).ack).toBe(false);
     // A version the phone cannot read is rejected rather than guessed at.
     expect(
-      bridgeVoiceAdd({ t: 'voiceAdd', id: 'x', transcript: 'five hundred rupees', version: 99 }, noGroups)
-        .ack,
+      bridgeVoiceAdd(
+        { t: 'voiceAdd', id: 'x', transcript: 'five hundred rupees', version: 99 },
+        noGroups,
+      ).ack,
     ).toBe(false);
   });
 });

--- a/apps/mobile/test/watchVoiceExpense.test.ts
+++ b/apps/mobile/test/watchVoiceExpense.test.ts
@@ -1,0 +1,132 @@
+/**
+ * "Say five hundred rupees, tea shop" — from the wrist to a booked expense.
+ *
+ * This walks the whole watch→phone path with the exact words a person speaks,
+ * and asserts an expense comes out the far end with the right money on it:
+ *
+ *   WatchRelay.voiceAdd(transcript)   targets/watch/WavesWatchApp.swift
+ *     → parseWatchToPhone             @waves/core relay contract, the decoder
+ *     → parseVoiceExpenses            the phone's voice parser
+ *     → createCapture({ amount })     what the bridge writes to the queue
+ *
+ * The one thing it cannot cover is the microphone: dictation is a system
+ * service, and the watchOS Simulator has no audio capture at all (Quickboard
+ * reports `dictationLanguage = nil` and CoreMedia fails to allocate), so no
+ * automated test on a Mac can speak. It therefore starts where dictation
+ * finishes — at the transcript string — which is also exactly where a bug hid:
+ * every amount pattern in the parser is digit-based, and people say "five
+ * hundred", not "500".
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseWatchToPhone } from '@waves/core';
+
+import { parseVoiceExpenses, type VoiceGroupRef } from '@/lib/voiceExpense';
+
+/** The message the watch's `voiceAdd` puts on the wire (WavesWatchApp.swift). */
+function watchSaid(transcript: string) {
+  return { t: 'voiceAdd', id: 'watch-intent-1', transcript, version: 1 };
+}
+
+/**
+ * The bridge's voiceAdd arm (src/lib/watch/bridge.tsx), reduced to what it
+ * decides: parse the transcript, drop anything without money on it, and book
+ * the rest as unassigned captures.
+ */
+function bridgeVoiceAdd(raw: unknown, groups: readonly VoiceGroupRef[]) {
+  const msg = parseWatchToPhone(raw);
+  if (!msg || msg.t !== 'voiceAdd') return { ack: false, error: 'rejected', captures: [] };
+
+  const items = parseVoiceExpenses(msg.transcript, groups).items.filter(
+    (item) => item.amountMinor > 0n,
+  );
+  if (items.length === 0) return { ack: false, error: 'no-amount', captures: [] };
+
+  return {
+    ack: true,
+    error: null,
+    captures: items.map((item, i) => ({
+      // The single-expense case reuses the watch's intent id, so a replayed
+      // utterance upserts instead of duplicating.
+      captureId: items.length === 1 ? msg.id : undefined,
+      amountMinor: item.amountMinor,
+      currency: item.currency,
+      description: item.note,
+      index: i,
+    })),
+  };
+}
+
+const noGroups: VoiceGroupRef[] = [];
+
+describe('speaking an expense into the watch', () => {
+  it('books ₹500 from "five hundred rupees tea shop"', () => {
+    const result = bridgeVoiceAdd(watchSaid('five hundred rupees tea shop'), noGroups);
+
+    expect(result.ack).toBe(true);
+    expect(result.captures).toHaveLength(1);
+
+    const [capture] = result.captures;
+    // 500 rupees in minor units.
+    expect(capture.amountMinor).toBe(50000n);
+    expect(capture.currency).toBe('INR');
+    expect(capture.description).toBe('tea shop');
+    // Reused so a transport retry of the same utterance is idempotent.
+    expect(capture.captureId).toBe('watch-intent-1');
+  });
+
+  it('hears the amount whether it is spoken or dictated as digits', () => {
+    for (const said of [
+      'five hundred rupees tea shop',
+      '500 rupees tea shop',
+      'add five hundred rupees to tea shop',
+      'five hundred rupees t shop',
+    ]) {
+      const result = bridgeVoiceAdd(watchSaid(said), noGroups);
+      expect(result.ack, said).toBe(true);
+      expect(result.captures[0]?.amountMinor, said).toBe(50000n);
+    }
+  });
+
+  it('carries spoken tens, compounds and Indian scales through', () => {
+    const cases: [string, bigint][] = [
+      ['twenty rupees chai', 2000n],
+      ['fifty rupees auto', 5000n],
+      ['two thousand rupees hotel', 200000n],
+      ['five hundred and fifty rupees dinner', 55000n],
+      ['one lakh rupees deposit', 10000000n],
+    ];
+    for (const [said, expected] of cases) {
+      const result = bridgeVoiceAdd(watchSaid(said), noGroups);
+      expect(result.ack, said).toBe(true);
+      expect(result.captures[0]?.amountMinor, said).toBe(expected);
+    }
+  });
+
+  it('tells the watch when nothing it heard was money', () => {
+    const result = bridgeVoiceAdd(watchSaid('remind me about the tea shop'), noGroups);
+    expect(result.ack).toBe(false);
+    expect(result.error).toBe('no-amount');
+    expect(result.captures).toHaveLength(0);
+  });
+
+  it('does not invent an amount out of ordinary speech', () => {
+    // "one" and "two" here are words, not money — a parser that turned every
+    // number word into digits would book a ₹1 expense for this sentence.
+    const result = bridgeVoiceAdd(watchSaid('one of us paid at the tea shop'), noGroups);
+    expect(result.ack).toBe(false);
+    expect(result.error).toBe('no-amount');
+  });
+
+  it('refuses a malformed intent before it can reach the queue', () => {
+    expect(bridgeVoiceAdd({ t: 'voiceAdd', id: '', transcript: 'five hundred rupees' }, noGroups).ack)
+      .toBe(false);
+    expect(bridgeVoiceAdd({ t: 'voiceAdd', id: 'x', transcript: '   ' }, noGroups).ack).toBe(false);
+    // A version the phone cannot read is rejected rather than guessed at.
+    expect(
+      bridgeVoiceAdd({ t: 'voiceAdd', id: 'x', transcript: 'five hundred rupees', version: 99 }, noGroups)
+        .ack,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Speaking an expense into the watch produced **nothing at all**. `"five hundred rupees tea shop"` parsed to zero items, the bridge's `voiceAdd` arm took its `items.length === 0` branch, and the watch got back `ack ok:false, error:'no-amount'`. No expense, and nothing explaining why.

Every amount pattern in the parser is digit-based — `CURRENCY_ADJACENT`, `SPLIT_COUNT` and the bare `\d[\d,]*` fallback — while `normalizeDigits` only rewrote *native-script* digits (Devanagari, Tamil, Arabic, Persian) into ASCII. Nothing ever turned an English number word into a digit. Fine for the typed paths this parser was built against, but dictation returns what was said, and people say "five hundred". **The one input the watch's Speak screen exists to produce was the one input the parser could not read.**

| Transcript | Before | After |
|---|---|---|
| `five hundred rupees tea shop` | `items: []` | ₹500, note "tea shop" |
| `500 rupees tea shop` | ₹500 | ₹500 |

`normalizeSpokenNumbers` now rewrites spoken numbers ahead of those patterns — units, teens, tens, compounds ("five hundred and fifty"), and Indian scales (lakh, crore) alongside thousand/million/billion.

Deliberately conservative: a run is rewritten only when it carries a multiplier or sits against a currency word. A bare small number is left alone, because *"one of us paid"* and *"table for two"* are ordinary speech and rewriting them would invent a ₹1 expense from a sentence that never named money. There is a test holding that line.

In passing: `parseVoiceExpense` (singular) never called `normalizeDigits` at all, so it could not handle native-script digits either. Both entry points now share one normalisation.

### Verification
New `test/watchVoiceExpense.test.ts` walks the real path end to end — the wire message the watch's `voiceAdd` sends, through `parseWatchToPhone`'s decoder, the voice parser, and out to the capture the bridge would queue — asserting ₹500 (`50000n`), `INR`, note "tea shop", and the intent id reused for idempotency.

**Three of its six cases fail without this change.** Full suite green: 342 tests, 33 files. `tsc --noEmit` and ESLint clean.

**Not covered:** the microphone. Dictation is a system service and the watchOS Simulator has no audio capture, so no automated test on a Mac can speak. The test starts at the transcript — precisely where the bug was.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016n574mVBMyAw5XGnTasohe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved voice expense recognition for spoken number phrases, native-script digits, currency amounts, multipliers, and Indian or Western number scales.
  * Added support for split-count phrases such as “split among five” and “for five people.”
  * Enhanced multi-expense voice input parsing for amounts, currencies, groups, notes, and split counts.

* **Bug Fixes**
  * Reduced false amount and currency detection.
  * Improved handling of malformed or unsupported watch voice commands.
  * Prevented duplicate expense captures from repeated watch inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->