### PR TITLE
fix(watch): stop a phone with no watch logging unhandled rejections

### DIFF
--- a/apps/mobile/src/lib/watch/nativeModule.ts
+++ b/apps/mobile/src/lib/watch/nativeModule.ts
@@ -51,9 +51,7 @@ export function sendToWatch(message: PhoneToWatch): void {
     // so those failures surfaced as unhandled promise rejections, which is the
     // opposite of the safe no-op this module exists to promise. `Promise.resolve`
     // normalises iOS's undefined return so the same line covers both platforms.
-    void Promise.resolve(native?.sendToWatch(encodePhoneToWatch(message))).catch(
-      () => undefined,
-    );
+    void Promise.resolve(native?.sendToWatch(encodePhoneToWatch(message))).catch(() => undefined);
   } catch {
     // The transport went away between the check and the send; nothing to do.
   }

--- a/apps/mobile/src/lib/watch/nativeModule.ts
+++ b/apps/mobile/src/lib/watch/nativeModule.ts
@@ -14,7 +14,11 @@ import { encodePhoneToWatch, type PhoneToWatch } from '@waves/core';
 
 interface NativeWatch {
   isReachable(): boolean;
-  sendToWatch(payload: Record<string, unknown>): void;
+  // Android implements this as an Expo `AsyncFunction` — its Wear send has to
+  // await a connected-node lookup off the JS thread — so it hands back a
+  // promise. iOS's is a plain `Function` and returns nothing. Typed as both so
+  // callers cannot forget the promise half.
+  sendToWatch(payload: Record<string, unknown>): void | Promise<void>;
   addListener(
     event: 'onWatchMessage',
     handler: (event: { payload: unknown }) => void,
@@ -40,7 +44,16 @@ export function watchReachable(): boolean {
 /** Send one phone→watch message (stamped with the relay version). No-op if absent. */
 export function sendToWatch(message: PhoneToWatch): void {
   try {
-    native?.sendToWatch(encodePhoneToWatch(message));
+    // The rejection has to be swallowed as well as the throw. On Android this
+    // is an AsyncFunction, and its `Tasks.await(connectedNodes)` fails on any
+    // phone with no paired watch or no working Play Services — the ordinary
+    // case, not an edge one. A bare try/catch only covers the synchronous half,
+    // so those failures surfaced as unhandled promise rejections, which is the
+    // opposite of the safe no-op this module exists to promise. `Promise.resolve`
+    // normalises iOS's undefined return so the same line covers both platforms.
+    void Promise.resolve(native?.sendToWatch(encodePhoneToWatch(message))).catch(
+      () => undefined,
+    );
   } catch {
     // The transport went away between the check and the send; nothing to do.
   }


### PR DESCRIPTION
`sendToWatch` promises callers a safe no-op when the watch transport is absent or failing — that is why the native module is required *optionally*. On Android it did not keep that promise.

Android implements `sendToWatch` as an Expo `AsyncFunction` (its Wear send must `Tasks.await(connectedNodes)` off the JS thread); iOS implements the same name as a plain synchronous `Function`. The JS wrapper was written for the iOS shape, so its `try/catch` guarded only the synchronous half. On Android the node lookup fails on any phone with **no paired watch or no working Play Services** — the ordinary case, not an edge one — and the rejection sailed past the catch:

```
E/ReactNativeJS: [Error: Uncaught (in promise, id: 0)
  Error: Call to function 'WavesWatch.sendToWatch' has been rejected.
```

Two per cold start, from the settings relay that runs on mount. With Sentry wired up these are reported errors, not just log noise.

### Verification
Pixel 8 Pro emulator: two rejections on every launch before, **zero** after, no other JS error in logcat. `tsc --noEmit` clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016n574mVBMyAw5XGnTasohe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch communication reliability by supporting both immediate and asynchronous message delivery.
  * Prevented watch send errors from disrupting the app when the watch or required services are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->