### PR TITLE
fix(watch): open dictation straight from the Speak screen

### DIFF
--- a/apps/mobile/targets/watch/Views.swift
+++ b/apps/mobile/targets/watch/Views.swift
@@ -94,28 +94,51 @@ struct VoiceView: View {
   @Environment(\.dismiss) private var dismiss
   @State private var text: String = ""
 
+  private var transcript: String {
+    text.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
   var body: some View {
-    VStack(spacing: 12) {
-      Text("Say what you spent")
-        .font(.footnote)
-        .foregroundStyle(.secondary)
-      // On watchOS a TextField offers Scribble and Dictation; the mic there is
-      // the "speak an expense" path. The phone parses the transcript.
-      TextField("e.g. add 500 to Goa", text: $text)
-        .textFieldStyle(.plain)
-      Button {
-        let t = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !t.isEmpty else { return }
-        relay.voiceAdd(t)
-        dismiss()
-      } label: {
-        Label("Send", systemImage: "paperplane.fill").frame(maxWidth: .infinity)
+    ScrollView {
+      VStack(spacing: 10) {
+        // A plain TextField reaches dictation in two taps — open the field, then
+        // pick the mic out of the input menu — which is a strange way to enter a
+        // screen called "Speak". TextFieldLink presents that same system input
+        // controller straight from this button, so the screen opens speaking.
+        // Whatever comes back (dictated, scribbled, or typed on a Mac keyboard in
+        // the Simulator, which has no dictation) lands in `text` to be read back
+        // before it is sent, since a misheard amount is worth catching here
+        // rather than on the phone.
+        TextFieldLink(prompt: Text("Say what you spent")) {
+          Label(transcript.isEmpty ? "Speak" : "Say again", systemImage: "mic.fill")
+            .frame(maxWidth: .infinity)
+        } onSubmit: { spoken in
+          text = spoken
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(accent)
+
+        if transcript.isEmpty {
+          Text("e.g. add 500 to Goa")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        } else {
+          Text(transcript)
+            .font(.footnote)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        Button {
+          relay.voiceAdd(transcript)
+          dismiss()
+        } label: {
+          Label("Send", systemImage: "paperplane.fill").frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .disabled(transcript.isEmpty)
       }
-      .buttonStyle(.borderedProminent)
-      .tint(accent)
-      .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      .padding(.horizontal, 4)
     }
-    .padding()
     .navigationTitle("Speak")
   }
 }


### PR DESCRIPTION
The Speak screen reached dictation in two taps and a guess: tap the `TextField`, then find Dictation in the input menu that appears. `TextFieldLink` presents that same system input controller directly from a mic-labelled button, so a screen called "Speak" opens speaking.

The transcript is still read back before Send rather than fired straight off — a misheard amount is far cheaper to catch on the wrist than to undo on the phone. The button relabels to "Say again" once there is a transcript.

Also wraps the stack in a `ScrollView` (four elements clip on a 40mm screen) and hoists the whitespace trim into a `transcript` property that was being recomputed three times inline.

### Verification
Builds clean for `watchsimulator`, and `QuickboardViewService` — the watchOS input controller — is confirmed to launch from the new button on a watchOS 26.5 simulator.

**Not covered:** dictation itself. The watchOS Simulator has no audio capture stack at all (`AVSystemController` fails to allocate; Quickboard reports `dictationLanguage = nil`), so the mic path needs a physical Apple Watch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016n574mVBMyAw5XGnTasohe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct access to the watch’s system speech and text input.
  * Voice input is now trimmed automatically and displayed before sending.
  * The Send button is enabled only when valid text has been entered.
  * Added a prompt when no transcript is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->