### PR TITLE
fix(watch): relay the recent list when it changes, not when a write is made

### DIFF
--- a/apps/mobile/src/lib/watch/bridge.tsx
+++ b/apps/mobile/src/lib/watch/bridge.tsx
@@ -12,7 +12,7 @@
  * in the native transport, not here.
  */
 
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 
 import {
   coerceRecentCount,
@@ -101,6 +101,8 @@ export function WatchBridgeProvider({ children }: { children?: ReactNode }) {
     personal: t.captures.unassigned,
   });
   const createRef = useRef(createCapture);
+  /** The last recent payload sent, so an unchanged list is not re-sent. */
+  const lastRecentRef = useRef<string | null>(null);
 
   // Refs are written in an effect, never during render (react-hooks/refs): the
   // once-bound message handler reads the latest of everything through them.
@@ -118,24 +120,61 @@ export function WatchBridgeProvider({ children }: { children?: ReactNode }) {
     createRef.current = createCapture;
   });
 
+  /**
+   * Send the watch the current recent list.
+   *
+   * `force` is for a watch that asked (`requestRecent`): it must always get an
+   * answer, because a freshly launched watch has an empty list of its own and
+   * would otherwise be told nothing when the payload happens to match what the
+   * last watch session was sent. The automatic push deduplicates instead, so an
+   * unrelated sync tick — the mirror changes often — does not spend a
+   * WatchConnectivity message re-sending rows the watch already shows.
+   */
+  const relayRecent = useCallback((n: number, opts?: { force?: boolean }) => {
+    if (!watchAvailable()) return;
+    const s = stateRef.current;
+    const items = buildRecentItems(s.recent, n, {
+      myProfileId: s.myProfileId,
+      locale: s.locale,
+      fallbackCurrency: s.defaultCurrency,
+      someoneLabel: s.someone,
+      personalLabel: s.personal,
+      now: Date.now(),
+    });
+    const encoded = JSON.stringify(items);
+    if (!opts?.force && encoded === lastRecentRef.current) return;
+    lastRecentRef.current = encoded;
+    sendToWatch({ t: 'recent', items });
+  }, []);
+
+  /**
+   * Relay the list when it actually changes, rather than when a write is made.
+   *
+   * `useSync`'s `mutate` only enqueues — it does not touch the mirror — and
+   * `useRecentActivity` derives purely from the mirror, so relaying straight
+   * after `await mutateAsync` sent the watch the list from *before* the write
+   * every time: the expense just added from the wrist was the one row it could
+   * never contain. Waiting for the mirror to change means the watch is told once
+   * the write has actually landed, whenever that is.
+   */
+  useEffect(() => {
+    relayRecent(count);
+    // The two label strings rather than the whole `t` object, which is a fresh
+    // identity each render and would run this on every one.
+  }, [
+    relayRecent,
+    recent,
+    count,
+    defaultCurrency,
+    locale,
+    session?.user?.id,
+    t.misc.someone,
+    t.captures.unassigned,
+  ]);
+
   // Subscribe once. Everything the handler needs comes from the refs above.
   useEffect(() => {
     if (!watchAvailable()) return;
-
-    const sendRecent = (n: number) => {
-      const s = stateRef.current;
-      sendToWatch({
-        t: 'recent',
-        items: buildRecentItems(s.recent, n, {
-          myProfileId: s.myProfileId,
-          locale: s.locale,
-          fallbackCurrency: s.defaultCurrency,
-          someoneLabel: s.someone,
-          personalLabel: s.personal,
-          now: Date.now(),
-        }),
-      });
-    };
 
     const unsubscribe = onWatchMessage((raw) => {
       const msg = parseWatchToPhone(raw);
@@ -155,8 +194,10 @@ export function WatchBridgeProvider({ children }: { children?: ReactNode }) {
                 expenseDate: localDate(Date.now()),
                 rawText: msg.note || null,
               });
+              // No recent relay here: the write is only queued at this point,
+              // so the list would still be the pre-write one. The effect above
+              // sends it when the mirror actually changes.
               sendToWatch({ t: 'ack', ok: true });
-              sendRecent(s.count);
               break;
             }
             case 'voiceAdd': {
@@ -187,11 +228,10 @@ export function WatchBridgeProvider({ children }: { children?: ReactNode }) {
                 });
               }
               sendToWatch({ t: 'ack', ok: true });
-              sendRecent(s.count);
               break;
             }
             case 'requestRecent':
-              sendRecent(coerceRecentCount(msg.count));
+              relayRecent(coerceRecentCount(msg.count), { force: true });
               break;
             case 'notifAction':
               // Wired in the notification-actions phase; acknowledge for now.
@@ -205,7 +245,8 @@ export function WatchBridgeProvider({ children }: { children?: ReactNode }) {
     });
 
     return unsubscribe;
-  }, []);
+    // `relayRecent` is stable, so this still subscribes exactly once.
+  }, [relayRecent]);
 
   // Keep the watch's copy of the settings (list size + the currency a quick-add
   // is booked in) in step with the phone.

--- a/apps/mobile/src/lib/watch/bridge.tsx
+++ b/apps/mobile/src/lib/watch/bridge.tsx
@@ -143,8 +143,12 @@ export function WatchBridgeProvider({ children }: { children?: ReactNode }) {
     });
     const encoded = JSON.stringify(items);
     if (!opts?.force && encoded === lastRecentRef.current) return;
-    lastRecentRef.current = encoded;
-    sendToWatch({ t: 'recent', items });
+    // Only remember this payload as sent once the transport handoff succeeds; a
+    // failed send stays eligible for the next automatic relay, so a transient
+    // failure can't leave the watch stale until it asks for the list itself.
+    if (sendToWatch({ t: 'recent', items })) {
+      lastRecentRef.current = encoded;
+    }
   }, []);
 
   /**

--- a/apps/mobile/src/lib/watch/nativeModule.ts
+++ b/apps/mobile/src/lib/watch/nativeModule.ts
@@ -38,11 +38,20 @@ export function watchReachable(): boolean {
 }
 
 /** Send one phone→watch message (stamped with the relay version). No-op if absent. */
-export function sendToWatch(message: PhoneToWatch): void {
+/**
+ * Hand a payload to the native transport. Returns whether the handoff actually
+ * happened — false when no watch module is present or the native call threw —
+ * so a caller that dedupes on the last sent payload can hold its state until a
+ * send truly lands (see the recent-list relay in bridge.tsx).
+ */
+export function sendToWatch(message: PhoneToWatch): boolean {
+  if (!native) return false;
   try {
-    native?.sendToWatch(encodePhoneToWatch(message));
+    native.sendToWatch(encodePhoneToWatch(message));
+    return true;
   } catch {
     // The transport went away between the check and the send; nothing to do.
+    return false;
   }
 }
 


### PR DESCRIPTION
The expense you added from your wrist was the one row the watch's Recent list could never contain.

After servicing a `quickAdd` or `voiceAdd` the bridge relayed the recent list back immediately. But `useSync`'s `mutate` only calls `syncEngine.enqueue` — it applies no optimistic write — and `useRecentActivity` derives purely from the mirror. At that point the capture has been queued and nothing else: not sent, not synced back, not in the activity log. So the list sent *in response to a write* was always the list from *before* it. Not a race that usually lost — a send that could not ever include the row that triggered it.

Relay on mirror change instead, so the watch is told once the write has actually landed.

Two details this needs to get right:

- **A watch that asks always gets an answer.** `requestRecent` forces past the deduplication. A freshly launched watch has an empty list of its own and would otherwise be told nothing whenever the payload happened to match what the previous watch session was sent.
- **The automatic push deduplicates** on the encoded payload. The mirror changes on every sync tick and most ticks do not touch the top few rows; without this each would spend a WatchConnectivity message re-sending rows already on screen.

### Verification
`tsc --noEmit` clean, ESLint clean, 336 mobile tests pass. On a Pixel 8 Pro emulator the app boots clean with the relay rewired and startup stays at four transport calls, confirming the effect is not re-sending on every render.

> ⚠️ **This one is not backed by a test or a hardware check of the actual behaviour.** A write arriving from a real watch needs paired hardware, and the repo has no component-test library to drive the effect in isolation (nothing in `apps/mobile/test/` renders a component), so I did not add a test dependency unprompted. The reasoning above is the argument; a hardware pass is still owed before this is trusted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016n574mVBMyAw5XGnTasohe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of recent activity between the mobile app and watch.
  * Prevented outdated or duplicate recent-list updates.
  * Ensured watch requests receive a fresh response when explicitly requested.
  * Improved updates when mirrored activity or relevant settings change.
  * Enabled automatic retries when an update cannot be delivered.
  * Removed unnecessary immediate updates after quick-add actions.
  * Improved handling of synchronous and asynchronous watch message dispatch results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->