### PR TITLE
feat(activity): badge archived / unavailable groups in the feed

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -4,6 +4,7 @@ import { router } from 'expo-router';
 import { Pressable, RefreshControl, SectionList, View } from 'react-native';
 
 import {
+  Badge,
   Button,
   EmptyState,
   IconButton,
@@ -249,10 +250,50 @@ export default function ActivityScreen() {
                   </Row>
                   {/* The day is the heading's job now, so the row keeps only the
                       clock — "yesterday" printed under a heading that already
-                      said it was noise. */}
-                  <Text variant="micro" tone="muted" style={{ marginTop: 2 }}>
-                    {timeFormat.format(new Date(entry.created_at))}
-                  </Text>
+                      said it was noise. The group the entry belongs to rides
+                      here too: on a cross-group feed the row would otherwise not
+                      say which group it was, and — the point of this line — an
+                      archived group, or one no longer on this device (left or
+                      deleted), gets a badge so it is recognisable without
+                      opening it. */}
+                  <Row
+                    style={{
+                      gap: theme.spacing.sm,
+                      alignItems: 'center',
+                      marginTop: 2,
+                      flexWrap: 'wrap',
+                    }}
+                  >
+                    <Text variant="micro" tone="muted">
+                      {timeFormat.format(new Date(entry.created_at))}
+                    </Text>
+                    {(() => {
+                      const g = entry.group;
+                      const label = g
+                        ? [g.cover_emoji, g.name].filter(Boolean).join(' ').trim() ||
+                          t.captures.group
+                        : null;
+                      return (
+                        <>
+                          {label ? (
+                            <Text
+                              variant="micro"
+                              tone="muted"
+                              numberOfLines={1}
+                              style={{ flexShrink: 1 }}
+                            >
+                              {`· ${label}`}
+                            </Text>
+                          ) : null}
+                          {g?.archived_at ? (
+                            <Badge label={t.misc.archivedGroup} tone="neutral" />
+                          ) : !g ? (
+                            <Badge label={t.misc.unavailableGroup} tone="neutral" />
+                          ) : null}
+                        </>
+                      );
+                    })()}
+                  </Row>
                 </View>
               </Row>
             </Pressable>

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -152,7 +152,7 @@ export async function fetchRecentActivity(
       .from('activity_log')
       .select(
         `id, group_id, actor_member_id, verb, object_type, object_id, payload, created_at,
-         group:groups ( id, name, cover_emoji ),
+         group:groups ( id, name, cover_emoji, archived_at ),
          actor:group_members!activity_log_actor_member_id_fkey (
            id, profile_id, ghost_name, profile:profiles!profile_id ( display_name )
          )`,

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -476,8 +476,18 @@ export function useRecentActivity(): RecentActivityRow[] {
   return useMemo(() => {
     const groups = new Map<string, ActivityGroup>();
     for (const row of rowsFor(mirror, SyncTable.Groups)) {
-      const g = row as unknown as { id: string; name: string | null; cover_emoji: string | null };
-      groups.set(g.id, { id: g.id, name: g.name, cover_emoji: g.cover_emoji });
+      const g = row as unknown as {
+        id: string;
+        name: string | null;
+        cover_emoji: string | null;
+        archived_at: string | null;
+      };
+      groups.set(g.id, {
+        id: g.id,
+        name: g.name,
+        cover_emoji: g.cover_emoji,
+        archived_at: g.archived_at ?? null,
+      });
     }
 
     const actors = new Map<string, ActivityActor>();

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -221,6 +221,10 @@ export interface ActivityGroup {
   id: string;
   name: string | null;
   cover_emoji: string | null;
+  /** Set when the group has been archived — the activity feed shows a badge so a
+   *  row from an archived group is recognisable without opening it. Null on a
+   *  live group. */
+  archived_at: string | null;
 }
 
 export interface ActivityRow {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1264,6 +1264,10 @@ export interface UiStrings {
     startAGroup: string;
     pickDifferentPeople: string;
     someone: string;
+    /** Badges on a cross-group activity row: its group is archived, or no
+     *  longer on this device (left or deleted). */
+    archivedGroup: string;
+    unavailableGroup: string;
     serverRefused: string;
     offlineSaved: string;
     /** The mark on a row that is saved here but has not reached the server. */
@@ -2792,6 +2796,8 @@ const en: UiStrings = {
     startAGroup: 'Start a group',
     pickDifferentPeople: 'Pick different people',
     someone: 'Someone',
+    archivedGroup: 'Archived',
+    unavailableGroup: 'Unavailable',
     serverRefused: 'The server refused this change.',
     notSentYet: 'Not sent yet',
     offlineWithCount: {
@@ -4433,6 +4439,8 @@ const ta: UiStrings = {
     startAGroup: 'ஒரு குழுவைத் தொடங்கு',
     pickDifferentPeople: 'வேறு ஆட்களைத் தேர்ந்தெடு',
     someone: 'யாரோ',
+    archivedGroup: 'காப்பகம்',
+    unavailableGroup: 'கிடைக்கவில்லை',
     serverRefused: 'இந்த மாற்றத்தை சர்வர் ஏற்கவில்லை.',
     notSentYet: 'இன்னும் அனுப்பப்படவில்லை',
     offlineWithCount: {
@@ -6054,6 +6062,8 @@ const hi: UiStrings = {
     startAGroup: 'समूह शुरू करें',
     pickDifferentPeople: 'दूसरे लोग चुनें',
     someone: 'कोई',
+    archivedGroup: 'संग्रहीत',
+    unavailableGroup: 'अनुपलब्ध',
     serverRefused: 'सर्वर ने यह बदलाव नहीं माना।',
     notSentYet: 'अभी भेजा नहीं गया',
     offlineWithCount: {
@@ -7711,6 +7721,8 @@ const ar: UiStrings = {
     startAGroup: 'ابدأ مجموعة',
     pickDifferentPeople: 'اختر أشخاصًا آخرين',
     someone: 'أحدهم',
+    archivedGroup: 'مؤرشَف',
+    unavailableGroup: 'غير متاح',
     serverRefused: 'رفض الخادم هذا التغيير.',
     notSentYet: 'لم يُرسل بعد',
     offlineWithCount: {


### PR DESCRIPTION
@
## Problem

> In activities, I dont see if the group is archived or deleted.

The cross-group activity feed never showed **which group** a row belonged to, let alone its state — an entry from an archived group looked identical to any other.

## Change

Each activity row now has a compact meta line: **time · group (emoji + name) · badge**.

- **Archived** badge when the groups `archived_at` is set.
- **Unavailable** badge when the group row is no longer on this device (you left it, or it was deleted) — the join returns null.
- Live group with a name: just the name, no badge.

## Wiring

- `ActivityGroup` gains `archived_at`; `useRecentActivity` reads it from the **mirrored** group row — offline-first, no new fetch (ADR-005). The network `fetchRecentActivity` select adds the column too, for parity.
- i18n `misc.archivedGroup` / `misc.unavailableGroup` in en / ta / hi / ar.

Local: strings test (15) + typecheck + eslint pass. Copy + read-shape only — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Activity entries now show event times alongside their associated group name and cover emoji.
  - Archived groups are marked with an “Archived” badge.
  - Missing group information is clearly labeled as unavailable.
  - Added localized labels for archived and unavailable groups in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->