### PR TITLE
fix(watch): stop losing a queued relay in silence

### DIFF
--- a/apps/mobile/modules/waves-watch/ios/WavesWatchModule.swift
+++ b/apps/mobile/modules/waves-watch/ios/WavesWatchModule.swift
@@ -14,11 +14,18 @@ public final class WavesWatchModule: Module {
   public func definition() -> ModuleDefinition {
     Name("WavesWatch")
 
-    Events("onWatchMessage")
+    Events("onWatchMessage", "onWatchSendFailed")
 
     OnCreate {
       self.relay.onMessage = { [weak self] payload in
         self?.sendEvent("onWatchMessage", ["payload": payload])
+      }
+      // A queued transfer reports its outcome asynchronously and long after
+      // `sendToWatch` returned, so JS cannot learn of the failure from the call
+      // itself — this is the only signal it gets. `t` is the message kind that
+      // was lost, so the bridge can decide what to redo.
+      self.relay.onSendFailed = { [weak self] kind in
+        self?.sendEvent("onWatchSendFailed", ["t": kind ?? ""])
       }
       self.relay.activate()
     }
@@ -37,6 +44,8 @@ public final class WavesWatchModule: Module {
 // Objective-C must see) is isolated from Expo's generics.
 private final class WatchRelay: NSObject, WCSessionDelegate {
   var onMessage: (([String: Any]) -> Void)?
+  /** Called with the `t` of a queued payload that never reached the watch. */
+  var onSendFailed: ((String?) -> Void)?
 
   private var session: WCSession? {
     WCSession.isSupported() ? WCSession.default : nil
@@ -77,6 +86,29 @@ private final class WatchRelay: NSObject, WCSessionDelegate {
   // The queued counterpart of the live sendMessage path — delivered on wake.
   func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
     onMessage?(userInfo)
+  }
+
+  /**
+   * The outcome of a `transferUserInfo`.
+   *
+   * Without this method WatchConnectivity has nowhere to report a failed
+   * transfer and logs that the delegate does not implement it, so every queued
+   * payload that never arrived was dropped in silence. That matters most for
+   * `recent`: the bridge remembers the last list it sent and skips re-sending an
+   * identical one, so a lost transfer would otherwise leave the watch showing a
+   * stale list until the list itself changed.
+   *
+   * `error` is terminal — WatchConnectivity has already retried the queued
+   * transfer on its own — so this reports the loss rather than re-sending, which
+   * against an unpaired or deleted watch would only fail again in a loop.
+   */
+  func session(
+    _ session: WCSession,
+    didFinish userInfoTransfer: WCSessionUserInfoTransfer,
+    error: Error?
+  ) {
+    guard error != nil else { return }
+    onSendFailed?(userInfoTransfer.userInfo["t"] as? String)
   }
 
   func session(

--- a/apps/mobile/src/lib/watch/bridge.tsx
+++ b/apps/mobile/src/lib/watch/bridge.tsx
@@ -34,7 +34,7 @@ import { useAuth } from '@/lib/auth';
 import { useDefaultCurrency } from '@/lib/currency';
 import { useRecentCount } from '@/lib/recentCount';
 import { parseVoiceExpenses, type VoiceGroupRef } from '@/lib/voiceExpense';
-import { onWatchMessage, sendToWatch, watchAvailable } from './nativeModule';
+import { onWatchMessage, onWatchSendFailed, sendToWatch, watchAvailable } from './nativeModule';
 
 function pad2(n: number): string {
   return n < 10 ? `0${n}` : String(n);
@@ -149,6 +149,28 @@ export function WatchBridgeProvider({ children }: { children?: ReactNode }) {
     if (sendToWatch({ t: 'recent', items })) {
       lastRecentRef.current = encoded;
     }
+  }, []);
+
+  /**
+   * Forget the cached payload when a relay is reported lost in transit.
+   *
+   * `relayRecent` skips a list identical to the one it last sent, and a send
+   * that fails only after it left this side still counted as sent — so a lost
+   * transfer pinned the watch to a stale list until the list itself changed,
+   * which on a quiet ledger can be days. Clearing the cache makes the next
+   * automatic relay send the same list again.
+   *
+   * It deliberately does not re-send here. Both platforms report this only once
+   * their own retries are exhausted, so an immediate retry would fail again
+   * against an unpaired or deleted watch — and each failure would ask for
+   * another one. The watch also asks outright (`requestRecent`) whenever its
+   * Home or Recent screen appears, which is the faster path back in practice.
+   */
+  useEffect(() => {
+    if (!watchAvailable()) return;
+    return onWatchSendFailed((kind) => {
+      if (kind === null || kind === 'recent') lastRecentRef.current = null;
+    });
   }, []);
 
   /**

--- a/apps/mobile/src/lib/watch/nativeModule.ts
+++ b/apps/mobile/src/lib/watch/nativeModule.ts
@@ -23,6 +23,13 @@ interface NativeWatch {
     event: 'onWatchMessage',
     handler: (event: { payload: unknown }) => void,
   ): { remove(): void };
+  // iOS only: a queued WatchConnectivity transfer that never reached the watch.
+  // Android has no equivalent event — its failures surface as a rejection from
+  // `sendToWatch` above — and both are funnelled into `onWatchSendFailed`.
+  addListener(
+    event: 'onWatchSendFailed',
+    handler: (event: { t?: unknown }) => void,
+  ): { remove(): void };
 }
 
 const native = requireOptionalNativeModule<NativeWatch>('WavesWatch');
@@ -41,14 +48,62 @@ export function watchReachable(): boolean {
   }
 }
 
+type SendFailureHandler = (kind: string | null) => void;
+
+const failureHandlers = new Set<SendFailureHandler>();
+let failureSubscription: { remove(): void } | null = null;
+
+function notifySendFailed(kind: string | null): void {
+  // A copy, so a handler that unsubscribes itself cannot mutate the set mid-loop.
+  for (const handler of [...failureHandlers]) {
+    try {
+      handler(kind);
+    } catch {
+      // One subscriber's failure must not stop the others being told.
+    }
+  }
+}
+
+/**
+ * Learn that a payload never reached the watch.
+ *
+ * Delivery is asynchronous on both platforms, so `sendToWatch` returning true
+ * only means the payload left this side — the loss is reported later or not at
+ * all. Handlers receive the `t` of the lost message where the platform says
+ * which one it was (iOS names it; Android's rejection is per-send, so it is
+ * named from the call), and null when it is unknown.
+ *
+ * A build with no watch module, or one whose native half predates the event,
+ * simply never calls back — the same safe no-op the rest of this module keeps.
+ */
+export function onWatchSendFailed(handler: SendFailureHandler): () => void {
+  failureHandlers.add(handler);
+  if (native && !failureSubscription) {
+    try {
+      failureSubscription = native.addListener('onWatchSendFailed', (event) => {
+        const kind = event.t;
+        notifySendFailed(typeof kind === 'string' && kind !== '' ? kind : null);
+      });
+    } catch {
+      // An older native module without this event; Android's send-promise path
+      // below still reports, so leave the subscription unmade.
+      failureSubscription = null;
+    }
+  }
+  return () => {
+    failureHandlers.delete(handler);
+  };
+}
+
 /**
  * Hand a payload to the native transport. Returns whether the payload was
  * dispatched — false when no watch module is present or the native call threw
  * synchronously — so a caller that dedupes on the last sent payload can hold
  * its state until a send is at least dispatched (see the recent-list relay in
  * bridge.tsx). An asynchronous delivery failure (Android with no paired watch)
- * is swallowed below so it cannot become an unhandled rejection; those cases
- * still return true, since the payload did leave this side.
+ * cannot become an unhandled rejection and still returns true, since the
+ * payload did leave this side; it is reported through `onWatchSendFailed`
+ * instead, which is the only way a caller hears about it.
  */
 export function sendToWatch(message: PhoneToWatch): boolean {
   if (!native) return false;
@@ -60,7 +115,9 @@ export function sendToWatch(message: PhoneToWatch): boolean {
     // so those failures surfaced as unhandled promise rejections, which is the
     // opposite of the safe no-op this module exists to promise. `Promise.resolve`
     // normalises iOS's undefined return so the same line covers both platforms.
-    void Promise.resolve(native.sendToWatch(encodePhoneToWatch(message))).catch(() => undefined);
+    void Promise.resolve(native.sendToWatch(encodePhoneToWatch(message))).catch(() => {
+      notifySendFailed(message.t);
+    });
     return true;
   } catch {
     // The transport went away between the check and the send; nothing to do.

--- a/apps/mobile/targets/watch/Views.swift
+++ b/apps/mobile/targets/watch/Views.swift
@@ -21,6 +21,20 @@ struct HomeView: View {
         NavigationLink(destination: RecentView()) {
           Label("Recent", systemImage: "clock.fill")
         }
+
+        // The one place a dropped intent can be seen. Quick-add and Speak both
+        // dismiss the moment they send, and the phone's `ack` never arrives when
+        // the message itself did not, so without this row an expense entered
+        // here could vanish with nothing to show for it.
+        if relay.lastSendFailed {
+          Label {
+            Text("Last expense didn't reach your phone. Open Waves there and try again.")
+              .font(.caption2)
+          } icon: {
+            Image(systemName: "exclamationmark.triangle.fill")
+          }
+          .foregroundStyle(.orange)
+        }
       }
       .tint(accent)
       .navigationTitle("Waves")

--- a/apps/mobile/targets/watch/WavesWatchApp.swift
+++ b/apps/mobile/targets/watch/WavesWatchApp.swift
@@ -46,8 +46,11 @@ final class WatchRelay: NSObject, ObservableObject, WCSessionDelegate {
   }
 
   func quickAdd(amountMinor: Int, currency: String, note: String) {
-    lastSendFailed = false
-    send([
+    // Clear the warning only if the payload was actually accepted for delivery.
+    // Clearing up front and then hitting the guard in `send` — session not yet
+    // activated right after launch — dropped the expense and left no warning,
+    // the silent loss this whole change exists to stop.
+    lastSendFailed = !send([
       "t": "quickAdd",
       // A stable id per intent so a transport retry of the same tap is
       // idempotent on the phone rather than creating a duplicate expense.
@@ -59,12 +62,17 @@ final class WatchRelay: NSObject, ObservableObject, WCSessionDelegate {
   }
 
   func voiceAdd(_ transcript: String) {
-    lastSendFailed = false
-    send(["t": "voiceAdd", "id": UUID().uuidString, "transcript": transcript])
+    lastSendFailed = !send(["t": "voiceAdd", "id": UUID().uuidString, "transcript": transcript])
   }
 
-  private func send(_ message: [String: Any]) {
-    guard let session, session.activationState == .activated else { return }
+  /// Hand a message to WatchConnectivity for delivery. Returns whether it was
+  /// accepted: `false` means there was no activated session to take it, so the
+  /// caller (an expense send) must surface that rather than assume it left.
+  /// `requestRecent` ignores the result — a missed recent-list refresh is not a
+  /// lost expense and must not raise the expense-drop warning.
+  @discardableResult
+  private func send(_ message: [String: Any]) -> Bool {
+    guard let session, session.activationState == .activated else { return false }
     var payload = message
     payload["version"] = relayVersion
     if session.isReachable {
@@ -74,6 +82,7 @@ final class WatchRelay: NSObject, ObservableObject, WCSessionDelegate {
     } else {
       session.transferUserInfo(payload)
     }
+    return true
   }
 
   // MARK: WCSessionDelegate

--- a/apps/mobile/targets/watch/WavesWatchApp.swift
+++ b/apps/mobile/targets/watch/WavesWatchApp.swift
@@ -26,6 +26,8 @@ final class WatchRelay: NSObject, ObservableObject, WCSessionDelegate {
   @Published var currency: String = "USD"
   @Published var lastAckOk: Bool? = nil
   @Published var reachable: Bool = false
+  /// An expense this watch sent that WatchConnectivity could not deliver.
+  @Published var lastSendFailed: Bool = false
 
   private var session: WCSession? { WCSession.isSupported() ? WCSession.default : nil }
 
@@ -44,6 +46,7 @@ final class WatchRelay: NSObject, ObservableObject, WCSessionDelegate {
   }
 
   func quickAdd(amountMinor: Int, currency: String, note: String) {
+    lastSendFailed = false
     send([
       "t": "quickAdd",
       // A stable id per intent so a transport retry of the same tap is
@@ -56,6 +59,7 @@ final class WatchRelay: NSObject, ObservableObject, WCSessionDelegate {
   }
 
   func voiceAdd(_ transcript: String) {
+    lastSendFailed = false
     send(["t": "voiceAdd", "id": UUID().uuidString, "transcript": transcript])
   }
 
@@ -99,6 +103,30 @@ final class WatchRelay: NSObject, ObservableObject, WCSessionDelegate {
 
   func sessionReachabilityDidChange(_ session: WCSession) {
     DispatchQueue.main.async { self.reachable = session.isReachable }
+  }
+
+  /**
+   * The outcome of a `transferUserInfo` — the path every intent takes whenever
+   * the phone is not reachable, which on a wrist is most of the time.
+   *
+   * Without this method WatchConnectivity has nowhere to report a failed
+   * transfer, so an expense spoken or dialled here could disappear between the
+   * watch and the phone with nothing shown: the view dismisses on tap and the
+   * only other signal, `ack`, comes from a phone that never got the message.
+   *
+   * Only the intents that carry an expense raise the warning. A lost
+   * `requestRecent` costs nothing — the list simply stays as it was, which the
+   * Recent screen already shows honestly.
+   */
+  func session(
+    _ session: WCSession,
+    didFinish userInfoTransfer: WCSessionUserInfoTransfer,
+    error: Error?
+  ) {
+    let kind = userInfoTransfer.userInfo["t"] as? String
+    guard kind == "quickAdd" || kind == "voiceAdd" else { return }
+    let failed = error != nil
+    DispatchQueue.main.async { self.lastSendFailed = failed }
   }
 
   private func handle(_ message: [String: Any]) {

--- a/apps/mobile/test/watchSendFailure.test.ts
+++ b/apps/mobile/test/watchSendFailure.test.ts
@@ -1,0 +1,225 @@
+/**
+ * What happens to a phone→watch payload that never arrives.
+ *
+ * Delivery is asynchronous on both platforms, so `sendToWatch` returning true
+ * only means the payload left the phone. iOS hands a queued transfer to
+ * WatchConnectivity and hears the outcome much later through
+ * `didFinishUserInfoTransfer` (surfaced as an `onWatchSendFailed` event);
+ * Android rejects the send promise. Before this, neither reached JS: the iOS
+ * delegate method did not exist — WatchConnectivity logged that the delegate
+ * "does not implement session:didFinishUserInfoTransfer:error:" — and the
+ * Android rejection was swallowed whole to stop it becoming an unhandled
+ * rejection.
+ *
+ * That silence had a cost beyond the lost message. The recent-list relay skips
+ * a list identical to the one it last sent, and a send that failed after
+ * leaving still counted as sent, so the watch could sit on a stale list until
+ * the list itself changed. These cover both transports reporting the loss, and
+ * the bridge's rule for acting on it.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Set before each dynamic import; the module reads it once at load. */
+const stub = vi.hoisted(() => ({ native: null as Record<string, unknown> | null }));
+
+vi.mock('expo', () => ({
+  requireOptionalNativeModule: () => stub.native,
+}));
+
+type EventHandler = (event: { t?: unknown }) => void;
+
+/**
+ * A fake native module. `sendResult` is what `sendToWatch` hands back — a
+ * rejected promise stands in for Android's failed node lookup; `undefined` for
+ * iOS, whose send is synchronous and reports later through the event instead.
+ */
+function nativeStub(opts: { sendResult?: () => unknown; noEvent?: boolean } = {}) {
+  const listeners: Record<string, EventHandler[]> = {};
+  let removed = 0;
+  return {
+    module: {
+      isReachable: () => true,
+      sendToWatch: () => (opts.sendResult ? opts.sendResult() : undefined),
+      addListener: (event: string, handler: EventHandler) => {
+        if (opts.noEvent && event === 'onWatchSendFailed') {
+          throw new Error('unknown event');
+        }
+        (listeners[event] ??= []).push(handler);
+        return {
+          remove() {
+            removed += 1;
+          },
+        };
+      },
+    },
+    /** Fire what iOS's delegate would send up. */
+    emit(event: string, payload: { t?: unknown }) {
+      for (const handler of listeners[event] ?? []) handler(payload);
+    },
+    get removeCount() {
+      return removed;
+    },
+  };
+}
+
+async function loadModule(native: Record<string, unknown> | null) {
+  stub.native = native;
+  vi.resetModules();
+  return import('@/lib/watch/nativeModule');
+}
+
+/** Let the swallowed rejection's `.catch` run. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const RECENT = { t: 'recent' as const, items: [] };
+
+beforeEach(() => {
+  stub.native = null;
+});
+
+describe('watch send failures reach JS', () => {
+  it('reports the message kind when the native send rejects (Android)', async () => {
+    const fake = nativeStub({ sendResult: () => Promise.reject(new Error('no nodes')) });
+    const { onWatchSendFailed, sendToWatch } = await loadModule(fake.module);
+
+    const seen: (string | null)[] = [];
+    onWatchSendFailed((kind) => seen.push(kind));
+
+    // True: the payload did leave this side. The loss is only known later.
+    expect(sendToWatch(RECENT)).toBe(true);
+    expect(seen).toEqual([]);
+
+    await flush();
+    expect(seen).toEqual(['recent']);
+  });
+
+  it('reports the kind named by the iOS transfer event', async () => {
+    const fake = nativeStub();
+    const { onWatchSendFailed } = await loadModule(fake.module);
+
+    const seen: (string | null)[] = [];
+    onWatchSendFailed((kind) => seen.push(kind));
+
+    fake.emit('onWatchSendFailed', { t: 'ack' });
+    expect(seen).toEqual(['ack']);
+  });
+
+  it('reports null when the transfer does not name a kind', async () => {
+    const fake = nativeStub();
+    const { onWatchSendFailed } = await loadModule(fake.module);
+
+    const seen: (string | null)[] = [];
+    onWatchSendFailed((kind) => seen.push(kind));
+
+    // The Swift side sends "" for a payload with no readable `t`.
+    fake.emit('onWatchSendFailed', { t: '' });
+    fake.emit('onWatchSendFailed', {});
+    expect(seen).toEqual([null, null]);
+  });
+
+  it('stops calling a handler once it unsubscribes', async () => {
+    const fake = nativeStub();
+    const { onWatchSendFailed } = await loadModule(fake.module);
+
+    const seen: (string | null)[] = [];
+    const unsubscribe = onWatchSendFailed((kind) => seen.push(kind));
+
+    fake.emit('onWatchSendFailed', { t: 'recent' });
+    unsubscribe();
+    fake.emit('onWatchSendFailed', { t: 'recent' });
+
+    expect(seen).toEqual(['recent']);
+  });
+
+  it('tells every subscriber even when one of them throws', async () => {
+    const fake = nativeStub();
+    const { onWatchSendFailed } = await loadModule(fake.module);
+
+    const seen: string[] = [];
+    onWatchSendFailed(() => {
+      throw new Error('subscriber blew up');
+    });
+    onWatchSendFailed(() => seen.push('second'));
+
+    expect(() => fake.emit('onWatchSendFailed', { t: 'recent' })).not.toThrow();
+    expect(seen).toEqual(['second']);
+  });
+
+  it('stays a no-op in a build with no watch module', async () => {
+    const { onWatchSendFailed, sendToWatch, watchAvailable } = await loadModule(null);
+
+    expect(watchAvailable()).toBe(false);
+    const seen: unknown[] = [];
+    const unsubscribe = onWatchSendFailed((kind) => seen.push(kind));
+
+    expect(sendToWatch(RECENT)).toBe(false);
+    await flush();
+    expect(seen).toEqual([]);
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it('still reports rejections when the native half predates the event', async () => {
+    // An older build: `addListener('onWatchSendFailed')` throws, so only the
+    // send-promise path is left. Subscribing must not take the module down.
+    const fake = nativeStub({
+      noEvent: true,
+      sendResult: () => Promise.reject(new Error('no nodes')),
+    });
+    const { onWatchSendFailed, sendToWatch } = await loadModule(fake.module);
+
+    const seen: (string | null)[] = [];
+    expect(() => onWatchSendFailed((kind) => seen.push(kind))).not.toThrow();
+
+    sendToWatch({ t: 'ack', ok: true });
+    await flush();
+    expect(seen).toEqual(['ack']);
+  });
+});
+
+describe("the bridge's rule for a lost relay", () => {
+  /**
+   * `relayRecent`'s dedupe, reduced to the decision under test: a lost `recent`
+   * must clear the remembered payload so the identical list is sent again.
+   */
+  function dedupe() {
+    let lastSent: string | null = null;
+    return {
+      relay(items: string): 'sent' | 'skipped' {
+        if (items === lastSent) return 'skipped';
+        lastSent = items;
+        return 'sent';
+      },
+      onFailure(kind: string | null) {
+        if (kind === null || kind === 'recent') lastSent = null;
+      },
+      get remembered() {
+        return lastSent;
+      },
+    };
+  }
+
+  it('re-sends an unchanged list after that list was lost in transit', () => {
+    const d = dedupe();
+    expect(d.relay('[A]')).toBe('sent');
+    expect(d.relay('[A]')).toBe('skipped');
+
+    d.onFailure('recent');
+    expect(d.relay('[A]')).toBe('sent');
+  });
+
+  it('clears on an unnamed loss, since it may have been the list', () => {
+    const d = dedupe();
+    d.relay('[A]');
+    d.onFailure(null);
+    expect(d.remembered).toBeNull();
+  });
+
+  it('keeps the cache when some other message was the one lost', () => {
+    const d = dedupe();
+    d.relay('[A]');
+    d.onFailure('ack');
+    // An ack is not worth re-sending the whole list for.
+    expect(d.relay('[A]')).toBe('skipped');
+  });
+});


### PR DESCRIPTION
## The bug

`transferUserInfo` is the queued path both ends fall back to whenever the peer is unreachable — on a wrist, most of the time. Its outcome is reported **only** through `session(_:didFinishUserInfoTransfer:error:)`, and neither `WatchRelay` implemented it. WatchConnectivity said so itself, on device:

```
delegate …WatchRelay does not implement session:didFinishUserInfoTransfer:error:
```

So any payload that failed to arrive vanished with nothing observing it.

Found by running the app on the iOS simulator and reading the `com.apple.wcd` log.

## What it cost

**On the phone**, the silence outlived the send. `relayRecent` skips a list identical to the one it last sent, and a send that failed *after* leaving still counted as sent — so a lost transfer pinned the watch to a stale list until the list itself changed. On a quiet ledger that is days.

**On the watch**, the lost payloads are `quickAdd` and `voiceAdd` — money. Both views dismiss the instant they send, and the only other signal (`ack`) comes from a phone that never got the message, so an expense spoken from the wrist could disappear with nothing shown at all.

## The change

| File | |
|---|---|
| `WavesWatchModule.swift` | implements the delegate; emits `onWatchSendFailed` with the lost message's `t` |
| `nativeModule.ts` | one `onWatchSendFailed` API fed by **both** transports — the new iOS event, and the Android send-promise rejection previously swallowed to `undefined` |
| `bridge.tsx` | a lost `recent` clears `lastRecentRef` so the next relay re-sends; a lost `ack` does not |
| `WavesWatchApp.swift`, `Views.swift` | raises `lastSendFailed` and shows it on Home — only for intents carrying an expense; a lost `requestRecent` costs nothing |

Both sides **report rather than re-send**: the error arrives only once the platform has exhausted its own retries, so sending again would just fail again against an unpaired or deleted watch, and each failure would ask for another attempt.

## Verification

| Check | Result |
|---|---|
| `xcodebuild` (all 3 Swift files) | BUILD SUCCEEDED — 0 errors, 0 warnings in them |
| `tsc --noEmit` | clean |
| `expo lint` | clean |
| `vitest run` | 354 passed / 34 files |
| new `watchSendFailure.test.ts` | 10 passed |
| the log line above, on device | **0 occurrences** (was present) |

New tests cover both transports, unsubscribe, a throwing subscriber, the no-module and older-native-module builds, and the bridge's cache rule.

## Caveat

The Swift **failure path is compile-verified, not executed** — making a transfer genuinely fail needs a real paired watch, and the simulator's `WCSession` never gets there. What is confirmed on device is that the delegate is now registered: the warning no longer appears. The JS half is properly tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016n574mVBMyAw5XGnTasohe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer notifications when an expense fails to transfer between the watch and phone.
  - The watch now displays a warning when the latest expense could not reach the phone.
  - Failed transfers are reported consistently across supported platforms.

- **Bug Fixes**
  - Recent expense data can be resent automatically after relevant transfer failures.
  - Improved handling for delayed, unnamed, or unsupported transfer-failure responses.
  - Prevented unrelated transfer failures from clearing pending recent data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->