### PR TITLE
fix(errors): stop echoing raw network exceptions to the UI

### DIFF
--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -122,7 +122,9 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
     try {
       return await action();
     } catch (caught) {
-      setError(friendlyError(caught, t.signIn.couldNotSignIn, 'auth.signIn'));
+      setError(
+        friendlyError(caught, t.signIn.couldNotSignIn, 'auth.signIn', t.misc.connectionProblem),
+      );
       return undefined;
     } finally {
       setBusy(false);

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1276,6 +1276,10 @@ export interface UiStrings {
     cantReachServer: PluralForms;
     /** Server unreachable but nothing is queued — no count to quote. */
     cantReachServerIdle: string;
+    /** A network call failed for a reason that is not worth quoting (the raw
+     *  transport error is internal noise). Said on foreground actions like
+     *  signing in, where "saved here" does not apply. */
+    connectionProblem: string;
     syncingCount: PluralForms;
     notAnAmount: string;
     notARate: string;
@@ -2809,6 +2813,7 @@ const en: UiStrings = {
       other: "Can't reach the server — {n} changes saved here, waiting to send",
     },
     cantReachServerIdle: "Can't reach the server — everything here is saved",
+    connectionProblem: 'Check your connection and try again.',
     syncingCount: { one: 'Sending {n} change…', other: 'Sending {n} changes…' },
     offlineSaved: 'Offline — everything here is saved on this phone',
     notAnAmount: 'That does not look like an amount',
@@ -4452,6 +4457,7 @@ const ta: UiStrings = {
       other: 'சர்வரை அடைய முடியவில்லை — {n} மாற்றங்கள் இங்கே சேமிக்கப்பட்டு காத்திருக்கின்றன',
     },
     cantReachServerIdle: 'சர்வரை அடைய முடியவில்லை — எல்லாம் இங்கே சேமிக்கப்பட்டுள்ளது',
+    connectionProblem: 'இணைப்பைச் சரிபார்த்து மீண்டும் முயற்சிக்கவும்.',
     syncingCount: {
       one: '{n} மாற்றம் அனுப்பப்படுகிறது…',
       other: '{n} மாற்றங்கள் அனுப்பப்படுகின்றன…',
@@ -6075,6 +6081,7 @@ const hi: UiStrings = {
       other: 'सर्वर तक नहीं पहुँच पा रहे — {n} बदलाव यहीं सेव हैं, भेजने का इंतज़ार',
     },
     cantReachServerIdle: 'सर्वर तक नहीं पहुँच पा रहे — सब कुछ यहीं सेव है',
+    connectionProblem: 'अपना कनेक्शन जाँचें और फिर से कोशिश करें।',
     syncingCount: { one: '{n} बदलाव भेजा जा रहा है…', other: '{n} बदलाव भेजे जा रहे हैं…' },
     offlineSaved: 'ऑफ़लाइन — यहाँ का सब कुछ इसी फ़ोन पर सेव है',
     notAnAmount: 'यह रकम जैसा नहीं लगता',
@@ -7742,6 +7749,7 @@ const ar: UiStrings = {
       other: 'تعذّر الوصول إلى الخادم — {n} تغيير محفوظ هنا في انتظار الإرسال',
     },
     cantReachServerIdle: 'تعذّر الوصول إلى الخادم — كل شيء هنا محفوظ',
+    connectionProblem: 'تحقّق من اتصالك وحاول مرة أخرى.',
     syncingCount: {
       zero: 'جارٍ الإرسال…',
       one: 'جارٍ إرسال تغيير واحد…',

--- a/apps/mobile/src/lib/errors.ts
+++ b/apps/mobile/src/lib/errors.ts
@@ -23,7 +23,12 @@ interface Postgrestish {
   code?: string;
 }
 
-export function friendlyError(caught: unknown, fallback: string, where: string): string {
+export function friendlyError(
+  caught: unknown,
+  fallback: string,
+  where: string,
+  offline?: string,
+): string {
   const error = (caught ?? {}) as Postgrestish;
   const message =
     typeof error.message === 'string' ? error.message : typeof caught === 'string' ? caught : '';
@@ -45,9 +50,18 @@ export function friendlyError(caught: unknown, fallback: string, where: string):
     return fallback;
   }
 
-  // A network failure already reads plainly, and telling somebody their
-  // connection dropped is worth more than a generic apology. Everything else is
-  // a sentence about the schema, so it stays in the crash report only.
-  if (/network request failed|fetch failed|timeout|offline/i.test(message)) return message;
+  // A network failure is worth naming — telling somebody their connection
+  // dropped beats a generic apology. But the raw message is not safe to echo:
+  // a native transport failure surfaces as internal noise, e.g. a TLS
+  // handshake error arriving as "fetch failed: UnexpectedException: A TLS
+  // error caused the secure connection to fail. (at
+  // ExpoModulesCore/Promise.swift:56)". That names an exception class and a
+  // Swift file:line to a person trying to sign in. So: recognise the network
+  // case, but return the caller's clean connection sentence (or the generic
+  // fallback), never the raw string. The original still goes to the crash
+  // report via reportHandled above. Everything else is a sentence about the
+  // schema, so it stays in the crash report only.
+  if (/network request failed|fetch failed|timeout|offline|tls|secure connection/i.test(message))
+    return offline ?? fallback;
   return fallback;
 }


### PR DESCRIPTION
## Problem
On the sign-in screen a TLS handshake failure surfaced to the user as:

> fetch failed: UnexpectedException: A TLS error caused the secure connection to fail. (at ExpoModulesCore/Promise.swift:56)

`friendlyError` treated any message matching `/fetch failed|network request failed|timeout|offline/` as "plain enough to show" and returned it **verbatim** — leaking an exception class and a Swift `file:line` to a person trying to log in.

## Fix
- `friendlyError` still recognises the network case (now also `tls` / `secure connection`) but returns a **clean, localized** sentence instead of the raw string: a caller-supplied connection message, or the generic fallback.
- New optional `offline` argument; defaults to the existing fallback, so **every current call site is immediately safe** with no behaviour change beyond no longer leaking internals.
- `AuthFlow` passes `t.misc.connectionProblem` — a new "Check your connection and try again." string (en/ta/hi/ar).
- The raw error still reaches the crash reporter via `reportHandled`, unchanged.

## Gates
- `tsc --noEmit` ✓
- `expo lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in error messages for connection problems.
  * Added clearer handling for secure-connection and network failures.
  * Prevented raw transport errors from being shown to users.

* **Localization**
  * Added connection-problem messages in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->