### PR TITLE
fix(scan): cancelling the receipt scanner no longer opens the OS camera

### DIFF
--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -270,8 +270,16 @@ export async function pickReceiptImage(): Promise<PickedImage | null> {
  * screen asking for a receipt has no business knowing which one it got.
  */
 export async function captureReceipt(): Promise<PickedImage | null> {
-  const scanned = await scanDocument();
-  if (!scanned) return pickReceiptPhoto();
+  const outcome = await scanDocument();
+  // No scanner in this build (web, or a binary from before it was installed) or
+  // one that would not open: fall through to the plain camera, which is what
+  // every scan used until the scanner existed.
+  if (outcome.kind === 'unavailable') return pickReceiptPhoto();
+  // Backed out of the scanner. That is a cancel, not a request for a different
+  // camera — the old code fell back here and surprised the person with the OS
+  // camera. Do nothing.
+  if (outcome.kind === 'cancelled') return null;
+  const scanned = outcome.uri;
 
   // The scanner reports no dimensions, and `shrink` caps whichever edge is
   // longer. Asking the file is cheap; failing to ask would send a 4000px scan

--- a/apps/mobile/src/lib/scanner.ts
+++ b/apps/mobile/src/lib/scanner.ts
@@ -39,18 +39,31 @@ export function scannerAvailable(): boolean {
 }
 
 /**
- * Open the scanner and return the cropped page as a local file URI.
+ * How a scan ended. The three cases are deliberately kept apart because the
+ * caller must treat them differently:
  *
- * Null covers every ordinary way this ends without an image: no scanner in
- * this build, and the person backing out of the camera. Neither is an error to
- * report — the caller falls back to the plain camera, or does nothing.
+ *  - `image`       — a cropped page, use it.
+ *  - `cancelled`   — the scanner opened and the person backed out. Do nothing;
+ *                    they did not ask for a different camera.
+ *  - `unavailable` — there is no scanner in this build, or it would not open at
+ *                    all. Falling back to the plain camera is right here.
+ *
+ * Collapsing `cancelled` and `unavailable` into one "no image" was the bug this
+ * type exists to prevent: it made backing out of the scanner silently launch
+ * the OS camera instead.
+ */
+export type ScanResult =
+  { kind: 'image'; uri: string } | { kind: 'cancelled' } | { kind: 'unavailable' };
+
+/**
+ * Open the scanner and report how it ended (see `ScanResult`).
  *
  * One page only. A restaurant bill is one page, and a second image would have
  * to be reconciled against the first before either could become an expense —
  * work with no home in ADR-008's "the model proposes, the person confirms".
  */
-export async function scanDocument(): Promise<string | null> {
-  if (!scannerAvailable()) return null;
+export async function scanDocument(): Promise<ScanResult> {
+  if (!scannerAvailable()) return { kind: 'unavailable' };
 
   let scanner: DocumentScanner;
   try {
@@ -62,7 +75,7 @@ export async function scanDocument(): Promise<string | null> {
     };
     scanner = loaded.default;
   } catch {
-    return null;
+    return { kind: 'unavailable' };
   }
 
   try {
@@ -73,10 +86,13 @@ export async function scanDocument(): Promise<string | null> {
       // strokes that were already marginal.
       croppedImageQuality: 100,
     });
-    return scannedImages?.[0] ?? null;
+    const uri = scannedImages?.[0];
+    // An image means success. No image with no throw is the person backing out
+    // of the scanner — a cancel, not a reason to open another camera.
+    return uri ? { kind: 'image', uri } : { kind: 'cancelled' };
   } catch {
-    // A camera that will not open is a reason to fall back to the picker, not
-    // a reason to put an error in front of somebody holding a bill.
-    return null;
+    // A scanner that will not open at all is a reason to fall back to the plain
+    // camera, not to put an error in front of somebody holding a bill.
+    return { kind: 'unavailable' };
   }
 }


### PR DESCRIPTION
## Problem (from a screen recording)
Tapping the dashboard scan icon opens the document scanner. **Backing out of the scanner** dropped the user straight into the phone's **native camera** (Portrait/Photo) instead of returning to the form.

## Root cause
`scanDocument()` returned `null` for three different endings — no scanner in this build, user cancelled, and scanner failed to open — and `captureReceipt()` fell back to the native camera on *any* `null`. So a cancel was misread as "no scanner, use the camera instead." The scanner's own docstring already said a cancel should "do nothing"; the caller just didn't honour it.

## Fix
- `scanDocument()` now returns a 3-way `ScanResult`: `image` | `cancelled` | `unavailable`.
- `captureReceipt()` falls back to the plain camera **only** on `unavailable` (web / old binary / won't-open). A `cancelled` scan returns `null` and does nothing.

No behaviour change for the genuine no-scanner fallback or a successful scan.

## Gates
- `tsc --noEmit` ✓
- `expo lint` ✓

## Note
The floating gear seen over the modal in the recording is the **expo-dev-client dev-menu button** (debug builds only) — not app UI, not shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt capture handling for scanner availability, user cancellations, and successful scans.
  * Automatically falls back to the camera when document scanning is unavailable or cannot be opened.
  * Prevented cancelled scans from unintentionally launching the camera.
  * Continued processing scanned images through the existing resizing and encoding flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->