### PR TITLE
fix(location): probe ExpoLocation before requiring it, so a stale build fails soft

### DIFF
--- a/apps/mobile/src/components/LocationField.tsx
+++ b/apps/mobile/src/components/LocationField.tsx
@@ -20,7 +20,7 @@ import type { ExpenseLocation } from '@waves/core';
 import { Button, Callout, Card, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
-import { captureLocation, coordLabel, LocationFailure, locationSupported } from '@/lib/location';
+import { captureLocation, coordLabel, LocationFailure, locationAvailable } from '@/lib/location';
 
 export function LocationField({
   value,
@@ -38,7 +38,7 @@ export function LocationField({
 
   // Web and a build with no location module have nothing to offer — the whole
   // field is absent rather than a button that can only fail.
-  if (!locationSupported) return null;
+  if (!locationAvailable()) return null;
 
   const add = async (): Promise<void> => {
     setFailure(null);

--- a/apps/mobile/src/lib/location.ts
+++ b/apps/mobile/src/lib/location.ts
@@ -73,6 +73,17 @@ function locationModuleLinked(): boolean {
   return host?.modules?.ExpoLocation != null;
 }
 
+/**
+ * Whether a location can actually be read on this device right now: a native
+ * platform *and* the `ExpoLocation` module linked into this binary. The UI gates
+ * on this (not `locationSupported`) so a stale build shows no add-location
+ * button rather than one that taps to nothing — `captureLocation` would return
+ * `Unsupported`, which the field deliberately swallows.
+ */
+export function locationAvailable(): boolean {
+  return locationSupported && locationModuleLinked();
+}
+
 function loadLocation(): ExpoLocation | null {
   if (!locationSupported || !locationModuleLinked()) return null;
   try {

--- a/apps/mobile/src/lib/location.ts
+++ b/apps/mobile/src/lib/location.ts
@@ -55,8 +55,26 @@ interface LocationGeocodedAddress {
   region?: string | null;
 }
 
+/**
+ * Whether the `ExpoLocation` native module is linked into this binary.
+ *
+ * Expo modules register on the JSI host object (`globalThis.expo.modules`) as
+ * the app starts. Reading it is a plain property lookup that cannot throw —
+ * unlike `require('expo-location')`, which evaluates ExpoLocation.js and calls
+ * `requireNativeModule('ExpoLocation')`, throwing on a binary that never linked
+ * it (a stale dev client, most often). In dev that throw is surfaced as a redbox
+ * even when caught, so a try around the require is not enough on its own; this
+ * check keeps us from ever requiring the wrapper when the module is not there.
+ * Kept dependency-free (no `expo-modules-core` import) for the same reason the
+ * scanner is: nothing loaded here may fail.
+ */
+function locationModuleLinked(): boolean {
+  const host = (globalThis as { expo?: { modules?: Record<string, unknown> } }).expo;
+  return host?.modules?.ExpoLocation != null;
+}
+
 function loadLocation(): ExpoLocation | null {
-  if (!locationSupported) return null;
+  if (!locationSupported || !locationModuleLinked()) return null;
   try {
     // Lazy so a build that did not link the module fails soft, not at launch.
     // eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
## Problem
Tapping **Add location** on a dev client built before `expo-location` was linked crashed with a redbox:

> Cannot find native module 'ExpoLocation'

`loadLocation()` already required `expo-location` lazily inside a `try`, but that isn't enough: `require('expo-location')` evaluates `ExpoLocation.js`, which calls `requireNativeModule('ExpoLocation')` and **throws** when the binary never linked it — and in dev that throw is surfaced as a redbox even when caught downstream.

## Fix
Check the Expo host object (`globalThis.expo.modules.ExpoLocation`) first — a plain property read that cannot throw — and only `require` the wrapper when the module is actually linked. A build without it degrades to "location unavailable" quietly, exactly as the module's own docstring promises.

Kept dependency-free (no `expo-modules-core` import — the app doesn't resolve it directly) for the same reason the scanner guard is.

## Note
This stops the **crash**. Actually using location still needs the dev client rebuilt with `expo-location` linked.

## Gates
- `tsc --noEmit` ✓
- `expo lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location detection on unsupported platforms and builds without the required native location module.
  * Prevented location loading errors when the location capability is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->