### PR TITLE
feat(welcome): remove the redundant "Trouble signing in?" link

### DIFF
--- a/apps/mobile/src/app/welcome.tsx
+++ b/apps/mobile/src/app/welcome.tsx
@@ -7,10 +7,6 @@
  * `sign-in`), which carry the actual ways in (Google, phone, email). This
  * screen only asks which errand you are on, the way Tinder, Bumble and Hinge
  * all open — brand first, one decision, nothing to read past the terms.
- *
- * NOTE — "Trouble signing in?" points at the sign-in door for now, not a
- * dedicated recovery flow; that is a follow-up. The copy is translated (see
- * `t.entry`).
  */
 
 import { useEffect } from 'react';
@@ -128,9 +124,8 @@ export default function WelcomeScreen() {
           </View>
           <View style={{ flex: 1.3 }} />
 
-          {/* The legal line and the choices are anchored to the bottom, lifted
-              off the safe-area edge so "Trouble signing in?" does not sit flush
-              against the very bottom. */}
+          {/* The legal line and the two gateway choices are anchored to the
+              bottom, lifted off the safe-area edge. */}
           <View
             style={{
               paddingHorizontal: theme.spacing.xl,
@@ -158,21 +153,6 @@ export default function WelcomeScreen() {
               label={t.signIn.signInAction}
               onPress={() => router.push('/sign-in')}
             />
-
-            <Pressable
-              accessibilityRole="button"
-              onPress={() => router.push('/sign-in')}
-              hitSlop={8}
-              style={({ pressed }) => ({
-                alignSelf: 'center',
-                paddingVertical: theme.spacing.md,
-                opacity: pressed ? 0.6 : 1,
-              })}
-            >
-              <Text style={{ color: theme.color.onBrand, fontWeight: '800' }}>
-                {t.entry.troubleSigningIn}
-              </Text>
-            </Pressable>
           </View>
         </SafeAreaView>
       </LinearGradient>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -738,7 +738,6 @@ export interface UiStrings {
     agreeTerms: string;
     termsWord: string;
     privacyWord: string;
-    troubleSigningIn: string;
     notifyTitle: string;
     notifyBody: string;
     notifyEnable: string;
@@ -2306,7 +2305,6 @@ const en: UiStrings = {
     agreeTerms: 'By continuing you agree to our {terms} and {privacy}.',
     termsWord: 'Terms',
     privacyWord: 'Privacy Policy',
-    troubleSigningIn: 'Trouble signing in?',
     notifyTitle: 'Turn on notifications',
     notifyBody:
       "We'll let you know when someone adds an expense, settles up, or invites you to a group. No spam.",
@@ -3930,7 +3928,6 @@ const ta: UiStrings = {
     agreeTerms: 'தொடர்வதன் மூலம் எங்கள் {terms} மற்றும் {privacy}யை ஏற்கிறீர்கள்.',
     termsWord: 'விதிமுறைகள்',
     privacyWord: 'தனியுரிமைக் கொள்கை',
-    troubleSigningIn: 'உள்நுழைவதில் சிக்கலா?',
     notifyTitle: 'அறிவிப்புகளை இயக்கவும்',
     notifyBody:
       'யாராவது செலவைச் சேர்க்கும்போது, தீர்த்துக்கொள்ளும்போது, அல்லது ஒரு குழுவிற்கு உங்களை அழைக்கும்போது தெரிவிப்போம். ஸ்பேம் இல்லை.',
@@ -5585,7 +5582,6 @@ const hi: UiStrings = {
     agreeTerms: 'जारी रखकर आप हमारी {terms} और {privacy} से सहमत होते हैं।',
     termsWord: 'शर्तें',
     privacyWord: 'गोपनीयता नीति',
-    troubleSigningIn: 'साइन इन में परेशानी?',
     notifyTitle: 'सूचनाएँ चालू करें',
     notifyBody:
       'जब कोई खर्च जोड़े, हिसाब चुकाए, या आपको समूह में आमंत्रित करे तो हम आपको बताएँगे। कोई स्पैम नहीं।',
@@ -7222,7 +7218,6 @@ const ar: UiStrings = {
     agreeTerms: 'بالمتابعة فإنك توافق على {terms} و{privacy}.',
     termsWord: 'الشروط',
     privacyWord: 'سياسة الخصوصية',
-    troubleSigningIn: 'تواجه مشكلة في تسجيل الدخول؟',
     notifyTitle: 'تفعيل الإشعارات',
     notifyBody:
       'سنُعلمك عندما يضيف أحدهم مصروفًا، أو يسوّي حسابًا، أو يدعوك إلى مجموعة. بلا إزعاج.',


### PR DESCRIPTION
The welcome screen's "Trouble signing in?" link routed to `/sign-in` — the exact same door as the **Sign in** gateway button directly above it — and pointed at no password-recovery flow. A duplicate tap with nothing behind it.

Removed:
- the link (`Pressable` + `Text`)
- its now-stale header NOTE
- the orphaned `t.entry.troubleSigningIn` string (interface + en/ta/hi/ar)

## Gates
- `tsc --noEmit` ✓
- `expo lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the temporary “Trouble signing in?” action from the welcome screen.
  * Updated the welcome screen layout so the legal text and gateway choices remain anchored at the bottom.
* **Localization**
  * Removed the unused “Trouble signing in?” translation from supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->