### PR TITLE
fix(privacy): hide account data controls when signed out

### DIFF
--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -1,7 +1,30 @@
+const path = require('path');
+
 const expoConfig = require('eslint-config-expo/flat');
 
+/**
+ * Expo's shared config already turns on `import/no-unresolved` and wires an
+ * `import/resolver.typescript` entry — but that only resolves the `@/*` path
+ * alias if `eslint-import-resolver-typescript` is actually installed. It has
+ * been reaching us transitively through `eslint-config-expo`, which is fragile:
+ * a hoist change or a fresh install in a different layout (e.g. a reviewer's CI)
+ * drops the resolver and every `@/lib/...` import lights up as unresolved.
+ *
+ * So we depend on the resolver directly (see package.json) and point it at this
+ * app's tsconfig here, making `@/*` resolution explicit and layout-independent
+ * rather than a side effect of Expo's dependency tree.
+ */
 module.exports = [
   ...expoConfig,
+  {
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: path.join(__dirname, 'tsconfig.json'),
+        },
+      },
+    },
+  },
   {
     ignores: ['dist/*', '.expo/*', 'expo-env.d.ts'],
   },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -75,6 +75,7 @@
     "@types/react": "~19.2.2",
     "eslint": "^9.39.5",
     "eslint-config-expo": "~57.0.1",
+    "eslint-import-resolver-typescript": "^3.10.1",
     "typescript": "~6.0.3",
     "vitest": "^4.1.10"
   },

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -19,6 +19,7 @@ import {
 } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
 import { clarityConfigured } from '@/lib/clarity';
 import { sessionReplayConsent, setSessionReplayConsent } from '@/lib/sessionReplay';
 
@@ -36,6 +37,13 @@ export default function PrivacyScreen() {
   const theme = useTheme();
   const clearance = useTabBarClearance();
   const { t } = useStrings();
+  // This same screen is the app's privacy *policy*, reached from the legal line
+  // on the signed-out welcome/sign-up gate as well as from Settings. The policy
+  // text is for everyone; the account data-controls below (block list, export,
+  // delete) act on an account that a signed-out reader does not have yet, so
+  // they are shown only once there is a session (a guest counts — they have
+  // data to manage).
+  const { session } = useAuth();
 
   // The session-replay opt-in, mirrored from storage. Only meaningful when a
   // Clarity project is configured; on a build without one the switch is hidden
@@ -183,64 +191,68 @@ export default function PrivacyScreen() {
 
         {/* The controls the "choices" card promises, made tappable rather than
             described — export a copy, or close the account, both routes that
-            already exist. Delete wears the negative tone: it ends something. */}
-        <View style={{ gap: theme.spacing.sm }}>
-          <SectionHeader title={t.privacy.dataControlsSection} />
-          <Card style={{ paddingVertical: theme.spacing.xs }}>
-            <ListRow
-              title={t.blocked.row}
-              subtitle={t.blocked.rowHint}
-              onPress={() => router.push('/settings/blocked')}
-              leading={
-                <Ionicons
-                  name="person-remove-outline"
-                  size={iconSize.md}
-                  color={theme.color.brand}
-                />
-              }
-              trailing={
-                <Ionicons
-                  name={directionalIcon('chevron-forward')}
-                  size={iconSize.md}
-                  color={theme.color.textFaint}
-                />
-              }
-            />
-            <View style={{ height: 1, backgroundColor: theme.color.border }} />
-            <ListRow
-              title={t.privacy.exportRow}
-              subtitle={t.privacy.exportRowHint}
-              onPress={() => router.push('/settings/export')}
-              leading={
-                <Ionicons name="download-outline" size={iconSize.md} color={theme.color.brand} />
-              }
-              trailing={
-                <Ionicons
-                  name={directionalIcon('chevron-forward')}
-                  size={iconSize.md}
-                  color={theme.color.textFaint}
-                />
-              }
-            />
-            <View style={{ height: 1, backgroundColor: theme.color.border }} />
-            <ListRow
-              title={t.privacy.deleteRow}
-              subtitle={t.privacy.deleteRowHint}
-              destructive
-              onPress={() => router.push('/settings/delete-account')}
-              leading={
-                <Ionicons name="trash-outline" size={iconSize.md} color={theme.color.negative} />
-              }
-              trailing={
-                <Ionicons
-                  name={directionalIcon('chevron-forward')}
-                  size={iconSize.md}
-                  color={theme.color.textFaint}
-                />
-              }
-            />
-          </Card>
-        </View>
+            already exist. Delete wears the negative tone: it ends something.
+            Hidden when signed out: opened as the policy from the login gate,
+            these would act on an account the reader does not have. */}
+        {session ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <SectionHeader title={t.privacy.dataControlsSection} />
+            <Card style={{ paddingVertical: theme.spacing.xs }}>
+              <ListRow
+                title={t.blocked.row}
+                subtitle={t.blocked.rowHint}
+                onPress={() => router.push('/settings/blocked')}
+                leading={
+                  <Ionicons
+                    name="person-remove-outline"
+                    size={iconSize.md}
+                    color={theme.color.brand}
+                  />
+                }
+                trailing={
+                  <Ionicons
+                    name={directionalIcon('chevron-forward')}
+                    size={iconSize.md}
+                    color={theme.color.textFaint}
+                  />
+                }
+              />
+              <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              <ListRow
+                title={t.privacy.exportRow}
+                subtitle={t.privacy.exportRowHint}
+                onPress={() => router.push('/settings/export')}
+                leading={
+                  <Ionicons name="download-outline" size={iconSize.md} color={theme.color.brand} />
+                }
+                trailing={
+                  <Ionicons
+                    name={directionalIcon('chevron-forward')}
+                    size={iconSize.md}
+                    color={theme.color.textFaint}
+                  />
+                }
+              />
+              <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              <ListRow
+                title={t.privacy.deleteRow}
+                subtitle={t.privacy.deleteRowHint}
+                destructive
+                onPress={() => router.push('/settings/delete-account')}
+                leading={
+                  <Ionicons name="trash-outline" size={iconSize.md} color={theme.color.negative} />
+                }
+                trailing={
+                  <Ionicons
+                    name={directionalIcon('chevron-forward')}
+                    size={iconSize.md}
+                    color={theme.color.textFaint}
+                  />
+                }
+              />
+            </Card>
+          </View>
+        ) : null}
 
         <View style={{ gap: theme.spacing.sm }}>
           <SectionHeader title={t.privacy.legalSection} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       eslint-config-expo:
         specifier: ~57.0.1
         version: 57.0.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      eslint-import-resolver-typescript:
+        specifier: ^3.10.1
+        version: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       typescript:
         specifier: ~6.0.3
         version: 6.0.3


### PR DESCRIPTION
## What

The Privacy screen doubles as the app's privacy **policy**, reached from the legal line on the signed-out welcome / sign-up gate as well as from Settings. The account data-controls at the bottom — **Blocked people**, **Export your data**, **Delete my data** — act on an account a signed-out reader does not have yet, so tapping them from the gate led nowhere.

## Change

Show that section only when there is a session (a guest counts — they have data to manage). The policy text and the Licenses section stay visible to everyone.

- `apps/mobile/src/app/settings/privacy.tsx`: read `session` from `useAuth`, wrap the Data-controls `SectionHeader` + `Card` in `{session ? … : null}`.

## Test

- typecheck + lint clean.
- Signed out (opened as policy from the gate): Data-controls section absent; policy + Licenses present.
- Signed in / guest: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Privacy screen to show account data controls only for signed-in users.
  * Signed-out users can still view privacy policy content without seeing unavailable blocked-user, data export, or account deletion actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->