### PR TITLE
fix(privacy): let the open-source licenses screen open when signed out

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -453,11 +453,15 @@ function AuthGate() {
     segments[0] === 'verify-email';
   // The privacy screen is reachable signed-out too, so the Terms & Privacy line
   // on the welcome and guest doorways can open it before anybody has an account.
+  // Its open-source licenses screen is part of that same policy, opened from a
+  // row inside it, so it has to be public as well — otherwise tapping it bounces
+  // a signed-out reader back to /welcome.
   const onPublicRoute =
     onAuth ||
     segments[0] === 'join' ||
     segments[0] === 'language' ||
-    (segments[0] === 'settings' && (segments as string[])[1] === 'privacy');
+    (segments[0] === 'settings' &&
+      ((segments as string[])[1] === 'privacy' || (segments as string[])[1] === 'licenses'));
 
   /**
    * The route we are on disagrees with the session we have, and the effect


### PR DESCRIPTION
## Bug

From the signed-out welcome / sign-up gate, opening the privacy policy and tapping **Open source** did nothing useful — it bounced back to `/welcome`.

## Cause

The root layout (`app/_layout.tsx`) whitelists the routes a signed-out person may sit on; everything else `replace`s to `/welcome`. `settings/privacy` was whitelisted (the policy is public), but `settings/licenses` — reached from a row inside that policy — was not. So the guard evicted it on arrival.

## Fix

Add `settings/licenses` to the public-route set alongside `settings/privacy`. It's part of the same policy document and only reachable from within it.

## Test

- typecheck + lint clean.
- Signed out → gate → privacy → **Open source**: licenses screen now opens; back returns to the policy.
- Signed in: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signed-out users can now access the Settings licenses screen, alongside existing publicly available screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->