### PR TITLE
feat(auth): white login/sign-up sheet with an email one-time-code path

### DIFF
--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -1,41 +1,38 @@
 /**
  * Getting in — the shared machinery behind the login and the sign-up screens.
  *
- * There are two front doors now, one file. `flow` decides which: `'login'` is
- * the entry screen a returning person lands on (providers, phone, email — the
- * ways back into an account that exists), and `'signup'` is the separate page
- * behind "Create account", where a new person picks how to start and where the
- * guest way in lives. Keeping both in one component is deliberate: the OTP and
- * password forms underneath are identical, and two copies of a login form is
- * exactly how one drifts from the other.
+ * There are two front doors, one file. `flow` decides which: `'login'` is the
+ * screen a returning person lands on, and `'signup'` is the separate page behind
+ * "Create account", where a new person picks how to start and where the guest
+ * way in lives. Keeping both in one component is deliberate: the form underneath
+ * is identical, and two copies of a login form is exactly how one drifts from
+ * the other.
  *
- * ADR-006 is that nobody is made to register before they can split a bill. The
- * guest button used to sit on the very first screen for that reason; it now
- * sits on the sign-up page instead, one tap behind "Create account" — still not
- * behind a form, still reachable before any detail is asked, but off the login
- * screen a returning member sees. (ADR-006 addendum — see the PR.)
+ * The layout is a plain white sheet — a heading, the email-and-password fields,
+ * the primary action, then the providers at the foot — the shape every mainstream
+ * login uses (the reference here is Quizlet's). Above the providers sit two
+ * passwordless conveniences that both mail a one-time code to whatever address is
+ * in the field: "Email me a code" (sign in without a password) and, on the login
+ * door, "Forgot password" (recover the same way). A tapped code carries a
+ * one-minute resend cool-down so a frustrated tap cannot spray the mailbox.
  *
  * Which Supabase call each button makes is decided in @waves/core, not here. A
- * guest who taps "Google" must have Google *added* to the account they already
- * have — signing them in would create a different account and strand a week of
- * expenses on one they can no longer reach. That is easy to get wrong in a
- * screen and impossible to notice afterwards, so the screen does not decide.
+ * guest who taps a provider or types a password must have that way *added* to the
+ * account they already have — signing them in fresh would strand a week of
+ * expenses on an account they can no longer reach (ADR-006). The passwordless
+ * email-code path cannot express that "add in place", so it is hidden for a guest
+ * (`isGuest`): they upgrade with a password or a provider, never a fresh code.
  *
- * The language chip is here for the same reason the guest way is kept early:
- * this is the first screen, and the first screen has to work for somebody it
- * opened wrong. Waves follows the phone by default, and a phone is one setting
- * for one person — a shared handset, a borrowed one, or a person who reads Tamil
- * and set their phone up in English.
+ * ADR-006 is that nobody is made to register before they can split a bill. The
+ * guest button sits on the sign-up page, one tap behind "Create account" — still
+ * not behind a form, still reachable before any detail is asked, but off the
+ * login screen a returning member sees. (ADR-006 addendum — see the PR.)
  */
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import Constants from 'expo-constants';
-import { Image } from 'expo-image';
 import { router } from 'expo-router';
-import Svg, { Path } from 'react-native-svg';
 import {
-  ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -44,77 +41,71 @@ import {
   View,
 } from 'react-native';
 
-import {
-  Button,
-  Callout,
-  Card,
-  CurvedPanel,
-  directionalIcon,
-  iconSize,
-  Row,
-  Screen,
-  SegmentedTabs,
-  Text,
-  useTheme,
-} from '@waves/ui';
+import { Button, Callout, directionalIcon, iconSize, Row, Screen, Text, useTheme } from '@waves/ui';
 
-import { dialingCodeForCountry } from '@waves/core';
-
-import { CountryCodePicker } from '@/components/CountryCodePicker';
 import { SocialButton } from '@/components/SocialButton';
-import { deviceCountry, useStrings, type UiStrings } from '@/i18n';
+import { useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { friendlyError } from '@/lib/errors';
 
 export type AuthFlowKind = 'login' | 'signup';
 
-enum Mode {
-  Otp = 'otp',
-  Password = 'password',
+/** Which face the middle of the sheet is showing: the email-and-password form,
+ *  or the one-time code the two passwordless links drop into. */
+enum Stage {
+  Form = 'form',
+  Code = 'code',
 }
+
+/** A liberal check — enough to tell "this is an email, mail a code to it" from
+ *  "this is a phone number or a username". The server is the real judge. */
+function looksLikeEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+}
+
+const RESEND_SECONDS = 60;
 
 export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
   const theme = useTheme();
   const { t } = useStrings();
-  const { sendOtp, verifyOtp, withPassword, withGoogle, withApple, isGuest } = useAuth();
+  const { withPassword, withGoogle, withApple, sendEmailOtp, verifyEmailOtp, isGuest } = useAuth();
 
   const isSignup = flow === 'signup';
+  const intent: 'sign_in' | 'sign_up' = isSignup ? 'sign_up' : 'sign_in';
 
-  /**
-   * A guest arriving here is not choosing how to start — they already have an
-   * account and are adding a way back into it. Showing them the welcome would
-   * be asking a question they answered a week ago.
-   */
-  const [showOptions, setShowOptions] = useState(isGuest);
-
-  // The dial code is a tappable country, not a prefix typed into the field. It
-  // starts on the country this handset is set to — +971 in the UAE, +44 in the
-  // UK — and falls back to India only when the region is unknown or unstocked,
-  // because the picker beside it makes any wrong guess a one-tap fix rather than
-  // a number to backspace over. The number field holds the local digits alone.
-  const [country, setCountry] = useState<string>(() => {
-    const guess = deviceCountry();
-    return guess && dialingCodeForCountry(guess) ? guess : 'IN';
-  });
-  const dialCode = dialingCodeForCountry(country) ?? '+91';
-
-  const [mode, setMode] = useState<Mode>(Mode.Otp);
-  const [phone, setPhone] = useState('');
-  // What actually goes to Supabase: the dial code and the local digits, no
-  // spaces or punctuation — E.164 in all but the leading-zero rules the server
-  // enforces. Display keeps the two apart; the wire joins them.
-  const fullPhone = `${dialCode}${phone.replace(/\D/g, '')}`;
-  const [code, setCode] = useState('');
-  const [stage, setStage] = useState<'phone' | 'code'>('phone');
+  const [stage, setStage] = useState<Stage>(Stage.Form);
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [passwordShown, setPasswordShown] = useState(false);
-  // The flow fixes the intent: the login screen only ever signs in, the sign-up
-  // page only ever registers. The old in-form toggle is gone — the two doors are
-  // the choice now.
-  const intent: 'sign_in' | 'sign_up' = isSignup ? 'sign_up' : 'sign_in';
+  const [code, setCode] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Seconds left on the resend cool-down; 0 means "you may send again". A ref
+  // holds the interval so a second send does not stack timers.
+  const [resendLeft, setResendLeft] = useState(0);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+    };
+  }, []);
+
+  const startResendTimer = (): void => {
+    if (tickRef.current) clearInterval(tickRef.current);
+    setResendLeft(RESEND_SECONDS);
+    tickRef.current = setInterval(() => {
+      setResendLeft((left) => {
+        if (left <= 1) {
+          if (tickRef.current) clearInterval(tickRef.current);
+          tickRef.current = null;
+          return 0;
+        }
+        return left - 1;
+      });
+    }, 1000);
+  };
 
   const run = async <T,>(action: () => Promise<T>): Promise<T | undefined> => {
     setBusy(true);
@@ -131,56 +122,50 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
     }
   };
 
-  /**
-   * The welcome: a round photo hero with a scribble, the value line in heavy
-   * ink, the language in the corner, and the ways in beneath — Google first,
-   * then "continue with email", then a hairline and the phone path, and last the
-   * line to the other door. On the sign-up page the guest way sits among them; on
-   * the login screen it does not.
-   */
-  if (!showOptions) {
-    return (
-      <View style={{ flex: 1, backgroundColor: theme.color.brand }}>
-        {/* The language sits in the corner of the hero — reachable from the
-            first frame for somebody who opened the app in a script they cannot
-            read, without taking a line in the action column. */}
-        <View
-          style={{
-            position: 'absolute',
-            top: Constants.statusBarHeight + theme.spacing.sm,
-            right: theme.spacing.sm,
-            zIndex: 10,
-          }}
-        >
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.language}
-            hitSlop={12}
-            onPress={() => router.push('/language')}
-            style={({ pressed }) => ({
-              width: 44,
-              height: 44,
-              alignItems: 'center',
-              justifyContent: 'center',
-              opacity: pressed ? 0.6 : 1,
-            })}
-          >
-            <Ionicons name="globe-outline" size={iconSize.lg} color={theme.color.onBrand} />
-          </Pressable>
-        </View>
+  // Both passwordless links mail to the address in the field. If it is not an
+  // email, say so rather than mailing nowhere.
+  const mailCode = (): void => {
+    if (!looksLikeEmail(identifier)) {
+      setError(t.signIn.enterEmailFirst);
+      return;
+    }
+    void run(async () => {
+      await sendEmailOtp(identifier, isSignup);
+      setCode('');
+      setStage(Stage.Code);
+      startResendTimer();
+    });
+  };
 
-        {/* A way back to the welcome gateway, in the opposite corner from the
-            language so leaving is as reachable. A chevron in the primary ink,
-            shown on both doors — login and sign-up are both reached from the
-            gateway, so both return to it. */}
-        <View
-          style={{
-            position: 'absolute',
-            top: Constants.statusBarHeight + theme.spacing.sm,
-            left: theme.spacing.sm,
-            zIndex: 10,
-          }}
-        >
+  const submitPassword = (): void => {
+    void (async () => {
+      const outcome = await run(() => withPassword(identifier, password, intent));
+      // A confirmation mail went out — send them to check it rather than leave
+      // them on a form that looks inert.
+      if (outcome?.verifyEmail) {
+        router.push({ pathname: '/verify-email', params: { email: outcome.verifyEmail } });
+      }
+    })();
+  };
+
+  const fieldStyle = {
+    backgroundColor: theme.color.surfaceMuted,
+    borderRadius: theme.radius.lg,
+    paddingHorizontal: theme.spacing.lg,
+  } as const;
+
+  const title = isSignup ? t.signIn.createAccount : t.signIn.signInAction;
+
+  return (
+    <Screen edges={['top', 'bottom']} style={{ backgroundColor: theme.color.surface }}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={{ flex: 1 }}
+      >
+        {/* Header: back on the leading side, language on the trailing side —
+            reachable from the first frame for somebody who opened the app in a
+            script they cannot read. */}
+        <Row style={{ paddingHorizontal: theme.spacing.md, minHeight: 44 }}>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={t.common.back}
@@ -197,360 +182,95 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
             <Ionicons
               name={directionalIcon('chevron-back')}
               size={iconSize.lg}
-              color={theme.color.onBrand}
+              color={theme.color.text}
             />
           </Pressable>
-        </View>
+          <View style={{ flex: 1 }} />
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.language}
+            hitSlop={12}
+            onPress={() => router.push('/language')}
+            style={({ pressed }) => ({
+              width: 44,
+              height: 44,
+              alignItems: 'center',
+              justifyContent: 'center',
+              opacity: pressed ? 0.6 : 1,
+            })}
+          >
+            <Ionicons name="globe-outline" size={iconSize.lg} color={theme.color.text} />
+          </Pressable>
+        </Row>
 
-        {/* Below the curve, the ways in — centred in the space the hero leaves.
-            A ScrollView so a short screen scrolls rather than clipping. */}
         <ScrollView
           style={{ flex: 1 }}
           contentContainerStyle={{
             flexGrow: 1,
-            justifyContent: 'center',
-            paddingHorizontal: theme.spacing.xxxl,
-            paddingTop: Constants.statusBarHeight + theme.spacing.xxxl,
-            paddingBottom: theme.spacing.xl,
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: theme.spacing.xxl,
+            gap: theme.spacing.xl,
           }}
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
         >
-          <View style={{ gap: theme.spacing.xl }}>
-            {/* The hero: a round photo with a hand-drawn scribble tucked behind
-                its shoulder, then the value line in heavy ink. This replaces the
-                brand-wash panel — the way in is the screen now, not a banner over
-                it. Placeholder photo (assets/images/auth-hero.jpg) and no Terms
-                line yet; both are follow-ups. */}
-            <AuthHero />
-            <Text
-              align="center"
-              style={{
-                fontSize: 30,
-                lineHeight: 38,
-                fontWeight: '800',
-                letterSpacing: -0.5,
-                color: theme.color.onBrand,
-              }}
-            >
-              {t.signIn.splitAnything}
-            </Text>
+          <Text
+            style={{
+              fontSize: 40,
+              lineHeight: 48,
+              fontWeight: '800',
+              letterSpacing: -1,
+              color: theme.color.text,
+              marginTop: theme.spacing.sm,
+            }}
+          >
+            {title}
+          </Text>
 
-            {/* The fastest way in goes first. Somebody who has a Google account
-                is one tap from being in, and every app that does this well puts
-                that tap above the form rather than under it. */}
-            <View style={{ gap: theme.spacing.md }}>
-              <SocialRow
-                busy={busy}
-                wording={isSignup ? 'continue' : 'signIn'}
-                onGoogle={() => void run(withGoogle)}
-                onApple={() => void run(withApple)}
-                t={t}
-              />
-              {/* Email as its own top-level way in: a tap that drops straight
-                  into the email-and-password form rather than a tab the person
-                  has to find inside a card. */}
-              <Button
-                label={t.signIn.continueEmail}
-                variant="primary"
-                size="lg"
-                fullWidth
-                disabled={busy}
-                icon={
-                  <Ionicons name="mail-outline" size={iconSize.md} color={theme.color.onBrand} />
-                }
-                onPress={() => {
-                  setMode(Mode.Password);
-                  setShowOptions(true);
-                }}
-              />
-            </View>
-
-            {/* A hairline either side of the label, not bare text — the seam
-                between "one tap" above and "an email and a password" below. */}
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}>
-              <View style={{ flex: 1, height: 1, backgroundColor: '#FFFFFF5C' }} />
-              <Text variant="caption" tone="onBrand" style={{ opacity: 0.9 }}>
-                {t.signIn.or}
-              </Text>
-              <View style={{ flex: 1, height: 1, backgroundColor: '#FFFFFF5C' }} />
-            </View>
-
-            <View style={{ gap: theme.spacing.sm }}>
-              {/* The phone way in, below the seam — the two email/phone ways in
-                  read as one pair. */}
-              <Button
-                label={t.signIn.continuePhone}
-                size="lg"
-                fullWidth
-                disabled={busy}
-                icon={
-                  <Ionicons name="call-outline" size={iconSize.md} color={theme.color.onBrand} />
-                }
-                onPress={() => router.push('/phone')}
-              />
-              {/* ADR-006 addendum: the guest way in lives on the sign-up page,
-                  not the login screen — quieter than the account buttons, still
-                  never behind a form. */}
-              {isSignup ? (
-                <Button
-                  label={t.signIn.continueGuest}
-                  variant="onBrandOutline"
-                  size="lg"
-                  fullWidth
-                  disabled={busy}
-                  onPress={() => router.push('/guest-welcome')}
-                />
-              ) : null}
-            </View>
-
-            {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
-            {error ? <Callout tone="negative">{error}</Callout> : null}
-          </View>
-        </ScrollView>
-      </View>
-    );
-  }
-
-  return (
-    <Screen edges={['bottom']} style={{ backgroundColor: theme.color.brand }}>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        style={{ flex: 1 }}
-      >
-        <ScrollView
-          contentContainerStyle={{ paddingBottom: theme.spacing.xxxl }}
-          showsVerticalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-        >
-          <CurvedPanel height={180} curve={0.7}>
-            <View
-              style={{
-                flex: 1,
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: theme.spacing.xs,
-              }}
-            >
-              <Text
+          {/* The email/username field is always here; the password sits below it
+              on the form face, and gives way to the code field once a code has
+              been mailed. */}
+          <View style={{ gap: theme.spacing.md }}>
+            <View style={fieldStyle}>
+              <TextInput
+                value={identifier}
+                onChangeText={setIdentifier}
+                editable={stage === Stage.Form}
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="email-address"
+                autoComplete="username"
+                accessibilityLabel={t.signIn.identifier}
+                placeholder={t.signIn.identifier}
+                placeholderTextColor={theme.color.textFaint}
                 style={{
-                  fontSize: 34,
-                  lineHeight: 46,
-                  fontWeight: '700',
-                  color: theme.color.onBrand,
+                  fontSize: 17,
+                  fontWeight: '500',
+                  color: theme.color.text,
+                  paddingVertical: theme.spacing.lg,
                 }}
-              >
-                {t.common.appName}
-              </Text>
-              <Text variant="caption" tone="onBrand" align="center">
-                {isGuest
-                  ? t.signIn.keepOnNextPhone
-                  : isSignup
-                    ? t.signIn.createAccount
-                    : t.signIn.welcomeBack}
-              </Text>
-            </View>
-          </CurvedPanel>
-
-          <View style={{ gap: theme.spacing.xxl, paddingHorizontal: theme.spacing.xl }}>
-            <Text variant="body" tone="onBrand" align="center" style={{ opacity: 0.9 }}>
-              {isGuest ? t.signIn.guestAddWay : t.signIn.signInHowever}
-            </Text>
-
-            {/* Above the form rather than below it. A guest arrives straight
-                here without passing the welcome, so this is their only sight of
-                the language switch before they are asked to read a form — the
-                same globe as the gateway, opening the full language screen. */}
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t.language}
-              hitSlop={12}
-              onPress={() => router.push('/language')}
-              style={({ pressed }) => ({
-                alignSelf: 'flex-end',
-                width: 44,
-                height: 44,
-                alignItems: 'center',
-                justifyContent: 'center',
-                opacity: pressed ? 0.6 : 1,
-              })}
-            >
-              <Ionicons name="globe-outline" size={iconSize.lg} color={theme.color.onBrand} />
-            </Pressable>
-
-            {/* The providers sit above the form here too. They were a row of
-                small squares under it, which put the one-tap way in below a
-                keyboard on every phone. */}
-            <View style={{ gap: theme.spacing.md }}>
-              <SocialRow
-                busy={busy}
-                wording={isGuest || isSignup ? 'continue' : 'signIn'}
-                onGoogle={() => void run(withGoogle)}
-                onApple={() => void run(withApple)}
-                t={t}
               />
             </View>
 
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}>
-              <View style={{ flex: 1, height: 1, backgroundColor: '#FFFFFF5C' }} />
-              <Text variant="caption" tone="onBrand" style={{ opacity: 0.9 }}>
-                {t.signIn.or}
-              </Text>
-              <View style={{ flex: 1, height: 1, backgroundColor: '#FFFFFF5C' }} />
-            </View>
-
-            <Card style={{ gap: theme.spacing.lg }}>
-              {/* Two ways in, named for what they ask for. The password face
-                  says "email" out loud: somebody looking for an email field
-                  should not have to guess it lives behind a tab about
-                  passwords. */}
-              <SegmentedTabs<Mode>
-                value={mode}
-                onChange={(next) => {
-                  setMode(next);
-                  setError(null);
-                }}
-                tabs={[
-                  { value: Mode.Otp, label: t.signIn.sendMeACode },
-                  { value: Mode.Password, label: t.signIn.useAPassword },
-                ]}
-              />
-
-              {mode === Mode.Otp && stage === 'phone' ? (
-                <>
-                  <Text variant="caption" tone="muted">
-                    {t.signIn.phoneNumber}
-                  </Text>
-                  {/* The code is its own control now — a tapped country, not a
-                      prefix in the field — so the number beside it is just the
-                      local digits. */}
-                  <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
-                    <CountryCodePicker code={country} onChange={setCountry} />
-                    <TextInput
-                      value={phone}
-                      onChangeText={setPhone}
-                      keyboardType="phone-pad"
-                      autoComplete="tel"
-                      accessibilityLabel={t.signIn.phoneNumber}
-                      placeholderTextColor={theme.color.textFaint}
-                      style={{
-                        flex: 1,
-                        fontSize: 22,
-                        fontWeight: '600',
-                        color: theme.color.text,
-                        paddingVertical: theme.spacing.sm,
-                      }}
-                    />
-                  </Row>
-                  <Text variant="micro" tone="muted">
-                    {t.signIn.countryCodeHint}
-                  </Text>
-                  <Button
-                    label={t.signIn.sendCode}
-                    size="lg"
-                    fullWidth
-                    disabled={busy || phone.replace(/\D/g, '').length < 6}
-                    onPress={() =>
-                      void run(async () => {
-                        await sendOtp(fullPhone);
-                        setStage('code');
-                      })
-                    }
-                  />
-                </>
-              ) : null}
-
-              {mode === Mode.Otp && stage === 'code' ? (
-                <>
-                  <Text variant="caption" tone="muted">
-                    {t.signIn.codeSentTo.replace('{value}', `${dialCode} ${phone}`)}
-                  </Text>
-                  <TextInput
-                    value={code}
-                    onChangeText={setCode}
-                    keyboardType="number-pad"
-                    autoComplete="sms-otp"
-                    accessibilityLabel={t.contact.verificationCode}
-                    placeholder="123456"
-                    placeholderTextColor={theme.color.textFaint}
-                    style={{
-                      fontSize: 28,
-                      fontWeight: '700',
-                      letterSpacing: 8,
-                      color: theme.color.text,
-                      paddingVertical: theme.spacing.sm,
-                    }}
-                  />
-                  <Button
-                    label={t.signIn.verify}
-                    size="lg"
-                    fullWidth
-                    disabled={busy || code.trim().length < 4}
-                    onPress={() => void run(() => verifyOtp(fullPhone, code.trim()))}
-                  />
-                  <Button
-                    label={t.signIn.differentNumber}
-                    variant="ghost"
-                    onPress={() => {
-                      setStage('phone');
-                      setCode('');
-                    }}
-                  />
-                </>
-              ) : null}
-
-              {mode === Mode.Password ? (
-                <>
-                  <Text variant="caption" tone="muted">
-                    {t.signIn.identifier}
-                  </Text>
-                  {/* One field: "email or phone?" is a question the text already
-                    answers. */}
-                  <TextInput
-                    value={identifier}
-                    onChangeText={setIdentifier}
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                    keyboardType="email-address"
-                    autoComplete="username"
-                    accessibilityLabel={t.signIn.identifier}
-                    placeholder={t.signIn.identifierPlaceholder.replace('{code}', dialCode)}
-                    placeholderTextColor={theme.color.textFaint}
-                    style={{
-                      fontSize: 18,
-                      fontWeight: '500',
-                      color: theme.color.text,
-                      paddingVertical: theme.spacing.sm,
-                    }}
-                  />
-                  <Text variant="caption" tone="muted">
-                    {t.signIn.password}
-                  </Text>
-                  {/* The eye is not a nicety on this field: the app asks for
-                      eight characters, the keyboard is a phone keyboard, and a
-                      password typed blind is the most common reason a correct
-                      one is reported wrong. Every reference login has it.
-
-                      The dots are the placeholder for the same reason: these
-                      fields carry no border, so an empty one with no
-                      placeholder reads as a gap rather than as somewhere to
-                      type. Dots need no translating. */}
-                  <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+            {stage === Stage.Form ? (
+              <>
+                <View style={fieldStyle}>
+                  <Row style={{ alignItems: 'center' }}>
                     <TextInput
                       value={password}
                       onChangeText={setPassword}
                       secureTextEntry={!passwordShown}
                       autoCapitalize="none"
-                      autoComplete={intent === 'sign_up' ? 'new-password' : 'current-password'}
+                      autoComplete={isSignup ? 'new-password' : 'current-password'}
                       accessibilityLabel={t.signIn.password}
-                      placeholder="••••••••"
+                      placeholder={t.signIn.password}
                       placeholderTextColor={theme.color.textFaint}
                       style={{
                         flex: 1,
-                        fontSize: 18,
+                        fontSize: 17,
                         fontWeight: '500',
                         color: theme.color.text,
-                        paddingVertical: theme.spacing.sm,
+                        paddingVertical: theme.spacing.lg,
                       }}
                     />
                     <Pressable
@@ -569,111 +289,171 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                       />
                     </Pressable>
                   </Row>
-                  <Text variant="micro" tone="muted">
-                    {t.signIn.passwordHint}
-                  </Text>
-                  <Button
-                    label={
-                      isGuest
-                        ? t.signIn.addToAccount
-                        : intent === 'sign_up'
-                          ? t.signIn.createAccount
-                          : t.signIn.signInAction
-                    }
-                    size="lg"
-                    fullWidth
-                    disabled={busy || !identifier.trim() || password.length < 8}
-                    onPress={() =>
-                      void (async () => {
-                        const outcome = await run(() => withPassword(identifier, password, intent));
-                        // A confirmation mail went out — send them to check it
-                        // rather than leave them on a form that looks inert.
-                        if (outcome?.verifyEmail) {
-                          router.push({
-                            pathname: '/verify-email',
-                            params: { email: outcome.verifyEmail },
-                          });
-                        }
-                      })()
-                    }
+                </View>
+
+                <Button
+                  label={isGuest ? t.signIn.addToAccount : title}
+                  size="lg"
+                  fullWidth
+                  disabled={busy || !identifier.trim() || password.length < 8}
+                  onPress={submitPassword}
+                />
+
+                {/* Passwordless conveniences, hidden for a guest (a fresh code
+                    cannot upgrade their account in place). "Forgot password" is
+                    login-only; "Email me a code" is on both doors. */}
+                {!isGuest ? (
+                  <View style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+                    {!isSignup ? (
+                      <Pressable
+                        accessibilityRole="button"
+                        onPress={mailCode}
+                        disabled={busy}
+                        hitSlop={8}
+                        style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+                      >
+                        <Text variant="subheading" style={{ color: theme.color.brand }}>
+                          {t.signIn.forgotPassword}
+                        </Text>
+                      </Pressable>
+                    ) : null}
+                    <Button
+                      label={t.signIn.emailMeACode}
+                      variant="secondary"
+                      size="lg"
+                      fullWidth
+                      disabled={busy}
+                      icon={
+                        <Ionicons name="mail-outline" size={iconSize.md} color={theme.color.text} />
+                      }
+                      onPress={mailCode}
+                    />
+                  </View>
+                ) : null}
+              </>
+            ) : (
+              <>
+                {/* The code face: what was mailed, where, and the way back. */}
+                <Text variant="caption" tone="muted">
+                  {t.signIn.emailCodeSentTo.replace('{value}', identifier.trim())}
+                </Text>
+                <View style={fieldStyle}>
+                  <TextInput
+                    value={code}
+                    onChangeText={setCode}
+                    keyboardType="number-pad"
+                    autoComplete="one-time-code"
+                    accessibilityLabel={t.contact.verificationCode}
+                    placeholder="123456"
+                    placeholderTextColor={theme.color.textFaint}
+                    style={{
+                      fontSize: 28,
+                      fontWeight: '700',
+                      letterSpacing: 8,
+                      color: theme.color.text,
+                      paddingVertical: theme.spacing.md,
+                    }}
                   />
-                </>
-              ) : null}
+                </View>
+                <Button
+                  label={t.signIn.verify}
+                  size="lg"
+                  fullWidth
+                  disabled={busy || code.trim().length < 6}
+                  onPress={() => void run(() => verifyEmailOtp(identifier, code))}
+                />
 
-              {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
-              {error ? <Callout tone="negative">{error}</Callout> : null}
-            </Card>
+                <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => {
+                      setStage(Stage.Form);
+                      setCode('');
+                      setError(null);
+                    }}
+                    hitSlop={8}
+                    style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+                  >
+                    <Text variant="subheading" tone="muted">
+                      {t.signIn.usePasswordInstead}
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={mailCode}
+                    disabled={busy || resendLeft > 0}
+                    hitSlop={8}
+                    style={({ pressed }) => ({ opacity: pressed || resendLeft > 0 ? 0.5 : 1 })}
+                  >
+                    <Text
+                      variant="subheading"
+                      style={{
+                        color: resendLeft > 0 ? theme.color.textFaint : theme.color.brand,
+                      }}
+                    >
+                      {resendLeft > 0
+                        ? t.signIn.resendIn.replace('{s}', String(resendLeft))
+                        : t.signIn.resendCode}
+                    </Text>
+                  </Pressable>
+                </Row>
+              </>
+            )}
 
-            {/* ADR-006 addendum: the guest way in belongs to the sign-up page.
-                A guest reconnecting (isGuest) never needs it, and the login
-                screen no longer carries it — so it shows only in the sign-up
-                form, for somebody who came to register and changed their mind. */}
+            {error ? <Callout tone="negative">{error}</Callout> : null}
+          </View>
+
+          {/* Push the providers to the foot of the sheet the way the reference
+              does — the account-you-already-have shortcuts sit apart from the
+              form, under a seam. */}
+          <View style={{ flex: 1 }} />
+
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.md }}>
+            <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+            <Text variant="caption" tone="muted">
+              {t.signIn.or}
+            </Text>
+            <View style={{ flex: 1, height: 1, backgroundColor: theme.color.border }} />
+          </View>
+
+          <View style={{ gap: theme.spacing.md }}>
+            <SocialRow
+              busy={busy}
+              wording={isGuest || isSignup ? 'continue' : 'signIn'}
+              onGoogle={() => void run(withGoogle)}
+              onApple={() => void run(withApple)}
+              t={t}
+            />
+            {/* Phone kept as a quiet way in — off the main path the reference
+                shows, but not dropped. */}
+            <Button
+              label={t.signIn.continuePhone}
+              variant="ghost"
+              size="lg"
+              fullWidth
+              disabled={busy}
+              icon={<Ionicons name="call-outline" size={iconSize.md} color={theme.color.brand} />}
+              onPress={() => router.push('/phone')}
+            />
+            {/* ADR-006 addendum: the guest way in belongs to the sign-up page. */}
             {isSignup && !isGuest ? (
               <Button
                 label={t.signIn.continueGuest}
-                variant="onBrandOutline"
+                variant="ghost"
                 size="lg"
                 fullWidth
                 disabled={busy}
                 onPress={() => router.push('/guest-welcome')}
               />
             ) : null}
-
-            <Text variant="micro" tone="onBrand" align="center" style={{ opacity: 0.85 }}>
-              {isGuest ? t.signIn.guestFootnote : t.signIn.memberFootnote}
-            </Text>
           </View>
+
+          <Text variant="micro" tone="muted" align="center">
+            {isGuest ? t.signIn.guestFootnote : t.signIn.memberFootnote}
+          </Text>
         </ScrollView>
       </KeyboardAvoidingView>
     </Screen>
-  );
-}
-
-/**
- * The welcome hero: a round photo with a scribble tucked behind its shoulder.
- *
- * The photo is a placeholder stock shot (`assets/images/auth-hero.jpg`) — the
- * shape and the scribble are the design; the picture inside gets swapped for the
- * brand's own. The scribble is a single hand-drawn stroke in the brand's light
- * lilac, positioned to peek out from the top-right the way the reference does.
- */
-const AUTH_HERO = require('../../assets/images/auth-hero.jpg');
-
-function AuthHero() {
-  const theme = useTheme();
-  const size = 200;
-  return (
-    <View style={{ alignItems: 'center' }}>
-      <View style={{ width: size, height: size }}>
-        {/* Scribble first so the circle sits over its lower end, letting the
-            stroke read as tucked *behind* the shoulder. */}
-        <Svg
-          width={size * 0.62}
-          height={size * 0.5}
-          viewBox="0 0 120 90"
-          style={{ position: 'absolute', top: -10, right: -14 }}
-        >
-          <Path
-            d="M8 70 C40 20 50 80 70 30 M20 78 C55 30 60 84 82 40 M34 82 C68 42 72 88 96 48"
-            stroke="#B4A5FB"
-            strokeWidth={7}
-            strokeLinecap="round"
-            fill="none"
-          />
-        </Svg>
-        <View
-          style={{
-            width: size,
-            height: size,
-            borderRadius: size / 2,
-            overflow: 'hidden',
-            backgroundColor: theme.color.surfaceMuted,
-          }}
-        >
-          <Image source={AUTH_HERO} style={{ width: '100%', height: '100%' }} contentFit="cover" />
-        </View>
-      </View>
-    </View>
   );
 }
 
@@ -687,8 +467,7 @@ function AuthHero() {
  * "Sign in with" is reserved for the login screen, where it is true. On the
  * sign-up page — and for a guest attaching a way back into the groups already
  * on this phone — Google's own guidelines say to write "Continue with", because
- * the same button both makes an account and returns to one, and "sign in" would
- * suggest landing somewhere else.
+ * the same button both makes an account and returns to one.
  */
 function SocialRow({
   busy,
@@ -722,8 +501,5 @@ function SocialRow({
       onPress={onApple}
     />
   );
-  // Apple's guidelines want its button at least as prominent as the others on
-  // iOS, so it leads there; Google leads on every other platform, where Apple
-  // is the browser fallback.
   return <>{Platform.OS === 'ios' ? [apple, google] : [google, apple]}</>;
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -812,6 +812,19 @@ export interface UiStrings {
     continueGuest: string;
     guestFootnote: string;
     memberFootnote: string;
+    /** The passwordless email-code way in, and the recovery link beside the
+        password field. */
+    forgotPassword: string;
+    emailMeACode: string;
+    /** Carries {value} — the address the code was mailed to. */
+    emailCodeSentTo: string;
+    resendCode: string;
+    /** Carries {s} — seconds left on the one-minute resend cool-down. */
+    resendIn: string;
+    usePasswordInstead: string;
+    /** Shown when the email-code or forgot-password link is tapped with no
+        address typed, since both mail to whatever is in the field. */
+    enterEmailFirst: string;
     /** Fallback when a sign-in attempt fails with nothing a person can act on. */
     couldNotSignIn: string;
     restartToMirror: string;
@@ -2376,6 +2389,13 @@ const en: UiStrings = {
       'Everything you have already added stays exactly where it is. This only adds a way to sign back in.',
     memberFootnote:
       'A guest account keeps everything on this device until you add a way to sign in. Your ledger is never held hostage.',
+    forgotPassword: 'Forgot password',
+    emailMeACode: 'Email me a code',
+    emailCodeSentTo: 'We emailed a code to {value}',
+    resendCode: 'Resend code',
+    resendIn: 'Resend in {s}s',
+    usePasswordInstead: 'Use a password instead',
+    enterEmailFirst: 'Enter your email first',
     couldNotSignIn: 'Could not sign in. Please try again.',
     restartToMirror: 'Close and open Waves once to mirror the layout.',
     restartToUnmirror: 'Close and open Waves once to turn the layout back.',
@@ -4003,6 +4023,13 @@ const ta: UiStrings = {
       'நீங்கள் ஏற்கனவே சேர்த்த அனைத்தும் அப்படியே இருக்கும். இது மீண்டும் உள்நுழைய ஒரு வழியை மட்டுமே சேர்க்கிறது.',
     memberFootnote:
       'உள்நுழைய ஒரு வழியைச் சேர்க்கும் வரை விருந்தினர் கணக்கு அனைத்தையும் இந்தச் சாதனத்திலேயே வைத்திருக்கும். உங்கள் கணக்கு எப்போதும் பணயம் வைக்கப்படுவதில்லை.',
+    forgotPassword: 'கடவுச்சொல் மறந்துவிட்டதா',
+    emailMeACode: 'எனக்கு ஒரு குறியீட்டை மின்னஞ்சல் அனுப்பு',
+    emailCodeSentTo: '{value} க்கு ஒரு குறியீட்டை மின்னஞ்சல் அனுப்பினோம்',
+    resendCode: 'குறியீட்டை மீண்டும் அனுப்பு',
+    resendIn: '{s}வி இல் மீண்டும் அனுப்பு',
+    usePasswordInstead: 'பதிலாக கடவுச்சொல்லைப் பயன்படுத்து',
+    enterEmailFirst: 'முதலில் உங்கள் மின்னஞ்சலை உள்ளிடவும்',
     couldNotSignIn: 'உள்நுழைய முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
     restartToMirror: 'தளவமைப்பைப் பிரதிபலிக்க பாக்கியை ஒருமுறை மூடித் திறக்கவும்.',
     restartToUnmirror: 'தளவமைப்பை மீண்டும் மாற்ற பாக்கியை ஒருமுறை மூடித் திறக்கவும்.',
@@ -5653,6 +5680,13 @@ const hi: UiStrings = {
       'आपने जो जोड़ा है वह जहाँ है वहीं रहेगा। इससे सिर्फ़ दोबारा साइन इन करने का रास्ता जुड़ता है।',
     memberFootnote:
       'जब तक आप साइन इन का कोई तरीका न जोड़ें, मेहमान खाता सब कुछ इसी डिवाइस पर रखता है। आपका हिसाब कभी बंधक नहीं बनाया जाता।',
+    forgotPassword: 'पासवर्ड भूल गए',
+    emailMeACode: 'मुझे एक कोड ईमेल करें',
+    emailCodeSentTo: 'हमने {value} पर एक कोड ईमेल किया है',
+    resendCode: 'कोड फिर से भेजें',
+    resendIn: '{s}से में फिर भेजें',
+    usePasswordInstead: 'इसके बजाय पासवर्ड इस्तेमाल करें',
+    enterEmailFirst: 'पहले अपना ईमेल दर्ज करें',
     couldNotSignIn: 'साइन इन नहीं हो सका। फिर से कोशिश करें।',
     restartToMirror: 'लेआउट की दिशा बदलने के लिए बाकी को एक बार बंद करके खोलें।',
     restartToUnmirror: 'लेआउट वापस पलटने के लिए बाकी को एक बार बंद करके खोलें।',
@@ -7286,6 +7320,13 @@ const ar: UiStrings = {
     guestFootnote: 'كل ما أضفته يبقى كما هو تمامًا. هذا يضيف فقط طريقة للعودة وتسجيل الدخول.',
     memberFootnote:
       'يحتفظ حساب الضيف بكل شيء على هذا الجهاز حتى تضيف طريقة لتسجيل الدخول. دفترك ليس رهينة أبدًا.',
+    forgotPassword: 'نسيت كلمة المرور',
+    emailMeACode: 'أرسل لي رمزًا بالبريد',
+    emailCodeSentTo: 'أرسلنا رمزًا إلى {value}',
+    resendCode: 'إعادة إرسال الرمز',
+    resendIn: 'إعادة الإرسال خلال {s} ث',
+    usePasswordInstead: 'استخدم كلمة مرور بدلاً من ذلك',
+    enterEmailFirst: 'أدخل بريدك الإلكتروني أولاً',
     couldNotSignIn: 'تعذّر تسجيل الدخول. حاول مرة أخرى.',
     restartToMirror: 'أغلق باقي وافتحه مرة واحدة لعكس اتجاه الواجهة.',
     restartToUnmirror: 'أغلق باقي وافتحه مرة واحدة لإعادة اتجاه الواجهة.',

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -193,6 +193,13 @@ interface AuthValue {
   isGuest: boolean;
   sendOtp: (phone: string) => Promise<void>;
   verifyOtp: (phone: string, token: string) => Promise<void>;
+  /**
+   * A one-time code mailed to an address — the passwordless way in, and the
+   * recovery path behind "Forgot password". `createUser` is false on the login
+   * door (a typo must not mint an empty account) and true on sign-up.
+   */
+  sendEmailOtp: (email: string, createUser: boolean) => Promise<void>;
+  verifyEmailOtp: (email: string, token: string) => Promise<void>;
   continueAsGuest: () => Promise<void>;
   /**
    * Email or phone plus a password. Which Supabase call this makes is decided
@@ -321,6 +328,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       async verifyOtp(phone, token) {
         const { error } = await supabase.auth.verifyOtp({ phone, token, type: 'sms' });
+        if (error) throw error;
+      },
+
+      async sendEmailOtp(email, createUser) {
+        // A one-time code mailed to the address, the passwordless way in. On the
+        // login door `shouldCreateUser` is false so a typo cannot silently mint
+        // a new empty account; on sign-up it is true so the code both makes the
+        // account and lands the session. Supabase mails a six-digit code (not a
+        // magic link) as long as the email template carries `{{ .Token }}`.
+        const { error } = await supabase.auth.signInWithOtp({
+          email: email.trim(),
+          options: { shouldCreateUser: createUser },
+        });
+        if (error) throw error;
+      },
+
+      async verifyEmailOtp(email, token) {
+        const { error } = await supabase.auth.verifyOtp({
+          email: email.trim(),
+          token: token.trim(),
+          type: 'email',
+        });
         if (error) throw error;
       },
 


### PR DESCRIPTION
## What

Reskins both auth doors to the plain **white sheet** layout from the reference (Quizlet): heading → email + password fields → primary action → providers at the foot. Replaces the purple hero + segmented-tab card.

Adds a **passwordless email code** next to the password:

- **Email me a code** (both doors) — mails a one-time code to the address in the field, then a code face verifies it.
- **Forgot password** (login only) — recovers the same way: a code to the email, no password.
- **60-second resend cool-down** — the link counts down ("Resend in 42s") and re-enables at zero.

## How

- `useAuth`: new `sendEmailOtp(email, createUser)` / `verifyEmailOtp(email, token)`. `shouldCreateUser` is `false` on login (a typo can't mint an empty account), `true` on sign-up.
- Guests don't see the email-code path — a fresh code can't upgrade their account in place (ADR-006); they keep the password/provider upgrade.
- Providers stay **Google + Apple** (per decision — Facebook not wired). Phone kept as a quiet ghost button, not dropped.
- New i18n keys across en/ta/hi/ar.

## Ops note (not code)

The code only arrives once Supabase's **Magic Link** email template includes `{{ .Token }}` — same class of dashboard step as the signup confirmation template. Client is fully wired.

## Test

- typecheck + lint clean.
- Login/sign-up render the white sheet; password login unchanged.
- Email me a code → code face → resend counts down from 60 → re-enables.
- Non-email in the field → "Enter your email first".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added passwordless email sign-in and sign-up with one-time verification codes.
  - Added code resend controls with cooldown timers.
  - Added password recovery and the option to switch between password and code-based login.
  - Guests can add passwords or social sign-in providers while retaining guest access.
  - Added English, Tamil, Hindi, and Arabic translations for the new authentication options.

- **Improvements**
  - Simplified authentication into a unified email and password flow.
  - Improved validation, navigation, and sign-in provider placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->