### PR TITLE
test(auth): Maestro flows for the white auth sheet + rate-limit message

### DIFF
--- a/apps/mobile/src/components/AuthFlow.tsx
+++ b/apps/mobile/src/components/AuthFlow.tsx
@@ -114,7 +114,13 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
       return await action();
     } catch (caught) {
       setError(
-        friendlyError(caught, t.signIn.couldNotSignIn, 'auth.signIn', t.misc.connectionProblem),
+        friendlyError(
+          caught,
+          t.signIn.couldNotSignIn,
+          'auth.signIn',
+          t.misc.connectionProblem,
+          t.misc.tooManyTries,
+        ),
       );
       return undefined;
     } finally {
@@ -292,6 +298,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                 </View>
 
                 <Button
+                  testID="auth-submit"
                   label={isGuest ? t.signIn.addToAccount : title}
                   size="lg"
                   fullWidth
@@ -306,6 +313,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                   <View style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
                     {!isSignup ? (
                       <Pressable
+                        testID="auth-forgot"
                         accessibilityRole="button"
                         onPress={mailCode}
                         disabled={busy}
@@ -318,6 +326,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                       </Pressable>
                     ) : null}
                     <Button
+                      testID="auth-email-code"
                       label={t.signIn.emailMeACode}
                       variant="secondary"
                       size="lg"
@@ -339,6 +348,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                 </Text>
                 <View style={fieldStyle}>
                   <TextInput
+                    testID="auth-code"
                     value={code}
                     onChangeText={setCode}
                     keyboardType="number-pad"
@@ -356,6 +366,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                   />
                 </View>
                 <Button
+                  testID="auth-verify"
                   label={t.signIn.verify}
                   size="lg"
                   fullWidth
@@ -379,6 +390,7 @@ export function AuthFlow({ flow }: { flow: AuthFlowKind }) {
                     </Text>
                   </Pressable>
                   <Pressable
+                    testID="auth-resend"
                     accessibilityRole="button"
                     onPress={mailCode}
                     disabled={busy || resendLeft > 0}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1303,6 +1303,9 @@ export interface UiStrings {
      *  transport error is internal noise). Said on foreground actions like
      *  signing in, where "saved here" does not apply. */
     connectionProblem: string;
+    /** Shown on a 429 from the one-time-code buttons — the request was fine,
+        there were just too many in a short window. */
+    tooManyTries: string;
     syncingCount: PluralForms;
     notAnAmount: string;
     notARate: string;
@@ -2850,6 +2853,7 @@ const en: UiStrings = {
     },
     cantReachServerIdle: "Can't reach the server — everything here is saved",
     connectionProblem: 'Check your connection and try again.',
+    tooManyTries: 'Too many attempts. Wait a minute and try again.',
     syncingCount: { one: 'Sending {n} change…', other: 'Sending {n} changes…' },
     offlineSaved: 'Offline — everything here is saved on this phone',
     notAnAmount: 'That does not look like an amount',
@@ -4507,6 +4511,7 @@ const ta: UiStrings = {
     },
     cantReachServerIdle: 'சர்வரை அடைய முடியவில்லை — எல்லாம் இங்கே சேமிக்கப்பட்டுள்ளது',
     connectionProblem: 'இணைப்பைச் சரிபார்த்து மீண்டும் முயற்சிக்கவும்.',
+    tooManyTries: 'அதிக முயற்சிகள். ஒரு நிமிடம் காத்திருந்து மீண்டும் முயற்சிக்கவும்.',
     syncingCount: {
       one: '{n} மாற்றம் அனுப்பப்படுகிறது…',
       other: '{n} மாற்றங்கள் அனுப்பப்படுகின்றன…',
@@ -6144,6 +6149,7 @@ const hi: UiStrings = {
     },
     cantReachServerIdle: 'सर्वर तक नहीं पहुँच पा रहे — सब कुछ यहीं सेव है',
     connectionProblem: 'अपना कनेक्शन जाँचें और फिर से कोशिश करें।',
+    tooManyTries: 'बहुत ज़्यादा कोशिशें। एक मिनट रुककर फिर से कोशिश करें।',
     syncingCount: { one: '{n} बदलाव भेजा जा रहा है…', other: '{n} बदलाव भेजे जा रहे हैं…' },
     offlineSaved: 'ऑफ़लाइन — यहाँ का सब कुछ इसी फ़ोन पर सेव है',
     notAnAmount: 'यह रकम जैसा नहीं लगता',
@@ -7825,6 +7831,7 @@ const ar: UiStrings = {
     },
     cantReachServerIdle: 'تعذّر الوصول إلى الخادم — كل شيء هنا محفوظ',
     connectionProblem: 'تحقّق من اتصالك وحاول مرة أخرى.',
+    tooManyTries: 'محاولات كثيرة. انتظر دقيقة وحاول مرة أخرى.',
     syncingCount: {
       zero: 'جارٍ الإرسال…',
       one: 'جارٍ إرسال تغيير واحد…',

--- a/apps/mobile/src/lib/errors.ts
+++ b/apps/mobile/src/lib/errors.ts
@@ -17,10 +17,12 @@
 
 import { reportHandled } from '@/lib/observability';
 
-/** The shape supabase-js hands back on a failed rpc. */
+/** The shape supabase-js hands back on a failed rpc or auth call. */
 interface Postgrestish {
   message?: string;
   code?: string;
+  /** supabase-js AuthError carries the HTTP status — 429 on a rate limit. */
+  status?: number;
 }
 
 export function friendlyError(
@@ -28,6 +30,7 @@ export function friendlyError(
   fallback: string,
   where: string,
   offline?: string,
+  tooMany?: string,
 ): string {
   const error = (caught ?? {}) as Postgrestish;
   const message =
@@ -48,6 +51,18 @@ export function friendlyError(
   // Anything the database rejected by name is still not a sentence.
   if (/violates|constraint|permission denied|relation .* does not exist/i.test(message)) {
     return fallback;
+  }
+
+  // Too many requests in too short a window — the one-time-code buttons hit
+  // Supabase's email send-rate limit if tapped repeatedly. "Could not sign in"
+  // reads as a rejected credential here, which is wrong: the request was fine,
+  // there were just too many. Say to wait, not to doubt what they typed.
+  if (
+    error.status === 429 ||
+    /rate limit|too many requests|over_.*_rate_limit/i.test(message) ||
+    /rate.?limit/i.test(typeof error.code === 'string' ? error.code : '')
+  ) {
+    return tooMany ?? fallback;
   }
 
   // A network failure is worth naming — telling somebody their connection

--- a/apps/mobile/test/errors.test.ts
+++ b/apps/mobile/test/errors.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// friendlyError reports the raw error to the crash reporter, which pulls the
+// native Sentry pipeline — stub it so the pure string logic can be tested.
+vi.mock('@/lib/observability', () => ({ reportHandled: vi.fn() }));
+
+import { friendlyError } from '@/lib/errors';
+
+const FALLBACK = 'Could not sign in.';
+const OFFLINE = 'Check your connection.';
+const TOO_MANY = 'Too many attempts. Wait a minute.';
+
+const friendly = (caught: unknown): string =>
+  friendlyError(caught, FALLBACK, 'test', OFFLINE, TOO_MANY);
+
+describe('friendlyError', () => {
+  it('maps a 429 status to the too-many-tries sentence', () => {
+    // supabase-js AuthError shape on an email send-rate limit.
+    expect(friendly({ status: 429, message: 'email rate limit exceeded' })).toBe(TOO_MANY);
+  });
+
+  it('maps a rate-limit message with no status to the too-many-tries sentence', () => {
+    expect(friendly({ message: 'over_email_send_rate_limit' })).toBe(TOO_MANY);
+  });
+
+  it('returns the connection sentence for a network failure, never the raw string', () => {
+    // The exact native-transport noise the offline branch exists to hide.
+    const raw =
+      'fetch failed: UnexpectedException: A TLS error caused the secure connection to fail. (at ExpoModulesCore/Promise.swift:56)';
+    expect(friendly({ message: raw })).toBe(OFFLINE);
+  });
+
+  it('falls back for a schema-cache error rather than naming a function', () => {
+    expect(friendly({ code: 'PGRST202', message: 'Could not find the function public.x' })).toBe(
+      FALLBACK,
+    );
+  });
+
+  it('falls back for anything unrecognised', () => {
+    expect(friendly({ message: 'something odd' })).toBe(FALLBACK);
+  });
+
+  it('prefers the too-many sentence over the network branch when both could match', () => {
+    // A 429 whose message also contains a network-ish word must still read as
+    // rate-limited, because the rate-limit branch is checked first.
+    expect(friendly({ status: 429, message: 'request failed: rate limit' })).toBe(TOO_MANY);
+  });
+});

--- a/e2e/auth-providers.yaml
+++ b/e2e/auth-providers.yaml
@@ -1,17 +1,20 @@
-# The sign-in wall offers both providers.
+# The login sheet offers both providers and the passwordless code path.
 #
-# Google and Apple sit side by side on the sign-in screen. This asserts both
-# buttons render with their own wording — the Apple button is the new one
-# (native sheet on iOS, browser fallback on Android). It does not tap through:
-# completing either provider needs a real IdP round-trip, which belongs to a
-# manual/device pass, not a deterministic flow.
+# On the white login sheet, Google and Apple sit at the foot under an "or" seam,
+# and the email one-time-code conveniences sit above them: "Email me a code" on
+# both doors and "Forgot password" on the login door. This asserts all four
+# render with their own wording — it does not tap through a provider (completing
+# either needs a real IdP round-trip, which belongs to a manual/device pass) and
+# it does not send a code (that hits the mail provider — see login-email-code).
 appId: app.waves.mobile
 ---
 - launchApp:
     clearState: true
 
-# /welcome → /sign-in, where the provider row lives above the email option.
+# /welcome → /sign-in, the white sheet.
 - tapOn: 'Sign in'
 - assertVisible: 'Sign in with Google'
 - assertVisible: 'Sign in with Apple'
-- assertVisible: 'Continue with email'
+- assertVisible: 'Email me a code'
+- assertVisible: 'Forgot password'
+- assertVisible: 'Continue with phone'

--- a/e2e/login-email-code.yaml
+++ b/e2e/login-email-code.yaml
@@ -1,0 +1,40 @@
+# The passwordless email one-time-code path on the login sheet.
+#
+# Types the seeded email, taps "Email me a code", and asserts the sheet turns to
+# its code face — the six-digit field (`auth-code`), the resend control, and the
+# way back to the password form. It stops there: verifying a real code needs the
+# inbox, which is not deterministic in a flow, so this proves the *path* renders
+# and returns, not that a specific code is accepted.
+#
+# Sending the code hits Supabase, so this flow — like login.yaml — needs the
+# seeded staging project and a working Magic Link email template (the one that
+# carries {{ .Token }}). It is part of the gated `e2e (Maestro)` job, not a
+# device-free unit test.
+appId: app.waves.mobile
+---
+- launchApp:
+    clearState: true
+
+# /welcome → /sign-in, the white sheet.
+- tapOn: 'Sign in'
+
+# Enter the address the code is mailed to, then ask for the code.
+- tapOn: 'Email or phone number'
+- inputText: '${E2E_EMAIL}'
+- hideKeyboard
+- tapOn:
+    id: 'auth-email-code'
+
+# The sheet turns to its code face.
+- extendedWaitUntilVisible:
+    element:
+      id: 'auth-code'
+    timeout: 30000
+- assertVisible: 'Use a password instead'
+- assertVisible:
+    id: 'auth-resend'
+
+# The way back to the password form works.
+- tapOn: 'Use a password instead'
+- assertVisible:
+    id: 'auth-submit'

--- a/e2e/login.yaml
+++ b/e2e/login.yaml
@@ -7,20 +7,26 @@
 #
 # Credentials come from the Maestro env, matching the account e2e/seed-e2e.mjs
 # creates:  maestro test --env E2E_EMAIL=… --env E2E_PASSWORD=… e2e/
+#
+# The login screen is a single white sheet now (no "Continue with email" step):
+# tapping "Sign in" on the welcome gateway lands straight on the email +
+# password form. The final tap targets the submit button by its testID
+# (`auth-submit`) because the screen carries the word "Sign in" three times —
+# the heading, the submit button, and the "Sign in with …" providers.
 appId: app.waves.mobile
 ---
 - launchApp:
     clearState: true
 
-# /welcome → /sign-in → the email form
+# /welcome → /sign-in, straight onto the white email + password sheet.
 - tapOn: 'Sign in'
-- tapOn: 'Continue with email'
 - tapOn: 'Email or phone number'
 - inputText: '${E2E_EMAIL}'
 - tapOn: 'Password'
 - inputText: '${E2E_PASSWORD}'
 - hideKeyboard
-- tapOn: 'Sign in'
+- tapOn:
+    id: 'auth-submit'
 
 # The dashboard appears once the first sync has pulled the seeded group. Give it
 # room — a cold sign-in does an auth round-trip and a full cursor pull.

--- a/e2e/signup.yaml
+++ b/e2e/signup.yaml
@@ -4,8 +4,11 @@
 # login). It carries the same email + password form and provider foot, plus the
 # two things the login door does not: the guest way in ("Continue as guest",
 # ADR-006 — reachable before any form) and no "Forgot password" (there is no
-# password to recover before the account exists). It does not submit — creating
-# an account would need a throwaway address and hit the mail provider.
+# password to recover before the account exists). It does not submit the email
+# form — creating an account would need a throwaway address and hit the mail
+# provider — but it does exercise the guest way in, which only navigates to the
+# guest doorway (the anonymous session is minted a screen later, on Continue),
+# so it is deterministic and touches nothing on the server.
 appId: app.waves.mobile
 ---
 - launchApp:
@@ -20,3 +23,9 @@ appId: app.waves.mobile
 - assertNotVisible: 'Forgot password'
 - assertVisible:
     id: 'auth-submit'
+
+# The guest way in navigates to the guest doorway (no session yet).
+- tapOn: 'Continue as guest'
+- extendedWaitUntilVisible:
+    element: 'Start splitting with'
+    timeout: 10000

--- a/e2e/signup.yaml
+++ b/e2e/signup.yaml
@@ -1,0 +1,22 @@
+# The sign-up door renders the white sheet with its own affordances.
+#
+# The gateway's "Create account" opens the sign-up sheet (a separate page from
+# login). It carries the same email + password form and provider foot, plus the
+# two things the login door does not: the guest way in ("Continue as guest",
+# ADR-006 — reachable before any form) and no "Forgot password" (there is no
+# password to recover before the account exists). It does not submit — creating
+# an account would need a throwaway address and hit the mail provider.
+appId: app.waves.mobile
+---
+- launchApp:
+    clearState: true
+
+# /welcome → /sign-up, the white sheet.
+- tapOn: 'Create account'
+- assertVisible: 'Email or phone number'
+- assertVisible: 'Password'
+- assertVisible: 'Email me a code'
+- assertVisible: 'Continue as guest'
+- assertNotVisible: 'Forgot password'
+- assertVisible:
+    id: 'auth-submit'


### PR DESCRIPTION
## Live check

Walked the new login/sign-up flow on the emulator as a user:

| | |
|---|---|
| **Login sheet** | white, "Sign in" heading, email + password (eye), disabled primary, Forgot password, Email me a code, or-divider, Google/Apple, phone, footnote — matches the reference |
| **Sign-up sheet** | same shape, "Continue with" wording, **Continue as guest** present, **no** Forgot password |
| **Password error** | clean localized "Could not sign in" (no raw leak) |
| **Email code** | Supabase accepts the send — repeated test taps hit a real `429 over_email_send_rate_limit` |

## Gap found + fixed

The 429 reached the UI as "Could not sign in", which reads as a rejected credential when the request was actually fine.

- `errors.ts`: `friendlyError` gains a rate-limit branch (`429` / `over_*_rate_limit` / "rate limit") → new **"Too many attempts. Wait a minute."** (`misc.tooManyTries`, en/ta/hi/ar). `AuthFlow` passes it through.

## Tests

- **testIDs** on submit / email-code / verify / resend / forgot + the code field (the sheet carries "Sign in" three times, so text alone is ambiguous).
- **e2e**: `login.yaml` + `auth-providers.yaml` updated for the white sheet (old "Continue with email" step removed); new `login-email-code.yaml` (email code → code face → back) and `signup.yaml`.
- **test/errors.test.ts**: unit-covers rate-limit / network / schema-cache / fallback (6 cases).

Maestro flows run in the gated `e2e (Maestro)` CI job (staging + seed). Unit + typecheck + lint green locally (360 mobile tests pass).

## Ops reminder

Email codes deliver once Supabase's **Magic Link** template carries `{{ .Token }}` and a real SMTP provider is set (the default has a tiny hourly cap — what the 429 was).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear localized messaging when too many one-time-code attempts are detected.
  * Improved authentication controls with reliable identifiers for password, email-code, verification, resend, and recovery actions.
  * Added passwordless email-code sign-in and expanded sign-up flow coverage.

* **Bug Fixes**
  * Authentication errors now correctly identify rate-limit responses and prioritize helpful guidance over generic or network errors.

* **Tests**
  * Expanded automated coverage for rate-limit handling, login options, passwordless sign-in, direct password login, and sign-up flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->