### PR TITLE
feat(trip): fairness, burn-rate forecast and post-trip recap

### DIFF
--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -23,8 +23,11 @@ import {
   budgetVariance,
   buildTimeline,
   dayNumber,
+  fairness,
+  forecast,
   spendByMember,
   type BudgetProgress,
+  type MemberContribution,
   type PlanItem,
   type TimelineExpense,
 } from '@waves/core';
@@ -299,6 +302,68 @@ export default function PlanScreen() {
   };
 
   const isTrip = group.data?.type === 'trip';
+
+  const nameOf = (memberId: string): string => {
+    const member = (members.data ?? []).find((m) => m.id === memberId);
+    return member ? displayName(member, myProfileId) : '—';
+  };
+
+  // Burn-rate: the pace so far, projected across the whole trip, per currency
+  // and against the overall cap in its own currency (ADR-004). Empty until the
+  // trip has both dates and a day of spend to read a pace from.
+  const forecasts = useMemo(
+    () =>
+      isTrip
+        ? forecast({
+            spentByCurrency: timeline.spentByCurrency,
+            budget:
+              groupBudget.data?.amountMinor != null
+                ? {
+                    amountMinor: groupBudget.data.amountMinor,
+                    currency: groupBudget.data.currency ?? currency,
+                  }
+                : null,
+            today,
+            startDate: group.data?.start_date?.slice(0, 10) ?? null,
+            endDate: group.data?.end_date?.slice(0, 10) ?? null,
+          })
+        : [],
+    [
+      isTrip,
+      timeline.spentByCurrency,
+      groupBudget.data,
+      today,
+      group.data?.start_date,
+      group.data?.end_date,
+      currency,
+    ],
+  );
+
+  // Fairness: who has fronted a lopsided share, and who could pick up the next
+  // bill. Paid comes from the payers, owed from the shares — both already on the
+  // mirrored ledger, never re-divided here.
+  const fairnessSignals = useMemo(() => {
+    if (!isTrip) return [];
+    const byKey = new Map<string, MemberContribution & { paidMinor: bigint; owedMinor: bigint }>();
+    const touch = (member: string, cur: string) => {
+      const key = `${member}|${cur}`;
+      let row = byKey.get(key);
+      if (!row) {
+        row = { member, currency: cur, paidMinor: 0n, owedMinor: 0n };
+        byKey.set(key, row);
+      }
+      return row;
+    };
+    for (const expense of expenses.rows) {
+      const version = expense.currentVersion;
+      if (!version || expense.deleted_at) continue;
+      for (const payer of version.payers)
+        touch(payer.member_id, version.currency).paidMinor += BigInt(payer.amount);
+      for (const share of version.shares)
+        touch(share.member_id, version.currency).owedMinor += BigInt(share.amount);
+    }
+    return fairness([...byKey.values()]).filter((block) => block.overpayer || block.nextPayer);
+  }, [isTrip, expenses.rows]);
 
   // `busy` is async state, so a double-tap can fire two submits in the same tick
   // before it re-renders — each mints a fresh itemId, so both post. A synchronous
@@ -577,6 +642,94 @@ export default function PlanScreen() {
                 />
               ))}
           </Card>
+        ) : null}
+
+        {isTrip && forecasts.length > 0 ? (
+          <Card style={{ gap: theme.spacing.sm }}>
+            <Text variant="subheading">{t.tripInsights.forecast}</Text>
+            {forecasts.map((f) => (
+              <Row
+                key={f.currency}
+                style={{ justifyContent: 'space-between', alignItems: 'center' }}
+              >
+                <View>
+                  <Text variant="caption" tone="muted">
+                    {t.tripInsights.projectedTotal}
+                  </Text>
+                  <MoneyText
+                    amount={f.projectedTotalMinor}
+                    currency={f.currency}
+                    locale={locale}
+                    variant="subheading"
+                    mode="plain"
+                  />
+                </View>
+                {f.capMinor !== null ? (
+                  <View style={{ alignItems: 'flex-end' }}>
+                    <Text variant="caption" tone={f.onTrack ? 'muted' : 'negative'}>
+                      {f.onTrack ? t.tripInsights.onTrack : t.overBudget}
+                    </Text>
+                    {!f.onTrack && f.projectedOverrunMinor !== null ? (
+                      <MoneyText
+                        amount={
+                          f.projectedOverrunMinor < 0n
+                            ? -f.projectedOverrunMinor
+                            : f.projectedOverrunMinor
+                        }
+                        currency={f.currency}
+                        locale={locale}
+                        variant="caption"
+                        mode="plain"
+                      />
+                    ) : null}
+                  </View>
+                ) : null}
+              </Row>
+            ))}
+          </Card>
+        ) : null}
+
+        {isTrip && fairnessSignals.length > 0 ? (
+          <Card style={{ gap: theme.spacing.sm }}>
+            <Text variant="subheading">{t.tripInsights.fairness}</Text>
+            {fairnessSignals.map((block) => (
+              <View key={block.currency} style={{ gap: theme.spacing.xs }}>
+                {block.overpayer ? (
+                  <Text variant="caption">
+                    {fill(t.tripInsights.paidShare, {
+                      name: nameOf(block.overpayer.member),
+                      percent: String(Math.round(block.overpayer.paidRatio * 100)),
+                    })}
+                  </Text>
+                ) : null}
+                {block.nextPayer ? (
+                  <Text variant="caption" tone="brand">
+                    {fill(t.tripInsights.nextUp, { name: nameOf(block.nextPayer) })}
+                  </Text>
+                ) : null}
+              </View>
+            ))}
+          </Card>
+        ) : null}
+
+        {isTrip ? (
+          <Pressable
+            onPress={() => router.push(`/group/${groupId}/recap`)}
+            accessibilityRole="button"
+            accessibilityLabel={t.tripInsights.recap}
+            style={{ paddingVertical: theme.spacing.xs }}
+          >
+            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+              <Text variant="caption" tone="brand">
+                {t.tripInsights.recap}
+              </Text>
+              <Ionicons
+                name={directionalIcon('chevron-forward')}
+                size={iconSize.sm}
+                color={theme.color.brand}
+              />
+            </Row>
+          </Pressable>
         ) : null}
 
         {timeline.days.length === 0 ? (

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -654,7 +654,7 @@ export default function PlanScreen() {
               >
                 <View>
                   <Text variant="caption" tone="muted">
-                    {t.tripInsights.projectedTotal}
+                    {f.ended ? t.tripInsights.total : t.tripInsights.projectedTotal}
                   </Text>
                   <MoneyText
                     amount={f.projectedTotalMinor}

--- a/apps/mobile/src/app/group/[id]/recap.tsx
+++ b/apps/mobile/src/app/group/[id]/recap.tsx
@@ -1,0 +1,238 @@
+/**
+ * Trip recap: the trip, once it is done, in the numbers people repeat.
+ *
+ * A read of the ledger the phone already mirrors (ADR-005) — no fetch, works
+ * offline. Currencies stay apart (ADR-004): a trip billed in rupees and baht
+ * gets a card each, never a single total made up by a rate nobody agreed. The
+ * per-member figures are the shares and payments the ledger stored; nothing is
+ * re-divided here.
+ */
+
+import { useMemo } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { ScrollView, View } from 'react-native';
+
+import { recap, resolveCategory, type RecapExpense } from '@waves/core';
+import {
+  Card,
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  iconSize,
+  MoneyText,
+  Row,
+  Screen,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { displayName } from '@/data/types';
+import { useGroup } from '@/data/hooks';
+import { useAuth } from '@/lib/auth';
+import { InsightsSkeleton } from '@/components/Skeletons';
+import { useStrings, fill } from '@/i18n';
+
+export default function RecapScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const groupId = id ?? '';
+  const { profile } = useAuth();
+
+  const { group, members, expenses } = useGroup(groupId);
+  const myProfileId = profile?.id ?? null;
+
+  const nameOf = (memberId: string): string => {
+    const member = (members.data ?? []).find((m) => m.id === memberId);
+    return member ? displayName(member, myProfileId) : '—';
+  };
+
+  // category id → its display meta, so a custom tag names itself rather than
+  // folding into "Other". Built once from the ledger.
+  const metaByCategory = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof resolveCategory>>();
+    for (const expense of expenses.rows) {
+      const version = expense.currentVersion;
+      if (!version || expense.deleted_at || !version.category) continue;
+      if (!map.has(version.category)) {
+        map.set(version.category, resolveCategory(version.category, version.category_meta ?? null));
+      }
+    }
+    return map;
+  }, [expenses.rows]);
+
+  const categoryLabel = (category: string): string => {
+    const resolved = metaByCategory.get(category) ?? resolveCategory(category, null);
+    if (resolved.custom) return resolved.label;
+    return t.categories[resolved.builtinId ?? 'other'];
+  };
+
+  const recapData = useMemo(() => {
+    const rows: RecapExpense[] = expenses.rows
+      .filter((expense) => expense.currentVersion && !expense.deleted_at)
+      .map((expense) => {
+        const version = expense.currentVersion!;
+        return {
+          id: expense.id,
+          date: version.expense_date.slice(0, 10),
+          description: version.description,
+          category: version.category,
+          amountMinor: BigInt(version.amount),
+          currency: version.currency,
+          payers: version.payers.map((payer) => ({
+            member: payer.member_id,
+            amountMinor: BigInt(payer.amount),
+          })),
+        };
+      });
+    return recap({
+      expenses: rows,
+      startDate: group.data?.start_date?.slice(0, 10) ?? null,
+      endDate: group.data?.end_date?.slice(0, 10) ?? null,
+    });
+  }, [expenses.rows, group.data?.start_date, group.data?.end_date]);
+
+  const loading = group.isLoading || members.isLoading || expenses.isLoading;
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.tripInsights.recap}</Text>
+            <Text variant="micro" tone="muted">
+              {group.data?.name}
+            </Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        {loading ? (
+          <InsightsSkeleton />
+        ) : recapData.byCurrency.length === 0 ? (
+          <EmptyState title={t.tripInsights.noneYet} body={t.tripInsights.recapSubtitle} />
+        ) : (
+          recapData.byCurrency.map((block) => (
+            <View key={block.currency} style={{ gap: theme.spacing.md }}>
+              <Card style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+                <MoneyText
+                  amount={block.totalMinor}
+                  currency={block.currency}
+                  locale={locale}
+                  variant="display"
+                />
+                <Text variant="caption" tone="muted">
+                  {fill(t.tripInsights.expenseCount, { n: String(block.expenseCount) })}
+                </Text>
+              </Card>
+
+              <Card style={{ gap: theme.spacing.md }}>
+                <RecapRow
+                  label={t.tripInsights.perDay}
+                  value={
+                    <MoneyText
+                      amount={block.dailyAverageMinor}
+                      currency={block.currency}
+                      locale={locale}
+                      variant="body"
+                      mode="plain"
+                    />
+                  }
+                />
+                {block.biggestExpense ? (
+                  <RecapRow
+                    label={t.tripInsights.biggestBill}
+                    detail={block.biggestExpense.description}
+                    value={
+                      <MoneyText
+                        amount={block.biggestExpense.amountMinor}
+                        currency={block.currency}
+                        locale={locale}
+                        variant="body"
+                        mode="plain"
+                      />
+                    }
+                  />
+                ) : null}
+                {block.topCategory ? (
+                  <RecapRow
+                    label={t.tripInsights.mostSpentOn}
+                    detail={categoryLabel(block.topCategory.category)}
+                    value={
+                      <MoneyText
+                        amount={block.topCategory.totalMinor}
+                        currency={block.currency}
+                        locale={locale}
+                        variant="body"
+                        mode="plain"
+                      />
+                    }
+                  />
+                ) : null}
+                {block.topPayer ? (
+                  <RecapRow
+                    label={t.tripInsights.paidMost}
+                    detail={nameOf(block.topPayer.member)}
+                    value={
+                      <MoneyText
+                        amount={block.topPayer.paidMinor}
+                        currency={block.currency}
+                        locale={locale}
+                        variant="body"
+                        mode="plain"
+                      />
+                    }
+                  />
+                ) : null}
+              </Card>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}
+
+function RecapRow({
+  label,
+  detail,
+  value,
+}: {
+  label: string;
+  detail?: string;
+  value: React.ReactNode;
+}) {
+  const theme = useTheme();
+  return (
+    <Row style={{ justifyContent: 'space-between', alignItems: 'center', gap: theme.spacing.md }}>
+      <View style={{ flex: 1 }}>
+        <Text variant="caption" tone="muted">
+          {label}
+        </Text>
+        {detail ? (
+          <Text variant="caption" numberOfLines={1}>
+            {detail}
+          </Text>
+        ) : null}
+      </View>
+      {value}
+    </Row>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -311,6 +311,29 @@ export interface UiStrings {
   spent: string;
   overBudget: string;
   underBudget: string;
+  /** Trip insights: burn-rate forecast, fairness nudges, post-trip recap. */
+  tripInsights: {
+    forecast: string;
+    /** Projected end-of-trip total. */
+    projectedTotal: string;
+    onTrack: string;
+    fairness: string;
+    /** `{name}` has fronted `{percent}`% of the trip. */
+    paidShare: string;
+    evenlyMatched: string;
+    /** Suggest `{name}` picks up the next bill. */
+    nextUp: string;
+    recap: string;
+    recapSubtitle: string;
+    total: string;
+    perDay: string;
+    biggestBill: string;
+    mostSpentOn: string;
+    paidMost: string;
+    /** `{n}` expenses. */
+    expenseCount: string;
+    noneYet: string;
+  };
   /** Trip budgets. */
   budgets: string;
   overallBudget: string;
@@ -1923,6 +1946,24 @@ const en: UiStrings = {
   spent: 'Spent',
   overBudget: 'over',
   underBudget: 'under',
+  tripInsights: {
+    forecast: 'On this pace',
+    projectedTotal: 'Projected total',
+    onTrack: 'On track',
+    fairness: 'Fairness',
+    paidShare: '{name} has fronted {percent}% of the trip',
+    evenlyMatched: 'Everyone’s chipping in evenly',
+    nextUp: '{name} could pick up the next one',
+    recap: 'Trip recap',
+    recapSubtitle: 'How the trip added up',
+    total: 'Total',
+    perDay: 'Per day',
+    biggestBill: 'Biggest bill',
+    mostSpentOn: 'Most spent on',
+    paidMost: 'Fronted the most',
+    expenseCount: '{n} expenses',
+    noneYet: 'Nothing to recap yet',
+  },
   budgets: 'Budgets',
   overallBudget: 'Overall',
   myBudget: 'My budget',
@@ -3553,6 +3594,24 @@ const ta: UiStrings = {
   spent: 'செலவானது',
   overBudget: 'அதிகம்',
   underBudget: 'குறைவு',
+  tripInsights: {
+    forecast: 'இந்த வேகத்தில்',
+    projectedTotal: 'எதிர்பார்க்கும் மொத்தம்',
+    onTrack: 'சரியான பாதையில்',
+    fairness: 'நியாயம்',
+    paidShare: '{name} பயணத்தில் {percent}% செலுத்தியுள்ளார்',
+    evenlyMatched: 'அனைவரும் சமமாக பங்களிக்கிறார்கள்',
+    nextUp: 'அடுத்த பில்லை {name} எடுக்கலாம்',
+    recap: 'பயண சுருக்கம்',
+    recapSubtitle: 'பயணம் எப்படி கூடியது',
+    total: 'மொத்தம்',
+    perDay: 'நாள் ஒன்றுக்கு',
+    biggestBill: 'மிகப்பெரிய பில்',
+    mostSpentOn: 'அதிகம் செலவழித்தது',
+    paidMost: 'அதிகம் செலுத்தியவர்',
+    expenseCount: '{n} செலவுகள்',
+    noneYet: 'இன்னும் சுருக்க எதுவும் இல்லை',
+  },
   budgets: 'பட்ஜெட்',
   overallBudget: 'மொத்தம்',
   myBudget: 'என் பட்ஜெட்',
@@ -5248,6 +5307,24 @@ const hi: UiStrings = {
   spent: 'खर्च हुआ',
   overBudget: 'ज़्यादा',
   underBudget: 'कम',
+  tripInsights: {
+    forecast: 'इस रफ़्तार पर',
+    projectedTotal: 'अनुमानित कुल',
+    onTrack: 'सही राह पर',
+    fairness: 'बराबरी',
+    paidShare: '{name} ने ट्रिप का {percent}% चुकाया है',
+    evenlyMatched: 'सब बराबर योगदान दे रहे हैं',
+    nextUp: 'अगला बिल {name} ले सकते हैं',
+    recap: 'ट्रिप का सार',
+    recapSubtitle: 'ट्रिप का हिसाब कैसे बना',
+    total: 'कुल',
+    perDay: 'प्रति दिन',
+    biggestBill: 'सबसे बड़ा बिल',
+    mostSpentOn: 'सबसे ज़्यादा खर्च',
+    paidMost: 'सबसे ज़्यादा चुकाया',
+    expenseCount: '{n} खर्च',
+    noneYet: 'अभी सार के लिए कुछ नहीं',
+  },
   budgets: 'बजट',
   overallBudget: 'कुल',
   myBudget: 'मेरा बजट',
@@ -6893,6 +6970,24 @@ const ar: UiStrings = {
   spent: 'المصروف',
   overBudget: 'زيادة',
   underBudget: 'أقل',
+  tripInsights: {
+    forecast: 'بهذه الوتيرة',
+    projectedTotal: 'الإجمالي المتوقع',
+    onTrack: 'على المسار',
+    fairness: 'الإنصاف',
+    paidShare: 'دفع {name} ‏{percent}٪ من الرحلة',
+    evenlyMatched: 'الجميع يساهمون بالتساوي',
+    nextUp: 'يمكن أن يدفع {name} الفاتورة التالية',
+    recap: 'ملخص الرحلة',
+    recapSubtitle: 'كيف تجمّعت مصاريف الرحلة',
+    total: 'الإجمالي',
+    perDay: 'لكل يوم',
+    biggestBill: 'أكبر فاتورة',
+    mostSpentOn: 'الأكثر إنفاقًا',
+    paidMost: 'الأكثر دفعًا',
+    expenseCount: '{n} مصاريف',
+    noneYet: 'لا شيء للتلخيص بعد',
+  },
   budgets: 'الميزانية',
   overallBudget: 'الإجمالي',
   myBudget: 'ميزانيتي',

--- a/packages/core/src/trip/fairness.ts
+++ b/packages/core/src/trip/fairness.ts
@@ -1,0 +1,145 @@
+/**
+ * Fairness: is one person carrying the trip?
+ *
+ * Two questions travellers actually ask, both answered from the ledger the
+ * group already has, and both obeying the same rule the rest of the trip maths
+ * obeys — **currencies never mix (ADR-004).** Rupees fronted and euros fronted
+ * are two different sacrifices; there is no rate that makes "who paid most"
+ * comparable across them, so every figure here is per currency and the screen
+ * shows each on its own line.
+ *
+ *   * **Who paid too much** — "Ananya has paid 70% of the trip." A share of what
+ *     the group *fronted*, not what anybody owes. Flagged only when it runs past
+ *     a multiple of an even share, so a two-person trip does not nag at 55%.
+ *   * **Who should pay next** — the person whose net (fronted minus their share
+ *     of consumption) is furthest negative: they have consumed more of the trip
+ *     than they have laid out, so handing them the next bill nudges the group
+ *     back toward even without anyone settling up mid-trip.
+ *
+ * Nothing here is money that moves. It never proposes a transfer — `simplify`
+ * does that. This only surfaces a lopsidedness a human then acts on.
+ *
+ * Minor units and bigint throughout; the only float is a display ratio, taken
+ * with scaled-integer division so it is exact for amounts a double would round.
+ */
+
+/** One member's standing in one currency, already reduced from the ledger. */
+export interface MemberContribution {
+  readonly member: string;
+  readonly currency: string;
+  /** What they fronted at the counter, in minor units. */
+  readonly paidMinor: bigint;
+  /** Their share of what was consumed, in minor units (the split's verdict). */
+  readonly owedMinor: bigint;
+}
+
+export interface MemberFairness {
+  readonly member: string;
+  readonly paidMinor: bigint;
+  readonly owedMinor: bigint;
+  /** paid − owed. Positive: fronted more than their share (a creditor). */
+  readonly netMinor: bigint;
+  /** paid / totalPaid, clamped to [0, 1]. Zero when nobody has paid yet. */
+  readonly paidRatio: number;
+}
+
+export interface Overpayer {
+  readonly member: string;
+  readonly paidRatio: number;
+}
+
+export interface CurrencyFairness {
+  readonly currency: string;
+  readonly totalPaidMinor: bigint;
+  /** Members sorted by paidRatio, largest first; ties broken by member id. */
+  readonly members: readonly MemberFairness[];
+  /** The one carrying a disproportionate share of the fronting, or null. */
+  readonly overpayer: Overpayer | null;
+  /** Who should front the next bill to even things out, or null when balanced. */
+  readonly nextPayer: string | null;
+}
+
+export interface FairnessOptions {
+  /**
+   * How many times an even share a member's paid-share must exceed before they
+   * count as an overpayer. 1.5 means: in a four-person trip (even share 25%),
+   * the flag trips at 37.5%; in a two-person trip (even share 50%), at 75%.
+   */
+  readonly overpayerMultiple?: number;
+}
+
+const DEFAULT_OVERPAYER_MULTIPLE = 1.5;
+
+/** A paid/total ratio in [0, 1], exact via scaled-integer division. */
+function ratioOf(part: bigint, total: bigint): number {
+  if (total <= 0n) return 0;
+  if (part <= 0n) return 0;
+  if (part >= total) return 1;
+  return Number((part * 10_000n) / total) / 10_000;
+}
+
+/**
+ * Fairness, one block per currency present in the contributions.
+ *
+ * A currency appears if anyone paid or owed anything in it. Members with no
+ * activity in a currency are simply absent from that block — nobody's standing
+ * is invented as a zero.
+ */
+export function fairness(
+  contributions: readonly MemberContribution[],
+  options: FairnessOptions = {},
+): CurrencyFairness[] {
+  const multiple = options.overpayerMultiple ?? DEFAULT_OVERPAYER_MULTIPLE;
+
+  const byCurrency = new Map<string, Map<string, { paid: bigint; owed: bigint }>>();
+  for (const c of contributions) {
+    const currency = c.currency.toUpperCase();
+    const members = byCurrency.get(currency) ?? new Map();
+    const row = members.get(c.member) ?? { paid: 0n, owed: 0n };
+    row.paid += c.paidMinor;
+    row.owed += c.owedMinor;
+    members.set(c.member, row);
+    byCurrency.set(currency, members);
+  }
+
+  const out: CurrencyFairness[] = [];
+  for (const [currency, members] of byCurrency) {
+    let totalPaid = 0n;
+    for (const { paid } of members.values()) totalPaid += paid;
+
+    const rows: MemberFairness[] = [...members.entries()]
+      .map(([member, { paid, owed }]) => ({
+        member,
+        paidMinor: paid,
+        owedMinor: owed,
+        netMinor: paid - owed,
+        paidRatio: ratioOf(paid, totalPaid),
+      }))
+      .sort((a, b) => b.paidRatio - a.paidRatio || a.member.localeCompare(b.member));
+
+    // The fair share of the *fronting* is 1/n; the flag trips past a multiple of
+    // it. n counts members who took any part in this currency.
+    const evenShare = rows.length > 0 ? 1 / rows.length : 0;
+    const threshold = evenShare * multiple;
+    const leader = rows[0];
+    const overpayer =
+      leader && totalPaid > 0n && leader.paidRatio >= threshold
+        ? { member: leader.member, paidRatio: leader.paidRatio }
+        : null;
+
+    // Who should pay next: the furthest-negative net. Null when nobody has
+    // underpaid (everyone is square or a creditor) — there is no one to nudge.
+    let nextPayer: string | null = null;
+    let worst = 0n;
+    for (const row of rows) {
+      if (row.netMinor < worst || (row.netMinor === worst && nextPayer === null && row.netMinor < 0n)) {
+        worst = row.netMinor;
+        nextPayer = row.member;
+      }
+    }
+
+    out.push({ currency, totalPaidMinor: totalPaid, members: rows, overpayer, nextPayer });
+  }
+
+  return out.sort((a, b) => a.currency.localeCompare(b.currency));
+}

--- a/packages/core/src/trip/fairness.ts
+++ b/packages/core/src/trip/fairness.ts
@@ -115,7 +115,7 @@ export function fairness(
         netMinor: paid - owed,
         paidRatio: ratioOf(paid, totalPaid),
       }))
-      .sort((a, b) => b.paidRatio - a.paidRatio || a.member.localeCompare(b.member));
+      .sort((a, b) => b.paidRatio - a.paidRatio || compareId(a.member, b.member));
 
     // The fair share of the *fronting* is 1/n; the flag trips past a multiple of
     // it. n counts members who took any part in this currency.
@@ -127,14 +127,18 @@ export function fairness(
         ? { member: leader.member, paidRatio: leader.paidRatio }
         : null;
 
-    // Who should pay next: the furthest-negative net. Null when nobody has
-    // underpaid (everyone is square or a creditor) — there is no one to nudge.
+    // Who should pay next: the furthest-negative net. Only underpayers are
+    // candidates; null when nobody has underpaid (everyone is square or a
+    // creditor). Ties break by member id so every device agrees on who — the
+    // paidRatio order the rows are in is not a stable enough tiebreak.
     let nextPayer: string | null = null;
-    let worst = 0n;
+    let worst: bigint | null = null;
     for (const row of rows) {
+      if (row.netMinor >= 0n) continue;
       if (
+        worst === null ||
         row.netMinor < worst ||
-        (row.netMinor === worst && nextPayer === null && row.netMinor < 0n)
+        (row.netMinor === worst && row.member < nextPayer!)
       ) {
         worst = row.netMinor;
         nextPayer = row.member;
@@ -144,5 +148,11 @@ export function fairness(
     out.push({ currency, totalPaidMinor: totalPaid, members: rows, overpayer, nextPayer });
   }
 
-  return out.sort((a, b) => a.currency.localeCompare(b.currency));
+  return out.sort((a, b) => compareId(a.currency, b.currency));
+}
+
+/** Deterministic string order by code unit — locale-independent, so every
+ * device sorts identically (localeCompare's default locale is not). */
+function compareId(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }

--- a/packages/core/src/trip/fairness.ts
+++ b/packages/core/src/trip/fairness.ts
@@ -132,7 +132,10 @@ export function fairness(
     let nextPayer: string | null = null;
     let worst = 0n;
     for (const row of rows) {
-      if (row.netMinor < worst || (row.netMinor === worst && nextPayer === null && row.netMinor < 0n)) {
+      if (
+        row.netMinor < worst ||
+        (row.netMinor === worst && nextPayer === null && row.netMinor < 0n)
+      ) {
         worst = row.netMinor;
         nextPayer = row.member;
       }

--- a/packages/core/src/trip/forecast.ts
+++ b/packages/core/src/trip/forecast.ts
@@ -1,0 +1,100 @@
+/**
+ * Burn-rate forecast: at this pace, where does the trip land?
+ *
+ * "You've spent ₹28,000 in three days of a seven-day trip; on this pace it ends
+ * around ₹65,000 — ₹5,000 over the budget." A projection, not a promise: it
+ * assumes tomorrow looks like the days so far, which is exactly the assumption a
+ * traveller is testing when they ask.
+ *
+ * The rules, unchanged from the rest of the trip maths:
+ *
+ *   * **Currencies never mix (ADR-004).** Each currency is projected on its own
+ *     pace against its own cap. A rupee pace never spends a euro budget.
+ *   * **Minor units and bigint throughout.** The projection is
+ *     `spent × totalDays ÷ elapsedDays`, all bigint, truncating — no float, no
+ *     rounding a projection into a promise of precision it does not have.
+ *   * **`today` is passed in, never read from a clock.** The answer depends on
+ *     the trip's timezone, which this package does not know.
+ */
+
+import type { Budget } from './budget';
+import { daysBetween } from './timeline';
+
+export interface Forecast {
+  readonly currency: string;
+  readonly spentMinor: bigint;
+  /** Days counted so far, from the start through today (clamped to the end). ≥1. */
+  readonly elapsedDays: number;
+  /** The trip's full length in days. */
+  readonly totalDays: number;
+  /** spent ÷ elapsedDays, truncating. */
+  readonly dailyBurnMinor: bigint;
+  /** spent × totalDays ÷ elapsedDays. Equals spent once the trip has ended. */
+  readonly projectedTotalMinor: bigint;
+  /** The cap for this currency, or null when nothing is budgeted in it. */
+  readonly capMinor: bigint | null;
+  /** projectedTotal − cap (signed; positive is over), or null with no cap. */
+  readonly projectedOverrunMinor: bigint | null;
+  /** projectedTotal ≤ cap, or null with no cap. */
+  readonly onTrack: boolean | null;
+  /** True once today is past the trip's end: the projection is now the actual. */
+  readonly ended: boolean;
+}
+
+export interface ForecastInput {
+  readonly spentByCurrency: Readonly<Record<string, bigint>>;
+  /** A single-currency cap, if the trip has one. Only its currency gets a cap. */
+  readonly budget?: Budget | null;
+  /** `YYYY-MM-DD` in the trip's timezone. */
+  readonly today: string;
+  readonly startDate?: string | null;
+  readonly endDate?: string | null;
+}
+
+/**
+ * One forecast per currency, or an empty list when a forecast makes no sense:
+ * the trip has no dates, or it has not started yet (nothing has elapsed to
+ * extrapolate from). A currency that is budgeted but not yet spent still gets a
+ * row, so an untouched budget shows as on track rather than vanishing.
+ */
+export function forecast(input: ForecastInput): Forecast[] {
+  const { startDate, endDate, today } = input;
+  if (!startDate || !endDate || endDate < startDate) return [];
+  if (today < startDate) return []; // not started; no pace to read yet
+
+  const ended = today > endDate;
+  const effectiveToday = ended ? endDate : today;
+  const elapsedDays = Math.max(1, daysBetween(startDate, effectiveToday).length);
+  const totalDays = Math.max(elapsedDays, daysBetween(startDate, endDate).length);
+
+  const budgetCurrency = input.budget ? input.budget.currency.toUpperCase() : null;
+
+  const currencies = new Set<string>();
+  for (const key of Object.keys(input.spentByCurrency)) currencies.add(key.toUpperCase());
+  if (budgetCurrency) currencies.add(budgetCurrency);
+
+  const elapsed = BigInt(elapsedDays);
+  const total = BigInt(totalDays);
+
+  const out: Forecast[] = [];
+  for (const currency of currencies) {
+    const spent = input.spentByCurrency[currency] ?? 0n;
+    const projected = (spent * total) / elapsed; // bigint, truncating
+    const capMinor = budgetCurrency === currency ? (input.budget?.amountMinor ?? null) : null;
+
+    out.push({
+      currency,
+      spentMinor: spent,
+      elapsedDays,
+      totalDays,
+      dailyBurnMinor: spent / elapsed,
+      projectedTotalMinor: projected,
+      capMinor,
+      projectedOverrunMinor: capMinor === null ? null : projected - capMinor,
+      onTrack: capMinor === null ? null : projected <= capMinor,
+      ended,
+    });
+  }
+
+  return out.sort((a, b) => a.currency.localeCompare(b.currency));
+}

--- a/packages/core/src/trip/forecast.ts
+++ b/packages/core/src/trip/forecast.ts
@@ -69,8 +69,15 @@ export function forecast(input: ForecastInput): Forecast[] {
 
   const budgetCurrency = input.budget ? input.budget.currency.toUpperCase() : null;
 
-  const currencies = new Set<string>();
-  for (const key of Object.keys(input.spentByCurrency)) currencies.add(key.toUpperCase());
+  // Normalise the spend map up front so a lowercase-keyed input still matches
+  // the uppercased currency the forecast is keyed on.
+  const spentByCurrency: Record<string, bigint> = {};
+  for (const [key, value] of Object.entries(input.spentByCurrency)) {
+    const code = key.toUpperCase();
+    spentByCurrency[code] = (spentByCurrency[code] ?? 0n) + value;
+  }
+
+  const currencies = new Set<string>(Object.keys(spentByCurrency));
   if (budgetCurrency) currencies.add(budgetCurrency);
 
   const elapsed = BigInt(elapsedDays);
@@ -78,7 +85,7 @@ export function forecast(input: ForecastInput): Forecast[] {
 
   const out: Forecast[] = [];
   for (const currency of currencies) {
-    const spent = input.spentByCurrency[currency] ?? 0n;
+    const spent = spentByCurrency[currency] ?? 0n;
     const projected = (spent * total) / elapsed; // bigint, truncating
     const capMinor = budgetCurrency === currency ? (input.budget?.amountMinor ?? null) : null;
 
@@ -96,5 +103,5 @@ export function forecast(input: ForecastInput): Forecast[] {
     });
   }
 
-  return out.sort((a, b) => a.currency.localeCompare(b.currency));
+  return out.sort((a, b) => (a.currency < b.currency ? -1 : a.currency > b.currency ? 1 : 0));
 }

--- a/packages/core/src/trip/index.ts
+++ b/packages/core/src/trip/index.ts
@@ -1,2 +1,5 @@
 export * from './timeline';
 export * from './budget';
+export * from './fairness';
+export * from './recap';
+export * from './forecast';

--- a/packages/core/src/trip/recap.ts
+++ b/packages/core/src/trip/recap.ts
@@ -80,10 +80,6 @@ export interface RecapInput {
   readonly endDate?: string | null;
 }
 
-function max(a: bigint, b: bigint): bigint {
-  return a > b ? a : b;
-}
-
 /**
  * Reduce a ledger to its recap. Deterministic: ties (equal category totals,
  * equal payer totals) break by name/id so the same trip recaps the same way on
@@ -179,9 +175,11 @@ export function recap(input: RecapInput): Recap {
       }
     }
 
-    // Prefer the trip's real length so a two-day trip with spend on one day
-    // still averages over two. Never divide by zero.
-    const dayCount = max(BigInt(tripDays), BigInt(block.days.size)) || 1n;
+    // The trip's real length is the honest denominator when it's known — a
+    // two-day trip with spend on one day still averages over two. Only when the
+    // trip has no dates does the average fall back to days that had spend.
+    // Never divide by zero.
+    const dayCount = (tripDays > 0 ? BigInt(tripDays) : BigInt(block.days.size)) || 1n;
 
     return {
       currency,
@@ -197,7 +195,7 @@ export function recap(input: RecapInput): Recap {
 
   byCurrency.sort((a, b) => {
     if (a.totalMinor !== b.totalMinor) return a.totalMinor > b.totalMinor ? -1 : 1;
-    return a.currency.localeCompare(b.currency);
+    return a.currency < b.currency ? -1 : a.currency > b.currency ? 1 : 0;
   });
 
   return {

--- a/packages/core/src/trip/recap.ts
+++ b/packages/core/src/trip/recap.ts
@@ -1,0 +1,209 @@
+/**
+ * Trip recap: the trip, once it is over, in the few numbers people repeat.
+ *
+ * "We spent ₹84,000, mostly on stays, the biggest single bill was the
+ * houseboat, and Ravi fronted the most." Every one of those is already in the
+ * ledger; this reduces it to the headline.
+ *
+ * The two rules the rest of the trip maths obeys hold here too:
+ *
+ *   * **Currencies never mix (ADR-004).** There is no single "total" — a trip
+ *     billed in rupees and baht has two totals, and the recap carries a block
+ *     per currency. A screen may lead with the biggest block; it must not add
+ *     them up.
+ *   * **Minor units and bigint throughout.** The daily average is the only
+ *     division, taken with truncating bigint division — no float touches money.
+ *
+ * Multi-payer is respected: `payers` is a list, so "who paid most" counts every
+ * hand that actually fronted cash, not just the first name on the expense.
+ */
+
+import { daysBetween } from './timeline';
+
+/** An expense, reduced to what a recap needs of it. */
+export interface RecapExpense {
+  readonly id: string;
+  /** `YYYY-MM-DD`, in the trip's timezone. */
+  readonly date: string;
+  readonly description: string;
+  /** null is "uncategorised" and is left out of the top-category race. */
+  readonly category: string | null;
+  readonly amountMinor: bigint;
+  readonly currency: string;
+  /** Who fronted this expense, in minor units. Sums to the amount by convention. */
+  readonly payers: readonly { readonly member: string; readonly amountMinor: bigint }[];
+}
+
+export interface CategoryTotal {
+  readonly category: string;
+  readonly totalMinor: bigint;
+}
+
+export interface BiggestExpense {
+  readonly id: string;
+  readonly description: string;
+  readonly amountMinor: bigint;
+}
+
+export interface TopPayer {
+  readonly member: string;
+  readonly paidMinor: bigint;
+}
+
+export interface CurrencyRecap {
+  readonly currency: string;
+  readonly totalMinor: bigint;
+  readonly expenseCount: number;
+  /** Highest-spending real category, or null when nothing was categorised. */
+  readonly topCategory: CategoryTotal | null;
+  readonly biggestExpense: BiggestExpense | null;
+  readonly topPayer: TopPayer | null;
+  /** Days the average is spread over: the trip's length if known, else days
+   * that actually had spend. Never zero. */
+  readonly dayCount: number;
+  /** total / dayCount, truncating. */
+  readonly dailyAverageMinor: bigint;
+}
+
+export interface Recap {
+  /** One block per currency, largest total first (nominal, not converted). */
+  readonly byCurrency: readonly CurrencyRecap[];
+  readonly expenseCount: number;
+  readonly firstDay: string | null;
+  readonly lastDay: string | null;
+}
+
+export interface RecapInput {
+  readonly expenses: readonly RecapExpense[];
+  /** The trip's dates, if it has them: fixes the average's denominator. */
+  readonly startDate?: string | null;
+  readonly endDate?: string | null;
+}
+
+function max(a: bigint, b: bigint): bigint {
+  return a > b ? a : b;
+}
+
+/**
+ * Reduce a ledger to its recap. Deterministic: ties (equal category totals,
+ * equal payer totals) break by name/id so the same trip recaps the same way on
+ * every device.
+ */
+export function recap(input: RecapInput): Recap {
+  const currencies = new Map<
+    string,
+    {
+      total: bigint;
+      count: number;
+      categories: Map<string, bigint>;
+      biggest: BiggestExpense | null;
+      payers: Map<string, bigint>;
+      days: Set<string>;
+    }
+  >();
+
+  let firstDay: string | null = null;
+  let lastDay: string | null = null;
+
+  for (const expense of input.expenses) {
+    if (firstDay === null || expense.date < firstDay) firstDay = expense.date;
+    if (lastDay === null || expense.date > lastDay) lastDay = expense.date;
+
+    const currency = expense.currency.toUpperCase();
+    const block = currencies.get(currency) ?? {
+      total: 0n,
+      count: 0,
+      categories: new Map<string, bigint>(),
+      biggest: null,
+      payers: new Map<string, bigint>(),
+      days: new Set<string>(),
+    };
+
+    block.total += expense.amountMinor;
+    block.count += 1;
+    block.days.add(expense.date);
+
+    if (expense.category) {
+      block.categories.set(
+        expense.category,
+        (block.categories.get(expense.category) ?? 0n) + expense.amountMinor,
+      );
+    }
+
+    // Strictly greater keeps the first-seen expense on a tie, which — because
+    // input order is the caller's, not guaranteed — we make deterministic by
+    // also comparing the id below.
+    if (
+      block.biggest === null ||
+      expense.amountMinor > block.biggest.amountMinor ||
+      (expense.amountMinor === block.biggest.amountMinor && expense.id < block.biggest.id)
+    ) {
+      block.biggest = {
+        id: expense.id,
+        description: expense.description,
+        amountMinor: expense.amountMinor,
+      };
+    }
+
+    for (const payer of expense.payers) {
+      if (payer.amountMinor === 0n) continue;
+      block.payers.set(payer.member, (block.payers.get(payer.member) ?? 0n) + payer.amountMinor);
+    }
+
+    currencies.set(currency, block);
+  }
+
+  const tripDays =
+    input.startDate && input.endDate ? daysBetween(input.startDate, input.endDate).length : 0;
+
+  const byCurrency: CurrencyRecap[] = [...currencies.entries()].map(([currency, block]) => {
+    let topCategory: CategoryTotal | null = null;
+    for (const [category, total] of block.categories) {
+      if (
+        topCategory === null ||
+        total > topCategory.totalMinor ||
+        (total === topCategory.totalMinor && category < topCategory.category)
+      ) {
+        topCategory = { category, totalMinor: total };
+      }
+    }
+
+    let topPayer: TopPayer | null = null;
+    for (const [member, paid] of block.payers) {
+      if (
+        topPayer === null ||
+        paid > topPayer.paidMinor ||
+        (paid === topPayer.paidMinor && member < topPayer.member)
+      ) {
+        topPayer = { member, paidMinor: paid };
+      }
+    }
+
+    // Prefer the trip's real length so a two-day trip with spend on one day
+    // still averages over two. Never divide by zero.
+    const dayCount = max(BigInt(tripDays), BigInt(block.days.size)) || 1n;
+
+    return {
+      currency,
+      totalMinor: block.total,
+      expenseCount: block.count,
+      topCategory,
+      biggestExpense: block.biggest,
+      topPayer,
+      dayCount: Number(dayCount),
+      dailyAverageMinor: block.total / dayCount,
+    };
+  });
+
+  byCurrency.sort((a, b) => {
+    if (a.totalMinor !== b.totalMinor) return a.totalMinor > b.totalMinor ? -1 : 1;
+    return a.currency.localeCompare(b.currency);
+  });
+
+  return {
+    byCurrency,
+    expenseCount: input.expenses.length,
+    firstDay,
+    lastDay,
+  };
+}

--- a/packages/core/test/fairness.test.ts
+++ b/packages/core/test/fairness.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Fairness pins the two ways the maths could mislead a group: mixing currencies
+ * into one "who paid most", and nagging a small group where someone paying half
+ * is simply their turn.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { fairness, type MemberContribution } from '../src/trip/fairness';
+
+describe('fairness', () => {
+  it('keeps each currency on its own, never adding rupees to euros', () => {
+    const contributions: MemberContribution[] = [
+      { member: 'ravi', currency: 'INR', paidMinor: 7000n, owedMinor: 3000n },
+      { member: 'asha', currency: 'INR', paidMinor: 3000n, owedMinor: 3000n },
+      { member: 'neha', currency: 'INR', paidMinor: 0n, owedMinor: 4000n },
+      { member: 'ravi', currency: 'EUR', paidMinor: 9000n, owedMinor: 3000n },
+    ];
+    const result = fairness(contributions);
+    const inr = result.find((r) => r.currency === 'INR');
+    const eur = result.find((r) => r.currency === 'EUR');
+    expect(inr?.totalPaidMinor).toBe(10000n);
+    expect(eur?.totalPaidMinor).toBe(9000n); // ravi's rupees never inflate his euros
+  });
+
+  it('names the overpayer only past a multiple of an even share', () => {
+    // Four members, even share 25%; ravi fronted 70% → flagged at the 37.5% line.
+    const four: MemberContribution[] = [
+      { member: 'ravi', currency: 'INR', paidMinor: 7000n, owedMinor: 2500n },
+      { member: 'a', currency: 'INR', paidMinor: 1000n, owedMinor: 2500n },
+      { member: 'b', currency: 'INR', paidMinor: 1000n, owedMinor: 2500n },
+      { member: 'c', currency: 'INR', paidMinor: 1000n, owedMinor: 2500n },
+    ];
+    expect(fairness(four)[0].overpayer).toMatchObject({ member: 'ravi' });
+
+    // Two members, even share 50%; a 60/40 split is not a flag (threshold 75%).
+    const two: MemberContribution[] = [
+      { member: 'ravi', currency: 'INR', paidMinor: 6000n, owedMinor: 5000n },
+      { member: 'asha', currency: 'INR', paidMinor: 4000n, owedMinor: 5000n },
+    ];
+    expect(fairness(two)[0].overpayer).toBeNull();
+  });
+
+  it('picks the furthest-negative net as who pays next, and null when square', () => {
+    const lopsided: MemberContribution[] = [
+      { member: 'ravi', currency: 'INR', paidMinor: 9000n, owedMinor: 3000n },
+      { member: 'asha', currency: 'INR', paidMinor: 0n, owedMinor: 3000n },
+      { member: 'neha', currency: 'INR', paidMinor: 0n, owedMinor: 3000n },
+    ];
+    // asha and neha both owe 3000 net; tie breaks to the first by id.
+    expect(fairness(lopsided)[0].nextPayer).toBe('asha');
+
+    const square: MemberContribution[] = [
+      { member: 'ravi', currency: 'INR', paidMinor: 3000n, owedMinor: 3000n },
+      { member: 'asha', currency: 'INR', paidMinor: 3000n, owedMinor: 3000n },
+    ];
+    expect(fairness(square)[0].nextPayer).toBeNull();
+  });
+
+  it('reports a zero paid-ratio when nobody has fronted anything yet', () => {
+    const unpaid: MemberContribution[] = [
+      { member: 'ravi', currency: 'INR', paidMinor: 0n, owedMinor: 2000n },
+      { member: 'asha', currency: 'INR', paidMinor: 0n, owedMinor: 2000n },
+    ];
+    const block = fairness(unpaid)[0];
+    expect(block.totalPaidMinor).toBe(0n);
+    expect(block.members.every((m) => m.paidRatio === 0)).toBe(true);
+    expect(block.overpayer).toBeNull();
+  });
+});

--- a/packages/core/test/fairness.test.ts
+++ b/packages/core/test/fairness.test.ts
@@ -31,14 +31,14 @@ describe('fairness', () => {
       { member: 'b', currency: 'INR', paidMinor: 1000n, owedMinor: 2500n },
       { member: 'c', currency: 'INR', paidMinor: 1000n, owedMinor: 2500n },
     ];
-    expect(fairness(four)[0].overpayer).toMatchObject({ member: 'ravi' });
+    expect(fairness(four)[0]!.overpayer).toMatchObject({ member: 'ravi' });
 
     // Two members, even share 50%; a 60/40 split is not a flag (threshold 75%).
     const two: MemberContribution[] = [
       { member: 'ravi', currency: 'INR', paidMinor: 6000n, owedMinor: 5000n },
       { member: 'asha', currency: 'INR', paidMinor: 4000n, owedMinor: 5000n },
     ];
-    expect(fairness(two)[0].overpayer).toBeNull();
+    expect(fairness(two)[0]!.overpayer).toBeNull();
   });
 
   it('picks the furthest-negative net as who pays next, and null when square', () => {
@@ -48,13 +48,13 @@ describe('fairness', () => {
       { member: 'neha', currency: 'INR', paidMinor: 0n, owedMinor: 3000n },
     ];
     // asha and neha both owe 3000 net; tie breaks to the first by id.
-    expect(fairness(lopsided)[0].nextPayer).toBe('asha');
+    expect(fairness(lopsided)[0]!.nextPayer).toBe('asha');
 
     const square: MemberContribution[] = [
       { member: 'ravi', currency: 'INR', paidMinor: 3000n, owedMinor: 3000n },
       { member: 'asha', currency: 'INR', paidMinor: 3000n, owedMinor: 3000n },
     ];
-    expect(fairness(square)[0].nextPayer).toBeNull();
+    expect(fairness(square)[0]!.nextPayer).toBeNull();
   });
 
   it('reports a zero paid-ratio when nobody has fronted anything yet', () => {
@@ -62,7 +62,7 @@ describe('fairness', () => {
       { member: 'ravi', currency: 'INR', paidMinor: 0n, owedMinor: 2000n },
       { member: 'asha', currency: 'INR', paidMinor: 0n, owedMinor: 2000n },
     ];
-    const block = fairness(unpaid)[0];
+    const block = fairness(unpaid)[0]!;
     expect(block.totalPaidMinor).toBe(0n);
     expect(block.members.every((m) => m.paidRatio === 0)).toBe(true);
     expect(block.overpayer).toBeNull();

--- a/packages/core/test/forecast.test.ts
+++ b/packages/core/test/forecast.test.ts
@@ -13,11 +13,11 @@ describe('forecast', () => {
 
   it('projects the pace so far across the whole trip', () => {
     // Day 3 of 7, ₹28,000 spent → pace 28000/3, projected 28000×7/3 = 65333.
-    const [f] = forecast({
+    const f = forecast({
       spentByCurrency: { INR: 28000n },
       today: '2026-03-16',
       ...dates,
-    });
+    })[0]!;
     expect(f.elapsedDays).toBe(3);
     expect(f.totalDays).toBe(7);
     expect(f.dailyBurnMinor).toBe(9333n);
@@ -41,23 +41,23 @@ describe('forecast', () => {
   });
 
   it('gives a budgeted-but-unspent currency an on-track row', () => {
-    const [f] = forecast({
+    const f = forecast({
       spentByCurrency: {},
       budget: { amountMinor: 60000n, currency: 'INR' },
       today: '2026-03-16',
       ...dates,
-    });
+    })[0]!;
     expect(f.currency).toBe('INR');
     expect(f.projectedTotalMinor).toBe(0n);
     expect(f.onTrack).toBe(true);
   });
 
   it('freezes the projection to the actual once the trip has ended', () => {
-    const [f] = forecast({
+    const f = forecast({
       spentByCurrency: { INR: 70000n },
       today: '2026-03-25', // past the end
       ...dates,
-    });
+    })[0]!;
     expect(f.ended).toBe(true);
     expect(f.elapsedDays).toBe(7);
     expect(f.projectedTotalMinor).toBe(70000n); // no extrapolation past the end

--- a/packages/core/test/forecast.test.ts
+++ b/packages/core/test/forecast.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Forecast pins the projection maths and its guards: no forecast before a trip
+ * starts or without dates, the projection freezes to the actual once the trip
+ * ends, and each currency is projected against only its own cap.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { forecast } from '../src/trip/forecast';
+
+describe('forecast', () => {
+  const dates = { startDate: '2026-03-14', endDate: '2026-03-20' }; // 7 days
+
+  it('projects the pace so far across the whole trip', () => {
+    // Day 3 of 7, ₹28,000 spent → pace 28000/3, projected 28000×7/3 = 65333.
+    const [f] = forecast({
+      spentByCurrency: { INR: 28000n },
+      today: '2026-03-16',
+      ...dates,
+    });
+    expect(f.elapsedDays).toBe(3);
+    expect(f.totalDays).toBe(7);
+    expect(f.dailyBurnMinor).toBe(9333n);
+    expect(f.projectedTotalMinor).toBe(65333n);
+  });
+
+  it('measures the projection against a cap only in the cap’s currency', () => {
+    const result = forecast({
+      spentByCurrency: { INR: 28000n, THB: 5000n },
+      budget: { amountMinor: 60000n, currency: 'INR' },
+      today: '2026-03-16',
+      ...dates,
+    });
+    const inr = result.find((f) => f.currency === 'INR');
+    const thb = result.find((f) => f.currency === 'THB');
+    expect(inr?.capMinor).toBe(60000n);
+    expect(inr?.projectedOverrunMinor).toBe(5333n); // 65333 − 60000
+    expect(inr?.onTrack).toBe(false);
+    expect(thb?.capMinor).toBeNull(); // baht is not budgeted
+    expect(thb?.onTrack).toBeNull();
+  });
+
+  it('gives a budgeted-but-unspent currency an on-track row', () => {
+    const [f] = forecast({
+      spentByCurrency: {},
+      budget: { amountMinor: 60000n, currency: 'INR' },
+      today: '2026-03-16',
+      ...dates,
+    });
+    expect(f.currency).toBe('INR');
+    expect(f.projectedTotalMinor).toBe(0n);
+    expect(f.onTrack).toBe(true);
+  });
+
+  it('freezes the projection to the actual once the trip has ended', () => {
+    const [f] = forecast({
+      spentByCurrency: { INR: 70000n },
+      today: '2026-03-25', // past the end
+      ...dates,
+    });
+    expect(f.ended).toBe(true);
+    expect(f.elapsedDays).toBe(7);
+    expect(f.projectedTotalMinor).toBe(70000n); // no extrapolation past the end
+  });
+
+  it('returns nothing before the trip starts or without dates', () => {
+    expect(forecast({ spentByCurrency: { INR: 1n }, today: '2026-03-10', ...dates })).toEqual([]);
+    expect(forecast({ spentByCurrency: { INR: 1n }, today: '2026-03-16' })).toEqual([]);
+  });
+});

--- a/packages/core/test/recap.test.ts
+++ b/packages/core/test/recap.test.ts
@@ -51,37 +51,37 @@ describe('recap', () => {
   it('carries one block per currency, biggest total first', () => {
     const r = recap({ expenses });
     expect(r.byCurrency.map((b) => b.currency)).toEqual(['INR', 'THB']);
-    expect(r.byCurrency[0].totalMinor).toBe(84000n);
+    expect(r.byCurrency[0]!.totalMinor).toBe(84000n);
     expect(r.expenseCount).toBe(4);
   });
 
   it('ranks the top category by spend, breaking ties by name', () => {
     const r = recap({ expenses });
     // food = 44000, stays = 40000 → food leads.
-    expect(r.byCurrency[0].topCategory).toEqual({ category: 'food', totalMinor: 44000n });
+    expect(r.byCurrency[0]!.topCategory).toEqual({ category: 'food', totalMinor: 44000n });
   });
 
   it('breaks a biggest-expense tie deterministically by id', () => {
     const r = recap({ expenses });
-    expect(r.byCurrency[0].biggestExpense?.id).toBe('e1');
+    expect(r.byCurrency[0]!.biggestExpense?.id).toBe('e1');
   });
 
   it('credits the top payer across every expense they fronted', () => {
     const r = recap({ expenses });
-    expect(r.byCurrency[0].topPayer).toEqual({ member: 'ravi', paidMinor: 80000n });
+    expect(r.byCurrency[0]!.topPayer).toEqual({ member: 'ravi', paidMinor: 80000n });
   });
 
   it('averages over the trip length when given dates, not just active days', () => {
     const r = recap({ expenses, startDate: '2026-03-14', endDate: '2026-03-17' });
     // 84000 over 4 trip days, not 2 days-with-spend.
-    expect(r.byCurrency[0].dayCount).toBe(4);
-    expect(r.byCurrency[0].dailyAverageMinor).toBe(21000n);
+    expect(r.byCurrency[0]!.dayCount).toBe(4);
+    expect(r.byCurrency[0]!.dailyAverageMinor).toBe(21000n);
   });
 
   it('falls back to days-with-spend when the trip has no dates', () => {
     const r = recap({ expenses });
-    expect(r.byCurrency[0].dayCount).toBe(2); // the 14th and 15th
-    expect(r.byCurrency[0].dailyAverageMinor).toBe(42000n);
+    expect(r.byCurrency[0]!.dayCount).toBe(2); // the 14th and 15th
+    expect(r.byCurrency[0]!.dailyAverageMinor).toBe(42000n);
     expect(r.firstDay).toBe('2026-03-14');
     expect(r.lastDay).toBe('2026-03-15');
   });
@@ -100,6 +100,6 @@ describe('recap', () => {
         },
       ],
     });
-    expect(r.byCurrency[0].topCategory).toBeNull();
+    expect(r.byCurrency[0]!.topCategory).toBeNull();
   });
 });

--- a/packages/core/test/recap.test.ts
+++ b/packages/core/test/recap.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Recap pins: currencies stay in separate blocks, the daily average divides by
+ * the trip's real length (not just days with spend), and every "top" is
+ * deterministic on a tie.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { recap, type RecapExpense } from '../src/trip/recap';
+
+const expenses: RecapExpense[] = [
+  {
+    id: 'e1',
+    date: '2026-03-14',
+    description: 'Houseboat',
+    category: 'stays',
+    amountMinor: 40000n,
+    currency: 'INR',
+    payers: [{ member: 'ravi', amountMinor: 40000n }],
+  },
+  {
+    id: 'e2',
+    date: '2026-03-14',
+    description: 'Lunch',
+    category: 'food',
+    amountMinor: 4000n,
+    currency: 'INR',
+    payers: [{ member: 'asha', amountMinor: 4000n }],
+  },
+  {
+    id: 'e3',
+    date: '2026-03-15',
+    description: 'Beers',
+    category: 'food',
+    amountMinor: 40000n, // ties the houseboat; e1 wins the biggest by id order
+    currency: 'INR',
+    payers: [{ member: 'ravi', amountMinor: 40000n }],
+  },
+  {
+    id: 'e4',
+    date: '2026-03-15',
+    description: 'Spa',
+    category: 'wellness',
+    amountMinor: 9000n,
+    currency: 'THB',
+    payers: [{ member: 'neha', amountMinor: 9000n }],
+  },
+];
+
+describe('recap', () => {
+  it('carries one block per currency, biggest total first', () => {
+    const r = recap({ expenses });
+    expect(r.byCurrency.map((b) => b.currency)).toEqual(['INR', 'THB']);
+    expect(r.byCurrency[0].totalMinor).toBe(84000n);
+    expect(r.expenseCount).toBe(4);
+  });
+
+  it('ranks the top category by spend, breaking ties by name', () => {
+    const r = recap({ expenses });
+    // food = 44000, stays = 40000 → food leads.
+    expect(r.byCurrency[0].topCategory).toEqual({ category: 'food', totalMinor: 44000n });
+  });
+
+  it('breaks a biggest-expense tie deterministically by id', () => {
+    const r = recap({ expenses });
+    expect(r.byCurrency[0].biggestExpense?.id).toBe('e1');
+  });
+
+  it('credits the top payer across every expense they fronted', () => {
+    const r = recap({ expenses });
+    expect(r.byCurrency[0].topPayer).toEqual({ member: 'ravi', paidMinor: 80000n });
+  });
+
+  it('averages over the trip length when given dates, not just active days', () => {
+    const r = recap({ expenses, startDate: '2026-03-14', endDate: '2026-03-17' });
+    // 84000 over 4 trip days, not 2 days-with-spend.
+    expect(r.byCurrency[0].dayCount).toBe(4);
+    expect(r.byCurrency[0].dailyAverageMinor).toBe(21000n);
+  });
+
+  it('falls back to days-with-spend when the trip has no dates', () => {
+    const r = recap({ expenses });
+    expect(r.byCurrency[0].dayCount).toBe(2); // the 14th and 15th
+    expect(r.byCurrency[0].dailyAverageMinor).toBe(42000n);
+    expect(r.firstDay).toBe('2026-03-14');
+    expect(r.lastDay).toBe('2026-03-15');
+  });
+
+  it('leaves uncategorised spend out of the category race', () => {
+    const r = recap({
+      expenses: [
+        {
+          id: 'x',
+          date: '2026-03-14',
+          description: 'ATM',
+          category: null,
+          amountMinor: 5000n,
+          currency: 'INR',
+          payers: [{ member: 'ravi', amountMinor: 5000n }],
+        },
+      ],
+    });
+    expect(r.byCurrency[0].topCategory).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Three trip gaps from the travel-features audit, built on the ledger the app already has — no schema, no money-write path touched, per-currency and bigint throughout (ADR-004).

**Core (`@waves/core`)**
- `trip/fairness.ts` — who has fronted a lopsided share of the trip, and who could pick up the next bill to even out. Over the existing payers/shares.
- `trip/recap.ts` — post-trip headline numbers per currency: total, top category, biggest bill, top payer, daily average over the trip's real length.
- `trip/forecast.ts` — burn-rate projection (`spent × totalDays ÷ elapsedDays`) vs the overall cap in its own currency; freezes to the actual once the trip ends; no forecast before it starts.

**Mobile**
- `plan.tsx` (trips only): a Forecast card and a Fairness card, plus a link to the recap.
- `recap.tsx`: new post-trip recap screen, local-first (works offline).
- i18n `tripInsights` across en/ta/hi/ar, RTL-safe.

## Design notes
- **Currencies never mix (ADR-004):** every figure is per currency; nothing is converted.
- Per-member figures are the stored shares/payments, never re-divided on screen.
- Fairness only *surfaces* imbalance; it never proposes a transfer (`simplify` owns that).

## Tests
16 unit tests (fairness/recap/forecast). Typecheck, lint, prettier all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trip spending forecasts by currency, including projected totals, budget tracking, and end-of-trip status.
  * Added fairness insights showing contribution balance, overpayers, and who should pay next.
  * Added an offline-capable trip recap with totals, daily averages, largest expense, top category, top payer, and expense counts.
  * Added navigation from the plan screen to trip recaps.
* **Localization**
  * Added trip insights and recap translations in English, Tamil, Hindi, and Arabic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->