### PR TITLE
feat(export): PDF trip ledger export

### DIFF
--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { decode } from 'base64-arraybuffer';
 import * as FileSystem from 'expo-file-system';
 import { router } from 'expo-router';
 import * as Sharing from 'expo-sharing';
@@ -30,7 +31,14 @@ import { useStrings } from '@/i18n';
 enum Format {
   Json = 'json',
   Csv = 'csv',
+  Pdf = 'pdf',
 }
+
+const UTI: Record<Format, string> = {
+  [Format.Json]: 'public.json',
+  [Format.Csv]: 'public.comma-separated-values-text',
+  [Format.Pdf]: 'com.adobe.pdf',
+};
 
 /**
  * ADR-012: your ledger leaves whenever you want it to, in full, for free.
@@ -63,16 +71,26 @@ export default function ExportScreen() {
       const file = new FileSystem.File(FileSystem.Paths.cache, result.filename);
       if (file.exists) file.delete();
       file.create();
-      file.write(result.content);
+
+      // A PDF arrives base64-encoded (binary); text formats are written as-is.
+      let sizeBytes: number;
+      if (result.encoding === 'base64') {
+        const bytes = new Uint8Array(decode(result.content));
+        file.write(bytes);
+        sizeBytes = bytes.byteLength;
+      } else {
+        file.write(result.content);
+        sizeBytes = result.content.length;
+      }
 
       if (await Sharing.isAvailableAsync()) {
         await Sharing.shareAsync(file.uri, {
           mimeType: result.contentType,
           dialogTitle: t.exportData.shareTitle,
-          UTI: format === Format.Json ? 'public.json' : 'public.comma-separated-values-text',
+          UTI: UTI[format],
         });
       }
-      setDone(`${result.filename} · ${Math.ceil(result.content.length / 1024)} KB`);
+      setDone(`${result.filename} · ${Math.ceil(sizeBytes / 1024)} KB`);
     } catch (caught) {
       setError(friendlyError(caught, t.exportData.exportFailed, 'export.run'));
     } finally {
@@ -124,6 +142,7 @@ export default function ExportScreen() {
             options={[
               { value: Format.Json, label: t.exportData.json },
               { value: Format.Csv, label: t.exportData.csv },
+              { value: Format.Pdf, label: t.exportData.pdf },
             ]}
           />
         </View>

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1016,11 +1016,13 @@ export interface ExportResult {
   filename: string;
   contentType: string;
   content: string;
+  /** 'base64' when `content` is binary (PDF); text formats omit it. */
+  encoding?: 'utf8' | 'base64';
 }
 
 export async function exportData(input: {
   groupId?: string;
-  format: 'json' | 'csv';
+  format: 'json' | 'csv' | 'pdf';
   csvSeparator?: string;
 }): Promise<ExportResult> {
   const { data, error } = await supabase.functions.invoke('export-data', { body: input });

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -394,6 +394,7 @@ export interface UiStrings {
     format: string;
     json: string;
     csv: string;
+    pdf: string;
     whatToExport: string;
     allMyGroups: string;
     preparing: string;
@@ -1994,6 +1995,7 @@ const en: UiStrings = {
     format: 'Format',
     json: 'JSON (lossless)',
     csv: 'CSV (spreadsheet)',
+    pdf: 'PDF (printable)',
     whatToExport: 'What to export',
     allMyGroups: 'All my groups',
     preparing: 'Preparing…',
@@ -3621,6 +3623,7 @@ const ta: UiStrings = {
     format: 'வடிவம்',
     json: 'JSON (முழுமையானது)',
     csv: 'CSV (விரிதாள்)',
+    pdf: 'PDF (அச்சிடக்கூடியது)',
     whatToExport: 'எதை ஏற்றுமதி செய்ய',
     allMyGroups: 'என் குழுக்கள் அனைத்தும்',
     preparing: 'தயாராகிறது…',
@@ -5315,6 +5318,7 @@ const hi: UiStrings = {
     format: 'प्रारूप',
     json: 'JSON (कुछ छूटता नहीं)',
     csv: 'CSV (स्प्रेडशीट)',
+    pdf: 'PDF (प्रिंट करने योग्य)',
     whatToExport: 'क्या निर्यात करें',
     allMyGroups: 'मेरे सभी समूह',
     preparing: 'तैयार हो रहा है…',
@@ -6960,6 +6964,7 @@ const ar: UiStrings = {
     format: 'الصيغة',
     json: 'JSON (بلا فقدان)',
     csv: 'CSV (جدول بيانات)',
+    pdf: 'PDF (قابل للطباعة)',
     whatToExport: 'ما الذي تريد تصديره',
     allMyGroups: 'كل مجموعاتي',
     preparing: 'جارٍ التحضير…',

--- a/packages/core/src/export/index.ts
+++ b/packages/core/src/export/index.ts
@@ -1,0 +1,1 @@
+export * from './pdf';

--- a/packages/core/src/export/pdf.ts
+++ b/packages/core/src/export/pdf.ts
@@ -1,0 +1,228 @@
+/**
+ * A tiny, dependency-free PDF writer — enough for a human-readable ledger, no
+ * more. Deno has no PDF library we trust and native deps are off the table in
+ * an edge function, so this hand-rolls the format: a catalog, a page tree, one
+ * content stream per page, and the three base-14 fonts (Helvetica,
+ * Helvetica-Bold, Courier) that every reader ships, so nothing is embedded.
+ *
+ * The lossless exports are JSON and CSV (ADR-012). This is the summary you hand
+ * someone: it degrades gracefully rather than perfectly. Base-14 fonts speak
+ * WinAnsi, not Unicode, so a Tamil or Arabic description is transliterated to
+ * '?' here while remaining exact in the JSON/CSV. Money never degrades — amounts
+ * are printed with their ISO currency *code* (ASCII), never a symbol, and each
+ * currency stands on its own line (ADR-004: currencies never mix).
+ *
+ * The whole document is assembled as a Latin-1 string (every char ≤ 0xFF, so
+ * one char is one byte), which makes xref byte offsets equal string offsets and
+ * lets the caller `btoa()` it straight to base64.
+ */
+
+import { minorUnitExponent, type CurrencyCode } from '../money/currency';
+
+/**
+ * Minor units → a human decimal, ASCII only, using the same decimal-places
+ * table the rest of the app uses (`minorUnitExponent`). The ISO code (never a
+ * symbol) is appended by the caller, so the string stays WinAnsi-safe and two
+ * currencies never look interchangeable (ADR-004).
+ */
+export function formatMinor(amount: bigint | number | string, currency: string): string {
+  const minor = typeof amount === 'bigint' ? amount : BigInt(amount);
+  const places = minorUnitExponent((currency ?? '').toUpperCase() as CurrencyCode);
+  const negative = minor < 0n;
+  const digits = (negative ? -minor : minor).toString().padStart(places + 1, '0');
+  const whole = digits.slice(0, digits.length - places) || '0';
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const fraction = places > 0 ? `.${digits.slice(digits.length - places)}` : '';
+  return `${negative ? '-' : ''}${grouped}${fraction}`;
+}
+
+const PAGE_WIDTH = 595; // A4 at 72 dpi, near enough
+const PAGE_HEIGHT = 842;
+const MARGIN = 44;
+const BOTTOM = MARGIN;
+
+type FontId = 'F1' | 'F2' | 'F3'; // Helvetica, Helvetica-Bold, Courier
+
+interface Line {
+  readonly text: string;
+  readonly font: FontId;
+  readonly size: number;
+  /** Extra space, in points, above this line. */
+  readonly gapBefore: number;
+}
+
+/**
+ * Collapse anything a base-14 font cannot draw to a WinAnsi-safe string.
+ * Printable ASCII and Latin-1 pass; a tab becomes a space; everything else
+ * (CJK, Indic, Arabic, emoji) becomes '?'. Control characters are dropped.
+ */
+export function winAnsi(input: string): string {
+  let out = '';
+  for (const ch of input) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code === 9) out += ' ';
+    else if (code < 32) continue;
+    else if (code <= 126) out += ch;
+    else if (code >= 160 && code <= 255) out += ch;
+    else out += '?';
+  }
+  return out;
+}
+
+/** Escape a PDF text string: backslash, parens, and keep it Latin-1. */
+function pdfString(input: string): string {
+  return winAnsi(input).replace(/[\\()]/g, (m) => `\\${m}`);
+}
+
+/** Rough width of a base-14 string at a size, for truncation only. */
+function approxWidth(text: string, font: FontId, size: number): number {
+  // Courier is a true monospace at 0.6em; Helvetica averages ~0.5em.
+  const em = font === 'F3' ? 0.6 : 0.5;
+  return text.length * size * em;
+}
+
+/** Truncate with an ellipsis so a long cell never runs off the page. */
+function clip(text: string, font: FontId, size: number, maxWidth: number): string {
+  if (approxWidth(text, font, size) <= maxWidth) return text;
+  const perChar = (font === 'F3' ? 0.6 : 0.5) * size;
+  const room = Math.max(1, Math.floor(maxWidth / perChar) - 1);
+  return `${text.slice(0, room)}…`;
+}
+
+export class PdfBuilder {
+  private readonly lines: Line[] = [];
+
+  /** A heading in Helvetica-Bold. */
+  heading(text: string, size = 15): this {
+    this.lines.push({ text, font: 'F2', size, gapBefore: this.lines.length ? 14 : 0 });
+    return this;
+  }
+
+  subheading(text: string, size = 11): this {
+    this.lines.push({ text, font: 'F2', size, gapBefore: 10 });
+    return this;
+  }
+
+  /** Body text in Helvetica. */
+  body(text: string, size = 10): this {
+    this.lines.push({ text, font: 'F1', size, gapBefore: 2 });
+    return this;
+  }
+
+  /** A monospaced row (Courier) so columns line up. */
+  row(text: string, size = 9): this {
+    this.lines.push({ text, font: 'F3', size, gapBefore: 1 });
+    return this;
+  }
+
+  spacer(points = 8): this {
+    this.lines.push({ text: '', font: 'F1', size: 0, gapBefore: points });
+    return this;
+  }
+
+  /** A single-line Courier row from fixed-width columns. */
+  columns(cells: readonly { text: string; width: number }[], size = 9): this {
+    let line = '';
+    for (const cell of cells) {
+      const chars = Math.max(1, Math.floor(cell.width / (size * 0.6)));
+      const text = clip(cell.text, 'F3', size, cell.width);
+      line += text.padEnd(chars + 1, ' ');
+    }
+    return this.row(line.trimEnd(), size);
+  }
+
+  /** Lay the lines out into paginated content streams. */
+  private paginate(): string[] {
+    const usableWidth = PAGE_WIDTH - MARGIN * 2;
+    const pages: string[] = [];
+    let stream = '';
+    let y = PAGE_HEIGHT - MARGIN;
+    let open = false;
+
+    const flush = (): void => {
+      if (open) {
+        stream += 'ET\n';
+        pages.push(stream);
+        open = false;
+      }
+    };
+
+    for (const line of this.lines) {
+      const advance = (line.size || 10) + line.gapBefore;
+      if (!open || y - advance < BOTTOM) {
+        flush();
+        stream = 'BT\n';
+        y = PAGE_HEIGHT - MARGIN;
+        open = true;
+      }
+      y -= advance;
+      if (line.text) {
+        const text = clip(line.text, line.font, line.size, usableWidth);
+        stream += `/${line.font} ${line.size} Tf\n1 0 0 1 ${MARGIN} ${y.toFixed(1)} Tm\n(${pdfString(text)}) Tj\n`;
+      }
+    }
+    flush();
+    if (pages.length === 0) pages.push('BT\nET\n');
+    return pages;
+  }
+
+  /** Serialise to a Latin-1 PDF string; `btoa()` it for base64. */
+  build(): string {
+    const pageStreams = this.paginate();
+
+    const objects: string[] = [];
+    const add = (body: string): number => {
+      objects.push(body);
+      return objects.length; // 1-based object number
+    };
+
+    // Reserve: 1 catalog, 2 pages; fonts and page/content objects follow.
+    const catalogNo = 1;
+    const pagesNo = 2;
+    objects.push('', ''); // placeholders for 1 and 2
+
+    const helv = add(
+      '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>',
+    );
+    const helvBold = add(
+      '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>',
+    );
+    const courier = add(
+      '<< /Type /Font /Subtype /Type1 /BaseFont /Courier /Encoding /WinAnsiEncoding >>',
+    );
+
+    const resources = `<< /Font << /F1 ${helv} 0 R /F2 ${helvBold} 0 R /F3 ${courier} 0 R >> >>`;
+
+    const pageNumbers: number[] = [];
+    for (const stream of pageStreams) {
+      const contentNo = add(`<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`);
+      const pageNo = add(
+        `<< /Type /Page /Parent ${pagesNo} 0 R /MediaBox [0 0 ${PAGE_WIDTH} ${PAGE_HEIGHT}] ` +
+          `/Resources ${resources} /Contents ${contentNo} 0 R >>`,
+      );
+      pageNumbers.push(pageNo);
+    }
+
+    objects[catalogNo - 1] = `<< /Type /Catalog /Pages ${pagesNo} 0 R >>`;
+    objects[pagesNo - 1] =
+      `<< /Type /Pages /Kids [${pageNumbers.map((n) => `${n} 0 R`).join(' ')}] /Count ${pageNumbers.length} >>`;
+
+    let pdf = '%PDF-1.4\n';
+    const offsets: number[] = [];
+    objects.forEach((body, index) => {
+      offsets[index] = pdf.length;
+      pdf += `${index + 1} 0 obj\n${body}\nendobj\n`;
+    });
+
+    const xrefOffset = pdf.length;
+    pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+    for (const offset of offsets) {
+      pdf += `${offset.toString().padStart(10, '0')} 00000 n \n`;
+    }
+    pdf +=
+      `trailer\n<< /Size ${objects.length + 1} /Root ${catalogNo} 0 R >>\n` +
+      `startxref\n${xrefOffset}\n%%EOF`;
+
+    return pdf;
+  }
+}

--- a/packages/core/src/export/pdf.ts
+++ b/packages/core/src/export/pdf.ts
@@ -41,7 +41,41 @@ const PAGE_HEIGHT = 842;
 const MARGIN = 44;
 const BOTTOM = MARGIN;
 
+/** The printable width of one line, in points, once both margins are taken. */
+export const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2; // 507
+
 type FontId = 'F1' | 'F2' | 'F3'; // Helvetica, Helvetica-Bold, Courier
+
+/** Points per Courier glyph at a given size (Courier is a true monospace). */
+const COURIER_EM = 0.6;
+
+/**
+ * The upper-bound rendered width, in points, of a `columns()` row with these
+ * point widths — before the trailing gap is trimmed. Each column is floored to
+ * a whole number of Courier glyphs and padded with one separator glyph, exactly
+ * as `columns()` lays it out, so a row that clears CONTENT_WIDTH here is
+ * guaranteed not to be clipped when the page is drawn.
+ */
+export function columnsMaxWidth(widths: readonly number[], size = 9): number {
+  const perChar = size * COURIER_EM;
+  let chars = 0;
+  for (const width of widths) chars += Math.max(1, Math.floor(width / perChar)) + 1;
+  return chars * perChar;
+}
+
+/**
+ * The expenses table's columns, in points, sized so the whole row clears
+ * CONTENT_WIDTH at 9pt Courier (guarded by a test). Shared with the export
+ * function so the widths that lay out the header are the widths that lay out
+ * every row — and the same widths a test measures against the page.
+ */
+export const LEDGER_TABLE_COLUMNS = [
+  { key: 'date', width: 56 },
+  { key: 'description', width: 160 },
+  { key: 'category', width: 68 },
+  { key: 'amount', width: 98 },
+  { key: 'paidBy', width: 78 },
+] as const;
 
 interface Line {
   readonly text: string;
@@ -75,18 +109,26 @@ function pdfString(input: string): string {
 }
 
 /** Rough width of a base-14 string at a size, for truncation only. */
-function approxWidth(text: string, font: FontId, size: number): number {
-  // Courier is a true monospace at 0.6em; Helvetica averages ~0.5em.
-  const em = font === 'F3' ? 0.6 : 0.5;
-  return text.length * size * em;
+function emOf(font: FontId): number {
+  // Courier is a true monospace; Helvetica averages ~0.5em.
+  return font === 'F3' ? COURIER_EM : 0.5;
 }
 
-/** Truncate with an ellipsis so a long cell never runs off the page. */
+function approxWidth(text: string, font: FontId, size: number): number {
+  return text.length * size * emOf(font);
+}
+
+/**
+ * Truncate a cell that would run off the page. The marker is an ASCII '...',
+ * not '…' (U+2026), because the base-14 WinAnsi encoding has no ellipsis glyph
+ * and would draw it as '?'. Three dots cost two extra glyphs, so we make room
+ * for them.
+ */
 function clip(text: string, font: FontId, size: number, maxWidth: number): string {
   if (approxWidth(text, font, size) <= maxWidth) return text;
-  const perChar = (font === 'F3' ? 0.6 : 0.5) * size;
-  const room = Math.max(1, Math.floor(maxWidth / perChar) - 1);
-  return `${text.slice(0, room)}…`;
+  const perChar = emOf(font) * size;
+  const room = Math.max(1, Math.floor(maxWidth / perChar) - 3);
+  return `${text.slice(0, room)}...`;
 }
 
 export class PdfBuilder {
@@ -124,7 +166,7 @@ export class PdfBuilder {
   columns(cells: readonly { text: string; width: number }[], size = 9): this {
     let line = '';
     for (const cell of cells) {
-      const chars = Math.max(1, Math.floor(cell.width / (size * 0.6)));
+      const chars = Math.max(1, Math.floor(cell.width / (size * COURIER_EM)));
       const text = clip(cell.text, 'F3', size, cell.width);
       line += text.padEnd(chars + 1, ' ');
     }
@@ -133,7 +175,7 @@ export class PdfBuilder {
 
   /** Lay the lines out into paginated content streams. */
   private paginate(): string[] {
-    const usableWidth = PAGE_WIDTH - MARGIN * 2;
+    const usableWidth = CONTENT_WIDTH;
     const pages: string[] = [];
     let stream = '';
     let y = PAGE_HEIGHT - MARGIN;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,3 +27,4 @@ export * from './billing/index';
 export * from './session/index';
 export * from './trip/index';
 export * from './watch/index';
+export * from './export/index';

--- a/packages/core/test/pdf.test.ts
+++ b/packages/core/test/pdf.test.ts
@@ -8,7 +8,14 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { formatMinor, PdfBuilder, winAnsi } from '../src/export/pdf';
+import {
+  CONTENT_WIDTH,
+  columnsMaxWidth,
+  formatMinor,
+  LEDGER_TABLE_COLUMNS,
+  PdfBuilder,
+  winAnsi,
+} from '../src/export/pdf';
 
 describe('formatMinor', () => {
   it('uses each currency’s own decimal places', () => {
@@ -58,5 +65,20 @@ describe('PdfBuilder', () => {
     const pdf = new PdfBuilder().build();
     expect(pdf).toContain('/Type /Page');
     expect(pdf.trimEnd().endsWith('%%EOF')).toBe(true);
+  });
+
+  it('keeps the ledger table within the printable page width', () => {
+    // The last column is cut off if the row is wider than the page; this is the
+    // guard that the export's chosen widths clear it.
+    const widths = LEDGER_TABLE_COLUMNS.map((column) => column.width);
+    expect(columnsMaxWidth(widths, 9)).toBeLessThanOrEqual(CONTENT_WIDTH);
+  });
+
+  it('truncates an overflowing cell with an ASCII marker, never a ? ellipsis', () => {
+    const pdf = new PdfBuilder()
+      .columns([{ text: 'x'.repeat(400), width: LEDGER_TABLE_COLUMNS[1].width }])
+      .build();
+    expect(pdf).toContain('...'); // ASCII, draws correctly in WinAnsi
+    expect(pdf).not.toContain('…'); // U+2026 would render as '?'
   });
 });

--- a/packages/core/test/pdf.test.ts
+++ b/packages/core/test/pdf.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The PDF export is a summary, not the lossless path (JSON/CSV are). These
+ * tests pin the three things that must not break: money formats with the right
+ * decimals per currency, non-WinAnsi text degrades to '?' rather than corrupting
+ * the file, and the assembled document is a structurally valid, single-byte
+ * (Latin-1) PDF that paginates.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { formatMinor, PdfBuilder, winAnsi } from '../src/export/pdf';
+
+describe('formatMinor', () => {
+  it('uses each currency’s own decimal places', () => {
+    expect(formatMinor(123456n, 'INR')).toBe('1,234.56');
+    expect(formatMinor(1000n, 'JPY')).toBe('1,000'); // zero-decimal
+    expect(formatMinor(1000n, 'KWD')).toBe('1.000'); // three-decimal
+    expect(formatMinor(5n, 'USD')).toBe('0.05');
+  });
+
+  it('groups thousands and keeps a sign', () => {
+    expect(formatMinor(1234567890n, 'USD')).toBe('12,345,678.90');
+    expect(formatMinor(-4200n, 'INR')).toBe('-42.00');
+    expect(formatMinor('700', 'INR')).toBe('7.00'); // accepts a numeric string
+  });
+});
+
+describe('winAnsi', () => {
+  it('keeps ASCII and Latin-1, degrades the rest to a question mark', () => {
+    expect(winAnsi('Café résumé')).toBe('Café résumé');
+    expect(winAnsi('கறி dinner')).toBe('??? dinner'); // 3 Tamil code points
+    expect(winAnsi('pay 🎉 now')).toBe('pay ? now'); // emoji -> single '?'
+    expect(winAnsi('taxi\tride')).toBe('taxi ride'); // tab -> space
+  });
+});
+
+describe('PdfBuilder', () => {
+  it('emits a structurally valid, Latin-1-only PDF', () => {
+    const pdf = new PdfBuilder().heading('Trip').body('Line one').build();
+    expect(pdf.startsWith('%PDF-1.4')).toBe(true);
+    expect(pdf).toContain('/Type /Catalog');
+    expect(pdf).toContain('endobj');
+    expect(pdf).toContain('startxref');
+    expect(pdf.trimEnd().endsWith('%%EOF')).toBe(true);
+    // Every char must be <= 0xFF so string offsets equal byte offsets and btoa works.
+    for (const ch of pdf) expect(ch.codePointAt(0)!).toBeLessThanOrEqual(0xff);
+  });
+
+  it('paginates when the content outgrows one page', () => {
+    const builder = new PdfBuilder().heading('Big trip');
+    for (let i = 0; i < 200; i += 1) builder.row(`row ${i}`);
+    const pdf = builder.build();
+    const pageCount = (pdf.match(/\/Type \/Page[^s]/g) ?? []).length;
+    expect(pageCount).toBeGreaterThan(1);
+  });
+
+  it('always produces at least one page, even empty', () => {
+    const pdf = new PdfBuilder().build();
+    expect(pdf).toContain('/Type /Page');
+    expect(pdf.trimEnd().endsWith('%%EOF')).toBe(true);
+  });
+});

--- a/supabase/functions/export-data/index.ts
+++ b/supabase/functions/export-data/index.ts
@@ -19,11 +19,12 @@ import {
   requireMembership,
 } from '../_shared/auth.ts';
 import { enforceRateLimit } from '../_shared/rateLimit.ts';
+import { formatMinor, PdfBuilder } from '../_shared/core.js';
 
 interface ExportRequest {
   /** Omit to export every group the caller belongs to. */
   groupId?: string;
-  format?: 'json' | 'csv';
+  format?: 'json' | 'csv' | 'pdf';
   /** ';' for locales where ',' is the decimal separator (TDR §8). */
   csvSeparator?: string;
 }
@@ -155,6 +156,123 @@ serveWithCors(async (request) => {
           null,
           2,
         ),
+      });
+    }
+
+    if (format === 'pdf') {
+      const pdf = new PdfBuilder();
+      const today = new Date().toISOString().slice(0, 10);
+      pdf.heading('Baaki — ledger export', 17);
+      pdf.body(`Exported ${today}`, 9);
+
+      for (const entry of exported) {
+        const group = entry.group as Record<string, unknown> | null;
+        const nameOf = (memberId: string | null): string => {
+          const member = entry.members.find(
+            (row: Record<string, unknown>) => row.id === memberId,
+          ) as Record<string, unknown> | undefined;
+          const profile = member?.profile as { display_name?: string } | undefined;
+          return profile?.display_name ?? (member?.ghost_name as string) ?? 'unknown';
+        };
+
+        pdf.spacer(10);
+        pdf.heading((group?.name as string) ?? 'Group', 14);
+        const range =
+          group?.start_date && group?.end_date ? `${group.start_date} → ${group.end_date}` : null;
+        const meta = [range, group?.type as string, group?.default_currency as string]
+          .filter(Boolean)
+          .join('  ·  ');
+        if (meta) pdf.body(meta, 9);
+
+        // Per-currency totals — active expenses only, never summed across
+        // currencies (ADR-004).
+        const totals = new Map<string, bigint>();
+        const activeExpenses: {
+          date: string;
+          description: string;
+          category: string;
+          currency: string;
+          amount: bigint;
+          payers: string;
+        }[] = [];
+
+        for (const expense of entry.expenses) {
+          if (expense.deleted_at) continue;
+          const current = expense.versions?.find(
+            (version: Record<string, unknown>) => version.id === expense.current_version_id,
+          );
+          if (!current) continue;
+          const currency = String(current.currency).toUpperCase();
+          const amount = BigInt(current.amount);
+          totals.set(currency, (totals.get(currency) ?? 0n) + amount);
+          activeExpenses.push({
+            date: String(current.expense_date ?? ''),
+            description: String(current.description ?? ''),
+            category: String(current.category ?? ''),
+            currency,
+            amount,
+            payers: (current.payers ?? [])
+              .map((payer: Record<string, unknown>) => nameOf(payer.member_id as string))
+              .join(' + '),
+          });
+        }
+
+        pdf.subheading('Totals', 11);
+        if (totals.size === 0) {
+          pdf.body('No expenses yet.', 10);
+        } else {
+          for (const [currency, total] of [...totals].sort((a, b) => a[0].localeCompare(b[0]))) {
+            pdf.body(`${formatMinor(total, currency)} ${currency}`, 11);
+          }
+        }
+
+        if (activeExpenses.length > 0) {
+          pdf.subheading('Expenses', 11);
+          pdf.columns(
+            [
+              { text: 'Date', width: 62 },
+              { text: 'Description', width: 168 },
+              { text: 'Category', width: 74 },
+              { text: 'Amount', width: 110 },
+              { text: 'Paid by', width: 90 },
+            ],
+            9,
+          );
+          activeExpenses.sort((a, b) => a.date.localeCompare(b.date));
+          for (const row of activeExpenses) {
+            pdf.columns(
+              [
+                { text: row.date, width: 62 },
+                { text: row.description, width: 168 },
+                { text: row.category, width: 74 },
+                { text: `${formatMinor(row.amount, row.currency)} ${row.currency}`, width: 110 },
+                { text: row.payers, width: 90 },
+              ],
+              9,
+            );
+          }
+        }
+
+        // Settlements — the per-person detail, matching the CSV's fidelity.
+        if (entry.settlements.length > 0) {
+          pdf.subheading('Settlements', 11);
+          for (const settlement of entry.settlements) {
+            pdf.body(
+              `${settlement.initiated_at?.slice(0, 10) ?? ''}  ` +
+                `${nameOf(settlement.from_member_id)} → ${nameOf(settlement.to_member_id)}  ` +
+                `${formatMinor(settlement.amount, settlement.currency)} ` +
+                `${String(settlement.currency).toUpperCase()}  (${settlement.status})`,
+              9,
+            );
+          }
+        }
+      }
+
+      return json({
+        filename: `baaki-export-${today}.pdf`,
+        contentType: 'application/pdf',
+        encoding: 'base64',
+        content: btoa(pdf.build()),
       });
     }
 

--- a/supabase/functions/export-data/index.ts
+++ b/supabase/functions/export-data/index.ts
@@ -19,7 +19,7 @@ import {
   requireMembership,
 } from '../_shared/auth.ts';
 import { enforceRateLimit } from '../_shared/rateLimit.ts';
-import { formatMinor, PdfBuilder } from '../_shared/core.js';
+import { formatMinor, LEDGER_TABLE_COLUMNS, PdfBuilder } from '../_shared/core.js';
 
 interface ExportRequest {
   /** Omit to export every group the caller belongs to. */
@@ -162,7 +162,7 @@ serveWithCors(async (request) => {
     if (format === 'pdf') {
       const pdf = new PdfBuilder();
       const today = new Date().toISOString().slice(0, 10);
-      pdf.heading('Baaki — ledger export', 17);
+      pdf.heading('Baaki - ledger export', 17);
       pdf.body(`Exported ${today}`, 9);
 
       for (const entry of exported) {
@@ -178,7 +178,7 @@ serveWithCors(async (request) => {
         pdf.spacer(10);
         pdf.heading((group?.name as string) ?? 'Group', 14);
         const range =
-          group?.start_date && group?.end_date ? `${group.start_date} → ${group.end_date}` : null;
+          group?.start_date && group?.end_date ? `${group.start_date} - ${group.end_date}` : null;
         const meta = [range, group?.type as string, group?.default_currency as string]
           .filter(Boolean)
           .join('  ·  ');
@@ -227,14 +227,17 @@ serveWithCors(async (request) => {
         }
 
         if (activeExpenses.length > 0) {
+          // Column widths come from @waves/core, where a test proves the row
+          // clears the printable page width so the last column is never cut off.
+          const [dateW, descW, catW, amountW, paidW] = LEDGER_TABLE_COLUMNS.map((c) => c.width);
           pdf.subheading('Expenses', 11);
           pdf.columns(
             [
-              { text: 'Date', width: 62 },
-              { text: 'Description', width: 168 },
-              { text: 'Category', width: 74 },
-              { text: 'Amount', width: 110 },
-              { text: 'Paid by', width: 90 },
+              { text: 'Date', width: dateW },
+              { text: 'Description', width: descW },
+              { text: 'Category', width: catW },
+              { text: 'Amount', width: amountW },
+              { text: 'Paid by', width: paidW },
             ],
             9,
           );
@@ -242,11 +245,14 @@ serveWithCors(async (request) => {
           for (const row of activeExpenses) {
             pdf.columns(
               [
-                { text: row.date, width: 62 },
-                { text: row.description, width: 168 },
-                { text: row.category, width: 74 },
-                { text: `${formatMinor(row.amount, row.currency)} ${row.currency}`, width: 110 },
-                { text: row.payers, width: 90 },
+                { text: row.date, width: dateW },
+                { text: row.description, width: descW },
+                { text: row.category, width: catW },
+                {
+                  text: `${formatMinor(row.amount, row.currency)} ${row.currency}`,
+                  width: amountW,
+                },
+                { text: row.payers, width: paidW },
               ],
               9,
             );
@@ -259,7 +265,7 @@ serveWithCors(async (request) => {
           for (const settlement of entry.settlements) {
             pdf.body(
               `${settlement.initiated_at?.slice(0, 10) ?? ''}  ` +
-                `${nameOf(settlement.from_member_id)} → ${nameOf(settlement.to_member_id)}  ` +
+                `${nameOf(settlement.from_member_id)} -> ${nameOf(settlement.to_member_id)}  ` +
                 `${formatMinor(settlement.amount, settlement.currency)} ` +
                 `${String(settlement.currency).toUpperCase()}  (${settlement.status})`,
               9,


### PR DESCRIPTION
## What

Adds a **printable PDF** export alongside the existing lossless JSON/CSV exports (ADR-012).

## How
- **`@waves/core/export/pdf.ts`** — a dependency-free, Deno-safe PDF writer (`PdfBuilder`) plus `formatMinor` / `winAnsi`. Lives in core so it's bundled into the edge (`core.js`) with **no native deps** pulled into `export-data`.
  - `PdfBuilder`: catalog + page tree + base-14 fonts (Helvetica / Helvetica-Bold / Courier), auto-pagination, assembled as a Latin-1 string for a clean `btoa()`.
  - `formatMinor`: minor-units → human decimal via the app's own `minorUnitExponent`, printed with the ISO **code** (never a symbol) so amounts stay ASCII and currencies never look mixed (**ADR-004**).
  - `winAnsi`: text a base-14 font can't draw (Indic/Arabic/CJK/emoji) degrades to `?`; JSON/CSV remain the lossless path.
- **`export-data`** gains `format: 'pdf'`, returning `{ content: <base64>, encoding: 'base64' }`, scoped by the same `requireMembership` check as json/csv — **no new data exposure**. Renders per-currency totals, an expenses table, and per-person settlement detail.
- **Mobile** export screen offers PDF, decodes base64 → bytes, shares via `com.adobe.pdf` UTI. New i18n key in **all four languages**.

## Edge cases
- Empty ledger → title + "No expenses yet".
- Huge ledger → paginates.
- Deleted expenses excluded from the summary.
- PDF is a **summary**; JSON/CSV stay the lossless/re-importable path.

## Tests
`packages/core/test/pdf.test.ts` (6): per-currency decimals, WinAnsi degradation, valid Latin-1 PDF structure, pagination, empty doc. Full suite: **602 core tests pass**, typecheck + lint clean, edge bundle builds.

## Not included
No migration, no deploy. `export-data` is already in the `edge:deploy` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added PDF export alongside JSON and CSV formats.
  - PDF files include expense summaries, details, payer information, and settlement data.
  - Added localized PDF format labels in English, Tamil, Hindi, and Arabic.
  - PDF exports can be shared using the appropriate file type.

- **Bug Fixes**
  - Improved handling of encoded PDF content and file-size calculation.
  - Preserved existing JSON and CSV export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->