### PR TITLE
feat(split): travel split presets (nights, car rental, per-ride, my treat)

### DIFF
--- a/packages/core/src/split/index.ts
+++ b/packages/core/src/split/index.ts
@@ -3,3 +3,4 @@ export * from './remainder';
 export * from './computeShares';
 export * from './verify';
 export * from './wire';
+export * from './travel';

--- a/packages/core/src/split/travel.ts
+++ b/packages/core/src/split/travel.ts
@@ -1,0 +1,163 @@
+/**
+ * Travel split presets: the four ways a trip divides a bill that a plain
+ * equal/exact split makes tedious to enter by hand.
+ *
+ * None of these is a new kind of money. Each is a *builder* that returns the
+ * split params the ledger already understands — `shares`, `adjustment`,
+ * `equal`, `exact` — so every travel split flows through the one audited,
+ * property-tested `computeShares` and the server recomputes it with no special
+ * case (TDR §3.1, §4). What the ledger stores is canonical params; "this was a
+ * room split" is a convenience at entry time, not a new row type.
+ *
+ *   * **By nights / presence** → `shares` weighted by how many nights each
+ *     person stayed (a five-night hotel where two joined for two nights).
+ *   * **Car rental** → the base splits equally among the people sharing the
+ *     car, fuel and tolls ride on top as per-person `adjustment`s, and the
+ *     driver can be left out entirely.
+ *   * **This ride only** → an `equal` split across just the people who were in
+ *     the taxi, not the whole group.
+ *   * **My treat** → an `exact` split where the host's share is the whole bill
+ *     and everyone else owes nothing: it shows in the history, it moves no debt.
+ *
+ * Minor units and bigint for every amount; weights are counts (nights, people)
+ * and stay integers.
+ */
+
+import type { AdjustmentParams, EqualParams, ExactParams, MemberId, SharesParams } from './types';
+import { SplitError, SplitErrorCode } from './types';
+
+/**
+ * Split by a per-member count — nights stayed, days present, seats taken.
+ * A member with a zero (or absent) count carries no weight and pays nothing;
+ * at least one positive count is required, the same rule `shares` enforces.
+ *
+ * The counts are *weights*, not money: the expense total is divided in their
+ * proportion by `computeShares`, remainder and all, so it stays exact.
+ */
+export function splitByUnits(unitsByMember: Readonly<Record<MemberId, number>>): SharesParams {
+  const weights: Record<MemberId, number> = {};
+  let positive = false;
+  for (const [member, units] of Object.entries(unitsByMember)) {
+    if (!Number.isInteger(units) || units < 0) {
+      throw new SplitError(
+        SplitErrorCode.InvalidWeight,
+        `Units must be non-negative integers, got ${units} for ${member}`,
+      );
+    }
+    if (units > 0) positive = true;
+    weights[member] = units;
+  }
+  if (!positive) {
+    throw new SplitError(
+      SplitErrorCode.NoPositiveWeight,
+      'A by-nights split needs at least one member with a positive count',
+    );
+  }
+  return { kind: 'shares', weights };
+}
+
+export interface CarRentalInput {
+  /** Everyone sharing the car, before the driver is (optionally) excused. */
+  readonly participants: readonly MemberId[];
+  /** Per-member fuel/toll amounts in minor units, added on top of the base. */
+  readonly extrasByMember?: Readonly<Record<MemberId, bigint>>;
+  /** A driver who pays nothing — left out of the base split entirely. */
+  readonly exemptDriver?: MemberId;
+}
+
+export interface CarRentalSplit {
+  readonly params: AdjustmentParams;
+  /** The people the base is split across — the driver removed if exempt. */
+  readonly participants: MemberId[];
+}
+
+/**
+ * Base rental split equally among the riders, fuel and tolls added per person.
+ *
+ * The base is the residual an `adjustment` split divides equally after the
+ * per-member extras are taken out, so `Σ shares` is still the expense total.
+ * Excusing the driver simply drops them from the participant set: they take no
+ * base and, unless they are also given an extra, owe nothing.
+ */
+export function carRentalSplit(input: CarRentalInput): CarRentalSplit {
+  const participants = input.participants.filter((member) => member !== input.exemptDriver);
+  if (participants.length === 0) {
+    throw new SplitError(
+      SplitErrorCode.EmptyParticipants,
+      'A car-rental split needs at least one rider paying the base',
+    );
+  }
+
+  const adjustments: Record<MemberId, bigint> = {};
+  for (const [member, amount] of Object.entries(input.extrasByMember ?? {})) {
+    if (amount < 0n) {
+      throw new SplitError(
+        SplitErrorCode.InvalidItem,
+        `A fuel/toll extra cannot be negative (${amount} for ${member})`,
+      );
+    }
+    // An extra for the excused driver would put them back in the split; that is
+    // a contradiction, so refuse it rather than silently re-including them.
+    if (member === input.exemptDriver) {
+      throw new SplitError(
+        SplitErrorCode.UnknownMember,
+        'The exempt driver cannot also carry a fuel/toll extra',
+      );
+    }
+    adjustments[member] = amount;
+  }
+
+  return { params: { kind: 'adjustment', adjustments }, participants };
+}
+
+export interface RidersSplit {
+  readonly params: EqualParams;
+  readonly participants: MemberId[];
+}
+
+/**
+ * This ride only: an equal split across just the people who were in it. A thin
+ * convenience over an `equal` split with a hand-picked participant set — named
+ * because "the airport taxi was only four of us" is a thing people say.
+ */
+export function ridersSplit(riders: readonly MemberId[]): RidersSplit {
+  const participants = [...new Set(riders)];
+  if (participants.length === 0) {
+    throw new SplitError(SplitErrorCode.EmptyParticipants, 'A ride needs at least one rider');
+  }
+  return { params: { kind: 'equal' }, participants };
+}
+
+export interface TreatInput {
+  /** The host — the one whose treat this is. Ends up owing the whole bill. */
+  readonly host: MemberId;
+  /** Everyone the treat covers, the host included. */
+  readonly participants: readonly MemberId[];
+  /** The bill, in minor units. */
+  readonly amountMinor: bigint;
+}
+
+/**
+ * My treat: the host's share is the entire bill, everyone else owes nothing.
+ *
+ * Modelled as an `exact` split so it is honest in the ledger — the expense is
+ * real, it shows in the history and the spend charts, and it settles to no
+ * debt because the only non-zero share belongs to the person who paid. The
+ * guests appear with a zero share so the row set still lists who was there.
+ */
+export function treatSplit(input: TreatInput): ExactParams {
+  if (input.amountMinor < 0n) {
+    throw new SplitError(SplitErrorCode.NegativeTotal, 'A treat cannot be a negative amount');
+  }
+  if (!input.participants.includes(input.host)) {
+    throw new SplitError(
+      SplitErrorCode.UnknownMember,
+      'The host of a treat must be one of its participants',
+    );
+  }
+  const amounts: Record<MemberId, bigint> = {};
+  for (const member of new Set(input.participants)) {
+    amounts[member] = member === input.host ? input.amountMinor : 0n;
+  }
+  return { kind: 'exact', amounts };
+}

--- a/packages/core/src/split/travel.ts
+++ b/packages/core/src/split/travel.ts
@@ -96,12 +96,14 @@ export function carRentalSplit(input: CarRentalInput): CarRentalSplit {
         `A fuel/toll extra cannot be negative (${amount} for ${member})`,
       );
     }
-    // An extra for the excused driver would put them back in the split; that is
-    // a contradiction, so refuse it rather than silently re-including them.
-    if (member === input.exemptDriver) {
+    // The extra must name someone actually sharing the car — which excludes
+    // the excused driver (already filtered out) and anyone who was never a
+    // rider. Otherwise computeShares would later reject it as an unknown
+    // member; catching it here names the real mistake.
+    if (!participants.includes(member)) {
       throw new SplitError(
         SplitErrorCode.UnknownMember,
-        'The exempt driver cannot also carry a fuel/toll extra',
+        `A fuel/toll extra names "${member}", who is not sharing the car`,
       );
     }
     adjustments[member] = amount;

--- a/packages/core/test/travelSplit.test.ts
+++ b/packages/core/test/travelSplit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Travel presets are builders over the canonical split params — so the one
+ * property that matters is that whatever they return, fed through the audited
+ * computeShares, still sums exactly to the bill and lands the money where the
+ * preset intends. These tests pin both.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+
+import { computeShares, sumShares } from '../src/split/computeShares';
+import { carRentalSplit, ridersSplit, splitByUnits, treatSplit } from '../src/split/travel';
+import { SplitError } from '../src/split/types';
+
+const seed = 'expense-1';
+
+describe('splitByUnits (nights / presence)', () => {
+  it('divides in proportion to the counts', () => {
+    // Five-night hotel, ₹5,000: two stayed 5 nights, one stayed 2.
+    const params = splitByUnits({ ravi: 5, asha: 5, neha: 2 });
+    const shares = computeShares({
+      amount: 6000n,
+      currency: 'INR',
+      params,
+      participants: ['ravi', 'asha', 'neha'],
+      seed,
+    });
+    expect(sumShares(shares)).toBe(6000n);
+    // 12 night-units → 500/unit; ravi & asha 2500, neha 1000.
+    expect(shares.get('ravi')).toBe(2500n);
+    expect(shares.get('asha')).toBe(2500n);
+    expect(shares.get('neha')).toBe(1000n);
+  });
+
+  it('refuses a split where nobody stayed a night', () => {
+    expect(() => splitByUnits({ ravi: 0, asha: 0 })).toThrow(SplitError);
+    expect(() => splitByUnits({ ravi: 1.5 })).toThrow(SplitError);
+  });
+
+  it('always sums to the total for any counts and amount', () => {
+    fc.assert(
+      fc.property(
+        fc.dictionary(fc.constantFrom('a', 'b', 'c', 'd'), fc.integer({ min: 0, max: 9 }), {
+          minKeys: 1,
+        }),
+        fc.bigInt({ min: 0n, max: 10_000_000n }),
+        (units, amount) => {
+          const hasPositive = Object.values(units).some((u) => u > 0);
+          if (!hasPositive) return; // guarded by NoPositiveWeight, tested above
+          const params = splitByUnits(units);
+          const shares = computeShares({
+            amount,
+            currency: 'INR',
+            params,
+            participants: Object.keys(units),
+            seed,
+          });
+          expect(sumShares(shares)).toBe(amount);
+        },
+      ),
+    );
+  });
+});
+
+describe('carRentalSplit', () => {
+  it('splits the base equally and adds fuel on top, excusing the driver', () => {
+    // ₹4,000 total: ₹1,000 fuel (asha), ₹3,000 base across the two non-drivers.
+    const { params, participants } = carRentalSplit({
+      participants: ['ravi', 'asha', 'driver'],
+      extrasByMember: { asha: 1000n },
+      exemptDriver: 'driver',
+    });
+    const shares = computeShares({
+      amount: 4000n,
+      currency: 'INR',
+      params,
+      participants,
+      seed,
+    });
+    expect(sumShares(shares)).toBe(4000n);
+    expect(shares.get('driver')).toBeUndefined(); // excused entirely
+    // base 3000 split two ways = 1500 each; asha carries +1000 fuel.
+    expect(shares.get('ravi')).toBe(1500n);
+    expect(shares.get('asha')).toBe(2500n);
+  });
+
+  it('refuses a fuel extra for the excused driver', () => {
+    expect(() =>
+      carRentalSplit({
+        participants: ['ravi', 'driver'],
+        extrasByMember: { driver: 500n },
+        exemptDriver: 'driver',
+      }),
+    ).toThrow(SplitError);
+  });
+});
+
+describe('ridersSplit (this ride only)', () => {
+  it('splits equally across just the riders', () => {
+    const { params, participants } = ridersSplit(['ravi', 'asha', 'neha', 'neha']);
+    expect(participants).toEqual(['ravi', 'asha', 'neha']); // deduped
+    const shares = computeShares({ amount: 900n, currency: 'INR', params, participants, seed });
+    expect(sumShares(shares)).toBe(900n);
+    expect([...shares.values()].every((s) => s === 300n)).toBe(true);
+  });
+});
+
+describe('treatSplit (my treat)', () => {
+  it('puts the whole bill on the host and zero on the guests', () => {
+    const params = treatSplit({
+      host: 'ravi',
+      participants: ['ravi', 'asha', 'neha'],
+      amountMinor: 4200n,
+    });
+    const shares = computeShares({
+      amount: 4200n,
+      currency: 'INR',
+      params,
+      participants: ['ravi', 'asha', 'neha'],
+      seed,
+    });
+    expect(sumShares(shares)).toBe(4200n);
+    expect(shares.get('ravi')).toBe(4200n);
+    expect(shares.get('asha')).toBe(0n); // shows in history, owes nothing
+    expect(shares.get('neha')).toBe(0n);
+  });
+
+  it('requires the host to be one of the participants', () => {
+    expect(() =>
+      treatSplit({ host: 'outsider', participants: ['ravi', 'asha'], amountMinor: 100n }),
+    ).toThrow(SplitError);
+  });
+});


### PR DESCRIPTION
## What

Travel-specific split modes from the audit — built as **builders over the existing split params**, not a new money path. Each returns canonical params the ledger already understands (`shares`/`adjustment`/`equal`/`exact`), so every travel split flows through the one audited, property-tested `computeShares` and the server recomputes it with no special case (TDR §3.1, §4).

- `splitByUnits` — room/hotel by nights stayed, or any presence count → weighted `shares`.
- `carRentalSplit` — base equal among riders, fuel/tolls as per-person `adjustment`s, driver exemptable.
- `ridersSplit` — this ride only: equal across just the people in the taxi.
- `treatSplit` — "my treat": host's share is the whole bill, guests owe nothing (shows in history, moves no debt).

## Why this shape
No new `SplitType`, no wire-format change, **no migration**, and the money-critical server-recompute path is untouched. "This was a room split" is a convenience at entry time; the ledger stores canonical params, so it round-trips and settles like any other split.

## Tests
8 unit + property tests — every builder's output, fed through `computeShares`, sums exactly to the bill and lands the money where the preset intends. bigint minor units; currencies never mix. Core typecheck + suite green.

## Follow-up (UI, not in this PR)
The split params are built inline in `apps/mobile/src/app/group/[id]/add-expense.tsx`. A follow-up wires a "trip preset" affordance there: nights inputs per member (splitByUnits), a driver toggle + fuel field (carRentalSplit), a rider subset (ridersSplit), and a one-tap "My treat" (treatSplit). Presets produce standard params, so this can land incrementally without blocking anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added travel-focused split presets for proportional unit sharing, car rentals, rides, and host-funded treats.
  * Car rental splits support fuel and toll extras, with optional driver exemption.
  * Rider lists are automatically deduplicated for fair participant splits.
  * Added validation for invalid amounts, participants, and weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->