### PR TITLE
feat(money): currency exposure summary

### DIFF
--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -3,7 +3,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Alert, ScrollView, TextInput, View } from 'react-native';
 
-import { isValidVpa } from '@waves/core';
+import { currencyExposure, isValidVpa } from '@waves/core';
 import {
   Avatar,
   Badge,
@@ -109,6 +109,21 @@ export default function MemberScreen() {
     expense.currentVersion?.shares.some((share) => share.member_id === member.id),
   );
 
+  // What this person actually fronted, per currency (ADR-004: never summed into
+  // one). "You paid ₹12,400, €90 and ฿2,100" — the honest answer on a trip that
+  // touched more than one currency, drawn from the payments the ledger stored.
+  const paidExposure = currencyExposure(
+    expenses.rows.reduce<Record<string, bigint>>((acc, expense) => {
+      const version = expense.currentVersion;
+      if (!version || expense.deleted_at) return acc;
+      for (const payer of version.payers) {
+        if (payer.member_id !== member.id) continue;
+        acc[version.currency] = (acc[version.currency] ?? 0n) + BigInt(payer.amount);
+      }
+      return acc;
+    }, {}),
+  );
+
   const save = (patch: { ghost_name?: string; vpa?: string | null }): void => {
     setStatus(null);
     updateMember.mutate(
@@ -177,6 +192,33 @@ export default function MemberScreen() {
             <Button label={t.settleUp} onPress={() => router.push(`/group/${groupId}/settle`)} />
           ) : null}
         </TintCard>
+
+        {paidExposure.length > 0 ? (
+          <Card style={{ gap: theme.spacing.sm }}>
+            <Text variant="caption" tone="muted">
+              {t.people.paidAcross}
+            </Text>
+            <View
+              style={{
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                gap: theme.spacing.md,
+              }}
+            >
+              {paidExposure.map((entry) => (
+                <MoneyText
+                  key={entry.currency}
+                  amount={entry.amountMinor}
+                  currency={entry.currency}
+                  locale={locale}
+                  variant="subheading"
+                  mode="plain"
+                />
+              ))}
+            </View>
+          </Card>
+        ) : null}
 
         {ghost ? (
           <Card style={{ gap: theme.spacing.md }}>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1142,6 +1142,8 @@ export interface UiStrings {
     adminNeedsAccount: string;
     you: string;
     memberName: string;
+    /** Member detail: label over their per-currency outlay (currency exposure). */
+    paidAcross: string;
     ghostNote: string;
     upiForGroup: string;
     upiForGroupNote: string;
@@ -2714,6 +2716,7 @@ const en: UiStrings = {
     adminNeedsAccount: 'They have not joined yet. Only a member with an account can be an admin.',
     you: 'you',
     memberName: 'Member name',
+    paidAcross: 'Paid',
     ghostNote: 'This person holds real balances. When they join, they can claim this history.',
     upiForGroup: 'UPI ID for this group',
     upiForGroupNote:
@@ -4385,6 +4388,7 @@ const ta: UiStrings = {
       'இவர் இன்னும் சேரவில்லை. கணக்கு உள்ள உறுப்பினர் மட்டுமே நிர்வாகியாக முடியும்.',
     you: 'நீங்கள்',
     memberName: 'உறுப்பினர் பெயர்',
+    paidAcross: 'செலுத்தியது',
     ghostNote:
       'இவருக்கு உண்மையான இருப்புகள் உள்ளன. அவர்கள் சேரும்போது இந்த வரலாற்றைத் தங்களுடையதாக்கிக் கொள்ளலாம்.',
     upiForGroup: 'இந்தக் குழுவுக்கான UPI ID',
@@ -6043,6 +6047,7 @@ const hi: UiStrings = {
     adminNeedsAccount: 'ये अभी शामिल नहीं हुए हैं. सिर्फ़ अकाउंट वाला सदस्य ही एडमिन बन सकता है.',
     you: 'आप',
     memberName: 'सदस्य का नाम',
+    paidAcross: 'चुकाया',
     ghostNote: 'इस व्यक्ति का असली हिसाब है। जुड़ने पर वे यह इतिहास अपने नाम कर सकते हैं।',
     upiForGroup: 'इस समूह के लिए UPI ID',
     upiForGroupNote:
@@ -7717,6 +7722,7 @@ const ar: UiStrings = {
     adminNeedsAccount: 'لم ينضم بعد. المشرف يجب أن يكون عضوًا لديه حساب.',
     you: 'أنت',
     memberName: 'اسم العضو',
+    paidAcross: 'دفع',
     ghostNote: 'لهذا الشخص أرصدة حقيقية. حين ينضم يمكنه أن يطالب بهذا السجل.',
     upiForGroup: 'معرّف الدفع لهذه المجموعة',
     upiForGroupNote: 'يتجاوز معرّف حسابك هنا فقط — مفيد حين تُسوّى مجموعة إلى حساب مختلف.',

--- a/packages/core/src/money/exposure.ts
+++ b/packages/core/src/money/exposure.ts
@@ -33,6 +33,8 @@ export function currencyExposure(
   }
   return out.sort((a, b) => {
     if (a.amountMinor !== b.amountMinor) return a.amountMinor > b.amountMinor ? -1 : 1;
-    return a.currency.localeCompare(b.currency);
+    // Code-unit order, not localeCompare: the default locale is environment
+    // dependent, and this ordering must be identical on every device.
+    return a.currency < b.currency ? -1 : a.currency > b.currency ? 1 : 0;
   });
 }

--- a/packages/core/src/money/exposure.ts
+++ b/packages/core/src/money/exposure.ts
@@ -1,0 +1,38 @@
+/**
+ * Currency exposure: "You paid ₹12,400, €90 and ฿2,100."
+ *
+ * On a trip that touched three currencies, the one number people want that the
+ * app deliberately refuses to give is a single total — because the rate that
+ * would make one exists only in the moment somebody accepts it (ADR-004). So
+ * exposure is the honest alternative: what you are *out*, in each currency, side
+ * by side. Nothing is converted; nothing is added.
+ *
+ * The ordering is by nominal minor units, largest first — a rough "biggest
+ * first" for the eye, not a claim that ₹12,400 is "more" than €90. Ties break by
+ * currency code so the line reads the same on every device. Zero and negative
+ * balances are dropped: a currency you are not out anything in is not exposure.
+ */
+
+export interface CurrencyExposure {
+  readonly currency: string;
+  /** What was paid in this currency, in its own minor units. Always positive. */
+  readonly amountMinor: bigint;
+}
+
+/**
+ * A per-currency paid map reduced to an ordered exposure list. The input is
+ * whatever "paid" means to the caller — what one member fronted, or the group's
+ * whole outlay — this only sorts and filters it, it never mixes currencies.
+ */
+export function currencyExposure(
+  paidByCurrency: Readonly<Record<string, bigint>>,
+): CurrencyExposure[] {
+  const out: CurrencyExposure[] = [];
+  for (const [currency, amount] of Object.entries(paidByCurrency)) {
+    if (amount > 0n) out.push({ currency: currency.toUpperCase(), amountMinor: amount });
+  }
+  return out.sort((a, b) => {
+    if (a.amountMinor !== b.amountMinor) return a.amountMinor > b.amountMinor ? -1 : 1;
+    return a.currency.localeCompare(b.currency);
+  });
+}

--- a/packages/core/src/money/index.ts
+++ b/packages/core/src/money/index.ts
@@ -3,3 +3,4 @@ export * from './money';
 export * from './format';
 export * from './fx';
 export * from './region';
+export * from './exposure';

--- a/packages/core/test/exposure.test.ts
+++ b/packages/core/test/exposure.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Exposure is the trip's honest answer to "what did I pay" when the answer is
+ * three currencies, not one. These pin that it never mixes them and never
+ * invents a total: it filters, orders, and hands each currency back whole.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { currencyExposure } from '../src/money/exposure';
+
+describe('currencyExposure', () => {
+  it('orders currencies by nominal amount, largest first', () => {
+    const out = currencyExposure({ INR: 1240000n, EUR: 9000n, THB: 210000n });
+    expect(out).toEqual([
+      { currency: 'INR', amountMinor: 1240000n },
+      { currency: 'THB', amountMinor: 210000n },
+      { currency: 'EUR', amountMinor: 9000n },
+    ]);
+  });
+
+  it('drops currencies with zero or negative exposure', () => {
+    const out = currencyExposure({ INR: 5000n, USD: 0n, GBP: -100n });
+    expect(out).toEqual([{ currency: 'INR', amountMinor: 5000n }]);
+  });
+
+  it('normalises the currency code and breaks ties by code', () => {
+    const out = currencyExposure({ eur: 1000n, usd: 1000n });
+    expect(out).toEqual([
+      { currency: 'EUR', amountMinor: 1000n },
+      { currency: 'USD', amountMinor: 1000n },
+    ]);
+  });
+
+  it('is empty when nothing was paid', () => {
+    expect(currencyExposure({})).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What
The trip's honest answer to "what did I pay" when the answer is three currencies: **"You paid ₹12,400, €90 and ฿2,100"** — side by side, nothing converted, nothing summed (ADR-004).

- `@waves/core` `money/exposure.ts` — `currencyExposure(paidByCurrency)` → ordered `{currency, amountMinor}[]`, nominal largest-first, zero/negative dropped.
- Member detail screen: a "Paid" card showing each currency the person fronted, from the stored payments. i18n en/ta/hi/ar.

## Note on the gap list
This is the **ADR-004-respecting** stand-in for "per-person settlement currency conversion". Currencies never mix; each settles on its own. Full auto-conversion at settle time would require an ADR-004 amendment and is deliberately **not** done here.

## Tests
4 unit tests. Core + mobile typecheck, lint, prettier green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Paid across” card to member profiles, showing payments by currency.
  * Currency amounts are displayed separately without conversion, with positive balances prioritized.

* **Localization**
  * Added translations for the new “Paid across” label in English, Tamil, Hindi, and Arabic.

* **Bug Fixes**
  * Excludes deleted or incomplete expenses from displayed payment totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->