### PR TITLE
feat(trip): places list for expense locations

### DIFF
--- a/apps/mobile/src/app/group/[id]/map.tsx
+++ b/apps/mobile/src/app/group/[id]/map.tsx
@@ -1,23 +1,25 @@
 /**
- * The trip on a map: every expense that carries a location, dropped as a pin.
+ * The trip's places: every expense that carries a location, as a tappable list
+ * that opens the spot in the phone's own maps app.
  *
  * A read of the ledger the phone already mirrors (ADR-005) — no fetch, works
- * offline, and it plots only what the reader is already allowed to see (RLS
+ * offline, and it lists only what the reader is already allowed to see (RLS
  * dropped the rest before it ever reached the device). It never asks for the
- * phone's own location; these are expense pins, not "where am I".
+ * phone's own location; these are expense places, not "where am I".
  *
- * The map is a native module (`react-native-maps`), loaded lazily behind a
- * non-throwing require exactly like `expo-location` (the native-module rule): a
- * build that did not link it — or the web visual-check surface — degrades to a
- * tappable list of places instead of taking the screen down at launch. Either
- * way a place opens in the phone's own maps app, so the feature is useful even
- * with no embedded map.
+ * Deliberately NOT an embedded map. A native map module (`react-native-maps`)
+ * is not a dependency of this app, and adding an unverifiable native dependency
+ * is a known way to break a build in a way JS-only CI never catches. So this
+ * hands off to the OS maps app via `mapsUrl` instead — honest and useful today.
+ * To add an in-app map later: add `react-native-maps` + its config plugin, then
+ * render pins behind a lazy, non-throwing require (the native-module rule) with
+ * this list as the fallback.
  */
 
 import { useMemo } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { Linking, Platform, Pressable, ScrollView, View } from 'react-native';
+import { Linking, Pressable, ScrollView, View } from 'react-native';
 
 import type { ExpenseLocation } from '@waves/core';
 import {
@@ -47,46 +49,7 @@ interface Place {
   readonly currency: string;
 }
 
-interface MapModule {
-  readonly default: React.ComponentType<Record<string, unknown>>;
-  readonly Marker: React.ComponentType<Record<string, unknown>>;
-}
-
-/**
- * `react-native-maps`, or null when it is not linked into this binary (web, or
- * a build without the module). A property-free try/require: a missing module
- * throws on resolution and is caught, never reaching launch.
- */
-function loadMaps(): MapModule | null {
-  if (Platform.OS !== 'ios' && Platform.OS !== 'android') return null;
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = require('react-native-maps') as Partial<MapModule>;
-    if (!mod?.default || !mod?.Marker) return null;
-    return mod as MapModule;
-  } catch {
-    return null;
-  }
-}
-
-/** A region that fits every pin, with a little padding so none sits on the edge. */
-function regionFor(places: readonly Place[]) {
-  const lats = places.map((p) => p.location.lat);
-  const lngs = places.map((p) => p.location.lng);
-  const minLat = Math.min(...lats);
-  const maxLat = Math.max(...lats);
-  const minLng = Math.min(...lngs);
-  const maxLng = Math.max(...lngs);
-  return {
-    latitude: (minLat + maxLat) / 2,
-    longitude: (minLng + maxLng) / 2,
-    // A single pin has a zero span; give it a street-level default instead.
-    latitudeDelta: Math.max((maxLat - minLat) * 1.4, 0.02),
-    longitudeDelta: Math.max((maxLng - minLng) * 1.4, 0.02),
-  };
-}
-
-export default function MapScreen() {
+export default function PlacesScreen() {
   const theme = useTheme();
   const clearance = useScreenClearance();
   const { t, locale } = useStrings();
@@ -114,7 +77,6 @@ export default function MapScreen() {
     [expenses.rows],
   );
 
-  const maps = useMemo(() => loadMaps(), []);
   const loading = group.isLoading || expenses.isLoading;
 
   const openInMaps = (place: Place): void => {
@@ -153,83 +115,45 @@ export default function MapScreen() {
         ) : places.length === 0 ? (
           <EmptyState title={t.tripMap.empty} body={t.tripMap.emptyBody} />
         ) : (
-          <>
-            {maps ? <EmbeddedMap maps={maps} places={places} radius={theme.radius.lg} /> : null}
-
-            <View style={{ gap: theme.spacing.sm }}>
-              <Text variant="subheading">{t.tripMap.places}</Text>
-              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-                {places.map((place) => (
-                  <Pressable
-                    key={place.id}
-                    onPress={() => openInMaps(place)}
-                    accessibilityRole="button"
-                    accessibilityLabel={`${place.location.name ?? coordLabel(place.location)} — ${t.tripMap.openInMaps}`}
-                    style={{
-                      paddingVertical: theme.spacing.md,
-                      gap: theme.spacing.md,
-                      flexDirection: 'row',
-                      alignItems: 'center',
-                    }}
-                  >
-                    <Ionicons
-                      name="location-outline"
-                      size={iconSize.md}
-                      color={theme.color.brand}
-                    />
-                    <View style={{ flex: 1 }}>
-                      <Text variant="body" numberOfLines={1}>
-                        {place.location.name ?? coordLabel(place.location)}
-                      </Text>
-                      <Text variant="micro" tone="muted" numberOfLines={1}>
-                        {place.description}
-                      </Text>
-                    </View>
-                    <MoneyText
-                      amount={place.amountMinor}
-                      currency={place.currency}
-                      locale={locale}
-                      variant="caption"
-                    />
-                  </Pressable>
-                ))}
-              </Card>
-            </View>
-          </>
+          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            {places.map((place) => (
+              <Pressable
+                key={place.id}
+                onPress={() => openInMaps(place)}
+                accessibilityRole="button"
+                accessibilityLabel={`${place.location.name ?? coordLabel(place.location)} — ${t.tripMap.openInMaps}`}
+                style={{
+                  paddingVertical: theme.spacing.md,
+                  gap: theme.spacing.md,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                }}
+              >
+                <Ionicons name="location-outline" size={iconSize.md} color={theme.color.brand} />
+                <View style={{ flex: 1 }}>
+                  <Text variant="body" numberOfLines={1}>
+                    {place.location.name ?? coordLabel(place.location)}
+                  </Text>
+                  <Text variant="micro" tone="muted" numberOfLines={1}>
+                    {place.description}
+                  </Text>
+                </View>
+                <MoneyText
+                  amount={place.amountMinor}
+                  currency={place.currency}
+                  locale={locale}
+                  variant="caption"
+                />
+                <Ionicons
+                  name={directionalIcon('chevron-forward')}
+                  size={iconSize.sm}
+                  color={theme.color.textFaint}
+                />
+              </Pressable>
+            ))}
+          </Card>
         )}
       </ScrollView>
     </Screen>
-  );
-}
-
-/**
- * The embedded native map. Isolated in its own component so the lazy-required
- * components are only ever referenced when the module actually loaded.
- */
-function EmbeddedMap({
-  maps,
-  places,
-  radius,
-}: {
-  maps: MapModule;
-  places: readonly Place[];
-  radius: number;
-}) {
-  const MapView = maps.default;
-  const Marker = maps.Marker;
-  const region = useMemo(() => regionFor(places), [places]);
-  return (
-    <View style={{ height: 280, borderRadius: radius, overflow: 'hidden' }}>
-      <MapView style={{ flex: 1 }} initialRegion={region}>
-        {places.map((place) => (
-          <Marker
-            key={place.id}
-            coordinate={{ latitude: place.location.lat, longitude: place.location.lng }}
-            title={place.location.name ?? place.description}
-            description={place.description}
-          />
-        ))}
-      </MapView>
-    </View>
   );
 }

--- a/apps/mobile/src/app/group/[id]/map.tsx
+++ b/apps/mobile/src/app/group/[id]/map.tsx
@@ -1,0 +1,235 @@
+/**
+ * The trip on a map: every expense that carries a location, dropped as a pin.
+ *
+ * A read of the ledger the phone already mirrors (ADR-005) — no fetch, works
+ * offline, and it plots only what the reader is already allowed to see (RLS
+ * dropped the rest before it ever reached the device). It never asks for the
+ * phone's own location; these are expense pins, not "where am I".
+ *
+ * The map is a native module (`react-native-maps`), loaded lazily behind a
+ * non-throwing require exactly like `expo-location` (the native-module rule): a
+ * build that did not link it — or the web visual-check surface — degrades to a
+ * tappable list of places instead of taking the screen down at launch. Either
+ * way a place opens in the phone's own maps app, so the feature is useful even
+ * with no embedded map.
+ */
+
+import { useMemo } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { Linking, Platform, Pressable, ScrollView, View } from 'react-native';
+
+import type { ExpenseLocation } from '@waves/core';
+import {
+  Card,
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  iconSize,
+  MoneyText,
+  Row,
+  Screen,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { useGroup } from '@/data/hooks';
+import { coordLabel, mapsUrl } from '@/lib/location';
+import { InsightsSkeleton } from '@/components/Skeletons';
+import { useStrings } from '@/i18n';
+
+interface Place {
+  readonly id: string;
+  readonly description: string;
+  readonly location: ExpenseLocation;
+  readonly amountMinor: bigint;
+  readonly currency: string;
+}
+
+interface MapModule {
+  readonly default: React.ComponentType<Record<string, unknown>>;
+  readonly Marker: React.ComponentType<Record<string, unknown>>;
+}
+
+/**
+ * `react-native-maps`, or null when it is not linked into this binary (web, or
+ * a build without the module). A property-free try/require: a missing module
+ * throws on resolution and is caught, never reaching launch.
+ */
+function loadMaps(): MapModule | null {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') return null;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('react-native-maps') as Partial<MapModule>;
+    if (!mod?.default || !mod?.Marker) return null;
+    return mod as MapModule;
+  } catch {
+    return null;
+  }
+}
+
+/** A region that fits every pin, with a little padding so none sits on the edge. */
+function regionFor(places: readonly Place[]) {
+  const lats = places.map((p) => p.location.lat);
+  const lngs = places.map((p) => p.location.lng);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const minLng = Math.min(...lngs);
+  const maxLng = Math.max(...lngs);
+  return {
+    latitude: (minLat + maxLat) / 2,
+    longitude: (minLng + maxLng) / 2,
+    // A single pin has a zero span; give it a street-level default instead.
+    latitudeDelta: Math.max((maxLat - minLat) * 1.4, 0.02),
+    longitudeDelta: Math.max((maxLng - minLng) * 1.4, 0.02),
+  };
+}
+
+export default function MapScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const groupId = id ?? '';
+
+  const { group, expenses } = useGroup(groupId);
+
+  const places: Place[] = useMemo(
+    () =>
+      expenses.rows
+        .filter((expense) => expense.currentVersion && !expense.deleted_at)
+        .map((expense) => {
+          const version = expense.currentVersion!;
+          if (!version.location) return null;
+          return {
+            id: expense.id,
+            description: version.description,
+            location: version.location,
+            amountMinor: BigInt(version.amount),
+            currency: version.currency,
+          };
+        })
+        .filter((place): place is Place => place !== null),
+    [expenses.rows],
+  );
+
+  const maps = useMemo(() => loadMaps(), []);
+  const loading = group.isLoading || expenses.isLoading;
+
+  const openInMaps = (place: Place): void => {
+    void Linking.openURL(mapsUrl(place.location));
+  };
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.tripMap.title}</Text>
+            <Text variant="micro" tone="muted">
+              {group.data?.name}
+            </Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
+
+        {loading ? (
+          <InsightsSkeleton />
+        ) : places.length === 0 ? (
+          <EmptyState title={t.tripMap.empty} body={t.tripMap.emptyBody} />
+        ) : (
+          <>
+            {maps ? <EmbeddedMap maps={maps} places={places} radius={theme.radius.lg} /> : null}
+
+            <View style={{ gap: theme.spacing.sm }}>
+              <Text variant="subheading">{t.tripMap.places}</Text>
+              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                {places.map((place) => (
+                  <Pressable
+                    key={place.id}
+                    onPress={() => openInMaps(place)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${place.location.name ?? coordLabel(place.location)} — ${t.tripMap.openInMaps}`}
+                    style={{
+                      paddingVertical: theme.spacing.md,
+                      gap: theme.spacing.md,
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Ionicons
+                      name="location-outline"
+                      size={iconSize.md}
+                      color={theme.color.brand}
+                    />
+                    <View style={{ flex: 1 }}>
+                      <Text variant="body" numberOfLines={1}>
+                        {place.location.name ?? coordLabel(place.location)}
+                      </Text>
+                      <Text variant="micro" tone="muted" numberOfLines={1}>
+                        {place.description}
+                      </Text>
+                    </View>
+                    <MoneyText
+                      amount={place.amountMinor}
+                      currency={place.currency}
+                      locale={locale}
+                      variant="caption"
+                    />
+                  </Pressable>
+                ))}
+              </Card>
+            </View>
+          </>
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}
+
+/**
+ * The embedded native map. Isolated in its own component so the lazy-required
+ * components are only ever referenced when the module actually loaded.
+ */
+function EmbeddedMap({
+  maps,
+  places,
+  radius,
+}: {
+  maps: MapModule;
+  places: readonly Place[];
+  radius: number;
+}) {
+  const MapView = maps.default;
+  const Marker = maps.Marker;
+  const region = useMemo(() => regionFor(places), [places]);
+  return (
+    <View style={{ height: 280, borderRadius: radius, overflow: 'hidden' }}>
+      <MapView style={{ flex: 1 }} initialRegion={region}>
+        {places.map((place) => (
+          <Marker
+            key={place.id}
+            coordinate={{ latitude: place.location.lat, longitude: place.location.lng }}
+            title={place.location.name ?? place.description}
+            description={place.description}
+          />
+        ))}
+      </MapView>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -389,7 +389,7 @@ export default function PlanScreen() {
               label={t.tripMap.title}
               onPress={() => router.push(`/group/${groupId}/map`)}
             >
-              <Ionicons name="map-outline" size={iconSize.lg} color={theme.color.text} />
+              <Ionicons name="location-outline" size={iconSize.lg} color={theme.color.text} />
             </IconButton>
           ) : null}
         </Row>

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -383,6 +383,15 @@ export default function PlanScreen() {
             />
           </IconButton>
           <Text variant="heading">{t.plan}</Text>
+          <View style={{ flex: 1 }} />
+          {group.data?.type === 'trip' ? (
+            <IconButton
+              label={t.tripMap.title}
+              onPress={() => router.push(`/group/${groupId}/map`)}
+            >
+              <Ionicons name="map-outline" size={iconSize.lg} color={theme.color.text} />
+            </IconButton>
+          ) : null}
         </Row>
 
         {error ? <Callout tone="negative">{error}</Callout> : null}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -303,10 +303,9 @@ export interface UiStrings {
    */
   onboarding: readonly { title: string; body: string }[];
   plan: string;
-  /** Trip map: expense pins, with a places-list fallback when no map module. */
+  /** Trip places: a list of located expenses that hands off to the OS maps app. */
   tripMap: {
     title: string;
-    places: string;
     empty: string;
     emptyBody: string;
     openInMaps: string;
@@ -1926,10 +1925,9 @@ const en: UiStrings = {
   },
   plan: 'Plan',
   tripMap: {
-    title: 'Map',
-    places: 'Places',
+    title: 'Places',
     empty: 'No places yet',
-    emptyBody: 'Add a location to an expense to see it on the map.',
+    emptyBody: 'Add a location to an expense to see it here.',
     openInMaps: 'Open in Maps',
   },
   dayNumber: 'day {n}',
@@ -3563,10 +3561,9 @@ const ta: UiStrings = {
   },
   plan: 'திட்டம்',
   tripMap: {
-    title: 'வரைபடம்',
-    places: 'இடங்கள்',
+    title: 'இடங்கள்',
     empty: 'இன்னும் இடங்கள் இல்லை',
-    emptyBody: 'ஒரு செலவுக்கு இடத்தைச் சேர்த்தால் அது வரைபடத்தில் தெரியும்.',
+    emptyBody: 'ஒரு செலவுக்கு இடத்தைச் சேர்த்தால் அது இங்கே தெரியும்.',
     openInMaps: 'வரைபடத்தில் திற',
   },
   dayNumber: 'நாள் {n}',
@@ -5265,10 +5262,9 @@ const hi: UiStrings = {
   },
   plan: 'योजना',
   tripMap: {
-    title: 'नक्शा',
-    places: 'जगहें',
+    title: 'जगहें',
     empty: 'अभी कोई जगह नहीं',
-    emptyBody: 'किसी खर्च में जगह जोड़ें, वह नक्शे पर दिखेगी.',
+    emptyBody: 'किसी खर्च में जगह जोड़ें, वह यहाँ दिखेगी.',
     openInMaps: 'नक्शे में खोलें',
   },
   dayNumber: 'दिन {n}',
@@ -6917,10 +6913,9 @@ const ar: UiStrings = {
   },
   plan: 'الخطة',
   tripMap: {
-    title: 'الخريطة',
-    places: 'الأماكن',
+    title: 'الأماكن',
     empty: 'لا أماكن بعد',
-    emptyBody: 'أضف موقعًا إلى مصروف لتراه على الخريطة.',
+    emptyBody: 'أضف موقعًا إلى مصروف لتراه هنا.',
     openInMaps: 'افتح في الخرائط',
   },
   dayNumber: 'اليوم {n}',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -303,6 +303,14 @@ export interface UiStrings {
    */
   onboarding: readonly { title: string; body: string }[];
   plan: string;
+  /** Trip map: expense pins, with a places-list fallback when no map module. */
+  tripMap: {
+    title: string;
+    places: string;
+    empty: string;
+    emptyBody: string;
+    openInMaps: string;
+  };
   /** The plan header's "day N" section marker. `{n}` is the current day. */
   dayNumber: string;
   /** Trip carousel card: which day of the trip today is. `{day}`/`{total}`. */
@@ -1917,6 +1925,13 @@ const en: UiStrings = {
     other: 'Other',
   },
   plan: 'Plan',
+  tripMap: {
+    title: 'Map',
+    places: 'Places',
+    empty: 'No places yet',
+    emptyBody: 'Add a location to an expense to see it on the map.',
+    openInMaps: 'Open in Maps',
+  },
   dayNumber: 'day {n}',
   tripDay: 'Day {day} of {total}',
   planned: 'Planned',
@@ -3547,6 +3562,13 @@ const ta: UiStrings = {
     other: 'மற்றவை',
   },
   plan: 'திட்டம்',
+  tripMap: {
+    title: 'வரைபடம்',
+    places: 'இடங்கள்',
+    empty: 'இன்னும் இடங்கள் இல்லை',
+    emptyBody: 'ஒரு செலவுக்கு இடத்தைச் சேர்த்தால் அது வரைபடத்தில் தெரியும்.',
+    openInMaps: 'வரைபடத்தில் திற',
+  },
   dayNumber: 'நாள் {n}',
   tripDay: 'நாள் {day}/{total}',
   planned: 'திட்டமிட்டது',
@@ -5242,6 +5264,13 @@ const hi: UiStrings = {
     other: 'अन्य',
   },
   plan: 'योजना',
+  tripMap: {
+    title: 'नक्शा',
+    places: 'जगहें',
+    empty: 'अभी कोई जगह नहीं',
+    emptyBody: 'किसी खर्च में जगह जोड़ें, वह नक्शे पर दिखेगी.',
+    openInMaps: 'नक्शे में खोलें',
+  },
   dayNumber: 'दिन {n}',
   tripDay: 'दिन {day}/{total}',
   planned: 'तय किया',
@@ -6887,6 +6916,13 @@ const ar: UiStrings = {
     other: 'أخرى',
   },
   plan: 'الخطة',
+  tripMap: {
+    title: 'الخريطة',
+    places: 'الأماكن',
+    empty: 'لا أماكن بعد',
+    emptyBody: 'أضف موقعًا إلى مصروف لتراه على الخريطة.',
+    openInMaps: 'افتح في الخرائط',
+  },
   dayNumber: 'اليوم {n}',
   tripDay: 'اليوم {day} من {total}',
   planned: 'المخطط',


### PR DESCRIPTION
## What
A trip **Places** screen listing every expense that carries a `{lat,lng}` location, each row tappable to open that spot in the **phone's own maps app**. Reachable from a location button in the trip plan header. Built entirely on data the app already stores (A43 expense location); no schema, no migration.

- `apps/mobile/src/app/group/[id]/map.tsx` — a list of located expenses (name/coords + amount + description); empty state when none; hands off to the OS maps app via the existing `mapsUrl` helper.
- Link from `plan.tsx` header (trips only).
- i18n `tripMap` across en/ta/hi/ar, RTL-safe.

## Why a list, not an embedded map
`react-native-maps` is **not** a dependency of this app, and adding an unverifiable native dependency to `main` is a known way to break a build in a way JS-only CI never catches (and this environment can't run a device/gradlew build). So this ships an honest, useful **places list that hands off to the OS maps app** — no native module, nothing that promises an in-app map that isn't there.

## Future enhancement (not in this PR)
To add an in-app map later: add `react-native-maps` + its config plugin (no Google Maps key committed), then render pins behind a lazy, non-throwing require (the native-module rule) with this list as the fallback. A code comment at the top of `map.tsx` records exactly this.

## Privacy
Reads the mirrored ledger only (offline, RLS-scoped) — lists just what the reader is already allowed to see. Never requests the device's own location; these are expense places, not "where am I".

## Gates
Mobile typecheck + lint + prettier green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)