### PR TITLE
feat(split): travel split presets in add-expense

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -15,11 +15,15 @@ import {
 } from 'react-native';
 
 import {
+  carRentalSplit,
   CategoryId,
   computeShares,
   currencySymbol,
   guessCategory,
   MutationKind,
+  ridersSplit,
+  splitByUnits,
+  treatSplit,
   type CategoryMeta,
   type ExpenseLocation,
   type FxRecord,
@@ -28,6 +32,7 @@ import {
   type SplitParams,
 } from '@waves/core';
 import {
+  AmountField,
   Avatar,
   Button,
   Callout,
@@ -246,6 +251,27 @@ export default function AddExpenseScreen() {
   // reinterpret one number as the other.
   const [weights, setWeights] = useState<SplitEntries>({});
   const [percents, setPercents] = useState<SplitEntries>({});
+  // Travel split presets (trip groups). Each produces the canonical split params
+  // the ledger already understands, so nothing new is stored: nights → shares,
+  // this-ride → equal (both drive the normal fields), car rental → an
+  // `adjustment` held in `presetParams`, and "my treat" → an `exact` recomputed
+  // live from the amount via `treatHost`. Any manual edit clears the preset.
+  const [presetParams, setPresetParams] = useState<SplitParams | null>(null);
+  const [treatHost, setTreatHost] = useState<MemberId | null>(null);
+  const [presetLabel, setPresetLabel] = useState<string | null>(null);
+  const [presetEditor, setPresetEditor] = useState<'nights' | 'car' | 'ride' | 'treat' | null>(
+    null,
+  );
+  const [nightCounts, setNightCounts] = useState<Record<MemberId, string>>({});
+  const [riderPick, setRiderPick] = useState<MemberId[]>([]);
+  const [fuelAmounts, setFuelAmounts] = useState<Record<MemberId, bigint>>({});
+  const [exemptDriver, setExemptDriver] = useState<MemberId | null>(null);
+  const [treatHostPick, setTreatHostPick] = useState<MemberId | null>(null);
+  const clearPreset = (): void => {
+    setPresetParams(null);
+    setTreatHost(null);
+    setPresetLabel(null);
+  };
   // Guessed from the description until somebody picks one themselves, at which
   // point the guess must stop moving it — see `categoryChosen`.
   // A built-in id or a custom tag's id; `categoryMeta` carries a custom tag's
@@ -491,6 +517,7 @@ export default function AddExpenseScreen() {
 
   const entries = splitKind === SplitKind.Shares ? weights : percents;
   const setEntry = (memberId: MemberId, text: string): void => {
+    clearPreset();
     const update = (current: SplitEntries): SplitEntries => ({ ...current, [memberId]: text });
     if (splitKind === SplitKind.Shares) setWeights(update);
     else setPercents(update);
@@ -519,6 +546,7 @@ export default function AddExpenseScreen() {
   const [splitOpen, setSplitOpen] = useState(false);
   const showSplit = splitOpen || !isDefaultSplit || splitIssue !== null;
 
+  const isTrip = group.data?.type === 'trip';
   const groupCurrency = group.data?.default_currency ?? 'INR';
   // The expense keeps the currency it was paid in; the group's is only the
   // default and what a converted total would be shown in (ADR-003).
@@ -555,6 +583,17 @@ export default function AddExpenseScreen() {
   );
 
   const splitParams: SplitParams = useMemo(() => {
+    // "My treat" owes the whole current amount to the host — recomputed live so
+    // changing the total keeps the exact split valid.
+    if (treatHost) {
+      try {
+        return treatSplit({ host: treatHost, participants, amountMinor: amount });
+      } catch {
+        // The host fell out of the participants; drop to the manual split below.
+      }
+    }
+    // A car-rental preset is a fixed adjustment, valid at any total.
+    if (presetParams) return presetParams;
     if (splitKind === SplitKind.Shares) {
       return { kind: 'shares', weights: entryValues('shares', weights, participants) };
     }
@@ -562,7 +601,7 @@ export default function AddExpenseScreen() {
       return { kind: 'percent', basisPoints: entryValues('percent', percents, participants) };
     }
     return { kind: 'equal' };
-  }, [splitKind, weights, percents, participants]);
+  }, [splitKind, weights, percents, participants, treatHost, presetParams, amount]);
 
   // Preview with the same engine the server uses; if they ever disagree the
   // server wins and tells us why (SHARE_MISMATCH).
@@ -823,11 +862,116 @@ export default function AddExpenseScreen() {
   };
 
   const toggleParticipant = (memberId: MemberId): void => {
+    clearPreset();
     setParticipants((current) =>
       current.includes(memberId)
         ? current.filter((item) => item !== memberId)
         : [...current, memberId],
     );
+  };
+
+  // Travel split presets — each seeds the split from a small sheet, then hands
+  // the ledger canonical params via the core builders. A SplitError from the
+  // builder (nobody stayed a night, host not a rider) surfaces as a friendly
+  // message rather than a crash, and nothing is applied.
+  const roster = members.data ?? [];
+
+  const openPreset = (kind: 'nights' | 'car' | 'ride' | 'treat'): void => {
+    setError(null);
+    setRiderPick(participants.length > 0 ? participants : roster.map((member) => member.id));
+    setNightCounts({});
+    setFuelAmounts({});
+    setExemptDriver(null);
+    setTreatHostPick(payer ?? myMemberId);
+    setPresetEditor(kind);
+  };
+
+  const toggleRider = (memberId: MemberId): void => {
+    setRiderPick((current) =>
+      current.includes(memberId)
+        ? current.filter((item) => item !== memberId)
+        : [...current, memberId],
+    );
+  };
+
+  const applyNights = (): void => {
+    try {
+      const units: Record<MemberId, number> = {};
+      for (const member of roster) {
+        const parsed = Number.parseInt(nightCounts[member.id] ?? '', 10);
+        units[member.id] = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+      }
+      splitByUnits(units); // throws unless someone stayed a night
+      const chosen = roster.filter((member) => (units[member.id] ?? 0) > 0).map((m) => m.id);
+      clearPreset();
+      setSplitKind(SplitKind.Shares);
+      setParticipants(chosen);
+      setWeights(Object.fromEntries(chosen.map((id) => [id, String(units[id])])));
+      setPresetLabel(t.expense.presets.nights);
+      setPresetEditor(null);
+      setSplitOpen(true);
+    } catch (caught) {
+      setError(friendlyError(caught, t.couldNotSave, 'preset.nights'));
+    }
+  };
+
+  const applyRide = (): void => {
+    try {
+      const result = ridersSplit(riderPick);
+      clearPreset();
+      setSplitKind(SplitKind.Equal);
+      setParticipants(result.participants);
+      setPresetLabel(t.expense.presets.ride);
+      setPresetEditor(null);
+      setSplitOpen(true);
+    } catch (caught) {
+      setError(friendlyError(caught, t.couldNotSave, 'preset.ride'));
+    }
+  };
+
+  const applyCar = (): void => {
+    try {
+      const extras: Record<MemberId, bigint> = {};
+      for (const id of riderPick) {
+        const fuel = fuelAmounts[id] ?? 0n;
+        if (fuel > 0n) extras[id] = fuel;
+      }
+      const result = carRentalSplit({
+        participants: riderPick,
+        extrasByMember: extras,
+        exemptDriver: exemptDriver ?? undefined,
+      });
+      clearPreset();
+      setSplitKind(SplitKind.Equal);
+      setParticipants(result.participants);
+      setPresetParams(result.params);
+      setPresetLabel(t.expense.presets.car);
+      setPresetEditor(null);
+      setSplitOpen(true);
+    } catch (caught) {
+      setError(friendlyError(caught, t.couldNotSave, 'preset.car'));
+    }
+  };
+
+  const applyTreat = (): void => {
+    const host = treatHostPick ?? myMemberId;
+    if (!host) {
+      setError(t.expense.chooseWhoPaid);
+      return;
+    }
+    try {
+      const parts = participants.includes(host) ? participants : [...participants, host];
+      treatSplit({ host, participants: parts, amountMinor: amount }); // validate
+      clearPreset();
+      setParticipants(parts);
+      setPayer(host);
+      setTreatHost(host);
+      setPresetLabel(t.expense.presets.treat);
+      setPresetEditor(null);
+      setSplitOpen(true);
+    } catch (caught) {
+      setError(friendlyError(caught, t.couldNotSave, 'preset.treat'));
+    }
   };
 
   // Why Save is disabled, in one line, so a greyed-out button is never a dead
@@ -1075,11 +1219,12 @@ export default function AddExpenseScreen() {
                   </Text>
                   <Text variant="subheading" numberOfLines={2}>
                     {[
-                      splitKind === SplitKind.Equal
-                        ? t.expense.equally
-                        : splitKind === SplitKind.Shares
-                          ? t.expense.shares
-                          : t.expense.percent,
+                      presetLabel ??
+                        (splitKind === SplitKind.Equal
+                          ? t.expense.equally
+                          : splitKind === SplitKind.Shares
+                            ? t.expense.shares
+                            : t.expense.percent),
                       plural(locale, participants.length, t.memberCount),
                     ].join(' · ')}
                   </Text>
@@ -1102,9 +1247,38 @@ export default function AddExpenseScreen() {
             fields hold text somebody is mid-way through typing, and a fold that
             threw it away would be a worse trade than a taller tree. */}
           <View style={{ gap: theme.spacing.md, display: showSplit ? 'flex' : 'none' }}>
+            {isTrip && !editing ? (
+              <View style={{ gap: theme.spacing.xs }}>
+                <Text variant="micro" tone="muted">
+                  {t.expense.presets.title}
+                </Text>
+                <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
+                  {(
+                    [
+                      ['nights', t.expense.presets.nights],
+                      ['car', t.expense.presets.car],
+                      ['ride', t.expense.presets.ride],
+                      ['treat', t.expense.presets.treat],
+                    ] as const
+                  ).map(([kind, label]) => (
+                    <Button
+                      key={kind}
+                      label={label}
+                      size="sm"
+                      variant={presetLabel === label ? 'primary' : 'secondary'}
+                      onPress={() => openPreset(kind)}
+                    />
+                  ))}
+                </Row>
+              </View>
+            ) : null}
+
             <ChipRow<SplitKind>
               value={splitKind}
-              onChange={setSplitKind}
+              onChange={(next) => {
+                clearPreset();
+                setSplitKind(next);
+              }}
               options={[
                 { value: SplitKind.Equal, label: t.expense.equally },
                 { value: SplitKind.Shares, label: t.expense.shares },
@@ -1319,6 +1493,199 @@ export default function AddExpenseScreen() {
           ) : null}
         </View>
       </KeyboardAvoidingView>
+
+      {/* Travel split presets, as a sheet over the form (trip groups). Each
+          gathers just its inputs, then applies canonical split params through
+          the core builders — nothing new is stored. */}
+      {presetEditor ? (
+        <SheetOverlay
+          title={
+            presetEditor === 'nights'
+              ? t.expense.presets.nightsTitle
+              : presetEditor === 'car'
+                ? t.expense.presets.carTitle
+                : presetEditor === 'ride'
+                  ? t.expense.presets.rideTitle
+                  : t.expense.presets.treatTitle
+          }
+          onClose={() => setPresetEditor(null)}
+        >
+          <View style={{ gap: theme.spacing.md }}>
+            <Text variant="caption" tone="muted">
+              {presetEditor === 'nights'
+                ? t.expense.presets.nightsHint
+                : presetEditor === 'car'
+                  ? t.expense.presets.carRiders
+                  : presetEditor === 'ride'
+                    ? t.expense.presets.rideHint
+                    : t.expense.presets.treatHint}
+            </Text>
+
+            {presetEditor === 'nights'
+              ? roster.map((member) => (
+                  <Row
+                    key={member.id}
+                    style={{
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      gap: theme.spacing.md,
+                    }}
+                  >
+                    <Row
+                      style={{ gap: theme.spacing.sm, alignItems: 'center', flex: 1, minWidth: 0 }}
+                    >
+                      <Avatar name={displayName(member)} ghost={isGhost(member)} size={32} />
+                      <Text variant="body" numberOfLines={1}>
+                        {displayName(member, profile?.id)}
+                      </Text>
+                    </Row>
+                    <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+                      <TextInput
+                        value={nightCounts[member.id] ?? ''}
+                        onChangeText={(text) =>
+                          setNightCounts((current) => ({
+                            ...current,
+                            [member.id]: text.replace(/[^0-9]/g, ''),
+                          }))
+                        }
+                        keyboardType="number-pad"
+                        placeholder="0"
+                        placeholderTextColor={theme.color.textFaint}
+                        accessibilityLabel={displayName(member, profile?.id)}
+                        style={{
+                          width: 56,
+                          minHeight: 44,
+                          textAlign: 'right',
+                          fontSize: 16,
+                          fontWeight: '700',
+                          color: theme.color.text,
+                          backgroundColor: theme.color.bg,
+                          borderRadius: theme.radius.sm,
+                          paddingHorizontal: theme.spacing.sm,
+                        }}
+                      />
+                      <Text variant="micro" tone="muted">
+                        {t.expense.presets.nightUnit}
+                      </Text>
+                    </Row>
+                  </Row>
+                ))
+              : null}
+
+            {presetEditor === 'ride'
+              ? roster.map((member) => (
+                  <ChoiceRow
+                    key={member.id}
+                    label={displayName(member, profile?.id)}
+                    selected={riderPick.includes(member.id)}
+                    onPress={() => toggleRider(member.id)}
+                    leading={
+                      <Avatar name={displayName(member)} ghost={isGhost(member)} size={32} />
+                    }
+                  />
+                ))
+              : null}
+
+            {presetEditor === 'car'
+              ? roster.map((member) => {
+                  const isRider = riderPick.includes(member.id);
+                  const isDriver = exemptDriver === member.id;
+                  return (
+                    <View key={member.id} style={{ gap: theme.spacing.xs }}>
+                      <Row
+                        style={{
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          gap: theme.spacing.md,
+                        }}
+                      >
+                        <Pressable
+                          onPress={() => toggleRider(member.id)}
+                          accessibilityRole="checkbox"
+                          accessibilityState={{ checked: isRider }}
+                          accessibilityLabel={displayName(member, profile?.id)}
+                          style={{
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            gap: theme.spacing.sm,
+                            flex: 1,
+                            minWidth: 0,
+                          }}
+                        >
+                          <Ionicons
+                            name={isRider ? 'checkmark-circle' : 'ellipse-outline'}
+                            size={iconSize.lg}
+                            color={isRider ? theme.color.brand : theme.color.textFaint}
+                          />
+                          <Text variant="body" numberOfLines={1}>
+                            {displayName(member, profile?.id)}
+                          </Text>
+                        </Pressable>
+                        {isRider ? (
+                          <Pressable
+                            onPress={() =>
+                              setExemptDriver((current) => (isDriver ? null : member.id))
+                            }
+                            accessibilityRole="radio"
+                            accessibilityState={{ selected: isDriver }}
+                            accessibilityLabel={t.expense.presets.carDriver}
+                            hitSlop={6}
+                          >
+                            <Text variant="micro" tone={isDriver ? 'brand' : 'faint'}>
+                              {t.expense.presets.carDriver}
+                            </Text>
+                          </Pressable>
+                        ) : null}
+                      </Row>
+                      {isRider && !isDriver ? (
+                        <AmountField
+                          currency={currency}
+                          value={fuelAmounts[member.id] ?? 0n}
+                          onChange={(value) =>
+                            setFuelAmounts((current) => ({ ...current, [member.id]: value }))
+                          }
+                        />
+                      ) : null}
+                    </View>
+                  );
+                })
+              : null}
+
+            {presetEditor === 'car' ? (
+              <Text variant="micro" tone="muted">
+                {t.expense.presets.carFuel}
+              </Text>
+            ) : null}
+
+            {presetEditor === 'treat'
+              ? roster.map((member) => (
+                  <ChoiceRow
+                    key={member.id}
+                    label={displayName(member, profile?.id)}
+                    selected={(treatHostPick ?? myMemberId) === member.id}
+                    onPress={() => setTreatHostPick(member.id)}
+                    leading={
+                      <Avatar name={displayName(member)} ghost={isGhost(member)} size={32} />
+                    }
+                  />
+                ))
+              : null}
+
+            <Button
+              label={t.expense.presets.apply}
+              onPress={() =>
+                presetEditor === 'nights'
+                  ? applyNights()
+                  : presetEditor === 'car'
+                    ? applyCar()
+                    : presetEditor === 'ride'
+                      ? applyRide()
+                      : applyTreat()
+              }
+            />
+          </View>
+        </SheetOverlay>
+      ) : null}
 
       {/* Currency picker, as a sheet over the form — the same shortlist and the
           same sheet the capture screen uses, so a person meets the same

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1247,6 +1247,26 @@ export interface UiStrings {
     scanReadItemsCta: PluralForms;
     descriptionPlaceholder: string;
     howToSplit: string;
+    /** Travel split presets, shown on trip groups. */
+    presets: {
+      title: string;
+      nights: string;
+      car: string;
+      ride: string;
+      treat: string;
+      nightsTitle: string;
+      nightsHint: string;
+      nightUnit: string;
+      carTitle: string;
+      carRiders: string;
+      carFuel: string;
+      carDriver: string;
+      rideTitle: string;
+      rideHint: string;
+      treatTitle: string;
+      treatHint: string;
+      apply: string;
+    };
     equally: string;
     shares: string;
     percent: string;
@@ -2849,6 +2869,25 @@ const en: UiStrings = {
     },
     descriptionPlaceholder: 'Beach shack dinner',
     howToSplit: 'How to split',
+    presets: {
+      title: 'Trip presets',
+      nights: 'By nights',
+      car: 'Car rental',
+      ride: 'This ride',
+      treat: 'My treat',
+      nightsTitle: 'Split by nights',
+      nightsHint: 'How many nights each person stayed',
+      nightUnit: 'nights',
+      carTitle: 'Car rental',
+      carRiders: 'Who shared the car',
+      carFuel: 'Fuel / tolls (optional)',
+      carDriver: 'Driver pays nothing',
+      rideTitle: 'This ride only',
+      rideHint: 'Who was in it',
+      treatTitle: 'My treat',
+      treatHint: 'Who’s covering it',
+      apply: 'Apply',
+    },
     equally: 'Equally',
     shares: 'Shares',
     percent: 'Percent',
@@ -4550,6 +4589,25 @@ const ta: UiStrings = {
     },
     descriptionPlaceholder: 'கடற்கரை உணவகச் சாப்பாடு',
     howToSplit: 'எப்படிப் பிரிப்பது',
+    presets: {
+      title: 'பயண முன்னமைவுகள்',
+      nights: 'இரவுகள் வாரியாக',
+      car: 'கார் வாடகை',
+      ride: 'இந்த பயணம்',
+      treat: 'என் விருந்து',
+      nightsTitle: 'இரவுகள் வாரியாகப் பிரி',
+      nightsHint: 'ஒவ்வொருவரும் தங்கிய இரவுகள்',
+      nightUnit: 'இரவுகள்',
+      carTitle: 'கார் வாடகை',
+      carRiders: 'காரைப் பகிர்ந்தவர்கள்',
+      carFuel: 'எரிபொருள் / சுங்கம் (விருப்பம்)',
+      carDriver: 'ஓட்டுநர் எதுவும் செலுத்தவில்லை',
+      rideTitle: 'இந்தப் பயணம் மட்டும்',
+      rideHint: 'இதில் இருந்தவர்கள்',
+      treatTitle: 'என் விருந்து',
+      treatHint: 'யார் செலுத்துகிறார்',
+      apply: 'பயன்படுத்து',
+    },
     equally: 'சமமாக',
     shares: 'பங்குகள்',
     percent: 'சதவீதம்',
@@ -6231,6 +6289,25 @@ const hi: UiStrings = {
     },
     descriptionPlaceholder: 'बीच शैक का खाना',
     howToSplit: 'कैसे बाँटें',
+    presets: {
+      title: 'ट्रिप प्रीसेट',
+      nights: 'रातों के हिसाब से',
+      car: 'कार किराया',
+      ride: 'यह सवारी',
+      treat: 'मेरी तरफ़ से',
+      nightsTitle: 'रातों के हिसाब से बाँटें',
+      nightsHint: 'हर कोई कितनी रातें रुका',
+      nightUnit: 'रातें',
+      carTitle: 'कार किराया',
+      carRiders: 'कार किसने साझा की',
+      carFuel: 'ईंधन / टोल (वैकल्पिक)',
+      carDriver: 'ड्राइवर कुछ नहीं देगा',
+      rideTitle: 'सिर्फ़ यह सवारी',
+      rideHint: 'इसमें कौन था',
+      treatTitle: 'मेरी तरफ़ से',
+      treatHint: 'कौन दे रहा है',
+      apply: 'लागू करें',
+    },
     equally: 'बराबर',
     shares: 'हिस्से',
     percent: 'प्रतिशत',
@@ -7934,6 +8011,25 @@ const ar: UiStrings = {
     },
     descriptionPlaceholder: 'عشاء على الشاطئ',
     howToSplit: 'طريقة التقسيم',
+    presets: {
+      title: 'إعدادات الرحلة',
+      nights: 'حسب الليالي',
+      car: 'إيجار سيارة',
+      ride: 'هذه الرحلة',
+      treat: 'على حسابي',
+      nightsTitle: 'التقسيم حسب الليالي',
+      nightsHint: 'كم ليلة أقام كل شخص',
+      nightUnit: 'ليالٍ',
+      carTitle: 'إيجار سيارة',
+      carRiders: 'من شارك السيارة',
+      carFuel: 'الوقود / الرسوم (اختياري)',
+      carDriver: 'السائق لا يدفع شيئًا',
+      rideTitle: 'هذه الرحلة فقط',
+      rideHint: 'من كان فيها',
+      treatTitle: 'على حسابي',
+      treatHint: 'من يتكفّل بها',
+      apply: 'تطبيق',
+    },
     equally: 'بالتساوي',
     shares: 'حصص',
     percent: 'نسبة مئوية',


### PR DESCRIPTION
## What
Wires the travel split presets from #399 into the add-expense UI. Shown on **trip groups only**, new-entry only (editing keeps the saved split). Four presets in a small sheet each:

- **By nights** → `splitByUnits` → `shares` (populates the normal weight fields).
- **This ride** → `ridersSplit` → `equal` over the chosen riders.
- **Car rental** → `carRentalSplit` → `adjustment` (base equal among riders, per-rider fuel via AmountField, a "driver pays nothing" toggle).
- **My treat** → `treatSplit` → `exact`, host owes the whole bill — recomputed live from the amount so changing the total stays valid.

## How it stays safe
- Each preset produces the **canonical split params the ledger already stores** — no new persistence path, no schema, round-trips and settles like any other split. Preview + submit flow through the existing `computeShares`/expected-shares path unchanged.
- **Any manual edit** (split-kind chip, participant toggle, weight field) **clears the preset** and hands control back to the fields.
- A `SplitError` from a builder (no nights entered, host not a rider) surfaces as a **friendly message**, never a crash.
- Existing manual Equal/Shares/Percent splits are untouched.

## Notes
- **Device-unverified** (UI-only): mobile + core typecheck, lint, prettier all green; the money math is the property-tested core from #399.
- i18n `expense.presets` added across en/ta/hi/ar (RTL-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)