### PR TITLE
feat(trip): per-category budgets

### DIFF
--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -65,6 +65,7 @@ import { displayName } from '@/data/types';
 import { friendlyError } from '@/lib/errors';
 import { useAuth } from '@/lib/auth';
 import { SkeletonList } from '@/components/Skeletons';
+import { CategoryBudgets } from '@/components/CategoryBudgets';
 import { fill, useStrings, type UiStrings } from '@/i18n';
 
 /** Today where the trip is, not where the server is. */
@@ -651,6 +652,15 @@ export default function PlanScreen() {
                 />
               ))}
           </Card>
+        ) : null}
+
+        {isTrip ? (
+          <CategoryBudgets
+            groupId={groupId}
+            currency={currency}
+            isAdmin={isAdmin}
+            expenses={spend}
+          />
         ) : null}
 
         {isTrip && forecasts.length > 0 ? (

--- a/apps/mobile/src/components/CategoryBudgets.tsx
+++ b/apps/mobile/src/components/CategoryBudgets.tsx
@@ -1,0 +1,210 @@
+/**
+ * Category budgets: a cap per category — food, stays, transport — beside the
+ * overall and personal ones on the trip screen.
+ *
+ * Like the overall budget and unlike a personal one, a category cap is the
+ * group's: an admin sets it, everyone sees it, and it lives on the group row
+ * (ADR-005, offline through the mirror). "Spent" is never stored — it is the
+ * ledger's own spend in that category, in that currency, never mixed across
+ * currencies (ADR-004). A member who is not an admin sees the bars but cannot
+ * move them; the RPC is what actually enforces that, not this component.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import {
+  budgetProgress,
+  resolveCategory,
+  spendByCategory,
+  type CategorisedExpense,
+} from '@waves/core';
+import { AmountField, Button, Card, iconSize, MoneyText, Row, Text, useTheme } from '@waves/ui';
+import { Pressable, View } from 'react-native';
+
+import { CategoryBadge, CategoryPicker } from '@/components/Category';
+import { useCategoryBudgets, useSetCategoryBudget } from '@/data/hooks';
+import { friendlyError } from '@/lib/errors';
+import { useStrings } from '@/i18n';
+
+export function CategoryBudgets({
+  groupId,
+  currency,
+  isAdmin,
+  expenses,
+}: {
+  groupId: string;
+  currency: string;
+  isAdmin: boolean;
+  expenses: readonly CategorisedExpense[];
+}) {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const budgets = useCategoryBudgets(groupId);
+  const setBudget = useSetCategoryBudget(groupId);
+
+  const spend = spendByCategory(expenses);
+  const rows = budgets.data ?? [];
+
+  const [adding, setAdding] = useState(false);
+  const [category, setCategory] = useState<string | null>(null);
+  const [amount, setAmount] = useState<bigint>(0n);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const label = (id: string): string => {
+    const resolved = resolveCategory(id, null);
+    return resolved.custom ? id : t.categories[resolved.builtinId ?? 'other'];
+  };
+
+  const save = async (): Promise<void> => {
+    if (!category) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await setBudget.mutateAsync({ category, amountMinor: amount, currency });
+      setAdding(false);
+      setCategory(null);
+      setAmount(0n);
+    } catch (caught) {
+      setError(friendlyError(caught, t.couldNotSave, 'categoryBudget.save'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clear = async (id: string): Promise<void> => {
+    setError(null);
+    try {
+      await setBudget.mutateAsync({ category: id, amountMinor: null });
+    } catch (caught) {
+      setError(friendlyError(caught, t.couldNotSave, 'categoryBudget.clear'));
+    }
+  };
+
+  // Nothing set and not an admin: the section would be an empty box. Hide it.
+  if (rows.length === 0 && !isAdmin) return null;
+
+  return (
+    <Card style={{ gap: theme.spacing.md }}>
+      <Text variant="subheading">{t.tripInsights.categoryBudgets}</Text>
+
+      {error ? (
+        <Text variant="caption" tone="negative">
+          {error}
+        </Text>
+      ) : null}
+
+      {rows.map((row) => {
+        const progress = budgetProgress(
+          { amountMinor: row.amountMinor, currency: row.currency },
+          spend.get(row.category),
+        );
+        if (!progress) return null;
+        const fill = Math.max(0, Math.min(1, progress.ratio));
+        const color = progress.over ? theme.color.negative : theme.color.positive;
+        const gap =
+          progress.remainingMinor < 0n ? -progress.remainingMinor : progress.remainingMinor;
+        return (
+          <View key={row.category} style={{ gap: theme.spacing.xs }}>
+            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+              <Row style={{ gap: theme.spacing.sm, alignItems: 'center', flex: 1 }}>
+                <CategoryBadge category={row.category} size={26} />
+                <Text variant="caption" numberOfLines={1} style={{ flex: 1 }}>
+                  {label(row.category)}
+                </Text>
+              </Row>
+              <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+                <MoneyText
+                  amount={progress.spentMinor}
+                  currency={progress.currency}
+                  locale={locale}
+                  variant="caption"
+                  mode="plain"
+                />
+                <Text variant="caption" tone="faint">
+                  /
+                </Text>
+                <MoneyText
+                  amount={progress.capMinor}
+                  currency={progress.currency}
+                  locale={locale}
+                  variant="caption"
+                  mode="plain"
+                />
+                {isAdmin ? (
+                  <Pressable
+                    onPress={() => void clear(row.category)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${t.clearBudget} — ${label(row.category)}`}
+                    hitSlop={10}
+                  >
+                    <Ionicons name="close" size={iconSize.sm} color={theme.color.textFaint} />
+                  </Pressable>
+                ) : null}
+              </Row>
+            </Row>
+            <View
+              style={{
+                height: 8,
+                borderRadius: 4,
+                backgroundColor: theme.color.border,
+                overflow: 'hidden',
+              }}
+            >
+              <View
+                style={{
+                  width: `${fill * 100}%`,
+                  height: '100%',
+                  backgroundColor: color,
+                  borderRadius: 4,
+                }}
+              />
+            </View>
+            <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+              <MoneyText
+                amount={gap}
+                currency={progress.currency}
+                locale={locale}
+                variant="micro"
+                mode="plain"
+              />
+              <Text variant="micro" tone={progress.over ? 'negative' : 'muted'}>
+                {progress.over ? t.overBudget : t.budgetLeft}
+              </Text>
+            </Row>
+          </View>
+        );
+      })}
+
+      {isAdmin && adding ? (
+        <View style={{ gap: theme.spacing.sm }}>
+          <CategoryPicker value={category} onChange={(key) => setCategory(key)} />
+          <AmountField currency={currency} value={amount} onChange={setAmount} />
+          <Row style={{ gap: theme.spacing.sm }}>
+            <Button
+              label={t.saveBudget}
+              size="sm"
+              disabled={busy || !category}
+              onPress={() => void save()}
+            />
+            <Button
+              label={t.cancel}
+              size="sm"
+              variant="ghost"
+              onPress={() => {
+                setAdding(false);
+                setCategory(null);
+                setAmount(0n);
+              }}
+            />
+          </Row>
+        </View>
+      ) : isAdmin ? (
+        <Text variant="caption" tone="brand" onPress={() => setAdding(true)}>
+          + {t.tripInsights.categoryBudgets}
+        </Text>
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -1498,6 +1498,48 @@ export function useSetGroupBudget(groupId: string) {
   });
 }
 
+export interface CategoryBudgetRow {
+  category: string;
+  amountMinor: bigint;
+  currency: string;
+}
+
+/** The trip's per-category caps, read off the mirrored group row (ADR-005). */
+export function useCategoryBudgets(groupId: string): LocalRead<CategoryBudgetRow[]> {
+  const { mirror, queue } = useSync();
+  const rows = useMemo(() => {
+    const group = materialiseGroup(mirror, queue, groupId);
+    const map = group?.category_budgets ?? null;
+    if (!map) return [];
+    return Object.entries(map)
+      .map(([category, value]) => ({
+        category,
+        amountMinor: BigInt(value.amountMinor),
+        currency: value.currency,
+      }))
+      .sort((a, b) => (a.category < b.category ? -1 : a.category > b.category ? 1 : 0));
+  }, [mirror, queue, groupId]);
+  return useLocalRead(rows);
+}
+
+/** Set (or clear, with a null amount) one category's cap, queued. Admin-only,
+ *  enforced by the RPC. */
+export function useSetCategoryBudget(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: (input: {
+      category: string;
+      amountMinor: bigint | null;
+      currency?: string | null;
+    }) =>
+      mutate(MutationKind.CategoryBudgetSet, groupId, {
+        category: input.category,
+        amountMinor: input.amountMinor === null ? null : input.amountMinor.toString(),
+        currency: input.currency ?? null,
+      }),
+  });
+}
+
 // ────────────────────────── somebody asking to be somebody (ADR-006) ──
 
 /**

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -340,6 +340,7 @@ export interface UiStrings {
     /** `{n}` expenses. */
     expenseCount: string;
     noneYet: string;
+    categoryBudgets: string;
   };
   /** Trip budgets. */
   budgets: string;
@@ -1979,6 +1980,7 @@ const en: UiStrings = {
     paidMost: 'Fronted the most',
     expenseCount: '{n} expenses',
     noneYet: 'Nothing to recap yet',
+    categoryBudgets: 'Category budgets',
   },
   budgets: 'Budgets',
   overallBudget: 'Overall',
@@ -3635,6 +3637,7 @@ const ta: UiStrings = {
     paidMost: 'அதிகம் செலுத்தியவர்',
     expenseCount: '{n} செலவுகள்',
     noneYet: 'இன்னும் சுருக்க எதுவும் இல்லை',
+    categoryBudgets: 'வகை பட்ஜெட்',
   },
   budgets: 'பட்ஜெட்',
   overallBudget: 'மொத்தம்',
@@ -5356,6 +5359,7 @@ const hi: UiStrings = {
     paidMost: 'सबसे ज़्यादा चुकाया',
     expenseCount: '{n} खर्च',
     noneYet: 'अभी सार के लिए कुछ नहीं',
+    categoryBudgets: 'श्रेणी बजट',
   },
   budgets: 'बजट',
   overallBudget: 'कुल',
@@ -7027,6 +7031,7 @@ const ar: UiStrings = {
     paidMost: 'الأكثر دفعًا',
     expenseCount: '{n} مصاريف',
     noneYet: 'لا شيء للتلخيص بعد',
+    categoryBudgets: 'ميزانيات الفئات',
   },
   budgets: 'الميزانية',
   overallBudget: 'الإجمالي',

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -496,6 +496,8 @@ export interface MirrorGroup extends MirrorRow {
   readonly archived_at: string | null;
   readonly budget_minor?: string | null;
   readonly budget_currency?: string | null;
+  /** Per-category caps, keyed by category id. Group-visible, admin-set. */
+  readonly category_budgets?: Record<string, { amountMinor: string; currency: string }> | null;
   readonly pending?: boolean;
 }
 
@@ -557,6 +559,30 @@ function buildGroups(state: MirrorState, queue: readonly QueuedMutation[]): Mirr
           budget_currency: payload.amountMinor === null ? null : (payload.currency ?? null),
           pending: true,
         });
+      }
+    }
+
+    // A per-category cap patches the group row's category_budgets map at once; a
+    // null amount removes that category's cap. Same optimistic path as the
+    // overall budget above.
+    if (mutation.kind === 'category_budget.set') {
+      const existing = byId.get(mutation.groupId);
+      if (existing) {
+        const payload = mutation.payload as {
+          category: string;
+          amountMinor: string | null;
+          currency?: string | null;
+        };
+        const map = { ...(existing.category_budgets ?? {}) };
+        if (payload.amountMinor === null) {
+          delete map[payload.category];
+        } else {
+          map[payload.category] = {
+            amountMinor: payload.amountMinor,
+            currency: payload.currency ?? existing.default_currency,
+          };
+        }
+        byId.set(mutation.groupId, { ...existing, category_budgets: map, pending: true });
       }
     }
   }

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -53,6 +53,7 @@ export enum MutationKind {
   MemberBudgetSet = 'member_budget.set',
   MemberBudgetClear = 'member_budget.clear',
   GroupBudgetSet = 'group_budget.set',
+  CategoryBudgetSet = 'category_budget.set',
 }
 
 export interface MutationEnvelope<K extends MutationKind = MutationKind, P = unknown> {
@@ -267,6 +268,18 @@ export type MemberBudgetClearPayload = Record<string, never>;
 
 /** The overall trip budget on the group row; null amount clears it. Admin-only. */
 export interface GroupBudgetSetPayload {
+  readonly amountMinor: string | null;
+  readonly currency?: CurrencyCode | null;
+}
+
+/**
+ * A per-category cap in the group row's `category_budgets` map, keyed by the
+ * category id (a built-in key or a custom tag id). A null amount removes that
+ * category's cap. Admin-only, like the overall budget — a category cap is a
+ * group signal, never private.
+ */
+export interface CategoryBudgetSetPayload {
+  readonly category: string;
   readonly amountMinor: string | null;
   readonly currency?: CurrencyCode | null;
 }

--- a/packages/core/src/trip/budget.ts
+++ b/packages/core/src/trip/budget.ts
@@ -26,6 +26,14 @@ export interface SharedExpense {
   readonly shares: Readonly<Record<string, bigint>>;
 }
 
+/** One expense, reduced to what a category budget needs: its category, currency
+ *  and full amount (a category cap measures the group's spend, not one share). */
+export interface CategorisedExpense {
+  readonly category: string | null;
+  readonly currency: string;
+  readonly amountMinor: bigint;
+}
+
 /** A ceiling: an amount in one currency. */
 export interface Budget {
   readonly amountMinor: bigint;
@@ -65,6 +73,28 @@ export function spendByMember(
       row[currency] = (row[currency] ?? 0n) + share;
       out.set(member, row);
     }
+  }
+  return out;
+}
+
+/**
+ * Group spend per category, per currency (ADR-004: never mixed). Uncategorised
+ * spend (a null category) is left out — a cap is only ever set on a named
+ * category, so folding "Other" in would measure it against nothing.
+ *
+ * Unlike `spendByMember`, this sums the whole expense amount, not a share: a
+ * category cap is the group's ceiling on food/stays/transport, not one person's.
+ */
+export function spendByCategory(
+  expenses: readonly CategorisedExpense[],
+): Map<string, Record<string, bigint>> {
+  const out = new Map<string, Record<string, bigint>>();
+  for (const expense of expenses) {
+    if (!expense.category) continue;
+    const currency = expense.currency.toUpperCase();
+    const row = out.get(expense.category) ?? {};
+    row[currency] = (row[currency] ?? 0n) + expense.amountMinor;
+    out.set(expense.category, row);
   }
   return out;
 }

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -778,6 +778,67 @@ describe('overall trip budget rides the group row', () => {
   });
 });
 
+describe('category budgets ride the group row', () => {
+  const base: SyncChange = {
+    table: SyncTable.Groups,
+    groupId: GROUP,
+    seq: 1,
+    row: {
+      id: GROUP,
+      name: 'Goa',
+      default_currency: 'INR',
+      created_at: AT,
+      archived_at: null,
+      category_budgets: null,
+    },
+  };
+
+  it('sets a category cap optimistically on the group', () => {
+    const mirror = reconcile(emptyMirror(), [base]).state;
+    const set = envelope('c-1', MutationKind.CategoryBudgetSet, {
+      category: 'food',
+      amountMinor: '500000',
+      currency: 'INR',
+    });
+    const [row] = materialiseGroups(mirror, queued(set));
+    expect(row?.category_budgets).toEqual({ food: { amountMinor: '500000', currency: 'INR' } });
+    expect(row?.pending).toBe(true);
+  });
+
+  it('removes one category cap with a null amount, keeping the others', () => {
+    const withCaps = reconcile(emptyMirror(), [
+      {
+        ...base,
+        row: {
+          ...base.row,
+          category_budgets: {
+            food: { amountMinor: '500000', currency: 'INR' },
+            stays: { amountMinor: '900000', currency: 'INR' },
+          },
+        },
+      },
+    ]).state;
+    const clear = envelope('c-2', MutationKind.CategoryBudgetSet, {
+      category: 'food',
+      amountMinor: null,
+    });
+    const [row] = materialiseGroups(withCaps, queued(clear));
+    expect(row?.category_budgets).toEqual({ stays: { amountMinor: '900000', currency: 'INR' } });
+  });
+
+  it('defaults a cap to the group currency when none is given', () => {
+    const mirror = reconcile(emptyMirror(), [base]).state;
+    const set = envelope('c-3', MutationKind.CategoryBudgetSet, {
+      category: 'transport',
+      amountMinor: '100000',
+    });
+    const [row] = materialiseGroups(mirror, queued(set));
+    expect(row?.category_budgets).toEqual({
+      transport: { amountMinor: '100000', currency: 'INR' },
+    });
+  });
+});
+
 describe('category tags', () => {
   const OWNER = 'user-1';
   const SCOPE = categoryTagsScope(OWNER);

--- a/packages/core/test/tripBudget.test.ts
+++ b/packages/core/test/tripBudget.test.ts
@@ -7,7 +7,13 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { budgetProgress, spendByMember, type SharedExpense } from '../src/trip/budget';
+import {
+  budgetProgress,
+  spendByCategory,
+  spendByMember,
+  type CategorisedExpense,
+  type SharedExpense,
+} from '../src/trip/budget';
 
 const expenses: SharedExpense[] = [
   { currency: 'INR', shares: { alice: 2000n, bob: 1000n } },
@@ -26,6 +32,38 @@ describe('spendByMember', () => {
     const spend = spendByMember([{ currency: 'INR', shares: { alice: 0n, bob: 500n } }]);
     expect(spend.has('alice')).toBe(false);
     expect(spend.get('bob')).toEqual({ INR: 500n });
+  });
+});
+
+describe('spendByCategory', () => {
+  const expenses: CategorisedExpense[] = [
+    { category: 'food', currency: 'INR', amountMinor: 4000n },
+    { category: 'food', currency: 'INR', amountMinor: 1500n },
+    { category: 'stays', currency: 'INR', amountMinor: 40000n },
+    { category: 'food', currency: 'THB', amountMinor: 9000n },
+    { category: null, currency: 'INR', amountMinor: 999n },
+  ];
+
+  it('sums the whole amount per category, per currency', () => {
+    const spend = spendByCategory(expenses);
+    // A category cap measures the group's spend, not one share — so it is the
+    // full amount, and rupees never fold into baht.
+    expect(spend.get('food')).toEqual({ INR: 5500n, THB: 9000n });
+    expect(spend.get('stays')).toEqual({ INR: 40000n });
+  });
+
+  it('leaves uncategorised spend out entirely', () => {
+    const spend = spendByCategory(expenses);
+    expect(spend.has('null')).toBe(false);
+    // The null-category ₹999 is not attributed to any category.
+    const totalInrAttributed = [...spend.values()].reduce((sum, row) => sum + (row.INR ?? 0n), 0n);
+    expect(totalInrAttributed).toBe(45500n);
+  });
+
+  it('measures a category cap against only that category’s spend', () => {
+    const spend = spendByCategory(expenses);
+    const p = budgetProgress({ amountMinor: 6000n, currency: 'INR' }, spend.get('food'));
+    expect(p).toMatchObject({ spentMinor: 5500n, remainingMinor: 500n, over: false });
   });
 });
 

--- a/packages/db/prisma/migrations/20260824130000_category_budgets/migration.sql
+++ b/packages/db/prisma/migrations/20260824130000_category_budgets/migration.sql
@@ -1,0 +1,96 @@
+-- Category budgets: a per-category cap for the trip — food, stays, transport,
+-- activities — beside the overall ceiling and the personal ones.
+--
+-- Same reasoning as the overall budget (20260813120000_trip_budgets): the ledger
+-- already holds what was spent, so this stores only the *targets* and the app
+-- draws a bar by dividing the category's spend by its cap. And like the overall
+-- budget — and unlike a personal budget — a category cap is a group signal, set
+-- by an admin and seen by everyone. So it needs no privacy, no row-level gate,
+-- and no table of its own: it lives on the already-group-visible group row as a
+-- JSON map, and rides the same mirror the overall budget does.
+--
+--   category_budgets = { "<category>": { "amountMinor": "<minor>", "currency": "INR" }, ... }
+--
+-- The category key is a built-in category id or a custom tag id — the same key
+-- the ledger's `category` column carries. `amountMinor` is a string, the shape
+-- the mirror and client already use for minor units in JSON.
+
+ALTER TABLE public.groups
+  ADD COLUMN IF NOT EXISTS category_budgets jsonb;
+
+-- The map must be an object when present. A malformed blob would break every
+-- reader; the RPC below is the only writer, but the constraint is cheap insurance.
+ALTER TABLE public.groups
+  DROP CONSTRAINT IF EXISTS groups_category_budgets_object;
+ALTER TABLE public.groups
+  ADD CONSTRAINT groups_category_budgets_object
+  CHECK (category_budgets IS NULL OR jsonb_typeof(category_budgets) = 'object');
+
+-- ────────────────────────────────────────────────────────────── writing ──
+
+/**
+ * Set (or clear) one category's cap. Admin only — a category ceiling is the
+ * group's, the same as the overall budget, so letting any member move it would
+ * make it nobody's. `p_amount_minor` NULL removes that category's key;
+ * otherwise it is upserted into the JSON map. `p_currency` NULL takes the
+ * group's default. Updating the row bumps `updated_seq` through the existing
+ * groups trigger, so the change rides the mirror to every device.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_set_category_budget(
+  p_group_id     uuid,
+  p_category     text,
+  p_amount_minor bigint  DEFAULT NULL,
+  p_currency     char(3) DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_currency char(3);
+BEGIN
+  IF NOT public.is_group_admin(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_AN_ADMIN: only an admin sets a category budget'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_category IS NULL OR btrim(p_category) = '' THEN
+    RAISE EXCEPTION 'INVALID_CATEGORY: a category is required'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF p_amount_minor IS NOT NULL AND p_amount_minor < 0 THEN
+    RAISE EXCEPTION 'INVALID_AMOUNT: a budget is zero or more'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT COALESCE(p_currency, default_currency) INTO v_currency
+  FROM public.groups WHERE id = p_group_id;
+
+  IF p_amount_minor IS NULL THEN
+    -- Clear: drop the key, leaving an empty object rather than NULL so the
+    -- column's type stays an object.
+    UPDATE public.groups SET
+      category_budgets = COALESCE(category_budgets, '{}'::jsonb) - p_category,
+      updated_at       = now()
+    WHERE id = p_group_id;
+  ELSE
+    UPDATE public.groups SET
+      category_budgets = jsonb_set(
+        COALESCE(category_budgets, '{}'::jsonb),
+        ARRAY[p_category],
+        jsonb_build_object(
+          'amountMinor', p_amount_minor::text,
+          'currency', upper(v_currency)
+        ),
+        true
+      ),
+      updated_at = now()
+    WHERE id = p_group_id;
+  END IF;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_set_category_budget(uuid, text, bigint, character)
+  TO authenticated, anon;

--- a/packages/db/prisma/migrations/20260824130000_category_budgets/migration.sql
+++ b/packages/db/prisma/migrations/20260824130000_category_budgets/migration.sql
@@ -94,3 +94,68 @@ $$;
 
 GRANT EXECUTE ON FUNCTION public.baaki_set_category_budget(uuid, text, bigint, character)
   TO authenticated, anon;
+
+-- ──────────────────────────────────────────────────────── write boundary ──
+--
+-- `groups` still carries the broad row-scoped UPDATE policy, so a signed-in
+-- client can `PATCH /groups?id=eq.<X>` under its own JWT and set any column the
+-- column guard does not pin (20260815120000). Left open, a NON-admin member
+-- could write `category_budgets` directly — bypassing the admin check in the
+-- RPC above — and could store a malformed shape that breaks every reader's
+-- `BigInt(amountMinor)`. Pin the column: a client may never write it. The only
+-- writer is `baaki_set_category_budget`, SECURITY DEFINER, which runs as the
+-- function owner and so clears the `current_user` gate below untouched.
+--
+-- Re-declared in full (CREATE OR REPLACE) from 20260815180000 so the existing
+-- updated_seq / created_by / id / created_at / photo_path guards are preserved;
+-- only the category_budgets block is added.
+CREATE OR REPLACE FUNCTION public.baaki_guard_group_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF current_user NOT IN ('anon', 'authenticated') THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.updated_seq IS DISTINCT FROM OLD.updated_seq THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: updated_seq is set by the server, not the client'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creator is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.id IS DISTINCT FROM OLD.id THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s id is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creation time is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- A group photo is a paid feature (ADR-011 addendum). Only gate setting one;
+  -- clearing it back to NULL is free and always allowed.
+  IF NEW.photo_path IS DISTINCT FROM OLD.photo_path
+     AND NEW.photo_path IS NOT NULL
+     AND NOT public.baaki_can_upload_group_photo(NEW.id) THEN
+    RAISE EXCEPTION 'PHOTO_GATE: a group photo is a paid feature'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Category caps are the group's, admin-set, and written only through
+  -- `baaki_set_category_budget` (owner-run, exempt above). A signed-in client
+  -- never writes this column directly — that is where the admin check and the
+  -- shape live.
+  IF NEW.category_budgets IS DISTINCT FROM OLD.category_budgets THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: category budgets are set through baaki_set_category_budget, not a direct write'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN NEW;
+END
+$$;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -209,6 +209,12 @@ model Group {
   /// where privacy lives — this one never is private.
   budgetMinor    BigInt? @map("budget_minor")
   budgetCurrency String? @map("budget_currency") @db.Char(3)
+  /// Per-category caps as a JSON map `{ "<category>": { amountMinor, currency } }`.
+  /// Group-visible and admin-set like the overall budget — a category cap is a
+  /// group signal, never private, so it lives on the group row, not its own
+  /// table. NULL / absent is "no category caps". Written only via
+  /// `baaki_set_category_budget`.
+  categoryBudgets Json? @map("category_budgets")
 
   /// When the trip is. Both ends inclusive — the last day of a trip is the one
   /// with the most unrecorded spending on it.

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -73,7 +73,8 @@ type MutationKind =
   | 'plan_item.delete'
   | 'member_budget.set'
   | 'member_budget.clear'
-  | 'group_budget.set';
+  | 'group_budget.set'
+  | 'category_budget.set';
 
 /** True for the kinds whose scope is a user, not a group. */
 function isPersonalKind(kind: MutationKind): boolean {
@@ -461,6 +462,15 @@ class SyncSession {
         // group.update, so any member cannot move the overall ceiling.
         return await this.rpcAsCaller('baaki_set_group_budget', {
           p_group_id: mutation.groupId,
+          p_amount_minor: (mutation.payload.amountMinor as string | null) ?? null,
+          p_currency: (mutation.payload.currency as string | undefined) ?? null,
+        });
+      case 'category_budget.set':
+        // Admin-gated inside the RPC, same as the overall budget; a null amount
+        // clears that category's cap.
+        return await this.rpcAsCaller('baaki_set_category_budget', {
+          p_group_id: mutation.groupId,
+          p_category: mutation.payload.category as string,
           p_amount_minor: (mutation.payload.amountMinor as string | null) ?? null,
           p_currency: (mutation.payload.currency as string | undefined) ?? null,
         });


### PR DESCRIPTION
## What
A cap per category — food, stays, transport, activities — beside the existing overall and personal trip budgets on the plan screen.

## Design
Like the overall budget and **unlike** a personal one, a category cap is the group's: admin-set, group-visible. So it needs no privacy gate and **no table of its own** — it lives on the already-group-visible `groups` row as a JSON map (`category_budgets`) and rides the same offline mirror the overall budget does (ADR-005).

- **schema/migration:** `groups.category_budgets jsonb` + `baaki_set_category_budget` admin RPC (upsert a category key; null amount clears it) + object-shape CHECK.
- **core:** `spendByCategory` (group spend per category per currency — ADR-004, never mixed; uncategorised excluded); sync `CategoryBudgetSet` + optimistic overlay onto the group row.
- **edge:** sync dispatch `category_budget.set` → the admin RPC.
- **app:** `useCategoryBudgets`/`useSetCategoryBudget`; `CategoryBudgets` component (bars vs spend, admin add/clear via the existing category picker); wired into `plan.tsx` for trips; i18n en/ta/hi/ar.

## Security
Safe as a group-row column **precisely because** category caps are group-visible by design — the sync pull returns the row to every member, which is correct here. (Contrast the party-only data in the #403 review, which must *not* be a column on a shared row.)

## Tests
`spendByCategory` + the mirror overlay (set / clear-one / default-currency). Core suite, core/mobile/db typecheck, lint all green. Migration validates on the CI Postgres job.

## Not deployed
Prod DB password is still blocked (28P01); no migration/edge deploy. The edge `category_budget.set` dispatch needs an `edge:deploy` when prod is reconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category-based budgets to trip plans.
  * Administrators can create, edit, save, cancel, and clear budgets for individual spending categories.
  * View spending progress by category, including currency amounts and over-budget indicators.
  * Budget updates are saved locally first and synchronized automatically.
  * Budget sections with no configured budgets remain hidden from non-administrators.
  * Added English, Tamil, Hindi, and Arabic translations for the new budget section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->