### PR TITLE
feat(trip): shared album — group photos, offline-first, R2 (A45)

### DIFF
--- a/apps/mobile/src/app/group/[id]/album.tsx
+++ b/apps/mobile/src/app/group/[id]/album.tsx
@@ -1,0 +1,156 @@
+/**
+ * The trip album — every shared photo, as a grid (plan feature #2).
+ *
+ * A read of the mirror (ADR-005), so it opens with no connection: photos added
+ * offline sit in the queue and show at once, a removal is a tombstone that
+ * reaches every device. Any member may add or remove — a shared album only its
+ * author can prune goes stale the way a shared plan would.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { Alert, ScrollView, useWindowDimensions, View } from 'react-native';
+
+import {
+  Button,
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  iconSize,
+  Screen,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { AlbumThumb, AlbumViewer, useAlbumUpload } from '@/components/TripAlbum';
+import { useGroup, useRemoveTripPhoto, useTripPhotos, type TripPhotoRow } from '@/data/hooks';
+import { useStrings } from '@/i18n';
+
+const COLUMNS = 3;
+
+export default function AlbumScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t } = useStrings();
+  const { width } = useWindowDimensions();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const groupId = id ?? '';
+
+  const { group } = useGroup(groupId);
+  const photos = useTripPhotos(groupId);
+  const { addPhoto, uploading, error, clearError } = useAlbumUpload(groupId);
+  const remove = useRemoveTripPhoto(groupId);
+
+  const [viewing, setViewing] = useState<TripPhotoRow | null>(null);
+
+  const gap = theme.spacing.sm;
+  const side = theme.spacing.xl;
+  const cell = Math.floor((width - side * 2 - gap * (COLUMNS - 1)) / COLUMNS);
+
+  const confirmRemove = (photo: TripPhotoRow) => {
+    Alert.alert(t.album.removeConfirm, undefined, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.album.remove,
+        style: 'destructive',
+        onPress: () => {
+          setViewing(null);
+          remove.mutate({ photoId: photo.id, storagePath: photo.storagePath });
+        },
+      },
+    ]);
+  };
+
+  const rows = photos.data;
+
+  return (
+    <Screen>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: side,
+          paddingTop: theme.spacing.md,
+        }}
+      >
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.album.title}</Text>
+          <Text variant="micro" tone="muted">
+            {group.data?.name}
+          </Text>
+        </View>
+        <IconButton label={t.album.add} onPress={() => void addPhoto()}>
+          <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
+        </IconButton>
+      </View>
+
+      {error ? (
+        <View style={{ paddingHorizontal: side, paddingTop: theme.spacing.sm }}>
+          <Text variant="caption" tone="negative" onPress={clearError}>
+            {error === 'cap' ? t.storage.full : t.couldNotSave}
+          </Text>
+        </View>
+      ) : null}
+
+      {rows.length === 0 ? (
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            paddingHorizontal: side,
+            gap: theme.spacing.lg,
+          }}
+        >
+          <EmptyState
+            title={t.album.empty}
+            body={t.album.emptyBody}
+            action={
+              <Button
+                label={uploading ? t.album.uploading : t.album.add}
+                onPress={() => void addPhoto()}
+                disabled={uploading}
+              />
+            }
+          />
+        </View>
+      ) : (
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: side,
+            paddingTop: theme.spacing.lg,
+            paddingBottom: clearance,
+          }}
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap }}>
+            {rows.map((photo) => (
+              <AlbumThumb
+                key={photo.id}
+                path={photo.storagePath}
+                size={cell}
+                dimmed={photo.pending}
+                onPress={() => setViewing(photo)}
+              />
+            ))}
+          </View>
+        </ScrollView>
+      )}
+
+      <AlbumViewer
+        photo={viewing}
+        onClose={() => setViewing(null)}
+        onRemove={confirmRemove}
+        removing={remove.isPending}
+      />
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -26,6 +26,7 @@ import {
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
+import { TripAlbumStrip } from '@/components/TripAlbum';
 import {
   memberLookup,
   useDeleteExpense,
@@ -340,6 +341,11 @@ export default function ExpenseDetailScreen() {
             </Card>
           </Pressable>
         ) : null}
+
+        {/* The album strip for this bill — photos of the meal, the room, the view.
+            Distinct from the receipt above: many, free, and browsed for the memory
+            rather than the amount. */}
+        <TripAlbumStrip groupId={groupId} expenseId={expense.id} />
 
         {version.payers.length > 1 ? (
           <View>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -354,6 +354,7 @@ export default function GroupScreen() {
   // a trip to plan; a flatshare has no use for the row.
   const menuItems: OverflowMenuItem[] = [
     { icon: 'pie-chart-outline', label: t.spending, route: `/group/${groupId}/insights` },
+    { icon: 'images-outline', label: t.album.title, route: `/group/${groupId}/album` },
     ...(group.data.type === 'trip'
       ? [
           {

--- a/apps/mobile/src/components/TripAlbum.tsx
+++ b/apps/mobile/src/components/TripAlbum.tsx
@@ -1,0 +1,331 @@
+/**
+ * The trip album — shared photos, the memory layer (plan feature #2).
+ *
+ * A third photo concept next to the group cover and a receipt: many per trip,
+ * free for any member to add, browsable as a grid on its own screen and as a
+ * strip under an expense. The pieces here are shared between those two surfaces
+ * so an "add" and a "remove" behave the same wherever they appear.
+ *
+ * The bytes go to Cloudflare R2 under the `trip-photos` bucket through the same
+ * storage seam every image uses (`putImage`/`imageUrl`/`removeImage`); this file
+ * only ever holds the object path. The image is re-encoded before it leaves the
+ * phone, which is what strips its EXIF GPS — an album photo must not carry the
+ * place it was taken to everyone in the group.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Image } from 'expo-image';
+import { randomUUID } from 'expo-crypto';
+import { ActivityIndicator, Alert, Modal, Pressable, ScrollView, View } from 'react-native';
+
+import { IconButton, iconSize, Text, useTheme } from '@waves/ui';
+
+import { ZoomableImage } from '@/components/ZoomableImage';
+import {
+  useAddTripPhoto,
+  useRemoveTripPhoto,
+  useTripPhotos,
+  type TripPhotoRow,
+} from '@/data/hooks';
+import { pickAlbumPhoto } from '@/lib/image';
+import { imageUrl, putImage, StorageCapError } from '@/lib/storage';
+import { useStrings } from '@/i18n';
+
+/**
+ * Resolve an object path to a signed URL, cached across mounts.
+ *
+ * A grid of a dozen thumbnails must not fire a dozen edge calls on every render.
+ * Signed URLs live an hour; this keeps each resolved URL for fifty minutes, so
+ * the same photo shown in the grid and again in the viewer is signed once.
+ */
+const urlCache = new Map<string, { url: string; at: number }>();
+const URL_CACHE_MS = 50 * 60 * 1000;
+
+function cachedUrl(path: string | null): string | null {
+  if (!path) return null;
+  const hit = urlCache.get(path);
+  return hit && Date.now() - hit.at < URL_CACHE_MS ? hit.url : null;
+}
+
+function useResolvedImage(path: string | null): string | null {
+  // What is known synchronously — a cache hit — is derived at render, never
+  // pushed through setState in an effect (that cascades renders). The async
+  // resolve is the only writer, and its result is keyed by the path it was for,
+  // so a fast scroll to a new photo never shows the previous one's URL.
+  const cached = cachedUrl(path);
+  const [fetched, setFetched] = useState<{ path: string; url: string | null } | null>(null);
+
+  useEffect(() => {
+    if (!path || cachedUrl(path)) return; // Nothing to fetch.
+    let active = true;
+    void (async () => {
+      const resolved = await imageUrl('trip-photos', path);
+      if (!active) return;
+      if (resolved) urlCache.set(path, { url: resolved, at: Date.now() });
+      setFetched({ path, url: resolved });
+    })();
+    return () => {
+      active = false;
+    };
+  }, [path]);
+
+  if (cached) return cached;
+  return fetched && fetched.path === path ? fetched.url : null;
+}
+
+/** One tappable album thumbnail. A path that will not resolve is a calm blank,
+ *  never a crash — a photo removed on another device simply shows nothing. */
+export function AlbumThumb({
+  path,
+  size,
+  onPress,
+  dimmed,
+}: {
+  path: string;
+  size: number;
+  onPress?: () => void;
+  dimmed?: boolean;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const url = useResolvedImage(path);
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={!onPress}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: theme.radius.md,
+        overflow: 'hidden',
+        backgroundColor: theme.color.surfaceMuted,
+        opacity: dimmed ? 0.5 : 1,
+      }}
+    >
+      {url ? (
+        <Image source={{ uri: url }} style={{ width: '100%', height: '100%' }} contentFit="cover" />
+      ) : (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={theme.color.textFaint} />
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+/**
+ * Pick, shrink, upload and record one album photo. The upload happens before the
+ * mutation is queued — the object path is what the queued `trip_photo.add`
+ * carries, and it has to exist first. A storage-cap refusal is surfaced as a
+ * distinct message the person can act on; anything else is a generic failure.
+ */
+export function useAlbumUpload(groupId: string): {
+  addPhoto: (opts?: { expenseId?: string | null; day?: string | null }) => Promise<void>;
+  uploading: boolean;
+  error: 'cap' | 'failed' | null;
+  clearError: () => void;
+} {
+  const add = useAddTripPhoto(groupId);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<'cap' | 'failed' | null>(null);
+  // Guard against a double-tap kicking off two pickers at once.
+  const busy = useRef(false);
+
+  const addPhoto = async (opts?: { expenseId?: string | null; day?: string | null }) => {
+    if (busy.current) return;
+    busy.current = true;
+    setError(null);
+    try {
+      const picked = await pickAlbumPhoto();
+      if (!picked) return; // Cancelled or declined — an ordinary answer.
+      setUploading(true);
+      const ext = picked.mimeType === 'image/webp' ? 'webp' : 'jpg';
+      const path = `${groupId}/${randomUUID()}.${ext}`;
+      await putImage({
+        bucket: 'trip-photos',
+        path,
+        base64: picked.base64,
+        contentType: picked.mimeType,
+        groupId,
+      });
+      await add.mutateAsync({
+        storagePath: path,
+        expenseId: opts?.expenseId ?? null,
+        day: opts?.day ?? null,
+      });
+    } catch (caught) {
+      setError(caught instanceof StorageCapError ? 'cap' : 'failed');
+    } finally {
+      setUploading(false);
+      busy.current = false;
+    }
+  };
+
+  return { addPhoto, uploading, error, clearError: () => setError(null) };
+}
+
+/** The full-screen viewer: pinch-to-zoom, with a remove action for any member. */
+export function AlbumViewer({
+  photo,
+  onClose,
+  onRemove,
+  removing,
+}: {
+  photo: TripPhotoRow | null;
+  onClose: () => void;
+  onRemove: (photo: TripPhotoRow) => void;
+  removing: boolean;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const url = useResolvedImage(photo?.storagePath ?? null);
+
+  return (
+    <Modal
+      visible={photo !== null}
+      animationType="fade"
+      onRequestClose={onClose}
+      transparent={false}
+    >
+      <View style={{ flex: 1, backgroundColor: theme.color.bg }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            paddingHorizontal: theme.spacing.xl,
+            paddingTop: theme.spacing.xxl,
+            paddingBottom: theme.spacing.sm,
+          }}
+        >
+          <IconButton label={t.common.close} onPress={onClose}>
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+          </IconButton>
+          {photo ? (
+            <IconButton
+              label={t.album.remove}
+              onPress={() => {
+                if (!removing) onRemove(photo);
+              }}
+            >
+              {removing ? (
+                <ActivityIndicator color={theme.color.negative} />
+              ) : (
+                <Ionicons name="trash-outline" size={iconSize.lg} color={theme.color.negative} />
+              )}
+            </IconButton>
+          ) : (
+            <View style={{ width: 44 }} />
+          )}
+        </View>
+
+        {url ? (
+          <ZoomableImage uri={url} />
+        ) : (
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            <ActivityIndicator color={theme.color.brand} />
+          </View>
+        )}
+
+        {photo?.caption ? (
+          <View style={{ padding: theme.spacing.xl }}>
+            <Text variant="caption" tone="muted">
+              {photo.caption}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+    </Modal>
+  );
+}
+
+/** Longest edge of a strip thumbnail. */
+const STRIP_THUMB = 96;
+
+/**
+ * The photo strip under one expense — the album filtered to this bill, plus an
+ * "add" tile. Self-contained: it owns its viewer and its remove, so an expense
+ * screen only has to drop it in. Hidden entirely when there is nothing to show
+ * and nothing to add would be surprising — so the add tile is always present.
+ */
+export function TripAlbumStrip({
+  groupId,
+  expenseId,
+}: {
+  groupId: string;
+  expenseId: string;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const photos = useTripPhotos(groupId, { expenseId });
+  const { addPhoto, uploading } = useAlbumUpload(groupId);
+  const remove = useRemoveTripPhoto(groupId);
+  const [viewing, setViewing] = useState<TripPhotoRow | null>(null);
+
+  const confirmRemove = (photo: TripPhotoRow) => {
+    Alert.alert(t.album.removeConfirm, undefined, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.album.remove,
+        style: 'destructive',
+        onPress: () => {
+          setViewing(null);
+          remove.mutate({ photoId: photo.id, storagePath: photo.storagePath });
+        },
+      },
+    ]);
+  };
+
+  return (
+    <View style={{ gap: theme.spacing.sm }}>
+      <Text variant="caption" tone="muted">
+        {t.album.photos}
+      </Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: theme.spacing.sm }}
+      >
+        <Pressable
+          onPress={() => void addPhoto({ expenseId })}
+          disabled={uploading}
+          accessibilityRole="button"
+          accessibilityLabel={t.album.add}
+          style={{
+            width: STRIP_THUMB,
+            height: STRIP_THUMB,
+            borderRadius: theme.radius.md,
+            borderWidth: 1,
+            borderColor: theme.color.border,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.color.surfaceMuted,
+          }}
+        >
+          {uploading ? (
+            <ActivityIndicator color={theme.color.brand} />
+          ) : (
+            <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
+          )}
+        </Pressable>
+
+        {photos.data.map((photo) => (
+          <AlbumThumb
+            key={photo.id}
+            path={photo.storagePath}
+            size={STRIP_THUMB}
+            dimmed={photo.pending}
+            onPress={() => setViewing(photo)}
+          />
+        ))}
+      </ScrollView>
+
+      <AlbumViewer
+        photo={viewing}
+        onClose={() => setViewing(null)}
+        onRemove={confirmRemove}
+        removing={remove.isPending}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/components/TripAlbum.tsx
+++ b/apps/mobile/src/components/TripAlbum.tsx
@@ -29,7 +29,7 @@ import {
   type TripPhotoRow,
 } from '@/data/hooks';
 import { pickAlbumPhoto } from '@/lib/image';
-import { imageUrl, putImage, StorageCapError } from '@/lib/storage';
+import { imageUrl, putImage, removeImage, StorageCapError } from '@/lib/storage';
 import { useStrings } from '@/i18n';
 
 /**
@@ -135,6 +135,10 @@ export function useAlbumUpload(groupId: string): {
     if (busy.current) return;
     busy.current = true;
     setError(null);
+    // Set once the bytes are committed to R2 — so a failure to queue the row
+    // afterwards can free them again rather than leave a committed object no
+    // trip_photo row references, silently eating the group's storage cap.
+    let committedPath: string | null = null;
     try {
       const picked = await pickAlbumPhoto();
       if (!picked) return; // Cancelled or declined — an ordinary answer.
@@ -148,12 +152,18 @@ export function useAlbumUpload(groupId: string): {
         contentType: picked.mimeType,
         groupId,
       });
+      committedPath = path;
+      // enqueue() persists the mutation before it resolves, so once this returns
+      // the row is durable and the object has an owner. If it throws, the object
+      // is orphaned — the catch below reclaims it.
       await add.mutateAsync({
         storagePath: path,
         expenseId: opts?.expenseId ?? null,
         day: opts?.day ?? null,
       });
+      committedPath = null;
     } catch (caught) {
+      if (committedPath) await removeImage('trip-photos', committedPath).catch(() => {});
       setError(caught instanceof StorageCapError ? 'cap' : 'failed');
     } finally {
       setUploading(false);

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -28,6 +28,7 @@ import {
   materialiseMembers,
   materialisePlanItems,
   materialiseSettlements,
+  materialiseTripPhotos,
   MutationKind,
   nextSortOrder,
   openCaptures,
@@ -85,6 +86,7 @@ import {
   type PersonContribution,
 } from './peopleBalances';
 import { totalsByCurrency } from './totals';
+import { removeImage } from '@/lib/storage';
 import { SettlementStatus } from './types';
 import type {
   ActivityActor,
@@ -1537,6 +1539,91 @@ export function useSetCategoryBudget(groupId: string) {
         amountMinor: input.amountMinor === null ? null : input.amountMinor.toString(),
         currency: input.currency ?? null,
       }),
+  });
+}
+
+// ─────────────────────────────────────────── trip album (shared photos) ──
+
+export interface TripPhotoRow {
+  id: string;
+  groupId: string;
+  expenseId: string | null;
+  day: string | null;
+  storagePath: string;
+  caption: string | null;
+  createdBy: string | null;
+  createdAt: string | null;
+  /** Still in the queue — uploaded, not yet acknowledged by the server. */
+  pending: boolean;
+}
+
+/**
+ * The trip album, read from the mirror so it opens with no connection. Removed
+ * photos (tombstones) are filtered out here. `expenseId` narrows to the strip on
+ * one expense; omitting it returns the whole album, newest first.
+ */
+export function useTripPhotos(
+  groupId: string,
+  opts?: { expenseId?: string },
+): LocalRead<TripPhotoRow[]> {
+  const { mirror, queue } = useSync();
+  const expenseId = opts?.expenseId;
+  const photos = useMemo(() => {
+    return materialiseTripPhotos(mirror, queue, { groupId })
+      .filter((row) => row.deleted_at === null || row.deleted_at === undefined)
+      .filter((row) => (expenseId ? row.expense_id === expenseId : true))
+      .map((row): TripPhotoRow => ({
+        id: row.id,
+        groupId: row.group_id,
+        expenseId: row.expense_id,
+        day: row.day,
+        storagePath: row.storage_path,
+        caption: row.caption,
+        createdBy: row.created_by,
+        createdAt: row.created_at,
+        pending: row.pending === true,
+      }));
+  }, [mirror, queue, groupId, expenseId]);
+  return useLocalRead(photos);
+}
+
+/**
+ * Record an album photo, queued. The bytes are uploaded by the caller first
+ * (through the storage seam), and its returned path is passed here; the client
+ * chooses the id so the overlay and the RPC's replay guard both key on it.
+ */
+export function useAddTripPhoto(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: (input: {
+      storagePath: string;
+      expenseId?: string | null;
+      day?: string | null;
+      caption?: string | null;
+    }) =>
+      mutate(MutationKind.TripPhotoAdd, groupId, {
+        photoId: randomUUID(),
+        storagePath: input.storagePath,
+        expenseId: input.expenseId ?? null,
+        day: input.day ?? null,
+        caption: input.caption ?? null,
+      }),
+  });
+}
+
+/**
+ * Remove an album photo, queued. Soft-deletes the row (a tombstone the pull
+ * carries to every device) and, best-effort while online, frees the R2 bytes
+ * through the storage seam. If offline the bytes stay until the storage sweep
+ * reclaims them — the tombstone still propagates either way.
+ */
+export function useRemoveTripPhoto(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: async (input: { photoId: string; storagePath: string }) => {
+      await mutate(MutationKind.TripPhotoDelete, groupId, { photoId: input.photoId });
+      await removeImage('trip-photos', input.storagePath).catch(() => {});
+    },
   });
 }
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -342,6 +342,18 @@ export interface UiStrings {
     noneYet: string;
     categoryBudgets: string;
   };
+  /** Trip album (shared photos). */
+  album: {
+    title: string;
+    add: string;
+    empty: string;
+    emptyBody: string;
+    remove: string;
+    removeConfirm: string;
+    /** Header of the photo strip on an expense. */
+    photos: string;
+    uploading: string;
+  };
   /** Trip budgets. */
   budgets: string;
   overallBudget: string;
@@ -2001,6 +2013,16 @@ const en: UiStrings = {
     expenseCount: '{n} expenses',
     noneYet: 'Nothing to recap yet',
     categoryBudgets: 'Category budgets',
+  },
+  album: {
+    title: 'Album',
+    add: 'Add photo',
+    empty: 'No photos yet',
+    emptyBody: 'Photos you add to this trip show up here for everyone.',
+    remove: 'Remove photo',
+    removeConfirm: 'Remove this photo?',
+    photos: 'Photos',
+    uploading: 'Adding…',
   },
   budgets: 'Budgets',
   overallBudget: 'Overall',
@@ -3677,6 +3699,16 @@ const ta: UiStrings = {
     expenseCount: '{n} செலவுகள்',
     noneYet: 'இன்னும் சுருக்க எதுவும் இல்லை',
     categoryBudgets: 'வகை பட்ஜெட்',
+  },
+  album: {
+    title: 'ஆல்பம்',
+    add: 'படம் சேர்',
+    empty: 'இன்னும் படங்கள் இல்லை',
+    emptyBody: 'இந்த பயணத்திற்கு நீங்கள் சேர்க்கும் படங்கள் அனைவருக்கும் இங்கே தோன்றும்.',
+    remove: 'படத்தை நீக்கு',
+    removeConfirm: 'இந்தப் படத்தை நீக்கவா?',
+    photos: 'படங்கள்',
+    uploading: 'சேர்க்கிறது…',
   },
   budgets: 'பட்ஜெட்',
   overallBudget: 'மொத்தம்',
@@ -5419,6 +5451,16 @@ const hi: UiStrings = {
     noneYet: 'अभी सार के लिए कुछ नहीं',
     categoryBudgets: 'श्रेणी बजट',
   },
+  album: {
+    title: 'एल्बम',
+    add: 'फ़ोटो जोड़ें',
+    empty: 'अभी कोई फ़ोटो नहीं',
+    emptyBody: 'इस ट्रिप में आप जो फ़ोटो जोड़ेंगे वे यहाँ सबको दिखेंगी।',
+    remove: 'फ़ोटो हटाएँ',
+    removeConfirm: 'यह फ़ोटो हटाएँ?',
+    photos: 'फ़ोटो',
+    uploading: 'जोड़ रहे हैं…',
+  },
   budgets: 'बजट',
   overallBudget: 'कुल',
   myBudget: 'मेरा बजट',
@@ -7109,6 +7151,16 @@ const ar: UiStrings = {
     expenseCount: '{n} مصاريف',
     noneYet: 'لا شيء للتلخيص بعد',
     categoryBudgets: 'ميزانيات الفئات',
+  },
+  album: {
+    title: 'الألبوم',
+    add: 'إضافة صورة',
+    empty: 'لا توجد صور بعد',
+    emptyBody: 'الصور التي تضيفها لهذه الرحلة تظهر هنا للجميع.',
+    remove: 'إزالة الصورة',
+    removeConfirm: 'إزالة هذه الصورة؟',
+    photos: 'الصور',
+    uploading: 'جارٍ الإضافة…',
   },
   budgets: 'الميزانية',
   overallBudget: 'الإجمالي',

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -221,8 +221,14 @@ export const ALBUM_MAX_EDGE = 1600;
  *
  * Re-encoding through the manipulator is what strips the EXIF metadata (a beach
  * photo should not carry the GPS of where it was taken into a shared album), so
- * the resize here is a privacy step as much as a size one. Returns null when the
- * person cancels or declines access — both ordinary answers, not errors.
+ * the resize here is a privacy step as much as a size one.
+ *
+ * And unlike a receipt, there is **no `readUnshrunk` fallback**: a receipt's
+ * audience is the group's ledger and losing the resize only costs bytes, but an
+ * album photo is group-visible and uploading the untouched original would ship
+ * its GPS EXIF to everyone. So if the manipulator cannot run (a dev client built
+ * before it existed), the add fails safe — null, no upload — rather than leak a
+ * location. Returns null for a cancel/decline too; both are ordinary answers.
  */
 export async function pickAlbumPhoto(): Promise<PickedImage | null> {
   const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
@@ -238,14 +244,16 @@ export async function pickAlbumPhoto(): Promise<PickedImage | null> {
   const asset = result.assets[0];
   if (!asset) return null;
 
-  const shrunk =
-    (await shrink({
-      uri: asset.uri,
-      width: asset.width,
-      height: asset.height,
-      maxEdge: ALBUM_MAX_EDGE,
-      compress: 0.8,
-    })) ?? (await readUnshrunk(asset.uri));
+  const shrunk = await shrink({
+    uri: asset.uri,
+    width: asset.width,
+    height: asset.height,
+    maxEdge: ALBUM_MAX_EDGE,
+    compress: 0.8,
+  });
+  // No un-stripped fallback — see the doc comment. A missing manipulator means
+  // "cannot add safely", which reads as a cancel to the caller.
+  if (!shrunk) return null;
   return { base64: shrunk.base64, mimeType: shrunk.mimeType ?? 'image/jpeg', uri: shrunk.uri };
 }
 

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -212,6 +212,43 @@ export async function pickSquarePhoto(maxEdge: number): Promise<PickedImage | nu
 export const pickAvatarPhoto = () => pickSquarePhoto(AVATAR_MAX_EDGE);
 export const pickGroupPhoto = () => pickSquarePhoto(COVER_MAX_EDGE);
 
+/** Longest edge for an album photo — big enough to look good full-screen,
+ *  small enough to stay light in the free-tier storage cap. */
+export const ALBUM_MAX_EDGE = 1600;
+
+/**
+ * A photo for the trip album — from the library, uncropped, any shape.
+ *
+ * Re-encoding through the manipulator is what strips the EXIF metadata (a beach
+ * photo should not carry the GPS of where it was taken into a shared album), so
+ * the resize here is a privacy step as much as a size one. Returns null when the
+ * person cancels or declines access — both ordinary answers, not errors.
+ */
+export async function pickAlbumPhoto(): Promise<PickedImage | null> {
+  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (!permission.granted) return null;
+
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images'],
+    quality: 1,
+    base64: false,
+  });
+  if (result.canceled) return null;
+
+  const asset = result.assets[0];
+  if (!asset) return null;
+
+  const shrunk =
+    (await shrink({
+      uri: asset.uri,
+      width: asset.width,
+      height: asset.height,
+      maxEdge: ALBUM_MAX_EDGE,
+      compress: 0.8,
+    })) ?? (await readUnshrunk(asset.uri));
+  return { base64: shrunk.base64, mimeType: shrunk.mimeType ?? 'image/jpeg', uri: shrunk.uri };
+}
+
 /**
  * A receipt, from the camera by default (ADR-008). Not cropped to a square and
  * not compressed as hard: fidelity is worth the bytes when a model has to read

--- a/apps/mobile/src/lib/storage/index.ts
+++ b/apps/mobile/src/lib/storage/index.ts
@@ -21,7 +21,7 @@ import { decode } from 'base64-arraybuffer';
 import { supabase } from '@/lib/supabase';
 
 /** The four private buckets. Values match the R2 namespace and the old bucket. */
-export type LogicalBucket = 'receipts' | 'group-photos' | 'avatars' | 'captures';
+export type LogicalBucket = 'receipts' | 'group-photos' | 'avatars' | 'captures' | 'trip-photos';
 
 /**
  * The free-tier storage ceiling was hit. Thrown so a caller can show the upgrade

--- a/docs/trip-album.md
+++ b/docs/trip-album.md
@@ -50,6 +50,12 @@ thing — a group's shared, non-money list that must work offline:
 New capability, not in the current TDR/ADR. Owed: a short addendum to
 `baaki-adr.md` recording the three-photo-concepts split and the album's
 free/membership-only storage rule, and a TDR note that `trip_photos` is a
-group-scoped, mirror-backed, non-money table. Not deployed (prod DB password is
-stale, 28P01): the migration and the `trip_photo.*` sync dispatch need a
-`db:migrate deploy` + `edge:deploy` window, like the category-budgets work.
+group-scoped, mirror-backed, non-money table.
+
+**Release gate.** The mobile album UI uploads to `trip-photos` and queues
+`trip_photo.add`/`trip_photo.delete`; production must have the migration
+`20260824140000_trip_album` **and** the updated `sync` + `r2-sign` functions
+first, or a client add fails to record and a browse shows nothing. Not deployed
+(prod DB password is stale, 28P01): gate the mobile release on a successful
+`pnpm db:migrate` + `pnpm edge:deploy`, the same window the category-budgets
+work needs.

--- a/docs/trip-album.md
+++ b/docs/trip-album.md
@@ -1,0 +1,55 @@
+# Trip album — the third photo concept
+
+Status: **built** (this PR). A formal addendum to `baaki-adr.md` is owed — see
+_Deviation_ below.
+
+## Why a new table, not another column
+
+The app already had two photo concepts, and the album is neither:
+
+| Concept         | Where it lives              | How many        | Who / cost                                       | Browsed as                           |
+| --------------- | --------------------------- | --------------- | ------------------------------------------------ | ------------------------------------ |
+| Group **cover** | `groups.photo_path`         | one per group   | admin, **paid** (`baaki_can_upload_group_photo`) | the group's identity                 |
+| **Receipt**     | `receipts` bucket + expense | one per expense | any member, evidence of a bill                   | a full-screen viewer, for the amount |
+| **Album** photo | `trip_photos` (new)         | many per trip   | any member, **free**                             | a grid / a strip, for the memory     |
+
+Folding the album into either of the other two would break something concrete:
+a receipt is one-per-expense and read by OCR; a cover is one-per-group and paid.
+The album is many, free, and optionally pinned to an expense **or** just a day.
+So it is its own table.
+
+## Shape
+
+`trip_photos` mirrors `trip_plan_items` exactly, because it is the same kind of
+thing — a group's shared, non-money list that must work offline:
+
+- **Not money.** It moves no balance, touches no split, appears in no export.
+- **Offline-first (ADR-005).** `updated_seq` + the shared `baaki_stamp_seq`
+  trigger, so the `/sync` pull carries it; a removal is a soft-delete
+  `deleted_at` tombstone (a hard `DELETE` never reaches a seq-based pull), which
+  the client mirror filters out.
+- **RPC-only writes.** `REVOKE ALL … GRANT SELECT`; `baaki_add_trip_photo` /
+  `baaki_remove_trip_photo` are the only way in, so `created_by` comes from the
+  session, not a client argument, and an expense link is validated against the
+  same group (no pinning to a stranger's bill).
+
+## Storage & privacy
+
+- Bytes go to Cloudflare R2 under a new logical bucket `trip-photos`, brokered by
+  `r2-sign` (the client holds no R2 key). A `get`/`put` is authorised by group
+  membership — **no paid gate**, unlike the cover. Album photos count against the
+  free-tier storage cap exactly like a receipt (`baaki_storage_reserve/record`).
+- **EXIF is stripped on device.** The photo is re-encoded (WebP, JPEG fallback)
+  before upload, which drops GPS/orientation metadata — a beach photo must not
+  carry the place it was taken into a shared album.
+- A removal soft-deletes the row (tombstone) and, best-effort while online, frees
+  the R2 bytes through `r2-sign`; the storage sweep is the backstop offline.
+
+## Deviation
+
+New capability, not in the current TDR/ADR. Owed: a short addendum to
+`baaki-adr.md` recording the three-photo-concepts split and the album's
+free/membership-only storage rule, and a TDR note that `trip_photos` is a
+group-scoped, mirror-backed, non-money table. Not deployed (prod DB password is
+stale, 28P01): the migration and the `trip_photo.*` sync dispatch need a
+`db:migrate deploy` + `edge:deploy` window, like the category-budgets work.

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -37,6 +37,8 @@ import type {
   SyncChange,
   TagDeletePayload,
   TagUpsertPayload,
+  TripPhotoAddPayload,
+  TripPhotoDeletePayload,
 } from './protocol';
 import type { QueuedMutation } from './queue';
 
@@ -64,6 +66,7 @@ const TABLES: readonly SyncTable[] = [
   SyncTable.CategoryTags,
   SyncTable.TripPlanItems,
   SyncTable.TripMemberBudgets,
+  SyncTable.TripPhotos,
 ];
 
 export function emptyMirror(): MirrorState {
@@ -975,6 +978,87 @@ export function materialisePlanItems(
       return a.pending_rank - b.pending_rank;
     }
     return String(a.id).localeCompare(String(b.id));
+  });
+}
+
+/** One album photo as the mirror holds it (server row shape + optimistic flags). */
+export interface MirrorTripPhoto extends MirrorRow {
+  readonly id: string;
+  readonly group_id: string;
+  readonly expense_id: string | null;
+  readonly day: string | null;
+  readonly storage_path: string;
+  readonly caption: string | null;
+  readonly created_by: string | null;
+  readonly created_at: string | null;
+  readonly deleted_at: string | null;
+  readonly pending?: boolean;
+  /** Queue order for a pending add, so newest-first stays the typed order. */
+  readonly pending_rank?: number;
+}
+
+/**
+ * The album of one group: server rows with queued add/delete on top. Tombstones
+ * (`deleted_at`) are kept in the returned list, exactly like the plan — the
+ * caller filters them, which lets a screen that wants to show "removed" do so.
+ * Newest first (a gallery reads most-recent-first); a pending add, which has no
+ * server `created_at` yet, sorts to the very top by its queue order.
+ */
+export function materialiseTripPhotos(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: { readonly groupId: string },
+): MirrorTripPhoto[] {
+  const byId = new Map<string, MirrorTripPhoto>();
+  for (const row of rowsFor(state, SyncTable.TripPhotos, options.groupId) as MirrorTripPhoto[]) {
+    byId.set(row.id, row);
+  }
+
+  for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (mutation.groupId !== options.groupId) continue;
+
+    switch (mutation.kind) {
+      case 'trip_photo.add': {
+        const payload = mutation.payload as TripPhotoAddPayload;
+        if (byId.has(payload.photoId)) break;
+        byId.set(payload.photoId, {
+          id: payload.photoId,
+          group_id: mutation.groupId,
+          expense_id: payload.expenseId ?? null,
+          day: payload.day ?? null,
+          storage_path: payload.storagePath,
+          caption: payload.caption ?? null,
+          created_by: null,
+          created_at: mutation.clientCreatedAt,
+          deleted_at: null,
+          pending: true,
+          pending_rank: mutation.seq,
+        });
+        break;
+      }
+      case 'trip_photo.delete': {
+        const { photoId } = mutation.payload as TripPhotoDeletePayload;
+        const existing = byId.get(photoId);
+        if (existing) {
+          byId.set(photoId, { ...existing, deleted_at: mutation.clientCreatedAt, pending: true });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return [...byId.values()].sort((a, b) => {
+    // Newest first. A pending add (no server timestamp yet) sorts above all
+    // committed rows, tie-broken by queue order so two quick adds keep order.
+    const at = a.created_at ?? '';
+    const bt = b.created_at ?? '';
+    if (at !== bt) return bt.localeCompare(at);
+    if (a.pending_rank !== undefined && b.pending_rank !== undefined) {
+      return b.pending_rank - a.pending_rank;
+    }
+    return String(b.id).localeCompare(String(a.id));
   });
 }
 

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -54,6 +54,12 @@ export enum MutationKind {
   MemberBudgetClear = 'member_budget.clear',
   GroupBudgetSet = 'group_budget.set',
   CategoryBudgetSet = 'category_budget.set',
+  // Trip album (shared photos) — group-scoped, authorised by membership, so also
+  // not personal. Add carries the R2 path of an already-uploaded image plus an
+  // optional expense/day link; delete is a soft tombstone so a removal reaches
+  // every device. No update: a photo is not edited, only added or removed.
+  TripPhotoAdd = 'trip_photo.add',
+  TripPhotoDelete = 'trip_photo.delete',
 }
 
 export interface MutationEnvelope<K extends MutationKind = MutationKind, P = unknown> {
@@ -284,6 +290,25 @@ export interface CategoryBudgetSetPayload {
   readonly currency?: CurrencyCode | null;
 }
 
+/**
+ * A photo added to the trip album. `photoId` is client-chosen and the
+ * idempotency key. `storagePath` is the R2 object key the client already
+ * uploaded to (the `trip-photos` bucket) — the bytes are not on the wire.
+ * `expenseId` pins it to one bill (else it is a photo of the trip itself);
+ * `day` is the trip day it belongs to. Both optional.
+ */
+export interface TripPhotoAddPayload {
+  readonly photoId: string;
+  readonly storagePath: string;
+  readonly expenseId?: string | null;
+  readonly day?: string | null;
+  readonly caption?: string | null;
+}
+
+export interface TripPhotoDeletePayload {
+  readonly photoId: string;
+}
+
 export interface SyncRequest {
   readonly deviceId: string;
   readonly mutations: readonly MutationEnvelope[];
@@ -351,6 +376,9 @@ export enum SyncTable {
   /** Group-scoped, read+write. A member's personal spend ceiling for a trip;
    * a `private` one is only ever pulled to its owner (RLS). */
   TripMemberBudgets = 'trip_member_budgets',
+  /** Group-scoped, read+write (album). Shared trip photos; not money. A removal
+   * is a soft-delete tombstone the pull carries, like the plan. */
+  TripPhotos = 'trip_photos',
 }
 
 /**

--- a/packages/core/test/tripAlbum.test.ts
+++ b/packages/core/test/tripAlbum.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The trip album overlay (plan feature #2). A photo added offline shows at once
+ * as a pending row; a removal is a tombstone the caller filters, not a hard drop
+ * a second device never sees. These pin the overlay and the newest-first order.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  emptyMirror,
+  enqueue,
+  materialiseTripPhotos,
+  MutationKind,
+  reconcile,
+  type MutationEnvelope,
+  type QueuedMutation,
+  type SyncChange,
+} from '../src/sync/index.js';
+
+const GROUP = 'g-1';
+const AT = '2026-03-01T09:00:00Z';
+
+function envelope(
+  id: string,
+  kind: MutationEnvelope['kind'],
+  payload: Record<string, unknown>,
+  groupId = GROUP,
+): MutationEnvelope {
+  return { clientMutationId: id, kind, groupId, clientCreatedAt: AT, payload };
+}
+
+function queued(...envelopes: MutationEnvelope[]): QueuedMutation[] {
+  let queue: QueuedMutation[] = [];
+  for (const item of envelopes) queue = enqueue(queue, item);
+  return queue;
+}
+
+function serverPhoto(id: string, createdAt: string, over: Partial<Record<string, unknown>> = {}) {
+  const row: SyncChange = {
+    table: 'trip_photos' as SyncChange['table'],
+    groupId: GROUP,
+    seq: 1,
+    row: {
+      id,
+      group_id: GROUP,
+      expense_id: null,
+      day: null,
+      storage_path: `${GROUP}/${id}.webp`,
+      caption: null,
+      created_by: 'member-a',
+      created_at: createdAt,
+      deleted_at: null,
+      updated_seq: 1,
+      ...over,
+    },
+  };
+  return row;
+}
+
+describe('materialiseTripPhotos', () => {
+  it('shows a photo added with no network, marked pending', () => {
+    const add = envelope('m-1', MutationKind.TripPhotoAdd, {
+      photoId: 'p-1',
+      storagePath: `${GROUP}/p-1.webp`,
+      expenseId: 'e-9',
+      day: '2026-03-01',
+      caption: 'the view',
+    });
+    const rows = materialiseTripPhotos(emptyMirror(), queued(add), { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'p-1',
+      storage_path: `${GROUP}/p-1.webp`,
+      expense_id: 'e-9',
+      day: '2026-03-01',
+      caption: 'the view',
+      deleted_at: null,
+      pending: true,
+    });
+  });
+
+  it('carries a removal as a tombstone rather than dropping the row', () => {
+    const remove = envelope('m-2', MutationKind.TripPhotoDelete, { photoId: 'p-1' });
+    const { state } = reconcile(emptyMirror(), [serverPhoto('p-1', AT)]);
+    const rows = materialiseTripPhotos(state, queued(remove), { groupId: GROUP });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.deleted_at).toBe(AT);
+    expect(rows[0]?.pending).toBe(true);
+  });
+
+  it('orders newest first, and a pending add sits above committed rows', () => {
+    const { state } = reconcile(emptyMirror(), [
+      serverPhoto('old', '2026-03-01T08:00:00Z'),
+      serverPhoto('new', '2026-03-01T10:00:00Z'),
+    ]);
+    const add = envelope('m-3', MutationKind.TripPhotoAdd, {
+      photoId: 'fresh',
+      storagePath: `${GROUP}/fresh.webp`,
+    });
+    const rows = materialiseTripPhotos(state, queued(add), { groupId: GROUP });
+    // Pending add first (clientCreatedAt AT = 09:00 is newer than 08:00 but the
+    // server 'new' at 10:00 is newer still) — order is purely by timestamp desc.
+    expect(rows.map((r) => r.id)).toEqual(['new', 'fresh', 'old']);
+  });
+
+  it('ignores a photo added to another group', () => {
+    const add = envelope(
+      'm-4',
+      MutationKind.TripPhotoAdd,
+      { photoId: 'p-x', storagePath: 'other/p-x.webp' },
+      'g-2',
+    );
+    expect(materialiseTripPhotos(emptyMirror(), queued(add), { groupId: GROUP })).toHaveLength(0);
+  });
+});

--- a/packages/db/prisma/migrations/20260824140000_trip_album/migration.sql
+++ b/packages/db/prisma/migrations/20260824140000_trip_album/migration.sql
@@ -1,0 +1,177 @@
+-- A trip's shared album: photos the group takes together, browsable as a strip
+-- on an expense and as a grid on the trip screen.
+--
+-- This is a THIRD photo concept, deliberately distinct from the two the app
+-- already has, and the distinction is the whole reason it needs its own table
+-- rather than another column:
+--   * the group *cover* photo (`groups.photo_path`) — one image, the group's
+--     identity, a paid feature gated by `baaki_can_upload_group_photo`;
+--   * a *receipt* — the evidence behind one expense's amount, OCR'd, one per
+--     expense, never browsed as a gallery;
+--   * an *album* photo (here) — the memory layer. Many per trip, optionally
+--     pinned to an expense or a day, free for any member to add, and the thing
+--     a person scrolls back through after the trip is over.
+--
+-- Like the trip plan (20260807160000) it is a group's shared list, not money:
+-- it moves nobody's balance and never touches a split. So it rides the same
+-- offline mirror the plan does — an `updated_seq` the /sync pull walks, stamped
+-- by the shared `baaki_stamp_seq` trigger, and a soft-delete `deleted_at` so a
+-- removal propagates to a second device as a tombstone (a hard DELETE never
+-- reaches a seq-based pull). The bytes live in Cloudflare R2 under a new logical
+-- bucket `trip-photos`, brokered by `r2-sign` and counted against the free-tier
+-- storage cap exactly like a receipt; this table holds only the pointer.
+
+CREATE TABLE IF NOT EXISTS public.trip_photos (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id     uuid NOT NULL REFERENCES public.groups(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  /**
+   * The expense this photo belongs to, or NULL for a photo of the trip itself
+   * (a group meal, a view) that is not tied to one bill. SET NULL on delete —
+   * losing the expense unpins the photo, it does not delete the memory.
+   */
+  expense_id   uuid REFERENCES public.expenses(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  /** The day it belongs to, in the trip's own timezone; NULL for "no day". */
+  day          date,
+  /** The R2 object key within the `trip-photos` bucket. Never a URL. */
+  storage_path text NOT NULL,
+  /** A one-line caption, optional. */
+  caption      text,
+  /** Who added it. SET NULL if that membership is later removed. */
+  created_by   uuid REFERENCES public.group_members(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  -- Sync plumbing (ADR-005), identical to trip_plan_items.
+  updated_seq  bigint NOT NULL DEFAULT 0,
+  deleted_at   timestamptz,
+
+  CONSTRAINT trip_photos_path_present CHECK (btrim(storage_path) <> ''),
+  CONSTRAINT trip_photos_caption_sane CHECK (caption IS NULL OR char_length(caption) <= 500)
+);
+
+CREATE INDEX IF NOT EXISTS trip_photos_group_day_idx
+  ON public.trip_photos (group_id, day);
+CREATE INDEX IF NOT EXISTS trip_photos_group_id_updated_seq_idx
+  ON public.trip_photos (group_id, updated_seq);
+-- The expense-detail strip reads by expense.
+CREATE INDEX IF NOT EXISTS trip_photos_expense_idx
+  ON public.trip_photos (expense_id);
+
+DROP TRIGGER IF EXISTS trip_photos_stamp_seq ON public.trip_photos;
+CREATE TRIGGER trip_photos_stamp_seq
+  BEFORE INSERT OR UPDATE ON public.trip_photos
+  FOR EACH ROW EXECUTE FUNCTION public.baaki_stamp_seq();
+
+ALTER TABLE public.trip_photos ENABLE ROW LEVEL SECURITY;
+
+-- Everybody in the group sees the album; that is the point of a shared one.
+CREATE POLICY trip_photos_select ON public.trip_photos
+  FOR SELECT TO anon, authenticated
+  USING (public.is_group_member(group_id));
+
+-- No INSERT/UPDATE/DELETE policy and no privilege: the RPCs below are the only
+-- way in, for the same reason as the plan — a client that writes the row picks
+-- its own `created_by`, and "who added this" is not a question a client answers
+-- about itself.
+REVOKE ALL ON public.trip_photos FROM anon, authenticated;
+GRANT SELECT ON public.trip_photos TO anon, authenticated;
+
+-- ────────────────────────────────────────────────────────────── writing ──
+
+/**
+ * Add one photo to the album. Membership is enough — an album is a shared, free
+ * surface, not an admin one. `p_photo_id` is client-chosen and the idempotency
+ * key: replaying a create returns the same row rather than a duplicate, which a
+ * phone on trip signal will do. `p_expense_id`, when given, must be an expense
+ * in THIS group, or a photo could pin to a stranger's bill and leak its
+ * description through the join the app makes.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_add_trip_photo(
+  p_group_id     uuid,
+  p_storage_path text,
+  p_photo_id     uuid DEFAULT NULL,
+  p_expense_id   uuid DEFAULT NULL,
+  p_day          date DEFAULT NULL,
+  p_caption      text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF coalesce(btrim(p_storage_path), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_PATH: a photo needs a stored image'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying a create must return the same row, not a second one (ADR-005).
+  IF p_photo_id IS NOT NULL THEN
+    SELECT id INTO v_id FROM public.trip_photos WHERE id = p_photo_id;
+    IF v_id IS NOT NULL THEN
+      RETURN v_id;
+    END IF;
+  END IF;
+
+  IF p_expense_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.expenses WHERE id = p_expense_id AND group_id = p_group_id
+  ) THEN
+    RAISE EXCEPTION 'UNKNOWN_EXPENSE: that expense is not in this group'
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  INSERT INTO public.trip_photos
+    (id, group_id, expense_id, day, storage_path, caption, created_by)
+  VALUES
+    (COALESCE(p_photo_id, gen_random_uuid()), p_group_id, p_expense_id, p_day,
+     btrim(p_storage_path), NULLIF(btrim(COALESCE(p_caption, '')), ''),
+     public.baaki_my_member_id(p_group_id))
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_add_trip_photo(uuid, text, uuid, uuid, date, text)
+  TO authenticated, anon;
+
+/**
+ * Remove one. A soft delete, so the tombstone rides the pull to every device
+ * (a hard DELETE would never reach a seq-based pull, leaving the photo on other
+ * phones forever). The R2 bytes are freed separately: the client deletes the
+ * object through `r2-sign` when online, and the storage sweep is the backstop
+ * for a tombstone whose bytes were never reclaimed. Any member may remove a
+ * photo, matching the plan — a shared list only its author can prune goes stale.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_remove_trip_photo(p_photo_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+BEGIN
+  SELECT group_id INTO v_group_id FROM public.trip_photos WHERE id = p_photo_id;
+  IF v_group_id IS NULL THEN
+    RETURN; -- Never existed. Removing nothing is not an error.
+  END IF;
+  IF NOT public.is_group_member(v_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Only when still live, so removing twice does not re-stamp the tombstone.
+  UPDATE public.trip_photos
+     SET deleted_at = now()
+   WHERE id = p_photo_id AND deleted_at IS NULL;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_remove_trip_photo(uuid) TO authenticated, anon;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -249,6 +249,7 @@ model Group {
   usageEvents   UsageEvent[]
   passes        GroupPass[]
   planItems     TripPlanItem[]
+  tripPhotos    TripPhoto[]
   syncMutations SyncMutation[]
   memberClaims   MemberClaim[]
   memberBudgets  TripMemberBudget[]
@@ -300,6 +301,7 @@ model GroupMember {
   settlementsGot    Settlement[]       @relation("SettlementTo")
   itemClaims        ReceiptItemClaim[]
   planItems         TripPlanItem[]
+  tripPhotos        TripPhoto[]
   activity          ActivityLog[]
   disputesRaised    ExpenseDispute[]   @relation("DisputeRaisedBy")
   disputesResolved  ExpenseDispute[]   @relation("DisputeResolvedBy")
@@ -425,6 +427,7 @@ model Expense {
   allocations    SettlementAllocation[]
   disputes       ExpenseDispute[]
   planItems      TripPlanItem[]
+  tripPhotos     TripPhoto[]
 
   @@index([groupId, deletedAt])
   /// The sync pull is "everything in this group since seq N" (TDR §4).
@@ -1242,6 +1245,41 @@ model TripPlanItem {
   @@index([groupId, day, position], map: "trip_plan_items_group_day_idx")
   @@index([groupId, updatedSeq])
   @@map("trip_plan_items")
+  @@schema("public")
+}
+
+/// A photo in the trip's shared album — the memory layer.
+///
+/// A third photo concept, distinct from the group cover photo (one image, the
+/// group's identity, paid) and a receipt (evidence for one bill, OCR'd). Many
+/// per trip, optionally pinned to an expense or a day, free for any member to
+/// add. Not money: it moves no balance, so it rides the offline mirror like the
+/// plan does (`updatedSeq` + soft-delete `deletedAt`). The bytes live in R2
+/// under the `trip-photos` bucket; this row holds only the pointer.
+model TripPhoto {
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  groupId     String    @map("group_id") @db.Uuid
+  /// The expense this belongs to, or NULL for a photo of the trip itself.
+  expenseId   String?   @map("expense_id") @db.Uuid
+  /// The day it belongs to, in the trip's own timezone; NULL for "no day".
+  day         DateTime? @db.Date
+  /// The R2 object key within the `trip-photos` bucket. Never a URL.
+  storagePath String    @map("storage_path")
+  caption     String?
+  createdBy   String?   @map("created_by") @db.Uuid
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  updatedSeq  BigInt    @default(0) @map("updated_seq")
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz(6)
+
+  group   Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  expense Expense?     @relation(fields: [expenseId], references: [id], onDelete: SetNull)
+  author  GroupMember? @relation(fields: [createdBy], references: [id], onDelete: SetNull)
+
+  @@index([groupId, day], map: "trip_photos_group_day_idx")
+  @@index([groupId, updatedSeq])
+  @@index([expenseId], map: "trip_photos_expense_idx")
+  @@map("trip_photos")
   @@schema("public")
 }
 

--- a/packages/db/test/trip-album.test.ts
+++ b/packages/db/test/trip-album.test.ts
@@ -1,0 +1,220 @@
+/**
+ * The trip album: shared photos, addable and removable by anybody in the group,
+ * never money — the same boundaries as the plan, one table over.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, expectDenied, seedGroup, type SeededGroup } from './helpers';
+
+let client: Client;
+let group: SeededGroup;
+
+beforeAll(async () => {
+  client = await connect();
+  group = await seedGroup(client, { memberCount: 2, name: 'Goa' });
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+beforeEach(async () => {
+  await client.query(`DELETE FROM trip_photos WHERE group_id = $1`, [group.groupId]);
+});
+
+/** Run as somebody, and commit — half these tests assert on what is still there. */
+async function as<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query('SET ROLE authenticated');
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+/** path, then optional photo_id / expense_id / day / caption. */
+const add = (path: string, photoId: string | null = null) =>
+  client.query(`SELECT baaki_add_trip_photo($1, $2, $3, NULL, NULL, NULL) AS id`, [
+    group.groupId,
+    path,
+    photoId,
+  ]);
+
+describe('adding to the album', () => {
+  it('records who added it, from the session rather than an argument', async () => {
+    const id = await as(group.profileIds[0] as string, async () => {
+      const { rows } = await add(`${group.groupId}/a.webp`);
+      return String(rows[0].id);
+    });
+    const { rows } = await client.query(
+      `SELECT created_by, storage_path FROM trip_photos WHERE id = $1`,
+      [id],
+    );
+    expect(rows[0].created_by).toBe(group.memberIds[0]);
+    expect(rows[0].storage_path).toBe(`${group.groupId}/a.webp`);
+  });
+
+  it('refuses a photo with no stored image', async () => {
+    await as(group.profileIds[0] as string, async () => {
+      const message = await expectDenied(add('   '));
+      expect(message).toMatch(/INVALID_PATH/);
+    });
+  });
+
+  it('refuses somebody who is not in the group', async () => {
+    const outsider = randomUUID();
+    await client.query(
+      `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Mallory', 'INR')`,
+      [outsider],
+    );
+    await as(outsider, async () => {
+      const message = await expectDenied(add(`${group.groupId}/sneak.webp`));
+      expect(message).toMatch(/NOT_A_MEMBER/);
+    });
+  });
+
+  it('returns the same row when a create is replayed', async () => {
+    const photoId = randomUUID();
+    await as(group.profileIds[0] as string, async () => {
+      const first = await add(`${group.groupId}/b.webp`, photoId);
+      const second = await add(`${group.groupId}/b.webp`, photoId);
+      expect(String(second.rows[0].id)).toBe(String(first.rows[0].id));
+    });
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM trip_photos WHERE id = $1`,
+      [photoId],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+
+  it('refuses to pin a photo to an expense from another group', async () => {
+    // Otherwise a photo could pin to a stranger's bill and leak its description
+    // through the join the app makes.
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+    const other = await seedGroup(client, { memberCount: 1, name: 'Elsewhere' });
+    const { rows: made } = await client.query(
+      `SELECT baaki_apply_expense($1, NULL, $2, 'Theirs', NULL, current_date, 'INR', 1000,
+        'equal', '{"kind":"equal"}'::jsonb, $3::jsonb, $4::jsonb, $5) AS out`,
+      [
+        other.groupId,
+        other.memberIds[0],
+        JSON.stringify([{ memberId: other.memberIds[0], amount: '1000' }]),
+        JSON.stringify([{ memberId: other.memberIds[0], amount: '1000' }]),
+        randomUUID(),
+      ],
+    );
+    const foreignExpense = (made[0].out as { expenseId: string }).expenseId;
+
+    await as(group.profileIds[0] as string, async () => {
+      const message = await expectDenied(
+        client.query(`SELECT baaki_add_trip_photo($1, $2, NULL, $3, NULL, NULL)`, [
+          group.groupId,
+          `${group.groupId}/c.webp`,
+          foreignExpense,
+        ]),
+      );
+      expect(message).toMatch(/UNKNOWN_EXPENSE/);
+    });
+  });
+});
+
+describe('removing from the album', () => {
+  async function seedPhoto(): Promise<string> {
+    const { rows } = await add(`${group.groupId}/keep.webp`);
+    return String(rows[0].id);
+  }
+
+  it('lets anybody in the group remove, not only whoever added it', async () => {
+    const id = await as(group.profileIds[0] as string, seedPhoto);
+    await as(group.profileIds[1] as string, async () => {
+      await client.query(`SELECT baaki_remove_trip_photo($1)`, [id]);
+    });
+    const { rows } = await client.query(`SELECT deleted_at FROM trip_photos WHERE id = $1`, [id]);
+    expect(rows[0].deleted_at).not.toBeNull();
+  });
+
+  it('removes as a soft delete so the tombstone can sync, and twice is fine', async () => {
+    const id = await as(group.profileIds[0] as string, seedPhoto);
+    const seqAfterFirst = await as(group.profileIds[0] as string, async () => {
+      await client.query(`SELECT baaki_remove_trip_photo($1)`, [id]);
+      const { rows } = await client.query(`SELECT updated_seq FROM trip_photos WHERE id = $1`, [
+        id,
+      ]);
+      const seq = Number(rows[0].updated_seq);
+      await client.query(`SELECT baaki_remove_trip_photo($1)`, [id]); // no-op
+      return seq;
+    });
+    const { rows } = await client.query(
+      `SELECT deleted_at, updated_seq FROM trip_photos WHERE id = $1`,
+      [id],
+    );
+    expect(rows[0].deleted_at).not.toBeNull();
+    expect(seqAfterFirst).toBeGreaterThan(0);
+    expect(Number(rows[0].updated_seq)).toBe(seqAfterFirst);
+  });
+
+  it('refuses an outsider removing', async () => {
+    const id = await as(group.profileIds[0] as string, seedPhoto);
+    const outsider = randomUUID();
+    await client.query(
+      `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Mallory', 'INR')`,
+      [outsider],
+    );
+    await as(outsider, async () => {
+      expect(await expectDenied(client.query(`SELECT baaki_remove_trip_photo($1)`, [id]))).toMatch(
+        /NOT_A_MEMBER/,
+      );
+    });
+  });
+});
+
+describe('an album is not a ledger', () => {
+  it('is not writable directly, so created_by cannot be forged', async () => {
+    await as(group.profileIds[1] as string, async () => {
+      const message = await expectDenied(
+        client.query(
+          `INSERT INTO trip_photos (group_id, storage_path, created_by)
+           VALUES ($1, $2, $3)`,
+          [group.groupId, `${group.groupId}/forged.webp`, group.memberIds[0]],
+        ),
+      );
+      expect(message).toMatch(/permission denied/i);
+    });
+  });
+
+  it('is readable by everybody in the group', async () => {
+    await as(group.profileIds[0] as string, async () => {
+      await add(`${group.groupId}/shared.webp`);
+    });
+    const seen = await as(group.profileIds[1] as string, async () => {
+      const { rows } = await client.query(
+        `SELECT count(*)::int AS n FROM trip_photos WHERE group_id = $1`,
+        [group.groupId],
+      );
+      return rows[0].n as number;
+    });
+    expect(seen).toBe(1);
+  });
+
+  it('changes nobody’s balance', async () => {
+    const before = await client.query(
+      `SELECT coalesce(sum(balance), 0)::text AS total FROM group_balances WHERE group_id = $1`,
+      [group.groupId],
+    );
+    await as(group.profileIds[0] as string, async () => {
+      await add(`${group.groupId}/nomoney.webp`);
+    });
+    const after = await client.query(
+      `SELECT coalesce(sum(balance), 0)::text AS total FROM group_balances WHERE group_id = $1`,
+      [group.groupId],
+    );
+    expect(after.rows[0].total).toBe(before.rows[0].total);
+  });
+});

--- a/supabase/functions/_shared/r2.ts
+++ b/supabase/functions/_shared/r2.ts
@@ -13,7 +13,13 @@ import { AwsClient } from 'npm:aws4fetch@1';
 
 import { HttpError, type SupabaseClient } from './auth.ts';
 
-export const LOGICAL_BUCKETS = ['receipts', 'group-photos', 'avatars', 'captures'] as const;
+export const LOGICAL_BUCKETS = [
+  'receipts',
+  'group-photos',
+  'avatars',
+  'captures',
+  'trip-photos',
+] as const;
 export type LogicalBucket = (typeof LOGICAL_BUCKETS)[number];
 
 function requiredEnv(name: string): string {

--- a/supabase/functions/r2-sign/index.ts
+++ b/supabase/functions/r2-sign/index.ts
@@ -87,6 +87,9 @@ function locate(
         ? { groupId: null, ownerSegment: second ?? null }
         : { groupId: first ?? null, ownerSegment: null };
     case 'group-photos':
+    case 'trip-photos':
+      // `<groupId>/<id>` — a group object. Membership (no paid gate for the
+      // album) is enforced by the generic group branch in authorize*.
       return { groupId: first ?? null, ownerSegment: null };
     case 'captures':
     case 'avatars':

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -74,7 +74,10 @@ type MutationKind =
   | 'member_budget.set'
   | 'member_budget.clear'
   | 'group_budget.set'
-  | 'category_budget.set';
+  | 'category_budget.set'
+  // Trip album (shared photos) — group-scoped, authorised by membership.
+  | 'trip_photo.add'
+  | 'trip_photo.delete';
 
 /** True for the kinds whose scope is a user, not a group. */
 function isPersonalKind(kind: MutationKind): boolean {
@@ -473,6 +476,22 @@ class SyncSession {
           p_category: mutation.payload.category as string,
           p_amount_minor: (mutation.payload.amountMinor as string | null) ?? null,
           p_currency: (mutation.payload.currency as string | undefined) ?? null,
+        });
+      case 'trip_photo.add':
+        // Membership-gated inside the RPC. The bytes were already PUT to R2 via
+        // r2-sign; this only records the pointer. Client-chosen id dedupes a
+        // replay. An expense link is validated against this same group in the RPC.
+        return await this.rpcAsCaller('baaki_add_trip_photo', {
+          p_group_id: mutation.groupId,
+          p_storage_path: requireString(mutation.payload.storagePath, 'storagePath'),
+          p_photo_id: requireString(mutation.payload.photoId, 'photoId'),
+          p_expense_id: (mutation.payload.expenseId as string | undefined) ?? null,
+          p_day: (mutation.payload.day as string | undefined) ?? null,
+          p_caption: (mutation.payload.caption as string | undefined) ?? null,
+        });
+      case 'trip_photo.delete':
+        return await this.rpcAsCaller('baaki_remove_trip_photo', {
+          p_photo_id: requireString(mutation.payload.photoId, 'photoId'),
         });
       default:
         throw new HttpError(
@@ -914,6 +933,9 @@ async function pull(
       // co-member's private budget is filtered by RLS and simply not returned.
       ['trip_plan_items', '*'],
       ['trip_member_budgets', '*'],
+      // Trip album (shared photos). Flat rows, no embeds; a removal arrives as a
+      // deleted_at tombstone the client mirror filters out.
+      ['trip_photos', '*'],
     ] as const) {
       const { data, error } = await caller
         .from(table)


### PR DESCRIPTION
## What

The **shared trip album** — plan feature #2 from `docs/travel-schema-features-plan.md`. A third photo concept beside the group cover and a receipt: many photos per trip, free for any member, optionally pinned to an expense or a day, browsed as a grid on its own screen and as a strip under an expense.

| | Cover | Receipt | **Album** |
|---|---|---|---|
| where | `groups.photo_path` | `receipts` bucket | `trip_photos` (new) |
| count | one/group | one/expense | many/trip |
| who / cost | admin, **paid** | any member, evidence | any member, **free** |

## How

- **core** — `trip_photo.add` / `trip_photo.delete` mutations, `SyncTable.TripPhotos`, and `materialiseTripPhotos` (optimistic pending add, soft-delete tombstone, newest-first). Not money: no balance, split, or export touches it.
- **db** — `trip_photos` mirrors `trip_plan_items`: `updated_seq` + shared `baaki_stamp_seq` trigger, `deleted_at` tombstone so a removal reaches every device offline. Writes are RPC-only (`REVOKE ALL … GRANT SELECT`), so `created_by` comes from the session and an expense link is validated against the same group.
- **supabase** — `r2-sign` gains a `trip-photos` logical bucket: authorised by group membership, **no paid gate** (unlike the cover), counted against the free-tier storage cap like a receipt. `sync` dispatches the two RPCs and pulls the table.
- **mobile** — album grid screen (`group/[id]/album`), a self-contained photo strip on the expense detail, a group-menu entry; add reuses the storage seam. **EXIF is stripped on device** (the photo is re-encoded before upload), so a beach photo's GPS never ships to the group. i18n en/ta/hi/ar.

## Security / privacy

- Client holds no R2 key — every read/write brokered by `r2-sign`, authorised by membership.
- Direct table writes revoked → `created_by` unforgeable; cross-group expense pin refused (`UNKNOWN_EXPENSE`).
- On-device EXIF strip; removal soft-deletes + best-effort frees R2 bytes, sweep is the offline backstop.

## Tests

- core: `materialiseTripPhotos` overlay (add/tombstone/order/other-group).
- db: 11 RLS/RPC boundary cases green on **local Postgres** (migrations applied, drift clean): records session author, refuses non-member, replay idempotent, cross-group pin refused, soft-delete + twice-is-fine, outsider blocked, direct-write blocked, group-readable, balance-neutral.
- Full suites green: core 666, db 511, typecheck/lint/format all pass, `edge:build` clean.

## Deviation / deploy

New capability — a short addendum to `baaki-adr.md` + a TDR note are owed (documented in `docs/trip-album.md`). **Not deployed**: the migration `20260824140000_trip_album` and the `trip_photo.*` sync dispatch need a `db:migrate deploy` + `edge:deploy` window (prod DB password stale, 28P01), same as the category-budgets work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared trip albums with three-column photo grids.
  * Upload, view, zoom, and remove trip photos.
  * Added offline-aware uploads with pending-photo status.
  * Added album access from trip menus and expense details.
  * Added expense-linked photo strips and storage-limit handling.
  * Added empty, error, and upload-progress states.
  * Added English, Tamil, Hindi, and Arabic album text.
* **Documentation**
  * Added trip album capability documentation.
* **Tests**
  * Added coverage for offline syncing, permissions, deletion, and photo handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->