### PR TITLE
feat(settle): payment-proof UI on settlements — payer attaches, payee views (A45 §4)

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -820,7 +820,15 @@ export default function GroupScreen() {
                   <Text variant="micro" tone="muted">
                     {fill(t.proof.awaiting, { name: nameOf(settlement.to_member_id) })}
                   </Text>
-                  <SettlementProof groupId={groupId} settlementId={settlement.id} canManage />
+                  {/* Manage only once the settlement has reached the server:
+                      the attach/remove RPCs check party against a real row, and
+                      `pending` means it has not synced yet. Until then the card
+                      still shows "waiting", just without the attach control. */}
+                  <SettlementProof
+                    groupId={groupId}
+                    settlementId={settlement.id}
+                    canManage={!settlement.pending}
+                  />
                 </Card>
               ))}
 

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -56,6 +56,7 @@ import { CategoryBadge } from '@/components/Category';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { PendingMark } from '@/components/PendingMark';
+import { SettlementProof } from '@/components/SettlementProof';
 import { SyncBanner, SyncStatusIcon } from '@/components/SyncBanner';
 import { useSync } from '@/sync';
 import { usePullRefresh } from '@/lib/pullRefresh';
@@ -347,6 +348,14 @@ export default function GroupScreen() {
   const pendingForMe = (settlements.data ?? []).filter(
     (settlement) =>
       settlement.status === 'initiated' && settlement.to_member_id === ledger.myMemberId,
+  );
+  // The other side of the same coin: settlements I said I made that the payee
+  // has not yet confirmed. These earn their own card so the payer has somewhere
+  // to attach a payment proof — and simply to be told their claim is in flight,
+  // which the app never acknowledged before.
+  const pendingByMe = (settlements.data ?? []).filter(
+    (settlement) =>
+      settlement.status === 'initiated' && settlement.from_member_id === ledger.myMemberId,
   );
 
   // The overflow: the same three-dot dropdown the dashboard uses, not a bottom
@@ -770,6 +779,14 @@ export default function GroupScreen() {
                     />
                     {settlement.pending ? <PendingMark size={16} /> : null}
                   </Row>
+                  {/* The payer's evidence, if they attached any — seen here
+                      before confirming, so a confirmation answers proof rather
+                      than a bare claim. View-only: this is the other side's. */}
+                  <SettlementProof
+                    groupId={groupId}
+                    settlementId={settlement.id}
+                    canManage={false}
+                  />
                   <Row style={{ gap: theme.spacing.md }}>
                     <Button
                       label={t.group.confirmReceived}
@@ -780,6 +797,30 @@ export default function GroupScreen() {
                       {t.group.autoConfirms}
                     </Text>
                   </Row>
+                </Card>
+              ))}
+
+              {/* My own recorded payments, waiting on the payee. The place to
+                  back the claim with a screenshot, and an acknowledgement that
+                  it is in flight. */}
+              {pendingByMe.map((settlement) => (
+                <Card key={settlement.id} style={{ gap: theme.spacing.md }}>
+                  <Text variant="subheading">
+                    {fill(t.proof.youPaid, { name: nameOf(settlement.to_member_id) })}
+                  </Text>
+                  <Row style={{ gap: theme.spacing.sm }}>
+                    <MoneyText
+                      amount={BigInt(settlement.amount)}
+                      currency={settlement.currency}
+                      locale={locale}
+                      variant="title"
+                    />
+                    {settlement.pending ? <PendingMark size={16} /> : null}
+                  </Row>
+                  <Text variant="micro" tone="muted">
+                    {fill(t.proof.awaiting, { name: nameOf(settlement.to_member_id) })}
+                  </Text>
+                  <SettlementProof groupId={groupId} settlementId={settlement.id} canManage />
                 </Card>
               ))}
 

--- a/apps/mobile/src/components/SettlementProof.tsx
+++ b/apps/mobile/src/components/SettlementProof.tsx
@@ -1,0 +1,200 @@
+/**
+ * The payment proof on a settlement — a screenshot the payer attaches, visible
+ * to the two parties only (feature §4).
+ *
+ * The payer records that they paid (ADR-007: Baaki never moves the money) and
+ * can back it with an image — a bank confirmation, a UPI receipt. The payee
+ * sees that image before tapping "Confirm received", so a confirmation is a
+ * response to evidence rather than to a bare claim. Nobody else in the group
+ * sees it: the row reached this device already RLS-filtered by the party
+ * predicate, and the URL is signed only for a party. The enforcement is the DB
+ * and r2-sign; this screen is the label on it.
+ *
+ * Unlike the offline-first ledger writes, attach and remove are direct online
+ * RPCs — the bytes need an upload, and the settlement they hang off must already
+ * exist server-side (its party check answers about a real row). So this control
+ * only ever appears on a settlement that has already synced, never mid-record.
+ */
+
+import { useEffect, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Image } from 'expo-image';
+import { ActivityIndicator, Alert, Modal, Pressable, View } from 'react-native';
+
+import { Button, IconButton, iconSize, Text, useTheme } from '@waves/ui';
+
+import { ZoomableImage } from '@/components/ZoomableImage';
+import {
+  useAttachSettlementProof,
+  useRemoveSettlementProof,
+  useSettlementProof,
+} from '@/data/hooks';
+import { restrictedImageUrl } from '@/lib/storage';
+import { useStrings } from '@/i18n';
+
+const THUMB = 72;
+
+/**
+ * Resolve a restricted key to a URL, telling "still resolving" apart from
+ * "resolved to nothing" — a signing failure or a disabled backend would
+ * otherwise spin forever. The async resolve is the only writer, keyed by the
+ * path it was for, so no setState runs synchronously in the effect.
+ */
+function useRestrictedUrl(
+  settlementId: string,
+  path: string | null,
+): { url: string | null; resolved: boolean } {
+  const [fetched, setFetched] = useState<{ path: string; url: string | null } | null>(null);
+  useEffect(() => {
+    if (!path) return;
+    let active = true;
+    void (async () => {
+      const resolved = await restrictedImageUrl('settlement-proofs', settlementId, path);
+      if (active) setFetched({ path, url: resolved });
+    })();
+    return () => {
+      active = false;
+    };
+  }, [settlementId, path]);
+  if (!path) return { url: null, resolved: true };
+  if (fetched && fetched.path === path) return { url: fetched.url, resolved: true };
+  return { url: null, resolved: false };
+}
+
+/**
+ * `canManage` is true only for the payer — the party who says they paid. The
+ * payee gets the same view but no add/remove: they are looking at the other
+ * side's evidence, not their own.
+ */
+export function SettlementProof({
+  groupId,
+  settlementId,
+  canManage,
+}: {
+  groupId: string;
+  settlementId: string;
+  canManage: boolean;
+}): React.JSX.Element | null {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const proof = useSettlementProof(settlementId);
+  const attach = useAttachSettlementProof(groupId, settlementId);
+  const remove = useRemoveSettlementProof(settlementId);
+  const [viewing, setViewing] = useState(false);
+
+  const row = proof.data;
+  const { url, resolved } = useRestrictedUrl(settlementId, row?.storagePath ?? null);
+
+  // No proof and I cannot add one → nothing to show. The payee sees this state
+  // as an absence, not an empty control, until the payer attaches.
+  if (!row && !canManage) return null;
+
+  if (!row) {
+    return (
+      <Button
+        label={t.proof.add}
+        variant="secondary"
+        size="md"
+        disabled={attach.isPending}
+        onPress={() => attach.mutate()}
+        icon={
+          attach.isPending ? undefined : (
+            <Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />
+          )
+        }
+      />
+    );
+  }
+
+  const confirmRemove = () => {
+    Alert.alert(t.proof.removeConfirm, undefined, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.proof.remove,
+        style: 'destructive',
+        onPress: () => {
+          setViewing(false);
+          remove.mutate({ proofId: row.id, storagePath: row.storagePath });
+        },
+      },
+    ]);
+  };
+
+  return (
+    <View style={{ gap: theme.spacing.sm }}>
+      <Text variant="caption" tone="muted">
+        {t.proof.title}
+      </Text>
+      <Pressable
+        onPress={() => setViewing(true)}
+        accessibilityRole="button"
+        accessibilityLabel={t.proof.view}
+        style={{
+          width: THUMB,
+          height: THUMB,
+          borderRadius: theme.radius.md,
+          overflow: 'hidden',
+          backgroundColor: theme.color.surfaceMuted,
+        }}
+      >
+        {url ? (
+          <Image
+            source={{ uri: url }}
+            style={{ width: '100%', height: '100%' }}
+            contentFit="cover"
+          />
+        ) : (
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            {resolved ? (
+              <Ionicons name="image-outline" size={iconSize.lg} color={theme.color.textFaint} />
+            ) : (
+              <ActivityIndicator color={theme.color.textFaint} />
+            )}
+          </View>
+        )}
+      </Pressable>
+
+      <Modal visible={viewing} animationType="fade" onRequestClose={() => setViewing(false)}>
+        <View style={{ flex: 1, backgroundColor: theme.color.bg }}>
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              paddingHorizontal: theme.spacing.xl,
+              paddingTop: theme.spacing.xxl,
+              paddingBottom: theme.spacing.sm,
+            }}
+          >
+            <IconButton label={t.common.close} onPress={() => setViewing(false)}>
+              <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+            </IconButton>
+            {canManage ? (
+              <IconButton
+                label={t.proof.remove}
+                onPress={() => {
+                  if (!remove.isPending) confirmRemove();
+                }}
+              >
+                <Ionicons name="trash-outline" size={iconSize.lg} color={theme.color.negative} />
+              </IconButton>
+            ) : (
+              <View style={{ width: 44 }} />
+            )}
+          </View>
+          {url ? (
+            <ZoomableImage uri={url} />
+          ) : (
+            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+              {resolved ? (
+                <Ionicons name="image-outline" size={iconSize.xl} color={theme.color.textFaint} />
+              ) : (
+                <ActivityIndicator color={theme.color.brand} />
+              )}
+            </View>
+          )}
+        </View>
+      </Modal>
+    </View>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -366,6 +366,21 @@ export interface UiStrings {
     remove: string;
     removeConfirm: string;
   };
+  /** A payment proof on a settlement, visible to its two parties only. */
+  proof: {
+    /** Section label. */
+    title: string;
+    /** Payer's action to attach a proof image. */
+    add: string;
+    /** Payer card heading; {name} is the payee. */
+    youPaid: string;
+    /** Payer card subtitle while the payee has not confirmed; {name} is the payee. */
+    awaiting: string;
+    /** Payee's cue that a proof is attached to view before confirming. */
+    view: string;
+    remove: string;
+    removeConfirm: string;
+  };
   /** Trip budgets. */
   budgets: string;
   overallBudget: string;
@@ -2044,6 +2059,15 @@ const en: UiStrings = {
     payersOnly: 'Only people on this bill',
     remove: 'Remove attachment',
     removeConfirm: 'Remove this attachment?',
+  },
+  proof: {
+    title: 'Payment proof',
+    add: 'Add payment proof',
+    youPaid: 'You paid {name}',
+    awaiting: 'Waiting for {name} to confirm',
+    view: 'View payment proof',
+    remove: 'Remove proof',
+    removeConfirm: 'Remove this payment proof?',
   },
   budgets: 'Budgets',
   overallBudget: 'Overall',
@@ -3739,6 +3763,15 @@ const ta: UiStrings = {
     payersOnly: 'இந்த பில்லில் உள்ளவர்கள் மட்டும்',
     remove: 'இணைப்பை நீக்கு',
     removeConfirm: 'இந்த இணைப்பை நீக்கவா?',
+  },
+  proof: {
+    title: 'கட்டண சான்று',
+    add: 'கட்டண சான்று சேர்',
+    youPaid: '{name} க்கு நீங்கள் கட்டினீர்கள்',
+    awaiting: '{name} உறுதிப்படுத்த காத்திருக்கிறது',
+    view: 'கட்டண சான்றைப் பார்',
+    remove: 'சான்றை நீக்கு',
+    removeConfirm: 'இந்த கட்டண சான்றை நீக்கவா?',
   },
   budgets: 'பட்ஜெட்',
   overallBudget: 'மொத்தம்',
@@ -5500,6 +5533,15 @@ const hi: UiStrings = {
     remove: 'अटैचमेंट हटाएँ',
     removeConfirm: 'यह अटैचमेंट हटाएँ?',
   },
+  proof: {
+    title: 'भुगतान प्रमाण',
+    add: 'भुगतान प्रमाण जोड़ें',
+    youPaid: 'आपने {name} को भुगतान किया',
+    awaiting: '{name} की पुष्टि का इंतज़ार',
+    view: 'भुगतान प्रमाण देखें',
+    remove: 'प्रमाण हटाएँ',
+    removeConfirm: 'यह भुगतान प्रमाण हटाएँ?',
+  },
   budgets: 'बजट',
   overallBudget: 'कुल',
   myBudget: 'मेरा बजट',
@@ -7209,6 +7251,15 @@ const ar: UiStrings = {
     payersOnly: 'أصحاب هذه الفاتورة فقط',
     remove: 'إزالة المرفق',
     removeConfirm: 'إزالة هذا المرفق؟',
+  },
+  proof: {
+    title: 'إثبات الدفع',
+    add: 'إضافة إثبات الدفع',
+    youPaid: 'لقد دفعت إلى {name}',
+    awaiting: 'في انتظار تأكيد {name}',
+    view: 'عرض إثبات الدفع',
+    remove: 'إزالة الإثبات',
+    removeConfirm: 'إزالة إثبات الدفع هذا؟',
   },
   budgets: 'الميزانية',
   overallBudget: 'الإجمالي',

--- a/docs/private-attachments.md
+++ b/docs/private-attachments.md
@@ -33,7 +33,25 @@ again at the presign (`r2-sign`), never in the client.
   (#194), not the offline queue.
 - **UI** — a hidden/visible attachment section on the expense detail, with a
   visibility choice at add time and a lock badge on `parties` rows. The
-  settlement-proof UI (§4) reuses the same hooks and is a small follow-up.
+  settlement-proof UI (§4) reuses the same hooks (see below).
+
+## §4 settlement-proof UI — built (follow-up PR)
+
+`SettlementProof` (`apps/mobile/src/components/SettlementProof.tsx`) — a single
+party-only image on a settlement, wired into the group screen:
+
+- **Payer side** — a new `pendingByMe` card on the group screen surfaces the
+  payer's own recorded-but-unconfirmed settlements (which the app never
+  acknowledged before). It carries "You paid {name}", "Waiting for {name} to
+  confirm", and the attach/view/remove control (`canManage`).
+- **Payee side** — the existing `pendingForMe` confirm card now shows the proof
+  **view-only** above "Confirm received", so a confirmation answers evidence
+  rather than a bare claim.
+- **Ordering** — attach and remove are the same direct SECURITY DEFINER RPCs; a
+  proof can only hang off a settlement that has already **synced** (its party
+  check answers about a real row), so the control never appears mid-record. The
+  proof image is picked with `pickAlbumPhoto` (EXIF-stripped re-encode) and
+  resolved through the restricted `r2-sign` branch (60 s TTL, no dual-read).
 
 ## Threat tests
 


### PR DESCRIPTION
Feature #4 of the travel-schema plan: the **settlement-proof UI**. The party-only
security infra (table, predicate, restricted `r2-sign` branch, hooks) landed in
#407 — this PR is the screen on it.

## What this adds
- **`SettlementProof` component** — a single party-only image on a settlement.
  Resolved through the restricted `r2-sign` branch (60 s TTL, no dual-read),
  picked EXIF-stripped via `pickAlbumPhoto`. Payer can add/view/remove; payee
  sees view-only.
- **Payer side (group screen)** — a new `pendingByMe` card surfaces settlements
  *I recorded* that the payee has not confirmed yet — which the app never
  acknowledged before. Carries "You paid {name}", "Waiting for {name} to
  confirm", and the attach control.
- **Payee side (group screen)** — the existing `pendingForMe` confirm card now
  shows the payer's proof **view-only** above "Confirm received", so a
  confirmation answers evidence rather than a bare claim.

## Design notes
- **Ordering constraint**: attach/remove are direct SECURITY DEFINER RPCs; a
  proof can only hang off an **already-synced** settlement (the party check
  answers about a real DB row), so the control never appears mid-record — only
  on the persistent pending cards.
- **Enforcement is DB + presign, never client** (per #407). The lock/visibility
  is RLS-filtered before the row reaches the device; the URL is signed only for
  a party.
- i18n: new `proof` group across en/ta/hi/ar.

## Scope
Pure mobile UI + i18n + doc. No core/db/edge changes — hooks and schema shipped
in #407.

## Not deployed
Rides the same ops window as #407's migration + edge (`20260824150000` + `sync`
+ `r2-sign`); prod DB password stale (28P01).

## Deviations owed
ADR-007 addendum (a party-only image proof as evidence attached to, not a
precondition of, confirmation) — noted in `docs/private-attachments.md` §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added payment-proof support for pending settlements.
  * Payers can attach, view, zoom, and remove proof images.
  * Recipients can view submitted proof before confirming payments.
  * Added pending and awaiting-confirmation status details.
  * Proof management becomes available after settlements are synced.
* **Accessibility & Localization**
  * Added payment-proof labels and actions in English, Tamil, Hindi, and Arabic.
* **Documentation**
  * Updated guidance for managing and viewing settlement payment proofs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->