### PR TITLE
feat(expense): "just for me" — route a private trip spend to personal captures (plan §5)

### DIFF
--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -65,6 +65,21 @@ function safeMinor(value: number): bigint {
   return Number.isFinite(value) ? BigInt(Math.round(value)) : 0n;
 }
 
+/**
+ * A minor-unit amount carried in as a query param, made safe. It is a string
+ * from the URL, so only a run of digits is trusted; anything else (empty, a
+ * sign, a decimal, junk) becomes zero — the same "type it yourself" fallback the
+ * OCR path uses. No `BigInt()` on unvalidated text, which would throw.
+ */
+function amountFromParam(value: string | undefined): bigint {
+  if (!value || !/^\d+$/.test(value)) return 0n;
+  try {
+    return BigInt(value);
+  } catch {
+    return 0n;
+  }
+}
+
 /** Today as `YYYY-MM-DD` in the phone's own zone — never midnight UTC. */
 function todayIso(): string {
   const now = new Date();
@@ -145,7 +160,17 @@ export default function CaptureScreen() {
   const insets = useSafeAreaInsets();
   const { t, locale } = useStrings();
   const createCapture = useCreateCapture();
-  const { scan } = useLocalSearchParams<{ scan?: string }>();
+  // `scan` fires the camera on entry; the rest are an optional prefill when this
+  // screen is reached from a group's "just for me" affordance — the amount, note
+  // and currency already typed there carry over so nothing is entered twice. A
+  // group is never carried: the point of the private route is that this spend
+  // stays personal, off any shared ledger, so `targetGroupId` remains null.
+  const {
+    scan,
+    amount: amountParam,
+    desc: descParam,
+    cur: curParam,
+  } = useLocalSearchParams<{ scan?: string; amount?: string; desc?: string; cur?: string }>();
 
   // Chosen here so the photo can be uploaded under it before the row exists —
   // the storage path keys off the capture id, exactly as add-expense seeds its
@@ -162,12 +187,12 @@ export default function CaptureScreen() {
   // an untouched capture is never saved in the device currency when the account
   // says something else. Their pick then wins and sticks. Derived, not synced in
   // an effect, so there is no setState-in-effect and no first-render snapshot.
-  const [pickedCurrency, setPickedCurrency] = useState<string | null>(null);
+  const [pickedCurrency, setPickedCurrency] = useState<string | null>(() => curParam ?? null);
   const currency = pickedCurrency ?? defaultCurrency;
   const [pickingCurrency, setPickingCurrency] = useState(false);
 
-  const [amount, setAmount] = useState<bigint>(0n);
-  const [description, setDescription] = useState('');
+  const [amount, setAmount] = useState<bigint>(() => amountFromParam(amountParam));
+  const [description, setDescription] = useState(() => descParam ?? '');
   // A built-in id or a custom tag's id; `categoryMeta` carries the display of a
   // custom tag so it rides onto the capture (extends TDR §8).
   const [category, setCategory] = useState<string | null>(CategoryId.Food);
@@ -214,7 +239,9 @@ export default function CaptureScreen() {
   // point it stops moving under the user's finger (the same rule add-expense
   // uses). Seeding guessedFrom to the initial empty description means the guess
   // does not fire on mount, so that default survives until the person types.
-  const [guessedFrom, setGuessedFrom] = useState<string | null>('');
+  // Seeded to the carried-in note (or empty) so the category guesser does not
+  // fire on mount and overwrite the Food default before the person types.
+  const [guessedFrom, setGuessedFrom] = useState<string | null>(() => descParam ?? '');
   if (!categoryChosen && description !== guessedFrom) {
     setGuessedFrom(description);
     // Keep the current category when the description matches no bucket:

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1443,6 +1443,40 @@ export default function AddExpenseScreen() {
               }
             />
           </Card>
+
+          {/* The way out of splitting. Some spend on a trip is nobody else's —
+              a souvenir, a private treat — and forcing it onto the shared ledger
+              (even split 1:1 with yourself) is noise in everyone's balances. This
+              hands the amount and note already typed to the personal captures
+              inbox, which never touches a group balance (plan §5). Only offered
+              on a new expense; converting an existing shared row is a different,
+              destructive act. `replace` so the abandoned split form is not left
+              on the back stack behind the capture. */}
+          {!editing ? (
+            <View style={{ gap: theme.spacing.xs, alignItems: 'flex-start' }}>
+              <Button
+                label={t.expense.justForMe}
+                variant="ghost"
+                onPress={() => {
+                  const params: Record<string, string> = { cur: currency };
+                  if (amount > 0n) params.amount = amount.toString();
+                  const note = description.trim();
+                  if (note) params.desc = note;
+                  router.replace({ pathname: '/capture', params });
+                }}
+                icon={
+                  <Ionicons
+                    name="lock-closed-outline"
+                    size={iconSize.md}
+                    color={theme.color.brand}
+                  />
+                }
+              />
+              <Text variant="micro" tone="muted">
+                {t.expense.justForMeBody}
+              </Text>
+            </View>
+          ) : null}
         </ScrollView>
 
         {/* The one action, pinned. The screen is tall — keypad, scan, currency,

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1255,6 +1255,10 @@ export interface UiStrings {
     splitByItem: string;
     scanBillTitle: string;
     scanBillBody: string;
+    /** Route this spend to the personal captures inbox instead of splitting it. */
+    justForMe: string;
+    /** One line under it: what "just for me" means. */
+    justForMeBody: string;
     scan: string;
     reading: string;
     scanReconciles: string;
@@ -2902,6 +2906,8 @@ const en: UiStrings = {
     scanBillTitle: 'Scan the bill',
     scanBillBody:
       'The total and the name of the place come out filled in. Check them — entering them by hand is always free.',
+    justForMe: 'Just for me',
+    justForMeBody: "Not splitting this? Keep it in your own captures — off the group's ledger.",
     scan: 'Scan',
     reading: 'Reading…',
     scanReconciles: 'Read the total off the bill. Check it, then split it however you like.',
@@ -4646,6 +4652,9 @@ const ta: UiStrings = {
       'திருத்தினாலும் பழைய பதிப்பு இருக்கும். என்ன மாறியது என்பதை அனைவரும் பார்க்கலாம், மீட்கவும் முடியும்.',
     splitByItem: 'பொருள் வாரியாகப் பிரி',
     scanBillTitle: 'ரசீதை ஸ்கேன் செய்',
+    justForMe: 'எனக்கு மட்டும்',
+    justForMeBody:
+      'இதைப் பங்கிடவில்லையா? உங்கள் சொந்த கேப்சர்களில் வைத்திரு — குழுக் கணக்கில் இல்லாமல்.',
     scanBillBody:
       'மொத்தமும் இடத்தின் பெயரும் தானாக நிரப்பப்படும். சரிபாருங்கள் — கையால் உள்ளிடுவது எப்போதும் இலவசம்.',
     scan: 'ஸ்கேன்',
@@ -6377,6 +6386,8 @@ const hi: UiStrings = {
       'बदलने पर पुराना संस्करण बना रहता है। सब देख सकते हैं क्या बदला, और उसे वापस भी लाया जा सकता है।',
     splitByItem: 'चीज़-वार बाँटें',
     scanBillTitle: 'बिल स्कैन करें',
+    justForMe: 'सिर्फ़ मेरे लिए',
+    justForMeBody: 'इसे बाँट नहीं रहे? इसे अपने कैप्चर में रखें — ग्रुप के हिसाब से बाहर।',
     scanBillBody:
       'कुल रकम और जगह का नाम अपने आप भर जाते हैं। जाँच लें — हाथ से डालना हमेशा मुफ़्त है।',
     scan: 'स्कैन',
@@ -8122,6 +8133,8 @@ const ar: UiStrings = {
     editingKeepsVersion: 'التعديل يحتفظ بالنسخة القديمة. يرى الجميع ما تغيّر، ويمكن استرجاعها.',
     splitByItem: 'التقسيم حسب الصنف',
     scanBillTitle: 'امسح الفاتورة',
+    justForMe: 'لي وحدي',
+    justForMeBody: 'لن تقسّم هذه؟ احتفظ بها في التقاطاتك الخاصة — خارج حساب المجموعة.',
     scanBillBody: 'يُملأ المجموع واسم المكان تلقائيًا. تحقّق منهما — والإدخال اليدوي مجاني دائمًا.',
     scan: 'مسح',
     reading: 'جارٍ القراءة…',

--- a/docs/travel-schema-features-plan.md
+++ b/docs/travel-schema-features-plan.md
@@ -195,3 +195,27 @@ Each lands as its own PR with the migration validated on local Postgres
 test:db`), behind a feature flag, and **not** deployed until an ops window
 restores the prod DB password and an `edge:deploy` + `db:migrate` run is
 coordinated.
+
+---
+
+## Status — all built
+
+- **#1 Category budgets** — PR #405 (merged). `category_budgets` on the group,
+  admin-gated via `baaki_guard_group_columns`.
+- **#3 Attachment visibility (`parties`) + RLS/presign** — PR #407 (merged).
+  Security review in `private-attachments-security-review.md`; 16 threat tests.
+- **#4 Settlement proof** — schema/hooks in #407, UI in PR #408 (merged). Payer
+  attaches on a synced settlement, payee views before confirming.
+- **#2 Shared album** — PR #406 (merged). `trip_photos`, `trip-photos` bucket,
+  EXIF-stripped upload, album grid + expense strip.
+- **#5 Private personal spend** — built (this PR), **no schema**. A "Just for me"
+  affordance on the group add-expense screen routes the typed amount/note into
+  the personal captures inbox (`/capture`, `targetGroupId` stays null), which
+  never touches a group balance. No hidden ledger row was invented, per the
+  design tension above — a truly private spend that moves no one else's balance
+  _is_ the existing capture, so the honest change is a contextual doorway to it.
+
+The schema-carrying features (#1–#4) remain **deploy-gated**: their migrations
+(`20260824130000`, `20260824140000`, `20260824150000`) + `sync`/`r2-sign` edge
+await the same ops window (prod `DIRECT_URL` password stale, 28P01). #5 carries
+no migration and no edge change, so it has nothing to deploy.


### PR DESCRIPTION
The final item of the travel-schema plan (§5), and the only one with **no
schema**. Marks the whole schema-heavy set (#1–#5) built.

## The idea
Some spend on a trip is nobody else's — a souvenir, a private treat. Forcing it
onto the shared ledger (even split 1:1 with yourself) is noise in everyone's
balances. The plan's own design tension: a truly private spend that moves no
one else's balance *already exists* — it's the personal **captures** inbox. So
this is a contextual doorway to it, not a new hidden ledger row.

## What this adds
- **Group add-expense** — a "Just for me" affordance (new expense only, not when
  editing). It hands the amount and note already typed to `/capture`, with
  `targetGroupId` left **null** so the capture stays personal and never touches a
  group balance. `router.replace` so the abandoned split form is not left on the
  back stack behind the capture.
- **Capture screen** — accepts optional `amount` / `desc` / `cur` prefill params.
  Amount is validated **digits-only** before `BigInt` (no throw on junk from the
  URL); `guessedFrom` is seeded so the category guesser does not fire on mount
  and overwrite a carried note. **No group is ever carried** — the private route
  is personal by definition.
- **i18n** — `expense.justForMe` + `justForMeBody` across en/ta/hi/ar.

## Scope
Pure mobile UI + i18n + one route-param extension. **No migration, no core, no
edge** — nothing to deploy.

## Context
The schema-carrying siblings (#1 #405, #2 #406, #3/#4 #407/#408) remain
deploy-gated for the same ops window (prod DB password stale, 28P01). §5 carries
no migration, so it has nothing gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Just for me” option when creating group expenses, sending personal expenses to the captures inbox.
  * Capture links can now prefill the amount, description, and currency.
  * Added localized text for the new personal expense option in English, Tamil, Hindi, and Arabic.
* **Bug Fixes**
  * Improved category suggestions when opening a prefilled capture.
* **Documentation**
  * Updated the travel features plan to reflect completed features and deployment requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->