### PR TITLE
fix(capture): camera-first from the scan icon — open the camera, form only after a photo

### DIFF
--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -213,6 +213,15 @@ export default function CaptureScreen() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Camera-first: entered from the dashboard camera icon (`?scan`), this screen
+  // opens the camera and shows nothing but a launcher until a photo is taken —
+  // the form is not what the person asked for, the camera is. Seeded false on a
+  // remount whose nonce is already consumed (Android recreates the screen when
+  // it returns from the native camera) so the form is not blocked a second time.
+  const [awaitingScan, setAwaitingScan] = useState<boolean>(() =>
+    scan ? !consumedScans.has(scan) : false,
+  );
+
   // How it was paid and which group it is bound for — both tags that ride the
   // capture and survive until it is assigned. Payment defaults to cash (the most
   // common answer, and one fewer tap for it); the group defaults to "decide
@@ -266,7 +275,7 @@ export default function CaptureScreen() {
    * travel with the capture as `rawText`; there is no group here, so nothing is
    * sent to be parsed — the amount stays the user's to type.
    */
-  const addReceipt = async (): Promise<void> => {
+  const addReceipt = async (opts?: { scanEntry?: boolean }): Promise<void> => {
     setError(null);
 
     // The camera and the document scanner are native, and a native failure —
@@ -280,8 +289,17 @@ export default function CaptureScreen() {
     } catch {
       picked = null;
     }
-    if (!picked) return;
+    if (!picked) {
+      // Cancelled at the camera. On the camera-first entry there is no form to
+      // fall back to — the person asked for the camera, backed out, so leave
+      // rather than stranding them on an empty capture they never opened.
+      if (opts?.scanEntry) router.back();
+      return;
+    }
 
+    // A photo exists now: on the camera-first entry, reveal the form (with the
+    // shot and its OCR) — this is the moment the person confirmed "okay".
+    if (opts?.scanEntry) setAwaitingScan(false);
     setPhoto(picked);
     setScanning(true);
     try {
@@ -316,7 +334,7 @@ export default function CaptureScreen() {
       // Deferred a microtask so the state addReceipt sets on entry does not run
       // synchronously inside the effect body — the same async-callback shape the
       // other effects here use. The camera still opens effectively at once.
-      void Promise.resolve().then(() => addReceipt());
+      void Promise.resolve().then(() => addReceipt({ scanEntry: true }));
     }
     // addReceipt is stable enough for a one-shot; deps intentionally minimal.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -382,6 +400,30 @@ export default function CaptureScreen() {
       setSaving(false);
     }
   };
+
+  // Camera-first entry: nothing but a launcher behind the native camera, so the
+  // form never flashes up before a photo is taken. The scan effect above has
+  // already opened the camera; on "okay" it flips this off and the form below
+  // renders with the shot, on cancel it navigates back.
+  if (awaitingScan) {
+    return (
+      <Screen edges={['top', 'bottom']}>
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: theme.spacing.md,
+          }}
+        >
+          <ActivityIndicator color={theme.color.brand} />
+          <Text variant="caption" tone="muted">
+            {t.captures.openingCamera}
+          </Text>
+        </View>
+      </Screen>
+    );
+  }
 
   return (
     <Screen edges={['top', 'bottom']}>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1055,6 +1055,7 @@ export interface UiStrings {
     itemizedTitle: string;
     itemCount: PluralForms;
     couldNotRead: string;
+    openingCamera: string;
     savedOnDevice: string;
     couldNotSave: string;
     save: string;
@@ -2715,6 +2716,7 @@ const en: UiStrings = {
       other: '{n} items',
     },
     couldNotRead: "Couldn't read this bill — enter the amount yourself.",
+    openingCamera: 'Opening camera…',
     savedOnDevice: 'Saved on this device',
     couldNotSave: "Couldn't save this — please try again in a moment.",
     save: 'Save draft',
@@ -4446,6 +4448,7 @@ const ta: UiStrings = {
       other: '{n} உருப்படிகள்',
     },
     couldNotRead: 'இந்த ரசீதைப் படிக்க முடியவில்லை — தொகையை நீங்களே உள்ளிடவும்.',
+    openingCamera: 'கேமராவைத் திறக்கிறது…',
     savedOnDevice: 'இந்தச் சாதனத்தில் சேமிக்கப்பட்டது',
     couldNotSave: 'இதைச் சேமிக்க முடியவில்லை — சிறிது நேரத்தில் மீண்டும் முயற்சிக்கவும்.',
     save: 'சேமி',
@@ -6193,6 +6196,7 @@ const hi: UiStrings = {
       other: '{n} वस्तुएँ',
     },
     couldNotRead: 'यह रसीद पढ़ी नहीं जा सकी — राशि स्वयं दर्ज करें।',
+    openingCamera: 'कैमरा खुल रहा है…',
     savedOnDevice: 'इस डिवाइस पर सहेजा गया',
     couldNotSave: 'इसे सहेजा नहीं जा सका — कृपया थोड़ी देर में फिर से कोशिश करें।',
     save: 'सहेजें',
@@ -7933,6 +7937,7 @@ const ar: UiStrings = {
       other: '{n} عنصر',
     },
     couldNotRead: 'تعذّر قراءة هذا الإيصال — أدخل المبلغ بنفسك.',
+    openingCamera: 'جارٍ فتح الكاميرا…',
     savedOnDevice: 'محفوظ على هذا الجهاز',
     couldNotSave: 'تعذّر حفظ هذا — يُرجى المحاولة مرة أخرى بعد قليل.',
     save: 'حفظ',


### PR DESCRIPTION
## Reported
Tapping the dashboard **camera** icon opened the capture ("new expense") form
*and* fired the camera on top of it. Backing out of the camera stranded the
person on an empty form they never asked to open.

## Fix
The camera-first entry (`/capture?scan=…`) now shows **only a launcher** until a
photo is taken:
- **On "okay"** → the form appears, prefilled with the shot and its on-device OCR.
- **On cancel** → navigates straight back (no empty form left behind).

## How
- New `awaitingScan` gate. While true, the screen renders a spinner + "Opening
  camera…", not the form. Seeded **false** when the scan nonce is already
  consumed, so the Android screen-recreation after returning from the native
  camera does not re-block the form.
- `addReceipt({ scanEntry })` — on the camera-first path a cancel routes back and
  a taken photo flips the gate off. The manual **Add receipt** button inside the
  form passes no `scanEntry`, so its behaviour is unchanged.
- i18n: `captures.openingCamera` across en/ta/hi/ar.

## Scope
Mobile-only (`capture.tsx` + i18n). typecheck + lint clean. Hot-reloadable,
nothing to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera-first scanning for dashboard scan entries.
  * Displays a camera-opening state while the camera launches.
  * Shows the scan form after a photo is captured.
  * Returns to the previous screen when scanning is cancelled.
  * Added localized camera-opening text in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->