### PR TITLE
feat(expense): comment thread on an expense — members discuss, roles enforced (A46)

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -28,6 +28,7 @@ import {
 import { CategoryBadge } from '@/components/Category';
 import { TripAlbumStrip } from '@/components/TripAlbum';
 import { ExpenseAttachments } from '@/components/ExpenseAttachments';
+import { ExpenseComments } from '@/components/ExpenseComments';
 import {
   memberLookup,
   useDeleteExpense,
@@ -114,6 +115,11 @@ export default function ExpenseDetailScreen() {
     (version.author_member_id === myMemberId ||
       version.payers.some((p) => p.member_id === myMemberId)),
   );
+  // Admin of this group — the moderation lever on the comment thread (delete
+  // anyone's, resolve a report). The server re-checks; this only shows controls.
+  const iAmAdmin =
+    (members.data ?? []).find((m) => m.profile_id === profile?.id && m.left_at === null)?.role ===
+    'admin';
   const nameOf = (memberId: string | null): string => {
     const member = memberId ? lookup.get(memberId) : undefined;
     return member ? displayName(member, profile?.id, blockedIds, t.misc.someone) : t.misc.someone;
@@ -476,6 +482,22 @@ export default function ExpenseDetailScreen() {
                 ) : null}
               </View>
             ))}
+          </Card>
+        </View>
+
+        {/* The thread on this bill. Any member reads and adds; the author edits
+            and deletes their own; an admin deletes anyone's and resolves reports.
+            The controls the component offers mirror what the RPCs allow. */}
+        <View>
+          <SectionHeader title={t.comments.title} />
+          <Card>
+            <ExpenseComments
+              groupId={groupId}
+              expenseId={expense.id}
+              myMemberId={myMemberId}
+              iAmAdmin={iAmAdmin}
+              nameOf={nameOf}
+            />
           </Card>
         </View>
 

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import type { ScrollView as RNScrollView } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
@@ -65,6 +66,7 @@ export default function ExpenseDetailScreen() {
 
   const { group, members, expenses } = useGroup(groupId);
   const versions = useExpenseVersions(expenseId ?? '');
+  const scrollRef = useRef<RNScrollView>(null);
   const deleteExpense = useDeleteExpense(groupId);
   const restoreExpense = useRestoreExpense(groupId);
 
@@ -189,6 +191,13 @@ export default function ExpenseDetailScreen() {
   const heroInk = theme.tint[heroTint].ink;
   const heroInkMuted = theme.tint[heroTint].inkMuted;
 
+  // Bring the comment composer above the keyboard when it focuses: the thread is
+  // the last thing on a long page, so without this the input opens under the
+  // keyboard. A short delay lets the resized layout settle before scrolling.
+  const scrollToComposer = (): void => {
+    setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 150);
+  };
+
   const confirmDelete = (): void => {
     Alert.alert(t.expense.deleteQuestion, t.expense.deleteBody, [
       { text: t.common.cancel, style: 'cancel' },
@@ -205,12 +214,17 @@ export default function ExpenseDetailScreen() {
   return (
     <Screen>
       <ScrollView
+        ref={scrollRef}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
+        // The comment composer lives at the very bottom; keep tapping its actions
+        // working while the keyboard is up, and let iOS inset for the keyboard.
+        keyboardShouldPersistTaps="handled"
+        automaticallyAdjustKeyboardInsets
       >
         <Row style={{ paddingTop: theme.spacing.md }}>
           <IconButton label={t.common.back} onPress={() => router.back()}>
@@ -497,6 +511,7 @@ export default function ExpenseDetailScreen() {
               myMemberId={myMemberId}
               iAmAdmin={iAmAdmin}
               nameOf={nameOf}
+              onComposerFocus={scrollToComposer}
             />
           </Card>
         </View>

--- a/apps/mobile/src/components/ExpenseComments.tsx
+++ b/apps/mobile/src/components/ExpenseComments.tsx
@@ -42,12 +42,15 @@ export function ExpenseComments({
   myMemberId,
   iAmAdmin,
   nameOf,
+  onComposerFocus,
 }: {
   groupId: string;
   expenseId: string;
   myMemberId: string | null;
   iAmAdmin: boolean;
   nameOf: (memberId: string | null) => string;
+  /** Called when the composer focuses — the parent scrolls it above the keyboard. */
+  onComposerFocus?: () => void;
 }): React.JSX.Element {
   const theme = useTheme();
   const { t, locale } = useStrings();
@@ -216,6 +219,7 @@ export function ExpenseComments({
         <TextInput
           value={draft}
           onChangeText={setDraft}
+          onFocus={onComposerFocus}
           multiline
           placeholder={t.comments.placeholder}
           placeholderTextColor={theme.color.textFaint}

--- a/apps/mobile/src/components/ExpenseComments.tsx
+++ b/apps/mobile/src/components/ExpenseComments.tsx
@@ -1,0 +1,275 @@
+/**
+ * The comment thread on one expense (a group-visible discussion of one bill).
+ *
+ * The permission matrix is enforced by the RPCs, not here — this screen only
+ * offers the controls a person is allowed to use, so the UI and the server
+ * agree: any member adds and reads; the author edits and deletes their own; an
+ * admin can delete anyone's and resolve a report; any member can flag/report a
+ * comment for an admin to look at. A denied action still fails safe at the DB.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { ActivityIndicator, Alert, Pressable, TextInput, View } from 'react-native';
+
+import { Avatar, Button, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+import {
+  useAddExpenseComment,
+  useDeleteExpenseComment,
+  useEditExpenseComment,
+  useFlagExpenseComment,
+  useExpenseComments,
+  type ExpenseCommentRow,
+} from '@/data/hooks';
+import { useStrings } from '@/i18n';
+
+function whenLabel(iso: string | null, locale: string): string {
+  if (!iso) return '';
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return '';
+  return new Date(parsed).toLocaleString(locale, {
+    day: 'numeric',
+    month: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export function ExpenseComments({
+  groupId,
+  expenseId,
+  myMemberId,
+  iAmAdmin,
+  nameOf,
+}: {
+  groupId: string;
+  expenseId: string;
+  myMemberId: string | null;
+  iAmAdmin: boolean;
+  nameOf: (memberId: string | null) => string;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const comments = useExpenseComments(expenseId);
+  const add = useAddExpenseComment(groupId, expenseId);
+  const edit = useEditExpenseComment();
+  const remove = useDeleteExpenseComment();
+  const flag = useFlagExpenseComment();
+
+  const [draft, setDraft] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingBody, setEditingBody] = useState('');
+
+  const rows = comments.data;
+
+  const submit = () => {
+    const body = draft.trim();
+    if (body === '') return;
+    add.mutate(
+      { body },
+      {
+        onSuccess: () => setDraft(''),
+        onError: () => Alert.alert(t.comments.couldNotPost),
+      },
+    );
+  };
+
+  const saveEdit = (commentId: string) => {
+    const body = editingBody.trim();
+    if (body === '') return;
+    edit.mutate(
+      { commentId, body },
+      {
+        onSuccess: () => setEditingId(null),
+        onError: () => Alert.alert(t.comments.couldNotPost),
+      },
+    );
+  };
+
+  const confirmDelete = (row: ExpenseCommentRow) => {
+    Alert.alert(t.comments.deleteConfirm, undefined, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.comments.delete,
+        style: 'destructive',
+        onPress: () =>
+          remove.mutate(
+            { commentId: row.id },
+            { onError: () => Alert.alert(t.comments.couldNotDelete) },
+          ),
+      },
+    ]);
+  };
+
+  const inputStyle = {
+    flex: 1,
+    minHeight: 40,
+    maxHeight: 120,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    borderRadius: theme.radius.md,
+    backgroundColor: theme.color.surfaceMuted,
+    color: theme.color.text,
+  } as const;
+
+  return (
+    <View style={{ gap: theme.spacing.md }}>
+      {rows.length === 0 ? (
+        <Text variant="caption" tone="muted">
+          {t.comments.empty}
+        </Text>
+      ) : (
+        rows.map((row) => {
+          const mine = myMemberId !== null && row.authorMemberId === myMemberId;
+          const canDelete = mine || iAmAdmin;
+          const flagged = row.flaggedAt !== null;
+          const editing = editingId === row.id;
+          return (
+            <View key={row.id} style={{ gap: theme.spacing.xs }}>
+              <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+                <Avatar name={nameOf(row.authorMemberId)} size={28} />
+                <Text variant="caption" style={{ flex: 1 }} numberOfLines={1}>
+                  {mine ? t.comments.you : nameOf(row.authorMemberId)}
+                </Text>
+                <Text variant="micro" tone="muted">
+                  {whenLabel(row.createdAt, locale)}
+                  {row.editedAt ? ` · ${t.comments.edited}` : ''}
+                </Text>
+                {/* A report is visible to admins (who resolve it); the flagger
+                    sees it reflected too. It never names who reported. */}
+                {flagged && iAmAdmin ? (
+                  <Ionicons name="flag" size={12} color={theme.color.negative} />
+                ) : null}
+              </Row>
+
+              {editing ? (
+                <View style={{ gap: theme.spacing.xs }}>
+                  <TextInput
+                    value={editingBody}
+                    onChangeText={setEditingBody}
+                    multiline
+                    style={inputStyle}
+                    accessibilityLabel={t.comments.editLabel}
+                  />
+                  <Row style={{ gap: theme.spacing.sm, justifyContent: 'flex-end' }}>
+                    <Button
+                      label={t.common.cancel}
+                      variant="ghost"
+                      size="sm"
+                      onPress={() => setEditingId(null)}
+                    />
+                    <Button
+                      label={t.common.save}
+                      size="sm"
+                      disabled={edit.isPending || editingBody.trim() === ''}
+                      onPress={() => saveEdit(row.id)}
+                    />
+                  </Row>
+                </View>
+              ) : (
+                <>
+                  <Text variant="body" style={{ marginStart: 36 }}>
+                    {row.body}
+                  </Text>
+                  <Row style={{ gap: theme.spacing.lg, marginStart: 36 }}>
+                    {mine ? (
+                      <CommentAction
+                        label={t.comments.edit}
+                        onPress={() => {
+                          setEditingId(row.id);
+                          setEditingBody(row.body);
+                        }}
+                      />
+                    ) : null}
+                    {canDelete ? (
+                      <CommentAction
+                        label={t.comments.delete}
+                        tone="negative"
+                        onPress={() => confirmDelete(row)}
+                      />
+                    ) : null}
+                    {/* Reporting is for someone else's comment; an admin can also
+                        resolve a standing report. */}
+                    {!mine && !flagged ? (
+                      <CommentAction
+                        label={t.comments.report}
+                        onPress={() => flag.mutate({ commentId: row.id, flag: true })}
+                      />
+                    ) : null}
+                    {flagged && iAmAdmin ? (
+                      <CommentAction
+                        label={t.comments.resolve}
+                        onPress={() => flag.mutate({ commentId: row.id, flag: false })}
+                      />
+                    ) : null}
+                  </Row>
+                </>
+              )}
+            </View>
+          );
+        })
+      )}
+
+      {/* Composer — any member can add. */}
+      <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-end' }}>
+        <TextInput
+          value={draft}
+          onChangeText={setDraft}
+          multiline
+          placeholder={t.comments.placeholder}
+          placeholderTextColor={theme.color.textFaint}
+          style={inputStyle}
+          accessibilityLabel={t.comments.placeholder}
+        />
+        <Pressable
+          onPress={submit}
+          disabled={add.isPending || draft.trim() === ''}
+          accessibilityRole="button"
+          accessibilityLabel={t.comments.post}
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: theme.radius.md,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor:
+              draft.trim() === '' ? theme.color.surfaceMuted : theme.color.buttonPrimary,
+          }}
+        >
+          {add.isPending ? (
+            <ActivityIndicator color={theme.color.onBrand} />
+          ) : (
+            <Ionicons
+              name="send"
+              size={iconSize.md}
+              color={draft.trim() === '' ? theme.color.textFaint : theme.color.onBrand}
+            />
+          )}
+        </Pressable>
+      </Row>
+    </View>
+  );
+}
+
+function CommentAction({
+  label,
+  onPress,
+  tone,
+}: {
+  label: string;
+  onPress: () => void;
+  tone?: 'negative';
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Pressable onPress={onPress} accessibilityRole="button" accessibilityLabel={label} hitSlop={8}>
+      <Text
+        variant="micro"
+        style={{ color: tone === 'negative' ? theme.color.negative : theme.color.brand }}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -27,6 +27,7 @@ import {
   materialiseMemberBudgets,
   materialiseMembers,
   materialiseExpenseAttachments,
+  materialiseExpenseComments,
   materialisePlanItems,
   materialiseSettlementProof,
   materialiseSettlements,
@@ -1724,6 +1725,110 @@ export function useRemoveExpenseAttachment(expenseId: string) {
       await removeRestrictedImage('expense-attachments', expenseId, input.storagePath).catch(
         () => {},
       );
+    },
+    onSuccess: () => void flush(),
+  });
+}
+
+// ─────────────────────────────────────────────── expense comments (thread) ──
+// A group-visible thread on one expense. The reads ride the mirror (is_group_member
+// RLS decides what the pull returned); the writes are direct SECURITY DEFINER RPCs
+// that enforce the role matrix server-side, each followed by a flush to pull the
+// change back. Text only — no bytes, no R2.
+
+export interface ExpenseCommentRow {
+  id: string;
+  expenseId: string;
+  groupId: string;
+  authorMemberId: string | null;
+  body: string;
+  editedAt: string | null;
+  flaggedAt: string | null;
+  flaggedBy: string | null;
+  createdAt: string | null;
+}
+
+/** The comments on one expense, oldest first. */
+export function useExpenseComments(expenseId: string): LocalRead<ExpenseCommentRow[]> {
+  const { mirror } = useSync();
+  const rows = useMemo(
+    () =>
+      materialiseExpenseComments(mirror, { expenseId }).map((row): ExpenseCommentRow => ({
+        id: row.id,
+        expenseId: row.expense_id,
+        groupId: row.group_id,
+        authorMemberId: row.author_member_id,
+        body: row.body,
+        editedAt: row.edited_at,
+        flaggedAt: row.flagged_at,
+        flaggedBy: row.flagged_by,
+        createdAt: row.created_at,
+      })),
+    [mirror, expenseId],
+  );
+  return useLocalRead(rows);
+}
+
+/** Add a comment (any member). Client-chosen id is the idempotency key. */
+export function useAddExpenseComment(groupId: string, expenseId: string) {
+  const { flush } = useSync();
+  return useMutation({
+    mutationFn: async (input: { body: string }) => {
+      const body = input.body.trim();
+      if (body === '') return;
+      const { error } = await supabase.rpc('baaki_add_expense_comment', {
+        p_group_id: groupId,
+        p_expense_id: expenseId,
+        p_comment_id: randomUUID(),
+        p_body: body,
+      });
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => void flush(),
+  });
+}
+
+/** Edit a comment — the server allows it only for the author. */
+export function useEditExpenseComment() {
+  const { flush } = useSync();
+  return useMutation({
+    mutationFn: async (input: { commentId: string; body: string }) => {
+      const body = input.body.trim();
+      if (body === '') return;
+      const { error } = await supabase.rpc('baaki_edit_expense_comment', {
+        p_comment_id: input.commentId,
+        p_body: body,
+      });
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => void flush(),
+  });
+}
+
+/** Delete a comment — the server allows the author, or an admin for anyone's. */
+export function useDeleteExpenseComment() {
+  const { flush } = useSync();
+  return useMutation({
+    mutationFn: async (input: { commentId: string }) => {
+      const { error } = await supabase.rpc('baaki_delete_expense_comment', {
+        p_comment_id: input.commentId,
+      });
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => void flush(),
+  });
+}
+
+/** Flag (any member reports) or unflag (admin resolves) a comment. */
+export function useFlagExpenseComment() {
+  const { flush } = useSync();
+  return useMutation({
+    mutationFn: async (input: { commentId: string; flag: boolean }) => {
+      const { error } = await supabase.rpc('baaki_flag_expense_comment', {
+        p_comment_id: input.commentId,
+        p_flag: input.flag,
+      });
+      if (error) throw new Error(error.message);
     },
     onSuccess: () => void flush(),
   });

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -381,6 +381,32 @@ export interface UiStrings {
     remove: string;
     removeConfirm: string;
   };
+  /** The comment thread on an expense. */
+  comments: {
+    /** Section label. */
+    title: string;
+    /** Shown when there are no comments yet. */
+    empty: string;
+    /** Composer placeholder. */
+    placeholder: string;
+    /** Send-button accessibility label. */
+    post: string;
+    edit: string;
+    /** Accessibility label for the inline edit field. */
+    editLabel: string;
+    delete: string;
+    deleteConfirm: string;
+    /** Appended after a comment that was changed. */
+    edited: string;
+    /** Flag/report a comment (any member). */
+    report: string;
+    /** Clear a report (admin). */
+    resolve: string;
+    /** Author label for the current user's own comment. */
+    you: string;
+    couldNotPost: string;
+    couldNotDelete: string;
+  };
   /** Trip budgets. */
   budgets: string;
   overallBudget: string;
@@ -2073,6 +2099,22 @@ const en: UiStrings = {
     view: 'View payment proof',
     remove: 'Remove proof',
     removeConfirm: 'Remove this payment proof?',
+  },
+  comments: {
+    title: 'Comments',
+    empty: 'No comments yet. Start the conversation.',
+    placeholder: 'Add a comment…',
+    post: 'Post comment',
+    edit: 'Edit',
+    editLabel: 'Edit your comment',
+    delete: 'Delete',
+    deleteConfirm: 'Delete this comment?',
+    edited: 'edited',
+    report: 'Report',
+    resolve: 'Resolve',
+    you: 'You',
+    couldNotPost: "Couldn't post that — try again.",
+    couldNotDelete: "Couldn't delete that — try again.",
   },
   budgets: 'Budgets',
   overallBudget: 'Overall',
@@ -3780,6 +3822,22 @@ const ta: UiStrings = {
     view: 'கட்டண சான்றைப் பார்',
     remove: 'சான்றை நீக்கு',
     removeConfirm: 'இந்த கட்டண சான்றை நீக்கவா?',
+  },
+  comments: {
+    title: 'கருத்துகள்',
+    empty: 'இன்னும் கருத்துகள் இல்லை. உரையாடலைத் தொடங்குங்கள்.',
+    placeholder: 'ஒரு கருத்தைச் சேர்…',
+    post: 'கருத்தை இடு',
+    edit: 'திருத்து',
+    editLabel: 'உங்கள் கருத்தைத் திருத்து',
+    delete: 'நீக்கு',
+    deleteConfirm: 'இந்தக் கருத்தை நீக்கவா?',
+    edited: 'திருத்தப்பட்டது',
+    report: 'புகார்',
+    resolve: 'தீர்',
+    you: 'நீங்கள்',
+    couldNotPost: 'இட முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
+    couldNotDelete: 'நீக்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
   },
   budgets: 'பட்ஜெட்',
   overallBudget: 'மொத்தம்',
@@ -5554,6 +5612,22 @@ const hi: UiStrings = {
     remove: 'प्रमाण हटाएँ',
     removeConfirm: 'यह भुगतान प्रमाण हटाएँ?',
   },
+  comments: {
+    title: 'टिप्पणियाँ',
+    empty: 'अभी कोई टिप्पणी नहीं। बातचीत शुरू करें।',
+    placeholder: 'एक टिप्पणी जोड़ें…',
+    post: 'टिप्पणी भेजें',
+    edit: 'बदलें',
+    editLabel: 'अपनी टिप्पणी बदलें',
+    delete: 'हटाएँ',
+    deleteConfirm: 'यह टिप्पणी हटाएँ?',
+    edited: 'बदली गई',
+    report: 'रिपोर्ट',
+    resolve: 'हल करें',
+    you: 'आप',
+    couldNotPost: 'भेजा नहीं जा सका — फिर कोशिश करें।',
+    couldNotDelete: 'हटाया नहीं जा सका — फिर कोशिश करें।',
+  },
   budgets: 'बजट',
   overallBudget: 'कुल',
   myBudget: 'मेरा बजट',
@@ -7275,6 +7349,22 @@ const ar: UiStrings = {
     view: 'عرض إثبات الدفع',
     remove: 'إزالة الإثبات',
     removeConfirm: 'إزالة إثبات الدفع هذا؟',
+  },
+  comments: {
+    title: 'التعليقات',
+    empty: 'لا تعليقات بعد. ابدأ المحادثة.',
+    placeholder: 'أضف تعليقًا…',
+    post: 'نشر التعليق',
+    edit: 'تعديل',
+    editLabel: 'عدّل تعليقك',
+    delete: 'حذف',
+    deleteConfirm: 'حذف هذا التعليق؟',
+    edited: 'مُعدّل',
+    report: 'إبلاغ',
+    resolve: 'حل',
+    you: 'أنت',
+    couldNotPost: 'تعذّر النشر — حاول مرة أخرى.',
+    couldNotDelete: 'تعذّر الحذف — حاول مرة أخرى.',
   },
   budgets: 'الميزانية',
   overallBudget: 'الإجمالي',

--- a/docs/expense-comments.md
+++ b/docs/expense-comments.md
@@ -1,0 +1,62 @@
+# Expense comments — built
+
+Status: **built** (this PR). Validated on **local Postgres** (16 threat tests);
+not deployed until an ops window (migration + `sync` edge redeploy).
+
+A group-visible comment thread on one expense — a "what was this for?" that lives
+next to the bill instead of in a chat app. Text only; no bytes, no R2.
+
+## Permission matrix (enforced in the RPCs, never the client)
+
+| Action        | Member | Author (own) | Admin           |
+| ------------- | ------ | ------------ | --------------- |
+| view / add    | ✅     | ✅           | ✅              |
+| edit          | —      | ✅ own       | — (not others') |
+| delete        | —      | ✅ own       | ✅ any          |
+| flag / report | ✅ any | —            | ✅ any          |
+| clear a flag  | —      | —            | ✅ only         |
+
+The one asymmetry the feature turns on: **a non-admin can never edit or delete
+someone else's comment.** Editing is author-only even for an admin — an admin's
+lever is removal, not rewriting words. Flagging is a report any member can raise;
+only an admin resolves it (so a member cannot quietly un-report their own comment
+after it is flagged). The first flagger is kept; re-flagging is a no-op.
+
+## Shape
+
+- **Table** `expense_comments` (migration `20260824160000_expense_comments`) —
+  `author_member_id` (who, from the session), `body`, `edited_at`, `flagged_at`/
+  `flagged_by`, `deleted_at`/`deleted_by` (soft-delete tombstone), `updated_seq`.
+  RLS SELECT `is_group_member`; `REVOKE ALL` + `GRANT SELECT`; writes RPC-only.
+- **RPCs** (SECURITY DEFINER): `baaki_add_expense_comment` (idempotent on a
+  client id, expense-in-group check), `baaki_edit_expense_comment` (author only,
+  stamps `edited_at`), `baaki_delete_expense_comment` (author or `is_group_admin`,
+  soft-delete + `deleted_by`), `baaki_flag_expense_comment(id, flag)` (set = any
+  member, clear = admin).
+- **Sync** — rides the offline mirror pull like `trip_photos`/attachments: a new
+  `SyncTable.ExpenseComments`, a `materialiseExpenseComments` (oldest-first,
+  filters tombstones), the `['expense_comments','*']` pull entry (read as the
+  caller, so `is_group_member` filters at the boundary). Writes are **direct**
+  SECURITY DEFINER RPCs (not the queue) so the role matrix is server-checked.
+- **UI** — `ExpenseComments` on the expense detail, below History: a composer,
+  the thread, and per-comment controls that mirror exactly what the RPCs allow
+  (edit/delete for the author, delete/resolve for an admin, report for others).
+  i18n `comments` group ×4 (en/ta/hi/ar).
+
+## Threat tests
+
+`packages/db/test/expense-comments.test.ts` — **T1–T16 green on local pg**:
+member add + all-members read; non-member add denied + read 0; anon denied;
+author edits own (edited_at); non-author (incl. admin) cannot edit; author
+deletes own; non-admin cannot delete others'; admin deletes any (+ deleted_by);
+any member flags (first flagger kept); non-admin cannot clear a flag; admin
+resolves; idempotent re-add; cross-group expense refused; empty body refused;
+the table is not directly writable (INSERT/UPDATE/DELETE by a member denied).
+
+## Deviations owed
+
+- **TDR / ADR-006** — a new group-visible per-expense thread. A short amendment:
+  comments are group-visible (not party-tiered), moderation is `admin`-gated via
+  the existing `is_group_admin`, and reporting is any-member.
+- **Release gate** — not deployed. Needs `db:migrate deploy` (migration
+  `20260824160000`) + `edge:deploy` (`sync`).

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -69,6 +69,7 @@ const TABLES: readonly SyncTable[] = [
   SyncTable.TripPhotos,
   SyncTable.SettlementProofs,
   SyncTable.ExpenseAttachments,
+  SyncTable.ExpenseComments,
 ];
 
 export function emptyMirror(): MirrorState {
@@ -1117,6 +1118,31 @@ export function materialiseExpenseAttachments(
   return (rowsFor(state, SyncTable.ExpenseAttachments) as MirrorExpenseAttachment[])
     .filter((row) => row.expense_id === options.expenseId && row.deleted_at === null)
     .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''));
+}
+
+export interface MirrorExpenseComment extends MirrorRow {
+  readonly id: string;
+  readonly group_id: string;
+  readonly expense_id: string;
+  readonly author_member_id: string | null;
+  readonly body: string;
+  readonly edited_at: string | null;
+  readonly flagged_at: string | null;
+  readonly flagged_by: string | null;
+  readonly created_at: string | null;
+  readonly deleted_at: string | null;
+}
+
+/** The live comments on one expense, oldest first — a thread reads top-down.
+ *  A deleted comment is a tombstone in the mirror; it is filtered out here so a
+ *  removal (by the author or an admin) reaches every device as a disappearance. */
+export function materialiseExpenseComments(
+  state: MirrorState,
+  options: { readonly expenseId: string },
+): MirrorExpenseComment[] {
+  return (rowsFor(state, SyncTable.ExpenseComments) as MirrorExpenseComment[])
+    .filter((row) => row.expense_id === options.expenseId && row.deleted_at === null)
+    .sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''));
 }
 
 /** The plan to render: what has not been removed. */

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -389,6 +389,11 @@ export enum SyncTable {
    * a `parties` one only to the expense's payers/author. Pull-only, like the
    * proofs above. */
   ExpenseAttachments = 'expense_attachments',
+  /** Group-scoped, group-visible: a comment thread on one expense. Pull-only —
+   * the writes (add/edit/delete/flag) are direct SECURITY DEFINER RPCs that
+   * enforce the role matrix (author edits/deletes own, admin deletes any, any
+   * member flags), so there is no mutation kind; only the read rides the mirror. */
+  ExpenseComments = 'expense_comments',
 }
 
 /**

--- a/packages/db/prisma/migrations/20260824160000_expense_comments/migration.sql
+++ b/packages/db/prisma/migrations/20260824160000_expense_comments/migration.sql
@@ -1,0 +1,281 @@
+-- Per-expense comments: a thread on one bill that every group member can read
+-- and add to, so a "what was this for?" lives next to the expense instead of in
+-- a chat app nobody can find later.
+--
+-- Like the trip album (20260824140000) and the plan, this is a group's shared
+-- list, not money: it moves nobody's balance and never touches a split. So it
+-- rides the same offline mirror — an `updated_seq` the /sync pull walks, stamped
+-- by the shared `baaki_stamp_seq` trigger, and a soft-delete `deleted_at` so a
+-- removal reaches a second device as a tombstone (a hard DELETE never reaches a
+-- seq-based pull). The bytes are just text; there is no R2 object.
+--
+-- The permission matrix is the whole reason writes go through RPCs rather than a
+-- table grant (a client that writes the row would pick its own author):
+--   * any member  — add a comment; edit and delete their OWN; flag/report any;
+--   * an admin     — additionally delete ANY comment; clear a flag (resolve);
+--   * a non-admin  — may NOT delete or edit someone else's comment.
+-- Enforced here with `baaki_my_member_id` (author identity the caller cannot
+-- forge) and `is_group_admin` (the same predicate the role screens use).
+
+CREATE TABLE IF NOT EXISTS public.expense_comments (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id         uuid NOT NULL REFERENCES public.groups(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  expense_id       uuid NOT NULL REFERENCES public.expenses(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  /** Who wrote it. SET NULL if that membership is later removed — the comment
+      survives the person leaving, shown as "someone". */
+  author_member_id uuid REFERENCES public.group_members(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  body             text NOT NULL,
+  /** When the author last edited it, NULL if never — the UI shows "edited". */
+  edited_at        timestamptz,
+  /** A report: when it was flagged and by whom, NULL if not flagged. Any member
+      may set it; an admin clears it (resolves). */
+  flagged_at       timestamptz,
+  flagged_by       uuid REFERENCES public.group_members(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  /** Soft-delete tombstone + who removed it (the author, or an admin removing
+      someone else's). SET NULL keeps the tombstone if that membership is gone. */
+  deleted_at       timestamptz,
+  deleted_by       uuid REFERENCES public.group_members(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  -- Sync plumbing (ADR-005), identical to trip_photos / trip_plan_items.
+  updated_seq      bigint NOT NULL DEFAULT 0,
+
+  CONSTRAINT expense_comments_body_present CHECK (btrim(body) <> ''),
+  CONSTRAINT expense_comments_body_sane CHECK (char_length(body) <= 2000)
+);
+
+CREATE INDEX IF NOT EXISTS expense_comments_group_id_updated_seq_idx
+  ON public.expense_comments (group_id, updated_seq);
+-- The expense-detail thread reads by expense, oldest first.
+CREATE INDEX IF NOT EXISTS expense_comments_expense_idx
+  ON public.expense_comments (expense_id, created_at);
+
+DROP TRIGGER IF EXISTS expense_comments_stamp_seq ON public.expense_comments;
+CREATE TRIGGER expense_comments_stamp_seq
+  BEFORE INSERT OR UPDATE ON public.expense_comments
+  FOR EACH ROW EXECUTE FUNCTION public.baaki_stamp_seq();
+
+ALTER TABLE public.expense_comments ENABLE ROW LEVEL SECURITY;
+
+-- Everybody in the group sees the thread; a comment is a group-visible signal
+-- (unlike a party-only attachment). Deleted rows still match — they ride the
+-- pull as tombstones — but the client filters them out of the rendered list.
+CREATE POLICY expense_comments_select ON public.expense_comments
+  FOR SELECT TO anon, authenticated
+  USING (public.is_group_member(group_id));
+
+-- No INSERT/UPDATE/DELETE policy and no privilege: the RPCs below are the only
+-- way in, so author_member_id is the session's and the role matrix cannot be
+-- bypassed with a direct PostgREST write.
+REVOKE ALL ON public.expense_comments FROM anon, authenticated;
+GRANT SELECT ON public.expense_comments TO anon, authenticated;
+
+-- ────────────────────────────────────────────────────────────── writing ──
+
+/**
+ * Add a comment. Membership is enough — any member may speak. `p_comment_id` is
+ * client-chosen and the idempotency key: replaying a create returns the same row
+ * rather than a duplicate, which a phone on flaky signal will do. The expense
+ * must be in THIS group, or a comment could pin to a stranger's bill.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_add_expense_comment(
+  p_group_id   uuid,
+  p_expense_id uuid,
+  p_comment_id uuid,
+  p_body       text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id   uuid;
+  v_body text := btrim(COALESCE(p_body, ''));
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF v_body = '' THEN
+    RAISE EXCEPTION 'EMPTY_COMMENT: a comment needs some text'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  IF char_length(v_body) > 2000 THEN
+    RAISE EXCEPTION 'COMMENT_TOO_LONG: keep it under 2000 characters'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Replaying a create must return the same row, not a second one (ADR-005).
+  IF p_comment_id IS NOT NULL THEN
+    SELECT id INTO v_id FROM public.expense_comments WHERE id = p_comment_id;
+    IF v_id IS NOT NULL THEN
+      RETURN v_id;
+    END IF;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.expenses WHERE id = p_expense_id AND group_id = p_group_id
+  ) THEN
+    RAISE EXCEPTION 'UNKNOWN_EXPENSE: that expense is not in this group'
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  INSERT INTO public.expense_comments
+    (id, group_id, expense_id, author_member_id, body)
+  VALUES
+    (COALESCE(p_comment_id, gen_random_uuid()), p_group_id, p_expense_id,
+     public.baaki_my_member_id(p_group_id), v_body)
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_add_expense_comment(uuid, uuid, uuid, text)
+  TO authenticated, anon;
+
+/**
+ * Edit a comment. Only its author — editing someone else's words is not a thing
+ * even an admin does; an admin's lever is removal, not rewriting. Stamps
+ * `edited_at` so the UI can be honest that the text changed.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_edit_expense_comment(
+  p_comment_id uuid,
+  p_body       text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+  v_author   uuid;
+  v_body     text := btrim(COALESCE(p_body, ''));
+BEGIN
+  SELECT group_id, author_member_id INTO v_group_id, v_author
+    FROM public.expense_comments
+   WHERE id = p_comment_id AND deleted_at IS NULL;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'UNKNOWN_COMMENT: no such comment'
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF v_author IS NULL OR v_author <> public.baaki_my_member_id(v_group_id) THEN
+    RAISE EXCEPTION 'NOT_YOUR_COMMENT: you can only edit your own'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF v_body = '' THEN
+    RAISE EXCEPTION 'EMPTY_COMMENT: a comment needs some text'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  IF char_length(v_body) > 2000 THEN
+    RAISE EXCEPTION 'COMMENT_TOO_LONG: keep it under 2000 characters'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  UPDATE public.expense_comments
+     SET body = v_body, edited_at = now()
+   WHERE id = p_comment_id AND deleted_at IS NULL;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_edit_expense_comment(uuid, text)
+  TO authenticated, anon;
+
+/**
+ * Delete a comment. The author may delete their own; an admin may delete ANY (a
+ * moderation lever). A non-admin deleting someone else's is refused — the one
+ * asymmetry the whole feature turns on. Soft delete + `deleted_by` so the
+ * tombstone rides the pull and records who pruned it.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_delete_expense_comment(p_comment_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+  v_author   uuid;
+  v_me       uuid;
+BEGIN
+  SELECT group_id, author_member_id INTO v_group_id, v_author
+    FROM public.expense_comments WHERE id = p_comment_id;
+  IF v_group_id IS NULL THEN
+    RETURN; -- Never existed. Removing nothing is not an error.
+  END IF;
+  IF NOT public.is_group_member(v_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_me := public.baaki_my_member_id(v_group_id);
+  -- Own comment, or an admin reaching for anyone's. Nothing else.
+  IF NOT (v_author = v_me OR public.is_group_admin(v_group_id)) THEN
+    RAISE EXCEPTION 'CANNOT_DELETE: only the author or an admin can delete this'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  UPDATE public.expense_comments
+     SET deleted_at = now(), deleted_by = v_me
+   WHERE id = p_comment_id AND deleted_at IS NULL;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_delete_expense_comment(uuid)
+  TO authenticated, anon;
+
+/**
+ * Flag or unflag a comment. Flagging is a report any member can raise — "an
+ * admin should look at this". Clearing a flag is an admin's call (resolving the
+ * report), so a member cannot quietly un-report their own comment after someone
+ * flags it. The first flagger is kept; re-flagging an already-flagged comment is
+ * a no-op rather than a way to erase who reported it.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_flag_expense_comment(
+  p_comment_id uuid,
+  p_flag       boolean
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+BEGIN
+  SELECT group_id INTO v_group_id
+    FROM public.expense_comments WHERE id = p_comment_id AND deleted_at IS NULL;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'UNKNOWN_COMMENT: no such comment'
+      USING ERRCODE = 'no_data_found';
+  END IF;
+  IF NOT public.is_group_member(v_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_flag THEN
+    -- Any member reports; keep the first flagger (WHERE flagged_at IS NULL).
+    UPDATE public.expense_comments
+       SET flagged_at = now(), flagged_by = public.baaki_my_member_id(v_group_id)
+     WHERE id = p_comment_id AND deleted_at IS NULL AND flagged_at IS NULL;
+  ELSE
+    -- Only an admin resolves a report.
+    IF NOT public.is_group_admin(v_group_id) THEN
+      RAISE EXCEPTION 'ADMIN_ONLY: only an admin can clear a flag'
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    UPDATE public.expense_comments
+       SET flagged_at = NULL, flagged_by = NULL
+     WHERE id = p_comment_id AND deleted_at IS NULL;
+  END IF;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_flag_expense_comment(uuid, boolean)
+  TO authenticated, anon;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -250,6 +250,7 @@ model Group {
   passes        GroupPass[]
   planItems     TripPlanItem[]
   tripPhotos    TripPhoto[]
+  expenseComments ExpenseComment[]
   settlementProofs   SettlementProof[]
   expenseAttachments ExpenseAttachment[]
   syncMutations SyncMutation[]
@@ -306,6 +307,9 @@ model GroupMember {
   tripPhotos        TripPhoto[]
   settlementProofs   SettlementProof[]
   expenseAttachments ExpenseAttachment[]
+  commentsAuthored   ExpenseComment[]   @relation("ExpenseCommentAuthor")
+  commentsFlagged    ExpenseComment[]   @relation("ExpenseCommentFlagger")
+  commentsDeleted    ExpenseComment[]   @relation("ExpenseCommentDeleter")
   activity          ActivityLog[]
   disputesRaised    ExpenseDispute[]   @relation("DisputeRaisedBy")
   disputesResolved  ExpenseDispute[]   @relation("DisputeResolvedBy")
@@ -433,6 +437,7 @@ model Expense {
   planItems      TripPlanItem[]
   tripPhotos     TripPhoto[]
   attachments    ExpenseAttachment[]
+  comments       ExpenseComment[]
 
   @@index([groupId, deletedAt])
   /// The sync pull is "everything in this group since seq N" (TDR §4).
@@ -1286,6 +1291,40 @@ model TripPhoto {
   @@index([groupId, updatedSeq])
   @@index([expenseId], map: "trip_photos_expense_idx")
   @@map("trip_photos")
+  @@schema("public")
+}
+
+/// A comment on one expense, readable by the whole group.
+///
+/// A group-visible thread (unlike a party-only attachment): any member reads and
+/// adds; the author edits and deletes their own; an admin can delete anyone's; a
+/// member may flag/report and an admin resolves. That matrix is enforced in the
+/// RPCs, never here — writes are RPC-only so `author_member_id` is the session's.
+/// Rides the offline mirror (updated_seq + soft-delete tombstone), text only.
+model ExpenseComment {
+  id             String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  groupId        String    @map("group_id") @db.Uuid
+  expenseId      String    @map("expense_id") @db.Uuid
+  authorMemberId String?   @map("author_member_id") @db.Uuid
+  body           String
+  editedAt       DateTime? @map("edited_at") @db.Timestamptz(6)
+  flaggedAt      DateTime? @map("flagged_at") @db.Timestamptz(6)
+  flaggedBy      String?   @map("flagged_by") @db.Uuid
+  deletedAt      DateTime? @map("deleted_at") @db.Timestamptz(6)
+  deletedBy      String?   @map("deleted_by") @db.Uuid
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt      DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  updatedSeq     BigInt    @default(0) @map("updated_seq")
+
+  group          Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  expense        Expense      @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  author         GroupMember? @relation("ExpenseCommentAuthor", fields: [authorMemberId], references: [id], onDelete: SetNull)
+  flagger        GroupMember? @relation("ExpenseCommentFlagger", fields: [flaggedBy], references: [id], onDelete: SetNull)
+  deleter        GroupMember? @relation("ExpenseCommentDeleter", fields: [deletedBy], references: [id], onDelete: SetNull)
+
+  @@index([groupId, updatedSeq])
+  @@index([expenseId, createdAt], map: "expense_comments_expense_idx")
+  @@map("expense_comments")
   @@schema("public")
 }
 

--- a/packages/db/test/expense-comments.test.ts
+++ b/packages/db/test/expense-comments.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Per-expense comments — the permission matrix from the feature spec, enforced
+ * in the RPCs. Every case here guards the one asymmetry the feature turns on:
+ * any member speaks, the author owns their own words, and only an admin reaches
+ * across to someone else's — a non-admin never can.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+/** Run as a profile and commit — reads across role switches need the seed rows. */
+async function as<T>(profileId: string | null, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    profileId
+      ? JSON.stringify({ sub: profileId, role: 'authenticated' })
+      : JSON.stringify({ role: 'anon' }),
+  ]);
+  await client.query(`SET ROLE ${profileId ? 'authenticated' : 'anon'}`);
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+// A group of three: m0 = admin, m1 & m2 = plain members. One expense. An
+// outsider profile who is in no group. m0..m2 are the seeded members.
+let g: { groupId: string; profileIds: string[]; memberIds: string[] };
+let expenseId: string;
+let outsider: string;
+
+beforeAll(async () => {
+  g = await seedGroup(client, { memberCount: 3, name: 'Comments' });
+  outsider = randomUUID();
+  await client.query(
+    `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Outsider', 'INR')`,
+    [outsider],
+  );
+  ({ expenseId } = await addEqualSplitExpense(client, {
+    groupId: g.groupId,
+    payers: { [g.memberIds[0] as string]: 3000n },
+    participants: g.memberIds,
+    amount: 3000n,
+  }));
+});
+
+beforeEach(async () => {
+  await client.query(`DELETE FROM expense_comments WHERE group_id = $1`, [g.groupId]);
+});
+
+const P = (i: number) => g.profileIds[i] as string;
+
+/** Add a comment as a profile; returns the new comment id. */
+async function addComment(profileId: string, body: string, id = randomUUID()): Promise<string> {
+  await as(profileId, () =>
+    client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [
+      g.groupId,
+      expenseId,
+      id,
+      body,
+    ]),
+  );
+  return id;
+}
+
+/** How many live comments this profile can see (RLS + client filter of deleted). */
+const visibleTo = (profileId: string | null) =>
+  as(profileId, () =>
+    client
+      .query(
+        `SELECT count(*)::int AS n FROM expense_comments WHERE expense_id = $1 AND deleted_at IS NULL`,
+        [expenseId],
+      )
+      .then((r) => r.rows[0].n as number),
+  );
+
+const rowById = (id: string) =>
+  client
+    .query(
+      `SELECT author_member_id, deleted_at, deleted_by, edited_at, flagged_at, flagged_by
+         FROM expense_comments WHERE id = $1`,
+      [id],
+    )
+    .then((r) => r.rows[0]);
+
+describe('expense comments — permission matrix', () => {
+  it('T1 any member adds and every member reads it', async () => {
+    await addComment(P(1), 'What was this for?');
+    expect(await visibleTo(P(0))).toBe(1);
+    expect(await visibleTo(P(1))).toBe(1);
+    expect(await visibleTo(P(2))).toBe(1);
+  });
+
+  it('T2 a non-member cannot add and cannot read', async () => {
+    const msg = await expectDenied(
+      as(outsider, () =>
+        client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [
+          g.groupId,
+          expenseId,
+          randomUUID(),
+          'sneaking in',
+        ]),
+      ),
+    );
+    expect(msg).toMatch(/NOT_A_MEMBER/);
+    await addComment(P(1), 'members only');
+    expect(await visibleTo(outsider)).toBe(0);
+  });
+
+  it('T3 anon cannot add and cannot read', async () => {
+    await addComment(P(1), 'visible to members');
+    expect(await visibleTo(null)).toBe(0);
+    await expectDenied(
+      as(null, () =>
+        client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [
+          g.groupId,
+          expenseId,
+          randomUUID(),
+          'anon comment',
+        ]),
+      ),
+    );
+  });
+
+  it('T4 the author edits their own and it stamps edited_at', async () => {
+    const id = await addComment(P(1), 'frist draft');
+    await as(P(1), () =>
+      client.query(`SELECT baaki_edit_expense_comment($1, $2)`, [id, 'fixed typo']),
+    );
+    const row = await rowById(id);
+    expect(row.edited_at).not.toBeNull();
+    const body = await client
+      .query(`SELECT body FROM expense_comments WHERE id = $1`, [id])
+      .then((r) => r.rows[0].body);
+    expect(body).toBe('fixed typo');
+  });
+
+  it("T5 a non-author member cannot edit someone else's", async () => {
+    const id = await addComment(P(1), 'my words');
+    const msg = await expectDenied(
+      as(P(2), () => client.query(`SELECT baaki_edit_expense_comment($1, $2)`, [id, 'not yours'])),
+    );
+    expect(msg).toMatch(/NOT_YOUR_COMMENT/);
+  });
+
+  it("T6 even an admin cannot edit someone else's (edit is author-only)", async () => {
+    const id = await addComment(P(1), 'my words');
+    const msg = await expectDenied(
+      as(P(0), () => client.query(`SELECT baaki_edit_expense_comment($1, $2)`, [id, 'admin edit'])),
+    );
+    expect(msg).toMatch(/NOT_YOUR_COMMENT/);
+  });
+
+  it('T7 the author deletes their own', async () => {
+    const id = await addComment(P(1), 'delete me');
+    await as(P(1), () => client.query(`SELECT baaki_delete_expense_comment($1)`, [id]));
+    const row = await rowById(id);
+    expect(row.deleted_at).not.toBeNull();
+    expect(await visibleTo(P(2))).toBe(0);
+  });
+
+  it("T8 a non-admin member cannot delete someone else's", async () => {
+    const id = await addComment(P(1), 'not yours to remove');
+    const msg = await expectDenied(
+      as(P(2), () => client.query(`SELECT baaki_delete_expense_comment($1)`, [id])),
+    );
+    expect(msg).toMatch(/CANNOT_DELETE/);
+    expect(await visibleTo(P(2))).toBe(1);
+  });
+
+  it("T9 an admin deletes anyone's, and it records who removed it", async () => {
+    const id = await addComment(P(1), 'admin will remove this');
+    await as(P(0), () => client.query(`SELECT baaki_delete_expense_comment($1)`, [id]));
+    const row = await rowById(id);
+    expect(row.deleted_at).not.toBeNull();
+    expect(String(row.deleted_by)).toBe(g.memberIds[0]);
+    expect(await visibleTo(P(1))).toBe(0);
+  });
+
+  it('T10 any member flags/reports; the first flagger is kept', async () => {
+    const id = await addComment(P(1), 'questionable');
+    await as(P(2), () => client.query(`SELECT baaki_flag_expense_comment($1, true)`, [id]));
+    let row = await rowById(id);
+    expect(row.flagged_at).not.toBeNull();
+    expect(String(row.flagged_by)).toBe(g.memberIds[2]);
+    // A second flag does not overwrite the first flagger.
+    await as(P(0), () => client.query(`SELECT baaki_flag_expense_comment($1, true)`, [id]));
+    row = await rowById(id);
+    expect(String(row.flagged_by)).toBe(g.memberIds[2]);
+  });
+
+  it('T11 a non-admin cannot clear a flag', async () => {
+    const id = await addComment(P(1), 'reported');
+    await as(P(2), () => client.query(`SELECT baaki_flag_expense_comment($1, true)`, [id]));
+    const msg = await expectDenied(
+      as(P(1), () => client.query(`SELECT baaki_flag_expense_comment($1, false)`, [id])),
+    );
+    expect(msg).toMatch(/ADMIN_ONLY/);
+  });
+
+  it('T12 an admin resolves a report', async () => {
+    const id = await addComment(P(1), 'reported then resolved');
+    await as(P(2), () => client.query(`SELECT baaki_flag_expense_comment($1, true)`, [id]));
+    await as(P(0), () => client.query(`SELECT baaki_flag_expense_comment($1, false)`, [id]));
+    const row = await rowById(id);
+    expect(row.flagged_at).toBeNull();
+    expect(row.flagged_by).toBeNull();
+  });
+
+  it('T13 re-adding the same id is idempotent (one row)', async () => {
+    const id = randomUUID();
+    await addComment(P(1), 'once', id);
+    await addComment(P(1), 'twice', id);
+    const n = await client
+      .query(`SELECT count(*)::int AS n FROM expense_comments WHERE id = $1`, [id])
+      .then((r) => r.rows[0].n as number);
+    expect(n).toBe(1);
+  });
+
+  it('T14 a comment cannot target an expense in another group', async () => {
+    const other = await seedGroup(client, { memberCount: 2, name: 'Other' });
+    const { expenseId: otherExpense } = await addEqualSplitExpense(client, {
+      groupId: other.groupId,
+      payers: { [other.memberIds[0] as string]: 1000n },
+      participants: other.memberIds,
+      amount: 1000n,
+    });
+    // m1 is in g, not in `other` — claims g's group but a foreign expense.
+    const msg = await expectDenied(
+      as(P(1), () =>
+        client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [
+          g.groupId,
+          otherExpense,
+          randomUUID(),
+          'cross-group',
+        ]),
+      ),
+    );
+    expect(msg).toMatch(/UNKNOWN_EXPENSE/);
+  });
+
+  it('T15 an empty comment is refused', async () => {
+    const msg = await expectDenied(
+      as(P(1), () =>
+        client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [
+          g.groupId,
+          expenseId,
+          randomUUID(),
+          '   ',
+        ]),
+      ),
+    );
+    expect(msg).toMatch(/EMPTY_COMMENT/);
+  });
+
+  it('T16 the table is not directly writable — RPCs are the only way in', async () => {
+    const id = await addComment(P(1), 'legit');
+    // Direct INSERT forging an author.
+    await expectDenied(
+      as(P(2), () =>
+        client.query(
+          `INSERT INTO expense_comments (id, group_id, expense_id, author_member_id, body)
+           VALUES ($1, $2, $3, $4, 'forged')`,
+          [randomUUID(), g.groupId, expenseId, g.memberIds[0]],
+        ),
+      ),
+    );
+    // Direct UPDATE bypassing the author check.
+    await expectDenied(
+      as(P(2), () =>
+        client.query(`UPDATE expense_comments SET body = 'hijacked' WHERE id = $1`, [id]),
+      ),
+    );
+    // Direct DELETE bypassing the role matrix.
+    await expectDenied(
+      as(P(2), () => client.query(`DELETE FROM expense_comments WHERE id = $1`, [id])),
+    );
+  });
+});

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -943,6 +943,9 @@ async function pull(
       // SETTLEMENT_SELECT / EXPENSE_SELECT — that would ship the key to everyone.
       ['settlement_proofs', '*'],
       ['expense_attachments', '*'],
+      // Expense comment threads — group-visible, read as the caller (is_group_member
+      // RLS). Tombstones (deleted_at set) ride the pull so a delete propagates.
+      ['expense_comments', '*'],
     ] as const) {
       const { data, error } = await caller
         .from(table)


### PR DESCRIPTION
Part 1 of the expense discussion/audit request: **per-expense comments**. (Part 2
— the image-change audit trail — follows as a separate PR.)

A group-visible thread on one bill — a "what was this for?" that lives next to
the expense instead of in a chat app. Text only; it rides the offline mirror like
the trip album, no bytes.

## Permission matrix (enforced in the RPCs, never the client)

| Action | Member | Author (own) | Admin |
|---|---|---|---|
| view / add | ✅ | ✅ | ✅ |
| edit | — | ✅ own | — (not others') |
| delete | — | ✅ own | ✅ any |
| flag / report | ✅ any | — | ✅ any |
| clear a flag | — | — | ✅ only |

The asymmetry the feature turns on: **a non-admin can never edit or delete
someone else's comment.** Editing is author-only even for an admin (an admin's
lever is removal, not rewriting). Flagging is a report any member can raise; only
an admin resolves it. First flagger kept; re-flag is a no-op.

## Shape
- **Migration** `20260824160000_expense_comments` — table + `baaki_stamp_seq` +
  `updated_seq` + soft-delete tombstone (`deleted_at`/`deleted_by`); RLS SELECT
  `is_group_member`; `REVOKE ALL` / `GRANT SELECT`; writes RPC-only. RPCs
  add/edit/delete/flag with author from the session and admin via `is_group_admin`.
- **Sync** — `SyncTable.ExpenseComments` + `materialiseExpenseComments`
  (oldest-first, filters tombstones); edge pull `['expense_comments','*']` read
  as the caller. Writes are direct SECURITY DEFINER RPCs so the matrix is
  server-checked.
- **UI** — `ExpenseComments` on the expense detail below History; controls mirror
  exactly what the RPCs allow. i18n `comments` group ×4 (en/ta/hi/ar).

## Tests
`packages/db/test/expense-comments.test.ts` — **16 threat tests, green on local
pg** (T1–T16: member/non-member/anon; author-only edit incl. admin can't;
author-or-admin delete, non-admin can't; any-member flag, admin-only resolve;
idempotent add; cross-group refused; empty refused; table not directly writable).
Full DB suite 543 + core 666 green.

## Not deployed
Needs `db:migrate deploy` (`20260824160000`) + `edge:deploy` (`sync`).

## Deviation owed
TDR/ADR-006 amendment: a group-visible per-expense thread; moderation `admin`-gated
via existing `is_group_admin`; reporting is any-member. Noted in
`docs/expense-comments.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group-visible comments to expense details.
  * Members can post, edit, delete, and report comments.
  * Administrators can delete comments and resolve reported content.
  * Comment composer stays visible when the keyboard opens.
  * Added edited status, timestamps, and English, Tamil, Hindi, and Arabic localization.

* **Bug Fixes**
  * Prevented empty comments and unauthorized actions.
  * Added validation and error feedback for comment operations.

* **Documentation**
  * Documented comment behavior, permissions, synchronization, and moderation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->