### PR TITLE
fix(activity): name the actor in the group activity feed instead of "someone"

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -46,6 +46,7 @@ import {
   groupLabel,
   isBlockedMember,
   isGhost,
+  type ActivityActor,
   type ExpenseRow,
   type ExpenseVersionRow,
 } from '@/data/types';
@@ -248,6 +249,19 @@ export default function GroupScreen() {
   const nameOf = (memberId: string | null): string => {
     const member = memberId ? lookup.get(memberId) : undefined;
     return member ? displayName(member, profile?.id, blockedIds, t.misc.someone) : t.misc.someone;
+  };
+  // The joined actor an activity row would carry on the cross-group feed, rebuilt
+  // from this group's members — so the mirror-backed group feed can name who did
+  // the thing rather than falling back to "someone".
+  const actorFor = (memberId: string | null): ActivityActor | null => {
+    const member = memberId ? lookup.get(memberId) : undefined;
+    if (!member) return null;
+    return {
+      id: member.id,
+      profile_id: member.profile_id,
+      ghost_name: member.ghost_name,
+      profile: member.profile ? { display_name: member.profile.display_name } : null,
+    };
   };
 
   if (group.isLoading) {
@@ -975,7 +989,11 @@ export default function GroupScreen() {
                   <View key={entry.id}>
                     <ListRow
                       title={describeActivity(
-                        entry,
+                        // The group feed rides the mirror, where an activity row
+                        // carries only `actor_member_id` — not the joined actor the
+                        // cross-group feed gets. Resolve the actor from this group's
+                        // members so the row names the person instead of "someone".
+                        entry.actor ? entry : { ...entry, actor: actorFor(entry.actor_member_id) },
                         profile?.id ?? null,
                         blockedIds,
                         t.misc.someone,


### PR DESCRIPTION
## Reported
The group **Activity** tab showed "someone" instead of the person's name on
every row.

## Cause
The group activity feed rides the offline mirror, where an `activity_log` row
carries only `actor_member_id` — **not** the joined actor (member + profile) that
the cross-group Activity tab's direct query provides. `describeActivity` →
`actorName` therefore had a null `actor` and returned the "someone" fallback.

## Fix
Resolve the actor from **this group's members** by `actor_member_id` (the screen
already has the member lookup) and hand `describeActivity` a populated actor, so
the row names who did the thing. Rows with a genuinely null actor (system actions
like a 7-day auto-confirm) are unchanged — they still get no actor by design.

## Scope
One file, mobile-only. typecheck + lint clean. Hot-reloadable, nothing to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activity entries on group screens now display the correct member details when actor information is missing.
  * Existing actor information remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->