### PR TITLE
feat(invite): durable, reusable group join link + QR (industry model, A47)

### DIFF
--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { decode as decodeBase64 } from 'base64-arraybuffer';
 import * as Clipboard from 'expo-clipboard';
@@ -7,6 +7,7 @@ import * as Sharing from 'expo-sharing';
 import { router, useLocalSearchParams } from 'expo-router';
 import {
   ActivityIndicator,
+  Alert,
   Linking,
   Platform,
   Pressable,
@@ -17,7 +18,6 @@ import {
 import QRCodeStyled from 'react-native-qrcode-styled';
 
 import {
-  Badge,
   Button,
   Callout,
   Card,
@@ -30,9 +30,10 @@ import {
   useScreenClearance,
 } from '@waves/ui';
 
-import { mintInvite, type MintedInvite } from '@/data/api';
+import { ensureGroupJoinToken, resetGroupJoinToken } from '@/data/api';
 import { friendlyError } from '@/lib/errors';
 import { useGroup } from '@/data/hooks';
+import { useSync } from '@/sync';
 import { groupLabel } from '@/data/types';
 import { useAuth } from '@/lib/auth';
 import { useStrings } from '@/i18n';
@@ -43,38 +44,100 @@ import { useStrings } from '@/i18n';
  */
 const INVITE_BASE = 'https://baaki.app/join';
 
+/**
+ * The group's durable join link, shown as a QR (the WhatsApp/Signal model).
+ *
+ * The link is one stable, re-showable token per group — the same one every open
+ * and on every device — so the QR paints straight from the mirror with no server
+ * round-trip once it exists. The first time a group is ever shared, the token is
+ * minted on open (a brief spinner). An admin can Reset it, which rotates the
+ * token and kills every copy of the old QR. Sharing and copying are separate
+ * buttons that hand out the same link.
+ */
 export default function InviteScreen() {
   const theme = useTheme();
   const clearance = useScreenClearance();
-  const { t, locale } = useStrings();
+  const { t } = useStrings();
   const { id } = useLocalSearchParams<{ id: string }>();
   const groupId = id ?? '';
 
   const { group, members } = useGroup(groupId);
   const { profile } = useAuth();
-  const [invite, setInvite] = useState<MintedInvite | null>(null);
+  const { flush } = useSync();
+
+  // The token from the mirror is authoritative; `ensured` is the value ensure/
+  // reset just returned, held so the QR appears the instant the RPC replies
+  // rather than waiting for the next pull to carry the group row back.
+  const [ensured, setEnsured] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   // The rendered QR, so a share can send the image itself and not just the link.
   const qrRef = useRef<{ toDataURL?: (cb: (base64: string) => void) => void } | null>(null);
 
-  const link = invite ? `${INVITE_BASE}#${invite.token}` : null;
+  const joinToken = group.data?.join_token ?? ensured;
+  const link = joinToken ? `${INVITE_BASE}#${joinToken}` : null;
 
-  const mint = async (): Promise<void> => {
+  const iAmAdmin =
+    (members.data ?? []).find((m) => m.profile_id === profile?.id && m.left_at === null)?.role ===
+    'admin';
+
+  const ensure = async (): Promise<void> => {
     setBusy(true);
     setError(null);
     try {
-      setInvite(await mintInvite(groupId));
+      const token = await ensureGroupJoinToken(groupId);
+      setEnsured(token);
+      void flush();
     } catch (caught) {
-      setError(friendlyError(caught, t.couldNotSave, 'invite.create'));
+      setError(friendlyError(caught, t.couldNotSave, 'invite.ensure'));
     } finally {
       setBusy(false);
     }
   };
 
+  // Make the link on open the first time a group is ever shared; if the mirror
+  // already carries one, there is nothing to do and the QR is there immediately.
+  const started = useRef(false);
+  useEffect(() => {
+    if (started.current) return;
+    if (group.isLoading || !group.data) return;
+    started.current = true;
+    // Already have a link from the mirror → nothing to do; the QR is showing.
+    if (group.data.join_token) return;
+    // Deferred a microtask so the state ensure() sets does not run synchronously
+    // inside the effect (that cascades renders); the mint still starts at once.
+    void Promise.resolve().then(() => ensure());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [group.isLoading, group.data]);
+
   const label = groupLabel(group.data, members.data ?? [], profile?.id);
   const message = t.people.shareMessage.replace('{group}', label).replace('{link}', link ?? '');
+
+  const reset = (): void => {
+    Alert.alert(t.people.resetLink, t.people.resetLinkBody, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.people.resetLink,
+        style: 'destructive',
+        onPress: () => {
+          void (async () => {
+            setBusy(true);
+            setError(null);
+            try {
+              const token = await resetGroupJoinToken(groupId);
+              setEnsured(token);
+              void flush();
+            } catch (caught) {
+              setError(friendlyError(caught, t.couldNotSave, 'invite.reset'));
+            } finally {
+              setBusy(false);
+            }
+          })();
+        },
+      },
+    ]);
+  };
 
   const share = async (): Promise<void> => {
     if (!link) return;
@@ -96,10 +159,8 @@ export default function InviteScreen() {
   /**
    * Send the QR code itself, so the person on the other end of a chat can scan
    * it rather than only tap a link. The image is the one thing a plain URL
-   * scheme cannot carry, so this goes through the OS share sheet (the only way
-   * to hand an app a file in managed Expo). `fallback` is the link-only path for
-   * when the code cannot be captured or nothing on the phone can accept a
-   * share — better a working link than a dead button.
+   * scheme cannot carry, so this goes through the OS share sheet. `fallback` is
+   * the link-only path for when the code cannot be captured.
    */
   const shareQr = async (fallback: () => Promise<void>): Promise<void> => {
     if (!link) return;
@@ -109,8 +170,6 @@ export default function InviteScreen() {
         await fallback();
         return;
       }
-      // expo-file-system 57 API: File/Paths, not the old string paths. The PNG
-      // is base64, so decode to bytes before writing.
       const file = new FileSystem.File(FileSystem.Paths.cache, 'waves-invite-qr.png');
       if (file.exists) file.delete();
       file.create();
@@ -125,27 +184,17 @@ export default function InviteScreen() {
     }
   };
 
-  /**
-   * The share sheet already reaches every app on the phone, but the three
-   * people actually use are worth one tap rather than three. Each is a plain
-   * URL scheme, so nothing here depends on those apps having an SDK.
-   */
   const shareVia = async (channel: 'whatsapp' | 'sms' | 'email'): Promise<void> => {
     if (!link) return;
     const url =
       channel === 'whatsapp'
         ? `whatsapp://send?text=${encodeURIComponent(message)}`
         : channel === 'sms'
-          ? // iOS wants '&body=', Android wants '?body=' — the separator is the
-            // only difference, and getting it wrong silently drops the text.
-            `sms:${Platform.OS === 'ios' ? '&' : '?'}body=${encodeURIComponent(message)}`
+          ? `sms:${Platform.OS === 'ios' ? '&' : '?'}body=${encodeURIComponent(message)}`
           : `mailto:?subject=${encodeURIComponent(t.people.emailSubject.replace('{group}', label))}&body=${encodeURIComponent(message)}`;
-
     try {
       await Linking.openURL(url);
     } catch {
-      // WhatsApp not installed, no mail account configured, a browser with no
-      // handler: fall back to the sheet rather than showing an error.
       await Share.share({ message });
     }
   };
@@ -183,40 +232,15 @@ export default function InviteScreen() {
         <Card style={{ gap: theme.spacing.md }}>
           <Text variant="subheading">{t.people.anyoneWithLink}</Text>
           <Text variant="caption" tone="muted">
-            {t.people.anyoneWithLinkBody}
+            {t.people.durableLinkBody}
           </Text>
         </Card>
 
-        {invite && link ? (
+        {link ? (
           <>
-            <Card style={{ gap: theme.spacing.md }}>
-              <Text variant="caption" tone="muted">
-                {t.people.inviteLink}
-              </Text>
-              <Text variant="body" style={{ color: theme.color.brand }} selectable>
-                {link}
-              </Text>
-              <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
-                <Badge
-                  label={t.people.expires.replace(
-                    '{when}',
-                    new Intl.DateTimeFormat(locale, {
-                      day: 'numeric',
-                      month: 'short',
-                    }).format(new Date(invite.expiresAt)),
-                  )}
-                />
-                <Badge label={t.people.usesBadge.replace('{count}', String(invite.maxUses))} />
-              </Row>
-            </Card>
-
-            {/* The same link as a code to point a camera at — for handing the
-                group to someone sitting across the table, where typing a URL or
-                waiting on a message is the slow way. Any phone's camera reads
-                it: it encodes the identical invite URL, so scanning it deep-links
-                into the same join flow the link does. Drawn on a white quiet zone
-                regardless of theme, because a QR on a dark background does not
-                scan. */}
+            {/* The QR is the point of the screen — the identical join link as a
+                code to point a camera at. Drawn on a white quiet zone regardless
+                of theme, because a QR on a dark background does not scan. */}
             <Card style={{ gap: theme.spacing.md, alignItems: 'center' }}>
               <Text variant="caption" tone="muted">
                 {t.people.scanToJoin}
@@ -229,38 +253,19 @@ export default function InviteScreen() {
                 }}
               >
                 <QRCodeStyled
-                  // The ref forwards to the underlying react-native-svg <Svg>,
-                  // whose toDataURL(cb) captureQr calls to share the code as a
-                  // PNG — same contract the old library's getRef gave us, so no
-                  // native screenshot module is needed.
                   ref={(c) => {
                     qrRef.current = c;
                   }}
                   data={link}
-                  // 200pt of modules plus a white quiet border, so it stays
-                  // crisp inside the card and scans without crowding the edge.
                   size={200}
                   padding={16}
                   style={{ backgroundColor: '#ffffff' }}
-                  // A fixed near-black rather than a theme token: the code lives
-                  // on a permanently white tile in both light and dark, so the
-                  // ink must not follow the theme or it would vanish in dark mode.
                   color="#0A0A1A"
-                  // Level-H error correction leaves ~30% redundancy, enough that
-                  // the punched-out centre logo and the rounded dots never cost a
-                  // scan.
                   errorCorrectionLevel="H"
-                  // Each module a rounded dot with a hair of a gap between them —
-                  // the "scan with phone" wallet look — instead of a solid grid.
                   pieceBorderRadius="50%"
                   pieceScale={0.92}
-                  // The three corner finders as rounded squares with a rounded
-                  // pupil, matching the dot treatment.
                   outerEyesOptions={{ borderRadius: '28%', color: '#0A0A1A' }}
                   innerEyesOptions={{ borderRadius: '35%', color: '#0A0A1A' }}
-                  // The Waves glyph on its rounded tile, centred with a quiet
-                  // margin; hidePieces clears the modules behind it so it sits in
-                  // a clean gap rather than on top of the code.
                   logo={{
                     href: require('../../../../assets/images/icon.png'),
                     scale: 0.85,
@@ -271,11 +276,16 @@ export default function InviteScreen() {
               </View>
             </Card>
 
-            {/* The quick channels as an even three-across of round icon
-                buttons with the name beneath — the share-row every reference app
-                uses (Strava, Instacart, Urban Company). Equal columns, so it
-                reads as one control instead of the ragged, wrapping pills it was.
-                Full share sheet still lives under the button below. */}
+            <Card style={{ gap: theme.spacing.sm }}>
+              <Text variant="caption" tone="muted">
+                {t.people.inviteLink}
+              </Text>
+              <Text variant="body" style={{ color: theme.color.brand }} selectable>
+                {link}
+              </Text>
+            </Card>
+
+            {/* The quick channels — the share-row every reference app uses. */}
             <Row style={{ gap: theme.spacing.sm }}>
               {(
                 [
@@ -288,8 +298,6 @@ export default function InviteScreen() {
                   key={option.channel}
                   accessibilityRole="button"
                   accessibilityLabel={option.label}
-                  // Send the QR image itself; drop to the plain link if the code
-                  // cannot be captured (see shareQr).
                   onPress={() => void shareQr(() => shareVia(option.channel))}
                   style={({ pressed }) => ({
                     flex: 1,
@@ -334,21 +342,47 @@ export default function InviteScreen() {
               />
             </Row>
 
+            {/* Rotating the link is an admin's lever, for when a link has spread
+                too far. It kills the current QR and every shared copy. */}
+            {iAmAdmin ? (
+              <Button
+                label={t.people.resetLink}
+                variant="ghost"
+                size="lg"
+                fullWidth
+                disabled={busy}
+                onPress={reset}
+                icon={
+                  <Ionicons name="refresh-outline" size={iconSize.md} color={theme.color.brand} />
+                }
+              />
+            ) : null}
+
             <Text variant="micro" tone="muted" align="center">
               {t.people.mintMistakeNote}
             </Text>
           </>
+        ) : error ? (
+          // Minting failed — a retry, not a first step.
+          <Button label={t.people.createLink} size="lg" fullWidth onPress={() => void ensure()} />
         ) : (
-          <Button
-            label={t.people.createLink}
-            size="lg"
-            fullWidth
-            disabled={busy}
-            onPress={() => void mint()}
-          />
+          // First-ever share (or still loading): the durable link is being made.
+          // Hold the QR's place so the screen reads as "your code is coming".
+          <Card
+            style={{
+              alignItems: 'center',
+              justifyContent: 'center',
+              paddingVertical: theme.spacing.xxxl,
+              gap: theme.spacing.md,
+            }}
+          >
+            <ActivityIndicator color={theme.color.brand} />
+            <Text variant="caption" tone="muted">
+              {t.common.loading}
+            </Text>
+          </Card>
         )}
 
-        {busy ? <ActivityIndicator color={theme.color.brand} /> : null}
         {error ? <Callout tone="negative">{error}</Callout> : null}
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -1010,6 +1010,28 @@ export async function revokeInvite(inviteId: string): Promise<void> {
   if (error) throw new Error(error.message);
 }
 
+/**
+ * The group's durable join link (WhatsApp-style): a stable, re-showable token,
+ * made on first use. Any member may fetch it; it is the same token on every call
+ * while it is live, so the QR is stable across opens and devices.
+ */
+export async function ensureGroupJoinToken(groupId: string): Promise<string> {
+  const { data, error } = await supabase.rpc('baaki_ensure_group_join_token', {
+    p_group_id: groupId,
+  });
+  if (error) throw new Error(error.message);
+  return data as string;
+}
+
+/** Rotate the durable link (admin only) — the old QR and every shared copy die. */
+export async function resetGroupJoinToken(groupId: string): Promise<string> {
+  const { data, error } = await supabase.rpc('baaki_reset_group_join_token', {
+    p_group_id: groupId,
+  });
+  if (error) throw new Error(error.message);
+  return data as string;
+}
+
 // ──────────────────────────────────────── export (ADR-012) ──
 
 export interface ExportResult {

--- a/apps/mobile/src/data/types.ts
+++ b/apps/mobile/src/data/types.ts
@@ -38,6 +38,10 @@ export interface GroupRow {
   cover_emoji: string | null;
   /** Object path in the private `group-photos` bucket, or null. */
   photo_path: string | null;
+  /** Raw token of the group's durable join link (re-showable as a QR), or null
+   *  until first created. Member-only (the group row is RLS-scoped). Optional
+   *  because the narrow REST selects omit it; the `*` mirror pull carries it. */
+  join_token?: string | null;
   /** ISO dates, both ends inclusive. Null on a group that is not a trip. */
   start_date: string | null;
   end_date: string | null;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1255,6 +1255,12 @@ export interface UiStrings {
     shareAnotherWay: string;
     copyLink: string;
     createLink: string;
+    /** Body under "anyone with the link" — the durable-link explainer. */
+    durableLinkBody: string;
+    /** Admin action to rotate the durable link. */
+    resetLink: string;
+    /** Confirm body before rotating. */
+    resetLinkBody: string;
     linkCopied: string;
     expires: string;
     usesBadge: string;
@@ -2924,6 +2930,11 @@ const en: UiStrings = {
     shareAnotherWay: 'Share another way',
     copyLink: 'Copy link',
     createLink: 'Create an invite link',
+    durableLinkBody:
+      'Anyone with this link or QR can join. It stays the same every time — reset it if it spreads too far.',
+    resetLink: 'Reset link',
+    resetLinkBody:
+      'The current link and QR stop working. Everyone you already invited is unaffected.',
     linkCopied: 'Link copied',
     expires: 'expires {when}',
     usesBadge: '{count} uses',
@@ -4689,6 +4700,11 @@ const ta: UiStrings = {
     shareAnotherWay: 'வேறு வழியில் பகிர்',
     copyLink: 'இணைப்பை நகலெடு',
     createLink: 'அழைப்பு இணைப்பை உருவாக்கு',
+    durableLinkBody:
+      'இந்த இணைப்பு அல்லது QR உள்ள யாரும் சேரலாம். இது எப்போதும் ஒரே மாதிரியாக இருக்கும் — அதிகம் பரவினால் மீட்டமை.',
+    resetLink: 'இணைப்பை மீட்டமை',
+    resetLinkBody:
+      'தற்போதைய இணைப்பும் QR-ம் வேலை செய்யாது. நீங்கள் ஏற்கனவே அழைத்தவர்கள் பாதிக்கப்பட மாட்டார்கள்.',
     linkCopied: 'இணைப்பு நகலெடுக்கப்பட்டது',
     expires: '{when} க்கு காலாவதி',
     usesBadge: '{count} பயன்பாடுகள்',
@@ -6440,6 +6456,11 @@ const hi: UiStrings = {
     shareAnotherWay: 'किसी और तरीके से साझा करें',
     copyLink: 'लिंक कॉपी करें',
     createLink: 'निमंत्रण लिंक बनाएँ',
+    durableLinkBody:
+      'इस लिंक या QR वाला कोई भी जुड़ सकता है। यह हर बार एक जैसा रहता है — ज़्यादा फैल जाए तो रीसेट करें।',
+    resetLink: 'लिंक रीसेट करें',
+    resetLinkBody:
+      'मौजूदा लिंक और QR काम करना बंद कर देंगे। जिन्हें आपने पहले बुलाया है वे प्रभावित नहीं होंगे।',
     linkCopied: 'लिंक कॉपी हो गया',
     expires: '{when} को खत्म',
     usesBadge: '{count} उपयोग',
@@ -8205,6 +8226,10 @@ const ar: UiStrings = {
     shareAnotherWay: 'شارك بطريقة أخرى',
     copyLink: 'نسخ الرابط',
     createLink: 'أنشئ رابط دعوة',
+    durableLinkBody:
+      'يمكن لأي شخص لديه هذا الرابط أو رمز QR الانضمام. يبقى كما هو في كل مرة — أعِد تعيينه إذا انتشر كثيرًا.',
+    resetLink: 'إعادة تعيين الرابط',
+    resetLinkBody: 'يتوقف الرابط ورمز QR الحاليان عن العمل. لن يتأثر من دعوتهم من قبل.',
     linkCopied: 'تم نسخ الرابط',
     expires: 'ينتهي {when}',
     usesBadge: '{count} استخدامات',

--- a/docs/group-join-link.md
+++ b/docs/group-join-link.md
@@ -1,0 +1,62 @@
+# Durable group join link — built
+
+Status: **built** (this PR). Validated on **local Postgres** (7 threat tests);
+not deployed until an ops window (migration only — no edge change).
+
+The industry-standard group invite (WhatsApp / Signal / Telegram / Splitwise): a
+single **durable, reusable link per group**, shown as a QR by default and the
+same on every open and device, with an **admin Reset** to rotate it.
+
+## Why it needed a change
+
+Today's `invites` are one-time-reveal — the raw token is returned once by
+`invite-mint` and only its **SHA-256 hash** is stored, so a link can never be
+re-shown. That is right for "share a limited invite", but it forced the QR screen
+to mint a fresh link every visit. The durable model needs a **re-showable** token.
+
+## Shape (reuses the entire existing join pipeline)
+
+- The group keeps **one durable invite** whose raw token is stored on
+  `groups.join_token` (re-showable), while an ordinary `invites` row carries its
+  hash with a **100-year expiry** and an effectively unlimited use count. So
+  preview / accept / ghost-claim / device-cap / guest all work on the durable
+  link **unchanged** — `invite-accept` just hashes the token it receives and
+  looks it up. Nothing new joins; only the link's lifecycle is new.
+- `join_token` rides the normal `select('*')` group pull, so the QR **paints from
+  the mirror** with no server round-trip once it exists.
+- **RPCs** (migration `20260824170000_group_join_link`):
+  - `baaki_ensure_group_join_token(group_id)` — any member; get-or-create; returns
+    the same token while it is live (stable QR).
+  - `baaki_reset_group_join_token(group_id)` — **admin only**; revokes the current
+    durable invite (old QR dies) and mints a fresh one.
+  - `baaki_new_group_join_token` — internal helper (REVOKEd from clients).
+- The token is a bearer credential but reaches only **members** (the group row is
+  RLS-scoped). `join_token` is pinned in `baaki_guard_group_columns` so a client
+  can never write it directly — only the SECURITY DEFINER RPCs (which run as the
+  owner and skip the guard) may.
+- **pgcrypto**: SHA-256 must match the edge's plain `sha256`. The migration
+  creates the `extensions` schema + pgcrypto there (a no-op on Supabase, where it
+  already lives) and qualifies every call `extensions.digest` / — so resolution is
+  identical on prod and on a bare test Postgres.
+- **UI** — the invite screen reads `group.join_token`; the QR is there on open
+  (or minted once with a brief spinner the first time a group is ever shared).
+  Share / Copy / channel buttons hand out the same link. Admins get a **Reset
+  link** button (confirm → rotates). i18n `durableLinkBody` / `resetLink` /
+  `resetLinkBody` ×4.
+
+## Threat tests
+
+`packages/db/test/group-join-link.test.ts` — **T1–T7 green on local pg**: member
+gets a token backed by a live 100-yr invite stored on the group; ensure is
+idempotent (one invite, stable token); non-member refused; admin reset (new
+token, old invite revoked, new live); non-admin reset refused; direct
+`join_token` write refused (guarded column); a dead stored token is replaced on
+the next ensure. The tests hash the returned token with Node's `crypto` and match
+it against the stored `token_hash`, proving the accept path will resolve it.
+
+## Deploy
+
+Needs `db:migrate deploy` (migration `20260824170000`). **No edge change** — the
+group pull is already `select('*')`, so `join_token` flows without redeploying
+`sync`, and preview/accept are unchanged. Superseded the auto-mint tweak (closed
+PR #414).

--- a/packages/db/prisma/migrations/20260824170000_group_join_link/migration.sql
+++ b/packages/db/prisma/migrations/20260824170000_group_join_link/migration.sql
@@ -1,0 +1,201 @@
+-- A durable, reusable group join link (the WhatsApp/Signal/Telegram model).
+--
+-- Today's invites are one-time-reveal: the raw token is returned once by
+-- invite-mint and only its SHA-256 hash is stored, so a link can never be shown
+-- again. That is right for a "share a limited invite" flow, but it means the QR
+-- screen had to mint a fresh link every visit. The industry pattern is a single
+-- stable link per group, shown instantly and re-showable, with a Reset to rotate
+-- it if it leaks.
+--
+-- So the group keeps ONE durable invite whose raw token is stored on the group
+-- (`groups.join_token`) — re-showable — while an ordinary `invites` row carries
+-- its hash with a 100-year expiry and an effectively unlimited use count. That
+-- means the entire existing preview / accept / ghost-claim / device-cap / guest
+-- pipeline works on the durable link UNCHANGED (invite-accept just hashes the
+-- token it receives and looks it up). Nothing new joins; only the link's
+-- lifecycle is new. `join_token` rides the normal `select('*')` group pull, so
+-- the QR paints from the mirror with no server round-trip once it exists.
+--
+-- The token is a bearer credential, but it reaches only group members: the group
+-- row is RLS-scoped, so a non-member never receives `join_token`. Members can
+-- already mint invites, so this widens nothing. Resetting is admin-only.
+
+-- SHA-256 must match the edge's (plain sha256, no secret), so we need pgcrypto's
+-- digest. On Supabase it already lives in the `extensions` schema; create that
+-- schema + extension so a bare Postgres (the test DB) has it in the same place,
+-- and qualify every call `extensions.*` so the resolution is identical in both.
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
+
+ALTER TABLE public.groups ADD COLUMN IF NOT EXISTS join_token text;
+
+-- Pin join_token against a direct client write: only the SECURITY DEFINER RPCs
+-- below (which run as the owner and so skip this guard) may set it. Otherwise a
+-- member could PATCH it to garbage and break the group's QR. This re-declares
+-- the guard from 20260824130000 with one added clause.
+CREATE OR REPLACE FUNCTION public.baaki_guard_group_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF current_user NOT IN ('anon', 'authenticated') THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.updated_seq IS DISTINCT FROM OLD.updated_seq THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: updated_seq is set by the server, not the client'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creator is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.id IS DISTINCT FROM OLD.id THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s id is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creation time is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.photo_path IS DISTINCT FROM OLD.photo_path
+     AND NEW.photo_path IS NOT NULL
+     AND NOT public.baaki_can_upload_group_photo(NEW.id) THEN
+    RAISE EXCEPTION 'PHOTO_GATE: a group photo is a paid feature'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.category_budgets IS DISTINCT FROM OLD.category_budgets THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: category budgets are set through baaki_set_category_budget, not a direct write'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.join_token IS DISTINCT FROM OLD.join_token THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: the join link is set through baaki_ensure_group_join_token / baaki_reset_group_join_token, not a direct write'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN NEW;
+END
+$$;
+
+-- ────────────────────────────────────────────────────────── the durable link ──
+
+/**
+ * A fresh durable invite for a group: a random raw token, its hash in `invites`
+ * with a 100-year life and an effectively unlimited use count, and the raw token
+ * on the group so it can be re-shown. Internal — the two entry points below call
+ * it. `p_revoke_existing` retires the group's current durable link first (reset);
+ * ensure leaves other live links alone.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_new_group_join_token(
+  p_group_id uuid,
+  p_revoke_existing boolean
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_old   text;
+  v_token text;
+BEGIN
+  SELECT join_token INTO v_old FROM public.groups WHERE id = p_group_id;
+
+  IF p_revoke_existing AND v_old IS NOT NULL THEN
+    UPDATE public.invites
+       SET revoked_at = now()
+     WHERE group_id = p_group_id
+       AND token_hash = encode(extensions.digest(v_old, 'sha256'), 'hex')
+       AND revoked_at IS NULL;
+  END IF;
+
+  -- 256 bits from two UUIDs (no pgcrypto needed for the token itself), hex, so
+  -- it is URL-safe and needs no encoding in the link.
+  v_token := replace(gen_random_uuid()::text || gen_random_uuid()::text, '-', '');
+
+  INSERT INTO public.invites (group_id, token_hash, created_by, expires_at, max_uses)
+  VALUES (
+    p_group_id,
+    encode(extensions.digest(v_token, 'sha256'), 'hex'),
+    public.baaki_current_profile_id(),
+    now() + interval '100 years',
+    1000000
+  );
+
+  UPDATE public.groups SET join_token = v_token WHERE id = p_group_id;
+  RETURN v_token;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_new_group_join_token(uuid, boolean) FROM public, anon, authenticated;
+
+/**
+ * The group's durable join token, making one on first use. Any member may fetch
+ * it — a shared link is a member-level convenience, not an admin one, matching
+ * who can mint an invite today. Returns the same token on every call while the
+ * durable link is still live, so the QR is stable across opens and devices.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_ensure_group_join_token(p_group_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_token text;
+  v_live  boolean;
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  SELECT join_token INTO v_token FROM public.groups WHERE id = p_group_id;
+  IF v_token IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.invites
+       WHERE group_id = p_group_id
+         AND token_hash = encode(extensions.digest(v_token, 'sha256'), 'hex')
+         AND revoked_at IS NULL
+         AND expires_at > now()
+         AND use_count < max_uses
+    ) INTO v_live;
+    IF v_live THEN
+      RETURN v_token;
+    END IF;
+  END IF;
+
+  RETURN public.baaki_new_group_join_token(p_group_id, false);
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_ensure_group_join_token(uuid) TO authenticated, anon;
+
+/**
+ * Rotate the durable link: revoke the current one (its QR and every copy of it
+ * stop working) and mint a fresh one. Admin-only — one member should not be able
+ * to invalidate the link the whole group has been sharing.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_reset_group_join_token(p_group_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF NOT public.is_group_admin(p_group_id) THEN
+    RAISE EXCEPTION 'ADMIN_ONLY: only an admin can reset the join link'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN public.baaki_new_group_join_token(p_group_id, true);
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_reset_group_join_token(uuid) TO authenticated, anon;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -191,6 +191,10 @@ model Group {
   name            String?
   /// Object path in the private `group-photos` bucket, read via a signed URL.
   photoPath       String?   @map("photo_path")
+  /// The raw token of the group's durable join link (WhatsApp-style), re-showable
+  /// as a QR. Written only by baaki_ensure/reset_group_join_token; a member-only
+  /// bearer credential (the group row is RLS-scoped).
+  joinToken       String?   @map("join_token")
   type            GroupType @default(other)
   /// ISO-3166 alpha-2 — where this group settles, which is not always where its
   /// members live. A Goa trip run from Dubai settles in rupees over UPI, and

--- a/packages/db/test/group-join-link.test.ts
+++ b/packages/db/test/group-join-link.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The durable group join link — a stable, re-showable invite (the WhatsApp
+ * model). These guard its lifecycle: any member can fetch it, only an admin can
+ * rotate it, nobody can write the token directly, and the token it hands out
+ * really resolves to a live invite the accept path will honour.
+ */
+
+import { randomUUID, createHash } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, expectDenied, seedGroup } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+async function as<T>(profileId: string | null, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    profileId
+      ? JSON.stringify({ sub: profileId, role: 'authenticated' })
+      : JSON.stringify({ role: 'anon' }),
+  ]);
+  await client.query(`SET ROLE ${profileId ? 'authenticated' : 'anon'}`);
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+let g: { groupId: string; profileIds: string[]; memberIds: string[] };
+
+beforeAll(async () => {
+  g = await seedGroup(client, { memberCount: 3, name: 'JoinLink' });
+});
+
+beforeEach(async () => {
+  await client.query(`UPDATE groups SET join_token = NULL WHERE id = $1`, [g.groupId]);
+  await client.query(`DELETE FROM invites WHERE group_id = $1`, [g.groupId]);
+});
+
+const P = (i: number) => g.profileIds[i] as string;
+
+const ensure = (profileId: string) =>
+  as(profileId, () =>
+    client
+      .query(`SELECT baaki_ensure_group_join_token($1) AS token`, [g.groupId])
+      .then((r) => r.rows[0].token as string),
+  );
+
+const reset = (profileId: string) =>
+  as(profileId, () =>
+    client
+      .query(`SELECT baaki_reset_group_join_token($1) AS token`, [g.groupId])
+      .then((r) => r.rows[0].token as string),
+  );
+
+const sha256Hex = (value: string) => createHash('sha256').update(value).digest('hex');
+
+const inviteFor = (token: string) =>
+  client
+    .query(
+      `SELECT revoked_at, expires_at, max_uses, use_count FROM invites
+        WHERE group_id = $1 AND token_hash = $2`,
+      [g.groupId, sha256Hex(token)],
+    )
+    .then((r) => r.rows[0]);
+
+describe('durable group join link', () => {
+  it('T1 a member gets a token backed by a live invite, stored on the group', async () => {
+    const token = await ensure(P(1));
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    const stored = await client
+      .query(`SELECT join_token FROM groups WHERE id = $1`, [g.groupId])
+      .then((r) => r.rows[0].join_token);
+    expect(stored).toBe(token);
+    const invite = await inviteFor(token);
+    expect(invite).toBeTruthy();
+    expect(invite.revoked_at).toBeNull();
+    expect(Number(invite.max_uses)).toBeGreaterThan(1000);
+    expect(new Date(invite.expires_at).getFullYear()).toBeGreaterThan(2100);
+  });
+
+  it('T2 ensure is idempotent while the link is live (stable QR)', async () => {
+    const a = await ensure(P(1));
+    const b = await ensure(P(2));
+    expect(b).toBe(a);
+    const n = await client
+      .query(`SELECT count(*)::int AS n FROM invites WHERE group_id = $1`, [g.groupId])
+      .then((r) => r.rows[0].n as number);
+    expect(n).toBe(1);
+  });
+
+  it('T3 a non-member cannot fetch the link', async () => {
+    const outsider = randomUUID();
+    await client.query(
+      `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Out', 'INR')`,
+      [outsider],
+    );
+    const msg = await expectDenied(
+      as(outsider, () => client.query(`SELECT baaki_ensure_group_join_token($1)`, [g.groupId])),
+    );
+    expect(msg).toMatch(/NOT_A_MEMBER/);
+  });
+
+  it('T4 an admin resets: new token, old invite revoked, new one live', async () => {
+    const first = await ensure(P(1));
+    const second = await reset(P(0));
+    expect(second).not.toBe(first);
+    expect(await inviteFor(first).then((r) => r.revoked_at)).not.toBeNull();
+    expect(await inviteFor(second).then((r) => r.revoked_at)).toBeNull();
+    const stored = await client
+      .query(`SELECT join_token FROM groups WHERE id = $1`, [g.groupId])
+      .then((r) => r.rows[0].join_token);
+    expect(stored).toBe(second);
+  });
+
+  it('T5 a non-admin member cannot reset', async () => {
+    await ensure(P(1));
+    const msg = await expectDenied(
+      as(P(1), () => client.query(`SELECT baaki_reset_group_join_token($1)`, [g.groupId])),
+    );
+    expect(msg).toMatch(/ADMIN_ONLY/);
+  });
+
+  it('T6 a client cannot write join_token directly (guarded column)', async () => {
+    const msg = await expectDenied(
+      as(P(1), () =>
+        client.query(`UPDATE groups SET join_token = 'forged' WHERE id = $1`, [g.groupId]),
+      ),
+    );
+    expect(msg).toMatch(/FORBIDDEN_COLUMN/);
+  });
+
+  it('T7 a stale/dead stored token is replaced on the next ensure', async () => {
+    const token = await ensure(P(1));
+    // Kill the invite behind it (as if it were revoked out of band).
+    await client.query(`UPDATE invites SET revoked_at = now() WHERE group_id = $1`, [g.groupId]);
+    const fresh = await ensure(P(1));
+    expect(fresh).not.toBe(token);
+    expect(await inviteFor(fresh).then((r) => r.revoked_at)).toBeNull();
+  });
+});


### PR DESCRIPTION
The industry-standard group invite you asked for (WhatsApp / Signal / Telegram /
Splitwise): **one durable, reusable link per group**, shown as a QR by default —
the same link on every open and device — with an **admin Reset** to rotate it.
Supersedes #414 (the mint-per-visit tweak, now closed).

## Why a change was needed
Today's `invites` are one-time-reveal — only the token **hash** is stored, so a
link can never be re-shown. That forced the QR screen to mint a fresh link each
visit. The durable model needs a re-showable token.

## How (reuses the whole existing join pipeline)
- The group keeps **one durable invite** whose raw token lives on
  `groups.join_token` (re-showable), while an ordinary `invites` row carries its
  hash with a **100-year** expiry and an effectively unlimited use count. So
  preview / accept / ghost-claim / device-cap / guest all work on the durable
  link **unchanged** — `invite-accept` just hashes the token and looks it up.
- `join_token` rides the `select('*')` group pull → the QR **paints from the
  mirror**, no server round-trip once it exists.
- RPCs: `baaki_ensure_group_join_token` (any member, get-or-create, stable token)
  and `baaki_reset_group_join_token` (**admin only**, revokes the old → old QR
  dies, mints new). `join_token` is pinned in `baaki_guard_group_columns` so no
  client can write it directly.
- pgcrypto is created in the `extensions` schema (no-op on Supabase) so SQL
  SHA-256 matches the edge's on prod **and** on a bare test Postgres.
- UI: QR on open (minted once on first-ever share, brief spinner), admin **Reset
  link** button, Share/Copy unchanged. i18n ×4.

## Tests
`packages/db/test/group-join-link.test.ts` — **7 threat tests green on local pg**
(member get-or-create backed by a live 100-yr invite; idempotent/stable token;
non-member refused; admin reset revokes old + mints new; non-admin reset refused;
direct `join_token` write refused; dead token replaced). They hash the returned
token with Node crypto and match the stored `token_hash`, proving accept resolves
it. Full DB suite 550 green.

## Deploy
`db:migrate deploy` (`20260824170000`). **No edge change** (group pull is already
`select('*')`; preview/accept unchanged).

## Deviation owed
ADR-006 addendum: a durable member-visible bearer join link + admin reset,
alongside the existing one-time limited invites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable group join links and QR codes that remain valid until reset.
  * Group admins can reset a join link, immediately invalidating the previous link and QR code.
  * Added loading, retry, and error states for link creation.
  * Added localized explanations and reset confirmations in English, Tamil, Hindi, and Arabic.

* **Documentation**
  * Added documentation covering durable group join links and their behavior.

* **Tests**
  * Added coverage for link creation, access controls, rotation, revocation, and security protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->