### PR TITLE
feat(comments): window a long expense thread with reveal-older paging

### DIFF
--- a/apps/mobile/src/components/ExpenseComments.tsx
+++ b/apps/mobile/src/components/ExpenseComments.tsx
@@ -44,6 +44,16 @@ function whenLabel(iso: string | null, locale: string): string {
 
 const AVATAR = 32;
 
+/**
+ * How many comments to render at once. A long thread is all on the device
+ * already (it rides the mirror), so this bounds the render cost, not a fetch —
+ * the newest page shows, older pages reveal on demand as the person scrolls up,
+ * the pattern every embedded comment thread uses (Instagram, YouTube). Rendering
+ * a nested FlatList inside the page's ScrollView would trip React Native's
+ * "VirtualizedLists should never be nested" warning, so the window is manual.
+ */
+const PAGE = 20;
+
 export function ExpenseComments({
   groupId,
   expenseId,
@@ -75,10 +85,16 @@ export function ExpenseComments({
   // of waiting on the sync pull that carries it back from the mirror. Each drops
   // out of the merge below the moment the mirror row with the same id arrives.
   const [optimistic, setOptimistic] = useState<ExpenseCommentRow[]>([]);
+  // How many of the newest comments are rendered. Grows a page at a time when
+  // the person taps "show earlier" — the just-posted comment always sits in this
+  // tail window, so an echo never lands out of view.
+  const [visibleCount, setVisibleCount] = useState(PAGE);
 
   const mirrorRows = comments.data;
   const mirrorIds = new Set(mirrorRows.map((r) => r.id));
   const rows = [...mirrorRows, ...optimistic.filter((o) => !mirrorIds.has(o.id))];
+  const shown = rows.length > visibleCount ? rows.slice(rows.length - visibleCount) : rows;
+  const hidden = rows.length - shown.length;
 
   const submit = () => {
     const body = draft.trim();
@@ -197,12 +213,29 @@ export function ExpenseComments({
 
   return (
     <View style={{ gap: theme.spacing.lg }}>
+      {hidden > 0 ? (
+        <Pressable
+          onPress={() => setVisibleCount((c) => c + PAGE)}
+          accessibilityRole="button"
+          accessibilityLabel={`${t.comments.showEarlier} (${hidden})`}
+          hitSlop={8}
+          style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, alignSelf: 'flex-start' })}
+        >
+          <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            <Ionicons name="chevron-up" size={14} color={theme.color.buttonPrimary} />
+            <Text variant="caption" style={{ color: theme.color.buttonPrimary, fontWeight: '600' }}>
+              {`${t.comments.showEarlier} (${hidden})`}
+            </Text>
+          </Row>
+        </Pressable>
+      ) : null}
+
       {rows.length === 0 ? (
         <Text variant="caption" tone="muted">
           {t.comments.empty}
         </Text>
       ) : (
-        rows.map((row) => {
+        shown.map((row) => {
           const mine = myMemberId !== null && row.authorMemberId === myMemberId;
           const flagged = row.flaggedAt !== null;
           const editing = editingId === row.id;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -395,6 +395,8 @@ export interface UiStrings {
     you: string;
     couldNotPost: string;
     couldNotDelete: string;
+    /** Reveal the previous page of older comments (a count is appended). */
+    showEarlier: string;
   };
   /** Trip budgets. */
   budgets: string;
@@ -2100,6 +2102,7 @@ const en: UiStrings = {
     you: 'You',
     couldNotPost: "Couldn't post that — try again.",
     couldNotDelete: "Couldn't delete that — try again.",
+    showEarlier: 'Show earlier comments',
   },
   budgets: 'Budgets',
   overallBudget: 'Overall',
@@ -3818,6 +3821,7 @@ const ta: UiStrings = {
     you: 'நீங்கள்',
     couldNotPost: 'இட முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
     couldNotDelete: 'நீக்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
+    showEarlier: 'முந்தைய கருத்துகளைக் காட்டு',
   },
   budgets: 'பட்ஜெட்',
   overallBudget: 'மொத்தம்',
@@ -5602,6 +5606,7 @@ const hi: UiStrings = {
     you: 'आप',
     couldNotPost: 'भेजा नहीं जा सका — फिर कोशिश करें।',
     couldNotDelete: 'हटाया नहीं जा सका — फिर कोशिश करें।',
+    showEarlier: 'पहले की टिप्पणियाँ दिखाएँ',
   },
   budgets: 'बजट',
   overallBudget: 'कुल',
@@ -7335,6 +7340,7 @@ const ar: UiStrings = {
     you: 'أنت',
     couldNotPost: 'تعذّر النشر — حاول مرة أخرى.',
     couldNotDelete: 'تعذّر الحذف — حاول مرة أخرى.',
+    showEarlier: 'عرض التعليقات السابقة',
   },
   budgets: 'الميزانية',
   overallBudget: 'الإجمالي',


### PR DESCRIPTION
## What

A comment thread rendered **every** row inline inside the expense-detail `ScrollView`. On a busy bill that mounts hundreds of Views at once and buries the composer below all of them. This windows the thread.

- Render only the newest **20** comments; older ones reveal a page at a time via a **"show earlier comments (N)"** affordance at the top of the thread.
- The optimistic echo always sits in the tail window, so a just-posted comment never lands out of view.
- Comments ride the mirror — every row is already on the device — so this bounds the **render**, not a fetch. A nested `FlatList` would trip RN's *"VirtualizedLists should never be nested inside a ScrollView"* warning, so the window is manual (Instagram/YouTube embedded-thread pattern).
- New i18n key `comments.showEarlier` in en/ta/hi/ar.

## Test

- `pnpm --filter @waves/mobile typecheck` ✅
- `pnpm --filter @waves/mobile lint` ✅
- `pnpm format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expense comments now load in manageable groups, initially showing the 20 newest comments.
  * Added a “Show earlier” control to reveal older comments incrementally.
  * Newly posted comments remain visible immediately.
  * Added translations for the new control in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->