### PR TITLE
feat(expense): audit trail for receipt & attachment image changes (A46 part 2)

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -32,9 +32,12 @@ import { ExpenseComments } from '@/components/ExpenseComments';
 import {
   memberLookup,
   useDeleteExpense,
+  useExpenseImageEvents,
   useExpenseVersions,
   useGroup,
+  useRemoveExpenseReceipt,
   useRestoreExpense,
+  type ExpenseImageEventRow,
 } from '@/data/hooks';
 import { expenseTitle } from '@/data/expenseTitle';
 import { useBlockedUsers } from '@/data/blocked';
@@ -55,6 +58,19 @@ function splitLabels(t: UiStrings): Record<string, string> {
   };
 }
 
+/** One line of the image audit — "{name} added the receipt", etc. */
+function imageAuditLine(t: UiStrings, event: ExpenseImageEventRow, name: string): string {
+  const template =
+    event.kind === 'receipt'
+      ? event.action === 'added'
+        ? t.imageAudit.receiptAdded
+        : t.imageAudit.receiptRemoved
+      : event.action === 'added'
+        ? t.imageAudit.attachmentAdded
+        : t.imageAudit.attachmentRemoved;
+  return fill(template, { name });
+}
+
 export default function ExpenseDetailScreen() {
   const theme = useTheme();
   const clearance = useScreenClearance();
@@ -65,6 +81,8 @@ export default function ExpenseDetailScreen() {
 
   const { group, members, expenses } = useGroup(groupId);
   const versions = useExpenseVersions(expenseId ?? '');
+  const imageEvents = useExpenseImageEvents(expenseId ?? '');
+  const removeReceipt = useRemoveExpenseReceipt(groupId, expenseId ?? '');
   const scrollRef = useRef<RNScrollView>(null);
   const deleteExpense = useDeleteExpense(groupId);
   const restoreExpense = useRestoreExpense(groupId);
@@ -183,6 +201,24 @@ export default function ExpenseDetailScreen() {
       `/receipt/${expense.id}?path=${encodeURIComponent(expenseReceiptPath(groupId, expense.id))}`,
     );
   };
+  // Only a party to the expense (a payer or the author) — or an admin — may
+  // remove the kept bill, since the bill is evidence for the amount. The removal
+  // is recorded in the image audit below, so a swap is never silent.
+  const canManageReceipt = isExpenseParty || iAmAdmin;
+  const confirmRemoveReceipt = (): void => {
+    Alert.alert(t.imageAudit.removeReceiptConfirm, undefined, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.imageAudit.removeReceipt,
+        style: 'destructive',
+        onPress: () =>
+          removeReceipt.mutate(undefined, {
+            onSuccess: () => setReceiptUri(null),
+            onError: () => Alert.alert(t.imageAudit.couldNotRemove),
+          }),
+      },
+    ]);
+  };
   // The hero wears the expense's category colour, not a money colour: this
   // amount is a total that belongs to nobody, shown neutral. Ink from the same
   // pair keeps it legible on the tint.
@@ -289,13 +325,23 @@ export default function ExpenseDetailScreen() {
             pinch-zoom viewer; the image is served from R2 to any group member.
             Absent entirely when no bill was kept. */}
         {hasReceipt ? (
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.expense.viewReceipt}
-            onPress={openReceipt}
-          >
-            <Card style={{ paddingVertical: theme.spacing.md }}>
-              <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+          <Card style={{ paddingVertical: theme.spacing.md }}>
+            <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+              {/* The view tap is its own Pressable so the remove button beside it
+                  is not swallowed by it (no nested-Pressable ambiguity). */}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.expense.viewReceipt}
+                onPress={openReceipt}
+                style={({ pressed }) => ({
+                  flex: 1,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: theme.spacing.md,
+                  minWidth: 0,
+                  opacity: pressed ? 0.6 : 1,
+                })}
+              >
                 {receiptUri ? (
                   <Image
                     source={{ uri: receiptUri }}
@@ -330,9 +376,24 @@ export default function ExpenseDetailScreen() {
                   size={iconSize.md}
                   color={theme.color.textFaint}
                 />
-              </Row>
-            </Card>
-          </Pressable>
+              </Pressable>
+              {canManageReceipt ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={t.imageAudit.removeReceipt}
+                  onPress={confirmRemoveReceipt}
+                  disabled={removeReceipt.isPending}
+                  hitSlop={10}
+                  style={({ pressed }) => ({
+                    padding: theme.spacing.xs,
+                    opacity: removeReceipt.isPending ? 0.4 : pressed ? 0.5 : 1,
+                  })}
+                >
+                  <Ionicons name="trash-outline" size={iconSize.md} color={theme.color.negative} />
+                </Pressable>
+              ) : null}
+            </Row>
+          </Card>
         ) : null}
 
         {/* Where it happened (A43). A tap opens the point in the phone's maps
@@ -492,6 +553,50 @@ export default function ExpenseDetailScreen() {
             ))}
           </Card>
         </View>
+
+        {/* The image audit (A46): who added or removed a receipt or an attachment,
+            oldest first. A `parties` line only reaches a party's device (RLS on
+            the pull), so anyone who sees a line here was allowed to. Absent until
+            something happens to an image. */}
+        {(imageEvents.data ?? []).length > 0 ? (
+          <View>
+            <SectionHeader title={t.imageAudit.title} />
+            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+              {(imageEvents.data ?? []).map((event, index, arr) => (
+                <View key={event.id}>
+                  <ListRow
+                    title={imageAuditLine(t, event, nameOf(event.actorMemberId))}
+                    subtitle={
+                      event.createdAt
+                        ? new Intl.DateTimeFormat(locale, {
+                            day: 'numeric',
+                            month: 'short',
+                            hour: 'numeric',
+                            minute: '2-digit',
+                          }).format(new Date(event.createdAt))
+                        : undefined
+                    }
+                    leading={
+                      <Avatar
+                        name={nameOf(event.actorMemberId)}
+                        emoji={event.action === 'added' ? '📎' : '🗑️'}
+                        size={38}
+                      />
+                    }
+                    trailing={
+                      event.visibility === 'parties' ? (
+                        <Badge label={t.imageAudit.partyOnly} tone="neutral" />
+                      ) : undefined
+                    }
+                  />
+                  {index < arr.length - 1 ? (
+                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                  ) : null}
+                </View>
+              ))}
+            </Card>
+          </View>
+        ) : null}
 
         {/* The thread on this bill. Any member reads and adds; the author edits
             and deletes their own; an admin deletes anyone's and resolves reports.

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -489,7 +489,43 @@ export async function uploadExpenseReceipt(input: {
     contentType: normaliseImageMime(input.mimeType),
     groupId: input.groupId,
   });
+  // Record the add in the image audit (A46). Best-effort: the bill is kept even
+  // if the line fails to write — the trail is evidence, not a gate.
+  await logReceiptEvent(input.groupId, input.expenseId, 'added');
   return path;
+}
+
+/**
+ * The kept bill has no DB row — its history lives in `expense_image_events`.
+ * The upload/remove goes straight to R2, so the client writes the audit line
+ * through this RPC, which stamps the actor from the session. The event id is
+ * client-chosen so a retry is idempotent. Swallows failure: a missing audit
+ * line must never break keeping or removing a bill.
+ */
+async function logReceiptEvent(
+  groupId: string,
+  expenseId: string,
+  action: 'added' | 'removed',
+): Promise<void> {
+  const { error } = await supabase.rpc('baaki_log_receipt_event', {
+    p_event_id: randomUUID(),
+    p_group_id: groupId,
+    p_expense_id: expenseId,
+    p_action: action,
+  });
+  if (error) {
+    console.warn('receipt audit log failed', error.message);
+  }
+}
+
+/**
+ * Remove a group expense's kept bill (E2) from R2 and record the removal in the
+ * image audit. Best-effort on the bytes (the sweep is the backstop); the audit
+ * line is what the group reads later.
+ */
+export async function removeExpenseReceipt(groupId: string, expenseId: string): Promise<void> {
+  await removeImage(RECEIPT_BUCKET, expenseReceiptPath(groupId, expenseId));
+  await logReceiptEvent(groupId, expenseId, 'removed');
 }
 
 /**

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -28,6 +28,7 @@ import {
   materialiseMembers,
   materialiseExpenseAttachments,
   materialiseExpenseComments,
+  materialiseExpenseImageEvents,
   materialisePlanItems,
   materialiseSettlementProof,
   materialiseSettlements,
@@ -79,6 +80,7 @@ import {
   updateMember,
   setMemberRole,
   withdrawDispute,
+  removeExpenseReceipt,
   type PersonBalanceRow,
   type WriteExpenseInput,
 } from './api';
@@ -1681,6 +1683,53 @@ export function useExpenseComments(expenseId: string): LocalRead<ExpenseCommentR
     [mirror, expenseId],
   );
   return useLocalRead(rows);
+}
+
+// ────────────────────────────────────────────── expense image audit (A46) ──
+// An append-only trail of who added/removed a receipt or attachment on one
+// expense. Reads ride the mirror (the pull's RLS decides whether a `parties`
+// line reached this device at all); the writes are the receipt log RPC and the
+// attachment RPCs, which stamp the actor server-side.
+
+export interface ExpenseImageEventRow {
+  id: string;
+  expenseId: string;
+  groupId: string;
+  actorMemberId: string | null;
+  kind: 'receipt' | 'attachment';
+  action: 'added' | 'removed';
+  visibility: 'group' | 'parties';
+  createdAt: string | null;
+}
+
+/** The image audit for one expense, oldest first. */
+export function useExpenseImageEvents(expenseId: string): LocalRead<ExpenseImageEventRow[]> {
+  const { mirror } = useSync();
+  const rows = useMemo(
+    () =>
+      materialiseExpenseImageEvents(mirror, { expenseId }).map((row): ExpenseImageEventRow => ({
+        id: row.id,
+        expenseId: row.expense_id,
+        groupId: row.group_id,
+        actorMemberId: row.actor_member_id,
+        kind: row.kind === 'attachment' ? 'attachment' : 'receipt',
+        action: row.action === 'removed' ? 'removed' : 'added',
+        visibility: row.visibility === 'parties' ? 'parties' : 'group',
+        createdAt: row.created_at,
+      })),
+    [mirror, expenseId],
+  );
+  return useLocalRead(rows);
+}
+
+/** Remove the kept bill (E2) and record the removal in the image audit, then
+ *  flush so the new line pulls back. */
+export function useRemoveExpenseReceipt(groupId: string, expenseId: string) {
+  const { flush } = useSync();
+  return useMutation({
+    mutationFn: () => removeExpenseReceipt(groupId, expenseId),
+    onSuccess: () => void flush(),
+  });
 }
 
 /**

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -398,6 +398,22 @@ export interface UiStrings {
     /** Reveal the previous page of older comments (a count is appended). */
     showEarlier: string;
   };
+  /** The image audit on an expense — who added/removed a receipt or attachment. */
+  imageAudit: {
+    /** Section header. */
+    title: string;
+    /** One line per event; `{name}` is the actor (or "someone"). */
+    receiptAdded: string;
+    receiptRemoved: string;
+    attachmentAdded: string;
+    attachmentRemoved: string;
+    /** A tag on a party-only attachment's line. */
+    partyOnly: string;
+    /** Remove-the-kept-bill control + its confirm and failure. */
+    removeReceipt: string;
+    removeReceiptConfirm: string;
+    couldNotRemove: string;
+  };
   /** Trip budgets. */
   budgets: string;
   overallBudget: string;
@@ -2103,6 +2119,17 @@ const en: UiStrings = {
     couldNotPost: "Couldn't post that — try again.",
     couldNotDelete: "Couldn't delete that — try again.",
     showEarlier: 'Show earlier comments',
+  },
+  imageAudit: {
+    title: 'Image history',
+    receiptAdded: '{name} added the receipt',
+    receiptRemoved: '{name} removed the receipt',
+    attachmentAdded: '{name} added an attachment',
+    attachmentRemoved: '{name} removed an attachment',
+    partyOnly: 'Private',
+    removeReceipt: 'Remove receipt',
+    removeReceiptConfirm: 'Remove this receipt? The change is recorded.',
+    couldNotRemove: "Couldn't remove that — try again.",
   },
   budgets: 'Budgets',
   overallBudget: 'Overall',
@@ -3822,6 +3849,17 @@ const ta: UiStrings = {
     couldNotPost: 'இட முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
     couldNotDelete: 'நீக்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
     showEarlier: 'முந்தைய கருத்துகளைக் காட்டு',
+  },
+  imageAudit: {
+    title: 'படத்தின் வரலாறு',
+    receiptAdded: 'ரசீதை {name} சேர்த்தார்',
+    receiptRemoved: 'ரசீதை {name} அகற்றினார்',
+    attachmentAdded: 'இணைப்பை {name} சேர்த்தார்',
+    attachmentRemoved: 'இணைப்பை {name} அகற்றினார்',
+    partyOnly: 'தனிப்பட்டது',
+    removeReceipt: 'ரசீதை அகற்று',
+    removeReceiptConfirm: 'இந்த ரசீதை அகற்றவா? இந்த மாற்றம் பதிவு செய்யப்படும்.',
+    couldNotRemove: 'அகற்ற முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
   },
   budgets: 'பட்ஜெட்',
   overallBudget: 'மொத்தம்',
@@ -5608,6 +5646,17 @@ const hi: UiStrings = {
     couldNotDelete: 'हटाया नहीं जा सका — फिर कोशिश करें।',
     showEarlier: 'पहले की टिप्पणियाँ दिखाएँ',
   },
+  imageAudit: {
+    title: 'छवि इतिहास',
+    receiptAdded: '{name} ने रसीद जोड़ी',
+    receiptRemoved: '{name} ने रसीद हटाई',
+    attachmentAdded: '{name} ने एक अटैचमेंट जोड़ा',
+    attachmentRemoved: '{name} ने एक अटैचमेंट हटाया',
+    partyOnly: 'निजी',
+    removeReceipt: 'रसीद हटाएँ',
+    removeReceiptConfirm: 'यह रसीद हटाएँ? यह बदलाव दर्ज किया जाएगा।',
+    couldNotRemove: 'हटाया नहीं जा सका — फिर कोशिश करें।',
+  },
   budgets: 'बजट',
   overallBudget: 'कुल',
   myBudget: 'मेरा बजट',
@@ -7341,6 +7390,17 @@ const ar: UiStrings = {
     couldNotPost: 'تعذّر النشر — حاول مرة أخرى.',
     couldNotDelete: 'تعذّر الحذف — حاول مرة أخرى.',
     showEarlier: 'عرض التعليقات السابقة',
+  },
+  imageAudit: {
+    title: 'سجل الصور',
+    receiptAdded: 'أضاف {name} الإيصال',
+    receiptRemoved: 'أزال {name} الإيصال',
+    attachmentAdded: 'أضاف {name} مرفقًا',
+    attachmentRemoved: 'أزال {name} مرفقًا',
+    partyOnly: 'خاص',
+    removeReceipt: 'إزالة الإيصال',
+    removeReceiptConfirm: 'إزالة هذا الإيصال؟ سيُسجَّل هذا التغيير.',
+    couldNotRemove: 'تعذّرت الإزالة — حاول مرة أخرى.',
   },
   budgets: 'الميزانية',
   overallBudget: 'الإجمالي',

--- a/docs/expense-image-audit.md
+++ b/docs/expense-image-audit.md
@@ -1,0 +1,79 @@
+# Expense image audit (A46, part 2)
+
+Who added or removed a receipt or an attachment on an expense, and when — the
+image equivalent of the version history that already sits beside it. A bill's
+photo is evidence for the amount; swapping or deleting it silently is a way to
+change what an expense claims after the fact, and until now that left no trace.
+
+## Why a new table, not `activity_log`
+
+The group already has `activity_log`, and image events would fit its shape. But
+`activity_log` is **group-visible** (`is_group_member` RLS), and an expense
+attachment can be **party-only** (`visibility = 'parties'`, #407). Logging a
+private attachment's add/remove into a group-visible feed would leak its very
+existence to non-parties — the line "someone removed an attachment" is itself
+the leak. So the audit lives in its own table whose SELECT policy embeds the
+party predicate, exactly like the `expense_attachments` table it describes.
+
+## Shape — `expense_image_events`
+
+Migration `20260824180000_expense_image_events`. A group-scoped, mirror-backed,
+**append-only** list (a correction is another line, never an erasure — so there
+is no `deleted_at` tombstone here):
+
+- `kind` `receipt | attachment`, `action` `added | removed`, `visibility`
+  `group | parties` (mirrors the image's own visibility).
+- `actor_member_id` — who did it, `SET NULL` if they later leave (shown as
+  "someone").
+- `updated_seq` + the shared `baaki_stamp_seq` trigger, so the `/sync` pull
+  carries it like every other group table.
+- RLS SELECT: `is_group_member(group_id) AND (visibility = 'group' OR
+  baaki_is_expense_party(expense_id))`. `REVOKE ALL … GRANT SELECT`; writes are
+  RPC-only.
+
+## Who writes a line
+
+- **Attachments** — the existing `baaki_attach_expense_attachment` /
+  `baaki_remove_expense_attachment` RPCs emit their own line inline, on the path
+  that actually changed a row (an idempotent re-attach or a repeated remove does
+  not stutter the trail). The event carries the attachment's own visibility, so
+  a `parties` attachment's line is party-only too. Server-authoritative: a client
+  cannot skip it.
+- **The kept bill (E2)** has no DB row — its bytes go straight to R2 at
+  `<groupId>/<expenseId>.jpg`. So the client calls `baaki_log_receipt_event`
+  after a successful upload/remove. The door is receipt-only (kind hard-coded,
+  visibility forced `group`), so it can never be used to fabricate a party-only
+  attachment line. The actor is the session's; the event id is client-chosen so
+  a retry is idempotent.
+
+A missing audit line never blocks keeping or removing an image — the client
+logs best-effort; the trail is evidence, not a gate.
+
+## Client
+
+- Read: `useExpenseImageEvents(expenseId)` off the mirror
+  (`materialiseExpenseImageEvents`) → the "Image history" section on the expense
+  detail, oldest first, a `Private` tag on a party-only line.
+- The kept bill now has a **remove** control (trash) on its card, shown to a
+  party or an admin; it deletes the R2 object and records the removal. Uploading
+  again records an add — so "deleted then re-uploaded" reads as two lines.
+
+## Scope
+
+Expense images only — receipts and expense attachments. Settlement proofs are a
+separate surface (settlement-scoped, shown on the settlement card) and already
+carry `uploader_member_id`; they are out of this pass.
+
+## Deviation
+
+New capability, an extension of the A46 comments/audit work. Owed: a one-line
+ADR-004/ADR-006 note that an expense's image changes are audited in a
+party-aware, append-only table, and a TDR entry that `expense_image_events` is a
+group-scoped, mirror-backed, RPC-only table.
+
+## Release gate
+
+Production needs the migration `20260824180000_expense_image_events` **and** the
+updated `sync` edge function (it pulls the new table) before the mobile release,
+or a client add/remove records nothing and the history shows blank. Same deploy
+window as any migration + `edge:deploy`.

--- a/docs/expense-image-audit.md
+++ b/docs/expense-image-audit.md
@@ -28,7 +28,7 @@ is no `deleted_at` tombstone here):
 - `updated_seq` + the shared `baaki_stamp_seq` trigger, so the `/sync` pull
   carries it like every other group table.
 - RLS SELECT: `is_group_member(group_id) AND (visibility = 'group' OR
-  baaki_is_expense_party(expense_id))`. `REVOKE ALL … GRANT SELECT`; writes are
+baaki_is_expense_party(expense_id))`. `REVOKE ALL … GRANT SELECT`; writes are
   RPC-only.
 
 ## Who writes a line

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -67,6 +67,7 @@ const TABLES: readonly SyncTable[] = [
   SyncTable.SettlementProofs,
   SyncTable.ExpenseAttachments,
   SyncTable.ExpenseComments,
+  SyncTable.ExpenseImageEvents,
 ];
 
 export function emptyMirror(): MirrorState {
@@ -1058,6 +1059,31 @@ export function materialiseExpenseComments(
 ): MirrorExpenseComment[] {
   return (rowsFor(state, SyncTable.ExpenseComments) as MirrorExpenseComment[])
     .filter((row) => row.expense_id === options.expenseId && row.deleted_at === null)
+    .sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''));
+}
+
+export interface MirrorExpenseImageEvent extends MirrorRow {
+  readonly id: string;
+  readonly group_id: string;
+  readonly expense_id: string;
+  readonly actor_member_id: string | null;
+  readonly kind: string;
+  readonly action: string;
+  readonly visibility: string;
+  readonly created_at: string | null;
+}
+
+/** The image audit for one expense — who added/removed a receipt or attachment,
+ *  oldest first, so the trail reads top-down like the version history beside it.
+ *  Append-only: there is no tombstone to filter (a correction is another line).
+ *  A `parties` row only reaches a device the pull deemed a party, so nothing to
+ *  hide here. */
+export function materialiseExpenseImageEvents(
+  state: MirrorState,
+  options: { readonly expenseId: string },
+): MirrorExpenseImageEvent[] {
+  return (rowsFor(state, SyncTable.ExpenseImageEvents) as MirrorExpenseImageEvent[])
+    .filter((row) => row.expense_id === options.expenseId)
     .sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''));
 }
 

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -366,6 +366,11 @@ export enum SyncTable {
    * enforce the role matrix (author edits/deletes own, admin deletes any, any
    * member flags), so there is no mutation kind; only the read rides the mirror. */
   ExpenseComments = 'expense_comments',
+  /** Group-scoped, append-only image audit: who added/removed a receipt or an
+   * attachment on one expense, and when. Pull-only — the writes are the receipt
+   * log RPC and the attachment RPCs, which stamp the actor from the session; a
+   * `parties` row is RLS-filtered so a non-party never receives it. */
+  ExpenseImageEvents = 'expense_image_events',
 }
 
 /**

--- a/packages/db/prisma/migrations/20260824180000_expense_image_events/migration.sql
+++ b/packages/db/prisma/migrations/20260824180000_expense_image_events/migration.sql
@@ -1,0 +1,248 @@
+-- An append-only audit line for an expense's images (A46 part 2): who added or
+-- removed a receipt or an attachment, and when.
+--
+-- A bill's photo is evidence. Swapping or deleting it silently changes what the
+-- expense claims after the fact, and today that leaves no trace: the kept bill
+-- (the `receipts` R2 object at `<groupId>/<expenseId>.jpg`) has no DB row at
+-- all, and an attachment removal records `deleted_at` but not who. This table is
+-- the trail — one immutable line per add/remove — so the group can read an
+-- image's history the same way ADR-004 lets it read the amount's. A correction
+-- is another line, never an erasure; there is no soft-delete here.
+--
+-- It is a group's shared, non-money list, so it rides the same offline mirror as
+-- comments and the plan: an `updated_seq` the /sync pull walks, stamped by the
+-- shared `baaki_stamp_seq` trigger. There is no tombstone because a row is never
+-- retracted.
+--
+-- Visibility inherits the image it describes. A `parties` attachment is hidden
+-- from non-parties (#407); its events must be too, or the mere line "someone
+-- removed an attachment" would leak that a private attachment ever existed. The
+-- SELECT policy embeds `baaki_is_expense_party`, exactly like the attachment
+-- table's own policy, so a non-party's read returns zero party rows. A receipt
+-- is group-wide, so its events are `group` and everybody in the group sees them.
+--
+-- Writes are RPC-only: the actor is taken from the session (`baaki_my_member_id`)
+-- so a line cannot be forged, and a direct PostgREST insert has no privilege.
+
+CREATE TABLE IF NOT EXISTS public.expense_image_events (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id        uuid NOT NULL REFERENCES public.groups(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  expense_id      uuid NOT NULL REFERENCES public.expenses(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  /** Who did it. SET NULL if that membership is later removed — the line
+      survives the person leaving, shown as "someone". */
+  actor_member_id uuid REFERENCES public.group_members(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  /** `receipt` (the group-wide bill) or `attachment`. */
+  kind            text NOT NULL,
+  /** `added` or `removed`. */
+  action          text NOT NULL,
+  /** `group` or `parties` — mirrors the image's own visibility. */
+  visibility      text NOT NULL DEFAULT 'group',
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  -- Sync plumbing (ADR-005), identical to expense_comments / trip_plan_items.
+  updated_seq     bigint NOT NULL DEFAULT 0,
+
+  CONSTRAINT expense_image_events_kind_ck CHECK (kind IN ('receipt', 'attachment')),
+  CONSTRAINT expense_image_events_action_ck CHECK (action IN ('added', 'removed')),
+  CONSTRAINT expense_image_events_visibility_ck CHECK (visibility IN ('group', 'parties'))
+);
+
+CREATE INDEX IF NOT EXISTS expense_image_events_group_id_updated_seq_idx
+  ON public.expense_image_events (group_id, updated_seq);
+-- The expense-detail trail reads by expense, oldest first.
+CREATE INDEX IF NOT EXISTS expense_image_events_expense_idx
+  ON public.expense_image_events (expense_id, created_at);
+
+DROP TRIGGER IF EXISTS expense_image_events_stamp_seq ON public.expense_image_events;
+CREATE TRIGGER expense_image_events_stamp_seq
+  BEFORE INSERT OR UPDATE ON public.expense_image_events
+  FOR EACH ROW EXECUTE FUNCTION public.baaki_stamp_seq();
+
+ALTER TABLE public.expense_image_events ENABLE ROW LEVEL SECURITY;
+
+-- A group member sees an event only when the image it describes is one they may
+-- see: a `group` event is group-wide; a `parties` event needs the caller to be
+-- a party to the expense. Same shape as the expense_attachments SELECT policy.
+CREATE POLICY expense_image_events_select ON public.expense_image_events
+  FOR SELECT TO anon, authenticated
+  USING (
+    public.is_group_member(group_id)
+    AND (visibility = 'group' OR public.baaki_is_expense_party(expense_id))
+  );
+
+-- No write policy or privilege: the RPCs below are the only way in.
+REVOKE ALL ON public.expense_image_events FROM anon, authenticated;
+GRANT SELECT ON public.expense_image_events TO anon, authenticated;
+
+-- ────────────────────────────────────────────────────────────── writing ──
+
+/**
+ * Record a receipt add/remove. The kept bill has no table and its upload goes
+ * straight to R2, so the client calls this after a successful put/delete. A
+ * receipt is group-wide, so the event is always `group`; kind is fixed here so
+ * this door can never be used to fabricate a party-only attachment line. The
+ * event id is the caller's, so a retried call is idempotent (ON CONFLICT).
+ */
+CREATE OR REPLACE FUNCTION public.baaki_log_receipt_event(
+  p_event_id   uuid,
+  p_group_id   uuid,
+  p_expense_id uuid,
+  p_action     text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+  v_member   uuid;
+BEGIN
+  IF p_action NOT IN ('added', 'removed') THEN
+    RAISE EXCEPTION 'INVALID_ACTION: added or removed' USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT group_id INTO v_group_id FROM public.expenses WHERE id = p_expense_id;
+  IF v_group_id IS NULL OR v_group_id <> p_group_id THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such expense in this group' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- Membership is the authorisation: only a member of the group may write a line
+  -- about it, and their identity is the session's, not a client argument.
+  v_member := public.baaki_my_member_id(p_group_id);
+  IF v_member IS NULL THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: only a group member may log this'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  INSERT INTO public.expense_image_events
+    (id, group_id, expense_id, actor_member_id, kind, action, visibility)
+  VALUES
+    (p_event_id, p_group_id, p_expense_id, v_member, 'receipt', p_action, 'group')
+  ON CONFLICT (id) DO NOTHING;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_log_receipt_event(uuid, uuid, uuid, text)
+  TO authenticated, anon;
+
+-- ─────────────────────────────────────────── attachment RPCs, now audited ──
+-- The attach/remove RPCs already know the expense, the group, the actor and the
+-- visibility, so they emit their own event inline — the trail cannot be skipped
+-- by a client, and a `parties` attachment's event carries `parties` so it stays
+-- hidden from non-parties. Re-declared verbatim from 20260824150000 with the
+-- single INSERT added on the path that actually changed a row.
+
+CREATE OR REPLACE FUNCTION public.baaki_attach_expense_attachment(
+  p_expense_id   uuid,
+  p_storage_path text,
+  p_visibility   text DEFAULT 'group',
+  p_attachment_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+  v_member   uuid;
+  v_id       uuid;
+BEGIN
+  IF coalesce(btrim(p_storage_path), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_PATH: an attachment needs a stored image'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  IF p_visibility NOT IN ('group', 'parties') THEN
+    RAISE EXCEPTION 'INVALID_VISIBILITY: group or parties' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- The key MUST be scoped to this expense: `<expenseId>/…` (see the proof RPC).
+  IF p_storage_path NOT LIKE p_expense_id::text || '/%' THEN
+    RAISE EXCEPTION 'INVALID_PATH: the key must be scoped to its expense'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Authorise before resolving the client id (an existence oracle otherwise).
+  SELECT group_id INTO v_group_id FROM public.expenses WHERE id = p_expense_id;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such expense' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF NOT public.baaki_is_expense_party(p_expense_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only a payer or the author may attach to this expense'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Replay bound to the subject: same id + same expense returns the existing row
+  -- (and, because it returns here, never emits a second audit line).
+  IF p_attachment_id IS NOT NULL THEN
+    SELECT id INTO v_id
+    FROM public.expense_attachments
+    WHERE id = p_attachment_id AND expense_id = p_expense_id;
+    IF v_id IS NOT NULL THEN
+      RETURN v_id;
+    END IF;
+  END IF;
+
+  v_member := public.baaki_my_member_id(v_group_id);
+
+  INSERT INTO public.expense_attachments
+    (id, expense_id, group_id, uploader_member_id, storage_path, visibility)
+  VALUES
+    (COALESCE(p_attachment_id, gen_random_uuid()), p_expense_id, v_group_id, v_member,
+     btrim(p_storage_path), p_visibility)
+  RETURNING id INTO v_id;
+
+  INSERT INTO public.expense_image_events
+    (id, group_id, expense_id, actor_member_id, kind, action, visibility)
+  VALUES
+    (gen_random_uuid(), v_group_id, p_expense_id, v_member, 'attachment', 'added', p_visibility);
+
+  RETURN v_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_attach_expense_attachment(uuid, text, text, uuid)
+  TO authenticated, anon;
+
+/** Remove an expense attachment. A party may; soft delete, twice is a no-op. The
+    audit line is emitted only when a live row actually flips to deleted, so a
+    repeated remove does not stutter the trail. It carries the attachment's own
+    visibility, so a `parties` removal stays hidden from non-parties. */
+CREATE OR REPLACE FUNCTION public.baaki_remove_expense_attachment(p_attachment_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_expense_id uuid;
+  v_group_id   uuid;
+  v_visibility text;
+BEGIN
+  SELECT expense_id, group_id, visibility
+    INTO v_expense_id, v_group_id, v_visibility
+  FROM public.expense_attachments WHERE id = p_attachment_id;
+  IF v_expense_id IS NULL THEN
+    RETURN;
+  END IF;
+  IF NOT public.baaki_is_expense_party(v_expense_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only a party may remove this attachment'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  UPDATE public.expense_attachments
+     SET deleted_at = now()
+   WHERE id = p_attachment_id AND deleted_at IS NULL;
+
+  IF FOUND THEN
+    INSERT INTO public.expense_image_events
+      (id, group_id, expense_id, actor_member_id, kind, action, visibility)
+    VALUES
+      (gen_random_uuid(), v_group_id, v_expense_id,
+       public.baaki_my_member_id(v_group_id), 'attachment', 'removed', v_visibility);
+  END IF;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_remove_expense_attachment(uuid) TO authenticated, anon;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -257,6 +257,7 @@ model Group {
   expenseComments ExpenseComment[]
   settlementProofs   SettlementProof[]
   expenseAttachments ExpenseAttachment[]
+  imageEvents        ExpenseImageEvent[]
   syncMutations SyncMutation[]
   memberClaims   MemberClaim[]
   memberBudgets  TripMemberBudget[]
@@ -314,6 +315,7 @@ model GroupMember {
   commentsAuthored   ExpenseComment[]   @relation("ExpenseCommentAuthor")
   commentsFlagged    ExpenseComment[]   @relation("ExpenseCommentFlagger")
   commentsDeleted    ExpenseComment[]   @relation("ExpenseCommentDeleter")
+  imageEvents        ExpenseImageEvent[]
   activity          ActivityLog[]
   disputesRaised    ExpenseDispute[]   @relation("DisputeRaisedBy")
   disputesResolved  ExpenseDispute[]   @relation("DisputeResolvedBy")
@@ -442,6 +444,7 @@ model Expense {
   tripPhotos     TripPhoto[]
   attachments    ExpenseAttachment[]
   comments       ExpenseComment[]
+  imageEvents    ExpenseImageEvent[]
 
   @@index([groupId, deletedAt])
   /// The sync pull is "everything in this group since seq N" (TDR §4).
@@ -1329,6 +1332,43 @@ model ExpenseComment {
   @@index([groupId, updatedSeq])
   @@index([expenseId, createdAt], map: "expense_comments_expense_idx")
   @@map("expense_comments")
+  @@schema("public")
+}
+
+/// An append-only audit line for an expense's images — who added or removed a
+/// receipt or an attachment, and when.
+///
+/// A bill's photo is evidence, and swapping it silently is a way to change what
+/// an expense claims after the fact. This records each add/remove so the group
+/// (ADR-004: every change is kept and visible) can see the image's history the
+/// same way it sees the amount's. Never edited, never deleted — a correction is
+/// another line, not an erasure.
+///
+/// `visibility` inherits the image it describes: a `parties` attachment's events
+/// are party-only too (the SELECT policy embeds `baaki_is_expense_party`), so a
+/// non-party never learns a private attachment existed. Writes are RPC-only, the
+/// actor taken from the session, so the line cannot be forged.
+model ExpenseImageEvent {
+  id            String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  groupId       String   @map("group_id") @db.Uuid
+  expenseId     String   @map("expense_id") @db.Uuid
+  actorMemberId String?  @map("actor_member_id") @db.Uuid
+  /// The image kind: `receipt` (the group-wide bill) or `attachment`.
+  kind          String
+  /// `added` or `removed`.
+  action        String
+  /// `group` or `parties` — mirrors the image's own visibility.
+  visibility    String   @default("group")
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedSeq    BigInt   @default(0) @map("updated_seq")
+
+  group   Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  expense Expense      @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  actor   GroupMember? @relation(fields: [actorMemberId], references: [id], onDelete: SetNull)
+
+  @@index([groupId, updatedSeq])
+  @@index([expenseId, createdAt], map: "expense_image_events_expense_idx")
+  @@map("expense_image_events")
   @@schema("public")
 }
 

--- a/packages/db/test/expense-image-events.test.ts
+++ b/packages/db/test/expense-image-events.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The expense image audit (A46 part 2) — the append-only trail of who added or
+ * removed a receipt or an attachment. Two properties matter and are tested here:
+ *
+ *   1. A line is unforgeable and membership-gated: the actor is the session's,
+ *      an outsider cannot write one, and the receipt door only writes receipts.
+ *   2. A `parties` line inherits the attachment's visibility — a non-party
+ *      member of the group never sees that a private attachment existed.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+async function as<T>(profileId: string | null, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    profileId
+      ? JSON.stringify({ sub: profileId, role: 'authenticated' })
+      : JSON.stringify({ role: 'anon' }),
+  ]);
+  await client.query(`SET ROLE ${profileId ? 'authenticated' : 'anon'}`);
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+// m0 = admin, author and sole payer → the only PARTY. m1 & m2 are members but
+// non-parties. An outsider profile in no group.
+let g: { groupId: string; profileIds: string[]; memberIds: string[] };
+let expenseId: string;
+let outsider: string;
+
+beforeAll(async () => {
+  g = await seedGroup(client, { memberCount: 3, name: 'ImageAudit' });
+  outsider = randomUUID();
+  await client.query(
+    `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Outsider', 'INR')`,
+    [outsider],
+  );
+  ({ expenseId } = await addEqualSplitExpense(client, {
+    groupId: g.groupId,
+    payers: { [g.memberIds[0] as string]: 3000n },
+    participants: g.memberIds,
+    amount: 3000n,
+  }));
+});
+
+beforeEach(async () => {
+  await client.query(`DELETE FROM expense_image_events WHERE group_id = $1`, [g.groupId]);
+  await client.query(`DELETE FROM expense_attachments WHERE group_id = $1`, [g.groupId]);
+});
+
+const P = (i: number) => g.profileIds[i] as string;
+const M = (i: number) => g.memberIds[i] as string;
+
+const logReceipt = (profileId: string, action: string, id = randomUUID()) =>
+  as(profileId, () =>
+    client.query(`SELECT baaki_log_receipt_event($1, $2, $3, $4)`, [
+      id,
+      g.groupId,
+      expenseId,
+      action,
+    ]),
+  );
+
+const attach = (profileId: string, visibility: string, id = randomUUID()) =>
+  as(profileId, () =>
+    client
+      .query(`SELECT baaki_attach_expense_attachment($1, $2, $3, $4) AS id`, [
+        expenseId,
+        `${expenseId}/${randomUUID()}.webp`,
+        visibility,
+        id,
+      ])
+      .then((r) => r.rows[0].id as string),
+  );
+
+const remove = (profileId: string, attachmentId: string) =>
+  as(profileId, () => client.query(`SELECT baaki_remove_expense_attachment($1)`, [attachmentId]));
+
+/** The events on this expense that `profileId` may see (RLS applied). */
+const eventsVisibleTo = (profileId: string | null) =>
+  as(profileId, () =>
+    client
+      .query(
+        `SELECT kind, action, visibility, actor_member_id
+           FROM expense_image_events WHERE expense_id = $1 ORDER BY created_at`,
+        [expenseId],
+      )
+      .then((r) => r.rows),
+  );
+
+describe('receipt audit line', () => {
+  it('a member records an add, stamped with their own member id', async () => {
+    await logReceipt(P(0), 'added');
+    const rows = await eventsVisibleTo(P(0));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: 'receipt',
+      action: 'added',
+      visibility: 'group',
+      actor_member_id: M(0),
+    });
+  });
+
+  it('is group-visible — every member sees a receipt line', async () => {
+    await logReceipt(P(0), 'added');
+    expect(await eventsVisibleTo(P(1))).toHaveLength(1);
+    expect(await eventsVisibleTo(P(2))).toHaveLength(1);
+  });
+
+  it('is idempotent on the event id — a retry writes no second line', async () => {
+    const id = randomUUID();
+    await logReceipt(P(0), 'added', id);
+    await logReceipt(P(0), 'added', id);
+    expect(await eventsVisibleTo(P(0))).toHaveLength(1);
+  });
+
+  it('rejects an action that is not added/removed', async () => {
+    await expectDenied(logReceipt(P(0), 'edited'));
+  });
+
+  it('rejects an expense that is not in the named group', async () => {
+    const otherExpense = randomUUID();
+    await expectDenied(
+      as(P(0), () =>
+        client.query(`SELECT baaki_log_receipt_event($1, $2, $3, 'added')`, [
+          randomUUID(),
+          g.groupId,
+          otherExpense,
+        ]),
+      ),
+    );
+  });
+
+  it('an outsider (no membership) cannot write a line', async () => {
+    await expectDenied(logReceipt(outsider, 'added'));
+  });
+
+  it('the receipt door cannot be used to fabricate an attachment line', async () => {
+    // Only four positional args exist and kind is hard-coded to 'receipt'; there
+    // is no parameter that could make this an 'attachment' or a 'parties' row.
+    await logReceipt(P(0), 'added');
+    const rows = await eventsVisibleTo(P(0));
+    expect(rows.every((r) => r.kind === 'receipt' && r.visibility === 'group')).toBe(true);
+  });
+});
+
+describe('attachment audit line, emitted by the attach/remove RPCs', () => {
+  it('a group attachment emits a group-visible added line', async () => {
+    await attach(P(0), 'group');
+    const rows = await eventsVisibleTo(P(0));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ kind: 'attachment', action: 'added', visibility: 'group' });
+    // A non-party member still sees a group line.
+    expect(await eventsVisibleTo(P(1))).toHaveLength(1);
+  });
+
+  it('a parties attachment emits a line only its parties can see', async () => {
+    await attach(P(0), 'parties');
+    // The party (author + payer) sees it.
+    const partyRows = await eventsVisibleTo(P(0));
+    expect(partyRows).toHaveLength(1);
+    expect(partyRows[0]).toMatchObject({ visibility: 'parties' });
+    // A non-party member of the same group does NOT — the line would otherwise
+    // leak that a private attachment ever existed.
+    expect(await eventsVisibleTo(P(1))).toHaveLength(0);
+    expect(await eventsVisibleTo(P(2))).toHaveLength(0);
+  });
+
+  it('a removal emits one removed line, carrying the attachment visibility', async () => {
+    const id = await attach(P(0), 'parties');
+    await remove(P(0), id);
+    const rows = await eventsVisibleTo(P(0));
+    expect(rows.map((r) => r.action)).toEqual(['added', 'removed']);
+    expect(rows[1]).toMatchObject({ visibility: 'parties' });
+    // The removed line is party-only too.
+    expect(await eventsVisibleTo(P(1))).toHaveLength(0);
+  });
+
+  it('a repeated removal does not stutter the trail', async () => {
+    const id = await attach(P(0), 'group');
+    await remove(P(0), id);
+    await remove(P(0), id);
+    const rows = await eventsVisibleTo(P(0));
+    expect(rows.filter((r) => r.action === 'removed')).toHaveLength(1);
+  });
+
+  it('an idempotent re-attach (same id) does not double the added line', async () => {
+    const id = randomUUID();
+    await attach(P(0), 'group', id);
+    await attach(P(0), 'group', id);
+    const rows = await eventsVisibleTo(P(0));
+    expect(rows.filter((r) => r.action === 'added')).toHaveLength(1);
+  });
+});
+
+describe('anon', () => {
+  it('sees no events and cannot log one', async () => {
+    await logReceipt(P(0), 'added');
+    expect(await eventsVisibleTo(null)).toHaveLength(0);
+    await expectDenied(
+      as(null, () =>
+        client.query(`SELECT baaki_log_receipt_event($1, $2, $3, 'added')`, [
+          randomUUID(),
+          g.groupId,
+          expenseId,
+        ]),
+      ),
+    );
+  });
+});

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -926,6 +926,11 @@ async function pull(
       // Expense comment threads — group-visible, read as the caller (is_group_member
       // RLS). Tombstones (deleted_at set) ride the pull so a delete propagates.
       ['expense_comments', '*'],
+      // Expense image audit — who added/removed a receipt or attachment. Read AS
+      // THE CALLER: a `parties` row is RLS-filtered exactly like the attachment
+      // it describes, so a non-party never receives the line. Append-only, no
+      // tombstone.
+      ['expense_image_events', '*'],
     ] as const) {
       const { data, error } = await caller
         .from(table)


### PR DESCRIPTION
## What

The image equivalent of the version history that already sits beside an expense — **who added or removed a receipt or an attachment, and when**. A bill's photo is evidence for the amount; until now, swapping or deleting it left no trace (the kept bill has no DB row; an attachment removal recorded `deleted_at` but not who).

## Design

New table **`expense_image_events`** (migration `20260824180000`): group-scoped, mirror-backed, **append-only** (a correction is another line, never an erasure).

**Not `activity_log`** — that feed is group-visible, and an expense attachment can be **party-only** (#407). Logging a private attachment's add/remove into a group-visible feed would leak its existence. So the table's SELECT policy embeds `baaki_is_expense_party`, exactly like the `expense_attachments` table it describes: a non-party never receives a `parties` line, at RLS and at the `/sync` pull.

## Who writes a line

- **Attachments** — the existing `baaki_attach_/remove_expense_attachment` RPCs emit their line inline, only on the path that actually changed a row (idempotent re-attach / repeated remove don't stutter), carrying the attachment's own visibility. Server-authoritative — a client can't skip it.
- **Kept bill (E2)** has no RPC (bytes go straight to R2), so the client calls a new **receipt-only** door `baaki_log_receipt_event` after a successful upload/remove — kind hard-coded, visibility forced `group`, actor from the session, idempotent on a client-chosen id. It can't fabricate a party-only attachment line.

## Client

- `useExpenseImageEvents` (mirror read) → an **"Image history"** section on the expense detail, oldest first, a `Private` tag on a party-only line.
- The kept bill gains a **remove** control (party or admin) that deletes the R2 object and logs the removal — so "deleted then re-uploaded" reads as two lines.
- Sync wiring (`SyncTable.ExpenseImageEvents` + materialiser + pull), i18n en/ta/hi/ar.

Settlement proofs are out of scope (separate settlement-scoped surface, already carry `uploader_member_id`).

## Test

- **13 DB threat cases** (`expense-image-events.test.ts`): unforgeable actor, membership gate, receipt-only door, party visibility of add/remove lines, idempotency.
- Full db suite **563 green**, `db:drift` clean, core **662**, mobile typecheck + lint, `edge:build`, `format`. Migration applied to local pg cleanly.

## Deploy gate

Prod needs migration `20260824180000` **and** the updated `sync` edge fn before the mobile release, or an add/remove records nothing. Doc: `docs/expense-image-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expense image history showing receipt and attachment additions or removals, timestamps, actors, and visibility.
  * Expense parties and group admins can remove receipts with confirmation and clear local copies.
  * Added localized image audit and receipt removal messaging in English, Tamil, Hindi, and Arabic.
* **Bug Fixes**
  * Improved handling of receipt-removal progress states and errors.
  * Prevented duplicate audit entries for repeated image actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->