### PR TITLE
feat(expense): receipt markup editor — pen + text (A46 PR2)

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -4,6 +4,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, Alert, Linking, Pressable, ScrollView, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
 
 import {
   Avatar,
@@ -242,6 +243,9 @@ export default function ExpenseDetailScreen() {
 
   return (
     <Screen edges={[]}>
+      {/* The hero runs dark under the status bar, so its icons must be light —
+          overriding the app's theme-driven default for this route. */}
+      <StatusBar style="light" />
       <ScrollView
         ref={scrollRef}
         contentContainerStyle={{
@@ -317,7 +321,7 @@ export default function ExpenseDetailScreen() {
                 timeZone: 'UTC',
               }).format(new Date(version.expense_date))}`}
             </Text>
-            <Row style={{ gap: theme.spacing.sm }}>
+            <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap', justifyContent: 'center' }}>
               <HeroTag label={splitLabels(t)[version.split_type] ?? version.split_type} />
               {version.version_no > 1 ? (
                 <HeroTag label={plural(locale, version.version_no - 1, t.expense.editedTimes)} />
@@ -334,6 +338,7 @@ export default function ExpenseDetailScreen() {
           groupId={groupId}
           expenseId={expense.id}
           canManage={isExpenseParty}
+          canRemoveLegacy={isExpenseParty || iAmAdmin}
           legacyReceiptPath={receiptUri ? expenseReceiptPath(groupId, expense.id) : null}
           onLegacyRemoved={() => setReceiptUri(null)}
         />

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -5,6 +5,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { Pressable, RefreshControl, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
 
 import {
   Avatar,
@@ -554,6 +555,8 @@ export default function GroupScreen() {
 
   return (
     <Screen edges={[]}>
+      {/* The hero runs dark under the status bar; force light icons for it. */}
+      <StatusBar style="light" />
       <DetailEnter>
         <FlashList
           data={tab === Tab.Expenses ? feedItems : []}
@@ -643,7 +646,7 @@ export default function GroupScreen() {
               turning arrow mid-sync, a red mark for a refused change — nothing
               when all is well. It replaces the wide banner this screen used to
               stack under the header. */}
-                  <SyncStatusIcon onBrand />
+                  <SyncStatusIcon onBrand groupId={groupId} />
                   {/* A code to hand the group across the table. The whole invite
               surface — link, share sheet and the QR to point a camera at — lives
               one tap behind this, so it is the fast way to get somebody in

--- a/apps/mobile/src/components/AnnotationOverlay.tsx
+++ b/apps/mobile/src/components/AnnotationOverlay.tsx
@@ -1,0 +1,71 @@
+import { Svg, Polyline, Text as SvgText } from 'react-native-svg';
+
+import type { Annotations } from '@/lib/annotations';
+
+/**
+ * Draws a receipt's pen/text markup over the image. Pure and read-only — the
+ * same renderer the editor previews live and the viewer shows over a saved
+ * image, so what you drew is exactly what everyone later sees.
+ *
+ * Every coordinate is normalised (0..1) to the image, so this only needs the
+ * pixel size the image is currently drawn at: it scales points by width/height
+ * and a stroke width / text size by the smaller edge, and the overlay lines up
+ * at a thumbnail or a full-screen zoom alike.
+ */
+export function AnnotationOverlay({
+  annotations,
+  width,
+  height,
+}: {
+  annotations: Annotations;
+  width: number;
+  height: number;
+}): React.JSX.Element | null {
+  if (width <= 0 || height <= 0) return null;
+  const minEdge = Math.min(width, height);
+
+  return (
+    <Svg
+      width={width}
+      height={height}
+      pointerEvents="none"
+      style={{ position: 'absolute', left: 0, top: 0 }}
+    >
+      {annotations.strokes.map((stroke, i) => {
+        const pts: string[] = [];
+        for (let p = 0; p + 1 < stroke.points.length; p += 2) {
+          pts.push(
+            `${(stroke.points[p] as number) * width},${(stroke.points[p + 1] as number) * height}`,
+          );
+        }
+        return (
+          <Polyline
+            key={`s${i}`}
+            points={pts.join(' ')}
+            fill="none"
+            stroke={stroke.color}
+            strokeWidth={Math.max(1, stroke.width * minEdge)}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        );
+      })}
+      {annotations.texts.map((note, i) => (
+        <SvgText
+          key={`t${i}`}
+          x={note.x * width}
+          y={note.y * height}
+          fill={note.color}
+          fontSize={Math.max(8, note.size * minEdge)}
+          fontWeight="700"
+          // A thin contrasting outline so a note stays legible over a busy
+          // receipt whatever colour it is.
+          stroke="rgba(0,0,0,0.45)"
+          strokeWidth={0.5}
+        >
+          {note.text}
+        </SvgText>
+      ))}
+    </Svg>
+  );
+}

--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -20,8 +20,10 @@ import { ActivityIndicator, Alert, Modal, Pressable, ScrollView, View } from 're
 
 import { IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
 
-import { ZoomableGallery } from '@/components/ZoomableGallery';
+import { ZoomableGallery, type GalleryPage } from '@/components/ZoomableGallery';
+import { ReceiptAnnotator } from '@/components/ReceiptAnnotator';
 import {
+  useAnnotateExpenseAttachment,
   useAttachExpenseAttachment,
   useExpenseAttachments,
   useRemoveExpenseAttachment,
@@ -29,6 +31,7 @@ import {
   type ExpenseAttachmentRow,
 } from '@/data/hooks';
 import { captureReceipt, pickReceiptImage } from '@/lib/image';
+import { EMPTY_ANNOTATIONS, isEmptyAnnotations, type Annotations } from '@/lib/annotations';
 import { imageUrl, restrictedImageUrl } from '@/lib/storage';
 import { fill, useStrings } from '@/i18n';
 
@@ -135,13 +138,22 @@ export function ExpenseReceipts({
   groupId,
   expenseId,
   canManage,
+  canRemoveLegacy,
   legacyReceiptPath,
   onLegacyRemoved,
 }: {
   groupId: string;
   expenseId: string;
-  /** Whether the viewer may add/remove — a party to the expense (payer/author). */
+  /** Whether the viewer may add and manage attachments — a party to the expense
+   *  (payer/author). This never widens to admins: the attach/remove/annotate
+   *  RPCs are party-only, so an admin who is not a party gets no attachment
+   *  controls. */
   canManage: boolean;
+  /** Whether the viewer may remove the legacy kept bill — a party OR a group
+   *  admin (moderation of a group-visible image), matching the pre-gallery rule.
+   *  The legacy bill lives in the group-readable `receipts` bucket, not the
+   *  party-gated attachment table, so an admin removal is server-allowed. */
+  canRemoveLegacy: boolean;
   /** The fixed key of the legacy kept bill, when one exists; null otherwise. */
   legacyReceiptPath: string | null;
   /** Called after the legacy bill is removed, so the parent can hide its item. */
@@ -153,6 +165,7 @@ export function ExpenseReceipts({
   const attach = useAttachExpenseAttachment(groupId, expenseId);
   const removeAttachment = useRemoveExpenseAttachment(expenseId);
   const removeLegacy = useRemoveExpenseReceipt(groupId, expenseId);
+  const annotate = useAnnotateExpenseAttachment();
 
   const items = useMemo<GalleryItem[]>(() => {
     const list: GalleryItem[] = [];
@@ -167,6 +180,20 @@ export function ExpenseReceipts({
 
   const urls = useResolvedUrls(expenseId, items);
   const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+  const [editing, setEditing] = useState<{
+    attachmentId: string;
+    uri: string;
+    initial: Annotations;
+  } | null>(null);
+
+  const pages = useMemo<GalleryPage[]>(
+    () =>
+      items.map((it, i) => ({
+        url: urls[i] ?? null,
+        annotations: it.kind === 'attachment' ? (it.row.annotations ?? undefined) : undefined,
+      })),
+    [items, urls],
+  );
 
   // Nothing to show and cannot add → render nothing, so a non-party's bill is
   // not cluttered with an empty section.
@@ -216,10 +243,16 @@ export function ExpenseReceipts({
         style: 'destructive',
         onPress: () => {
           setViewerIndex(null);
+          const onError = () => Alert.alert(t.imageAudit.couldNotRemove);
           if (it.kind === 'legacy') {
-            removeLegacy.mutate(undefined, { onSuccess: () => onLegacyRemoved?.() });
+            // Only clear the parent's receipt state on a confirmed delete — if the
+            // byte removal throws, the bill is still there and must keep showing.
+            removeLegacy.mutate(undefined, { onSuccess: () => onLegacyRemoved?.(), onError });
           } else {
-            removeAttachment.mutate({ attachmentId: it.row.id, storagePath: it.row.storagePath });
+            removeAttachment.mutate(
+              { attachmentId: it.row.id, storagePath: it.row.storagePath },
+              { onError },
+            );
           }
         },
       },
@@ -310,26 +343,86 @@ export function ExpenseReceipts({
                 </Row>
               ) : null}
             </View>
-            {canManage && viewerIndex !== null ? (
-              <IconButton
-                label={t.receipts.remove}
-                onPress={() => {
-                  if (!removeAttachment.isPending && !removeLegacy.isPending) removeAt(viewerIndex);
-                }}
-              >
-                <Ionicons name="trash-outline" size={iconSize.lg} color={theme.color.negative} />
-              </IconButton>
-            ) : (
-              <View style={{ width: 44 }} />
-            )}
+            {(() => {
+              // An attachment's edit/remove is party-only (`canManage`); the
+              // legacy bill's remove also allows a group admin (`canRemoveLegacy`)
+              // — the same split the RPCs enforce. Nothing to offer → a spacer,
+              // so the counter stays centred.
+              const showEdit =
+                canManage && viewing?.kind === 'attachment' && viewerIndex !== null
+                  ? urls[viewerIndex]
+                  : null;
+              const showRemove =
+                viewing !== null && (viewing.kind === 'legacy' ? canRemoveLegacy : canManage);
+              if (viewerIndex === null || (!showEdit && !showRemove)) {
+                return <View style={{ width: 44 }} />;
+              }
+              return (
+                <Row style={{ gap: theme.spacing.xs }}>
+                  {showEdit ? (
+                    <IconButton
+                      label={t.annotate.title}
+                      onPress={() => {
+                        const url = urls[viewerIndex];
+                        if (viewing?.kind === 'attachment' && url) {
+                          setEditing({
+                            attachmentId: viewing.row.id,
+                            uri: url,
+                            initial: viewing.row.annotations ?? EMPTY_ANNOTATIONS,
+                          });
+                        }
+                      }}
+                    >
+                      <Ionicons name="pencil" size={iconSize.md} color={theme.color.text} />
+                    </IconButton>
+                  ) : null}
+                  {showRemove ? (
+                    <IconButton
+                      label={t.receipts.remove}
+                      onPress={() => {
+                        if (!removeAttachment.isPending && !removeLegacy.isPending)
+                          removeAt(viewerIndex);
+                      }}
+                    >
+                      <Ionicons
+                        name="trash-outline"
+                        size={iconSize.lg}
+                        color={theme.color.negative}
+                      />
+                    </IconButton>
+                  ) : null}
+                </Row>
+              );
+            })()}
           </Row>
           <ZoomableGallery
-            uris={urls.map((u) => u ?? null)}
+            pages={pages}
             index={viewerIndex ?? 0}
             onIndexChange={(i) => setViewerIndex(i)}
           />
         </View>
       </Modal>
+
+      {editing ? (
+        <ReceiptAnnotator
+          uri={editing.uri}
+          initial={editing.initial}
+          saving={annotate.isPending}
+          onCancel={() => setEditing(null)}
+          onSave={(next) =>
+            annotate.mutate(
+              {
+                attachmentId: editing.attachmentId,
+                annotations: isEmptyAnnotations(next) ? null : next,
+              },
+              {
+                onSuccess: () => setEditing(null),
+                onError: () => Alert.alert(t.annotate.couldNotSave),
+              },
+            )
+          }
+        />
+      ) : null}
     </View>
   );
 }

--- a/apps/mobile/src/components/ReceiptAnnotator.tsx
+++ b/apps/mobile/src/components/ReceiptAnnotator.tsx
@@ -1,0 +1,352 @@
+/**
+ * The receipt markup editor (A46): draw on a bill with a pen and drop text
+ * notes, then save. Non-destructive — it produces an {@link Annotations} overlay
+ * in normalised image coordinates; the image bytes are never touched, so the
+ * markup stays editable and renders the same everywhere.
+ *
+ * Drawing is on the View responder API (the JS thread) rather than a worklet
+ * gesture: a receipt scribble is low-frequency, and keeping the points in React
+ * state is what lets undo, the live preview and the saved overlay all read from
+ * one source. The tap-to-place text path shares the same normalised space.
+ *
+ * The overlay must line up with the image at every size, so everything is scaled
+ * off the *displayed* image rectangle (letterboxed inside the screen via
+ * `contain`), computed from the image's natural size — the same rectangle the
+ * read-only {@link AnnotationOverlay} uses.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Image as ExpoImage } from 'expo-image';
+import {
+  ActivityIndicator,
+  Image as RNImage,
+  Modal,
+  Pressable,
+  TextInput,
+  View,
+  type LayoutChangeEvent,
+} from 'react-native';
+
+import { IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+import { AnnotationOverlay } from '@/components/AnnotationOverlay';
+import {
+  ANNOT_COLORS,
+  containRect,
+  EMPTY_ANNOTATIONS,
+  isEmptyAnnotations,
+  type AnnotStroke,
+  type AnnotText,
+  type Annotations,
+} from '@/lib/annotations';
+import { useStrings } from '@/i18n';
+
+/** Default pen width and text size, as a fraction of the image's smaller edge. */
+const PEN_WIDTH = 0.006;
+const TEXT_SIZE = 0.05;
+
+type Action = { kind: 'stroke'; stroke: AnnotStroke } | { kind: 'text'; text: AnnotText };
+
+export function ReceiptAnnotator({
+  uri,
+  initial,
+  saving,
+  onCancel,
+  onSave,
+}: {
+  uri: string;
+  initial: Annotations;
+  saving: boolean;
+  onCancel: () => void;
+  onSave: (annotations: Annotations) => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  const [history, setHistory] = useState<Action[]>(() => [
+    ...initial.strokes.map((stroke): Action => ({ kind: 'stroke', stroke })),
+    ...initial.texts.map((text): Action => ({ kind: 'text', text })),
+  ]);
+  const [mode, setMode] = useState<'pen' | 'text'>('pen');
+  const [color, setColor] = useState(ANNOT_COLORS[0] as string);
+  const [live, setLive] = useState<number[] | null>(null);
+  const [pending, setPending] = useState<{ x: number; y: number } | null>(null);
+  const [draft, setDraft] = useState('');
+
+  const [box, setBox] = useState({ w: 0, h: 0 });
+  const [natural, setNatural] = useState({ w: 0, h: 0 });
+  // Memoised so the drawn rectangle is a stable value while a stroke is in
+  // progress (box/natural do not change mid-gesture); the draw handlers below
+  // scale their points by it.
+  const rect = useMemo(() => containRect(box, natural), [box, natural]);
+
+  // Resolve the image's natural size so the letterbox rectangle is right; the
+  // remote/local URI both answer `getSize`.
+  useEffect(() => {
+    let active = true;
+    RNImage.getSize(
+      uri,
+      (w, h) => active && setNatural({ w, h }),
+      () => active && setNatural({ w: 1, h: 1 }),
+    );
+    return () => {
+      active = false;
+    };
+  }, [uri]);
+
+  // Freehand drawing via the View responder API, inline rather than a memoised
+  // PanResponder: the handlers close over the current rect/colour/live points
+  // and read no refs, so they satisfy the React Compiler. The in-progress stroke
+  // lives in `live` state; the release commits the last-rendered points, which
+  // is the latest set since every move re-rendered.
+  const norm = (v: number, span: number) => Math.min(1, Math.max(0, v / span));
+  const drawHandlers = {
+    onStartShouldSetResponder: () => rect.w > 0 && rect.h > 0,
+    onMoveShouldSetResponder: () => rect.w > 0 && rect.h > 0,
+    onResponderGrant: (e: { nativeEvent: { locationX: number; locationY: number } }) => {
+      setLive([norm(e.nativeEvent.locationX, rect.w), norm(e.nativeEvent.locationY, rect.h)]);
+    },
+    onResponderMove: (e: { nativeEvent: { locationX: number; locationY: number } }) => {
+      const nx = norm(e.nativeEvent.locationX, rect.w);
+      const ny = norm(e.nativeEvent.locationY, rect.h);
+      setLive((prev) => (prev ? [...prev, nx, ny] : [nx, ny]));
+    },
+    onResponderRelease: () => {
+      if (live && live.length >= 4) {
+        const points = live;
+        setHistory((h) => [...h, { kind: 'stroke', stroke: { color, width: PEN_WIDTH, points } }]);
+      }
+      setLive(null);
+    },
+    onResponderTerminate: () => setLive(null),
+  };
+
+  const annotations = useMemo<Annotations>(() => {
+    const strokes = history
+      .filter((a): a is Extract<Action, { kind: 'stroke' }> => a.kind === 'stroke')
+      .map((a) => a.stroke);
+    const texts = history
+      .filter((a): a is Extract<Action, { kind: 'text' }> => a.kind === 'text')
+      .map((a) => a.text);
+    const withLive =
+      live && live.length >= 4 ? [...strokes, { color, width: PEN_WIDTH, points: live }] : strokes;
+    return { strokes: withLive, texts };
+  }, [history, live, color]);
+
+  const undo = () => setHistory((h) => h.slice(0, -1));
+  const clear = () => setHistory([]);
+
+  const placeText = (e: { nativeEvent: { locationX: number; locationY: number } }) => {
+    if (rect.w <= 0 || rect.h <= 0) return;
+    setPending({
+      x: Math.min(1, Math.max(0, e.nativeEvent.locationX / rect.w)),
+      y: Math.min(1, Math.max(0, e.nativeEvent.locationY / rect.h)),
+    });
+    setDraft('');
+  };
+
+  const commitText = () => {
+    const text = draft.trim();
+    if (pending && text !== '') {
+      const note: AnnotText = { x: pending.x, y: pending.y, color, size: TEXT_SIZE, text };
+      setHistory((h) => [...h, { kind: 'text', text: note }]);
+    }
+    setPending(null);
+    setDraft('');
+  };
+
+  const onBoxLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    setBox({ w: width, h: height });
+  };
+
+  const save = () => onSave(isEmptyAnnotations(annotations) ? EMPTY_ANNOTATIONS : annotations);
+
+  return (
+    <Modal visible animationType="slide" onRequestClose={onCancel}>
+      <View style={{ flex: 1, backgroundColor: '#000' }}>
+        {/* Top bar: cancel / mode label / save. */}
+        <Row
+          style={{
+            justifyContent: 'space-between',
+            paddingHorizontal: theme.spacing.xl,
+            paddingTop: theme.spacing.xxl,
+            paddingBottom: theme.spacing.sm,
+          }}
+        >
+          <IconButton label={t.common.cancel} onPress={onCancel}>
+            <Ionicons name="close" size={iconSize.lg} color="#FFFFFF" />
+          </IconButton>
+          <Text variant="subheading" style={{ color: '#FFFFFF' }}>
+            {t.annotate.title}
+          </Text>
+          <IconButton label={t.common.save} onPress={save}>
+            {saving ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Ionicons name="checkmark" size={iconSize.lg} color="#FFFFFF" />
+            )}
+          </IconButton>
+        </Row>
+
+        {/* The canvas: the image, the overlay, and the input layer over its
+            drawn rectangle. */}
+        <View style={{ flex: 1 }} onLayout={onBoxLayout}>
+          <ExpoImage source={{ uri }} style={{ flex: 1 }} contentFit="contain" transition={100} />
+          <View
+            style={{
+              position: 'absolute',
+              left: rect.x,
+              top: rect.y,
+              width: rect.w,
+              height: rect.h,
+            }}
+          >
+            <AnnotationOverlay annotations={annotations} width={rect.w} height={rect.h} />
+            {mode === 'pen' ? (
+              <View style={{ position: 'absolute', inset: 0 }} {...drawHandlers} />
+            ) : (
+              <Pressable
+                style={{ position: 'absolute', inset: 0 }}
+                onPress={placeText}
+                accessibilityRole="button"
+                accessibilityLabel={t.annotate.addText}
+              />
+            )}
+          </View>
+        </View>
+
+        {/* Toolbar: pen/text, colour swatches, undo, clear. */}
+        <Row
+          style={{
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            paddingHorizontal: theme.spacing.xl,
+            paddingVertical: theme.spacing.md,
+            gap: theme.spacing.md,
+          }}
+        >
+          <Row style={{ gap: theme.spacing.sm }}>
+            <ToolButton
+              icon="pencil"
+              active={mode === 'pen'}
+              label={t.annotate.pen}
+              onPress={() => setMode('pen')}
+            />
+            <ToolButton
+              icon="text"
+              active={mode === 'text'}
+              label={t.annotate.addText}
+              onPress={() => setMode('text')}
+            />
+          </Row>
+          <Row style={{ gap: theme.spacing.sm, flex: 1, justifyContent: 'center' }}>
+            {ANNOT_COLORS.map((c) => (
+              <Pressable
+                key={c}
+                onPress={() => setColor(c)}
+                accessibilityRole="button"
+                accessibilityLabel={c}
+                accessibilityState={{ selected: color === c }}
+                style={{
+                  width: 26,
+                  height: 26,
+                  borderRadius: 13,
+                  backgroundColor: c,
+                  borderWidth: color === c ? 3 : 1,
+                  borderColor: color === c ? '#FFFFFF' : 'rgba(255,255,255,0.4)',
+                }}
+              />
+            ))}
+          </Row>
+          <Row style={{ gap: theme.spacing.sm }}>
+            <ToolButton icon="arrow-undo" label={t.annotate.undo} onPress={undo} />
+            <ToolButton icon="trash-outline" label={t.annotate.clear} onPress={clear} />
+          </Row>
+        </Row>
+
+        {/* Text entry for a dropped note. */}
+        <Modal
+          visible={pending !== null}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setPending(null)}
+        >
+          <View
+            style={{
+              flex: 1,
+              backgroundColor: 'rgba(0,0,0,0.6)',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <View
+              style={{
+                padding: theme.spacing.xl,
+                gap: theme.spacing.md,
+                backgroundColor: theme.color.surface,
+              }}
+            >
+              <TextInput
+                value={draft}
+                onChangeText={setDraft}
+                autoFocus
+                placeholder={t.annotate.textPlaceholder}
+                placeholderTextColor={theme.color.textFaint}
+                onSubmitEditing={commitText}
+                style={{
+                  minHeight: 44,
+                  paddingHorizontal: theme.spacing.md,
+                  borderRadius: theme.radius.md,
+                  backgroundColor: theme.color.surfaceMuted,
+                  color: theme.color.text,
+                }}
+              />
+              <Row style={{ justifyContent: 'flex-end', gap: theme.spacing.md }}>
+                <Pressable onPress={() => setPending(null)} accessibilityRole="button">
+                  <Text tone="muted">{t.common.cancel}</Text>
+                </Pressable>
+                <Pressable onPress={commitText} accessibilityRole="button">
+                  <Text style={{ color: theme.color.brand, fontWeight: '700' }}>
+                    {t.common.done}
+                  </Text>
+                </Pressable>
+              </Row>
+            </View>
+          </View>
+        </Modal>
+      </View>
+    </Modal>
+  );
+}
+
+function ToolButton({
+  icon,
+  label,
+  active,
+  onPress,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  active?: boolean;
+  onPress: () => void;
+}): React.JSX.Element {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: Boolean(active) }}
+      style={{
+        width: 40,
+        height: 40,
+        borderRadius: 20,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: active ? 'rgba(255,255,255,0.22)' : 'transparent',
+      }}
+    >
+      <Ionicons name={icon} size={iconSize.md} color="#FFFFFF" />
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -30,11 +30,22 @@ import { SyncStatus, useSync } from '@/sync';
  * is nothing to report — online, idle, nothing queued — it renders nothing, so
  * the header is not carrying a permanent "all good" badge nobody asked for.
  */
-export function SyncStatusIcon({ onBrand = false }: { onBrand?: boolean } = {}) {
+export function SyncStatusIcon({
+  onBrand = false,
+  groupId,
+}: { onBrand?: boolean; groupId?: string } = {}) {
   const theme = useTheme();
   const { t, locale } = useStrings();
   const { animated } = useMotion();
   const { status, queue, rejected } = useSync();
+
+  // On a group screen, scope the queued/refused counts to this group — the same
+  // predicate the inline SyncBanner uses — so the header glyph reflects THIS
+  // group's state, not another group's refused change. Omitted (the dashboard)
+  // keeps the whole-account view. Connection status (offline/syncing) stays
+  // global, since the network is not per-group.
+  const refused = groupId ? rejected.filter((item) => item.groupId === groupId) : rejected;
+  const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
 
   const spin = useState(() => new Animated.Value(0))[0];
   const spinning = status === SyncStatus.Syncing && animated;
@@ -65,7 +76,7 @@ export function SyncStatusIcon({ onBrand = false }: { onBrand?: boolean } = {}) 
   // as an alert whatever it sits on.
   const neutral = onBrand ? theme.color.onBrand : theme.color.text;
   const state =
-    rejected.length > 0
+    refused.length > 0
       ? {
           icon: 'alert-circle' as const,
           color: theme.color.negative,
@@ -81,11 +92,11 @@ export function SyncStatusIcon({ onBrand = false }: { onBrand?: boolean } = {}) 
             }
           : status === SyncStatus.Metered
             ? { icon: 'cloud-offline-outline' as const, color: neutral, label: t.sync.waitingWifi }
-            : status === SyncStatus.Syncing || queue.length > 0
+            : status === SyncStatus.Syncing || pending.length > 0
               ? {
                   icon: 'sync-outline' as const,
                   color: neutral,
-                  label: plural(locale, queue.length, t.misc.syncingCount),
+                  label: plural(locale, pending.length, t.misc.syncingCount),
                 }
               : null;
 

--- a/apps/mobile/src/components/ZoomableGallery.tsx
+++ b/apps/mobile/src/components/ZoomableGallery.tsx
@@ -2,6 +2,13 @@ import { useRef, useState } from 'react';
 import { FlatList, useWindowDimensions, View, type ListRenderItemInfo } from 'react-native';
 
 import { ZoomableImage } from '@/components/ZoomableImage';
+import type { Annotations } from '@/lib/annotations';
+
+/** One gallery page: its resolved URL (null while resolving) and any markup. */
+export interface GalleryPage {
+  url: string | null;
+  annotations?: Annotations;
+}
 
 /**
  * A full-screen, swipeable gallery: one {@link ZoomableImage} per page, paged
@@ -14,29 +21,31 @@ import { ZoomableImage } from '@/components/ZoomableImage';
  * draws them; a still-resolving page shows nothing rather than a broken frame.
  */
 export function ZoomableGallery({
-  uris,
+  pages,
   index,
   onIndexChange,
 }: {
-  /** One resolved image URL per page, in order. A null page is still resolving. */
-  uris: readonly (string | null)[];
+  /** One page per image, in order. A page's null url is still resolving. */
+  pages: readonly GalleryPage[];
   index: number;
   onIndexChange: (index: number) => void;
 }): React.JSX.Element {
   const { width } = useWindowDimensions();
   const [zoomed, setZoomed] = useState(false);
-  const listRef = useRef<FlatList<string | null>>(null);
+  const listRef = useRef<FlatList<GalleryPage>>(null);
 
-  const renderItem = ({ item }: ListRenderItemInfo<string | null>) => (
+  const renderItem = ({ item }: ListRenderItemInfo<GalleryPage>) => (
     <View style={{ width, flex: 1, justifyContent: 'center' }}>
-      {item ? <ZoomableImage uri={item} onZoomChange={setZoomed} /> : null}
+      {item.url ? (
+        <ZoomableImage uri={item.url} onZoomChange={setZoomed} annotations={item.annotations} />
+      ) : null}
     </View>
   );
 
   return (
     <FlatList
       ref={listRef}
-      data={uris as (string | null)[]}
+      data={pages as GalleryPage[]}
       keyExtractor={(_, i) => String(i)}
       renderItem={renderItem}
       horizontal

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useState } from 'react';
 import { Image } from 'expo-image';
-import { useWindowDimensions } from 'react-native';
+import { Image as RNImage, useWindowDimensions } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
@@ -7,6 +8,9 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+
+import { AnnotationOverlay } from '@/components/AnnotationOverlay';
+import { containRect, type Annotations } from '@/lib/annotations';
 
 const AnimatedImage = Animated.createAnimatedComponent(Image);
 
@@ -24,13 +28,35 @@ const AnimatedImage = Animated.createAnimatedComponent(Image);
 export function ZoomableImage({
   uri,
   onZoomChange,
+  annotations,
 }: {
   uri: string;
   /** Fires when the image crosses between fit (1×) and zoomed (>1×). A pager uses
    *  it to stop swiping between pages while a page is zoomed in. */
   onZoomChange?: (zoomed: boolean) => void;
+  /** Pen/text markup to draw over the image, tracking it through zoom/pan. When
+   *  present the image is sized to its exact fit rectangle so the overlay lines
+   *  up with the pixels; without it the plain full-box behaviour is unchanged. */
+  annotations?: Annotations;
 }): React.JSX.Element {
   const { width, height } = useWindowDimensions();
+  const boxHeight = height * 0.8;
+
+  // The image's natural size, only needed to place an overlay on its exact fit
+  // rectangle. Resolved once per uri; until then the rect falls back to the box.
+  const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
+  useEffect(() => {
+    if (!annotations) return;
+    let active = true;
+    RNImage.getSize(
+      uri,
+      (w, h) => active && setNatural({ w, h }),
+      () => active && setNatural(null),
+    );
+    return () => {
+      active = false;
+    };
+  }, [uri, annotations]);
 
   const scale = useSharedValue(1);
   const savedScale = useSharedValue(1);
@@ -94,15 +120,41 @@ export function ZoomableImage({
     ],
   }));
 
+  // Without an overlay: the original, unchanged full-box image. With one: size
+  // the image to its fit rectangle and lay the overlay over the same rectangle,
+  // both inside the zoom transform so they magnify together.
+  if (!annotations) {
+    return (
+      <GestureDetector gesture={composed}>
+        <Animated.View style={{ flex: 1, justifyContent: 'center' }} collapsable={false}>
+          <AnimatedImage
+            source={{ uri }}
+            style={[{ width, height: boxHeight }, animatedStyle]}
+            contentFit="contain"
+            transition={150}
+          />
+        </Animated.View>
+      </GestureDetector>
+    );
+  }
+
+  const rect = containRect({ w: width, h: boxHeight }, natural ?? { w: 0, h: 0 });
+
   return (
     <GestureDetector gesture={composed}>
-      <Animated.View style={{ flex: 1, justifyContent: 'center' }} collapsable={false}>
-        <AnimatedImage
-          source={{ uri }}
-          style={[{ width, height: height * 0.8 }, animatedStyle]}
-          contentFit="contain"
-          transition={150}
-        />
+      <Animated.View
+        style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
+        collapsable={false}
+      >
+        <Animated.View style={[{ width: rect.w, height: rect.h }, animatedStyle]}>
+          <Image
+            source={{ uri }}
+            style={{ width: rect.w, height: rect.h }}
+            contentFit="contain"
+            transition={150}
+          />
+          <AnnotationOverlay annotations={annotations} width={rect.w} height={rect.h} />
+        </Animated.View>
       </Animated.View>
     </GestureDetector>
   );

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -92,6 +92,7 @@ import {
 import { totalsByCurrency } from './totals';
 import { putImage, removeRestrictedImage } from '@/lib/storage';
 import { pickAlbumPhoto, type PickedImage } from '@/lib/image';
+import { parseAnnotations, type Annotations } from '@/lib/annotations';
 import { SettlementStatus } from './types';
 import type {
   ActivityActor,
@@ -1562,6 +1563,8 @@ export interface ExpenseAttachmentRow {
   storagePath: string;
   visibility: 'group' | 'parties';
   uploaderMemberId: string;
+  /** Parsed pen/text markup over the image, or null when unmarked. */
+  annotations: Annotations | null;
   createdAt: string | null;
 }
 
@@ -1579,11 +1582,31 @@ export function useExpenseAttachments(expenseId: string): LocalRead<ExpenseAttac
         storagePath: row.storage_path,
         visibility: row.visibility === 'parties' ? 'parties' : 'group',
         uploaderMemberId: row.uploader_member_id,
+        annotations: row.annotations == null ? null : parseAnnotations(row.annotations),
         createdAt: row.created_at,
       })),
     [mirror, expenseId],
   );
   return useLocalRead(rows);
+}
+
+/**
+ * Set or clear the pen/text markup on an attachment (a party only, server-
+ * enforced). `null` clears it. Direct RPC → flush, the same shape as the other
+ * attachment writes; the overlay is data on the row, the bytes are untouched.
+ */
+export function useAnnotateExpenseAttachment() {
+  const { flush } = useSync();
+  return useMutation({
+    mutationFn: async (input: { attachmentId: string; annotations: Annotations | null }) => {
+      const { error } = await supabase.rpc('baaki_annotate_expense_attachment', {
+        p_attachment_id: input.attachmentId,
+        p_annotations: input.annotations,
+      });
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => void flush(),
+  });
 }
 
 /**

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -435,6 +435,16 @@ export interface UiStrings {
     /** Viewer counter, e.g. "2 of 5" — `{index}` and `{total}`. */
     counter: string;
   };
+  /** The receipt markup editor (pen + text over an image). */
+  annotate: {
+    title: string;
+    pen: string;
+    addText: string;
+    undo: string;
+    clear: string;
+    textPlaceholder: string;
+    couldNotSave: string;
+  };
   /** Trip budgets. */
   budgets: string;
   overallBudget: string;
@@ -2165,6 +2175,15 @@ const en: UiStrings = {
     removeConfirm: 'Remove this receipt? The change is recorded.',
     couldNotAdd: "Couldn't add that — try again.",
     counter: '{index} of {total}',
+  },
+  annotate: {
+    title: 'Markup',
+    pen: 'Pen',
+    addText: 'Add text',
+    undo: 'Undo',
+    clear: 'Clear',
+    textPlaceholder: 'Add a note',
+    couldNotSave: "Couldn't save the markup — try again.",
   },
   budgets: 'Budgets',
   overallBudget: 'Overall',
@@ -3909,6 +3928,15 @@ const ta: UiStrings = {
     removeConfirm: 'இந்த ரசீதை அகற்றவா? இந்த மாற்றம் பதிவு செய்யப்படும்.',
     couldNotAdd: 'சேர்க்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
     counter: '{total} இல் {index}',
+  },
+  annotate: {
+    title: 'குறிப்புகள்',
+    pen: 'பேனா',
+    addText: 'உரை சேர்',
+    undo: 'செயல்தவிர்',
+    clear: 'அழி',
+    textPlaceholder: 'குறிப்பு சேர்',
+    couldNotSave: 'குறிப்புகளைச் சேமிக்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
   },
   budgets: 'பட்ஜெட்',
   overallBudget: 'மொத்தம்',
@@ -5720,6 +5748,15 @@ const hi: UiStrings = {
     couldNotAdd: 'जोड़ा नहीं जा सका — फिर कोशिश करें।',
     counter: '{total} में से {index}',
   },
+  annotate: {
+    title: 'मार्कअप',
+    pen: 'पेन',
+    addText: 'टेक्स्ट जोड़ें',
+    undo: 'पूर्ववत करें',
+    clear: 'साफ़ करें',
+    textPlaceholder: 'एक नोट जोड़ें',
+    couldNotSave: 'मार्कअप सहेजा नहीं जा सका — फिर कोशिश करें।',
+  },
   budgets: 'बजट',
   overallBudget: 'कुल',
   myBudget: 'मेरा बजट',
@@ -7478,6 +7515,15 @@ const ar: UiStrings = {
     removeConfirm: 'إزالة هذا الإيصال؟ سيُسجَّل هذا التغيير.',
     couldNotAdd: 'تعذّرت الإضافة — حاول مرة أخرى.',
     counter: '{index} من {total}',
+  },
+  annotate: {
+    title: 'توصيف',
+    pen: 'قلم',
+    addText: 'إضافة نص',
+    undo: 'تراجع',
+    clear: 'مسح',
+    textPlaceholder: 'أضف ملاحظة',
+    couldNotSave: 'تعذّر حفظ التوصيف — حاول مرة أخرى.',
   },
   budgets: 'الميزانية',
   overallBudget: 'الإجمالي',

--- a/apps/mobile/src/lib/annotations.ts
+++ b/apps/mobile/src/lib/annotations.ts
@@ -1,0 +1,123 @@
+/**
+ * Receipt markup — the small vector overlay a person draws over a receipt image
+ * (A46). It is stored as data on the attachment row, never baked into the pixels,
+ * so it stays editable and the same image serves everyone.
+ *
+ * Every coordinate is normalised to the image: `0..1` across the width and the
+ * height, and a stroke width / text size is a fraction of the image's smaller
+ * edge. That way the overlay lines up whatever size the image is drawn at — a
+ * thumbnail, a full-screen zoom, another phone.
+ *
+ * The parser is defensive: the JSON came from the database (which a determined
+ * client could have written directly), so it clamps every number into range and
+ * caps the counts, and a value it cannot make sense of is dropped rather than
+ * trusted. A garbage blob parses to an empty overlay, never a crash.
+ */
+
+/** A freehand stroke: a flat list of points `[x0, y0, x1, y1, …]`, each 0..1. */
+export interface AnnotStroke {
+  readonly color: string;
+  readonly width: number;
+  readonly points: readonly number[];
+}
+
+/** A text note anchored at (x, y) in 0..1 image space; `size` is a fraction of
+ *  the image's smaller edge. */
+export interface AnnotText {
+  readonly x: number;
+  readonly y: number;
+  readonly color: string;
+  readonly size: number;
+  readonly text: string;
+}
+
+export interface Annotations {
+  readonly strokes: readonly AnnotStroke[];
+  readonly texts: readonly AnnotText[];
+}
+
+export const EMPTY_ANNOTATIONS: Annotations = { strokes: [], texts: [] };
+
+/** The pen/text palette — a short, high-contrast set that reads on a receipt. */
+export const ANNOT_COLORS = ['#EF4444', '#2563EB', '#16A34A', '#F59E0B', '#111827', '#FFFFFF'];
+
+// Caps: enough for real markup, small enough to bound render cost and the 256KB
+// column the migration enforces.
+const MAX_STROKES = 300;
+const MAX_POINTS = 2000; // per stroke (flat, so 1000 x/y pairs)
+const MAX_TEXTS = 60;
+const MAX_TEXT_LEN = 200;
+
+function clamp01(n: unknown): number {
+  return typeof n === 'number' && Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : 0;
+}
+
+function clampSize(n: unknown): number {
+  // A stroke width / text size is a fraction of the smaller edge; keep it sane.
+  return typeof n === 'number' && Number.isFinite(n) ? Math.min(0.5, Math.max(0.001, n)) : 0.01;
+}
+
+function safeColor(c: unknown): string {
+  // Only accept a `#rgb`/`#rrggbb` hex — never arbitrary text that a renderer
+  // might treat as something else.
+  return typeof c === 'string' && /^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(c) ? c : '#EF4444';
+}
+
+export function parseAnnotations(raw: unknown): Annotations {
+  if (!raw || typeof raw !== 'object') return EMPTY_ANNOTATIONS;
+  const obj = raw as { strokes?: unknown; texts?: unknown };
+
+  const strokes: AnnotStroke[] = [];
+  if (Array.isArray(obj.strokes)) {
+    for (const s of obj.strokes.slice(0, MAX_STROKES)) {
+      if (!s || typeof s !== 'object') continue;
+      const st = s as { color?: unknown; width?: unknown; points?: unknown };
+      if (!Array.isArray(st.points)) continue;
+      const points = st.points.slice(0, MAX_POINTS).map(clamp01);
+      if (points.length < 2) continue; // Need at least one point (x, y).
+      strokes.push({ color: safeColor(st.color), width: clampSize(st.width), points });
+    }
+  }
+
+  const texts: AnnotText[] = [];
+  if (Array.isArray(obj.texts)) {
+    for (const t of obj.texts.slice(0, MAX_TEXTS)) {
+      if (!t || typeof t !== 'object') continue;
+      const tx = t as { x?: unknown; y?: unknown; color?: unknown; size?: unknown; text?: unknown };
+      const text = typeof tx.text === 'string' ? tx.text.slice(0, MAX_TEXT_LEN) : '';
+      if (text.trim() === '') continue;
+      texts.push({
+        x: clamp01(tx.x),
+        y: clamp01(tx.y),
+        color: safeColor(tx.color),
+        size: clampSize(tx.size),
+        text,
+      });
+    }
+  }
+
+  return { strokes, texts };
+}
+
+export function isEmptyAnnotations(a: Annotations): boolean {
+  return a.strokes.length === 0 && a.texts.length === 0;
+}
+
+/**
+ * The letterboxed rectangle an image of `natural` size is drawn at when fit
+ * (`contain`) inside a `box`. Both the editor and the viewer size the image and
+ * its overlay to this exact rectangle so normalised markup lines up with the
+ * pixels. Falls back to the whole box until the natural size is known.
+ */
+export function containRect(
+  box: { w: number; h: number },
+  natural: { w: number; h: number },
+): { x: number; y: number; w: number; h: number } {
+  if (box.w <= 0 || box.h <= 0 || natural.w <= 0 || natural.h <= 0) {
+    return { x: 0, y: 0, w: box.w, h: box.h };
+  }
+  const scale = Math.min(box.w / natural.w, box.h / natural.h);
+  const w = natural.w * scale;
+  const h = natural.h * scale;
+  return { x: (box.w - w) / 2, y: (box.h - h) / 2, w, h };
+}

--- a/apps/mobile/src/lib/storage/index.ts
+++ b/apps/mobile/src/lib/storage/index.ts
@@ -232,12 +232,18 @@ export async function imageUrl(bucket: LogicalBucket, path: string | null): Prom
   }
 }
 
-/** Delete an object from whichever backend holds it. */
+/**
+ * Delete an object from whichever backend holds it. Throws when the delete
+ * fails, so a caller does not record a removal (or clear its UI) for bytes that
+ * are still there — the R2 path already threw; this makes the Supabase path
+ * match instead of swallowing the error.
+ */
 export async function removeImage(bucket: LogicalBucket, path: string | null): Promise<void> {
   if (!path) return;
 
   if (!r2Enabled()) {
-    await supabase.storage.from(bucket).remove([path]);
+    const { error } = await supabase.storage.from(bucket).remove([path]);
+    if (error) throw new Error(error.message);
     return;
   }
   await signCall({ action: 'delete', bucket, path });

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -1021,6 +1021,8 @@ export interface MirrorExpenseAttachment extends MirrorRow {
   readonly storage_path: string;
   readonly visibility: string;
   readonly uploader_member_id: string;
+  /** Non-destructive pen/text markup (jsonb), or null. Shape parsed at the UI. */
+  readonly annotations: unknown;
   readonly created_at: string | null;
   readonly deleted_at: string | null;
 }

--- a/packages/db/prisma/migrations/20260824190000_receipt_annotations/migration.sql
+++ b/packages/db/prisma/migrations/20260824190000_receipt_annotations/migration.sql
@@ -1,0 +1,63 @@
+-- Receipt markup (A46): non-destructive pen/text annotations on an expense
+-- image.
+--
+-- The bytes are never touched — a marked-up receipt is the same image plus a
+-- small vector overlay (freehand strokes + text), stored here in normalised
+-- (0..1) image coordinates so it renders crisp at any zoom and survives a device
+-- with a different screen. Keeping it as data, not baked pixels, means the
+-- markup stays editable and needs no image re-encode or re-upload, and every
+-- member who can see the image sees the same notes over it.
+--
+-- Only a party to the expense (a payer or its author) may mark up an image — the
+-- same gate as attaching one. The column rides the existing mirror (`updated_seq`
+-- is bumped by the shared stamp trigger on UPDATE), so an edit propagates like
+-- any other change to the row.
+
+ALTER TABLE public.expense_attachments
+  ADD COLUMN IF NOT EXISTS annotations jsonb;
+
+-- Bound the overlay so a client cannot park megabytes of "annotation" on a row.
+-- A page of strokes and a handful of text notes is a few KB; 256KB is generous.
+ALTER TABLE public.expense_attachments
+  DROP CONSTRAINT IF EXISTS expense_attachments_annotations_sane;
+ALTER TABLE public.expense_attachments
+  ADD CONSTRAINT expense_attachments_annotations_sane
+  CHECK (annotations IS NULL OR pg_column_size(annotations) <= 262144);
+
+/**
+ * Set (or clear, with NULL) the markup on an attachment. A party only — the same
+ * predicate that guards attaching. Soft-deleted rows are inert. The stamp trigger
+ * bumps `updated_seq`, so the edit reaches every device on the next pull.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_annotate_expense_attachment(
+  p_attachment_id uuid,
+  p_annotations   jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_expense_id uuid;
+BEGIN
+  SELECT expense_id INTO v_expense_id
+  FROM public.expense_attachments
+  WHERE id = p_attachment_id AND deleted_at IS NULL;
+  IF v_expense_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF NOT public.baaki_is_expense_party(v_expense_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only a party may mark up this image'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  UPDATE public.expense_attachments
+     SET annotations = p_annotations
+   WHERE id = p_attachment_id AND deleted_at IS NULL;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_annotate_expense_attachment(uuid, jsonb)
+  TO authenticated, anon;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1417,6 +1417,10 @@ model ExpenseAttachment {
   uploaderMemberId String    @map("uploader_member_id") @db.Uuid
   storagePath      String    @map("storage_path")
   visibility       String    @default("group")
+  /// Non-destructive pen/text markup drawn over the image, in normalised (0..1)
+  /// image coordinates so it renders at any size. Null when the image is not
+  /// marked up. Edited by a party through an RPC; the bytes are never touched.
+  annotations      Json?
   createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
   updatedSeq       BigInt    @default(0) @map("updated_seq")

--- a/packages/db/test/receipt-annotations.test.ts
+++ b/packages/db/test/receipt-annotations.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Receipt markup (A46): only a party to the expense may set or clear the pen/text
+ * overlay on an attachment, and the column bounds how large it can be.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+async function as<T>(profileId: string | null, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    profileId
+      ? JSON.stringify({ sub: profileId, role: 'authenticated' })
+      : JSON.stringify({ role: 'anon' }),
+  ]);
+  await client.query(`SET ROLE ${profileId ? 'authenticated' : 'anon'}`);
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+// m0 = author + sole payer → the only PARTY. m1 = a member but non-party.
+let g: { groupId: string; profileIds: string[]; memberIds: string[] };
+let expenseId: string;
+let attachmentId: string;
+let outsider: string;
+
+beforeAll(async () => {
+  g = await seedGroup(client, { memberCount: 3, name: 'Markup' });
+  outsider = randomUUID();
+  await client.query(
+    `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Outsider', 'INR')`,
+    [outsider],
+  );
+  ({ expenseId } = await addEqualSplitExpense(client, {
+    groupId: g.groupId,
+    payers: { [g.memberIds[0] as string]: 3000n },
+    participants: g.memberIds,
+    amount: 3000n,
+  }));
+});
+
+const P = (i: number) => g.profileIds[i] as string;
+
+beforeEach(async () => {
+  await client.query(`DELETE FROM expense_attachments WHERE group_id = $1`, [g.groupId]);
+  // A fresh group-visible attachment owned by the party each test.
+  attachmentId = randomUUID();
+  await as(P(0), () =>
+    client.query(`SELECT baaki_attach_expense_attachment($1, $2, 'group', $3)`, [
+      expenseId,
+      `${expenseId}/${randomUUID()}.webp`,
+      attachmentId,
+    ]),
+  );
+});
+
+const annotate = (profileId: string, id: string, annotations: unknown) =>
+  as(profileId, () =>
+    client.query(`SELECT baaki_annotate_expense_attachment($1, $2::jsonb)`, [
+      id,
+      annotations === null ? null : JSON.stringify(annotations),
+    ]),
+  );
+
+const readAnnotations = (id: string) =>
+  client
+    .query(`SELECT annotations FROM expense_attachments WHERE id = $1`, [id])
+    .then((r) => r.rows[0]?.annotations ?? null);
+
+const sample = {
+  strokes: [{ color: '#EF4444', width: 0.01, points: [0.1, 0.2, 0.3, 0.4] }],
+  texts: [],
+};
+
+describe('receipt annotations', () => {
+  it('a party sets the markup', async () => {
+    await annotate(P(0), attachmentId, sample);
+    expect(await readAnnotations(attachmentId)).toMatchObject(sample);
+  });
+
+  it('a party clears the markup with null', async () => {
+    await annotate(P(0), attachmentId, sample);
+    await annotate(P(0), attachmentId, null);
+    expect(await readAnnotations(attachmentId)).toBeNull();
+  });
+
+  it('a non-party member cannot mark up', async () => {
+    await expectDenied(annotate(P(1), attachmentId, sample));
+    expect(await readAnnotations(attachmentId)).toBeNull();
+  });
+
+  it('an outsider cannot mark up', async () => {
+    await expectDenied(annotate(outsider, attachmentId, sample));
+  });
+
+  it('an unknown attachment id is a silent no-op, not an error', async () => {
+    await annotate(P(0), randomUUID(), sample); // resolves, changes nothing
+  });
+
+  it('rejects an oversized overlay (column cap)', async () => {
+    const huge = {
+      strokes: [
+        { color: '#EF4444', width: 0.01, points: Array.from({ length: 200000 }, () => 0.5) },
+      ],
+      texts: [],
+    };
+    await expectDenied(annotate(P(0), attachmentId, huge));
+  });
+});


### PR DESCRIPTION
## What

**Part 2** of the receipts request: a non-destructive **markup editor** on a receipt. A party opens a full-screen editor from the gallery viewer, **draws with a pen** and **drops text notes**, and saves.

The markup is a small vector overlay in normalised (0..1) image coordinates stored on the attachment row — the **image bytes are never touched**, so it stays editable, needs no re-encode/re-upload, and every member who can see the image sees the same notes. It renders live in the editor and read-only in the viewer through one shared SVG overlay, tracking the image through **pinch-zoom** (both size to the image's exact fit rectangle).

**No new native dependency**: drawing uses the View responder API (JS thread — no refs read in render, so the React Compiler is happy); the overlay is `react-native-svg` (already installed). **Crop + rotate is a later PR (PR3).**

## Changes

- **DB**: `expense_attachments.annotations jsonb` (+256KB `CHECK`) and a **party-only** `baaki_annotate_expense_attachment` RPC. Rides the existing mirror via the stamp trigger. **6 threat tests** (party sets/clears, non-party + outsider denied, unknown-id no-op, size cap).
- **Client**: `ReceiptAnnotator` (pen/text/undo/clear/colour), `AnnotationOverlay` (shared renderer), `ZoomableImage` gains an optional aligned overlay, `ExpenseReceipts` gains a pencil in the viewer + `useAnnotateExpenseAttachment`. New i18n `annotate` group **en/ta/hi/ar**.

## Folded-in review fixes (on the just-merged receipts/hero work)

- **Legacy-bill removal is party OR admin again** (new `canRemoveLegacy` prop) while attachment add/remove/annotate stay party-only — an admin never gains attachment controls. *(regression from the gallery unification)*
- **Group header sync glyph scopes to this group** (`SyncStatusIcon` gains optional `groupId`), matching the inline banner.
- **`removeImage` throws on a failed Supabase delete** (R2 path already did) — a receipt removal is not logged and the UI not cleared for bytes still present; gallery removes now surface an error.
- **Route-scoped light StatusBar** over the dark indigo hero on the expense + group screens (icons were dark-on-dark on light theme).
- **Expense hero tag row wraps + centres** so long split labels never overflow.

## Test

- `pnpm --filter @waves/mobile typecheck` + `lint` ✅ · `pnpm format` ✅
- core **662** ✅ · db **569** (incl. 6 new) ✅ · `db:drift` clean ✅ · `edge:build` ✅
- Migration applied to local pg cleanly.

## Deploy gate

Prod needs migration `20260824190000` before the markup RPC works there (the `annotations` column rides the existing `select('*')` pull, so no edge change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added non-destructive receipt markup with pen drawings, text notes, colors, undo, clear, and save options.
  * Annotated receipts now display consistently while zooming and panning.
  * Added localized markup-editor text in English, Tamil, Hindi, and Arabic.
* **Bug Fixes**
  * Improved receipt removal error handling and permissions.
  * Sync indicators now show status relevant to the current group.
  * Improved dark-header status-bar visibility and metadata wrapping on mobile screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->