### PR TITLE
feat(expense): rotate + crop a receipt image (A46 PR3)

### DIFF
--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -22,12 +22,14 @@ import { IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { ZoomableGallery, type GalleryPage } from '@/components/ZoomableGallery';
 import { ReceiptAnnotator } from '@/components/ReceiptAnnotator';
+import { ReceiptCropper } from '@/components/ReceiptCropper';
 import {
   useAnnotateExpenseAttachment,
   useAttachExpenseAttachment,
   useExpenseAttachments,
   useRemoveExpenseAttachment,
   useRemoveExpenseReceipt,
+  useReplaceExpenseAttachmentImage,
   type ExpenseAttachmentRow,
 } from '@/data/hooks';
 import { captureReceipt, pickReceiptImage } from '@/lib/image';
@@ -166,6 +168,7 @@ export function ExpenseReceipts({
   const removeAttachment = useRemoveExpenseAttachment(expenseId);
   const removeLegacy = useRemoveExpenseReceipt(groupId, expenseId);
   const annotate = useAnnotateExpenseAttachment();
+  const replace = useReplaceExpenseAttachmentImage(groupId, expenseId);
 
   const items = useMemo<GalleryItem[]>(() => {
     const list: GalleryItem[] = [];
@@ -184,6 +187,11 @@ export function ExpenseReceipts({
     attachmentId: string;
     uri: string;
     initial: Annotations;
+  } | null>(null);
+  const [adjusting, setAdjusting] = useState<{
+    attachmentId: string;
+    uri: string;
+    oldStoragePath: string;
   } | null>(null);
 
   const pages = useMemo<GalleryPage[]>(
@@ -361,6 +369,23 @@ export function ExpenseReceipts({
                 <Row style={{ gap: theme.spacing.xs }}>
                   {showEdit ? (
                     <IconButton
+                      label={t.adjust.title}
+                      onPress={() => {
+                        const url = urls[viewerIndex];
+                        if (viewing?.kind === 'attachment' && url) {
+                          setAdjusting({
+                            attachmentId: viewing.row.id,
+                            uri: url,
+                            oldStoragePath: viewing.row.storagePath,
+                          });
+                        }
+                      }}
+                    >
+                      <Ionicons name="crop" size={iconSize.md} color={theme.color.text} />
+                    </IconButton>
+                  ) : null}
+                  {showEdit ? (
+                    <IconButton
                       label={t.annotate.title}
                       onPress={() => {
                         const url = urls[viewerIndex];
@@ -418,6 +443,27 @@ export function ExpenseReceipts({
               {
                 onSuccess: () => setEditing(null),
                 onError: () => Alert.alert(t.annotate.couldNotSave),
+              },
+            )
+          }
+        />
+      ) : null}
+
+      {adjusting ? (
+        <ReceiptCropper
+          uri={adjusting.uri}
+          saving={replace.isPending}
+          onCancel={() => setAdjusting(null)}
+          onSave={(picked) =>
+            replace.mutate(
+              {
+                attachmentId: adjusting.attachmentId,
+                oldStoragePath: adjusting.oldStoragePath,
+                picked,
+              },
+              {
+                onSuccess: () => setAdjusting(null),
+                onError: () => Alert.alert(t.adjust.couldNotSave),
               },
             )
           }

--- a/apps/mobile/src/components/ReceiptCropper.tsx
+++ b/apps/mobile/src/components/ReceiptCropper.tsx
@@ -1,0 +1,344 @@
+/**
+ * The receipt "adjust" editor (A46): rotate in 90° steps and crop, baking new
+ * pixels. Unlike the pen/text overlay (data on the row), rotate and crop change
+ * the image itself, so a save re-encodes and replaces the stored bytes — which
+ * is also why it clears any markup (the old overlay no longer lines up).
+ *
+ * Rotation bakes immediately (each tap re-renders the working image and swaps
+ * its dimensions); the crop is a normalised rectangle over the *displayed* image
+ * rectangle, applied at save. One touch responder drives the crop: the grant
+ * point is hit-tested against the four corner handles and the interior, so a
+ * drag near a corner resizes and a drag inside moves — no per-handle views to
+ * mis-measure. Everything is state (no refs) so the React Compiler is content.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Image as ExpoImage } from 'expo-image';
+import {
+  ActivityIndicator,
+  Image as RNImage,
+  Modal,
+  View,
+  type LayoutChangeEvent,
+} from 'react-native';
+
+import { IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+import { containRect } from '@/lib/annotations';
+import { transformReceipt, type PickedImage } from '@/lib/image';
+import { useStrings } from '@/i18n';
+
+type Crop = { x: number; y: number; w: number; h: number };
+const FULL: Crop = { x: 0, y: 0, w: 1, h: 1 };
+const MIN = 0.1; // Smallest crop, as a fraction — a sliver is never intended.
+const HANDLE_HIT = 0.09; // How near a corner (fraction of the smaller edge) grabs it.
+
+type DragMode = 'tl' | 'tr' | 'bl' | 'br' | 'move';
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+export function ReceiptCropper({
+  uri,
+  saving,
+  onCancel,
+  onSave,
+}: {
+  uri: string;
+  saving: boolean;
+  onCancel: () => void;
+  onSave: (picked: PickedImage) => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+
+  const [workingUri, setWorkingUri] = useState(uri);
+  const [natural, setNatural] = useState({ w: 0, h: 0 });
+  const [box, setBox] = useState({ w: 0, h: 0 });
+  const [crop, setCrop] = useState<Crop>(FULL);
+  const [rotated, setRotated] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [drag, setDrag] = useState<{
+    mode: DragMode;
+    startCrop: Crop;
+    startX: number;
+    startY: number;
+  } | null>(null);
+
+  const rect = useMemo(() => containRect(box, natural), [box, natural]);
+
+  useEffect(() => {
+    let active = true;
+    RNImage.getSize(
+      workingUri,
+      (w, h) => active && setNatural({ w, h }),
+      () => active && setNatural({ w: 1, h: 1 }),
+    );
+    return () => {
+      active = false;
+    };
+  }, [workingUri]);
+
+  const rotate = async (deg: number) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const out = await transformReceipt(workingUri, { rotate: deg });
+      if (out) {
+        setWorkingUri(out.uri);
+        setNatural((n) => ({ w: n.h, h: n.w })); // 90° swaps the edges
+        setCrop(FULL);
+        setRotated(true);
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const dirty = rotated || crop.x > 0 || crop.y > 0 || crop.w < 1 || crop.h < 1;
+
+  const save = async () => {
+    if (busy || saving) return;
+    setBusy(true);
+    try {
+      const isFull = crop.x === 0 && crop.y === 0 && crop.w === 1 && crop.h === 1;
+      const out = await transformReceipt(workingUri, {
+        crop: isFull
+          ? undefined
+          : {
+              originX: Math.round(crop.x * natural.w),
+              originY: Math.round(crop.y * natural.h),
+              width: Math.max(1, Math.round(crop.w * natural.w)),
+              height: Math.max(1, Math.round(crop.h * natural.h)),
+            },
+      });
+      if (out) onSave(out);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // One responder over the image rectangle: hit-test the grant against the
+  // corners, then resize or move from the touch position.
+  const norm = (v: number, span: number) => (span > 0 ? clamp01(v / span) : 0);
+  const cropHandlers = {
+    onStartShouldSetResponder: () => rect.w > 0 && rect.h > 0,
+    onMoveShouldSetResponder: () => rect.w > 0 && rect.h > 0,
+    onResponderGrant: (e: { nativeEvent: { locationX: number; locationY: number } }) => {
+      const nx = norm(e.nativeEvent.locationX, rect.w);
+      const ny = norm(e.nativeEvent.locationY, rect.h);
+      const near = (a: number, b: number) => Math.abs(a - b) <= HANDLE_HIT;
+      const nearX0 = near(nx, crop.x);
+      const nearX1 = near(nx, crop.x + crop.w);
+      const nearY0 = near(ny, crop.y);
+      const nearY1 = near(ny, crop.y + crop.h);
+      let mode: DragMode | null = null;
+      if (nearX0 && nearY0) mode = 'tl';
+      else if (nearX1 && nearY0) mode = 'tr';
+      else if (nearX0 && nearY1) mode = 'bl';
+      else if (nearX1 && nearY1) mode = 'br';
+      else if (nx > crop.x && nx < crop.x + crop.w && ny > crop.y && ny < crop.y + crop.h)
+        mode = 'move';
+      if (mode) setDrag({ mode, startCrop: crop, startX: nx, startY: ny });
+    },
+    onResponderMove: (e: { nativeEvent: { locationX: number; locationY: number } }) => {
+      if (!drag) return;
+      const nx = norm(e.nativeEvent.locationX, rect.w);
+      const ny = norm(e.nativeEvent.locationY, rect.h);
+      const s = drag.startCrop;
+      if (drag.mode === 'move') {
+        const dx = nx - drag.startX;
+        const dy = ny - drag.startY;
+        setCrop({
+          x: Math.min(Math.max(0, s.x + dx), 1 - s.w),
+          y: Math.min(Math.max(0, s.y + dy), 1 - s.h),
+          w: s.w,
+          h: s.h,
+        });
+        return;
+      }
+      const right = s.x + s.w;
+      const bottom = s.y + s.h;
+      let { x, y, w, h } = s;
+      if (drag.mode === 'tl') {
+        x = Math.min(clamp01(nx), right - MIN);
+        y = Math.min(clamp01(ny), bottom - MIN);
+        w = right - x;
+        h = bottom - y;
+      } else if (drag.mode === 'tr') {
+        y = Math.min(clamp01(ny), bottom - MIN);
+        w = Math.max(MIN, clamp01(nx) - s.x);
+        h = bottom - y;
+      } else if (drag.mode === 'bl') {
+        x = Math.min(clamp01(nx), right - MIN);
+        w = right - x;
+        h = Math.max(MIN, clamp01(ny) - s.y);
+      } else {
+        w = Math.max(MIN, clamp01(nx) - s.x);
+        h = Math.max(MIN, clamp01(ny) - s.y);
+      }
+      setCrop({ x, y, w, h });
+    },
+    onResponderRelease: () => setDrag(null),
+    onResponderTerminate: () => setDrag(null),
+  };
+
+  const onBoxLayout = (e: LayoutChangeEvent) =>
+    setBox({ w: e.nativeEvent.layout.width, h: e.nativeEvent.layout.height });
+
+  // Crop rectangle in display pixels, for the mask + handles.
+  const cx = rect.x + crop.x * rect.w;
+  const cy = rect.y + crop.y * rect.h;
+  const cw = crop.w * rect.w;
+  const ch = crop.h * rect.h;
+  const mask = 'rgba(0,0,0,0.55)';
+  const handle = (left: number, top: number) => (
+    <View
+      pointerEvents="none"
+      style={{
+        position: 'absolute',
+        left: left - 10,
+        top: top - 10,
+        width: 20,
+        height: 20,
+        borderRadius: 10,
+        backgroundColor: '#FFFFFF',
+        borderWidth: 2,
+        borderColor: theme.color.brand,
+      }}
+    />
+  );
+
+  return (
+    <Modal visible animationType="slide" onRequestClose={onCancel}>
+      <View style={{ flex: 1, backgroundColor: '#000' }}>
+        <Row
+          style={{
+            justifyContent: 'space-between',
+            paddingHorizontal: theme.spacing.xl,
+            paddingTop: theme.spacing.xxl,
+            paddingBottom: theme.spacing.sm,
+          }}
+        >
+          <IconButton label={t.common.cancel} onPress={onCancel}>
+            <Ionicons name="close" size={iconSize.lg} color="#FFFFFF" />
+          </IconButton>
+          <Text variant="subheading" style={{ color: '#FFFFFF' }}>
+            {t.adjust.title}
+          </Text>
+          <IconButton label={t.common.save} onPress={save}>
+            {saving || busy ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Ionicons
+                name="checkmark"
+                size={iconSize.lg}
+                color={dirty ? '#FFFFFF' : 'rgba(255,255,255,0.35)'}
+              />
+            )}
+          </IconButton>
+        </Row>
+
+        <View style={{ flex: 1 }} onLayout={onBoxLayout}>
+          <ExpoImage source={{ uri: workingUri }} style={{ flex: 1 }} contentFit="contain" />
+          {/* Dim everything outside the crop with four bands, and draw the
+              handles. The responder sits over the whole image rectangle. */}
+          {rect.w > 0 ? (
+            <>
+              <View
+                pointerEvents="none"
+                style={{
+                  position: 'absolute',
+                  left: rect.x,
+                  top: rect.y,
+                  width: rect.w,
+                  height: cy - rect.y,
+                  backgroundColor: mask,
+                }}
+              />
+              <View
+                pointerEvents="none"
+                style={{
+                  position: 'absolute',
+                  left: rect.x,
+                  top: cy + ch,
+                  width: rect.w,
+                  height: rect.y + rect.h - (cy + ch),
+                  backgroundColor: mask,
+                }}
+              />
+              <View
+                pointerEvents="none"
+                style={{
+                  position: 'absolute',
+                  left: rect.x,
+                  top: cy,
+                  width: cx - rect.x,
+                  height: ch,
+                  backgroundColor: mask,
+                }}
+              />
+              <View
+                pointerEvents="none"
+                style={{
+                  position: 'absolute',
+                  left: cx + cw,
+                  top: cy,
+                  width: rect.x + rect.w - (cx + cw),
+                  height: ch,
+                  backgroundColor: mask,
+                }}
+              />
+              <View
+                pointerEvents="none"
+                style={{
+                  position: 'absolute',
+                  left: cx,
+                  top: cy,
+                  width: cw,
+                  height: ch,
+                  borderWidth: 1,
+                  borderColor: '#FFFFFF',
+                }}
+              />
+              {handle(cx, cy)}
+              {handle(cx + cw, cy)}
+              {handle(cx, cy + ch)}
+              {handle(cx + cw, cy + ch)}
+              <View
+                style={{
+                  position: 'absolute',
+                  left: rect.x,
+                  top: rect.y,
+                  width: rect.w,
+                  height: rect.h,
+                }}
+                {...cropHandlers}
+              />
+            </>
+          ) : null}
+        </View>
+
+        <Row
+          style={{
+            justifyContent: 'center',
+            gap: theme.spacing.xl,
+            paddingVertical: theme.spacing.lg,
+          }}
+        >
+          <IconButton label={t.adjust.rotateLeft} onPress={() => void rotate(-90)}>
+            <Ionicons name="return-up-back" size={iconSize.lg} color="#FFFFFF" />
+          </IconButton>
+          <IconButton label={t.adjust.rotateRight} onPress={() => void rotate(90)}>
+            <Ionicons name="return-up-forward" size={iconSize.lg} color="#FFFFFF" />
+          </IconButton>
+          <IconButton label={t.adjust.reset} onPress={() => setCrop(FULL)}>
+            <Ionicons name="scan-outline" size={iconSize.lg} color="#FFFFFF" />
+          </IconButton>
+        </Row>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -1652,6 +1652,53 @@ export function useAttachExpenseAttachment(groupId: string, expenseId: string) {
   });
 }
 
+/**
+ * Replace an attachment's image with an adjusted (rotated/cropped) one: upload
+ * the new bytes to a fresh key, repoint the row (which also clears any markup,
+ * since the pixels moved), then free the old object best-effort. A party only,
+ * server-enforced.
+ */
+export function useReplaceExpenseAttachmentImage(groupId: string, expenseId: string) {
+  const { flush } = useSync();
+  return useMutation({
+    mutationFn: async (input: {
+      attachmentId: string;
+      oldStoragePath: string;
+      picked: PickedImage;
+    }) => {
+      const ext = input.picked.mimeType === 'image/webp' ? 'webp' : 'jpg';
+      const path = `${expenseId}/${randomUUID()}.${ext}`;
+      let committed: string | null = null;
+      try {
+        await putImage({
+          bucket: 'expense-attachments',
+          path,
+          base64: input.picked.base64,
+          contentType: input.picked.mimeType,
+          groupId,
+          subjectId: expenseId,
+        });
+        committed = path;
+        const { error } = await supabase.rpc('baaki_replace_expense_attachment_image', {
+          p_attachment_id: input.attachmentId,
+          p_new_path: path,
+        });
+        if (error) throw new Error(error.message);
+        committed = null;
+        // The row now points at the new key; free the old bytes best-effort.
+        await removeRestrictedImage('expense-attachments', expenseId, input.oldStoragePath).catch(
+          () => {},
+        );
+      } catch (caught) {
+        if (committed)
+          await removeRestrictedImage('expense-attachments', expenseId, committed).catch(() => {});
+        throw caught;
+      }
+    },
+    onSuccess: () => void flush(),
+  });
+}
+
 /** Remove an expense attachment: soft-delete via RPC, then free the R2 bytes. */
 export function useRemoveExpenseAttachment(expenseId: string) {
   const { flush } = useSync();

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -445,6 +445,14 @@ export interface UiStrings {
     textPlaceholder: string;
     couldNotSave: string;
   };
+  /** The receipt adjust editor (rotate + crop, bakes new pixels). */
+  adjust: {
+    title: string;
+    rotateLeft: string;
+    rotateRight: string;
+    reset: string;
+    couldNotSave: string;
+  };
   /** Trip budgets. */
   budgets: string;
   overallBudget: string;
@@ -2184,6 +2192,13 @@ const en: UiStrings = {
     clear: 'Clear',
     textPlaceholder: 'Add a note',
     couldNotSave: "Couldn't save the markup — try again.",
+  },
+  adjust: {
+    title: 'Adjust',
+    rotateLeft: 'Rotate left',
+    rotateRight: 'Rotate right',
+    reset: 'Reset crop',
+    couldNotSave: "Couldn't save the change — try again.",
   },
   budgets: 'Budgets',
   overallBudget: 'Overall',
@@ -3937,6 +3952,13 @@ const ta: UiStrings = {
     clear: 'அழி',
     textPlaceholder: 'குறிப்பு சேர்',
     couldNotSave: 'குறிப்புகளைச் சேமிக்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
+  },
+  adjust: {
+    title: 'சரிசெய்',
+    rotateLeft: 'இடதுபுறம் சுழற்று',
+    rotateRight: 'வலதுபுறம் சுழற்று',
+    reset: 'வெட்டலை மீட்டமை',
+    couldNotSave: 'மாற்றத்தைச் சேமிக்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
   },
   budgets: 'பட்ஜெட்',
   overallBudget: 'மொத்தம்',
@@ -5757,6 +5779,13 @@ const hi: UiStrings = {
     textPlaceholder: 'एक नोट जोड़ें',
     couldNotSave: 'मार्कअप सहेजा नहीं जा सका — फिर कोशिश करें।',
   },
+  adjust: {
+    title: 'समायोजित करें',
+    rotateLeft: 'बाएँ घुमाएँ',
+    rotateRight: 'दाएँ घुमाएँ',
+    reset: 'क्रॉप रीसेट करें',
+    couldNotSave: 'बदलाव सहेजा नहीं जा सका — फिर कोशिश करें।',
+  },
   budgets: 'बजट',
   overallBudget: 'कुल',
   myBudget: 'मेरा बजट',
@@ -7524,6 +7553,13 @@ const ar: UiStrings = {
     clear: 'مسح',
     textPlaceholder: 'أضف ملاحظة',
     couldNotSave: 'تعذّر حفظ التوصيف — حاول مرة أخرى.',
+  },
+  adjust: {
+    title: 'تعديل',
+    rotateLeft: 'تدوير لليسار',
+    rotateRight: 'تدوير لليمين',
+    reset: 'إعادة ضبط القص',
+    couldNotSave: 'تعذّر حفظ التغيير — حاول مرة أخرى.',
   },
   budgets: 'الميزانية',
   overallBudget: 'الإجمالي',

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -372,6 +372,53 @@ export async function captureReceipt(): Promise<PickedImage | null> {
   return { base64: shrunk.base64, mimeType: shrunk.mimeType ?? 'image/jpeg', uri: shrunk.uri };
 }
 
+/**
+ * Rotate and/or crop a receipt image, baking new pixels (A46, adjust). Rotation
+ * is degrees clockwise; the crop is a pixel rectangle on the *rotated* image.
+ * Re-encodes WebP-preferred with a JPEG fallback, the same rule as {@link shrink},
+ * so an adjusted receipt is stored as the format the platform could produce.
+ * Returns null when the native manipulator is missing (nothing to bake with).
+ */
+export async function transformReceipt(
+  uri: string,
+  ops: {
+    rotate?: number;
+    crop?: { originX: number; originY: number; width: number; height: number };
+  },
+): Promise<PickedImage | null> {
+  const module = await loadManipulator();
+  if (!module) return null;
+
+  const render = async () => {
+    // Rebuilt per attempt: a rendered context is consumed by saveAsync and
+    // cannot be re-saved in another format.
+    let context = module.ImageManipulator.manipulate(uri);
+    if (ops.rotate) context = context.rotate(ops.rotate);
+    if (ops.crop) context = context.crop(ops.crop);
+    return context.renderAsync();
+  };
+
+  const webp = module.SaveFormat.WEBP;
+  if (webp) {
+    try {
+      const saved = await (await render()).saveAsync({ base64: true, compress: 0.9, format: webp });
+      if (saved.base64) return { base64: saved.base64, uri: saved.uri, mimeType: 'image/webp' };
+    } catch {
+      // iOS without a WebP encoder — fall through to JPEG.
+    }
+  }
+
+  const saved = await (
+    await render()
+  ).saveAsync({
+    base64: true,
+    compress: 0.9,
+    format: module.SaveFormat.JPEG,
+  });
+  if (!saved.base64) throw new Error('Could not read that image.');
+  return { base64: saved.base64, uri: saved.uri, mimeType: 'image/jpeg' };
+}
+
 function imageSize(uri: string): Promise<{ width: number; height: number } | null> {
   return new Promise((resolve) => {
     Image.getSize(

--- a/packages/db/prisma/migrations/20260825120000_replace_attachment_image/migration.sql
+++ b/packages/db/prisma/migrations/20260825120000_replace_attachment_image/migration.sql
@@ -1,0 +1,56 @@
+-- Adjust a receipt image (A46): rotate / crop replaces the stored bytes.
+--
+-- Rotate and crop bake new pixels (unlike the pen/text overlay, which is data on
+-- the row). The new image goes to a fresh key in the same expense-scoped folder,
+-- then this RPC repoints the row at it. Because the pixels changed, any markup
+-- drawn over the old image no longer lines up, so the replace clears it — a
+-- correction, not a silent drift.
+--
+-- Party-only, the same gate as attaching or marking up. The stamp trigger bumps
+-- `updated_seq`, so the swap reaches every device on the next pull, and the
+-- client frees the old object best-effort once the row points at the new one.
+
+CREATE OR REPLACE FUNCTION public.baaki_replace_expense_attachment_image(
+  p_attachment_id uuid,
+  p_new_path      text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_expense_id uuid;
+BEGIN
+  IF coalesce(btrim(p_new_path), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_PATH: a replacement needs a stored image'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT expense_id INTO v_expense_id
+  FROM public.expense_attachments
+  WHERE id = p_attachment_id AND deleted_at IS NULL;
+  IF v_expense_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- The new key MUST stay scoped to this expense, exactly like the attach RPC.
+  IF p_new_path NOT LIKE v_expense_id::text || '/%' THEN
+    RAISE EXCEPTION 'INVALID_PATH: the key must be scoped to its expense'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF NOT public.baaki_is_expense_party(v_expense_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only a party may adjust this image'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  UPDATE public.expense_attachments
+     SET storage_path = btrim(p_new_path),
+         annotations  = NULL
+   WHERE id = p_attachment_id AND deleted_at IS NULL;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_replace_expense_attachment_image(uuid, text)
+  TO authenticated, anon;

--- a/packages/db/test/replace-attachment-image.test.ts
+++ b/packages/db/test/replace-attachment-image.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Adjust (rotate/crop) a receipt image (A46): only a party may repoint an
+ * attachment at new bytes, the key must stay scoped to the expense, and the
+ * replace clears any markup (the pixels moved).
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+async function as<T>(profileId: string | null, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    profileId
+      ? JSON.stringify({ sub: profileId, role: 'authenticated' })
+      : JSON.stringify({ role: 'anon' }),
+  ]);
+  await client.query(`SET ROLE ${profileId ? 'authenticated' : 'anon'}`);
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+let g: { groupId: string; profileIds: string[]; memberIds: string[] };
+let expenseId: string;
+let attachmentId: string;
+let outsider: string;
+
+beforeAll(async () => {
+  g = await seedGroup(client, { memberCount: 3, name: 'Adjust' });
+  outsider = randomUUID();
+  await client.query(
+    `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Outsider', 'INR')`,
+    [outsider],
+  );
+  ({ expenseId } = await addEqualSplitExpense(client, {
+    groupId: g.groupId,
+    payers: { [g.memberIds[0] as string]: 3000n },
+    participants: g.memberIds,
+    amount: 3000n,
+  }));
+});
+
+const P = (i: number) => g.profileIds[i] as string;
+
+beforeEach(async () => {
+  await client.query(`DELETE FROM expense_attachments WHERE group_id = $1`, [g.groupId]);
+  attachmentId = randomUUID();
+  await as(P(0), () =>
+    client.query(`SELECT baaki_attach_expense_attachment($1, $2, 'group', $3)`, [
+      expenseId,
+      `${expenseId}/${randomUUID()}.webp`,
+      attachmentId,
+    ]),
+  );
+  // Give it markup so we can prove the replace clears it.
+  await as(P(0), () =>
+    client.query(`SELECT baaki_annotate_expense_attachment($1, $2::jsonb)`, [
+      attachmentId,
+      JSON.stringify({
+        strokes: [{ color: '#EF4444', width: 0.01, points: [0.1, 0.2] }],
+        texts: [],
+      }),
+    ]),
+  );
+});
+
+const replace = (profileId: string, id: string, path: string) =>
+  as(profileId, () =>
+    client.query(`SELECT baaki_replace_expense_attachment_image($1, $2)`, [id, path]),
+  );
+
+const row = (id: string) =>
+  client
+    .query(`SELECT storage_path, annotations FROM expense_attachments WHERE id = $1`, [id])
+    .then((r) => r.rows[0]);
+
+describe('replace attachment image', () => {
+  it('a party repoints the row and the markup is cleared', async () => {
+    const newPath = `${expenseId}/${randomUUID()}.webp`;
+    await replace(P(0), attachmentId, newPath);
+    const r = await row(attachmentId);
+    expect(r.storage_path).toBe(newPath);
+    expect(r.annotations).toBeNull();
+  });
+
+  it('a non-party member cannot replace', async () => {
+    await expectDenied(replace(P(1), attachmentId, `${expenseId}/${randomUUID()}.webp`));
+  });
+
+  it('an outsider cannot replace', async () => {
+    await expectDenied(replace(outsider, attachmentId, `${expenseId}/${randomUUID()}.webp`));
+  });
+
+  it('rejects a key not scoped to the expense', async () => {
+    await expectDenied(replace(P(0), attachmentId, `${randomUUID()}/evil.webp`));
+  });
+
+  it('an unknown attachment id is a silent no-op', async () => {
+    await replace(P(0), randomUUID(), `${expenseId}/${randomUUID()}.webp`);
+  });
+});


### PR DESCRIPTION
## What

**Part 3** of the receipts request — the **"Adjust"** editor, opened from the gallery viewer next to the pen. A party **rotates in 90° steps** and **crops** with a draggable rectangle; saving bakes the new pixels and replaces the stored image.

This completes the editor the request asked for: **PR2** gave pen + text, **this** gives crop + rotate.

## How

Rotate and crop change the image itself (unlike the pen/text overlay, which is data on the row), so a save re-encodes via `expo-image-manipulator`, uploads to a fresh expense-scoped key, and repoints the row — which also **clears any markup**, since the old overlay no longer lines up with the moved pixels.

**No new native dependency**: `expo-image-manipulator` was already installed (the resize seam) and is loaded behind the same lazy native-existence check, WebP with a JPEG fallback. The crop UI is one touch responder over the image rectangle that hit-tests the grant point against the four corners and the interior — resize a corner, drag inside to move — all in state (no refs → React Compiler happy), with the same `containRect` used everywhere keeping the crop aligned to the displayed pixels.

## Changes

- **DB**: party-only `baaki_replace_expense_attachment_image(id, new_path)` — repoints `storage_path` (key must stay scoped to the expense) and nulls `annotations`; rides the existing mirror via the stamp trigger. **5 threat tests** (party replaces + markup cleared, non-party/outsider denied, off-expense key rejected, unknown-id no-op).
- **Client**: `ReceiptCropper`, `transformReceipt` (rotate/crop helper), `useReplaceExpenseAttachmentImage` (upload → replace RPC → free old bytes), a crop button in the viewer, i18n `adjust` group **en/ta/hi/ar**.

## Test

- `pnpm --filter @waves/mobile typecheck` + `lint` ✅ · `pnpm format:check` ✅
- core **662** · db **574** (incl. 5 new) · `db:drift` clean · `edge:build` ✅
- Migration applied to local pg cleanly.

## Deploy gate

Prod needs migration `20260825120000` before Adjust works there (no edge change — repoint rides the existing pull). Same window as PR2's `20260824190000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added receipt image editing with cropping, resizing, rotation, reset, and save options.
  * Added the ability to replace an expense receipt image while preserving expense details.
  * Added localized editor controls and error messages in English, Tamil, Hindi, and Arabic.
* **Bug Fixes**
  * Replacing a receipt now clears outdated annotations and handles invalid or unavailable attachments safely.
* **Tests**
  * Added coverage for authorized replacements, access restrictions, invalid paths, and missing attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->