### PR TITLE
feat(infra): self-host escape hatch + Supabase migration runbook

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,176 @@
+# Migrating Waves off Supabase
+
+How to move Waves from Supabase's cloud to **anywhere else** — a self-hosted box,
+another managed Postgres, AWS / GCP / Azure, or a private VPS — without rewriting
+the app. Read this with [`infra/self-host/`](infra/self-host/README.md), which
+boots the escape-hatch stack the first two paths use.
+
+---
+
+## 1. What is actually locked in
+
+Most of Waves is **not** Supabase-specific. Be honest about the split before
+planning any move:
+
+| Layer                                      | Where                                  | Portability                                   |
+| ------------------------------------------ | -------------------------------------- | --------------------------------------------- |
+| Schema, RLS, RPCs, triggers, cron          | `packages/db` (Prisma)                 | **Plain Postgres.** Runs anywhere.            |
+| Money/split logic                          | `@waves/core`                          | Pure TS. No backend at all.                   |
+| Image storage                              | `apps/mobile/src/lib/storage`, R2      | **Already provider-neutral** (Cloudflare R2). |
+| Reads (`.from().select()`)                 | mobile `data/api.ts`, web `api-client` | PostgREST — open source, self-hostable.       |
+| Auth (anon guest, in-place upgrade, OAuth) | `api-client`, mobile `lib/auth.tsx`    | **GoTrue — the stickiest piece.**             |
+| Edge functions (15, Deno)                  | `supabase/functions/*`                 | Portable code, Supabase deploy target.        |
+| `pg_net` HTTP-from-DB (push fan-out)       | `push_fanout` migration                | **The one real hard dependency.** See §6.     |
+
+The takeaway: "leave Supabase" is really "re-home GoTrue, PostgREST, the edge
+runtime, and the data." All four are open source. None require touching app code
+if you keep running them (§3). Only a move to _native cloud primitives_ (§4)
+touches code — and even then, behind a seam, incrementally.
+
+---
+
+## 2. Pick a target
+
+| Path                                    | Effort | App code change        | When                                                                          |
+| --------------------------------------- | ------ | ---------------------- | ----------------------------------------------------------------------------- |
+| **A. Self-host the same stack**         | Low    | **None** (one env var) | Escape Supabase pricing/lock; keep everything else.                           |
+| **B. Managed Postgres + self-host aux** | Medium | Small (§6 pg_net only) | Want a cloud provider's managed DB (RDS/Cloud SQL) but keep GoTrue/PostgREST. |
+| **C. Native cloud** (Cognito, own API)  | High   | Large, but seam-able   | Full independence, willing to replace auth + read layer.                      |
+
+**Recommended:** A first (it's insurance you can stand up today), then B if a
+specific cloud is mandated. C only if you truly must shed GoTrue/PostgREST — and
+only after the code seam (the "option A / ports" work) exists.
+
+---
+
+## 3. Path A — self-host the same stack (no app rewrite)
+
+1. **Stand up the stack** on the target host — see `infra/self-host/README.md`.
+   Same on a laptop, an EC2/GCE/Azure VM, or a VPS.
+2. **Recreate `public`** with Prisma:
+   ```bash
+   DATABASE_URL=postgres://postgres:<pw>@<host>:5432/postgres \
+   DIRECT_URL=postgres://postgres:<pw>@<host>:5432/postgres \
+   pnpm --filter @waves/db exec prisma migrate deploy
+   ```
+3. **Move the data** — §5.
+4. **Redeploy edge functions** — they already run in the stack's Edge runtime
+   from the mounted `supabase/functions/*`. Just fill `functions.env`.
+5. **Flip the app** — set `EXPO_PUBLIC_SUPABASE_URL` (+ `ANON_KEY`) to the new
+   gateway, ship an OTA update (mobile) / redeploy (web). Done.
+
+Because GoTrue, PostgREST and the Edge runtime are byte-for-byte the same
+software, the app cannot tell the difference. This is the whole point.
+
+---
+
+## 4. Path C — native cloud (only with the code seam)
+
+This is the only path that edits app code. Do it **behind ports**, one adapter
+at a time, never as a big-bang rewrite:
+
+- **Reads** — replace PostgREST with your own REST/GraphQL service (or run
+  PostgREST standalone in front of the managed DB — cheapest). The `.select()`
+  embed strings are the coupling; a `DataPort` interface hides them.
+- **Auth** — replace GoTrue with Cognito / Clerk / Keycloak behind an `AuthPort`.
+  ⚠️ **Preserve `auth.users.id` UUIDs** — they are `profile_id` across the whole
+  ledger. And **anonymous guest + in-place upgrade (ADR-006) is a GoTrue
+  feature** with no drop-in equivalent; budget real work to reproduce it, or
+  keep GoTrue just for that flow.
+- **Functions** — Deno code runs on Deno Deploy, or port to Node/Lambda.
+- **Storage** — already R2; nothing to do.
+
+The port interfaces + adapter wrapping is the separate "option A" workstream.
+Land that first; then C is writing one adapter class and a data move.
+
+---
+
+## 5. The data migration (Supabase → any Postgres)
+
+Scripts in `infra/self-host/scripts/`. The principle: **structure from Prisma,
+data from `pg_dump`, UUIDs preserved.**
+
+```bash
+cd infra/self-host/scripts
+
+# 1. Pull from the cloud (DIRECT connection, port 5432 — not the pooler).
+export SOURCE_DB_URL="postgres://postgres:<pw>@db.<ref>.supabase.co:5432/postgres"
+./dump-from-supabase.sh          # -> out/auth.sql, out/public.sql, out/public.schema.sql
+
+# 2. Target must already have `public` STRUCTURE (Prisma migrate deploy, §3.2)
+#    and the stack must be UP (so GoTrue created the auth tables).
+
+# 3. Load: auth users first (FKs), then public data.
+export TARGET_DB_URL="postgres://postgres:<pw>@<target-host>:5432/postgres"
+./restore-to-selfhost.sh ./out   # prints row counts to compare against source
+```
+
+Notes:
+
+- **Auth users keep their UUIDs.** `auth.sql` is data-only for `auth.users` +
+  `auth.identities`. Never let a new auth system regenerate ids — every
+  `profile_id` FK would dangle.
+- **`public` is data-only.** Structure comes from Prisma so RLS/RPCs/cron are
+  identical to prod; loading data-only avoids owner/permission mismatches.
+- **`_prisma_migrations` is excluded** from the data load — the target already
+  has its own from `migrate deploy`.
+- **Storage objects:** new ones are already in R2 (nothing to move). Pre-R2
+  objects still in Supabase Storage → `rclone`/S3-sync the buckets to R2 or the
+  target's `storage-data` volume. Waves' `lib/storage` dual-reads during the
+  window.
+
+---
+
+## 6. `pg_net` and cron — the one thing to watch
+
+- **Self-host / `supabase/postgres` image (Path A):** `pg_net` and `pg_cron`
+  are present. Push fan-out and the scheduled jobs (auto-archive, settlement
+  auto-confirm, storage sweep) run **unchanged**.
+- **Vanilla managed Postgres (Path B/C — RDS, Cloud SQL, Azure DB):** no
+  `pg_net`. The `notify-fanout` path that calls HTTP from inside the DB must be
+  replaced with an **external worker** — a small process (or the edge function
+  on a cron) that polls the fan-out queue table and makes the HTTP calls. Cron
+  itself: use the provider's scheduler or `pg_cron` where offered, else a
+  systemd timer / cloud scheduler hitting a function.
+
+This is the single code change a managed-DB move forces. Everything else in
+`public` is standard SQL.
+
+---
+
+## 7. Cutover checklist (zero-loss)
+
+Do **not** flip a live app at the destination without a verified restore.
+
+1. [ ] Target stack up; `prisma migrate deploy` applied; smoke test passes
+       (`infra/self-host/README.md` § Smoke test).
+2. [ ] Dry-run dump/restore into the target. Compare row counts (the restore
+       script prints them) against the source for `auth.users`, `groups`,
+       `expenses`, `settlements`. They must match.
+3. [ ] `functions.env` filled; edge functions answer.
+4. [ ] Storage: R2 reachable; any pre-R2 objects synced.
+5. [ ] **Announce a short write freeze** (or accept a small replay window — the
+       app's `clientMutationId` idempotency makes a re-sent write harmless).
+6. [ ] Final delta: re-dump/restore, or replay the mutation queue.
+7. [ ] Flip `EXPO_PUBLIC_SUPABASE_URL` + `ANON_KEY`; ship OTA (mobile) / redeploy
+       (web).
+8. [ ] Watch errors for a day. **Keep the Supabase project paused, not deleted**,
+       until confident.
+
+**Rollback:** because step 7 is just an env flip, reverting is flipping it back
+and shipping again — provided you have not yet accepted new writes at the
+destination. Once destination writes are live, roll-back means replaying those
+back to Supabase, so keep the freeze window short and the destination watched.
+
+---
+
+## 8. Summary
+
+- ~80% of Waves is plain Postgres + R2 — already portable.
+- The escape-hatch stack (`infra/self-host/`) re-homes the other 20% with **no
+  app change** and is worth standing up now as insurance.
+- Data moves with `pg_dump` + `pg_restore`, UUIDs preserved.
+- The only forced code change is `pg_net` → external worker, and only if you
+  drop to a vanilla managed Postgres.
+- Full native-cloud independence is real but should ride the ports/adapters
+  seam, incrementally — never a big-bang rewrite.

--- a/infra/self-host/.gitignore
+++ b/infra/self-host/.gitignore
@@ -1,0 +1,4 @@
+.env
+functions.env
+out/
+volumes/storage/

--- a/infra/self-host/README.md
+++ b/infra/self-host/README.md
@@ -1,0 +1,146 @@
+# Waves — self-hosted Supabase stack (the escape hatch)
+
+This folder boots the **same open-source components** Waves runs on Supabase's
+cloud — Postgres, GoTrue (auth), PostgREST, Storage, Realtime, the Edge runtime
+— behind a Kong gateway that reproduces the hosted URL layout. Point the apps'
+`EXPO_PUBLIC_SUPABASE_URL` at this gateway and **they run unchanged**.
+
+Why it exists: it proves Waves is not locked to Supabase-the-company. Every
+piece here is Apache-2 / MIT and runs on any Docker host — your laptop, an EC2 /
+GCE / Azure VM, or a bare VPS. If Supabase's cloud ever raises prices, degrades,
+or disappears, migrating off is a weekend (see [`../../MIGRATION.md`](../../MIGRATION.md)),
+not a rewrite.
+
+> This is the **infrastructure** half. Everything that makes the app portable in
+> _code_ — routing all `supabase.*` calls through injected ports so a non-Supabase
+> backend can be dropped in — is the separate "option A" work. This stack is
+> useful on its own: it's your insurance today.
+
+---
+
+## What's here
+
+| File                             | Purpose                                                        |
+| -------------------------------- | -------------------------------------------------------------- |
+| `docker-compose.yml`             | The stack. Image tags mirror the official self-host (2026-08). |
+| `volumes/api/kong.yml`           | Gateway routing — makes `:8000` behave like the hosted API.    |
+| `volumes/db/init/00-init.sh`     | One-time: aligns role passwords, ensures schemas + extensions. |
+| `env.example`                    | Copy to `.env`. All stack config + how to generate keys.       |
+| `functions.env.example`          | Copy to `functions.env`. Edge-function secrets.                |
+| `scripts/dump-from-supabase.sh`  | Pull data out of the cloud project.                            |
+| `scripts/restore-to-selfhost.sh` | Load it into this stack (or any Postgres).                     |
+
+The Edge runtime mounts the repo's real `supabase/functions/*` read-only — no
+copy, so the functions never drift from what's deployed.
+
+---
+
+## Boot it (laptop)
+
+Prereqs: Docker Desktop (or Docker Engine) with Compose v2.
+
+```bash
+cd infra/self-host
+cp env.example .env
+cp functions.env.example functions.env          # blank is fine to start
+# 1. fill POSTGRES_PASSWORD, JWT_SECRET, ANON_KEY, SERVICE_ROLE_KEY,
+#    REALTIME_SECRET_KEY_BASE in .env  (see § Keys below)
+docker compose up -d
+docker compose ps                                 # all healthy?
+```
+
+### Keys
+
+`ANON_KEY` and `SERVICE_ROLE_KEY` must be JWTs **signed with your `JWT_SECRET`**.
+Generate both with the official tool
+(<https://supabase.com/docs/guides/self-hosting/docker#securing-your-services>)
+or locally:
+
+```bash
+JWT_SECRET="$(openssl rand -base64 48)"
+node -e '
+  const jwt=require("jsonwebtoken"), s=process.env.JWT_SECRET, now=Math.floor(Date.now()/1e3);
+  const mk=r=>jwt.sign({role:r,iss:"supabase",iat:now,exp:now+10*365*24*3600},s);
+  console.log("ANON_KEY="+mk("anon"));
+  console.log("SERVICE_ROLE_KEY="+mk("service_role"));
+' JWT_SECRET="$JWT_SECRET"
+echo "JWT_SECRET=$JWT_SECRET"
+```
+
+Paste all three into `.env`. **The keys and the secret are one set** — change
+`JWT_SECRET` later and you must regenerate the keys.
+
+### Create the app schema
+
+`public` (tables, RLS, RPCs, cron) is owned by Prisma, not this stack. After the
+DB is healthy, apply the migrations against it:
+
+```bash
+# from repo root
+DATABASE_URL="postgres://postgres:<POSTGRES_PASSWORD>@localhost:5432/postgres" \
+DIRECT_URL="postgres://postgres:<POSTGRES_PASSWORD>@localhost:5432/postgres" \
+pnpm --filter @waves/db exec prisma migrate deploy
+```
+
+---
+
+## Smoke test (prove it works)
+
+With the stack up and migrations applied:
+
+```bash
+BASE=http://localhost:8000
+ANON=<your ANON_KEY>
+
+# 1. PostgREST is serving under the hosted path, RLS on (empty list, not error)
+curl -s "$BASE/rest/v1/groups?select=id" -H "apikey: $ANON" -H "Authorization: Bearer $ANON"
+
+# 2. GoTrue mints an anonymous guest (ADR-006 flow) through the gateway
+curl -s -X POST "$BASE/auth/v1/signup" -H "apikey: $ANON" \
+  -H "Content-Type: application/json" -d '{}'
+# -> a session with access_token + "is_anonymous": true
+
+# 3. An edge function answers
+curl -s "$BASE/functions/v1/fx-rate" -H "Authorization: Bearer $ANON"
+```
+
+Then point a real client at it and run the app end-to-end:
+
+```bash
+# apps/web/.env.local  (or an EAS/dev profile for mobile)
+EXPO_PUBLIC_SUPABASE_URL=http://localhost:8000
+EXPO_PUBLIC_SUPABASE_ANON_KEY=<your ANON_KEY>
+```
+
+Sign in as a guest, make a group, add an expense, settle. If it behaves exactly
+as against the cloud — which it will — the escape hatch is proven.
+
+Optional admin UI (Supabase Studio): `docker compose --profile studio up -d`
+then <http://localhost:8100>.
+
+---
+
+## Going to production (server)
+
+This compose is a **working reference, not a hardened deployment**. For a real
+server add, outside the app's concern:
+
+- **TLS** — put Caddy / nginx / a cloud LB in front of Kong `:8000`; set
+  `API_EXTERNAL_URL=https://api.waves.example`.
+- **Secrets** — inject `.env` from your host's secret manager, don't commit it.
+- **Backups** — scheduled `pg_dump` (or a managed Postgres instead of the `db`
+  container — but keep the `supabase/postgres` image or you lose `pg_net`).
+- **Resource limits, log shipping, restart policies, monitoring.**
+
+### The one real portability caveat: `pg_net`
+
+Waves' push fan-out (`notify-fanout`, the `push_fanout` migration) calls
+`pg_net` to make HTTP requests **from inside Postgres**. `pg_net` and `pg_cron`
+ship in the `supabase/postgres` image, so **this stack has them**. A generic
+managed Postgres (RDS, Cloud SQL, Azure DB) does **not**. So:
+
+- Self-host on the `supabase/postgres` image (this compose): works unchanged.
+- Move to vanilla managed Postgres: replace the in-DB HTTP call with an external
+  worker (a small poller / queue consumer). Tracked in `MIGRATION.md`.
+
+Everything else in `public` is standard Postgres and moves anywhere untouched.

--- a/infra/self-host/docker-compose.yml
+++ b/infra/self-host/docker-compose.yml
@@ -1,0 +1,276 @@
+# Waves — self-hosted Supabase stack (the "escape hatch").
+#
+# This boots the SAME open-source components Waves already runs on Supabase's
+# cloud — Postgres, GoTrue (auth), PostgREST, Storage, Realtime, the Edge
+# runtime — behind a Kong gateway that reproduces the exact hosted routing
+# (/auth/v1, /rest/v1, /storage/v1, /functions/v1, /realtime/v1). So the mobile
+# and web apps point one env var (EXPO_PUBLIC_SUPABASE_URL) at this gateway and
+# run UNCHANGED. Nothing about the app is Supabase-the-company specific; this
+# proves it.
+#
+# Runs on any Docker host: a laptop, an EC2 / GCE / Azure VM, or a bare VPS.
+# `docker compose up -d`, then see README.md for the smoke test.
+#
+# Image tags mirror the official self-host stack (supabase/supabase/docker) as
+# of 2026-08. Postgres 17.6 matches supabase/config.toml major_version = 17.
+# Bump deliberately; do not float to :latest.
+#
+# NOT a production hardening reference. TLS, backups, secret management and
+# resource limits are your host's job — see README.md § Going to production.
+
+name: waves-selfhost
+
+services:
+  # ── Postgres ──────────────────────────────────────────────────────────────
+  # The supabase/postgres image, NOT stock postgres: it ships the extensions
+  # Waves migrations require — pg_cron (auto-archive, settlement auto-confirm,
+  # storage sweep) and pg_net (push fan-out over HTTP from the DB), plus pgjwt,
+  # pgcrypto, uuid-ossp. Stock RDS/Cloud SQL lacks pg_net — see MIGRATION.md.
+  db:
+    image: supabase/postgres:17.6.1.136
+    restart: unless-stopped
+    ports:
+      - '${POSTGRES_PORT:-5432}:5432'
+    environment:
+      POSTGRES_HOST: /var/run/postgresql
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET in .env}
+      JWT_EXP: ${JWT_EXPIRY:-3600}
+    volumes:
+      - db-data:/var/lib/postgresql/data
+      # Runs once on an empty data volume. Creates the roles GoTrue/PostgREST/
+      # Storage authenticate as, and the auth/storage schemas.
+      - ./volumes/db/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'postgres', '-h', 'localhost']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ── Kong API gateway ──────────────────────────────────────────────────────
+  # The single public entrypoint. Declarative config in volumes/api/kong.yml
+  # maps the hosted URL layout onto the internal services, so the app's
+  # supabase-js client cannot tell this apart from the cloud.
+  kong:
+    image: kong:2.8.1
+    restart: unless-stopped
+    ports:
+      - '${KONG_HTTP_PORT:-8000}:8000/tcp'
+      - '${KONG_HTTPS_PORT:-8443}:8443/tcp'
+    environment:
+      KONG_DATABASE: 'off'
+      KONG_DECLARATIVE_CONFIG: /home/kong/kong.yml
+      KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_PLUGINS: request-transformer,cors,key-auth,acl
+      KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
+      KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
+      SUPABASE_ANON_KEY: ${ANON_KEY:?set ANON_KEY in .env}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY:?set SERVICE_ROLE_KEY in .env}
+    volumes:
+      - ./volumes/api/kong.yml:/home/kong/kong.yml:ro
+    depends_on:
+      - auth
+      - rest
+      - storage
+
+  # ── GoTrue (auth) ─────────────────────────────────────────────────────────
+  # The stickiest piece to leave (anonymous guests + in-place upgrade are
+  # GoTrue features — MIGRATION.md § Auth). Self-hosting it means ZERO app
+  # change: same JWTs, same anon flow, same OAuth.
+  auth:
+    image: supabase/gotrue:v2.189.0
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: 9999
+      API_EXTERNAL_URL: ${API_EXTERNAL_URL:-http://localhost:8000}
+
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
+
+      GOTRUE_SITE_URL: ${SITE_URL:-waves://}
+      GOTRUE_URI_ALLOW_LIST: ${ADDITIONAL_REDIRECT_URLS:-waves://,waves://auth,baaki://,baaki://auth,http://localhost:3000}
+      GOTRUE_DISABLE_SIGNUP: 'false'
+
+      GOTRUE_JWT_SECRET: ${JWT_SECRET}
+      GOTRUE_JWT_EXP: ${JWT_EXPIRY:-3600}
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_JWT_ADMIN_ROLES: service_role
+      GOTRUE_JWT_AUD: authenticated
+
+      # ADR-006: a guest is a real anonymous account, upgraded in place.
+      GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED: 'true'
+
+      GOTRUE_MAILER_AUTOCONFIRM: ${MAILER_AUTOCONFIRM:-false}
+      GOTRUE_SMTP_HOST: ${SMTP_HOST:-}
+      GOTRUE_SMTP_PORT: ${SMTP_PORT:-}
+      GOTRUE_SMTP_USER: ${SMTP_USER:-}
+      GOTRUE_SMTP_PASS: ${SMTP_PASS:-}
+      GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL:-admin@example.com}
+      GOTRUE_SMTP_SENDER_NAME: ${SMTP_SENDER_NAME:-Waves}
+
+      # OAuth. Fill in .env to enable; left blank = provider off.
+      GOTRUE_EXTERNAL_GOOGLE_ENABLED: ${GOOGLE_ENABLED:-false}
+      GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOOGLE_SECRET:-}
+      GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: ${API_EXTERNAL_URL:-http://localhost:8000}/auth/v1/callback
+      GOTRUE_EXTERNAL_APPLE_ENABLED: ${APPLE_ENABLED:-false}
+      GOTRUE_EXTERNAL_APPLE_CLIENT_ID: ${APPLE_CLIENT_ID:-}
+      GOTRUE_EXTERNAL_APPLE_SECRET: ${APPLE_SECRET:-}
+      GOTRUE_EXTERNAL_APPLE_REDIRECT_URI: ${API_EXTERNAL_URL:-http://localhost:8000}/auth/v1/callback
+
+  # ── PostgREST ─────────────────────────────────────────────────────────────
+  # Serves every read the app does (the .from().select() calls). Open source,
+  # runs on any Postgres — this is why the app's read layer is portable as-is.
+  rest:
+    image: postgrest/postgrest:v14.12
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS:-public,graphql_public}
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${JWT_SECRET}
+      PGRST_DB_USE_LEGACY_GUCS: 'false'
+      PGRST_APP_SETTINGS_JWT_SECRET: ${JWT_SECRET}
+      PGRST_APP_SETTINGS_JWT_EXP: ${JWT_EXPIRY:-3600}
+    command: ['postgrest']
+
+  # ── Realtime ──────────────────────────────────────────────────────────────
+  realtime:
+    image: supabase/realtime:v2.102.3
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PORT: 4000
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: supabase_admin
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      DB_NAME: ${POSTGRES_DB:-postgres}
+      DB_AFTER_CONNECT_QUERY: 'SET search_path TO _realtime'
+      DB_ENC_KEY: ${REALTIME_ENC_KEY:-supabaserealtime}
+      API_JWT_SECRET: ${JWT_SECRET}
+      SECRET_KEY_BASE: ${REALTIME_SECRET_KEY_BASE:?set REALTIME_SECRET_KEY_BASE in .env}
+      ERL_AFLAGS: -proto_dist inet_tcp
+      DNS_NODES: "''"
+      RLIMIT_NOFILE: '10000'
+      APP_NAME: realtime
+      SEED_SELF_HOST: 'true'
+      RUN_JANITOR: 'true'
+
+  # ── Storage + imgproxy ────────────────────────────────────────────────────
+  # Waves has already moved new image I/O to Cloudflare R2 (lib/storage). This
+  # exists to serve pre-R2 objects during a migration window and to keep the
+  # /storage/v1 route alive so nothing 404s. STORAGE_BACKEND=s3 can point
+  # straight at R2 instead of local disk — see .env.example.
+  storage:
+    image: supabase/storage-api:v1.60.4
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+      rest:
+        condition: service_started
+    environment:
+      ANON_KEY: ${ANON_KEY}
+      SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      POSTGREST_URL: http://rest:3000
+      PGRST_JWT_SECRET: ${JWT_SECRET}
+      DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
+      FILE_SIZE_LIMIT: 10485760
+      STORAGE_BACKEND: ${STORAGE_BACKEND:-file}
+      FILE_STORAGE_BACKEND_PATH: /var/lib/storage
+      TENANT_ID: stub
+      REGION: ${STORAGE_S3_REGION:-auto}
+      GLOBAL_S3_BUCKET: ${STORAGE_S3_BUCKET:-}
+      GLOBAL_S3_ENDPOINT: ${STORAGE_S3_ENDPOINT:-}
+      GLOBAL_S3_FORCE_PATH_STYLE: 'true'
+      AWS_ACCESS_KEY_ID: ${STORAGE_S3_ACCESS_KEY:-}
+      AWS_SECRET_ACCESS_KEY: ${STORAGE_S3_SECRET_KEY:-}
+      ENABLE_IMAGE_TRANSFORMATION: 'true'
+      IMGPROXY_URL: http://imgproxy:5001
+    volumes:
+      - storage-data:/var/lib/storage
+
+  imgproxy:
+    image: darthsim/imgproxy:v3.30.1
+    restart: unless-stopped
+    environment:
+      IMGPROXY_BIND: ':5001'
+      IMGPROXY_LOCAL_FILESYSTEM_ROOT: /
+      IMGPROXY_USE_ETAG: 'true'
+      IMGPROXY_ENABLE_WEBP_DETECTION: 'true'
+    volumes:
+      - storage-data:/var/lib/storage:ro
+
+  # ── Edge Functions (Deno runtime) ─────────────────────────────────────────
+  # Runs the 15 functions in supabase/functions/* unchanged. Same Deno runtime
+  # as the cloud, so expense-write / invite-accept / r2-sign / notify-fanout
+  # behave identically. Secrets come from ./functions.env.
+  functions:
+    image: supabase/edge-runtime:v1.74.0
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      JWT_SECRET: ${JWT_SECRET}
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
+      SUPABASE_DB_URL: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-postgres}
+      VERIFY_JWT: '${FUNCTIONS_VERIFY_JWT:-false}'
+    volumes:
+      # Mounts the repo's real functions — no copy, no drift.
+      - ../../supabase/functions:/home/deno/functions:ro
+      - ./functions.env:/home/deno/functions/.env:ro
+    command:
+      - start
+      - --main-service
+      - /home/deno/functions
+
+  # ── Postgres-meta + Studio (optional admin UI) ────────────────────────────
+  meta:
+    image: supabase/postgres-meta:v0.96.6
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PG_META_PORT: 8080
+      PG_META_DB_HOST: db
+      PG_META_DB_PORT: 5432
+      PG_META_DB_NAME: ${POSTGRES_DB:-postgres}
+      PG_META_DB_USER: supabase_admin
+      PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
+
+  studio:
+    image: supabase/studio:2026.08.03-sha-022b374
+    restart: unless-stopped
+    profiles: ['studio'] # only starts with: docker compose --profile studio up -d
+    depends_on:
+      - meta
+    ports:
+      - '${STUDIO_PORT:-8100}:3000'
+    environment:
+      STUDIO_PG_META_URL: http://meta:8080
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_PUBLIC_URL: ${API_EXTERNAL_URL:-http://localhost:8000}
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      DEFAULT_ORGANIZATION_NAME: Waves
+      DEFAULT_PROJECT_NAME: Waves (self-host)
+
+volumes:
+  db-data:
+  storage-data:

--- a/infra/self-host/env.example
+++ b/infra/self-host/env.example
@@ -1,0 +1,71 @@
+# Waves self-host stack — copy to `.env` in this folder and fill in.
+#   cp env.example .env
+# `.env` is gitignored.
+#
+# ── Generate the secrets ────────────────────────────────────────────────────
+# JWT_SECRET: any 40+ char random string. e.g. `openssl rand -base64 48`
+# ANON_KEY / SERVICE_ROLE_KEY: JWTs SIGNED WITH JWT_SECRET, roles "anon" and
+#   "service_role". Generate both at
+#   https://supabase.com/docs/guides/self-hosting/docker#securing-your-services
+#   (the "API keys" generator) OR with the node snippet in README.md § Keys.
+#   They MUST be signed with the JWT_SECRET below or every request 401s.
+# REALTIME_SECRET_KEY_BASE: `openssl rand -base64 48`
+
+POSTGRES_PASSWORD=change-me-strong
+POSTGRES_DB=postgres
+POSTGRES_PORT=5432
+
+JWT_SECRET=change-me-at-least-40-chars-of-random
+JWT_EXPIRY=3600
+ANON_KEY=eyJ...anon-jwt-signed-with-JWT_SECRET
+SERVICE_ROLE_KEY=eyJ...service-role-jwt-signed-with-JWT_SECRET
+REALTIME_SECRET_KEY_BASE=change-me-random
+
+# ── Gateway / external URL ──────────────────────────────────────────────────
+# What the apps point at. Localhost for a laptop; https://api.waves.example on
+# a server (put TLS in front — see README § Going to production).
+KONG_HTTP_PORT=8000
+KONG_HTTPS_PORT=8443
+API_EXTERNAL_URL=http://localhost:8000
+STUDIO_PORT=8100
+
+# ── Auth ────────────────────────────────────────────────────────────────────
+# Keep the app's schemes so OAuth deep links resolve (matches config.toml).
+SITE_URL=waves://
+ADDITIONAL_REDIRECT_URLS=waves://,waves://auth,baaki://,baaki://auth,http://localhost:3000
+MAILER_AUTOCONFIRM=false
+
+# SMTP for magic-link / OTP email (leave blank to disable email login).
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+SMTP_ADMIN_EMAIL=admin@waves.example
+SMTP_SENDER_NAME=Waves
+
+# OAuth providers (set *_ENABLED=true and fill ids to turn on).
+GOOGLE_ENABLED=false
+GOOGLE_CLIENT_ID=
+GOOGLE_SECRET=
+APPLE_ENABLED=false
+APPLE_CLIENT_ID=
+APPLE_SECRET=
+
+# ── Edge functions ──────────────────────────────────────────────────────────
+# false = functions accept the app's anon-key requests as the cloud does.
+FUNCTIONS_VERIFY_JWT=false
+
+# ── PostgREST ───────────────────────────────────────────────────────────────
+PGRST_DB_SCHEMAS=public,graphql_public
+
+# ── Storage backend ─────────────────────────────────────────────────────────
+# `file` = local disk (fine for a migration window / dev). To serve straight
+# from Cloudflare R2 instead, set STORAGE_BACKEND=s3 and fill the S3_* vars
+# (R2 is S3-compatible). New Waves image I/O already goes to R2 via the r2-sign
+# edge function regardless — this only covers the /storage/v1 legacy path.
+STORAGE_BACKEND=file
+STORAGE_S3_REGION=auto
+STORAGE_S3_BUCKET=
+STORAGE_S3_ENDPOINT=
+STORAGE_S3_ACCESS_KEY=
+STORAGE_S3_SECRET_KEY=

--- a/infra/self-host/functions.env.example
+++ b/infra/self-host/functions.env.example
@@ -1,0 +1,24 @@
+# Secrets for the edge functions when self-hosted.
+#   cp functions.env.example functions.env
+# `functions.env` is gitignored and mounted read-only into the runtime.
+#
+# These mirror what you set on the cloud project's Function secrets today.
+# Copy the values from supabase/.env.example (or the cloud dashboard) — only
+# the ones your functions actually read are needed.
+
+# Fan-out / email (notify-fanout, email-events, campaign-broadcast)
+RESEND_API_KEY=
+# Push (notify-fanout) — FCM / APNs
+FCM_SERVICE_ACCOUNT_JSON=
+APNS_KEY=
+APNS_KEY_ID=
+APNS_TEAM_ID=
+
+# R2 object storage (r2-sign, storage-*)
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=
+
+# FX (fx-rate)
+FX_API_KEY=

--- a/infra/self-host/scripts/dump-from-supabase.sh
+++ b/infra/self-host/scripts/dump-from-supabase.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Dump a Supabase (or any Postgres) project into portable .sql files.
+#
+# Produces three files in ./out so you can restore selectively:
+#   roles.sql   — the auth users' owning grants (kept minimal)
+#   auth.sql    — the `auth` schema: users + identities (PRESERVES UUIDs, which
+#                 are referenced as profile_id everywhere — do NOT regenerate)
+#   public.sql  — the app data (groups, expenses, ledger, ...)
+#
+# `public` structure is owned by Prisma; on restore you run migrations first
+# then load public.sql as DATA ONLY. See MIGRATION.md.
+#
+# Usage:
+#   export SOURCE_DB_URL="postgres://postgres:PASSWORD@db.<ref>.supabase.co:5432/postgres"
+#   ./dump-from-supabase.sh
+#
+# SOURCE_DB_URL = the project's DIRECT connection (Project Settings > Database >
+# Connection string > URI, session mode / port 5432). Not the pooler.
+set -euo pipefail
+
+: "${SOURCE_DB_URL:?export SOURCE_DB_URL=the Supabase DIRECT connection URI}"
+OUT="${OUT_DIR:-./out}"
+mkdir -p "$OUT"
+
+echo "==> auth schema (users + identities, UUIDs preserved)"
+pg_dump "$SOURCE_DB_URL" \
+  --schema=auth \
+  --no-owner --no-privileges --disable-triggers \
+  --data-only \
+  --table='auth.users' --table='auth.identities' \
+  > "$OUT/auth.sql"
+
+echo "==> public schema — DATA ONLY (structure comes from Prisma migrations)"
+pg_dump "$SOURCE_DB_URL" \
+  --schema=public \
+  --no-owner --no-privileges --disable-triggers \
+  --data-only \
+  --exclude-table-data='public._prisma_migrations' \
+  > "$OUT/public.sql"
+
+echo "==> public schema — STRUCTURE snapshot (reference / diff only, not restored)"
+pg_dump "$SOURCE_DB_URL" \
+  --schema=public --schema-only --no-owner --no-privileges \
+  > "$OUT/public.schema.sql"
+
+echo "Done. Files in $OUT/ :"
+ls -lh "$OUT"
+echo
+echo "NEXT: bring up the self-host stack, run Prisma migrations against it,"
+echo "then ./restore-to-selfhost.sh . See MIGRATION.md."

--- a/infra/self-host/scripts/restore-to-selfhost.sh
+++ b/infra/self-host/scripts/restore-to-selfhost.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Load the dumped data into a self-host (or any target) Postgres.
+#
+# ORDER MATTERS. Before running this:
+#   1. the self-host stack is UP (docker compose up -d), so GoTrue has created
+#      the `auth` tables and the platform roles exist;
+#   2. Prisma migrations have been applied to TARGET_DB_URL, so `public`
+#      structure (tables, RLS, RPCs, cron) exists and is empty.
+# Then this loads auth users first (so profile FKs resolve) and public data.
+#
+# Usage:
+#   export TARGET_DB_URL="postgres://postgres:PASSWORD@localhost:5432/postgres"
+#   ./restore-to-selfhost.sh ./out
+set -euo pipefail
+
+: "${TARGET_DB_URL:?export TARGET_DB_URL=the target Postgres connection URI}"
+IN="${1:-./out}"
+[ -f "$IN/auth.sql" ]   || { echo "missing $IN/auth.sql — run dump-from-supabase.sh first"; exit 1; }
+[ -f "$IN/public.sql" ] || { echo "missing $IN/public.sql"; exit 1; }
+
+echo "==> auth users + identities (UUIDs preserved)"
+psql "$TARGET_DB_URL" -v ON_ERROR_STOP=1 -f "$IN/auth.sql"
+
+echo "==> public data"
+# --single-transaction: all-or-nothing, so a mid-load failure leaves no
+# half-populated ledger. session_replication_role=replica defers FK/trigger
+# checks during the bulk load (the data is already internally consistent).
+psql "$TARGET_DB_URL" -v ON_ERROR_STOP=1 --single-transaction \
+  -c "SET session_replication_role = replica;" \
+  -f "$IN/public.sql"
+
+echo "==> verify row counts"
+psql "$TARGET_DB_URL" -v ON_ERROR_STOP=1 <<'SQL'
+  SELECT 'auth.users'  AS tbl, count(*) FROM auth.users
+  UNION ALL SELECT 'groups',      count(*) FROM public.groups
+  UNION ALL SELECT 'expenses',    count(*) FROM public.expenses
+  UNION ALL SELECT 'settlements', count(*) FROM public.settlements;
+SQL
+
+echo "Done. Compare these counts against the source before cutting writes over."

--- a/infra/self-host/scripts/restore-to-selfhost.sh
+++ b/infra/self-host/scripts/restore-to-selfhost.sh
@@ -19,7 +19,9 @@ IN="${1:-./out}"
 [ -f "$IN/public.sql" ] || { echo "missing $IN/public.sql"; exit 1; }
 
 echo "==> auth users + identities (UUIDs preserved)"
-psql "$TARGET_DB_URL" -v ON_ERROR_STOP=1 -f "$IN/auth.sql"
+# --single-transaction: all-or-nothing here too, so a mid-load failure leaves
+# no half-populated auth schema for the public restore below to build FKs onto.
+psql "$TARGET_DB_URL" -v ON_ERROR_STOP=1 --single-transaction -f "$IN/auth.sql"
 
 echo "==> public data"
 # --single-transaction: all-or-nothing, so a mid-load failure leaves no

--- a/infra/self-host/volumes/api/kong.yml
+++ b/infra/self-host/volumes/api/kong.yml
@@ -1,0 +1,148 @@
+_format_version: '2.1'
+_transform: true
+
+# Reproduces the hosted Supabase URL layout so supabase-js works unchanged:
+#   /auth/v1/*       -> GoTrue
+#   /rest/v1/*       -> PostgREST
+#   /realtime/v1/*   -> Realtime
+#   /storage/v1/*    -> Storage
+#   /functions/v1/*  -> Edge runtime
+#
+# The two consumers below carry the anon and service_role JWTs. key-auth reads
+# the `apikey` header supabase-js sends; the acl plugin then scopes which routes
+# each key may reach. These keys are swapped in by `docker compose` from .env.
+
+consumers:
+  - username: anon
+    keyauth_credentials:
+      - key: ${ANON_KEY}
+  - username: service_role
+    keyauth_credentials:
+      - key: ${SERVICE_ROLE_KEY}
+
+acls:
+  - consumer: anon
+    group: anon
+  - consumer: service_role
+    group: admin
+
+plugins:
+  - name: cors
+
+services:
+  # ── GoTrue ──────────────────────────────────────────────────────────────
+  - name: auth-v1-open
+    url: http://auth:9999/verify
+    routes:
+      - name: auth-v1-open
+        strip_path: true
+        paths: ['/auth/v1/verify']
+    plugins:
+      - name: cors
+  - name: auth-v1-open-callback
+    url: http://auth:9999/callback
+    routes:
+      - name: auth-v1-open-callback
+        strip_path: true
+        paths: ['/auth/v1/callback']
+    plugins:
+      - name: cors
+  - name: auth-v1-open-authorize
+    url: http://auth:9999/authorize
+    routes:
+      - name: auth-v1-open-authorize
+        strip_path: true
+        paths: ['/auth/v1/authorize']
+    plugins:
+      - name: cors
+  - name: auth-v1
+    url: http://auth:9999/
+    routes:
+      - name: auth-v1-all
+        strip_path: true
+        paths: ['/auth/v1/']
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow: ['admin', 'anon']
+
+  # ── PostgREST ───────────────────────────────────────────────────────────
+  - name: rest-v1
+    url: http://rest:3000/
+    routes:
+      - name: rest-v1-all
+        strip_path: true
+        paths: ['/rest/v1/']
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: true
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow: ['admin', 'anon']
+
+  # ── GraphQL (pg_graphql via PostgREST) ──────────────────────────────────
+  - name: graphql-v1
+    url: http://rest:3000/rpc/graphql
+    routes:
+      - name: graphql-v1-all
+        strip_path: true
+        paths: ['/graphql/v1']
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: true
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - Content-Profile:graphql_public
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow: ['admin', 'anon']
+
+  # ── Realtime ────────────────────────────────────────────────────────────
+  - name: realtime-v1
+    url: http://realtime:4000/socket/
+    routes:
+      - name: realtime-v1-all
+        strip_path: true
+        paths: ['/realtime/v1/']
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow: ['admin', 'anon']
+
+  # ── Storage ─────────────────────────────────────────────────────────────
+  - name: storage-v1
+    url: http://storage:5000/
+    routes:
+      - name: storage-v1-all
+        strip_path: true
+        paths: ['/storage/v1/']
+    plugins:
+      - name: cors
+
+  # ── Edge Functions ──────────────────────────────────────────────────────
+  - name: functions-v1
+    url: http://functions:9000/
+    routes:
+      - name: functions-v1-all
+        strip_path: true
+        paths: ['/functions/v1/']
+    plugins:
+      - name: cors

--- a/infra/self-host/volumes/db/init/00-init.sh
+++ b/infra/self-host/volumes/db/init/00-init.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Runs ONCE, on an empty data volume, before anything connects.
+#
+# The supabase/postgres image already creates the platform roles (anon,
+# authenticated, service_role, authenticator, supabase_auth_admin,
+# supabase_storage_admin, supabase_admin, ...). Two things still need doing
+# per-deployment, both idempotent:
+#   1. set those roles' passwords to POSTGRES_PASSWORD so GoTrue / PostgREST /
+#      Storage can authenticate with the one secret from .env;
+#   2. ensure the schemas GoTrue / Storage / Realtime own exist, so their own
+#      boot migrations land in the right place.
+#
+# Waves' public schema (tables, RLS, RPCs, cron) is NOT created here — Prisma
+# owns it (packages/db). After the stack is up, run the migrations against it;
+# see infra/self-host/README.md.
+set -euo pipefail
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-SQL
+  DO \$\$
+  BEGIN
+    -- (1) Align role passwords with POSTGRES_PASSWORD.
+    ALTER ROLE authenticator          WITH LOGIN PASSWORD '${POSTGRES_PASSWORD}';
+    ALTER ROLE supabase_auth_admin    WITH LOGIN PASSWORD '${POSTGRES_PASSWORD}';
+    ALTER ROLE supabase_storage_admin WITH LOGIN PASSWORD '${POSTGRES_PASSWORD}';
+    ALTER ROLE supabase_admin         WITH LOGIN PASSWORD '${POSTGRES_PASSWORD}';
+  EXCEPTION WHEN undefined_object THEN
+    RAISE NOTICE 'a platform role was missing; image may differ — check supabase/postgres tag';
+  END
+  \$\$;
+
+  -- (2) Schemas the services own (safe if the image already made them).
+  CREATE SCHEMA IF NOT EXISTS auth      AUTHORIZATION supabase_auth_admin;
+  CREATE SCHEMA IF NOT EXISTS storage   AUTHORIZATION supabase_storage_admin;
+  CREATE SCHEMA IF NOT EXISTS _realtime AUTHORIZATION supabase_admin;
+
+  -- Extensions Waves migrations require. pg_net + pg_cron ship in the
+  -- supabase/postgres image; they will NOT exist on stock RDS/Cloud SQL.
+  CREATE EXTENSION IF NOT EXISTS pgcrypto  WITH SCHEMA extensions;
+  CREATE EXTENSION IF NOT EXISTS pg_net    WITH SCHEMA extensions;
+  CREATE EXTENSION IF NOT EXISTS pg_cron;
+SQL
+
+echo "waves self-host: roles aligned, schemas + extensions ensured."


### PR DESCRIPTION
## Why

We're tied to Supabase. This buys the **option** to leave — for any cloud (AWS/GCP/Azure) or a private VPS — without a rewrite, and documents the data migration. Option **B** from the decoupling discussion (cheapest insurance first).

## The insight

~80% of Waves is already portable — plain Postgres (Prisma-owned schema/RLS/RPCs/cron), `@waves/core` (pure TS), and image storage (already on Cloudflare R2). The only Supabase-**company** lock-in is GoTrue, PostgREST, and the Edge deploy target — **all open source**. So "leave Supabase" = re-home those + move the data, not rewrite the app.

## What's here

**`infra/self-host/` — the escape hatch.** Boots the same OSS components (Postgres, GoTrue, PostgREST, Storage, Realtime, Edge runtime) behind a Kong gateway reproducing the hosted `/auth/v1 /rest/v1 /storage/v1 /functions/v1` layout. Apps point `EXPO_PUBLIC_SUPABASE_URL` at it and run **unchanged**.
- `docker-compose.yml` — pinned tags mirroring the official self-host; Postgres 17.6 matches `config.toml`.
- `volumes/api/kong.yml` — gateway routing.
- `volumes/db/init/00-init.sh` — aligns role passwords, ensures schemas + `pg_cron`/`pg_net`.
- `env.example`, `functions.env.example` — config + key generation.
- `scripts/dump-from-supabase.sh`, `scripts/restore-to-selfhost.sh` — the data move.
- `README.md` — boot + smoke test that proves it.

**`MIGRATION.md` — the runbook.** Locked-in vs portable map; three target paths (self-host / managed Postgres / native cloud) with effort + code-change per path; `pg_dump` data move with **UUID preservation** (auth ids are `profile_id` everywhere); the one real caveat (`pg_net` → external worker on vanilla managed Postgres); zero-loss cutover + rollback checklist.

## Safety

- **No app code touched.** New files only.
- **Nothing wired to prod.** Pure opt-in infra.
- **No secrets committed** — `.env`/`functions.env` gitignored; only `.example` templates.
- Compose **validated** (`docker compose config`, default + studio profiles). Stack not booted in CI — boot + smoke test is a one-command local step in the README.

## Not in scope

The **code** seam (routing `supabase.*` through injected ports — "option A") is a separate PR. This stack is useful standalone as insurance today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete self-hosting setup for the platform’s database, authentication, APIs, realtime services, storage, and edge functions.
  * Added configurable environment templates for secrets, authentication, OAuth, email, storage, and deployment settings.
  * Added tools to export data from Supabase and restore it to a self-hosted PostgreSQL instance.
  * Added routing and initialization configuration for Supabase-compatible APIs.

* **Documentation**
  * Added migration guidance covering self-hosting, managed databases, cloud services, cutover, rollback, and portability considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->