### PR TITLE
feat(expense): left-align hero, header action menu, fuller receipt empty-state

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -29,6 +29,7 @@ import {
 import { CategoryBadge } from '@/components/Category';
 import { ExpenseReceipts } from '@/components/ExpenseReceipts';
 import { ExpenseComments } from '@/components/ExpenseComments';
+import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
 import {
   memberLookup,
   useDeleteExpense,
@@ -104,6 +105,7 @@ export default function ExpenseDetailScreen() {
   const versions = useExpenseVersions(expenseId ?? '');
   const imageEvents = useExpenseImageEvents(expenseId ?? '');
   const scrollRef = useRef<RNScrollView>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
   const deleteExpense = useDeleteExpense(groupId);
   const restoreExpense = useRestoreExpense(groupId);
 
@@ -241,6 +243,36 @@ export default function ExpenseDetailScreen() {
     ]);
   };
 
+  // The bill's actions, gathered into the header's three-dot menu. A live bill
+  // offers Edit and a red Delete; a deleted one offers only Restore, matching
+  // Splitwise's deleted-transaction header. The mutations' pending flags disable
+  // the row so a double-tap cannot fire twice.
+  const menuItems: OverflowMenuItem[] = deleted
+    ? [
+        {
+          icon: 'refresh',
+          label: t.expense.restore,
+          onPress: () => {
+            if (!restoreExpense.isPending) restoreExpense.mutate(expense.id);
+          },
+        },
+      ]
+    : [
+        {
+          icon: 'create-outline',
+          label: t.common.edit,
+          onPress: () => router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}`),
+        },
+        {
+          icon: 'trash-outline',
+          label: t.expense.deleteAction,
+          tone: 'danger',
+          onPress: () => {
+            if (!deleteExpense.isPending) confirmDelete();
+          },
+        },
+      ];
+
   return (
     <Screen edges={[]}>
       {/* The hero runs dark under the status bar, so its icons must be light —
@@ -286,7 +318,7 @@ export default function ExpenseDetailScreen() {
                 color={theme.color.onBrand}
               />
             </IconButton>
-            <View style={{ flex: 1, alignItems: 'center' }}>
+            <View style={{ flex: 1, alignItems: 'flex-start' }}>
               <Text variant="heading" tone="onBrand" numberOfLines={1}>
                 {expenseTitle(version.description, version.category, t, version.category_meta)}
               </Text>
@@ -294,15 +326,16 @@ export default function ExpenseDetailScreen() {
                 {groupLabel(group.data, members.data ?? [])}
               </Text>
             </View>
-            <IconButton
-              label={t.common.edit}
-              onPress={() => router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}`)}
-            >
-              <Ionicons name="create-outline" size={iconSize.md} color={theme.color.onBrand} />
+            {/* Every action on this bill lives behind one three-dot menu, the same
+                trailing control the group and dashboard headers carry — Edit and
+                Delete (or Restore) instead of a full-width button stacked at the
+                bottom of a long scroll. */}
+            <IconButton label={t.group.more} onPress={() => setMenuOpen(true)}>
+              <Ionicons name="ellipsis-vertical" size={iconSize.lg} color={theme.color.onBrand} />
             </IconButton>
           </Row>
 
-          <View style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+          <View style={{ alignItems: 'flex-start', gap: theme.spacing.sm }}>
             <CategoryBadge category={version.category} meta={version.category_meta} size={48} />
             <MoneyText
               amount={BigInt(version.amount)}
@@ -321,7 +354,7 @@ export default function ExpenseDetailScreen() {
                 timeZone: 'UTC',
               }).format(new Date(version.expense_date))}`}
             </Text>
-            <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap', justifyContent: 'center' }}>
+            <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap', justifyContent: 'flex-start' }}>
               <HeroTag label={splitLabels(t)[version.split_type] ?? version.split_type} />
               {version.version_no > 1 ? (
                 <HeroTag label={plural(locale, version.version_no - 1, t.expense.editedTimes)} />
@@ -557,29 +590,14 @@ export default function ExpenseDetailScreen() {
           </Card>
         </View>
 
-        {deleted ? (
-          <Button
-            label={t.expense.restore}
-            size="lg"
-            fullWidth
-            disabled={restoreExpense.isPending}
-            onPress={() => restoreExpense.mutate(expense.id)}
-          />
-        ) : (
-          <Button
-            label={t.expense.deleteAction}
-            variant="ghost"
-            size="lg"
-            fullWidth
-            disabled={deleteExpense.isPending}
-            onPress={confirmDelete}
-          />
-        )}
-
+        {/* Edit and Delete moved up into the header's three-dot menu; the only
+            note left here is the reassurance that an edit keeps every version. */}
         <Text variant="micro" tone="muted" align="center">
           {t.extras.nothingOverwritten}
         </Text>
       </ScrollView>
+
+      <OverflowMenu visible={menuOpen} onClose={() => setMenuOpen(false)} items={menuItems} />
     </Screen>
   );
 }

--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -274,49 +274,98 @@ export function ExpenseReceipts({
       <Text variant="caption" tone="muted">
         {t.receipts.title}
       </Text>
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={{ gap: theme.spacing.sm }}
-      >
-        {canManage ? (
-          <Pressable
-            onPress={startAdd}
-            disabled={attach.isPending}
-            accessibilityRole="button"
-            accessibilityLabel={t.receipts.add}
+      {items.length === 0 ? (
+        // No receipt yet (and, per the guard above, the viewer may add one). A
+        // lone 96px tile left a wide empty band under it; a full-width row that
+        // reads "Add receipt" fills the space and makes the affordance obvious.
+        <Pressable
+          onPress={startAdd}
+          disabled={attach.isPending}
+          accessibilityRole="button"
+          accessibilityLabel={t.receipts.add}
+          style={({ pressed }) => ({
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: theme.spacing.md,
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+            borderRadius: theme.radius.lg,
+            borderWidth: 1,
+            borderColor: theme.color.border,
+            borderStyle: 'dashed',
+            backgroundColor: theme.color.surfaceMuted,
+            opacity: pressed ? 0.6 : 1,
+          })}
+        >
+          <View
             style={{
-              width: THUMB,
-              height: THUMB,
+              width: 40,
+              height: 40,
               borderRadius: theme.radius.md,
-              borderWidth: 1,
-              borderColor: theme.color.border,
               alignItems: 'center',
               justifyContent: 'center',
-              backgroundColor: theme.color.surfaceMuted,
+              backgroundColor: theme.color.surface,
             }}
           >
             {attach.isPending ? (
               <ActivityIndicator color={theme.color.brand} />
             ) : (
-              <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
+              <Ionicons name="camera-outline" size={iconSize.lg} color={theme.color.brand} />
             )}
-          </Pressable>
-        ) : null}
+          </View>
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <Text variant="subheading">{t.receipts.add}</Text>
+            <Text variant="micro" tone="muted">
+              {`${t.receipts.scan} · ${t.receipts.choosePhoto}`}
+            </Text>
+          </View>
+          <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
+        </Pressable>
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: theme.spacing.sm }}
+        >
+          {canManage ? (
+            <Pressable
+              onPress={startAdd}
+              disabled={attach.isPending}
+              accessibilityRole="button"
+              accessibilityLabel={t.receipts.add}
+              style={{
+                width: THUMB,
+                height: THUMB,
+                borderRadius: theme.radius.md,
+                borderWidth: 1,
+                borderColor: theme.color.border,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.color.surfaceMuted,
+              }}
+            >
+              {attach.isPending ? (
+                <ActivityIndicator color={theme.color.brand} />
+              ) : (
+                <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
+              )}
+            </Pressable>
+          ) : null}
 
-        {items.map((it, index) => (
-          <Thumb
-            key={it.key}
-            url={urls[index] ?? null}
-            resolved={urls[index] !== undefined}
-            isPrivate={isPrivate(it)}
-            label={
-              isPrivate(it) ? `${t.receipts.title} — ${t.receipts.privateTag}` : t.receipts.title
-            }
-            onPress={() => setViewerIndex(index)}
-          />
-        ))}
-      </ScrollView>
+          {items.map((it, index) => (
+            <Thumb
+              key={it.key}
+              url={urls[index] ?? null}
+              resolved={urls[index] !== undefined}
+              isPrivate={isPrivate(it)}
+              label={
+                isPrivate(it) ? `${t.receipts.title} — ${t.receipts.privateTag}` : t.receipts.title
+              }
+              onPress={() => setViewerIndex(index)}
+            />
+          ))}
+        </ScrollView>
+      )}
 
       <Modal
         visible={viewing !== null}

--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -29,6 +29,9 @@ export interface OverflowMenuItem {
   // whose `section` differs; items with no `section` never draw one, so a menu
   // that omits it (the group header) stays a flat, undivided list.
   section?: string;
+  // A destructive row (Delete) paints its icon and label in the negative colour,
+  // the WhatsApp/Vipps convention that a delete reads red before it is tapped.
+  tone?: 'default' | 'danger';
 }
 
 export function OverflowMenu({
@@ -138,8 +141,14 @@ export function OverflowMenu({
                       backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',
                     })}
                   >
-                    <Ionicons name={item.icon} size={iconSize.lg} color={theme.color.textMuted} />
-                    <Text variant="body">{item.label}</Text>
+                    <Ionicons
+                      name={item.icon}
+                      size={iconSize.lg}
+                      color={item.tone === 'danger' ? theme.color.negative : theme.color.textMuted}
+                    />
+                    <Text variant="body" tone={item.tone === 'danger' ? 'negative' : undefined}>
+                      {item.label}
+                    </Text>
                   </Pressable>
                 </View>
               );


### PR DESCRIPTION
## What

Makes the expense detail header consistent with the group and dashboard panels, and cleans up two rough edges the user flagged.

### Header — left-aligned, actions in a menu
- The hero's title, amount, "paid by" line and meta tags are now **left-aligned** instead of centred, so the expense, group and dashboard heroes read the same.
- **Edit** and **Delete** leave the full-width button stacked at the bottom of a long scroll and move up into the header's **three-dot overflow menu** — the same trailing control the group and dashboard headers carry.
  - Live bill → Edit + a red Delete. Deleted bill → Restore (Splitwise/Vipps convention).
  - `OverflowMenu` gains an optional `tone: "danger"` so Delete paints red before it is tapped.

### Receipts — no more wasted band
- With no receipt yet, the section showed a lone 96px add tile and left a wide empty band beside it. It now shows a **full-width "Add receipt" card** (camera chip + label + scan/choose hint).
- Once images exist, the horizontal gallery with the leading add tile is unchanged.

## Design references (Mobbin)
- [Vipps — ••• → Edit / Delete (red)](https://mobbin.com/screens/ca15c1d5-0229-4fd4-9b54-c18d84d61884)
- [Splitwise — Restore in the deleted-transaction header](https://mobbin.com/screens/2b1a86c7-6122-40be-be7d-725a04ce24b8)

## Test
- `tsc --noEmit` — pass
- `eslint` (3 files) — pass
- `prettier --write` — applied

No behaviour change to the mutations themselves; Delete keeps its confirm dialog, and both mutations' pending flags block a double-fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an overflow menu for expense actions, including Edit, Delete, and Restore.
  * Added a full-width “Add receipt” prompt when no receipts are available.
* **UI Improvements**
  * Improved expense header alignment and presentation.
  * Added visual styling for destructive menu actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->