### PR TITLE
fix(infra): render kong.yml at start so the self-host API keys resolve

### DIFF
--- a/infra/self-host/docker-compose.yml
+++ b/infra/self-host/docker-compose.yml
@@ -58,6 +58,15 @@ services:
     ports:
       - '${KONG_HTTP_PORT:-8000}:8000/tcp'
       - '${KONG_HTTPS_PORT:-8443}:8443/tcp'
+    # Kong 2.8's db-less declarative parser does NOT expand ${VARS} inside the
+    # config file, so the anon/service keys cannot be referenced there directly.
+    # Render the file at start-up instead — the same trick the hosted Supabase
+    # compose uses: `eval "echo"` expands the $SUPABASE_* shell vars in the
+    # mounted template into the real kong.yml, then Kong starts on the result.
+    entrypoint:
+      - bash
+      - -c
+      - 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
     environment:
       KONG_DATABASE: 'off'
       KONG_DECLARATIVE_CONFIG: /home/kong/kong.yml
@@ -68,7 +77,8 @@ services:
       SUPABASE_ANON_KEY: ${ANON_KEY:?set ANON_KEY in .env}
       SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY:?set SERVICE_ROLE_KEY in .env}
     volumes:
-      - ./volumes/api/kong.yml:/home/kong/kong.yml:ro
+      # Mounted as a TEMPLATE; the entrypoint renders it to /home/kong/kong.yml.
+      - ./volumes/api/kong.yml:/home/kong/temp.yml:ro
     depends_on:
       - auth
       - rest

--- a/infra/self-host/volumes/api/kong.yml
+++ b/infra/self-host/volumes/api/kong.yml
@@ -9,16 +9,22 @@ _transform: true
 #   /functions/v1/*  -> Edge runtime
 #
 # The two consumers below carry the anon and service_role JWTs. key-auth reads
-# the `apikey` header supabase-js sends; the acl plugin then scopes which routes
-# each key may reach. These keys are swapped in by `docker compose` from .env.
+# the apikey header supabase-js sends; the acl plugin then scopes which routes
+# each key may reach. Kong 2.8 does not expand variables in a declarative file,
+# so this file is a TEMPLATE: the kong service entrypoint renders it at start
+# and substitutes the two SUPABASE keys below before Kong reads it.
+#
+# Because that rendering step evaluates the whole file, keep it free of any
+# backtick, double-quote or stray dollar sign outside the two key lines below,
+# or the render will choke on them.
 
 consumers:
   - username: anon
     keyauth_credentials:
-      - key: ${ANON_KEY}
+      - key: $SUPABASE_ANON_KEY
   - username: service_role
     keyauth_credentials:
-      - key: ${SERVICE_ROLE_KEY}
+      - key: $SUPABASE_SERVICE_KEY
 
 acls:
   - consumer: anon


### PR DESCRIPTION
## What

Follow-up to #425. CodeRabbit flagged (Major) that **Kong 2.8's db-less declarative parser does not expand `${VARS}` inside the config file**, so the `${ANON_KEY}` / `${SERVICE_ROLE_KEY}` placeholders in `kong.yml` were never substituted. The `anon` and `service_role` key-auth credentials would have been the literal placeholder strings, and every `apikey` the client sends would `401` at the gateway — the self-host stack would not authenticate at all.

## Fix

Adopt the same trick the hosted Supabase compose uses:

- Mount `kong.yml` as a **template** at `/home/kong/temp.yml`.
- The kong service `entrypoint` renders it at start with `eval "echo"`, expanding `$SUPABASE_ANON_KEY` / `$SUPABASE_SERVICE_KEY` (already set on the container from `.env`) into the real `/home/kong/kong.yml`, then runs `kong docker-start`.
- The two credential lines now use the `$VAR` form.
- Because that step evaluates the **whole file**, the surrounding comments were scrubbed of backticks, double-quotes and stray `$` so the render does not choke on them (a `` `apikey` `` in a comment would otherwise trigger command substitution).

## Test

- `docker compose --env-file env.example config` — valid.
- Verified `kong.yml` contains no `$` / backtick / `"` outside the two intended key lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-hosted startup handling for Kong configuration.
  * Consumer keys are now populated from the configured anonymous and service keys.
  * Added guidance for supported key formats and startup-time configuration rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->