### PR TITLE
feat(expense): cap free gallery receipts at two per expense

### DIFF
--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -16,9 +16,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
+import { router } from 'expo-router';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ActivityIndicator, Alert, Modal, Pressable, ScrollView, View } from 'react-native';
 
 import { IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+import { canAddExpenseAttachment } from '@/data/api';
+import { receiptCapStatus } from '@/lib/receiptCapGate';
 
 import { ZoomableGallery, type GalleryPage } from '@/components/ZoomableGallery';
 import { ReceiptAnnotator } from '@/components/ReceiptAnnotator';
@@ -169,6 +174,20 @@ export function ExpenseReceipts({
   const removeLegacy = useRemoveExpenseReceipt(groupId, expenseId);
   const annotate = useAnnotateExpenseAttachment();
   const replace = useReplaceExpenseAttachmentImage(groupId, expenseId);
+  const queryClient = useQueryClient();
+
+  // The per-expense receipt ceiling (A46): a free group keeps a small number of
+  // gallery images per expense; paid lifts it. This is the affordance — the
+  // attach RPC enforces the same limit — so a failed fetch defaults to "allowed"
+  // and lets the server be the boundary, the same stance as the scan cap.
+  const cap = useQuery({
+    queryKey: ['attachmentCap', expenseId],
+    queryFn: () => canAddExpenseAttachment(expenseId),
+    staleTime: 30_000,
+  });
+  const capLocked = !cap.isError && receiptCapStatus(cap.data, cap.isLoading) === 'locked';
+  const refreshCap = () =>
+    void queryClient.invalidateQueries({ queryKey: ['attachmentCap', expenseId] });
 
   const items = useMemo<GalleryItem[]>(() => {
     const list: GalleryItem[] = [];
@@ -210,6 +229,29 @@ export function ExpenseReceipts({
   const isPrivate = (it: GalleryItem) =>
     it.kind === 'attachment' && it.row.visibility === 'parties';
 
+  // The free per-expense limit is reached (and the group is not paid): point the
+  // person at the upgrade rather than open the add sheet. Reuses the scan cap's
+  // strings and upgrade route so both ceilings read and route the same.
+  const showCapUpsell = () => {
+    Alert.alert(t.expense.capReachedTitle, t.expense.capReachedBody, [
+      { text: t.common.cancel, style: 'cancel' },
+      { text: t.expense.capUpgrade, onPress: () => router.push('/settings/upgrade') },
+    ]);
+  };
+
+  // The server may still refuse over the cap even when the local gate allowed it
+  // (another party filled the last slot from another device); surface that as the
+  // upgrade prompt, not a generic failure. Anything else is the generic message.
+  const onAddError = (error: unknown) => {
+    const message = error instanceof Error ? error.message : '';
+    if (message.includes('ATTACHMENT_CAP')) {
+      showCapUpsell();
+      refreshCap();
+    } else {
+      Alert.alert(t.receipts.couldNotAdd);
+    }
+  };
+
   const add = (picked: Awaited<ReturnType<typeof captureReceipt>>) => {
     if (!picked) return; // Cancelled/declined.
     Alert.alert(t.receipts.chooseVisibility, undefined, [
@@ -218,7 +260,7 @@ export function ExpenseReceipts({
         onPress: () =>
           attach.mutate(
             { picked, visibility: 'group' },
-            { onError: () => Alert.alert(t.receipts.couldNotAdd) },
+            { onError: onAddError, onSuccess: refreshCap },
           ),
       },
       {
@@ -226,7 +268,7 @@ export function ExpenseReceipts({
         onPress: () =>
           attach.mutate(
             { picked, visibility: 'parties' },
-            { onError: () => Alert.alert(t.receipts.couldNotAdd) },
+            { onError: onAddError, onSuccess: refreshCap },
           ),
       },
       { text: t.common.cancel, style: 'cancel' },
@@ -239,6 +281,12 @@ export function ExpenseReceipts({
       { text: t.receipts.choosePhoto, onPress: () => void pickReceiptImage().then(add) },
       { text: t.common.cancel, style: 'cancel' },
     ]);
+  };
+
+  // The add affordance's tap: locked → upsell, otherwise the scan/choose sheet.
+  const handleAddPress = () => {
+    if (capLocked) showCapUpsell();
+    else startAdd();
   };
 
   const removeAt = (index: number) => {
@@ -259,7 +307,8 @@ export function ExpenseReceipts({
           } else {
             removeAttachment.mutate(
               { attachmentId: it.row.id, storagePath: it.row.storagePath },
-              { onError },
+              // Removing a live attachment frees a slot, so re-ask the cap gate.
+              { onError, onSuccess: refreshCap },
             );
           }
         },
@@ -279,7 +328,7 @@ export function ExpenseReceipts({
         // lone 96px tile left a wide empty band under it; a full-width row that
         // reads "Add receipt" fills the space and makes the affordance obvious.
         <Pressable
-          onPress={startAdd}
+          onPress={handleAddPress}
           disabled={attach.isPending}
           accessibilityRole="button"
           accessibilityLabel={t.receipts.add}
@@ -329,7 +378,7 @@ export function ExpenseReceipts({
         >
           {canManage ? (
             <Pressable
-              onPress={startAdd}
+              onPress={handleAddPress}
               disabled={attach.isPending}
               accessibilityRole="button"
               accessibilityLabel={t.receipts.add}

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -389,6 +389,20 @@ export async function canAddReceipt(groupId: string): Promise<boolean> {
 }
 
 /**
+ * May the caller add one more gallery receipt to THIS expense? The per-expense
+ * twin of `canAddReceipt` (A46): a free group holds a small number of gallery
+ * images per expense, paid lifts it. The affordance, not the boundary —
+ * `baaki_attach_expense_attachment` enforces the same ceiling server-side.
+ */
+export async function canAddExpenseAttachment(expenseId: string): Promise<boolean> {
+  const { data, error } = await backend.rpc('baaki_can_add_expense_attachment', {
+    p_expense_id: expenseId,
+  });
+  if (error) throw new Error(error.message);
+  return data === true;
+}
+
+/**
  * The signed-in caller's own image-storage usage (A44), for the settings meter.
  *
  * `used` counts only the bytes that are charged against a ceiling — a paid

--- a/packages/db/prisma/migrations/20260825130000_attachment_cap/migration.sql
+++ b/packages/db/prisma/migrations/20260825130000_attachment_cap/migration.sql
@@ -1,0 +1,187 @@
+-- A per-EXPENSE ceiling on gallery receipts (A46 attachments).
+--
+-- The legacy scan cap (20260818160000_receipt_cap) counts rows in `receipts`
+-- per GROUP. The A46 gallery is a different surface: many images per expense in
+-- `expense_attachments`, added straight to R2 with no count limit — only the
+-- 10 MB storage cap held it back. Product now wants the same "free gets a
+-- little, paid gets everything" shape here too: a free group may keep a small
+-- number of gallery receipts PER EXPENSE, and past that it is a paid feature.
+--
+-- Same knob table and same paid rule as the legacy cap: one `app_config` row the
+-- admin console turns without a deploy, and `baaki_group_is_paid` lifts it for
+-- the whole group (a member's subscription or an unexpired group pass). The
+-- 10 MB storage cap is unchanged and still applies underneath this — the two are
+-- independent ceilings, and free must clear both.
+
+-- ─────────────────────────────────────────────────── the knob ──
+
+INSERT INTO public.app_config (key, value, description)
+VALUES (
+  'attachment_cap_per_expense',
+  2,
+  'Free gallery receipts an expense may hold before the group must upgrade.'
+)
+ON CONFLICT (key) DO NOTHING;
+
+/**
+ * The per-expense attachment ceiling, with a floor to fall back to. A missing
+ * row (a project the seed never reached) yields a sensible default rather than
+ * zero, so a misconfiguration is generous, not a lockout — the same stance as
+ * baaki_receipt_cap().
+ */
+CREATE OR REPLACE FUNCTION public.baaki_attachment_cap()
+RETURNS integer
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE((SELECT value FROM public.app_config WHERE key = 'attachment_cap_per_expense'), 2);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_attachment_cap() TO authenticated, anon, service_role;
+
+-- ────────────────────── may the caller add one more attachment ──
+
+/**
+ * May the caller add one more gallery receipt to this expense?
+ *   * not a party  → no (only a payer or the author may attach at all);
+ *   * paid group   → always yes, the cap does not apply;
+ *   * otherwise     → yes while the expense holds fewer than the cap.
+ *
+ * A bare boolean, the twin of baaki_can_add_receipt. The client uses it to pick
+ * the add affordance or the upsell; baaki_attach_expense_attachment enforces the
+ * same rule at the real boundary, so a client that ignores this cannot exceed it.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_can_add_expense_attachment(p_expense_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+BEGIN
+  IF p_expense_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  SELECT group_id INTO v_group_id FROM public.expenses WHERE id = p_expense_id;
+  IF v_group_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  -- Only a party may attach; a non-party gets no affordance and no count.
+  IF NOT public.baaki_is_expense_party(p_expense_id) THEN
+    RETURN false;
+  END IF;
+
+  IF public.baaki_group_is_paid(v_group_id) THEN
+    RETURN true;
+  END IF;
+
+  RETURN (
+    SELECT count(*) FROM public.expense_attachments
+     WHERE expense_id = p_expense_id AND deleted_at IS NULL
+  ) < public.baaki_attachment_cap();
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_can_add_expense_attachment(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_can_add_expense_attachment(uuid) TO authenticated, anon;
+
+-- ──────────────────────── the cap as the real boundary ──
+-- Re-declared whole (CREATE OR REPLACE) from the 20260824180000 version — the
+-- one that emits the image-audit line — with the per-expense ceiling added just
+-- before the insert. A paid group is exempt; a replay of an existing attachment
+-- id has already returned above, so the count only ever gates a genuinely new
+-- row. The failure cleans up after itself: the client uploaded the bytes to R2
+-- before calling this, and its catch path releases that object when the RPC
+-- throws, so a refused add leaves nothing behind.
+
+CREATE OR REPLACE FUNCTION public.baaki_attach_expense_attachment(
+  p_expense_id   uuid,
+  p_storage_path text,
+  p_visibility   text DEFAULT 'group',
+  p_attachment_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+  v_member   uuid;
+  v_id       uuid;
+BEGIN
+  IF coalesce(btrim(p_storage_path), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_PATH: an attachment needs a stored image'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  IF p_visibility NOT IN ('group', 'parties') THEN
+    RAISE EXCEPTION 'INVALID_VISIBILITY: group or parties' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- The key MUST be scoped to this expense: `<expenseId>/…` (see the proof RPC).
+  IF p_storage_path NOT LIKE p_expense_id::text || '/%' THEN
+    RAISE EXCEPTION 'INVALID_PATH: the key must be scoped to its expense'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Authorise before resolving the client id (an existence oracle otherwise).
+  SELECT group_id INTO v_group_id FROM public.expenses WHERE id = p_expense_id;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such expense' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF NOT public.baaki_is_expense_party(p_expense_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only a payer or the author may attach to this expense'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Replay bound to the subject: same id + same expense returns the existing row
+  -- (and, because it returns here, never emits a second audit line and is never
+  -- re-counted against the cap).
+  IF p_attachment_id IS NOT NULL THEN
+    SELECT id INTO v_id
+    FROM public.expense_attachments
+    WHERE id = p_attachment_id AND expense_id = p_expense_id;
+    IF v_id IS NOT NULL THEN
+      RETURN v_id;
+    END IF;
+  END IF;
+
+  -- The per-expense ceiling, enforced at the one insert path. A paid group is
+  -- exempt; only live (non-deleted) attachments count, so removing one frees a
+  -- slot.
+  IF NOT public.baaki_group_is_paid(v_group_id)
+     AND (SELECT count(*) FROM public.expense_attachments
+           WHERE expense_id = p_expense_id AND deleted_at IS NULL)
+         >= public.baaki_attachment_cap()
+  THEN
+    RAISE EXCEPTION 'ATTACHMENT_CAP'
+      USING ERRCODE = 'check_violation',
+            HINT = 'This expense has reached its free receipt limit; upgrade to add more.';
+  END IF;
+
+  v_member := public.baaki_my_member_id(v_group_id);
+
+  INSERT INTO public.expense_attachments
+    (id, expense_id, group_id, uploader_member_id, storage_path, visibility)
+  VALUES
+    (COALESCE(p_attachment_id, gen_random_uuid()), p_expense_id, v_group_id, v_member,
+     btrim(p_storage_path), p_visibility)
+  RETURNING id INTO v_id;
+
+  INSERT INTO public.expense_image_events
+    (id, group_id, expense_id, actor_member_id, kind, action, visibility)
+  VALUES
+    (gen_random_uuid(), v_group_id, p_expense_id, v_member, 'attachment', 'added', p_visibility);
+
+  RETURN v_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_attach_expense_attachment(uuid, text, text, uuid)
+  TO authenticated, anon;

--- a/packages/db/prisma/migrations/20260825130000_attachment_cap/migration.sql
+++ b/packages/db/prisma/migrations/20260825130000_attachment_cap/migration.sql
@@ -152,6 +152,15 @@ BEGIN
     END IF;
   END IF;
 
+  -- Serialize the count-then-insert against other attaches to THIS expense: a
+  -- transaction-scoped advisory lock keyed on the expense id. Without it two
+  -- concurrent adds could both read a live count below the cap and both insert,
+  -- landing one over (the same race the ghost-merge path guards). Only other
+  -- attach calls take this key, so it never blocks unrelated writers, and it is
+  -- released at commit. Taken before the count so a paid group pays only a
+  -- trivial, uncontended lock and nothing else.
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_expense_id::text, 0));
+
   -- The per-expense ceiling, enforced at the one insert path. A paid group is
   -- exempt; only live (non-deleted) attachments count, so removing one frees a
   -- slot.

--- a/packages/db/test/private-attachments.test.ts
+++ b/packages/db/test/private-attachments.test.ts
@@ -232,6 +232,68 @@ describe('expense attachments', () => {
   });
 });
 
+describe('T17 — the per-expense gallery cap (A46)', () => {
+  const addOne = (eid: string) => attachExpense(eid, `${eid}/${randomUUID()}.webp`, 'group');
+
+  it('a free group is capped at two gallery attachments per expense', async () => {
+    // `g` is an unpaid group; `expenseId` is paid by m0, so m0 is the party.
+    // beforeEach cleared any attachment, so the count starts at zero.
+    await as(g.profileIds[0] as string, () => addOne(expenseId));
+    await as(g.profileIds[0] as string, () => addOne(expenseId));
+    expect(await countAttachments(expenseId)).toBe(2);
+
+    const message = await as(g.profileIds[0] as string, () => expectDenied(addOne(expenseId)));
+    expect(message).toMatch(/ATTACHMENT_CAP/);
+    expect(await countAttachments(expenseId)).toBe(2);
+  });
+
+  it('removing one frees a slot', async () => {
+    await as(g.profileIds[0] as string, () => addOne(expenseId));
+    const { rows } = await as(g.profileIds[0] as string, () => addOne(expenseId));
+    const secondId = rows[0].id as string;
+    // At the cap; a third is refused.
+    expect(await as(g.profileIds[0] as string, () => expectDenied(addOne(expenseId)))).toMatch(
+      /ATTACHMENT_CAP/,
+    );
+    // Remove one → a live count of 1 → the next add is allowed again.
+    await as(g.profileIds[0] as string, () =>
+      client.query(`SELECT baaki_remove_expense_attachment($1)`, [secondId]),
+    );
+    await as(g.profileIds[0] as string, () => addOne(expenseId));
+    // Two live (the first and the re-add); the soft-deleted one is not counted.
+    const live = await client
+      .query(
+        `SELECT count(*)::int AS n FROM expense_attachments
+          WHERE expense_id = $1 AND deleted_at IS NULL`,
+        [expenseId],
+      )
+      .then((r) => r.rows[0].n as number);
+    expect(live).toBe(2);
+  });
+
+  it('a paid group has no attachment cap', async () => {
+    const grp = await seedGroup(client, { memberCount: 1, name: 'PaidGallery' });
+    const { expenseId: eid } = await addEqualSplitExpense(client, {
+      groupId: grp.groupId,
+      payers: { [grp.memberIds[0] as string]: 1000n },
+      participants: grp.memberIds,
+      amount: 1000n,
+    });
+    // One member holds an active subscription → the whole group is paid, so the
+    // cap does not apply (baaki_group_is_paid).
+    await client.query(
+      `INSERT INTO subscriptions (profile_id, tier, period, status, current_period_end, store)
+       VALUES ($1, 'plus', 'monthly', 'active', now() + interval '30 days', 'play')`,
+      [grp.profileIds[0]],
+    );
+
+    for (let i = 0; i < 4; i += 1) {
+      await as(grp.profileIds[0] as string, () => addOne(eid));
+    }
+    expect(await countAttachments(eid)).toBe(4);
+  });
+});
+
 describe('the outer gates', () => {
   it('T6 — anon sees no restricted rows', async () => {
     await as(g.profileIds[0] as string, () =>


### PR DESCRIPTION
## What

Free users get a small number of A46 **gallery receipts per expense**; paid is unlimited. The gallery previously had no count limit — only the 10 MB storage cap.

- **Scope:** per expense. Each expense allows 2 gallery attachments for free; the 3rd needs paid.
- **Paid = the group is paid** (any member with an active subscription, or an unexpired group pass) — the same rule the legacy scan cap and photo gate use. So one paid member puts the whole group in "full mode."
- **Storage cap unchanged:** the 10 MB free-tier ceiling still applies underneath; free must clear both.
- **Admin-tunable:** the "2" is a new `app_config` row `attachment_cap_per_expense`, turned from the console without a deploy (same knob table as `receipt_cap_per_group`).

## How

- `baaki_attachment_cap()` — reads the knob (default 2).
- `baaki_can_add_expense_attachment(expense)` — the client affordance (party + paid + count).
- `baaki_attach_expense_attachment` — enforces the ceiling at the single insert path: paid-exempt, and a replay of an existing attachment id is never re-counted. The client already releases the uploaded R2 object when the RPC throws, so a refused add leaves nothing behind.
- Client (`ExpenseReceipts`): gates the add control on the RPC; when locked, shows the existing upgrade prompt instead of the add sheet; on a lost race, maps the `ATTACHMENT_CAP` error to the same prompt. Reuses `t.expense.capReached*` strings and the `/settings/upgrade` route — no new i18n.

## Tests

Ran against local Postgres:
- New `T17`: free group capped at two, removing one frees a slot, a paid group is uncapped.
- The existing 40 attachment tests stay green (they add ≤2 per expense; `beforeEach` clears between tests).

## Deploy note

This adds a migration (`20260825130000_attachment_cap`). It is **not** on prod yet — the cap only takes effect after `migrate deploy`. Until then the new RPCs are absent, so the client gate defaults to "allowed" and attachments stay uncapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a limit of two active gallery receipts per expense for free plans.
  * Paid plans can continue adding receipts without this limit.
  * Added upgrade prompts when the attachment limit is reached.
* **Bug Fixes**
  * Attachment availability now refreshes after receipts are added or removed.
  * Server-side limit errors now display the same upgrade prompt and update the available capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->