### PR TITLE
fix(sync): surface the real refusal reason, not "[object Object]"

### DIFF
--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -1089,7 +1089,20 @@ function sanitiseLocation(value: unknown): { lat: number; lng: number; name?: st
 function classify(error: unknown): { code: string; message: string } {
   if (error instanceof HttpError) return { code: error.code, message: error.message };
 
-  const message = error instanceof Error ? error.message : String(error);
+  // A raw PostgrestError / RPC failure is a plain object ({ message, code,
+  // details, hint }), not an Error — so `String(error)` flattens it to the
+  // literal "[object Object]", which then reached the banner as the reason and
+  // told the user nothing. Read the object's own `message` before falling back,
+  // so the DB's own words (RAISE EXCEPTION text, RLS 42501, SHARE_MISMATCH …)
+  // survive to the screen and to Sentry.
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'object' &&
+          error !== null &&
+          typeof (error as { message?: unknown }).message === 'string'
+        ? (error as { message: string }).message
+        : String(error);
   // The database raises 'UNKNOWN_MEMBER: ...', 'NOT_A_MEMBER: ...' and friends;
   // keep its own word for what went wrong rather than flattening to INTERNAL.
   const raised = /^([A-Z_]+):/.exec(message)?.[1];


### PR DESCRIPTION
## Problem
The offline sync banner showed **`[object Object]`** as the reason for any RPC-rejected mutation. A raw PostgREST/RPC error is a plain object, not an `Error`, so `classify()` in the `sync` edge function stringified it via `String(error)` — yielding the literal `"[object Object]"` and discarding the DB's real message before it reached the banner *or* Sentry.

## Fix
`classify` now reads the object's own `message` before falling back to `String()`, so the real reason (a `RAISE EXCEPTION` text, an RLS `42501`, `SHARE_MISMATCH`, a cap hit) survives. The two `throw error` sites that bubble raw RPC errors are both covered by fixing the single chokepoint.

## Deploy
⚠️ Needs the `sync` edge function **redeployed** to take effect on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to preserve and surface detailed database error messages.
  * Enhanced logging for errors returned by database requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->