### PR TITLE
feat(voice): more currencies, spoken decimals, paise & scale words

### DIFF
--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -26,7 +26,7 @@ import { router } from 'expo-router';
 import { ActivityIndicator, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { computeShares, type ExpenseLocation, type SplitParams } from '@waves/core';
+import { computeShares, minorUnitScale, type ExpenseLocation, type SplitParams } from '@waves/core';
 import {
   Button,
   Callout,
@@ -81,11 +81,17 @@ function today(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-/** A major-unit amount string to minor units, or null when it is not a number. */
-function toMinor(amount: string): bigint | null {
+/**
+ * A major-unit amount string to minor units in the given currency, or null when
+ * it is not a number. The scale is the currency's own — 100 for rupees and
+ * dollars, but 1 for yen and 1000 for dinar — so a "¥3000" expense is ¥3000, not
+ * a hundredfold ¥300000. (Was a flat ×100, which only held for two-decimal
+ * currencies.)
+ */
+function toMinor(amount: string, currency: string): bigint | null {
   const value = Number.parseFloat(amount.replace(/,/g, ''));
   if (!Number.isFinite(value) || value <= 0) return null;
-  return BigInt(Math.round(value * 100));
+  return BigInt(Math.round(value * Number(minorUnitScale(currency))));
 }
 
 export default function VoiceScreen() {
@@ -219,7 +225,8 @@ export default function VoiceScreen() {
 
       if (dest.kind === 'unassigned') {
         for (const draft of drafts) {
-          const amount = toMinor(draft.amount);
+          const currency = draft.currency ?? dc;
+          const amount = toMinor(draft.amount, currency);
           if (amount === null) continue;
           // The draft's own id is the capture id, so a save retried after a
           // partial failure re-uses it rather than minting a second capture.
@@ -227,7 +234,7 @@ export default function VoiceScreen() {
             captureId: draft.key,
             description: draft.note.trim() || fallback,
             expenseDate: date,
-            currency: draft.currency ?? dc,
+            currency,
             amount,
             location,
           });
@@ -266,7 +273,7 @@ export default function VoiceScreen() {
       if (participants.length === 0 || !payer) throw new Error('no members to split among');
 
       for (const draft of drafts) {
-        const amount = toMinor(draft.amount);
+        const amount = toMinor(draft.amount, groupCurrency);
         if (amount === null) continue;
         // Every spoken expense is "I paid, split it equally" — the group's own
         // currency, everyone in, me as payer. The reader can refine any of it on
@@ -308,7 +315,9 @@ export default function VoiceScreen() {
   // otherwise be silently skipped, and a screenful of them would "save" nothing
   // while still navigating away.
   const canSave =
-    drafts.length > 0 && !saving && drafts.every((draft) => toMinor(draft.amount) !== null);
+    drafts.length > 0 &&
+    !saving &&
+    drafts.every((draft) => toMinor(draft.amount, draft.currency ?? dc) !== null);
 
   // The footer total must read in the same currency the Save will persist, or
   // it lies about what lands. A group save writes every expense in the group's
@@ -324,9 +333,9 @@ export default function VoiceScreen() {
         : (target.group.data?.default_currency ?? dc);
   const draftTotals = new Map<string, bigint>();
   for (const draft of drafts) {
-    const minor = toMinor(draft.amount);
-    if (minor === null) continue;
     const currency = destCurrency ?? draft.currency ?? dc;
+    const minor = toMinor(draft.amount, currency);
+    if (minor === null) continue;
     draftTotals.set(currency, (draftTotals.get(currency) ?? 0n) + minor);
   }
   const singleTotal = draftTotals.size === 1 ? [...draftTotals.entries()][0] : null;

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -564,11 +564,13 @@ const MINOR_UNIT_AFTER = /^(?:paise|paisa|cents?|pence|fils)\b/i;
  * kept so {@link detectCurrency} still reads it.
  */
 function foldMinorUnits(text: string): string {
-  const majorCurrency =
-    '(rupees?|rs|inr|dollars?|usd|bucks?|euros?|eur|pounds?|quid|gbp|dirhams?|aed)';
+  // The shared currency alternation, so a qualified name ("Canadian dollars")
+  // folds its cents too — a hand-kept subset here dropped the qualifier and lost
+  // the 0.99 on "20 Canadian dollars 99 cents". The whole phrase is captured and
+  // kept so detectCurrency still reads CAD, not a bare USD "dollars".
   const minorWord = '(?:paise|paisa|cents?|pence|fils)';
   const pattern = new RegExp(
-    `(\\d[\\d,]*)\\s+${majorCurrency}\\s+(?:and\\s+)?(\\d{1,2})\\s+${minorWord}\\b`,
+    `(\\d[\\d,]*)\\s+(${CURRENCY_WORD_ALT})\\s+(?:and\\s+)?(\\d{1,2})\\s+${minorWord}\\b`,
     'gi',
   );
   return text.replace(

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -40,14 +40,114 @@ export interface ParsedVoiceExpense {
   splitCount: number | null;
 }
 
-/** Currency words to ISO codes. Indian-first, then the common cross-border ones. */
-const CURRENCY_WORDS: readonly (readonly [RegExp, string])[] = [
-  [/\b(rupees?|rupaye|rs|inr)\b|₹/i, 'INR'],
-  [/\b(dollars?|usd|bucks?)\b|\$/i, 'USD'],
-  [/\b(euros?|eur)\b|€/i, 'EUR'],
-  [/\b(pounds?|quid|gbp)\b|£/i, 'GBP'],
-  [/\b(dirhams?|aed)\b/i, 'AED'],
+/**
+ * Currency signals — a spoken word, an ISO code, or a symbol — to an ISO-4217
+ * code. Indian-first, then the corridors this app's people actually use, then
+ * the common cross-border ones. Order matters: a qualified name ("canadian
+ * dollars", "sri lankan rupees") and every symbol must come before the bare
+ * word it contains ("dollars", "rupees"), because {@link detectCurrency} takes
+ * the first that fits.
+ *
+ * Deliberately left out: bare "lira"/"try" (TRY) — "try" is an ordinary English
+ * verb and would mint a false currency on "I'll try the …". A code is only read
+ * when it stands as its own word.
+ */
+const CURRENCY_SIGNALS: readonly (readonly [RegExp, string])[] = [
+  // Symbols — unambiguous, so they lead.
+  [/₹/, 'INR'],
+  [/\$/, 'USD'],
+  [/€/, 'EUR'],
+  [/£/, 'GBP'],
+  [/¥/, 'JPY'],
+  [/₩/, 'KRW'],
+  [/₫/, 'VND'],
+  [/฿/, 'THB'],
+  [/₦/, 'NGN'],
+  // Qualified rupee and dollar names, before the bare words below.
+  [/\bsri[\s-]?lankan\s+rupees?\b|\blkr\b/i, 'LKR'],
+  [/\bnepali\s+rupees?\b|\bnpr\b/i, 'NPR'],
+  [/\bpakistani\s+rupees?\b|\bpkr\b/i, 'PKR'],
+  [/\bcanadian\s+dollars?\b|\bcad\b/i, 'CAD'],
+  [/\baustralian\s+dollars?\b|\baud\b/i, 'AUD'],
+  [/\bsingapore(?:an)?\s+dollars?\b|\bsgd\b/i, 'SGD'],
+  [/\bnew\s+zealand\s+dollars?\b|\bnzd\b/i, 'NZD'],
+  [/\bhong\s+kong\s+dollars?\b|\bhkd\b/i, 'HKD'],
+  // Bare words.
+  [/\b(?:rupees?|rupaye|rupya|rs|inr)\b/i, 'INR'],
+  [/\b(?:dollars?|usd|bucks?)\b/i, 'USD'],
+  [/\b(?:euros?|eur)\b/i, 'EUR'],
+  [/\b(?:pounds?|quid|gbp)\b/i, 'GBP'],
+  [/\b(?:dirhams?|aed)\b/i, 'AED'],
+  [/\b(?:yen|jpy)\b/i, 'JPY'],
+  [/\b(?:won|krw)\b/i, 'KRW'],
+  [/\b(?:yuan|renminbi|rmb|cny)\b/i, 'CNY'],
+  [/\b(?:ringgit|myr)\b/i, 'MYR'],
+  [/\b(?:baht|thb)\b/i, 'THB'],
+  [/\b(?:dong|vnd)\b/i, 'VND'],
+  [/\b(?:francs?|chf)\b/i, 'CHF'],
+  [/\b(?:naira|ngn)\b/i, 'NGN'],
 ];
+
+/**
+ * Every alphabetic currency word and code, longest phrases first, as one
+ * alternation — the shared source for the amount-adjacency, spoken-number and
+ * note-stripping patterns, so a currency added above is understood everywhere
+ * at once instead of drifting between four hand-kept lists.
+ */
+const CURRENCY_WORD_ALT = [
+  'sri[\\s-]?lankan\\s+rupees?',
+  'nepali\\s+rupees?',
+  'pakistani\\s+rupees?',
+  'canadian\\s+dollars?',
+  'australian\\s+dollars?',
+  'singapore(?:an)?\\s+dollars?',
+  'new\\s+zealand\\s+dollars?',
+  'hong\\s+kong\\s+dollars?',
+  'rupees?',
+  'rupaye',
+  'rupya',
+  'rs',
+  'inr',
+  'dollars?',
+  'usd',
+  'bucks?',
+  'euros?',
+  'eur',
+  'pounds?',
+  'quid',
+  'gbp',
+  'dirhams?',
+  'aed',
+  'yen',
+  'jpy',
+  'won',
+  'krw',
+  'yuan',
+  'renminbi',
+  'rmb',
+  'cny',
+  'ringgit',
+  'myr',
+  'baht',
+  'thb',
+  'dong',
+  'vnd',
+  'francs?',
+  'chf',
+  'naira',
+  'ngn',
+  'lkr',
+  'npr',
+  'pkr',
+  'cad',
+  'aud',
+  'sgd',
+  'nzd',
+  'hkd',
+].join('|');
+
+/** The currency symbols, as a character-class body. */
+const CURRENCY_SYMBOL_CLASS = '₹$€£¥₩₫฿₦';
 
 /** Words that carry no meaning for matching or for the note. */
 const STOPWORDS: ReadonlySet<string> = new Set([
@@ -90,11 +190,25 @@ const STOPWORDS: ReadonlySet<string> = new Set([
   'us',
   'with',
   'by',
+  // Decimal and minor-unit words — normalisation turns "point five" and "fifty
+  // paise" into digits, but any that slip through (a fraction with no currency
+  // beside it) must not survive into a description or a group match.
+  'point',
+  'dot',
+  'decimal',
+  'paise',
+  'paisa',
+  'cent',
+  'cents',
+  'pence',
+  'fils',
 ]);
 
 /** A number sitting next to a currency word or symbol — the amount, said plainly. */
-const CURRENCY_ADJACENT =
-  /(?:₹|\$|€|£)\s*(\d[\d,]*(?:\.\d+)?)|(\d[\d,]*(?:\.\d+)?)\s*(?:rupees?|rupaye|rs|inr|dollars?|usd|bucks?|euros?|eur|pounds?|quid|gbp|dirhams?|aed)\b/i;
+const CURRENCY_ADJACENT = new RegExp(
+  `(?:[${CURRENCY_SYMBOL_CLASS}])\\s*(\\d[\\d,]*(?:\\.\\d+)?)|(\\d[\\d,]*(?:\\.\\d+)?)\\s*(?:${CURRENCY_WORD_ALT})\\b`,
+  'i',
+);
 
 /**
  * A count of people to split among: "among 3", "between 4", "3 people", "3 ways".
@@ -145,9 +259,9 @@ function extractAmount(text: string): number | null {
   return toAmount(first?.[0]);
 }
 
-/** Which currency, if any, the sentence names. */
+/** Which currency, if any, the sentence names. First signal that fits wins. */
 function detectCurrency(text: string): string | null {
-  for (const [pattern, code] of CURRENCY_WORDS) {
+  for (const [pattern, code] of CURRENCY_SIGNALS) {
     if (pattern.test(text)) return code;
   }
   return null;
@@ -191,12 +305,11 @@ function matchGroup(tokens: readonly string[], groups: readonly VoiceGroupRef[])
  */
 function buildNote(transcript: string, matchedGroupName: string | null): string {
   const nameTokens = new Set(matchedGroupName ? tokenize(matchedGroupName) : []);
-  const currencyWord =
-    /\b(rupees?|rupaye|rs|inr|dollars?|usd|bucks?|euros?|eur|pounds?|quid|gbp|dirhams?|aed)\b/gi;
+  const currencyWord = new RegExp(`\\b(?:${CURRENCY_WORD_ALT})\\b`, 'gi');
 
   return transcript
     .replace(currencyWord, ' ')
-    .replace(/[₹$€£]/g, ' ')
+    .replace(new RegExp(`[${CURRENCY_SYMBOL_CLASS}]`, 'g'), ' ')
     .replace(/\d[\d,]*(?:\.\d+)?/g, ' ')
     .split(/\s+/)
     .filter((word) => {
@@ -392,9 +505,35 @@ const NUMBER_MULTIPLIERS: ReadonlyMap<string, { factor: number; group: boolean }
 /** Any single word that can appear inside a spoken number. */
 const NUMBER_WORD_RE = [...NUMBER_WORDS.keys(), ...NUMBER_MULTIPLIERS.keys()].join('|');
 
-/** A run of number words, joined by spaces, hyphens or a linking "and". */
+/** A digit group inside a spoken run: "3", "3,000", "3.5". */
+const DIGIT_VALUE_RE = String.raw`\d[\d,]*(?:\.\d+)?`;
+
+/** One value in a run — a digit group or a number word — so "3 thousand" reads as one. */
+const NUMBER_VALUE_RE = `(?:${DIGIT_VALUE_RE}|${NUMBER_WORD_RE})`;
+
+/** Test for a lone digit token (used to tell "3 thousand" from bare "5 10"). */
+const DIGIT_TOKEN = new RegExp(`^${DIGIT_VALUE_RE}$`);
+
+/** Words that introduce a decimal fraction in speech: "point five", "dot five". */
+const DECIMAL_WORD_RE = 'point|dot|decimal';
+
+/** A spoken decimal tail — the "point five zero" after a whole number. */
+const DECIMAL_TAIL_RE = `(?:[\\s-]+(?:${DECIMAL_WORD_RE})(?:[\\s-]+${NUMBER_VALUE_RE})+)`;
+
+/** True when a run carries a spoken decimal marker. */
+const HAS_DECIMAL = new RegExp(`\\b(?:${DECIMAL_WORD_RE})\\b`, 'i');
+
+/**
+ * A run of numbers, joined by spaces, hyphens or a linking "and", with an
+ * optional spoken decimal tail ("hundred point five"). Digits are allowed
+ * alongside words because dictation mixes them — "3 thousand", "5 lakh" — and
+ * those must fold to one amount, not split into two. The second alternative
+ * catches a bare fraction with no whole part ("point five"), which the callback
+ * only rewrites when it sits against money.
+ */
 const SPOKEN_NUMBER = new RegExp(
-  `\\b(?:${NUMBER_WORD_RE})(?:[\\s-]+(?:and[\\s-]+)?(?:${NUMBER_WORD_RE}))*\\b`,
+  `\\b${NUMBER_VALUE_RE}(?:[\\s-]+(?:and[\\s-]+)?${NUMBER_VALUE_RE})*${DECIMAL_TAIL_RE}?\\b` +
+    `|\\b(?:${DECIMAL_WORD_RE})(?:[\\s-]+${NUMBER_VALUE_RE})+\\b`,
   'gi',
 );
 
@@ -405,20 +544,90 @@ const SPOKEN_NUMBER = new RegExp(
  * match inside an ordinary word ("person" → "pe-rs-on"): without them "one
  * person paid" would read "rs" as currency and mint a false amount.
  */
-const CURRENCY_TOKEN =
-  /(?:₹|\$|€|£|\b(?:rupees?|rupaye|rs|inr|dollars?|usd|bucks?|euros?|eur|pounds?|quid|gbp|dirhams?|aed)\b)/i;
+const CURRENCY_TOKEN = new RegExp(
+  `(?:[${CURRENCY_SYMBOL_CLASS}]|\\b(?:${CURRENCY_WORD_ALT})\\b)`,
+  'i',
+);
 
 /** Split-phrase context — a number here is a people count, still worth digitising. */
 const SPLIT_BEFORE_WORD = /^(?:among|amongst|between)$/i;
 const SPLIT_AFTER_WORD = /^(?:people|persons?|ppl|ways?|folks?|heads?)\b/i;
 
-/** Add up one run of number words: "five hundred and fifty" → 550. */
+/** A minor-unit word ("fifty paise", "ninety nine cents") — the number before it is money. */
+const MINOR_UNIT_AFTER = /^(?:paise|paisa|cents?|pence|fils)\b/i;
+
+/**
+ * Fold a spoken minor amount into the major one: "100 rupees 50 paise" →
+ * "100.50 rupees", "20 dollars 99 cents" → "20.99 dollars". Runs after the
+ * spoken numbers are digits, so both parts are already numeric. The minor part
+ * is padded to two places ("5 paise" is 0.05, not 0.5) and the currency word is
+ * kept so {@link detectCurrency} still reads it.
+ */
+function foldMinorUnits(text: string): string {
+  const majorCurrency =
+    '(rupees?|rs|inr|dollars?|usd|bucks?|euros?|eur|pounds?|quid|gbp|dirhams?|aed)';
+  const minorWord = '(?:paise|paisa|cents?|pence|fils)';
+  const pattern = new RegExp(
+    `(\\d[\\d,]*)\\s+${majorCurrency}\\s+(?:and\\s+)?(\\d{1,2})\\s+${minorWord}\\b`,
+    'gi',
+  );
+  return text.replace(
+    pattern,
+    (_match, major: string, currency: string, minor: string) =>
+      `${major.replace(/,/g, '')}.${minor.padStart(2, '0')} ${currency}`,
+  );
+}
+
+/**
+ * Add up one run of number words: "five hundred and fifty" → 550, "hundred
+ * point five" → 100.5.
+ *
+ * Two modes, split by a spoken decimal word. Before it, the ordinary
+ * whole-number arithmetic (units add, a multiplier scales the current chunk, a
+ * "group" multiplier like thousand banks it). After it, every value is read as
+ * its own fraction digit — "point five zero" is ".50", not ".fifty" — because
+ * that is how people speak the part after a decimal.
+ */
 function spokenRunToNumber(run: string): number | null {
   let total = 0;
   let current = 0;
   let seen = false;
+  let fraction: string | null = null; // non-null once a decimal word is passed
+
   for (const word of run.toLowerCase().split(/[\s-]+/)) {
     if (!word || word === 'and') continue;
+
+    if (word === 'point' || word === 'dot' || word === 'decimal') {
+      // Close the whole-number part; everything after is fraction digits.
+      total += current;
+      current = 0;
+      fraction = '';
+      seen = true;
+      continue;
+    }
+
+    if (fraction !== null) {
+      // Fraction digits, each value contributing its own digit(s). A multiplier
+      // here ("point five hundred") is not real speech — bail so the run is left
+      // as spoken rather than turned into a wrong number.
+      if (DIGIT_TOKEN.test(word)) {
+        fraction += String(Number.parseInt(word.replace(/,/g, ''), 10));
+      } else {
+        const unit = NUMBER_WORDS.get(word);
+        if (unit === undefined) return null;
+        fraction += String(unit);
+      }
+      seen = true;
+      continue;
+    }
+
+    // A spoken digit ("3" in "3 thousand") counts as the current chunk, so the
+    // multiplier that follows scales it.
+    if (DIGIT_TOKEN.test(word)) {
+      current += Number.parseFloat(word.replace(/,/g, ''));
+      seen = true;
+      continue;
+    }
     const unit = NUMBER_WORDS.get(word);
     if (unit !== undefined) {
       current += unit;
@@ -435,7 +644,9 @@ function spokenRunToNumber(run: string): number | null {
     }
     seen = true;
   }
-  const value = total + current;
+
+  let value = total + current;
+  if (fraction) value += Number.parseFloat(`0.${fraction}`);
   return seen && value > 0 ? value : null;
 }
 
@@ -456,22 +667,37 @@ function spokenRunToNumber(run: string): number | null {
  * into digits would invent an amount out of a sentence that never named one.
  */
 export function normalizeSpokenNumbers(text: string): string {
-  return text.replace(SPOKEN_NUMBER, (run, offset: number, whole: string) => {
+  const digitised = text.replace(SPOKEN_NUMBER, (run, offset: number, whole: string) => {
     const words = run
       .toLowerCase()
       .split(/[\s-]+/)
       .filter((w: string) => w && w !== 'and');
     const hasMultiplier = words.some((w: string) => NUMBER_MULTIPLIERS.has(w));
+    const hasDigit = words.some((w: string) => DIGIT_TOKEN.test(w));
+    const hasDecimal = HAS_DECIMAL.test(run);
+    // A run that already carries a bare digit but no scale word and no decimal is
+    // left exactly as spoken: "5 10" is two amounts (two expenses), not fifteen,
+    // and a lone "3000" is already a number. Only a digit joined to a scale word
+    // ("3 thousand", "5 lakh") or a spoken decimal ("100 point five") is folded.
+    if (hasDigit && !hasMultiplier && !hasDecimal) return run;
     const after = whole.slice(offset + run.length).trimStart();
     const before = whole.slice(0, offset).trimEnd();
     const prevWord = before.split(/\s+/).pop() ?? '';
-    const nextIsCurrency = CURRENCY_TOKEN.test(after.split(/\s+/)[0] ?? '');
+    // The first two words after the run, so a qualified name ("canadian
+    // dollars") still reads as currency where a single-word check would miss it.
+    const nextIsCurrency = CURRENCY_TOKEN.test(after.split(/\s+/).slice(0, 2).join(' '));
     const prevIsCurrency = CURRENCY_TOKEN.test(prevWord);
+    const nextIsMinor = MINOR_UNIT_AFTER.test(after);
     const splitContext = SPLIT_BEFORE_WORD.test(prevWord) || SPLIT_AFTER_WORD.test(after);
-    if (!hasMultiplier && !nextIsCurrency && !prevIsCurrency && !splitContext) return run;
+    if (!hasMultiplier && !nextIsCurrency && !prevIsCurrency && !splitContext && !nextIsMinor) {
+      return run;
+    }
     const value = spokenRunToNumber(run);
     return value === null ? run : String(value);
   });
+  // Now that both parts are digits, fold a spoken minor amount ("… 50 paise")
+  // into the major one.
+  return foldMinorUnits(digitised);
 }
 
 /**

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -48,6 +48,37 @@ describe('parseVoiceExpense', () => {
     expect(parsed.currency).toBe('USD');
   });
 
+  it('recognises currencies beyond rupees and dollars', () => {
+    const cases: [string, string][] = [
+      ['2000 yen for sushi', 'JPY'],
+      ['50 euros hotel', 'EUR'],
+      ['100 pounds tickets', 'GBP'],
+      ['300 dirhams taxi', 'AED'],
+      ['5000 won lunch', 'KRW'],
+      ['1000 ringgit shopping', 'MYR'],
+      ['200 baht food', 'THB'],
+      ['500 dong snacks', 'VND'],
+      ['80 francs cab', 'CHF'],
+      ['500 canadian dollars flight', 'CAD'],
+      ['600 australian dollars tour', 'AUD'],
+      ['sri lankan rupees 400 tea', 'LKR'],
+    ];
+    for (const [sentence, code] of cases) {
+      expect(parseVoiceExpense(sentence, groups).currency).toBe(code);
+    }
+  });
+
+  it('reads currency symbols', () => {
+    expect(parseVoiceExpense('¥3000 ramen', groups).currency).toBe('JPY');
+    expect(parseVoiceExpense('$25 coffee', groups).currency).toBe('USD');
+    expect(parseVoiceExpense('€15 museum', groups).currency).toBe('EUR');
+    expect(parseVoiceExpense('₹500 chai', groups).currency).toBe('INR');
+  });
+
+  it('does not mint a currency from the ordinary word "try"', () => {
+    expect(parseVoiceExpense("I'll try the new place, 500 rupees", groups).currency).toBe('INR');
+  });
+
   it('returns nulls for a sentence with no number', () => {
     const parsed = parseVoiceExpense('groceries for the flat', groups);
     expect(parsed.amountMinor).toBeNull();
@@ -93,6 +124,69 @@ describe('parseVoiceExpense', () => {
 
   it('leaves the count null when no split is said', () => {
     expect(parseVoiceExpense('add 500 for dinner', groups).splitCount).toBeNull();
+  });
+
+  // How real people actually say amounts out loud — proper English and not —
+  // captured as one table so a phrasing that regresses is obvious. Each row is
+  // [sentence, expected major amount].
+  describe('the many ways a person speaks an amount', () => {
+    const amountCases: [string, number][] = [
+      // Whole numbers in words
+      ['hundred rupees for coffee', 100],
+      ['one hundred rupees coffee', 100],
+      ['five hundred and fifty rupees', 550],
+      ['thousand rupees petrol', 1000],
+      ['fifteen hundred rupees hotel', 1500],
+      ['twenty five hundred rupees flight', 2500],
+      ['thousand five hundred rupees', 1500],
+      ['lakh rupees rent', 100000],
+      // Digit joined to a spoken scale word (common dictation output)
+      ['3 thousand rupees petrol', 3000],
+      ['5 lakh for the car', 500000],
+      ['2 crore rupees flat', 20000000],
+      // Spoken decimals — "point" and, less often, "dot"
+      ['hundred point five rupees snacks', 100.5],
+      ['hundred dot five rupees snacks', 100.5],
+      ['ninety nine point nine nine rupees', 99.99],
+      ['one hundred point five zero dollars', 100.5],
+      ['point five zero rupees tip', 0.5],
+      // Minor units spoken out — paise and cents
+      ['hundred rupees fifty paise milk', 100.5],
+      ['hundred rupees and fifty paise milk', 100.5],
+      ['twenty dollars ninety nine cents', 20.99],
+      ['five rupees five paise', 5.05],
+      // Written digits with separators and decimals
+      ['1,299.50 dollars', 1299.5],
+      ['99.99 dollars', 99.99],
+      // Currency named before the amount
+      ['rupees hundred for auto', 100],
+      ['$40 for lunch', 40],
+      // Not-so-proper English word order — the amount still comes through
+      ['petrol 100 rupees', 100],
+      ['i paid 500 rupees for dinner', 500],
+      ['dinner 250 rupees me and two friends', 250],
+    ];
+    for (const [sentence, expected] of amountCases) {
+      it(`hears "${sentence}" as ${expected}`, () => {
+        expect(parseVoiceExpense(sentence, groups).amountMajor).toBe(expected);
+      });
+    }
+  });
+
+  // The flip side: phrasings a person did NOT mean as an amount must stay null,
+  // so the screen asks rather than inventing money out of ordinary speech.
+  describe('phrasings that must NOT become an amount', () => {
+    const noAmount = [
+      'groceries for the flat',
+      'table for two please',
+      'split it between us',
+      'one of us will pay later',
+    ];
+    for (const sentence of noAmount) {
+      it(`hears no amount in "${sentence}"`, () => {
+        expect(parseVoiceExpense(sentence, groups).amountMajor).toBeNull();
+      });
+    }
   });
 });
 
@@ -156,6 +250,57 @@ describe('parseVoiceExpenses (several in one breath)', () => {
   it('drops segments that carry no amount', () => {
     const result = parseVoiceExpenses('hello, 50 for coffee, um', groups);
     expect(result.items.map((item) => item.amountMajor)).toEqual([50]);
+  });
+
+  // Dictation often hands back a digit glued to a spoken scale word — "3
+  // thousand", "5 lakh", "2 crore" — rather than the fully-spelled words or the
+  // finished digits. These must fold to one amount, not split into a phantom
+  // "₹3" expense plus a "₹1000" one (the bug that made "three thousand rupees
+  // for petrol" save as ₹3 with no description).
+  it('folds a digit joined to a scale word into one amount', () => {
+    const result = parseVoiceExpenses('3 thousand rupees for petrol', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(3000);
+    expect(result.items[0].note).toBe('petrol');
+    expect(result.items[0].currency).toBe('INR');
+  });
+
+  it('folds Indian scale words (lakh, crore) onto a leading digit', () => {
+    expect(parseVoiceExpenses('5 lakh for car', groups).items[0].amountMajor).toBe(500000);
+    expect(parseVoiceExpenses('2 crore rupees', groups).items[0].amountMajor).toBe(20000000);
+  });
+
+  it('folds a fully-spoken scale amount too', () => {
+    const result = parseVoiceExpenses('three thousand rupees for petrol', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(3000);
+    expect(result.items[0].note).toBe('petrol');
+  });
+
+  it('still splits a bare run of digits into separate expenses (5 10 ≠ 15)', () => {
+    const result = parseVoiceExpenses('5 rupees snacks 10 rupees tea', groups);
+    expect(result.items.map((item) => item.amountMajor)).toEqual([5, 10]);
+  });
+
+  it('assigns the named group even with "split equally" phrasing', () => {
+    const result = parseVoiceExpenses('split equally for the Goa trip 3000 rupees', groups);
+    expect(result.group).toEqual({ kind: 'existing', groupId: 'g-goa' });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(3000);
+    expect(result.items[0].currency).toBe('INR');
+  });
+
+  it('assigns the group and reads a people-count in one breath', () => {
+    const result = parseVoiceExpenses('1000 rupees groceries on Goa trip split among 4', groups);
+    expect(result.group).toEqual({ kind: 'existing', groupId: 'g-goa' });
+    expect(result.splitCount).toBe(4);
+    expect(result.items[0].amountMajor).toBe(1000);
+  });
+
+  it('carries non-rupee currencies through the multi-expense path', () => {
+    const result = parseVoiceExpenses('20 euros coffee, 15 euros cake', groups);
+    expect(result.items.map((item) => item.currency)).toEqual(['EUR', 'EUR']);
+    expect(result.items.map((item) => item.amountMajor)).toEqual([20, 15]);
   });
 });
 

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -62,6 +62,8 @@ describe('parseVoiceExpense', () => {
       ['500 canadian dollars flight', 'CAD'],
       ['600 australian dollars tour', 'AUD'],
       ['sri lankan rupees 400 tea', 'LKR'],
+      // Cents folded in must not demote the qualified name to a bare-dollar USD
+      ['twenty canadian dollars ninety nine cents', 'CAD'],
     ];
     for (const [sentence, code] of cases) {
       expect(parseVoiceExpense(sentence, groups).currency).toBe(code);
@@ -154,6 +156,8 @@ describe('parseVoiceExpense', () => {
       ['hundred rupees fifty paise milk', 100.5],
       ['hundred rupees and fifty paise milk', 100.5],
       ['twenty dollars ninety nine cents', 20.99],
+      // A qualified name must fold its cents too, not drop them
+      ['twenty canadian dollars ninety nine cents', 20.99],
       ['five rupees five paise', 5.05],
       // Written digits with separators and decimals
       ['1,299.50 dollars', 1299.5],


### PR DESCRIPTION
## What
Real spoken amounts were mis-parsed by on-device voice quick-add. Fixes, all in the pure `voiceExpense.ts` parser (+ `voice.tsx` minor-unit scaling):

- **Digit + scale word** — `"3 thousand rupees"` (how dictation returns it) parsed as ₹3 + a phantom ₹1000, losing the note. Now folds to one amount; a bare digit run (`"5 … 10 …"`) still splits into separate expenses.
- **~20 currencies** by spoken word, ISO code, or symbol (₹ $ € £ ¥ ₩ ₫ ฿ ₦). Qualified names beat bare (`"canadian dollars"` → CAD). Excludes bare `"try"`/`"lira"` so *"I'll try…"* doesn't mint a currency.
- **Spoken decimals** — `"hundred point five"` → 100.5, `"ninety nine point nine nine"` → 99.99, `"hundred dot five"`.
- **Minor units** — `"hundred rupees fifty paise"` → 100.50, `"twenty dollars ninety nine cents"` → 20.99.
- **Minor-unit scaling** — `¥3000` is now ¥3000, not a hundredfold ¥300000 (was a flat ×100).

Ambiguous colloquials (`"two fifty"`) and non-English number words stay unparsed (safe; the model tier covers other languages).

## Tests
31 new regression cases (proper + broken English). Full parser suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded voice expense entry with broader currency recognition, including symbols, names, and codes.
  - Added support for spoken decimals, fractions, minor units, and phrases such as “50 paise.”
  - Improved handling of group expenses, split counts, notes, and multiple currencies.

- **Bug Fixes**
  - Corrected conversions for currencies with different minor-unit scales.
  - Improved validation and displayed totals when saving voice-entered expenses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->