### PR TITLE
feat(activity): flat tinted-tile redesign for both activity feeds

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -17,7 +17,15 @@ import {
   useTheme,
 } from '@waves/ui';
 
-import { dayHeading, describeActivity, groupByDay, parseMoney, verbIcon } from '@/data/activity';
+import {
+  dayHeading,
+  describeActivity,
+  groupByDay,
+  parseMoney,
+  relativeTime,
+  verbIcon,
+  verbTint,
+} from '@/data/activity';
 import { useBlockedUsers } from '@/data/blocked';
 import { FeedSkeleton } from '@/components/Skeletons';
 import { useNotifications, useRecentActivity, type RecentActivityRow } from '@/data/hooks';
@@ -59,14 +67,6 @@ export default function ActivityScreen() {
         data: section.entries,
       })),
     [allEntries],
-  );
-
-  // One formatter per locale, not one per row per render. Building an
-  // `Intl.DateTimeFormat` is costly, and the row clock did it O(rows) times a
-  // render — the single most avoidable cost in a long feed.
-  const timeFormat = useMemo(
-    () => new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' }),
-    [locale],
   );
 
   const notifications = useNotifications();
@@ -180,9 +180,20 @@ export default function ActivityScreen() {
             {dayHeading(locale, section.first.created_at)}
           </Text>
         )}
-        renderItem={({ item: entry, index, section }) => {
-          const isLast = index === section.data.length - 1;
+        ItemSeparatorComponent={() => (
+          <View style={{ height: 1, backgroundColor: theme.color.border }} />
+        )}
+        renderItem={({ item: entry }) => {
           const money = parseMoney(entry.payload);
+          // A soft rounded-square tile whose tint leans with the verb — the same
+          // row the group's Activity tab and the Expenses tab use, so activity
+          // reads one way everywhere. No timeline rail; the day headings above
+          // do the sectioning, hairlines do the between-row separation.
+          const tint = theme.tint[verbTint(entry.verb)];
+          const g = entry.group;
+          const groupLabel = g
+            ? [g.cover_emoji, g.name].filter(Boolean).join(' ').trim() || t.captures.group
+            : null;
           return (
             <Pressable
               accessibilityRole="button"
@@ -190,76 +201,34 @@ export default function ActivityScreen() {
               onPress={() => router.push(`/group/${entry.group_id}`)}
               style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
             >
-              <Row style={{ alignItems: 'stretch' }}>
-                {/* The rail: the node — the dashboard's line glyph in a soft
-                    circle — and a thin connector running from it down to the
-                    next node, so the day reads as one continuous timeline rather
-                    than loose rows. The connector stops at the last node so it
-                    ends, not dangles. */}
-                <View style={{ width: 42, alignItems: 'center' }}>
-                  <View
-                    style={{
-                      width: 42,
-                      height: 42,
-                      borderRadius: 21,
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}
-                  >
-                    <Ionicons
-                      name={verbIcon(entry.verb)}
-                      size={iconSize.xl}
-                      color={theme.color.brand}
-                    />
-                  </View>
-                  {!isLast ? (
-                    <View
-                      style={{
-                        flex: 1,
-                        width: 2,
-                        marginTop: theme.spacing.xs,
-                        borderRadius: 1,
-                        backgroundColor: theme.color.border,
-                      }}
-                    />
-                  ) : null}
-                </View>
-
+              <Row
+                style={{
+                  gap: theme.spacing.md,
+                  alignItems: 'center',
+                  paddingVertical: theme.spacing.md,
+                }}
+              >
                 <View
                   style={{
-                    flex: 1,
-                    paddingStart: theme.spacing.md,
-                    paddingBottom: isLast ? 0 : theme.spacing.xl,
+                    width: 40,
+                    height: 40,
+                    borderRadius: theme.radius.md,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: tint.bg,
                   }}
                 >
-                  <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
-                    <Text variant="body" numberOfLines={3} style={{ flex: 1 }}>
-                      {describeActivity(entry, myProfileId, blockedIds, t.misc.someone)}
-                    </Text>
-                    {/* `payload` is an untyped JSON blob, so a bad amount must
-                        render as no amount, not as a crashed tab. */}
-                    {money ? (
-                      <MoneyText
-                        amount={money.amount}
-                        currency={money.currency}
-                        locale={locale}
-                        variant="subheading"
-                        // The feed amount is money spent/owed on the entry, so it
-                        // wears the same owe colour as the shares and balances
-                        // elsewhere — one money colour across every screen. Forced
-                        // (the payload amount is unsigned), not sign-derived.
-                        tone="negative"
-                      />
-                    ) : null}
-                  </Row>
-                  {/* The day is the heading's job now, so the row keeps only the
-                      clock — "yesterday" printed under a heading that already
-                      said it was noise. The group the entry belongs to rides
-                      here too: on a cross-group feed the row would otherwise not
-                      say which group it was, and — the point of this line — an
-                      archived group, or one no longer on this device (left or
-                      deleted), gets a badge so it is recognisable without
-                      opening it. */}
+                  <Ionicons name={verbIcon(entry.verb)} size={iconSize.lg} color={tint.ink} />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text variant="body" numberOfLines={2}>
+                    {describeActivity(entry, myProfileId, blockedIds, t.misc.someone)}
+                  </Text>
+                  {/* The relative time, plus which group the entry belongs to —
+                      this is a cross-group feed, so the row would otherwise not
+                      say. An archived group, or one no longer on this device
+                      (left or deleted), gets a badge so it is recognisable
+                      without opening it. */}
                   <Row
                     style={{
                       gap: theme.spacing.sm,
@@ -268,37 +237,38 @@ export default function ActivityScreen() {
                       flexWrap: 'wrap',
                     }}
                   >
-                    <Text variant="micro" tone="muted">
-                      {timeFormat.format(new Date(entry.created_at))}
+                    <Text variant="caption" tone="muted">
+                      {relativeTime(locale, entry.created_at)}
                     </Text>
-                    {(() => {
-                      const g = entry.group;
-                      const label = g
-                        ? [g.cover_emoji, g.name].filter(Boolean).join(' ').trim() ||
-                          t.captures.group
-                        : null;
-                      return (
-                        <>
-                          {label ? (
-                            <Text
-                              variant="micro"
-                              tone="muted"
-                              numberOfLines={1}
-                              style={{ flexShrink: 1 }}
-                            >
-                              {`· ${label}`}
-                            </Text>
-                          ) : null}
-                          {g?.archived_at ? (
-                            <Badge label={t.misc.archivedGroup} tone="neutral" />
-                          ) : !g ? (
-                            <Badge label={t.misc.unavailableGroup} tone="neutral" />
-                          ) : null}
-                        </>
-                      );
-                    })()}
+                    {groupLabel ? (
+                      <Text
+                        variant="caption"
+                        tone="muted"
+                        numberOfLines={1}
+                        style={{ flexShrink: 1 }}
+                      >
+                        {`· ${groupLabel}`}
+                      </Text>
+                    ) : null}
+                    {g?.archived_at ? (
+                      <Badge label={t.misc.archivedGroup} tone="neutral" />
+                    ) : !g ? (
+                      <Badge label={t.misc.unavailableGroup} tone="neutral" />
+                    ) : null}
                   </Row>
                 </View>
+                {/* `payload` is an untyped JSON blob, so a bad amount must render
+                    as no amount, not as a crashed tab. Red like the shares and
+                    balances — one money colour across every screen. */}
+                {money ? (
+                  <MoneyText
+                    amount={money.amount}
+                    currency={money.currency}
+                    locale={locale}
+                    variant="subheading"
+                    tone="negative"
+                  />
+                ) : null}
               </Row>
             </Pressable>
           );

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -17,7 +17,6 @@ import {
   Fab,
   Gradient,
   iconSize,
-  ListRow,
   MoneyText,
   Row,
   Screen,
@@ -36,7 +35,7 @@ import {
   useGroupRealtime,
   useOpenReceipts,
 } from '@/data/hooks';
-import { describeActivity, parseMoney, verbIcon } from '@/data/activity';
+import { describeActivity, parseMoney, relativeTime, verbIcon, verbTint } from '@/data/activity';
 import { nudgeToSettle } from '@/data/api';
 import { expenseTitle } from '@/data/expenseTitle';
 import { GroupSkeleton } from '@/components/Skeletons';
@@ -1034,65 +1033,82 @@ export default function GroupScreen() {
                 icon={<Ionicons name="pulse" size={iconSize.xxl} color={theme.color.brand} />}
               />
             ) : (
-              // Flat like the Expenses and Balances tabs — bare rows and
-              // hairlines, not a boxed Card, so all three tabs read alike.
+              // The same row shape as the Expenses tab, so the three tabs read as
+              // one screen: a soft tinted tile on the left, the sentence and a
+              // relative time beside it, the amount on the right, hairlines
+              // between. The event wears a rounded-square tile (not the expense's
+              // circle, not a bare timeline node or a bold filled disc) in a tint
+              // that leans with the verb — mint for money in and confirmations,
+              // coral for a delete or a dispute — so the feed is skimmable by
+              // colour at a glance without a connector line drawing the eye down.
               <View>
-                {(activity.data ?? []).map((entry, index) => (
-                  <View key={entry.id}>
-                    <ListRow
-                      title={describeActivity(
-                        // The group feed rides the mirror, where an activity row
-                        // carries only `actor_member_id` — not the joined actor the
-                        // cross-group feed gets. Resolve the actor from this group's
-                        // members so the row names the person instead of "someone".
-                        entry.actor ? entry : { ...entry, actor: actorFor(entry.actor_member_id) },
-                        profile?.id ?? null,
-                        blockedIds,
-                        t.misc.someone,
-                      )}
-                      subtitle={new Intl.DateTimeFormat(locale, {
-                        day: 'numeric',
-                        month: 'short',
-                        hour: 'numeric',
-                        minute: '2-digit',
-                      }).format(new Date(entry.created_at))}
-                      leading={
-                        // Same node as the Activity tab and the dashboard: the
-                        // verb as a line glyph in a soft-brand circle, one accent.
+                {(activity.data ?? []).map((entry, index) => {
+                  const isLast = index === (activity.data?.length ?? 0) - 1;
+                  const money = parseMoney(entry.payload, currency);
+                  const tint = theme.tint[verbTint(entry.verb)];
+                  return (
+                    <View key={entry.id}>
+                      <Row
+                        style={{
+                          gap: theme.spacing.md,
+                          alignItems: 'center',
+                          paddingVertical: theme.spacing.md,
+                        }}
+                      >
                         <View
                           style={{
-                            width: 38,
-                            height: 38,
-                            borderRadius: 19,
+                            width: 40,
+                            height: 40,
+                            borderRadius: theme.radius.md,
                             alignItems: 'center',
                             justifyContent: 'center',
-                            backgroundColor: theme.color.buttonPrimary,
+                            backgroundColor: tint.bg,
                           }}
                         >
                           <Ionicons
                             name={verbIcon(entry.verb)}
                             size={iconSize.lg}
-                            color={theme.color.onBrand}
+                            color={tint.ink}
                           />
                         </View>
-                      }
-                      trailing={(() => {
-                        const money = parseMoney(entry.payload, currency);
-                        return money ? (
+                        <View style={{ flex: 1 }}>
+                          <Text variant="body" numberOfLines={2}>
+                            {describeActivity(
+                              // The group feed rides the mirror, where an activity
+                              // row carries only `actor_member_id` — not the joined
+                              // actor the cross-group feed gets. Resolve the actor
+                              // from this group's members so the row names the
+                              // person instead of "someone".
+                              entry.actor
+                                ? entry
+                                : { ...entry, actor: actorFor(entry.actor_member_id) },
+                              profile?.id ?? null,
+                              blockedIds,
+                              t.misc.someone,
+                            )}
+                          </Text>
+                          <Text variant="caption" tone="muted" numberOfLines={1}>
+                            {relativeTime(locale, entry.created_at)}
+                          </Text>
+                        </View>
+                        {money ? (
                           <MoneyText
                             amount={money.amount}
                             currency={money.currency}
                             locale={locale}
-                            variant="caption"
+                            variant="subheading"
+                            // Same owe colour as the shares, balances and the
+                            // global feed — one money colour across every screen.
+                            tone="negative"
                           />
-                        ) : null;
-                      })()}
-                    />
-                    {index < (activity.data?.length ?? 0) - 1 ? (
-                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                    ) : null}
-                  </View>
-                ))}
+                        ) : null}
+                      </Row>
+                      {!isLast ? (
+                        <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                      ) : null}
+                    </View>
+                  );
+                })}
               </View>
             )
           }

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -150,6 +150,42 @@ export function verbIcon(verb: string): React.ComponentProps<typeof Ionicons>['n
   }
 }
 
+/** The pastel tint keys an activity tile can wear (a subset of the app's tint family). */
+export type ActivityTint = 'mint' | 'coral' | 'sky' | 'lilac';
+
+/**
+ * The soft tile colour for an activity verb, so the feed is skimmable by hue:
+ * mint for money arriving and for confirmations, coral for a delete or a
+ * dispute, sky for something added or someone joining, lilac (the brand-leaning
+ * neutral) for edits, creation and anything a newer build introduces. Shared by
+ * both feeds — the group Activity tab and the cross-group one — so an event
+ * wears the same colour wherever it is shown. The caller maps the key through
+ * `theme.tint[...]`, keeping this free of the UI theme.
+ */
+export function verbTint(verb: string): ActivityTint {
+  switch (verb) {
+    case 'settled':
+    case 'confirmed':
+    case 'auto_confirmed':
+    case 'accepted_dispute':
+    case 'restored':
+    case 'withdrew_dispute':
+      return 'mint';
+    case 'deleted':
+    case 'disputed':
+    case 'rejected_dispute':
+      return 'coral';
+    case 'added':
+    case 'joined':
+      return 'sky';
+    case 'edited':
+    case 'superseded':
+    case 'created':
+    default:
+      return 'lilac';
+  }
+}
+
 /**
  * "19m ago", "yesterday" — a localized relative time for a timeline entry.
  *


### PR DESCRIPTION
> Stacked on #431 (shares `activity.tsx`). Merge #431 first, then this retargets to `main`.

## What
The group Activity tab drew a bold filled disc / boxed rows, and both feeds used a vertical connector "timeline" that read as heavy. Replaced with a Splitwise-style flat list ([reference](https://mobbin.com/screens/fc2ae3b0-231d-4171-9d59-55375d138a5b)):

- A **soft rounded-square tile** whose tint leans with the verb — mint for settle/confirm, coral for delete/dispute, sky for add/join, lilac for edits.
- Sentence + **relative time** beside it, amount on the right, hairline separators. No rail.
- Both feeds now share one design; helpers (`verbTint`, `verbIcon`, `relativeTime`) live in `data/activity.ts`.
- The global feed keeps its **day-section headings** and cross-group label + archived/unavailable badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)