### PR TITLE
feat(receipts): offline receipts, upload progress bar, nav polish

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -9,6 +9,7 @@ import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import {
   ActivityIndicator,
+  I18nManager,
   Platform,
   Text as RNText,
   useWindowDimensions,
@@ -30,6 +31,7 @@ import {
 import { Onboarding } from '@/components/Onboarding';
 import { AnimatedSplash } from '@/components/AnimatedSplash';
 import { AppTabBar } from '@/components/AppTabBar';
+import { TransferProgressBar } from '@/components/TransferProgressBar';
 import { CampaignPopup } from '@/components/CampaignPopup';
 import { NotificationPrompt } from '@/components/NotificationPrompt';
 import { TourOverlay } from '@/components/TourOverlay';
@@ -421,6 +423,16 @@ function AuthGate() {
    */
   const push = 'none' as const;
   const modal = { presentation: 'modal' as const, animation: 'slide_from_bottom' as const };
+  // A normal forward page: a plain horizontal translate (and back out the way it
+  // came) rather than rising like a modal — the "went to a page", not "on top of"
+  // feel. A bare translate is the cheapest native transition on the UI thread, so
+  // it stays smooth where the platform 'default' (which drags an elevation/shadow
+  // across) can stutter in a dev build. The edge follows the writing direction —
+  // from the right in LTR, from the left in RTL (Arabic) — so it never slides the
+  // wrong way.
+  const slide = {
+    animation: I18nManager.isRTL ? ('slide_from_left' as const) : ('slide_from_right' as const),
+  };
 
   // The two auth doors and the invite-accept screen are the only routes a
   // signed-out person is allowed to sit on. `onAuth` covers both doors so a
@@ -568,7 +580,7 @@ function AuthGate() {
           <Stack.Screen name="capture" options={modal} />
           <Stack.Screen name="captures" />
           <Stack.Screen name="group/[id]/index" />
-          <Stack.Screen name="group/[id]/add-expense" options={modal} />
+          <Stack.Screen name="group/[id]/add-expense" options={slide} />
           <Stack.Screen name="group/[id]/settle" options={modal} />
           <Stack.Screen name="group/[id]/simplify" />
           <Stack.Screen name="group/[id]/settings" />
@@ -605,6 +617,10 @@ function AuthGate() {
         {/* One bar over the whole stack, so every screen keeps it — it hides
           itself on the modals and the camera. */}
         <AppTabBar />
+        {/* A slim upload/download progress bar across the very top, over every
+          screen — behind the `upload_progress` flag, so it renders nothing until
+          the flag is on. */}
+        <TransferProgressBar />
       </View>
     </ShortcutGesture>
   );

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1010,6 +1010,7 @@ export default function AddExpenseScreen() {
           showsVerticalScrollIndicator={false}
         >
           <ExpenseHeader
+            leading="back"
             title={editing ? t.expense.edit : t.addExpense}
             subtitle={groupLabel(group.data, members.data ?? [], profile?.id)}
             right={

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -627,7 +627,7 @@ export default function AddExpenseScreen() {
     return (
       <Screen edges={['top', 'bottom']}>
         <View style={{ paddingHorizontal: theme.spacing.xl }}>
-          <ExpenseHeader title={editing ? t.expense.edit : t.addExpense} />
+          <ExpenseHeader leading="back" title={editing ? t.expense.edit : t.addExpense} />
           <View style={{ paddingTop: theme.spacing.xxxl, alignItems: 'center' }}>
             <ActivityIndicator color={theme.color.brand} />
           </View>

--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -13,7 +13,7 @@
  * orphaned; new images are all attachment rows.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
@@ -40,14 +40,27 @@ import {
 import { captureReceipt, pickReceiptImage } from '@/lib/image';
 import { EMPTY_ANNOTATIONS, isEmptyAnnotations, type Annotations } from '@/lib/annotations';
 import { imageUrl, restrictedImageUrl } from '@/lib/storage';
+import { cacheImage, cachedImageUri, evictImage } from '@/lib/storage/imageCache';
+import {
+  discardPendingReceipt,
+  enqueueReceipt,
+  flushReceiptQueue,
+  isOnline,
+  listPendingReceipts,
+  pendingReceiptUri,
+  type PendingReceipt,
+} from '@/lib/receiptQueue';
+import { SyncStatus, useSync } from '@/sync';
 import { fill, useStrings } from '@/i18n';
 
 const THUMB = 96;
 
-/** One gallery entry: the legacy kept bill, or an attachment row. */
+/** One gallery entry: the legacy kept bill, an uploaded attachment, or a capture
+ *  that was taken offline and is still waiting to upload. */
 type GalleryItem =
   | { kind: 'legacy'; key: string; path: string; visibility: 'group' }
-  | { kind: 'attachment'; key: string; row: ExpenseAttachmentRow };
+  | { kind: 'attachment'; key: string; row: ExpenseAttachmentRow }
+  | { kind: 'pending'; key: string; entry: PendingReceipt };
 
 /**
  * Resolve every item to a displayable URL, each through its own backend (the
@@ -67,12 +80,39 @@ function useResolvedUrls(
     void (async () => {
       for (const it of items) {
         if (urls[it.key] !== undefined) continue;
+
+        // A still-unsent capture is already a local file — show it straight from
+        // there, no network and no cache round-trip.
+        if (it.kind === 'pending') {
+          if (!active) return;
+          setUrls((prev) => ({ ...prev, [it.key]: pendingReceiptUri(it.entry) }));
+          continue;
+        }
+
+        const bucket = it.kind === 'legacy' ? 'receipts' : 'expense-attachments';
+        const path = it.kind === 'legacy' ? it.path : it.row.storagePath;
+
+        // A bill seen before is on disk under its stable path — show it straight
+        // away, so an already-opened receipt renders with no network (ADR-005).
+        const cached = cachedImageUri(bucket, path);
+        if (cached) {
+          if (!active) return;
+          setUrls((prev) => ({ ...prev, [it.key]: cached }));
+          continue;
+        }
+
+        // Not cached: resolve the short-lived signed URL. Offline this is null
+        // and the tile stays a blank placeholder, exactly as before.
         const url =
           it.kind === 'legacy'
-            ? await imageUrl('receipts', it.path)
-            : await restrictedImageUrl('expense-attachments', expenseId, it.row.storagePath);
+            ? await imageUrl('receipts', path)
+            : await restrictedImageUrl('expense-attachments', expenseId, path);
         if (!active) return;
         setUrls((prev) => ({ ...prev, [it.key]: url }));
+        // Show it now over the network, and quietly save the bytes so the next
+        // view — including offline — reads the local copy. Fire-and-forget: a
+        // failed cache write never blocks or breaks the on-screen image.
+        if (url) void cacheImage(bucket, path, url);
       }
     })();
     return () => {
@@ -89,12 +129,15 @@ function Thumb({
   url,
   resolved,
   isPrivate,
+  pending,
   onPress,
   label,
 }: {
   url: string | null;
   resolved: boolean;
   isPrivate: boolean;
+  /** A capture not yet uploaded — wears an upload glyph so the wait is visible. */
+  pending?: boolean;
   onPress: () => void;
   label: string;
 }): React.JSX.Element {
@@ -137,6 +180,21 @@ function Thumb({
           <Ionicons name="lock-closed" size={12} color={theme.color.text} />
         </View>
       ) : null}
+      {pending ? (
+        // A soft scrim plus a cloud-upload glyph, so an unsent capture reads as
+        // "saved, waiting to send" rather than a finished receipt.
+        <View
+          style={{
+            position: 'absolute',
+            inset: 0,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'rgba(10, 10, 26, 0.35)',
+          }}
+        >
+          <Ionicons name="cloud-upload-outline" size={iconSize.lg} color="#FFFFFF" />
+        </View>
+      ) : null}
     </Pressable>
   );
 }
@@ -175,6 +233,21 @@ export function ExpenseReceipts({
   const annotate = useAnnotateExpenseAttachment();
   const replace = useReplaceExpenseAttachmentImage(groupId, expenseId);
   const queryClient = useQueryClient();
+  const { status, flush } = useSync();
+
+  // Captures taken while offline (or when an upload could not reach R2), held on
+  // the device until they can be sent. They show in the gallery straight away
+  // from their local file, and a flush uploads them the moment there is network.
+  const [pending, setPending] = useState<PendingReceipt[]>([]);
+  const refreshPending = useCallback(async () => {
+    setPending(await listPendingReceipts(expenseId));
+  }, [expenseId]);
+  useEffect(() => {
+    // An async load from AsyncStorage — the setState lands after an await, not
+    // synchronously, so the cascading-render rule does not apply here.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refreshPending();
+  }, [refreshPending]);
 
   // The per-expense receipt ceiling (A46): a free group keeps a small number of
   // gallery images per expense; paid lifts it. This is the affordance — the
@@ -189,6 +262,28 @@ export function ExpenseReceipts({
   const refreshCap = () =>
     void queryClient.invalidateQueries({ queryKey: ['attachmentCap', expenseId] });
 
+  // Try to send any parked captures when there is a usable network — on mount
+  // and whenever the connection comes back. A success pulls the freshly-recorded
+  // rows into the mirror (so the optimistic tile becomes the real attachment) and
+  // re-asks the cap; a permanent refusal (cap reached, not a party) just clears
+  // the stuck entry. All best-effort — a flush never throws into the screen.
+  useEffect(() => {
+    if (status === SyncStatus.Offline || status === SyncStatus.Metered) return;
+    void (async () => {
+      const result = await flushReceiptQueue();
+      if (result.uploadedExpenseIds.length > 0) {
+        await refreshPending();
+        await flush();
+        refreshCap();
+      } else if (result.hadPermanentFailure) {
+        await refreshPending();
+        refreshCap();
+      }
+    })();
+    // Re-run when the connection state flips; refreshers are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
+
   const items = useMemo<GalleryItem[]>(() => {
     const list: GalleryItem[] = [];
     if (legacyReceiptPath) {
@@ -197,8 +292,17 @@ export function ExpenseReceipts({
     for (const row of attachments.data) {
       list.push({ kind: 'attachment', key: row.id, row });
     }
+    // Show a parked capture only until its real row lands — once the upload has
+    // been pulled into the mirror, the entry shares that row's id, so drop it
+    // here to avoid a duplicate tile for the same receipt.
+    const uploaded = new Set(attachments.data.map((row) => row.id));
+    for (const entry of pending) {
+      if (!uploaded.has(entry.attachmentId)) {
+        list.push({ kind: 'pending', key: `pending-${entry.attachmentId}`, entry });
+      }
+    }
     return list;
-  }, [legacyReceiptPath, attachments.data]);
+  }, [legacyReceiptPath, attachments.data, pending]);
 
   const urls = useResolvedUrls(expenseId, items);
   const [viewerIndex, setViewerIndex] = useState<number | null>(null);
@@ -227,7 +331,8 @@ export function ExpenseReceipts({
   if (items.length === 0 && !canManage) return null;
 
   const isPrivate = (it: GalleryItem) =>
-    it.kind === 'attachment' && it.row.visibility === 'parties';
+    (it.kind === 'attachment' && it.row.visibility === 'parties') ||
+    (it.kind === 'pending' && it.entry.visibility === 'parties');
 
   // The free per-expense limit is reached (and the group is not paid): point the
   // person at the upgrade rather than open the add sheet. Reuses the scan cap's
@@ -252,25 +357,47 @@ export function ExpenseReceipts({
     }
   };
 
+  // Add at a chosen visibility. Online it uploads now; offline (or if the upload
+  // cannot reach R2) the capture is parked on the device and shown at once, to
+  // be sent automatically on reconnect — the receipt equivalent of ADR-005's
+  // offline writes.
+  const commitAdd = (
+    picked: NonNullable<Awaited<ReturnType<typeof captureReceipt>>>,
+    visibility: 'group' | 'parties',
+  ) => {
+    const contentType = picked.mimeType ?? 'image/jpeg';
+    const park = async () => {
+      await enqueueReceipt({ expenseId, groupId, visibility, base64: picked.base64, contentType });
+      await refreshPending();
+    };
+    void (async () => {
+      if (!(await isOnline())) {
+        await park();
+        return;
+      }
+      attach.mutate(
+        { picked, visibility },
+        {
+          onSuccess: refreshCap,
+          onError: (error) =>
+            void (async () => {
+              // The connection dropped mid-upload → park it rather than fail.
+              if (!(await isOnline())) {
+                await park();
+                return;
+              }
+              onAddError(error);
+            })(),
+        },
+      );
+    })();
+  };
+
   const add = (picked: Awaited<ReturnType<typeof captureReceipt>>) => {
     if (!picked) return; // Cancelled/declined.
     Alert.alert(t.receipts.chooseVisibility, undefined, [
-      {
-        text: t.receipts.everyone,
-        onPress: () =>
-          attach.mutate(
-            { picked, visibility: 'group' },
-            { onError: onAddError, onSuccess: refreshCap },
-          ),
-      },
-      {
-        text: t.receipts.payersOnly,
-        onPress: () =>
-          attach.mutate(
-            { picked, visibility: 'parties' },
-            { onError: onAddError, onSuccess: refreshCap },
-          ),
-      },
+      { text: t.receipts.everyone, onPress: () => commitAdd(picked, 'group') },
+      { text: t.receipts.payersOnly, onPress: () => commitAdd(picked, 'parties') },
       { text: t.common.cancel, style: 'cancel' },
     ]);
   };
@@ -300,15 +427,31 @@ export function ExpenseReceipts({
         onPress: () => {
           setViewerIndex(null);
           const onError = () => Alert.alert(t.imageAudit.couldNotRemove);
-          if (it.kind === 'legacy') {
+          if (it.kind === 'pending') {
+            // Not uploaded yet: just drop the parked capture and its local bytes.
+            void discardPendingReceipt(it.entry.attachmentId).then(refreshPending);
+          } else if (it.kind === 'legacy') {
             // Only clear the parent's receipt state on a confirmed delete — if the
             // byte removal throws, the bill is still there and must keep showing.
-            removeLegacy.mutate(undefined, { onSuccess: () => onLegacyRemoved?.(), onError });
+            removeLegacy.mutate(undefined, {
+              onSuccess: () => {
+                evictImage('receipts', it.path);
+                onLegacyRemoved?.();
+              },
+              onError,
+            });
           } else {
+            const storagePath = it.row.storagePath;
             removeAttachment.mutate(
-              { attachmentId: it.row.id, storagePath: it.row.storagePath },
+              { attachmentId: it.row.id, storagePath },
               // Removing a live attachment frees a slot, so re-ask the cap gate.
-              { onError, onSuccess: refreshCap },
+              {
+                onError,
+                onSuccess: () => {
+                  evictImage('expense-attachments', storagePath);
+                  refreshCap();
+                },
+              },
             );
           }
         },
@@ -407,6 +550,7 @@ export function ExpenseReceipts({
               url={urls[index] ?? null}
               resolved={urls[index] !== undefined}
               isPrivate={isPrivate(it)}
+              pending={it.kind === 'pending'}
               label={
                 isPrivate(it) ? `${t.receipts.title} — ${t.receipts.privateTag}` : t.receipts.title
               }
@@ -560,7 +704,12 @@ export function ExpenseReceipts({
                 picked,
               },
               {
-                onSuccess: () => setAdjusting(null),
+                onSuccess: () => {
+                  // The row now points at fresh bytes under a new path; drop the
+                  // old cached copy so a later view fetches the replacement.
+                  evictImage('expense-attachments', adjusting.oldStoragePath);
+                  setAdjusting(null);
+                },
                 onError: () => Alert.alert(t.adjust.couldNotSave),
               },
             )

--- a/apps/mobile/src/components/TransferProgressBar.tsx
+++ b/apps/mobile/src/components/TransferProgressBar.tsx
@@ -1,0 +1,92 @@
+/**
+ * A slim progress bar across the top of the app while transfers run — the
+ * browser's page-load / download bar, for receipt uploads (and any future
+ * transfer that reports through {@link useTransferProgress}).
+ *
+ * It is behind the `upload_progress` feature flag, so it can be turned on or off
+ * from the console without a ship. Off (or outside the rollout) it renders
+ * nothing; the transfer store still ticks, it just goes unseen.
+ *
+ * Visual-only, no text, and `pointerEvents="none"` so it never intercepts a tap.
+ * It fills toward the current fraction, nudges off zero so the first upload does
+ * not look stuck, then runs to full and fades out when the batch finishes.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Animated, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useTheme } from '@waves/ui';
+
+import { useFlagEnabled } from '@/lib/flags';
+import { useTransferProgress } from '@/lib/transferProgress';
+
+const BAR_HEIGHT = 3;
+
+export function TransferProgressBar(): React.JSX.Element | null {
+  const enabled = useFlagEnabled('upload_progress');
+  const { active, fraction } = useTransferProgress();
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+
+  // Stable Animated values via useState (not useRef) so reading them in render
+  // is not a ref access — the pattern the rest of the app's animations use.
+  const progress = useState(() => new Animated.Value(0))[0];
+  const opacity = useState(() => new Animated.Value(0))[0];
+  // Whether the bar was in an active run, so its end can be animated (fill to
+  // full, then fade) rather than snapping away the instant work finishes.
+  const wasActive = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (active) {
+      wasActive.current = true;
+      Animated.parallel([
+        Animated.timing(opacity, { toValue: 1, duration: 150, useNativeDriver: true }),
+        Animated.timing(progress, {
+          // Never sit at a dead zero while the first file is in flight — a small
+          // floor keeps the bar visibly moving before any step has completed.
+          toValue: Math.max(fraction, 0.08),
+          duration: 300,
+          useNativeDriver: false,
+        }),
+      ]).start();
+    } else if (wasActive.current) {
+      wasActive.current = false;
+      Animated.sequence([
+        Animated.timing(progress, { toValue: 1, duration: 150, useNativeDriver: false }),
+        Animated.timing(opacity, { toValue: 0, duration: 250, useNativeDriver: true }),
+      ]).start(({ finished }) => {
+        if (finished) progress.setValue(0);
+      });
+    }
+  }, [enabled, active, fraction, progress, opacity]);
+
+  if (!enabled) return null;
+
+  return (
+    <View
+      pointerEvents="none"
+      style={{
+        position: 'absolute',
+        top: insets.top,
+        left: 0,
+        right: 0,
+        height: BAR_HEIGHT,
+        zIndex: 1000,
+      }}
+    >
+      <Animated.View
+        style={{
+          height: BAR_HEIGHT,
+          opacity,
+          backgroundColor: theme.color.brand,
+          width: progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: ['0%', '100%'],
+          }),
+        }}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/components/expense/ExpenseHeader.tsx
+++ b/apps/mobile/src/components/expense/ExpenseHeader.tsx
@@ -15,7 +15,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { View } from 'react-native';
 
-import { IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { directionalIcon, IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -23,18 +23,32 @@ export function ExpenseHeader({
   title,
   subtitle,
   right,
+  leading = 'close',
 }: {
   title: string;
   subtitle?: string;
   /** A trailing action; a 44pt spacer keeps the title centred when omitted. */
   right?: ReactNode;
+  /**
+   * The leading affordance. A modal (capture) dismisses with an X; a pushed
+   * page (add-expense) goes back with a direction-aware chevron, so the glyph
+   * matches how the screen was opened.
+   */
+  leading?: 'close' | 'back';
 }): React.JSX.Element {
   const theme = useTheme();
   const { t } = useStrings();
   return (
     <Row style={{ paddingTop: theme.spacing.md }}>
-      <IconButton label={t.common.close} onPress={() => router.back()}>
-        <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+      <IconButton
+        label={leading === 'back' ? t.common.back : t.common.close}
+        onPress={() => router.back()}
+      >
+        <Ionicons
+          name={leading === 'back' ? directionalIcon('chevron-back') : 'close'}
+          size={iconSize.lg}
+          color={theme.color.text}
+        />
       </IconButton>
       <View style={{ flex: 1, alignItems: 'center' }}>
         <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -1,0 +1,258 @@
+/**
+ * The offline half of adding a receipt (ADR-005 for images).
+ *
+ * Attaching a receipt online is upload → RPC → done. Offline, both steps need
+ * the network, so instead of failing this parks the capture: the bytes are
+ * written to a durable file, a queue entry is recorded, and the gallery shows
+ * the image straight away from that local file. When the device is back online
+ * a flush walks the queue — uploading each capture to R2 and recording the
+ * attachment row exactly as the online path would, then seeding the view cache
+ * so the receipt keeps showing with no network and dropping the queue entry.
+ *
+ * The queue index lives in AsyncStorage (small, structured); the image bytes
+ * live under the OS *document* directory — not the cache — because a pending
+ * upload is unsent data the OS must not reclaim, unlike the view cache which it
+ * may. A flushed capture's bytes move into the view cache and out of here.
+ *
+ * The entry's `attachmentId` is the eventual row id, chosen up front, so the
+ * optimistic gallery item and the real row that arrives after the flush share
+ * one identity — the gallery de-dupes on it, and a retry never doubles a row.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { decode } from 'base64-arraybuffer';
+import { randomUUID } from 'expo-crypto';
+import { Directory, File, Paths } from 'expo-file-system';
+import * as Network from 'expo-network';
+
+import { backend } from '@/lib/backend';
+import { putImage } from '@/lib/storage';
+import { cacheImageBytes } from '@/lib/storage/imageCache';
+import { endTransfer, setTransferProgress, startTransfer } from '@/lib/transferProgress';
+
+/** The transfer id the receipt-upload flush reports under (one bar for the batch). */
+const FLUSH_TRANSFER_ID = 'receipt-upload';
+
+/** AsyncStorage key for the queue index. Versioned so a shape change can migrate. */
+const QUEUE_KEY = 'receipt-upload-queue.v1';
+
+/** Durable subdirectory (under the document dir) holding unsent capture bytes. */
+const PENDING_DIR = 'pending-receipts';
+
+/** A capture waiting to be uploaded. */
+export interface PendingReceipt {
+  /** The eventual attachment row id — the optimistic item and the real row share it. */
+  attachmentId: string;
+  expenseId: string;
+  groupId: string;
+  visibility: 'group' | 'parties';
+  /** The R2 object key, chosen up front so upload and RPC agree. */
+  storagePath: string;
+  contentType: string;
+  /** Basename of the bytes file under {@link PENDING_DIR} (dir resolved at read time). */
+  fileName: string;
+  createdAt: string;
+  attempts: number;
+  lastError: string | null;
+}
+
+/** The extension for a stored image, matching the online attach path. */
+function extensionFor(contentType: string): string {
+  return contentType === 'image/webp' ? 'webp' : 'jpg';
+}
+
+async function readQueue(): Promise<PendingReceipt[]> {
+  try {
+    const raw = await AsyncStorage.getItem(QUEUE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as PendingReceipt[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeQueue(queue: readonly PendingReceipt[]): Promise<void> {
+  await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+}
+
+/** The durable file holding one pending capture's bytes. */
+function pendingFile(entry: Pick<PendingReceipt, 'fileName'>): File {
+  return new File(Paths.document, PENDING_DIR, entry.fileName);
+}
+
+/** The `file://` a gallery renders for a still-unsent capture. */
+export function pendingReceiptUri(entry: PendingReceipt): string {
+  return pendingFile(entry).uri;
+}
+
+/** Is there a usable network right now? Fail-open, matching the sync engine. */
+export async function isOnline(): Promise<boolean> {
+  try {
+    const state = await Network.getNetworkStateAsync();
+    return state.isInternetReachable ?? state.isConnected ?? true;
+  } catch {
+    return true;
+  }
+}
+
+/** Every pending capture, or those for one expense, oldest first. */
+export async function listPendingReceipts(expenseId?: string): Promise<PendingReceipt[]> {
+  const queue = await readQueue();
+  return expenseId ? queue.filter((entry) => entry.expenseId === expenseId) : queue;
+}
+
+/**
+ * Park a picked image for later upload: write its bytes to a durable file and
+ * record the queue entry. Returns the entry so the caller can show it at once.
+ */
+export async function enqueueReceipt(input: {
+  expenseId: string;
+  groupId: string;
+  visibility: 'group' | 'parties';
+  base64: string;
+  contentType: string;
+}): Promise<PendingReceipt> {
+  const attachmentId = randomUUID();
+  const ext = extensionFor(input.contentType);
+  const entry: PendingReceipt = {
+    attachmentId,
+    expenseId: input.expenseId,
+    groupId: input.groupId,
+    visibility: input.visibility,
+    storagePath: `${input.expenseId}/${randomUUID()}.${ext}`,
+    contentType: input.contentType,
+    fileName: `${attachmentId}.${ext}`,
+    createdAt: new Date().toISOString(),
+    attempts: 0,
+    lastError: null,
+  };
+
+  const dir = new Directory(Paths.document, PENDING_DIR);
+  if (!dir.exists) dir.create({ intermediates: true });
+  pendingFile(entry).write(new Uint8Array(decode(input.base64)));
+
+  const queue = await readQueue();
+  await writeQueue([...queue, entry]);
+  return entry;
+}
+
+/** Drop a pending capture the user chose not to keep, deleting its bytes too. */
+export async function discardPendingReceipt(attachmentId: string): Promise<void> {
+  const queue = await readQueue();
+  const entry = queue.find((item) => item.attachmentId === attachmentId);
+  if (entry) {
+    try {
+      const file = pendingFile(entry);
+      if (file.exists) file.delete();
+    } catch {
+      // Already gone — nothing to clean up.
+    }
+  }
+  await writeQueue(queue.filter((item) => item.attachmentId !== attachmentId));
+}
+
+/** A server error that will never succeed on retry — the capture must not loop forever. */
+function isPermanent(message: string): boolean {
+  return (
+    message.includes('ATTACHMENT_CAP') ||
+    message.includes('NOT_A_PARTY') ||
+    message.includes('not authorized') ||
+    message.includes('permission')
+  );
+}
+
+/** The outcome of a flush, for the caller to refresh the right queries. */
+export interface FlushResult {
+  /** Expense ids that gained at least one uploaded attachment. */
+  uploadedExpenseIds: string[];
+  /** True when a capture was refused for good (cap reached / not a party). */
+  hadPermanentFailure: boolean;
+}
+
+/**
+ * Upload every pending capture that can be sent now. Best-effort and safe to
+ * call often (screen mount, reconnect): it no-ops when the queue is empty or the
+ * device is offline, and each entry is handled in isolation so one stuck capture
+ * never blocks the rest.
+ *
+ * On success the bytes move into the view cache (so the receipt stays offline-
+ * readable) and the entry and its file are dropped. A transient failure leaves
+ * the entry to retry; a permanent one (cap, not a party) is dropped with its
+ * reason surfaced, so it does not loop forever.
+ */
+export async function flushReceiptQueue(): Promise<FlushResult> {
+  const queue = await readQueue();
+  if (queue.length === 0) return { uploadedExpenseIds: [], hadPermanentFailure: false };
+  if (!(await isOnline())) return { uploadedExpenseIds: [], hadPermanentFailure: false };
+
+  const remaining: PendingReceipt[] = [];
+  const uploaded = new Set<string>();
+  let hadPermanentFailure = false;
+
+  // Drive the in-app progress bar for the batch: one step per capture, marked
+  // done as each is handled (uploaded, dropped, or failed). The bar is behind a
+  // feature flag, but reporting is cheap and always on — the flag only decides
+  // whether anything is drawn.
+  startTransfer(FLUSH_TRANSFER_ID, queue.length);
+  let handled = 0;
+
+  for (const entry of queue) {
+    const file = pendingFile(entry);
+    if (!file.exists) {
+      // The bytes are gone (a wipe, a failed write) — nothing to send; drop it.
+      handled += 1;
+      setTransferProgress(FLUSH_TRANSFER_ID, handled);
+      continue;
+    }
+
+    try {
+      const base64 = await file.base64();
+      await putImage({
+        bucket: 'expense-attachments',
+        path: entry.storagePath,
+        base64,
+        contentType: entry.contentType,
+        groupId: entry.groupId,
+        subjectId: entry.expenseId,
+      });
+      const { error } = await backend.rpc('baaki_attach_expense_attachment', {
+        p_expense_id: entry.expenseId,
+        p_storage_path: entry.storagePath,
+        p_visibility: entry.visibility,
+        p_attachment_id: entry.attachmentId,
+      });
+      if (error) throw new Error(error.message);
+
+      // Uploaded and recorded. Keep it viewable offline by moving the bytes into
+      // the view cache, then delete the pending file.
+      cacheImageBytes('expense-attachments', entry.storagePath, new Uint8Array(decode(base64)));
+      try {
+        file.delete();
+      } catch {
+        // Best-effort; a lingering file is reclaimed with the app's document dir.
+      }
+      uploaded.add(entry.expenseId);
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : String(caught);
+      if (isPermanent(message)) {
+        hadPermanentFailure = true;
+        try {
+          file.delete();
+        } catch {
+          /* ignore */
+        }
+        continue; // Drop — a retry would only fail the same way.
+      }
+      // Transient (offline mid-flush, a 5xx): keep it to try again later.
+      remaining.push({ ...entry, attempts: entry.attempts + 1, lastError: message });
+    } finally {
+      handled += 1;
+      setTransferProgress(FLUSH_TRANSFER_ID, handled);
+    }
+  }
+
+  endTransfer(FLUSH_TRANSFER_ID);
+  await writeQueue(remaining);
+  return { uploadedExpenseIds: [...uploaded], hadPermanentFailure };
+}

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -181,7 +181,21 @@ export interface FlushResult {
  * the entry to retry; a permanent one (cap, not a party) is dropped with its
  * reason surfaced, so it does not loop forever.
  */
-export async function flushReceiptQueue(): Promise<FlushResult> {
+let inFlight: Promise<FlushResult> | null = null;
+
+export function flushReceiptQueue(): Promise<FlushResult> {
+  // Single-flight: two concurrent flushes would upload the same entries twice,
+  // share one FLUSH_TRANSFER_ID (the first endTransfer clearing the bar mid-way
+  // through the second), and race their write-backs. Callers reconnect and mount
+  // independently, so overlap is real — coalesce them onto one run.
+  if (inFlight) return inFlight;
+  inFlight = runFlush().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+async function runFlush(): Promise<FlushResult> {
   const queue = await readQueue();
   if (queue.length === 0) return { uploadedExpenseIds: [], hadPermanentFailure: false };
   if (!(await isOnline())) return { uploadedExpenseIds: [], hadPermanentFailure: false };
@@ -197,62 +211,75 @@ export async function flushReceiptQueue(): Promise<FlushResult> {
   startTransfer(FLUSH_TRANSFER_ID, queue.length);
   let handled = 0;
 
-  for (const entry of queue) {
-    const file = pendingFile(entry);
-    if (!file.exists) {
-      // The bytes are gone (a wipe, a failed write) — nothing to send; drop it.
-      handled += 1;
-      setTransferProgress(FLUSH_TRANSFER_ID, handled);
-      continue;
-    }
-
-    try {
-      const base64 = await file.base64();
-      await putImage({
-        bucket: 'expense-attachments',
-        path: entry.storagePath,
-        base64,
-        contentType: entry.contentType,
-        groupId: entry.groupId,
-        subjectId: entry.expenseId,
-      });
-      const { error } = await backend.rpc('baaki_attach_expense_attachment', {
-        p_expense_id: entry.expenseId,
-        p_storage_path: entry.storagePath,
-        p_visibility: entry.visibility,
-        p_attachment_id: entry.attachmentId,
-      });
-      if (error) throw new Error(error.message);
-
-      // Uploaded and recorded. Keep it viewable offline by moving the bytes into
-      // the view cache, then delete the pending file.
-      cacheImageBytes('expense-attachments', entry.storagePath, new Uint8Array(decode(base64)));
-      try {
-        file.delete();
-      } catch {
-        // Best-effort; a lingering file is reclaimed with the app's document dir.
+  // The loop sits in try/finally so a throw from pendingFile/file.exists (which
+  // run outside the per-entry try) still ends the transfer — otherwise the bar
+  // sticks on screen at done < total until some later flush completes.
+  try {
+    for (const entry of queue) {
+      const file = pendingFile(entry);
+      if (!file.exists) {
+        // The bytes are gone (a wipe, a failed write) — nothing to send; drop it.
+        handled += 1;
+        setTransferProgress(FLUSH_TRANSFER_ID, handled);
+        continue;
       }
-      uploaded.add(entry.expenseId);
-    } catch (caught) {
-      const message = caught instanceof Error ? caught.message : String(caught);
-      if (isPermanent(message)) {
-        hadPermanentFailure = true;
+
+      try {
+        const base64 = await file.base64();
+        await putImage({
+          bucket: 'expense-attachments',
+          path: entry.storagePath,
+          base64,
+          contentType: entry.contentType,
+          groupId: entry.groupId,
+          subjectId: entry.expenseId,
+        });
+        const { error } = await backend.rpc('baaki_attach_expense_attachment', {
+          p_expense_id: entry.expenseId,
+          p_storage_path: entry.storagePath,
+          p_visibility: entry.visibility,
+          p_attachment_id: entry.attachmentId,
+        });
+        if (error) throw new Error(error.message);
+
+        // Uploaded and recorded. Keep it viewable offline by moving the bytes into
+        // the view cache, then delete the pending file.
+        cacheImageBytes('expense-attachments', entry.storagePath, new Uint8Array(decode(base64)));
         try {
           file.delete();
         } catch {
-          /* ignore */
+          // Best-effort; a lingering file is reclaimed with the app's document dir.
         }
-        continue; // Drop — a retry would only fail the same way.
+        uploaded.add(entry.expenseId);
+      } catch (caught) {
+        const message = caught instanceof Error ? caught.message : String(caught);
+        if (isPermanent(message)) {
+          hadPermanentFailure = true;
+          try {
+            file.delete();
+          } catch {
+            /* ignore */
+          }
+          continue; // Drop — a retry would only fail the same way.
+        }
+        // Transient (offline mid-flush, a 5xx): keep it to try again later.
+        remaining.push({ ...entry, attempts: entry.attempts + 1, lastError: message });
+      } finally {
+        handled += 1;
+        setTransferProgress(FLUSH_TRANSFER_ID, handled);
       }
-      // Transient (offline mid-flush, a 5xx): keep it to try again later.
-      remaining.push({ ...entry, attempts: entry.attempts + 1, lastError: message });
-    } finally {
-      handled += 1;
-      setTransferProgress(FLUSH_TRANSFER_ID, handled);
     }
+  } finally {
+    endTransfer(FLUSH_TRANSFER_ID);
   }
 
-  endTransfer(FLUSH_TRANSFER_ID);
-  await writeQueue(remaining);
+  // Re-read before writing back: enqueueReceipt may have appended during the
+  // uploads above, and writing `remaining` alone would silently drop it (its
+  // bytes then orphaned under PENDING_DIR). Keep only the entries this run
+  // handled out of the write, and carry any that arrived meanwhile.
+  const handledIds = new Set(queue.map((entry) => entry.attachmentId));
+  const current = await readQueue();
+  const arrivedDuringFlush = current.filter((entry) => !handledIds.has(entry.attachmentId));
+  await writeQueue([...remaining, ...arrivedDuringFlush]);
   return { uploadedExpenseIds: [...uploaded], hadPermanentFailure };
 }

--- a/apps/mobile/src/lib/storage/imageCache.ts
+++ b/apps/mobile/src/lib/storage/imageCache.ts
@@ -15,6 +15,7 @@
  * receipt view.
  */
 
+import { randomUUID } from 'expo-crypto';
 import { fetch as expoFetch } from 'expo/fetch';
 import { Directory, File, Paths } from 'expo-file-system';
 
@@ -22,6 +23,30 @@ import type { LogicalBucket } from './index';
 
 /** Subdirectory under the OS cache dir that holds every cached receipt image. */
 const CACHE_DIR = 'receipt-image-cache';
+
+/**
+ * Write bytes to the cache atomically: to a unique temp sibling first, then move
+ * it onto the final path. A direct `file.write` can leave a truncated file if
+ * the process is killed mid-write, and `cachedImageUri` accepts any existing
+ * file — so a later read would hand back half an image. The move is the last,
+ * near-atomic step, so a reader only ever sees the whole file or none. The temp
+ * name is random so two writers to the same key never collide.
+ */
+function writeAtomic(dir: Directory, file: File, bytes: Uint8Array): void {
+  if (!dir.exists) dir.create({ intermediates: true });
+  const temp = new File(dir, `.${randomUUID()}.tmp`);
+  try {
+    temp.write(bytes);
+    temp.moveSync(file, { overwrite: true });
+  } catch (err) {
+    try {
+      if (temp.exists) temp.delete();
+    } catch {
+      // Best-effort cleanup; a stray temp is reclaimed with the cache dir.
+    }
+    throw err;
+  }
+}
 
 /**
  * A deterministic, filesystem-safe filename for a stored object. The bucket and
@@ -65,13 +90,10 @@ export async function cacheImage(
     const file = fileFor(bucket, path);
     if (file.exists) return file.uri;
 
-    const dir = new Directory(Paths.cache, CACHE_DIR);
-    if (!dir.exists) dir.create({ intermediates: true });
-
     const response = await expoFetch(remoteUrl);
     if (!response.ok) return null;
     const bytes = await response.bytes();
-    file.write(bytes);
+    writeAtomic(new Directory(Paths.cache, CACHE_DIR), file, bytes);
     return file.uri;
   } catch {
     return null;
@@ -91,9 +113,7 @@ export function cacheImageBytes(
 ): string | null {
   try {
     const file = fileFor(bucket, path);
-    const dir = new Directory(Paths.cache, CACHE_DIR);
-    if (!dir.exists) dir.create({ intermediates: true });
-    file.write(bytes);
+    writeAtomic(new Directory(Paths.cache, CACHE_DIR), file, bytes);
     return file.uri;
   } catch {
     return null;

--- a/apps/mobile/src/lib/storage/imageCache.ts
+++ b/apps/mobile/src/lib/storage/imageCache.ts
@@ -1,0 +1,115 @@
+/**
+ * An on-device cache for receipt images, so a bill you have opened once stays
+ * readable with no network — the offline half of ADR-005 applied to images.
+ *
+ * The problem it solves: receipt bytes live behind short-lived signed URLs
+ * (`r2-sign`), and the signature rotates every time, so expo-image's own
+ * URL-keyed disk cache never gets a hit — and offline the URL cannot even be
+ * minted. This keeps the bytes under a stable key (the object's storage path),
+ * so the same image resolves to a local `file://` that works on a plane.
+ *
+ * It lives in `Paths.cache`, which the OS may reclaim under storage pressure —
+ * correct for a cache: a purge only means the next online view re-downloads it,
+ * never lost data. Every call is best-effort and swallows its own errors: a
+ * cache miss or a write failure must degrade to the online path, never throw a
+ * receipt view.
+ */
+
+import { fetch as expoFetch } from 'expo/fetch';
+import { Directory, File, Paths } from 'expo-file-system';
+
+import type { LogicalBucket } from './index';
+
+/** Subdirectory under the OS cache dir that holds every cached receipt image. */
+const CACHE_DIR = 'receipt-image-cache';
+
+/**
+ * A deterministic, filesystem-safe filename for a stored object. The bucket and
+ * path together are unique, and every character a path can carry (slashes, the
+ * uuid dots) is flattened to `_` so it is one flat filename rather than a nested
+ * tree — the lookup only needs identity, not the original shape.
+ */
+function fileFor(bucket: LogicalBucket, path: string): File {
+  const name = `${bucket}__${path}`.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return new File(Paths.cache, CACHE_DIR, name);
+}
+
+/**
+ * The local `file://` for a cached object, or null when it is not on disk. Sync
+ * and cheap (a stat), so a resolver can check it first on every render before
+ * reaching for the network.
+ */
+export function cachedImageUri(bucket: LogicalBucket, path: string | null): string | null {
+  if (!path) return null;
+  try {
+    const file = fileFor(bucket, path);
+    return file.exists ? file.uri : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Download an already-resolved remote URL into the cache under its stable key,
+ * so the next view — online or off — reads the local copy. Returns the local
+ * `file://` on success, or null on any failure (the caller then keeps showing
+ * the remote URL). A no-op when the bytes are already cached.
+ */
+export async function cacheImage(
+  bucket: LogicalBucket,
+  path: string | null,
+  remoteUrl: string,
+): Promise<string | null> {
+  if (!path) return null;
+  try {
+    const file = fileFor(bucket, path);
+    if (file.exists) return file.uri;
+
+    const dir = new Directory(Paths.cache, CACHE_DIR);
+    if (!dir.exists) dir.create({ intermediates: true });
+
+    const response = await expoFetch(remoteUrl);
+    if (!response.ok) return null;
+    const bytes = await response.bytes();
+    file.write(bytes);
+    return file.uri;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Seed the cache directly from bytes already on the device — used the moment a
+ * queued offline capture finishes uploading, so the receipt stays viewable with
+ * no network without a needless round-trip to re-download what we just sent.
+ * Best-effort; returns the local `file://` or null.
+ */
+export function cacheImageBytes(
+  bucket: LogicalBucket,
+  path: string,
+  bytes: Uint8Array,
+): string | null {
+  try {
+    const file = fileFor(bucket, path);
+    const dir = new Directory(Paths.cache, CACHE_DIR);
+    if (!dir.exists) dir.create({ intermediates: true });
+    file.write(bytes);
+    return file.uri;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Drop a cached object — called when its source is removed or replaced, so a
+ * stale copy cannot outlive the real one. Best-effort.
+ */
+export function evictImage(bucket: LogicalBucket, path: string | null): void {
+  if (!path) return;
+  try {
+    const file = fileFor(bucket, path);
+    if (file.exists) file.delete();
+  } catch {
+    // Already gone, or unreadable — nothing to do.
+  }
+}

--- a/apps/mobile/src/lib/transferProgress.ts
+++ b/apps/mobile/src/lib/transferProgress.ts
@@ -1,0 +1,85 @@
+/**
+ * A tiny global store for in-flight transfers, so a thin progress bar can track
+ * work that happens outside React — the receipt upload queue flushes from plain
+ * library code, not a component, and still needs to drive the bar.
+ *
+ * It is deliberately framework-free: `start`/`advance`/`end` are called from
+ * anywhere (the queue, a future download path), and the UI subscribes through
+ * `useSyncExternalStore`. The snapshot is a single aggregate — are we busy, and
+ * how far along across everything in flight — because the bar shows one line for
+ * the whole app, the way a browser shows one download bar for many files.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+interface Transfer {
+  done: number;
+  total: number;
+}
+
+const transfers = new Map<string, Transfer>();
+const listeners = new Set<() => void>();
+
+/** The one aggregate the bar renders. Recomputed only on change, cached so
+ *  `useSyncExternalStore` sees a stable reference between mutations. */
+export interface TransferSnapshot {
+  /** True while at least one transfer is unfinished. */
+  active: boolean;
+  /** 0‑1 across every transfer, by count of steps done over total. */
+  fraction: number;
+}
+
+const IDLE: TransferSnapshot = { active: false, fraction: 0 };
+let snapshot: TransferSnapshot = IDLE;
+
+function recompute(): void {
+  let done = 0;
+  let total = 0;
+  for (const t of transfers.values()) {
+    done += t.done;
+    total += t.total;
+  }
+  const active = transfers.size > 0 && done < total;
+  snapshot = active ? { active, fraction: total === 0 ? 0 : done / total } : IDLE;
+}
+
+function emit(): void {
+  recompute();
+  for (const listener of listeners) listener();
+}
+
+/** Begin a transfer of `total` steps under a caller-owned id (replaces any prior
+ *  transfer with that id, so a re-run resets cleanly). */
+export function startTransfer(id: string, total: number): void {
+  transfers.set(id, { done: 0, total: Math.max(0, total) });
+  emit();
+}
+
+/** Mark `done` steps complete for a transfer (absolute, not a delta). */
+export function setTransferProgress(id: string, done: number): void {
+  const t = transfers.get(id);
+  if (!t) return;
+  t.done = Math.min(t.total, Math.max(0, done));
+  emit();
+}
+
+/** Finish and drop a transfer, so a completed run leaves nothing lingering. */
+export function endTransfer(id: string): void {
+  if (transfers.delete(id)) emit();
+}
+
+export function subscribeTransfers(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getTransferSnapshot(): TransferSnapshot {
+  return snapshot;
+}
+
+/** React binding: the current aggregate, re-rendered as transfers change. */
+export function useTransferProgress(): TransferSnapshot {
+  return useSyncExternalStore(subscribeTransfers, getTransferSnapshot, getTransferSnapshot);
+}


### PR DESCRIPTION
Three related mobile-UX changes that share app-root and receipt files.

## Offline receipts (ADR-005 for images)
- **View** — a device cache keyed by the object's storage path (`imageCache.ts`). A receipt opened once shows instantly, offline too. expo-image's own cache can't help (signed R2 URLs rotate). Evicted on remove/replace.
- **Add** — an upload queue (`receiptQueue.ts`). Capturing offline parks the bytes in a durable file and shows the receipt at once with an upload badge; a flush on reconnect uploads it, pulls the real row into the mirror, seeds the view cache, and drops the entry. Same-identity id → no duplicate; permanent refusals (cap / not-a-party) drop, transient ones retry.

## Upload progress bar
- A slim top bar (`transferProgress.ts` + `TransferProgressBar.tsx`) driven by the receipt-upload flush. **Behind the `upload_progress` feature flag** — renders nothing until the flag is on.

## Nav polish
- `add-expense` now slides in horizontally (platform default, RTL-aware) instead of rising as a modal, and shows a **back chevron** (`ExpenseHeader` gains a `leading` prop) rather than the modal X. Capture keeps its X.

## Caveats
- Offline paths need **on-device verification** (R2 live). Queue is FileSystem/AsyncStorage-heavy — no unit tests there; lint + tsc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added offline receipt capture with local queuing, immediate gallery display, automatic uploads when connectivity returns, retries, and upload status indicators.
  - Added receipt image caching for faster viewing and improved offline availability.
  - Added transfer progress indicators for active uploads and downloads.
  - Added right-to-left layout support with direction-aware navigation and transitions.
- **Improvements**
  - Updated expense navigation to use smooth slide transitions.
  - Added clearer back navigation on the add-expense screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->