### PR TITLE
feat(voice): cloud-STT entitlement & config plumbing (A48 Phase 1)

### DIFF
--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -93,6 +93,7 @@ import { totalsByCurrency } from './totals';
 import { putImage, removeRestrictedImage } from '@/lib/storage';
 import { pickAlbumPhoto, type PickedImage } from '@/lib/image';
 import { parseAnnotations, type Annotations } from '@/lib/annotations';
+import type { VoiceAccess } from '@/lib/voiceAccess';
 import { SettlementStatus } from './types';
 import type {
   ActivityActor,
@@ -2047,5 +2048,24 @@ export function useOpenReceipts(groupId: string) {
     queryKey: ['open-receipts', groupId],
     queryFn: () => fetchOpenReceipts(groupId),
     enabled: groupId !== '',
+  });
+}
+
+/**
+ * The reader's cloud-STT entitlement (A48): paid → unlimited, free → a monthly
+ * allowance, resolved per person by `baaki_my_voice_access`. The UI uses it to
+ * show remaining free talk-time and to pick the cloud vs on-device tier
+ * (`pickVoiceMode`). A minute of staleness is harmless — the server re-meters on
+ * every real STT call.
+ */
+export function useVoiceAccess() {
+  return useQuery({
+    queryKey: ['voiceAccess'],
+    queryFn: async (): Promise<VoiceAccess> => {
+      const { data, error } = await backend.rpc('baaki_my_voice_access');
+      if (error) throw new Error(error.message);
+      return data as VoiceAccess;
+    },
+    staleTime: 60_000,
   });
 }

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -2059,13 +2059,19 @@ export function useOpenReceipts(groupId: string) {
  * every real STT call.
  */
 export function useVoiceAccess() {
+  // Key on the signed-in profile: baaki_my_voice_access resolves the caller from
+  // the JWT, and the QueryClient is persisted across sign-outs, so a bare
+  // ['voiceAccess'] key would let a second person on the same device read the
+  // first person's cached entitlement for up to staleTime.
+  const { profile } = useAuth();
   return useQuery({
-    queryKey: ['voiceAccess'],
+    queryKey: ['voiceAccess', profile?.id ?? null],
     queryFn: async (): Promise<VoiceAccess> => {
       const { data, error } = await backend.rpc('baaki_my_voice_access');
       if (error) throw new Error(error.message);
       return data as VoiceAccess;
     },
+    enabled: !!profile?.id,
     staleTime: 60_000,
   });
 }

--- a/apps/mobile/src/lib/voiceAccess.ts
+++ b/apps/mobile/src/lib/voiceAccess.ts
@@ -1,0 +1,50 @@
+/**
+ * The reader's cloud-STT entitlement shape, and the rule for choosing the cloud
+ * tier over the on-device fallback (A48, Phase 1).
+ *
+ * The entitlement is PER PERSON: a paid person has unlimited cloud STT, a free
+ * person has a monthly allowance, and a groupmate being paid changes nothing.
+ * The server (`baaki_my_voice_access`) is the source of truth; the `useVoiceAccess`
+ * hook (in `@/data/hooks`) reads it, and this turns it into a mode. The actual
+ * cloud STT call arrives in Phase 2 — this seam lets the UI show "X:XX free left"
+ * and lets the picker decide which recogniser to use, before the provider wiring
+ * exists.
+ *
+ * Kept free of React and the backend client so the whole decision is one pure,
+ * unit-testable function.
+ */
+
+/** The shape `baaki_my_voice_access` returns (already camelCase jsonb). */
+export interface VoiceAccess {
+  paid: boolean;
+  freeSeconds: number;
+  usedSeconds: number;
+  /** Seconds of cloud STT left this month, or null when unlimited (paid). */
+  remainingSeconds: number | null;
+  /** The metering period, 'YYYY-MM'. */
+  period: string;
+}
+
+/** Which recogniser a spoken capture should use. */
+export type VoiceMode = 'cloud' | 'basic';
+
+/**
+ * Choose the cloud STT tier or the on-device fallback. Pure, so the whole rule
+ * is one testable function:
+ *
+ *  - offline, or cloud STT switched off (the feature flag / no provider): basic;
+ *  - no entitlement loaded yet: basic (never gamble a paid call on unknown state);
+ *  - paid, or unlimited (remaining null): cloud;
+ *  - free with allowance left: cloud; free and spent: basic.
+ *
+ * "basic" is always safe — it is the on-device recogniser, which needs no
+ * network and no third-party call.
+ */
+export function pickVoiceMode(
+  access: VoiceAccess | null | undefined,
+  ctx: { online: boolean; cloudEnabled: boolean },
+): VoiceMode {
+  if (!ctx.online || !ctx.cloudEnabled || !access) return 'basic';
+  if (access.paid || access.remainingSeconds === null) return 'cloud';
+  return access.remainingSeconds > 0 ? 'cloud' : 'basic';
+}

--- a/apps/mobile/test/voiceAccess.test.ts
+++ b/apps/mobile/test/voiceAccess.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { pickVoiceMode, type VoiceAccess } from '@/lib/voiceAccess';
+
+const free = (remainingSeconds: number | null): VoiceAccess => ({
+  paid: false,
+  freeSeconds: 300,
+  usedSeconds: 300 - (remainingSeconds ?? 0),
+  remainingSeconds,
+  period: '2026-08',
+});
+
+const paid: VoiceAccess = {
+  paid: true,
+  freeSeconds: 300,
+  usedSeconds: 0,
+  remainingSeconds: null,
+  period: '2026-08',
+};
+
+const online = { online: true, cloudEnabled: true };
+
+describe('pickVoiceMode', () => {
+  it('uses the on-device basic tier when offline', () => {
+    expect(pickVoiceMode(paid, { online: false, cloudEnabled: true })).toBe('basic');
+  });
+
+  it('uses basic when cloud STT is switched off', () => {
+    expect(pickVoiceMode(paid, { online: true, cloudEnabled: false })).toBe('basic');
+  });
+
+  it('uses basic when entitlement has not loaded yet', () => {
+    expect(pickVoiceMode(null, online)).toBe('basic');
+    expect(pickVoiceMode(undefined, online)).toBe('basic');
+  });
+
+  it('gives a paid person the cloud tier', () => {
+    expect(pickVoiceMode(paid, online)).toBe('cloud');
+  });
+
+  it('gives a free person with allowance left the cloud tier', () => {
+    expect(pickVoiceMode(free(120), online)).toBe('cloud');
+  });
+
+  it('falls a spent free person back to basic', () => {
+    expect(pickVoiceMode(free(0), online)).toBe('basic');
+  });
+
+  it('treats a null remaining as unlimited (cloud)', () => {
+    expect(pickVoiceMode(free(null), online)).toBe('cloud');
+  });
+});

--- a/docs/voice-cloud-stt-and-structuring.md
+++ b/docs/voice-cloud-stt-and-structuring.md
@@ -1,0 +1,324 @@
+# Voice — cloud STT + managed LLM structuring (design)
+
+**Status:** Proposed (design review before build)
+**Feature id:** A48 (proposed)
+**Author:** design draft for review
+**Supersedes/extends:** the existing on-device voice quick-add ([`apps/mobile/src/app/voice.tsx`](../apps/mobile/src/app/voice.tsx), [`voiceExpense.ts`](../apps/mobile/src/lib/voiceExpense.ts), [`voiceLlm.ts`](../apps/mobile/src/lib/voiceLlm.ts), [`dictation.ts`](../apps/mobile/src/lib/dictation.ts))
+
+---
+
+## 1. What we are building
+
+Two upgrades to "speak an expense", both **configurable** and both with a **graceful
+fallback** to what exists today:
+
+1. **Cloud speech-to-text (STT)** as a higher-quality tier over the on-device
+   recogniser. Metered for free users (a monthly allowance of talk-time),
+   unlimited for paid users, and **falling back to the on-device recogniser**
+   whenever cloud STT is unavailable (offline, quota spent, provider disabled).
+
+2. **Managed LLM structuring**: after we have text, an admin-configured LLM turns
+   it into a **versioned structured expense payload** — so the parsing quality no
+   longer depends on the reader bringing their own key, and future app versions
+   can rely on a stable, versioned contract.
+
+### Locked decisions (from product review)
+
+| Question             | Decision                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------- |
+| First STT provider   | **Deepgram**, behind a provider-agnostic seam (Gemini/others addable by config)             |
+| Free STT quota reset | **Per calendar month** (amount set by an admin/API-tunable knob)                            |
+| LLM structuring      | **Managed, admin-configured** model + versioned output; **BYOK stays an optional override** |
+| Entitlement scope    | **Per person, never per group** — unlike the group "full mode" rule                         |
+| Rollout              | Design doc first (this), then phased build                                                  |
+
+---
+
+## 2. Entitlement — per person, not per group
+
+This is the one rule that departs from every other paid gate in the app. Today,
+[`baaki_group_is_paid`](../packages/db) makes a whole group "full mode" if **any**
+member is subscribed (group photo, receipt cap, attachment cap all use it). Voice
+STT is **the person's own capability** and must **not** leak across a group.
+
+- New definer helper **`baaki_user_is_paid(p_profile uuid) → boolean`**: true iff
+  that profile has an `active` subscription (or an unexpired pass **owned by that
+  profile**, not a group pass). Deliberately independent of `baaki_group_is_paid`.
+- A paid person gets **unlimited** cloud STT. A free person is metered.
+- Group membership is irrelevant. A free user in a group with a paid member is
+  **still metered** — the paid member's benefit does not extend to them.
+
+```
+access(profile) =
+  baaki_user_is_paid(profile) ? 'unlimited'
+  : remaining_free_seconds(profile) > 0 ? 'metered'
+  : 'exhausted'   // → on-device fallback
+```
+
+---
+
+## 3. Metering & configuration
+
+### 3.1 Config knobs (admin + API tunable)
+
+Reuse the existing `app_config` numeric-knob table for integers; add a small
+**text** config surface for provider/model names (which `app_config.value int`
+cannot hold).
+
+| Key                          | Type | Where                  | Meaning                                     | Default          |
+| ---------------------------- | ---- | ---------------------- | ------------------------------------------- | ---------------- |
+| `voice_stt_free_seconds`     | int  | `app_config`           | Free talk-time per month, in seconds        | `300` (5 min)    |
+| `voice_stt_max_clip_seconds` | int  | `app_config`           | Hard cap on a single request's audio length | `60`             |
+| `voice_stt_enabled`          | flag | `feature_flags`        | Master on/off for cloud STT                 | off              |
+| `voice_stt_provider`         | text | `service_config` (new) | `deepgram` \| `gemini`                      | `deepgram`       |
+| `voice_stt_model`            | text | `service_config`       | Provider model id (e.g. `nova-2`)           | provider default |
+| `voice_llm_provider`         | text | `service_config`       | Managed structuring provider                | (chosen)         |
+| `voice_llm_model`            | text | `service_config`       | Managed structuring model                   | (chosen)         |
+| `voice_llm_schema_version`   | int  | `app_config`           | Output contract version the server emits    | `1`              |
+
+**New `service_config` table** (text knobs — `app_config` is int-only):
+`key text primary key, value text, description text, updated_at timestamptz`.
+Same trust shape as `app_config`/`feature_flags`: anon/authenticated **SELECT**
+(non-secret names only), **service-role write**. Secrets (Deepgram key, LLM key)
+live in **edge-function env**, never in a readable table.
+
+The admin **Limits/Config** page (`apps/admin/src/app/config/page.tsx`) gains the
+new numeric knobs; a sibling page edits the `service_config` text knobs. "Through
+an API" = the same service-role RPC the admin console calls, callable by an
+integration.
+
+### 3.2 Usage table
+
+```
+voice_stt_usage (
+  profile_id  uuid    not null references profiles(id),
+  period      text    not null,          -- 'YYYY-MM' calendar month
+  seconds     integer not null default 0,
+  updated_at  timestamptz not null default now(),
+  primary key (profile_id, period)
+)
+```
+
+- RLS: a person may **SELECT own** rows (to show "3:20 of 5:00 used"); **writes are
+  service-role only** (the edge function), so usage cannot be forged from a client.
+- `remaining_free_seconds(profile)` = `max(0, voice_stt_free_seconds - seconds_this_month)`.
+- Monthly reset is implicit: a new `period` key ⇒ a fresh row ⇒ full allowance. No
+  cron needed.
+
+---
+
+## 4. The STT edge function (`voice-stt`)
+
+A metered proxy so **the device never holds the provider key** and every second is
+counted server-side.
+
+### 4.1 Contract (v1)
+
+`POST /functions/v1/voice-stt` (authenticated; user JWT)
+
+Request (multipart or base64 JSON):
+
+```
+{ "audio": "<base64>", "mimeType": "audio/m4a", "durationSeconds": 7.2,
+  "language": "en" | "ta" | "hi" | "ar" }
+```
+
+Response:
+
+```
+{ "transcript": "three thousand rupees for petrol",
+  "provider": "deepgram", "billedSeconds": 8,
+  "remainingFreeSeconds": 292 | null }   // null = unlimited (paid)
+```
+
+Refusals (so the client can fall back cleanly, never a raw error):
+
+```
+409 { "code": "STT_QUOTA_EXHAUSTED", "remainingFreeSeconds": 0 }
+403 { "code": "STT_DISABLED" }              // flag off / no provider configured
+413 { "code": "STT_CLIP_TOO_LONG", "maxSeconds": 60 }
+```
+
+### 4.2 Server flow (all inside the function, single trust boundary)
+
+1. Resolve the caller's profile from the JWT.
+2. If `!voice_stt_enabled` → `STT_DISABLED`.
+3. `paid = baaki_user_is_paid(profile)`.
+4. If not paid: read `voice_stt_free_seconds` and this month's usage.
+   - If `durationSeconds` would exceed the remaining allowance → `STT_QUOTA_EXHAUSTED`
+     (the client falls back to on-device; **no partial charge**).
+5. Enforce `voice_stt_max_clip_seconds`.
+6. Call the **provider adapter** (`deepgram` first) with the server-side key and
+   `voice_stt_model`.
+7. On success **and** not paid: `voice_stt_usage.seconds += ceil(billedSeconds)`
+   for the current period (atomic upsert). Paid users are **not** metered.
+8. Return the transcript + `remainingFreeSeconds`.
+
+**Metering integrity:** we bill the **provider-reported** audio seconds, not the
+client's claimed `durationSeconds`, so a client cannot under-report to stretch the
+free tier. The clip cap bounds a single abusive request before the provider call.
+
+### 4.3 Provider seam
+
+```ts
+interface SttProvider {
+  transcribe(
+    audio: Uint8Array,
+    opts: {
+      mimeType: string;
+      language: string;
+      model: string;
+    },
+  ): Promise<{ transcript: string; billedSeconds: number }>;
+}
+```
+
+`deepgram` implemented first (per-minute billing maps straight to `billedSeconds`).
+`gemini` addable later; because Gemini bills per token, its adapter derives
+`billedSeconds` from the audio length it was given, keeping the meter uniform.
+Which adapter runs is read from `voice_stt_provider` at request time.
+
+---
+
+## 5. Managed LLM structuring (`voice-structure` edge function)
+
+Separate function so STT and structuring scale and fail independently, and either
+can be turned off alone.
+
+`POST /functions/v1/voice-structure` (authenticated)
+
+```
+{ "transcript": "...", "groups": [{id,name}], "locale": "en",
+  "defaultCurrency": "INR" }
+```
+
+- Reads `voice_llm_provider` / `voice_llm_model` / `voice_llm_schema_version` from
+  config; calls the model with the **server-side** key.
+- Returns a **versioned** payload (see §6). On any failure returns
+  `{ "code": "STRUCTURE_UNAVAILABLE" }` so the client falls back to the on-device
+  heuristic parser ([`parseVoiceExpenses`](../apps/mobile/src/lib/voiceExpense.ts)).
+- **BYOK override:** if the reader has a personal key configured
+  ([`aiKeys.ts`](../apps/mobile/src/lib/aiKeys.ts)/[`voiceLlm.ts`](../apps/mobile/src/lib/voiceLlm.ts)),
+  the client may prefer the BYOK path (their key, their model) and skip the managed
+  call — a per-user choice, unchanged from today.
+
+Access to the managed LLM follows the **same per-person entitlement** as STT unless
+you decide otherwise — recorded as an open question (§9).
+
+---
+
+## 6. Versioned output contract
+
+The structured result is **versioned** so a newer server can enrich the payload
+without breaking an older app, and a newer app can require a minimum version.
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "items": [
+    { "amountMinor": "300000", "currency": "INR",
+      "description": "petrol", "category": null,
+      "confidence": 0.94 }
+  ],
+  "group": { "kind": "existing", "groupId": "..." } | { "kind": "create", "name": "Goa" } | null,
+  "splitCount": null,
+  "provider": "…", "model": "…"
+}
+```
+
+Rules:
+
+- `schemaVersion` is **mandatory** and monotonic. v2+ may **add** optional fields;
+  it may **never** repurpose or remove a v1 field.
+- The client keeps a `MIN_SUPPORTED / MAX_SUPPORTED` window. A payload above the
+  window → treat unknown fields as absent (forward-compatible). Below the window →
+  fall back to the heuristic parser.
+- `amountMinor` is a **string** (bigint-safe, ADR-003), scaled to the currency's
+  real exponent server-side — no float ever crosses the wire.
+- Every amount still passes the client's existing sanity checks before it prefills
+  the review screen; a model is never trusted blindly (matches today's stance).
+
+---
+
+## 7. Client flow (three tiers, one review screen)
+
+```
+speak → record audio
+      │
+      ├─ online & cloud STT allowed?  → voice-stt  → transcript
+      │        (quota / paid / flag)      │ refusal → fall through
+      └─ else                            → on-device dictation.ts (basic)
+                                            │
+transcript → structure:
+      ├─ managed allowed?  → voice-structure → versioned payload
+      ├─ BYOK key set?     → voiceLlm.ts (user's key)
+      └─ else              → parseVoiceExpenses (heuristic, always works offline)
+                                            │
+                                    editable review (voice.tsx) → save
+```
+
+- The **review screen is unchanged** — every tier feeds the same editable drafts,
+  so quality improves without a new surface.
+- Fallbacks are **silent and automatic**; the only user-visible signal is an
+  optional "X:XX of 5:00 free voice left this month" line for free users.
+- Offline is a first-class path: no network ⇒ on-device STT + heuristic parser,
+  exactly today's behaviour. The feature never blocks the core action.
+
+---
+
+## 8. Phasing
+
+- **Phase 1 — entitlement & config plumbing (no external calls).**
+  `baaki_user_is_paid`, `voice_stt_usage`, `service_config`, the `app_config`
+  knobs, `remaining_free_seconds`, admin config UI, `feature_flags:voice_stt_enabled`.
+  Fully testable with DB tests; ships dark.
+- **Phase 2 — `voice-stt` edge function + Deepgram adapter + client wiring**
+  (metered proxy, fallback). Needs the Deepgram key in edge env.
+- **Phase 3 — `voice-structure` edge function + managed LLM + versioned contract**
+  - client tier selection. Needs the LLM key in edge env.
+- **Phase 4 — usage surfacing** ("free voice left"), admin dashboards, and a
+  second STT provider adapter (Gemini) to prove the seam.
+
+Each phase is its own PR; Phases 2–3 are **deploy-gated** on the provider keys.
+
+---
+
+## 9. Open questions (decide before Phase 2/3)
+
+1. **Managed LLM entitlement** — same per-person paid/metered rule as STT, or free
+   for everyone within their STT quota, or paid-only? (Cost driver.)
+2. **Whose key pays** — a single platform Deepgram/LLM account (we absorb cost,
+   the usual SaaS model), confirmed? Any per-tenant key story for enterprise?
+3. **Audio retention** — do we keep the uploaded audio at all? Proposed: **no**
+   server-side retention; transcribe and discard, log only seconds + provider.
+4. **Language coverage** — Deepgram model per language (en/ta/hi/ar); confirm the
+   model ids and that all four are supported at acceptable quality, else fall back
+   to on-device for the unsupported language.
+5. **Abuse / rate limits** — beyond the monthly quota, a per-minute request cap on
+   `voice-stt` (reuse `_shared/rateLimit.ts`).
+
+---
+
+## 10. Security & cost notes
+
+- Provider keys live **only in edge-function env**; the device and every readable
+  table are keyless (same posture as `r2-sign`).
+- Metering is **server-authoritative** (provider-reported seconds), so the free
+  tier cannot be stretched from the client.
+- No audio retention (proposed) keeps this out of the privacy blast radius; only
+  derived counts persist.
+- Hard caps (`max_clip_seconds`, monthly quota, optional rate limit) bound spend
+  before any provider bill.
+
+---
+
+## 11. Spec amendments required
+
+- **ADR:** a new ADR for "per-person paid capabilities" — the first gate that is
+  **not** group-inherited, to sit beside the group "full mode" rule.
+- **ADR-002 addendum:** two new edge functions (`voice-stt`, `voice-structure`)
+  and the `service_config` text-knob table.
+- **TDR:** the versioned voice output contract (§6) as a stable, documented
+  interface; the metering table and reset semantics.
+- Note the existing SMS/voice/receipt deviations already tracked, so this joins
+  them rather than duplicating.

--- a/docs/voice-cloud-stt-and-structuring.md
+++ b/docs/voice-cloud-stt-and-structuring.md
@@ -41,16 +41,17 @@ This is the one rule that departs from every other paid gate in the app. Today,
 member is subscribed (group photo, receipt cap, attachment cap all use it). Voice
 STT is **the person's own capability** and must **not** leak across a group.
 
-- New definer helper **`baaki_user_is_paid(p_profile uuid) → boolean`**: true iff
-  that profile has an `active` subscription (or an unexpired pass **owned by that
-  profile**, not a group pass). Deliberately independent of `baaki_group_is_paid`.
+- Reuse the existing definer helper **`baaki_profile_is_paid(p_profile uuid) →
+boolean`**: true iff that profile has an `active` subscription (or an unexpired
+  pass **owned by that profile**, not a group pass). Deliberately independent of
+  `baaki_group_is_paid`.
 - A paid person gets **unlimited** cloud STT. A free person is metered.
 - Group membership is irrelevant. A free user in a group with a paid member is
   **still metered** — the paid member's benefit does not extend to them.
 
 ```
 access(profile) =
-  baaki_user_is_paid(profile) ? 'unlimited'
+  baaki_profile_is_paid(profile) ? 'unlimited'
   : remaining_free_seconds(profile) > 0 ? 'metered'
   : 'exhausted'   // → on-device fallback
 ```
@@ -70,6 +71,7 @@ cannot hold).
 | `voice_stt_free_seconds`     | int  | `app_config`           | Free talk-time per month, in seconds        | `300` (5 min)    |
 | `voice_stt_max_clip_seconds` | int  | `app_config`           | Hard cap on a single request's audio length | `60`             |
 | `voice_stt_enabled`          | flag | `feature_flags`        | Master on/off for cloud STT                 | off              |
+| `voice_llm_enabled`          | flag | `feature_flags`        | Master on/off for managed LLM structuring   | off              |
 | `voice_stt_provider`         | text | `service_config` (new) | `deepgram` \| `gemini`                      | `deepgram`       |
 | `voice_stt_model`            | text | `service_config`       | Provider model id (e.g. `nova-2`)           | provider default |
 | `voice_llm_provider`         | text | `service_config`       | Managed structuring provider                | (chosen)         |
@@ -143,20 +145,35 @@ Refusals (so the client can fall back cleanly, never a raw error):
 
 1. Resolve the caller's profile from the JWT.
 2. If `!voice_stt_enabled` → `STT_DISABLED`.
-3. `paid = baaki_user_is_paid(profile)`.
-4. If not paid: read `voice_stt_free_seconds` and this month's usage.
-   - If `durationSeconds` would exceed the remaining allowance → `STT_QUOTA_EXHAUSTED`
-     (the client falls back to on-device; **no partial charge**).
-5. Enforce `voice_stt_max_clip_seconds`.
+3. `paid = baaki_profile_is_paid(profile)`.
+4. **Derive the duration server-side.** Decode the uploaded audio and read its
+   real length; the client's `durationSeconds` is a hint only and is never
+   trusted for admission (a client could send full audio with
+   `durationSeconds: 0` and slip past the check). Reject a non-finite or
+   non-positive duration. Enforce `voice_stt_max_clip_seconds` against the
+   decoded length → `STT_CLIP_TOO_LONG`.
+5. **If not paid, reserve atomically before the provider call.** A single
+   conditional statement adds `ceil(decodedSeconds)` to this month's usage _only
+   if_ it stays within `voice_stt_free_seconds`, and reports whether it
+   succeeded — so two concurrent requests cannot both pass on the same balance
+   (e.g. two 200 s clips against 300 s remaining). If the reservation fails →
+   `STT_QUOTA_EXHAUSTED` (client falls back to on-device; **no charge**). The
+   request carries an **idempotency key**, so a replay reserves once, not twice.
 6. Call the **provider adapter** (`deepgram` first) with the server-side key and
    `voice_stt_model`.
-7. On success **and** not paid: `voice_stt_usage.seconds += ceil(billedSeconds)`
-   for the current period (atomic upsert). Paid users are **not** metered.
+7. **Reconcile the reservation.** On provider failure, **release** the reserved
+   seconds (delete/subtract under the same idempotency key) and surface a clean
+   refusal. On success, reconcile the reservation to the **provider-reported**
+   `billedSeconds` (the meter of record) rather than the decoded estimate. Paid
+   users skip both reserve and reconcile — they are **never** metered.
 8. Return the transcript + `remainingFreeSeconds`.
 
-**Metering integrity:** we bill the **provider-reported** audio seconds, not the
-client's claimed `durationSeconds`, so a client cannot under-report to stretch the
-free tier. The clip cap bounds a single abusive request before the provider call.
+**Metering integrity:** admission is gated on a **server-decoded** duration, and
+the final charge is the **provider-reported** seconds — the client's claimed
+`durationSeconds` is trusted for neither, so it cannot be under-reported to
+stretch the free tier. Reservation-before-call plus an idempotency key makes
+concurrent and replayed requests safe; the clip cap bounds a single abusive
+request before the provider is ever called.
 
 ### 4.3 Provider seam
 
@@ -183,7 +200,11 @@ Which adapter runs is read from `voice_stt_provider` at request time.
 ## 5. Managed LLM structuring (`voice-structure` edge function)
 
 Separate function so STT and structuring scale and fail independently, and either
-can be turned off alone.
+can be turned off alone — STT by `voice_stt_enabled`, structuring by its own
+`voice_llm_enabled` flag. When `voice_llm_enabled` is off (or no
+`voice_llm_provider` is configured) the function returns `STRUCTURE_UNAVAILABLE`
+and the client falls back to the on-device heuristic parser, exactly as it does
+on a provider error.
 
 `POST /functions/v1/voice-structure` (authenticated)
 
@@ -268,14 +289,21 @@ transcript → structure:
 
 ## 8. Phasing
 
-- **Phase 1 — entitlement & config plumbing (no external calls).**
-  `baaki_user_is_paid`, `voice_stt_usage`, `service_config`, the `app_config`
-  knobs, `remaining_free_seconds`, admin config UI, `feature_flags:voice_stt_enabled`.
-  Fully testable with DB tests; ships dark.
-- **Phase 2 — `voice-stt` edge function + Deepgram adapter + client wiring**
-  (metered proxy, fallback). Needs the Deepgram key in edge env.
-- **Phase 3 — `voice-structure` edge function + managed LLM + versioned contract**
-  - client tier selection. Needs the LLM key in edge env.
+- **Phase 1 — entitlement & config plumbing (no external calls).** Reuse
+  `baaki_profile_is_paid`; `voice_stt_usage`, `service_config`, the `app_config`
+  knobs, `baaki_voice_stt_remaining_seconds`, `baaki_voice_stt_record`
+  (service-role), and the client-facing `baaki_my_voice_access`. On the client:
+  the `useVoiceAccess` hook that reads it and the pure `pickVoiceMode(access,
+{online, cloudEnabled})` selector — both land here so the tier decision is
+  unit-tested before any network tier exists. Fully testable with DB + unit
+  tests; ships dark (`feature_flags:voice_stt_enabled` off, no provider keys, and
+  no caller invokes the cloud tier yet).
+- **Phase 2 — `voice-stt` edge function + Deepgram adapter + wiring it in**
+  (metered proxy, fallback): the client starts _calling_ `voice-stt` and routing
+  on the `pickVoiceMode` decision that shipped in Phase 1. Needs the Deepgram key
+  in edge env.
+- **Phase 3 — `voice-structure` edge function + managed LLM + versioned contract.**
+  Needs the LLM key in edge env.
 - **Phase 4 — usage surfacing** ("free voice left"), admin dashboards, and a
   second STT provider adapter (Gemini) to prove the seam.
 

--- a/packages/db/prisma/migrations/20260825200000_voice_entitlements/migration.sql
+++ b/packages/db/prisma/migrations/20260825200000_voice_entitlements/migration.sql
@@ -1,0 +1,198 @@
+-- Voice cloud-STT entitlement & config plumbing (A48, Phase 1).
+--
+-- No external calls here — this is only the metering, entitlement and config
+-- surface the later phases (the `voice-stt` and `voice-structure` edge
+-- functions) build on. It ships dark: the master `voice_stt_enabled` flag is
+-- off, so nothing changes until a provider key exists and the flag is turned on.
+--
+-- The entitlement rule is deliberately PER PERSON, not per group: unlike the
+-- group "full mode" gate (baaki_group_is_paid, used by photos / receipt caps),
+-- cloud STT is the individual's own capability and must not leak to a free user
+-- just because a groupmate is paid. We reuse the existing per-profile check
+-- `baaki_profile_is_paid` for exactly this.
+
+-- ── Numeric knobs (admin/API-tunable via the existing app_config surface) ────
+INSERT INTO public.app_config (key, value, description) VALUES
+  ('voice_stt_free_seconds', 300,
+     'Free cloud speech-to-text talk-time per calendar month, in seconds.'),
+  ('voice_stt_max_clip_seconds', 60,
+     'Hard cap on the audio length of a single cloud STT request, in seconds.'),
+  ('voice_llm_schema_version', 1,
+     'Version of the structured voice output contract the server emits.')
+ON CONFLICT (key) DO NOTHING;
+
+-- ── Text knobs (provider/model names — app_config.value is int-only) ─────────
+-- Same trust shape as app_config / feature_flags: names are non-secret and
+-- readable; only service-role writes. Secrets (provider API keys) live in the
+-- edge-function environment, NEVER in this table.
+CREATE TABLE IF NOT EXISTS public.service_config (
+  key         text PRIMARY KEY,
+  value       text,
+  description text,
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.service_config ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS service_config_select ON public.service_config;
+CREATE POLICY service_config_select ON public.service_config
+  FOR SELECT USING (true);
+
+REVOKE ALL ON public.service_config FROM anon, authenticated;
+GRANT SELECT ON public.service_config TO anon, authenticated;
+-- No INSERT/UPDATE/DELETE grant: writes go through service_role, which bypasses
+-- RLS. The admin console edits these via a service-role connection.
+
+INSERT INTO public.service_config (key, value, description) VALUES
+  ('voice_stt_provider', 'deepgram', 'Cloud STT provider adapter: deepgram | gemini.'),
+  ('voice_stt_model', '', 'Provider model id for STT (empty = provider default).'),
+  ('voice_llm_provider', '', 'Managed LLM provider for voice structuring.'),
+  ('voice_llm_model', '', 'Managed LLM model id for voice structuring.')
+ON CONFLICT (key) DO NOTHING;
+
+-- ── Per-person monthly usage meter ──────────────────────────────────────────
+-- One row per (person, calendar month). A new month is simply a new period key,
+-- so the free allowance resets with no cron. Writes are service-role only (the
+-- edge function), so usage cannot be forged from a client; a person may read
+-- their own row to see how much free talk-time is left.
+CREATE TABLE IF NOT EXISTS public.voice_stt_usage (
+  profile_id uuid    NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  period     text    NOT NULL,                       -- 'YYYY-MM' (UTC)
+  seconds    integer NOT NULL DEFAULT 0,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (profile_id, period),
+  CONSTRAINT voice_stt_usage_seconds_nonneg CHECK (seconds >= 0)
+);
+
+ALTER TABLE public.voice_stt_usage ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS voice_stt_usage_select_own ON public.voice_stt_usage;
+CREATE POLICY voice_stt_usage_select_own ON public.voice_stt_usage
+  FOR SELECT USING (profile_id = public.baaki_current_profile_id());
+
+REVOKE ALL ON public.voice_stt_usage FROM anon, authenticated;
+GRANT SELECT ON public.voice_stt_usage TO authenticated;
+
+-- ── Readers & recorders ─────────────────────────────────────────────────────
+
+-- The monthly free allowance, in seconds, with a safe fallback if the knob row
+-- is ever missing. Mirrors baaki_attachment_cap / baaki_receipt_cap.
+CREATE OR REPLACE FUNCTION public.baaki_voice_stt_free_seconds()
+RETURNS integer
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE((SELECT value FROM public.app_config WHERE key = 'voice_stt_free_seconds'), 300);
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_voice_stt_free_seconds() FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_voice_stt_free_seconds()
+  TO authenticated, anon, service_role;
+
+-- Seconds of cloud STT a profile has left this month. NULL means unlimited (a
+-- paid person is never metered); otherwise max(0, free - used-this-month).
+CREATE OR REPLACE FUNCTION public.baaki_voice_stt_remaining_seconds(p_profile uuid)
+RETURNS integer
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_period text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM');
+  v_free   integer;
+  v_used   integer;
+BEGIN
+  IF public.baaki_profile_is_paid(p_profile) THEN
+    RETURN NULL; -- unlimited
+  END IF;
+  v_free := public.baaki_voice_stt_free_seconds();
+  SELECT seconds INTO v_used
+    FROM public.voice_stt_usage
+   WHERE profile_id = p_profile AND period = v_period;
+  RETURN GREATEST(0, v_free - COALESCE(v_used, 0));
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_voice_stt_remaining_seconds(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_voice_stt_remaining_seconds(uuid)
+  TO authenticated, service_role;
+
+-- Record used seconds for a profile in the current month, returning the new
+-- monthly total. Service-role only: this is called by the metering edge
+-- function after a provider transcribes, never from a client (a client that
+-- could write here could zero or inflate its own usage).
+CREATE OR REPLACE FUNCTION public.baaki_voice_stt_record(p_profile uuid, p_seconds integer)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_period text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM');
+  v_total  integer;
+BEGIN
+  IF p_seconds IS NULL OR p_seconds < 0 THEN
+    RAISE EXCEPTION 'VOICE_STT_BAD_SECONDS';
+  END IF;
+  INSERT INTO public.voice_stt_usage (profile_id, period, seconds, updated_at)
+  VALUES (p_profile, v_period, p_seconds, now())
+  ON CONFLICT (profile_id, period) DO UPDATE
+    SET seconds = public.voice_stt_usage.seconds + EXCLUDED.seconds,
+        updated_at = now()
+  RETURNING seconds INTO v_total;
+  RETURN v_total;
+END;
+$$;
+
+-- Explicitly strip anon/authenticated too: a default-privilege grant to those
+-- roles is not removed by revoking from PUBLIC, and this must be service-role
+-- only so a client cannot write its own usage.
+REVOKE ALL ON FUNCTION public.baaki_voice_stt_record(uuid, integer)
+  FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_voice_stt_record(uuid, integer) TO service_role;
+
+-- The client-facing summary the app reads to show "X:XX of 5:00 free left" and
+-- to choose the cloud vs on-device tier. Resolves the caller from the JWT, so it
+-- takes no argument and cannot be asked about anyone else.
+CREATE OR REPLACE FUNCTION public.baaki_my_voice_access()
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_profile uuid := public.baaki_current_profile_id();
+  v_period  text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM');
+  v_paid    boolean;
+  v_free    integer;
+  v_used    integer;
+BEGIN
+  IF v_profile IS NULL THEN
+    RETURN jsonb_build_object(
+      'paid', false, 'freeSeconds', 0, 'usedSeconds', 0,
+      'remainingSeconds', 0, 'period', v_period);
+  END IF;
+
+  v_paid := public.baaki_profile_is_paid(v_profile);
+  v_free := public.baaki_voice_stt_free_seconds();
+  SELECT seconds INTO v_used
+    FROM public.voice_stt_usage
+   WHERE profile_id = v_profile AND period = v_period;
+  v_used := COALESCE(v_used, 0);
+
+  RETURN jsonb_build_object(
+    'paid', v_paid,
+    'freeSeconds', v_free,
+    'usedSeconds', v_used,
+    'remainingSeconds', CASE WHEN v_paid THEN NULL ELSE GREATEST(0, v_free - v_used) END,
+    'period', v_period
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_my_voice_access() FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_my_voice_access() TO authenticated;

--- a/packages/db/prisma/migrations/20260825200000_voice_entitlements/migration.sql
+++ b/packages/db/prisma/migrations/20260825200000_voice_entitlements/migration.sql
@@ -28,7 +28,7 @@ ON CONFLICT (key) DO NOTHING;
 CREATE TABLE IF NOT EXISTS public.service_config (
   key         text PRIMARY KEY,
   value       text,
-  description text,
+  description text NOT NULL DEFAULT '',
   updated_at  timestamptz NOT NULL DEFAULT now()
 );
 
@@ -56,7 +56,7 @@ ON CONFLICT (key) DO NOTHING;
 -- edge function), so usage cannot be forged from a client; a person may read
 -- their own row to see how much free talk-time is left.
 CREATE TABLE IF NOT EXISTS public.voice_stt_usage (
-  profile_id uuid    NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  profile_id uuid    NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE ON UPDATE CASCADE,
   period     text    NOT NULL,                       -- 'YYYY-MM' (UTC)
   seconds    integer NOT NULL DEFAULT 0,
   updated_at timestamptz NOT NULL DEFAULT now(),
@@ -116,9 +116,15 @@ BEGIN
 END;
 $$;
 
-REVOKE ALL ON FUNCTION public.baaki_voice_stt_remaining_seconds(uuid) FROM public;
-GRANT EXECUTE ON FUNCTION public.baaki_voice_stt_remaining_seconds(uuid)
-  TO authenticated, service_role;
+-- Service-role only: this takes an ARBITRARY profile id, so exposing it to
+-- authenticated callers would let anyone infer another person's paid status and
+-- remaining allowance. Clients read their own entitlement through the
+-- JWT-scoped baaki_my_voice_access() below, which takes no argument. The
+-- explicit anon/authenticated revoke is needed because a default-privilege
+-- EXECUTE grant to those roles survives a plain REVOKE FROM public.
+REVOKE ALL ON FUNCTION public.baaki_voice_stt_remaining_seconds(uuid)
+  FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_voice_stt_remaining_seconds(uuid) TO service_role;
 
 -- Record used seconds for a profile in the current month, returning the new
 -- monthly total. Service-role only: this is called by the metering edge

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -177,6 +177,7 @@ model Profile {
   deviceSessions      DeviceSession[]
   ghostMerges         GhostMerge[]
   storageObjects      StorageObject[]
+  voiceSttUsage       VoiceSttUsage[]
 
   @@map("profiles")
   @@schema("public")
@@ -211,14 +212,14 @@ model Group {
   /// Group-visible by design: everyone sees the overall budget; only an admin
   /// sets it. Personal per-member caps live in `trip_member_budgets`, which is
   /// where privacy lives — this one never is private.
-  budgetMinor    BigInt? @map("budget_minor")
-  budgetCurrency String? @map("budget_currency") @db.Char(3)
+  budgetMinor     BigInt? @map("budget_minor")
+  budgetCurrency  String? @map("budget_currency") @db.Char(3)
   /// Per-category caps as a JSON map `{ "<category>": { amountMinor, currency } }`.
   /// Group-visible and admin-set like the overall budget — a category cap is a
   /// group signal, never private, so it lives on the group row, not its own
   /// table. NULL / absent is "no category caps". Written only via
   /// `baaki_set_category_budget`.
-  categoryBudgets Json? @map("category_budgets")
+  categoryBudgets Json?   @map("category_budgets")
 
   /// When the trip is. Both ends inclusive — the last day of a trip is the one
   /// with the most unrecorded spending on it.
@@ -240,28 +241,28 @@ model Group {
   createdAt  DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt  DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  members       GroupMember[]
-  invites       Invite[]
-  expenses      Expense[]
-  receipts      Receipt[]
-  settlements   Settlement[]
-  activity      ActivityLog[]
-  reminders     Reminder[]
-  balances      GroupBalance[]
-  pairwise      PairwiseBalance[]
-  notifications Notification[]
-  usageEvents   UsageEvent[]
-  passes        GroupPass[]
-  planItems     TripPlanItem[]
-  tripPhotos    TripPhoto[]
-  expenseComments ExpenseComment[]
+  members            GroupMember[]
+  invites            Invite[]
+  expenses           Expense[]
+  receipts           Receipt[]
+  settlements        Settlement[]
+  activity           ActivityLog[]
+  reminders          Reminder[]
+  balances           GroupBalance[]
+  pairwise           PairwiseBalance[]
+  notifications      Notification[]
+  usageEvents        UsageEvent[]
+  passes             GroupPass[]
+  planItems          TripPlanItem[]
+  tripPhotos         TripPhoto[]
+  expenseComments    ExpenseComment[]
   settlementProofs   SettlementProof[]
   expenseAttachments ExpenseAttachment[]
   imageEvents        ExpenseImageEvent[]
-  syncMutations SyncMutation[]
-  memberClaims   MemberClaim[]
-  memberBudgets  TripMemberBudget[]
-  storageObjects StorageObject[]
+  syncMutations      SyncMutation[]
+  memberClaims       MemberClaim[]
+  memberBudgets      TripMemberBudget[]
+  storageObjects     StorageObject[]
 
   @@index([archivedAt])
   /// The nudge job only ever looks at groups that have said when they are
@@ -302,34 +303,34 @@ model GroupMember {
   group   Group    @relation(fields: [groupId], references: [id], onDelete: Cascade)
   profile Profile? @relation(fields: [profileId], references: [id], onDelete: SetNull)
 
-  authoredVersions  ExpenseVersion[]   @relation("VersionAuthor")
-  paidFor           ExpensePayer[]
-  owes              ExpenseShare[]
-  settlementsSent   Settlement[]       @relation("SettlementFrom")
-  settlementsGot    Settlement[]       @relation("SettlementTo")
-  itemClaims        ReceiptItemClaim[]
-  planItems         TripPlanItem[]
-  tripPhotos        TripPhoto[]
+  authoredVersions   ExpenseVersion[]    @relation("VersionAuthor")
+  paidFor            ExpensePayer[]
+  owes               ExpenseShare[]
+  settlementsSent    Settlement[]        @relation("SettlementFrom")
+  settlementsGot     Settlement[]        @relation("SettlementTo")
+  itemClaims         ReceiptItemClaim[]
+  planItems          TripPlanItem[]
+  tripPhotos         TripPhoto[]
   settlementProofs   SettlementProof[]
   expenseAttachments ExpenseAttachment[]
-  commentsAuthored   ExpenseComment[]   @relation("ExpenseCommentAuthor")
-  commentsFlagged    ExpenseComment[]   @relation("ExpenseCommentFlagger")
-  commentsDeleted    ExpenseComment[]   @relation("ExpenseCommentDeleter")
+  commentsAuthored   ExpenseComment[]    @relation("ExpenseCommentAuthor")
+  commentsFlagged    ExpenseComment[]    @relation("ExpenseCommentFlagger")
+  commentsDeleted    ExpenseComment[]    @relation("ExpenseCommentDeleter")
   imageEvents        ExpenseImageEvent[]
-  activity          ActivityLog[]
-  disputesRaised    ExpenseDispute[]   @relation("DisputeRaisedBy")
-  disputesResolved  ExpenseDispute[]   @relation("DisputeResolvedBy")
-  remindersSent     Reminder[]         @relation("ReminderFrom")
-  remindersGot      Reminder[]         @relation("ReminderTo")
-  balances          GroupBalance[]
-  pairwiseFrom      PairwiseBalance[]  @relation("PairwiseFrom")
-  pairwiseTo        PairwiseBalance[]  @relation("PairwiseTo")
-  createdExpenses   Expense[]          @relation("ExpenseCreatedBy")
-  deletedExpenses   Expense[]          @relation("ExpenseDeletedBy")
-  claimsOnThisPlace MemberClaim[]      @relation("ClaimTarget")
-  claimsDecided     MemberClaim[]      @relation("ClaimDecider")
-  tripBudget        TripMemberBudget?
-  ghostMerges       GhostMerge[]
+  activity           ActivityLog[]
+  disputesRaised     ExpenseDispute[]    @relation("DisputeRaisedBy")
+  disputesResolved   ExpenseDispute[]    @relation("DisputeResolvedBy")
+  remindersSent      Reminder[]          @relation("ReminderFrom")
+  remindersGot       Reminder[]          @relation("ReminderTo")
+  balances           GroupBalance[]
+  pairwiseFrom       PairwiseBalance[]   @relation("PairwiseFrom")
+  pairwiseTo         PairwiseBalance[]   @relation("PairwiseTo")
+  createdExpenses    Expense[]           @relation("ExpenseCreatedBy")
+  deletedExpenses    Expense[]           @relation("ExpenseDeletedBy")
+  claimsOnThisPlace  MemberClaim[]       @relation("ClaimTarget")
+  claimsDecided      MemberClaim[]       @relation("ClaimDecider")
+  tripBudget         TripMemberBudget?
+  ghostMerges        GhostMerge[]
 
   @@unique([groupId, profileId])
   @@index([groupId])
@@ -1323,11 +1324,11 @@ model ExpenseComment {
   updatedAt      DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
   updatedSeq     BigInt    @default(0) @map("updated_seq")
 
-  group          Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  expense        Expense      @relation(fields: [expenseId], references: [id], onDelete: Cascade)
-  author         GroupMember? @relation("ExpenseCommentAuthor", fields: [authorMemberId], references: [id], onDelete: SetNull)
-  flagger        GroupMember? @relation("ExpenseCommentFlagger", fields: [flaggedBy], references: [id], onDelete: SetNull)
-  deleter        GroupMember? @relation("ExpenseCommentDeleter", fields: [deletedBy], references: [id], onDelete: SetNull)
+  group   Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  expense Expense      @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  author  GroupMember? @relation("ExpenseCommentAuthor", fields: [authorMemberId], references: [id], onDelete: SetNull)
+  flagger GroupMember? @relation("ExpenseCommentFlagger", fields: [flaggedBy], references: [id], onDelete: SetNull)
+  deleter GroupMember? @relation("ExpenseCommentDeleter", fields: [deletedBy], references: [id], onDelete: SetNull)
 
   @@index([groupId, updatedSeq])
   @@index([expenseId, createdAt], map: "expense_comments_expense_idx")
@@ -1529,6 +1530,38 @@ model AppConfig {
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@map("app_config")
+  @@schema("public")
+}
+
+/// Admin/API-tunable TEXT config (provider and model names) — app_config holds
+/// only integers. Same trust shape: names are non-secret and readable, writes
+/// are service-role only (RLS in the migration). Secrets never live here; the
+/// provider API keys sit in edge-function env. Introduced with voice cloud STT
+/// (A48).
+model ServiceConfig {
+  key         String   @id
+  value       String?
+  description String   @default("")
+  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@map("service_config")
+  @@schema("public")
+}
+
+/// Per-person monthly cloud-STT usage meter (A48). One row per (profile, YYYY-MM
+/// calendar month); a new month is a new period key, so the free allowance
+/// resets with no cron. Written only by the service role through
+/// `baaki_voice_stt_record`; a person may read their own row.
+model VoiceSttUsage {
+  profileId String   @map("profile_id") @db.Uuid
+  period    String
+  seconds   Int      @default(0)
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  @@id([profileId, period])
+  @@map("voice_stt_usage")
   @@schema("public")
 }
 

--- a/packages/db/test/voice-entitlements.test.ts
+++ b/packages/db/test/voice-entitlements.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Voice cloud-STT entitlement & metering (A48, Phase 1).
+ *
+ * The rule under test is per-person, not per-group: a free user is metered
+ * against a monthly allowance; a paid person is unlimited; and a groupmate's
+ * subscription must NOT lift a free user (unlike the group "full mode" gate).
+ * Usage is service-role-only to write and own-row-only to read.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { asRole, connect, expectDenied, seedGroup } from './helpers';
+
+let client: Client;
+let free: string;
+let paid: string;
+let other: string;
+
+beforeAll(async () => {
+  client = await connect();
+  const group = await seedGroup(client, { memberCount: 3 });
+  [free, paid, other] = group.profileIds;
+});
+
+afterAll(async () => {
+  await client.query(`DELETE FROM voice_stt_usage WHERE profile_id = ANY($1::uuid[])`, [
+    [free, paid, other],
+  ]);
+  await client.query(`DELETE FROM subscriptions WHERE profile_id = ANY($1::uuid[])`, [
+    [free, paid, other],
+  ]);
+  await client.end();
+});
+
+beforeEach(async () => {
+  // Usage and subscriptions persist (they are written by the superuser client,
+  // not inside a rolled-back asRole tx), so reset them between cases.
+  await client.query(`DELETE FROM voice_stt_usage WHERE profile_id = ANY($1::uuid[])`, [
+    [free, paid, other],
+  ]);
+  await client.query(`DELETE FROM subscriptions WHERE profile_id = ANY($1::uuid[])`, [
+    [free, paid, other],
+  ]);
+});
+
+/** Call the client-facing summary RPC as a given signed-in profile. */
+async function myAccess(profileId: string): Promise<Record<string, unknown>> {
+  return asRole(client, 'authenticated', { sub: profileId, role: 'authenticated' }, async () => {
+    const { rows } = await client.query(`SELECT public.baaki_my_voice_access() AS a`);
+    return rows[0].a as Record<string, unknown>;
+  });
+}
+
+function makePaid(profileId: string): Promise<unknown> {
+  return client.query(
+    `INSERT INTO subscriptions (profile_id, tier, period, status, current_period_end, store)
+     VALUES ($1, 'plus', 'monthly', 'active', now() + interval '30 days', 'play')`,
+    [profileId],
+  );
+}
+
+describe('voice STT entitlement (A48 Phase 1)', () => {
+  it('gives a free user the default monthly allowance', async () => {
+    const access = await myAccess(free);
+    expect(access.paid).toBe(false);
+    expect(access.freeSeconds).toBe(300);
+    expect(access.usedSeconds).toBe(0);
+    expect(access.remainingSeconds).toBe(300);
+  });
+
+  it('counts recorded seconds down from the allowance', async () => {
+    await client.query(`SELECT public.baaki_voice_stt_record($1, 100)`, [free]);
+    let access = await myAccess(free);
+    expect(access.usedSeconds).toBe(100);
+    expect(access.remainingSeconds).toBe(200);
+
+    // A second clip adds to the same month and clamps at zero, never negative.
+    await client.query(`SELECT public.baaki_voice_stt_record($1, 250)`, [free]);
+    access = await myAccess(free);
+    expect(access.usedSeconds).toBe(350);
+    expect(access.remainingSeconds).toBe(0);
+  });
+
+  it('treats a paid person as unlimited (remaining = null), ignoring usage', async () => {
+    await makePaid(paid);
+    await client.query(`SELECT public.baaki_voice_stt_record($1, 500)`, [paid]);
+    const access = await myAccess(paid);
+    expect(access.paid).toBe(true);
+    expect(access.remainingSeconds).toBeNull();
+    const { rows } = await client.query(
+      `SELECT public.baaki_voice_stt_remaining_seconds($1) AS r`,
+      [paid],
+    );
+    expect(rows[0].r).toBeNull();
+  });
+
+  it('does NOT lift a free user because a groupmate is paid (per-person, not per-group)', async () => {
+    await makePaid(paid); // paid is in the same seeded group as `free`
+    const access = await myAccess(free);
+    expect(access.paid).toBe(false);
+    expect(access.remainingSeconds).toBe(300);
+  });
+
+  it("resets by calendar month — last month's usage does not count against this month", async () => {
+    // Drop a big usage row into an old period directly; the current-month reader
+    // must ignore it.
+    await client.query(
+      `INSERT INTO voice_stt_usage (profile_id, period, seconds) VALUES ($1, '2020-01', 9999)`,
+      [other],
+    );
+    const access = await myAccess(other);
+    expect(access.usedSeconds).toBe(0);
+    expect(access.remainingSeconds).toBe(300);
+  });
+
+  it('lets the allowance be re-tuned from app_config', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query(`UPDATE app_config SET value = 120 WHERE key = 'voice_stt_free_seconds'`);
+      const { rows } = await client.query(`SELECT public.baaki_voice_stt_free_seconds() AS s`);
+      expect(rows[0].s).toBe(120);
+    } finally {
+      await client.query('ROLLBACK'); // keep the seeded default for other tests
+    }
+  });
+});
+
+describe('voice STT metering is not client-forgeable', () => {
+  it('refuses baaki_voice_stt_record to an ordinary authenticated caller', async () => {
+    // The EXECUTE grant is service-role only; authenticated is denied.
+    const message = await expectDenied(
+      asRole(client, 'authenticated', { sub: free, role: 'authenticated' }, () =>
+        client.query(`SELECT public.baaki_voice_stt_record($1, 50)`, [free]),
+      ),
+    );
+    expect(message).toMatch(/permission denied|not.*allowed/i);
+  });
+
+  it("does not let one user read another user's usage row", async () => {
+    await client.query(`SELECT public.baaki_voice_stt_record($1, 42)`, [free]);
+    const seen = await asRole(
+      client,
+      'authenticated',
+      { sub: other, role: 'authenticated' },
+      async () => {
+        const { rows } = await client.query(
+          `SELECT count(*)::int AS n FROM voice_stt_usage WHERE profile_id = $1`,
+          [free],
+        );
+        return rows[0].n as number;
+      },
+    );
+    expect(seen).toBe(0);
+  });
+
+  it('rejects a negative record', async () => {
+    const message = await expectDenied(
+      client.query(`SELECT public.baaki_voice_stt_record($1, -5)`, [free]),
+    );
+    expect(message).toContain('VOICE_STT_BAD_SECONDS');
+  });
+});
+
+describe('service_config text knobs', () => {
+  it('seeds the provider default and is readable by an authenticated user', async () => {
+    const value = await asRole(
+      client,
+      'authenticated',
+      { sub: free, role: 'authenticated' },
+      async () => {
+        const { rows } = await client.query(
+          `SELECT value FROM service_config WHERE key = 'voice_stt_provider'`,
+        );
+        return rows[0]?.value as string;
+      },
+    );
+    expect(value).toBe('deepgram');
+  });
+});

--- a/packages/db/test/voice-entitlements.test.ts
+++ b/packages/db/test/voice-entitlements.test.ts
@@ -20,7 +20,11 @@ let other: string;
 beforeAll(async () => {
   client = await connect();
   const group = await seedGroup(client, { memberCount: 3 });
-  [free, paid, other] = group.profileIds;
+  const [f, p, o] = group.profileIds;
+  if (!f || !p || !o) throw new Error('seedGroup should return three member profile ids');
+  free = f;
+  paid = p;
+  other = o;
 });
 
 afterAll(async () => {


### PR DESCRIPTION
Phase 1 of the voice cloud-STT design (`docs/voice-cloud-stt-and-structuring.md`) — the metering, entitlement and config surface later phases build on. **Ships dark**: the `voice_stt_enabled` flag is off and nothing here calls out.

## Entitlement — per person, not per group
Reuses the existing `baaki_profile_is_paid` (own active subscription), deliberately **not** `baaki_group_is_paid`. A free user in a paid member's group stays metered (tested).

## Metering
- `voice_stt_usage(profile, period='YYYY-MM', seconds)` — a new month is a new period key, so the allowance **auto-resets, no cron**.
- Writes are **service-role only** — a client cannot forge its own usage (verified denied); own-row read via RLS.

## Config
- `app_config` int knobs (`voice_stt_free_seconds=300`, `max_clip_seconds`, `llm_schema_version`) — already editable in the admin Limits page.
- New `service_config` **text** table for provider/model names. Secrets stay in edge env.
- RPCs: `baaki_voice_stt_free_seconds` / `_remaining_seconds` / `_record` / `baaki_my_voice_access`.
- Prisma models `ServiceConfig` + `VoiceSttUsage`.

## Client
`voiceAccess.ts` (pure `pickVoiceMode` — cloud vs on-device fallback) + `useVoiceAccess`.

## Tests
**10 DB tests + 7 unit tests** pass. Caught mid-build: the service-role `_record` fn needed an explicit `REVOKE FROM authenticated` (a default-privilege grant survives `REVOKE FROM public`), else a client could zero its own usage.

## Deploy
⚠️ Migration is applied locally only; prod deploy is gated on landing + provider keys. Phase 2 (Deepgram) needs the §9 open questions answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added access controls for cloud and on-device speech recognition.
  * Paid access includes unlimited cloud transcription; free access uses a configurable monthly allowance.
  * Added offline fallback so voice recognition remains available when cloud services are unavailable.
  * Added usage tracking, monthly allowance resets, and configurable speech-to-text settings.

* **Documentation**
  * Documented the planned cloud transcription and structured voice-processing architecture.

* **Tests**
  * Added coverage for access selection, usage limits, subscription scope, resets, security, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->