### PR TITLE
fix(voice): currency-exponent minor units + three-word currency names

### DIFF
--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -14,10 +14,24 @@
  * and the group are cheap and certain here, and everyone gets them.
  */
 
+import { isCurrencyCode, minorUnitScale } from '@waves/core';
+
 /** The minimum a group needs to be matched by name. */
 export interface VoiceGroupRef {
   id: string;
   name: string | null;
+}
+
+/**
+ * A spoken major amount to its currency's minor units. A flat ×100 inflated a
+ * zero-decimal currency (¥3000 → 300000 = ¥300000) and truncated a three-decimal
+ * one; scaling by the currency's real exponent fixes both. Falls back to the
+ * common two-decimal scale when the currency is unknown or unheard, which keeps
+ * every existing INR/USD case identical.
+ */
+function toMinorUnits(amountMajor: number, currency: string | null): bigint {
+  const scale = currency && isCurrencyCode(currency) ? Number(minorUnitScale(currency)) : 100;
+  return BigInt(Math.round(amountMajor * scale));
 }
 
 export interface ParsedVoiceExpense {
@@ -335,14 +349,15 @@ export function parseVoiceExpense(
   const said = normalizeSpokenNumbers(normalizeDigits(transcript));
   const tokens = tokenize(said);
   const amountMajor = extractAmount(said);
-  const amountMinor = amountMajor === null ? null : BigInt(Math.round(amountMajor * 100));
+  const currency = detectCurrency(said);
+  const amountMinor = amountMajor === null ? null : toMinorUnits(amountMajor, currency);
   const groupId = matchGroup(tokens, groups);
   const matchedName = groupId ? (groups.find((group) => group.id === groupId)?.name ?? null) : null;
 
   return {
     amountMinor,
     amountMajor,
-    currency: detectCurrency(said),
+    currency,
     note: buildNote(said, matchedName),
     groupId,
     splitCount: extractSplitCount(said),
@@ -549,6 +564,19 @@ const CURRENCY_TOKEN = new RegExp(
   'i',
 );
 
+/**
+ * A currency word or symbol *immediately* after a number — anchored at the start
+ * of the following text. Whole-name (CURRENCY_WORD_ALT is longest-first), so a
+ * three-word name like "sri lankan rupees" or "new zealand dollars" is caught
+ * where a fixed two-word window would clip it and miss the currency signal. The
+ * anchor keeps it to true adjacency, so a currency word later in the sentence
+ * ("five hundred for dinner, 20 rupees") does not make the earlier run money.
+ */
+const CURRENCY_AT_START = new RegExp(
+  `^(?:[${CURRENCY_SYMBOL_CLASS}]|(?:${CURRENCY_WORD_ALT})\\b)`,
+  'i',
+);
+
 /** Split-phrase context — a number here is a people count, still worth digitising. */
 const SPLIT_BEFORE_WORD = /^(?:among|amongst|between)$/i;
 const SPLIT_AFTER_WORD = /^(?:people|persons?|ppl|ways?|folks?|heads?)\b/i;
@@ -685,9 +713,11 @@ export function normalizeSpokenNumbers(text: string): string {
     const after = whole.slice(offset + run.length).trimStart();
     const before = whole.slice(0, offset).trimEnd();
     const prevWord = before.split(/\s+/).pop() ?? '';
-    // The first two words after the run, so a qualified name ("canadian
-    // dollars") still reads as currency where a single-word check would miss it.
-    const nextIsCurrency = CURRENCY_TOKEN.test(after.split(/\s+/).slice(0, 2).join(' '));
+    // Whole currency name right after the run, so a three-word qualified name
+    // ("sri lankan rupees", "new zealand dollars") reads as currency where a
+    // fixed two-word window clipped it and let the spoken amount slip through
+    // unconverted. Anchored, so only true adjacency counts.
+    const nextIsCurrency = CURRENCY_AT_START.test(after);
     const prevIsCurrency = CURRENCY_TOKEN.test(prevWord);
     const nextIsMinor = MINOR_UNIT_AFTER.test(after);
     const splitContext = SPLIT_BEFORE_WORD.test(prevWord) || SPLIT_AFTER_WORD.test(after);
@@ -825,7 +855,7 @@ export function parseVoiceExpenses(
     if (currency) carriedCurrency = currency;
     items.push({
       amountMajor,
-      amountMinor: BigInt(Math.round(amountMajor * 100)),
+      amountMinor: toMinorUnits(amountMajor, currency),
       currency,
       note: buildNote(segment, matchedName),
     });

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -35,7 +35,12 @@ function toMinorUnits(amountMajor: number, currency: string | null): bigint {
 }
 
 export interface ParsedVoiceExpense {
-  /** The amount in minor units (a two-decimal assumption), or null if none was heard. */
+  /**
+   * The amount in minor units, scaled by the currency's own exponent when a
+   * valid ISO code was heard (so JPY is not inflated ×100, KWD not truncated),
+   * falling back to a two-decimal scale when the currency is unknown or invalid.
+   * Null if no amount was heard.
+   */
   amountMinor: bigint | null;
   /** The amount as spoken, in major units, or null. */
   amountMajor: number | null;

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -48,6 +48,29 @@ describe('parseVoiceExpense', () => {
     expect(parsed.currency).toBe('USD');
   });
 
+  it('scales minor units by the currency exponent, not a flat 100', () => {
+    // JPY is zero-decimal: ¥3000 is 3000 minor units, not 300000.
+    const jpy = parseVoiceExpense('¥3000 ramen', groups);
+    expect(jpy.currency).toBe('JPY');
+    expect(jpy.amountMajor).toBe(3000);
+    expect(jpy.amountMinor).toBe(3000n);
+    // Two-decimal currencies are unchanged.
+    expect(parseVoiceExpense('500 rupees', groups).amountMinor).toBe(50000n);
+  });
+
+  it('reads a spoken amount before a three-word currency name', () => {
+    const cases: [string, number, string][] = [
+      ['five hundred sri lankan rupees tea', 500, 'LKR'],
+      ['six hundred new zealand dollars tour', 600, 'NZD'],
+      ['three hundred hong kong dollars dinner', 300, 'HKD'],
+    ];
+    for (const [sentence, major, code] of cases) {
+      const parsed = parseVoiceExpense(sentence, groups);
+      expect(parsed.amountMajor).toBe(major);
+      expect(parsed.currency).toBe(code);
+    }
+  });
+
   it('recognises currencies beyond rupees and dollars', () => {
     const cases: [string, string][] = [
       ['2000 yen for sushi', 'JPY'],


### PR DESCRIPTION
Two CodeRabbit findings on `voiceExpense.ts` (from the merged #433), verified against current code and fixed:

1. **Amount → minor units ignored the currency exponent.** Both `parseVoiceExpense` and `parseVoiceExpenses` did `amountMajor * 100`, so a zero-decimal currency was inflated (¥3000 → 300000) and a three-decimal one truncated. A shared `toMinorUnits(amountMajor, currency)` scales by `minorUnitScale(currency)`, falling back to ×100 when the currency is unknown/unheard — every existing INR/USD case is unchanged.
2. **Spoken amount before a three-word currency was missed.** `normalizeSpokenNumbers` tested only the first two words after a spoken run, so "five hundred **sri lankan rupees**" left the amount unconverted. A start-anchored `CURRENCY_AT_START` matches the whole qualified name at true adjacency (longest-first), without matching a currency word elsewhere in the sentence.

Regression tests: ¥3000 → 3000n minor units, and spoken amounts before "sri lankan rupees" / "new zealand dollars" / "hong kong dollars". 72 voice tests pass; lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Voice expense amounts now convert correctly for currencies with different decimal conventions, including JPY, INR, LKR, NZD, and HKD.
  - Improved recognition of spoken amounts placed directly before longer currency names.
  - Corrected conversion for both single and multiple voice-recorded expenses.
  - Unknown currencies continue to use a two-decimal fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->