### PR TITLE
fix(sync,r2,self-host): backlog row-loss, R2 delete/MIME hardening, DB bind

### DIFF
--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -73,6 +73,9 @@ interface SyncResponseBody {
   changes: SyncChange[];
   cursors: Record<string, number>;
   serverTime: string;
+  /** The server truncated at least one table's page; more rows are waiting.
+   *  Absent on older servers, so treated as false. */
+  hasMore?: boolean;
 }
 
 /** While the app is open and online, catch anything Realtime missed. */
@@ -423,6 +426,16 @@ export class SyncEngine {
         lastSyncedAt: response.serverTime ?? new Date().toISOString(),
         lastError: null,
       });
+
+      // The server capped a table at MAX_ROWS_PER_TABLE and left the cursor
+      // below its high-water; the rest is still on the server. Drain it now
+      // rather than waiting out the 30s poll, so a large backlog (a fresh device
+      // joining a big group) catches up in a burst instead of a page every half
+      // minute. Scheduled after this flush settles, since flush() is single-
+      // in-flight; guarded by the cursor moving, so it cannot spin forever.
+      if (response.hasMore) {
+        setTimeout(() => void this.flush(), 0);
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const queue = markFailed(this.state.queue, batch, message, now);

--- a/infra/self-host/docker-compose.yml
+++ b/infra/self-host/docker-compose.yml
@@ -30,7 +30,11 @@ services:
     image: supabase/postgres:17.6.1.136
     restart: unless-stopped
     ports:
-      - '${POSTGRES_PORT:-5432}:5432'
+      # Bound to loopback by default: Kong is the intended public entrypoint, and
+      # publishing 0.0.0.0:5432 puts the primary database straight on the internet
+      # on any VPS unless the host firewall is perfect. Override POSTGRES_BIND to
+      # 0.0.0.0 only for a deliberately reachable DB behind its own firewall.
+      - '${POSTGRES_BIND:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432'
     environment:
       POSTGRES_HOST: /var/run/postgresql
       POSTGRES_DB: ${POSTGRES_DB:-postgres}

--- a/infra/self-host/env.example
+++ b/infra/self-host/env.example
@@ -14,6 +14,11 @@
 POSTGRES_PASSWORD=change-me-strong
 POSTGRES_DB=postgres
 POSTGRES_PORT=5432
+# Host interface the DB port binds to. Defaults to 127.0.0.1 (loopback only) so
+# the database is not exposed publicly — reach it through Kong, or over an SSH
+# tunnel for admin. Set to 0.0.0.0 only for a deliberately reachable DB that has
+# its own firewall in front of it.
+POSTGRES_BIND=127.0.0.1
 
 JWT_SECRET=change-me-at-least-40-chars-of-random
 JWT_EXPIRY=3600

--- a/supabase/functions/r2-sign/index.ts
+++ b/supabase/functions/r2-sign/index.ts
@@ -49,6 +49,22 @@ const URL_TTL_SECONDS = 60 * 60;
  */
 const MAX_OBJECT_BYTES = 12 * 1024 * 1024;
 
+/**
+ * The only content types a client may reserve. Every upload the app makes is an
+ * image (the shrink pipeline emits webp/jpeg; the picker may hand up png/heic),
+ * so this rejects a direct caller trying to park `text/html` or `image/svg+xml`
+ * in an image bucket — bytes that, served back under their own content type,
+ * would be a stored-XSS vector rather than a receipt. No PDF: nothing in the app
+ * uploads one, so allowing it would only widen the surface.
+ */
+const ALLOWED_CONTENT_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+
 interface Body {
   action?: unknown;
   bucket?: unknown;
@@ -339,6 +355,9 @@ serveWithCors(async (request) => {
       }
 
       const contentType = typeof body.contentType === 'string' ? body.contentType : 'image/webp';
+      if (!ALLOWED_CONTENT_TYPES.has(contentType)) {
+        throw new HttpError(415, 'BAD_CONTENT_TYPE', 'Only image uploads are allowed');
+      }
 
       // Reserve the space *now*, before the URL exists — a presign the client
       // never commits still holds cap until it is swept, which is what stops
@@ -384,6 +403,9 @@ serveWithCors(async (request) => {
     if (action === 'commit') {
       const { groupId } = await authorizeWrite(caller, service, uid, bucket, path, subjectId);
       const contentType = typeof body.contentType === 'string' ? body.contentType : 'image/webp';
+      if (!ALLOWED_CONTENT_TYPES.has(contentType)) {
+        throw new HttpError(415, 'BAD_CONTENT_TYPE', 'Only image uploads are allowed');
+      }
 
       const head = await r2().client.fetch(objectUrl(bucket, path), { method: 'HEAD' });
       if (!head.ok) throw new HttpError(404, 'NOT_UPLOADED', 'Object was not uploaded');
@@ -485,6 +507,15 @@ serveWithCors(async (request) => {
     // ── delete an object and forget it ────────────────────────────────────
     if (action === 'delete') {
       await authorizeWrite(caller, service, uid, bucket, path, subjectId);
+      // authorizeWrite proves party + subject-scoped path, but not that this
+      // exact object is a live attachment/proof the caller may take down. For a
+      // restricted bucket, require a live row that references this path (the same
+      // check a `get` makes): otherwise any party to the subject could delete a
+      // co-party's bytes out of band — the row and audit trail left pointing at
+      // nothing — bypassing the author/admin-only delete matrix in the DB RPCs.
+      if (restricted) {
+        await assertRestrictedPath(caller, bucket, subjectId as string, path);
+      }
       await r2().client.fetch(objectUrl(bucket, path), { method: 'DELETE' });
       // A legacy object may still live on Supabase Storage (dual-read); remove it
       // there too, or the fallback read would keep serving a deleted image.

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -244,12 +244,17 @@ serveWithCors(async (request) => {
       ...session.touchedGroups,
       ...(mine.data ?? []).map((row) => row.group_id as string),
     ]);
-    const { changes, cursors: nextCursors } = await pull(caller, groupIds, cursors, profileId);
+    const {
+      changes,
+      cursors: nextCursors,
+      hasMore,
+    } = await pull(caller, groupIds, cursors, profileId);
 
     return json({
       outcomes,
       changes,
       cursors: nextCursors,
+      hasMore,
       serverTime: new Date().toISOString(),
     });
   } catch (error) {
@@ -859,9 +864,13 @@ async function pull(
   groupIds: Set<string>,
   cursors: Record<string, number>,
   profileId: string,
-): Promise<{ changes: SyncChange[]; cursors: Record<string, number> }> {
+): Promise<{ changes: SyncChange[]; cursors: Record<string, number>; hasMore: boolean }> {
   const changes: SyncChange[] = [];
   const nextCursors: Record<string, number> = {};
+  // Set whenever any table returned a full page, so at least one scope's cursor
+  // was pinned below its high-water and more rows remain. The client drains them
+  // by re-syncing promptly instead of waiting out the poll interval.
+  let hasMore = false;
 
   // The personal scope is keyed by the caller's own user id (A34). It rides the
   // same cursor map as the groups, but it is not a group — drop it here so the
@@ -893,7 +902,16 @@ async function pull(
     if (!group) continue;
 
     const highWater = Number(group.updated_seq ?? 0);
-    nextCursors[groupId] = highWater;
+
+    // The group's cursor covers every child table below, and may only advance to
+    // a seq under which ALL of them have been fully delivered. A table capped at
+    // MAX_ROWS_PER_TABLE has more rows past its last delivered seq, so it pins the
+    // cursor there and the next pull resumes from it. Previously the cursor jumped
+    // straight to `highWater`, so a table with more than a page of changes since
+    // `since` had its overflow skipped for good — worst case, a fresh device
+    // joining a group with >500 expenses synced only the first page and lost the
+    // rest. Starts at highWater and is dragged down by any truncated table.
+    let groupCursor = highWater;
 
     if (highWater > since) {
       changes.push({ table: 'groups', groupId, seq: highWater, row: group });
@@ -944,11 +962,22 @@ async function pull(
       // client silently ends up with half a ledger.
       if (error) throw new HttpError(500, 'PULL_FAILED', `${table}: ${error.message}`);
 
-      for (const row of data ?? []) {
+      const rows = data ?? [];
+      for (const row of rows) {
         const record = row as Record<string, unknown>;
         changes.push({ table, groupId, seq: Number(record.updated_seq ?? 0), row: record });
       }
+      if (rows.length === MAX_ROWS_PER_TABLE) {
+        // Truncated page: rows ordered by ascending updated_seq, so the last one
+        // is the highest we delivered. Pin the group cursor there — nothing past
+        // it in this table has been sent yet.
+        const lastSeq = Number((rows[rows.length - 1] as Record<string, unknown>).updated_seq ?? 0);
+        if (lastSeq < groupCursor) groupCursor = lastSeq;
+        hasMore = true;
+      }
     }
+
+    nextCursors[groupId] = groupCursor;
   }
 
   // Personal scope (A34): the caller's own captures, keyed by their user id.
@@ -973,6 +1002,7 @@ async function pull(
     if (seq > capturesHighWater) capturesHighWater = seq;
   }
   nextCursors[profileId] = capturesHighWater;
+  if ((captures ?? []).length === MAX_ROWS_PER_TABLE) hasMore = true;
 
   // Personal scope (A38): the caller's own ghost merges, pull-only. Read as the
   // caller so owner-only RLS (`ghost_merges_select_own`) already guarantees they
@@ -1002,6 +1032,7 @@ async function pull(
     if (seq > gmHighWater) gmHighWater = seq;
   }
   nextCursors[gmScope] = gmHighWater;
+  if ((merges ?? []).length === MAX_ROWS_PER_TABLE) hasMore = true;
 
   // Personal scope (extends TDR §8): the caller's own category-tag catalog, its
   // own suffixed cursor. Read as the caller so owner-only RLS guarantees they
@@ -1024,8 +1055,9 @@ async function pull(
     if (seq > tagsHighWater) tagsHighWater = seq;
   }
   nextCursors[tagScope] = tagsHighWater;
+  if ((tags ?? []).length === MAX_ROWS_PER_TABLE) hasMore = true;
 
-  return { changes, cursors: nextCursors };
+  return { changes, cursors: nextCursors, hasMore };
 }
 
 function requireString(value: unknown, field: string): string {


### PR DESCRIPTION
Fixes four findings from the security/correctness audit, each verified against current code (the report's other items were Low/partially-overstated — see the evaluation in the thread).

### High — sync skips rows for backlogged clients
`sync/index.ts` advanced a group's cursor to the group high-water **before** reading its child tables, each capped at `MAX_ROWS_PER_TABLE` (500). A group — or a **fresh device at cursor 0** — with more than a page of changes in one table since the cursor received only the first page while the cursor jumped past the rest; the client persists server cursors as authoritative, so those rows were skipped permanently (a new device joining a >500-expense group lost everything past the first page).

The group cursor now advances only to a seq under which **every** child table was fully delivered — a truncated page pins it to its last delivered row and the next pull resumes there. A new `hasMore` response flag lets the client drain a large backlog promptly instead of a page per 30s poll.

### Medium — restricted R2 delete bypassed row intent
`delete` ran only `authorizeWrite` (party + subject-scoped path), not that a live attachment/proof row referenced the exact path. A co-party could delete another party's bytes out of band, leaving the row + audit trail pointing at nothing. Restricted delete now requires `assertRestrictedPath` — the same live-row check `get` makes.

### Medium — client-controlled upload MIME
`put`/`commit` accepted any `contentType`, so a direct caller could store `text/html`/`svg` in an image bucket (stored-XSS when served back). Both now reject anything outside an image allowlist (jpeg/png/webp/heic/heif) with 415.

### Medium — self-host exposed Postgres
Compose published `0.0.0.0:5432` by default. Now binds `127.0.0.1` (override via `POSTGRES_BIND`), keeping Kong the only intended public entrypoint.

### Tests
Mobile suite green (409). The sync pull and r2-sign are **Deno edge functions with no test harness in this repo and no CI type-check/test step**, so these are verified by review. The prioritised regression tests — >500-row sync backlog, r2 invalid-MIME / non-party & co-party restricted delete / tombstoned-row URL minting — need a Deno edge-function test harness that does not exist yet. Filed as follow-up rather than shipped hollow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sync now automatically continues fetching data when additional records are available.
  - Added configuration to control the database host interface, defaulting to local-only access.

- **Bug Fixes**
  - Improved sync pagination to ensure all records are delivered.
  - Restricted uploads and commits to supported image formats.
  - Prevented deletion of storage files unless they correspond to valid, visible attachments or proofs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->