### PR TITLE
test: security & scale coverage for sync, r2, comments, invites

### DIFF
--- a/apps/mobile/test/storage.test.ts
+++ b/apps/mobile/test/storage.test.ts
@@ -1,0 +1,75 @@
+/**
+ * `removeRestrictedImage` (party-only buckets — settlement proofs, expense
+ * attachments) is documented as best-effort: its one call site is a
+ * housekeeping delete after a replace/removal, and the caller must not be
+ * blown up by an `r2-sign` failure it cannot do anything about (offline,
+ * expired session, the object already gone). The guard is a bare
+ * `.catch(() => {})` around the `signCall`. This is the regression test for
+ * that contract: it never shipped with one, so nothing caught it if a future
+ * edit dropped the `.catch`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock('@/lib/backend', () => ({
+  backend: { functions: { invoke: h.invoke } },
+  backendConfigured: true,
+}));
+
+const { removeRestrictedImage } = await import('../src/lib/storage');
+
+const ORIGINAL_R2_ENABLED = process.env.EXPO_PUBLIC_R2_ENABLED;
+
+beforeEach(() => {
+  h.invoke.mockReset();
+  process.env.EXPO_PUBLIC_R2_ENABLED = 'true';
+});
+
+describe('removeRestrictedImage — best-effort delete', () => {
+  it('does not throw when the r2-sign delete call rejects', async () => {
+    h.invoke.mockRejectedValue(new Error('network unreachable'));
+
+    await expect(
+      removeRestrictedImage('expense-attachments', 'expense-1', 'expense-1/receipt.webp'),
+    ).resolves.toBeUndefined();
+    expect(h.invoke).toHaveBeenCalledWith(
+      'r2-sign',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          action: 'delete',
+          bucket: 'expense-attachments',
+          subjectId: 'expense-1',
+          path: 'expense-1/receipt.webp',
+        }),
+      }),
+    );
+  });
+
+  it('does not throw when r2-sign returns an application error (data null, error set)', async () => {
+    h.invoke.mockResolvedValue({ data: null, error: { message: 'NOT_A_PARTY' } });
+
+    await expect(
+      removeRestrictedImage('settlement-proofs', 'settlement-1', 'settlement-1/proof.webp'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('still calls through and resolves cleanly when the delete succeeds', async () => {
+    h.invoke.mockResolvedValue({ data: {}, error: null });
+
+    await expect(
+      removeRestrictedImage('expense-attachments', 'expense-2', 'expense-2/photo.webp'),
+    ).resolves.toBeUndefined();
+    expect(h.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op — never calls r2-sign at all — when R2 is disabled', async () => {
+    process.env.EXPO_PUBLIC_R2_ENABLED = ORIGINAL_R2_ENABLED;
+
+    await expect(
+      removeRestrictedImage('expense-attachments', 'expense-3', 'expense-3/photo.webp'),
+    ).resolves.toBeUndefined();
+    expect(h.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/test/storage.test.ts
+++ b/apps/mobile/test/storage.test.ts
@@ -9,7 +9,7 @@
  * edit dropped the `.catch`.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const h = vi.hoisted(() => ({ invoke: vi.fn() }));
 
@@ -25,6 +25,13 @@ const ORIGINAL_R2_ENABLED = process.env.EXPO_PUBLIC_R2_ENABLED;
 beforeEach(() => {
   h.invoke.mockReset();
   process.env.EXPO_PUBLIC_R2_ENABLED = 'true';
+});
+
+afterEach(() => {
+  // Restore whatever the process started with, so a test that flips the flag
+  // never leaks it into a later file.
+  if (ORIGINAL_R2_ENABLED === undefined) delete process.env.EXPO_PUBLIC_R2_ENABLED;
+  else process.env.EXPO_PUBLIC_R2_ENABLED = ORIGINAL_R2_ENABLED;
 });
 
 describe('removeRestrictedImage — best-effort delete', () => {
@@ -65,7 +72,7 @@ describe('removeRestrictedImage — best-effort delete', () => {
   });
 
   it('is a no-op — never calls r2-sign at all — when R2 is disabled', async () => {
-    process.env.EXPO_PUBLIC_R2_ENABLED = ORIGINAL_R2_ENABLED;
+    process.env.EXPO_PUBLIC_R2_ENABLED = 'false';
 
     await expect(
       removeRestrictedImage('expense-attachments', 'expense-3', 'expense-3/photo.webp'),

--- a/e2e/m3-invites.mjs
+++ b/e2e/m3-invites.mjs
@@ -42,7 +42,10 @@ const service = createClient(URL, SERVICE, { auth: { persistSession: false } });
 // ── the organiser sets up a group with a ghost who owes money ───────────────
 const organiser = client(ANON);
 await organiser.auth.signInAnonymously();
-await organiser.from('profiles').update({ display_name: 'Asha' }).eq('id', (await organiser.auth.getUser()).data.user.id);
+await organiser
+  .from('profiles')
+  .update({ display_name: 'Asha' })
+  .eq('id', (await organiser.auth.getUser()).data.user.id);
 
 const { data: groupId } = await organiser.rpc('baaki_create_group', {
   p_name: 'Hostel mess',
@@ -52,8 +55,13 @@ const { data: groupId } = await organiser.rpc('baaki_create_group', {
   p_simplify: false,
 });
 
-await organiser.from('group_members').insert({ group_id: groupId, ghost_name: 'Rahul', joined_via: 'ghost' });
-const { data: members } = await organiser.from('group_members').select('id, profile_id, ghost_name').eq('group_id', groupId);
+await organiser
+  .from('group_members')
+  .insert({ group_id: groupId, ghost_name: 'Rahul', joined_via: 'ghost' });
+const { data: members } = await organiser
+  .from('group_members')
+  .select('id, profile_id, ghost_name')
+  .eq('group_id', groupId);
 const organiserMember = members.find((m) => m.profile_id).id;
 const ghostMember = members.find((m) => m.ghost_name === 'Rahul').id;
 
@@ -73,11 +81,18 @@ const { error: expenseError } = await organiser.functions.invoke('expense-write'
 check('set up an expense the ghost owes a share of', !expenseError, await describe(expenseError));
 
 const balancesOf = async () => {
-  const { data } = await service.from('group_balances').select('member_id, balance').eq('group_id', groupId);
+  const { data } = await service
+    .from('group_balances')
+    .select('member_id, balance')
+    .eq('group_id', groupId);
   return new Map((data ?? []).map((row) => [row.member_id, BigInt(row.balance)]));
 };
 const beforeClaim = await balancesOf();
-check('the ghost owes half the bill', (beforeClaim.get(ghostMember) ?? 0n) === -120000n, `${beforeClaim.get(ghostMember)}`);
+check(
+  'the ghost owes half the bill',
+  (beforeClaim.get(ghostMember) ?? 0n) === -120000n,
+  `${beforeClaim.get(ghostMember)}`,
+);
 
 // ── minting ────────────────────────────────────────────────────────────────
 const { data: invite, error: mintError } = await organiser.functions.invoke('invite-mint', {
@@ -85,7 +100,10 @@ const { data: invite, error: mintError } = await organiser.functions.invoke('inv
 });
 check('member can mint an invite link', !mintError && !!invite?.token, await describe(mintError));
 
-const { data: storedInvites } = await service.from('invites').select('token_hash').eq('group_id', groupId);
+const { data: storedInvites } = await service
+  .from('invites')
+  .select('token_hash')
+  .eq('group_id', groupId);
 check(
   'only a hash of the token is stored (TDR §2)',
   (storedInvites ?? []).every((row) => row.token_hash !== invite.token),
@@ -101,8 +119,16 @@ check('nobody can read the invites table, not even a member', (leaked ?? []).len
 const { data: preview, error: previewError } = await outsider.functions.invoke('invite-accept', {
   body: { token: invite.token, mode: 'preview' },
 });
-check('link shows a preview before asking for anything', !previewError && preview?.group?.id === groupId, await describe(previewError));
-check('preview offers the ghost as claimable', preview?.claimable?.some((c) => c.memberId === ghostMember), JSON.stringify(preview?.claimable));
+check(
+  'link shows a preview before asking for anything',
+  !previewError && preview?.group?.id === groupId,
+  await describe(previewError),
+);
+check(
+  'preview offers the ghost as claimable',
+  preview?.claimable?.some((c) => c.memberId === ghostMember),
+  JSON.stringify(preview?.claimable),
+);
 
 const { data: stillHidden } = await outsider.from('expenses').select('id').eq('group_id', groupId);
 check('previewing does not grant access to the ledger', (stillHidden ?? []).length === 0);
@@ -138,6 +164,15 @@ check(
   JSON.stringify(stillGhost),
 );
 
+// Without a well-formed { pending, claimId } response there is nothing to
+// approve — pressing on would throw a raw TypeError on `joined.claimId` and
+// bury the real cause. Fail loudly and stop the scenario here instead.
+if (!joined?.claimId) {
+  check('invite-accept returned a claimId to approve', false, JSON.stringify(joined ?? null));
+  console.error('\nCannot approve a claim without a claimId — stopping.');
+  process.exit(1);
+}
+
 // The organiser is the group's admin — approve it the way the app's admin
 // screen would, through the same RPC invite-accept used to run inline.
 const { data: decision, error: decisionError } = await organiser.rpc('baaki_decide_member_claim', {
@@ -165,10 +200,21 @@ const { data: claimedRow } = await service
   .select('profile_id, ghost_name, joined_via')
   .eq('id', ghostMember)
   .single();
-check('the ghost is now a real member, not a duplicate', claimedRow?.profile_id !== null && claimedRow?.ghost_name === null, claimedRow?.joined_via);
+check(
+  'the ghost is now a real member, not a duplicate',
+  claimedRow?.profile_id !== null && claimedRow?.ghost_name === null,
+  claimedRow?.joined_via,
+);
 
-const { data: memberCount } = await service.from('group_members').select('id').eq('group_id', groupId);
-check('claiming did not create an extra member', (memberCount ?? []).length === 2, `${memberCount?.length}`);
+const { data: memberCount } = await service
+  .from('group_members')
+  .select('id')
+  .eq('group_id', groupId);
+check(
+  'claiming did not create an extra member',
+  (memberCount ?? []).length === 2,
+  `${memberCount?.length}`,
+);
 
 // ── the same ghost cannot be claimed twice ─────────────────────────────────
 const secondComer = client(ANON);
@@ -182,11 +228,22 @@ check('a claimed ghost cannot be claimed again', !!doubleClaim, await describe(d
 const { data: freshJoin, error: freshError } = await secondComer.functions.invoke('invite-accept', {
   body: { token: invite.token, mode: 'join' },
 });
-check('a new person can join without claiming anyone', !freshError && !!freshJoin?.memberId, await describe(freshError));
+check(
+  'a new person can join without claiming anyone',
+  !freshError && !!freshJoin?.memberId,
+  await describe(freshError),
+);
 
 // ── revocation ─────────────────────────────────────────────────────────────
-const { data: inviteRow } = await service.from('invites').select('id').eq('group_id', groupId).single();
-await service.from('invites').update({ revoked_at: new Date().toISOString() }).eq('id', inviteRow.id);
+const { data: inviteRow } = await service
+  .from('invites')
+  .select('id')
+  .eq('group_id', groupId)
+  .single();
+await service
+  .from('invites')
+  .update({ revoked_at: new Date().toISOString() })
+  .eq('id', inviteRow.id);
 
 const lateComer = client(ANON);
 await lateComer.auth.signInAnonymously();
@@ -203,21 +260,29 @@ check('balances still sum to zero after the claim', total === 0n, `${total}`);
 
 const { data: rows } = await service
   .from('expenses')
-  .select(`id, deleted_at,
+  .select(
+    `id, deleted_at,
     currentVersion:expense_versions!expenses_current_version_id_fkey (
       currency, amount, expense_date,
       payers:expense_payers ( member_id, amount ),
-      shares:expense_shares ( member_id, amount ))`)
+      shares:expense_shares ( member_id, amount ))`,
+  )
   .eq('group_id', groupId);
-const snapshots = (rows ?? []).filter((r) => r.currentVersion).map((row) => ({
-  id: row.id,
-  currency: row.currentVersion.currency,
-  amount: BigInt(row.currentVersion.amount),
-  payers: Object.fromEntries(row.currentVersion.payers.map((p) => [p.member_id, BigInt(p.amount)])),
-  shares: Object.fromEntries(row.currentVersion.shares.map((s) => [s.member_id, BigInt(s.amount)])),
-  date: row.currentVersion.expense_date,
-  deletedAt: row.deleted_at,
-}));
+const snapshots = (rows ?? [])
+  .filter((r) => r.currentVersion)
+  .map((row) => ({
+    id: row.id,
+    currency: row.currentVersion.currency,
+    amount: BigInt(row.currentVersion.amount),
+    payers: Object.fromEntries(
+      row.currentVersion.payers.map((p) => [p.member_id, BigInt(p.amount)]),
+    ),
+    shares: Object.fromEntries(
+      row.currentVersion.shares.map((s) => [s.member_id, BigInt(s.amount)]),
+    ),
+    date: row.currentVersion.expense_date,
+    deletedAt: row.deleted_at,
+  }));
 const recomputed = computeNetBalances(snapshots, []).get('INR') ?? new Map();
 const agree = [...new Set([...recomputed.keys(), ...finalBalances.keys()])].every(
   (member) => (recomputed.get(member) ?? 0n) === (finalBalances.get(member) ?? 0n),

--- a/e2e/m3-invites.mjs
+++ b/e2e/m3-invites.mjs
@@ -114,11 +114,41 @@ const { error: badToken } = await outsider.functions.invoke('invite-accept', {
 check('an invalid token is refused', !!badToken, await describe(badToken));
 
 // ── joining by claiming the ghost ──────────────────────────────────────────
+// invite-accept no longer hands the ghost over on the spot (ADR-006's
+// organiser-confirms step, "asking is not taking"): claiming a ghost files a
+// pending `member_claims` row and returns { pending, claimId }. Nothing about
+// membership or balances moves until an admin decides.
 const { data: joined, error: joinError } = await outsider.functions.invoke('invite-accept', {
   body: { token: invite.token, mode: 'join', claimMemberId: ghostMember, displayName: 'Rahul' },
 });
-check('guest joins by claiming the ghost', !joinError && joined?.claimed === true, await describe(joinError));
-check('the claimed membership is the same row', joined?.memberId === ghostMember, `${joined?.memberId}`);
+check(
+  'claiming the ghost files a pending request, not an immediate join',
+  !joinError && joined?.pending === true && !!joined?.claimId,
+  await describe(joinError),
+);
+
+const { data: stillGhost } = await service
+  .from('group_members')
+  .select('profile_id, ghost_name')
+  .eq('id', ghostMember)
+  .single();
+check(
+  'the ghost is untouched while the claim is pending',
+  stillGhost?.profile_id === null && stillGhost?.ghost_name === 'Rahul',
+  JSON.stringify(stillGhost),
+);
+
+// The organiser is the group's admin — approve it the way the app's admin
+// screen would, through the same RPC invite-accept used to run inline.
+const { data: decision, error: decisionError } = await organiser.rpc('baaki_decide_member_claim', {
+  p_claim_id: joined.claimId,
+  p_approve: true,
+});
+check(
+  'the organiser approves the claim',
+  !decisionError && decision?.ok === true && decision?.status === 'approved',
+  decisionError?.message ?? JSON.stringify(decision),
+);
 
 const afterClaim = await balancesOf();
 check(

--- a/e2e/m3-web-lite.mjs
+++ b/e2e/m3-web-lite.mjs
@@ -119,10 +119,27 @@ check('the guest account is anonymous', guestSession?.user?.is_anonymous === tru
 const { data: accepted, error: acceptError } = await guest.functions.invoke('invite-accept', {
   body: { token, mode: 'join', claimMemberId: ghostId },
 });
+// invite-accept no longer hands the ghost over on the spot (ADR-006's
+// organiser-confirms step, "asking is not taking"): claiming files a pending
+// `member_claims` row and returns { pending, claimId } — the guest is not a
+// member yet.
 check(
-  'guest joins and claims Ravi',
-  !acceptError && accepted?.claimed === true && accepted?.memberId === ghostId,
+  'guest claims Ravi and it files a pending request',
+  !acceptError && accepted?.pending === true && !!accepted?.claimId,
   await describeError(acceptError),
+);
+
+// The host is the group's only admin — approve it the way the app's admin
+// screen would, so everything below (reading the group, writing an expense)
+// exercises a real member exactly as this scenario always intended.
+const { data: decision, error: decisionError } = await host.rpc('baaki_decide_member_claim', {
+  p_claim_id: accepted.claimId,
+  p_approve: true,
+});
+check(
+  'host approves the claim',
+  !decisionError && decision?.ok === true && decision?.status === 'approved',
+  decisionError?.message ?? JSON.stringify(decision),
 );
 
 // 3. Reading the group — what apps/web-lite/src/app/g/[groupId] does.

--- a/e2e/m3-web-lite.mjs
+++ b/e2e/m3-web-lite.mjs
@@ -129,6 +129,15 @@ check(
   await describeError(acceptError),
 );
 
+// No claimId means there is nothing to approve, and everything below assumes a
+// real member — pressing on would throw on `accepted.claimId`. Fail loudly and
+// stop rather than crash with a bare TypeError.
+if (!accepted?.claimId) {
+  check('invite-accept returned a claimId to approve', false, JSON.stringify(accepted ?? null));
+  console.error('\nCannot approve a claim without a claimId — stopping.');
+  process.exit(1);
+}
+
 // The host is the group's only admin — approve it the way the app's admin
 // screen would, so everything below (reading the group, writing an expense)
 // exercises a real member exactly as this scenario always intended.

--- a/packages/db/prisma/migrations/20260825210000_expense_comment_idempotency_scope/migration.sql
+++ b/packages/db/prisma/migrations/20260825210000_expense_comment_idempotency_scope/migration.sql
@@ -1,0 +1,95 @@
+-- baaki_add_expense_comment's idempotency replay was keyed on `p_comment_id`
+-- alone: `SELECT id FROM expense_comments WHERE id = p_comment_id` then return
+-- it if found, with no check that the row belongs to THIS group, THIS expense,
+-- or the calling member. That makes a client-chosen id an existence oracle
+-- across every group the caller happens to be a member of — reuse a
+-- `p_comment_id` from group A while a member of group B and the call silently
+-- "succeeds" (echoes A's id back) without inserting anything into B, which is
+-- both a leak (does that id exist anywhere?) and a footgun (the caller believes
+-- their comment was posted; it was not).
+--
+-- The sibling attach RPC (baaki_attach_expense_attachment, 20260824150000)
+-- already scopes its own replay check to `id = p_attachment_id AND expense_id
+-- = p_expense_id` — this brings the comment RPC in line with that precedent,
+-- scoping to group + expense + author so a replay only ever matches the
+-- caller's own prior write. A `p_comment_id` that collides with somebody
+-- else's comment (or the caller's own comment on a different expense/group) is
+-- now a conflict, not a silent echo.
+--
+-- Body-only change (CREATE OR REPLACE), no shape change — no Prisma drift.
+
+CREATE OR REPLACE FUNCTION public.baaki_add_expense_comment(
+  p_group_id   uuid,
+  p_expense_id uuid,
+  p_comment_id uuid,
+  p_body       text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id            uuid;
+  v_body          text := btrim(COALESCE(p_body, ''));
+  v_me            uuid;
+  v_existing_group    uuid;
+  v_existing_expense  uuid;
+  v_existing_author   uuid;
+BEGIN
+  IF NOT public.is_group_member(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_A_MEMBER: you are not in that group'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF v_body = '' THEN
+    RAISE EXCEPTION 'EMPTY_COMMENT: a comment needs some text'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  IF char_length(v_body) > 2000 THEN
+    RAISE EXCEPTION 'COMMENT_TOO_LONG: keep it under 2000 characters'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  v_me := public.baaki_my_member_id(p_group_id);
+
+  -- Replaying a create must return the same row, not a second one (ADR-005) —
+  -- but only when the id really is a replay of THIS caller's THIS write. A
+  -- collision with an unrelated comment (another group, another expense,
+  -- another author) is refused rather than echoed back.
+  IF p_comment_id IS NOT NULL THEN
+    SELECT id, group_id, expense_id, author_member_id
+      INTO v_id, v_existing_group, v_existing_expense, v_existing_author
+      FROM public.expense_comments
+     WHERE id = p_comment_id;
+    IF v_id IS NOT NULL THEN
+      IF v_existing_group = p_group_id
+         AND v_existing_expense = p_expense_id
+         AND v_existing_author IS NOT DISTINCT FROM v_me
+      THEN
+        RETURN v_id;
+      END IF;
+      RAISE EXCEPTION 'COMMENT_ID_CONFLICT: that id belongs to a different comment'
+        USING ERRCODE = 'unique_violation';
+    END IF;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.expenses WHERE id = p_expense_id AND group_id = p_group_id
+  ) THEN
+    RAISE EXCEPTION 'UNKNOWN_EXPENSE: that expense is not in this group'
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  INSERT INTO public.expense_comments
+    (id, group_id, expense_id, author_member_id, body)
+  VALUES
+    (COALESCE(p_comment_id, gen_random_uuid()), p_group_id, p_expense_id, v_me, v_body)
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_add_expense_comment(uuid, uuid, uuid, text)
+  TO authenticated, anon;

--- a/packages/db/test/expense-comments.test.ts
+++ b/packages/db/test/expense-comments.test.ts
@@ -267,6 +267,82 @@ describe('expense comments — permission matrix', () => {
     expect(msg).toMatch(/EMPTY_COMMENT/);
   });
 
+  it('T17 a comment id from another group is not a replay — it is a conflict', async () => {
+    const other = await seedGroup(client, { memberCount: 2, name: 'Cross-scope A' });
+    const { expenseId: otherExpense } = await addEqualSplitExpense(client, {
+      groupId: other.groupId,
+      payers: { [other.memberIds[0] as string]: 1000n },
+      participants: other.memberIds,
+      amount: 1000n,
+    });
+    const id = randomUUID();
+    // A genuine comment in `other`, owned by other.profileIds[0].
+    await as(other.profileIds[0] as string, () =>
+      client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [
+        other.groupId,
+        otherExpense,
+        id,
+        'belongs to the other group',
+      ]),
+    );
+    // A member of `g` reuses that same id, targeting g's own group/expense.
+    // Before the fix this silently returned `id` (an existence oracle) with
+    // no row inserted into g; now it is a clean conflict.
+    const msg = await expectDenied(
+      as(P(1), () =>
+        client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [
+          g.groupId,
+          expenseId,
+          id,
+          'trying to reuse a foreign id',
+        ]),
+      ),
+    );
+    expect(msg).toMatch(/COMMENT_ID_CONFLICT/);
+    // And the original, untouched.
+    const row = await rowById(id);
+    expect(String(row.author_member_id)).toBe(other.memberIds[0]);
+  });
+
+  it('T18 a comment id already used on a different expense in the same group is a conflict', async () => {
+    const { expenseId: secondExpense } = await addEqualSplitExpense(client, {
+      groupId: g.groupId,
+      payers: { [g.memberIds[0] as string]: 1000n },
+      participants: g.memberIds,
+      amount: 1000n,
+      description: 'A second bill',
+    });
+    const id = await addComment(P(1), 'on the first expense');
+    const msg = await expectDenied(
+      as(P(1), () =>
+        client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [
+          g.groupId,
+          secondExpense,
+          id,
+          'same group, different expense',
+        ]),
+      ),
+    );
+    expect(msg).toMatch(/COMMENT_ID_CONFLICT/);
+  });
+
+  it('T19 a comment id already used by a different author on the same expense is a conflict', async () => {
+    const id = await addComment(P(1), "P1's comment");
+    const msg = await expectDenied(
+      as(P(2), () =>
+        client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [
+          g.groupId,
+          expenseId,
+          id,
+          'P2 tries to reuse it',
+        ]),
+      ),
+    );
+    expect(msg).toMatch(/COMMENT_ID_CONFLICT/);
+    const row = await rowById(id);
+    expect(String(row.author_member_id)).toBe(g.memberIds[1]);
+  });
+
   it('T16 the table is not directly writable — RPCs are the only way in', async () => {
     const id = await addComment(P(1), 'legit');
     // Direct INSERT forging an author.

--- a/packages/db/test/invite-claim-use-count.test.ts
+++ b/packages/db/test/invite-claim-use-count.test.ts
@@ -1,0 +1,149 @@
+/**
+ * A wrinkle in the "asking is not taking" design (memberClaims / A6): claiming
+ * a ghost is a two-step handshake — `invite-accept` files a pending
+ * `member_claims` row via `baaki_request_member_claim`, and nothing about the
+ * group changes until an admin decides via `baaki_decide_member_claim`.
+ *
+ * But the invite's `max_uses` slot is NOT part of that handshake. Per
+ * `invite-accept` (see the "Reserve a use atomically before creating
+ * anything" comment there), `baaki_consume_invite` is called BEFORE the claim
+ * branch runs, so the slot is burned the moment someone taps "claim Ravi" —
+ * whether or not an admin ever agrees they are Ravi.
+ *
+ * These tests lock in that current behaviour at the DB/RPC level (the edge
+ * function itself is Deno and out of scope here): a one-use invite is spent by
+ * a claim request alone, and staying spent even if the claim is later
+ * declined or withdrawn. Nothing here is changed — see the TODO(product) on
+ * each test for the actual wrinkle.
+ */
+
+import { randomUUID, createHash } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, seedGroup } from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+/** Session-scoped (not a rolled-back tx): baaki_decide_member_claim's writes
+ *  have to survive the call to be asserted on, same as memberClaims.test.ts. */
+async function asProfile<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  try {
+    return await run();
+  } finally {
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+async function newcomer(name = 'Arrival'): Promise<string> {
+  const id = randomUUID();
+  await client.query(
+    `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, $2, 'INR')`,
+    [id, name],
+  );
+  return id;
+}
+
+/** A one-use invite, inserted directly the way invite-mint would leave it —
+ *  not the durable join-link RPC, whose max_uses is effectively unlimited. */
+async function mintSingleUseInvite(groupId: string): Promise<string> {
+  const inviteId = randomUUID();
+  const token = randomUUID().replace(/-/g, '');
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+  await client.query(
+    `INSERT INTO invites (id, group_id, token_hash, expires_at, max_uses, use_count)
+     VALUES ($1, $2, $3, now() + interval '7 days', 1, 0)`,
+    [inviteId, groupId, tokenHash],
+  );
+  return inviteId;
+}
+
+const consume = (inviteId: string) =>
+  client
+    .query(`SELECT baaki_consume_invite($1) AS ok`, [inviteId])
+    .then((r) => (r.rows[0].ok as boolean | null) ?? null);
+
+const useCountOf = (inviteId: string) =>
+  client
+    .query(`SELECT use_count, max_uses FROM invites WHERE id = $1`, [inviteId])
+    .then((r) => r.rows[0] as { use_count: number; max_uses: number });
+
+describe('a pending claim spends the invite slot before anyone decides', () => {
+  it('TODO(product): filing the claim (not deciding it) exhausts a one-use link', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 1, ghostCount: 1 });
+    const ghostId = memberIds[1] as string;
+    const arrival = await newcomer();
+
+    const inviteId = await mintSingleUseInvite(groupId);
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 0, max_uses: 1 });
+
+    // Mirrors invite-accept's order: reserve the use, THEN ask for the claim.
+    expect(await consume(inviteId)).toBe(true);
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });
+
+    const { rows } = await client.query(
+      `SELECT public.baaki_request_member_claim($1, $2, $3, $4) AS verdict`,
+      [groupId, ghostId, arrival, 'Ravi'],
+    );
+    const verdict = rows[0].verdict as { ok: boolean; claim_id?: string };
+    expect(verdict.ok).toBe(true);
+
+    // The claim is only PENDING — nobody has decided anything — yet the
+    // link's only slot is already spent. A second person who wanted to join
+    // this same link (as themselves, or to dispute the claim) finds it dead.
+    expect(await consume(inviteId)).toBeNull();
+
+    // The ghost itself is still untouched while the claim waits, same as
+    // memberClaims.test.ts's first assertion — the slot burns independently
+    // of whether the claim ever succeeds.
+    const ghost = await client
+      .query(`SELECT profile_id, ghost_name FROM group_members WHERE id = $1`, [ghostId])
+      .then((r) => r.rows[0]);
+    expect(ghost.profile_id).toBeNull();
+    expect(ghost.ghost_name).toBe('Ghost 1');
+  });
+
+  it('TODO(product): the slot stays spent even when the admin declines the claim', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 1,
+      ghostCount: 1,
+    });
+    const ghostId = memberIds[1] as string;
+    const admin = profileIds[0] as string;
+    const arrival = await newcomer();
+
+    const inviteId = await mintSingleUseInvite(groupId);
+    await consume(inviteId);
+
+    const { rows } = await client.query(
+      `SELECT public.baaki_request_member_claim($1, $2, $3, $4) AS verdict`,
+      [groupId, ghostId, arrival, 'Ravi'],
+    );
+    const claimId = (rows[0].verdict as { claim_id: string }).claim_id;
+
+    const decision = await asProfile(admin, () =>
+      client
+        .query(`SELECT public.baaki_decide_member_claim($1, $2) AS v`, [claimId, false])
+        .then((r) => r.rows[0].v as { ok: boolean; status: string }),
+    );
+    expect(decision).toMatchObject({ ok: true, status: 'declined' });
+
+    // Nobody ever joined this group through this link — the request was
+    // refused — but the link's one use is gone all the same, and nobody who
+    // holds it can try again.
+    expect(await consume(inviteId)).toBeNull();
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });
+  });
+});

--- a/packages/db/test/replace-attachment-image.test.ts
+++ b/packages/db/test/replace-attachment-image.test.ts
@@ -113,4 +113,33 @@ describe('replace attachment image', () => {
   it('an unknown attachment id is a silent no-op', async () => {
     await replace(P(0), randomUUID(), `${expenseId}/${randomUUID()}.webp`);
   });
+
+  // TODO(integrity): the RPC only checks that the new path is scoped to the
+  // expense (`<expenseId>/…`) — it never checks that a committed row for that
+  // path exists in `storage_objects`. A party can repoint an attachment at
+  // bytes that were never uploaded (a typo'd path, a path from a different
+  // logical bucket, or one that was only ever `pending`/released and never
+  // committed), and the RPC clears the markup and succeeds anyway, leaving the
+  // row pointing at nothing. This matches the sibling
+  // `baaki_attach_expense_attachment` (20260824150000 / 20260825130000), which
+  // has the exact same gap — it is not unique to replace, so this is
+  // documented rather than fixed here: fixing one without the other would be
+  // an inconsistent half-measure, and fixing both is a wider change (every
+  // other DB test that attaches with a made-up path — expense-image-events,
+  // receipt-annotations — would need a real `storage_objects` row too).
+  it('TODO(integrity): a syntactically valid but never-committed path is accepted', async () => {
+    // Scoped correctly, never went through r2-sign's `put`/`commit` — no row
+    // for it in storage_objects.
+    const neverUploaded = `${expenseId}/${randomUUID()}.webp`;
+    const orphaned = await client
+      .query(`SELECT count(*)::int AS n FROM storage_objects WHERE path = $1`, [neverUploaded])
+      .then((r) => r.rows[0].n as number);
+    expect(orphaned).toBe(0);
+
+    await replace(P(0), attachmentId, neverUploaded);
+
+    const r = await row(attachmentId);
+    expect(r.storage_path).toBe(neverUploaded);
+    expect(r.annotations).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adds the tractable tests from the security/coverage sweep. Every committed test passes locally; two edge-function findings (sync backlog, r2-sign delete/MIME) turned out to have no runnable harness in this environment and are reported, not fabricated.

### Per-finding

| Finding | Result |
|---|---|
| A. Cross-scope comment idempotency | **Fixed the RPC** — `baaki_add_expense_comment`'s replay check matched on `p_comment_id` alone (any group/expense/author). New migration `20260825210000_expense_comment_idempotency_scope` scopes it to id+group+expense+author, matching the precedent already set by the sibling `baaki_attach_expense_attachment`. Body-only, no Prisma drift. 3 new tests (T17-T19) in `expense-comments.test.ts`. |
| B. Attachment replace with a nonexistent path | **Documented, not fixed** — `baaki_replace_expense_attachment_image` never checks the new path exists in `storage_objects` before repointing + clearing markup. Same gap exists in the sibling attach RPC, so a replace-only fix would be an inconsistent half-measure, and fixing both needs other DB tests (expense-image-events, receipt-annotations) to start seeding real `storage_objects` rows. Test added with a `TODO(integrity)` label documenting current behavior. |
| C. Invite + pending claim use-count | **Documented current behavior** — `invite-accept` calls `baaki_consume_invite` before the claim branch, so filing a pending ghost-claim burns a one-use invite's only slot even though nothing about membership moves until an admin decides, and the slot stays burned if the claim is declined. New `invite-claim-use-count.test.ts`, 2 tests, `TODO(product)` notes. `invite-accept` itself untouched (Deno, out of scope). |
| D. Silent restricted cleanup | **Added** — `apps/mobile/test/storage.test.ts`: `removeRestrictedImage` never throws on a rejected/erroring `r2-sign` delete, and is a true no-op when R2 is disabled. |
| E. Stale e2e assertions | **Updated, not run** — `e2e/m3-invites.mjs` and `e2e/m3-web-lite.mjs` still expected the old immediate-claim shape (`claimed === true`, `memberId === ghostMember`). Updated both to expect `{ pending: true, claimId }`, then approve via `baaki_decide_member_claim` as the group's admin before continuing. Both scripts hit a live Supabase project via `SUPABASE_URL`/`ANON_KEY`/`SERVICE_KEY` — no such stack or credentials exist in this environment, so these are syntax-checked (`node --check`) only, not executed. |
| F. Edge-function tests (sync backlog, r2 delete/MIME) | **Infeasible here, not fabricated** — no Deno runtime, no Supabase CLI, no local edge-function server; only a bare Postgres container is running (`docker ps` shows `baaki-pg` alone), and no `SUPABASE_URL`/`ANON_KEY`/`SERVICE_KEY` are set. The `e2e/*.mjs` scripts default to a real hosted project. Building a harness would need either a local Supabase stack (`supabase start`, Docker-based, with the edge runtime) or the staging project's credentials from `e2e/README-e2e.md`'s CI setup — neither is available here. |

### Real bug found (fixed above)

`baaki_add_expense_comment`'s idempotency replay was an unscoped existence oracle — reusing a UUID from a comment in a group you're not even in silently "succeeded" (echoed the id back) with nothing written, which both leaks whether that id exists and can mislead a caller into thinking their comment posted. Fixed in this PR (finding A).

### Verification

- `pnpm --filter @waves/db exec vitest run` — 592/593 pass; the 1 failure (`campaigns.test.ts` holdout-percentage split) is a pre-existing flaky statistical assertion unrelated to this change (passes on rerun in isolation, confirmed before and after these changes).
- `cd apps/mobile && npx vitest run` — 413/413 pass (37 files, +1 new).
- `pnpm format` — clean, no changes.
- `pnpm lint` — clean across admin/mobile/web.
- `apps/mobile`: `tsc --noEmit` clean.
- `packages/db`: `tsc --noEmit` has one pre-existing, unrelated failure (`generated/client` missing — `prisma generate` needs `DIRECT_URL` from `packages/db/.env`, a known environment trap, not something this PR touches); the actual test files type-check cleanly once that's supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invitees claiming existing guest memberships now submit a pending claim for organizer approval.
  * Approved claims preserve existing history and balances while converting the guest into a member.
* **Bug Fixes**
  * Invite usage is correctly consumed when a claim is submitted, including when the claim is later declined.
  * Expense comment identifiers are now scoped correctly, preventing conflicting comments from being silently accepted.
* **Tests**
  * Expanded coverage for invite claims, expense comments, image removal, and attachment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->