### PR TITLE
style(expense): match the dashboard/group hero header buttons

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -310,14 +310,22 @@ export default function ExpenseDetailScreen() {
             gap: theme.spacing.lg,
           }}
         >
-          <Row>
-            <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Row style={{ alignItems: 'center' }}>
+            {/* Back and overflow match the dashboard/group hero: a chip-less xxl
+                white glyph, not the smaller boxed IconButton. */}
+            <Pressable
+              onPress={() => router.back()}
+              accessibilityRole="button"
+              accessibilityLabel={t.common.back}
+              hitSlop={10}
+              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+            >
               <Ionicons
                 name={directionalIcon('chevron-back')}
-                size={iconSize.lg}
+                size={iconSize.xxl}
                 color={theme.color.onBrand}
               />
-            </IconButton>
+            </Pressable>
             <View style={{ flex: 1, alignItems: 'flex-start' }}>
               <Text variant="heading" tone="onBrand" numberOfLines={1}>
                 {expenseTitle(version.description, version.category, t, version.category_meta)}
@@ -330,9 +338,15 @@ export default function ExpenseDetailScreen() {
                 trailing control the group and dashboard headers carry — Edit and
                 Delete (or Restore) instead of a full-width button stacked at the
                 bottom of a long scroll. */}
-            <IconButton label={t.group.more} onPress={() => setMenuOpen(true)}>
-              <Ionicons name="ellipsis-vertical" size={iconSize.lg} color={theme.color.onBrand} />
-            </IconButton>
+            <Pressable
+              onPress={() => setMenuOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel={t.group.more}
+              hitSlop={10}
+              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+            >
+              <Ionicons name="ellipsis-vertical" size={iconSize.xxl} color={theme.color.onBrand} />
+            </Pressable>
           </Row>
 
           <View style={{ alignItems: 'flex-start', gap: theme.spacing.sm }}>


### PR DESCRIPTION
The expense hero already shared the dashboard's height and panel, but its back and overflow controls used the smaller boxed `IconButton` (`iconSize.lg`) where the dashboard and group heroes use a chip-less `xxl` white glyph. Swapped them for the same bare `Pressable` + `iconSize.xxl` pattern so the three heroes' header buttons match. Height/layout unchanged; the group hero already used this style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated expense header controls with larger icons and improved pressed-state feedback.
  * Improved accessibility labels and touch target areas for Back and More actions.
  * Preserved the existing header layout and menu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->