### PR TITLE
feat(expense): comments composer first + redesigned empty state

### DIFF
--- a/apps/mobile/src/components/ExpenseComments.tsx
+++ b/apps/mobile/src/components/ExpenseComments.tsx
@@ -213,6 +213,47 @@ export function ExpenseComments({
 
   return (
     <View style={{ gap: theme.spacing.lg }}>
+      {/* Composer first: writing a comment is what you came here to do, so the
+          field leads and the thread you're replying to sits beneath it. */}
+      <Row style={{ gap: 10, alignItems: 'flex-end' }}>
+        <Avatar name={nameOf(myMemberId)} size={AVATAR} />
+        <TextInput
+          value={draft}
+          onChangeText={setDraft}
+          onFocus={onComposerFocus}
+          multiline
+          placeholder={t.comments.placeholder}
+          placeholderTextColor={theme.color.textFaint}
+          style={fieldStyle}
+          accessibilityLabel={t.comments.placeholder}
+        />
+        <Pressable
+          onPress={submit}
+          disabled={add.isPending || draft.trim() === ''}
+          accessibilityRole="button"
+          accessibilityLabel={t.comments.post}
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 20,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor:
+              draft.trim() === '' ? theme.color.surfaceMuted : theme.color.buttonPrimary,
+          }}
+        >
+          {add.isPending ? (
+            <ActivityIndicator color={theme.color.onBrand} />
+          ) : (
+            <Ionicons
+              name="arrow-up"
+              size={iconSize.md}
+              color={draft.trim() === '' ? theme.color.textFaint : theme.color.onBrand}
+            />
+          )}
+        </Pressable>
+      </Row>
+
       {hidden > 0 ? (
         <Pressable
           onPress={() => setVisibleCount((c) => c + PAGE)}
@@ -231,9 +272,29 @@ export function ExpenseComments({
       ) : null}
 
       {rows.length === 0 ? (
-        <Text variant="caption" tone="muted">
-          {t.comments.empty}
-        </Text>
+        // A centred icon-over-title-over-subtitle empty state (the pattern most
+        // comment threads use), so a bill with no discussion reads as an
+        // invitation, not a bare line of grey text.
+        <View
+          style={{ alignItems: 'center', gap: theme.spacing.sm, paddingVertical: theme.spacing.xl }}
+        >
+          <View
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 28,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.color.surfaceMuted,
+            }}
+          >
+            <Ionicons name="chatbubbles-outline" size={26} color={theme.color.textMuted} />
+          </View>
+          <Text variant="heading">{t.comments.emptyTitle}</Text>
+          <Text variant="caption" tone="muted">
+            {t.comments.empty}
+          </Text>
+        </View>
       ) : (
         shown.map((row) => {
           const mine = myMemberId !== null && row.authorMemberId === myMemberId;
@@ -307,46 +368,6 @@ export function ExpenseComments({
           );
         })
       )}
-
-      {/* Composer — a pinned pill: your avatar, a rounded field, a round send. */}
-      <Row style={{ gap: 10, alignItems: 'flex-end', paddingTop: theme.spacing.xs }}>
-        <Avatar name={nameOf(myMemberId)} size={AVATAR} />
-        <TextInput
-          value={draft}
-          onChangeText={setDraft}
-          onFocus={onComposerFocus}
-          multiline
-          placeholder={t.comments.placeholder}
-          placeholderTextColor={theme.color.textFaint}
-          style={fieldStyle}
-          accessibilityLabel={t.comments.placeholder}
-        />
-        <Pressable
-          onPress={submit}
-          disabled={add.isPending || draft.trim() === ''}
-          accessibilityRole="button"
-          accessibilityLabel={t.comments.post}
-          style={{
-            width: 40,
-            height: 40,
-            borderRadius: 20,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor:
-              draft.trim() === '' ? theme.color.surfaceMuted : theme.color.buttonPrimary,
-          }}
-        >
-          {add.isPending ? (
-            <ActivityIndicator color={theme.color.onBrand} />
-          ) : (
-            <Ionicons
-              name="arrow-up"
-              size={iconSize.md}
-              color={draft.trim() === '' ? theme.color.textFaint : theme.color.onBrand}
-            />
-          )}
-        </Pressable>
-      </Row>
     </View>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -374,7 +374,9 @@ export interface UiStrings {
   comments: {
     /** Section label. */
     title: string;
-    /** Shown when there are no comments yet. */
+    /** Bold title of the empty state ("No comments yet"). */
+    emptyTitle: string;
+    /** Subtitle under the empty-state title, inviting the first comment. */
     empty: string;
     /** Composer placeholder. */
     placeholder: string;
@@ -2124,7 +2126,8 @@ const en: UiStrings = {
   },
   comments: {
     title: 'Comments',
-    empty: 'No comments yet. Start the conversation.',
+    emptyTitle: 'No comments yet',
+    empty: 'Start the conversation.',
     placeholder: 'Add a comment…',
     post: 'Post comment',
     edit: 'Edit',
@@ -3863,7 +3866,8 @@ const ta: UiStrings = {
   },
   comments: {
     title: 'கருத்துகள்',
-    empty: 'இன்னும் கருத்துகள் இல்லை. உரையாடலைத் தொடங்குங்கள்.',
+    emptyTitle: 'இன்னும் கருத்துகள் இல்லை',
+    empty: 'உரையாடலைத் தொடங்குங்கள்.',
     placeholder: 'ஒரு கருத்தைச் சேர்…',
     post: 'கருத்தை இடு',
     edit: 'திருத்து',
@@ -5666,7 +5670,8 @@ const hi: UiStrings = {
   },
   comments: {
     title: 'टिप्पणियाँ',
-    empty: 'अभी कोई टिप्पणी नहीं। बातचीत शुरू करें।',
+    emptyTitle: 'अभी कोई टिप्पणी नहीं',
+    empty: 'बातचीत शुरू करें।',
     placeholder: 'एक टिप्पणी जोड़ें…',
     post: 'टिप्पणी भेजें',
     edit: 'बदलें',
@@ -7420,7 +7425,8 @@ const ar: UiStrings = {
   },
   comments: {
     title: 'التعليقات',
-    empty: 'لا تعليقات بعد. ابدأ المحادثة.',
+    emptyTitle: 'لا تعليقات بعد',
+    empty: 'ابدأ المحادثة.',
     placeholder: 'أضف تعليقًا…',
     post: 'نشر التعليق',
     edit: 'تعديل',


### PR DESCRIPTION
Two expense-screen comment changes you asked for:

- **Composer first.** The comment field now leads the thread instead of being pinned at the bottom — writing is the action you open the section for, so it comes first and the existing comments follow.
- **Redesigned empty state** (grounded in Mobbin — [Base](https://mobbin.com/screens/7bed043f-4987-452b-9adc-d4e630473b74), [Vrbo](https://mobbin.com/screens/d36f4498-9a0c-4d9f-9b84-db1a296f3bb9)): a centred chat icon over a bold "No comments yet" title over an inviting subtitle, replacing the lone line of grey text. New `comments.emptyTitle` string across all four locales (en/ta/hi/ar); the existing `empty` string becomes the subtitle.

tsc + lint clean, 411 mobile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a chat icon and localized title to the empty comments state.
  * Updated comment translations across English, Tamil, Hindi, and Arabic.

* **Improvements**
  * Moved the comment composer above the comment thread for easier access.
  * Separated the empty-state title and description for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->