### PR TITLE
fix(nav): slide into group & expense screens, match hero height to dashboard

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -579,14 +579,14 @@ function AuthGate() {
           {paywallEnabled ? <Stack.Screen name="paywall" options={modal} /> : null}
           <Stack.Screen name="capture" options={modal} />
           <Stack.Screen name="captures" />
-          <Stack.Screen name="group/[id]/index" />
+          <Stack.Screen name="group/[id]/index" options={slide} />
           <Stack.Screen name="group/[id]/add-expense" options={slide} />
           <Stack.Screen name="group/[id]/settle" options={modal} />
           <Stack.Screen name="group/[id]/simplify" />
           <Stack.Screen name="group/[id]/settings" />
           <Stack.Screen name="group/[id]/members" />
           <Stack.Screen name="group/[id]/member/[memberId]" />
-          <Stack.Screen name="group/[id]/expense/[expenseId]" />
+          <Stack.Screen name="group/[id]/expense/[expenseId]" options={slide} />
           <Stack.Screen name="group/[id]/invite" options={modal} />
           <Stack.Screen name="group/[id]/itemize" options={modal} />
           <Stack.Screen name="receipt/[id]" options={modal} />

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -304,7 +304,8 @@ export default function ExpenseDetailScreen() {
             marginHorizontal: -theme.spacing.xl,
             paddingTop: insets.top + theme.spacing.md,
             paddingHorizontal: theme.spacing.xl,
-            paddingBottom: theme.spacing.xl,
+            // Match the dashboard/group hero height: lg bottom padding, not xl.
+            paddingBottom: theme.spacing.lg,
             borderBottomLeftRadius: theme.radius.xxl,
             borderBottomRightRadius: theme.radius.xxl,
             gap: theme.spacing.lg,

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -590,7 +590,9 @@ export default function GroupScreen() {
                   marginHorizontal: -theme.spacing.xl,
                   paddingTop: insets.top + theme.spacing.md,
                   paddingHorizontal: theme.spacing.xl,
-                  paddingBottom: theme.spacing.xl,
+                  // Match the dashboard hero's bottom padding so the three heroes
+                  // are the same height (dashboard is lg, not xl).
+                  paddingBottom: theme.spacing.lg,
                   borderBottomLeftRadius: theme.radius.xxl,
                   borderBottomRightRadius: theme.radius.xxl,
                   gap: theme.spacing.xl,


### PR DESCRIPTION
## What

Two small polish fixes on the group and expense screens, reported on device.

### 1. Slide instead of a "bounce" opening them
`group/[id]/index` and `group/[id]/expense/[expenseId]` inherited the app-wide default `animation: 'none'`, so they cut in with no directional motion. Give both the same `slide` (slide_from_right, RTL-aware from the left) that the add-expense route already uses.

### 2. Hero height matches the dashboard
The dashboard green hero pads its bottom with `spacing.lg`; the group and expense heroes used `spacing.xl`, so their saturated panels sat taller than the dashboard reference. Both dropped to `lg`.

## Test
- `pnpm format` + `pnpm lint` green.
- Manual: open a group and an expense — both slide in; the blue heroes match the dashboard green header height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated group detail and expense screens with smoother horizontal slide transitions.
  * Reduced excess spacing at the bottom of group and expense headers for a more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->