### PR TITLE
feat(group,dashboard): hero action trio + browsable All groups screen

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -19,6 +19,7 @@ import { dayNumber, daysBetween, type GuestGate } from '@waves/core';
 import {
   Avatar,
   Button,
+  directionalIcon,
   EmptyState,
   Gradient,
   iconSize,
@@ -451,10 +452,36 @@ export default function HomeScreen() {
             </View>
           ) : (
             <>
-              <Text variant="subheading">{t.yourGroups}</Text>
+              {/* The heading carries the door to the full list: the card below is
+                  a capped preview, "All groups" opens the whole roster. */}
+              <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+                <Text variant="subheading">{t.yourGroups}</Text>
+                <Pressable
+                  onPress={() => router.push('/groups')}
+                  accessibilityRole="button"
+                  accessibilityLabel={t.allGroups}
+                  hitSlop={8}
+                  style={({ pressed }) => ({
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 2,
+                    opacity: pressed ? 0.5 : 1,
+                  })}
+                >
+                  <Text variant="caption" tone="brand" style={{ fontWeight: '700' }}>
+                    {t.allGroups}
+                  </Text>
+                  <Ionicons
+                    name={directionalIcon('chevron-forward')}
+                    size={iconSize.md}
+                    color={theme.color.brand}
+                  />
+                </Pressable>
+              </Row>
               {/* The groups as one clean list on a single card — an emoji chip, the
                   name and its standing, the balance to the right — the banking-app
-                  "recent" list the reference leans on, hairline-divided. */}
+                  "recent" list the reference leans on, hairline-divided. Capped to
+                  a preview; the full list lives behind "All groups". */}
               <View
                 style={{
                   backgroundColor: theme.color.surface,
@@ -464,7 +491,7 @@ export default function HomeScreen() {
                   overflow: 'hidden',
                 }}
               >
-                {list.map((group, index) => {
+                {list.slice(0, GROUPS_PREVIEW).map((group, index) => {
                   const members = summary.membersFor(group.id);
                   const balance = summary.balanceFor(group.id);
                   // A running trip earns a live "on trip" tag; failing that, a
@@ -759,6 +786,11 @@ function HeroIconButton({
 
 /** How long after creation a group still counts as "New" — 48 hours. */
 const NEW_GROUP_WINDOW_MS = 48 * 60 * 60 * 1000;
+
+/** How many groups the dashboard shows inline before deferring to the full
+    "All groups" screen — enough to cover most people's active set without the
+    home list growing without bound. */
+const GROUPS_PREVIEW = 5;
 
 /** The AsyncStorage key holding the day the guest last closed the prompt. */
 const GUEST_PROMPT_DISMISS_KEY = 'guestPrompt:dismissedOn';

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -579,6 +579,7 @@ function AuthGate() {
           {paywallEnabled ? <Stack.Screen name="paywall" options={modal} /> : null}
           <Stack.Screen name="capture" options={modal} />
           <Stack.Screen name="captures" />
+          <Stack.Screen name="groups" options={slide} />
           <Stack.Screen name="group/[id]/index" options={slide} />
           <Stack.Screen name="group/[id]/add-expense" options={slide} />
           <Stack.Screen name="group/[id]/settle" options={modal} />

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -14,7 +14,6 @@ import {
   Card,
   directionalIcon,
   EmptyState,
-  Fab,
   Gradient,
   iconSize,
   MoneyText,
@@ -75,6 +74,41 @@ enum Tab {
  * same manner: once tapped it stops offering, and a rate limit reads as "already
  * nudged today" rather than as an error. Nobody should be told off for asking.
  */
+/**
+ * One round translucent action on the group hero — a white glyph on a dim
+ * white disc, the same on-panel circle the dashboard hero uses. Icon-only;
+ * its name rides on the accessibility label.
+ */
+function HeroActionCircle({
+  icon,
+  label,
+  onPress,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        width: 46,
+        height: 46,
+        borderRadius: 23,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(255, 255, 255, 0.18)',
+        opacity: pressed ? 0.7 : 1,
+      })}
+    >
+      <Ionicons name={icon} size={iconSize.xl} color={theme.color.onBrand} />
+    </Pressable>
+  );
+}
+
 function RemindChip({
   groupId,
   memberId,
@@ -708,55 +742,46 @@ export default function GroupScreen() {
                     style={{ color: theme.color.onBrand }}
                   />
 
-                  {/* Two actions on the hero: Settle up is the white pill (the one
-                    primary), Simplify a translucent-white pill behind it. Both
-                    hold their label on the wash. */}
-                  <Row style={{ gap: theme.spacing.md }}>
+                  {/* Three actions on the hero, like the dashboard: a white
+                    "add expense" pill leads (the one primary), then two
+                    translucent circles — settle up and who-pays-whom. */}
+                  <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
                     <Pressable
-                      onPress={() => router.push(`/group/${groupId}/settle`)}
+                      onPress={() => router.push(`/group/${groupId}/add-expense`)}
                       accessibilityRole="button"
-                      accessibilityLabel={t.settleUp}
+                      accessibilityLabel={t.addExpense}
                       style={({ pressed }) => ({
-                        flex: 1,
                         flexDirection: 'row',
                         alignItems: 'center',
-                        justifyContent: 'center',
                         gap: theme.spacing.xs,
                         paddingVertical: theme.spacing.sm + 2,
-                        paddingHorizontal: theme.spacing.md,
+                        paddingHorizontal: theme.spacing.lg,
                         borderRadius: theme.radius.pill,
                         backgroundColor: '#FFFFFF',
                         opacity: pressed ? 0.85 : 1,
                       })}
                     >
-                      <Ionicons name="swap-horizontal" size={iconSize.md} color={heroGradient[0]} />
+                      <Ionicons name="add" size={iconSize.lg} color={heroGradient[0]} />
                       <Text
                         variant="subheading"
                         style={{ color: heroGradient[0] }}
                         numberOfLines={1}
                       >
-                        {t.settleUp}
+                        {t.addExpense}
                       </Text>
                     </Pressable>
-                    <Pressable
-                      onPress={() => router.push(`/group/${groupId}/simplify`)}
-                      accessibilityRole="button"
-                      accessibilityLabel={group.data.simplify_debts ? t.simplify : t.whoPaysWhom}
-                      style={({ pressed }) => ({
-                        flex: 1,
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        paddingVertical: theme.spacing.sm + 2,
-                        paddingHorizontal: theme.spacing.md,
-                        borderRadius: theme.radius.pill,
-                        backgroundColor: 'rgba(255, 255, 255, 0.18)',
-                        opacity: pressed ? 0.7 : 1,
-                      })}
-                    >
-                      <Text variant="subheading" tone="onBrand" numberOfLines={1}>
-                        {group.data.simplify_debts ? t.simplify : t.whoPaysWhom}
-                      </Text>
-                    </Pressable>
+                    <Row style={{ marginLeft: 'auto', gap: theme.spacing.sm }}>
+                      <HeroActionCircle
+                        icon="swap-horizontal"
+                        label={t.settleUp}
+                        onPress={() => router.push(`/group/${groupId}/settle`)}
+                      />
+                      <HeroActionCircle
+                        icon="git-compare-outline"
+                        label={group.data.simplify_debts ? t.simplify : t.whoPaysWhom}
+                        onPress={() => router.push(`/group/${groupId}/simplify`)}
+                      />
+                    </Row>
                   </Row>
                 </View>
               </Gradient>
@@ -1116,16 +1141,9 @@ export default function GroupScreen() {
           }
         />
 
-        {/* The empty state carries its own Add expense button, and two of the
-            same button on one screen is a screen that cannot decide. The FAB
-            stands down for exactly that case. */}
-        {tab === Tab.Expenses && visibleExpenses.length === 0 ? null : (
-          <Fab
-            label={t.addExpense}
-            onPress={() => router.push(`/group/${groupId}/add-expense`)}
-            icon={<Ionicons name="add" size={iconSize.lg} color={theme.color.onBrand} />}
-          />
-        )}
+        {/* No FAB: adding an expense now lives on the hero's white pill, the
+            same as the dashboard, so a floating button would be a second door
+            to the same room. */}
       </DetailEnter>
     </Screen>
   );

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -1,0 +1,149 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, View } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
+
+import {
+  directionalIcon,
+  EmptyState,
+  iconSize,
+  MoneyText,
+  Row,
+  Screen,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { useGroups, useHomeSummary } from '@/data/hooks';
+import { groupLabel } from '@/data/types';
+import { plural, useStrings } from '@/i18n';
+import { useAuth } from '@/lib/auth';
+import { SkeletonList } from '@/components/Skeletons';
+
+/**
+ * The full, browsable list of every group — the "All groups" door off the
+ * dashboard's capped preview. Built in the Activity feed's shape: a plain
+ * hairline-divided list of soft-tile rows, not the dashboard's single card,
+ * so a long roster reads the same skimmable way the activity timeline does.
+ */
+export default function AllGroupsScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const { profile } = useAuth();
+  const summary = useHomeSummary(profile?.id ?? null);
+  const groups = useGroups();
+  const list = groups.data ?? [];
+  const loading = groups.isLoading || summary.isLoading;
+
+  const header = (
+    <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center', gap: theme.spacing.sm }}>
+      <Pressable
+        onPress={() => router.back()}
+        accessibilityRole="button"
+        accessibilityLabel={t.common.back}
+        hitSlop={10}
+        style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+      >
+        <Ionicons
+          name={directionalIcon('chevron-back')}
+          size={iconSize.xxl}
+          color={theme.color.text}
+        />
+      </Pressable>
+      <Text variant="title">{t.allGroups}</Text>
+    </Row>
+  );
+
+  return (
+    <Screen>
+      <FlashList
+        data={list}
+        keyExtractor={(group) => group.id}
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+        }}
+        showsVerticalScrollIndicator={false}
+        ListHeaderComponent={header}
+        ListEmptyComponent={
+          loading ? (
+            <View style={{ paddingTop: theme.spacing.xl }}>
+              <SkeletonList rows={5} />
+            </View>
+          ) : (
+            <View style={{ paddingTop: theme.spacing.xxxl }}>
+              <EmptyState
+                title={t.tabs.noGroups}
+                icon={
+                  <Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.brand} />
+                }
+              />
+            </View>
+          )
+        }
+        ItemSeparatorComponent={() => (
+          <View style={{ height: 1, backgroundColor: theme.color.border }} />
+        )}
+        renderItem={({ item: group }) => {
+          const members = summary.membersFor(group.id);
+          const balance = summary.balanceFor(group.id);
+          const pending = summary.hasPending(group.id);
+          const statusLabel =
+            balance === 0n ? t.allSettled : balance > 0n ? t.youAreOwed : t.youOwe;
+          return (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`${groupLabel(group, members, profile?.id)}. ${statusLabel}`}
+              onPress={() => router.push(`/group/${group.id}`)}
+              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+            >
+              <Row
+                style={{
+                  gap: theme.spacing.md,
+                  alignItems: 'center',
+                  paddingVertical: theme.spacing.md,
+                }}
+              >
+                <View
+                  style={{
+                    width: 44,
+                    height: 44,
+                    borderRadius: 22,
+                    backgroundColor: theme.color.surfaceMuted,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Text style={{ fontSize: 20 }}>{group.cover_emoji ?? '👥'}</Text>
+                </View>
+                <View style={{ flex: 1, gap: 2 }}>
+                  <Text
+                    variant="body"
+                    numberOfLines={1}
+                    style={{ flexShrink: 1, fontWeight: '600' }}
+                  >
+                    {groupLabel(group, members, profile?.id)}
+                  </Text>
+                  <Text variant="caption" tone="muted" numberOfLines={1}>
+                    {pending
+                      ? t.pendingConfirmation
+                      : `${plural(locale, summary.memberCountFor(group.id), t.memberCount)} · ${statusLabel}`}
+                  </Text>
+                </View>
+                <MoneyText
+                  amount={balance}
+                  currency={group.default_currency as never}
+                  locale={locale}
+                  mode="balance"
+                  variant="subheading"
+                />
+              </Row>
+            </Pressable>
+          );
+        }}
+      />
+    </Screen>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -189,6 +189,7 @@ export interface UiStrings {
   youOwe: string;
   allSettled: string;
   yourGroups: string;
+  allGroups: string;
   /** The "show every category" chip at the head of the group filter strip. */
   filterAll: string;
   /** A small tag on a just-created group row. */
@@ -1980,6 +1981,7 @@ const en: UiStrings = {
   youOwe: 'You owe',
   allSettled: 'All settled',
   yourGroups: 'Your groups',
+  allGroups: 'All groups',
   filterAll: 'All',
   tagNew: 'New',
   tagOnTrip: 'On trip',
@@ -3718,6 +3720,7 @@ const ta: UiStrings = {
   youOwe: 'நீங்கள் தர வேண்டியது',
   allSettled: 'எல்லாம் சரி',
   yourGroups: 'உங்கள் குழுக்கள்',
+  allGroups: 'அனைத்து குழுக்கள்',
   filterAll: 'அனைத்தும்',
   tagNew: 'புதியது',
   tagOnTrip: 'பயணத்தில்',
@@ -5524,6 +5527,7 @@ const hi: UiStrings = {
   youOwe: 'आपको देने हैं',
   allSettled: 'सब बराबर',
   yourGroups: 'आपके समूह',
+  allGroups: 'सभी समूह',
   filterAll: 'सभी',
   tagNew: 'नया',
   tagOnTrip: 'यात्रा जारी',
@@ -7272,6 +7276,7 @@ const ar: UiStrings = {
   youOwe: 'عليك',
   allSettled: 'تمت التسوية',
   yourGroups: 'مجموعاتك',
+  allGroups: 'كل المجموعات',
   filterAll: 'الكل',
   tagNew: 'جديد',
   tagOnTrip: 'في رحلة',


### PR DESCRIPTION
Three device-reported requests, on top of #443.

## Group hero — three actions like the dashboard
The group hero's two pills (Settle up / Simplify) become the dashboard's action layout:
- **Add expense** — white pill, icon + label (the primary)
- **Settle up** — translucent circle (icon)
- **Who pays whom** — translucent circle (icon; the Simplify toggle)

The floating **Add expense** FAB is removed — the pill is now that door, and two of the same action on one screen reads as indecision (the same call the dashboard already made). The empty state keeps its own Add-expense button.

## Dashboard — "All groups" link + capped preview
- The **Your groups** heading gains an **All groups** link on the right.
- The inline card is capped to a **5-group preview**; the full roster lives behind the link.

## New `/groups` screen — Activity-styled, offline
Built in the Activity feed's shape: a hairline-divided list of soft-tile rows (emoji tile · name · members·standing · balance). It reads the **same mirror-backed hooks the dashboard uses** (`useGroups` / `useHomeSummary`, materialised from the on-disk mirror via `useLocalRead`), so it **works fully offline** (ADR-005) — no network read added.

New i18n key `allGroups` across en/ta/hi/ar.

## Test
- `pnpm typecheck` (mobile) clean; `pnpm format` + `pnpm lint` green.
- Manual: group hero shows the three actions; dashboard shows ≤5 groups + All groups; the screen lists every group and opens offline.

## Note
Removing the group FAB is a deliberate match to the dashboard; if you'd rather keep a FAB alongside the hero pill, say so and I'll restore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “All groups” action from the dashboard.
  - Added a dedicated, scrollable groups list with loading and empty states, member counts, pending status, and balances.
  - Limited the dashboard preview to five groups.
  - Added navigation from each group to its details.

- **Improvements**
  - Refined group actions with clearer, more accessible controls.
  - Promoted “Add expense” and added quick actions for settling up and viewing payment details.
  - Improved directional transitions between group screens.
  - Added localized “All groups” text in English, Tamil, Hindi, and Arabic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->