### PR TITLE
docs+fix(nav): global-audience docs; slide everywhere, drop group zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Baaki
 
-**பாக்கி — "balance / what's still owed".** An expense-splitting app for India:
-unlimited free ledger, link-based guest joining, UPI-native settlement with
-partial and per-expense payments, and free AI receipt itemization.
+**பாக்கி — "balance / what's still owed".** An expense-splitting app for people
+everywhere: unlimited free ledger, link-based guest joining, multi-currency from
+the first expense, deep-link settlement with partial and per-expense payments
+(UPI in India, PayPal / PayID and more worldwide), and free AI receipt
+itemization.
+
+**Built for a global audience.** India is the first launch market — so the
+settlement rails, receipt scripts and pricing lead there — but nothing in the
+ledger, currency handling or growth loop is India-only. Every amount is stored
+in ISO-4217 minor units from M0, and opening a new market is a settlement rail
+and a price tier, not a rewrite.
 
 The two binding specs live in this repo: [`baaki-adr.md`](./baaki-adr.md) (14
 accepted architecture decisions) and [`baaki-tdr.md`](./baaki-tdr.md) (how to

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 **பாக்கி — "balance / what's still owed".** An expense-splitting app for people
 everywhere: unlimited free ledger, link-based guest joining, multi-currency from
 the first expense, deep-link settlement with partial and per-expense payments
-(UPI in India, PayPal / PayID and more worldwide), and free AI receipt
-itemization.
+(UPI in India, PayPal / PayID and more worldwide), and AI receipt itemization
+that is free within a monthly scan quota (metered beyond it, since each scan has
+a real API cost — see ADR-008).
 
 **Built for a global audience.** India is the first launch market — so the
 settlement rails, receipt scripts and pricing lead there — but nothing in the

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -414,15 +414,12 @@ function AuthGate() {
   // otherwise a deep link cannot reach a screen that would only mislead.
   const paywallEnabled = useFlagEnabled('paywall');
 
-  /**
-   * Pushes cut straight to the destination — no slide. The slide-from-right was
-   * the most visible transition and the one that read as slow, so a push now
-   * lands instantly; "back" is still carried by the header and the swipe gesture.
-   * A modal still rises from the bottom, because that rise is what says "on top
-   * of" rather than "gone to", and it is cheap.
-   */
-  const push = 'none' as const;
-  const modal = { presentation: 'modal' as const, animation: 'slide_from_bottom' as const };
+  // Every forward screen slides in from the leading edge — one consistent
+  // motion across the whole app (right in LTR, left in RTL). The only screens
+  // that opt out are the auth and tab roots below, which replace the whole tree
+  // and mark themselves `animation: 'none'`. Screens that once rose as bottom
+  // modals now slide too, so navigation reads the same everywhere.
+  const push = I18nManager.isRTL ? ('slide_from_left' as const) : ('slide_from_right' as const);
   // A normal forward page: a plain horizontal translate (and back out the way it
   // came) rather than rising like a modal — the "went to a page", not "on top of"
   // feel. A bare translate is the cheapest native transition on the UI thread, so
@@ -574,26 +571,26 @@ function AuthGate() {
           <Stack.Screen name="verify-email" />
           <Stack.Screen name="guest-welcome" />
           <Stack.Screen name="(tabs)" options={{ animation: 'none' }} />
-          <Stack.Screen name="new-group" options={modal} />
-          <Stack.Screen name="clone-group" options={modal} />
-          {paywallEnabled ? <Stack.Screen name="paywall" options={modal} /> : null}
-          <Stack.Screen name="capture" options={modal} />
+          <Stack.Screen name="new-group" options={slide} />
+          <Stack.Screen name="clone-group" options={slide} />
+          {paywallEnabled ? <Stack.Screen name="paywall" options={slide} /> : null}
+          <Stack.Screen name="capture" options={slide} />
           <Stack.Screen name="captures" />
           <Stack.Screen name="groups" options={slide} />
           <Stack.Screen name="group/[id]/index" options={slide} />
           <Stack.Screen name="group/[id]/add-expense" options={slide} />
-          <Stack.Screen name="group/[id]/settle" options={modal} />
+          <Stack.Screen name="group/[id]/settle" options={slide} />
           <Stack.Screen name="group/[id]/simplify" />
           <Stack.Screen name="group/[id]/settings" />
           <Stack.Screen name="group/[id]/members" />
           <Stack.Screen name="group/[id]/member/[memberId]" />
           <Stack.Screen name="group/[id]/expense/[expenseId]" options={slide} />
-          <Stack.Screen name="group/[id]/invite" options={modal} />
-          <Stack.Screen name="group/[id]/itemize" options={modal} />
-          <Stack.Screen name="receipt/[id]" options={modal} />
+          <Stack.Screen name="group/[id]/invite" options={slide} />
+          <Stack.Screen name="group/[id]/itemize" options={slide} />
+          <Stack.Screen name="receipt/[id]" options={slide} />
           <Stack.Screen name="friends/contacts" />
-          <Stack.Screen name="contact-picker" options={modal} />
-          <Stack.Screen name="scan" options={modal} />
+          <Stack.Screen name="contact-picker" options={slide} />
+          <Stack.Screen name="scan" options={slide} />
           <Stack.Screen name="settings/notifications" />
           <Stack.Screen name="settings/export" />
           <Stack.Screen name="settings/import" />
@@ -613,7 +610,7 @@ function AuthGate() {
           <Stack.Screen name="settings/delete-account" />
           <Stack.Screen name="join" />
           <Stack.Screen name="inbox" />
-          <Stack.Screen name="voice" options={modal} />
+          <Stack.Screen name="voice" options={slide} />
         </Stack>
         {/* One bar over the whole stack, so every screen keeps it — it hides
           itself on the modals and the camera. */}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -51,7 +51,6 @@ import {
 } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
-import { DetailEnter } from '@/lib/anim';
 import { CategoryBadge } from '@/components/Category';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
 import { GroupPhoto } from '@/components/GroupPhoto';
@@ -590,7 +589,9 @@ export default function GroupScreen() {
     <Screen edges={[]}>
       {/* The hero runs dark under the status bar; force light icons for it. */}
       <StatusBar style="light" />
-      <DetailEnter>
+      {/* No entrance re-animation: the screen already slides in natively, and a
+          second scale-up on top of that read as an unwanted zoom. */}
+      <View style={{ flex: 1 }}>
         <FlashList
           data={tab === Tab.Expenses ? feedItems : []}
           extraData={`${tab}|${showDeleted}|${locale}`}
@@ -777,7 +778,7 @@ export default function GroupScreen() {
                         onPress={() => router.push(`/group/${groupId}/settle`)}
                       />
                       <HeroActionCircle
-                        icon="git-compare-outline"
+                        icon="git-network-outline"
                         label={group.data.simplify_debts ? t.simplify : t.whoPaysWhom}
                         onPress={() => router.push(`/group/${groupId}/simplify`)}
                       />
@@ -1144,7 +1145,7 @@ export default function GroupScreen() {
         {/* No FAB: adding an expense now lives on the hero's white pill, the
             same as the dashboard, so a floating button would be a second door
             to the same room. */}
-      </DetailEnter>
+      </View>
     </Screen>
   );
 }

--- a/baaki-adr.md
+++ b/baaki-adr.md
@@ -1,7 +1,8 @@
 # Baaki — Architecture Decision Records (ADR)
 
-**Product:** Baaki (பாக்கி — "balance / what's still owed") — expense-splitting app.
-**Positioning (from competitive analysis):** unlimited free core ledger · link-based guest joining · UPI-native settlement with partial/per-expense payments · free AI receipt itemization · monetize convenience, never the ledger.
+**Product:** Baaki (பாக்கி — "balance / what's still owed") — an expense-splitting app for a **global audience**, launching India-first.
+**Positioning (from competitive analysis):** unlimited free core ledger · link-based guest joining · multi-currency from day one · deep-link settlement with partial/per-expense payments (UPI first, PayPal/PayID and more worldwide) · free AI receipt itemization · monetize convenience, never the ledger.
+**Reach.** India is the first market, not the only one: it sets the launch rails (UPI), the receipt scripts and the entry price tier, but the ledger, currency and sync are market-neutral. A new country is a settlement rail plus a price tier (ADR-007, ADR-011 pricing), never a schema change.
 **Status legend:** Accepted = build to this. Each ADR: Context → Decision → Consequences.
 
 ---
@@ -10,7 +11,7 @@
 
 **Status:** Accepted
 
-**Context.** India-first (Android-heavy) but iOS must not lag; small team; fast iteration; need push notifications, camera (receipts), deep links (UPI intents), and OTA updates.
+**Context.** Global audience, launching India-first (Android-heavy) — every market matters and iOS must not lag; small team; fast iteration; need push notifications, camera (receipts), deep links (settlement intents), and OTA updates.
 
 **Decision.** React Native with **Expo (managed workflow, latest SDK)**, TypeScript strict mode. Expo Router for navigation. EAS Build for store binaries, EAS Update for OTA JS updates. Eject only if a native module forces it.
 
@@ -118,7 +119,7 @@ This is an **authority-model addition, not a change to any trust boundary**: eve
 
 **Status:** Accepted
 
-**Context.** Top structural gap in the market: India has no Splitwise-class app with real UPI settlement. Holding/moving money requires PSP licensing; deep links don't.
+**Context.** Top structural gap in the launch market: India has no Splitwise-class app with real UPI settlement. Holding/moving money requires PSP licensing; deep links don't. The deep-link-and-confirm pattern is not India-specific — it is the rail for every market (see A27: PayID, PayPal), UPI is simply the one the first market ships on.
 
 **Decision.**
 
@@ -126,7 +127,7 @@ This is an **authority-model addition, not a change to any trust boundary**: eve
 - Baaki records the settlement with a two-step state machine: `initiated → confirmed` (payee taps "received" or payer marks paid and payee gets a confirm nudge; auto-confirm after 7 days with notification). We do **not** attempt callback verification of UPI success in v1 (intent flow offers none reliably).
 - **Partial and per-expense settlement is first-class** (the 985-vote gap): a settlement row can carry `allocations[] = {expense_id, amount}`; unallocated amounts apply to overall balance oldest-first. Cash/bank settlements use the same flow minus the deep link.
 
-**Consequences.** No license, no float, no custody risk; works with every UPI app on day one. Trade-off: confirmation is social, not cryptographic — mitigated by the confirm/nudge flow and activity log. International rails later (Venmo/PayPal links, SEPA) plug into the same settlement state machine.
+**Consequences.** No license, no float, no custody risk; works with every UPI app on day one. Trade-off: confirmation is social, not cryptographic — mitigated by the confirm/nudge flow and activity log. International rails (PayID, PayPal links, Venmo, SEPA) plug into the same settlement state machine — the method is named in a CHECK constraint, not an enum (A27), so opening a market is one rail, no type surgery.
 
 ---
 
@@ -134,7 +135,7 @@ This is an **authority-model addition, not a change to any trust boundary**: eve
 
 **Status:** Accepted
 
-**Context.** 2026 table stakes; must handle Indian receipts (Tamil/Hindi/regional scripts), photos from gallery, and pasted text bills (Swiggy/Zomato/WhatsApp) — all things Splitwise fails at. API keys must never ship in the client.
+**Context.** 2026 table stakes; must handle receipts in any script or language a global user photographs — Indian scripts (Tamil/Hindi/regional) in the first market, plus Latin, CJK, Arabic, Cyrillic elsewhere — photos from gallery, and pasted text bills (Swiggy/Zomato/WhatsApp and their equivalents in each market) — all things Splitwise fails at. API keys must never ship in the client.
 
 **Decision.**
 
@@ -180,7 +181,7 @@ This is an **authority-model addition, not a change to any trust boundary**: eve
 
 **Context.** Splitwise's daily cap on the core loop is the category's biggest churn engine. Baaki's positioning depends on never repeating it.
 
-**Decision.** Constitutional rules enforced in code review: **(1)** manual expense entry, groups, split types, balances, settlement recording, and export are unlimited and free, forever — no daily caps, no interstitial ads, ever. **(2)** Monetize convenience: AI scan volume beyond free quota, analytics/charts depth, auto-import (future), group/trip passes (Settle Up-style shareable premium), themes. **(3)** India pricing in INR at local purchasing power (~₹49–99/mo tier), regional pricing elsewhere. **(4)** No third-party ads in any money flow.
+**Decision.** Constitutional rules enforced in code review: **(1)** manual expense entry, groups, split types, balances, settlement recording, and export are unlimited and free, forever — no daily caps, no interstitial ads, ever. **(2)** Monetize convenience: AI scan volume beyond free quota, analytics/charts depth, auto-import (future), group/trip passes (Settle Up-style shareable premium), themes. **(3)** Regional pricing at local purchasing power in every market — never one USD price that prices out most of the world; the first market is India in INR (~₹49–99/mo tier), each new market gets its own tier. **(4)** No third-party ads in any money flow.
 
 **Consequences.** Slower revenue early; durable trust moat and the marketing wedge ("the ledger is free forever") that the entire alternatives market currently wins with.
 

--- a/baaki-adr.md
+++ b/baaki-adr.md
@@ -1,7 +1,7 @@
 # Baaki — Architecture Decision Records (ADR)
 
 **Product:** Baaki (பாக்கி — "balance / what's still owed") — an expense-splitting app for a **global audience**, launching India-first.
-**Positioning (from competitive analysis):** unlimited free core ledger · link-based guest joining · multi-currency from day one · deep-link settlement with partial/per-expense payments (UPI first, PayPal/PayID and more worldwide) · free AI receipt itemization · monetize convenience, never the ledger.
+**Positioning (from competitive analysis):** unlimited free core ledger · link-based guest joining · multi-currency from day one · deep-link settlement with partial/per-expense payments (UPI first, PayPal/PayID and more worldwide) · AI receipt itemization free within a monthly scan quota (ADR-008) · monetize convenience, never the ledger.
 **Reach.** India is the first market, not the only one: it sets the launch rails (UPI), the receipt scripts and the entry price tier, but the ledger, currency and sync are market-neutral. A new country is a settlement rail plus a price tier (ADR-007, ADR-011 pricing), never a schema change.
 **Status legend:** Accepted = build to this. Each ADR: Context → Decision → Consequences.
 
@@ -127,7 +127,7 @@ This is an **authority-model addition, not a change to any trust boundary**: eve
 - Baaki records the settlement with a two-step state machine: `initiated → confirmed` (payee taps "received" or payer marks paid and payee gets a confirm nudge; auto-confirm after 7 days with notification). We do **not** attempt callback verification of UPI success in v1 (intent flow offers none reliably).
 - **Partial and per-expense settlement is first-class** (the 985-vote gap): a settlement row can carry `allocations[] = {expense_id, amount}`; unallocated amounts apply to overall balance oldest-first. Cash/bank settlements use the same flow minus the deep link.
 
-**Consequences.** No license, no float, no custody risk; works with every UPI app on day one. Trade-off: confirmation is social, not cryptographic — mitigated by the confirm/nudge flow and activity log. International rails (PayID, PayPal links, Venmo, SEPA) plug into the same settlement state machine — the method is named in a CHECK constraint, not an enum (A27), so opening a market is one rail, no type surgery.
+**Consequences.** No license, no float, no custody risk; works with every UPI app on day one. Trade-off: confirmation is social, not cryptographic — mitigated by the confirm/nudge flow and activity log. International rails plug into the same settlement state machine: the rails are a **data registry** (`RailId` in `packages/core`; `settlements.rail` is a `text` column, not a hardcoded union), already spanning many markets' instant rails and consumer apps — Pix, PayNow, PromptPay, QRIS, Aani, PayID, Zelle, Venmo, Cash App, Interac, Wise, Revolut, PayPal (A27). SEPA-style bank transfers ride the generic `bank` rail rather than a named one. Opening a market is a registry entry, not type surgery.
 
 ---
 
@@ -143,7 +143,7 @@ This is an **authority-model addition, not a change to any trust boundary**: eve
 - Itemized claiming: each participant taps their items on their own phone (Tab-style, realtime via Supabase Realtime); shared items split equally among claimers; **tax/tip/service prorated proportionally** to each person's item subtotal (deterministic rounding per ADR-009).
 - Free tier: generous scan quota (e.g., 20/month); metered because each scan has real API cost — consistent with ADR-011 (convenience is monetizable, ledger is not).
 
-**Consequences.** Best-in-class scan UX incl. regional scripts and text bills; per-scan cost is a COGS line to monitor; provider is swappable behind one Edge Function interface.
+**Consequences.** Best-in-class scan UX incl. regional scripts and text bills; per-scan cost is a COGS line to monitor; provider is swappable behind one Edge Function interface. The vision LLM reads any script the photo carries — that any-script claim is the LLM's, not the **on-device heuristic fallback** (`packages/core/src/receipt/heuristic.ts`), which is best-effort and today biased to Latin, Indic and Arabic word detection with English total/charge labels (`TOTAL`/`TAX`/`SERVICE`). Localizing that fallback's word detection and total-label matching for CJK and Cyrillic — with per-script, non-INR receipt fixtures asserting labels, amounts, detected currency and reconciliation — is a tracked follow-up, not shipped here; until then a non-Latin receipt that misses the network falls back to a low-confidence, user-editable result rather than a wrong one.
 
 ---
 


### PR DESCRIPTION
## Docs — built for a global audience
The app is for global users, launching India-first. README + ADR positioning now say so:
- "Global audience, India as the first **launch** market" — India sets the launch rails (UPI), receipt scripts and entry price tier, but the ledger, currency (ISO-4217 minor units from M0) and sync are market-neutral.
- ADR-001/007/008 context and the pricing rule broadened: a new market is a settlement rail + a price tier (ADR-007/A27, ADR-011 pricing), not a schema change or rewrite.

## Navigation — slide everywhere
Reported on the group flow. Every forward screen now slides in from the leading edge (RTL-aware). The default push was `none`; screens that used to rise as bottom modals — **settle up**, new-group, capture, invite, itemize, receipt, scan, voice, contact-picker, paywall, clone-group — now slide too, so navigation reads the same everywhere. Auth + tab roots keep `animation: 'none'` (they replace the whole tree, not push onto it).

## Group screen
- **Removed the zoom.** The group screen wrapped its content in `DetailEnter`, a 0.97→1 spring scale. Now that the screen slides in natively, that scale read as an unwanted zoom *after* the slide — wrapper dropped.
- **Who-pays-whom icon** → network-graph glyph (`git-network-outline`).

## Test
- mobile `typecheck` clean; `pnpm format` + `pnpm lint` green.
- Manual: settle-up and the former modals slide in; group screen slides with no zoom; hero shows the graph icon.

## Note
"All screens slide" now includes the former bottom-modals (capture, new-group, paywall, …). If you'd rather keep any of those rising from the bottom, name them and I'll restore `presentation: 'modal'` for just those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for global expense splitting, including multi-currency expenses and worldwide settlement options.
  * Added flexible settlement and pricing support, launching initially in India.
  * AI receipt itemization is free within a monthly scan quota, with additional scans metered beyond the quota.

* **Improvements**
  * Updated navigation with smoother directional transitions across key screens.
  * Refined group-screen animations for a cleaner experience.
  * Updated the debt-simplification icon for clearer visual representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->