### PR TITLE
feat(expense): edit-history audit in its own tab (old → new per field)

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -21,6 +21,7 @@ import {
   Row,
   Screen,
   SectionHeader,
+  SegmentedTabs,
   Text,
   useTheme,
   useScreenClearance,
@@ -29,6 +30,7 @@ import {
 import { CategoryBadge } from '@/components/Category';
 import { ExpenseReceipts } from '@/components/ExpenseReceipts';
 import { ExpenseComments } from '@/components/ExpenseComments';
+import { ExpenseHistory } from '@/components/ExpenseHistory';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
 import {
   memberLookup,
@@ -37,7 +39,6 @@ import {
   useExpenseVersions,
   useGroup,
   useRestoreExpense,
-  type ExpenseImageEventRow,
 } from '@/data/hooks';
 import { expenseTitle } from '@/data/expenseTitle';
 import { useBlockedUsers } from '@/data/blocked';
@@ -56,19 +57,6 @@ function splitLabels(t: UiStrings): Record<string, string> {
     adjustment: t.expense.withAdjustments,
     itemized: t.expense.itemized,
   };
-}
-
-/** One line of the image audit — "{name} added the receipt", etc. */
-function imageAuditLine(t: UiStrings, event: ExpenseImageEventRow, name: string): string {
-  const template =
-    event.kind === 'receipt'
-      ? event.action === 'added'
-        ? t.imageAudit.receiptAdded
-        : t.imageAudit.receiptRemoved
-      : event.action === 'added'
-        ? t.imageAudit.attachmentAdded
-        : t.imageAudit.attachmentRemoved;
-  return fill(template, { name });
 }
 
 /** A small translucent-white pill for the meta tags on the hero wash (split
@@ -106,6 +94,9 @@ export default function ExpenseDetailScreen() {
   const imageEvents = useExpenseImageEvents(expenseId ?? '');
   const scrollRef = useRef<RNScrollView>(null);
   const [menuOpen, setMenuOpen] = useState(false);
+  // The page has two faces: its breakdown, and its edit history. The hero stays
+  // above both; only the body below the tab bar swaps.
+  const [tab, setTab] = useState<'details' | 'history'>('details');
   const deleteExpense = useDeleteExpense(groupId);
   const restoreExpense = useRestoreExpense(groupId);
 
@@ -379,243 +370,189 @@ export default function ExpenseDetailScreen() {
           </View>
         </Gradient>
 
-        {/* Receipts — one gallery, many images, each group-visible or private.
-            Folds in the legacy single bill (E2) as its first item. A party can
-            add (scan or library) and remove; anyone sees the group images. */}
-        <ExpenseReceipts
-          groupId={groupId}
-          expenseId={expense.id}
-          canManage={isExpenseParty}
-          canRemoveLegacy={isExpenseParty || iAmAdmin}
-          legacyReceiptPath={receiptUri ? expenseReceiptPath(groupId, expense.id) : null}
-          onLegacyRemoved={() => setReceiptUri(null)}
+        {/* The two faces of the page — its breakdown and its edit history —
+            sectioned so the audit is its own place rather than the tail of a
+            long scroll. */}
+        <SegmentedTabs
+          value={tab}
+          onChange={setTab}
+          tabs={[
+            { value: 'details', label: t.expense.detailsTab },
+            { value: 'history', label: t.expense.history },
+          ]}
         />
 
-        {/* Where it happened (A43). A tap opens the point in the phone's maps
-            app; absent when the author attached no location. */}
-        {location ? (
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.location.openMap}
-            onPress={() => void Linking.openURL(mapsUrl(location)).catch(() => undefined)}
-          >
-            <Card style={{ paddingVertical: theme.spacing.md }}>
-              <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-                <View
-                  style={{
-                    width: 52,
-                    height: 52,
-                    borderRadius: theme.radius.md,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    backgroundColor: theme.color.bg,
-                  }}
-                >
-                  <Ionicons name="location" size={iconSize.lg} color={theme.color.brand} />
-                </View>
-                <View style={{ flex: 1, minWidth: 0 }}>
-                  <Text variant="subheading" numberOfLines={1}>
-                    {location.name?.trim() || coordLabel(location)}
-                  </Text>
-                  <Text variant="micro" tone="muted" numberOfLines={1}>
-                    {t.location.openMap}
-                  </Text>
-                </View>
-                <Ionicons
-                  name={directionalIcon('chevron-forward')}
-                  size={iconSize.md}
-                  color={theme.color.textFaint}
-                />
-              </Row>
-            </Card>
-          </Pressable>
-        ) : null}
-
-        {version.payers.length > 1 ? (
-          <View>
-            <SectionHeader title={t.paidBy} />
-            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-              {version.payers.map((payer, index) => {
-                const payerMember = lookup.get(payer.member_id);
-                return (
-                  <View key={payer.member_id}>
-                    <ListRow
-                      title={nameOf(payer.member_id)}
-                      leading={
-                        <Avatar
-                          name={avatarNameOf(payer.member_id)}
-                          ghost={
-                            payerMember
-                              ? isGhost(payerMember) || isBlockedMember(payerMember, blockedIds)
-                              : false
-                          }
-                          size={38}
-                        />
-                      }
-                      trailing={
-                        <MoneyText
-                          amount={BigInt(payer.amount)}
-                          currency={currency}
-                          locale={locale}
-                          variant="caption"
-                        />
-                      }
-                    />
-                    {index < version.payers.length - 1 ? (
-                      <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                    ) : null}
-                  </View>
-                );
-              })}
-            </Card>
-          </View>
-        ) : null}
-
-        <View>
-          <SectionHeader title={t.expense.whoOwesWhat} />
-          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-            {version.shares.map((share, index) => {
-              const member = lookup.get(share.member_id);
-              return (
-                <View key={share.member_id}>
-                  <ListRow
-                    title={nameOf(share.member_id)}
-                    subtitle={member && isGhost(member) ? t.notJoinedYet : undefined}
-                    leading={
-                      <Avatar
-                        name={avatarNameOf(share.member_id)}
-                        ghost={
-                          member ? isGhost(member) || isBlockedMember(member, blockedIds) : false
-                        }
-                        size={38}
-                      />
-                    }
-                    trailing={
-                      <MoneyText
-                        amount={BigInt(share.amount)}
-                        currency={currency}
-                        locale={locale}
-                        variant="caption"
-                        // A share is money owed toward this bill, so it wears the
-                        // same owe colour the balances do across the app — not the
-                        // neutral ink of a total. Forced (not sign-derived): every
-                        // share is a positive owe, so mode="balance" would read it
-                        // as "owed to you" (green) instead.
-                        tone="negative"
-                      />
-                    }
-                  />
-                  {index < version.shares.length - 1 ? (
-                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                  ) : null}
-                </View>
-              );
-            })}
-          </Card>
-        </View>
-
-        {/* ADR-004: every edit is kept, and the group can see what changed. */}
-        <View>
-          <SectionHeader title={t.expense.history} />
-          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-            {(versions.data ?? []).map((entry, index) => (
-              <View key={entry.id}>
-                <ListRow
-                  title={entry.description}
-                  subtitle={`v${entry.version_no} · ${nameOf(entry.author_member_id)} · ${new Intl.DateTimeFormat(
-                    locale,
-                    { day: 'numeric', month: 'short', hour: 'numeric', minute: '2-digit' },
-                  ).format(new Date(entry.created_at))}`}
-                  leading={
-                    <Avatar
-                      name={`v${entry.version_no}`}
-                      emoji={entry.version_no === 1 ? '🧾' : '✏️'}
-                      size={38}
-                    />
-                  }
-                  trailing={
-                    <MoneyText
-                      amount={BigInt(entry.amount)}
-                      currency={entry.currency}
-                      locale={locale}
-                      variant="caption"
-                    />
-                  }
-                />
-                {index < (versions.data?.length ?? 0) - 1 ? (
-                  <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                ) : null}
-              </View>
-            ))}
-          </Card>
-        </View>
-
-        {/* The image audit (A46): who added or removed a receipt or an attachment,
-            oldest first. A `parties` line only reaches a party's device (RLS on
-            the pull), so anyone who sees a line here was allowed to. Absent until
-            something happens to an image. */}
-        {(imageEvents.data ?? []).length > 0 ? (
-          <View>
-            <SectionHeader title={t.imageAudit.title} />
-            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-              {(imageEvents.data ?? []).map((event, index, arr) => (
-                <View key={event.id}>
-                  <ListRow
-                    title={imageAuditLine(t, event, nameOf(event.actorMemberId))}
-                    subtitle={
-                      event.createdAt
-                        ? new Intl.DateTimeFormat(locale, {
-                            day: 'numeric',
-                            month: 'short',
-                            hour: 'numeric',
-                            minute: '2-digit',
-                          }).format(new Date(event.createdAt))
-                        : undefined
-                    }
-                    leading={
-                      <Avatar
-                        name={nameOf(event.actorMemberId)}
-                        emoji={event.action === 'added' ? '📎' : '🗑️'}
-                        size={38}
-                      />
-                    }
-                    trailing={
-                      event.visibility === 'parties' ? (
-                        <Badge label={t.imageAudit.partyOnly} tone="neutral" />
-                      ) : undefined
-                    }
-                  />
-                  {index < arr.length - 1 ? (
-                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                  ) : null}
-                </View>
-              ))}
-            </Card>
-          </View>
-        ) : null}
-
-        {/* The thread on this bill. Any member reads and adds; the author edits
-            and deletes their own; an admin deletes anyone's and resolves reports.
-            The controls the component offers mirror what the RPCs allow. */}
-        <View>
-          <SectionHeader title={t.comments.title} />
-          <Card>
-            <ExpenseComments
+        {tab === 'history' ? (
+          <ExpenseHistory
+            versions={versions.data ?? []}
+            imageEvents={imageEvents.data ?? []}
+            nameOf={nameOf}
+            t={t}
+            locale={locale}
+          />
+        ) : (
+          <>
+            {/* Receipts — one gallery, many images, each group-visible or private.
+            Folds in the legacy single bill (E2) as its first item. A party can
+            add (scan or library) and remove; anyone sees the group images. */}
+            <ExpenseReceipts
               groupId={groupId}
               expenseId={expense.id}
-              myMemberId={myMemberId}
-              iAmAdmin={iAmAdmin}
-              nameOf={nameOf}
-              onComposerFocus={scrollToComposer}
+              canManage={isExpenseParty}
+              canRemoveLegacy={isExpenseParty || iAmAdmin}
+              legacyReceiptPath={receiptUri ? expenseReceiptPath(groupId, expense.id) : null}
+              onLegacyRemoved={() => setReceiptUri(null)}
             />
-          </Card>
-        </View>
 
-        {/* Edit and Delete moved up into the header's three-dot menu; the only
+            {/* Where it happened (A43). A tap opens the point in the phone's maps
+            app; absent when the author attached no location. */}
+            {location ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.location.openMap}
+                onPress={() => void Linking.openURL(mapsUrl(location)).catch(() => undefined)}
+              >
+                <Card style={{ paddingVertical: theme.spacing.md }}>
+                  <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                    <View
+                      style={{
+                        width: 52,
+                        height: 52,
+                        borderRadius: theme.radius.md,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        backgroundColor: theme.color.bg,
+                      }}
+                    >
+                      <Ionicons name="location" size={iconSize.lg} color={theme.color.brand} />
+                    </View>
+                    <View style={{ flex: 1, minWidth: 0 }}>
+                      <Text variant="subheading" numberOfLines={1}>
+                        {location.name?.trim() || coordLabel(location)}
+                      </Text>
+                      <Text variant="micro" tone="muted" numberOfLines={1}>
+                        {t.location.openMap}
+                      </Text>
+                    </View>
+                    <Ionicons
+                      name={directionalIcon('chevron-forward')}
+                      size={iconSize.md}
+                      color={theme.color.textFaint}
+                    />
+                  </Row>
+                </Card>
+              </Pressable>
+            ) : null}
+
+            {version.payers.length > 1 ? (
+              <View>
+                <SectionHeader title={t.paidBy} />
+                <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                  {version.payers.map((payer, index) => {
+                    const payerMember = lookup.get(payer.member_id);
+                    return (
+                      <View key={payer.member_id}>
+                        <ListRow
+                          title={nameOf(payer.member_id)}
+                          leading={
+                            <Avatar
+                              name={avatarNameOf(payer.member_id)}
+                              ghost={
+                                payerMember
+                                  ? isGhost(payerMember) || isBlockedMember(payerMember, blockedIds)
+                                  : false
+                              }
+                              size={38}
+                            />
+                          }
+                          trailing={
+                            <MoneyText
+                              amount={BigInt(payer.amount)}
+                              currency={currency}
+                              locale={locale}
+                              variant="caption"
+                            />
+                          }
+                        />
+                        {index < version.payers.length - 1 ? (
+                          <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                        ) : null}
+                      </View>
+                    );
+                  })}
+                </Card>
+              </View>
+            ) : null}
+
+            <View>
+              <SectionHeader title={t.expense.whoOwesWhat} />
+              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                {version.shares.map((share, index) => {
+                  const member = lookup.get(share.member_id);
+                  return (
+                    <View key={share.member_id}>
+                      <ListRow
+                        title={nameOf(share.member_id)}
+                        subtitle={member && isGhost(member) ? t.notJoinedYet : undefined}
+                        leading={
+                          <Avatar
+                            name={avatarNameOf(share.member_id)}
+                            ghost={
+                              member
+                                ? isGhost(member) || isBlockedMember(member, blockedIds)
+                                : false
+                            }
+                            size={38}
+                          />
+                        }
+                        trailing={
+                          <MoneyText
+                            amount={BigInt(share.amount)}
+                            currency={currency}
+                            locale={locale}
+                            variant="caption"
+                            // A share is money owed toward this bill, so it wears the
+                            // same owe colour the balances do across the app — not the
+                            // neutral ink of a total. Forced (not sign-derived): every
+                            // share is a positive owe, so mode="balance" would read it
+                            // as "owed to you" (green) instead.
+                            tone="negative"
+                          />
+                        }
+                      />
+                      {index < version.shares.length - 1 ? (
+                        <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                      ) : null}
+                    </View>
+                  );
+                })}
+              </Card>
+            </View>
+
+            {/* The thread on this bill. Any member reads and adds; the author edits
+            and deletes their own; an admin deletes anyone's and resolves reports.
+            The controls the component offers mirror what the RPCs allow. */}
+            <View>
+              <SectionHeader title={t.comments.title} />
+              <Card>
+                <ExpenseComments
+                  groupId={groupId}
+                  expenseId={expense.id}
+                  myMemberId={myMemberId}
+                  iAmAdmin={iAmAdmin}
+                  nameOf={nameOf}
+                  onComposerFocus={scrollToComposer}
+                />
+              </Card>
+            </View>
+
+            {/* Edit and Delete moved up into the header's three-dot menu; the only
             note left here is the reassurance that an edit keeps every version. */}
-        <Text variant="micro" tone="muted" align="center">
-          {t.extras.nothingOverwritten}
-        </Text>
+            <Text variant="micro" tone="muted" align="center">
+              {t.extras.nothingOverwritten}
+            </Text>
+          </>
+        )}
       </ScrollView>
 
       <OverflowMenu visible={menuOpen} onClose={() => setMenuOpen(false)} items={menuItems} />

--- a/apps/mobile/src/components/ExpenseHistory.tsx
+++ b/apps/mobile/src/components/ExpenseHistory.tsx
@@ -1,0 +1,370 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { View } from 'react-native';
+
+import {
+  Avatar,
+  Badge,
+  Card,
+  directionalIcon,
+  iconSize,
+  MoneyText,
+  Row,
+  SectionHeader,
+  Text,
+  useTheme,
+} from '@waves/ui';
+
+import type { ExpenseVersionAudit } from '@/data/api';
+import type { ExpenseImageEventRow } from '@/data/hooks';
+import { coordLabel } from '@/lib/location';
+import { fill, type UiStrings } from '@/i18n';
+
+/**
+ * The edit history of one expense, said as an audit: for every version after
+ * the first, exactly which fields changed and what they went from and to
+ * (ADR-004 — nothing is overwritten, and the group can see what changed). The
+ * image audit (A46 — who added or removed a receipt or attachment) rides in the
+ * same timeline underneath.
+ *
+ * The bug this fixes: the old history was a flat list of versions showing only
+ * each version's amount, so editing 30,000 → 300 left no trace of *what*
+ * happened. Now each edit spells out `Amount  30,000 → 300`.
+ */
+
+function splitLabel(t: UiStrings, splitType: string): string {
+  const map: Record<string, string> = {
+    equal: t.expense.splitEqually,
+    exact: t.expense.exactAmounts,
+    percent: t.expense.byPercentage,
+    shares: t.expense.byShares,
+    adjustment: t.expense.withAdjustments,
+    itemized: t.expense.itemized,
+  };
+  return map[splitType] ?? splitType;
+}
+
+function categoryLabel(t: UiStrings, version: ExpenseVersionAudit): string {
+  const builtins = t.categories as Record<string, string>;
+  return (
+    version.category_meta?.label ??
+    (version.category ? (builtins[version.category] ?? version.category) : t.expense.audit.none)
+  );
+}
+
+function locationLabel(t: UiStrings, version: ExpenseVersionAudit): string {
+  const location = version.location;
+  if (!location) return t.expense.audit.none;
+  return location.name?.trim() || coordLabel(location);
+}
+
+/** A date with no time (the expense's own date), read in UTC to match the rest
+ *  of the screen. */
+function dateLabel(locale: string, iso: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(iso));
+}
+
+/** A wall-clock timestamp (when the edit was saved). */
+function stampLabel(locale: string, iso: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(iso));
+}
+
+/** The set of member ids on a side, sorted, as a stable comparison key. */
+function memberKey(rows: { member_id: string }[]): string {
+  return rows
+    .map((row) => row.member_id)
+    .sort()
+    .join(',');
+}
+
+type Change =
+  | {
+      key: string;
+      label: string;
+      kind: 'money';
+      oldAmount: bigint;
+      newAmount: bigint;
+      currency: string;
+    }
+  | { key: string; label: string; kind: 'text'; oldText: string; newText: string };
+
+function diffVersions(
+  t: UiStrings,
+  locale: string,
+  nameOf: (id: string | null) => string,
+  prev: ExpenseVersionAudit,
+  cur: ExpenseVersionAudit,
+): Change[] {
+  const changes: Change[] = [];
+
+  if (prev.amount !== cur.amount || prev.currency !== cur.currency) {
+    changes.push({
+      key: 'amount',
+      label: t.expense.audit.amount,
+      kind: 'money',
+      oldAmount: BigInt(prev.amount),
+      newAmount: BigInt(cur.amount),
+      currency: cur.currency,
+    });
+  }
+  if ((prev.description ?? '').trim() !== (cur.description ?? '').trim()) {
+    changes.push({
+      key: 'description',
+      label: t.expense.audit.description,
+      kind: 'text',
+      oldText: (prev.description ?? '').trim() || t.expense.audit.none,
+      newText: (cur.description ?? '').trim() || t.expense.audit.none,
+    });
+  }
+  if (
+    (prev.category ?? '') !== (cur.category ?? '') ||
+    prev.category_meta?.label !== cur.category_meta?.label
+  ) {
+    changes.push({
+      key: 'category',
+      label: t.expense.audit.category,
+      kind: 'text',
+      oldText: categoryLabel(t, prev),
+      newText: categoryLabel(t, cur),
+    });
+  }
+  if (prev.split_type !== cur.split_type) {
+    changes.push({
+      key: 'split',
+      label: t.expense.audit.split,
+      kind: 'text',
+      oldText: splitLabel(t, prev.split_type),
+      newText: splitLabel(t, cur.split_type),
+    });
+  }
+  if (prev.expense_date !== cur.expense_date) {
+    changes.push({
+      key: 'date',
+      label: t.expense.audit.date,
+      kind: 'text',
+      oldText: dateLabel(locale, prev.expense_date),
+      newText: dateLabel(locale, cur.expense_date),
+    });
+  }
+  if (locationLabel(t, prev) !== locationLabel(t, cur)) {
+    changes.push({
+      key: 'location',
+      label: t.expense.audit.location,
+      kind: 'text',
+      oldText: locationLabel(t, prev),
+      newText: locationLabel(t, cur),
+    });
+  }
+  // Who paid: compare the set of payers, not amounts (an amount move is already
+  // the Amount line). A changed set is a real "someone else paid".
+  if (memberKey(prev.payers) !== memberKey(cur.payers)) {
+    changes.push({
+      key: 'payers',
+      label: t.expense.audit.payers,
+      kind: 'text',
+      oldText: prev.payers.map((p) => nameOf(p.member_id)).join(', ') || t.expense.audit.none,
+      newText: cur.payers.map((p) => nameOf(p.member_id)).join(', ') || t.expense.audit.none,
+    });
+  }
+  // Participants: the count of people splitting the bill, which is what "3 → 2"
+  // means. Amount-only edits keep the same set, so they never show here.
+  if (memberKey(prev.shares) !== memberKey(cur.shares)) {
+    changes.push({
+      key: 'participants',
+      label: t.expense.audit.participants,
+      kind: 'text',
+      oldText: String(prev.shares.length),
+      newText: String(cur.shares.length),
+    });
+  }
+
+  return changes;
+}
+
+/** One "old → new" line: a field name, then the two values with a direction
+ *  arrow between them. Money renders through MoneyText; everything else is
+ *  plain text with the previous value struck through. */
+function ChangeLine({ change, locale }: { change: Change; locale: string }) {
+  const theme = useTheme();
+  return (
+    <View style={{ gap: 2 }}>
+      <Text variant="micro" tone="muted">
+        {change.label}
+      </Text>
+      <Row style={{ alignItems: 'center', gap: theme.spacing.sm, flexWrap: 'wrap' }}>
+        {change.kind === 'money' ? (
+          <MoneyText
+            amount={change.oldAmount}
+            currency={change.currency as never}
+            locale={locale}
+            variant="caption"
+            tone="muted"
+          />
+        ) : (
+          <Text
+            variant="caption"
+            tone="muted"
+            style={{ textDecorationLine: 'line-through' }}
+            numberOfLines={2}
+          >
+            {change.oldText}
+          </Text>
+        )}
+        <Ionicons
+          name={directionalIcon('arrow-forward')}
+          size={iconSize.sm}
+          color={theme.color.textFaint}
+        />
+        {change.kind === 'money' ? (
+          <MoneyText
+            amount={change.newAmount}
+            currency={change.currency as never}
+            locale={locale}
+            variant="caption"
+          />
+        ) : (
+          <Text variant="caption" numberOfLines={2} style={{ flexShrink: 1 }}>
+            {change.newText}
+          </Text>
+        )}
+      </Row>
+    </View>
+  );
+}
+
+/** One line of the image audit — "{name} added the receipt", etc. */
+function imageAuditLine(t: UiStrings, event: ExpenseImageEventRow, name: string): string {
+  const template =
+    event.kind === 'receipt'
+      ? event.action === 'added'
+        ? t.imageAudit.receiptAdded
+        : t.imageAudit.receiptRemoved
+      : event.action === 'added'
+        ? t.imageAudit.attachmentAdded
+        : t.imageAudit.attachmentRemoved;
+  return fill(template, { name });
+}
+
+export function ExpenseHistory({
+  versions,
+  imageEvents,
+  nameOf,
+  t,
+  locale,
+}: {
+  /** Newest version first, as `fetchExpenseVersions` returns them. */
+  versions: ExpenseVersionAudit[];
+  imageEvents: ExpenseImageEventRow[];
+  nameOf: (id: string | null) => string;
+  t: UiStrings;
+  locale: string;
+}) {
+  const theme = useTheme();
+
+  // Ascending, so each version can look one step back for its diff.
+  const ascending = [...versions].sort((a, b) => a.version_no - b.version_no);
+  const entries = ascending.map((version, index) => ({
+    version,
+    changes: index === 0 ? [] : diffVersions(t, locale, nameOf, ascending[index - 1]!, version),
+    created: index === 0,
+  }));
+  // Newest first for display.
+  entries.reverse();
+
+  return (
+    <View style={{ gap: theme.spacing.xl }}>
+      <View>
+        <SectionHeader title={t.expense.history} />
+        <View style={{ gap: theme.spacing.md }}>
+          {entries.map(({ version, changes, created }) => (
+            <Card key={version.id} style={{ gap: theme.spacing.md }}>
+              <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+                <Avatar name={`v${version.version_no}`} emoji={created ? '🧾' : '✏️'} size={38} />
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text variant="subheading" numberOfLines={1}>
+                    {fill(created ? t.expense.createdByName : t.expense.editedByName, {
+                      name: nameOf(version.author_member_id),
+                    })}
+                  </Text>
+                  <Text variant="micro" tone="muted" numberOfLines={1}>
+                    {stampLabel(locale, version.created_at)}
+                  </Text>
+                </View>
+                <MoneyText
+                  amount={BigInt(version.amount)}
+                  currency={version.currency as never}
+                  locale={locale}
+                  variant="caption"
+                />
+              </Row>
+              {created ? null : changes.length === 0 ? (
+                <Text variant="caption" tone="muted">
+                  {t.expense.noChanges}
+                </Text>
+              ) : (
+                <View style={{ gap: theme.spacing.sm, paddingLeft: 38 + theme.spacing.md }}>
+                  {changes.map((change) => (
+                    <ChangeLine key={change.key} change={change} locale={locale} />
+                  ))}
+                </View>
+              )}
+            </Card>
+          ))}
+        </View>
+      </View>
+
+      {/* The image audit (A46): who added or removed a receipt or attachment,
+          oldest first. A `parties` line only reaches a party's device (RLS on
+          the pull). Absent until something happens to an image. */}
+      {imageEvents.length > 0 ? (
+        <View>
+          <SectionHeader title={t.imageAudit.title} />
+          <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+            {imageEvents.map((event, index) => (
+              <View key={event.id}>
+                <Row
+                  style={{
+                    alignItems: 'center',
+                    gap: theme.spacing.md,
+                    paddingVertical: theme.spacing.md,
+                  }}
+                >
+                  <Avatar
+                    name={nameOf(event.actorMemberId)}
+                    emoji={event.action === 'added' ? '📎' : '🗑️'}
+                    size={38}
+                  />
+                  <View style={{ flex: 1, minWidth: 0 }}>
+                    <Text variant="body" numberOfLines={2}>
+                      {imageAuditLine(t, event, nameOf(event.actorMemberId))}
+                    </Text>
+                    {event.createdAt ? (
+                      <Text variant="micro" tone="muted" numberOfLines={1}>
+                        {stampLabel(locale, event.createdAt)}
+                      </Text>
+                    ) : null}
+                  </View>
+                  {event.visibility === 'parties' ? (
+                    <Badge label={t.imageAudit.partyOnly} tone="neutral" />
+                  ) : null}
+                </Row>
+                {index < imageEvents.length - 1 ? (
+                  <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                ) : null}
+              </View>
+            ))}
+          </Card>
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ExpenseHistory.tsx
+++ b/apps/mobile/src/components/ExpenseHistory.tsx
@@ -93,7 +93,8 @@ type Change =
       kind: 'money';
       oldAmount: bigint;
       newAmount: bigint;
-      currency: string;
+      oldCurrency: string;
+      newCurrency: string;
     }
   | { key: string; label: string; kind: 'text'; oldText: string; newText: string };
 
@@ -113,7 +114,8 @@ function diffVersions(
       kind: 'money',
       oldAmount: BigInt(prev.amount),
       newAmount: BigInt(cur.amount),
-      currency: cur.currency,
+      oldCurrency: prev.currency,
+      newCurrency: cur.currency,
     });
   }
   if ((prev.description ?? '').trim() !== (cur.description ?? '').trim()) {
@@ -175,15 +177,18 @@ function diffVersions(
       newText: cur.payers.map((p) => nameOf(p.member_id)).join(', ') || t.expense.audit.none,
     });
   }
-  // Participants: the count of people splitting the bill, which is what "3 → 2"
-  // means. Amount-only edits keep the same set, so they never show here.
+  // Participants: who is splitting the bill, by name — the same treatment as
+  // payers. Named rather than counted, so replacing one person with another
+  // (the set changes but the count does not) reads as a real change instead of
+  // an identical "3 → 3". Amount-only edits keep the same set, so they never
+  // show here.
   if (memberKey(prev.shares) !== memberKey(cur.shares)) {
     changes.push({
       key: 'participants',
       label: t.expense.audit.participants,
       kind: 'text',
-      oldText: String(prev.shares.length),
-      newText: String(cur.shares.length),
+      oldText: prev.shares.map((s) => nameOf(s.member_id)).join(', ') || t.expense.audit.none,
+      newText: cur.shares.map((s) => nameOf(s.member_id)).join(', ') || t.expense.audit.none,
     });
   }
 
@@ -204,7 +209,7 @@ function ChangeLine({ change, locale }: { change: Change; locale: string }) {
         {change.kind === 'money' ? (
           <MoneyText
             amount={change.oldAmount}
-            currency={change.currency as never}
+            currency={change.oldCurrency as never}
             locale={locale}
             variant="caption"
             tone="muted"
@@ -227,7 +232,7 @@ function ChangeLine({ change, locale }: { change: Change; locale: string }) {
         {change.kind === 'money' ? (
           <MoneyText
             amount={change.newAmount}
-            currency={change.currency as never}
+            currency={change.newCurrency as never}
             locale={locale}
             variant="caption"
           />

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -762,16 +762,43 @@ export async function restoreExpense(expenseId: string): Promise<void> {
   if (error) throw new Error(error.message);
 }
 
-export async function fetchExpenseVersions(expenseId: string) {
+/**
+ * One historical version of an expense, rich enough to diff against its
+ * neighbour for the edit-history audit: the scalar fields plus the payer and
+ * share rows, so "what changed" can name a field and show old → new.
+ */
+export interface ExpenseVersionAudit {
+  id: string;
+  version_no: number;
+  description: string;
+  /** Total, in minor units, as a string (bigint over the wire). */
+  amount: string;
+  currency: string;
+  created_at: string;
+  author_member_id: string | null;
+  split_type: string;
+  category: string | null;
+  /** The custom tag snapshot when the category is a user tag; carries its label. */
+  category_meta: { label?: string } | null;
+  expense_date: string;
+  location: ExpenseLocation | null;
+  payers: { member_id: string; amount: string }[];
+  shares: { member_id: string; amount: string }[];
+}
+
+export async function fetchExpenseVersions(expenseId: string): Promise<ExpenseVersionAudit[]> {
   return unwrap(
     await backend
       .from('expense_versions')
       .select(
-        'id, version_no, description, amount, currency, created_at, author_member_id, split_type',
+        'id, version_no, description, amount, currency, created_at, author_member_id, split_type, ' +
+          'category, category_meta, expense_date, location, ' +
+          'payers:expense_payers ( member_id, amount ), ' +
+          'shares:expense_shares ( member_id, amount )',
       )
       .eq('expense_id', expenseId)
       .order('version_no', { ascending: false }),
-  );
+  ) as unknown as ExpenseVersionAudit[];
 }
 
 export async function recordSettlement(input: {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1414,6 +1414,26 @@ export interface UiStrings {
     byShares: string;
     withAdjustments: string;
     itemized: string;
+    /** The two faces of the expense page: its breakdown, and its edit history. */
+    detailsTab: string;
+    /** "Created by Asha" / "Edited by Ravi" — the head of one audit entry. */
+    createdByName: string;
+    editedByName: string;
+    /** Shown on an edit that touched nothing this audit tracks. */
+    noChanges: string;
+    /** Field names on the edit-history audit, each shown as old → new. */
+    audit: {
+      amount: string;
+      description: string;
+      category: string;
+      split: string;
+      date: string;
+      location: string;
+      payers: string;
+      participants: string;
+      /** Placeholder for a field that was empty on one side (e.g. no location). */
+      none: string;
+    };
   };
   /** Starting a group, joining one by link, and the odds and ends around both. */
   misc: {
@@ -3091,6 +3111,21 @@ const en: UiStrings = {
     byShares: 'By shares',
     withAdjustments: 'With adjustments',
     itemized: 'Itemized',
+    detailsTab: 'Details',
+    createdByName: 'Created by {name}',
+    editedByName: 'Edited by {name}',
+    noChanges: 'No tracked fields changed',
+    audit: {
+      amount: 'Amount',
+      description: 'Description',
+      category: 'Category',
+      split: 'Split',
+      date: 'Date',
+      location: 'Location',
+      payers: 'Who paid',
+      participants: 'People',
+      none: 'None',
+    },
   },
   misc: {
     couldNotAddGeneric: 'Could not add everyone. Please try again.',
@@ -4876,6 +4911,21 @@ const ta: UiStrings = {
     byShares: 'பங்குகளின்படி',
     withAdjustments: 'சரிசெய்தலுடன்',
     itemized: 'பொருள் வாரியாக',
+    detailsTab: 'விவரங்கள்',
+    createdByName: '{name} உருவாக்கியது',
+    editedByName: '{name} திருத்தியது',
+    noChanges: 'கண்காணிக்கப்படும் புலங்கள் மாறவில்லை',
+    audit: {
+      amount: 'தொகை',
+      description: 'விவரம்',
+      category: 'வகை',
+      split: 'பிரிப்பு',
+      date: 'தேதி',
+      location: 'இடம்',
+      payers: 'செலுத்தியவர்',
+      participants: 'நபர்கள்',
+      none: 'இல்லை',
+    },
   },
   misc: {
     couldNotAddGeneric: 'எல்லாரையும் சேர்க்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
@@ -6642,6 +6692,21 @@ const hi: UiStrings = {
     byShares: 'हिस्सों से',
     withAdjustments: 'समायोजन के साथ',
     itemized: 'चीज़-वार',
+    detailsTab: 'विवरण',
+    createdByName: '{name} ने बनाया',
+    editedByName: '{name} ने बदला',
+    noChanges: 'कोई ट्रैक किया गया फ़ील्ड नहीं बदला',
+    audit: {
+      amount: 'राशि',
+      description: 'विवरण',
+      category: 'श्रेणी',
+      split: 'बँटवारा',
+      date: 'तारीख़',
+      location: 'स्थान',
+      payers: 'किसने चुकाया',
+      participants: 'लोग',
+      none: 'कोई नहीं',
+    },
   },
   misc: {
     couldNotAddGeneric: 'सभी को नहीं जोड़ा जा सका। कृपया फिर कोशिश करें।',
@@ -8443,6 +8508,21 @@ const ar: UiStrings = {
     byShares: 'بالحصص',
     withAdjustments: 'مع تعديلات',
     itemized: 'حسب الأصناف',
+    detailsTab: 'التفاصيل',
+    createdByName: 'أنشأها {name}',
+    editedByName: 'عدّلها {name}',
+    noChanges: 'لم تتغيّر أي حقول متتبَّعة',
+    audit: {
+      amount: 'المبلغ',
+      description: 'الوصف',
+      category: 'الفئة',
+      split: 'التقسيم',
+      date: 'التاريخ',
+      location: 'الموقع',
+      payers: 'من دفع',
+      participants: 'الأشخاص',
+      none: 'لا شيء',
+    },
   },
   misc: {
     couldNotAddGeneric: 'تعذّرت إضافة الجميع. حاول مرة أخرى.',


### PR DESCRIPTION
## The bug
Editing an expense — e.g. amount 30,000 → 300 — left no visible trace of *what* changed. The expense detail's "history" was a flat list of versions showing only each version's amount.

## Fix
**Two tabs** on the expense detail via `SegmentedTabs`, with the hero (amount, category, paid-by) always above:
- **Details** — the breakdown: receipts, location, who paid, who owes what, comments.
- **History** — a real audit trail.

**The audit** (`ExpenseHistory.tsx`): for each version after the first, it diffs against the previous version and spells out every changed field as **old → new**:
- amount (rendered with `MoneyText`), description, category, split type, date, location, who paid, and participant count ("3 → 2").
- first version → "Created by {name}"; each later one → "Edited by {name}" + timestamp, with its changes beneath.
- the A46 receipt/attachment image audit folds into the same timeline.

## Data
`fetchExpenseVersions` now selects the richer version columns (category, category_meta, expense_date, location) plus payer/share rows, typed as `ExpenseVersionAudit`. **Read-only — no migration, no edge change.**

## i18n
New keys `detailsTab`, `createdByName`, `editedByName`, `noChanges`, `audit.*` across en/ta/hi/ar; arrow is `directionalIcon('arrow-forward')` so it mirrors in RTL.

## Test
- mobile `tsc --noEmit` clean; `pnpm format` + `pnpm lint` green.
- Couldn't verify on a device from here — the diff logic is covered by types and the render mirrors the existing history/section idiom.

## Coordination
Left `ExpenseComments.tsx` untouched (a parallel branch owns it). Edits to `hooks`/`api`/`i18n` are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Details and History tabs to expense screens.
  - Added a consolidated history view showing changes to amounts, descriptions, categories, splits, dates, locations, payers, and participants.
  - Added receipt and attachment audit events with timestamps and visibility indicators.
  - Added localized labels and messages for expense details and edit history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->