### PR TITLE
feat(expense): rich-text (Markdown) comments with a bottom-sheet editor

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -214,13 +214,6 @@ export default function ExpenseDetailScreen() {
   // wash is the neutral brand indigo, never a money verdict. The category keeps
   // its own colour as the badge chip on the wash.
 
-  // Bring the comment composer above the keyboard when it focuses: the thread is
-  // the last thing on a long page, so without this the input opens under the
-  // keyboard. A short delay lets the resized layout settle before scrolling.
-  const scrollToComposer = (): void => {
-    setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 150);
-  };
-
   const confirmDelete = (): void => {
     Alert.alert(t.expense.deleteQuestion, t.expense.deleteBody, [
       { text: t.common.cancel, style: 'cancel' },
@@ -541,7 +534,10 @@ export default function ExpenseDetailScreen() {
                   myMemberId={myMemberId}
                   iAmAdmin={iAmAdmin}
                   nameOf={nameOf}
-                  onComposerFocus={scrollToComposer}
+                  avatarNameOf={avatarNameOf}
+                  photoOf={(memberId) =>
+                    memberId ? (lookup.get(memberId)?.profile?.avatar_url ?? null) : null
+                  }
                 />
               </Card>
             </View>

--- a/apps/mobile/src/components/CommentMarkdown.tsx
+++ b/apps/mobile/src/components/CommentMarkdown.tsx
@@ -1,0 +1,109 @@
+/**
+ * Renders the tiny Markdown subset a comment may carry — and nothing else.
+ *
+ * Supported: `**bold**`, `*italic*` / `_italic_`, `~~strike~~`, and `- ` / `* `
+ * bullet lines, plus hard line breaks. Anything outside that subset is rendered
+ * as literal text: no links, no images, no headings, no raw HTML. Because this
+ * only ever emits React Native `<Text>`/`<View>` — never HTML — there is no DOM
+ * and nothing to execute, so an unrecognised or hostile construct is at worst
+ * ugly, never dangerous. The write side (`sanitizeCommentMarkdown`) keeps the
+ * stored value inside this same subset, so the two never disagree.
+ *
+ * The inline parser is a small recursive splitter rather than a dependency: the
+ * subset is fixed and narrow, a custom parser keeps links/images/HTML
+ * unrepresentable by construction, and it adds no native module (which the
+ * current Expo SDK / RN pin makes worth avoiding).
+ */
+
+import type { ReactNode } from 'react';
+import type { TextStyle } from 'react-native';
+import { View } from 'react-native';
+
+import { Text, useTheme } from '@waves/ui';
+
+// Each inline marker, in precedence order. Bold before italic so `**x**` is read
+// as bold rather than italic-of-`*x*`; on a tie of start position the earlier
+// entry wins (see `firstMatch`). The backreference (`\1`) on italic forces the
+// same delimiter to open and close, so `*x*` and `_x_` match but `*x_` does not.
+const INLINE: { re: RegExp; style: TextStyle; group: number }[] = [
+  { re: /\*\*([\s\S]+?)\*\*/, style: { fontWeight: '700' }, group: 1 },
+  { re: /~~([\s\S]+?)~~/, style: { textDecorationLine: 'line-through' }, group: 1 },
+  { re: /(\*|_)([\s\S]+?)\1/, style: { fontStyle: 'italic' }, group: 2 },
+];
+
+/** The earliest inline match across all markers, or null when the text is plain. */
+function firstMatch(text: string): { m: RegExpExecArray; style: TextStyle; group: number } | null {
+  let best: { m: RegExpExecArray; style: TextStyle; group: number } | null = null;
+  for (const marker of INLINE) {
+    const m = marker.re.exec(text);
+    // Strictly-smaller keeps ties on the first (higher-precedence) marker.
+    if (m && (best === null || m.index < best.m.index)) {
+      best = { m, style: marker.style, group: marker.group };
+    }
+  }
+  return best;
+}
+
+/**
+ * Turn one line of inline Markdown into styled `<Text>` spans. Recurses into the
+ * matched inner text (so `**_x_**` nests) and the trailing remainder. `counter`
+ * hands out stable keys; RN happily mixes raw strings and `<Text>` as children.
+ */
+function renderInline(text: string, counter: { n: number }): ReactNode[] {
+  if (text === '') return [];
+  const hit = firstMatch(text);
+  if (!hit) return [text];
+  const before = text.slice(0, hit.m.index);
+  const inner = hit.m[hit.group] ?? '';
+  const after = text.slice(hit.m.index + hit.m[0].length);
+  const nodes: ReactNode[] = [];
+  if (before) nodes.push(before);
+  nodes.push(
+    <Text key={`s${counter.n++}`} style={hit.style}>
+      {renderInline(inner, counter)}
+    </Text>,
+  );
+  nodes.push(...renderInline(after, counter));
+  return nodes;
+}
+
+const BULLET = /^[ \t]*[-*][ \t]+(.*)$/;
+
+/**
+ * Render a comment body. Block structure is line-based: a `- `/`* ` line is a
+ * bullet row, a blank line is a small gap, anything else is a paragraph line.
+ */
+export function CommentMarkdown({ source }: { source: string }): React.JSX.Element {
+  const theme = useTheme();
+  const counter = { n: 0 };
+  const lines = source.split('\n');
+  return (
+    <View style={{ gap: 2 }}>
+      {lines.map((line, index) => {
+        const bullet = BULLET.exec(line);
+        if (bullet) {
+          return (
+            <View key={`l${index}`} style={{ flexDirection: 'row', gap: theme.spacing.sm }}>
+              <Text variant="body" style={{ color: theme.color.textMuted }}>
+                {'•'}
+              </Text>
+              <Text variant="body" style={{ flex: 1 }}>
+                {renderInline(bullet[1] ?? '', counter)}
+              </Text>
+            </View>
+          );
+        }
+        if (line.trim() === '') {
+          // A blank line is a paragraph break — a little vertical air, not a
+          // full empty text row (which would collapse to nothing anyway).
+          return <View key={`l${index}`} style={{ height: theme.spacing.xs }} />;
+        }
+        return (
+          <Text key={`l${index}`} variant="body">
+            {renderInline(line, counter)}
+          </Text>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ExpenseComments.tsx
+++ b/apps/mobile/src/components/ExpenseComments.tsx
@@ -10,13 +10,29 @@
  * The layout follows the comment-thread pattern every social app converges on
  * (Substack, Beli, Digg, Meta): avatar on the left, name and time on one line,
  * the body aligned under the name, and the per-comment actions folded behind a
- * "···" so the row stays clean. The composer is a pinned pill — your avatar, a
- * rounded field, a round send button.
+ * "···" so the row stays clean.
+ *
+ * Comments are **rich text stored as Markdown** — a deliberately small subset:
+ * bold, italic, strikethrough and bullet lists (see `CommentMarkdown` for the
+ * render and `sanitizeCommentMarkdown` for the write side). No images, ever.
+ * Instead of a live field, a "+" launcher opens a bottom-sheet editor carrying a
+ * formatting toolbar, so the formatting controls have somewhere to live and the
+ * thread stays uncluttered.
  */
 
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { ActivityIndicator, Alert, Pressable, TextInput, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  TextInput,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Avatar, Button, iconSize, Row, Text, useTheme } from '@waves/ui';
 
@@ -28,6 +44,9 @@ import {
   useExpenseComments,
   type ExpenseCommentRow,
 } from '@/data/hooks';
+import { MAX_COMMENT_LENGTH } from '@/lib/commentMarkdown';
+import { useAvatarUrl } from '@/components/ProfileAvatar';
+import { CommentMarkdown } from '@/components/CommentMarkdown';
 import { useStrings } from '@/i18n';
 
 function whenLabel(iso: string | null, locale: string): string {
@@ -54,23 +73,40 @@ const AVATAR = 32;
  */
 const PAGE = 20;
 
+type Selection = { start: number; end: number };
+
+/**
+ * One author's avatar. `useAvatarUrl` signs the private-bucket path so the real
+ * picture can load; it's a hook, so it lives in its own component instance —
+ * one per row — rather than being called inside a `.map`. Falls back to initials
+ * when the person has no picture.
+ */
+function CommentAvatar({ name, photo }: { name: string; photo: string | null }): React.JSX.Element {
+  const url = useAvatarUrl(photo);
+  return <Avatar name={name} size={AVATAR} photoUrl={url} />;
+}
+
 export function ExpenseComments({
   groupId,
   expenseId,
   myMemberId,
   iAmAdmin,
   nameOf,
-  onComposerFocus,
+  avatarNameOf,
+  photoOf,
 }: {
   groupId: string;
   expenseId: string;
   myMemberId: string | null;
   iAmAdmin: boolean;
   nameOf: (memberId: string | null) => string;
-  /** Called when the composer focuses — the parent scrolls it above the keyboard. */
-  onComposerFocus?: () => void;
+  /** The real name to seed an avatar's initial/colour (not the "You" label). */
+  avatarNameOf?: (memberId: string | null) => string;
+  /** The author's raw (unsigned) avatar path, if any, for their picture. */
+  photoOf?: (memberId: string | null) => string | null;
 }): React.JSX.Element {
   const theme = useTheme();
+  const insets = useSafeAreaInsets();
   const { t, locale } = useStrings();
   const comments = useExpenseComments(expenseId);
   const add = useAddExpenseComment(groupId, expenseId);
@@ -78,9 +114,19 @@ export function ExpenseComments({
   const remove = useDeleteExpenseComment();
   const flag = useFlagExpenseComment();
 
-  const [draft, setDraft] = useState('');
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingBody, setEditingBody] = useState('');
+  const avatarName = (memberId: string | null): string => (avatarNameOf ?? nameOf)(memberId);
+  const photo = (memberId: string | null): string | null => photoOf?.(memberId) ?? null;
+
+  // The editor bottom sheet. `commentId === null` means a new comment; otherwise
+  // it edits that comment. `forcedSel`, when set, is handed to the TextInput's
+  // `selection` for exactly one render after a toolbar action moves the caret,
+  // then cleared by the next selection change so the person can move freely.
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editorCommentId, setEditorCommentId] = useState<string | null>(null);
+  const [editorBody, setEditorBody] = useState('');
+  const [sel, setSel] = useState<Selection>({ start: 0, end: 0 });
+  const [forcedSel, setForcedSel] = useState<Selection | null>(null);
+
   // Just-posted comments, shown at once so a text comment feels instant instead
   // of waiting on the sync pull that carries it back from the mirror. Each drops
   // out of the merge below the moment the mirror row with the same id arrives.
@@ -96,49 +142,96 @@ export function ExpenseComments({
   const shown = rows.length > visibleCount ? rows.slice(rows.length - visibleCount) : rows;
   const hidden = rows.length - shown.length;
 
-  const submit = () => {
-    const body = draft.trim();
-    if (body === '') return;
-    setDraft('');
-    add.mutate(
-      { body },
-      {
-        onSuccess: (result) => {
-          if (result) {
-            setOptimistic((current) => [
-              ...current,
-              {
-                id: result.id,
-                expenseId,
-                groupId,
-                authorMemberId: myMemberId,
-                body: result.body,
-                editedAt: null,
-                flaggedAt: null,
-                flaggedBy: null,
-                createdAt: new Date().toISOString(),
-              },
-            ]);
-          }
-        },
-        onError: () => {
-          setDraft(body);
-          Alert.alert(t.comments.couldNotPost);
-        },
-      },
-    );
+  const busy = add.isPending || edit.isPending;
+
+  const openNew = () => {
+    setEditorCommentId(null);
+    setEditorBody('');
+    setSel({ start: 0, end: 0 });
+    setForcedSel({ start: 0, end: 0 });
+    setEditorOpen(true);
   };
 
-  const saveEdit = (commentId: string) => {
-    const body = editingBody.trim();
+  const openEdit = (row: ExpenseCommentRow) => {
+    setEditorCommentId(row.id);
+    setEditorBody(row.body);
+    const end = row.body.length;
+    setSel({ start: end, end });
+    setForcedSel({ start: end, end });
+    setEditorOpen(true);
+  };
+
+  const closeEditor = () => setEditorOpen(false);
+
+  const send = () => {
+    const body = editorBody.trim();
     if (body === '') return;
-    edit.mutate(
-      { commentId, body },
-      {
-        onSuccess: () => setEditingId(null),
-        onError: () => Alert.alert(t.comments.couldNotPost),
-      },
-    );
+    if (editorCommentId === null) {
+      add.mutate(
+        { body: editorBody },
+        {
+          onSuccess: (result) => {
+            setEditorOpen(false);
+            setEditorBody('');
+            if (result) {
+              setOptimistic((current) => [
+                ...current,
+                {
+                  id: result.id,
+                  expenseId,
+                  groupId,
+                  authorMemberId: myMemberId,
+                  body: result.body,
+                  editedAt: null,
+                  flaggedAt: null,
+                  flaggedBy: null,
+                  createdAt: new Date().toISOString(),
+                },
+              ]);
+            }
+          },
+          onError: () => Alert.alert(t.comments.couldNotPost),
+        },
+      );
+    } else {
+      edit.mutate(
+        { commentId: editorCommentId, body: editorBody },
+        {
+          onSuccess: () => setEditorOpen(false),
+          onError: () => Alert.alert(t.comments.couldNotPost),
+        },
+      );
+    }
+  };
+
+  // Wrap the current selection (or drop an empty pair at the caret) with an
+  // inline marker. Bold/italic/strike all share this; only the delimiter differs.
+  const wrapInline = (marker: string) => {
+    const { start, end } = sel;
+    const selected = editorBody.slice(start, end);
+    const next = editorBody.slice(0, start) + marker + selected + marker + editorBody.slice(end);
+    const caret =
+      selected === ''
+        ? { start: start + marker.length, end: start + marker.length }
+        : {
+            start: start + marker.length + selected.length + marker.length,
+            end: start + marker.length + selected.length + marker.length,
+          };
+    setEditorBody(next);
+    setSel(caret);
+    setForcedSel(caret);
+  };
+
+  // Prefix the caret's line with a bullet marker, unless it already has one.
+  const toggleBullet = () => {
+    const { start } = sel;
+    const lineStart = editorBody.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
+    if (editorBody.slice(lineStart, lineStart + 2) === '- ') return;
+    const next = editorBody.slice(0, lineStart) + '- ' + editorBody.slice(lineStart);
+    const caret = { start: start + 2, end: start + 2 };
+    setEditorBody(next);
+    setSel(caret);
+    setForcedSel(caret);
   };
 
   const confirmDelete = (row: ExpenseCommentRow) => {
@@ -163,13 +256,7 @@ export function ExpenseComments({
     const flagged = row.flaggedAt !== null;
     const options: { text: string; style?: 'destructive' | 'cancel'; onPress?: () => void }[] = [];
     if (mine) {
-      options.push({
-        text: t.comments.edit,
-        onPress: () => {
-          setEditingId(row.id);
-          setEditingBody(row.body);
-        },
-      });
+      options.push({ text: t.comments.edit, onPress: () => openEdit(row) });
     }
     if (mine || iAmAdmin) {
       options.push({
@@ -200,57 +287,62 @@ export function ExpenseComments({
     return mine || iAmAdmin || row.flaggedAt === null;
   };
 
-  const fieldStyle = {
-    flex: 1,
-    minHeight: 40,
-    maxHeight: 120,
-    paddingHorizontal: theme.spacing.md,
-    paddingVertical: theme.spacing.sm,
-    borderRadius: theme.radius.pill,
-    backgroundColor: theme.color.surfaceMuted,
-    color: theme.color.text,
-  } as const;
+  // Ionicons has no bold/italic/strike glyph, so those three read as a styled
+  // letter (the toolbar convention every editor uses); the bullet is an icon.
+  const glyph = (letter: string, style: object) => (
+    <Text variant="subheading" style={{ color: theme.color.text, ...style }}>
+      {letter}
+    </Text>
+  );
+  const toolbar: { label: string; node: React.ReactNode; onPress: () => void }[] = [
+    {
+      label: t.comments.bold,
+      node: glyph('B', { fontWeight: '800' }),
+      onPress: () => wrapInline('**'),
+    },
+    {
+      label: t.comments.italic,
+      node: glyph('I', { fontStyle: 'italic' }),
+      onPress: () => wrapInline('_'),
+    },
+    {
+      label: t.comments.strike,
+      node: glyph('S', { textDecorationLine: 'line-through' }),
+      onPress: () => wrapInline('~~'),
+    },
+    {
+      label: t.comments.bulletList,
+      node: <Ionicons name="list-outline" size={iconSize.md} color={theme.color.text} />,
+      onPress: toggleBullet,
+    },
+  ];
 
   return (
     <View style={{ gap: theme.spacing.lg }}>
-      {/* Composer first: writing a comment is what you came here to do, so the
-          field leads and the thread you're replying to sits beneath it. */}
-      <Row style={{ gap: 10, alignItems: 'flex-end' }}>
-        <Avatar name={nameOf(myMemberId)} size={AVATAR} />
-        <TextInput
-          value={draft}
-          onChangeText={setDraft}
-          onFocus={onComposerFocus}
-          multiline
-          placeholder={t.comments.placeholder}
-          placeholderTextColor={theme.color.textFaint}
-          style={fieldStyle}
-          accessibilityLabel={t.comments.placeholder}
-        />
+      {/* The launcher: a "+" pill in place of a live field. Tapping it raises the
+          editor sheet, where the formatting controls live. */}
+      <Row style={{ gap: 10, alignItems: 'center' }}>
+        <CommentAvatar name={avatarName(myMemberId)} photo={photo(myMemberId)} />
         <Pressable
-          onPress={submit}
-          disabled={add.isPending || draft.trim() === ''}
+          onPress={openNew}
           accessibilityRole="button"
-          accessibilityLabel={t.comments.post}
-          style={{
-            width: 40,
-            height: 40,
-            borderRadius: 20,
+          accessibilityLabel={t.comments.addComment}
+          style={({ pressed }) => ({
+            flex: 1,
+            flexDirection: 'row',
             alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor:
-              draft.trim() === '' ? theme.color.surfaceMuted : theme.color.buttonPrimary,
-          }}
+            gap: theme.spacing.xs,
+            minHeight: 40,
+            paddingHorizontal: theme.spacing.md,
+            borderRadius: theme.radius.pill,
+            backgroundColor: theme.color.surfaceMuted,
+            opacity: pressed ? 0.7 : 1,
+          })}
         >
-          {add.isPending ? (
-            <ActivityIndicator color={theme.color.onBrand} />
-          ) : (
-            <Ionicons
-              name="arrow-up"
-              size={iconSize.md}
-              color={draft.trim() === '' ? theme.color.textFaint : theme.color.onBrand}
-            />
-          )}
+          <Ionicons name="add" size={iconSize.md} color={theme.color.textMuted} />
+          <Text variant="body" style={{ color: theme.color.textFaint }}>
+            {t.comments.addComment}
+          </Text>
         </Pressable>
       </Row>
 
@@ -299,10 +391,12 @@ export function ExpenseComments({
         shown.map((row) => {
           const mine = myMemberId !== null && row.authorMemberId === myMemberId;
           const flagged = row.flaggedAt !== null;
-          const editing = editingId === row.id;
           return (
             <Row key={row.id} style={{ gap: 10, alignItems: 'flex-start' }}>
-              <Avatar name={nameOf(row.authorMemberId)} size={AVATAR} />
+              <CommentAvatar
+                name={avatarName(row.authorMemberId)}
+                photo={photo(row.authorMemberId)}
+              />
               <View style={{ flex: 1, gap: 2 }}>
                 <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
                   <Text variant="caption" style={{ fontWeight: '600' }} numberOfLines={1}>
@@ -318,7 +412,7 @@ export function ExpenseComments({
                     <Ionicons name="flag" size={11} color={theme.color.negative} />
                   ) : null}
                   <View style={{ flex: 1 }} />
-                  {!editing && hasActions(row) ? (
+                  {hasActions(row) ? (
                     <Pressable
                       onPress={() => openActions(row)}
                       accessibilityRole="button"
@@ -335,39 +429,101 @@ export function ExpenseComments({
                   ) : null}
                 </Row>
 
-                {editing ? (
-                  <View style={{ gap: theme.spacing.xs, paddingTop: theme.spacing.xs }}>
-                    <TextInput
-                      value={editingBody}
-                      onChangeText={setEditingBody}
-                      multiline
-                      autoFocus
-                      style={fieldStyle}
-                      accessibilityLabel={t.comments.editLabel}
-                    />
-                    <Row style={{ gap: theme.spacing.sm, justifyContent: 'flex-end' }}>
-                      <Button
-                        label={t.common.cancel}
-                        variant="ghost"
-                        size="sm"
-                        onPress={() => setEditingId(null)}
-                      />
-                      <Button
-                        label={t.common.save}
-                        size="sm"
-                        disabled={edit.isPending || editingBody.trim() === ''}
-                        onPress={() => saveEdit(row.id)}
-                      />
-                    </Row>
-                  </View>
-                ) : (
-                  <Text variant="body">{row.body}</Text>
-                )}
+                <CommentMarkdown source={row.body} />
               </View>
             </Row>
           );
         })
       )}
+
+      {/* The editor sheet — always mounted, driven by `visible`, the same shape
+          as the dashboard's tip sheet (a Modal toggled after mount presents
+          reliably on Android only when it stays mounted). A formatting toolbar,
+          the field, and Send. Text only: no image control lives here. */}
+      <Modal transparent animationType="fade" visible={editorOpen} onRequestClose={closeEditor}>
+        <Pressable
+          onPress={closeEditor}
+          accessibilityLabel={t.common.close}
+          style={{ flex: 1, backgroundColor: 'rgba(10, 10, 26, 0.55)', justifyContent: 'flex-end' }}
+        >
+          <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+            {/* Swallow taps so pressing the sheet does not dismiss it. */}
+            <Pressable
+              onPress={() => {}}
+              style={{
+                backgroundColor: theme.color.surface,
+                borderTopLeftRadius: theme.radius.xxl,
+                borderTopRightRadius: theme.radius.xxl,
+                paddingHorizontal: theme.spacing.xl,
+                paddingTop: theme.spacing.lg,
+                paddingBottom: theme.spacing.lg + insets.bottom,
+                gap: theme.spacing.md,
+              }}
+            >
+              <Text variant="heading">
+                {editorCommentId === null ? t.comments.editorTitle : t.comments.editLabel}
+              </Text>
+
+              <TextInput
+                value={editorBody}
+                onChangeText={setEditorBody}
+                onSelectionChange={(e) => {
+                  setSel(e.nativeEvent.selection);
+                  setForcedSel(null);
+                }}
+                selection={forcedSel ?? undefined}
+                multiline
+                autoFocus
+                maxLength={MAX_COMMENT_LENGTH}
+                placeholder={t.comments.placeholder}
+                placeholderTextColor={theme.color.textFaint}
+                style={{
+                  minHeight: 96,
+                  maxHeight: 200,
+                  paddingHorizontal: theme.spacing.md,
+                  paddingVertical: theme.spacing.sm,
+                  borderRadius: theme.radius.lg,
+                  backgroundColor: theme.color.surfaceMuted,
+                  color: theme.color.text,
+                  textAlignVertical: 'top',
+                }}
+                accessibilityLabel={t.comments.placeholder}
+              />
+
+              <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+                {toolbar.map((tool) => (
+                  <Pressable
+                    key={tool.label}
+                    onPress={tool.onPress}
+                    accessibilityRole="button"
+                    accessibilityLabel={tool.label}
+                    hitSlop={6}
+                    style={({ pressed }) => ({
+                      width: 38,
+                      height: 38,
+                      borderRadius: theme.radius.md,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: theme.color.surfaceMuted,
+                      opacity: pressed ? 0.6 : 1,
+                    })}
+                  >
+                    {tool.node}
+                  </Pressable>
+                ))}
+                <View style={{ flex: 1 }} />
+                <Button
+                  label={t.comments.post}
+                  size="sm"
+                  disabled={busy || editorBody.trim() === ''}
+                  onPress={send}
+                />
+                {busy ? <ActivityIndicator color={theme.color.buttonPrimary} /> : null}
+              </Row>
+            </Pressable>
+          </KeyboardAvoidingView>
+        </Pressable>
+      </Modal>
     </View>
   );
 }

--- a/apps/mobile/src/components/ExpenseComments.tsx
+++ b/apps/mobile/src/components/ExpenseComments.tsx
@@ -44,7 +44,7 @@ import {
   useExpenseComments,
   type ExpenseCommentRow,
 } from '@/data/hooks';
-import { MAX_COMMENT_LENGTH } from '@/lib/commentMarkdown';
+import { MAX_COMMENT_LENGTH, sanitizeCommentMarkdown } from '@/lib/commentMarkdown';
 import { useAvatarUrl } from '@/components/ProfileAvatar';
 import { CommentMarkdown } from '@/components/CommentMarkdown';
 import { useStrings } from '@/i18n';
@@ -164,11 +164,16 @@ export function ExpenseComments({
   const closeEditor = () => setEditorOpen(false);
 
   const send = () => {
-    const body = editorBody.trim();
+    // Sanitize here, not just trim: the mutations sanitize too and resolve
+    // without calling the RPC when the result is empty, so a body that is only
+    // image markdown or HTML-shaped tags (`![x](y)`, `<b></b>`) would pass a
+    // bare trim, sanitize to '', and silently close the sheet with the text
+    // lost. Validate against the same sanitizer and keep the sheet open on empty.
+    const body = sanitizeCommentMarkdown(editorBody);
     if (body === '') return;
     if (editorCommentId === null) {
       add.mutate(
-        { body: editorBody },
+        { body },
         {
           onSuccess: (result) => {
             setEditorOpen(false);
@@ -195,7 +200,7 @@ export function ExpenseComments({
       );
     } else {
       edit.mutate(
-        { commentId: editorCommentId, body: editorBody },
+        { commentId: editorCommentId, body },
         {
           onSuccess: () => setEditorOpen(false),
           onError: () => Alert.alert(t.comments.couldNotPost),

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -93,6 +93,7 @@ import { totalsByCurrency } from './totals';
 import { putImage, removeRestrictedImage } from '@/lib/storage';
 import { pickAlbumPhoto, type PickedImage } from '@/lib/image';
 import { parseAnnotations, type Annotations } from '@/lib/annotations';
+import { sanitizeCommentMarkdown } from '@/lib/commentMarkdown';
 import type { VoiceAccess } from '@/lib/voiceAccess';
 import { SettlementStatus } from './types';
 import type {
@@ -1812,7 +1813,9 @@ export function useAddExpenseComment(groupId: string, expenseId: string) {
   const { flush } = useSync();
   return useMutation({
     mutationFn: async (input: { body: string }): Promise<{ id: string; body: string } | null> => {
-      const body = input.body.trim();
+      // Sanitise before it leaves the device: the stored value is Markdown but
+      // only ever the safe subset the renderer understands (no HTML, no images).
+      const body = sanitizeCommentMarkdown(input.body);
       if (body === '') return null;
       const id = randomUUID();
       const { error } = await backend.rpc('baaki_add_expense_comment', {
@@ -1833,7 +1836,7 @@ export function useEditExpenseComment() {
   const { flush } = useSync();
   return useMutation({
     mutationFn: async (input: { commentId: string; body: string }) => {
-      const body = input.body.trim();
+      const body = sanitizeCommentMarkdown(input.body);
       if (body === '') return;
       const { error } = await backend.rpc('baaki_edit_expense_comment', {
         p_comment_id: input.commentId,

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -400,6 +400,15 @@ export interface UiStrings {
     couldNotDelete: string;
     /** Reveal the previous page of older comments (a count is appended). */
     showEarlier: string;
+    /** Launcher button (a "+") that opens the comment editor sheet. */
+    addComment: string;
+    /** Title of the editor bottom sheet when writing a new comment. */
+    editorTitle: string;
+    /** Formatting-toolbar accessibility labels. */
+    bold: string;
+    italic: string;
+    strike: string;
+    bulletList: string;
   };
   /** The image audit on an expense — who added/removed a receipt or attachment. */
   imageAudit: {
@@ -2163,6 +2172,12 @@ const en: UiStrings = {
     couldNotPost: "Couldn't post that — try again.",
     couldNotDelete: "Couldn't delete that — try again.",
     showEarlier: 'Show earlier comments',
+    addComment: 'Add a comment',
+    editorTitle: 'Write a comment',
+    bold: 'Bold',
+    italic: 'Italic',
+    strike: 'Strikethrough',
+    bulletList: 'Bullet list',
   },
   imageAudit: {
     title: 'Image history',
@@ -3919,6 +3934,12 @@ const ta: UiStrings = {
     couldNotPost: 'இட முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
     couldNotDelete: 'நீக்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
     showEarlier: 'முந்தைய கருத்துகளைக் காட்டு',
+    addComment: 'ஒரு கருத்தைச் சேர்',
+    editorTitle: 'ஒரு கருத்தை எழுது',
+    bold: 'தடிமன்',
+    italic: 'சாய்வு',
+    strike: 'குறுக்குக் கோடு',
+    bulletList: 'புள்ளிப் பட்டியல்',
   },
   imageAudit: {
     title: 'படத்தின் வரலாறு',
@@ -5739,6 +5760,12 @@ const hi: UiStrings = {
     couldNotPost: 'भेजा नहीं जा सका — फिर कोशिश करें।',
     couldNotDelete: 'हटाया नहीं जा सका — फिर कोशिश करें।',
     showEarlier: 'पहले की टिप्पणियाँ दिखाएँ',
+    addComment: 'टिप्पणी जोड़ें',
+    editorTitle: 'टिप्पणी लिखें',
+    bold: 'बोल्ड',
+    italic: 'इटैलिक',
+    strike: 'स्ट्राइकथ्रू',
+    bulletList: 'बुलेट सूची',
   },
   imageAudit: {
     title: 'छवि इतिहास',
@@ -7510,6 +7537,12 @@ const ar: UiStrings = {
     couldNotPost: 'تعذّر النشر — حاول مرة أخرى.',
     couldNotDelete: 'تعذّر الحذف — حاول مرة أخرى.',
     showEarlier: 'عرض التعليقات السابقة',
+    addComment: 'إضافة تعليق',
+    editorTitle: 'اكتب تعليقًا',
+    bold: 'عريض',
+    italic: 'مائل',
+    strike: 'يتوسطه خط',
+    bulletList: 'قائمة نقطية',
   },
   imageAudit: {
     title: 'سجل الصور',

--- a/apps/mobile/src/lib/commentMarkdown.ts
+++ b/apps/mobile/src/lib/commentMarkdown.ts
@@ -1,0 +1,72 @@
+/**
+ * Sanitising and normalising the Markdown a comment carries.
+ *
+ * Expense comments are stored as Markdown, but only a deliberately tiny subset
+ * is ever meaningful — bold, italic, strikethrough and bullet lists (see
+ * `CommentMarkdown`). Everything the renderer does not understand renders as
+ * literal text, so the render side is inherently safe. This module is the write
+ * side of that contract: whatever a client sends is normalised down to the same
+ * subset before it leaves the device, so the stored value never carries anything
+ * the renderer would have to be trusted to ignore.
+ *
+ * Comments are text only — no images, ever (ADR-046 keeps comment bytes off R2).
+ * Image Markdown is therefore stripped here as well as never offered in the UI.
+ *
+ * React Native renders through `<Text>`, which has no DOM and executes no HTML,
+ * so a `<script>` in a comment is only ever the five literal characters. The
+ * sanitiser still strips HTML-shaped tags so the *stored* value stays clean for
+ * any future reader (e.g. an export, or a web client that must render to HTML —
+ * where raw HTML would be an XSS vector and must additionally be sanitised at
+ * that renderer).
+ */
+
+/** Matches the server CHECK (`char_length(body) <= 2000`) and the RPC guard. */
+export const MAX_COMMENT_LENGTH = 2000;
+
+// An HTML-shaped tag: `<tag …>`, `</tag>` or `<tag/>`. Anchored on a letter
+// after the `<` so ordinary prose like `a < b` or `x <- y` is left untouched.
+const HTML_TAG = /<\/?[a-zA-Z][^>]*>/g;
+
+// Image Markdown: `![alt](url)` — removed outright (comments never carry bytes).
+const IMAGE_MD = /!\[[^\]]*\]\([^)]*\)/g;
+
+// Link Markdown: `[text](url)` — the renderer has no link support, so keep the
+// visible text and drop the target rather than leave a raw URL sitting in the
+// body. Runs after image stripping so an image's `![…]` is already gone.
+const LINK_MD = /\[([^\]]*)\]\([^)]*\)/g;
+
+// Control characters that are never legitimate in a typed comment. Tab and
+// newline are kept (newlines carry the line structure the renderer reads);
+// everything else in the C0/C1 range and the DEL is dropped.
+const CONTROL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+/**
+ * Reduce a raw comment string to the stored, safe Markdown subset:
+ *
+ * - normalise CRLF / CR to LF,
+ * - strip control characters (keeping tab and newline),
+ * - remove HTML-shaped tags and image Markdown, and flatten links to their text,
+ * - collapse three-or-more blank lines to a single blank line,
+ * - trim, and hard-cap at {@link MAX_COMMENT_LENGTH}.
+ *
+ * Pure and deterministic. The empty string is a valid result (an empty comment
+ * is refused by the caller, not here).
+ */
+export function sanitizeCommentMarkdown(input: string): string {
+  let text = input.replace(/\r\n?/g, '\n');
+  text = text.replace(CONTROL_CHARS, '');
+  text = text.replace(IMAGE_MD, '');
+  text = text.replace(LINK_MD, '$1');
+  text = text.replace(HTML_TAG, '');
+  // Collapse runs of blank lines: at most one empty line between paragraphs.
+  text = text.replace(/\n{3,}/g, '\n\n');
+  // Trim outer whitespace, then also strip trailing spaces on each line so the
+  // stored value is stable regardless of how the toolbar inserted markers.
+  text = text
+    .split('\n')
+    .map((line) => line.replace(/[ \t]+$/, ''))
+    .join('\n')
+    .trim();
+  if (text.length > MAX_COMMENT_LENGTH) text = text.slice(0, MAX_COMMENT_LENGTH).trim();
+  return text;
+}


### PR DESCRIPTION
Expense comments become **rich text stored as Markdown** — no schema change, no new RPC (the body column already holds text).

## Subset supported
`**bold**`, `*italic*` / `_italic_`, `~~strikethrough~~`, and `- ` / `* ` bullet lists, plus hard line breaks. **Text only — no images**, ever.

## UX: "+" launcher → bottom-sheet editor
The always-on composer is replaced with a **"+" launcher**. Tapping it raises a **bottom-sheet editor** modelled on the dashboard tip sheet (an always-mounted `Modal` driven by `visible`, the shape that presents reliably on Android). The sheet has:
- a **formatting toolbar** — **B** / *I* / ~~S~~ (styled letters, since Ionicons has no bold/italic/strike glyph) + a bullet-list icon — each wraps the current selection or drops markers at the caret,
- a multiline field, and **Send**.

Editing a comment reuses the same sheet.

## Rendering — safe by construction
`CommentMarkdown` is a small custom subset renderer that emits **only** RN `<Text>`/`<View>`, never HTML. There is no DOM and nothing to execute, so anything outside the subset renders as literal text — an unrecognised or hostile construct is at worst ugly, never dangerous. No markdown dependency added: that keeps links/images/HTML unrepresentable by construction and avoids native/build risk on the current Expo SDK / RN pin.

## Security — sanitize on save
`sanitizeCommentMarkdown` runs on the **write path** (add *and* edit) before the body leaves the device:
- normalise CRLF/CR → LF, strip control characters (keeping tab/newline),
- remove **HTML-shaped tags** (`</?tag …>`) and **image Markdown** (`![alt](url)`),
- flatten links `[text](url)` → `text` (renderer has no link support, and this avoids leaving a raw URL),
- collapse 3+ blank lines, trim, and **hard-cap at 2000 chars** (matches the server `CHECK`).

The renderer and the sanitiser share one subset, so the stored value never carries anything the renderer must be trusted to ignore.

**Web finding:** the web app renders **no** comments today (grepped — no comment UI in `apps/web`). If it ever does, its Markdown→HTML path must disable raw HTML and sanitise there too (RN's `<Text>` is inherently XSS-safe; a browser DOM is not). Noted for that future work.

## Also: comment author avatars
Author avatars now show **real profile pictures**. Each row resolves the signed private-bucket URL via `useAvatarUrl` inside a per-row `CommentAvatar` (keeps the hook out of a `.map`), falling back to initials; the parent passes `photoOf` / `avatarNameOf` off the member lookup.

## Files
- new `apps/mobile/src/lib/commentMarkdown.ts` — sanitizer + `MAX_COMMENT_LENGTH`
- new `apps/mobile/src/components/CommentMarkdown.tsx` — subset renderer
- `apps/mobile/src/components/ExpenseComments.tsx` — "+" launcher, editor sheet, toolbar, markdown render, avatars
- `apps/mobile/src/data/hooks.ts` — sanitize in add/edit paths
- `apps/mobile/src/app/group/[id]/expense/[expenseId].tsx` — pass `photoOf`/`avatarNameOf` (dropped the now-unused composer-scroll)
- `apps/mobile/src/i18n/index.ts` — `addComment`, `editorTitle`, `bold`, `italic`, `strike`, `bulletList` ×4 locales

## Gates
mobile `tsc --noEmit` clean; `pnpm format` + `pnpm lint` green.

## Not device-verified
No emulator/device here. Two things to eyeball on a device: (1) the editor sheet lifting above the keyboard (KeyboardAvoidingView on iOS; Android relies on the Modal + adjustResize) and (2) the toolbar-then-field selection handoff (tapping a toolbar button after selecting text — RN blurs the field on the tap; the last selection is used and the caret is re-applied via a one-shot `selection` prop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Details and History tabs to expense screens.
  - Added expense edit-history information, including changed fields and editors.
  - Added a bottom-sheet editor for creating and editing comments.
  - Added Markdown formatting for bold, italic, strikethrough, and bullet lists.
  - Added member avatars to comment authors.

- **Improvements**
  - Comment text is cleaned and limited to 2,000 characters.
  - Improved comment layout, paragraph spacing, and bullet formatting.
  - Added clearer posting and editing error handling.
  - Added localized labels in English, Tamil, Hindi, and Arabic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->