### PR TITLE
fix(members): read a bare phone in the user's region, never a raw refusal

### DIFF
--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -35,6 +35,7 @@ import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { requestContacts } from '@/lib/contactPickerBridge';
 import { friendlyError } from '@/lib/errors';
+import { isPhoneCountryError } from '@/lib/phone';
 
 export default function MembersScreen() {
   const theme = useTheme();
@@ -115,7 +116,11 @@ export default function MembersScreen() {
           setGhostContact('');
         },
         onError: (caught) =>
-          setError(friendlyError(caught, t.misc.couldNotAddGeneric, 'members.addGhost')),
+          setError(
+            isPhoneCountryError(caught)
+              ? t.people.phoneNeedsCountryCode
+              : friendlyError(caught, t.misc.couldNotAddGeneric, 'members.addGhost'),
+          ),
       },
     );
   };
@@ -149,7 +154,9 @@ export default function MembersScreen() {
         // Report every refusal (friendlyError's side effect sends each to
         // Sentry); keep only the first one's words for the UI, so the message
         // can say why rather than only which names did not make it.
-        const message = friendlyError(caught, t.misc.tryAgainMoment, 'members.addPicked');
+        const message = isPhoneCountryError(caught)
+          ? t.people.phoneNeedsCountryCode
+          : friendlyError(caught, t.misc.tryAgainMoment, 'members.addPicked');
         if (!reason) reason = message;
       }
     }

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -31,6 +31,7 @@ import {
 
 import { GroupPhoto } from '@/components/GroupPhoto';
 import { friendlyError } from '@/lib/errors';
+import { isPhoneCountryError, normaliseContactPhone } from '@/lib/phone';
 import { type PickedContact } from '@/components/ContactPicker';
 import { CoverEmojiPicker } from '@/components/CoverEmojiPicker';
 import { InfoDisclosure } from '@/components/InfoDisclosure';
@@ -401,7 +402,10 @@ export default function NewGroupScreen() {
           memberId: randomUUID(),
           name: ghost.name,
           email: ghost.email,
-          phone: ghost.phone,
+          // Read a bare local number in this group's region before queueing it —
+          // the country chosen for the group above, else the account/device — so
+          // the server is never handed an unroutable number to refuse.
+          phone: normaliseContactPhone(ghost.phone, country),
         });
       }
 
@@ -431,7 +435,11 @@ export default function NewGroupScreen() {
 
       router.replace(`/group/${groupId}`);
     } catch (caught) {
-      setError(friendlyError(caught, t.couldNotSave, 'newGroup.create'));
+      setError(
+        isPhoneCountryError(caught)
+          ? t.people.phoneNeedsCountryCode
+          : friendlyError(caught, t.couldNotSave, 'newGroup.create'),
+      );
     }
   };
 

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -45,6 +45,7 @@ import {
 } from '@waves/ui';
 
 import { plural, useStrings } from '@/i18n';
+import { normaliseContactPhone } from '@/lib/phone';
 import { SkeletonList } from '@/components/Skeletons';
 
 export interface PickedContact {
@@ -752,13 +753,23 @@ function keyOf(contact: PickedContact): string {
 }
 
 /**
- * A contact card writes a number however the owner typed it. Keep only digits
- * and a leading plus; a number with no country code is returned as-is and the
- * server refuses it, rather than this guessing +91 for somebody's friend
- * abroad — a trip is exactly when foreign numbers turn up.
+ * A contact card writes a number however the owner typed it.
+ *
+ * A bare local number is read in the device's own region — the WhatsApp-style
+ * default every messaging app on the phone already uses — so the address the
+ * picker shows matches the E.164 the server keeps, and a contact already in the
+ * group greys out instead of looking new. This is best-effort and never throws:
+ * if there is no region to read it in, or the result is not a valid number, the
+ * cleaned digits are kept so the person is still invitable (the add path
+ * normalises once more, with the group's region, before anything is queued).
  */
 function normalisePhone(raw: string | null): string | null {
   if (!raw) return null;
   const cleaned = raw.replace(/[^0-9+]/g, '');
-  return cleaned.length >= 8 ? cleaned : null;
+  if (cleaned.length < 8) return null;
+  try {
+    return normaliseContactPhone(cleaned) ?? cleaned;
+  } catch {
+    return cleaned;
+  }
 }

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -15,6 +15,7 @@ import { Card, iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { plural, useStrings } from '@/i18n';
 
+import { isPhoneCountryError } from '@/lib/phone';
 import { SyncNetworkPreference, useSyncNetwork } from '@/lib/syncNetwork';
 import { SyncStatus, useSync } from '@/sync';
 
@@ -145,8 +146,15 @@ export function SyncBanner({ groupId }: { groupId?: string }) {
             {t.extras.oneChangeFailed}
           </Text>
         </Row>
+        {/* Never the raw server string. `first.message` arrives as an internal
+            code like "PHONE_NEEDS_COUNTRY_CODE: 9535621101 has no country code";
+            a bare uncoded number gets the one friendly, localized sentence that
+            actually helps, and anything else the neutral "refused" line. The raw
+            reason still travels to Sentry via the sync engine. */}
         <Text variant="caption" tone="muted">
-          {first?.message ?? t.misc.serverRefused}
+          {first && isPhoneCountryError(first)
+            ? t.people.phoneNeedsCountryCode
+            : t.misc.serverRefused}
         </Text>
         {/* The two recovery actions for a refused change — the buttons a person
             most needs to hit. A caption Text alone left the tap area ~18pt tall;

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -27,6 +27,7 @@ import {
 
 import { activeStrings } from '@/i18n';
 import type { DeviceIdentity } from '@/lib/device';
+import { normaliseContactPhone } from '@/lib/phone';
 import { imageUrl, putImage, removeImage } from '@/lib/storage';
 import { backend } from '@/lib/backend';
 import type {
@@ -624,20 +625,33 @@ export async function addGhostMember(
   groupId: string,
   name: string,
   contact: { email?: string | null; phone?: string | null } = {},
+  accountCountry?: string | null,
 ): Promise<string> {
+  // Read a bare local number in the caller's region before it ever reaches the
+  // server, which refuses an uncoded number by design (the `member_contact_hints`
+  // guard stays in place as defence in depth). No region and no country code is
+  // the one case we genuinely cannot complete — a friendly ask, never raw.
+  let phone: string | null;
+  try {
+    phone = normaliseContactPhone(contact.phone, accountCountry);
+  } catch {
+    throw new Error(activeStrings().people.phoneNeedsCountryCode);
+  }
   const { data, error } = await backend.rpc('baaki_add_ghost_member', {
     p_group_id: groupId,
     p_name: name.trim() || null,
     p_member_id: null,
     p_email: contact.email?.trim() || null,
-    p_phone: contact.phone?.trim() || null,
+    p_phone: phone,
   });
   if (error) {
-    // The database speaks in codes; surface them rather than a raw SQL string.
+    // The database speaks in codes; surface a sentence rather than a raw SQL
+    // string. The phone guard should be unreachable now that entry normalises,
+    // but keep the friendly line for defence in depth.
     const code = /^([A-Z_]+):/.exec(error.message)?.[1];
     throw new Error(
       code === 'PHONE_NEEDS_COUNTRY_CODE'
-        ? 'That number needs a country code, like +91'
+        ? activeStrings().people.phoneNeedsCountryCode
         : code === 'NOTHING_TO_ADD'
           ? 'Give a name, an email or a number'
           : error.message,

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -53,6 +53,7 @@ import {
 } from '@waves/core';
 
 import { useAuth } from '@/lib/auth';
+import { normaliseContactPhone } from '@/lib/phone';
 import { backend } from '@/lib/backend';
 import { syncEngine, useSync } from '@/sync';
 import {
@@ -1294,11 +1295,20 @@ export function useResolveDispute(groupId: string) {
 
 export function useAddGhostMember(groupId: string) {
   const { mutate } = useSync();
+  const { profile } = useAuth();
   return useMutation({
     mutationFn: async (
       input: string | { name: string; email?: string | null; phone?: string | null },
     ) => {
       const person = typeof input === 'string' ? { name: input } : input;
+      // A bare local number ("9535621101") is read in the member's own region
+      // before it is ever queued — the account country, else the device's — so
+      // the server never sees an unroutable number to refuse. No blind default:
+      // with no region and no country code this throws PHONE_NEEDS_COUNTRY_CODE,
+      // which the screen turns into a friendly ask rather than a background
+      // banner (far better to catch it here, at the keystroke, than after sync).
+      const phone =
+        'phone' in person ? normaliseContactPhone(person.phone, profile?.country_code) : null;
       // Chosen here so the expenses queued behind this member can already name
       // them. Adding somebody and immediately splitting a bill with them is one
       // action to a person, and offline it has to work like one.
@@ -1307,7 +1317,7 @@ export function useAddGhostMember(groupId: string) {
         memberId,
         name: person.name,
         email: 'email' in person ? (person.email ?? null) : null,
-        phone: 'phone' in person ? (person.phone ?? null) : null,
+        phone,
       });
       return memberId;
     },

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1266,6 +1266,9 @@ export interface UiStrings {
     addSomeone: string;
     namePlaceholder: string;
     contactPlaceholder: string;
+    /** Shown when a number was typed with no country code and none can be read
+     *  from the region — the one friendly ask, never a raw internal code. */
+    phoneNeedsCountryCode: string;
     yetToJoin: PluralForms;
     sendInviteLink: string;
     memberNotFound: string;
@@ -2980,6 +2983,7 @@ const en: UiStrings = {
     addSomeone: 'Add someone',
     namePlaceholder: 'Rahul',
     contactPlaceholder: 'Email or phone, if you want to send them the link',
+    phoneNeedsCountryCode: 'Add the country code to that number, like +91.',
     yetToJoin: { one: '{n} yet to join', other: '{n} yet to join' },
     sendInviteLink: 'Send an invite link',
     memberNotFound: 'Member not found',
@@ -4779,6 +4783,7 @@ const ta: UiStrings = {
     addSomeone: 'ஒருவரைச் சேர்',
     namePlaceholder: 'ராகுல்',
     contactPlaceholder: 'இணைப்பை அனுப்ப விரும்பினால் மின்னஞ்சல் அல்லது தொலைபேசி',
+    phoneNeedsCountryCode: 'அந்த எண்ணுடன் நாட்டுக் குறியீட்டைச் சேர்க்கவும், எடுத்துக்காட்டாக +91.',
     yetToJoin: { one: '{n} பேர் இன்னும் சேரவில்லை', other: '{n} பேர் இன்னும் சேரவில்லை' },
     sendInviteLink: 'அழைப்பு இணைப்பை அனுப்பு',
     memberNotFound: 'உறுப்பினர் கிடைக்கவில்லை',
@@ -6572,6 +6577,7 @@ const hi: UiStrings = {
     addSomeone: 'किसी को जोड़ें',
     namePlaceholder: 'राहुल',
     contactPlaceholder: 'ईमेल या फ़ोन, अगर उन्हें लिंक भेजना हो',
+    phoneNeedsCountryCode: 'उस नंबर में देश का कोड जोड़ें, जैसे +91।',
     yetToJoin: { one: '{n} अभी जुड़ना बाकी', other: '{n} अभी जुड़ना बाकी' },
     sendInviteLink: 'निमंत्रण लिंक भेजें',
     memberNotFound: 'सदस्य नहीं मिला',
@@ -8371,6 +8377,7 @@ const ar: UiStrings = {
     addSomeone: 'أضف شخصًا',
     namePlaceholder: 'راكيش',
     contactPlaceholder: 'بريد أو هاتف، إن أردت إرسال الرابط إليه',
+    phoneNeedsCountryCode: 'أضِف رمز الدولة إلى هذا الرقم أولًا.',
     yetToJoin: {
       zero: '{n} لم ينضموا بعد',
       one: 'واحد لم ينضم بعد',

--- a/apps/mobile/src/lib/phone.ts
+++ b/apps/mobile/src/lib/phone.ts
@@ -1,0 +1,67 @@
+/**
+ * Reading a phone number the way the phone's own messaging apps do.
+ *
+ * The core rule (`normalisePhone`) refuses a number with no country code — the
+ * right call for a sign-in field, where a silent `+91` on a friend's foreign
+ * number would send the invite to a stranger. But adding a friend by their
+ * local number is the everyday case, and every messaging app on the device
+ * already solves it the same way: the number is read in *your* region, not
+ * guessed. This is the mobile side of that — it turns the account or device
+ * country into a dialing code and hands it to the pure core helper, so nothing
+ * with a bare, unroutable number is ever queued for the server to refuse.
+ *
+ * There is still no blind default: when neither the account nor the device
+ * names a region, `regionDialCode` returns null and the core helper falls back
+ * to its honest refusal, which the caller turns into a friendly ask for the
+ * country code rather than a raw internal error.
+ */
+
+import { dialingCodeForCountry, IdentityError, normalisePhoneInRegion } from '@waves/core';
+
+import { deviceCountry } from '@/i18n';
+
+/**
+ * The dialing code to read a bare national number in, or null.
+ *
+ * The account country (set on "Your account") is preferred over the device's
+ * region — someone travelling keeps their home region — and the device is the
+ * fallback. Null means neither could be determined, i.e. no region to borrow a
+ * country code from; the caller must then require an explicit one.
+ */
+export function regionDialCode(accountCountry?: string | null): string | null {
+  return dialingCodeForCountry(accountCountry ?? deviceCountry());
+}
+
+/**
+ * An optional contact phone, normalised to E.164 in the caller's region.
+ *
+ * Empty stays empty (a contact may be an email only). A number with its own
+ * country code is kept as typed; a bare national number is read in the resolved
+ * region. Throws `IdentityError` when there is no region and no country code, or
+ * when the result is not a valid number — the caller decides how to say so.
+ */
+export function normaliseContactPhone(
+  phone: string | null | undefined,
+  accountCountry?: string | null,
+): string | null {
+  const raw = phone?.trim();
+  if (!raw) return null;
+  return normalisePhoneInRegion(raw, regionDialCode(accountCountry));
+}
+
+/**
+ * Whether an error — a thrown `IdentityError` at entry, or a server refusal
+ * folded into the sync queue — is the "this number needs a country code / is
+ * not a valid number" case, so a screen can show the one friendly, localized
+ * sentence that helps rather than a raw internal code.
+ */
+export function isPhoneCountryError(caught: unknown): boolean {
+  if (caught instanceof IdentityError) {
+    return caught.code === 'PHONE_NEEDS_COUNTRY_CODE' || caught.code === 'PHONE_NOT_VALID';
+  }
+  const parts = caught as { code?: unknown; message?: unknown } | null;
+  const haystack = `${typeof parts?.code === 'string' ? parts.code : ''} ${
+    typeof parts?.message === 'string' ? parts.message : ''
+  }`;
+  return /PHONE_NEEDS_COUNTRY_CODE|PHONE_NOT_VALID/.test(haystack);
+}

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -13,7 +13,6 @@
  */
 
 import * as Network from 'expo-network';
-import { randomUUID } from 'expo-crypto';
 import {
   applyOutcomes,
   dialingCodeForCountry,
@@ -33,7 +32,6 @@ import {
   type SyncRejectionCode,
 } from '@waves/core';
 
-import { deviceCountry } from '@/i18n';
 import { reportHandled } from '@/lib/observability';
 import { backend } from '@/lib/backend';
 import { loadSyncNetworkPreference, SyncNetworkPreference } from '@/lib/syncNetwork';
@@ -489,11 +487,17 @@ export class SyncEngine {
   // ─────────────────────────────────────────────── phone healing ──
   // A bare local number ("9535621101") has no country code, and the server
   // refuses it by design (a silent +91 would misroute an invite to a stranger).
-  // Rather than let that surface as a raw banner, the number is read in a known
-  // region — the group's own country first, then the device's — the same
-  // WhatsApp-style default every messaging app on the phone already uses. There
-  // is no blind default: with no region to read it in, the healers do nothing
-  // and the refusal becomes a friendly ask for the country code.
+  // Rather than let that surface as a raw banner, the number is read in the
+  // group's own region — the same WhatsApp-style default every messaging app on
+  // the phone already uses. There is no blind default: with the group carrying
+  // no country the healers do nothing and the refusal becomes a friendly ask.
+  //
+  // The region is deliberately the *group's* country and nothing else: it keeps
+  // this module free of any import that reaches react-native (its `deviceCountry`
+  // lives behind expo-localization + RN's I18nManager, which cannot be parsed by
+  // the pure vitest suite that imports this engine). The device/account fallback
+  // stays where it belongs — the entry-point normalisers in the RN components,
+  // which import react-native legitimately — so nothing here drags it in.
 
   /** The dialing code to read this group's bare numbers in, or null. */
   private regionDialCodeForGroup(groupId: string): string | null {
@@ -501,7 +505,7 @@ export class SyncEngine {
       Record<string, MirrorRow> | undefined;
     const group = groups?.[groupId] as { country_code?: unknown } | undefined;
     const groupCountry = typeof group?.country_code === 'string' ? group.country_code : null;
-    return dialingCodeForCountry(groupCountry ?? deviceCountry());
+    return dialingCodeForCountry(groupCountry);
   }
 
   /**
@@ -528,7 +532,13 @@ export class SyncEngine {
    * A corrected envelope for a refused "add member" whose number only lacked a
    * country code, or null when it cannot (or need not) be healed — a different
    * kind, a different refusal, no region, an already-coded or invalid number.
-   * A fresh id, so the server treats it as the new attempt it is.
+   *
+   * The new client mutation id is derived from the rejected one (`…:healed`)
+   * rather than freshly minted: the server never accepted the original, so this
+   * is genuinely a new attempt (a different id, not a duplicate), while staying
+   * deterministic and free of any UUID source that would reach react-native. The
+   * `memberId` in the payload is carried through unchanged, so the healed add
+   * still lands on the same member the caller chose.
    */
   private healRejectedGhostPhone(entry: {
     mutation: QueuedMutation;
@@ -552,7 +562,7 @@ export class SyncEngine {
     // not re-queue it, or a still-refused number would loop forever.
     if (healed === phone) return null;
     return {
-      clientMutationId: randomUUID(),
+      clientMutationId: `${entry.mutation.clientMutationId}:healed`,
       kind: MutationKind.MemberAddGhost,
       groupId: entry.mutation.groupId,
       clientCreatedAt: new Date().toISOString(),

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -13,12 +13,16 @@
  */
 
 import * as Network from 'expo-network';
+import { randomUUID } from 'expo-crypto';
 import {
   applyOutcomes,
+  dialingCodeForCountry,
   emptyMirror,
   enqueue as enqueueMutation,
   markFailed,
+  MutationKind,
   nextBatch,
+  normalisePhoneInRegion,
   reconcile,
   SyncTable,
   type MirrorRow,
@@ -29,6 +33,7 @@ import {
   type SyncRejectionCode,
 } from '@waves/core';
 
+import { deviceCountry } from '@/i18n';
 import { reportHandled } from '@/lib/observability';
 import { backend } from '@/lib/backend';
 import { loadSyncNetworkPreference, SyncNetworkPreference } from '@/lib/syncNetwork';
@@ -351,7 +356,13 @@ export class SyncEngine {
               kind: item.kind,
               groupId: item.groupId,
               clientCreatedAt: item.clientCreatedAt,
-              payload: item.payload,
+              // Heal a bare "add member" phone right before it is (re)sent: read
+              // it in the group's own region, so an old build's queued number —
+              // or anything that slipped past entry normalisation — syncs
+              // instead of being refused. The stored payload is left as-is; a
+              // healthy send removes it from the queue anyway, and a failed one
+              // is healed again next round.
+              payload: this.healGhostPhonePayload(item.kind, item.groupId, item.payload),
             })),
             cursors,
           },
@@ -378,7 +389,24 @@ export class SyncEngine {
         ),
       );
 
-      const rejected: RejectedMutation[] = folded.rejected.map((entry) => ({
+      // Auto-heal a refused "add member" whose only fault was a bare, uncoded
+      // phone: re-queue it with the number read in the group's region rather
+      // than surfacing a banner the user has to act on. Anything we cannot heal
+      // — no region, a genuinely invalid number, or a rejection for some other
+      // reason — falls through to `rejected` and is shown as a friendly line.
+      const requeue: MutationEnvelope[] = [];
+      const stillRejected: {
+        mutation: QueuedMutation;
+        code: SyncRejectionCode;
+        message: string;
+      }[] = [];
+      for (const entry of folded.rejected) {
+        const healed = this.healRejectedGhostPhone(entry);
+        if (healed) requeue.push(healed);
+        else stillRejected.push(entry);
+      }
+
+      const rejected: RejectedMutation[] = stillRejected.map((entry) => ({
         clientMutationId: entry.mutation.clientMutationId,
         kind: entry.mutation.kind,
         groupId: entry.mutation.groupId,
@@ -436,6 +464,15 @@ export class SyncEngine {
       if (response.hasMore) {
         setTimeout(() => void this.flush(), 0);
       }
+
+      // Persist and send the healed re-queues. enqueue writes each to disk (so a
+      // force-kill still keeps the correction) and its own flush is deduped
+      // behind this in-flight one; a fresh flush once this settles pushes the
+      // corrected member now rather than waiting out the 30s poll.
+      if (requeue.length > 0) {
+        for (const envelope of requeue) await this.enqueue(envelope);
+        setTimeout(() => void this.flush(), 0);
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const queue = markFailed(this.state.queue, batch, message, now);
@@ -447,6 +484,80 @@ export class SyncEngine {
         reportHandled(writeError, 'sync.markFailed');
       });
     }
+  }
+
+  // ─────────────────────────────────────────────── phone healing ──
+  // A bare local number ("9535621101") has no country code, and the server
+  // refuses it by design (a silent +91 would misroute an invite to a stranger).
+  // Rather than let that surface as a raw banner, the number is read in a known
+  // region — the group's own country first, then the device's — the same
+  // WhatsApp-style default every messaging app on the phone already uses. There
+  // is no blind default: with no region to read it in, the healers do nothing
+  // and the refusal becomes a friendly ask for the country code.
+
+  /** The dialing code to read this group's bare numbers in, or null. */
+  private regionDialCodeForGroup(groupId: string): string | null {
+    const groups = this.state.mirror.tables[SyncTable.Groups] as
+      Record<string, MirrorRow> | undefined;
+    const group = groups?.[groupId] as { country_code?: unknown } | undefined;
+    const groupCountry = typeof group?.country_code === 'string' ? group.country_code : null;
+    return dialingCodeForCountry(groupCountry ?? deviceCountry());
+  }
+
+  /**
+   * The outbound payload for a mutation, with a bare "add member" phone read in
+   * the group's region. Anything else is returned untouched. Best-effort: an
+   * uncodeable or invalid number is left exactly as it was for the server to
+   * answer, so this can never throw inside the flush.
+   */
+  private healGhostPhonePayload(kind: MutationKind, groupId: string, payload: unknown): unknown {
+    if (kind !== MutationKind.MemberAddGhost) return payload;
+    if (typeof payload !== 'object' || payload === null) return payload;
+    const record = payload as Record<string, unknown>;
+    const phone = typeof record.phone === 'string' ? record.phone : null;
+    if (!phone || phone.trim().startsWith('+')) return payload;
+    try {
+      const healed = normalisePhoneInRegion(phone, this.regionDialCodeForGroup(groupId));
+      return healed === phone ? payload : { ...record, phone: healed };
+    } catch {
+      return payload;
+    }
+  }
+
+  /**
+   * A corrected envelope for a refused "add member" whose number only lacked a
+   * country code, or null when it cannot (or need not) be healed — a different
+   * kind, a different refusal, no region, an already-coded or invalid number.
+   * A fresh id, so the server treats it as the new attempt it is.
+   */
+  private healRejectedGhostPhone(entry: {
+    mutation: QueuedMutation;
+    code: SyncRejectionCode | string;
+    message: string;
+  }): MutationEnvelope | null {
+    if (entry.mutation.kind !== MutationKind.MemberAddGhost) return null;
+    if (!/PHONE_NEEDS_COUNTRY_CODE|PHONE_NOT_VALID/.test(`${entry.code} ${entry.message}`)) {
+      return null;
+    }
+    const payload = entry.mutation.payload as Record<string, unknown>;
+    const phone = typeof payload.phone === 'string' ? payload.phone : null;
+    if (!phone) return null;
+    let healed: string;
+    try {
+      healed = normalisePhoneInRegion(phone, this.regionDialCodeForGroup(entry.mutation.groupId));
+    } catch {
+      return null;
+    }
+    // No change means the number already had a code (or none we can add) — do
+    // not re-queue it, or a still-refused number would loop forever.
+    if (healed === phone) return null;
+    return {
+      clientMutationId: randomUUID(),
+      kind: MutationKind.MemberAddGhost,
+      groupId: entry.mutation.groupId,
+      clientCreatedAt: new Date().toISOString(),
+      payload: { ...payload, phone: healed },
+    };
   }
 
   private async persist(

--- a/packages/core/src/auth/identity.ts
+++ b/packages/core/src/auth/identity.ts
@@ -157,6 +157,44 @@ export function normalisePhone(raw: string): string {
   return cleaned;
 }
 
+/**
+ * The same E.164 number, but a bare national one is read in a known region.
+ *
+ * `normalisePhone` refuses a number with no country code on purpose — a silent
+ * `+91` on a friend's foreign number sends the invite to a stranger. That
+ * refusal is right for a sign-in field, where the person is typing their *own*
+ * number and can be asked to add the code. It is wrong for the everyday act of
+ * adding a friend by their local number, which is how every messaging app on
+ * the phone already works: the number is read in *your* region, not guessed.
+ *
+ * So this takes the region as an explicit argument — the device, account or
+ * group country turned into a dialing code by the caller — rather than assuming
+ * one. The no-blind-default property is preserved: with no region to borrow
+ * (`defaultDialCode` null), it falls straight back to the same refusal. The
+ * region is the whole point; a caller that cannot name one gets no number.
+ *
+ *  - `+91 98765 43210`      → `+919876543210` (already coded; region ignored)
+ *  - `9535621101`, `+91`    → `+919535621101` (bare national, read in region)
+ *  - `09535621101`, `+91`   → `+919535621101` (trunk 0 dropped first)
+ *  - `9535621101`, null     → throws PHONE_NEEDS_COUNTRY_CODE (no region)
+ *
+ * Pure and deterministic: same inputs, same output or same throw, no clock, no
+ * device, no network.
+ */
+export function normalisePhoneInRegion(raw: string, defaultDialCode: string | null): string {
+  const cleaned = raw.replace(/[^\d+]/g, '');
+  // Already carries a country code: the region default is irrelevant and the
+  // ordinary rule applies unchanged.
+  if (cleaned.startsWith('+')) return normalisePhone(cleaned);
+  // No code and no region to lend one — the same honest refusal as before.
+  if (!defaultDialCode) return normalisePhone(cleaned);
+  // A bare national number, read in the caller's own region: drop the single
+  // trunk "0" some countries write before a local number (09876… → 9876…),
+  // prepend the region's dialing code, and validate as any other E.164 number.
+  const national = cleaned.replace(/^0/, '');
+  return normalisePhone(`${defaultDialCode}${national}`);
+}
+
 /** Lowercased and trimmed, because a login that is case-sensitive is a bug report. */
 export function normaliseEmail(raw: string): string {
   const cleaned = raw.trim().toLowerCase();

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -18,6 +18,7 @@ import {
   IdentityError,
   normaliseEmail,
   normalisePhone,
+  normalisePhoneInRegion,
   planAuth,
   readIdentifier,
   AuthMethod,
@@ -162,6 +163,41 @@ describe('phone numbers', () => {
   it('takes a number from anywhere, not only India', () => {
     expect(normalisePhone('+1 415 555 2671')).toBe('+14155552671');
     expect(normalisePhone('+44 20 7946 0958')).toBe('+442079460958');
+  });
+});
+
+describe('a bare national number, read in a known region', () => {
+  // The everyday case the sign-in refusal got wrong: adding a friend by their
+  // local number, the way every messaging app on the phone already does it.
+  it('reads a bare number in the region it was handed', () => {
+    // The exact number from the bug report: it just works, in India's region.
+    expect(normalisePhoneInRegion('9535621101', '+91')).toBe('+919535621101');
+    expect(normalisePhoneInRegion('98765 43210', '+91')).toBe('+919876543210');
+    expect(normalisePhoneInRegion('415 555 2671', '+1')).toBe('+14155552671');
+  });
+
+  it('drops the trunk 0 a local number is often written with', () => {
+    // 09876… is how the same number is written to dial it locally; the 0 is a
+    // trunk prefix, not part of the international number.
+    expect(normalisePhoneInRegion('09535621101', '+91')).toBe('+919535621101');
+  });
+
+  it('leaves a number that already has its own country code alone', () => {
+    // Someone pasted a full international number; the region is irrelevant and
+    // must not be prepended a second time.
+    expect(normalisePhoneInRegion('+14155552671', '+91')).toBe('+14155552671');
+    expect(normalisePhoneInRegion('+44 20 7946 0958', '+91')).toBe('+442079460958');
+  });
+
+  it('still refuses a bare number when there is no region to read it in', () => {
+    // The no-blind-default property, preserved: with no region the honest
+    // refusal is the only safe answer — better than guessing a country.
+    expect(() => normalisePhoneInRegion('9535621101', null)).toThrow(IdentityError);
+    expect(() => normalisePhoneInRegion('9535621101', null)).toThrow(/country code/);
+  });
+
+  it('rejects a region-completed number that still is not a phone number', () => {
+    expect(() => normalisePhoneInRegion('12', '+91')).toThrow(/phone number/);
   });
 });
 


### PR DESCRIPTION
## The bug

Adding a group member by a bare local number with no country code (e.g. `9535621101`) queued locally, then the server refused the sync push with `PHONE_NEEDS_COUNTRY_CODE: 9535621101 has no country code`, and the group screen showed a red **"One change could not be saved"** banner rendering that raw internal string. It should just work.

## The fix (region-aware, never a blind default)

`normalisePhone` refuses an uncoded number **on purpose** — a silent `+91` on a friend's foreign number would misroute the invite to a stranger. That's right for a sign-in field; it's wrong for adding a friend by their local number, which every messaging app on the phone solves the same way: **read the number in *your* region.** The no-blind-default safety property is preserved — the region is read from real context, and when there is genuinely no region *and* no country code, the number is refused with a friendly, localized ask instead of a raw code.

### The exact normalization rule

New pure core helper `normalisePhoneInRegion(raw, defaultDialCode)` beside `normalisePhone`:
- `raw` already starts with `+` → delegate to `normalisePhone` (region ignored).
- else if `defaultDialCode` is non-null → drop a single leading trunk `0`, prepend the dial code, validate via `normalisePhone`.
- else (no region) → fall back to the existing `normalisePhone` refusal.

Examples: `9535621101` + `+91` → `+919535621101`; `09535621101` + `+91` → `+919535621101`; `+14155552671` + `+91` → `+14155552671`; `9535621101` + `null` → throws `PHONE_NEEDS_COUNTRY_CODE`. Unit-tested.

The dial code is resolved from **account country ?? device region** (via `dialingCodeForCountry`), and for the sync heal, **the group's own `country_code` first**, then device.

## Four parts

1. **Core helper + tests** — `packages/core/src/auth/identity.ts`, `packages/core/test/identity.test.ts`.
2. **Normalize at every entry** so nothing invalid is queued — new shared `apps/mobile/src/lib/phone.ts` (`regionDialCode`, `normaliseContactPhone`, `isPhoneCountryError`), applied in `useAddGhostMember` (primary funnel: manual add + contact picker), `new-group` ghost add, `data/api.ts addGhostMember` (covers `contacts.tsx` + `merge.tsx`), and the `ContactPicker` loader (best-effort, never throws / never blanks the picker). When a region truly can't be determined and no code was typed, it fails fast at entry with the localized ask.
3. **Heal the already-queued stuck op (client-side, no migration)** — the sync engine reads a `MemberAddGhost` phone in the group's region **right before it is (re)sent** (`healGhostPhonePayload`), so an old build's queued number or anything that slipped past entry syncs instead of being refused. And because a rejection removes the mutation from the queue, a refused-for-no-country-code add is **auto-re-queued with the corrected number** (`healRejectedGhostPhone`, fresh id, loop-guarded) so **the banner clears itself with no user action**. No server/DB change was needed, so **nothing is deploy-gated**; the DB `PHONE_NEEDS_COUNTRY_CODE` guards stay in place as defence in depth.
4. **Never surface raw internal errors** — `SyncBanner` now shows the one friendly localized line (`people.phoneNeedsCountryCode`) for a phone-country refusal and the neutral "refused" line otherwise; it never renders the raw `PHONE_NEEDS_COUNTRY_CODE: …` string again. The raw reason still travels to Sentry.

## How the banner now reads

For a bare-number refusal: **"Add the country code to that number, like +91."** (localized in en/ta/hi/ar; Arabic phrased RTL-clean without the inline LTR example). Try again / Discard remain.

## Gates (Windows node)

- `apps/mobile` `tsc --noEmit`: clean.
- `pnpm format` + `pnpm lint`: green.
- `@waves/core` tests: 667 passed (49 in the identity suite, incl. the new region cases).

## Not verifiable without a device

The end-to-end flow (real device contacts, a live sync round-trip, the banner self-clearing) was not exercised on hardware — the change is covered by core unit tests and type/lint gates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone numbers are now normalized using the selected account, group, or device region.
  * Added clearer localized messages when a phone number is missing a country code.
  * Failed phone-number syncs may now be automatically corrected and retried.

* **Bug Fixes**
  * Improved handling of national, international, invalid, and unparseable phone numbers.
  * Replaced raw server errors with clearer user-facing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->