### PR TITLE
feat(activity): date / date-range filter on the Activity feed

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { Pressable, RefreshControl, SectionList, View } from 'react-native';
@@ -18,8 +18,10 @@ import {
 } from '@waves/ui';
 
 import {
+  activityDateSpan,
   dayHeading,
   describeActivity,
+  filterByDayRange,
   groupByDay,
   parseMoney,
   relativeTime,
@@ -27,6 +29,7 @@ import {
   verbTint,
 } from '@/data/activity';
 import { useBlockedUsers } from '@/data/blocked';
+import { ActivityDateFilter, type DateRange } from '@/components/ActivityDateFilter';
 import { FeedSkeleton } from '@/components/Skeletons';
 import { useNotifications, useRecentActivity, type RecentActivityRow } from '@/data/hooks';
 import { useStrings } from '@/i18n';
@@ -53,6 +56,23 @@ export default function ActivityScreen() {
   const { hydrated, status, flush } = useSync();
   const allEntries = useRecentActivity();
 
+  // Filtering a long feed to a date span. The whole history is on the phone, so
+  // this is a pure client-side cut — no fetch. `range` is the committed filter
+  // (null = the full feed); `filterOpen` toggles the range-picker sheet.
+  const [range, setRange] = useState<DateRange | null>(null);
+  const [filterOpen, setFilterOpen] = useState(false);
+
+  // The feed's own start and end, in the phone's timezone. Clamps the picker so
+  // a day outside the activity's span cannot be chosen. Null when the feed is
+  // empty — there is then nothing to filter and no button to offer.
+  const span = useMemo(() => activityDateSpan(allEntries), [allEntries]);
+
+  // The rows actually shown: the whole feed, or the slice inside the range.
+  const visibleEntries = useMemo(
+    () => (range ? filterByDayRange(allEntries, range.start, range.end) : allEntries),
+    [allEntries, range],
+  );
+
   // The whole history is already on the phone (the mirror), so there is no page
   // to fetch — the list is fully known. `SectionList` virtualizes it: only the
   // rows near the viewport are mounted, and they recycle as the feed scrolls, so
@@ -61,43 +81,120 @@ export default function ActivityScreen() {
   // recycled a mounted row.)
   const sections: DaySection[] = useMemo(
     () =>
-      groupByDay(allEntries).map((section) => ({
+      groupByDay(visibleEntries).map((section) => ({
         key: section.key,
         first: section.entries[0]!,
         data: section.entries,
       })),
-    [allEntries],
+    [visibleEntries],
   );
+
+  // The active range worded for the chip: one date when start and end share a
+  // day, "start – end" otherwise. Formatted in the current locale.
+  const showDay = (value: Date): string =>
+    value.toLocaleDateString(locale, { day: 'numeric', month: 'short' });
+  const sameDay = (a: Date, b: Date): boolean =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+  const rangeLabel = range
+    ? sameDay(range.start, range.end)
+      ? showDay(range.start)
+      : `${showDay(range.start)} – ${showDay(range.end)}`
+    : '';
 
   const notifications = useNotifications();
   const unread = (notifications.data ?? []).filter((row) => row.read_at === null).length;
 
   const header = (
-    <Row style={{ paddingTop: theme.spacing.md, justifyContent: 'space-between' }}>
-      <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
-        <Ionicons name="pulse" size={iconSize.xl} color={theme.color.brand} />
-        <Text variant="title">{t.activity}</Text>
+    <View>
+      <Row style={{ paddingTop: theme.spacing.md, justifyContent: 'space-between' }}>
+        <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+          <Ionicons name="pulse" size={iconSize.xl} color={theme.color.brand} />
+          <Text variant="title">{t.activity}</Text>
+        </Row>
+        <Row style={{ alignItems: 'center' }}>
+          {/* A long feed is easier to read a day or a span at a time — the
+              calendar opens a range picker clamped to the feed's own start and
+              end. Only offered once there is a feed to narrow. A filled glyph in
+              the brand tint marks an active filter, matching the app's
+              filled/outline idiom. */}
+          {span ? (
+            <IconButton label={t.activityFilter.open} onPress={() => setFilterOpen(true)}>
+              <Ionicons
+                name={range ? 'calendar' : 'calendar-outline'}
+                size={iconSize.lg}
+                color={range ? theme.color.brand : theme.color.text}
+              />
+            </IconButton>
+          ) : null}
+          {/* The feed is what happened in the groups; the inbox is what Baaki
+              said to you. Related enough to sit together, different enough not
+              to be interleaved. */}
+          <IconButton label={t.tabs.inbox} onPress={() => router.push('/inbox' as never)}>
+            <Ionicons name="notifications-outline" size={iconSize.lg} color={theme.color.text} />
+            {unread > 0 ? (
+              <View
+                style={{
+                  position: 'absolute',
+                  top: 6,
+                  right: 6,
+                  width: 9,
+                  height: 9,
+                  borderRadius: 5,
+                  backgroundColor: theme.color.brand,
+                }}
+              />
+            ) : null}
+          </IconButton>
+        </Row>
       </Row>
-      {/* The feed is what happened in the groups; the inbox is what Baaki said
-          to you. Related enough to sit together, different enough not to be
-          interleaved. */}
-      <IconButton label={t.tabs.inbox} onPress={() => router.push('/inbox' as never)}>
-        <Ionicons name="notifications-outline" size={iconSize.lg} color={theme.color.text} />
-        {unread > 0 ? (
-          <View
+
+      {/* The active range as a clearable pill: tap the body to adjust it, the ✕
+          to drop back to the full feed. Visible state so a narrowed feed never
+          looks like a short one. */}
+      {range ? (
+        <Row style={{ marginTop: theme.spacing.sm }}>
+          <Row
             style={{
-              position: 'absolute',
-              top: 6,
-              right: 6,
-              width: 9,
-              height: 9,
-              borderRadius: 5,
-              backgroundColor: theme.color.brand,
+              alignItems: 'center',
+              gap: theme.spacing.xs,
+              paddingLeft: theme.spacing.md,
+              paddingRight: theme.spacing.xs,
+              paddingVertical: 4,
+              borderRadius: theme.radius.pill,
+              backgroundColor: theme.color.brandSoft,
             }}
-          />
-        ) : null}
-      </IconButton>
-    </Row>
+          >
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`${t.activityFilter.open}: ${rangeLabel}`}
+              onPress={() => setFilterOpen(true)}
+              style={({ pressed }) => ({
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: theme.spacing.xs,
+                opacity: pressed ? 0.6 : 1,
+              })}
+            >
+              <Ionicons name="calendar" size={iconSize.sm} color={theme.color.brand} />
+              <Text variant="caption" style={{ color: theme.color.brand }}>
+                {rangeLabel}
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t.activityFilter.clearFilter}
+              onPress={() => setRange(null)}
+              hitSlop={8}
+              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+            >
+              <Ionicons name="close-circle" size={iconSize.md} color={theme.color.brand} />
+            </Pressable>
+          </Row>
+        </Row>
+      ) : null}
+    </View>
   );
 
   // The states the feed can be in when there are no rows to show — mounted as
@@ -123,6 +220,23 @@ export default function ActivityScreen() {
       // An empty feed after it lands is "nothing yet", not "failed".
       <FeedSkeleton />
     )
+  ) : range ? (
+    // A range is in force and nothing fell in it — distinct from "nothing yet",
+    // and the way out is to widen or clear the filter, not to start a group.
+    <View style={{ flex: 1, justifyContent: 'center' }}>
+      <EmptyState
+        title={t.activityFilter.noneTitle}
+        body={t.activityFilter.noneBody}
+        icon={<Ionicons name="calendar-outline" size={iconSize.xxl} color={theme.color.brand} />}
+        action={
+          <Button
+            label={t.activityFilter.clear}
+            variant="secondary"
+            onPress={() => setRange(null)}
+          />
+        }
+      />
+    </View>
   ) : (
     <View style={{ flex: 1, justifyContent: 'center' }}>
       <EmptyState
@@ -274,6 +388,19 @@ export default function ActivityScreen() {
           );
         }}
       />
+      {/* The range picker, over the feed. Rendered only when open and only when
+          there is a span to clamp to, so it can seed the picker from real dates. */}
+      {filterOpen && span ? (
+        <ActivityDateFilter
+          earliest={span.earliest}
+          latest={span.latest}
+          locale={locale}
+          initial={range}
+          onApply={setRange}
+          onClear={() => setRange(null)}
+          onClose={() => setFilterOpen(false)}
+        />
+      ) : null}
     </Screen>
   );
 }

--- a/apps/mobile/src/components/ActivityDateFilter.tsx
+++ b/apps/mobile/src/components/ActivityDateFilter.tsx
@@ -1,0 +1,205 @@
+/**
+ * The Activity feed's date-range filter — a bottom sheet holding a From and a
+ * To field over one shared date picker.
+ *
+ * The whole feed is already on the phone (the mirror), so narrowing it is a pure
+ * cut on the loaded rows; this component only gathers the range and hands it
+ * back. The picker is clamped to the feed's own span (`earliest`/`latest`), so a
+ * day before the first event or after the last cannot be chosen — the picker
+ * disables everything outside `[earliest, latest]`. (The library only supports
+ * that outer clamp; it cannot grey out an isolated empty day inside the span.)
+ *
+ * A From on its own is a single-day filter — the To defaults to it — and picking
+ * a To widens it; the receiver orders the two ends, so an end-first pick is
+ * still valid. The draft lives here and is only committed on Apply, so the feed
+ * behind the sheet does not flicker as the two ends are chosen.
+ */
+
+import { useState } from 'react';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Platform, Pressable, View } from 'react-native';
+
+import { Button, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+import { SheetOverlay } from '@/components/expense/SheetOverlay';
+import { useStrings } from '@/i18n';
+
+/** A committed filter range — both ends are calendar-day anchors (local noon). */
+export interface DateRange {
+  start: Date;
+  end: Date;
+}
+
+enum Field {
+  Start = 'start',
+  End = 'end',
+}
+
+/**
+ * One end of the range — its own bordered box, a small label over the date with
+ * a calendar glyph, lighting up in the brand tint once set. The two sit side by
+ * side like the from/to of a range picker, matching `TripDates`.
+ */
+function RangeEnd({
+  label,
+  value,
+  set,
+  onPress,
+}: {
+  label: string;
+  value: string;
+  set: boolean;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${label}: ${value}`}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flex: 1,
+        gap: 4,
+        paddingVertical: theme.spacing.md,
+        paddingHorizontal: theme.spacing.md,
+        borderRadius: theme.radius.lg,
+        borderWidth: 1,
+        borderColor: set ? theme.color.brand : theme.color.border,
+        backgroundColor: set ? theme.color.brandSoft : theme.color.surface,
+        opacity: pressed ? 0.7 : 1,
+      })}
+    >
+      <Text variant="caption" tone="muted">
+        {label}
+      </Text>
+      <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+        <Ionicons
+          name="calendar-outline"
+          size={iconSize.sm}
+          color={set ? theme.color.brand : theme.color.textMuted}
+        />
+        <Text variant="subheading" style={{ fontWeight: '700' }}>
+          {value}
+        </Text>
+      </Row>
+    </Pressable>
+  );
+}
+
+export function ActivityDateFilter({
+  earliest,
+  latest,
+  locale,
+  initial,
+  onApply,
+  onClear,
+  onClose,
+}: {
+  /** The feed's own start and end — the picker is clamped to this span. */
+  earliest: Date;
+  latest: Date;
+  locale: string;
+  /** The range already in force, so reopening the sheet shows it. */
+  initial: DateRange | null;
+  onApply: (range: DateRange) => void;
+  onClear: () => void;
+  onClose: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const [start, setStart] = useState<Date | null>(initial?.start ?? null);
+  const [end, setEnd] = useState<Date | null>(initial?.end ?? null);
+  const [editing, setEditing] = useState<Field | null>(null);
+
+  const showDate = (value: Date | null): string =>
+    value
+      ? value.toLocaleDateString(locale, { weekday: 'short', day: 'numeric', month: 'short' })
+      : t.pickers.notSet;
+
+  const apply = (field: Field, event: DateTimePickerEvent, picked?: Date): void => {
+    // Android's picker is a modal that reports its own dismissal; iOS's is
+    // inline and reports every scroll.
+    if (Platform.OS === 'android') setEditing(null);
+    if (event.type === 'dismissed' || !picked) return;
+    if (field === Field.Start) {
+      setStart(picked);
+      // A To before the new From is not a range — carry the To along rather than
+      // refuse the pick.
+      setEnd((prev) => (prev && prev < picked ? picked : prev));
+      return;
+    }
+    setEnd(picked);
+    setStart((prev) => (prev && prev > picked ? picked : prev));
+  };
+
+  return (
+    <SheetOverlay title={t.activityFilter.open} onClose={onClose}>
+      <View style={{ gap: theme.spacing.lg }}>
+        <Row style={{ alignItems: 'stretch', gap: theme.spacing.sm }}>
+          <RangeEnd
+            label={t.activityFilter.from}
+            value={showDate(start)}
+            set={Boolean(start)}
+            onPress={() => setEditing(Field.Start)}
+          />
+          <RangeEnd
+            label={t.activityFilter.to}
+            value={showDate(end ?? start)}
+            set={Boolean(end ?? start)}
+            onPress={() => setEditing(Field.End)}
+          />
+        </Row>
+
+        {editing ? (
+          <DateTimePicker
+            value={(editing === Field.Start ? start : (end ?? start)) ?? earliest}
+            mode="date"
+            // The selectable span is the feed's own — dates outside it are
+            // disabled. The To can never start before the chosen From.
+            minimumDate={editing === Field.End && start ? start : earliest}
+            maximumDate={latest}
+            onChange={(event, picked) => apply(editing, event, picked)}
+          />
+        ) : null}
+
+        {Platform.OS === 'ios' && editing ? (
+          <Button
+            label={t.common.done}
+            size="sm"
+            variant="secondary"
+            onPress={() => setEditing(null)}
+          />
+        ) : null}
+
+        <Row style={{ gap: theme.spacing.sm }}>
+          {initial || start ? (
+            <View style={{ flex: 1 }}>
+              <Button
+                label={t.activityFilter.clear}
+                variant="secondary"
+                fullWidth
+                onPress={() => {
+                  onClear();
+                  onClose();
+                }}
+              />
+            </View>
+          ) : null}
+          <View style={{ flex: 1 }}>
+            <Button
+              label={t.activityFilter.apply}
+              disabled={!start}
+              fullWidth
+              onPress={() => {
+                if (!start) return;
+                onApply({ start, end: end ?? start });
+                onClose();
+              }}
+            />
+          </View>
+        </Row>
+      </View>
+    </SheetOverlay>
+  );
+}

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -273,6 +273,64 @@ export function groupByDay<T extends { created_at: string }>(
   return sections;
 }
 
+/**
+ * The earliest and latest calendar day present in a feed, each as a local Date
+ * anchored at noon (a date-only value a picker is happy to seed from). Null for
+ * an empty feed.
+ *
+ * This is what the Activity filter clamps its range picker to: the selectable
+ * span is exactly the feed's own start and end, so a day before the first event
+ * or after the last cannot be picked. The bounds come from the rows'
+ * `created_at` read in the phone's own timezone — the same convention
+ * `groupByDay`/`dayHeading` bucket by — so the picker and the day headings
+ * agree on which day a timestamp belongs to. Noon, not midnight, so the anchor
+ * can never slip to the neighbouring day when the picker re-reads it locally.
+ */
+export function activityDateSpan(
+  entries: readonly { created_at: string }[],
+): { earliest: Date; latest: Date } | null {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const entry of entries) {
+    const parsed = Date.parse(entry.created_at);
+    if (!Number.isFinite(parsed)) continue;
+    if (parsed < min) min = parsed;
+    if (parsed > max) max = parsed;
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+  const noon = (ms: number): Date => {
+    const d = new Date(ms);
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 12);
+  };
+  return { earliest: noon(min), latest: noon(max) };
+}
+
+/**
+ * The rows whose calendar day falls within `[start, end]` inclusive, compared
+ * in the phone's own timezone so the cut agrees with the day headings above it.
+ * The bounds are taken at day granularity — a row's time of day never trims it —
+ * and the two ends are ordered defensively, so a range picked end-first still
+ * yields the same window. A pure cut on the already-loaded feed: no fetch, the
+ * whole history is on the phone (the mirror).
+ */
+export function filterByDayRange<T extends { created_at: string }>(
+  entries: readonly T[],
+  start: Date,
+  end: Date,
+): T[] {
+  const midnight = (d: Date): number =>
+    new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const lo = Math.min(midnight(start), midnight(end));
+  const hi = Math.max(midnight(start), midnight(end));
+  return entries.filter((entry) => {
+    const parsed = Date.parse(entry.created_at);
+    if (!Number.isFinite(parsed)) return false;
+    const when = new Date(parsed);
+    const day = new Date(when.getFullYear(), when.getMonth(), when.getDate()).getTime();
+    return day >= lo && day <= hi;
+  });
+}
+
 export function relativeTime(locale: string, iso: string, now: number = Date.now()): string {
   const parsed = Date.parse(iso);
   if (!Number.isFinite(parsed)) return iso;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1777,6 +1777,24 @@ export interface UiStrings {
     remindZoneNote: string;
     useMyTimezone: string;
   };
+  /** The Activity feed's date-range filter — narrowing a long feed to a span. */
+  activityFilter: {
+    /** Icon-button accessibility label and the range sheet's title. */
+    open: string;
+    /** The start-of-range field. */
+    from: string;
+    /** The end-of-range field. */
+    to: string;
+    /** Commits the picked range and closes the sheet. */
+    apply: string;
+    /** Drops the range and restores the full feed. */
+    clear: string;
+    /** Accessibility label on the active-range chip's ✕. */
+    clearFilter: string;
+    /** Empty state when a range is active but nothing falls in it. */
+    noneTitle: string;
+    noneBody: string;
+  };
   /** Somebody saying an expense is wrong, and the answer to it. */
   dispute: {
     yourReply: string;
@@ -3514,6 +3532,16 @@ const en: UiStrings = {
     removeName: 'Remove {name}',
     remindZoneNote: 'Asked in {zone} — where the trip is, not where each person is.',
     useMyTimezone: 'Use my timezone ({zone})',
+  },
+  activityFilter: {
+    open: 'Filter by date',
+    from: 'From',
+    to: 'To',
+    apply: 'Show results',
+    clear: 'Clear',
+    clearFilter: 'Clear date filter',
+    noneTitle: 'Nothing in this range',
+    noneBody: 'No activity falls on the dates you picked. Try a wider range or clear the filter.',
   },
   dispute: {
     yourReply: 'Your reply',
@@ -5344,6 +5372,17 @@ const ta: UiStrings = {
       '{zone} இல் கேட்கப்படுகிறது — பயணம் இருக்கும் இடம், ஒவ்வொருவரும் இருக்கும் இடம் அல்ல.',
     useMyTimezone: 'என் நேர மண்டலத்தைப் பயன்படுத்து ({zone})',
   },
+  activityFilter: {
+    open: 'தேதி வாரியாக வடிகட்டு',
+    from: 'முதல்',
+    to: 'வரை',
+    apply: 'முடிவுகளைக் காட்டு',
+    clear: 'அழி',
+    clearFilter: 'தேதி வடிப்பானை அழி',
+    noneTitle: 'இந்த வரம்பில் ஒன்றுமில்லை',
+    noneBody:
+      'நீங்கள் தேர்ந்தெடுத்த தேதிகளில் எந்தச் செயல்பாடும் இல்லை. பரந்த வரம்பை முயற்சிக்கவும் அல்லது வடிப்பானை அழிக்கவும்.',
+  },
   dispute: {
     yourReply: 'உங்கள் பதில்',
     replyPlaceholder: 'விருப்பம் — உண்மையில் என்ன நடந்தது',
@@ -7111,6 +7150,16 @@ const hi: UiStrings = {
     removeName: '{name} को हटाएँ',
     remindZoneNote: '{zone} में पूछा जाता है — जहाँ यात्रा है, न कि जहाँ हर कोई है।',
     useMyTimezone: 'मेरा टाइमज़ोन इस्तेमाल करें ({zone})',
+  },
+  activityFilter: {
+    open: 'तारीख़ से छाँटें',
+    from: 'से',
+    to: 'तक',
+    apply: 'नतीजे दिखाएँ',
+    clear: 'हटाएँ',
+    clearFilter: 'तारीख़ फ़िल्टर हटाएँ',
+    noneTitle: 'इस दायरे में कुछ नहीं',
+    noneBody: 'आपकी चुनी तारीख़ों में कोई गतिविधि नहीं है. बड़ा दायरा चुनें या फ़िल्टर हटाएँ.',
   },
   dispute: {
     yourReply: 'आपका जवाब',
@@ -9051,6 +9100,16 @@ const ar: UiStrings = {
     removeName: 'إزالة {name}',
     remindZoneNote: 'يُسأل بتوقيت {zone} — حيث الرحلة، لا حيث كل شخص.',
     useMyTimezone: 'استخدم منطقتي الزمنية ({zone})',
+  },
+  activityFilter: {
+    open: 'التصفية حسب التاريخ',
+    from: 'من',
+    to: 'إلى',
+    apply: 'عرض النتائج',
+    clear: 'مسح',
+    clearFilter: 'مسح تصفية التاريخ',
+    noneTitle: 'لا شيء في هذا النطاق',
+    noneBody: 'لا يوجد نشاط في التواريخ التي اخترتها. جرّب نطاقًا أوسع أو امسح التصفية.',
   },
   dispute: {
     yourReply: 'ردّك',

--- a/apps/mobile/test/activity.test.ts
+++ b/apps/mobile/test/activity.test.ts
@@ -14,7 +14,15 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { dayHeading, dayKey, describeActivity, relativeTime, verbIcon } from '@/data/activity';
+import {
+  activityDateSpan,
+  dayHeading,
+  dayKey,
+  describeActivity,
+  filterByDayRange,
+  relativeTime,
+  verbIcon,
+} from '@/data/activity';
 import type { ActivityActor, ActivityRow } from '@/data/types';
 
 const RAVI: ActivityActor = {
@@ -286,5 +294,77 @@ describe('dayHeading', () => {
   it('keys entries by local calendar day', () => {
     expect(dayKey('2026-08-15T00:10:00')).toBe(dayKey('2026-08-15T23:50:00'));
     expect(dayKey('2026-08-14T23:50:00')).not.toBe(dayKey('2026-08-15T00:10:00'));
+  });
+});
+
+/**
+ * The date filter over the feed.
+ *
+ * The two properties that must hold are the picker clamp — the selectable span
+ * is exactly the feed's own start and end — and the cut agreeing with the day
+ * headings: a row is kept by its calendar day, so its time of day never trims
+ * it, and a range picked end-first still works.
+ */
+describe('activityDateSpan', () => {
+  const at = (iso: string) => ({ created_at: iso });
+
+  it('returns the earliest and latest calendar day in the feed', () => {
+    const span = activityDateSpan([
+      at('2026-08-10T09:00:00'),
+      at('2026-08-06T23:00:00'),
+      at('2026-08-14T01:00:00'),
+    ]);
+    expect(span).not.toBeNull();
+    // Anchored at local noon on the first and last day present.
+    expect(span?.earliest.getFullYear()).toBe(2026);
+    expect(span?.earliest.getMonth()).toBe(7); // August (0-based)
+    expect(span?.earliest.getDate()).toBe(6);
+    expect(span?.earliest.getHours()).toBe(12);
+    expect(span?.latest.getDate()).toBe(14);
+    expect(span?.latest.getHours()).toBe(12);
+  });
+
+  it('is null for an empty feed — nothing to clamp', () => {
+    expect(activityDateSpan([])).toBeNull();
+  });
+
+  it('skips unparseable timestamps', () => {
+    const span = activityDateSpan([at('not-a-date'), at('2026-08-09T10:00:00')]);
+    expect(span?.earliest.getDate()).toBe(9);
+    expect(span?.latest.getDate()).toBe(9);
+  });
+});
+
+describe('filterByDayRange', () => {
+  const at = (id: string, iso: string) => ({ id, created_at: iso });
+  const day = (iso: string) => new Date(`${iso}T12:00:00`);
+
+  const feed = [
+    at('a', '2026-08-05T08:00:00'),
+    at('b', '2026-08-08T23:30:00'),
+    at('c', '2026-08-10T00:10:00'),
+    at('d', '2026-08-14T15:00:00'),
+  ];
+
+  it('keeps only the rows whose day is inside the range, inclusive', () => {
+    const kept = filterByDayRange(feed, day('2026-08-08'), day('2026-08-10')).map((r) => r.id);
+    expect(kept).toEqual(['b', 'c']);
+  });
+
+  it('treats a single day as a one-day range regardless of the time of day', () => {
+    // Row c is at 00:10 — still kept when the picked day is 2026-08-10.
+    const kept = filterByDayRange(feed, day('2026-08-10'), day('2026-08-10')).map((r) => r.id);
+    expect(kept).toEqual(['c']);
+  });
+
+  it('orders the ends defensively — an end-first range works the same', () => {
+    const forward = filterByDayRange(feed, day('2026-08-05'), day('2026-08-08')).map((r) => r.id);
+    const backward = filterByDayRange(feed, day('2026-08-08'), day('2026-08-05')).map((r) => r.id);
+    expect(backward).toEqual(forward);
+    expect(forward).toEqual(['a', 'b']);
+  });
+
+  it('returns nothing when the range misses every row', () => {
+    expect(filterByDayRange(feed, day('2026-08-11'), day('2026-08-13'))).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Adds a **date / date-range filter** to the Activity feed. Long feeds are easier to read a day or a span at a time — a calendar button in the Activity header opens a range-picker sheet (From + To over one shared date picker). The whole history rides the mirror, so filtering is a pure client-side cut on the already-loaded rows — no fetch, no server change.

## How it works

- **Filter affordance**: a `calendar-outline` `IconButton` beside the existing inbox button (only shown once there is a feed to narrow). It opens a `SheetOverlay` — the same bottom-sheet primitive the expense pickers use — reusing the `@react-native-community/datetimepicker` pattern from `TripDates`. No new date-picker dependency.
- **Clamped selectable dates**: `activityDateSpan()` derives `[earliest, latest]` from the loaded rows' `created_at`, read in the phone's own timezone (the same day-bucketing `groupByDay`/`dayHeading` use, so the picker and the day headings agree). The picker's `minimumDate`/`maximumDate` disable everything outside that span — a day before the first event or after the last cannot be picked. The `To` also cannot precede the chosen `From`.
  - *Empty in-between days*: `@react-native-community/datetimepicker` only supports the outer min/max clamp — it cannot grey out an isolated empty day inside the span. Per the task this was the nice-to-have; the required overall start/end clamp is in place.
- **Applying the filter**: `filterByDayRange()` keeps rows whose calendar day falls within `start..end` inclusive (day granularity, so a row's time of day never trims it; ends ordered defensively). Results are re-sectioned by day. A single `From` is a one-day filter.
- **Visible, clearable state**: a brand chip shows the active range ("6 Aug" or "6 Aug – 14 Aug") — tap the body to adjust, the ✕ to clear.
- **Empty-in-range state**: a distinct "Nothing in this range" `EmptyState` (separate from the existing "nothing yet"), with a Clear action.
- Pull-to-refresh, skeleton/loading, error and the inbox button are untouched.

## Scope

Kept to the **main Activity tab** (`(tabs)/activity.tsx`). The group screen's Activity tab renders its feed inline via `.map()` (no `SectionList`/`groupByDay`), so adding the same filter there would be a different, higher-risk change — left as-is.

## i18n / a11y

New `activityFilter` block localized in **en / ta / hi / ar** (tsc-enforced), RTL-clean, with accessibility labels on the filter button, the range chip, and its clear ✕.

## Tests / gates (Windows node)

- `apps/mobile` `npx tsc --noEmit` — clean
- `pnpm test:app` — **422 passed** (added pure-logic tests for `activityDateSpan` + `filterByDayRange`: clamp span, inclusive day cut, single-day, end-first ordering, empty range)
- `pnpm format` — clean
- `pnpm lint` — clean

No DB / edge / migration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date-range filtering to the Activity feed.
  * Users can select, apply, clear, and close date filters from a bottom-sheet picker.
  * Active date ranges are shown on the feed, with clear messaging when no entries match.
  * Added localized filter text in English, Tamil, Hindi, and Arabic.

* **Bug Fixes**
  * Date filtering now handles reversed ranges, invalid dates, and single-day selections consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->