### PR TITLE
feat(expense): show the note, auto-capture location, and a keyless inline map

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
@@ -53,6 +53,7 @@ import { CategoryPicker } from '@/components/Category';
 import { TagEditorSheet } from '@/components/TagEditorSheet';
 import { PaymentMethodPicker } from '@/components/PaymentMethodPicker';
 import { LocationField } from '@/components/LocationField';
+import { captureLocationIfGranted } from '@/lib/location';
 import { friendlyError } from '@/lib/errors';
 import { COMMON_CURRENCIES, CurrencyRate } from '@/components/CurrencyRate';
 import { AmountHeader } from '@/components/expense/AmountHeader';
@@ -322,6 +323,10 @@ export default function AddExpenseScreen() {
   // taps "Add location" and grants the permission. Kept in the draft so a crash
   // mid-entry does not lose it, and seeded from the version when editing.
   const [location, setLocation] = useState<ExpenseLocation | null>(null);
+  // Whether the one-shot auto-capture below has run for this screen. A ref, not
+  // state: it guards the attempt to a single run without itself forcing a render
+  // (and without a synchronous setState inside the effect).
+  const autoLocatedRef = useRef(false);
 
   // The per-group receipt ceiling. A group holds a few receipts for free (the
   // number is an admin knob); past it, scanning is a paid feature. A paid group
@@ -581,6 +586,32 @@ export default function AddExpenseScreen() {
     },
     { enabled: seededFor !== null },
   );
+
+  // Auto-stamp the current place on a brand-new expense (A43 follow-up), but
+  // only ever when the person already granted location on an earlier explicit
+  // "Add location" — opening this form must never raise a system prompt (the
+  // deferred-permission stance `lib/location` is built around). It runs once,
+  // never on an edit (that expense's place is a decision already made, and it
+  // may have happened elsewhere), never over a capture/voice/draft that already
+  // carried a place, and never over a pin set (or cleared) by hand: the
+  // functional set below drops the fix if a value appeared meanwhile. A denied
+  // or unavailable fix is simply no location, exactly as before.
+  useEffect(() => {
+    if (autoLocatedRef.current || seededFor === null) return;
+    if (editing || captureId || voice) return;
+    // One attempt, whatever the outcome — clearing the pin by hand is never
+    // undone, and a draft/seed that already placed it (checked next) is left be.
+    autoLocatedRef.current = true;
+    if (location) return;
+    let active = true;
+    void captureLocationIfGranted().then((loc) => {
+      // Never override a place set in the meantime — only fill an empty pin.
+      if (active && loc) setLocation((current) => current ?? loc);
+    });
+    return () => {
+      active = false;
+    };
+  }, [seededFor, editing, captureId, voice, location]);
 
   const splitParams: SplitParams = useMemo(() => {
     // "My treat" owes the whole current amount to the host — recomputed live so

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -28,6 +28,7 @@ import {
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
+import { MapPreview } from '@/components/MapPreview';
 import { ExpenseReceipts } from '@/components/ExpenseReceipts';
 import { ExpenseComments } from '@/components/ExpenseComments';
 import { ExpenseHistory } from '@/components/ExpenseHistory';
@@ -208,6 +209,15 @@ export default function ExpenseDetailScreen() {
   // Where it happened (A43), when the author attached one. A plain snapshot — a
   // tap opens the point in the phone's maps app.
   const location = version.location;
+  // The typed note. It also names the expense in the hero, but that heading is
+  // clamped to a single line while the field is multiline — so a long or
+  // multi-line note is only half-shown up top. Render the full text as a "Note"
+  // row whenever the hero cannot have conveyed all of it (more than one line, or
+  // longer than one fits), so nothing the author typed is lost on this screen.
+  const note = (version.description ?? '').trim();
+  // Roughly one line of the hero heading on a phone; past this the clamp bites.
+  const HERO_TITLE_CLAMP = 30;
+  const showNote = note !== '' && (note.includes('\n') || note.length > HERO_TITLE_CLAMP);
   // The hero is the dashboard/group panel: one saturated wash running edge to
   // edge under the status bar, white controls and amount on it. The expense
   // amount is a total that belongs to nobody — it is not owed or owned — so the
@@ -397,28 +407,31 @@ export default function ExpenseDetailScreen() {
               onLegacyRemoved={() => setReceiptUri(null)}
             />
 
-            {/* Where it happened (A43). A tap opens the point in the phone's maps
-            app; absent when the author attached no location. */}
+            {/* The full note, when the clamped hero heading could not have shown
+            all of it — a multi-line or long description is only half-visible up
+            top, so it gets its own readable, wrapping row here. */}
+            {showNote ? (
+              <View>
+                <SectionHeader title={t.expense.note} />
+                <Card>
+                  <Text variant="body">{note}</Text>
+                </Card>
+              </View>
+            ) : null}
+
+            {/* Where it happened (A43): a little map of the point, and a tap
+            anywhere on the card opens it in the phone's maps app. Absent when
+            the author attached no location. */}
             {location ? (
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={t.location.openMap}
                 onPress={() => void Linking.openURL(mapsUrl(location)).catch(() => undefined)}
               >
-                <Card style={{ paddingVertical: theme.spacing.md }}>
+                <Card style={{ gap: theme.spacing.sm, padding: theme.spacing.sm }}>
+                  <MapPreview location={location} accessibilityLabel={t.location.openMap} />
                   <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-                    <View
-                      style={{
-                        width: 52,
-                        height: 52,
-                        borderRadius: theme.radius.md,
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        backgroundColor: theme.color.bg,
-                      }}
-                    >
-                      <Ionicons name="location" size={iconSize.lg} color={theme.color.brand} />
-                    </View>
+                    <Ionicons name="location" size={iconSize.md} color={theme.color.brand} />
                     <View style={{ flex: 1, minWidth: 0 }}>
                       <Text variant="subheading" numberOfLines={1}>
                         {location.name?.trim() || coordLabel(location)}

--- a/apps/mobile/src/components/LocationField.tsx
+++ b/apps/mobile/src/components/LocationField.tsx
@@ -19,6 +19,8 @@ import { Linking, Pressable, View } from 'react-native';
 import type { ExpenseLocation } from '@waves/core';
 import { Button, Callout, Card, iconSize, Row, Text, useTheme } from '@waves/ui';
 
+import { LocationPickerSheet } from '@/components/LocationPickerSheet';
+import { MapPreview } from '@/components/MapPreview';
 import { useStrings } from '@/i18n';
 import { captureLocation, coordLabel, LocationFailure, locationAvailable } from '@/lib/location';
 
@@ -35,6 +37,9 @@ export function LocationField({
   // 'denied' offers Settings; 'unavailable' just invites another try. Cleared
   // the moment a fresh attempt starts.
   const [failure, setFailure] = useState<LocationFailure | null>(null);
+  // The full-screen map: opened to adjust an existing pin, or to pick a spot
+  // by hand when the person is not standing where the money was spent.
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   // Web and a build with no location module have nothing to offer — the whole
   // field is absent rather than a button that can only fail.
@@ -64,12 +69,27 @@ export function LocationField({
       </Text>
 
       {value ? (
-        <Card style={{ paddingVertical: theme.spacing.md }}>
+        <Card style={{ gap: theme.spacing.sm, padding: theme.spacing.sm }}>
+          {/* A little map of the point — tap it to open the picker and adjust. */}
+          <MapPreview
+            location={value}
+            onPress={() => setPickerOpen(true)}
+            accessibilityLabel={t.location.adjust}
+          />
           <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
             <Ionicons name="location" size={iconSize.md} color={theme.color.brand} />
             <Text variant="subheading" numberOfLines={1} style={{ flex: 1 }}>
               {label}
             </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t.location.adjust}
+              onPress={() => setPickerOpen(true)}
+              hitSlop={8}
+              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+            >
+              <Ionicons name="create-outline" size={iconSize.md} color={theme.color.brand} />
+            </Pressable>
             <Pressable
               accessibilityRole="button"
               accessibilityLabel={t.location.remove}
@@ -82,15 +102,36 @@ export function LocationField({
           </Row>
         </Card>
       ) : (
-        <Button
-          label={busy ? t.location.adding : t.location.add}
-          variant="secondary"
-          size="sm"
-          disabled={busy}
-          onPress={() => void add()}
-          icon={<Ionicons name="location-outline" size={iconSize.md} color={theme.color.brand} />}
-        />
+        <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
+          <Button
+            label={busy ? t.location.adding : t.location.add}
+            variant="secondary"
+            size="sm"
+            disabled={busy}
+            onPress={() => void add()}
+            icon={<Ionicons name="location-outline" size={iconSize.md} color={theme.color.brand} />}
+          />
+          {/* The manual path: choose a spot on the map when you are not there. */}
+          <Button
+            label={t.location.pick}
+            variant="secondary"
+            size="sm"
+            disabled={busy}
+            onPress={() => setPickerOpen(true)}
+            icon={<Ionicons name="map-outline" size={iconSize.md} color={theme.color.brand} />}
+          />
+        </Row>
       )}
+
+      <LocationPickerSheet
+        visible={pickerOpen}
+        initial={value}
+        onClose={() => setPickerOpen(false)}
+        onConfirm={(picked) => {
+          onChange(picked);
+          setPickerOpen(false);
+        }}
+      />
 
       {failure === LocationFailure.Denied ? (
         <View style={{ gap: theme.spacing.sm }}>

--- a/apps/mobile/src/components/LocationPickerSheet.tsx
+++ b/apps/mobile/src/components/LocationPickerSheet.tsx
@@ -1,0 +1,321 @@
+/**
+ * Choose or nudge an expense's location on a map (A43 follow-up).
+ *
+ * A full-screen map the person taps to move the pin, zooms with +/-, or snaps
+ * to their current position. It is built from the same keyless raster tiles as
+ * {@link MapPreview} — no native map, no API key — so "pick a point on a map"
+ * ships without the fragile native dependency `react-native-maps` would add on
+ * this Expo pin. On confirm the chosen coordinate is reverse-geocoded to a name
+ * (best-effort) and handed back as a plain {lat,lng,name}.
+ *
+ * Tapping recentres the map on the tapped point, so the pin — fixed at the
+ * centre — ends up exactly where the finger landed. "Use my current location"
+ * is the only path here that asks for permission, and only when tapped.
+ */
+
+import { useEffect, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Image } from 'expo-image';
+import { ActivityIndicator, type LayoutChangeEvent, Modal, Pressable, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import type { ExpenseLocation } from '@waves/core';
+import { Button, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+import { useStrings } from '@/i18n';
+import {
+  captureLocation,
+  captureLocationIfGranted,
+  coordLabel,
+  reverseGeocode,
+} from '@/lib/location';
+import {
+  clampZoom,
+  DEFAULT_TILE_URL,
+  DEFAULT_ZOOM,
+  type LatLng,
+  offsetLatLng,
+  TILE_SIZE,
+  tileGrid,
+  tileUrl,
+} from '@/lib/mapTiles';
+
+const TILE_URL = process.env.EXPO_PUBLIC_MAP_TILE_URL || DEFAULT_TILE_URL;
+// Where the map opens when there is no starting point and no granted fix — a
+// gentle world view the person zooms into or overrides with "use my location".
+const WORLD: LatLng = { lat: 20, lng: 0 };
+const WORLD_ZOOM = 2;
+
+export function LocationPickerSheet({
+  visible,
+  initial,
+  onClose,
+  onConfirm,
+}: {
+  visible: boolean;
+  initial: ExpenseLocation | null;
+  onClose: () => void;
+  onConfirm: (location: ExpenseLocation) => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const insets = useSafeAreaInsets();
+
+  const [center, setCenter] = useState<LatLng>(initial ?? WORLD);
+  const [zoom, setZoom] = useState(initial ? DEFAULT_ZOOM : WORLD_ZOOM);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  const [locating, setLocating] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Re-seed the moment the sheet opens: an edit reopens on its saved point; a
+  // fresh pick opens on the world view to tap or zoom into. Done during render
+  // (the "adjust state when the input changes" pattern the expense form uses)
+  // rather than in an effect, so it never fires a cascading extra render.
+  const [seededOpen, setSeededOpen] = useState(false);
+  if (visible && !seededOpen) {
+    setSeededOpen(true);
+    setCenter(initial ?? WORLD);
+    setZoom(initial ? DEFAULT_ZOOM : WORLD_ZOOM);
+  } else if (!visible && seededOpen) {
+    setSeededOpen(false);
+  }
+
+  // When opening a fresh pick (no starting point), upgrade the world view to the
+  // person's position if — and only if — they already granted location, never
+  // prompting. The setState lives in the async callback, not the effect body.
+  useEffect(() => {
+    if (!visible || initial) return;
+    let active = true;
+    void captureLocationIfGranted().then((loc) => {
+      if (active && loc) {
+        setCenter({ lat: loc.lat, lng: loc.lng });
+        setZoom(DEFAULT_ZOOM);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [visible, initial]);
+
+  const onLayout = (event: LayoutChangeEvent): void => {
+    const { width, height } = event.nativeEvent.layout;
+    setSize({ w: width, h: height });
+  };
+
+  // A tap recentres on the tapped point: the fixed centre pin lands where the
+  // finger did. The projection turns the pixel offset into a new {lat,lng}.
+  const onTapMap = (locationX: number, locationY: number): void => {
+    if (size.w <= 0 || size.h <= 0) return;
+    setCenter(offsetLatLng(center, zoom, locationX - size.w / 2, locationY - size.h / 2));
+  };
+
+  const snapToCurrentLocation = async (): Promise<void> => {
+    setLocating(true);
+    try {
+      const result = await captureLocation();
+      if (result.ok) {
+        setCenter({ lat: result.location.lat, lng: result.location.lng });
+        setZoom(DEFAULT_ZOOM);
+      }
+    } finally {
+      setLocating(false);
+    }
+  };
+
+  const confirm = async (): Promise<void> => {
+    setSaving(true);
+    try {
+      // Name the chosen point; the coordinate stands on its own if it has none.
+      const name = await reverseGeocode(center.lat, center.lng);
+      onConfirm({ lat: center.lat, lng: center.lng, name });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const tiles = size.w > 0 && size.h > 0 ? tileGrid(center, zoom, size.w, size.h) : [];
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      onRequestClose={onClose}
+      transparent={false}
+      statusBarTranslucent
+    >
+      <View style={{ flex: 1, backgroundColor: theme.color.bg }}>
+        {/* Header: close + title + coordinate readout. */}
+        <Row
+          style={{
+            paddingTop: insets.top + theme.spacing.sm,
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: theme.spacing.sm,
+            gap: theme.spacing.md,
+            alignItems: 'center',
+            backgroundColor: theme.color.surface,
+          }}
+        >
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.common.close}
+            onPress={onClose}
+            hitSlop={10}
+            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+          >
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+          </Pressable>
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <Text variant="subheading" numberOfLines={1}>
+              {t.location.pickerTitle}
+            </Text>
+            <Text variant="micro" tone="muted" numberOfLines={1}>
+              {coordLabel({ lat: center.lat, lng: center.lng })}
+            </Text>
+          </View>
+        </Row>
+
+        {/* The map. A Pressable captures the tap that moves the pin. */}
+        <View style={{ flex: 1 }} onLayout={onLayout}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.location.pickerHint}
+            onPress={(event) => onTapMap(event.nativeEvent.locationX, event.nativeEvent.locationY)}
+            style={{ flex: 1, backgroundColor: theme.color.bg }}
+          >
+            {tiles.map((tile) => (
+              <Image
+                key={`${tile.x}-${tile.y}-${tile.left}`}
+                source={{ uri: tileUrl(TILE_URL, tile.x, tile.y, zoom) }}
+                style={{
+                  position: 'absolute',
+                  left: tile.left,
+                  top: tile.top,
+                  width: TILE_SIZE,
+                  height: TILE_SIZE,
+                }}
+                contentFit="cover"
+                transition={120}
+                cachePolicy="memory-disk"
+              />
+            ))}
+          </Pressable>
+
+          {/* Fixed centre pin — the point that gets saved. */}
+          <View
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              top: 0,
+              bottom: 0,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Ionicons
+              name="location"
+              size={iconSize.xxl}
+              color={theme.color.brand}
+              style={{ marginTop: -iconSize.xxl / 2 }}
+            />
+          </View>
+
+          {/* Zoom controls, stacked at the trailing edge. */}
+          <View
+            style={{
+              position: 'absolute',
+              right: theme.spacing.lg,
+              top: theme.spacing.lg,
+              gap: theme.spacing.sm,
+            }}
+          >
+            {(
+              [
+                ['add', () => setZoom((z) => clampZoom(z + 1)), t.location.zoomIn],
+                ['remove', () => setZoom((z) => clampZoom(z - 1)), t.location.zoomOut],
+              ] as const
+            ).map(([icon, onPress, label]) => (
+              <Pressable
+                key={icon}
+                accessibilityRole="button"
+                accessibilityLabel={label}
+                onPress={onPress}
+                style={({ pressed }) => ({
+                  width: 44,
+                  height: 44,
+                  borderRadius: theme.radius.md,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: theme.color.surface,
+                  opacity: pressed ? 0.7 : 1,
+                })}
+              >
+                <Ionicons name={icon} size={iconSize.md} color={theme.color.text} />
+              </Pressable>
+            ))}
+          </View>
+
+          {/* Attribution — required by the OpenStreetMap tile licence. */}
+          <View
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              right: 0,
+              bottom: 0,
+              paddingHorizontal: 4,
+              paddingVertical: 2,
+              backgroundColor: 'rgba(255, 255, 255, 0.7)',
+              borderTopLeftRadius: theme.radius.sm,
+            }}
+          >
+            <Text variant="micro" style={{ color: '#333', fontSize: 9 }}>
+              © OpenStreetMap
+            </Text>
+          </View>
+        </View>
+
+        {/* Footer: the hint, "use my location", and the confirm. */}
+        <View
+          style={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingTop: theme.spacing.md,
+            paddingBottom: insets.bottom + theme.spacing.md,
+            gap: theme.spacing.sm,
+            borderTopWidth: 1,
+            borderTopColor: theme.color.border,
+            backgroundColor: theme.color.surface,
+          }}
+        >
+          <Text variant="micro" tone="muted" align="center">
+            {t.location.pickerHint}
+          </Text>
+          <Row style={{ gap: theme.spacing.md }}>
+            <View style={{ flex: 1 }}>
+              <Button
+                label={t.location.useCurrentLocation}
+                variant="secondary"
+                disabled={locating || saving}
+                onPress={() => void snapToCurrentLocation()}
+                icon={
+                  locating ? (
+                    <ActivityIndicator color={theme.color.brand} />
+                  ) : (
+                    <Ionicons name="locate" size={iconSize.md} color={theme.color.brand} />
+                  )
+                }
+              />
+            </View>
+            <View style={{ flex: 1 }}>
+              <Button
+                label={t.location.usePlace}
+                disabled={saving || locating}
+                onPress={() => void confirm()}
+              />
+            </View>
+          </Row>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/components/MapPreview.tsx
+++ b/apps/mobile/src/components/MapPreview.tsx
@@ -1,0 +1,134 @@
+/**
+ * A little map of where an expense happened (A43 follow-up).
+ *
+ * Drawn from raster tiles rather than a native map view, so no API key and no
+ * native module ever enter the build — the projection math lives in
+ * `@/lib/mapTiles` and this only paints its output. A fixed pin marks the point
+ * at the centre; the tiles fill in around it. If the tile server is unreachable
+ * the images simply do not appear and the neutral map-coloured background shows
+ * through, so a blocked network degrades to an empty frame, never a crash.
+ *
+ * The tile source is `EXPO_PUBLIC_MAP_TILE_URL` when set, else OpenStreetMap's
+ * public tiles (keyless, attributed below). A production build under real load
+ * should point that at a self-hosted or keyed provider.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Image } from 'expo-image';
+import { type LayoutChangeEvent, Pressable, View } from 'react-native';
+
+import type { ExpenseLocation } from '@waves/core';
+import { iconSize, Text, useTheme } from '@waves/ui';
+
+import { DEFAULT_TILE_URL, DEFAULT_ZOOM, TILE_SIZE, tileGrid, tileUrl } from '@/lib/mapTiles';
+
+const TILE_URL = process.env.EXPO_PUBLIC_MAP_TILE_URL || DEFAULT_TILE_URL;
+
+export function MapPreview({
+  location,
+  zoom = DEFAULT_ZOOM,
+  height = 150,
+  onPress,
+  accessibilityLabel,
+}: {
+  location: ExpenseLocation;
+  zoom?: number;
+  height?: number;
+  /** Makes the whole preview a button (e.g. open the picker, or the maps app). */
+  onPress?: () => void;
+  accessibilityLabel?: string;
+}): React.JSX.Element {
+  const theme = useTheme();
+  // Height is fixed; width is whatever the parent gives us, known only after the
+  // first layout pass — until then there is nothing to tile.
+  const [width, setWidth] = useState(0);
+  const onLayout = (event: LayoutChangeEvent): void => {
+    setWidth(event.nativeEvent.layout.width);
+  };
+
+  const tiles = width > 0 ? tileGrid(location, zoom, width, height) : [];
+
+  const body = (
+    <View
+      onLayout={onLayout}
+      style={{
+        height,
+        borderRadius: theme.radius.md,
+        overflow: 'hidden',
+        backgroundColor: theme.color.bg,
+      }}
+    >
+      {tiles.map((tile) => (
+        <Image
+          key={`${tile.x}-${tile.y}-${tile.left}`}
+          source={{ uri: tileUrl(TILE_URL, tile.x, tile.y, zoom) }}
+          style={{
+            position: 'absolute',
+            left: tile.left,
+            top: tile.top,
+            width: TILE_SIZE,
+            height: TILE_SIZE,
+          }}
+          contentFit="cover"
+          transition={120}
+          // A tile is a static image; hold it so panning/zooming does not refetch.
+          cachePolicy="memory-disk"
+        />
+      ))}
+
+      {/* The pin sits at the geometric centre, its tip on the point. */}
+      <View
+        pointerEvents="none"
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: 0,
+          bottom: 0,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Ionicons
+          name="location"
+          size={iconSize.xl}
+          color={theme.color.brand}
+          // Lift it so the point of the pin, not its middle, marks the spot.
+          style={{ marginTop: -iconSize.xl / 2 }}
+        />
+      </View>
+
+      {/* Attribution — required by the OpenStreetMap tile licence. Not translated:
+          it is a fixed credit, like a copyright line. */}
+      <View
+        pointerEvents="none"
+        style={{
+          position: 'absolute',
+          right: 0,
+          bottom: 0,
+          paddingHorizontal: 4,
+          paddingVertical: 2,
+          backgroundColor: 'rgba(255, 255, 255, 0.7)',
+          borderTopLeftRadius: theme.radius.sm,
+        }}
+      >
+        <Text variant="micro" style={{ color: '#333', fontSize: 9 }}>
+          © OpenStreetMap
+        </Text>
+      </View>
+    </View>
+  );
+
+  if (!onPress) return body;
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
+    >
+      {body}
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1135,6 +1135,21 @@ export interface UiStrings {
     unavailable: string;
     openSettings: string;
     openMap: string;
+    /** Open the map picker to nudge an existing pin. */
+    adjust: string;
+    /** Choose a spot on the map by hand (when you are not there). */
+    pick: string;
+    /** The map picker's header. */
+    pickerTitle: string;
+    /** How to use the picker — tap to move the pin. */
+    pickerHint: string;
+    /** Snap the picker to the device's current position (asks permission). */
+    useCurrentLocation: string;
+    /** Confirm the picked point. */
+    usePlace: string;
+    /** Accessibility labels for the picker's zoom controls. */
+    zoomIn: string;
+    zoomOut: string;
   };
   /** The custom expense-tag catalog (extends TDR §8): the create/edit sheet and
    *  the Settings manager. Built-in category labels stay in `categories`. */
@@ -1425,6 +1440,9 @@ export interface UiStrings {
     itemized: string;
     /** The two faces of the expense page: its breakdown, and its edit history. */
     detailsTab: string;
+    /** "Note" — the full typed description on the detail screen, shown when the
+     *  one-line hero heading could not have conveyed all of it. */
+    note: string;
     /** "Created by Asha" / "Edited by Ravi" — the head of one audit entry. */
     createdByName: string;
     editedByName: string;
@@ -2855,6 +2873,14 @@ const en: UiStrings = {
     unavailable: "Couldn't get a location just now — please try again.",
     openSettings: 'Open Settings',
     openMap: 'Open in maps',
+    adjust: 'Adjust on map',
+    pick: 'Pick on map',
+    pickerTitle: 'Choose location',
+    pickerHint: 'Tap the map to move the pin',
+    useCurrentLocation: 'Use my current location',
+    usePlace: 'Use this place',
+    zoomIn: 'Zoom in',
+    zoomOut: 'Zoom out',
   },
   tags: {
     manageTitle: 'Tags & categories',
@@ -3127,6 +3153,7 @@ const en: UiStrings = {
     withAdjustments: 'With adjustments',
     itemized: 'Itemized',
     detailsTab: 'Details',
+    note: 'Note',
     createdByName: 'Created by {name}',
     editedByName: 'Edited by {name}',
     noChanges: 'No tracked fields changed',
@@ -4640,6 +4667,14 @@ const ta: UiStrings = {
     unavailable: 'இப்போது இடத்தைப் பெற முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
     openSettings: 'அமைப்புகளைத் திற',
     openMap: 'வரைபடத்தில் திற',
+    adjust: 'வரைபடத்தில் சரிசெய்',
+    pick: 'வரைபடத்தில் தேர்ந்தெடு',
+    pickerTitle: 'இடத்தைத் தேர்ந்தெடு',
+    pickerHint: 'ஊசியை நகர்த்த வரைபடத்தைத் தட்டவும்',
+    useCurrentLocation: 'என் தற்போதைய இடத்தைப் பயன்படுத்து',
+    usePlace: 'இந்த இடத்தைப் பயன்படுத்து',
+    zoomIn: 'பெரிதாக்கு',
+    zoomOut: 'சிறிதாக்கு',
   },
   tags: {
     manageTitle: 'குறிச்சொற்கள் & வகைகள்',
@@ -4933,6 +4968,7 @@ const ta: UiStrings = {
     withAdjustments: 'சரிசெய்தலுடன்',
     itemized: 'பொருள் வாரியாக',
     detailsTab: 'விவரங்கள்',
+    note: 'குறிப்பு',
     createdByName: '{name} உருவாக்கியது',
     editedByName: '{name} திருத்தியது',
     noChanges: 'கண்காணிக்கப்படும் புலங்கள் மாறவில்லை',
@@ -6443,6 +6479,14 @@ const hi: UiStrings = {
     unavailable: 'अभी स्थान नहीं मिल सका — कृपया फिर से कोशिश करें।',
     openSettings: 'सेटिंग खोलें',
     openMap: 'मैप में खोलें',
+    adjust: 'मैप पर समायोजित करें',
+    pick: 'मैप पर चुनें',
+    pickerTitle: 'स्थान चुनें',
+    pickerHint: 'पिन हिलाने के लिए मैप पर टैप करें',
+    useCurrentLocation: 'मेरा मौजूदा स्थान इस्तेमाल करें',
+    usePlace: 'यह स्थान इस्तेमाल करें',
+    zoomIn: 'ज़ूम इन',
+    zoomOut: 'ज़ूम आउट',
   },
   tags: {
     manageTitle: 'टैग और श्रेणियाँ',
@@ -6720,6 +6764,7 @@ const hi: UiStrings = {
     withAdjustments: 'समायोजन के साथ',
     itemized: 'चीज़-वार',
     detailsTab: 'विवरण',
+    note: 'नोट',
     createdByName: '{name} ने बनाया',
     editedByName: '{name} ने बदला',
     noChanges: 'कोई ट्रैक किया गया फ़ील्ड नहीं बदला',
@@ -8239,6 +8284,14 @@ const ar: UiStrings = {
     unavailable: 'تعذّر تحديد الموقع الآن — يُرجى المحاولة مرة أخرى.',
     openSettings: 'فتح الإعدادات',
     openMap: 'فتح في الخرائط',
+    adjust: 'ضبط على الخريطة',
+    pick: 'اختيار على الخريطة',
+    pickerTitle: 'اختر الموقع',
+    pickerHint: 'انقر على الخريطة لتحريك الدبوس',
+    useCurrentLocation: 'استخدام موقعي الحالي',
+    usePlace: 'استخدام هذا المكان',
+    zoomIn: 'تكبير',
+    zoomOut: 'تصغير',
   },
   tags: {
     manageTitle: 'الوسوم والفئات',
@@ -8542,6 +8595,7 @@ const ar: UiStrings = {
     withAdjustments: 'مع تعديلات',
     itemized: 'حسب الأصناف',
     detailsTab: 'التفاصيل',
+    note: 'ملاحظة',
     createdByName: 'أنشأها {name}',
     editedByName: 'عدّلها {name}',
     noChanges: 'لم تتغيّر أي حقول متتبَّعة',

--- a/apps/mobile/src/lib/location.ts
+++ b/apps/mobile/src/lib/location.ts
@@ -193,6 +193,57 @@ export async function captureLocation(): Promise<LocationResult> {
   }
 }
 
+/**
+ * Read a fix *only if permission was already granted* — never prompting.
+ *
+ * This is what lets add-expense stamp the current place automatically: opening
+ * the form must never throw up a system location prompt (the anti-pattern this
+ * module exists to avoid), so a fix is read only when the person has already
+ * said yes on an earlier explicit "Add location". Undetermined, denied, no
+ * module, or no GPS lock all come back as `null`, and the expense saves with no
+ * place exactly as before. Reverse-geocoding stays best-effort.
+ */
+export async function captureLocationIfGranted(): Promise<ExpenseLocation | null> {
+  const Location = loadLocation();
+  if (!Location) return null;
+  try {
+    const { status } = await Location.getForegroundPermissionsAsync();
+    if (status !== 'granted') return null; // deliberately never requests here
+    const fix = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+    const lat = fix.coords.latitude;
+    const lng = fix.coords.longitude;
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+    let name: string | null = null;
+    try {
+      const addresses = await Location.reverseGeocodeAsync({ latitude: lat, longitude: lng });
+      name = placeName(addresses[0]);
+    } catch {
+      name = null;
+    }
+    return { lat, lng, name };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Name an arbitrary point picked on the map — best-effort, `null` when the
+ * lookup fails, runs offline, or the module is absent (the caller keeps the
+ * coordinates and shows the point). Unlike {@link captureLocation} this reads no
+ * GPS and asks for no permission: reverse geocoding a chosen coordinate does not
+ * reveal where the person is.
+ */
+export async function reverseGeocode(lat: number, lng: number): Promise<string | null> {
+  const Location = loadLocation();
+  if (!Location) return null;
+  try {
+    const addresses = await Location.reverseGeocodeAsync({ latitude: lat, longitude: lng });
+    return placeName(addresses[0]);
+  } catch {
+    return null;
+  }
+}
+
 /** A deep link that opens the point in whatever maps app the phone prefers. */
 export function mapsUrl(location: ExpenseLocation): string {
   const query = `${location.lat},${location.lng}`;

--- a/apps/mobile/src/lib/mapTiles.ts
+++ b/apps/mobile/src/lib/mapTiles.ts
@@ -1,0 +1,148 @@
+/**
+ * The slippy-map arithmetic behind the expense location map (A43 follow-up).
+ *
+ * The map is drawn from plain raster tiles — no native map module, no API key —
+ * so the app never grows a fragile native dependency or a build that breaks
+ * autolinking on this Expo pin. That leaves this: the Web Mercator projection
+ * that turns a {lat,lng} into which 256px tiles to fetch and where to place
+ * them, and the inverse that turns a tap back into a {lat,lng}. It is pure
+ * (no React Native, no network) so the projection round-trips can be tested,
+ * and so importing it never drags React Native into the vitest graph.
+ *
+ * The tile source is swappable: {@link tileUrl} takes a URL template, defaulting
+ * to OpenStreetMap's public tiles. That server is keyless but its usage policy
+ * discourages heavy app traffic, so a production build should point
+ * `EXPO_PUBLIC_MAP_TILE_URL` at a self-hosted or keyed provider — a config step,
+ * not a code change.
+ */
+
+/** Every raster tile is 256×256 device-independent pixels. */
+export const TILE_SIZE = 256;
+
+/** OpenStreetMap's public tiles: keyless, attributed "© OpenStreetMap". */
+export const DEFAULT_TILE_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+/** The latitudes Web Mercator can represent; beyond this the projection blows up. */
+export const MAX_MERCATOR_LAT = 85.05112878;
+
+/** A sensible street-level default, and the range the +/- buttons move within. */
+export const MIN_ZOOM = 2;
+export const MAX_ZOOM = 19;
+export const DEFAULT_ZOOM = 15;
+
+/** Keep a latitude inside the Mercator-representable band. */
+export function clampLat(lat: number): number {
+  return Math.max(-MAX_MERCATOR_LAT, Math.min(MAX_MERCATOR_LAT, lat));
+}
+
+/** Keep a longitude in [-180, 180). */
+export function wrapLng(lng: number): number {
+  let x = ((lng + 180) % 360) - 180;
+  if (x < -180) x += 360;
+  return x;
+}
+
+/** Clamp a zoom to the supported range and round to an integer tile level. */
+export function clampZoom(zoom: number): number {
+  return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, Math.round(zoom)));
+}
+
+/** The world's pixel span at a zoom level (tiles across × tile size). */
+function worldSize(zoom: number): number {
+  return TILE_SIZE * 2 ** zoom;
+}
+
+export interface WorldPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface LatLng {
+  readonly lat: number;
+  readonly lng: number;
+}
+
+/** Project a {lat,lng} to absolute world pixels at a zoom (Web Mercator). */
+export function project(lat: number, lng: number, zoom: number): WorldPoint {
+  const size = worldSize(zoom);
+  const x = ((wrapLng(lng) + 180) / 360) * size;
+  const sinLat = Math.sin((clampLat(lat) * Math.PI) / 180);
+  const y = (0.5 - Math.log((1 + sinLat) / (1 - sinLat)) / (4 * Math.PI)) * size;
+  return { x, y };
+}
+
+/** Invert {@link project}: absolute world pixels back to a {lat,lng}. */
+export function unproject(x: number, y: number, zoom: number): LatLng {
+  const size = worldSize(zoom);
+  const lng = (x / size) * 360 - 180;
+  const n = Math.PI - (2 * Math.PI * y) / size;
+  const lat = (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+  return { lat, lng: wrapLng(lng) };
+}
+
+/**
+ * The {lat,lng} a given pixel offset from a centre point resolves to — how a
+ * tap on the map (dx, dy pixels from the centre pin) becomes a new place.
+ */
+export function offsetLatLng(center: LatLng, zoom: number, dxPx: number, dyPx: number): LatLng {
+  const c = project(center.lat, center.lng, zoom);
+  return unproject(c.x + dxPx, c.y + dyPx, zoom);
+}
+
+export interface TilePlacement {
+  /** Tile column (already wrapped into [0, 2^zoom) for the URL). */
+  readonly x: number;
+  /** Tile row. */
+  readonly y: number;
+  /** Screen-space top-left of this tile within the viewport, in pixels. */
+  readonly left: number;
+  readonly top: number;
+}
+
+/**
+ * Which tiles cover a viewport centred on a {lat,lng}, and where each sits.
+ *
+ * The centre point lands exactly at (width/2, height/2); tiles are laid around
+ * it. Columns wrap around the globe; rows past the poles are dropped (there is
+ * no tile there), which simply leaves the map background showing.
+ */
+export function tileGrid(
+  center: LatLng,
+  zoom: number,
+  width: number,
+  height: number,
+): TilePlacement[] {
+  if (width <= 0 || height <= 0) return [];
+  const z = clampZoom(zoom);
+  const n = 2 ** z;
+  const c = project(center.lat, center.lng, z);
+  // The viewport's top-left corner in world pixels.
+  const originX = c.x - width / 2;
+  const originY = c.y - height / 2;
+
+  const firstCol = Math.floor(originX / TILE_SIZE);
+  const lastCol = Math.floor((originX + width) / TILE_SIZE);
+  const firstRow = Math.floor(originY / TILE_SIZE);
+  const lastRow = Math.floor((originY + height) / TILE_SIZE);
+
+  const tiles: TilePlacement[] = [];
+  for (let row = firstRow; row <= lastRow; row++) {
+    if (row < 0 || row >= n) continue; // above/below the map — nothing to draw
+    for (let col = firstCol; col <= lastCol; col++) {
+      // Wrap columns so panning across the antimeridian keeps showing tiles.
+      const wrappedCol = ((col % n) + n) % n;
+      tiles.push({
+        x: wrappedCol,
+        y: row,
+        left: col * TILE_SIZE - originX,
+        top: row * TILE_SIZE - originY,
+      });
+    }
+  }
+  return tiles;
+}
+
+/** Fill a `{z}/{x}/{y}` URL template for one tile. */
+export function tileUrl(template: string, x: number, y: number, zoom: number): string {
+  return template.replace('{z}', String(zoom)).replace('{x}', String(x)).replace('{y}', String(y));
+}

--- a/apps/mobile/test/mapTiles.test.ts
+++ b/apps/mobile/test/mapTiles.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The map projection, checked as numbers.
+ *
+ * The map is drawn from raster tiles, so a wrong projection is a pin that sits
+ * on the wrong street without ever throwing. Two things must hold: project and
+ * unproject are exact inverses (a tap comes back to the point it started from),
+ * and the tile grid actually covers the viewport it is asked to fill.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  clampLat,
+  clampZoom,
+  DEFAULT_TILE_URL,
+  MAX_MERCATOR_LAT,
+  offsetLatLng,
+  project,
+  tileGrid,
+  tileUrl,
+  TILE_SIZE,
+  unproject,
+  wrapLng,
+} from '@/lib/mapTiles';
+
+describe('project / unproject', () => {
+  it('round-trips a point back to itself', () => {
+    // Bengaluru — the kind of point an expense actually carries.
+    const lat = 12.9716;
+    const lng = 77.5946;
+    const z = 15;
+    const p = project(lat, lng, z);
+    const back = unproject(p.x, p.y, z);
+    expect(back.lat).toBeCloseTo(lat, 6);
+    expect(back.lng).toBeCloseTo(lng, 6);
+  });
+
+  it('puts the origin (0,0) at the centre of the world', () => {
+    const z = 10;
+    const size = TILE_SIZE * 2 ** z;
+    const p = project(0, 0, z);
+    expect(p.x).toBeCloseTo(size / 2, 6);
+    expect(p.y).toBeCloseTo(size / 2, 6);
+  });
+
+  it('round-trips a southern-hemisphere point too', () => {
+    const lat = -33.8688;
+    const lng = 151.2093;
+    const back = unproject(...([project(lat, lng, 12).x, project(lat, lng, 12).y] as const), 12);
+    expect(back.lat).toBeCloseTo(lat, 6);
+    expect(back.lng).toBeCloseTo(lng, 6);
+  });
+});
+
+describe('clamping and wrapping', () => {
+  it('clamps latitude to the Mercator band', () => {
+    expect(clampLat(90)).toBe(MAX_MERCATOR_LAT);
+    expect(clampLat(-90)).toBe(-MAX_MERCATOR_LAT);
+    expect(clampLat(10)).toBe(10);
+  });
+
+  it('wraps longitude into [-180, 180)', () => {
+    expect(wrapLng(190)).toBeCloseTo(-170, 6);
+    expect(wrapLng(-190)).toBeCloseTo(170, 6);
+    expect(wrapLng(45)).toBeCloseTo(45, 6);
+  });
+
+  it('rounds and clamps zoom to the supported range', () => {
+    expect(clampZoom(15.4)).toBe(15);
+    expect(clampZoom(-5)).toBe(2);
+    expect(clampZoom(99)).toBe(19);
+  });
+});
+
+describe('offsetLatLng', () => {
+  it('returns the centre for a zero offset', () => {
+    const center = { lat: 40.7128, lng: -74.006 };
+    const same = offsetLatLng(center, 14, 0, 0);
+    expect(same.lat).toBeCloseTo(center.lat, 6);
+    expect(same.lng).toBeCloseTo(center.lng, 6);
+  });
+
+  it('moves north when dragged up (negative dy) and east for positive dx', () => {
+    const center = { lat: 0, lng: 0 };
+    const up = offsetLatLng(center, 14, 0, -50);
+    const right = offsetLatLng(center, 14, 50, 0);
+    expect(up.lat).toBeGreaterThan(0); // up the screen is north
+    expect(right.lng).toBeGreaterThan(0); // right is east
+  });
+});
+
+describe('tileGrid', () => {
+  it('covers the whole viewport with tiles', () => {
+    const tiles = tileGrid({ lat: 12.9716, lng: 77.5946 }, 15, 300, 200);
+    expect(tiles.length).toBeGreaterThan(0);
+    // Some tile must cover the top-left corner and some the bottom-right.
+    expect(tiles.some((tile) => tile.left <= 0 && tile.top <= 0)).toBe(true);
+    expect(tiles.some((tile) => tile.left + TILE_SIZE >= 300 && tile.top + TILE_SIZE >= 200)).toBe(
+      true,
+    );
+  });
+
+  it('keeps tile columns inside [0, 2^zoom)', () => {
+    const z = 3;
+    const n = 2 ** z;
+    const tiles = tileGrid({ lat: 0, lng: 179.9 }, z, 512, 256);
+    for (const tile of tiles) {
+      expect(tile.x).toBeGreaterThanOrEqual(0);
+      expect(tile.x).toBeLessThan(n);
+    }
+  });
+
+  it('returns nothing for an empty viewport', () => {
+    expect(tileGrid({ lat: 0, lng: 0 }, 12, 0, 0)).toEqual([]);
+  });
+});
+
+describe('tileUrl', () => {
+  it('fills the z/x/y template', () => {
+    expect(tileUrl(DEFAULT_TILE_URL, 3, 5, 15)).toBe('https://tile.openstreetmap.org/15/3/5.png');
+  });
+});


### PR DESCRIPTION
Four expense-screen requests, in priority order. The certain ones (#1, #2) are complete; the map (#3, #4) ships as a keyless fallback rather than the risky native path.

## 1. BUG — description not shown on the detail screen
**Root cause:** the typed description *is* rendered — but only as the hero title, and that heading is clamped to a single line (`numberOfLines={1}`) while the description field is explicitly `multiline` for "the longer notes a group expense sometimes carries." A long or multi-line note was therefore only half-shown up top and never readable in full anywhere. There is no separate notes field — `version.description` is the only text.

**Fix:** a **"Note"** row in the Details tab that renders the full, wrapping text whenever the hero could not have conveyed all of it (contains a line break, or is longer than one line fits). Short single-line descriptions stay conveyed by the title alone, so no redundant row.

## 2. Auto-capture location on add
A brand-new expense now stamps the device's current place automatically via a new `captureLocationIfGranted()` — which reads a fix **only when permission was already granted**, and **never prompts**. Opening the add form therefore never raises a system location dialog (honouring the deferred-permission stance `lib/location` is built around). It runs once, never on an edit, never over a location a capture / voice / draft / manual pin already carried, and never overrides a value set in the meantime. Denied / undetermined / no-module / no-GPS-lock all fall back silently to no location; saving is never blocked. The explicit "Add location" button remains the opt-in path that prompts.

## 3 + 4. See / pick / adjust the location on a map — inline on add, edit, and view
**Decision: keyless OpenStreetMap raster tiles, NOT `react-native-maps`.** An interactive native map needs a native module that (a) wants a Google Maps API key, and (b) needs a native rebuild that cannot be verified on this Expo SDK 57 / RN 0.86 pin without a device — exactly the RN-0.87-revert autolinking trap. Neither `react-native-maps` nor `react-native-webview` is in the project, so adding one is the flagged risky path. Per the brief it is **not forced**.

Instead the map is built entirely in JS from keyless OSM tiles:
- **`lib/mapTiles.ts`** — pure Web Mercator projection (project/unproject/tileGrid/offsetLatLng), no React Native import, **unit-tested** (`test/mapTiles.test.ts`, 12 cases: projection round-trips, tile coverage, column wrapping).
- **`MapPreview`** — read-only inline tile map with a centre pin; shown on **add/edit** (in `LocationField`) and **view** (augmenting the existing "open in Maps" card, which still works via `Linking`).
- **`LocationPickerSheet`** — a full-screen `Modal` map: **tap to move the pin**, **+/- zoom**, **"use my current location"**, and reverse-geocodes the chosen point to a name on confirm. Opened from `LocationField` ("Pick on map" / "Adjust on map") on both add and edit.

No new native module, no API key, no build risk; a blocked tile server degrades to an empty frame, never a crash. Attribution ("© OpenStreetMap") is shown as the tile licence requires.

### Native-config follow-up (non-blocking)
The OSM public tile server is keyless but its usage policy discourages heavy app traffic. The tile source is swappable via **`EXPO_PUBLIC_MAP_TILE_URL`** (defaults to OSM) so production can point at a self-hosted or keyed provider — a config step, not a code change. No API key is hardcoded anywhere.

## Files
- `lib/mapTiles.ts` (new, pure + tested), `test/mapTiles.test.ts` (new)
- `components/MapPreview.tsx` (new), `components/LocationPickerSheet.tsx` (new)
- `components/LocationField.tsx` — preview + picker wiring (shared by capture/voice/add-expense)
- `lib/location.ts` — `captureLocationIfGranted()`, `reverseGeocode()`
- `app/group/[id]/add-expense.tsx` — one-shot auto-capture
- `app/group/[id]/expense/[expenseId].tsx` — Note row + map in the location card
- `i18n/index.ts` — `expense.note` + 8 location keys, all four locales (en/ta/hi/ar)

## Gates (Windows node)
- `npx tsc --noEmit` — clean
- `pnpm format` + `pnpm lint` — green (admin/web/mobile)
- `pnpm test:app` — **38 files / 427 tests pass** (incl. 12 new mapTiles tests)
- No DB migration (A43 columns already exist)

## Not verifiable without a device
On-device GPS permission flow and the actual auto-capture; OSM tiles rendering / whether the public server rate-limits the app in practice; tap-to-move + reverse-geocode against live geocoding; the picker `Modal` presentation on Android. The projection math is covered by unit tests; everything degrades safely if a fix or a tile is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive map previews for expense locations.
  - Choose a location manually on a map, recenter it, zoom, or use the current location.
  - Automatically capture location for eligible new expenses when permission is already granted.
  - Long expense descriptions now appear in a dedicated Note section.
- **Improvements**
  - Location fields support viewing, editing, and confirming selected places.
  - Added English, Tamil, Hindi, and Arabic translations for location and note controls.
  - Map and location features gracefully handle unavailable tiles, permissions, and lookup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->