### PR TITLE
feat(voice): spoken digit-strings ("two oh five" → ₹205) + "plus" addition

### DIFF
--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -350,8 +350,9 @@ export function parseVoiceExpense(
   transcript: string,
   groups: readonly VoiceGroupRef[],
 ): ParsedVoiceExpense {
-  // Spoken numbers become digits first; every pattern below is digit-based.
-  const said = normalizeSpokenNumbers(normalizeDigits(transcript));
+  // Spoken numbers become digits first; every pattern below is digit-based. A
+  // "plus"-joined run of amounts is summed into one before that.
+  const said = normalizeSpokenNumbers(collapseAdditionRuns(normalizeDigits(transcript)));
   const tokens = tokenize(said);
   const amountMajor = extractAmount(said);
   const currency = detectCurrency(said);
@@ -522,8 +523,33 @@ const NUMBER_MULTIPLIERS: ReadonlyMap<string, { factor: number; group: boolean }
   ['billion', { factor: 1_000_000_000, group: true }],
 ]);
 
-/** Any single word that can appear inside a spoken number. */
-const NUMBER_WORD_RE = [...NUMBER_WORDS.keys(), ...NUMBER_MULTIPLIERS.keys()].join('|');
+/**
+ * Spoken zero-fillers a person says inside a digit-by-digit amount: "two oh
+ * five" (₹205), "two naught five". Speech-to-text often writes the spoken
+ * "naught" as "not", so that spelling is handled too — but only inside a run,
+ * never as a standalone word (see {@link spokenDigitSequence}); "not" is an
+ * ordinary negation and must never mint a number on its own. Kept apart from
+ * {@link NUMBER_WORDS} so the compositional adder never sums them as a value.
+ */
+const SPOKEN_ZERO: ReadonlyMap<string, number> = new Map([
+  ['naught', 0],
+  ['nought', 0],
+  ['oh', 0],
+  ['o', 0],
+]);
+
+/**
+ * Any single word that can appear inside a spoken number. The zero-fillers and
+ * "not" are included so a digit-by-digit run stays whole ("two oh five", "two
+ * not five") for the callback to read; the callback, not the regex, decides
+ * whether "not" is really a zero.
+ */
+const NUMBER_WORD_RE = [
+  ...NUMBER_WORDS.keys(),
+  ...NUMBER_MULTIPLIERS.keys(),
+  ...SPOKEN_ZERO.keys(),
+  'not',
+].join('|');
 
 /** A digit group inside a spoken run: "3", "3,000", "3.5". */
 const DIGIT_VALUE_RE = String.raw`\d[\d,]*(?:\.\d+)?`;
@@ -632,6 +658,12 @@ function spokenRunToNumber(run: string): number | null {
   for (const word of run.toLowerCase().split(/[\s-]+/)) {
     if (!word || word === 'and') continue;
 
+    // A stray zero-filler or a spoken-zero "not" that reached the compositional
+    // path (a run with a tens word or a multiplier, so it is not a pure digit
+    // string) is ignored rather than nulling the whole run — "not five hundred"
+    // still reads 500, as it did before "not" was allowed to hold a run together.
+    if (word === 'not' || SPOKEN_ZERO.has(word)) continue;
+
     if (word === 'point' || word === 'dot' || word === 'decimal') {
       // Close the whole-number part; everything after is fraction digits.
       total += current;
@@ -685,6 +717,55 @@ function spokenRunToNumber(run: string): number | null {
   return seen && value > 0 ? value : null;
 }
 
+/** A word that can be one digit of a spoken digit-string: a 0–9 word or a zero-filler. */
+function isSingleDigitWord(word: string): boolean {
+  const unit = NUMBER_WORDS.get(word);
+  if (unit !== undefined) return unit <= 9;
+  return SPOKEN_ZERO.has(word);
+}
+
+/**
+ * Read a run as a string of individual digits, the way an Indian-English speaker
+ * dictates an amount: "two oh five" → "205", "two five" → "25". This is the
+ * digit-sequence reading, distinct from the compositional arithmetic in
+ * {@link spokenRunToNumber} ("twenty five" → 25, "two hundred five" → 205).
+ *
+ * It applies only when every word is a single digit (0–9), a spoken zero ("oh",
+ * "naught"), or a "not" that speech-to-text wrote for a spoken zero. A tens word
+ * (twenty…ninety), a multiplier (hundred, lakh…), a decimal or a bare digit
+ * token all mean the run is compositional, so this returns null and the caller
+ * falls back to {@link spokenRunToNumber}.
+ *
+ * "not" is the dangerous one — an ordinary negation, not a number. It is read as
+ * a zero only when it sits *inside* the run, flanked on both sides by number
+ * words, and only when the run is money-adjacent (`moneyAdjacent`), so a plain
+ * "I did not pay 500" can never fold a phantom 0 into an amount.
+ */
+function spokenDigitSequence(words: readonly string[], moneyAdjacent: boolean): string | null {
+  let digits = '';
+  for (let i = 0; i < words.length; i += 1) {
+    const word = words[i];
+    const unit = NUMBER_WORDS.get(word);
+    if (unit !== undefined) {
+      if (unit > 9) return null; // a tens/teens word — this run is compositional
+      digits += String(unit);
+      continue;
+    }
+    if (SPOKEN_ZERO.has(word)) {
+      digits += '0';
+      continue;
+    }
+    if (word === 'not') {
+      const flanked = digits.length > 0 && i + 1 < words.length && isSingleDigitWord(words[i + 1]);
+      if (!flanked || !moneyAdjacent) return null;
+      digits += '0';
+      continue;
+    }
+    return null; // a digit token, multiplier or decimal word — not a pure digit run
+  }
+  return digits.length > 0 ? digits : null;
+}
+
 /**
  * Rewrite spoken numbers as digits, so the digit-based patterns above see them.
  *
@@ -729,12 +810,129 @@ export function normalizeSpokenNumbers(text: string): string {
     if (!hasMultiplier && !nextIsCurrency && !prevIsCurrency && !splitContext && !nextIsMinor) {
       return run;
     }
+    // A money-adjacent run of only single digits ("two oh five", "two not five")
+    // is a digit-string an Indian-English speaker spelled out — read it as the
+    // concatenated digits, not the sum {@link spokenRunToNumber} would give.
+    // "not" is treated as a spoken zero only against currency, never a split count.
+    const moneyForNot = nextIsCurrency || prevIsCurrency || nextIsMinor;
+    const digitSeq = spokenDigitSequence(words, moneyForNot);
+    if (digitSeq !== null) return digitSeq;
     const value = spokenRunToNumber(run);
     return value === null ? run : String(value);
   });
   // Now that both parts are digits, fold a spoken minor amount ("… 50 paise")
   // into the major one.
   return foldMinorUnits(digitised);
+}
+
+/** A minor-unit word, for reading "… fifty paise" as part of an addition term. */
+const MINOR_UNIT_WORD_RE = '(?:paise|paisa|cents?|pence|fils)';
+
+/**
+ * One amount in an addition run: a spoken/written number (with an optional
+ * decimal tail), an optional currency word, and an optional spoken minor tail
+ * ("five rupees fifty paise"). Deliberately stops at description words, so a
+ * term is only ever an amount — "for tea" is never swallowed.
+ */
+const ADDITION_TERM_RE =
+  `${NUMBER_VALUE_RE}(?:[\\s-]+(?:and[\\s-]+)?${NUMBER_VALUE_RE})*${DECIMAL_TAIL_RE}?` +
+  `(?:[\\s-]+(?:${CURRENCY_WORD_ALT})\\b)?` +
+  `(?:[\\s-]+(?:and[\\s-]+)?${NUMBER_VALUE_RE}[\\s-]+${MINOR_UNIT_WORD_RE}\\b)?`;
+
+/** The explicit "add these up" signal between two amounts: the word "plus" or a "+". */
+const ADDITION_CONNECTIVE_RE = String.raw`\s*(?:\bplus\b|\+)\s*`;
+
+/**
+ * A run of amounts to sum into one: a first amount, one or more "plus"/"+"-joined
+ * amounts, then any number of comma-continued *bare* amounts. The comma tail only
+ * extends the sum while each piece is a bare amount followed by another comma, a
+ * "plus", or the end — a comma piece that carries a description ("… , 10 for tea")
+ * is left for the ordinary multi-expense split, so distinct items stay distinct.
+ */
+const ADDITION_RUN_RE = new RegExp(
+  `\\b(?:${ADDITION_TERM_RE})(?:${ADDITION_CONNECTIVE_RE}(?:${ADDITION_TERM_RE}))+` +
+    `(?:\\s*,\\s*(?:${ADDITION_TERM_RE})(?=\\s*(?:,|\\+|\\bplus\\b|$)))*`,
+  'gi',
+);
+
+/** Split an addition run into its terms, on "plus"/"+" or a comma. */
+const ADDITION_SPLIT_RE = /\s*(?:\bplus\b|\+)\s*|\s*,\s*/i;
+
+/** Any currency symbol or word — to find a run's primary currency and re-emit it. */
+const CURRENCY_ANY_RE = new RegExp(
+  `[${CURRENCY_SYMBOL_CLASS}]|\\b(?:${CURRENCY_WORD_ALT})\\b`,
+  'i',
+);
+
+/** A minor-unit total back to a major string, exact for the currency's own scale. */
+function minorToMajorString(minor: bigint, scale: number): string {
+  if (scale <= 1) return minor.toString();
+  const scaleBig = BigInt(Math.round(scale));
+  const whole = minor / scaleBig;
+  const rem = minor % scaleBig;
+  if (rem === 0n) return whole.toString();
+  const fracDigits = String(scale).length - 1;
+  return `${whole}.${rem.toString().padStart(fracDigits, '0')}`;
+}
+
+/**
+ * Add up one "plus"-joined run into a single amount, or null to leave it be.
+ *
+ * The sum is done in minor units, currency-aware (so JPY is not inflated and a
+ * paise/cents tail lands in the right place), to avoid float drift. A run's
+ * primary currency is the first one it names; every term is read in that
+ * currency, and a term that carries a *different* currency makes the whole run
+ * bail (no cross-currency conversion is invented) — the sentence then keeps its
+ * existing, well-tested multi-expense behaviour. The primary currency word is
+ * re-emitted so downstream currency detection still reads it.
+ */
+function sumAdditionRun(run: string): string | null {
+  const terms = run
+    .split(ADDITION_SPLIT_RE)
+    .map((term) => term.trim())
+    .filter(Boolean);
+  if (terms.length < 2) return null;
+
+  let primaryText: string | null = null;
+  for (const term of terms) {
+    const match = term.match(CURRENCY_ANY_RE);
+    if (match) {
+      primaryText = match[0];
+      break;
+    }
+  }
+  const primaryCode = primaryText ? detectCurrency(primaryText) : null;
+
+  let totalMinor = 0n;
+  for (const term of terms) {
+    // A term that names its own currency must match the run's; a differing one
+    // means this is not a single-currency sum, so leave the run untouched.
+    const ownCode = detectCurrency(term);
+    if (ownCode && primaryCode && ownCode !== primaryCode) return null;
+    // A bare term ("sixty") is read in the run's currency, so its decimals and
+    // minor units scale the same as the terms that named one.
+    const hasOwnCurrency = CURRENCY_ANY_RE.test(term);
+    const forNorm = hasOwnCurrency || !primaryText ? term : `${term} ${primaryText}`;
+    const major = extractAmount(normalizeSpokenNumbers(forNorm));
+    if (major === null) return null;
+    totalMinor += toMinorUnits(major, primaryCode);
+  }
+
+  const scale =
+    primaryCode && isCurrencyCode(primaryCode) ? Number(minorUnitScale(primaryCode)) : 100;
+  const major = minorToMajorString(totalMinor, scale);
+  return primaryText ? `${major} ${primaryText}` : major;
+}
+
+/**
+ * Collapse every "plus"/"+"-joined run of amounts into one summed amount, so a
+ * dictated "twenty rupees plus fifty rupees plus five rupees" becomes one
+ * ₹75 expense rather than three. Runs with no "plus" are untouched, so ordinary
+ * comma/"and"-separated items ("5 for snacks, 10 for tea") stay separate
+ * expenses, and the compositional "and" ("five hundred and fifty") is unaffected.
+ */
+export function collapseAdditionRuns(text: string): string {
+  return text.replace(ADDITION_RUN_RE, (match) => sumAdditionRun(match) ?? match);
 }
 
 /**
@@ -831,7 +1029,7 @@ export function parseVoiceExpenses(
   transcript: string,
   groups: readonly VoiceGroupRef[],
 ): VoiceParseResult {
-  const normalized = normalizeSpokenNumbers(normalizeDigits(transcript));
+  const normalized = normalizeSpokenNumbers(collapseAdditionRuns(normalizeDigits(transcript)));
   const created = detectCreateGroup(normalized);
   const body = created ? created.rest : normalized;
 

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -331,6 +331,99 @@ describe('parseVoiceExpenses (several in one breath)', () => {
   });
 });
 
+// An Indian-English speaker often dictates an amount digit-by-digit, and speech-
+// to-text renders the spoken zero as "oh"/"naught"/"nought" — and, mangled, as
+// "not". "two oh five rupees" means ₹205, not 2 + 0 + 5.
+describe('a spoken digit-by-digit amount', () => {
+  it('reads "two oh five rupees" as 205', () => {
+    const parsed = parseVoiceExpense('two oh five rupees', groups);
+    expect(parsed.amountMajor).toBe(205);
+    expect(parsed.currency).toBe('INR');
+    // Still scales to minor units the currency-aware way.
+    expect(parsed.amountMinor).toBe(20500n);
+  });
+
+  it('reads "naught" and "nought" as the spoken zero', () => {
+    expect(parseVoiceExpense('two naught five rupees', groups).amountMajor).toBe(205);
+    expect(parseVoiceExpense('two nought five rupees', groups).amountMajor).toBe(205);
+  });
+
+  it('reads a "not" the STT wrote for a spoken zero, inside a money run', () => {
+    expect(parseVoiceExpense('two not five rupees', groups).amountMajor).toBe(205);
+  });
+
+  it('reads a bare two-digit spelling as concatenated digits', () => {
+    // A pure single-digit run has no tens word, so "two five" is 25 by digits.
+    expect(parseVoiceExpense('two five rupees', groups).amountMajor).toBe(25);
+    expect(parseVoiceExpense('one two three four rupees', groups).amountMajor).toBe(1234);
+  });
+
+  it('keeps the compositional readings unchanged', () => {
+    // A tens word or a multiplier means arithmetic, not a digit string.
+    expect(parseVoiceExpense('twenty five rupees', groups).amountMajor).toBe(25);
+    expect(parseVoiceExpense('two hundred five rupees', groups).amountMajor).toBe(205);
+    expect(parseVoiceExpense('five hundred rupees', groups).amountMajor).toBe(500);
+    expect(parseVoiceExpense('two rupees', groups).amountMajor).toBe(2);
+  });
+
+  // "not" is an ordinary negation; it must never become a number on its own.
+  it('never turns a plain negation into an amount', () => {
+    // The real amount (500) still comes through, and no phantom 0 is folded in.
+    expect(parseVoiceExpense('i did not pay five hundred rupees', groups).amountMajor).toBe(500);
+    // A standalone "not" beside money does not merge with the amount.
+    expect(parseVoiceExpense('not sure, dinner 200 rupees', groups).amountMajor).toBe(200);
+    // No number at all stays null.
+    expect(parseVoiceExpense('i did not pay for this', groups).amountMajor).toBeNull();
+  });
+});
+
+// Amounts chained with "plus" (or "+") are one expense whose amount is the sum,
+// not several expenses. A comma continues an already-started plus run of bare
+// amounts.
+describe('spoken addition ("plus")', () => {
+  it('sums a plus-joined run into one expense', () => {
+    const result = parseVoiceExpenses('twenty rupees plus fifty rupees plus five rupees', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(75);
+    expect(result.items[0].currency).toBe('INR');
+  });
+
+  it('lets a comma continue the plus run', () => {
+    const result = parseVoiceExpenses(
+      'twenty rupees plus fifty rupees plus five rupees, sixty, seventy',
+      groups,
+    );
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(205);
+  });
+
+  it('sums decimals and minor units to the right total', () => {
+    const result = parseVoiceExpenses('ten rupees plus five rupees fifty paise', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(15.5);
+    expect(result.items[0].amountMinor).toBe(1550n);
+  });
+
+  it('reads the "+" symbol form', () => {
+    expect(parseVoiceExpense('20 + 50 + 5', groups).amountMajor).toBe(75);
+  });
+
+  it('composes with the digit-sequence reading', () => {
+    const result = parseVoiceExpenses('two oh five plus twenty rupees', groups);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].amountMajor).toBe(225);
+  });
+
+  it('does NOT sum plain comma-separated items with their own descriptions', () => {
+    const result = parseVoiceExpenses('5 rupees for snacks, 10 for tea', groups);
+    expect(result.items.map((item) => item.amountMajor)).toEqual([5, 10]);
+  });
+
+  it('does NOT read the compositional "and" as an addition', () => {
+    expect(parseVoiceExpense('five hundred and fifty rupees', groups).amountMajor).toBe(550);
+  });
+});
+
 describe('detectCreateGroup', () => {
   it('lifts the name and returns the rest', () => {
     expect(detectCreateGroup('create a group named Goa Trip and add 100')).toEqual({


### PR DESCRIPTION
## What

Two fixes to the on-device voice-expense parser (`apps/mobile/src/lib/voiceExpense.ts`). Both are pure (no react-native imports — the module stays test-importable) and fully covered by the vitest suite.

### 1. Digit-by-digit spoken amounts (the reported bug)

A user reported that dictating **"two not five rupees"** does not pick up the amount. An Indian-English speaker dictates an amount digit-by-digit — "two-oh-five" = ₹205 — and speech-to-text renders the spoken zero as **"oh" / "naught" / "nought"**, and, mangled, as **"not"**.

Rule added:
- **Zero aliases** `oh`, `o`, `naught`, `nought` → `0`, usable inside a spoken number run.
- **Digit-sequence reading**: a money-adjacent run composed only of single-digit values (0–9, **no** tens word, **no** multiplier, **no** decimal) is read as **concatenated digits** — "two oh five" → `205`, "two five" → `25` — instead of the sum. Runs with a tens word or multiplier keep the existing compositional arithmetic: "twenty five" → `25`, "two hundred five" → `205`, "five hundred" → `500`.
- **"not" is scoped**: it is read as a spoken zero **only** when it sits inside a digit-sequence run, flanked on both sides by number-words, **and** the run is money-adjacent (against a currency word/symbol). It is never mapped to `0` globally. Proven by negative tests: `"i did not pay five hundred rupees"` still reads **500**, `"not sure, dinner 200 rupees"` reads **200**, `"i did not pay for this"` stays null.

### 2. Spoken addition — sum "plus"-joined amounts into one expense

Amounts chained with **"plus"** (or **"+"**) collapse into a single summed expense rather than several:
- `"twenty rupees plus fifty rupees plus five rupees"` → one **₹75** item.
- A **comma continues** an already-started plus run of bare amounts: `"… plus five rupees, sixty, seventy"` → **205**.
- Summed **in minor units, currency-aware** (paise/cents tails and JPY-style scales land correctly), so no float drift.
- **Mixed currencies bail** to the existing behaviour (no cross-currency conversion invented).
- Composes with the digit-sequence fix: `"two oh five plus twenty rupees"` → **225**.

The existing multi-expense behaviour is untouched: plain comma/"and"-separated items with their own descriptions stay separate (`"5 rupees for snacks, 10 for tea"` → two items), and the compositional "and" (`"five hundred and fifty"`) is unaffected.

## How it's detected

- **Digit sequence**: in `normalizeSpokenNumbers`, once a run has passed the existing conservative money-adjacency gate, `spokenDigitSequence()` reads it as concatenated digits when every word is a single digit / zero-filler / (scoped) "not"; otherwise it falls back to the compositional `spokenRunToNumber()`.
- **Addition run**: a new `collapseAdditionRuns()` runs before `normalizeSpokenNumbers` in both `parseVoiceExpense` and `parseVoiceExpenses`. `ADDITION_RUN_RE` matches `term (plus|+ term)+ (, bare-term)*`; each term is summed via the existing normalize → `extractAmount` → `toMinorUnits` path in the run's primary currency, then re-emitted as one amount. A run with no "plus" is left completely untouched.

## Residual ambiguity (deliberate)

- A pure single-digit spoken run like **"two five rupees"** resolves to **25** (digit-sequence reading), matching how digit-by-digit dictation works; it is not summed to 7.
- In a "plus" run, a **mixed-currency** chain does not convert — it falls back to the existing multi-expense split rather than guessing an exchange rate.

## Tests

Added under `apps/mobile/test/voiceExpense.test.ts` (digit-sequence + negation cases, and a `spoken addition ("plus")` block). Gate results (Windows node):

- `test/voiceExpense.test.ts` — **85 passed** (existing + new)
- `pnpm test:app` (whole mobile vitest) — **428 passed (37 files)**
- `apps/mobile` `npx tsc --noEmit` — clean
- repo-root `pnpm format` + `pnpm lint` — green
- `scripts/check-filenames.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Voice expense entry now recognizes zero-fillers such as “oh,” “naught,” “nought,” and context-sensitive “not” in spoken amounts.
  - Supports digit-by-digit money amounts, including decimals and minor currency units.
  - Combines amounts connected with “plus” or “+” into a single total.
  - Rejects addition across different currencies.

- **Bug Fixes**
  - Preserves ordinary negation and comma-separated expenses as separate entries.
  - Improves handling of compositional number phrases and continued amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->