### PR TITLE
fix(map): CARTO keyless tiles + identifying User-Agent (OSM blocked app traffic)

### DIFF
--- a/apps/mobile/src/components/LocationPickerSheet.tsx
+++ b/apps/mobile/src/components/LocationPickerSheet.tsx
@@ -35,6 +35,8 @@ import {
   DEFAULT_ZOOM,
   type LatLng,
   offsetLatLng,
+  TILE_ATTRIBUTION,
+  TILE_HEADERS,
   TILE_SIZE,
   tileGrid,
   tileUrl,
@@ -185,7 +187,7 @@ export function LocationPickerSheet({
             {tiles.map((tile) => (
               <Image
                 key={`${tile.x}-${tile.y}-${tile.left}`}
-                source={{ uri: tileUrl(TILE_URL, tile.x, tile.y, zoom) }}
+                source={{ uri: tileUrl(TILE_URL, tile.x, tile.y, zoom), headers: TILE_HEADERS }}
                 style={{
                   position: 'absolute',
                   left: tile.left,
@@ -256,7 +258,7 @@ export function LocationPickerSheet({
             ))}
           </View>
 
-          {/* Attribution — required by the OpenStreetMap tile licence. */}
+          {/* Attribution — required by the tile licence (OSM data, CARTO tiles). */}
           <View
             pointerEvents="none"
             style={{
@@ -270,7 +272,7 @@ export function LocationPickerSheet({
             }}
           >
             <Text variant="micro" style={{ color: '#333', fontSize: 9 }}>
-              © OpenStreetMap
+              {TILE_ATTRIBUTION}
             </Text>
           </View>
         </View>

--- a/apps/mobile/src/components/MapPreview.tsx
+++ b/apps/mobile/src/components/MapPreview.tsx
@@ -8,9 +8,10 @@
  * the images simply do not appear and the neutral map-coloured background shows
  * through, so a blocked network degrades to an empty frame, never a crash.
  *
- * The tile source is `EXPO_PUBLIC_MAP_TILE_URL` when set, else OpenStreetMap's
- * public tiles (keyless, attributed below). A production build under real load
- * should point that at a self-hosted or keyed provider.
+ * The tile source is `EXPO_PUBLIC_MAP_TILE_URL` when set, else CARTO's keyless
+ * basemap (attributed below) — not OSM's public server, which refuses app
+ * traffic. A production build under real load should point that at a
+ * self-hosted or keyed provider.
  */
 
 import { useState } from 'react';
@@ -21,7 +22,15 @@ import { type LayoutChangeEvent, Pressable, View } from 'react-native';
 import type { ExpenseLocation } from '@waves/core';
 import { iconSize, Text, useTheme } from '@waves/ui';
 
-import { DEFAULT_TILE_URL, DEFAULT_ZOOM, TILE_SIZE, tileGrid, tileUrl } from '@/lib/mapTiles';
+import {
+  DEFAULT_TILE_URL,
+  DEFAULT_ZOOM,
+  TILE_ATTRIBUTION,
+  TILE_HEADERS,
+  TILE_SIZE,
+  tileGrid,
+  tileUrl,
+} from '@/lib/mapTiles';
 
 const TILE_URL = process.env.EXPO_PUBLIC_MAP_TILE_URL || DEFAULT_TILE_URL;
 
@@ -62,7 +71,7 @@ export function MapPreview({
       {tiles.map((tile) => (
         <Image
           key={`${tile.x}-${tile.y}-${tile.left}`}
-          source={{ uri: tileUrl(TILE_URL, tile.x, tile.y, zoom) }}
+          source={{ uri: tileUrl(TILE_URL, tile.x, tile.y, zoom), headers: TILE_HEADERS }}
           style={{
             position: 'absolute',
             left: tile.left,
@@ -99,8 +108,8 @@ export function MapPreview({
         />
       </View>
 
-      {/* Attribution — required by the OpenStreetMap tile licence. Not translated:
-          it is a fixed credit, like a copyright line. */}
+      {/* Attribution — required by the tile licence (OSM data, CARTO tiles).
+          Not translated: it is a fixed credit, like a copyright line. */}
       <View
         pointerEvents="none"
         style={{
@@ -114,7 +123,7 @@ export function MapPreview({
         }}
       >
         <Text variant="micro" style={{ color: '#333', fontSize: 9 }}>
-          © OpenStreetMap
+          {TILE_ATTRIBUTION}
         </Text>
       </View>
     </View>

--- a/apps/mobile/src/lib/mapTiles.ts
+++ b/apps/mobile/src/lib/mapTiles.ts
@@ -9,18 +9,41 @@
  * (no React Native, no network) so the projection round-trips can be tested,
  * and so importing it never drags React Native into the vitest graph.
  *
- * The tile source is swappable: {@link tileUrl} takes a URL template, defaulting
- * to OpenStreetMap's public tiles. That server is keyless but its usage policy
- * discourages heavy app traffic, so a production build should point
- * `EXPO_PUBLIC_MAP_TILE_URL` at a self-hosted or keyed provider — a config step,
- * not a code change.
+ * The tile source is swappable: {@link tileUrl} takes a URL template. The
+ * default is CARTO's keyless raster basemap, which — unlike OpenStreetMap's
+ * public tile server — permits use inside an app without prior arrangement.
+ * OSM's own tiles (tile.openstreetmap.org) are explicitly NOT for apps: its
+ * usage policy bans bulk/app traffic and blocks callers that do not send an
+ * identifying User-Agent, which surfaced in the app as "access blocked — not
+ * following the tile usage policy of OpenStreetMap". CARTO's CDN avoids that.
+ * A production build with real volume should still point
+ * `EXPO_PUBLIC_MAP_TILE_URL` at a self-hosted or keyed provider — a config
+ * step, not a code change — and {@link TILE_HEADERS} is sent on every request
+ * so whichever provider is configured sees a real, identifying User-Agent.
  */
 
 /** Every raster tile is 256×256 device-independent pixels. */
 export const TILE_SIZE = 256;
 
-/** OpenStreetMap's public tiles: keyless, attributed "© OpenStreetMap". */
-export const DEFAULT_TILE_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+/**
+ * CARTO's keyless "positron" (light) basemap: a CDN that tolerates app traffic,
+ * built from OpenStreetMap data. Keep {@link TILE_ATTRIBUTION} shown alongside.
+ */
+export const DEFAULT_TILE_URL = 'https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
+
+/** Credit required by the tile licence: OSM for the data, CARTO for the tiles. */
+export const TILE_ATTRIBUTION = '© OpenStreetMap © CARTO';
+
+/**
+ * Headers sent with every tile request. A real, identifying User-Agent is
+ * required by OpenStreetMap's tile policy and is good citizenship with any
+ * provider — the default `okhttp`/blank UA a bare `<Image>` sends is exactly
+ * what OSM's server refuses. Referenced by both map surfaces so the two never
+ * drift.
+ */
+export const TILE_HEADERS: Record<string, string> = {
+  'User-Agent': 'WavesApp/1.0 (+https://waves.app; expense location map)',
+};
 
 /** The latitudes Web Mercator can represent; beyond this the projection blows up. */
 export const MAX_MERCATOR_LAT = 85.05112878;

--- a/apps/mobile/src/lib/mapTiles.ts
+++ b/apps/mobile/src/lib/mapTiles.ts
@@ -9,30 +9,52 @@
  * (no React Native, no network) so the projection round-trips can be tested,
  * and so importing it never drags React Native into the vitest graph.
  *
- * The tile source is swappable: {@link tileUrl} takes a URL template. The
- * default is CARTO's keyless raster basemap, which — unlike OpenStreetMap's
- * public tile server — permits use inside an app without prior arrangement.
- * OSM's own tiles (tile.openstreetmap.org) are explicitly NOT for apps: its
- * usage policy bans bulk/app traffic and blocks callers that do not send an
- * identifying User-Agent, which surfaced in the app as "access blocked — not
- * following the tile usage policy of OpenStreetMap". CARTO's CDN avoids that.
- * A production build with real volume should still point
- * `EXPO_PUBLIC_MAP_TILE_URL` at a self-hosted or keyed provider — a config
- * step, not a code change — and {@link TILE_HEADERS} is sent on every request
- * so whichever provider is configured sees a real, identifying User-Agent.
+ * The tile source is swappable: {@link tileUrl} takes a URL template, and both
+ * the URL ({@link DEFAULT_TILE_URL}) and its credit ({@link TILE_ATTRIBUTION})
+ * can be overridden from the environment so a deployment can point at its own
+ * provider without a code change.
+ *
+ * On the defaults, and why neither built-in is a production tile source:
+ *   - OpenStreetMap's public server (tile.openstreetmap.org) *does* permit
+ *     normal interactive app viewing, but only under strict conditions: a
+ *     stable, identifying `User-Agent` (library-default UAs like okhttp are
+ *     blocked — that is the "access blocked, not following the tile usage
+ *     policy" we hit), fetching just the current viewport, honouring cache
+ *     headers, and no bulk/offline pre-fetching. It is community infrastructure,
+ *     not a hosting service.
+ *   - CARTO's `basemaps.cartocdn.com` is used here as the built-in default
+ *     because it tolerates this kind of light interactive traffic keylessly,
+ *     but CARTO's terms expect a plan for production/commercial use — an
+ *     unkeyed endpoint may start returning a watermarked or refused tile.
+ *
+ * So both built-ins are development conveniences. A production build MUST point
+ * `EXPO_PUBLIC_MAP_TILE_URL` at a keyed or self-hosted provider (and set
+ * `EXPO_PUBLIC_MAP_TILE_ATTRIBUTION` to that provider's required credit).
+ * {@link TILE_HEADERS} sends a real, identifying User-Agent to whichever
+ * provider is configured, satisfying OSM-style policies either way.
  */
 
 /** Every raster tile is 256×256 device-independent pixels. */
 export const TILE_SIZE = 256;
 
 /**
- * CARTO's keyless "positron" (light) basemap: a CDN that tolerates app traffic,
- * built from OpenStreetMap data. Keep {@link TILE_ATTRIBUTION} shown alongside.
+ * The built-in tile URL template: CARTO's keyless "positron" (light) basemap, a
+ * CDN that tolerates light interactive traffic, built from OpenStreetMap data.
+ * A development default only — override with `EXPO_PUBLIC_MAP_TILE_URL` for
+ * production (see the file header). Keep {@link TILE_ATTRIBUTION} shown alongside.
  */
-export const DEFAULT_TILE_URL = 'https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
+export const DEFAULT_TILE_URL =
+  process.env.EXPO_PUBLIC_MAP_TILE_URL || 'https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
 
-/** Credit required by the tile licence: OSM for the data, CARTO for the tiles. */
-export const TILE_ATTRIBUTION = '© OpenStreetMap © CARTO';
+/**
+ * The credit shown over the map. It follows the tile URL: when a deployment
+ * overrides `EXPO_PUBLIC_MAP_TILE_URL` it should also set
+ * `EXPO_PUBLIC_MAP_TILE_ATTRIBUTION` to that provider's required credit, so the
+ * attribution can never be wrong for the tiles actually being served. The
+ * default credits OSM (the data) and CARTO (the default tiles).
+ */
+export const TILE_ATTRIBUTION =
+  process.env.EXPO_PUBLIC_MAP_TILE_ATTRIBUTION || '© OpenStreetMap © CARTO';
 
 /**
  * Headers sent with every tile request. A real, identifying User-Agent is

--- a/apps/mobile/test/mapTiles.test.ts
+++ b/apps/mobile/test/mapTiles.test.ts
@@ -18,6 +18,7 @@ import {
   project,
   tileGrid,
   tileUrl,
+  TILE_ATTRIBUTION,
   TILE_SIZE,
   unproject,
   wrapLng,
@@ -124,12 +125,20 @@ describe('tileUrl', () => {
     );
   });
 
-  it('defaults to a keyless CARTO basemap, not OSM public tiles (app policy)', () => {
-    // OSM's public server refuses app traffic; the default must not point there.
+  it('defaults to the keyless CARTO basemap when no override is set', () => {
+    // A development default; production sets EXPO_PUBLIC_MAP_TILE_URL. With no
+    // override in the test env it must resolve to the CARTO template.
     expect(DEFAULT_TILE_URL).toContain('basemaps.cartocdn.com');
     expect(DEFAULT_TILE_URL).not.toContain('tile.openstreetmap.org');
     expect(tileUrl(DEFAULT_TILE_URL, 3, 5, 15)).toBe(
       'https://basemaps.cartocdn.com/light_all/15/3/5.png',
     );
+  });
+
+  it('credits OSM data + CARTO tiles by default, and the credit is env-overridable', () => {
+    // The attribution follows the tile URL so it can never be wrong for the
+    // tiles actually served (EXPO_PUBLIC_MAP_TILE_ATTRIBUTION overrides it).
+    expect(TILE_ATTRIBUTION).toContain('OpenStreetMap');
+    expect(TILE_ATTRIBUTION).toContain('CARTO');
   });
 });

--- a/apps/mobile/test/mapTiles.test.ts
+++ b/apps/mobile/test/mapTiles.test.ts
@@ -117,6 +117,19 @@ describe('tileGrid', () => {
 
 describe('tileUrl', () => {
   it('fills the z/x/y template', () => {
-    expect(tileUrl(DEFAULT_TILE_URL, 3, 5, 15)).toBe('https://tile.openstreetmap.org/15/3/5.png');
+    // A literal template, not DEFAULT_TILE_URL: this test is about the
+    // substitution, not about which provider the default happens to be.
+    expect(tileUrl('https://tiles.example/{z}/{x}/{y}.png', 3, 5, 15)).toBe(
+      'https://tiles.example/15/3/5.png',
+    );
+  });
+
+  it('defaults to a keyless CARTO basemap, not OSM public tiles (app policy)', () => {
+    // OSM's public server refuses app traffic; the default must not point there.
+    expect(DEFAULT_TILE_URL).toContain('basemaps.cartocdn.com');
+    expect(DEFAULT_TILE_URL).not.toContain('tile.openstreetmap.org');
+    expect(tileUrl(DEFAULT_TILE_URL, 3, 5, 15)).toBe(
+      'https://basemaps.cartocdn.com/light_all/15/3/5.png',
+    );
   });
 });


### PR DESCRIPTION
The expense-location map (add/edit/view + picker) defaulted to `tile.openstreetmap.org` and sent no `User-Agent`, so OSM's tile server refused the requests: **"access blocked — app is not following the tile usage policy of OpenStreetMap."** OSM's public tiles are explicitly not for app use, and they block callers with a blank/`okhttp` UA.

## Fix
- **`DEFAULT_TILE_URL`** → CARTO's keyless `light_all` basemap (`basemaps.cartocdn.com`), a CDN that tolerates app traffic, built from OSM data. Still overridable via `EXPO_PUBLIC_MAP_TILE_URL`.
- **`TILE_HEADERS`** — a real, identifying `User-Agent`, sent on every tile `Image` request from both `MapPreview` and `LocationPickerSheet`.
- **Attribution** corrected to `© OpenStreetMap © CARTO` via a shared `TILE_ATTRIBUTION`.
- `mapTiles` test decoupled from the default provider + pins the new default.

## Notes
- Pure JS — no native change, no new dependency (`react-native-maps` still deliberately avoided).
- For real production volume, point `EXPO_PUBLIC_MAP_TILE_URL` at a self-hosted/keyed provider — the UA header goes to whatever provider is configured.

## Gates
- `apps/mobile` tsc clean, `mapTiles` test 13 pass, format + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated mobile map previews and location pickers to use CARTO’s keyless light basemap.
  * Added required map attribution for OpenStreetMap and CARTO.
  * Improved tile requests with identifying request information.
  * Preserved support for configurable map tile providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->