### PR TITLE
fix(contacts): tapping the search row focuses the field

### DIFF
--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -318,8 +318,12 @@ export function ContactPicker({
     <View style={{ gap: theme.spacing.md, flex: 1 }}>
       <Pressable
         onPress={() => searchRef.current?.focus()}
-        accessibilityRole="search"
-        accessibilityLabel={t.pickers.searchContacts}
+        // Purely a tap target that forwards focus to the field. Kept out of the
+        // accessibility tree (accessible={false}, no role/label) so it can't
+        // absorb the TextInput and clear button under it — on iOS VoiceOver an
+        // accessible wrapper groups its descendants and they stop being reachable
+        // on their own. The role lives on the TextInput instead.
+        accessible={false}
         style={{
           flexDirection: 'row',
           alignItems: 'center',
@@ -336,6 +340,7 @@ export function ContactPicker({
           value={query}
           onChangeText={setQuery}
           autoCapitalize="none"
+          accessibilityRole="search"
           accessibilityLabel={t.pickers.searchContacts}
           // The phone's own contacts app puts the count here rather than the
           // word "search", and it answers the first question somebody has when

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -240,6 +240,10 @@ export function ContactPicker({
   }, [matches]);
 
   const listRef = useRef<FlashListRef<Entry>>(null);
+  // Tapping the search row (the magnifier or its padding, not just the input's
+  // own text) should put the caret in the field — a bare Ionicons is inert, so
+  // the icon looked tappable but did nothing.
+  const searchRef = useRef<TextInput>(null);
 
   /**
    * Back to the top whenever the search changes. Without this the list keeps
@@ -312,7 +316,10 @@ export function ContactPicker({
 
   return (
     <View style={{ gap: theme.spacing.md, flex: 1 }}>
-      <View
+      <Pressable
+        onPress={() => searchRef.current?.focus()}
+        accessibilityRole="search"
+        accessibilityLabel={t.pickers.searchContacts}
         style={{
           flexDirection: 'row',
           alignItems: 'center',
@@ -325,6 +332,7 @@ export function ContactPicker({
       >
         <Ionicons name="search" size={iconSize.md} color={theme.color.textFaint} />
         <TextInput
+          ref={searchRef}
           value={query}
           onChangeText={setQuery}
           autoCapitalize="none"
@@ -346,7 +354,7 @@ export function ContactPicker({
             <Ionicons name="close-circle" size={iconSize.md} color={theme.color.textFaint} />
           </Pressable>
         ) : null}
-      </View>
+      </Pressable>
 
       {!single && chosen.length > 0 ? <PickedStrip chosen={chosen} onRemove={toggle} /> : null}
 


### PR DESCRIPTION
The magnifier icon in the contact search bar was a bare, inert `Ionicons` — it (and the padding around the input) looked tappable but did nothing, so tapping it never moved focus into the field. Reported as misleading.

## Fix
- Wrapped the search row in a `Pressable` whose `onPress` focuses the `TextInput` via a ref.
- `accessibilityRole="search"` on the row.
- The input still focuses on a direct tap; the clear (×) button still works (nested Pressable).

## Gates
- `apps/mobile` tsc clean, format + lint green. Pure JS, no native change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved contact search interaction by allowing taps on the search area, icon, and surrounding padding to focus the input.
  * Added search-related accessibility metadata to the contact picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->