### PR TITLE
Harden admin console: trusted-origin secret, login throttle, CSRF/Origin on mutations

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -15,3 +15,13 @@ ADMIN_PASSWORD=
 # out. Generate one with:
 #   node -e "console.log(crypto.randomUUID() + crypto.randomUUID())"
 ADMIN_SESSION_SECRET=
+
+# The shared secret Cloudflare Access injects as the x-admin-origin-secret
+# header; src/proxy.ts requires it. In production, if unset the proxy refuses
+# every request (fail-closed). Generate a long random value; keep it identical
+# to the Cloudflare Transform Rule that sets the header.
+ADMIN_ORIGIN_SECRET=
+
+# Optional. Pins the origin the CSRF check compares against, e.g.
+# https://baaki.dmadan.com. Leave blank to derive it from the request Host.
+ADMIN_ALLOWED_ORIGIN=

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -68,9 +68,23 @@ because most of it is not obvious from the app's own config.
 3. **`.vercelignore` at the repo root is load-bearing.** Without it the upload
    includes `node_modules`, the Android build tree and a 165MB APK, and aborts
    partway through 2.9GB.
-4. Add the four environment variables from `.env.example` for **Production**.
-   Generate a fresh `ADMIN_PASSWORD` and `ADMIN_SESSION_SECRET`; do not reuse
-   the local ones.
+4. Add the environment variables from `.env.example` for **Production**, plus
+   the two this hardening added:
+   - `ADMIN_ORIGIN_SECRET` — a long random string. It is the shared secret
+     Cloudflare Access injects as a header and `src/proxy.ts` requires; see
+     "The custom domain took that door away" below. **In production, if this is
+     unset the proxy refuses every request** (fail-closed), so set it and the
+     Cloudflare Transform Rule together.
+   - `ADMIN_ALLOWED_ORIGIN` — optional, e.g. `https://baaki.dmadan.com`. Pins
+     the origin the CSRF check compares against; leave it unset to derive the
+     expected origin from the request `Host`, which is correct for a normal
+     single-domain deployment.
+
+   Generate a fresh `ADMIN_PASSWORD`, `ADMIN_SESSION_SECRET` and
+   `ADMIN_ORIGIN_SECRET`; do not reuse the local ones. See "Rotate after
+   hardening" below — anything that was live before this change should be
+   rotated once, because it lived on a publicly reachable hostname.
+
 5. Confirm **Deployment Protection → Vercel Authentication** covers Preview and
    Production. It was already on by default here — check rather than assume,
    with `vercel project protection`.
@@ -128,8 +142,61 @@ Two things that must be true together, or neither is worth doing:
    requires — a host check alone does not do it, because the host is exactly
    what an attacker sets.
 
-Until both hold, treat `ADMIN_PASSWORD` as the only control on a public
-hostname, and size it accordingly.
+**This is now enforced in the app.** `src/proxy.ts` refuses any request —
+the login form included — that does not carry the header
+`x-admin-origin-secret: <ADMIN_ORIGIN_SECRET>`. A valid session cookie is not
+enough on its own: that is the whole point, because the cookie is the thing an
+attacker on the open origin could obtain or replay. The compare is constant-time.
+
+Ops steps to make it hold, in Cloudflare's dashboard:
+
+1. **Zero Trust → Access → Applications**: add a self-hosted application for
+   `baaki.dmadan.com` with a one-time-PIN (or stricter) policy for your email.
+2. **Rules → Transform Rules → Modify Request Header**: on requests to
+   `baaki.dmadan.com`, _set_ `x-admin-origin-secret` to the same value you put
+   in the `ADMIN_ORIGIN_SECRET` env var. Set (not add), so a value a client
+   tried to send cannot survive.
+3. Set `ADMIN_ORIGIN_SECRET` in Vercel Production to that value and redeploy.
+
+Fail-safe: if `ADMIN_ORIGIN_SECRET` is unset **in production** the proxy denies
+everything rather than silently falling back to cookie-only — so a deploy that
+forgets it is visibly broken, not quietly open. Off production (localhost dev)
+an unset secret skips the check so the console still opens.
+
+Until Access + the Transform Rule are live, treat `ADMIN_PASSWORD` as the only
+control on a public hostname, and size it accordingly.
+
+### Login throttling
+
+`src/lib/loginThrottle.ts` caps failed password attempts per client address
+(ten per fifteen minutes) using the same Postgres limiter the edge functions use
+(`baaki_rate_limit`), so it works across Vercel's many short-lived isolates
+where an in-memory counter would not. A lockout logs a line prefixed
+`[ALERT] admin-login lockout` for log-based alerting to key on. It fails open: a
+database blip lets the one operator in rather than locking them out. No
+migration is needed — the bucket carries its own limit.
+
+### CSRF / Origin on mutations
+
+Every mutating server action calls `guardMutation` (`src/lib/csrf.ts`) first,
+which requires two independent things: an `Origin` header matching this host
+(or `ADMIN_ALLOWED_ORIGIN`), and a per-session CSRF token — derived from the
+session cookie under `ADMIN_SESSION_SECRET`, carried by `<CsrfField />` in each
+form. `SameSite=Lax` on the session cookie stays as one more layer, not the only
+one. The login form has no session yet, so it enforces the Origin check alone.
+
+### Rotate after hardening
+
+`ADMIN_PASSWORD`, `ADMIN_SESSION_SECRET` and `ADMIN_ORIGIN_SECRET` must be
+rotated **after** this is deployed, because until now the console answered on a
+public hostname with only the password in front of it:
+
+- **`ADMIN_PASSWORD`** — generate a new one; the old one may have been exposed to
+  brute force on the open origin.
+- **`ADMIN_SESSION_SECRET`** — rotating it invalidates every existing session
+  cookie _and_ every CSRF token derived from one, forcing a fresh sign-in.
+- **`ADMIN_ORIGIN_SECRET`** — set it for the first time here; rotate it (env +
+  Cloudflare Transform Rule together) on any suspicion it leaked.
 
 ## Notes for whoever changes this next
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start --port 3100",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@waves/core": "workspace:*",
@@ -24,6 +25,7 @@
     "@types/react-dom": "~19.2.2",
     "eslint": "^9.37.0",
     "eslint-config-next": "^16.3.0",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/admin/src/app/campaigns/page.tsx
+++ b/apps/admin/src/app/campaigns/page.tsx
@@ -15,6 +15,8 @@ import {
   type CampaignRevenueRow,
   type FunnelRow,
 } from '@/lib/data';
+import { guardMutation } from '@/lib/csrf';
+import { CsrfField } from '@/components/CsrfField';
 
 export const dynamic = 'force-dynamic';
 
@@ -93,6 +95,7 @@ export default async function Campaigns({
 
     let failure: string | null = null;
     try {
+      await guardMutation(formData);
       await createCampaign({
         name: String(formData.get('name') ?? ''),
         title: String(formData.get('title') ?? ''),
@@ -118,6 +121,7 @@ export default async function Campaigns({
     const id = String(formData.get('id') ?? '');
     let message: string;
     try {
+      await guardMutation(formData);
       const result = await broadcastCampaign(id);
       // The holdout is never in this count — it is the control group, and mailing
       // it is the one thing the whole design forbids.
@@ -283,6 +287,7 @@ export default async function Campaigns({
                 </p>
                 {live ? (
                   <form action={broadcast}>
+                    <CsrfField />
                     <input type="hidden" name="id" value={campaign.id} />
                     <button type="submit">Send email to targeted cohort</button>
                   </form>
@@ -300,6 +305,7 @@ export default async function Campaigns({
       <h2>New campaign</h2>
       <section>
         <form action={create} className="flag">
+          <CsrfField />
           <label>
             <span>Name (internal)</span>
             <input type="text" name="name" placeholder="Diwali 2026" />

--- a/apps/admin/src/app/config/page.tsx
+++ b/apps/admin/src/app/config/page.tsx
@@ -2,6 +2,8 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { appConfig, saveAppConfig } from '@/lib/data';
+import { guardMutation } from '@/lib/csrf';
+import { CsrfField } from '@/components/CsrfField';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,6 +25,7 @@ export default async function Config({
 
     let failure: string | null = null;
     try {
+      await guardMutation(formData);
       const rawValue = String(formData.get('value') ?? '').trim();
       if (rawValue === '') {
         throw new Error('A limit is a whole number, zero or more.');
@@ -69,6 +72,7 @@ export default async function Config({
           <h2>{row.key}</h2>
           <section>
             <form action={save} className="flag">
+              <CsrfField />
               <input type="hidden" name="key" value={row.key} />
               {row.description ? <p className="note">{row.description}</p> : null}
               <label>

--- a/apps/admin/src/app/countries/page.tsx
+++ b/apps/admin/src/app/countries/page.tsx
@@ -4,6 +4,8 @@ import { redirect } from 'next/navigation';
 import { COUNTRIES, countryFlag, dialingCodeForCountry } from '@waves/core';
 
 import { countrySettings, saveCountrySettings } from '@/lib/data';
+import { guardMutation } from '@/lib/csrf';
+import { CsrfField } from '@/components/CsrfField';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,6 +32,7 @@ export default async function Countries({
 
     let failure: string | null = null;
     try {
+      await guardMutation(formData);
       // An unticked box submits nothing, so its absence is "off". Every country
       // is written, so the table always mirrors the console's last full choice.
       await saveCountrySettings(
@@ -64,6 +67,7 @@ export default async function Countries({
 
       <section style={{ marginTop: 20 }}>
         <form action={save} className="flag">
+          <CsrfField />
           <div className="country-grid">
             {DIALABLE.map((country) => (
               <label key={country.code} className="country-row">

--- a/apps/admin/src/app/flags/page.tsx
+++ b/apps/admin/src/app/flags/page.tsx
@@ -2,6 +2,8 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { flagResults, flags, saveFlag, type FlagResultRow } from '@/lib/data';
+import { guardMutation } from '@/lib/csrf';
+import { CsrfField } from '@/components/CsrfField';
 
 export const dynamic = 'force-dynamic';
 
@@ -37,6 +39,7 @@ export default async function Flags({
     // a catch around it would swallow the navigation.
     let failure: string | null = null;
     try {
+      await guardMutation(formData);
       await saveFlag({
         key: String(formData.get('key') ?? '').trim(),
         description: String(formData.get('description') ?? '').trim(),
@@ -88,6 +91,7 @@ export default async function Flags({
             <h2>{flag.key}</h2>
             <section>
               <form action={save} className="flag">
+                <CsrfField />
                 <input type="hidden" name="key" value={flag.key} />
                 <label>
                   <span>Description</span>
@@ -172,6 +176,7 @@ export default async function Flags({
       <h2>New flag</h2>
       <section>
         <form action={save} className="flag">
+          <CsrfField />
           <label>
             <span>Key</span>
             <input type="text" name="key" placeholder="itemized_receipts" required />

--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -1,7 +1,9 @@
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { checkPassword, issueToken } from '@/lib/session';
+import { clientAddress, recordLoginAttempt } from '@/lib/loginThrottle';
+import { assertSameOrigin, RequestRejected } from '@/lib/csrf';
 
 export default async function Login({
   searchParams,
@@ -12,6 +14,25 @@ export default async function Login({
 
   async function signIn(formData: FormData) {
     'use server';
+
+    // Reject a cross-site POST at the login form too — a forged login is a way
+    // to fixate a session on somebody. There is no session-bound token yet, so
+    // this leans on the Origin check alone.
+    try {
+      await assertSameOrigin();
+    } catch (caught) {
+      if (caught instanceof RequestRejected) redirect('/login?error=1');
+      throw caught;
+    }
+
+    // Throttle next, on the address, so a locked source cannot even test a
+    // guess. Counts this attempt whether or not the password is right — the
+    // operator logs in a handful of times a day and never meets the limit.
+    const address = clientAddress((await headers()).get('x-forwarded-for'));
+    const gate = await recordLoginAttempt(address);
+    if (!gate.allowed) {
+      redirect('/login?error=locked');
+    }
 
     const password = String(formData.get('password') ?? '');
     if (!(await checkPassword(password))) {
@@ -49,7 +70,11 @@ export default async function Login({
           autoComplete="current-password"
         />
         <button type="submit">Sign in</button>
-        {error ? <p className="error">That did not work.</p> : null}
+        {error === 'locked' ? (
+          <p className="error">Too many attempts. Wait a few minutes and try again.</p>
+        ) : error ? (
+          <p className="error">That did not work.</p>
+        ) : null}
       </form>
     </main>
   );

--- a/apps/admin/src/app/promotions/page.tsx
+++ b/apps/admin/src/app/promotions/page.tsx
@@ -2,6 +2,8 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { createPromoCode, grantPromo, promoCodes } from '@/lib/data';
+import { guardMutation } from '@/lib/csrf';
+import { CsrfField } from '@/components/CsrfField';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,6 +23,7 @@ export default async function Promotions({
 
     let failure: string | null = null;
     try {
+      await guardMutation(formData);
       await createPromoCode({
         code: String(formData.get('code') ?? ''),
         days: Number(formData.get('days') ?? 30),
@@ -42,6 +45,7 @@ export default async function Promotions({
     let failure: string | null = null;
     let message = '';
     try {
+      await guardMutation(formData);
       message = await grantPromo(
         String(formData.get('profile') ?? ''),
         Number(formData.get('days') ?? 30),
@@ -74,6 +78,7 @@ export default async function Promotions({
       <h2>Comp an account</h2>
       <section>
         <form action={grant} className="flag">
+          <CsrfField />
           <label>
             <span>Profile id</span>
             <input type="text" name="profile" placeholder="uuid" required size={38} />
@@ -132,6 +137,7 @@ export default async function Promotions({
       <h2>New code</h2>
       <section>
         <form action={create} className="flag">
+          <CsrfField />
           <label>
             <span>Code</span>
             <input type="text" name="code" placeholder="DIWALI25" required />

--- a/apps/admin/src/app/rate-limits/page.tsx
+++ b/apps/admin/src/app/rate-limits/page.tsx
@@ -8,6 +8,8 @@ import {
   setRateLimitEnabled,
   type RateLimitRuleRow,
 } from '@/lib/data';
+import { guardMutation } from '@/lib/csrf';
+import { CsrfField } from '@/components/CsrfField';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,6 +32,7 @@ export default async function RateLimits({
     'use server';
     let failure: string | null = null;
     try {
+      await guardMutation(formData);
       await setRateLimitEnabled(formData.get('enabled') === 'on');
     } catch (caught) {
       failure = caught instanceof Error ? caught.message : String(caught);
@@ -43,6 +46,7 @@ export default async function RateLimits({
     'use server';
     let failure: string | null = null;
     try {
+      await guardMutation(formData);
       await saveRateLimitRule({
         bucket: String(formData.get('bucket') ?? '').trim(),
         enabled: formData.get('enabled') === 'on',
@@ -78,6 +82,7 @@ export default async function RateLimits({
       <h2>Master switch</h2>
       <section>
         <form action={toggleMaster} className="flag">
+          <CsrfField />
           <label className="inline">
             <input type="checkbox" name="enabled" defaultChecked={enabled} />
             <span>Rate limiting enabled</span>
@@ -115,6 +120,7 @@ export default async function RateLimits({
             </span>
           </h3>
           <form action={saveRule} className="flag">
+            <CsrfField />
             <input type="hidden" name="bucket" value={rule.bucket} />
             <label className="inline">
               <input type="checkbox" name="enabled" defaultChecked={rule.enabled} />
@@ -141,6 +147,7 @@ export default async function RateLimits({
       <h2>Add a bucket</h2>
       <section>
         <form action={saveRule} className="flag">
+          <CsrfField />
           <label>
             <span>Bucket</span>
             <input type="text" name="bucket" placeholder="expense-write" required />

--- a/apps/admin/src/app/users/page.tsx
+++ b/apps/admin/src/app/users/page.tsx
@@ -2,6 +2,8 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { confirmUserEmail, listUsers, upgradeUser, type AdminUserListRow } from '@/lib/data';
+import { assertSameOrigin, guardMutation } from '@/lib/csrf';
+import { CsrfField } from '@/components/CsrfField';
 
 export const dynamic = 'force-dynamic';
 
@@ -54,6 +56,8 @@ export default async function Users({
 
   async function filter(formData: FormData) {
     'use server';
+    // Navigation only, so no CSRF token — but still refuse a cross-site POST.
+    await assertSameOrigin();
     const p = new URLSearchParams();
     const n = String(formData.get('name') ?? '').trim();
     const c = String(formData.get('country') ?? '')
@@ -71,6 +75,7 @@ export default async function Users({
     const to = String(formData.get('back') ?? '/users');
     let failure: string | null = null;
     try {
+      await guardMutation(formData);
       await confirmUserEmail(id);
     } catch (caught) {
       failure = caught instanceof Error ? caught.message : String(caught);
@@ -89,6 +94,7 @@ export default async function Users({
     let message: string | null = null;
     let failure: string | null = null;
     try {
+      await guardMutation(formData);
       message = await upgradeUser(id, days);
     } catch (caught) {
       failure = caught instanceof Error ? caught.message : String(caught);
@@ -194,6 +200,7 @@ export default async function Users({
                       <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
                         {u.email_confirmed || !u.email ? null : (
                           <form action={confirm}>
+                            <CsrfField />
                             <input type="hidden" name="id" value={u.id} />
                             <input type="hidden" name="back" value={back} />
                             <button type="submit" title="Confirm this email by hand">
@@ -205,6 +212,7 @@ export default async function Users({
                           action={upgrade}
                           style={{ display: 'flex', gap: 4, alignItems: 'center' }}
                         >
+                          <CsrfField />
                           <input type="hidden" name="id" value={u.id} />
                           <input type="hidden" name="back" value={back} />
                           <input

--- a/apps/admin/src/components/CsrfField.tsx
+++ b/apps/admin/src/components/CsrfField.tsx
@@ -1,0 +1,14 @@
+import { csrfToken } from '@/lib/csrf';
+
+/**
+ * The hidden field that carries the per-session CSRF token into a mutating form.
+ *
+ * A component rather than a bare `<input>` so the token is fetched right here and
+ * no page can render the field with the wrong value — or, worse, forget the
+ * value and ship a form that always fails. Drop one `<CsrfField />` inside any
+ * form whose action calls `guardMutation`.
+ */
+export async function CsrfField() {
+  const token = await csrfToken();
+  return <input type="hidden" name="_csrf" value={token} />;
+}

--- a/apps/admin/src/lib/csrf.ts
+++ b/apps/admin/src/lib/csrf.ts
@@ -37,13 +37,17 @@ export class RequestRejected extends Error {
 const CSRF_FIELD = '_csrf';
 
 /**
- * Rejects a request whose `Origin` is missing or is not this host.
+ * Rejects a request whose `Origin` is missing or is not this site.
  *
- * The expected host is the request's own `Host` header — the value the browser
- * set to reach us, not anything in the request body — unless `ADMIN_ALLOWED_ORIGIN`
- * pins it explicitly, which is the belt for a deployment that terminates TLS
- * somewhere that rewrites `Host`. A cross-site form POST carries the attacker's
- * `Origin`, which will not match; a same-origin submit carries ours, which will.
+ * When `ADMIN_ALLOWED_ORIGIN` pins the origin — the belt for a deployment that
+ * terminates TLS somewhere that rewrites `Host` — the whole origin is compared:
+ * scheme, host and port, so an `http://` Origin cannot pass for an `https://`
+ * deployment. Otherwise the expected host is the request's own `Host` header
+ * (the value the browser set to reach us, not anything in the body), and in
+ * production the Origin must additionally be `https:` — a plain-HTTP Origin on a
+ * TLS-served tier is a downgrade, and `Host` carries no scheme of its own to
+ * catch it. A cross-site form POST carries the attacker's `Origin`, which will
+ * not match; a same-origin submit carries ours, which will.
  */
 export async function assertSameOrigin(): Promise<void> {
   const h = await headers();
@@ -52,18 +56,26 @@ export async function assertSameOrigin(): Promise<void> {
     throw new RequestRejected('This request arrived without an Origin and was refused.');
   }
 
-  let originHost: string;
+  let originUrl: URL;
   try {
-    originHost = new URL(origin).host;
+    originUrl = new URL(origin);
   } catch {
     throw new RequestRejected('This request carried a malformed Origin and was refused.');
   }
 
+  const rejected = new RequestRejected('This request came from another site and was refused.');
+
   const configured = process.env.ADMIN_ALLOWED_ORIGIN;
-  const expectedHost = configured ? new URL(configured).host : (h.get('host') ?? '');
-  if (!expectedHost || originHost !== expectedHost) {
-    throw new RequestRejected('This request came from another site and was refused.');
+  if (configured) {
+    // `URL.origin` normalises scheme + host + port, so the compare includes the
+    // scheme rather than accepting http for a configured https origin.
+    if (originUrl.origin !== new URL(configured).origin) throw rejected;
+    return;
   }
+
+  const host = h.get('host') ?? '';
+  if (!host || originUrl.host !== host) throw rejected;
+  if (process.env.NODE_ENV === 'production' && originUrl.protocol !== 'https:') throw rejected;
 }
 
 /**

--- a/apps/admin/src/lib/csrf.ts
+++ b/apps/admin/src/lib/csrf.ts
@@ -1,0 +1,101 @@
+import 'server-only';
+
+import { cookies, headers } from 'next/headers';
+
+import { SESSION_COOKIE, constantTimeEquals, csrfTokenFor } from './session';
+
+/**
+ * The browser-side half of the door.
+ *
+ * The trusted-origin secret in `proxy.ts` proves a request came through
+ * Cloudflare; this proves a *mutating* request came from this console's own
+ * pages rather than from another site a signed-in operator happened to visit.
+ * The session cookie is `SameSite=Lax`, which already blocks the cross-site POST
+ * in a modern browser — but Lax is one layer, and a console that reads and
+ * writes the whole business should not rest a mutation on a single one. So every
+ * server action that changes something calls `guardMutation` first, and it takes
+ * two independent things to pass: the request's `Origin` must be this host, and
+ * the form must carry a token only a holder of the session cookie could have
+ * computed.
+ *
+ * One helper, called at the top of each action, so a new action added later
+ * fails the same way rather than shipping unguarded.
+ */
+
+/**
+ * Refusal with a message safe to show. Distinct type so an action could tell it
+ * apart from a validation error if it ever wanted to; today they both surface as
+ * text on the page.
+ */
+export class RequestRejected extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RequestRejected';
+  }
+}
+
+const CSRF_FIELD = '_csrf';
+
+/**
+ * Rejects a request whose `Origin` is missing or is not this host.
+ *
+ * The expected host is the request's own `Host` header — the value the browser
+ * set to reach us, not anything in the request body — unless `ADMIN_ALLOWED_ORIGIN`
+ * pins it explicitly, which is the belt for a deployment that terminates TLS
+ * somewhere that rewrites `Host`. A cross-site form POST carries the attacker's
+ * `Origin`, which will not match; a same-origin submit carries ours, which will.
+ */
+export async function assertSameOrigin(): Promise<void> {
+  const h = await headers();
+  const origin = h.get('origin');
+  if (!origin) {
+    throw new RequestRejected('This request arrived without an Origin and was refused.');
+  }
+
+  let originHost: string;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    throw new RequestRejected('This request carried a malformed Origin and was refused.');
+  }
+
+  const configured = process.env.ADMIN_ALLOWED_ORIGIN;
+  const expectedHost = configured ? new URL(configured).host : (h.get('host') ?? '');
+  if (!expectedHost || originHost !== expectedHost) {
+    throw new RequestRejected('This request came from another site and was refused.');
+  }
+}
+
+/**
+ * The token to embed in a form, bound to the current session. Empty when there
+ * is no session (the login form, which has no session-bound token and leans on
+ * the Origin check alone).
+ */
+export async function csrfToken(): Promise<string> {
+  const session = (await cookies()).get(SESSION_COOKIE)?.value;
+  if (!session) return '';
+  return csrfTokenFor(session);
+}
+
+/** Rejects a form whose CSRF token is missing or does not match the session. */
+export async function assertCsrfToken(formData: FormData): Promise<void> {
+  const session = (await cookies()).get(SESSION_COOKIE)?.value;
+  if (!session) {
+    throw new RequestRejected('Your session has expired. Reload and sign in again.');
+  }
+  const expected = await csrfTokenFor(session);
+  const provided = String(formData.get(CSRF_FIELD) ?? '');
+  if (!provided || !(await constantTimeEquals(provided, expected))) {
+    throw new RequestRejected('This form was stale or forged. Reload the page and try again.');
+  }
+}
+
+/**
+ * The one call every mutating server action makes, first thing. Origin then
+ * token: a cross-site request usually fails the Origin check before a token is
+ * even looked at.
+ */
+export async function guardMutation(formData: FormData): Promise<void> {
+  await assertSameOrigin();
+  await assertCsrfToken(formData);
+}

--- a/apps/admin/src/lib/loginThrottle.ts
+++ b/apps/admin/src/lib/loginThrottle.ts
@@ -1,0 +1,94 @@
+import 'server-only';
+
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * Slows a brute-force at the login form.
+ *
+ * The console is one shared password. On a hostname that is (until Cloudflare
+ * Access is wired up) publicly reachable, that makes the login form the whole
+ * attack surface, and an unlimited form is a password guessed at line speed.
+ *
+ * The counting is done in Postgres by `baaki_rate_limit` — the same limiter the
+ * edge functions use (`supabase/functions/_shared/rateLimit.ts`) — and not in
+ * memory, for the same reason it is written up there: Vercel runs the middleware
+ * and server actions across many short-lived isolates, so an in-memory counter
+ * would count almost nothing and look like it worked in a single-instance test.
+ * Keyed on the client address, since there is no signed-in identity to blame at
+ * a login. The bucket carries its own limit here rather than relying on a
+ * `rate_limit_rules` row, so it works whether or not one has been configured.
+ *
+ * Fails open. If the count cannot be taken — the only realistic cause being the
+ * database being unreachable — the attempt proceeds. This console must keep
+ * working when the thing it watches is down, and a limiter that turns a database
+ * blip into a lockout of the one operator has done more harm than the slow
+ * guessing it was there to stop.
+ */
+
+const BUCKET = 'admin-login';
+
+/** Ten tries per quarter hour, per address. Far more than a person fat-fingering
+ * a password, far less than a script needs to be worth running. */
+const MAX_ATTEMPTS = 10;
+const WINDOW_SECONDS = 15 * 60;
+
+export interface ThrottleDecision {
+  allowed: boolean;
+  /** Seconds until the window reopens. Zero when allowed. */
+  retryAfter: number;
+}
+
+function service() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+/**
+ * Reads the client address the way the edge limiter does: the first entry of
+ * `x-forwarded-for`, which is the client as the first proxy saw it. Spoofable in
+ * general, but a caller willing to rotate that header per request only earns a
+ * slower oracle, not an open one — and behind Cloudflare the header is set by a
+ * hop the attacker does not control.
+ */
+export function clientAddress(forwardedFor: string | null | undefined): string {
+  const first = (forwardedFor ?? '').split(',')[0]?.trim();
+  return first || 'unknown';
+}
+
+/**
+ * Counts one login attempt against the address and reports whether it is now
+ * over the line. Call it on every submit, before checking the password, so a
+ * locked address cannot even test a guess.
+ */
+export async function recordLoginAttempt(address: string): Promise<ThrottleDecision> {
+  const svc = service();
+  if (!svc) return { allowed: true, retryAfter: 0 };
+
+  const { data, error } = await svc.rpc('baaki_rate_limit', {
+    p_subject: `ip:${address}`,
+    p_bucket: BUCKET,
+    p_limit: MAX_ATTEMPTS,
+    p_window_seconds: WINDOW_SECONDS,
+  });
+
+  if (error) {
+    console.error('admin login throttle check failed, allowing attempt:', error.message);
+    return { allowed: true, retryAfter: 0 };
+  }
+
+  const decision = data as { allowed?: boolean; retryAfter?: number } | null;
+  if (!decision || decision.allowed) return { allowed: true, retryAfter: 0 };
+
+  const retryAfter = Math.max(Number(decision.retryAfter) || 1, 1);
+  // The alert signal. A lockout means either the operator is having a bad day or
+  // somebody is guessing; both are worth a line that log-based alerting can key
+  // on. No secret, no address of ours, nothing that helps an attacker.
+  console.warn(
+    `[ALERT] admin-login lockout: address=${address} bucket=${BUCKET} retryAfterSeconds=${retryAfter}`,
+  );
+  return { allowed: false, retryAfter };
+}

--- a/apps/admin/src/lib/session.ts
+++ b/apps/admin/src/lib/session.ts
@@ -103,3 +103,63 @@ export async function isValidToken(token: string | undefined): Promise<boolean> 
 }
 
 export const SESSION_COOKIE = COOKIE;
+
+/**
+ * The second door: proof the request arrived through the trusted proxy.
+ *
+ * The custom domain (`baaki.dmadan.com`) is on Vercel Hobby, whose Deployment
+ * Protection does not cover custom domains, and the `*.vercel.app` origin stays
+ * reachable directly — so a valid session cookie alone does not prove a request
+ * came through Cloudflare Access. Cloudflare injects a shared secret header (a
+ * Transform Rule) that only it and this app know; a request that lacks it did
+ * not pass through the front door and is refused, cookie or no cookie. A host
+ * check would not do: the Host header is exactly what an attacker sets when
+ * sending a request straight to the `.vercel.app` origin.
+ *
+ * The compare is constant-time (HMAC-then-`===`, as everywhere else here) so the
+ * secret cannot be recovered a byte at a time from response timing.
+ */
+export const ORIGIN_SECRET_HEADER = 'x-admin-origin-secret';
+
+/**
+ * A constant-time string compare, exposed for the CSRF check next door. Same
+ * HMAC-then-`===` shape the rest of this file uses, so a token cannot be
+ * recovered a byte at a time from how long the comparison took.
+ */
+export async function constantTimeEquals(a: string, b: string): Promise<boolean> {
+  return equals(a, b);
+}
+
+/**
+ * A CSRF token bound to one session.
+ *
+ * Derived from the session cookie's value under the same secret, so it needs no
+ * second cookie to set (server components cannot set one during render anyway)
+ * and no server-side store. A cross-site attacker cannot read the victim's
+ * httpOnly session cookie, so cannot compute this, so cannot forge a form that
+ * carries it. The `csrf.` prefix keeps this HMAC from ever colliding with the
+ * session signature, which is the same input under the same key.
+ */
+export async function csrfTokenFor(sessionValue: string): Promise<string> {
+  return hmac(`csrf.${sessionValue}`, required('ADMIN_SESSION_SECRET'));
+}
+
+/**
+ * Fail-safe when `ADMIN_ORIGIN_SECRET` is unset.
+ *
+ * In production an unset secret means the second door was never wired up, and
+ * the safe answer to that is to refuse everything rather than silently fall back
+ * to cookie-only on a publicly reachable hostname — so this returns `false`,
+ * i.e. no request is trusted until the secret is configured. In development
+ * there is no Cloudflare in front of `localhost`, so an unset secret skips the
+ * check (returns `true`) and the console still opens on a dev machine.
+ */
+export async function hasTrustedOrigin(headerValue: string | null | undefined): Promise<boolean> {
+  const secret = process.env.ADMIN_ORIGIN_SECRET;
+  if (!secret) {
+    // Secure default: closed in production, open only off it.
+    return process.env.NODE_ENV !== 'production';
+  }
+  if (!headerValue) return false;
+  return equals(headerValue, secret);
+}

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -1,6 +1,11 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-import { isValidToken, SESSION_COOKIE } from '@/lib/session';
+import {
+  hasTrustedOrigin,
+  isValidToken,
+  ORIGIN_SECRET_HEADER,
+  SESSION_COOKIE,
+} from '@/lib/session';
 
 /**
  * The gate, in front of everything.
@@ -16,10 +21,32 @@ import { isValidToken, SESSION_COOKIE } from '@/lib/session';
  * sat at the project root instead of in `src/`, where Next silently does not
  * load it, and only the second check stopped the requests.
  *
+ * Two checks, in order:
+ *
+ * 1. **The trusted-origin secret.** Every request — the login screen included —
+ *    must carry the header Cloudflare Access injects. A valid session cookie is
+ *    not enough on its own, because the `*.vercel.app` origin is reachable
+ *    directly and the custom domain is not covered by Vercel's own protection;
+ *    without this a stolen or forged cookie walks straight in around Cloudflare.
+ *    Refused with a bare 403 that says nothing about what is behind it.
+ * 2. **The session cookie**, for everything except `/login` itself.
+ *
  * Note this may run on a CDN edge separately from the render, so it holds no
  * state and shares nothing with the pages beyond the cookie it validates.
  */
 export async function proxy(request: NextRequest) {
+  // The second door first: a request that did not come through the trusted
+  // proxy has no business reaching even the login form.
+  if (!(await hasTrustedOrigin(request.headers.get(ORIGIN_SECRET_HEADER)))) {
+    return new NextResponse(null, { status: 403 });
+  }
+
+  // The login screen is reachable without a session (that is where you get
+  // one) — but only now that the origin gate above has already let it through.
+  if (request.nextUrl.pathname === '/login') {
+    return NextResponse.next();
+  }
+
   if (await isValidToken(request.cookies.get(SESSION_COOKIE)?.value)) {
     return NextResponse.next();
   }
@@ -29,9 +56,12 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   /**
-   * Everything except the login screen itself and Next's own assets. Written as
-   * an exclusion so a route added later is protected by default — the opposite
-   * ordering is how a new page ships unguarded.
+   * Everything except Next's own static assets. `/login` is deliberately *not*
+   * excluded here any more: it still skips the cookie check inside `proxy`, but
+   * it must pass through the origin-secret gate like every other route, or the
+   * password form stays reachable on the open `*.vercel.app` back door. Written
+   * as an exclusion so a route added later is protected by default — the
+   * opposite ordering is how a new page ships unguarded.
    */
-  matcher: ['/((?!login|_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
 };

--- a/apps/admin/test/csrf.test.ts
+++ b/apps/admin/test/csrf.test.ts
@@ -69,6 +69,22 @@ describe('assertSameOrigin', () => {
     headerStore.set('origin', 'https://baaki-admin.vercel.app');
     await expect(assertSameOrigin()).rejects.toThrow(/another site/);
   });
+
+  it('rejects an http Origin for a pinned https ADMIN_ALLOWED_ORIGIN', async () => {
+    process.env.ADMIN_ALLOWED_ORIGIN = `https://${HOST}`;
+    headerStore.set('host', HOST);
+    headerStore.set('origin', `http://${HOST}`);
+    await expect(assertSameOrigin()).rejects.toThrow(/another site/);
+  });
+
+  it('rejects a plain-http Origin in production when deriving from Host', async () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    headerStore.set('host', HOST);
+    headerStore.set('origin', `http://${HOST}`);
+    await expect(assertSameOrigin()).rejects.toThrow(/another site/);
+    process.env.NODE_ENV = prev;
+  });
 });
 
 describe('CSRF token', () => {

--- a/apps/admin/test/csrf.test.ts
+++ b/apps/admin/test/csrf.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const headerStore = new Map<string, string>();
+const cookieStore = new Map<string, string>();
+
+vi.mock('next/headers', () => ({
+  headers: async () => ({
+    get: (key: string) => headerStore.get(key.toLowerCase()) ?? null,
+  }),
+  cookies: async () => ({
+    get: (key: string) => {
+      const value = cookieStore.get(key);
+      return value === undefined ? undefined : { value };
+    },
+  }),
+}));
+
+import { assertCsrfToken, assertSameOrigin, csrfToken, guardMutation } from '@/lib/csrf';
+import { SESSION_COOKIE, csrfTokenFor, issueToken } from '@/lib/session';
+
+const HOST = 'baaki.dmadan.com';
+
+beforeEach(() => {
+  headerStore.clear();
+  cookieStore.clear();
+  process.env.ADMIN_SESSION_SECRET = 'test-session-secret';
+  delete process.env.ADMIN_ALLOWED_ORIGIN;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function signedIn(): Promise<{ form: FormData }> {
+  const token = await issueToken();
+  cookieStore.set(SESSION_COOKIE, token.value);
+  const form = new FormData();
+  form.set('_csrf', await csrfTokenFor(token.value));
+  return { form };
+}
+
+describe('assertSameOrigin', () => {
+  it('rejects a missing Origin', async () => {
+    headerStore.set('host', HOST);
+    await expect(assertSameOrigin()).rejects.toThrow(/without an Origin/);
+  });
+
+  it('rejects a foreign Origin', async () => {
+    headerStore.set('host', HOST);
+    headerStore.set('origin', 'https://evil.example.com');
+    await expect(assertSameOrigin()).rejects.toThrow(/another site/);
+  });
+
+  it('accepts a same-origin request', async () => {
+    headerStore.set('host', HOST);
+    headerStore.set('origin', `https://${HOST}`);
+    await expect(assertSameOrigin()).resolves.toBeUndefined();
+  });
+
+  it('honours a pinned ADMIN_ALLOWED_ORIGIN over the Host header', async () => {
+    process.env.ADMIN_ALLOWED_ORIGIN = `https://${HOST}`;
+    // Host is attacker-controlled on the back door; the pin ignores it.
+    headerStore.set('host', 'baaki-admin.vercel.app');
+    headerStore.set('origin', `https://${HOST}`);
+    await expect(assertSameOrigin()).resolves.toBeUndefined();
+
+    headerStore.set('origin', 'https://baaki-admin.vercel.app');
+    await expect(assertSameOrigin()).rejects.toThrow(/another site/);
+  });
+});
+
+describe('CSRF token', () => {
+  it('accepts a matching session-bound token', async () => {
+    const { form } = await signedIn();
+    await expect(assertCsrfToken(form)).resolves.toBeUndefined();
+  });
+
+  it('rejects a missing token', async () => {
+    await signedIn();
+    await expect(assertCsrfToken(new FormData())).rejects.toThrow(/stale or forged/);
+  });
+
+  it('rejects a forged token', async () => {
+    await signedIn();
+    const form = new FormData();
+    form.set('_csrf', 'not-the-real-token');
+    await expect(assertCsrfToken(form)).rejects.toThrow(/stale or forged/);
+  });
+
+  it('rejects when there is no session', async () => {
+    const form = new FormData();
+    form.set('_csrf', 'anything');
+    await expect(assertCsrfToken(form)).rejects.toThrow(/session has expired/);
+  });
+
+  it('emits an empty token when signed out', async () => {
+    await expect(csrfToken()).resolves.toBe('');
+  });
+});
+
+describe('guardMutation', () => {
+  it('passes a same-origin request with a valid session token', async () => {
+    headerStore.set('host', HOST);
+    headerStore.set('origin', `https://${HOST}`);
+    const { form } = await signedIn();
+    await expect(guardMutation(form)).resolves.toBeUndefined();
+  });
+
+  it('rejects a foreign Origin before the token is considered', async () => {
+    headerStore.set('host', HOST);
+    headerStore.set('origin', 'https://evil.example.com');
+    const { form } = await signedIn();
+    await expect(guardMutation(form)).rejects.toThrow(/another site/);
+  });
+});

--- a/apps/admin/test/loginThrottle.test.ts
+++ b/apps/admin/test/loginThrottle.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `server-only` throws when imported outside a React Server Component build;
+// in the test runner it is a no-op.
+vi.mock('server-only', () => ({}));
+
+const rpc = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({ rpc }),
+}));
+
+import { clientAddress, recordLoginAttempt } from '@/lib/loginThrottle';
+
+beforeEach(() => {
+  rpc.mockReset();
+  process.env.SUPABASE_URL = 'https://project.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('clientAddress', () => {
+  it('takes the first x-forwarded-for entry', () => {
+    expect(clientAddress('1.2.3.4, 5.6.7.8')).toBe('1.2.3.4');
+    expect(clientAddress(' 9.9.9.9 ')).toBe('9.9.9.9');
+    expect(clientAddress(null)).toBe('unknown');
+    expect(clientAddress('')).toBe('unknown');
+  });
+});
+
+describe('recordLoginAttempt', () => {
+  it('allows while under the limit', async () => {
+    rpc.mockResolvedValue({ data: { allowed: true, retryAfter: 0 }, error: null });
+    await expect(recordLoginAttempt('1.2.3.4')).resolves.toEqual({
+      allowed: true,
+      retryAfter: 0,
+    });
+    expect(rpc).toHaveBeenCalledWith('baaki_rate_limit', {
+      p_subject: 'ip:1.2.3.4',
+      p_bucket: 'admin-login',
+      p_limit: 10,
+      p_window_seconds: 900,
+    });
+  });
+
+  it('locks out and emits an alert once over the limit', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    rpc.mockResolvedValue({ data: { allowed: false, retryAfter: 42 }, error: null });
+    await expect(recordLoginAttempt('1.2.3.4')).resolves.toEqual({
+      allowed: false,
+      retryAfter: 42,
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('[ALERT] admin-login lockout'));
+  });
+
+  it('fails open when the rate-limit RPC errors', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    rpc.mockResolvedValue({ data: null, error: { message: 'db down' } });
+    await expect(recordLoginAttempt('1.2.3.4')).resolves.toEqual({
+      allowed: true,
+      retryAfter: 0,
+    });
+  });
+
+  it('fails open when the service key is not configured', async () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    await expect(recordLoginAttempt('1.2.3.4')).resolves.toEqual({
+      allowed: true,
+      retryAfter: 0,
+    });
+    expect(rpc).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/test/proxy.test.ts
+++ b/apps/admin/test/proxy.test.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from 'next/server';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { proxy } from '@/proxy';
+import { issueToken, ORIGIN_SECRET_HEADER, SESSION_COOKIE } from '@/lib/session';
+
+const ORIGIN_SECRET = 'origin-secret-value';
+
+// The real vercel.app back door: an attacker sending a request straight to the
+// origin sets Host to the custom domain, but cannot forge the Cloudflare header.
+const VERCEL_ORIGIN = 'https://baaki-admin.vercel.app';
+const SPOOFED_HOST = 'baaki.dmadan.com';
+
+beforeAll(() => {
+  process.env.ADMIN_SESSION_SECRET = 'test-session-secret';
+  process.env.ADMIN_ORIGIN_SECRET = ORIGIN_SECRET;
+  process.env.NODE_ENV = 'production';
+});
+
+async function validCookie(): Promise<string> {
+  const token = await issueToken();
+  return `${SESSION_COOKIE}=${token.value}`;
+}
+
+function request(
+  path: string,
+  headers: Record<string, string>,
+  origin = 'https://baaki.dmadan.com',
+): NextRequest {
+  return new NextRequest(new URL(path, origin), { headers });
+}
+
+describe('proxy origin + session gate', () => {
+  it('rejects a valid cookie with a missing origin header and a spoofed Host (the back door)', async () => {
+    const res = await proxy(
+      request('/', { cookie: await validCookie(), host: SPOOFED_HOST }, VERCEL_ORIGIN),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('passes a valid origin header + valid cookie', async () => {
+    const res = await proxy(
+      request('/', {
+        cookie: await validCookie(),
+        [ORIGIN_SECRET_HEADER]: ORIGIN_SECRET,
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a valid cookie WITHOUT the origin header', async () => {
+    const res = await proxy(request('/', { cookie: await validCookie() }));
+    expect(res.status).toBe(403);
+  });
+
+  it('redirects a valid origin header but NO cookie to /login', async () => {
+    const res = await proxy(request('/', { [ORIGIN_SECRET_HEADER]: ORIGIN_SECRET }));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  it('lets the login form through the origin gate without a cookie', async () => {
+    const res = await proxy(request('/login', { [ORIGIN_SECRET_HEADER]: ORIGIN_SECRET }));
+    expect(res.status).toBe(200);
+  });
+
+  it('refuses even the login form when the origin header is missing (custom-domain back door)', async () => {
+    const res = await proxy(request('/login', { host: SPOOFED_HOST }, VERCEL_ORIGIN));
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/admin/test/session.test.ts
+++ b/apps/admin/test/session.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { hasTrustedOrigin, isValidToken, issueToken, checkPassword } from '@/lib/session';
+
+const ORIGIN_SECRET = 'origin-secret-value';
+
+beforeAll(() => {
+  process.env.ADMIN_SESSION_SECRET = 'test-session-secret';
+  process.env.ADMIN_PASSWORD = 'correct horse battery staple';
+});
+
+describe('hasTrustedOrigin', () => {
+  afterEach(() => {
+    process.env.ADMIN_ORIGIN_SECRET = ORIGIN_SECRET;
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('accepts the exact secret in the header', async () => {
+    process.env.ADMIN_ORIGIN_SECRET = ORIGIN_SECRET;
+    await expect(hasTrustedOrigin(ORIGIN_SECRET)).resolves.toBe(true);
+  });
+
+  it('rejects a missing header even when a secret is configured', async () => {
+    process.env.ADMIN_ORIGIN_SECRET = ORIGIN_SECRET;
+    await expect(hasTrustedOrigin(null)).resolves.toBe(false);
+    await expect(hasTrustedOrigin(undefined)).resolves.toBe(false);
+    await expect(hasTrustedOrigin('')).resolves.toBe(false);
+  });
+
+  it('rejects a wrong header value', async () => {
+    process.env.ADMIN_ORIGIN_SECRET = ORIGIN_SECRET;
+    await expect(hasTrustedOrigin('not-the-secret')).resolves.toBe(false);
+  });
+
+  it('fails closed in production when the secret is unset', async () => {
+    delete process.env.ADMIN_ORIGIN_SECRET;
+    process.env.NODE_ENV = 'production';
+    await expect(hasTrustedOrigin('anything')).resolves.toBe(false);
+    await expect(hasTrustedOrigin(null)).resolves.toBe(false);
+  });
+
+  it('opens off production when the secret is unset (localhost dev)', async () => {
+    delete process.env.ADMIN_ORIGIN_SECRET;
+    process.env.NODE_ENV = 'development';
+    await expect(hasTrustedOrigin(null)).resolves.toBe(true);
+  });
+});
+
+describe('session cookie', () => {
+  it('accepts a freshly issued token and rejects tampering', async () => {
+    const token = await issueToken();
+    await expect(isValidToken(token.value)).resolves.toBe(true);
+    await expect(isValidToken(undefined)).resolves.toBe(false);
+    await expect(isValidToken(`${token.value}x`)).resolves.toBe(false);
+    const [expiry] = token.value.split('.');
+    await expect(isValidToken(`${expiry}.forged`)).resolves.toBe(false);
+  });
+
+  it('checks the password constant-time-style', async () => {
+    await expect(checkPassword('correct horse battery staple')).resolves.toBe(true);
+    await expect(checkPassword('wrong')).resolves.toBe(false);
+    await expect(checkPassword('')).resolves.toBe(false);
+  });
+});

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    // The same `@/*` → `src/*` alias tsconfig declares, so the modules under
+    // test can import each other the way they do at build time.
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/agent-mcp:
     dependencies:


### PR DESCRIPTION
## Why

The admin console (`apps/admin`) answers on the custom domain `baaki.dmadan.com`, which on Vercel **Hobby** is not covered by Vercel Deployment Protection — the `*.vercel.app` origin stays directly reachable and a request with a spoofed `Host` walks around any intended edge layer. Before this PR the only control on that public hostname was the shared `ADMIN_PASSWORD` + an HMAC session cookie, with **service-role** Supabase access behind it. This PR closes the origin bypass, throttles login brute-force, and adds CSRF/Origin defense to every mutating server action.

## What changed (code)

1. **Origin/edge enforcement in the proxy** (`src/proxy.ts` + `src/lib/session.ts`)
   - Every request — the login form included — must now carry `x-admin-origin-secret: <ADMIN_ORIGIN_SECRET>` (the header Cloudflare Access injects), **in addition to** the session cookie. A valid cookie with no origin header now fails (this was the Cloudflare-Access-bypass hole). A spoofed `Host` does not help, because the check is on the secret header, not the host.
   - Constant-time compare (HMAC-then-`===`, reusing the existing pattern).
   - **Fail-safe default**: in production an unset `ADMIN_ORIGIN_SECRET` makes the proxy **refuse every request** (fail-closed) rather than silently drop to cookie-only; off production (localhost dev) an unset secret skips the check so local dev still works. Documented in the README.
   - Matcher widened so `/login` also passes through the origin gate (it still skips only the cookie check).

2. **Login throttling + alert** (`src/lib/loginThrottle.ts`, wired into `login/page.tsx`)
   - Reuses the repo's existing Postgres limiter `baaki_rate_limit` (as `supabase/functions/_shared/rateLimit.ts` does) rather than an in-memory counter, which would be per-isolate and worthless on Vercel. 10 attempts / 15 min per client address. Fails open (DB blip lets the operator in). Emits a `[ALERT] admin-login lockout` log line on lockout. **No migration needed** — the bucket carries its own limit.

3. **CSRF / Origin on mutations (finding 7)** (`src/lib/csrf.ts`, `src/components/CsrfField.tsx`)
   - One shared `guardMutation(formData)` called first in every mutating server action (flags, config, countries, campaigns create+broadcast, promotions create+grant, rate-limits master+rule, users confirm+upgrade). It requires **two independent** things: an `Origin` matching this host (or `ADMIN_ALLOWED_ORIGIN`), and a per-session CSRF token derived from the session cookie under `ADMIN_SESSION_SECRET`, carried by `<CsrfField />` in each form.
   - `SameSite=Lax` stays as one more layer, not the only one. The login form has no session yet, so it enforces the Origin check alone. The users `filter` action (pure navigation) enforces Origin only.

## Ops steps the owner must do

1. **Cloudflare Zero Trust → Access → Applications**: add a self-hosted app for `baaki.dmadan.com` with a one-time-PIN (or stricter) policy.
2. **Cloudflare Rules → Transform Rules → Modify Request Header**: on requests to `baaki.dmadan.com`, **set** header `x-admin-origin-secret` to a long random value. *Set*, not add, so a client-supplied value cannot survive.
3. **Vercel (Production env vars)**:
   - `ADMIN_ORIGIN_SECRET` = the same value as the Transform Rule (required; unset ⇒ proxy denies everything in prod).
   - `ADMIN_ALLOWED_ORIGIN` = `https://baaki.dmadan.com` (optional; else derived from `Host`).
4. **Rotate after deploy** (they were live on a public hostname): regenerate `ADMIN_PASSWORD`; rotate `ADMIN_SESSION_SECRET` (invalidates all existing session cookies *and* CSRF tokens, forcing re-login); set/keep `ADMIN_ORIGIN_SECRET` secret.

## Exact env vars

| Var | Required | Purpose |
| --- | --- | --- |
| `ADMIN_ORIGIN_SECRET` | **yes (prod)** | Value of the Cloudflare-injected `x-admin-origin-secret` header the proxy requires. Unset in prod ⇒ all requests refused. |
| `ADMIN_ALLOWED_ORIGIN` | no | Pins the CSRF Origin check (e.g. `https://baaki.dmadan.com`); else derived from request `Host`. |
| `ADMIN_PASSWORD` | yes (existing) | Rotate after deploy. |
| `ADMIN_SESSION_SECRET` | yes (existing) | Rotate after deploy (also invalidates CSRF tokens). |

## Tests (added — `apps/admin` now has a vitest suite; 29 passing)

- proxy: valid cookie + **missing origin header with a spoofed Host** ⇒ 403 (the back door)
- proxy: valid origin header + valid cookie ⇒ passes
- proxy: valid cookie **without** origin header ⇒ 403
- proxy: valid origin, no cookie ⇒ redirect to `/login`
- proxy: `/login` reachable through the origin gate, but refused when the origin header is missing (custom-domain smoke)
- session: `hasTrustedOrigin` fail-closed in prod / open in dev when secret unset; token round-trip
- throttle: locks out after the limit and emits the alert; fails open on RPC error and when the service key is unset
- csrf: rejects missing Origin, foreign Origin, missing/forged/no-session token; honours `ADMIN_ALLOWED_ORIGIN`; `guardMutation` rejects foreign Origin before the token

## Gates (Windows node)

`test` 29/29 · `typecheck` exit 0 · `lint` exit 0 · `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added CSRF protection to admin forms and data-changing actions.
  * Added trusted-origin validation for all admin requests, including login.
  * Added login throttling with clear lockout messaging.
* **Documentation**
  * Updated deployment guidance for origin-secret configuration, secure production setup, and secret rotation.
* **Tests**
  * Added automated coverage for CSRF, authentication, trusted origins, request filtering, and login throttling.
* **Configuration**
  * Added settings for trusted origin validation and optional CSRF origin pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->