### PR TITLE
fix(db): require a committed storage object before attaching receipt/proof metadata

### DIFF
--- a/packages/db/prisma/migrations/20260825240000_attachment_committed_object/migration.sql
+++ b/packages/db/prisma/migrations/20260825240000_attachment_committed_object/migration.sql
@@ -1,0 +1,321 @@
+-- Metadata may only point at bytes that were really uploaded (A46 integrity).
+--
+-- The attach / replace RPCs validated the shape of a storage key (scoped to its
+-- expense or settlement), the caller's party-ship, the visibility and the cap —
+-- but never that a committed object actually exists at that key. So a party (a
+-- buggy retry, or a malicious client bypassing the happy-path upload) could
+-- record an attachment or a settlement proof pointing at a path that was never
+-- PUT to R2: a typo, a key from a different logical bucket, or one that was only
+-- ever a `pending` reservation and never committed. The row then references
+-- nothing; sync distributes the broken pointer, the audit trail lies, and the
+-- storage ledger and the metadata drift apart.
+--
+-- The real upload path already writes the truth: `r2-sign` reserves the object
+-- (`storage_objects.pending = true`), the client PUTs the bytes, then `commit`
+-- clears `pending` via `baaki_storage_record`. Only AFTER that does the client
+-- call the attach RPC. So a committed `storage_objects` row for (bucket, path)
+-- is exactly the proof the bytes exist — and it is the invariant we now require
+-- at the one boundary the client cannot skip (ADR-013: the SECURITY DEFINER RPC
+-- is the enforcement point, a client-side check is only an affordance).
+--
+-- The subject-scoping of the key (`<expenseId>/…` / `<settlementId>/…`) is still
+-- checked in each RPC, so the committed-object check needs only confirm the
+-- object is real and committed in the RIGHT logical bucket; the RPC's own prefix
+-- check ties it to the right subject. `expense_attachments` map to the
+-- `expense-attachments` bucket and `settlement_proofs` to `settlement-proofs`
+-- (supabase/functions/_shared/r2.ts), and the stored `storage_path` equals the
+-- ledger `path` for that bucket (r2-sign records the same string), so the match
+-- is an exact (logical_bucket, path) lookup.
+
+-- ─────────────────────────────── the shared committed-object guard ──
+
+/**
+ * Require a committed (non-pending) object at (logical_bucket, path), or raise.
+ *
+ * One helper for both receipt attachments and settlement proofs — the check is
+ * identical, only the bucket differs — so the invariant lives in exactly one
+ * place. A `pending` reservation does NOT satisfy it: a presign the client never
+ * committed is not an uploaded image, and admitting it would let "reserve, never
+ * PUT" leave a row pointing at bytes that are not there.
+ *
+ * SECURITY DEFINER so it can read `storage_objects`, which is service-role-only
+ * (no client policy); it returns nothing and reveals nothing — a boolean-shaped
+ * gate its SECURITY DEFINER callers already stand in front of.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_require_committed_object(
+  p_logical_bucket text,
+  p_path           text
+)
+RETURNS void
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM public.storage_objects
+     WHERE logical_bucket = p_logical_bucket
+       AND path = p_path
+       AND NOT pending
+  ) THEN
+    RAISE EXCEPTION 'OBJECT_NOT_COMMITTED: no uploaded image backs this path'
+      USING ERRCODE = 'check_violation',
+            HINT = 'Upload the image (put + commit) before recording its metadata.';
+  END IF;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_require_committed_object(text, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.baaki_require_committed_object(text, text) TO service_role;
+
+-- ─────────────────────────────── attach a receipt attachment ──
+-- Re-declared whole from 20260825130000 (the cap + audit version), with the
+-- committed-object guard added just after the replay short-circuit: a replay
+-- returns the row already validated at its first attach, so only a genuinely new
+-- key is checked, and it is checked before the cap so a phantom path is refused
+-- cheaply.
+
+CREATE OR REPLACE FUNCTION public.baaki_attach_expense_attachment(
+  p_expense_id   uuid,
+  p_storage_path text,
+  p_visibility   text DEFAULT 'group',
+  p_attachment_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+  v_member   uuid;
+  v_id       uuid;
+BEGIN
+  IF coalesce(btrim(p_storage_path), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_PATH: an attachment needs a stored image'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  IF p_visibility NOT IN ('group', 'parties') THEN
+    RAISE EXCEPTION 'INVALID_VISIBILITY: group or parties' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- The key MUST be scoped to this expense: `<expenseId>/…` (see the proof RPC).
+  IF p_storage_path NOT LIKE p_expense_id::text || '/%' THEN
+    RAISE EXCEPTION 'INVALID_PATH: the key must be scoped to its expense'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Authorise before resolving the client id (an existence oracle otherwise).
+  SELECT group_id INTO v_group_id FROM public.expenses WHERE id = p_expense_id;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such expense' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF NOT public.baaki_is_expense_party(p_expense_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only a payer or the author may attach to this expense'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Replay bound to the subject: same id + same expense returns the existing row
+  -- (and, because it returns here, never emits a second audit line and is never
+  -- re-counted against the cap).
+  IF p_attachment_id IS NOT NULL THEN
+    SELECT id INTO v_id
+    FROM public.expense_attachments
+    WHERE id = p_attachment_id AND expense_id = p_expense_id;
+    IF v_id IS NOT NULL THEN
+      RETURN v_id;
+    END IF;
+  END IF;
+
+  -- The bytes must really exist: a committed object at this key, in the
+  -- attachments bucket. Blocks a phantom / never-uploaded / pending-only path
+  -- from being recorded as an attachment. Checked for a genuinely new row only.
+  PERFORM public.baaki_require_committed_object('expense-attachments', btrim(p_storage_path));
+
+  -- Serialize the count-then-insert against other attaches to THIS expense: a
+  -- transaction-scoped advisory lock keyed on the expense id. Without it two
+  -- concurrent adds could both read a live count below the cap and both insert,
+  -- landing one over (the same race the ghost-merge path guards). Only other
+  -- attach calls take this key, so it never blocks unrelated writers, and it is
+  -- released at commit. Taken before the count so a paid group pays only a
+  -- trivial, uncontended lock and nothing else.
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_expense_id::text, 0));
+
+  -- The per-expense ceiling, enforced at the one insert path. A paid group is
+  -- exempt; only live (non-deleted) attachments count, so removing one frees a
+  -- slot.
+  IF NOT public.baaki_group_is_paid(v_group_id)
+     AND (SELECT count(*) FROM public.expense_attachments
+           WHERE expense_id = p_expense_id AND deleted_at IS NULL)
+         >= public.baaki_attachment_cap()
+  THEN
+    RAISE EXCEPTION 'ATTACHMENT_CAP'
+      USING ERRCODE = 'check_violation',
+            HINT = 'This expense has reached its free receipt limit; upgrade to add more.';
+  END IF;
+
+  v_member := public.baaki_my_member_id(v_group_id);
+
+  INSERT INTO public.expense_attachments
+    (id, expense_id, group_id, uploader_member_id, storage_path, visibility)
+  VALUES
+    (COALESCE(p_attachment_id, gen_random_uuid()), p_expense_id, v_group_id, v_member,
+     btrim(p_storage_path), p_visibility)
+  RETURNING id INTO v_id;
+
+  INSERT INTO public.expense_image_events
+    (id, group_id, expense_id, actor_member_id, kind, action, visibility)
+  VALUES
+    (gen_random_uuid(), v_group_id, p_expense_id, v_member, 'attachment', 'added', p_visibility);
+
+  RETURN v_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_attach_expense_attachment(uuid, text, text, uuid)
+  TO authenticated, anon;
+
+-- ─────────────────────────────── attach a settlement proof ──
+-- Re-declared whole from 20260824150000, with the committed-object guard added
+-- after the replay short-circuit (before the one-live-proof check), so a proof
+-- can never point at bytes that were not uploaded.
+
+CREATE OR REPLACE FUNCTION public.baaki_attach_settlement_proof(
+  p_settlement_id uuid,
+  p_storage_path  text,
+  p_proof_id      uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_group_id uuid;
+  v_member   uuid;
+  v_id       uuid;
+BEGIN
+  IF coalesce(btrim(p_storage_path), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_PATH: a proof needs a stored image' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- The object key MUST be scoped to this subject: `<settlementId>/…`. This is
+  -- the canonical contract the client and r2-sign both hold, and it stops a party
+  -- to one settlement recording a path under another's prefix.
+  IF p_storage_path NOT LIKE p_settlement_id::text || '/%' THEN
+    RAISE EXCEPTION 'INVALID_PATH: the key must be scoped to its settlement'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Authorise BEFORE resolving the client-supplied id. Resolving first would let
+  -- a non-party who guesses an existing id short-circuit to a success (an
+  -- existence oracle), and skip the party check entirely.
+  SELECT group_id INTO v_group_id FROM public.settlements WHERE id = p_settlement_id;
+  IF v_group_id IS NULL THEN
+    RAISE EXCEPTION 'NOT_FOUND: no such settlement' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF NOT public.baaki_is_settlement_party(p_settlement_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only the payer or payee may attach a proof'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Replay: the SAME id for the SAME settlement returns the existing row. Bound
+  -- to the subject so a reused id against a different settlement cannot pass.
+  IF p_proof_id IS NOT NULL THEN
+    SELECT id INTO v_id
+    FROM public.settlement_proofs
+    WHERE id = p_proof_id AND settlement_id = p_settlement_id;
+    IF v_id IS NOT NULL THEN
+      RETURN v_id;
+    END IF;
+  END IF;
+
+  -- The bytes must really exist: a committed object at this key, in the
+  -- settlement-proofs bucket. Blocks a phantom / never-uploaded / pending-only
+  -- path. Checked for a genuinely new row only (a replay returned above).
+  PERFORM public.baaki_require_committed_object('settlement-proofs', btrim(p_storage_path));
+
+  -- One live proof per settlement. A replay reuses the same id (caught above);
+  -- a genuine second attach must remove the first — a proof is immutable.
+  IF EXISTS (
+    SELECT 1 FROM public.settlement_proofs
+    WHERE settlement_id = p_settlement_id AND deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'PROOF_EXISTS: this settlement already has a proof; remove it first'
+      USING ERRCODE = 'unique_violation';
+  END IF;
+
+  v_member := public.baaki_my_member_id(v_group_id);
+
+  INSERT INTO public.settlement_proofs
+    (id, settlement_id, group_id, uploader_member_id, storage_path)
+  VALUES
+    (COALESCE(p_proof_id, gen_random_uuid()), p_settlement_id, v_group_id, v_member,
+     btrim(p_storage_path))
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_attach_settlement_proof(uuid, text, uuid)
+  TO authenticated, anon;
+
+-- ─────────────────────────────── repoint an attachment image ──
+-- Re-declared whole from 20260825120000, with the committed-object guard added
+-- after the party check: the new bytes (a rotate / crop written to a fresh key)
+-- must have landed before the row is repointed at them.
+
+CREATE OR REPLACE FUNCTION public.baaki_replace_expense_attachment_image(
+  p_attachment_id uuid,
+  p_new_path      text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_expense_id uuid;
+BEGIN
+  IF coalesce(btrim(p_new_path), '') = '' THEN
+    RAISE EXCEPTION 'INVALID_PATH: a replacement needs a stored image'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT expense_id INTO v_expense_id
+  FROM public.expense_attachments
+  WHERE id = p_attachment_id AND deleted_at IS NULL;
+  IF v_expense_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- The new key MUST stay scoped to this expense, exactly like the attach RPC.
+  IF p_new_path NOT LIKE v_expense_id::text || '/%' THEN
+    RAISE EXCEPTION 'INVALID_PATH: the key must be scoped to its expense'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF NOT public.baaki_is_expense_party(v_expense_id) THEN
+    RAISE EXCEPTION 'NOT_A_PARTY: only a party may adjust this image'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- The replacement bytes must really exist: a committed object at the new key.
+  -- Without this the row could be repointed at a never-uploaded path, and the
+  -- markup would be cleared, leaving the attachment pointing at nothing.
+  PERFORM public.baaki_require_committed_object('expense-attachments', btrim(p_new_path));
+
+  UPDATE public.expense_attachments
+     SET storage_path = btrim(p_new_path),
+         annotations  = NULL
+   WHERE id = p_attachment_id AND deleted_at IS NULL;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.baaki_replace_expense_attachment_image(uuid, text)
+  TO authenticated, anon;

--- a/packages/db/prisma/migrations/20260825240000_attachment_committed_object/migration.sql
+++ b/packages/db/prisma/migrations/20260825240000_attachment_committed_object/migration.sql
@@ -67,7 +67,13 @@ BEGIN
 END
 $$;
 
-REVOKE ALL ON FUNCTION public.baaki_require_committed_object(text, text) FROM public;
+-- Supabase's default privileges grant EXECUTE on every new public function to
+-- anon + authenticated DIRECTLY (see 20260806200000), so a bare
+-- `REVOKE ... FROM public` would leave clients able to call this and use it as
+-- an existence oracle over the service-role-only `storage_objects` ledger. Revoke
+-- from the client roles explicitly; only the definer RPCs (and service_role) call it.
+REVOKE ALL ON FUNCTION public.baaki_require_committed_object(text, text)
+  FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.baaki_require_committed_object(text, text) TO service_role;
 
 -- ─────────────────────────────── attach a receipt attachment ──

--- a/packages/db/test/attachment-committed-object.test.ts
+++ b/packages/db/test/attachment-committed-object.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Integrity: an attachment / settlement proof may only point at bytes that were
+ * really uploaded (20260825240000). The attach RPCs require a committed
+ * `storage_objects` row at the key — a phantom, pending-only, or wrong-bucket
+ * path is refused at the SECURITY DEFINER boundary (ADR-013), so a client that
+ * ignores the happy-path upload still cannot record a broken pointer.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import {
+  addEqualSplitExpense,
+  connect,
+  expectDenied,
+  seedCommittedObject,
+  seedGroup,
+} from './helpers';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+async function as<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+async function makeSettlement(groupId: string, from: string, to: string): Promise<string> {
+  const id = randomUUID();
+  await client.query(
+    `INSERT INTO settlements (id, group_id, from_member_id, to_member_id, currency, amount, method, status)
+     VALUES ($1, $2, $3, $4, 'INR', 1000, 'upi', 'initiated')`,
+    [id, groupId, from, to],
+  );
+  return id;
+}
+
+// m0 = author + sole payer → the party; also the from-member of a settlement.
+let g: { groupId: string; profileIds: string[]; memberIds: string[] };
+let expenseId: string;
+let settlementId: string;
+
+beforeAll(async () => {
+  g = await seedGroup(client, { memberCount: 2, name: 'CommitCheck' });
+  ({ expenseId } = await addEqualSplitExpense(client, {
+    groupId: g.groupId,
+    payers: { [g.memberIds[0] as string]: 2000n },
+    participants: g.memberIds,
+    amount: 2000n,
+  }));
+  settlementId = await makeSettlement(
+    g.groupId,
+    g.memberIds[0] as string,
+    g.memberIds[1] as string,
+  );
+});
+
+const P = (i: number) => g.profileIds[i] as string;
+
+beforeEach(async () => {
+  await client.query(`DELETE FROM expense_attachments WHERE group_id = $1`, [g.groupId]);
+  await client.query(`DELETE FROM settlement_proofs WHERE group_id = $1`, [g.groupId]);
+});
+
+const attachExpense = (path: string) =>
+  as(P(0), () =>
+    client.query(`SELECT baaki_attach_expense_attachment($1, $2, 'group', NULL) AS id`, [
+      expenseId,
+      path,
+    ]),
+  );
+
+const attachProof = (path: string) =>
+  as(P(0), () =>
+    client.query(`SELECT baaki_attach_settlement_proof($1, $2, NULL) AS id`, [settlementId, path]),
+  );
+
+const countAttachments = () =>
+  client
+    .query(`SELECT count(*)::int AS n FROM expense_attachments WHERE expense_id = $1`, [expenseId])
+    .then((r) => r.rows[0].n as number);
+
+const countProofs = () =>
+  client
+    .query(`SELECT count(*)::int AS n FROM settlement_proofs WHERE settlement_id = $1`, [
+      settlementId,
+    ])
+    .then((r) => r.rows[0].n as number);
+
+describe('baaki_attach_expense_attachment requires a committed object', () => {
+  it('rejects a scoped path with no storage_objects row at all', async () => {
+    const path = `${expenseId}/${randomUUID()}.webp`; // never uploaded
+    const message = await expectDenied(attachExpense(path));
+    expect(message).toMatch(/OBJECT_NOT_COMMITTED/);
+    expect(await countAttachments()).toBe(0);
+  });
+
+  it('rejects a path that is only a pending reservation', async () => {
+    const path = `${expenseId}/${randomUUID()}.webp`;
+    await seedCommittedObject(client, {
+      bucket: 'expense-attachments',
+      path,
+      ownerProfileId: P(0),
+      pending: true, // reserved, never committed
+    });
+    const message = await expectDenied(attachExpense(path));
+    expect(message).toMatch(/OBJECT_NOT_COMMITTED/);
+    expect(await countAttachments()).toBe(0);
+  });
+
+  it('rejects a committed object that lives in a different logical bucket', async () => {
+    const path = `${expenseId}/${randomUUID()}.webp`;
+    // Committed, but under `receipts` — not the `expense-attachments` bucket.
+    await seedCommittedObject(client, { bucket: 'receipts', path, ownerProfileId: P(0) });
+    const message = await expectDenied(attachExpense(path));
+    expect(message).toMatch(/OBJECT_NOT_COMMITTED/);
+    expect(await countAttachments()).toBe(0);
+  });
+
+  it('accepts a committed object with the correct bucket and path', async () => {
+    const path = `${expenseId}/${randomUUID()}.webp`;
+    await seedCommittedObject(client, {
+      bucket: 'expense-attachments',
+      path,
+      ownerProfileId: P(0),
+    });
+    await attachExpense(path);
+    expect(await countAttachments()).toBe(1);
+    const { rows } = await client.query(
+      `SELECT storage_path FROM expense_attachments WHERE expense_id = $1`,
+      [expenseId],
+    );
+    expect(rows[0].storage_path).toBe(path);
+  });
+});
+
+describe('baaki_attach_settlement_proof requires a committed object', () => {
+  it('rejects a scoped path with no committed object', async () => {
+    const path = `${settlementId}/${randomUUID()}.webp`;
+    const message = await expectDenied(attachProof(path));
+    expect(message).toMatch(/OBJECT_NOT_COMMITTED/);
+    expect(await countProofs()).toBe(0);
+  });
+
+  it('rejects a pending-only reservation', async () => {
+    const path = `${settlementId}/${randomUUID()}.webp`;
+    await seedCommittedObject(client, {
+      bucket: 'settlement-proofs',
+      path,
+      ownerProfileId: P(0),
+      pending: true,
+    });
+    const message = await expectDenied(attachProof(path));
+    expect(message).toMatch(/OBJECT_NOT_COMMITTED/);
+    expect(await countProofs()).toBe(0);
+  });
+
+  it('accepts a committed object at the right key', async () => {
+    const path = `${settlementId}/${randomUUID()}.webp`;
+    await seedCommittedObject(client, {
+      bucket: 'settlement-proofs',
+      path,
+      ownerProfileId: P(0),
+    });
+    await attachProof(path);
+    expect(await countProofs()).toBe(1);
+  });
+});

--- a/packages/db/test/attachment-committed-object.test.ts
+++ b/packages/db/test/attachment-committed-object.test.ts
@@ -182,3 +182,19 @@ describe('baaki_attach_settlement_proof requires a committed object', () => {
     expect(await countProofs()).toBe(1);
   });
 });
+
+describe('the committed-object guard is not a client-callable oracle', () => {
+  it('a client cannot execute baaki_require_committed_object directly', async () => {
+    // Supabase grants EXECUTE on new public functions to anon/authenticated by
+    // default; the migration must revoke it, or a client could probe whether any
+    // (bucket, path) is committed in the service-role-only ledger.
+    const message = await as(P(0), () =>
+      expectDenied(
+        client.query(`SELECT baaki_require_committed_object('avatars', $1)`, [
+          `${randomUUID()}/a.webp`,
+        ]),
+      ),
+    );
+    expect(message).toMatch(/permission denied/i);
+  });
+});

--- a/packages/db/test/expense-image-events.test.ts
+++ b/packages/db/test/expense-image-events.test.ts
@@ -13,7 +13,13 @@ import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { Client } from 'pg';
 
-import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers';
+import {
+  addEqualSplitExpense,
+  connect,
+  expectDenied,
+  seedCommittedObject,
+  seedGroup,
+} from './helpers';
 
 let client: Client;
 
@@ -79,16 +85,24 @@ const logReceipt = (profileId: string, action: string, id = randomUUID()) =>
   );
 
 const attach = (profileId: string, visibility: string, id = randomUUID()) =>
-  as(profileId, () =>
-    client
+  as(profileId, async () => {
+    const path = `${expenseId}/${randomUUID()}.webp`;
+    // The attach RPC now requires a committed object at the key; seed it (the
+    // real client uploads via r2-sign's put + commit before attaching).
+    await seedCommittedObject(client, {
+      bucket: 'expense-attachments',
+      path,
+      ownerProfileId: profileId,
+    });
+    return client
       .query(`SELECT baaki_attach_expense_attachment($1, $2, $3, $4) AS id`, [
         expenseId,
-        `${expenseId}/${randomUUID()}.webp`,
+        path,
         visibility,
         id,
       ])
-      .then((r) => r.rows[0].id as string),
-  );
+      .then((r) => r.rows[0].id as string);
+  });
 
 const remove = (profileId: string, attachmentId: string) =>
   as(profileId, () => client.query(`SELECT baaki_remove_expense_attachment($1)`, [attachmentId]));

--- a/packages/db/test/helpers.ts
+++ b/packages/db/test/helpers.ts
@@ -224,6 +224,59 @@ export async function asRole<T>(
   }
 }
 
+/**
+ * Seed a `storage_objects` row so an attach / replace RPC — which now requires a
+ * committed object at the key (20260825240000) — accepts the metadata. In real
+ * life `r2-sign`'s put+commit writes this; a test that attaches a made-up path
+ * must stand one in first.
+ *
+ * `storage_objects` is service-role-only (REVOKE ALL from anon/authenticated), and
+ * a caller may be inside a `SET ROLE` block, so the insert runs as the DB
+ * superuser and the prior role is restored afterwards. `counted` is irrelevant to
+ * the committed-object check, so it is always false; `owner_profile_id` only has
+ * to be a real profile (the check ignores it), and `group_id` may be null.
+ */
+export async function seedCommittedObject(
+  client: Client,
+  options: {
+    bucket: string;
+    path: string;
+    ownerProfileId: string;
+    groupId?: string | null;
+    pending?: boolean;
+    bytes?: number;
+    contentType?: string;
+  },
+): Promise<void> {
+  const {
+    bucket,
+    path,
+    ownerProfileId,
+    groupId = null,
+    pending = false,
+    bytes = 1024,
+    contentType = 'image/webp',
+  } = options;
+
+  const prev = (await client.query(`SELECT current_setting('role') AS role`)).rows[0]
+    .role as string;
+  await client.query('RESET ROLE');
+  try {
+    await client.query(
+      `INSERT INTO storage_objects
+         (logical_bucket, path, owner_profile_id, group_id, bytes, content_type, counted, pending)
+       VALUES ($1, $2, $3, $4, $5, $6, false, $7)
+       ON CONFLICT (logical_bucket, path) DO UPDATE
+         SET pending = excluded.pending, bytes = excluded.bytes`,
+      [bucket, path, ownerProfileId, groupId, bytes, contentType, pending],
+    );
+  } finally {
+    if (prev && prev !== 'none') {
+      await client.query(`SET ROLE ${prev}`);
+    }
+  }
+}
+
 export async function expectDenied(promise: Promise<unknown>): Promise<string> {
   try {
     await promise;

--- a/packages/db/test/private-attachments.test.ts
+++ b/packages/db/test/private-attachments.test.ts
@@ -10,7 +10,13 @@ import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { Client } from 'pg';
 
-import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers';
+import {
+  addEqualSplitExpense,
+  connect,
+  expectDenied,
+  seedCommittedObject,
+  seedGroup,
+} from './helpers';
 
 let client: Client;
 
@@ -85,16 +91,37 @@ beforeEach(async () => {
   await client.query(`DELETE FROM expense_attachments WHERE group_id = $1`, [g.groupId]);
 });
 
-const attachProof = (sid: string, path: string, id: string | null = null) =>
-  client.query(`SELECT baaki_attach_settlement_proof($1, $2, $3) AS id`, [sid, path, id]);
+// The attach RPCs now require a committed `storage_objects` row at the key (the
+// real client uploads via r2-sign's put + commit first). Seed that row before
+// each attach; a call meant to fail earlier (non-party, bad path) simply never
+// reaches the committed-object check, so seeding is harmless there.
+const attachProof = async (sid: string, path: string, id: string | null = null) => {
+  await seedCommittedObject(client, {
+    bucket: 'settlement-proofs',
+    path,
+    ownerProfileId: g.profileIds[0] as string,
+  });
+  return client.query(`SELECT baaki_attach_settlement_proof($1, $2, $3) AS id`, [sid, path, id]);
+};
 
-const attachExpense = (eid: string, path: string, visibility: string, id: string | null = null) =>
-  client.query(`SELECT baaki_attach_expense_attachment($1, $2, $3, $4) AS id`, [
+const attachExpense = async (
+  eid: string,
+  path: string,
+  visibility: string,
+  id: string | null = null,
+) => {
+  await seedCommittedObject(client, {
+    bucket: 'expense-attachments',
+    path,
+    ownerProfileId: g.profileIds[0] as string,
+  });
+  return client.query(`SELECT baaki_attach_expense_attachment($1, $2, $3, $4) AS id`, [
     eid,
     path,
     visibility,
     id,
   ]);
+};
 
 describe('T13 — party predicates', () => {
   it('answer true for a party and false for a non-party', async () => {

--- a/packages/db/test/receipt-annotations.test.ts
+++ b/packages/db/test/receipt-annotations.test.ts
@@ -8,7 +8,13 @@ import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { Client } from 'pg';
 
-import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers';
+import {
+  addEqualSplitExpense,
+  connect,
+  expectDenied,
+  seedCommittedObject,
+  seedGroup,
+} from './helpers';
 
 let client: Client;
 
@@ -59,12 +65,19 @@ const P = (i: number) => g.profileIds[i] as string;
 
 beforeEach(async () => {
   await client.query(`DELETE FROM expense_attachments WHERE group_id = $1`, [g.groupId]);
-  // A fresh group-visible attachment owned by the party each test.
+  // A fresh group-visible attachment owned by the party each test. The attach
+  // RPC now requires a committed object at the key, so seed one first.
   attachmentId = randomUUID();
+  const path = `${expenseId}/${randomUUID()}.webp`;
+  await seedCommittedObject(client, {
+    bucket: 'expense-attachments',
+    path,
+    ownerProfileId: P(0),
+  });
   await as(P(0), () =>
     client.query(`SELECT baaki_attach_expense_attachment($1, $2, 'group', $3)`, [
       expenseId,
-      `${expenseId}/${randomUUID()}.webp`,
+      path,
       attachmentId,
     ]),
   );

--- a/packages/db/test/replace-attachment-image.test.ts
+++ b/packages/db/test/replace-attachment-image.test.ts
@@ -9,7 +9,13 @@ import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { Client } from 'pg';
 
-import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers';
+import {
+  addEqualSplitExpense,
+  connect,
+  expectDenied,
+  seedCommittedObject,
+  seedGroup,
+} from './helpers';
 
 let client: Client;
 
@@ -60,10 +66,18 @@ const P = (i: number) => g.profileIds[i] as string;
 beforeEach(async () => {
   await client.query(`DELETE FROM expense_attachments WHERE group_id = $1`, [g.groupId]);
   attachmentId = randomUUID();
+  const initialPath = `${expenseId}/${randomUUID()}.webp`;
+  // The attach RPC now requires a committed object at the key; the real client
+  // uploads (put + commit) before attaching, so seed that committed row.
+  await seedCommittedObject(client, {
+    bucket: 'expense-attachments',
+    path: initialPath,
+    ownerProfileId: P(0),
+  });
   await as(P(0), () =>
     client.query(`SELECT baaki_attach_expense_attachment($1, $2, 'group', $3)`, [
       expenseId,
-      `${expenseId}/${randomUUID()}.webp`,
+      initialPath,
       attachmentId,
     ]),
   );
@@ -92,6 +106,12 @@ const row = (id: string) =>
 describe('replace attachment image', () => {
   it('a party repoints the row and the markup is cleared', async () => {
     const newPath = `${expenseId}/${randomUUID()}.webp`;
+    // The rotate/crop bytes were uploaded to the fresh key first.
+    await seedCommittedObject(client, {
+      bucket: 'expense-attachments',
+      path: newPath,
+      ownerProfileId: P(0),
+    });
     await replace(P(0), attachmentId, newPath);
     const r = await row(attachmentId);
     expect(r.storage_path).toBe(newPath);
@@ -114,20 +134,12 @@ describe('replace attachment image', () => {
     await replace(P(0), randomUUID(), `${expenseId}/${randomUUID()}.webp`);
   });
 
-  // TODO(integrity): the RPC only checks that the new path is scoped to the
-  // expense (`<expenseId>/…`) — it never checks that a committed row for that
-  // path exists in `storage_objects`. A party can repoint an attachment at
-  // bytes that were never uploaded (a typo'd path, a path from a different
-  // logical bucket, or one that was only ever `pending`/released and never
-  // committed), and the RPC clears the markup and succeeds anyway, leaving the
-  // row pointing at nothing. This matches the sibling
-  // `baaki_attach_expense_attachment` (20260824150000 / 20260825130000), which
-  // has the exact same gap — it is not unique to replace, so this is
-  // documented rather than fixed here: fixing one without the other would be
-  // an inconsistent half-measure, and fixing both is a wider change (every
-  // other DB test that attaches with a made-up path — expense-image-events,
-  // receipt-annotations — would need a real `storage_objects` row too).
-  it('TODO(integrity): a syntactically valid but never-committed path is accepted', async () => {
+  // Integrity (20260825240000): the RPC now checks that a committed object for
+  // the new path exists in `storage_objects`. A party can no longer repoint an
+  // attachment at bytes that were never uploaded (a typo'd path, a path from a
+  // different logical bucket, or one that was only ever `pending`/released and
+  // never committed) — the row can never end up pointing at nothing.
+  it('rejects a syntactically valid but never-committed path, and leaves the row untouched', async () => {
     // Scoped correctly, never went through r2-sign's `put`/`commit` — no row
     // for it in storage_objects.
     const neverUploaded = `${expenseId}/${randomUUID()}.webp`;
@@ -136,10 +148,38 @@ describe('replace attachment image', () => {
       .then((r) => r.rows[0].n as number);
     expect(orphaned).toBe(0);
 
-    await replace(P(0), attachmentId, neverUploaded);
+    const before = await row(attachmentId);
+    const message = await expectDenied(replace(P(0), attachmentId, neverUploaded));
+    expect(message).toMatch(/OBJECT_NOT_COMMITTED/);
 
-    const r = await row(attachmentId);
-    expect(r.storage_path).toBe(neverUploaded);
-    expect(r.annotations).toBeNull();
+    // The row is unchanged: still the old path, and the failed replace did NOT
+    // clear the markup.
+    const after = await row(attachmentId);
+    expect(after.storage_path).toBe(before.storage_path);
+    expect(after.annotations).not.toBeNull();
+  });
+
+  it('rejects a path that is only a pending reservation (uploaded but never committed)', async () => {
+    const reservedOnly = `${expenseId}/${randomUUID()}.webp`;
+    await seedCommittedObject(client, {
+      bucket: 'expense-attachments',
+      path: reservedOnly,
+      ownerProfileId: P(0),
+      pending: true,
+    });
+    const message = await expectDenied(replace(P(0), attachmentId, reservedOnly));
+    expect(message).toMatch(/OBJECT_NOT_COMMITTED/);
+  });
+
+  it('rejects a committed object that lives in the wrong logical bucket', async () => {
+    const wrongBucket = `${expenseId}/${randomUUID()}.webp`;
+    // Committed, but under `receipts`, not `expense-attachments`.
+    await seedCommittedObject(client, {
+      bucket: 'receipts',
+      path: wrongBucket,
+      ownerProfileId: P(0),
+    });
+    const message = await expectDenied(replace(P(0), attachmentId, wrongBucket));
+    expect(message).toMatch(/OBJECT_NOT_COMMITTED/);
   });
 });


### PR DESCRIPTION
## Problem

Private expense attachments and settlement proofs could reference storage keys that were **never uploaded/committed**. The attach/replace RPCs validated the key's *shape* (scoped to its expense/settlement), party-ship, visibility, and the per-expense cap — but never that a committed object actually existed at that key.

A party (a buggy retry, or a malicious/manual client bypassing the happy-path upload) could record a row pointing at:
- a typo'd path,
- a key from a **different logical bucket**, or
- one that was only ever a `pending` reservation and never committed.

The row then pointed at nothing: sync distributed the broken metadata, the audit trail lied, and the storage ledger / metadata drifted. The gap was documented as a `TODO(integrity)` in `replace-attachment-image.test.ts`.

## Fix

New migration `20260825240000_attachment_committed_object` (functions only — `CREATE OR REPLACE`, no schema table change, no edit of already-applied migrations):

- **New shared helper** `baaki_require_committed_object(logical_bucket, path)` — one guard for both surfaces (the check is identical, only the bucket differs). Requires a **non-pending (committed)** `storage_objects` row at the exact `(logical_bucket, path)`. A `pending` reservation does **not** satisfy it. `SECURITY DEFINER` (reads the service-role-only ledger), returns nothing.
- **RPCs re-declared to call it** (for a genuinely new key, right after the replay short-circuit so a replay still returns its already-validated row):
  - `baaki_attach_expense_attachment` → `'expense-attachments'` bucket
  - `baaki_replace_expense_attachment_image` → `'expense-attachments'` bucket
  - `baaki_attach_settlement_proof` → `'settlement-proofs'` bucket

Subject/group ownership stays enforced by each RPC's existing `storage_path LIKE '<subjectId>/%'` prefix check; the new guard adds the "these bytes are real and committed, in the right bucket" half. It remains the ADR-013 SECURITY DEFINER boundary — a client ignoring any client-side check still cannot record a phantom pointer.

## Tests (`packages/db`)

New `attachment-committed-object.test.ts` — for **both** attach RPCs:
- reject when no `storage_objects` row exists
- reject a pending-only reservation
- reject a committed object in the wrong logical bucket
- accept a committed object with the correct bucket + path

`replace-attachment-image.test.ts` — the `TODO(integrity)` test is turned into rejection assertions (never-committed, pending-only, wrong-bucket) that also prove a **failed replace leaves the row and its markup untouched**.

New `seedCommittedObject` helper in `test/helpers.ts` (role-restoring insert, since `storage_objects` is service-role-only). The existing tests that attached with made-up paths — `private-attachments`, `receipt-annotations`, `expense-image-events`, `replace-attachment-image` — now seed a committed `storage_objects` row first.

## Gates
- `pnpm format` clean, `pnpm lint` clean
- `pnpm --filter @waves/db test`: **608 passed (49 files)** against local Postgres (migration applied to the local DB to exercise it)
- Prisma `drift` not run locally (needs live-DB creds); this change adds only functions, so there is no schema drift.

## Deploy
Needs a **`migrate deploy`** (`pnpm --filter @waves/db migrate:deploy` / the standard migrate-deploy path) to land the new functions on prod. Not deployed here — the repo owner deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Attachment and settlement-proof links now require a successfully committed storage object in the correct location.
  * Replacing an attachment image rejects missing, pending, or incorrectly categorized storage objects.
  * Existing authorization, validation, replay protection, attachment limits, and annotation behavior remain enforced.

* **Tests**
  * Added coverage for valid committed objects and rejection of invalid storage references across attachment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->