### PR TITLE
fix(invite): idempotent invite-use consumption for ghost-claims

### DIFF
--- a/packages/db/prisma/migrations/20260825240000_invite_claim_idempotent_consume/migration.sql
+++ b/packages/db/prisma/migrations/20260825240000_invite_claim_idempotent_consume/migration.sql
@@ -1,0 +1,165 @@
+-- A pending ghost-claim must not burn an invite use it can never give back.
+--
+-- The hole (invite-accept): `baaki_consume_invite` ran BEFORE the claim branch,
+-- so the moment someone tapped "I'm Ravi" a `max_uses` slot was spent — whether
+-- or not an admin ever agreed, and, worse, EVERY time they tapped. A pending
+-- claimant is not a member, so `baaki_request_member_claim` happily returned
+-- `already_pending` on the second, third, hundredth attempt while the caller had
+-- already re-run the consume each time. A valid link capped at N uses could be
+-- emptied by one person re-POSTing the same claim N times, or by N bogus claims
+-- on N ghosts, with nobody ever joining. The organizer's link looks "full"; no
+-- one is in the group.
+--
+-- The fix (semantic #2 from the brief — "consume at most once per
+-- (invite, profile, member), idempotently"): consumption moves OUT of the edge
+-- function's claim path and INTO this function, placed so it fires exactly once,
+-- for exactly one genuinely-new pending claim, and never for a repeat or a
+-- doomed request:
+--
+--   * NOT_CLAIMABLE / ALREADY_CLAIMED / ALREADY_A_MEMBER  -> no use spent.
+--   * already-pending (the same person asking again)      -> no use spent;
+--     the existing claim is the answer, so the link is not touched. This is the
+--     idempotency that closes the repeat-exhaustion abuse.
+--   * a brand-new, valid claim                            -> one use spent,
+--     atomically, in the same transaction as the INSERT. If the link is spent or
+--     invalid by then, the claim is refused and nothing is written.
+--
+-- Because the whole function is one transaction and the member row is held
+-- `FOR UPDATE`, two concurrent requests for the same place cannot both file a new
+-- claim — the loser sees the winner's pending row and returns already_pending
+-- without consuming. And `baaki_consume_invite` itself is a single atomic
+-- conditional UPDATE, so two DIFFERENT new claims racing for a link's LAST slot
+-- (or a claim racing a direct join) serialise on the invite row: exactly one wins.
+--
+-- A direct (non-claim) join is unchanged: invite-accept still calls
+-- `baaki_consume_invite` once, right before it inserts the membership, so a normal
+-- join still spends exactly one use.
+--
+-- Why not "consume only on approval"? That would need to carry the invite id to
+-- `baaki_decide_member_claim`, i.e. a new column on `member_claims` (a Prisma
+-- model) and the drift that comes with it. Reserving idempotently at request
+-- time closes the reported abuse (repeat / bogus exhaustion) with a functions-only
+-- change and no schema drift.
+
+-- Signature changes (a 5th argument), so the old overload must go first —
+-- CREATE OR REPLACE would otherwise leave a second, ambiguous function behind.
+DROP FUNCTION IF EXISTS public.baaki_request_member_claim(uuid, uuid, uuid, text);
+
+/**
+ * Record a request to take a ghost's place, reserving one invite use for a
+ * genuinely-new claim and nothing for a repeat or a doomed one.
+ *
+ * Service-role only, and takes the profile explicitly: the caller is
+ * `invite-accept`, which has already verified a signed invite token. The person
+ * asking is not a member of the group yet and has no other standing to be here,
+ * so there is nothing for a client-side check to check.
+ *
+ * `p_invite_id` is the link they came through. When given, one use is consumed
+ * for a new claim (and only then); when NULL — e.g. an internal caller with no
+ * link in hand — no use is touched. Returns a verdict rather than raising,
+ * because every refusal is a sentence to show somebody who just tapped their own
+ * name.
+ */
+CREATE OR REPLACE FUNCTION public.baaki_request_member_claim(
+  p_group_id   uuid,
+  p_member_id  uuid,
+  p_profile_id uuid,
+  p_name       text DEFAULT NULL,
+  p_invite_id  uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_member   public.group_members%ROWTYPE;
+  v_group    text;
+  v_id       uuid;
+  v_admin    record;
+  v_consumed boolean;
+BEGIN
+  SELECT * INTO v_member
+    FROM public.group_members
+   WHERE id = p_member_id AND group_id = p_group_id
+   FOR UPDATE;
+
+  IF NOT FOUND OR v_member.left_at IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'NOT_CLAIMABLE');
+  END IF;
+
+  -- Already somebody's. The check is repeated at decision time as well: this
+  -- one is for the sentence, that one is for the guarantee.
+  IF v_member.profile_id IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'ALREADY_CLAIMED');
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.group_members
+     WHERE group_id = p_group_id AND profile_id = p_profile_id AND left_at IS NULL
+  ) THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'ALREADY_A_MEMBER');
+  END IF;
+
+  -- The same person asking twice. Their existing request is the answer, and a
+  -- second notification to every admin is not — and, since this migration, a
+  -- second invite use is not either. Safe under the `FOR UPDATE` on the member
+  -- above, which serialises requests for one place, so two concurrent asks
+  -- cannot both slip past this into the consume below.
+  SELECT id INTO v_id
+    FROM public.member_claims
+   WHERE member_id = p_member_id AND requester_id = p_profile_id AND status = 'pending';
+
+  IF v_id IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', true, 'claim_id', v_id, 'already_pending', true);
+  END IF;
+
+  -- Past every short-circuit: this is a brand-new claim, and only now is a use
+  -- worth spending. The consume is atomic (a conditional UPDATE that re-checks
+  -- revocation, expiry and the cap under the invite's row lock), so if the link
+  -- has filled up — including a direct join or another new claim winning the
+  -- last slot in a concurrent race — this claim is refused and no row is written.
+  IF p_invite_id IS NOT NULL THEN
+    SELECT public.baaki_consume_invite(p_invite_id) INTO v_consumed;
+    IF v_consumed IS NOT TRUE THEN
+      RETURN jsonb_build_object('ok', false, 'reason', 'INVITE_INVALID');
+    END IF;
+  END IF;
+
+  INSERT INTO public.member_claims (group_id, member_id, requester_id, requested_name)
+  VALUES (p_group_id, p_member_id, p_profile_id, NULLIF(btrim(COALESCE(p_name, '')), ''))
+  RETURNING id INTO v_id;
+
+  SELECT name INTO v_group FROM public.groups WHERE id = p_group_id;
+
+  -- Every admin, not just the creator. A group whose only admin has stopped
+  -- opening the app is a group where nobody can ever join again.
+  FOR v_admin IN
+    SELECT profile_id FROM public.group_members
+     WHERE group_id = p_group_id AND role = 'admin'
+       AND profile_id IS NOT NULL AND left_at IS NULL
+  LOOP
+    PERFORM public.baaki_notify(
+      v_admin.profile_id,
+      p_group_id,
+      'ghost_claim_requested',
+      'Someone wants to join ' || COALESCE(v_group, 'a group'),
+      'They say they are ' || COALESCE(v_member.ghost_name, 'someone already listed'),
+      '/group/' || p_group_id::text || '/members',
+      jsonb_build_object(
+        'claim_id', v_id,
+        'member_id', p_member_id,
+        'ghost_name', v_member.ghost_name,
+        'requested_name', NULLIF(btrim(COALESCE(p_name, '')), '')
+      ),
+      'claim:' || v_id::text || ':' || v_admin.profile_id::text
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object('ok', true, 'claim_id', v_id, 'already_pending', false);
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_request_member_claim(uuid, uuid, uuid, text, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.baaki_request_member_claim(uuid, uuid, uuid, text, uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.baaki_request_member_claim(uuid, uuid, uuid, text, uuid) TO service_role;

--- a/packages/db/test/invite-claim-use-count.test.ts
+++ b/packages/db/test/invite-claim-use-count.test.ts
@@ -118,7 +118,10 @@ const useCountOf = (inviteId: string): Promise<{ use_count: number; max_uses: nu
 
 const pendingClaimCount = (groupId: string): Promise<number> =>
   client
-    .query(`SELECT count(*)::int AS n FROM member_claims WHERE group_id = $1`, [groupId])
+    .query(
+      `SELECT count(*)::int AS n FROM member_claims WHERE group_id = $1 AND status = 'pending'`,
+      [groupId],
+    )
     .then((r) => r.rows[0].n as number);
 
 describe('a pending claim reserves exactly one use, idempotently', () => {
@@ -153,6 +156,22 @@ describe('a pending claim reserves exactly one use, idempotently', () => {
       .then((r) => r.rows[0]);
     expect(ghost.profile_id).toBeNull();
     expect(ghost.ghost_name).toBe('Ghost 1');
+  });
+
+  it('spends no use when the caller passes no invite (internal / 4-arg callers)', async () => {
+    // baaki_request_member_claim(..., p_invite_id => NULL) files the claim but
+    // touches no link — the path that keeps memberClaims.test.ts's 4-arg calls
+    // working. A link that happens to exist for the group must be left alone.
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 1, ghostCount: 1 });
+    const ghostId = memberIds[1] as string;
+    const arrival = await newcomer();
+
+    const inviteId = await mintInvite(groupId, 1);
+    const verdict = await claim(client, groupId, ghostId, arrival, null, 'Ravi');
+    expect(verdict).toMatchObject({ ok: true, already_pending: false });
+
+    expect(await pendingClaimCount(groupId)).toBe(1);
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 0, max_uses: 1 });
   });
 
   it('lets a bogus claim spend nothing, so it cannot exhaust the link', async () => {
@@ -277,7 +296,7 @@ describe('concurrent redemption of the last slot', () => {
     const losers = results.filter((r) => !r.ok);
     expect(winners).toHaveLength(1);
     expect(losers).toHaveLength(1);
-    expect(losers[0].reason).toBe('INVITE_INVALID');
+    expect(losers[0]?.reason).toBe('INVITE_INVALID');
 
     // Exactly one slot spent, exactly one pending claim filed.
     expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });

--- a/packages/db/test/invite-claim-use-count.test.ts
+++ b/packages/db/test/invite-claim-use-count.test.ts
@@ -1,28 +1,35 @@
 /**
- * A wrinkle in the "asking is not taking" design (memberClaims / A6): claiming
- * a ghost is a two-step handshake — `invite-accept` files a pending
- * `member_claims` row via `baaki_request_member_claim`, and nothing about the
- * group changes until an admin decides via `baaki_decide_member_claim`.
+ * A pending ghost-claim must not burn an invite use it can never give back.
  *
- * But the invite's `max_uses` slot is NOT part of that handshake. Per
- * `invite-accept` (see the "Reserve a use atomically before creating
- * anything" comment there), `baaki_consume_invite` is called BEFORE the claim
- * branch runs, so the slot is burned the moment someone taps "claim Ravi" —
- * whether or not an admin ever agrees they are Ravi.
+ * Claiming a ghost is a two-step handshake (memberClaims / A6): `invite-accept`
+ * files a pending `member_claims` row via `baaki_request_member_claim`, and
+ * nothing about the group changes until an admin decides via
+ * `baaki_decide_member_claim`.
  *
- * These tests lock in that current behaviour at the DB/RPC level (the edge
- * function itself is Deno and out of scope here): a one-use invite is spent by
- * a claim request alone, and staying spent even if the claim is later
- * declined or withdrawn. Nothing here is changed — see the TODO(product) on
- * each test for the actual wrinkle.
+ * The abuse this file guards against: the invite's `max_uses` slot used to be
+ * consumed in `invite-accept` BEFORE the claim branch ran, so the slot was
+ * burned the instant someone tapped "claim Ravi" — every tap, whether or not an
+ * admin ever agreed. A pending claimant is not a member, so a repeat request
+ * returned `already_pending` while the caller had already re-run the consume,
+ * meaning one person could empty a valid link by re-POSTing the same claim.
+ *
+ * The fix (migration 20260825240000): consumption moved INTO
+ * `baaki_request_member_claim`, which now takes the invite id and spends exactly
+ * one use for a genuinely-NEW claim and nothing for a repeat or a doomed one. A
+ * direct (non-claim) join is unchanged — invite-accept still calls
+ * `baaki_consume_invite` once before inserting the membership.
+ *
+ * These tests exercise the RPC layer directly (the edge function is Deno and out
+ * of scope here). They mirror invite-accept's new order: the claim RPC is given
+ * the invite id and owns the reservation.
  */
 
 import { randomUUID, createHash } from 'node:crypto';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { Client } from 'pg';
+import { Client } from 'pg';
 
-import { connect, seedGroup } from './helpers';
+import { CONNECTION_STRING, connect, seedGroup } from './helpers';
 
 let client: Client;
 
@@ -56,58 +63,91 @@ async function newcomer(name = 'Arrival'): Promise<string> {
   return id;
 }
 
-/** A one-use invite, inserted directly the way invite-mint would leave it —
- *  not the durable join-link RPC, whose max_uses is effectively unlimited. */
-async function mintSingleUseInvite(groupId: string): Promise<string> {
+/** An invite inserted directly the way invite-mint would leave it. `maxUses`
+ *  defaults to a single use — the tightest cap, where an off-by-one matters. */
+async function mintInvite(groupId: string, maxUses = 1): Promise<string> {
   const inviteId = randomUUID();
   const token = randomUUID().replace(/-/g, '');
   const tokenHash = createHash('sha256').update(token).digest('hex');
   await client.query(
     `INSERT INTO invites (id, group_id, token_hash, expires_at, max_uses, use_count)
-     VALUES ($1, $2, $3, now() + interval '7 days', 1, 0)`,
-    [inviteId, groupId, tokenHash],
+     VALUES ($1, $2, $3, now() + interval '7 days', $4, 0)`,
+    [inviteId, groupId, tokenHash, maxUses],
   );
   return inviteId;
 }
 
-const consume = (inviteId: string) =>
+interface Verdict {
+  ok: boolean;
+  reason?: string;
+  claim_id?: string;
+  already_pending?: boolean;
+}
+
+/** The claim RPC as invite-accept now calls it: the invite id is passed, so the
+ *  RPC owns the (idempotent) reservation of a use. */
+const claim = (
+  db: Client,
+  groupId: string,
+  memberId: string,
+  profileId: string,
+  inviteId: string | null,
+  name: string | null = null,
+): Promise<Verdict> =>
+  db
+    .query(`SELECT public.baaki_request_member_claim($1, $2, $3, $4, $5) AS verdict`, [
+      groupId,
+      memberId,
+      profileId,
+      name,
+      inviteId,
+    ])
+    .then((r) => r.rows[0].verdict as Verdict);
+
+/** A direct (non-claim) join reserves its slot through this same primitive —
+ *  the regression guard for "a normal accept still consumes exactly one use". */
+const consume = (inviteId: string): Promise<boolean | null> =>
   client
-    .query(`SELECT baaki_consume_invite($1) AS ok`, [inviteId])
+    .query(`SELECT public.baaki_consume_invite($1) AS ok`, [inviteId])
     .then((r) => (r.rows[0].ok as boolean | null) ?? null);
 
-const useCountOf = (inviteId: string) =>
+const useCountOf = (inviteId: string): Promise<{ use_count: number; max_uses: number }> =>
   client
     .query(`SELECT use_count, max_uses FROM invites WHERE id = $1`, [inviteId])
     .then((r) => r.rows[0] as { use_count: number; max_uses: number });
 
-describe('a pending claim spends the invite slot before anyone decides', () => {
-  it('TODO(product): filing the claim (not deciding it) exhausts a one-use link', async () => {
+const pendingClaimCount = (groupId: string): Promise<number> =>
+  client
+    .query(`SELECT count(*)::int AS n FROM member_claims WHERE group_id = $1`, [groupId])
+    .then((r) => r.rows[0].n as number);
+
+describe('a pending claim reserves exactly one use, idempotently', () => {
+  it('spends one use for a genuinely-new claim and nothing on repeats', async () => {
     const { groupId, memberIds } = await seedGroup(client, { memberCount: 1, ghostCount: 1 });
     const ghostId = memberIds[1] as string;
     const arrival = await newcomer();
 
-    const inviteId = await mintSingleUseInvite(groupId);
-    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 0, max_uses: 1 });
+    const inviteId = await mintInvite(groupId, 3);
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 0, max_uses: 3 });
 
-    // Mirrors invite-accept's order: reserve the use, THEN ask for the claim.
-    expect(await consume(inviteId)).toBe(true);
-    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });
+    // First claim: a brand-new pending row, one use spent.
+    const first = await claim(client, groupId, ghostId, arrival, inviteId, 'Ravi');
+    expect(first).toMatchObject({ ok: true, already_pending: false });
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 3 });
 
-    const { rows } = await client.query(
-      `SELECT public.baaki_request_member_claim($1, $2, $3, $4) AS verdict`,
-      [groupId, ghostId, arrival, 'Ravi'],
-    );
-    const verdict = rows[0].verdict as { ok: boolean; claim_id?: string };
-    expect(verdict.ok).toBe(true);
+    // The same person tapping again, four more times. Each is already_pending
+    // against the same claim — and, the point of this file, spends no further
+    // use. Before the fix this loop would have driven use_count to 5.
+    for (let i = 0; i < 4; i += 1) {
+      const again = await claim(client, groupId, ghostId, arrival, inviteId, 'Ravi');
+      expect(again).toMatchObject({ ok: true, already_pending: true });
+      expect(again.claim_id).toBe(first.claim_id);
+    }
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 3 });
 
-    // The claim is only PENDING — nobody has decided anything — yet the
-    // link's only slot is already spent. A second person who wanted to join
-    // this same link (as themselves, or to dispute the claim) finds it dead.
-    expect(await consume(inviteId)).toBeNull();
-
-    // The ghost itself is still untouched while the claim waits, same as
-    // memberClaims.test.ts's first assertion — the slot burns independently
-    // of whether the claim ever succeeds.
+    // Only one pending claim exists, and the ghost is still untouched — the
+    // reservation is independent of the claim ever being approved.
+    expect(await pendingClaimCount(groupId)).toBe(1);
     const ghost = await client
       .query(`SELECT profile_id, ghost_name FROM group_members WHERE id = $1`, [ghostId])
       .then((r) => r.rows[0]);
@@ -115,7 +155,58 @@ describe('a pending claim spends the invite slot before anyone decides', () => {
     expect(ghost.ghost_name).toBe('Ghost 1');
   });
 
-  it('TODO(product): the slot stays spent even when the admin declines the claim', async () => {
+  it('lets a bogus claim spend nothing, so it cannot exhaust the link', async () => {
+    const { groupId, memberIds, profileIds } = await seedGroup(client, {
+      memberCount: 2,
+      ghostCount: 1,
+    });
+    const realMemberId = memberIds[1] as string; // already belongs to a person
+    const ghostId = memberIds[2] as string;
+    const arrival = await newcomer();
+
+    const inviteId = await mintInvite(groupId, 1);
+
+    // A claim on a place that already belongs to somebody: refused, no use spent.
+    const taken = await claim(client, groupId, realMemberId, arrival, inviteId);
+    expect(taken).toMatchObject({ ok: false, reason: 'ALREADY_CLAIMED' });
+
+    // A claim on a member that isn't in this group at all: refused, no use spent.
+    const nowhere = await claim(client, groupId, randomUUID(), arrival, inviteId);
+    expect(nowhere).toMatchObject({ ok: false, reason: 'NOT_CLAIMABLE' });
+
+    // A member of the group trying to claim a ghost of it: refused, no use spent.
+    const already = await claim(client, groupId, ghostId, profileIds[1] as string, inviteId);
+    expect(already).toMatchObject({ ok: false, reason: 'ALREADY_A_MEMBER' });
+
+    // None of that touched the link. Its single slot is still free for a real
+    // person to join.
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 0, max_uses: 1 });
+    expect(await pendingClaimCount(groupId)).toBe(0);
+    expect(await consume(inviteId)).toBe(true);
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });
+  });
+
+  it('refuses a claim on a link that is already spent, and writes nothing', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 1, ghostCount: 1 });
+    const ghostId = memberIds[1] as string;
+    const arrival = await newcomer();
+
+    const inviteId = await mintInvite(groupId, 1);
+    // A direct join takes the only slot.
+    expect(await consume(inviteId)).toBe(true);
+
+    // The claim now finds the link full: refused with INVITE_INVALID, and no
+    // pending row is left behind.
+    const verdict = await claim(client, groupId, ghostId, arrival, inviteId, 'Ravi');
+    expect(verdict).toMatchObject({ ok: false, reason: 'INVITE_INVALID' });
+    expect(await pendingClaimCount(groupId)).toBe(0);
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });
+  });
+
+  it('the declined claim keeps its reserved use spent (no auto-refund)', async () => {
+    // Documenting the chosen semantic: a genuinely-new claim reserves one use,
+    // and declining it does not hand the use back. The abuse that was fixed is
+    // *repeat* / bogus exhaustion (above), not the single legitimate reservation.
     const { groupId, memberIds, profileIds } = await seedGroup(client, {
       memberCount: 1,
       ghostCount: 1,
@@ -124,25 +215,86 @@ describe('a pending claim spends the invite slot before anyone decides', () => {
     const admin = profileIds[0] as string;
     const arrival = await newcomer();
 
-    const inviteId = await mintSingleUseInvite(groupId);
-    await consume(inviteId);
-
-    const { rows } = await client.query(
-      `SELECT public.baaki_request_member_claim($1, $2, $3, $4) AS verdict`,
-      [groupId, ghostId, arrival, 'Ravi'],
-    );
-    const claimId = (rows[0].verdict as { claim_id: string }).claim_id;
+    const inviteId = await mintInvite(groupId, 1);
+    const { claim_id } = await claim(client, groupId, ghostId, arrival, inviteId, 'Ravi');
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1 });
 
     const decision = await asProfile(admin, () =>
       client
-        .query(`SELECT public.baaki_decide_member_claim($1, $2) AS v`, [claimId, false])
+        .query(`SELECT public.baaki_decide_member_claim($1, $2) AS v`, [claim_id, false])
         .then((r) => r.rows[0].v as { ok: boolean; status: string }),
     );
     expect(decision).toMatchObject({ ok: true, status: 'declined' });
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });
+  });
+});
 
-    // Nobody ever joined this group through this link — the request was
-    // refused — but the link's one use is gone all the same, and nobody who
-    // holds it can try again.
+describe('the durable join link is unaffected', () => {
+  it('lets a claim through and stays effectively unlimited', async () => {
+    // The durable (WhatsApp-style) link carries an effectively unlimited
+    // max_uses, so a claim consuming one leaves it live for everyone else.
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 1, ghostCount: 1 });
+    const ghostId = memberIds[1] as string;
+    const arrival = await newcomer();
+
+    const inviteId = await mintInvite(groupId, 1_000_000);
+    const verdict = await claim(client, groupId, ghostId, arrival, inviteId, 'Ravi');
+    expect(verdict).toMatchObject({ ok: true, already_pending: false });
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1_000_000 });
+  });
+});
+
+describe('concurrent redemption of the last slot', () => {
+  it('admits only one real join when two new claims race for it', async () => {
+    // Two different arrivals, each claiming a different ghost through the SAME
+    // one-use link at the same moment. The atomic consume inside the RPC lets
+    // exactly one win the last slot; the other is turned away INVITE_INVALID and
+    // leaves no pending row.
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 1, ghostCount: 2 });
+    const ghostA = memberIds[1] as string;
+    const ghostB = memberIds[2] as string;
+    const arrivalA = await newcomer('A');
+    const arrivalB = await newcomer('B');
+
+    const inviteId = await mintInvite(groupId, 1);
+
+    // Two independent connections so the two RPC calls really are concurrent
+    // transactions racing on the invite row.
+    const a = new Client({ connectionString: CONNECTION_STRING });
+    const b = new Client({ connectionString: CONNECTION_STRING });
+    await Promise.all([a.connect(), b.connect()]);
+    let results: Verdict[];
+    try {
+      results = await Promise.all([
+        claim(a, groupId, ghostA, arrivalA, inviteId, 'Ravi'),
+        claim(b, groupId, ghostB, arrivalB, inviteId, 'Meera'),
+      ]);
+    } finally {
+      await Promise.all([a.end(), b.end()]);
+    }
+
+    const winners = results.filter((r) => r.ok);
+    const losers = results.filter((r) => !r.ok);
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(1);
+    expect(losers[0].reason).toBe('INVITE_INVALID');
+
+    // Exactly one slot spent, exactly one pending claim filed.
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });
+    expect(await pendingClaimCount(groupId)).toBe(1);
+  });
+});
+
+describe('a normal (non-claim) accept', () => {
+  it('still consumes exactly one use', async () => {
+    // The direct-join path in invite-accept reserves its slot through
+    // baaki_consume_invite, unchanged by this migration. Guard it: one success,
+    // then the link is spent.
+    const { groupId } = await seedGroup(client, { memberCount: 1 });
+    const inviteId = await mintInvite(groupId, 1);
+
+    expect(await consume(inviteId)).toBe(true);
+    expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });
     expect(await consume(inviteId)).toBeNull();
     expect(await useCountOf(inviteId)).toMatchObject({ use_count: 1, max_uses: 1 });
   });

--- a/supabase/functions/invite-accept/index.ts
+++ b/supabase/functions/invite-accept/index.ts
@@ -136,19 +136,6 @@ serveWithCors(async (request) => {
       }
     }
 
-    // Reserve a use atomically before creating anything. A plain read-then-write
-    // let two redemptions of the same link race past `max_uses`; this conditional
-    // increment lets exactly one of them win the last slot (and re-checks
-    // revocation/expiry under the row lock). Placed after the already-a-member
-    // and guest-ceiling short-circuits so those never burn a use.
-    const { data: consumed, error: consumeError } = await service.rpc('baaki_consume_invite', {
-      p_invite_id: invite.id,
-    });
-    if (consumeError) throw new HttpError(500, 'INTERNAL', consumeError.message);
-    if (consumed !== true) {
-      throw new HttpError(404, 'INVITE_INVALID', 'This invite link is no longer valid');
-    }
-
     let memberId: string;
 
     if (body.claimMemberId) {
@@ -167,13 +154,26 @@ serveWithCors(async (request) => {
       // Nobody joins here. The claim is decided by an admin through
       // `baaki_decide_member_claim`, and that function — not this one — is
       // where "who may approve this" lives, next to the table it guards.
+      //
+      // The invite use is NOT reserved here. This function used to call
+      // `baaki_consume_invite` before this branch, which burned a `max_uses`
+      // slot the instant a claim was tapped — every tap, whether or not an admin
+      // ever agreed, so one link could be emptied by repeated ghost-claims with
+      // nobody joining. The reservation now lives inside `baaki_request_member_claim`
+      // (with the invite id passed below): it spends exactly one use for a
+      // genuinely-new claim, and nothing for a repeat (already-pending) or a
+      // doomed one — atomically, in the same transaction as the claim row.
       const { data: verdict, error: claimError } = await service.rpc('baaki_request_member_claim', {
         p_group_id: invite.group_id,
         p_member_id: ghost.id,
         p_profile_id: profileId,
         p_name: body.displayName ?? null,
+        p_invite_id: invite.id,
       });
       if (claimError) throw new HttpError(500, 'CLAIM_FAILED', claimError.message);
+      if (verdict?.reason === 'INVITE_INVALID') {
+        throw new HttpError(404, 'INVITE_INVALID', 'This invite link is no longer valid');
+      }
       if (!verdict?.ok) {
         throw new HttpError(
           409,
@@ -192,6 +192,20 @@ serveWithCors(async (request) => {
         alreadyPending: verdict.already_pending === true,
       });
     } else {
+      // A direct join, and the one place a use is spent up front: reserve it
+      // atomically before creating the membership. A plain read-then-write let
+      // two redemptions of the same link race past `max_uses`; this conditional
+      // increment lets exactly one of them win the last slot (and re-checks
+      // revocation/expiry under the row lock). Placed after the already-a-member
+      // and guest-ceiling short-circuits so those never burn a use.
+      const { data: consumed, error: consumeError } = await service.rpc('baaki_consume_invite', {
+        p_invite_id: invite.id,
+      });
+      if (consumeError) throw new HttpError(500, 'INTERNAL', consumeError.message);
+      if (consumed !== true) {
+        throw new HttpError(404, 'INVITE_INVALID', 'This invite link is no longer valid');
+      }
+
       const { data: inserted, error: insertError } = await service
         .from('group_members')
         .insert({ group_id: invite.group_id, profile_id: profileId, joined_via: 'invite_link' })


### PR DESCRIPTION
## The hole

`invite-accept` called `baaki_consume_invite` **before** the `body.claimMemberId` branch, so a ghost-claim burned a `max_uses` slot the instant it was tapped — every tap. A pending claimant is not a member, so `baaki_request_member_claim` returned `{ pending: true, alreadyPending: true }` on repeats while the edge function had **already re-run the consume each time**. Result: one person could empty a still-valid link by re-POSTing the same claim (or N bogus claims on N ghosts), `max_uses` burned with nobody joining, organizer-facing availability degraded.

Verified against current code before acting; the repo already carried `packages/db/test/invite-claim-use-count.test.ts` locking in the buggy behavior with `TODO(product)` markers — those are now replaced with the fixed behavior.

## Semantic chosen — option 2: consume at most once per `(invite, profile, member)`, idempotently

Consumption moves **out** of `invite-accept`'s claim path and **into** `baaki_request_member_claim`, positioned so it fires exactly once for a genuinely-new claim and never for a repeat or a doomed one:

- `NOT_CLAIMABLE` / `ALREADY_CLAIMED` / `ALREADY_A_MEMBER` → no use spent
- already-pending (same person asking again) → no use spent; the existing claim is the answer → **closes the repeat/bogus exhaustion abuse**
- a brand-new, valid claim → one use spent, atomically, in the same transaction as the `INSERT`. If the link is spent/invalid by then → refused (`INVITE_INVALID`), nothing written.

The consume is the existing `baaki_consume_invite` atomic conditional `UPDATE`, run under the member's `FOR UPDATE` lock in the same transaction as the claim row, so two new claims racing for a link's **last** slot (or a claim racing a direct join) serialise on the invite row — exactly one wins. A **direct (non-claim) join is unchanged**: `invite-accept` still calls `baaki_consume_invite` once, right before inserting the membership → a normal join still spends exactly one use.

### Why not "consume on approval" (options 1/3)?
That needs to carry the invite id to `baaki_decide_member_claim`, i.e. a new column on `member_claims` — which **is** a Prisma model (`MemberClaim`), so it would introduce Prisma drift. Reserving idempotently at request time closes the reported abuse with a **functions-only** migration and no schema drift.

## Changes

- **Migration** `20260825240000_invite_claim_idempotent_consume` — `DROP`s the old 4-arg `baaki_request_member_claim` (signature change → avoid a leftover ambiguous overload) and `CREATE`s a 5-arg version adding `p_invite_id uuid DEFAULT NULL`; consumes one use only for a new valid claim. `NULL` invite id → no consume (internal callers / existing 4-arg tests).
- **Edge** `supabase/functions/invite-accept/index.ts` — removed the pre-branch consume; claim path passes `p_invite_id: invite.id` and maps `INVITE_INVALID` → 404; direct-join path now consumes right before the membership insert.
- **Tests** `packages/db/test/invite-claim-use-count.test.ts` — rewritten from the `TODO(product)` baseline.

## Tests (7 pass; full requested matrix)

- repeated identical ghost-claim does **not** increment `use_count` (5 taps → `use_count` stays 1)
- bogus claims (`ALREADY_CLAIMED` / `NOT_CLAIMABLE` / `ALREADY_A_MEMBER`) spend nothing → cannot exhaust `max_uses`
- claim on an already-spent link → `INVITE_INVALID`, no pending row written
- **concurrent** redemption of the last slot via two live connections → exactly one `ok`, one `INVITE_INVALID`, `use_count = 1`, one pending claim
- pending-claim response stays idempotent (`already_pending`, same `claim_id`)
- normal (non-claim) accept still consumes exactly one use (regression guard)
- durable join link (huge `max_uses`) still lets a claim through and stays live
- existing `memberClaims.test.ts` unchanged and green (4-arg calls resolve via the default)

## Gates
`pnpm format` clean · `pnpm lint` all projects done · `pnpm edge:build` ok · `pnpm --filter @waves/db test invite-claim-use-count memberClaims` → all green. (4 unrelated attachment-image test files fail identically on baseline — local test-DB storage-trigger setup gap, not this change.)

## Deploy note
Owner deploys: **migrate deploy** of the new migration **+ edge deploy of `invite-accept`** (the RPC signature and the edge ordering must land together). Not deployed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Invite uses are now reserved atomically when a new membership request is created.
  - Repeated, invalid, or rejected requests no longer consume invite uses.
  - Exhausted invites are rejected with a clear error.
  - Direct joins continue to consume invite uses correctly while preserving existing-member and guest-limit behavior.
  - Concurrent requests allow only one successful invite-use reservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->