### PR TITLE
fix(expense): direct expense-write ⇄ /sync write parity (categoryMeta, baseVersionNo)

### DIFF
--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -10,6 +10,7 @@
 import { randomUUID } from 'expo-crypto';
 
 import {
+  buildExpenseWriteBody,
   normaliseEmail,
   normalisePhone,
   serialiseSplitParams,
@@ -681,8 +682,18 @@ export interface WriteExpenseInput {
   categoryMeta?: CategoryMeta | null;
   /** Where the spend happened (A43); null unless the person opted in. */
   location?: ExpenseLocation | null;
+  /** A view-only link to the owner's own cloud copy of the receipt (E3). */
+  receiptShareUrl?: string | null;
+  /** Links a scanned receipt (ADR-008) to this expense; null when none. */
+  receiptId?: string | null;
   /** The rate used, when this expense is not in the group's currency. */
   fx?: FxRecord | null;
+  /**
+   * The version this edit is based on (ADR-004 / TDR §4.4). Set only for an
+   * edit; lets the server turn a concurrent edit into a logged conflict instead
+   * of a silent overwrite. Omitted for a create.
+   */
+  baseVersionNo?: number | null;
   clientMutationId?: string;
 }
 
@@ -695,38 +706,36 @@ export interface WriteExpenseResult {
 
 export async function writeExpense(input: WriteExpenseInput): Promise<WriteExpenseResult> {
   const { data, error } = await backend.functions.invoke('expense-write', {
-    body: {
+    // One shared body builder (`buildExpenseWriteBody` in @waves/core), so this
+    // direct write, the web client's direct write and the `/sync` queued write
+    // all carry the same fields — including `categoryMeta` and `baseVersionNo`,
+    // which this path used to drop (a direct edit lost the custom-tag display and
+    // skipped the concurrent-edit conflict check). Exact/adjustment/itemized
+    // splits hold minor units and JSON has no bigint, so the split is stringified
+    // here before the builder passes it through.
+    body: buildExpenseWriteBody({
       groupId: input.groupId,
       expenseId: input.expenseId,
       description: input.description,
       category: input.category ?? null,
       expenseDate: input.expenseDate,
       currency: input.currency,
-      amount: input.amount.toString(),
-      // Exact, adjustment and itemized splits hold minor units, and JSON has
-      // no bigint — stringify throws on one rather than rounding it. Without
-      // this an itemized bill could not be saved at all.
+      amount: input.amount,
       splitParams: serialiseSplitParams(input.splitParams),
       participants: input.participants,
-      payers: Object.fromEntries(
-        Object.entries(input.payers).map(([id, value]) => [id, value.toString()]),
-      ),
-      expectedShares: input.expectedShares
-        ? Object.fromEntries(
-            Object.entries(input.expectedShares).map(([id, value]) => [id, value.toString()]),
-          )
-        : undefined,
+      payers: input.payers,
+      expectedShares: input.expectedShares,
       notes: input.notes ?? null,
-      // Full snapshot, not a patch: an append-only version always carries the
-      // field, so an omitted method and an explicit null both mean "none".
       paymentMethod: input.paymentMethod ?? null,
-      // Where the spend happened (A43); null unless the person opted in. The
-      // server validates it to Earth's ranges before it is stored.
+      categoryMeta: input.categoryMeta ?? null,
       location: input.location ?? null,
+      receiptShareUrl: input.receiptShareUrl ?? null,
+      receiptId: input.receiptId ?? null,
       fx: input.fx ?? null,
+      baseVersionNo: input.baseVersionNo ?? null,
       // Idempotency key: a retry after a flaky network must not double-post.
       clientMutationId: input.clientMutationId ?? randomUUID(),
-    },
+    }),
   });
 
   if (error) {

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -704,6 +704,12 @@ export interface WriteExpenseResult {
   replayed?: boolean;
 }
 
+/**
+ * Write an expense through the `expense-write` edge function (the direct,
+ * online path). The server recomputes every share and owns authorization
+ * (TDR §4); the body is built by the one shared serializer the web client and
+ * `/sync` also use, so a direct write carries the same fields as a queued one.
+ */
 export async function writeExpense(input: WriteExpenseInput): Promise<WriteExpenseResult> {
   const { data, error } = await backend.functions.invoke('expense-write', {
     // One shared body builder (`buildExpenseWriteBody` in @waves/core), so this

--- a/apps/mobile/test/expenseWriteBody.test.ts
+++ b/apps/mobile/test/expenseWriteBody.test.ts
@@ -1,0 +1,65 @@
+/**
+ * `api.writeExpense()` posts the body that `buildExpenseWriteBody` (@waves/core)
+ * produces — the same builder the web client and, via the edge, `/sync` use. It
+ * used to hand-roll the body and silently drop `categoryMeta` and
+ * `baseVersionNo`, so a direct write lost custom-tag display and skipped the
+ * concurrent-edit conflict check.
+ *
+ * This asserts the builder — not `api.ts` itself — on purpose: `data/api.ts`
+ * pulls React Native (storage, the Supabase client, i18n) through its imports,
+ * and a React-Native module in the vitest graph breaks Rollup on Flow syntax.
+ * The body builder is the whole of `writeExpense`'s serialisation surface and is
+ * dependency-free, so testing it here keeps the tested surface RN-free while
+ * still pinning exactly what the function sends.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildExpenseWriteBody, type CategoryMeta } from '@waves/core';
+
+const meta: CategoryMeta = { label: 'Chai', icon: 'cup', tint: 'peach' };
+
+describe('writeExpense body', () => {
+  it('includes categoryMeta and baseVersionNo (an edit)', () => {
+    const body = buildExpenseWriteBody({
+      groupId: 'g1',
+      expenseId: 'e1',
+      description: 'Dinner',
+      expenseDate: '2026-03-01',
+      currency: 'INR',
+      amount: 2000n,
+      splitParams: { kind: 'equal' },
+      participants: ['m1', 'm2'],
+      payers: { m1: 2000n },
+      categoryMeta: meta,
+      baseVersionNo: 4,
+      clientMutationId: 'mut-1',
+    });
+
+    expect(body.categoryMeta).toEqual(meta);
+    expect(body.baseVersionNo).toBe(4);
+    // And the fields that were always sent are still there and wire-safe.
+    expect(body.amount).toBe('2000');
+    expect(body.payers).toEqual({ m1: '2000' });
+    expect(body.clientMutationId).toBe('mut-1');
+  });
+
+  it('sends explicit nulls for categoryMeta/baseVersionNo on a plain create', () => {
+    const body = buildExpenseWriteBody({
+      groupId: 'g1',
+      description: 'Coffee',
+      expenseDate: '2026-03-02',
+      currency: 'INR',
+      amount: 100n,
+      splitParams: { kind: 'equal' },
+      participants: ['m1'],
+      payers: { m1: 100n },
+      clientMutationId: 'mut-2',
+    });
+
+    // A version is a full snapshot: an omitted field must be an explicit null,
+    // never absent, or an edit would inherit the previous version's value.
+    expect(body.categoryMeta).toBeNull();
+    expect(body.baseVersionNo).toBeNull();
+  });
+});

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -20,10 +20,14 @@ import type { Session, SupabaseClient } from '@supabase/supabase-js';
 
 import {
   AuthMethod,
+  buildExpenseWriteBody,
   checkPassword,
   planAuth,
   readIdentifier,
+  type CategoryMeta,
   type ExpenseLocation,
+  type FxRecord,
+  type PaymentMethod,
   type Viewer,
 } from '@waves/core';
 
@@ -101,7 +105,10 @@ export function createBaakiClient({ supabase }: BaakiClientOptions) {
     return (data ?? []) as T[];
   }
 
-  async function callFunction<T>(name: string, body: Record<string, unknown>): Promise<T> {
+  // `object`, not `Record<string, unknown>`, so a typed request-shape (e.g. the
+  // shared `ExpenseWriteBody` from @waves/core) is accepted without an index
+  // signature; `invoke` serialises it to JSON either way.
+  async function callFunction<T>(name: string, body: object): Promise<T> {
     const { data, error } = await supabase.functions.invoke(name, { body });
     if (error) throw await describeFunctionError(error);
     return data as T;
@@ -557,31 +564,38 @@ export function createBaakiClient({ supabase }: BaakiClientOptions) {
      * browser.
      */
     writeExpense(input: WriteExpenseInput): Promise<WriteExpenseResult> {
-      return callFunction<WriteExpenseResult>('expense-write', {
-        groupId: input.groupId,
-        expenseId: input.expenseId,
-        description: input.description,
-        category: input.category ?? null,
-        expenseDate: input.expenseDate,
-        currency: input.currency,
-        amount: input.amount.toString(),
-        splitParams: input.splitParams,
-        participants: input.participants,
-        payers: Object.fromEntries(
-          Object.entries(input.payers).map(([id, value]) => [id, value.toString()]),
-        ),
-        expectedShares: input.expectedShares
-          ? Object.fromEntries(
-              Object.entries(input.expectedShares).map(([id, value]) => [id, value.toString()]),
-            )
-          : undefined,
-        notes: input.notes ?? null,
-        // Where the spend happened (A43); null unless the person opted in.
-        location: input.location ?? null,
-        // The idempotency key. A guest on a flaky phone browser is exactly who
-        // double-taps Save, and this is what makes the second one harmless.
-        clientMutationId: input.clientMutationId,
-      });
+      // One shared body builder (`buildExpenseWriteBody` in @waves/core), the
+      // same one the mobile client and — via the edge — `/sync` use, so a write
+      // from the browser carries every field the others do. It used to drop
+      // paymentMethod, categoryMeta, fx and baseVersionNo even when a caller
+      // supplied them; the split params arrive already in wire form here.
+      return callFunction<WriteExpenseResult>(
+        'expense-write',
+        buildExpenseWriteBody({
+          groupId: input.groupId,
+          expenseId: input.expenseId,
+          description: input.description,
+          category: input.category ?? null,
+          expenseDate: input.expenseDate,
+          currency: input.currency,
+          amount: input.amount,
+          splitParams: input.splitParams,
+          participants: input.participants,
+          payers: input.payers,
+          expectedShares: input.expectedShares,
+          notes: input.notes ?? null,
+          paymentMethod: input.paymentMethod ?? null,
+          categoryMeta: input.categoryMeta ?? null,
+          location: input.location ?? null,
+          receiptShareUrl: input.receiptShareUrl ?? null,
+          receiptId: input.receiptId ?? null,
+          fx: input.fx ?? null,
+          baseVersionNo: input.baseVersionNo ?? null,
+          // The idempotency key. A guest on a flaky phone browser is exactly who
+          // double-taps Save, and this is what makes the second one harmless.
+          clientMutationId: input.clientMutationId,
+        }),
+      );
     },
   };
 }
@@ -602,9 +616,22 @@ export interface WriteExpenseInput {
   payers: Record<string, bigint>;
   expectedShares?: Record<string, bigint>;
   notes?: string | null;
+  /** How the money moved: cash | upi | credit | debit | forex. */
+  paymentMethod?: PaymentMethod | null;
+  /** Denormalised custom-tag display (extends TDR §8); null for a built-in. */
+  categoryMeta?: CategoryMeta | null;
   /** Where the spend happened (A43); null unless the person opted in. The edge
    *  function validates it to Earth's ranges before it is stored. */
   location?: ExpenseLocation | null;
+  /** A view-only link to the owner's own cloud copy of the receipt (E3). */
+  receiptShareUrl?: string | null;
+  /** Links a scanned receipt (ADR-008) to this expense; null when none. */
+  receiptId?: string | null;
+  /** The rate used when the expense is not in the group's currency (ADR-003). */
+  fx?: FxRecord | null;
+  /** The version this edit is based on (ADR-004 / TDR §4.4); set only for an
+   *  edit, so the server can detect a concurrent edit instead of overwriting. */
+  baseVersionNo?: number | null;
   clientMutationId: string;
 }
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -105,9 +105,12 @@ export function createBaakiClient({ supabase }: BaakiClientOptions) {
     return (data ?? []) as T[];
   }
 
-  // `object`, not `Record<string, unknown>`, so a typed request-shape (e.g. the
-  // shared `ExpenseWriteBody` from @waves/core) is accepted without an index
-  // signature; `invoke` serialises it to JSON either way.
+  /**
+   * Invoke an edge function with a JSON body. Typed as `object`, not
+   * `Record<string, unknown>`, so a typed request-shape (e.g. the shared
+   * `ExpenseWriteBody` from @waves/core) is accepted without an index signature;
+   * `invoke` serialises it to JSON either way.
+   */
   async function callFunction<T>(name: string, body: object): Promise<T> {
     const { data, error } = await supabase.functions.invoke(name, { body });
     if (error) throw await describeFunctionError(error);

--- a/packages/core/src/sync/expenseWrite.ts
+++ b/packages/core/src/sync/expenseWrite.ts
@@ -1,0 +1,277 @@
+/**
+ * The one serialization contract for writing an expense — shared by every path
+ * that reaches `baaki_apply_expense`, so an expense written online, offline, from
+ * the phone or from the browser carries the *same* fields (TDR §4).
+ *
+ * There are two boundaries an expense write crosses, and this module owns both:
+ *
+ *   1. **client → edge** ({@link buildExpenseWriteBody}): the JSON body a direct
+ *      caller POSTs to the `expense-write` function. The mobile `api.ts` and the
+ *      web `api-client` both build it here, so neither can quietly drop a field
+ *      the other sends.
+ *
+ *   2. **edge → RPC** ({@link buildApplyExpenseArgs}): the named arguments both
+ *      the `expense-write` and the `/sync` edge functions pass to
+ *      `baaki_apply_expense`. Built here, so the direct write and the queued
+ *      write are byte-for-byte the same call — the bug this module exists to
+ *      prevent was `expense-write` silently omitting `p_category_meta` and
+ *      `p_base_version_no`, which made a direct edit lose custom-tag display and
+ *      skip the concurrent-edit conflict check that `/sync` had.
+ *
+ * The two validators ({@link sanitiseCategoryMeta}, {@link sanitiseExpenseLocation})
+ * live here too: both are denormalised snapshots shown to every group member, so
+ * a client can never write a NaN point or an unknown tint onto a ledger row.
+ *
+ * Pure and dependency-free like the rest of `@waves/core`, so the Deno edge
+ * bundle, the React Native app and the browser client all compute one shape.
+ */
+
+import { normaliseTint, type CategoryMeta } from '../category/catalog';
+import type { FxRecord } from '../money/fx';
+import type { SplitParams } from '../split/types';
+import { serialiseSplitParams } from '../split/wire';
+import type { ExpenseLocation, PaymentMethod } from './protocol';
+
+// ───────────────────────────────────────────────────────── validators ──
+
+/**
+ * Validate the denormalised custom-tag display before it lands on a ledger row
+ * (extends TDR §8). Anything not a proper {label, icon, tint} object becomes
+ * null (a built-in, which every client resolves from its own catalog); an
+ * unknown tint is coerced to a safe default rather than trusted, because the
+ * payload is client text and this snapshot is shown to every group member.
+ */
+export function sanitiseCategoryMeta(value: unknown): CategoryMeta | null {
+  if (!value || typeof value !== 'object') return null;
+  const meta = value as Record<string, unknown>;
+  const label = typeof meta.label === 'string' ? meta.label.trim() : '';
+  const icon = typeof meta.icon === 'string' ? meta.icon.trim() : '';
+  if (!label || !icon) return null;
+  return {
+    label: label.slice(0, 40),
+    icon: icon.slice(0, 64),
+    tint: normaliseTint(meta.tint as string),
+  };
+}
+
+/**
+ * Validate a client-supplied location before it lands on a ledger row (A43).
+ * Only a proper {lat, lng} inside Earth's ranges survives; the name is an
+ * optional trimmed label. Anything else — junk, NaN, an out-of-range point —
+ * becomes null, so a snapshot every group member sees can never carry garbage.
+ */
+export function sanitiseExpenseLocation(value: unknown): ExpenseLocation | null {
+  if (!value || typeof value !== 'object') return null;
+  const loc = value as Record<string, unknown>;
+  const lat = typeof loc.lat === 'number' ? loc.lat : NaN;
+  const lng = typeof loc.lng === 'number' ? loc.lng : NaN;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+  const name = typeof loc.name === 'string' ? loc.name.trim().slice(0, 120) : '';
+  return name ? { lat, lng, name } : { lat, lng };
+}
+
+// ─────────────────────────────────────────────── client → edge body ──
+
+/**
+ * Everything a direct caller (mobile `api.ts`, web `api-client`) needs to write
+ * an expense through the `expense-write` function. Money is bigint here and
+ * serialised to decimal strings on the way out — JSON has no bigint. Split
+ * params arrive already in wire form (`serialiseSplitParams`), because a caller
+ * that holds an itemized split has to stringify its minor units before this.
+ */
+export interface ExpenseWriteBodyInput {
+  readonly groupId: string;
+  /** Pass an id to append a new version to an existing expense (ADR-004). */
+  readonly expenseId?: string;
+  readonly description: string;
+  readonly category?: string | null;
+  readonly expenseDate: string;
+  readonly currency: string;
+  readonly amount: bigint;
+  /** Already in wire form — `serialiseSplitParams(params)`. */
+  readonly splitParams: unknown;
+  readonly participants: readonly string[];
+  readonly payers: Readonly<Record<string, bigint>>;
+  /** The caller's own share computation, checked against the server's. */
+  readonly expectedShares?: Readonly<Record<string, bigint>>;
+  readonly notes?: string | null;
+  /** How the money moved: cash | upi | credit | debit | forex. */
+  readonly paymentMethod?: PaymentMethod | null;
+  /** Denormalised custom-tag display (extends TDR §8); null for a built-in. */
+  readonly categoryMeta?: CategoryMeta | null;
+  /** Where the spend happened (A43); null unless the person opted in. */
+  readonly location?: ExpenseLocation | null;
+  /** A view-only link to the owner's own cloud copy of the receipt (E3). */
+  readonly receiptShareUrl?: string | null;
+  /** Links a scanned receipt (ADR-008) to this expense; null when none. */
+  readonly receiptId?: string | null;
+  /** The rate used when the expense is not in the group's currency (ADR-003). */
+  readonly fx?: FxRecord | null;
+  /**
+   * The version the caller edited (ADR-004 / TDR §4.4). Set only for an edit,
+   * and only by a caller that had actually seen a version — this is what turns a
+   * concurrent edit into a logged conflict instead of a silent overwrite. Its
+   * absence on the direct path was the parity hole this shared builder closes.
+   */
+  readonly baseVersionNo?: number | null;
+  /** Idempotency key: a retry after a flaky network must not double-post. */
+  readonly clientMutationId: string;
+}
+
+/** The JSON body sent to the `expense-write` function. */
+export interface ExpenseWriteBody {
+  readonly groupId: string;
+  readonly expenseId?: string;
+  readonly description: string;
+  readonly category: string | null;
+  readonly expenseDate: string;
+  readonly currency: string;
+  readonly amount: string;
+  readonly splitParams: unknown;
+  readonly participants: readonly string[];
+  readonly payers: Record<string, string>;
+  readonly expectedShares?: Record<string, string>;
+  readonly notes: string | null;
+  readonly paymentMethod: PaymentMethod | null;
+  readonly categoryMeta: CategoryMeta | null;
+  readonly location: ExpenseLocation | null;
+  readonly receiptShareUrl: string | null;
+  readonly receiptId: string | null;
+  readonly fx: FxRecord | null;
+  readonly baseVersionNo: number | null;
+  readonly clientMutationId: string;
+}
+
+/**
+ * Build the `expense-write` request body from a direct caller's input. Every
+ * optional field is emitted explicitly (null when absent), because an
+ * append-only version is a full snapshot: an omitted method and an explicit null
+ * both have to mean "none", or an edit would inherit the previous version's value.
+ */
+export function buildExpenseWriteBody(input: ExpenseWriteBodyInput): ExpenseWriteBody {
+  return {
+    groupId: input.groupId,
+    expenseId: input.expenseId,
+    description: input.description,
+    category: input.category ?? null,
+    expenseDate: input.expenseDate,
+    currency: input.currency,
+    amount: input.amount.toString(),
+    splitParams: input.splitParams,
+    participants: input.participants,
+    payers: Object.fromEntries(
+      Object.entries(input.payers).map(([id, value]) => [id, value.toString()]),
+    ),
+    expectedShares: input.expectedShares
+      ? Object.fromEntries(
+          Object.entries(input.expectedShares).map(([id, value]) => [id, value.toString()]),
+        )
+      : undefined,
+    notes: input.notes ?? null,
+    paymentMethod: input.paymentMethod ?? null,
+    categoryMeta: input.categoryMeta ?? null,
+    location: input.location ?? null,
+    receiptShareUrl: input.receiptShareUrl ?? null,
+    receiptId: input.receiptId ?? null,
+    fx: input.fx ?? null,
+    baseVersionNo: input.baseVersionNo ?? null,
+    clientMutationId: input.clientMutationId,
+  };
+}
+
+// ─────────────────────────────────────────────────── edge → RPC args ──
+
+/**
+ * The validated pieces an edge function has after it has parsed the amount,
+ * parsed the split params and recomputed the shares with `computeShares`. Money
+ * is bigint; the builder serialises it to the decimal strings the RPC's jsonb
+ * arguments expect. `categoryMeta` and `location` arrive raw (client text) and
+ * are sanitised in the builder — the one place either is validated.
+ */
+export interface ApplyExpenseArgsInput {
+  readonly groupId: string;
+  /** Already resolved — a create mints a fresh id before calling. */
+  readonly expenseId: string;
+  readonly authorMemberId: string;
+  readonly description: string;
+  readonly category?: string | null;
+  readonly expenseDate: string;
+  readonly currency: string;
+  readonly amount: bigint;
+  /** Parsed split params — the canonical wire form is derived here. */
+  readonly splitParams: SplitParams;
+  readonly payers: ReadonlyArray<readonly [string, bigint]>;
+  readonly shares: Iterable<readonly [string, bigint]>;
+  readonly clientMutationId: string;
+  readonly notes?: string | null;
+  readonly receiptId?: string | null;
+  readonly baseVersionNo?: number | null;
+  readonly fx?: FxRecord | null;
+  readonly paymentMethod?: string | null;
+  readonly receiptShareUrl?: string | null;
+  /** Raw client value; sanitised in the builder. */
+  readonly categoryMeta?: unknown;
+  /** Raw client value; sanitised in the builder. */
+  readonly location?: unknown;
+}
+
+/** The named arguments passed to `baaki_apply_expense`. `p_source` is left to
+ *  its default ('manual') by every caller, so it is not built here. */
+export interface ApplyExpenseRpcArgs {
+  readonly p_group_id: string;
+  readonly p_expense_id: string;
+  readonly p_author_member_id: string;
+  readonly p_description: string;
+  readonly p_category: string | null;
+  readonly p_expense_date: string;
+  readonly p_currency: string;
+  readonly p_amount: string;
+  readonly p_split_type: string;
+  readonly p_split_params: unknown;
+  readonly p_payers: { memberId: string; amount: string }[];
+  readonly p_shares: { memberId: string; amount: string }[];
+  readonly p_client_mutation_id: string;
+  readonly p_notes: string | null;
+  readonly p_receipt_id: string | null;
+  readonly p_base_version_no: number | null;
+  readonly p_fx: FxRecord | null;
+  readonly p_payment_method: string | null;
+  readonly p_receipt_share_url: string | null;
+  readonly p_category_meta: CategoryMeta | null;
+  readonly p_location: ExpenseLocation | null;
+}
+
+/**
+ * Build the `baaki_apply_expense` arguments. Both the direct (`expense-write`)
+ * and the queued (`/sync`) edge paths call this, so the RPC receives an
+ * identical set of fields whichever path a write took — the single source of
+ * truth for "what a write consists of".
+ */
+export function buildApplyExpenseArgs(input: ApplyExpenseArgsInput): ApplyExpenseRpcArgs {
+  return {
+    p_group_id: input.groupId,
+    p_expense_id: input.expenseId,
+    p_author_member_id: input.authorMemberId,
+    p_description: input.description,
+    p_category: input.category ?? null,
+    p_expense_date: input.expenseDate,
+    p_currency: input.currency.toUpperCase(),
+    p_amount: input.amount.toString(),
+    p_split_type: input.splitParams.kind,
+    // Stored in the canonical wire form: minor units as strings, whatever the
+    // client happened to send. A number in jsonb is a double.
+    p_split_params: serialiseSplitParams(input.splitParams),
+    p_payers: input.payers.map(([id, value]) => ({ memberId: id, amount: value.toString() })),
+    p_shares: [...input.shares].map(([id, value]) => ({ memberId: id, amount: value.toString() })),
+    p_client_mutation_id: input.clientMutationId,
+    p_notes: input.notes ?? null,
+    p_receipt_id: input.receiptId ?? null,
+    p_base_version_no: input.baseVersionNo ?? null,
+    p_fx: input.fx ?? null,
+    p_payment_method: input.paymentMethod ?? null,
+    p_receipt_share_url: input.receiptShareUrl ?? null,
+    p_category_meta: sanitiseCategoryMeta(input.categoryMeta),
+    p_location: sanitiseExpenseLocation(input.location),
+  };
+}

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -1,3 +1,4 @@
 export * from './protocol';
 export * from './queue';
 export * from './mirror';
+export * from './expenseWrite';

--- a/packages/core/test/expenseWrite.test.ts
+++ b/packages/core/test/expenseWrite.test.ts
@@ -48,6 +48,7 @@ const APPLY_EXPENSE_KEYS = [
   'p_location',
 ].sort();
 
+/** A representative custom-tag snapshot reused across the cases. */
 const meta: CategoryMeta = { label: 'Chai', icon: 'cup', tint: 'peach' };
 
 /** The normalised pieces an edge has after it has validated and computed. */

--- a/packages/core/test/expenseWrite.test.ts
+++ b/packages/core/test/expenseWrite.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The expense-write serialization contract (@waves/core).
+ *
+ * `buildApplyExpenseArgs` is the single serializer both the direct
+ * `expense-write` edge and the `/sync` edge use to call `baaki_apply_expense`,
+ * and `buildExpenseWriteBody` is the single body builder both the mobile and web
+ * direct clients use. These tests pin what a write consists of, so the parity
+ * hole this module closed — `expense-write` silently dropping `p_category_meta`
+ * and `p_base_version_no` — cannot reopen unnoticed.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildApplyExpenseArgs,
+  buildExpenseWriteBody,
+  sanitiseCategoryMeta,
+  sanitiseExpenseLocation,
+  type ApplyExpenseArgsInput,
+  type CategoryMeta,
+  type SplitParams,
+} from '../src/index';
+
+/** Every named argument `baaki_apply_expense` accepts except `p_source`, which
+ *  every caller leaves to its default. This is the contract with the DB; if the
+ *  RPC gains a parameter, this list and the builder must both learn it. */
+const APPLY_EXPENSE_KEYS = [
+  'p_group_id',
+  'p_expense_id',
+  'p_author_member_id',
+  'p_description',
+  'p_category',
+  'p_expense_date',
+  'p_currency',
+  'p_amount',
+  'p_split_type',
+  'p_split_params',
+  'p_payers',
+  'p_shares',
+  'p_client_mutation_id',
+  'p_notes',
+  'p_receipt_id',
+  'p_base_version_no',
+  'p_fx',
+  'p_payment_method',
+  'p_receipt_share_url',
+  'p_category_meta',
+  'p_location',
+].sort();
+
+const meta: CategoryMeta = { label: 'Chai', icon: 'cup', tint: 'peach' };
+
+/** The normalised pieces an edge has after it has validated and computed. */
+function baseArgs(overrides: Partial<ApplyExpenseArgsInput> = {}): ApplyExpenseArgsInput {
+  return {
+    groupId: 'g1',
+    expenseId: 'e1',
+    authorMemberId: 'm1',
+    description: 'Dinner',
+    category: 'custom-tag-id',
+    expenseDate: '2026-03-01',
+    currency: 'inr',
+    amount: 2000n,
+    splitParams: { kind: 'equal' } as SplitParams,
+    payers: [['m1', 2000n]],
+    shares: [
+      ['m1', 1000n],
+      ['m2', 1000n],
+    ],
+    clientMutationId: 'mut-1',
+    notes: 'tip included',
+    receiptId: 'r1',
+    baseVersionNo: 3,
+    fx: null,
+    paymentMethod: 'upi',
+    receiptShareUrl: 'https://drive.example/x',
+    categoryMeta: meta,
+    location: { lat: 12.9, lng: 77.6, name: 'Indiranagar' },
+    ...overrides,
+  };
+}
+
+describe('buildApplyExpenseArgs — the edge → RPC contract', () => {
+  it('emits exactly the RPC parameter set, including p_category_meta and p_base_version_no', () => {
+    const args = buildApplyExpenseArgs(baseArgs());
+    expect(Object.keys(args).sort()).toEqual(APPLY_EXPENSE_KEYS);
+    // The two fields the direct path used to drop.
+    expect(args.p_category_meta).toEqual(meta);
+    expect(args.p_base_version_no).toBe(3);
+  });
+
+  it('is identical whichever path builds it — the direct write and the /sync write agree', () => {
+    // Both edges normalise a write to the same shape before calling the builder;
+    // fed identical inputs, the RPC arguments must be byte-for-byte equal so a
+    // create/edit behaves the same online (direct) and offline (queued).
+    const direct = buildApplyExpenseArgs(baseArgs());
+    const queued = buildApplyExpenseArgs(baseArgs());
+    expect(direct).toEqual(queued);
+  });
+
+  it('serialises money and split params to the wire forms the RPC expects', () => {
+    const args = buildApplyExpenseArgs(baseArgs());
+    expect(args.p_amount).toBe('2000');
+    expect(args.p_currency).toBe('INR'); // upper-cased
+    expect(args.p_split_type).toBe('equal');
+    expect(args.p_payers).toEqual([{ memberId: 'm1', amount: '2000' }]);
+    expect(args.p_shares).toEqual([
+      { memberId: 'm1', amount: '1000' },
+      { memberId: 'm2', amount: '1000' },
+    ]);
+  });
+
+  it('sanitises the category snapshot and the location inside the builder', () => {
+    const args = buildApplyExpenseArgs(
+      baseArgs({
+        categoryMeta: { label: 'X', icon: 'i', tint: 'not-a-tint' },
+        location: { lat: 999, lng: 0 },
+      }),
+    );
+    // Unknown tint coerced, out-of-range point dropped — never trusted raw.
+    expect(args.p_category_meta?.tint).toBe('sky');
+    expect(args.p_location).toBeNull();
+  });
+
+  it('defaults every optional field to null when omitted', () => {
+    const args = buildApplyExpenseArgs({
+      groupId: 'g',
+      expenseId: 'e',
+      authorMemberId: 'm',
+      description: 'd',
+      expenseDate: '2026-01-01',
+      currency: 'INR',
+      amount: 100n,
+      splitParams: { kind: 'equal' } as SplitParams,
+      payers: [['m', 100n]],
+      shares: [['m', 100n]],
+      clientMutationId: 'x',
+    });
+    expect(args.p_category_meta).toBeNull();
+    expect(args.p_base_version_no).toBeNull();
+    expect(args.p_payment_method).toBeNull();
+    expect(args.p_location).toBeNull();
+    expect(args.p_fx).toBeNull();
+    expect(args.p_receipt_share_url).toBeNull();
+    expect(args.p_receipt_id).toBeNull();
+    expect(args.p_notes).toBeNull();
+  });
+});
+
+describe('buildExpenseWriteBody — the client → edge contract', () => {
+  it('carries categoryMeta and baseVersionNo in the body', () => {
+    const body = buildExpenseWriteBody({
+      groupId: 'g',
+      expenseId: 'e',
+      description: 'Dinner',
+      expenseDate: '2026-03-01',
+      currency: 'INR',
+      amount: 2000n,
+      splitParams: { kind: 'equal' },
+      participants: ['m1', 'm2'],
+      payers: { m1: 2000n },
+      categoryMeta: meta,
+      baseVersionNo: 3,
+      clientMutationId: 'mut-1',
+    });
+    expect(body.categoryMeta).toEqual(meta);
+    expect(body.baseVersionNo).toBe(3);
+  });
+
+  it('stringifies bigint money for JSON and defaults optionals to null', () => {
+    const body = buildExpenseWriteBody({
+      groupId: 'g',
+      description: 'Dinner',
+      expenseDate: '2026-03-01',
+      currency: 'INR',
+      amount: 2000n,
+      splitParams: { kind: 'equal' },
+      participants: ['m1'],
+      payers: { m1: 2000n },
+      expectedShares: { m1: 2000n },
+      clientMutationId: 'mut-1',
+    });
+    expect(body.amount).toBe('2000');
+    expect(body.payers).toEqual({ m1: '2000' });
+    expect(body.expectedShares).toEqual({ m1: '2000' });
+    expect(body.categoryMeta).toBeNull();
+    expect(body.baseVersionNo).toBeNull();
+    expect(body.paymentMethod).toBeNull();
+    expect(body.location).toBeNull();
+  });
+});
+
+describe('sanitisers', () => {
+  it('sanitiseCategoryMeta drops non-objects and coerces an unknown tint', () => {
+    expect(sanitiseCategoryMeta(null)).toBeNull();
+    expect(sanitiseCategoryMeta({ label: 'x' })).toBeNull(); // no icon
+    expect(sanitiseCategoryMeta({ label: 'x', icon: 'i', tint: 'nope' })).toEqual({
+      label: 'x',
+      icon: 'i',
+      tint: 'sky',
+    });
+  });
+
+  it('sanitiseExpenseLocation drops NaN and out-of-range points, keeps a valid one', () => {
+    expect(sanitiseExpenseLocation({ lat: NaN, lng: 0 })).toBeNull();
+    expect(sanitiseExpenseLocation({ lat: 91, lng: 0 })).toBeNull();
+    expect(sanitiseExpenseLocation({ lat: 12.9, lng: 77.6, name: '  Cafe  ' })).toEqual({
+      lat: 12.9,
+      lng: 77.6,
+      name: 'Cafe',
+    });
+  });
+});

--- a/packages/db/test/expense-write-parity.test.ts
+++ b/packages/db/test/expense-write-parity.test.ts
@@ -90,6 +90,7 @@ const halves = (a: string, b: string, amount: bigint) => ({
   ],
 });
 
+/** Read the stored `category_meta` snapshot for one version of an expense. */
 async function categoryMetaOfVersion(expenseId: string, versionNo: number): Promise<unknown> {
   const { rows } = await client.query(
     `SELECT category_meta FROM expense_versions WHERE expense_id = $1 AND version_no = $2`,

--- a/packages/db/test/expense-write-parity.test.ts
+++ b/packages/db/test/expense-write-parity.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Direct-write parity (the `expense-write` edge vs the `/sync` mutation).
+ *
+ * Both edge paths now call `baaki_apply_expense` through one shared argument
+ * builder (`buildApplyExpenseArgs` in @waves/core), so a create or edit carries
+ * an identical set of fields whichever path it took. These tests exercise the
+ * RPC the way both edges call it — with named arguments — to prove the two
+ * fields the direct path used to drop are honoured end to end:
+ *
+ *   • `p_category_meta` — the denormalised custom-tag snapshot is stored on the
+ *     version, on both a create and an edit (a new version).
+ *   • `p_base_version_no` — a stale edit is superseded, the same conflict
+ *     behaviour `/sync` has always had (TDR §4.4).
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, seedGroup } from './helpers.js';
+
+let client: Client;
+
+interface ApplyResult {
+  expenseId: string;
+  versionId: string;
+  versionNo: number;
+  replayed: boolean;
+  superseded: boolean;
+  supersededVersionNo: number | null;
+}
+
+/** Call `baaki_apply_expense` with NAMED arguments — exactly the shape both
+ *  edges send via `buildApplyExpenseArgs`, so field names, not positions, are
+ *  what this asserts against. */
+async function applyExpense(params: {
+  groupId: string;
+  author: string;
+  amount: bigint;
+  payers: { memberId: string; amount: string }[];
+  shares: { memberId: string; amount: string }[];
+  expenseId?: string | null;
+  mutationId?: string | null;
+  baseVersionNo?: number | null;
+  description?: string;
+  categoryMeta?: Record<string, unknown> | null;
+}): Promise<ApplyResult> {
+  const result = await client.query(
+    `SELECT baaki_apply_expense(
+        p_group_id           := $1,
+        p_expense_id         := $2,
+        p_author_member_id   := $3,
+        p_description        := $4,
+        p_category           := $5,
+        p_expense_date       := '2026-03-01',
+        p_currency           := 'INR',
+        p_amount             := $6,
+        p_split_type         := 'equal',
+        p_split_params       := '{"kind":"equal"}'::jsonb,
+        p_payers             := $7::jsonb,
+        p_shares             := $8::jsonb,
+        p_client_mutation_id := $9,
+        p_base_version_no    := $10,
+        p_category_meta      := $11::jsonb
+      ) AS out`,
+    [
+      params.groupId,
+      params.expenseId ?? null,
+      params.author,
+      params.description ?? 'Dinner',
+      params.categoryMeta ? 'custom-tag-id' : null,
+      params.amount.toString(),
+      JSON.stringify(params.payers),
+      JSON.stringify(params.shares),
+      params.mutationId ?? randomUUID(),
+      params.baseVersionNo ?? null,
+      params.categoryMeta ? JSON.stringify(params.categoryMeta) : null,
+    ],
+  );
+  return result.rows[0]?.out as ApplyResult;
+}
+
+/** An even two-way split, all these tests need. */
+const halves = (a: string, b: string, amount: bigint) => ({
+  payers: [{ memberId: a, amount: amount.toString() }],
+  shares: [
+    { memberId: a, amount: (amount / 2n).toString() },
+    { memberId: b, amount: (amount - amount / 2n).toString() },
+  ],
+});
+
+async function categoryMetaOfVersion(expenseId: string, versionNo: number): Promise<unknown> {
+  const { rows } = await client.query(
+    `SELECT category_meta FROM expense_versions WHERE expense_id = $1 AND version_no = $2`,
+    [expenseId, versionNo],
+  );
+  return rows[0]?.category_meta ?? null;
+}
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+describe('direct write preserves category_meta (parity with /sync)', () => {
+  it('stores the custom-tag snapshot on a create', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+    const tag = { label: 'Chai', icon: 'cup', tint: 'peach' };
+
+    const created = await applyExpense({
+      groupId,
+      author: a,
+      amount: 1000n,
+      categoryMeta: tag,
+      ...halves(a, b, 1000n),
+    });
+
+    expect(created.versionNo).toBe(1);
+    expect(await categoryMetaOfVersion(created.expenseId, 1)).toEqual(tag);
+  });
+
+  it('keeps category_meta on an edit, and per-version', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+    const first = { label: 'Chai', icon: 'cup', tint: 'peach' };
+    const second = { label: 'Feast', icon: 'plate', tint: 'coral' };
+
+    const created = await applyExpense({
+      groupId,
+      author: a,
+      amount: 1000n,
+      categoryMeta: first,
+      ...halves(a, b, 1000n),
+    });
+
+    const edited = await applyExpense({
+      groupId,
+      author: a,
+      expenseId: created.expenseId,
+      amount: 2000n,
+      description: 'Edited',
+      baseVersionNo: 1,
+      categoryMeta: second,
+      ...halves(a, b, 2000n),
+    });
+
+    expect(edited.versionNo).toBe(2);
+    // The append-only history keeps each version's own snapshot (ADR-004).
+    expect(await categoryMetaOfVersion(created.expenseId, 1)).toEqual(first);
+    expect(await categoryMetaOfVersion(created.expenseId, 2)).toEqual(second);
+  });
+});
+
+describe('direct stale edit is superseded (same as /sync, TDR §4.4)', () => {
+  it('supersedes an edit based on an out-of-date version', async () => {
+    const { groupId, memberIds } = await seedGroup(client, { memberCount: 2 });
+    const [a, b] = memberIds as [string, string];
+
+    const created = await applyExpense({
+      groupId,
+      author: a,
+      amount: 1000n,
+      ...halves(a, b, 1000n),
+    });
+    expect(created.superseded).toBe(false);
+
+    // First edit, correctly based on v1 — not a conflict.
+    const fresh = await applyExpense({
+      groupId,
+      author: a,
+      expenseId: created.expenseId,
+      amount: 2000n,
+      description: 'Fresh edit',
+      baseVersionNo: 1,
+      ...halves(a, b, 2000n),
+    });
+    expect(fresh.superseded).toBe(false);
+
+    // Second edit ALSO based on the now-stale v1 — the direct path supplies
+    // p_base_version_no just like /sync, so this is flagged, not silently
+    // overwritten.
+    const stale = await applyExpense({
+      groupId,
+      author: b,
+      expenseId: created.expenseId,
+      amount: 3000n,
+      description: 'Stale edit',
+      baseVersionNo: 1,
+      ...halves(b, a, 3000n),
+    });
+
+    expect(stale.superseded).toBe(true);
+    expect(stale.supersededVersionNo).toBe(fresh.versionNo);
+  });
+});

--- a/supabase/functions/expense-write/index.ts
+++ b/supabase/functions/expense-write/index.ts
@@ -11,10 +11,12 @@
  */
 
 import {
+  buildApplyExpenseArgs,
   computeShares,
   parseSplitParams,
-  serialiseSplitParams,
   verifyClientShares,
+  type CategoryMeta,
+  type ExpenseLocation,
   type FxRecord,
   type SplitParams,
 } from '../_shared/core.js';
@@ -57,7 +59,13 @@ interface ExpenseWriteRequest {
   receiptShareUrl?: string | null;
   /** Where the spend happened (A43): a {lat, lng, name} snapshot, set only on
    *  opt-in. Validated to Earth's ranges before it is stored. */
-  location?: { lat: number; lng: number; name?: string | null } | null;
+  location?: ExpenseLocation | null;
+  /**
+   * Denormalised custom-tag display (extends TDR §8), so a member without the
+   * author's catalog still renders the tag. Null/omitted for a built-in. Was
+   * missing here — a direct write silently lost it while `/sync` kept it.
+   */
+  categoryMeta?: CategoryMeta | null;
   receiptId?: string | null;
   /**
    * The rate used, when the expense is not in the group's currency (ADR-003).
@@ -65,24 +73,14 @@ interface ExpenseWriteRequest {
    * later. The server checks its direction; it does not invent one.
    */
   fx?: FxRecord | null;
+  /**
+   * The version the client edited (ADR-004 / TDR §4.4). Set only for an edit;
+   * lets the server turn a concurrent edit into a logged conflict rather than a
+   * silent overwrite. Was missing here — the direct edit path skipped the very
+   * conflict check `/sync` performs.
+   */
+  baseVersionNo?: number | null;
   clientMutationId: string;
-}
-
-/**
- * Validate a client-supplied location before it reaches the ledger (A43). Only a
- * finite {lat, lng} inside Earth's ranges survives; the name is an optional
- * trimmed label. Anything else becomes null — a snapshot shown to every group
- * member must never carry a NaN or an out-of-range point.
- */
-function sanitiseLocation(value: unknown): { lat: number; lng: number; name?: string } | null {
-  if (!value || typeof value !== 'object') return null;
-  const loc = value as Record<string, unknown>;
-  const lat = typeof loc.lat === 'number' ? loc.lat : NaN;
-  const lng = typeof loc.lng === 'number' ? loc.lng : NaN;
-  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
-  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
-  const name = typeof loc.name === 'string' ? loc.name.trim().slice(0, 120) : '';
-  return name ? { lat, lng, name } : { lat, lng };
 }
 
 serveWithCors(async (request) => {
@@ -169,29 +167,37 @@ serveWithCors(async (request) => {
     // as separate PostgREST calls would let the Σpayers = Σshares = amount
     // trigger fire against a half-written expense — and a crash in between
     // would leave a version with no shares in the ledger.
-    const { data: applied, error: applyError } = await service.rpc('baaki_apply_expense', {
-      p_group_id: body.groupId,
-      p_expense_id: body.expenseId ?? expenseId,
-      p_author_member_id: memberId,
-      p_description: body.description,
-      p_category: body.category ?? null,
-      p_expense_date: body.expenseDate,
-      p_currency: body.currency.toUpperCase(),
-      p_amount: amount.toString(),
-      p_split_type: splitParams.kind,
-      // Stored in the canonical wire form: minor units as strings, whatever
-      // the client happened to send. A number in jsonb is a double.
-      p_split_params: serialiseSplitParams(splitParams),
-      p_payers: payers.map(([id, value]) => ({ memberId: id, amount: value.toString() })),
-      p_shares: [...shares].map(([id, value]) => ({ memberId: id, amount: value.toString() })),
-      p_client_mutation_id: body.clientMutationId,
-      p_notes: body.notes ?? null,
-      p_receipt_id: body.receiptId ?? null,
-      p_fx: body.fx ?? null,
-      p_payment_method: body.paymentMethod ?? null,
-      p_receipt_share_url: body.receiptShareUrl ?? null,
-      p_location: sanitiseLocation(body.location),
-    });
+    //
+    // The argument object is built by the one shared builder `/sync` uses too
+    // (`buildApplyExpenseArgs` in @waves/core), so a direct write and a queued
+    // write reach `baaki_apply_expense` with an identical set of fields —
+    // including `p_category_meta` and `p_base_version_no`, which this path used
+    // to drop. Its sanitisers validate the category snapshot and the location.
+    const { data: applied, error: applyError } = await service.rpc(
+      'baaki_apply_expense',
+      buildApplyExpenseArgs({
+        groupId: body.groupId,
+        expenseId: body.expenseId ?? expenseId,
+        authorMemberId: memberId,
+        description: body.description,
+        category: body.category ?? null,
+        expenseDate: body.expenseDate,
+        currency: body.currency,
+        amount,
+        splitParams,
+        payers,
+        shares,
+        clientMutationId: body.clientMutationId,
+        notes: body.notes ?? null,
+        receiptId: body.receiptId ?? null,
+        baseVersionNo: body.baseVersionNo ?? null,
+        fx: body.fx ?? null,
+        paymentMethod: body.paymentMethod ?? null,
+        receiptShareUrl: body.receiptShareUrl ?? null,
+        categoryMeta: body.categoryMeta,
+        location: body.location,
+      }),
+    );
 
     if (applyError) {
       // Surface the database's own vocabulary — UNKNOWN_MEMBER, WRONG_GROUP,

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -25,10 +25,12 @@
 import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
 
 import {
+  buildApplyExpenseArgs,
   computeShares,
   GUEST_TRIAL_DAYS,
   parseSplitParams,
-  serialiseSplitParams,
+  sanitiseCategoryMeta,
+  sanitiseExpenseLocation,
   verifyClientShares,
   type FxRecord,
   type SplitParams,
@@ -566,37 +568,36 @@ class SyncSession {
       throw new HttpError(409, 'SHARE_MISMATCH', (mismatch as Error).message);
     }
 
-    const { data, error } = await this.service.rpc('baaki_apply_expense', {
-      p_group_id: mutation.groupId,
-      p_expense_id: expenseId,
-      p_author_member_id: memberId,
-      p_description: payload.description,
-      p_category: payload.category ?? null,
-      p_expense_date: payload.expenseDate,
-      p_currency: payload.currency.toUpperCase(),
-      p_amount: amount.toString(),
-      p_split_type: splitParams.kind,
-      p_split_params: serialiseSplitParams(splitParams),
-      p_payers: payers.map(([id, value]) => ({ memberId: id, amount: value.toString() })),
-      p_shares: [...shares].map(([id, value]) => ({ memberId: id, amount: value.toString() })),
-      p_client_mutation_id: mutation.clientMutationId,
-      p_notes: payload.notes ?? null,
-      p_receipt_id: payload.receiptId ?? null,
-      // Set only for edits, and only by a client that had actually seen a
-      // version — this is what turns a concurrent edit into a logged conflict
-      // instead of a silent overwrite (TDR §4.4).
-      p_base_version_no: payload.baseVersionNo ?? null,
-      p_fx: payload.fx ?? null,
-      p_payment_method: payload.paymentMethod ?? null,
-      p_receipt_share_url: payload.receiptShareUrl ?? null,
-      // Denormalised custom-tag display, so a member without the author's catalog
-      // still renders the tag (extends TDR §8). Null for a built-in category.
-      p_category_meta: sanitiseCategoryMeta(payload.categoryMeta),
-      // Where the spend happened (A43), validated so a client can never write a
-      // NaN or an out-of-range point onto a row every member reads. Null unless
-      // the author opted in.
-      p_location: sanitiseLocation(payload.location),
-    });
+    // The one shared builder the direct `expense-write` path uses too
+    // (`buildApplyExpenseArgs` in @waves/core), so a queued write and a direct
+    // write reach `baaki_apply_expense` with an identical set of fields. It
+    // carries `p_base_version_no` (edit conflict, TDR §4.4) and the sanitised
+    // `p_category_meta`/`p_location` snapshots every group member reads.
+    const { data, error } = await this.service.rpc(
+      'baaki_apply_expense',
+      buildApplyExpenseArgs({
+        groupId: mutation.groupId,
+        expenseId,
+        authorMemberId: memberId,
+        description: payload.description,
+        category: payload.category ?? null,
+        expenseDate: payload.expenseDate,
+        currency: payload.currency,
+        amount,
+        splitParams,
+        payers,
+        shares,
+        clientMutationId: mutation.clientMutationId,
+        notes: payload.notes ?? null,
+        receiptId: payload.receiptId ?? null,
+        baseVersionNo: payload.baseVersionNo ?? null,
+        fx: payload.fx ?? null,
+        paymentMethod: payload.paymentMethod ?? null,
+        receiptShareUrl: payload.receiptShareUrl ?? null,
+        categoryMeta: payload.categoryMeta,
+        location: payload.location,
+      }),
+    );
     if (error) throw error;
     return data;
   }
@@ -684,7 +685,7 @@ class SyncSession {
       // at assignment. Constrained to the known set on the client.
       payment_method: normalisePaymentMethod(payload.paymentMethod),
       target_group_id: payload.targetGroupId ?? null,
-      location: sanitiseLocation(payload.location),
+      location: sanitiseExpenseLocation(payload.location),
       status: 'open',
     });
     if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
@@ -724,7 +725,7 @@ class SyncSession {
       patch.category_meta = sanitiseCategoryMeta(patch.category_meta);
     }
     if (Object.prototype.hasOwnProperty.call(patch, 'location')) {
-      patch.location = sanitiseLocation(patch.location);
+      patch.location = sanitiseExpenseLocation(patch.location);
     }
     if (typeof patch.amount === 'string') {
       const amount = parseMinor(patch.amount, 'amount');
@@ -1079,43 +1080,10 @@ function normalisePaymentMethod(value: unknown): string | null {
 }
 
 /** The six design-system tints a custom tag may carry (kept in step with the
- *  client's `TINTS`); anything else is coerced to a safe default. */
+ *  client's `TINTS`); anything else is coerced to a safe default. Used to
+ *  validate a tag's own tint in `upsertTag`; the denormalised category snapshot
+ *  is validated by `sanitiseCategoryMeta` in @waves/core. */
 const TAG_TINTS = new Set(['lilac', 'pink', 'mint', 'peach', 'sky', 'coral']);
-
-/**
- * Validate the denormalised custom-tag display before it lands on a ledger row.
- * Anything not a proper {label, icon, tint} object becomes null (a built-in),
- * and an unknown tint is coerced rather than trusted — the payload is client
- * text, and this snapshot is shown to every group member.
- */
-function sanitiseCategoryMeta(
-  value: unknown,
-): { label: string; icon: string; tint: string } | null {
-  if (!value || typeof value !== 'object') return null;
-  const meta = value as Record<string, unknown>;
-  const label = typeof meta.label === 'string' ? meta.label.trim() : '';
-  const icon = typeof meta.icon === 'string' ? meta.icon.trim() : '';
-  if (!label || !icon) return null;
-  const tint = typeof meta.tint === 'string' && TAG_TINTS.has(meta.tint) ? meta.tint : 'sky';
-  return { label: label.slice(0, 40), icon: icon.slice(0, 64), tint };
-}
-
-/**
- * Validate a client-supplied location before it lands on a ledger row (A43).
- * Only a proper {lat, lng} inside Earth's ranges survives; a name is an optional
- * trimmed label. Anything else — junk, NaN, an out-of-range point — becomes
- * null, so a snapshot every group member sees can never carry garbage.
- */
-function sanitiseLocation(value: unknown): { lat: number; lng: number; name?: string } | null {
-  if (!value || typeof value !== 'object') return null;
-  const loc = value as Record<string, unknown>;
-  const lat = typeof loc.lat === 'number' ? loc.lat : NaN;
-  const lng = typeof loc.lng === 'number' ? loc.lng : NaN;
-  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
-  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
-  const name = typeof loc.name === 'string' ? loc.name.trim().slice(0, 120) : '';
-  return name ? { lat, lng, name } : { lat, lng };
-}
 
 /** Turn a thrown error into the vocabulary the client's queue understands. */
 function classify(error: unknown): { code: string; message: string } {


### PR DESCRIPTION
## The hole

The direct `expense-write` edge was **not** at parity with the `/sync` mutation write. Verified against current code:

| field → `baaki_apply_expense` | `/sync` writeExpense | `expense-write` (before) |
|---|---|---|
| `p_category_meta` | ✅ sent | ❌ **missing** |
| `p_base_version_no` | ✅ sent | ❌ **missing** |
| `p_payment_method` | ✅ | ✅ |
| `p_location` | ✅ | ✅ |
| `p_fx`, `p_receipt_share_url`, `p_receipt_id` | ✅ | ✅ |

Consequences: a client using the direct path **silently lost custom-tag display** (`categoryMeta`), and a **direct edit skipped the concurrent-edit conflict/superseded behavior** `/sync` has (TDR §4.4) — the same user action behaved differently online vs offline. The client payload builders were worse: mobile `api.ts` omitted `categoryMeta`/`baseVersionNo`; the web `api-client` also dropped `paymentMethod`/`fx`.

## The fix — one shared serializer

New `packages/core/src/sync/expenseWrite.ts` (`@waves/core`), used by every path:

- **`buildApplyExpenseArgs`** — the named-arg object BOTH the `expense-write` and `/sync` edges pass to `baaki_apply_expense`. A direct write and a queued write now reach the RPC with a byte-identical field set (all 20 non-default params, incl. `p_category_meta` + `p_base_version_no`). Sanitises the category/location snapshots inside.
- **`buildExpenseWriteBody`** — the `expense-write` request body BOTH the mobile (`apps/mobile/src/data/api.ts`) and web (`packages/api-client`) direct clients build, so neither can drop a field.
- **`sanitiseCategoryMeta` / `sanitiseExpenseLocation`** — lifted out of the edges (were duplicated in `/sync`, missing in `expense-write`) into core; `/sync` captures now use the shared ones too.

`api.ts` `writeExpense()` now sends `categoryMeta` and `baseVersionNo` (via the shared builder); `WriteExpenseInput` gained `baseVersionNo` (+ `receiptShareUrl`/`receiptId` passthrough). The web `api-client` reaches full parity the same way.

## Migration / deploy

**None.** `baaki_apply_expense` already accepts both params (current def: `20260823000000_expense_location`). No applied migration edited, **nothing deployed**. The edge bundle (`_shared/core.js`, git-ignored) is regenerated by `edge:build`; a future `edge:deploy` picks up the new shared code.

## Keep-or-deprecate decision

**KEEP `expense-write`.** It is not dead — the **web full client** writes through it via `api-client` (`apps/web/.../ExpenseForm.tsx`), while the mobile app writes through the `/sync` queue. `expense-write` is the deliberately-online write path (no SQLite mirror/cursors), so deprecating it would force the web client onto offline machinery it does not run. Both paths now share one serializer, so they cannot drift again.

## Tests

- **Contract** `packages/core/test/expenseWrite.test.ts` — builder emits exactly the RPC param set incl. `p_category_meta`/`p_base_version_no`; identical whichever path builds it; sanitisers coerce unknown tint / reject NaN & out-of-range points.
- **Mobile** `apps/mobile/test/expenseWriteBody.test.ts` (RN-free, runs under `pnpm test:app`) — the `writeExpense` body carries `categoryMeta` + `baseVersionNo`.
- **DB** `packages/db/test/expense-write-parity.test.ts` — direct create/edit preserves `category_meta` per version; a stale edit with `p_base_version_no` is **superseded**, same as `/sync`.

## Gates

typecheck (core/api-client/mobile) ✅ · lint ✅ · format ✅ · `test:app` (449) ✅ · core (681) ✅ · api-client (12) ✅ · db parity (3) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expense creation and editing now preserve receipt links, receipt sharing, payment details, currency conversion data, category metadata, locations, and edit-version information.
  * Expense updates better handle stale edits and maintain metadata across versions.
  * Numeric values and split details are consistently formatted for reliable syncing.

* **Bug Fixes**
  * Improved consistency between direct and queued expense updates.
  * Added safer handling for incomplete or invalid category and location metadata.

* **Tests**
  * Expanded coverage for expense creation, editing, syncing, metadata preservation, and stale-version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->