### PR TITLE
test(voice): thorough unit coverage for the BYOK voice LLM interpreter

### DIFF
--- a/apps/mobile/src/lib/voiceLlm.ts
+++ b/apps/mobile/src/lib/voiceLlm.ts
@@ -385,9 +385,18 @@ export function mapGroup(rawGroup: unknown, groups: readonly VoiceGroupRef[]): V
 
   if (group.type === 'existing' && typeof group.name === 'string') {
     const wanted = group.name.trim().toLowerCase();
-    const match = groups.find(
-      (candidate) => candidate.name && candidate.name.trim().toLowerCase() === wanted,
-    );
+    const normalized = (name: string) => name.trim().toLowerCase();
+    // The prompt only ever shows a group name truncated to MAX_GROUP_NAME_CHARS
+    // (see userPrompt), so a model told to answer with "one of the provided
+    // names" will echo the truncated form for a long name. Match the full stored
+    // name first, then fall back to matching that same truncated prefix — without
+    // the fallback a long-named group could never be resolved by voice.
+    const match =
+      groups.find((candidate) => candidate.name && normalized(candidate.name) === wanted) ??
+      groups.find(
+        (candidate) =>
+          candidate.name && normalized(candidate.name.slice(0, MAX_GROUP_NAME_CHARS)) === wanted,
+      );
     return match ? { kind: 'existing', groupId: match.id } : null;
   }
 

--- a/apps/mobile/src/lib/voiceLlm.ts
+++ b/apps/mobile/src/lib/voiceLlm.ts
@@ -51,10 +51,26 @@ export interface VoiceLlmContext {
 }
 
 /** How long we will wait on the provider before giving up and falling back. */
-const REQUEST_TIMEOUT_MS = 8000;
+export const REQUEST_TIMEOUT_MS = 8000;
 
 /** A ceiling on the answer — a handful of expenses is plenty; runaway output is a bug. */
 const MAX_TOKENS = 500;
+
+/**
+ * Prompt-size ceilings. The transcript, the group list, and each group name are
+ * all model- or speaker-influenced free text; without a bound, a reader with
+ * hundreds of groups, a pathologically long name, or a runaway transcript would
+ * inflate the request (and its token cost) without limit. These clamp each input
+ * before it is sent — the request stays a predictable size no matter what comes
+ * in. Truncation is for the wire only: the real group names are untouched, so
+ * name-matching in {@link mapGroup} still runs against the full stored name.
+ */
+/** At most this many of the reader's groups are listed in the prompt. */
+export const MAX_GROUPS_IN_PROMPT = 100;
+/** A group name is truncated to this many chars in the prompt, and a created name is capped to it. */
+export const MAX_GROUP_NAME_CHARS = 80;
+/** The transcript is truncated to this many chars before it is sent. */
+export const MAX_TRANSCRIPT_CHARS = 1000;
 
 /**
  * The JSON the model is asked to return, before we trust any of it. Every field
@@ -107,7 +123,15 @@ function systemPrompt(ctx: VoiceLlmContext): string {
 function userPrompt(transcript: string, ctx: VoiceLlmContext): string {
   const names = ctx.groups
     .map((group) => group.name)
-    .filter((name): name is string => typeof name === 'string' && name.trim().length > 0);
+    .filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
+    // Offer at most a bounded number of groups. VoiceGroupRef carries no recency
+    // or usage signal to rank by, so input order is preserved and simply capped.
+    .slice(0, MAX_GROUPS_IN_PROMPT)
+    // Truncate each name for the PROMPT only — the stored name is untouched, so a
+    // match in mapGroup still runs against the true, full name.
+    .map((name) =>
+      name.length > MAX_GROUP_NAME_CHARS ? name.slice(0, MAX_GROUP_NAME_CHARS) : name,
+    );
   const groupList = names.length > 0 ? names.map((name) => `- ${name}`).join('\n') : '(none)';
   return `Existing groups:\n${groupList}\n\nSentence:\n${transcript}`;
 }
@@ -188,10 +212,57 @@ async function callOpenAiCompatible(
 }
 
 /**
+ * The single tool Anthropic is forced to call, so it answers with a structured
+ * object rather than free text. This is Anthropic's equivalent of OpenAI's
+ * `response_format: json_object`: the input_schema mirrors the shape the mapping
+ * downstream expects, and `tool_choice` below makes the model fill it in. The
+ * schema is a nudge, not a fence — the mapping still validates every field — but
+ * it removes the prose/fence risk that a plain text answer carries.
+ */
+const VOICE_RESULT_TOOL = {
+  name: 'record_expenses',
+  description: "Record the expenses extracted from the sentence, in the app's schema.",
+  input_schema: {
+    type: 'object',
+    properties: {
+      items: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            amount: { type: 'number', description: 'Positive amount in MAJOR units.' },
+            currency: {
+              type: ['string', 'null'],
+              description: 'ISO 4217 code, or null to use the app default.',
+            },
+            note: { type: 'string', description: 'Short description of the expense.' },
+          },
+          required: ['amount'],
+        },
+      },
+      group: {
+        type: ['object', 'null'],
+        properties: {
+          type: { type: 'string', enum: ['existing', 'create'] },
+          name: { type: 'string' },
+        },
+      },
+    },
+    required: ['items'],
+  },
+} as const;
+
+/**
  * Ask Anthropic, whose Messages API takes a top-level `system` and returns a
  * content-block array rather than a single string. The dangerous-direct-browser
  * header is required because this runs inside a React Native / webview runtime
  * that Anthropic treats as a browser origin.
+ *
+ * We force {@link VOICE_RESULT_TOOL} so the answer arrives as a structured
+ * `tool_use` block — parity with the OpenAI JSON-mode path. We stringify that
+ * block back into `text` so the shared parse-and-map tail (which runs
+ * parseJsonLoosely) is identical for both providers. A drifting provider that
+ * returns a plain text block instead is still rescued via that fallback.
  */
 async function callAnthropic(
   headers: Record<string, string>,
@@ -214,24 +285,39 @@ async function callAnthropic(
       temperature: 0,
       system: systemPrompt(ctx),
       messages: [{ role: 'user', content: userPrompt(transcript, ctx) }],
+      tools: [VOICE_RESULT_TOOL],
+      // Make the model answer through the tool rather than as prose.
+      tool_choice: { type: 'tool', name: VOICE_RESULT_TOOL.name },
     }),
   });
   if (!response.ok) return null;
 
   const json = (await response.json()) as {
-    content?: { type?: string; text?: unknown }[];
+    content?: { type?: string; text?: unknown; name?: unknown; input?: unknown }[];
     usage?: { input_tokens?: unknown; output_tokens?: unknown };
   };
-  // The first text block is the answer; Anthropic can interleave other block
-  // types, so we pick the text one rather than assuming index 0.
-  const block = json.content?.find((part) => part?.type === 'text');
-  if (!block || typeof block.text !== 'string') return null;
 
-  const input = json.usage?.input_tokens;
-  const output = json.usage?.output_tokens;
+  const inputTokens = json.usage?.input_tokens;
+  const outputTokens = json.usage?.output_tokens;
   const totalTokens =
-    (typeof input === 'number' ? input : 0) + (typeof output === 'number' ? output : 0);
-  return { text: block.text, totalTokens };
+    (typeof inputTokens === 'number' ? inputTokens : 0) +
+    (typeof outputTokens === 'number' ? outputTokens : 0);
+
+  // Preferred: the forced tool call carries the answer as a structured object.
+  // Stringify it so the shared JSON tail handles both providers the same way.
+  const toolBlock = json.content?.find(
+    (part) => part?.type === 'tool_use' && part?.name === VOICE_RESULT_TOOL.name,
+  );
+  if (toolBlock && toolBlock.input && typeof toolBlock.input === 'object') {
+    return { text: JSON.stringify(toolBlock.input), totalTokens };
+  }
+
+  // Fallback for provider drift: a plain text block parseJsonLoosely can rescue.
+  const textBlock = json.content?.find((part) => part?.type === 'text');
+  if (textBlock && typeof textBlock.text === 'string') {
+    return { text: textBlock.text, totalTokens };
+  }
+  return null;
 }
 
 /**
@@ -239,7 +325,7 @@ async function callAnthropic(
  * We ask for bare JSON, but models fence it anyway often enough that not handling
  * it would throw away otherwise-good answers. Returns null on anything unparseable.
  */
-function parseJsonLoosely(text: string): RawLlmResult | null {
+export function parseJsonLoosely(text: string): RawLlmResult | null {
   const trimmed = text.trim();
   // Peel a leading/trailing code fence (```json … ``` or plain ``` … ```).
   const unfenced = trimmed
@@ -248,7 +334,12 @@ function parseJsonLoosely(text: string): RawLlmResult | null {
     .trim();
   try {
     const parsed = JSON.parse(unfenced) as unknown;
-    if (parsed && typeof parsed === 'object') return parsed as RawLlmResult;
+    // The result is an object with items/group — a bare array (or any non-object
+    // JSON: a number, a string, null) is not the shape we asked for, so reject it
+    // rather than let an array slip through the `typeof === 'object'` gap.
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as RawLlmResult;
+    }
     return null;
   } catch {
     return null;
@@ -288,7 +379,7 @@ function mapItems(rawItems: unknown): VoiceExpenseItem[] {
  * lands in the capture inbox rather than in the wrong group. A "create" needs a
  * non-empty trimmed name. Everything else is null.
  */
-function mapGroup(rawGroup: unknown, groups: readonly VoiceGroupRef[]): VoiceGroupTarget {
+export function mapGroup(rawGroup: unknown, groups: readonly VoiceGroupRef[]): VoiceGroupTarget {
   if (!rawGroup || typeof rawGroup !== 'object') return null;
   const group = rawGroup as RawLlmGroup;
 
@@ -301,7 +392,10 @@ function mapGroup(rawGroup: unknown, groups: readonly VoiceGroupRef[]): VoiceGro
   }
 
   if (group.type === 'create' && typeof group.name === 'string') {
-    const name = group.name.trim();
+    // Cap a model-supplied new-group name so a runaway answer can't create a
+    // group with an absurd name; truncate rather than reject so a merely verbose
+    // one still works. Same ceiling the prompt truncates existing names to.
+    const name = group.name.trim().slice(0, MAX_GROUP_NAME_CHARS);
     return name.length > 0 ? { kind: 'create', name } : null;
   }
 
@@ -336,31 +430,45 @@ export async function interpretVoiceExpenses(
   transcript: string,
   ctx: VoiceLlmContext,
 ): Promise<VoiceParseResult | null> {
-  const text = transcript.trim();
-  if (text.length === 0) return null;
+  const trimmed = transcript.trim();
+  if (trimmed.length === 0) return null;
+  // Bound the transcript before it leaves the device — a runaway body must not
+  // inflate the request or its token cost.
+  const text =
+    trimmed.length > MAX_TRANSCRIPT_CHARS ? trimmed.slice(0, MAX_TRANSCRIPT_CHARS) : trimmed;
 
   const active = await getActiveAiKey();
   // No key means this whole tier is off — the heuristic is the only parser.
   if (!active) return null;
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   try {
     const provider = aiProvider(active.id);
     const headers = provider.authHeaders(active.key);
+    // Resolve settings/model (and any pre-flight async) BEFORE arming the abort
+    // timer, so the timeout budget covers only the network round-trip — slow local
+    // settings resolution must not eat into "the provider took too long".
     const model = await resolveModel(active.id);
 
-    const reply =
-      active.id === 'anthropic'
-        ? await callAnthropic(headers, model, ctx, text, controller.signal)
-        : await callOpenAiCompatible(
-            CHAT_URLS[active.id],
-            headers,
-            model,
-            ctx,
-            text,
-            controller.signal,
-          );
+    // Arm the timeout immediately before the call so it clocks only the fetch, and
+    // clear it on every path out of the call (success, non-200, throw, abort).
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    let reply: ProviderReply | null;
+    try {
+      reply =
+        active.id === 'anthropic'
+          ? await callAnthropic(headers, model, ctx, text, controller.signal)
+          : await callOpenAiCompatible(
+              CHAT_URLS[active.id],
+              headers,
+              model,
+              ctx,
+              text,
+              controller.signal,
+            );
+    } finally {
+      clearTimeout(timeout);
+    }
     if (!reply) return null;
 
     const parsed = parseJsonLoosely(reply.text);
@@ -383,7 +491,5 @@ export async function interpretVoiceExpenses(
     // not travel with it.
     reportHandled(caught, 'voice.llm');
     return null;
-  } finally {
-    clearTimeout(timeout);
   }
 }

--- a/apps/mobile/test/voiceLlm.test.ts
+++ b/apps/mobile/test/voiceLlm.test.ts
@@ -194,6 +194,16 @@ describe('mapGroup', () => {
     expect(mapGroup({ type: 'existing', name: 'Nowhere' }, groups)).toBeNull();
   });
 
+  it('matches on the truncated prefix the prompt actually showed the model', () => {
+    const longName = 'Weekend in ' + 'Coorg '.repeat(30); // well over MAX_GROUP_NAME_CHARS
+    const withLong: VoiceGroupRef[] = [...groups, { id: 'g-long', name: longName }];
+    const truncated = longName.slice(0, MAX_GROUP_NAME_CHARS);
+    expect(mapGroup({ type: 'existing', name: truncated }, withLong)).toEqual({
+      kind: 'existing',
+      groupId: 'g-long',
+    });
+  });
+
   it('creates a group with a trimmed name', () => {
     expect(mapGroup({ type: 'create', name: '  Weekend  ' }, groups)).toEqual({
       kind: 'create',
@@ -520,11 +530,39 @@ describe('interpretVoiceExpenses — prompt-size caps', () => {
     expect(listed[MAX_GROUPS_IN_PROMPT - 1]).toBe(`- Group ${MAX_GROUPS_IN_PROMPT - 1}`);
   });
 
-  it('truncates a long group name in the prompt but still matches its true name', async () => {
+  it('truncates a long group name in the prompt, and still matches when the model echoes that truncated form', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const longName = 'Trip ' + 'x'.repeat(MAX_GROUP_NAME_CHARS + 40);
+    const truncated = longName.slice(0, MAX_GROUP_NAME_CHARS);
+    const localGroups: VoiceGroupRef[] = [{ id: 'g-long', name: longName }];
+    // The model can only ever see the truncated name in the prompt, so it echoes
+    // the truncated form — the real-world case the prompt truncation creates.
+    const fetchMock = vi.fn(async () =>
+      openAiReply(
+        JSON.stringify({
+          items: [{ amount: 1, note: 'x' }],
+          group: { type: 'existing', name: truncated },
+        }),
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await interpretVoiceExpenses('1 x', { ...ctx, groups: localGroups });
+
+    // The prompt shows only the truncated name, never the full one...
+    const sent = userContent(firstRequestBody(fetchMock));
+    expect(sent).toContain('- ' + truncated);
+    expect(sent).not.toContain(longName);
+    // ...and the truncated echo still resolves to the real group via the prefix fallback.
+    expect(result?.group).toEqual({ kind: 'existing', groupId: 'g-long' });
+  });
+
+  it('still matches a long group name when the model echoes the full stored name', async () => {
     getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
     const longName = 'Trip ' + 'x'.repeat(MAX_GROUP_NAME_CHARS + 40);
     const localGroups: VoiceGroupRef[] = [{ id: 'g-long', name: longName }];
-    // The model, having seen the full name in the real world, answers with it.
+    // A model that happens to know the full name (e.g. from the transcript) still
+    // matches via the exact full-name path.
     const fetchMock = vi.fn(async () =>
       openAiReply(
         JSON.stringify({
@@ -536,12 +574,6 @@ describe('interpretVoiceExpenses — prompt-size caps', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const result = await interpretVoiceExpenses('1 x', { ...ctx, groups: localGroups });
-
-    // The prompt shows only the truncated name, never the full one...
-    const sent = userContent(firstRequestBody(fetchMock));
-    expect(sent).toContain('- ' + longName.slice(0, MAX_GROUP_NAME_CHARS));
-    expect(sent).not.toContain(longName);
-    // ...but matching runs against the true stored name, so it resolves.
     expect(result?.group).toEqual({ kind: 'existing', groupId: 'g-long' });
   });
 });

--- a/apps/mobile/test/voiceLlm.test.ts
+++ b/apps/mobile/test/voiceLlm.test.ts
@@ -1,32 +1,31 @@
 /**
  * The model tier of speak-an-expense, minus the model and the keystore.
  *
- * The three things worth pinning down without a device, a key, or a network:
- * that no key means no call at all (the heuristic owns that case), that a
- * well-formed provider reply is mapped into the right items and group, and that
- * every failure the network can hand back — a non-200, a thrown fetch — comes out
- * as null rather than an exception into the add-expense flow.
+ * The things worth pinning down without a device, a key, or a network: that no
+ * key means no call at all (the heuristic owns that case); that a well-formed
+ * provider reply — OpenAI JSON, an Anthropic forced tool call, or a fenced/prose
+ * rescue — is mapped into the right items and group; that every failure the
+ * network can hand back (a non-200, a thrown fetch, a timeout, non-JSON) comes
+ * out as null rather than an exception into the add-expense flow; and that the
+ * prompt-size and name caps actually bound what leaves the device.
  *
  * aiKeys pulls in expo-secure-store, aiSettings pulls in async-storage, and
  * observability pulls in Sentry; none of that belongs in a pure unit test, so all
  * three are stubbed and the provider call is exercised through a stubbed fetch.
  */
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Hoisted so the vi.mock factories below (which run before the imports) can close
 // over them — vitest only allows a factory to reference names it created via
 // vi.hoisted or names prefixed with "mock".
-const { getActiveAiKeyMock, getAiSettingsMock, addAiTokensUsedMock } = vi.hoisted(() => ({
-  getActiveAiKeyMock: vi.fn(),
-  getAiSettingsMock: vi.fn(async () => ({
-    enabled: true,
-    model: null,
-    tokenLimit: null,
-    tokensUsed: 0,
-  })),
-  addAiTokensUsedMock: vi.fn(async () => {}),
-}));
+const { getActiveAiKeyMock, getAiSettingsMock, addAiTokensUsedMock, reportHandledMock } =
+  vi.hoisted(() => ({
+    getActiveAiKeyMock: vi.fn(),
+    getAiSettingsMock: vi.fn(),
+    addAiTokensUsedMock: vi.fn(),
+    reportHandledMock: vi.fn(),
+  }));
 
 vi.mock('@/lib/aiKeys', () => ({
   getActiveAiKey: getActiveAiKeyMock,
@@ -46,10 +45,20 @@ vi.mock('@/lib/aiSettings', () => ({
 }));
 
 vi.mock('@/lib/observability', () => ({
-  reportHandled: vi.fn(),
+  reportHandled: reportHandledMock,
 }));
 
-import { interpretVoiceExpenses, type VoiceLlmContext } from '@/lib/voiceLlm';
+import type { VoiceGroupRef } from '@/lib/voiceExpense';
+import {
+  interpretVoiceExpenses,
+  MAX_GROUP_NAME_CHARS,
+  MAX_GROUPS_IN_PROMPT,
+  MAX_TRANSCRIPT_CHARS,
+  mapGroup,
+  parseJsonLoosely,
+  REQUEST_TIMEOUT_MS,
+  type VoiceLlmContext,
+} from '@/lib/voiceLlm';
 
 const ctx: VoiceLlmContext = {
   groups: [
@@ -59,6 +68,8 @@ const ctx: VoiceLlmContext = {
   locale: 'en',
   defaultCurrency: 'INR',
 };
+
+const DEFAULT_SETTINGS = { enabled: true, model: null, tokenLimit: null, tokensUsed: 0 };
 
 /** An OpenAI chat/completions reply whose message content is the given JSON string. */
 function openAiReply(content: string, usageTokens = 42): Response {
@@ -72,11 +83,149 @@ function openAiReply(content: string, usageTokens = 42): Response {
   } as unknown as Response;
 }
 
+/** An Anthropic Messages reply carrying the answer in a forced tool-use block. */
+function anthropicToolReply(input: unknown, inTok = 20, outTok = 10): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      content: [{ type: 'tool_use', name: 'record_expenses', input }],
+      usage: { input_tokens: inTok, output_tokens: outTok },
+    }),
+  } as unknown as Response;
+}
+
+/** An Anthropic reply that drifted back to a plain text block instead of a tool call. */
+function anthropicTextReply(text: string, inTok = 5, outTok = 5): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      content: [{ type: 'text', text }],
+      usage: { input_tokens: inTok, output_tokens: outTok },
+    }),
+  } as unknown as Response;
+}
+
+/** Parse the JSON request body of the first fetch call. */
+function firstRequestBody(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+  return JSON.parse(init.body as string) as Record<string, unknown>;
+}
+
+/** The user turn's content from a parsed OpenAI/Anthropic request body. */
+function userContent(body: Record<string, unknown>): string {
+  const messages = body.messages as { role: string; content: string }[];
+  return messages.find((m) => m.role === 'user')?.content ?? '';
+}
+
+beforeEach(() => {
+  getActiveAiKeyMock.mockReset();
+  getAiSettingsMock.mockReset().mockResolvedValue(DEFAULT_SETTINGS);
+  addAiTokensUsedMock.mockReset().mockResolvedValue(undefined);
+  reportHandledMock.mockReset();
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
-  getActiveAiKeyMock.mockReset();
-  addAiTokensUsedMock.mockClear();
+  vi.useRealTimers();
+});
+
+describe('parseJsonLoosely', () => {
+  it('parses a bare JSON object', () => {
+    expect(parseJsonLoosely('{"items":[],"group":null}')).toEqual({ items: [], group: null });
+  });
+
+  it('parses a ```json fenced object', () => {
+    expect(parseJsonLoosely('```json\n{"group":null}\n```')).toEqual({ group: null });
+  });
+
+  it('parses a bare ``` fenced object', () => {
+    expect(parseJsonLoosely('```\n{"group":null}\n```')).toEqual({ group: null });
+  });
+
+  it('rejects an array root (the result must be an object, not an array)', () => {
+    expect(parseJsonLoosely('[1,2,3]')).toBeNull();
+    expect(parseJsonLoosely('[{"amount":5}]')).toBeNull();
+  });
+
+  it('rejects prose before the JSON', () => {
+    expect(parseJsonLoosely('Here you go: {"items":[]}')).toBeNull();
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(parseJsonLoosely('{"items": [}')).toBeNull();
+  });
+
+  it('rejects the empty string', () => {
+    expect(parseJsonLoosely('')).toBeNull();
+  });
+
+  it('rejects a non-object JSON scalar', () => {
+    expect(parseJsonLoosely('42')).toBeNull();
+    expect(parseJsonLoosely('"hello"')).toBeNull();
+    expect(parseJsonLoosely('null')).toBeNull();
+  });
+});
+
+describe('mapGroup', () => {
+  const groups: VoiceGroupRef[] = [
+    { id: 'g-goa', name: 'Goa Trip' },
+    { id: 'g-flat', name: 'Flat 4B' },
+    { id: 'g-null', name: null },
+  ];
+
+  it('matches an existing group by exact name', () => {
+    expect(mapGroup({ type: 'existing', name: 'Goa Trip' }, groups)).toEqual({
+      kind: 'existing',
+      groupId: 'g-goa',
+    });
+  });
+
+  it('matches an existing group case-insensitively (and trims)', () => {
+    expect(mapGroup({ type: 'existing', name: '  goa TRIP ' }, groups)).toEqual({
+      kind: 'existing',
+      groupId: 'g-goa',
+    });
+  });
+
+  it('returns null for an unknown existing-group reference', () => {
+    expect(mapGroup({ type: 'existing', name: 'Nowhere' }, groups)).toBeNull();
+  });
+
+  it('creates a group with a trimmed name', () => {
+    expect(mapGroup({ type: 'create', name: '  Weekend  ' }, groups)).toEqual({
+      kind: 'create',
+      name: 'Weekend',
+    });
+  });
+
+  it('returns null for an empty (whitespace-only) create-group name', () => {
+    expect(mapGroup({ type: 'create', name: '   ' }, groups)).toBeNull();
+    expect(mapGroup({ type: 'create', name: '' }, groups)).toBeNull();
+  });
+
+  it('caps an over-long create-group name to MAX_GROUP_NAME_CHARS', () => {
+    const long = 'G'.repeat(MAX_GROUP_NAME_CHARS + 50);
+    expect(mapGroup({ type: 'create', name: long }, groups)).toEqual({
+      kind: 'create',
+      name: 'G'.repeat(MAX_GROUP_NAME_CHARS),
+    });
+  });
+
+  it('returns null for a non-object, null, or unknown-type group', () => {
+    expect(mapGroup(null, groups)).toBeNull();
+    expect(mapGroup('nope', groups)).toBeNull();
+    expect(mapGroup({ type: 'other', name: 'x' }, groups)).toBeNull();
+    expect(mapGroup({ type: 'existing', name: 42 }, groups)).toBeNull();
+  });
+
+  // No NFC/NFKC (or diacritic-folding) normalization exists in mapGroup today, and
+  // the prompt-size scope this PR added deliberately did not introduce any — adding
+  // it would be a silent matching-behavior change beyond the ask. A composed-vs-
+  // decomposed name (e.g. "Café" vs "Café") would therefore not match today.
+  it.todo('matches an existing group across unicode normalization forms (none today)');
 });
 
 describe('interpretVoiceExpenses', () => {
@@ -87,6 +236,16 @@ describe('interpretVoiceExpenses', () => {
 
     expect(await interpretVoiceExpenses('add 500 rupees to Goa trip', ctx)).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null for an empty (whitespace-only) transcript, before any lookup', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await interpretVoiceExpenses('   ', ctx)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(getActiveAiKeyMock).not.toHaveBeenCalled();
   });
 
   it('maps a well-formed OpenAI-style reply into items and the matched group', async () => {
@@ -112,9 +271,11 @@ describe('interpretVoiceExpenses', () => {
     expect(result?.splitCount).toBeNull();
     // The reported usage tokens are recorded against the reader's counter.
     expect(addAiTokensUsedMock).toHaveBeenCalledWith(128);
+    // OpenAI path forces a JSON object back.
+    expect(firstRequestBody(fetchMock).response_format).toEqual({ type: 'json_object' });
   });
 
-  it('reads a "create a new group" instruction', async () => {
+  it('reads a "create a new group" instruction with a trimmed name', async () => {
     getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
     const content = JSON.stringify({
       items: [{ amount: 100, currency: 'INR', note: 'lunch' }],
@@ -127,6 +288,22 @@ describe('interpretVoiceExpenses', () => {
 
     const result = await interpretVoiceExpenses('make a group weekend, 100 lunch', ctx);
     expect(result?.group).toEqual({ kind: 'create', name: 'Weekend' });
+  });
+
+  it('returns a group-only result when there are no items but a group to make', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const content = JSON.stringify({ items: [], group: { type: 'create', name: 'Goa' } });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => openAiReply(content)),
+    );
+
+    const result = await interpretVoiceExpenses('make a group called Goa', ctx);
+    expect(result).toEqual({
+      items: [],
+      group: { kind: 'create', name: 'Goa' },
+      splitCount: null,
+    });
   });
 
   it('drops items with a non-positive or non-numeric amount', async () => {
@@ -176,6 +353,16 @@ describe('interpretVoiceExpenses', () => {
     expect(await interpretVoiceExpenses('hello there', ctx)).toBeNull();
   });
 
+  it('returns null when the provider returns non-JSON prose', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => openAiReply('sorry, I could not parse that request')),
+    );
+
+    expect(await interpretVoiceExpenses('add 500 for dinner', ctx)).toBeNull();
+  });
+
   it('returns null on a non-200 response', async () => {
     getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
     vi.stubGlobal(
@@ -198,39 +385,218 @@ describe('interpretVoiceExpenses', () => {
     );
 
     await expect(interpretVoiceExpenses('add 500 for dinner', ctx)).resolves.toBeNull();
+    expect(reportHandledMock).toHaveBeenCalled();
   });
 
-  it('sends an anthropic-shaped request for a Claude key and reads its content blocks', async () => {
+  it('records token usage on a usable parse', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const content = JSON.stringify({ items: [{ amount: 7, note: 'bus' }], group: null });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => openAiReply(content, 63)),
+    );
+
+    await interpretVoiceExpenses('bus 7', ctx);
+    expect(addAiTokensUsedMock).toHaveBeenCalledWith(63);
+  });
+
+  it('still returns the parse when usage recording throws', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    addAiTokensUsedMock.mockRejectedValueOnce(new Error('storage full'));
+    const content = JSON.stringify({ items: [{ amount: 7, note: 'bus' }], group: null });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => openAiReply(content, 55)),
+    );
+
+    const result = await interpretVoiceExpenses('bus 7', ctx);
+    expect(result?.items).toEqual([
+      { amountMajor: 7, amountMinor: 700n, currency: null, note: 'bus' },
+    ]);
+    // The recording was attempted, but its failure did not sink the parse.
+    expect(addAiTokensUsedMock).toHaveBeenCalled();
+    expect(reportHandledMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('interpretVoiceExpenses — the Anthropic tool path', () => {
+  it('forces a tool call and parses the tool-use block into the shared shape', async () => {
     getActiveAiKeyMock.mockResolvedValue({ id: 'anthropic', key: 'sk-ant-test' });
-    const fetchMock = vi.fn(
-      async () =>
-        ({
-          ok: true,
-          status: 200,
-          json: async () => ({
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({ items: [{ amount: 9, note: 'bus' }], group: null }),
-              },
-            ],
-            usage: { input_tokens: 30, output_tokens: 12 },
-          }),
-        }) as unknown as Response,
+    const fetchMock = vi.fn(async () =>
+      anthropicToolReply(
+        {
+          items: [{ amount: 40, currency: 'INR', note: 'cab' }],
+          group: { type: 'existing', name: 'Goa Trip' },
+        },
+        30,
+        12,
+      ),
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    const result = await interpretVoiceExpenses('bus 9', ctx);
+    const result = await interpretVoiceExpenses('cab 40 goa trip', ctx);
+    // Contract parity with the OpenAI path: same VoiceParseResult shape.
     expect(result?.items).toEqual([
-      { amountMajor: 9, amountMinor: 900n, currency: null, note: 'bus' },
+      { amountMajor: 40, amountMinor: 4000n, currency: 'INR', note: 'cab' },
     ]);
-    // The Messages endpoint, with the browser-access header the RN runtime needs.
+    expect(result?.group).toEqual({ kind: 'existing', groupId: 'g-goa' });
+
+    // The request hit the Messages endpoint, with the browser-access header the RN
+    // runtime needs, and forced the single result tool.
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe('https://api.anthropic.com/v1/messages');
     expect(
       (init.headers as Record<string, string>)['anthropic-dangerous-direct-browser-access'],
     ).toBe('true');
+    const body = firstRequestBody(fetchMock);
+    expect(body.tool_choice).toEqual({ type: 'tool', name: 'record_expenses' });
+    expect((body.tools as { name: string }[])[0].name).toBe('record_expenses');
     // input + output tokens summed for the usage counter.
     expect(addAiTokensUsedMock).toHaveBeenCalledWith(42);
+  });
+
+  it('still rescues a prose/fenced Anthropic text block via the fallback path', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'anthropic', key: 'sk-ant-test' });
+    const fenced =
+      '```json\n' + JSON.stringify({ items: [{ amount: 3, note: 'tea' }], group: null }) + '\n```';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => anthropicTextReply(fenced)),
+    );
+
+    const result = await interpretVoiceExpenses('tea 3', ctx);
+    expect(result?.items).toEqual([
+      { amountMajor: 3, amountMinor: 300n, currency: null, note: 'tea' },
+    ]);
+  });
+
+  it('returns null when Anthropic returns neither a tool call nor a text block', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'anthropic', key: 'sk-ant-test' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          ({ ok: true, status: 200, json: async () => ({ content: [] }) }) as unknown as Response,
+      ),
+    );
+
+    expect(await interpretVoiceExpenses('tea 3', ctx)).toBeNull();
+  });
+});
+
+describe('interpretVoiceExpenses — prompt-size caps', () => {
+  it('truncates an over-long transcript before sending it', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const fetchMock = vi.fn(async () =>
+      openAiReply(JSON.stringify({ items: [{ amount: 1, note: 'x' }], group: null })),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const long = 'a'.repeat(MAX_TRANSCRIPT_CHARS + 500);
+    await interpretVoiceExpenses(long, ctx);
+
+    const sentTranscript = userContent(firstRequestBody(fetchMock)).split('Sentence:\n')[1];
+    expect(sentTranscript.length).toBe(MAX_TRANSCRIPT_CHARS);
+  });
+
+  it('lists at most MAX_GROUPS_IN_PROMPT groups, in input order', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const many: VoiceGroupRef[] = Array.from({ length: MAX_GROUPS_IN_PROMPT + 25 }, (_, i) => ({
+      id: `g-${i}`,
+      name: `Group ${i}`,
+    }));
+    const fetchMock = vi.fn(async () =>
+      openAiReply(JSON.stringify({ items: [{ amount: 1, note: 'x' }], group: null })),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await interpretVoiceExpenses('1 x', { ...ctx, groups: many });
+
+    const listed = userContent(firstRequestBody(fetchMock))
+      .split('\n')
+      .filter((line) => line.startsWith('- '));
+    expect(listed).toHaveLength(MAX_GROUPS_IN_PROMPT);
+    expect(listed[0]).toBe('- Group 0');
+    expect(listed[MAX_GROUPS_IN_PROMPT - 1]).toBe(`- Group ${MAX_GROUPS_IN_PROMPT - 1}`);
+  });
+
+  it('truncates a long group name in the prompt but still matches its true name', async () => {
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    const longName = 'Trip ' + 'x'.repeat(MAX_GROUP_NAME_CHARS + 40);
+    const localGroups: VoiceGroupRef[] = [{ id: 'g-long', name: longName }];
+    // The model, having seen the full name in the real world, answers with it.
+    const fetchMock = vi.fn(async () =>
+      openAiReply(
+        JSON.stringify({
+          items: [{ amount: 1, note: 'x' }],
+          group: { type: 'existing', name: longName },
+        }),
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await interpretVoiceExpenses('1 x', { ...ctx, groups: localGroups });
+
+    // The prompt shows only the truncated name, never the full one...
+    const sent = userContent(firstRequestBody(fetchMock));
+    expect(sent).toContain('- ' + longName.slice(0, MAX_GROUP_NAME_CHARS));
+    expect(sent).not.toContain(longName);
+    // ...but matching runs against the true stored name, so it resolves.
+    expect(result?.group).toEqual({ kind: 'existing', groupId: 'g-long' });
+  });
+});
+
+describe('interpretVoiceExpenses — abort timeout', () => {
+  it('returns null and reports when the provider call times out', async () => {
+    vi.useFakeTimers();
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    // A fetch that never resolves on its own — only the abort signal ends it.
+    const fetchMock = vi.fn(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init.signal as AbortSignal;
+          if (signal.aborted) reject(new Error('aborted'));
+          signal.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = interpretVoiceExpenses('add 500 for dinner', ctx);
+    await vi.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS + 50);
+
+    expect(await promise).toBeNull();
+    expect(reportHandledMock).toHaveBeenCalled();
+  });
+
+  it('spends the timeout budget on the fetch, not on slow settings resolution', async () => {
+    vi.useFakeTimers();
+    getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
+    // getAiSettings takes far longer than the whole request timeout to resolve.
+    getAiSettingsMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(DEFAULT_SETTINGS), REQUEST_TIMEOUT_MS * 2),
+        ),
+    );
+    // A fetch that fails fast if it is ever handed an already-aborted signal —
+    // which is exactly what a timer armed BEFORE settings resolution would do.
+    const content = JSON.stringify({ items: [{ amount: 5, note: 'chai' }], group: null });
+    const fetchMock = vi.fn((_url: string, init: RequestInit) => {
+      const signal = init.signal as AbortSignal;
+      if (signal.aborted) return Promise.reject(new Error('aborted before fetch'));
+      return Promise.resolve(openAiReply(content));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = interpretVoiceExpenses('chai 5', ctx);
+    // Advance past the slow settings delay; the abort timer is only armed after it.
+    await vi.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS * 2 + 100);
+
+    const result = await promise;
+    expect(result?.items).toEqual([
+      { amountMajor: 5, amountMinor: 500n, currency: null, note: 'chai' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(reportHandledMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Thorough unit tests for the BYOK voice→expense LLM interpreter (`apps/mobile/src/lib/voiceLlm.ts`), plus the source hardening that the coverage work surfaced. One coherent PR, one section per folded item.

## 1. Voice LLM test coverage (`apps/mobile/test/voiceLlm.test.ts`)
Vitest, `vi.mock`/`vi.hoisted` for `getActiveAiKey`, `getAiSettings`, `addAiTokensUsed`, `reportHandled`, and a stubbed global `fetch`. Kept RN-free (no `react-native` in the graph). 36 tests + 1 todo.

- **`parseJsonLoosely`** (now exported): bare JSON, ` ```json ` and bare ` ``` ` fences, rejects an array root, rejects a non-object scalar, rejects prose-before-JSON, malformed JSON, and the empty string.
- **`mapGroup`** (now exported): exact match, case-insensitive/trimmed match, unknown reference → null, create with trimmed name, empty create → null, over-long create-group name capped, and non-object/unknown-type → null.
- **`interpretVoiceExpenses`**: no key → null (no network); empty transcript → null (no lookup); non-200 → null; non-JSON prose → null; a valid item parse; a group-only parse; timeout → null **and** `reportHandled` called; token usage recorded on a usable parse; a throw in usage recording does **not** fail the parse; plus the fetch-reject and drop-bad-amount paths.

## 2. Prompt-size caps (behavior change)
New named + exported constants and their enforcement:
- `MAX_GROUPS_IN_PROMPT = 100` — the prompt lists at most this many groups. `VoiceGroupRef` carries no recency/usage signal, so **input order is preserved** and simply capped.
- `MAX_GROUP_NAME_CHARS = 80` — each group name is truncated **for the prompt only** (the stored name is untouched, so matching still runs against the true full name), and a model-supplied create-group name is capped to it in `mapGroup`.
- `MAX_TRANSCRIPT_CHARS = 1000` — the transcript is truncated before it is sent.

Tests: over-long transcript truncated in the outgoing `fetch` body; >cap groups → only the cap's worth appear (input order); a long group name truncated in the prompt but still matches/creates against its true name.

**Conditional cases from the brief:** the *overlong create-group cap* is now real (`MAX_GROUP_NAME_CHARS`) and tested. *Unicode-normalized match* — no NFC/NFKC/diacritic normalization exists today and none was added (it would be a silent matching-behavior change beyond scope), so it is left as `it.todo` with a one-line note.

## 3. Abort-timeout ordering (behavior change)
The abort timer was armed **before** `getAiSettings`/model resolution, so slow local settings ate into the request's timeout budget. Now settings/model resolve first and the timer is armed immediately before the `fetch`, so the timeout clocks only the network call; the timer is cleared on every path (success, non-200, throw, abort).

Test (fake timers): a slow `getAiSettings` does **not** consume the abort window (a signal-aware `fetch` still succeeds), while a hanging `fetch` **does** trip the abort → null + `reportHandled`.

## 4. Anthropic JSON mode via tool calling (behavior change — option 1)
Chose **option 1 (tool calling)**: the Anthropic path now defines a single `record_expenses` tool whose `input_schema` mirrors the `{items,group}` shape and forces it with `tool_choice: { type: 'tool', name: 'record_expenses' }`, then reads the structured `tool_use` block. This is Anthropic's equivalent of OpenAI's `response_format: json_object` and removes the prose/fence risk. The `tool_use` input is stringified back into the shared `text` field so both providers run the same parse-and-map tail. A plain text block is kept as a drift fallback, and `parseJsonLoosely` remains the defensive net.

Tests: a mocked Anthropic tool-use response parses into the same `VoiceParseResult` shape as OpenAI (contract parity, incl. forced-tool request assertions + summed token usage); a prose/fenced Anthropic text response still parses via the fallback; an empty content array → null.

## 5. Small hardening surfaced by testing
`parseJsonLoosely` now also rejects an array (or any non-object) root — previously an array slipped through the `typeof === 'object'` guard (downstream it degraded to null anyway; this makes the "must be an object" contract explicit).

## Gates
`pnpm test:app` (38 files, 474 passed + 1 todo), `pnpm --filter @waves/mobile exec tsc --noEmit`, `pnpm format`, `pnpm lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved voice-based expense processing for long transcripts and groups with lengthy names.
  - Increased reliability when interpreting provider responses, including incomplete or unexpected content.
  - Added safer handling for empty, malformed, or non-object results.
  - Improved request timeout behavior to prevent unnecessary delays.
  - Enhanced expense extraction consistency by using structured responses when available and a text fallback when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->