### PR TITLE
fix(db): close anon/PUBLIC over-grant on SECURITY DEFINER RPCs (boundary audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
       # swept them in. Nothing type-checks a filename, so nothing complained.
       - name: No files from a mis-quoted shell command
         run: bash scripts/check-filenames.sh
+      # A SECURITY DEFINER function runs with the owner's rights and bypasses
+      # RLS, yet Supabase + Postgres grant EXECUTE on it to anon and PUBLIC by
+      # default. Every new one must state its caller model (a GRANT/REVOKE in the
+      # same migration) so an over-grant to the unauthenticated key fails here,
+      # not in production (audit 20260825240000).
+      - name: SECURITY DEFINER functions declare their caller model
+        run: node scripts/check-definer-grants.mjs
       # The edge functions import a bundled copy of @waves/core; build it first
       # so a broken bundle fails here rather than at deploy time.
       - run: pnpm edge:build

--- a/packages/db/prisma/migrations/20260825240000_definer_anon_grant_audit/migration.sql
+++ b/packages/db/prisma/migrations/20260825240000_definer_anon_grant_audit/migration.sql
@@ -1,0 +1,287 @@
+-- Audit and harden the SECURITY DEFINER RPC boundary: close the `anon`/PUBLIC
+-- over-grant on every definer function that no guest or pre-auth flow calls.
+--
+-- WHY THIS EXISTS
+-- ---------------
+-- Supabase runs `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON
+-- FUNCTIONS TO anon, authenticated, service_role` (reproduced locally by
+-- 20260806200000). On top of that, Postgres's own built-in default grants
+-- EXECUTE on every new function TO PUBLIC. So a freshly created SECURITY DEFINER
+-- function is reachable by `anon` — the UNauthenticated Supabase key — by TWO
+-- independent paths: a direct `anon` grant, and membership of PUBLIC. Revoking
+-- only one leaves the other open; several earlier migrations revoked `anon`
+-- (or nothing) but left PUBLIC, so `has_function_privilege('anon', …)` is still
+-- true today (e.g. baaki_consume_invite, whose 20260814120500 revoke missed
+-- PUBLIC). Every such function then relies ENTIRELY on its own internal
+-- membership/party/admin check to refuse anon — one missing check bypasses RLS.
+--
+-- THE CALLER MODEL (verified against apps/mobile, apps/web and supabase/functions)
+-- ------------------------------------------------------------------------------
+--   * A signed-in user (incl. a GUEST via signInAnonymously) runs as role
+--     `authenticated` — guests are NOT role `anon`. Every app RPC is issued
+--     with a session, i.e. as `authenticated`.
+--   * Edge functions call RPCs either as the caller's JWT (`authenticated`) or
+--     with the service-role key (`service_role`). None call an RPC as bare anon.
+--   * No pre-auth screen (login / landing / invite preview) invokes any
+--     `baaki_*` SECURITY DEFINER RPC; invite preview is an edge function doing
+--     service-role table reads, not an RPC.
+--   * => No SECURITY DEFINER RPC needs `anon` for a guest/pre-auth mutation.
+--
+-- WHAT THIS MIGRATION DOES
+-- ------------------------
+-- Group A — member-callable RPCs: revoke anon AND PUBLIC, keep authenticated +
+-- service_role (re-granted explicitly so revoking PUBLIC cannot strand a role
+-- that only held EXECUTE via PUBLIC). Behaviour for real users is unchanged;
+-- anon simply can no longer reach the door.
+-- Group B — trigger-only / cron / edge-service-only functions: locked to
+-- service_role.
+--
+-- LEFT WITH anon DELIBERATELY (not touched here): the five RLS-predicate helpers
+-- an anon-role SELECT evaluates directly on tables that GRANT SELECT TO anon —
+-- is_group_member, baaki_is_expense_party, baaki_is_settlement_party,
+-- baaki_my_member_id, baaki_version_group_id. Each only ever answers about the
+-- caller's OWN membership (returns nothing for a subject-less anon), and each is
+-- required for anon-facing RLS to evaluate at all. Revoking anon from these
+-- would break legitimate anon-role reads with "permission denied for function".
+--
+-- Idempotent (GRANT/REVOKE are declarative); safe to re-run. Grant/revoke only —
+-- no schema-table change, so Prisma drift is unaffected.
+--
+-- NOTE for the concurrent invite/join-token work: this also strips
+-- `authenticated` from baaki_consume_invite (Group B), matching 20260814120500's
+-- stated service-role-only intent; if that flow is being reshaped, re-confirm.
+
+-- ── Expense lifecycle, comments & disputes ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_add_expense_comment(p_group_id uuid, p_expense_id uuid, p_comment_id uuid, p_body text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_add_expense_comment(p_group_id uuid, p_expense_id uuid, p_comment_id uuid, p_body text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_assert_expense_caller(p_group_id uuid, p_author_member_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_assert_expense_caller(p_group_id uuid, p_author_member_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_delete_expense(p_expense_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_delete_expense(p_expense_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_delete_expense_comment(p_comment_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_delete_expense_comment(p_comment_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_dispute_expense(p_expense_id uuid, p_reason text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_dispute_expense(p_expense_id uuid, p_reason text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_edit_expense_comment(p_comment_id uuid, p_body text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_edit_expense_comment(p_comment_id uuid, p_body text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_flag_expense_comment(p_comment_id uuid, p_flag boolean) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_flag_expense_comment(p_comment_id uuid, p_flag boolean) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_resolve_dispute(p_dispute_id uuid, p_accept boolean, p_note text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_resolve_dispute(p_dispute_id uuid, p_accept boolean, p_note text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_restore_expense(p_expense_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_restore_expense(p_expense_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_withdraw_dispute(p_expense_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_withdraw_dispute(p_expense_id uuid) TO authenticated, service_role;
+
+-- ── Members, claims, roles & ghost merges ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_add_ghost_member(p_group_id uuid, p_name text, p_member_id uuid, p_email text, p_phone text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_add_ghost_member(p_group_id uuid, p_name text, p_member_id uuid, p_email text, p_phone text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_decide_member_claim(p_claim_id uuid, p_approve boolean) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_decide_member_claim(p_claim_id uuid, p_approve boolean) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_group_member_claims(p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_group_member_claims(p_group_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_member_group_id(p_member_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_member_group_id(p_member_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_merge_ghosts(p_member_ids uuid[], p_name text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_merge_ghosts(p_member_ids uuid[], p_name text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_my_member_claims() FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_my_member_claims() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_my_member_id_for(p_group_id uuid, p_profile_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_my_member_id_for(p_group_id uuid, p_profile_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_set_member_role(p_member_id uuid, p_role text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_set_member_role(p_member_id uuid, p_role text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_withdraw_member_claim(p_claim_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_withdraw_member_claim(p_claim_id uuid) TO authenticated, service_role;
+
+-- ── Trip plan items ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_add_plan_item(p_group_id uuid, p_day date, p_title text, p_starts_at time without time zone, p_note text, p_category text, p_planned_minor bigint, p_currency character, p_item_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_add_plan_item(p_group_id uuid, p_day date, p_title text, p_starts_at time without time zone, p_note text, p_category text, p_planned_minor bigint, p_currency character, p_item_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_group_plan(p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_group_plan(p_group_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_remove_plan_item(p_item_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_remove_plan_item(p_item_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_update_plan_item(p_item_id uuid, p_day date, p_starts_at time without time zone, p_title text, p_note text, p_category text, p_planned_minor bigint, p_done boolean, p_expense_id uuid, p_clear text[]) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_update_plan_item(p_item_id uuid, p_day date, p_starts_at time without time zone, p_title text, p_note text, p_category text, p_planned_minor bigint, p_done boolean, p_expense_id uuid, p_clear text[]) TO authenticated, service_role;
+
+-- ── Trip album (shared photos) ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_add_trip_photo(p_group_id uuid, p_storage_path text, p_photo_id uuid, p_expense_id uuid, p_day date, p_caption text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_add_trip_photo(p_group_id uuid, p_storage_path text, p_photo_id uuid, p_expense_id uuid, p_day date, p_caption text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_remove_trip_photo(p_photo_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_remove_trip_photo(p_photo_id uuid) TO authenticated, service_role;
+
+-- ── Attachments, settlement proofs & receipt-image annotations ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_annotate_expense_attachment(p_attachment_id uuid, p_annotations jsonb) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_annotate_expense_attachment(p_attachment_id uuid, p_annotations jsonb) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_attach_expense_attachment(p_expense_id uuid, p_storage_path text, p_visibility text, p_attachment_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_attach_expense_attachment(p_expense_id uuid, p_storage_path text, p_visibility text, p_attachment_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_attach_settlement_proof(p_settlement_id uuid, p_storage_path text, p_proof_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_attach_settlement_proof(p_settlement_id uuid, p_storage_path text, p_proof_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_can_add_expense_attachment(p_expense_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_can_add_expense_attachment(p_expense_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_remove_expense_attachment(p_attachment_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_remove_expense_attachment(p_attachment_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_remove_settlement_proof(p_proof_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_remove_settlement_proof(p_proof_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_replace_expense_attachment_image(p_attachment_id uuid, p_new_path text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_replace_expense_attachment_image(p_attachment_id uuid, p_new_path text) TO authenticated, service_role;
+
+-- ── Personal / account surfaces (voice, feedback, campaign, promo, account, plan) ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_campaign_seen(p_campaign_id uuid, p_acted boolean) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_campaign_seen(p_campaign_id uuid, p_acted boolean) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_delete_my_account(p_feedback text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_delete_my_account(p_feedback text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_my_campaign() FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_my_campaign() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_my_erasure_preview() FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_my_erasure_preview() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_my_plan(p_profile_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_my_plan(p_profile_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_my_voice_access() FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_my_voice_access() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_redeem_promo(p_code text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_redeem_promo(p_code text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_submit_feedback(p_message text, p_kind text, p_rating integer, p_app_version text, p_platform text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_submit_feedback(p_message text, p_kind text, p_rating integer, p_app_version text, p_platform text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_voice_stt_free_seconds() FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_voice_stt_free_seconds() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.is_group_admin(p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.is_group_admin(p_group_id uuid) TO authenticated, service_role;
+
+-- ── Receipts, scans & item claims ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_can_add_receipt(p_group_id uuid, p_receipt_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_can_add_receipt(p_group_id uuid, p_receipt_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_log_receipt_event(p_event_id uuid, p_group_id uuid, p_expense_id uuid, p_action text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_log_receipt_event(p_event_id uuid, p_group_id uuid, p_expense_id uuid, p_action text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_publish_receipt_items(p_receipt_id uuid, p_items jsonb) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_publish_receipt_items(p_receipt_id uuid, p_items jsonb) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_receipt_scan_quota() FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_receipt_scan_quota() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_scans_used_this_month(p_profile_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_scans_used_this_month(p_profile_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_set_item_claim(p_receipt_id uuid, p_item_index integer, p_claimed boolean, p_for_member_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_set_item_claim(p_receipt_id uuid, p_item_index integer, p_claimed boolean, p_for_member_id uuid) TO authenticated, service_role;
+
+-- ── Groups, join links & photo gating ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_can_upload_group_photo(p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_can_upload_group_photo(p_group_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_create_group(p_name text, p_type text, p_currency character, p_emoji text, p_simplify boolean, p_group_id uuid, p_photo_path text, p_country character, p_creator_member_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_create_group(p_name text, p_type text, p_currency character, p_emoji text, p_simplify boolean, p_group_id uuid, p_photo_path text, p_country character, p_creator_member_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_ensure_group_join_token(p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_ensure_group_join_token(p_group_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_group_is_paid(p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_group_is_paid(p_group_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_profiles_share_group(p_a uuid, p_b uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_profiles_share_group(p_a uuid, p_b uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_reset_group_join_token(p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_reset_group_join_token(p_group_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_shares_a_group_with(p_profile_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_shares_a_group_with(p_profile_id uuid) TO authenticated, service_role;
+
+-- ── Budgets (group / category / per-member) ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_clear_my_trip_budget(p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_clear_my_trip_budget(p_group_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_set_category_budget(p_group_id uuid, p_category text, p_amount_minor bigint, p_currency character) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_set_category_budget(p_group_id uuid, p_category text, p_amount_minor bigint, p_currency character) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_set_group_budget(p_group_id uuid, p_amount_minor bigint, p_currency character) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_set_group_budget(p_group_id uuid, p_amount_minor bigint, p_currency character) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_set_my_trip_budget(p_group_id uuid, p_amount_minor bigint, p_currency character, p_visibility text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_set_my_trip_budget(p_group_id uuid, p_amount_minor bigint, p_currency character, p_visibility text) TO authenticated, service_role;
+
+-- ── Settlements & nudges ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_confirm_settlement(p_settlement_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_confirm_settlement(p_settlement_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_nudge_to_settle(p_group_id uuid, p_to_member_id uuid, p_currency character) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_nudge_to_settle(p_group_id uuid, p_to_member_id uuid, p_currency character) TO authenticated, service_role;
+
+-- ── Other member-callable helpers ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_import_ledger(p_group_id uuid, p_people jsonb, p_expenses jsonb, p_settlements jsonb, p_origin text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_import_ledger(p_group_id uuid, p_people jsonb, p_expenses jsonb, p_settlements jsonb, p_origin text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_import_splitwise(p_group_id uuid, p_people jsonb, p_expenses jsonb) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_import_splitwise(p_group_id uuid, p_people jsonb, p_expenses jsonb) TO authenticated, service_role;
+
+-- ── Devices ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_list_devices() FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_list_devices() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_register_device(p_device_id text, p_label text, p_platform text, p_app_version text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_register_device(p_device_id text, p_label text, p_platform text, p_app_version text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_sign_out_other_devices(p_device_id text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_sign_out_other_devices(p_device_id text) TO authenticated, service_role;
+
+-- ── Storage (R2) accounting ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_my_storage_usage() FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_my_storage_usage() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_counts(p_profile_id uuid, p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_counts(p_profile_id uuid, p_group_id uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_enqueue_orphan() FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_enqueue_orphan() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_expire_pending(p_age interval) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_expire_pending(p_age interval) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_orphan_clear(p_logical_bucket text, p_path text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_orphan_clear(p_logical_bucket text, p_path text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_orphans(p_limit integer) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_orphans(p_limit integer) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_record(p_profile_id uuid, p_group_id uuid, p_logical_bucket text, p_path text, p_bytes bigint, p_content_type text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_record(p_profile_id uuid, p_group_id uuid, p_logical_bucket text, p_path text, p_bytes bigint, p_content_type text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_recount(p_logical_bucket text, p_path text, p_bytes bigint, p_content_type text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_recount(p_logical_bucket text, p_path text, p_bytes bigint, p_content_type text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_release(p_logical_bucket text, p_path text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_release(p_logical_bucket text, p_path text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_release_reservation(p_logical_bucket text, p_path text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_release_reservation(p_logical_bucket text, p_path text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_storage_reserve(p_profile_id uuid, p_group_id uuid, p_logical_bucket text, p_path text, p_bytes bigint, p_content_type text) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_storage_reserve(p_profile_id uuid, p_group_id uuid, p_logical_bucket text, p_path text, p_bytes bigint, p_content_type text) TO authenticated, service_role;
+
+-- ── Per-owner monotonic sequences ──
+-- Member-callable: each self-gates on the caller's membership/party/admin
+-- status (a subject-less anon fails every check); anon+PUBLIC removed.
+REVOKE EXECUTE ON FUNCTION public.baaki_next_capture_seq(p_owner uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_next_capture_seq(p_owner uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_next_category_tag_seq(p_owner uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_next_category_tag_seq(p_owner uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_next_ghost_merge_seq(p_owner uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_next_ghost_merge_seq(p_owner uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.baaki_next_group_seq(p_group_id uuid) FROM anon, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_next_group_seq(p_group_id uuid) TO authenticated, service_role;
+
+-- ── Group B: trigger-only, cron and edge-service-only — service_role only ──
+-- baaki_auto_archive_stale_groups: cron job (pg_cron), like baaki_auto_confirm_settlements
+REVOKE EXECUTE ON FUNCTION public.baaki_auto_archive_stale_groups(p_now timestamp with time zone, p_age interval) FROM anon, authenticated, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_auto_archive_stale_groups(p_now timestamp with time zone, p_age interval) TO service_role;
+-- baaki_close_disputes_on_new_version: expense-version trigger; not an RPC
+REVOKE EXECUTE ON FUNCTION public.baaki_close_disputes_on_new_version() FROM anon, authenticated, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_close_disputes_on_new_version() TO service_role;
+-- baaki_consume_invite: invite-accept edge, as service_role (20260814120500 intent)
+REVOKE EXECUTE ON FUNCTION public.baaki_consume_invite(p_invite_id uuid) FROM anon, authenticated, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_consume_invite(p_invite_id uuid) TO service_role;
+-- baaki_handle_new_user: AFTER INSERT trigger on auth.users; never an RPC
+REVOKE EXECUTE ON FUNCTION public.baaki_handle_new_user() FROM anon, authenticated, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_handle_new_user() TO service_role;
+-- baaki_touch_balances: expense trigger; EXECUTE grant is irrelevant to firing
+REVOKE EXECUTE ON FUNCTION public.baaki_touch_balances() FROM anon, authenticated, PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.baaki_touch_balances() TO service_role;

--- a/packages/db/test/definer-boundary.test.ts
+++ b/packages/db/test/definer-boundary.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Boundary tests for the SECURITY DEFINER mutators whose `anon`/PUBLIC grant was
+ * closed by 20260825240000_definer_anon_grant_audit.
+ *
+ * The migration removes anon's ability to even *reach* these functions; each
+ * also self-gates on the caller's membership/party/admin status. These tests pin
+ * both halves at the database — the layer that actually enforces them — across
+ * the five callers the audit brief named:
+ *
+ *   • anon (no JWT `sub`)                       → permission denied (no EXECUTE)
+ *   • guest / outsider (authenticated non-member) → the function's own refusal
+ *   • member                                     → allowed
+ *   • cross-group (a member of A acting on B's object) → refused
+ *
+ * A Supabase GUEST is an anonymous *sign-in*: it runs as role `authenticated`
+ * with a real `sub`, so at the database it is indistinguishable from any other
+ * authenticated non-member — which is exactly the "outsider" column. Both are
+ * covered by the authenticated-non-member cases below.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { addEqualSplitExpense, connect, expectDenied, seedGroup } from './helpers.js';
+import type { SeededGroup } from './helpers.js';
+
+let client: Client;
+
+interface Scene {
+  A: SeededGroup;
+  B: SeededGroup;
+  /** An authenticated user who is a member of no group (a fresh guest/outsider). */
+  outsiderProfile: string;
+  objA: Objects;
+  objB: Objects;
+}
+interface Objects {
+  attachmentId: string;
+  proofId: string;
+  photoId: string;
+  planItemId: string;
+  ghostIds: [string, string];
+}
+
+let scene: Scene;
+
+/** BEGIN…ROLLBACK as the anonymous key: role=anon, no `sub`. */
+async function asAnon<T>(run: () => Promise<T>): Promise<T> {
+  await client.query('BEGIN');
+  try {
+    await client.query(`SELECT set_config('request.jwt.claims', $1, true)`, [
+      JSON.stringify({ role: 'anon' }),
+    ]);
+    await client.query('SET LOCAL ROLE anon');
+    return await run();
+  } finally {
+    await client.query('ROLLBACK');
+  }
+}
+
+/** BEGIN…ROLLBACK as an authenticated user (JWT with role + sub). */
+async function asAuth<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query('BEGIN');
+  try {
+    await client.query(`SELECT set_config('request.jwt.claims', $1, true)`, [
+      JSON.stringify({ sub: profileId, role: 'authenticated' }),
+    ]);
+    await client.query('SET LOCAL ROLE authenticated');
+    return await run();
+  } finally {
+    await client.query('ROLLBACK');
+  }
+}
+
+async function seedObjects(group: SeededGroup): Promise<Objects> {
+  const payer = group.memberIds[0]!; // members[0] is admin
+  const other = group.memberIds[1]!; // [1] a plain member
+  const ghostIds: [string, string] = [group.memberIds[2]!, group.memberIds[3]!];
+
+  const { expenseId } = await addEqualSplitExpense(client, {
+    groupId: group.groupId,
+    payers: { [payer]: 1000n },
+    participants: [payer, other],
+    amount: 1000n,
+  });
+
+  const attachmentId = randomUUID();
+  await client.query(
+    `INSERT INTO expense_attachments (id, expense_id, group_id, uploader_member_id, storage_path, visibility)
+     VALUES ($1, $2, $3, $4, $5, 'group')`,
+    [attachmentId, expenseId, group.groupId, payer, `${expenseId}/a.webp`],
+  );
+
+  const settlementId = randomUUID();
+  await client.query(
+    `INSERT INTO settlements (id, group_id, from_member_id, to_member_id, amount, method, currency, status)
+     VALUES ($1, $2, $3, $4, 500, 'cash', 'INR', 'confirmed')`,
+    [settlementId, group.groupId, payer, other],
+  );
+  const proofId = randomUUID();
+  await client.query(
+    `INSERT INTO settlement_proofs (id, settlement_id, group_id, uploader_member_id, storage_path)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [proofId, settlementId, group.groupId, payer, `${settlementId}/p.webp`],
+  );
+
+  const photoId = randomUUID();
+  await client.query(
+    `INSERT INTO trip_photos (id, group_id, storage_path, created_by) VALUES ($1, $2, $3, $4)`,
+    [photoId, group.groupId, `${group.groupId}/photo.webp`, payer],
+  );
+
+  const planItemId = randomUUID();
+  await client.query(
+    `INSERT INTO trip_plan_items (id, group_id, day, title, created_by)
+     VALUES ($1, $2, current_date, 'Dudhsagar falls', $3)`,
+    [planItemId, group.groupId, payer],
+  );
+
+  return { attachmentId, proofId, photoId, planItemId, ghostIds };
+}
+
+beforeAll(async () => {
+  client = await connect();
+  const A = await seedGroup(client, { memberCount: 2, ghostCount: 2, name: 'Group A' });
+  const B = await seedGroup(client, { memberCount: 2, ghostCount: 2, name: 'Group B' });
+  const outsiderProfile = randomUUID();
+  await client.query(
+    `INSERT INTO profiles (id, display_name, default_currency) VALUES ($1, 'Outsider', 'INR')`,
+    [outsiderProfile],
+  );
+  const objA = await seedObjects(A);
+  const objB = await seedObjects(B);
+  scene = { A, B, outsiderProfile, objA, objB };
+});
+
+afterAll(async () => {
+  if (!scene) return;
+  const groupIds = [scene.A.groupId, scene.B.groupId];
+  const profileIds = [...scene.A.profileIds, ...scene.B.profileIds, scene.outsiderProfile];
+  // The ledger tables are append-only / no-hard-delete (ADR-004), and those
+  // guards fire even for the owner connection. `session_replication_role =
+  // replica` (session-local, only this connection) suspends user triggers —
+  // and with them FK cascades — so teardown deletes each table explicitly,
+  // children before parents.
+  await client.query(`SET session_replication_role = replica`);
+  try {
+    const inGroups = (col: string) => `${col} = ANY($1)`;
+    const versionScope = `expense_version_id IN (SELECT v.id FROM expense_versions v
+      JOIN expenses e ON e.id = v.expense_id WHERE ${inGroups('e.group_id')})`;
+    await client.query(`DELETE FROM expense_payers WHERE ${versionScope}`, [groupIds]);
+    await client.query(`DELETE FROM expense_shares WHERE ${versionScope}`, [groupIds]);
+    await client.query(`DELETE FROM expense_attachments WHERE ${inGroups('group_id')}`, [groupIds]);
+    await client.query(`DELETE FROM settlement_proofs WHERE ${inGroups('group_id')}`, [groupIds]);
+    await client.query(`DELETE FROM trip_photos WHERE ${inGroups('group_id')}`, [groupIds]);
+    await client.query(`DELETE FROM trip_plan_items WHERE ${inGroups('group_id')}`, [groupIds]);
+    await client.query(`DELETE FROM activity_log WHERE ${inGroups('group_id')}`, [groupIds]);
+    await client.query(
+      `DELETE FROM expense_versions WHERE expense_id IN (SELECT id FROM expenses WHERE ${inGroups('group_id')})`,
+      [groupIds],
+    );
+    await client.query(`DELETE FROM expenses WHERE ${inGroups('group_id')}`, [groupIds]);
+    await client.query(`DELETE FROM settlements WHERE ${inGroups('group_id')}`, [groupIds]);
+    await client.query(`DELETE FROM group_members WHERE ${inGroups('group_id')}`, [groupIds]);
+    await client.query(`DELETE FROM groups WHERE ${inGroups('id')}`, [groupIds]);
+    await client.query(`DELETE FROM profiles WHERE id = ANY($1)`, [profileIds]);
+  } finally {
+    await client.query(`SET session_replication_role = origin`);
+  }
+  await client.end();
+});
+
+/**
+ * One row per prioritized RPC. `call(obj, group)` builds the query for a target
+ * group's object; `memberActor(group)` picks a legitimate caller; `refuse` is
+ * the pattern the function raises for an authenticated non-party/non-member.
+ */
+interface Case {
+  name: string;
+  call: (obj: Objects, group: SeededGroup) => Promise<unknown>;
+  memberActor: (group: SeededGroup) => string; // profile id of an allowed caller
+  refuse: RegExp;
+}
+
+const q = (sql: string, params: unknown[]) => client.query(sql, params);
+
+const cases: Case[] = [
+  {
+    name: 'baaki_remove_expense_attachment (attachment removal)',
+    call: (o) => q(`SELECT baaki_remove_expense_attachment($1)`, [o.attachmentId]),
+    memberActor: (g) => g.profileIds[0]!, // the payer/author is a party
+    refuse: /NOT_A_PARTY/,
+  },
+  {
+    name: 'baaki_remove_settlement_proof (proof removal)',
+    call: (o) => q(`SELECT baaki_remove_settlement_proof($1)`, [o.proofId]),
+    memberActor: (g) => g.profileIds[0]!,
+    refuse: /NOT_A_PARTY/,
+  },
+  {
+    name: 'baaki_remove_trip_photo (album photo removal)',
+    call: (o) => q(`SELECT baaki_remove_trip_photo($1)`, [o.photoId]),
+    memberActor: (g) => g.profileIds[1]!, // any member may
+    refuse: /NOT_A_MEMBER/,
+  },
+  {
+    name: 'baaki_remove_plan_item (plan item removal)',
+    call: (o) => q(`SELECT baaki_remove_plan_item($1)`, [o.planItemId]),
+    memberActor: (g) => g.profileIds[1]!,
+    refuse: /NOT_A_MEMBER/,
+  },
+  {
+    name: 'baaki_merge_ghosts (merge ghosts)',
+    call: (o) => q(`SELECT baaki_merge_ghosts($1::uuid[], 'Priya')`, [o.ghostIds]),
+    memberActor: (g) => g.profileIds[0]!,
+    refuse: /NOT_MERGEABLE/,
+  },
+  {
+    name: 'baaki_reset_group_join_token (join-token reset, admin-only)',
+    call: (_o, g) => q(`SELECT baaki_reset_group_join_token($1)`, [g.groupId]),
+    memberActor: (g) => g.profileIds[0]!, // admin
+    refuse: /ADMIN_ONLY/,
+  },
+  {
+    name: 'baaki_import_ledger (import RPC)',
+    call: (_o, g) =>
+      q(`SELECT baaki_import_ledger($1, $2::jsonb, '[]'::jsonb, '[]'::jsonb, 'test')`, [
+        g.groupId,
+        JSON.stringify([{ name: 'Imported ghost', memberId: null }]),
+      ]),
+    memberActor: (g) => g.profileIds[0]!,
+    refuse: /NOT_A_MEMBER/,
+  },
+];
+
+describe.each(cases)('$name', ({ call, memberActor, refuse }) => {
+  it('anon (no subject) → permission denied', async () => {
+    const message = await expectDenied(asAnon(() => call(scene.objA, scene.A)));
+    expect(message).toMatch(/permission denied/i);
+  });
+
+  it('guest / outsider (authenticated non-member) → refused', async () => {
+    const message = await expectDenied(
+      asAuth(scene.outsiderProfile, () => call(scene.objA, scene.A)),
+    );
+    expect(message).toMatch(refuse);
+  });
+
+  it('member → allowed', async () => {
+    await asAuth(memberActor(scene.A), async () => {
+      await expect(call(scene.objA, scene.A)).resolves.toBeDefined();
+    });
+  });
+
+  it('cross-group (member of A acting on B) → refused', async () => {
+    // The actor is a legitimate caller in A, but the object/target is B's.
+    const message = await expectDenied(
+      asAuth(memberActor(scene.A), () => call(scene.objB, scene.B)),
+    );
+    expect(message).toMatch(refuse);
+  });
+});
+
+/**
+ * baaki_ensure_group_join_token is member-level (not admin), so it gets the same
+ * matrix but with NOT_A_MEMBER as the refusal and any member allowed.
+ */
+describe('baaki_ensure_group_join_token (durable join link, member-level)', () => {
+  const call = (groupId: string) => q(`SELECT baaki_ensure_group_join_token($1)`, [groupId]);
+
+  it('anon (no subject) → permission denied', async () => {
+    const message = await expectDenied(asAnon(() => call(scene.A.groupId)));
+    expect(message).toMatch(/permission denied/i);
+  });
+  it('guest / outsider → NOT_A_MEMBER', async () => {
+    const message = await expectDenied(asAuth(scene.outsiderProfile, () => call(scene.A.groupId)));
+    expect(message).toMatch(/NOT_A_MEMBER/);
+  });
+  it('member → allowed', async () => {
+    await asAuth(scene.A.profileIds[1]!, async () => {
+      await expect(call(scene.A.groupId)).resolves.toBeDefined();
+    });
+  });
+  it('cross-group (member of A on B) → NOT_A_MEMBER', async () => {
+    const message = await expectDenied(asAuth(scene.A.profileIds[0]!, () => call(scene.B.groupId)));
+    expect(message).toMatch(/NOT_A_MEMBER/);
+  });
+});

--- a/scripts/check-definer-grants.mjs
+++ b/scripts/check-definer-grants.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+//
+// Every SECURITY DEFINER function must declare its caller model.
+//
+// Supabase grants EXECUTE on new functions to `anon, authenticated,
+// service_role` by default, and Postgres itself grants EXECUTE to PUBLIC. So a
+// freshly created SECURITY DEFINER function — which runs with the owner's
+// rights and bypasses RLS — is reachable by the UNauthenticated `anon` key
+// unless the migration says otherwise. A missing membership check inside one
+// such function is an RLS bypass (audit 20260825240000).
+//
+// This guard forces the decision to be written down: any migration that CREATEs
+// (or OR REPLACEs) a SECURITY DEFINER function must, IN THE SAME FILE, contain
+// an explicit GRANT or REVOKE on that function. That is what makes a signature
+// change — which mints a NEW function and silently re-applies the anon/PUBLIC
+// default — fail here instead of in production (the exact way baaki_consume_invite
+// regained anon after its revoke).
+//
+// Grandfathered: migrations dated before the cutoff (the audit migration) are
+// exempt, so the existing tree passes; everything from the audit onward must
+// declare. Simple text scan — comments stripped first so prose about functions
+// never counts as a definition or a grant.
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const MIGRATIONS_DIR = 'packages/db/prisma/migrations';
+// The audit migration and everything after it must declare a caller model.
+const CUTOFF = '20260825240000';
+
+/** Remove -- line comments and /* *​/ block comments so only real SQL remains. */
+function stripComments(sql) {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
+}
+
+/**
+ * Names of SECURITY DEFINER functions defined in `sql`. A function's body runs
+ * from its `CREATE FUNCTION` to the next one (or end of file); if `SECURITY
+ * DEFINER` appears in that span, it is a definer function.
+ */
+function definerFunctions(sql) {
+  const create =
+    /\bCREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:public\.)?("?[a-zA-Z0-9_]+"?)\s*\(/gi;
+  const starts = [];
+  let m;
+  while ((m = create.exec(sql)) !== null) {
+    starts.push({ name: m[1].replace(/"/g, ''), index: m.index });
+  }
+  const names = new Set();
+  for (let i = 0; i < starts.length; i += 1) {
+    const from = starts[i].index;
+    const to = i + 1 < starts.length ? starts[i + 1].index : sql.length;
+    if (/\bSECURITY\s+DEFINER\b/i.test(sql.slice(from, to))) names.add(starts[i].name);
+  }
+  return names;
+}
+
+/** True if `sql` has a GRANT or REVOKE that names `fn` after ON FUNCTION. */
+function hasGrantOrRevoke(sql, fn) {
+  // Matches both single-function statements and the multi-function list form
+  //   GRANT EXECUTE ON FUNCTION
+  //     public.a(...),
+  //     public.b(...)
+  // by looking for the function name anywhere after an ON FUNCTION token that
+  // belongs to a GRANT/REVOKE, up to the terminating semicolon.
+  const re = new RegExp(
+    String.raw`\b(?:GRANT|REVOKE)\b[\s\S]*?\bON\s+FUNCTION\b[\s\S]*?\b(?:public\.)?${fn}\s*\([\s\S]*?;`,
+    'i',
+  );
+  return re.test(sql);
+}
+
+function main() {
+  if (!existsSync(MIGRATIONS_DIR)) {
+    console.error(`check-definer-grants: ${MIGRATIONS_DIR} not found`);
+    process.exit(1);
+  }
+  const dirs = readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && /^\d{14}_/.test(d.name))
+    .map((d) => d.name)
+    .filter((name) => name.slice(0, 14) >= CUTOFF)
+    .sort();
+
+  const failures = [];
+  for (const dir of dirs) {
+    const file = join(MIGRATIONS_DIR, dir, 'migration.sql');
+    if (!existsSync(file)) continue;
+    const sql = stripComments(readFileSync(file, 'utf8'));
+    for (const fn of definerFunctions(sql)) {
+      if (!hasGrantOrRevoke(sql, fn)) {
+        failures.push({ dir, fn });
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('SECURITY DEFINER functions created without an explicit GRANT/REVOKE:');
+    for (const { dir, fn } of failures) {
+      console.error(`  ${dir}: public.${fn}`);
+    }
+    console.error('');
+    console.error('A SECURITY DEFINER function bypasses RLS and is granted to anon + PUBLIC by');
+    console.error('default. In the SAME migration, state its caller model explicitly, e.g.:');
+    console.error('  REVOKE EXECUTE ON FUNCTION public.<fn>(<args>) FROM anon, PUBLIC;');
+    console.error(
+      '  GRANT  EXECUTE ON FUNCTION public.<fn>(<args>) TO authenticated, service_role;',
+    );
+    console.error('(service_role only for trigger/cron/edge-only functions).');
+    process.exit(1);
+  }
+
+  console.log(`check-definer-grants: OK (${dirs.length} migration(s) at or after ${CUTOFF})`);
+}
+
+main();


### PR DESCRIPTION
## SECURITY DEFINER boundary audit — close the `anon`/PUBLIC over-grant

A `SECURITY DEFINER` function runs with the owner's rights and **bypasses RLS**. Supabase's `ALTER DEFAULT PRIVILEGES … GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role` **and** Postgres's own built-in `EXECUTE TO PUBLIC` default both hand `anon` — the *unauthenticated* Supabase key — a way in. Reading the live grant state of a freshly-migrated database:

- **118** SECURITY DEFINER functions in `public`.
- **91** were executable by `anon` — many via a leftover **PUBLIC** grant that an earlier `REVOKE … FROM anon` never closed. Example: `baaki_consume_invite`, whose `20260814120500` revoke removed `anon`/`authenticated` but left `PUBLIC=X`, so `has_function_privilege('anon', …)` is still `true` today.

Each of those relies **entirely on its own internal membership/party/admin check** to refuse anon. One missing check is a full RLS bypass.

### Caller model (verified against `apps/mobile`, `apps/web`, `supabase/functions`)
- A signed-in user — **including a guest** (`signInAnonymously`) — runs as role `authenticated`, **not** `anon`. Guests carry a real JWT (`sub`); `is_anonymous` is just a claim.
- Edge functions call RPCs as the caller's JWT (`authenticated`) or with the service-role key. **None** call an RPC as bare `anon`.
- **No** pre-auth screen (login / landing / invite preview) invokes any `baaki_*` definer RPC; invite preview is an edge function doing service-role table reads.
- ⇒ **No** definer RPC needs `anon` for a guest/pre-auth mutation.

## What this migration does (`20260825240000_definer_anon_grant_audit`)

`REVOKE … FROM anon, PUBLIC` (closing **both** vectors), then re-`GRANT` the roles that legitimately keep access (explicitly, so revoking PUBLIC can't strand a role that only held EXECUTE via PUBLIC).

| Group | Count | Old effective grant | New grant | Caller model |
|---|---|---|---|---|
| **A — member-callable** | 81 | anon + authenticated (+PUBLIC/direct) | **authenticated, service_role** | Signed-in members; each self-gates on membership/party/admin (a subject-less anon fails every check). |
| **B — trigger / cron / edge-service-only** | 5 | anon + authenticated (+PUBLIC) | **service_role** | No signed-in client should call directly. |
| **Kept with anon (untouched)** | 5 | anon | anon (unchanged) | RLS-predicate helpers evaluated *as the anon role* during policy checks. |

**Net: anon-executable definer functions 91 → 5.**

### Group A categories (81)
Attachments/proofs/annotations · trip-album photos · plan items · budgets · expense lifecycle/comments/disputes · receipts/scans/item-claims · members/claims/roles/ghost-merges · groups/join-links/photo-gate · devices · R2 storage accounting · per-owner sequences · settlements/nudges · imports · personal/account (voice, feedback, campaign, promo, account, plan). Includes every mutator the brief flagged: `baaki_remove_expense_attachment`, `baaki_remove_settlement_proof`, `baaki_remove_trip_photo`, `baaki_remove_plan_item`, `baaki_merge_ghosts`, `baaki_reset_group_join_token`, `baaki_ensure_group_join_token`, `baaki_import_ledger`, `baaki_import_splitwise`.

### Group B — service_role only (5)
| Function | Why safe |
|---|---|
| `baaki_consume_invite` | invite-accept edge calls it as service_role; matches `20260814120500`'s stated service-only intent (which missed PUBLIC). |
| `baaki_auto_archive_stale_groups` | pg_cron job, like `baaki_auto_confirm_settlements`. |
| `baaki_handle_new_user` | `AFTER INSERT` trigger on `auth.users`; never an RPC (trigger firing doesn't check EXECUTE). |
| `baaki_touch_balances` | expense trigger. |
| `baaki_close_disputes_on_new_version` | expense-version trigger. |

### Kept with `anon` deliberately (5)
`is_group_member`, `baaki_is_expense_party`, `baaki_is_settlement_party`, `baaki_my_member_id`, `baaki_version_group_id` — referenced inside `FOR SELECT TO anon` RLS policies, which Postgres evaluates **as the querying role**. Revoking `anon` here would break legitimate anon-role reads with *"permission denied for function"*. Each only answers about the caller's own membership (returns nothing for a subject-less anon).

## Why the revokes are safe
- Guests are `authenticated`, so nothing anon-facing was ever a guest path.
- Grepped mobile + web + edge: no anon/pre-auth caller of any revoked function.
- **All 631 DB tests pass** against a clean, freshly-migrated database (599 existing + 32 new). The existing anon-read RLS suites (`rls`, `private-attachments`, `trip-album`, `invariants`, …) confirm the 5 kept helpers still serve anon reads.

## CI lint — `scripts/check-definer-grants.mjs`
Wired into `.github/workflows/ci.yml` next to `check-filenames`. Fails if a migration (at/after the audit cutoff) creates a `SECURITY DEFINER` function without an explicit `GRANT`/`REVOKE` on it **in the same file** — forcing every definer function to declare its caller model, and making a signature change that silently re-applies the anon/PUBLIC default fail in CI instead of production. Self-tested both ways (catches a missing grant; passes once one is added).

## Boundary tests — `packages/db/test/definer-boundary.test.ts`
Table-driven, following `rpc-boundary.test.ts` / `helpers.ts` (`request.jwt.claims` `sub`/`role`). For attachment removal, settlement-proof removal, trip-photo removal, plan-item removal, merge-ghosts, join-token reset, join-token ensure, and `import_ledger`:
- **anon (no `sub`)** → `permission denied` (no EXECUTE)
- **guest / outsider (authenticated non-member)** → the function's own refusal (`NOT_A_PARTY` / `NOT_A_MEMBER` / `ADMIN_ONLY`)
- **member** → allowed
- **cross-group** (member of A acting on B's object) → refused

## Coordination note
Purely additive (REVOKE/GRANT + a new test + a CI script); no RPC body was rewritten. It also strips `authenticated` from `baaki_consume_invite` (completing `20260814120500`'s service-role-only intent) — if the concurrent invite/join-token work reshapes that function, re-confirm this grant on rebase. The attachment-storage RPC bodies were only *read*, not changed.

## Deploy
Needs a **`prisma migrate deploy`** to prod (grant/revoke only — no schema-table change, so Prisma drift is unaffected). No edge/native/app change.
