### PR TITLE
ci(coverage): split app coverage workflows

### DIFF
--- a/.github/workflows/admin-coverage.yml
+++ b/.github/workflows/admin-coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/admin-coverage.yml
+++ b/.github/workflows/admin-coverage.yml
@@ -1,0 +1,31 @@
+name: Admin coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  admin-coverage:
+    name: admin coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm coverage:admin
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: admin-coverage
+          path: |
+            apps/admin/coverage/
+          retention-days: 14

--- a/.github/workflows/mobile-coverage.yml
+++ b/.github/workflows/mobile-coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mobile-coverage.yml
+++ b/.github/workflows/mobile-coverage.yml
@@ -1,0 +1,31 @@
+name: Mobile coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mobile-coverage:
+    name: mobile coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm coverage:app
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: mobile-coverage
+          path: |
+            apps/mobile/coverage/
+          retention-days: 14

--- a/.github/workflows/watches-coverage.yml
+++ b/.github/workflows/watches-coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/watches-coverage.yml
+++ b/.github/workflows/watches-coverage.yml
@@ -1,0 +1,31 @@
+name: Watches coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  watches-coverage:
+    name: watches coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm coverage:watches
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: watches-coverage
+          path: |
+            apps/mobile/coverage-watches/
+          retention-days: 14

--- a/.github/workflows/web-coverage.yml
+++ b/.github/workflows/web-coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/web-coverage.yml
+++ b/.github/workflows/web-coverage.yml
@@ -1,0 +1,31 @@
+name: Web coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web-coverage:
+    name: web coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm coverage:web
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: web-coverage
+          path: |
+            apps/web/coverage/
+          retention-days: 14

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -8,11 +8,12 @@
     "start": "next start --port 3100",
     "lint": "eslint src --max-warnings 0",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "coverage": "vitest run --coverage --passWithNoTests"
   },
   "dependencies": {
-    "@waves/core": "workspace:*",
     "@supabase/supabase-js": "^2.112.3",
+    "@waves/core": "workspace:*",
     "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.6",
     "next": "^16.3.0",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint src --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "coverage": "vitest run --coverage --passWithNoTests"
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.112.3",

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.ts'],
-    passWithNoTests: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'lcov'],

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -13,5 +13,12 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    passWithNoTests: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.d.ts', 'src/**/*.test.{ts,tsx}', 'test/**'],
+    },
   },
 });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -92,7 +92,9 @@
     "build:prod": "eas build --profile production --platform all",
     "build:local": "eas build --profile preview --platform android --local",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
+    "coverage:watches": "vitest run --coverage --config vitest.watch.config.ts"
   },
   "private": true,
   "expo": {

--- a/apps/mobile/test/localStore.test.ts
+++ b/apps/mobile/test/localStore.test.ts
@@ -366,6 +366,25 @@ describe('native local store lifecycle', () => {
     expect(await store.listDrafts()).toEqual([]);
   });
 
+  it('hydrates a large mirror without dropping rows on the chunked parse path', async () => {
+    const store = createLocalStore();
+    const rows = Array.from({ length: 1_025 }, (_, index) => ({
+      table: 'expenses',
+      id: `e${index}`,
+      groupId: `g${index % 3}`,
+      seq: index + 1,
+      row: { id: `e${index}`, amount: String(index) },
+    }));
+
+    await store.putRows(rows as never);
+
+    const hydrated = await store.readRows();
+    expect(hydrated).toHaveLength(rows.length);
+    expect(hydrated[0]).toEqual(rows[0]);
+    expect(hydrated[512]).toEqual(rows[512]);
+    expect(hydrated[1024]).toEqual(rows[1024]);
+  });
+
   it('does not open SQLite when asked to persist no rows', async () => {
     const store = createLocalStore();
 

--- a/apps/mobile/test/localStore.test.ts
+++ b/apps/mobile/test/localStore.test.ts
@@ -28,6 +28,16 @@ class FakeDatabase {
   /** How deep the nesting got. More than one means the lock is not working. */
   concurrent = 0;
   private live = 0;
+  readonly mirrorRows = new Map<
+    string,
+    { table_name: string; id: string; group_id: string; seq: number; json: string }
+  >();
+  readonly pendingMutations = new Map<
+    string,
+    { client_mutation_id: string; seq: number; json: string }
+  >();
+  readonly cursors = new Map<string, number>();
+  readonly drafts = new Map<string, { key: string; json: string; saved_at: string }>();
 
   private async enter<T>(run: () => Promise<T>): Promise<T> {
     this.live += 1;
@@ -58,26 +68,109 @@ class FakeDatabase {
     });
   }
 
-  async runAsync(source: string): Promise<void> {
+  async runAsync(source: string, params: unknown[] = []): Promise<void> {
     await this.enter(async () => {
       await tick();
       // Three tokens, so `INSERT INTO drafts` and `INSERT INTO
       // pending_mutations` stay tellable apart — the whole point of one test.
-      this.statements.push(source.trim().split(/\s+/).slice(0, 3).join(' '));
+      const statement = source.trim().split(/\s+/).slice(0, 3).join(' ');
+      this.statements.push(statement);
+
+      if (statement === 'INSERT INTO mirror_rows') {
+        const [tableName, id, groupId, seq, json] = params as [
+          string,
+          string,
+          string,
+          number,
+          string,
+        ];
+        this.mirrorRows.set(`${tableName}:${id}`, {
+          table_name: tableName,
+          id,
+          group_id: groupId,
+          seq,
+          json,
+        });
+        return;
+      }
+      if (statement === 'DELETE FROM mirror_rows') {
+        if (source.includes('group_id = ?')) {
+          const [groupId] = params as [string];
+          for (const [key, row] of [...this.mirrorRows]) {
+            if (row.group_id === groupId) this.mirrorRows.delete(key);
+          }
+        } else {
+          this.mirrorRows.clear();
+        }
+        return;
+      }
+      if (statement === 'INSERT INTO pending_mutations') {
+        const [clientMutationId, seq, json] = params as [string, number, string];
+        this.pendingMutations.set(clientMutationId, {
+          client_mutation_id: clientMutationId,
+          seq,
+          json,
+        });
+        return;
+      }
+      if (statement === 'DELETE FROM pending_mutations') {
+        this.pendingMutations.clear();
+        return;
+      }
+      if (statement === 'INSERT INTO sync_cursors') {
+        const [groupId, seq] = params as [string, number];
+        this.cursors.set(groupId, seq);
+        return;
+      }
+      if (statement === 'DELETE FROM sync_cursors') {
+        if (source.includes('group_id = ?')) {
+          const [groupId] = params as [string];
+          this.cursors.delete(groupId);
+        } else {
+          this.cursors.clear();
+        }
+        return;
+      }
+      if (statement === 'INSERT INTO drafts') {
+        const [key, json, savedAt] = params as [string, string, string];
+        this.drafts.set(key, { key, json, saved_at: savedAt });
+        return;
+      }
+      if (statement === 'DELETE FROM drafts') {
+        if (source.includes('key = ?')) {
+          const [key] = params as [string];
+          this.drafts.delete(key);
+        } else {
+          this.drafts.clear();
+        }
+      }
     });
   }
 
-  async getAllAsync<T>(): Promise<T[]> {
+  async getAllAsync<T>(source = ''): Promise<T[]> {
     return this.enter(async () => {
       await tick();
+      if (source.includes('FROM mirror_rows')) return [...this.mirrorRows.values()] as T[];
+      if (source.includes('FROM sync_cursors')) {
+        return [...this.cursors].map(([group_id, seq]) => ({ group_id, seq })) as T[];
+      }
+      if (source.includes('FROM pending_mutations')) {
+        return [...this.pendingMutations.values()].sort((a, b) => a.seq - b.seq) as T[];
+      }
+      if (source.includes('FROM drafts')) {
+        return [...this.drafts.values()].sort((a, b) =>
+          b.saved_at.localeCompare(a.saved_at),
+        ) as T[];
+      }
       return [];
     });
   }
 
-  async getFirstAsync<T>(): Promise<T | null> {
+  async getFirstAsync<T>(_source = '', params: unknown[] = []): Promise<T | null> {
     return this.enter(async () => {
       await tick();
-      return null;
+      const [key] = params as [string];
+      return (this.drafts.get(key) as T | undefined) ?? null;
     });
   }
 
@@ -201,5 +294,84 @@ describe('an open that fails', () => {
     const store = createLocalStore();
     await Promise.all([store.readQueue(), store.readRows(), store.readCursors()]);
     expect(openCalls).toBe(1);
+  });
+});
+
+describe('native local store lifecycle', () => {
+  it('round-trips rows, cursors, queue and drafts through SQLite', async () => {
+    const store = createLocalStore();
+
+    await store.ready();
+    await store.putRows([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1', amount: '100' } },
+      { table: 'expenses', id: 'e2', groupId: 'g2', seq: 2, row: { id: 'e2', amount: '200' } },
+    ] as never);
+    await store.putRows([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 3, row: { id: 'e1', amount: '300' } },
+    ] as never);
+    await store.writeCursors({ g1: 3, g2: 2 });
+    await store.writeQueue([mutation('b'), mutation('a')]);
+    await store.writeDraft('later', { amount: 200 });
+    await store.writeDraft('earlier', { amount: 100 });
+
+    expect(await store.readRows()).toEqual([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 3, row: { id: 'e1', amount: '300' } },
+      { table: 'expenses', id: 'e2', groupId: 'g2', seq: 2, row: { id: 'e2', amount: '200' } },
+    ]);
+    expect(await store.readCursors()).toEqual({ g1: 3, g2: 2 });
+    expect((await store.readQueue()).map((entry) => entry.clientMutationId)).toEqual(['b', 'a']);
+    expect(await store.readDraft('later')).toEqual({ amount: 200 });
+    expect((await store.listDrafts()).map((draft) => draft.key).sort()).toEqual([
+      'earlier',
+      'later',
+    ]);
+  });
+
+  it('forgets one group, its cursor, and replaces the queue in one transaction', async () => {
+    const store = createLocalStore();
+    await store.putRows([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
+      { table: 'expenses', id: 'e2', groupId: 'g2', seq: 2, row: { id: 'e2' } },
+    ] as never);
+    await store.writeCursors({ g1: 1, g2: 2 });
+    await store.writeQueue([mutation('a'), mutation('b')]);
+
+    await store.forgetGroup('g1', [mutation('b')]);
+
+    expect(await store.readRows()).toEqual([
+      { table: 'expenses', id: 'e2', groupId: 'g2', seq: 2, row: { id: 'e2' } },
+    ]);
+    expect(await store.readCursors()).toEqual({ g2: 2 });
+    expect((await store.readQueue()).map((entry) => entry.clientMutationId)).toEqual(['b']);
+  });
+
+  it('clears drafts and resets all persisted tables', async () => {
+    const store = createLocalStore();
+    await store.putRows([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
+    ] as never);
+    await store.writeCursors({ g1: 1 });
+    await store.writeQueue([mutation('a')]);
+    await store.writeDraft('expense:new', { amount: 100 });
+
+    await store.clearDraft('expense:new');
+    expect(await store.readDraft('expense:new')).toBeNull();
+
+    await store.writeDraft('expense:new', { amount: 100 });
+    await store.reset();
+
+    expect(await store.readRows()).toEqual([]);
+    expect(await store.readCursors()).toEqual({});
+    expect(await store.readQueue()).toEqual([]);
+    expect(await store.listDrafts()).toEqual([]);
+  });
+
+  it('does not open SQLite when asked to persist no rows', async () => {
+    const store = createLocalStore();
+
+    await store.putRows([]);
+
+    expect(openCalls).toBe(0);
+    expect(database.statements).toEqual([]);
   });
 });

--- a/apps/mobile/test/localStoreWeb.test.ts
+++ b/apps/mobile/test/localStoreWeb.test.ts
@@ -1,0 +1,107 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { QueuedMutation } from '@waves/core';
+
+import { createLocalStore } from '../src/sync/driver.web';
+import type { StoredRow } from '../src/sync/store';
+
+const mutation = (id: string, groupId = 'g1'): QueuedMutation =>
+  ({
+    clientMutationId: id,
+    seq: id === 'm1' ? 1 : 2,
+    kind: 'expense.create',
+    groupId,
+    clientCreatedAt: '2026-01-01T00:00:00.000Z',
+    payload: { expenseId: `e-${id}` },
+    attempts: 0,
+    nextAttemptAt: 0,
+    lastError: null,
+  }) as unknown as QueuedMutation;
+
+const row = (id: string, groupId = 'g1', seq = 1): StoredRow =>
+  ({
+    table: 'expenses',
+    id,
+    groupId,
+    seq,
+    row: { id, group_id: groupId, updated_seq: seq },
+  }) as StoredRow;
+
+describe('web local store', () => {
+  beforeEach(async () => {
+    vi.useRealTimers();
+    await AsyncStorage.clear();
+  });
+
+  it('round-trips rows, cursors, queue and drafts through AsyncStorage', async () => {
+    const store = createLocalStore();
+
+    await store.ready();
+    await store.putRows([row('e1', 'g1', 1), row('e2', 'g2', 2)]);
+    await store.putRows([row('e1', 'g1', 3)]);
+    await store.writeCursors({ g1: 3, g2: 2 });
+    await store.writeQueue([mutation('m1'), mutation('m2', 'g2')]);
+    await store.writeDraft('later', { amount: 200 });
+    await store.writeDraft('earlier', { amount: 100 });
+
+    expect(await store.readRows()).toEqual([row('e1', 'g1', 3), row('e2', 'g2', 2)]);
+    expect(await store.readCursors()).toEqual({ g1: 3, g2: 2 });
+    expect((await store.readQueue()).map((entry) => entry.clientMutationId)).toEqual(['m1', 'm2']);
+    expect(await store.readDraft<{ amount: number }>('later')).toEqual({ amount: 200 });
+    expect((await store.listDrafts()).map((draft) => draft.key).sort()).toEqual([
+      'earlier',
+      'later',
+    ]);
+  });
+
+  it('forgets one group without touching other groups or replacement queue', async () => {
+    const store = createLocalStore();
+    await store.putRows([row('e1', 'g1', 1), row('e2', 'g2', 2)]);
+    await store.writeCursors({ g1: 1, g2: 2 });
+    await store.writeQueue([mutation('m1'), mutation('m2', 'g2')]);
+
+    await store.forgetGroup('g1', [mutation('m2', 'g2')]);
+
+    expect(await store.readRows()).toEqual([row('e2', 'g2', 2)]);
+    expect(await store.readCursors()).toEqual({ g2: 2 });
+    expect((await store.readQueue()).map((entry) => entry.clientMutationId)).toEqual(['m2']);
+  });
+
+  it('clears drafts and resets every persisted collection', async () => {
+    const store = createLocalStore();
+    await store.putRows([row('e1')]);
+    await store.writeCursors({ g1: 1 });
+    await store.writeQueue([mutation('m1')]);
+    await store.writeDraft('expense:new', { amount: 100 });
+
+    await store.clearDraft('expense:new');
+    expect(await store.readDraft('expense:new')).toBeNull();
+
+    await store.writeDraft('expense:new', { amount: 100 });
+    await store.reset();
+
+    expect(await store.readRows()).toEqual([]);
+    expect(await store.readCursors()).toEqual({});
+    expect(await store.readQueue()).toEqual([]);
+    expect(await store.listDrafts()).toEqual([]);
+  });
+
+  it('treats corrupt or empty JSON as an empty store so the next sync can rebuild it', async () => {
+    await AsyncStorage.setItem('baaki:mirror', '{not-json');
+    await AsyncStorage.setItem('baaki:cursors', '{not-json');
+    await AsyncStorage.setItem('baaki:queue', '{not-json');
+    await AsyncStorage.setItem('baaki:drafts', '{not-json');
+
+    const store = createLocalStore();
+
+    expect(await store.readRows()).toEqual([]);
+    expect(await store.readCursors()).toEqual({});
+    expect(await store.readQueue()).toEqual([]);
+    expect(await store.readDraft('missing')).toBeNull();
+    expect(await store.listDrafts()).toEqual([]);
+
+    await AsyncStorage.setItem('baaki:mirror', '');
+    expect(await store.readRows()).toEqual([]);
+  });
+});

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -12,6 +12,19 @@ export default defineConfig({
   test: {
     globals: true,
     include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/app/**',
+        'src/**/*.test.{ts,tsx}',
+        'test/**',
+        'assets/**',
+        'modules/**',
+      ],
+    },
   },
   resolve: {
     alias: {

--- a/apps/mobile/vitest.watch.config.ts
+++ b/apps/mobile/vitest.watch.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['test/*watch*.test.ts', 'test/*wear*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      include: ['src/lib/watch/**/*.ts', 'src/lib/watch/**/*.tsx', 'plugins/withWavesWear.js'],
+      reportsDirectory: 'coverage-watches',
+    },
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint src --max-warnings 0",
     "test": "vitest run",
     "e2e": "playwright test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@waves/api-client": "workspace:*",

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,5 +4,11 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.d.ts', 'src/**/*.test.{ts,tsx}', 'test/**'],
+    },
   },
 });

--- a/package.json
+++ b/package.json
@@ -31,9 +31,18 @@
     "edge:serve": "pnpm edge:build && supabase functions serve --env-file supabase/functions/.env",
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",
-    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write sync invite-mint invite-accept export-data receipt-parse fx-rate notify-fanout email-events email-unsubscribe account-delete campaign-broadcast r2-sign storage-sweep storage-recount"
+    "edge:deploy": "pnpm edge:build && supabase functions deploy expense-write sync invite-mint invite-accept export-data receipt-parse fx-rate notify-fanout email-events email-unsubscribe account-delete campaign-broadcast r2-sign storage-sweep storage-recount",
+    "coverage": "pnpm -r --if-present run coverage",
+    "coverage:core": "pnpm --filter @waves/core run coverage",
+    "coverage:db": "pnpm --filter @waves/db run coverage",
+    "coverage:app": "pnpm --filter @waves/mobile run coverage",
+    "coverage:api": "pnpm --filter @waves/api-client run coverage",
+    "coverage:web": "pnpm --filter @waves/web run coverage",
+    "coverage:admin": "pnpm --filter @waves/admin run coverage",
+    "coverage:watches": "pnpm --filter @waves/mobile run coverage:watches"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "4.1.10",
     "prettier": "^3.4.2",
     "typescript": "~5.9.2",
     "vitest": "^4.1.10"

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@waves/core": "workspace:*"

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -4,5 +4,11 @@ export default defineConfig({
   test: {
     globals: true,
     include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts'],
+    },
   },
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "build": "esbuild src/index.ts --bundle --format=esm --platform=neutral --target=es2022 --outfile=dist/core.js",
-    "build:edge": "esbuild src/index.ts --bundle --format=esm --platform=neutral --target=es2022 --outfile=../../supabase/functions/_shared/core.js"
+    "build:edge": "esbuild src/index.ts --bundle --format=esm --platform=neutral --target=es2022 --outfile=../../supabase/functions/_shared/core.js",
+    "coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "fast-check": "^4.1.1",

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,5 +4,11 @@ export default defineConfig({
   test: {
     globals: true,
     include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts'],
+    },
   },
 });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,7 +16,8 @@
     "seed": "node ./scripts/seed-demo.mjs",
     "seed:purge": "node ./scripts/seed-demo.mjs --purge",
     "typecheck": "prisma generate --no-hints && tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@prisma/client": "7.9.1",

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -8,5 +8,11 @@ export default defineConfig({
     fileParallelism: false,
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts', 'generated/**'],
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
 
   .:
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: 4.1.10
+        version: 4.1.10(vitest@4.1.10)
       prettier:
         specifier: ^3.4.2
         version: 3.9.6
@@ -24,7 +27,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/admin:
     dependencies:
@@ -70,7 +73,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/agent-mcp:
     dependencies:
@@ -315,7 +318,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/web:
     dependencies:
@@ -370,7 +373,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   e2e:
     dependencies:
@@ -395,7 +398,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/core:
     devDependencies:
@@ -410,13 +413,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/db:
     dependencies:
       '@prisma/client':
         specifier: 7.9.1
-        version: 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)
       '@waves/core':
         specifier: workspace:*
         version: link:../core
@@ -435,13 +438,13 @@ importers:
         version: 8.23.0
       prisma:
         specifier: 7.9.1
-        version: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+        version: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -884,6 +887,10 @@ packages:
 
   '@bacons/xcode@1.0.0-alpha.32':
     resolution: {integrity: sha512-OGpH7+yMbWC2cgYZon5B+VVadH9HsB2V/abtEiplA65XnSuV4GAYAVixOCDc5k182WkfoakfdM0zW6U9cbcsbw==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
@@ -3245,6 +3252,15 @@ packages:
   '@visx/vendor@4.0.0-alpha.0':
     resolution: {integrity: sha512-6I+MuqXBcv9jnlcVowHoHKSdk9gXTWkHLKyqBwRWg7LY6A3Ei8SHfubpqGV5rBUSppxMq2RszPJUS6w+H0YgmQ==}
 
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -3498,6 +3514,9 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -5050,6 +5069,9 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -5275,6 +5297,18 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -5311,6 +5345,9 @@ packages:
 
   jose@6.2.9:
     resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -5587,6 +5624,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -7958,6 +8002,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
@@ -8974,16 +9020,16 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.9.1': {}
 
-  '@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.9.1
     optionalDependencies:
-      prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@prisma/config@7.9.1':
+  '@prisma/config@7.9.1(magicast@0.5.4)':
     dependencies:
-      c12: 3.3.4
+      c12: 3.3.4(magicast@0.5.4)
       deepmerge-ts: 7.1.5
       effect: 3.20.0
       empathic: 2.0.0
@@ -10497,6 +10543,20 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -10794,6 +10854,12 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   astring@1.9.0: {}
 
   async-function@1.0.0: {}
@@ -10989,7 +11055,7 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  c12@3.3.4:
+  c12@3.3.4(magicast@0.5.4):
     dependencies:
       chokidar: 5.0.0
       confbox: 0.2.4
@@ -11003,6 +11069,8 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       rc9: 3.0.1
+    optionalDependencies:
+      magicast: 0.5.4
 
   cacheable-lookup@5.0.4: {}
 
@@ -12736,6 +12804,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  html-escaper@2.0.2: {}
+
   http-cache-semantics@4.2.0: {}
 
   http-errors@2.0.1:
@@ -12958,6 +13028,19 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -13011,6 +13094,8 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@6.2.9: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -13214,6 +13299,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   makeerror@1.0.12:
     dependencies:
@@ -13833,9 +13928,9 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3):
+  prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3):
     dependencies:
-      '@prisma/config': 7.9.1
+      '@prisma/config': 7.9.1(magicast@0.5.4)
       '@prisma/dev': 0.24.17(typescript@5.9.3)
       '@prisma/engines': 7.9.1
       '@prisma/studio-core': 0.33.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -14967,7 +15062,7 @@ snapshots:
       tsx: 4.23.12
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -14992,6 +15087,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.2.0
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Summary
- add Vitest V8 coverage scripts/config for core, api-client, db, mobile, web, and admin
- add separate GitHub Actions workflows for mobile, web, admin, and watches coverage
- add a watch/wear-focused mobile coverage config and artifact upload paths

## Validation
- pnpm coverage:admin
- pnpm coverage:watches
- pnpm --filter @waves/api-client run coverage
- pnpm --filter @waves/core run coverage
- pnpm --filter @waves/mobile run coverage
- pnpm --filter @waves/web run coverage
- pnpm typecheck
- pnpm exec prettier --check package.json apps/admin/package.json apps/admin/vitest.config.ts apps/mobile/package.json apps/mobile/vitest.config.ts apps/mobile/vitest.watch.config.ts apps/web/package.json apps/web/vitest.config.ts packages/api-client/package.json packages/api-client/vitest.config.ts packages/core/package.json packages/core/vitest.config.ts packages/db/package.json packages/db/vitest.config.ts .github/workflows/mobile-coverage.yml .github/workflows/web-coverage.yml .github/workflows/admin-coverage.yml .github/workflows/watches-coverage.yml

Note: full pnpm coverage includes @waves/db and requires local Postgres on port 54330.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage reporting across core packages and applications.
  - Coverage results now include text, JSON summary, and LCOV formats.
  - Added coverage checks for admin, mobile, watch, and web projects.
  - Automated coverage runs are triggered for pull requests and updates to the main branch.
  - Coverage reports are retained as downloadable artifacts for 14 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->