### PR TITLE
fix(sync): harden image cache and sync polling

### DIFF
--- a/apps/mobile/src/lib/storage/imageCache.ts
+++ b/apps/mobile/src/lib/storage/imageCache.ts
@@ -24,6 +24,14 @@ import type { LogicalBucket } from './index';
 /** Subdirectory under the OS cache dir that holds every cached receipt image. */
 const CACHE_DIR = 'receipt-image-cache';
 
+/** Downloads already in flight, keyed by the stable local cache identity. */
+const inFlightDownloads = new Map<string, Promise<string | null>>();
+
+function usablePath(path: string | null): string | null {
+  if (!path || path.trim().length === 0) return null;
+  return path;
+}
+
 /**
  * Write bytes to the cache atomically: to a unique temp sibling first, then move
  * it onto the final path. A direct `file.write` can leave a truncated file if
@@ -50,12 +58,12 @@ function writeAtomic(dir: Directory, file: File, bytes: Uint8Array): void {
 
 /**
  * A deterministic, filesystem-safe filename for a stored object. The bucket and
- * path together are unique, and every character a path can carry (slashes, the
- * uuid dots) is flattened to `_` so it is one flat filename rather than a nested
- * tree — the lookup only needs identity, not the original shape.
+ * path together are unique. They are URI-encoded as one string rather than
+ * lossy-flattened, so distinct storage paths like `a/b` and `a_b` cannot map to
+ * the same local file.
  */
 function fileFor(bucket: LogicalBucket, path: string): File {
-  const name = `${bucket}__${path}`.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const name = encodeURIComponent(`${bucket}\u0000${path}`);
   return new File(Paths.cache, CACHE_DIR, name);
 }
 
@@ -65,9 +73,10 @@ function fileFor(bucket: LogicalBucket, path: string): File {
  * reaching for the network.
  */
 export function cachedImageUri(bucket: LogicalBucket, path: string | null): string | null {
-  if (!path) return null;
+  const key = usablePath(path);
+  if (!key) return null;
   try {
-    const file = fileFor(bucket, path);
+    const file = fileFor(bucket, key);
     return file.exists ? file.uri : null;
   } catch {
     return null;
@@ -85,16 +94,32 @@ export async function cacheImage(
   path: string | null,
   remoteUrl: string,
 ): Promise<string | null> {
-  if (!path) return null;
+  const key = usablePath(path);
+  if (!key) return null;
   try {
-    const file = fileFor(bucket, path);
+    const file = fileFor(bucket, key);
     if (file.exists) return file.uri;
 
-    const response = await expoFetch(remoteUrl);
-    if (!response.ok) return null;
-    const bytes = await response.bytes();
-    writeAtomic(new Directory(Paths.cache, CACHE_DIR), file, bytes);
-    return file.uri;
+    const inFlightKey = file.uri;
+    const existing = inFlightDownloads.get(inFlightKey);
+    if (existing) return await existing;
+
+    const download = (async () => {
+      try {
+        const response = await expoFetch(remoteUrl);
+        if (!response.ok) return null;
+        const bytes = await response.bytes();
+        if (bytes.byteLength === 0) return null;
+        writeAtomic(new Directory(Paths.cache, CACHE_DIR), file, bytes);
+        return file.uri;
+      } catch {
+        return null;
+      } finally {
+        inFlightDownloads.delete(inFlightKey);
+      }
+    })();
+    inFlightDownloads.set(inFlightKey, download);
+    return await download;
   } catch {
     return null;
   }
@@ -111,8 +136,10 @@ export function cacheImageBytes(
   path: string,
   bytes: Uint8Array,
 ): string | null {
+  const key = usablePath(path);
+  if (!key || bytes.byteLength === 0) return null;
   try {
-    const file = fileFor(bucket, path);
+    const file = fileFor(bucket, key);
     writeAtomic(new Directory(Paths.cache, CACHE_DIR), file, bytes);
     return file.uri;
   } catch {
@@ -125,9 +152,10 @@ export function cacheImageBytes(
  * stale copy cannot outlive the real one. Best-effort.
  */
 export function evictImage(bucket: LogicalBucket, path: string | null): void {
-  if (!path) return;
+  const key = usablePath(path);
+  if (!key) return;
   try {
-    const file = fileFor(bucket, path);
+    const file = fileFor(bucket, key);
     if (file.exists) file.delete();
   } catch {
     // Already gone, or unreadable — nothing to do.

--- a/apps/mobile/src/lib/storage/imageCache.ts
+++ b/apps/mobile/src/lib/storage/imageCache.ts
@@ -67,6 +67,23 @@ function fileFor(bucket: LogicalBucket, path: string): File {
   return new File(Paths.cache, CACHE_DIR, name);
 }
 
+function fileSize(file: File): number {
+  const size = (file as unknown as { size?: unknown }).size;
+  return typeof size === 'number' ? size : 0;
+}
+
+function isNonEmptyFile(file: File): boolean {
+  return file.exists && fileSize(file) > 0;
+}
+
+function deleteIfExists(file: File): void {
+  try {
+    if (file.exists) file.delete();
+  } catch {
+    // Best-effort cache cleanup.
+  }
+}
+
 /**
  * The local `file://` for a cached object, or null when it is not on disk. Sync
  * and cheap (a stat), so a resolver can check it first on every render before
@@ -77,7 +94,7 @@ export function cachedImageUri(bucket: LogicalBucket, path: string | null): stri
   if (!key) return null;
   try {
     const file = fileFor(bucket, key);
-    return file.exists ? file.uri : null;
+    return isNonEmptyFile(file) ? file.uri : null;
   } catch {
     return null;
   }
@@ -98,7 +115,8 @@ export async function cacheImage(
   if (!key) return null;
   try {
     const file = fileFor(bucket, key);
-    if (file.exists) return file.uri;
+    if (isNonEmptyFile(file)) return file.uri;
+    if (file.exists) deleteIfExists(file);
 
     const inFlightKey = file.uri;
     const existing = inFlightDownloads.get(inFlightKey);

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -442,7 +442,8 @@ export class SyncEngine {
       // those memos stay put. When changes did land — or the cursors or queue
       // actually moved — this is exactly the old path: a new mirror, the folded
       // queue.
-      const mirrorChanged = changes.length > merged.skipped;
+      const appliedChanges = merged.applied;
+      const mirrorChanged = appliedChanges.length > 0;
       const cursorsChanged = !sameCursors(this.state.mirror.cursors, nextCursors);
       const mirror: MirrorState =
         !mirrorChanged && !cursorsChanged
@@ -454,7 +455,7 @@ export class SyncEngine {
           : folded.queue;
       const madeProgress = mirrorChanged || cursorsChanged;
 
-      await this.persist(changes, mirror, queue);
+      await this.persist(appliedChanges, mirror, queue);
 
       this.set({
         status: SyncStatus.Idle,

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -442,17 +442,17 @@ export class SyncEngine {
       // those memos stay put. When changes did land — or the cursors or queue
       // actually moved — this is exactly the old path: a new mirror, the folded
       // queue.
-      const nothingApplied = changes.length === 0;
+      const mirrorChanged = changes.length > merged.skipped;
+      const cursorsChanged = !sameCursors(this.state.mirror.cursors, nextCursors);
       const mirror: MirrorState =
-        nothingApplied && sameCursors(this.state.mirror.cursors, nextCursors)
+        !mirrorChanged && !cursorsChanged
           ? this.state.mirror
           : { cursors: nextCursors, tables: merged.state.tables };
       const queue =
         folded.rejected.length === 0 && sameQueue(this.state.queue, folded.queue)
           ? this.state.queue
           : folded.queue;
-      const madeProgress =
-        changes.length > 0 || !sameCursors(this.state.mirror.cursors, nextCursors);
+      const madeProgress = mirrorChanged || cursorsChanged;
 
       await this.persist(changes, mirror, queue);
 

--- a/apps/mobile/src/sync/engine.ts
+++ b/apps/mobile/src/sync/engine.ts
@@ -130,6 +130,16 @@ function sameQueue(a: readonly QueuedMutation[], b: readonly QueuedMutation[]): 
   return true;
 }
 
+function appendRejected(
+  existing: readonly RejectedMutation[],
+  incoming: readonly RejectedMutation[],
+): RejectedMutation[] {
+  if (incoming.length === 0) return [...existing];
+  const byId = new Map(existing.map((item) => [item.clientMutationId, item]));
+  for (const item of incoming) byId.set(item.clientMutationId, item);
+  return [...byId.values()];
+}
+
 export class SyncEngine {
   private store: LocalStore = createLocalStore();
   private state: SyncState = {
@@ -441,6 +451,8 @@ export class SyncEngine {
         folded.rejected.length === 0 && sameQueue(this.state.queue, folded.queue)
           ? this.state.queue
           : folded.queue;
+      const madeProgress =
+        changes.length > 0 || !sameCursors(this.state.mirror.cursors, nextCursors);
 
       await this.persist(changes, mirror, queue);
 
@@ -448,7 +460,7 @@ export class SyncEngine {
         status: SyncStatus.Idle,
         mirror,
         queue,
-        rejected: [...this.state.rejected, ...rejected],
+        rejected: appendRejected(this.state.rejected, rejected),
         lastSyncedAt: response.serverTime ?? new Date().toISOString(),
         lastError: null,
       });
@@ -459,7 +471,7 @@ export class SyncEngine {
       // joining a big group) catches up in a burst instead of a page every half
       // minute. Scheduled after this flush settles, since flush() is single-
       // in-flight; guarded by the cursor moving, so it cannot spin forever.
-      if (response.hasMore) {
+      if (response.hasMore && madeProgress) {
         setTimeout(() => void this.flush(), 0);
       }
 

--- a/apps/mobile/test/imageCache.test.ts
+++ b/apps/mobile/test/imageCache.test.ts
@@ -41,6 +41,10 @@ class FakeFile {
     return fs.files.has(this.uri);
   }
 
+  get size(): number {
+    return fs.files.get(this.uri)?.byteLength ?? 0;
+  }
+
   write(bytes: Uint8Array): void {
     if (fs.failWrite) throw new Error('write failed');
     fs.files.set(this.uri, new Uint8Array(bytes));
@@ -133,6 +137,19 @@ describe('image cache', () => {
     expect(second).toBe(first);
     expect(fs.fetch).toHaveBeenCalledTimes(1);
     expect([...fs.files.keys()].filter((key) => key.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('treats an existing empty cache file as a miss and replaces it', async () => {
+    fs.files.set(cachedPath('g1/empty-existing.png'), new Uint8Array([]));
+    fs.fetch.mockResolvedValue({ ok: true, bytes: async () => new Uint8Array([4, 5, 6]) });
+
+    expect(cachedImageUri('expense-attachments', 'g1/empty-existing.png')).toBeNull();
+    await expect(
+      cacheImage('expense-attachments', 'g1/empty-existing.png', 'https://signed.example/retry'),
+    ).resolves.toBe(cachedPath('g1/empty-existing.png'));
+
+    expect(fs.fetch).toHaveBeenCalledTimes(1);
+    expect(Array.from(fs.files.get(cachedPath('g1/empty-existing.png')) ?? [])).toEqual([4, 5, 6]);
   });
 
   it('dedupes concurrent downloads for the same cache key', async () => {

--- a/apps/mobile/test/imageCache.test.ts
+++ b/apps/mobile/test/imageCache.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fs = vi.hoisted(() => ({
+  files: new Map<string, Uint8Array>(),
+  dirs: new Set<string>(),
+  fetch: vi.fn(),
+  uuid: vi.fn(),
+  failCreate: false,
+  failWrite: false,
+  failMove: false,
+  failDelete: false,
+}));
+
+class FakeDirectory {
+  readonly uri: string;
+
+  constructor(...parts: string[]) {
+    this.uri = parts.join('/');
+  }
+
+  get exists(): boolean {
+    return fs.dirs.has(this.uri);
+  }
+
+  create(): void {
+    if (fs.failCreate) throw new Error('mkdir failed');
+    fs.dirs.add(this.uri);
+  }
+}
+
+class FakeFile {
+  readonly uri: string;
+
+  constructor(...parts: unknown[]) {
+    this.uri = parts
+      .map((part) => (part instanceof FakeDirectory ? part.uri : String(part)))
+      .join('/');
+  }
+
+  get exists(): boolean {
+    return fs.files.has(this.uri);
+  }
+
+  write(bytes: Uint8Array): void {
+    if (fs.failWrite) throw new Error('write failed');
+    fs.files.set(this.uri, new Uint8Array(bytes));
+  }
+
+  moveSync(file: FakeFile, options?: { overwrite?: boolean }): void {
+    if (fs.failMove) throw new Error('move failed');
+    if (!this.exists) throw new Error('source missing');
+    if (file.exists && !options?.overwrite) throw new Error('target exists');
+    fs.files.set(file.uri, fs.files.get(this.uri) as Uint8Array);
+    fs.files.delete(this.uri);
+  }
+
+  delete(): void {
+    if (fs.failDelete) throw new Error('delete failed');
+    fs.files.delete(this.uri);
+  }
+}
+
+vi.mock('expo-crypto', () => ({ randomUUID: fs.uuid }));
+vi.mock('expo/fetch', () => ({ fetch: fs.fetch }));
+vi.mock('expo-file-system', () => ({
+  Directory: FakeDirectory,
+  File: FakeFile,
+  Paths: { cache: 'cache-root' },
+}));
+
+const { cacheImage, cachedImageUri, cacheImageBytes, evictImage } =
+  await import('../src/lib/storage/imageCache');
+
+const cachedPath = (path: string) =>
+  `cache-root/receipt-image-cache/${encodeURIComponent(`expense-attachments\u0000${path}`)}`;
+
+beforeEach(() => {
+  fs.files.clear();
+  fs.dirs.clear();
+  fs.fetch.mockReset();
+  fs.uuid.mockReset();
+  fs.uuid.mockReturnValue('uuid-1');
+  fs.failCreate = false;
+  fs.failWrite = false;
+  fs.failMove = false;
+  fs.failDelete = false;
+});
+
+describe('image cache', () => {
+  it('returns null for empty paths and filesystem errors', async () => {
+    expect(cachedImageUri('expense-attachments', null)).toBeNull();
+    expect(cachedImageUri('expense-attachments', '')).toBeNull();
+    expect(cacheImageBytes('expense-attachments', ' ', new Uint8Array([1]))).toBeNull();
+    await expect(
+      cacheImage('expense-attachments', '', 'https://signed.example/blank'),
+    ).resolves.toBeNull();
+    expect(fs.fetch).not.toHaveBeenCalled();
+
+    fs.failCreate = true;
+    expect(cacheImageBytes('expense-attachments', 'g1/e1.png', new Uint8Array([1]))).toBeNull();
+    expect(cachedImageUri('expense-attachments', 'g1/e1.png')).toBeNull();
+  });
+
+  it('encodes bucket and path into one stable collision-safe flat filename', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+
+    const uri = cacheImageBytes('expense-attachments', 'groups/g1/receipt #1.webp', bytes);
+
+    expect(uri).toBe(cachedPath('groups/g1/receipt #1.webp'));
+    expect(cachedImageUri('expense-attachments', 'groups/g1/receipt #1.webp')).toBe(uri);
+  });
+
+  it('keeps paths distinct when lossy filename sanitizing would collide', () => {
+    const slash = cacheImageBytes('expense-attachments', 'g1/a/b.png', new Uint8Array([1]));
+    const underscore = cacheImageBytes('expense-attachments', 'g1/a_b.png', new Uint8Array([2]));
+
+    expect(slash).not.toBe(underscore);
+    expect(Array.from(fs.files.get(cachedPath('g1/a/b.png')) ?? [])).toEqual([1]);
+    expect(Array.from(fs.files.get(cachedPath('g1/a_b.png')) ?? [])).toEqual([2]);
+  });
+
+  it('downloads once, then serves cache hits without another network call', async () => {
+    fs.fetch.mockResolvedValue({ ok: true, bytes: async () => new Uint8Array([7, 8, 9]) });
+
+    const first = await cacheImage('expense-attachments', 'g1/e1.png', 'https://signed.example/e1');
+    const second = await cacheImage(
+      'expense-attachments',
+      'g1/e1.png',
+      'https://signed.example/e1?v=2',
+    );
+
+    expect(first).toBe(cachedPath('g1/e1.png'));
+    expect(second).toBe(first);
+    expect(fs.fetch).toHaveBeenCalledTimes(1);
+    expect([...fs.files.keys()].filter((key) => key.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('dedupes concurrent downloads for the same cache key', async () => {
+    let release: (bytes: Uint8Array) => void = () => {};
+    fs.fetch.mockResolvedValue({
+      ok: true,
+      bytes: () =>
+        new Promise<Uint8Array>((resolve) => {
+          release = resolve;
+        }),
+    });
+
+    const first = cacheImage('expense-attachments', 'g1/e1.png', 'https://signed.example/e1');
+    const second = cacheImage('expense-attachments', 'g1/e1.png', 'https://signed.example/e1?v=2');
+    await Promise.resolve();
+    release(new Uint8Array([7, 8, 9]));
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      cachedPath('g1/e1.png'),
+      cachedPath('g1/e1.png'),
+    ]);
+    expect(fs.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache empty successful responses', async () => {
+    fs.fetch.mockResolvedValue({ ok: true, bytes: async () => new Uint8Array([]) });
+
+    await expect(
+      cacheImage('expense-attachments', 'g1/empty.png', 'https://signed.example/empty'),
+    ).resolves.toBeNull();
+    expect(
+      cacheImageBytes('expense-attachments', 'g1/empty-local.png', new Uint8Array([])),
+    ).toBeNull();
+    expect(fs.files.has(cachedPath('g1/empty.png'))).toBe(false);
+    expect(fs.files.has(cachedPath('g1/empty-local.png'))).toBe(false);
+  });
+
+  it('returns null and leaves no cache entry when download or atomic write fails', async () => {
+    fs.fetch.mockResolvedValueOnce({ ok: false, bytes: async () => new Uint8Array([1]) });
+    await expect(
+      cacheImage('expense-attachments', 'g1/missing.png', 'https://signed.example/missing'),
+    ).resolves.toBeNull();
+    expect(fs.files.has(cachedPath('g1/missing.png'))).toBe(false);
+
+    fs.fetch.mockResolvedValueOnce({ ok: true, bytes: async () => new Uint8Array([1]) });
+    fs.failMove = true;
+    await expect(
+      cacheImage('expense-attachments', 'g1/broken.png', 'https://signed.example/broken'),
+    ).resolves.toBeNull();
+    expect(fs.files.has(cachedPath('g1/broken.png'))).toBe(false);
+    expect([...fs.files.keys()].filter((key) => key.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('evicts cached bytes and swallows delete failures', () => {
+    const uri = cacheImageBytes('expense-attachments', 'g1/e1.png', new Uint8Array([5]));
+    expect(cachedImageUri('expense-attachments', 'g1/e1.png')).toBe(uri);
+
+    evictImage('expense-attachments', 'g1/e1.png');
+    expect(cachedImageUri('expense-attachments', 'g1/e1.png')).toBeNull();
+
+    cacheImageBytes('expense-attachments', 'g1/e1.png', new Uint8Array([5]));
+    fs.failDelete = true;
+    expect(() => evictImage('expense-attachments', 'g1/e1.png')).not.toThrow();
+    expect(() => evictImage('expense-attachments', null)).not.toThrow();
+  });
+
+  it('keeps the latest complete byte set when two writes target the same cache key', () => {
+    fs.uuid.mockReturnValueOnce('first').mockReturnValueOnce('second');
+
+    const first = cacheImageBytes('expense-attachments', 'g1/e1.png', new Uint8Array([1, 1]));
+    const second = cacheImageBytes('expense-attachments', 'g1/e1.png', new Uint8Array([2, 2]));
+
+    expect(second).toBe(first);
+    expect(Array.from(fs.files.get(cachedPath('g1/e1.png')) ?? [])).toEqual([2, 2]);
+    expect(
+      [...fs.files.keys()].filter((key) => key.includes('.first') || key.includes('.second')),
+    ).toEqual([]);
+  });
+});

--- a/apps/mobile/test/syncEngine.test.ts
+++ b/apps/mobile/test/syncEngine.test.ts
@@ -477,6 +477,62 @@ describe('background poll performance', () => {
       vi.useRealTimers();
     }
   });
+
+  it('does not schedule another immediate pull for a nonempty stale hasMore page', async () => {
+    vi.useFakeTimers();
+    try {
+      online();
+      h.disk.cursors = { 'g-goa': 2 };
+      h.disk.rows.set('groups:g-goa', {
+        table: 'groups',
+        id: 'g-goa',
+        groupId: 'g-goa',
+        seq: 1,
+        row: {
+          id: 'g-goa',
+          name: 'Goa Trip',
+          default_currency: 'INR',
+          created_at: '2026-08-01T00:00:00.000Z',
+          archived_at: null,
+        },
+      });
+      h.invoke.mockResolvedValue({
+        data: {
+          outcomes: [],
+          changes: [
+            {
+              table: 'groups',
+              groupId: 'g-goa',
+              seq: 1,
+              row: {
+                id: 'g-goa',
+                name: 'Goa Trip',
+                default_currency: 'INR',
+                created_at: '2026-08-01T00:00:00.000Z',
+                archived_at: null,
+              },
+            },
+          ],
+          cursors: { 'g-goa': 2 },
+          serverTime: 'stale-row-page',
+          hasMore: true,
+        },
+        error: null,
+      });
+      const engine = new SyncEngine();
+      await engine.hydrate();
+      const before = engine.getState().mirror;
+
+      await engine.flush();
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(h.invoke).toHaveBeenCalledTimes(1);
+      expect(engine.getState().mirror).toBe(before);
+      expect(engine.getState().lastSyncedAt).toBe('stale-row-page');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('queue and draft controls', () => {

--- a/apps/mobile/test/syncEngine.test.ts
+++ b/apps/mobile/test/syncEngine.test.ts
@@ -27,6 +27,7 @@ import { materialiseGroups, type MirrorState, type QueuedMutation } from '@waves
 // "disk" every `createLocalStore()` reads and writes.
 const h = vi.hoisted(() => ({
   net: vi.fn(),
+  syncPreference: vi.fn(),
   invoke: vi.fn(),
   disk: {
     rows: new Map<
@@ -38,11 +39,19 @@ const h = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('expo-network', () => ({ getNetworkStateAsync: h.net }));
+vi.mock('expo-network', () => ({
+  getNetworkStateAsync: h.net,
+  NetworkStateType: { WIFI: 'wifi', CELLULAR: 'cellular' },
+}));
 
 vi.mock('@/lib/backend', () => ({
   backend: { functions: { invoke: h.invoke } },
   backendConfigured: true,
+}));
+
+vi.mock('@/lib/syncNetwork', () => ({
+  SyncNetworkPreference: { Wifi: 'wifi', Cellular: 'cellular', Both: 'both' },
+  loadSyncNetworkPreference: h.syncPreference,
 }));
 
 // Keep Sentry out of a unit test; the engine only ever calls `reportHandled`.
@@ -124,6 +133,7 @@ const groupIds = (mirror: MirrorState, queue: QueuedMutation[] = []) =>
 
 beforeEach(() => {
   vi.clearAllMocks();
+  h.syncPreference.mockResolvedValue('both');
   h.disk.rows.clear();
   h.disk.cursors = {};
   h.disk.queue = [];
@@ -337,5 +347,256 @@ describe('leaving a group forgets it locally', () => {
     const relaunched = new SyncEngine();
     await relaunched.hydrate();
     expect(groupIds(relaunched.getState().mirror)).toEqual([]);
+  });
+});
+
+describe('network gates and failure handling', () => {
+  it('holds the queue on a metered connection the user has not allowed', async () => {
+    h.syncPreference.mockResolvedValue('wifi');
+    h.net.mockResolvedValue({ isInternetReachable: true, type: 'cellular' });
+    const engine = new SyncEngine();
+
+    await engine.enqueue({
+      clientMutationId: 'metered-edit',
+      kind: 'group.update' as never,
+      groupId: 'g-goa',
+      clientCreatedAt: '2026-08-09T00:00:00.000Z',
+      payload: { name: 'No mobile data' },
+    });
+    await engine.flush();
+
+    expect(h.invoke).not.toHaveBeenCalled();
+    expect(engine.getState().status).toBe('metered');
+    expect(engine.getState().queue.map((m) => m.clientMutationId)).toEqual(['metered-edit']);
+    expect(h.disk.queue.map((m) => m.clientMutationId)).toEqual(['metered-edit']);
+  });
+
+  it('marks the queued batch failed and keeps that reason durable when sync errors', async () => {
+    online();
+    h.invoke.mockResolvedValue({
+      data: null,
+      error: { context: { json: async () => ({ code: 'BAD_GATEWAY', message: 'Try later' }) } },
+    });
+    const engine = new SyncEngine();
+
+    await engine.enqueue({
+      clientMutationId: 'will-fail',
+      kind: 'group.update' as never,
+      groupId: 'g-goa',
+      clientCreatedAt: '2026-08-09T00:00:00.000Z',
+      payload: { name: 'fail' },
+    });
+    await engine.flush();
+
+    expect(engine.getState().status).toBe('error');
+    expect(engine.getState().lastError).toBe('BAD_GATEWAY: Try later');
+    expect(engine.getState().queue[0]?.attempts).toBeGreaterThan(0);
+    expect(engine.getState().queue[0]?.lastError).toBe('BAD_GATEWAY: Try later');
+    expect(h.disk.queue[0]?.lastError).toBe('BAD_GATEWAY: Try later');
+  });
+});
+
+describe('background poll performance', () => {
+  it('keeps mirror and queue references stable when a poll applies no changes', async () => {
+    online();
+    h.disk.rows.set('groups:g-goa', {
+      table: 'groups',
+      id: 'g-goa',
+      groupId: 'g-goa',
+      seq: 1,
+      row: {
+        id: 'g-goa',
+        name: 'Goa Trip',
+        default_currency: 'INR',
+        created_at: '2026-08-01T00:00:00.000Z',
+        archived_at: null,
+      },
+    });
+    h.disk.cursors = { 'g-goa': 2 };
+    h.invoke.mockResolvedValue({
+      data: { outcomes: [], changes: [], cursors: { 'g-goa': 2 }, serverTime: 'poll' },
+      error: null,
+    });
+    const engine = new SyncEngine();
+    await engine.hydrate();
+    const before = engine.getState();
+
+    await engine.flush();
+
+    expect(engine.getState().mirror).toBe(before.mirror);
+    expect(engine.getState().queue).toBe(before.queue);
+    expect(engine.getState().lastSyncedAt).toBe('poll');
+  });
+
+  it('schedules an immediate follow-up pull when the server says more rows are waiting', async () => {
+    vi.useFakeTimers();
+    try {
+      online();
+      h.invoke
+        .mockResolvedValueOnce({ data: { ...discoveryResponse(), hasMore: true }, error: null })
+        .mockResolvedValue({
+          data: { outcomes: [], changes: [], cursors: { 'g-goa': 2 }, serverTime: 'drained' },
+          error: null,
+        });
+      const engine = new SyncEngine();
+
+      await engine.flush();
+      expect(h.invoke).toHaveBeenCalledTimes(1);
+
+      await vi.runOnlyPendingTimersAsync();
+      expect(h.invoke).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not spin forever when hasMore arrives without cursor or row progress', async () => {
+    vi.useFakeTimers();
+    try {
+      online();
+      h.disk.cursors = { 'g-goa': 2 };
+      h.invoke.mockResolvedValue({
+        data: {
+          outcomes: [],
+          changes: [],
+          cursors: { 'g-goa': 2 },
+          serverTime: 'stalled-page',
+          hasMore: true,
+        },
+        error: null,
+      });
+      const engine = new SyncEngine();
+      await engine.hydrate();
+
+      await engine.flush();
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(h.invoke).toHaveBeenCalledTimes(1);
+      expect(engine.getState().lastSyncedAt).toBe('stalled-page');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('queue and draft controls', () => {
+  it('retry clears a rejected banner after the server removed that mutation from the queue', async () => {
+    online();
+    h.invoke.mockResolvedValue({
+      data: {
+        outcomes: [
+          {
+            clientMutationId: 'bad-edit',
+            status: 'rejected',
+            code: 'VALIDATION_FAILED',
+            message: 'Nope',
+          },
+        ],
+        changes: [],
+        cursors: {},
+        serverTime: 'reject',
+      },
+      error: null,
+    });
+    const engine = new SyncEngine();
+    await engine.enqueue({
+      clientMutationId: 'bad-edit',
+      kind: 'group.update' as never,
+      groupId: 'g-goa',
+      clientCreatedAt: '2026-08-09T00:00:00.000Z',
+      payload: { name: '' },
+    });
+    await engine.flush();
+    expect(engine.getState().queue).toEqual([]);
+    expect(engine.getState().rejected.map((item) => item.clientMutationId)).toEqual(['bad-edit']);
+
+    await engine.retry('bad-edit');
+    expect(engine.getState().rejected).toEqual([]);
+    expect(h.disk.queue).toEqual([]);
+  });
+
+  it('discard removes a still-queued failed mutation from memory and disk', async () => {
+    online();
+    h.invoke.mockResolvedValue({ data: null, error: new Error('network down') });
+    const engine = new SyncEngine();
+    await engine.enqueue({
+      clientMutationId: 'queued-edit',
+      kind: 'group.update' as never,
+      groupId: 'g-goa',
+      clientCreatedAt: '2026-08-09T00:00:00.000Z',
+      payload: { name: 'retry later' },
+    });
+    await engine.flush();
+    expect(engine.getState().queue.map((item) => item.clientMutationId)).toEqual(['queued-edit']);
+
+    await engine.discard('queued-edit');
+    expect(engine.getState().queue).toEqual([]);
+    expect(h.disk.queue).toEqual([]);
+  });
+
+  it('replaces repeated rejection banners for the same mutation id', async () => {
+    online();
+    h.invoke.mockResolvedValueOnce({
+      data: {
+        outcomes: [
+          {
+            clientMutationId: 'bad-edit',
+            status: 'rejected',
+            code: 'VALIDATION_FAILED',
+            message: 'First reason',
+          },
+        ],
+        changes: [],
+        cursors: {},
+        serverTime: 'first',
+      },
+      error: null,
+    });
+    const engine = new SyncEngine();
+    await engine.enqueue({
+      clientMutationId: 'bad-edit',
+      kind: 'group.update' as never,
+      groupId: 'g-goa',
+      clientCreatedAt: '2026-08-09T00:00:00.000Z',
+      payload: { name: '' },
+    });
+    await engine.flush();
+    expect(engine.getState().rejected.map((item) => item.message)).toEqual(['First reason']);
+
+    h.invoke.mockResolvedValueOnce({
+      data: {
+        outcomes: [
+          {
+            clientMutationId: 'bad-edit',
+            status: 'rejected',
+            code: 'VALIDATION_FAILED',
+            message: 'Second reason',
+          },
+        ],
+        changes: [],
+        cursors: {},
+        serverTime: 'second',
+      },
+      error: null,
+    });
+    await engine.enqueue({
+      clientMutationId: 'bad-edit',
+      kind: 'group.update' as never,
+      groupId: 'g-goa',
+      clientCreatedAt: '2026-08-09T00:00:01.000Z',
+      payload: { name: '' },
+    });
+    await engine.flush();
+
+    expect(engine.getState().rejected.map((item) => item.message)).toEqual(['Second reason']);
+  });
+
+  it('delegates draft saves, reads, listing and clearing to the local store', async () => {
+    const engine = new SyncEngine();
+
+    await engine.saveDraft('expense:new', { amount: 123 });
+    await expect(engine.readDraft('expense:new')).resolves.toBeNull();
+    await expect(engine.listDrafts()).resolves.toEqual([]);
+    await expect(engine.clearDraft('expense:new')).resolves.toBeUndefined();
   });
 });

--- a/apps/mobile/test/syncEngine.test.ts
+++ b/apps/mobile/test/syncEngine.test.ts
@@ -487,10 +487,10 @@ describe('background poll performance', () => {
         table: 'groups',
         id: 'g-goa',
         groupId: 'g-goa',
-        seq: 1,
+        seq: 2,
         row: {
           id: 'g-goa',
-          name: 'Goa Trip',
+          name: 'New durable name',
           default_currency: 'INR',
           created_at: '2026-08-01T00:00:00.000Z',
           archived_at: null,
@@ -506,7 +506,7 @@ describe('background poll performance', () => {
               seq: 1,
               row: {
                 id: 'g-goa',
-                name: 'Goa Trip',
+                name: 'Stale server replay',
                 default_currency: 'INR',
                 created_at: '2026-08-01T00:00:00.000Z',
                 archived_at: null,
@@ -528,7 +528,17 @@ describe('background poll performance', () => {
 
       expect(h.invoke).toHaveBeenCalledTimes(1);
       expect(engine.getState().mirror).toBe(before);
+      expect(groupIds(engine.getState().mirror)).toEqual(['g-goa']);
+      expect(engine.getState().mirror.tables.groups['g-goa']).toMatchObject({
+        name: 'New durable name',
+      });
       expect(engine.getState().lastSyncedAt).toBe('stale-row-page');
+
+      const relaunched = new SyncEngine();
+      await relaunched.hydrate();
+      expect(relaunched.getState().mirror.tables.groups['g-goa']).toMatchObject({
+        name: 'New durable name',
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -78,6 +78,8 @@ export function emptyMirror(): MirrorState {
 
 export interface ReconcileResult {
   readonly state: MirrorState;
+  /** Changes that actually advanced the mirror after stale rows were ignored. */
+  readonly applied: readonly SyncChange[];
   /** Changes ignored because we already had them — surfaced so tests can assert replay is free. */
   readonly skipped: number;
 }
@@ -98,6 +100,7 @@ export function reconcile(state: MirrorState, changes: readonly SyncChange[]): R
   // Track the winning seq per row so a batch containing two versions of the
   // same row resolves the same way regardless of the order it arrived in.
   const winningSeq = new Map<string, number>();
+  const applied: SyncChange[] = [];
   let skipped = 0;
 
   for (const change of [...changes].sort((a, b) => a.seq - b.seq)) {
@@ -120,9 +123,10 @@ export function reconcile(state: MirrorState, changes: readonly SyncChange[]): R
       tables[change.table][id] = change.row;
     }
     cursors[change.groupId] = Math.max(cursors[change.groupId] ?? 0, change.seq);
+    applied.push(change);
   }
 
-  return { state: { cursors, tables }, skipped };
+  return { state: { cursors, tables }, applied, skipped };
 }
 
 function idOf(row: MirrorRow): string | undefined {

--- a/packages/core/test/sync.property.test.ts
+++ b/packages/core/test/sync.property.test.ts
@@ -318,7 +318,9 @@ describe('reconciliation', () => {
     const once = reconcile(emptyMirror(), changes);
     const twice = reconcile(once.state, changes);
 
+    expect(once.applied).toEqual(changes);
     expect(twice.state).toEqual(once.state);
+    expect(twice.applied).toEqual([]);
     expect(twice.skipped).toBe(2);
     expect(once.state.cursors[GROUP]).toBe(2);
   });


### PR DESCRIPTION
## Summary
- make receipt image cache keys collision-safe and reject blank/empty-byte cache writes
- dedupe concurrent same-key image downloads to avoid duplicate network work
- guard sync hasMore follow-up polling so no-progress responses cannot spin
- dedupe rejected sync banners by client mutation id
- add focused sync engine and image cache regression/performance tests

## Validation
- pnpm --filter @waves/mobile exec vitest run test/syncEngine.test.ts test/imageCache.test.ts --coverage
- pnpm coverage:app
- pnpm --filter @waves/mobile run typecheck
- pnpm --filter @waves/mobile run lint
- pnpm exec prettier --check apps/mobile/src/sync/engine.ts apps/mobile/src/lib/storage/imageCache.ts apps/mobile/test/syncEngine.test.ts apps/mobile/test/imageCache.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image caching by detecting and replacing empty or incomplete files.
  * Prevented invalid image data from being cached and improved recovery after download failures.
  * Improved synchronization progress tracking to avoid unnecessary follow-up requests.
  * Ensured sync rejection records remain current without duplicate entries.
  * Prevented stale synchronization results from overwriting newer local data.
  * Improved synchronization reconciliation to accurately track applied changes.

* **Tests**
  * Expanded coverage for image caching, offline behavior, retries, failures, pagination, and synchronization preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->