### PR TITLE
test(mobile): cover OCR and split edge cases

### DIFF
--- a/apps/mobile/src/lib/ocr.ts
+++ b/apps/mobile/src/lib/ocr.ts
@@ -50,7 +50,7 @@ export async function recogniseReceipt(uri: string): Promise<OcrResult | null> {
     const result = await TextRecognition.recognize(uri);
 
     const text = (result.blocks ?? [])
-      .map((block) => (typeof block.text === 'string' ? block.text.trim() : ''))
+      .map((block) => (block && typeof block.text === 'string' ? block.text.trim() : ''))
       .filter((line) => line.length > 0)
       .join('\n');
 

--- a/apps/mobile/src/lib/ocr.ts
+++ b/apps/mobile/src/lib/ocr.ts
@@ -50,10 +50,9 @@ export async function recogniseReceipt(uri: string): Promise<OcrResult | null> {
     const result = await TextRecognition.recognize(uri);
 
     const text = (result.blocks ?? [])
-      .map((block) => block.text)
-      .join('\n')
-      .replace(/[ \t]+\n/g, '\n')
-      .trim();
+      .map((block) => (typeof block.text === 'string' ? block.text.trim() : ''))
+      .filter((line) => line.length > 0)
+      .join('\n');
 
     if (text.length < ENOUGH_TEXT || !LOOKS_LIKE_A_BILL.test(text)) return null;
     return { text, lines: result.blocks?.length ?? 0 };

--- a/apps/mobile/src/lib/split.ts
+++ b/apps/mobile/src/lib/split.ts
@@ -25,7 +25,7 @@ export type SplitEntries = Record<string, string>;
 const TOTAL_BASIS_POINTS = 10000;
 
 /** Up to three digits, then at most two decimal places. */
-const PERCENT = /^\d{0,3}(\.\d{0,2})?$/;
+const PERCENT = /^(?:\d{1,3}|\d{0,3}\.\d{1,2})$/;
 
 /** Whole numbers only, and not so many digits that the field stops being one. */
 const WEIGHT = /^\d{1,9}$/;
@@ -136,7 +136,7 @@ export function fillEntries(
   participants: readonly string[],
 ): SplitEntries | null {
   const missing = participants.filter((id) => entries[id] === undefined);
-  if (missing.length === 0) return null;
+  if (missing.length === 0 || participants.length === 0) return null;
 
   if (kind === 'shares') {
     return { ...entries, ...Object.fromEntries(missing.map((id) => [id, '1'])) };

--- a/apps/mobile/test/ocr.test.ts
+++ b/apps/mobile/test/ocr.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const native = vi.hoisted(() => ({
+  platform: { OS: 'ios' },
+  recognize: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({ Platform: native.platform }));
+vi.mock('@react-native-ml-kit/text-recognition', () => ({
+  default: { recognize: native.recognize },
+}));
+
+const { recogniseReceipt } = await import('../src/lib/ocr');
+
+beforeEach(() => {
+  native.platform.OS = 'ios';
+  native.recognize.mockReset();
+});
+
+describe('recogniseReceipt', () => {
+  it('does not load ML Kit on web', async () => {
+    native.platform.OS = 'web';
+
+    await expect(recogniseReceipt('file://receipt.jpg')).resolves.toBeNull();
+
+    expect(native.recognize).not.toHaveBeenCalled();
+  });
+
+  it('returns normalized text and block count for receipt-like OCR output', async () => {
+    native.recognize.mockResolvedValue({
+      blocks: [
+        { text: 'Cafe Baaki   \n' },
+        { text: 'Masala dosa      180.00' },
+        { text: 'Filter coffee     60.00' },
+        { text: 'Total            240.00' },
+      ],
+    });
+
+    await expect(recogniseReceipt('file://receipt.jpg')).resolves.toEqual({
+      text: [
+        'Cafe Baaki',
+        'Masala dosa      180.00',
+        'Filter coffee     60.00',
+        'Total            240.00',
+      ].join('\n'),
+      lines: 4,
+    });
+    expect(native.recognize).toHaveBeenCalledWith('file://receipt.jpg');
+  });
+
+  it('falls back to image upload for thin, non-bill, or failed recognizer results', async () => {
+    native.recognize.mockResolvedValueOnce({ blocks: [{ text: 'abc 1' }] });
+    await expect(recogniseReceipt('file://thin.jpg')).resolves.toBeNull();
+
+    native.recognize.mockResolvedValueOnce({
+      blocks: [{ text: 'This is a long paragraph without any receipt-style amount at all.' }],
+    });
+    await expect(recogniseReceipt('file://words.jpg')).resolves.toBeNull();
+
+    native.recognize.mockRejectedValueOnce(new Error('native recognizer unavailable'));
+    await expect(recogniseReceipt('file://broken.jpg')).resolves.toBeNull();
+  });
+
+  it('ignores malformed native blocks rather than failing the whole OCR attempt', async () => {
+    native.recognize.mockResolvedValue({
+      blocks: [
+        { text: 'Cafe Baaki' },
+        { text: null },
+        {},
+        { text: 'A receipt line that is long enough to pass the OCR threshold' },
+        { text: 'Total 123.45' },
+      ],
+    });
+
+    const result = await recogniseReceipt('file://receipt.jpg');
+
+    expect(result?.lines).toBe(5);
+    expect(result?.text).toContain('Cafe Baaki');
+    expect(result?.text).toContain('Total 123.45');
+  });
+
+  it('handles a large OCR result in one linear pass', async () => {
+    const blocks = Array.from({ length: 1_000 }, (_, index) => ({
+      text: `Item ${index} ${index}.00`,
+    }));
+    native.recognize.mockResolvedValue({ blocks });
+
+    const result = await recogniseReceipt('file://long-receipt.jpg');
+
+    expect(result?.lines).toBe(1_000);
+    expect(result?.text.startsWith('Item 0 0.00')).toBe(true);
+    expect(result?.text.endsWith('Item 999 999.00')).toBe(true);
+  });
+});

--- a/apps/mobile/test/ocr.test.ts
+++ b/apps/mobile/test/ocr.test.ts
@@ -65,6 +65,8 @@ describe('recogniseReceipt', () => {
     native.recognize.mockResolvedValue({
       blocks: [
         { text: 'Cafe Baaki' },
+        null,
+        undefined,
         { text: null },
         {},
         { text: 'A receipt line that is long enough to pass the OCR threshold' },
@@ -74,7 +76,7 @@ describe('recogniseReceipt', () => {
 
     const result = await recogniseReceipt('file://receipt.jpg');
 
-    expect(result?.lines).toBe(5);
+    expect(result?.lines).toBe(7);
     expect(result?.text).toContain('Cafe Baaki');
     expect(result?.text).toContain('Total 123.45');
   });

--- a/apps/mobile/test/split.test.ts
+++ b/apps/mobile/test/split.test.ts
@@ -23,11 +23,17 @@ describe('parseEntry', () => {
     expect(parseEntry('shares', 'two')).toBeNull();
   });
 
+  it('rejects share weights too large for the input field contract', () => {
+    expect(parseEntry('shares', '999999999')).toBe(999999999);
+    expect(parseEntry('shares', '1000000000')).toBeNull();
+  });
+
   it('reads percentages as basis points', () => {
     expect(parseEntry('percent', '25')).toBe(2500);
     expect(parseEntry('percent', '33.33')).toBe(3333);
     expect(parseEntry('percent', '33.3')).toBe(3330);
     expect(parseEntry('percent', '100')).toBe(10000);
+    expect(parseEntry('percent', '.5')).toBe(50);
   });
 
   it('converts in decimal, not in floating point', () => {
@@ -36,8 +42,10 @@ describe('parseEntry', () => {
     expect(parseEntry('percent', '8.11')).toBe(811);
   });
 
-  it('refuses a third decimal place and anything over 100', () => {
+  it('refuses a third decimal place, trailing decimal ambiguity, negatives and anything over 100', () => {
     expect(parseEntry('percent', '33.333')).toBeNull();
+    expect(parseEntry('percent', '33.')).toBeNull();
+    expect(parseEntry('percent', '-1')).toBeNull();
     expect(parseEntry('percent', '101')).toBeNull();
   });
 
@@ -91,6 +99,18 @@ describe('splitProblem', () => {
   it('ignores members who are not in the split', () => {
     expect(splitProblem(SplitKind.Percent, { a: '50', b: '50', c: '80' }, ['a', 'b'])).toBeNull();
   });
+
+  it('treats an empty participant list as not ready, not broken', () => {
+    expect(splitProblem(SplitKind.Shares, { outsider: 'abc' }, [])).toBeNull();
+    expect(splitProblem(SplitKind.Percent, { outsider: '150' }, [])).toBeNull();
+  });
+
+  it('maps invalid participant fields to zero only after splitProblem has flagged them', () => {
+    expect(splitProblem(SplitKind.Shares, { a: 'abc', b: '2' }, ['a', 'b'])).toBe(
+      'Shares must be whole numbers.',
+    );
+    expect(entryValues('shares', { a: 'abc', b: '2' }, ['a', 'b'])).toEqual({ a: 0, b: 2 });
+  });
 });
 
 describe('fillEntries', () => {
@@ -112,6 +132,21 @@ describe('fillEntries', () => {
 
   it('returns null when there is nothing to fill, so render does not loop', () => {
     expect(fillEntries('shares', { a: '1', b: '1', c: '1' }, people)).toBeNull();
+  });
+
+  it('returns null for a fresh percent split with nobody selected', () => {
+    expect(fillEntries('percent', {}, [])).toBeNull();
+  });
+
+  it('fills a large fresh percent split once and still sums to exactly 100%', () => {
+    const many = Array.from({ length: 128 }, (_, index) => `m${index}`);
+    const filled = fillEntries('percent', {}, many);
+
+    expect(filled).not.toBeNull();
+    expect(splitProblem(SplitKind.Percent, filled ?? {}, many)).toBeNull();
+    expect(
+      Object.values(entryValues('percent', filled ?? {}, many)).reduce((a, b) => a + b, 0),
+    ).toBe(10000);
   });
 });
 
@@ -158,5 +193,20 @@ describe('what the screen hands to the money engine', () => {
         seed: 'expense-1',
       }),
     ).toThrow();
+  });
+
+  it('handles a large shares split without dropping participants or minor units', () => {
+    const many = Array.from({ length: 256 }, (_, index) => `m${index}`);
+    const entries = Object.fromEntries(many.map((id, index) => [id, String((index % 5) + 1)]));
+    const shares = computeShares({
+      amount: 123456789n,
+      currency: 'INR',
+      params: { kind: 'shares', weights: entryValues('shares', entries, many) },
+      participants: many,
+      seed: 'large-expense',
+    });
+
+    expect(shares.size).toBe(many.length);
+    expect([...shares.values()].reduce((sum, share) => sum + share, 0n)).toBe(123456789n);
   });
 });


### PR DESCRIPTION
## Summary
- add OCR unit coverage for web fallback, native success, native failure, malformed blocks, and large OCR output
- normalize OCR block text before joining so trailing native newlines do not create blank receipt lines
- harden split parsing for trailing-decimal ambiguity and empty participant fills
- add split edge, integration, and large-participant performance regression tests

## Validation
- pnpm --filter @waves/mobile exec vitest run test/ocr.test.ts test/split.test.ts --coverage
- pnpm coverage:app
- pnpm --filter @waves/mobile run typecheck
- pnpm --filter @waves/mobile run lint
- pnpm exec prettier --check apps/mobile/src/lib/ocr.ts apps/mobile/src/lib/split.ts apps/mobile/test/ocr.test.ts apps/mobile/test/split.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt scanning by filtering malformed or empty OCR results and handling incomplete recognition more reliably.
  * Percentage-based bill splits now reject invalid formats, including missing digits and incomplete decimal values.
  * Empty participant lists are handled safely without creating an invalid split.
  * Added safeguards for large receipts, participant lists, share allocations, and invalid field values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->