### PR TITLE
test(mobile): cover QR guest and recent settings

### DIFF
--- a/apps/mobile/src/lib/guestGuard.ts
+++ b/apps/mobile/src/lib/guestGuard.ts
@@ -38,6 +38,29 @@ export interface GuestGuard {
   blockWrite: () => boolean;
 }
 
+export function createGuestGuard(
+  gate: GuestGate | null,
+  send: (reason: GuestBlock) => void,
+): GuestGuard {
+  const blockAddGroup = (): boolean => {
+    if (!gate) return false;
+    const reason = guestGroupBlock(gate);
+    if (!reason) return false;
+    send(reason);
+    return true;
+  };
+
+  const blockWrite = (): boolean => {
+    if (!gate) return false;
+    const reason = guestWriteBlock(gate);
+    if (!reason) return false;
+    send(reason);
+    return true;
+  };
+
+  return { gate, blockAddGroup, blockWrite };
+}
+
 export function useGuestGuard(): GuestGuard {
   const { isGuest, session } = useAuth();
   const groups = useGroups();
@@ -53,21 +76,5 @@ export function useGuestGuard(): GuestGuard {
     router.push(`/settings/account?reason=${reason}`);
   }, []);
 
-  const blockAddGroup = useCallback((): boolean => {
-    if (!gate) return false;
-    const reason = guestGroupBlock(gate);
-    if (!reason) return false;
-    send(reason);
-    return true;
-  }, [gate, send]);
-
-  const blockWrite = useCallback((): boolean => {
-    if (!gate) return false;
-    const reason = guestWriteBlock(gate);
-    if (!reason) return false;
-    send(reason);
-    return true;
-  }, [gate, send]);
-
-  return { gate, blockAddGroup, blockWrite };
+  return useMemo(() => createGuestGuard(gate, send), [gate, send]);
 }

--- a/apps/mobile/src/lib/qrScan.ts
+++ b/apps/mobile/src/lib/qrScan.ts
@@ -55,9 +55,11 @@ export function tokenFromScan(data: string): string | null {
   if (scheme === 'https') {
     if (parsed.hostname.toLowerCase() !== INVITE_HOST || path !== '/join') return null;
   } else if (INVITE_SCHEMES.has(scheme)) {
-    // `waves://join?token=…` parses with `join` as the host and an empty path.
+    // `waves://join?token=…` parses with `join` as the host and an empty path;
+    // `waves:///join?token=…` parses with an empty host and `/join` as the path.
+    // Do not accept arbitrary hosts just because their path is `/join`.
     const host = parsed.hostname.toLowerCase();
-    if (host !== 'join' && path !== '/join') return null;
+    if (!((host === 'join' && path === '/') || (host === '' && path === '/join'))) return null;
   } else {
     return null;
   }
@@ -68,8 +70,9 @@ export function tokenFromScan(data: string): string | null {
   const match = parsed.search.match(/[?&]token=([^&]+)/);
   if (!match || !match[1]) return null;
   try {
-    return decodeURIComponent(match[1]);
+    const token = decodeURIComponent(match[1]).trim();
+    return token.length > 0 ? token : null;
   } catch {
-    return match[1];
+    return match[1].trim().length > 0 ? match[1] : null;
   }
 }

--- a/apps/mobile/src/lib/qrScan.ts
+++ b/apps/mobile/src/lib/qrScan.ts
@@ -68,11 +68,12 @@ export function tokenFromScan(data: string): string | null {
   // is patchy in the React Native URL polyfill. The fragment is already gone, so
   // the capture cannot run past the query.
   const match = parsed.search.match(/[?&]token=([^&]+)/);
-  if (!match || !match[1]) return null;
+  const rawToken = match?.[1]?.trim();
+  if (!rawToken) return null;
   try {
-    const token = decodeURIComponent(match[1]).trim();
+    const token = decodeURIComponent(rawToken).trim();
     return token.length > 0 ? token : null;
   } catch {
-    return match[1].trim().length > 0 ? match[1] : null;
+    return rawToken;
   }
 }

--- a/apps/mobile/src/lib/recentCount.tsx
+++ b/apps/mobile/src/lib/recentCount.tsx
@@ -23,6 +23,15 @@ import { coerceRecentCount, DEFAULT_RECENT_COUNT, type RecentCount } from '@wave
 
 const KEY = 'recent.count';
 
+export async function loadStoredRecentCount(): Promise<RecentCount> {
+  const saved = await AsyncStorage.getItem(KEY).catch(() => null);
+  return coerceRecentCount(saved);
+}
+
+export async function saveStoredRecentCount(next: RecentCount): Promise<void> {
+  await AsyncStorage.setItem(KEY, String(next)).catch(() => undefined);
+}
+
 interface RecentCountValue {
   /** The chosen size; the default until the stored value loads. */
   count: RecentCount;
@@ -42,9 +51,9 @@ export function RecentCountProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let active = true;
     void (async () => {
-      const saved = await AsyncStorage.getItem(KEY).catch(() => null);
+      const saved = await loadStoredRecentCount();
       if (!active) return;
-      if (!dirty.current && saved !== null) setCountState(coerceRecentCount(saved));
+      if (!dirty.current) setCountState(saved);
       setLoading(false);
     })();
     return () => {
@@ -55,7 +64,7 @@ export function RecentCountProvider({ children }: { children: ReactNode }) {
   const setCount = useCallback(async (next: RecentCount) => {
     dirty.current = true;
     setCountState(next);
-    await AsyncStorage.setItem(KEY, String(next)).catch(() => undefined);
+    await saveStoredRecentCount(next);
   }, []);
 
   const value = useMemo<RecentCountValue>(

--- a/apps/mobile/test/guestGuard.test.ts
+++ b/apps/mobile/test/guestGuard.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { guestGate, GuestBlock } from '@waves/core';
+
+vi.mock('expo-router', () => ({ router: { push: vi.fn() } }));
+vi.mock('@/data/hooks', () => ({ useGroups: () => ({ data: [] }) }));
+vi.mock('../src/lib/auth', () => ({ useAuth: () => ({ isGuest: false, session: null }) }));
+
+const { createGuestGuard } = await import('../src/lib/guestGuard');
+
+describe('createGuestGuard', () => {
+  it('lets full users through without routing to upgrade', () => {
+    const send = vi.fn();
+    const guard = createGuestGuard(null, send);
+
+    expect(guard.gate).toBeNull();
+    expect(guard.blockAddGroup()).toBe(false);
+    expect(guard.blockWrite()).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('blocks group creation at the guest group limit but still allows ordinary writes', () => {
+    const send = vi.fn();
+    const gate = guestGate({
+      createdAt: '2026-08-20T00:00:00.000Z',
+      groupCount: 1,
+      now: new Date('2026-08-21T00:00:00.000Z'),
+    });
+    const guard = createGuestGuard(gate, send);
+
+    expect(guard.blockAddGroup()).toBe(true);
+    expect(send).toHaveBeenCalledWith(GuestBlock.GroupLimit);
+    expect(guard.blockWrite()).toBe(false);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks every write with trial-expired reason when the guest trial is over', () => {
+    const send = vi.fn();
+    const gate = guestGate({
+      createdAt: '2026-08-01T00:00:00.000Z',
+      groupCount: 0,
+      now: new Date('2026-08-20T00:00:00.000Z'),
+    });
+    const guard = createGuestGuard(gate, send);
+
+    expect(guard.blockAddGroup()).toBe(true);
+    expect(guard.blockWrite()).toBe(true);
+    expect(send).toHaveBeenNthCalledWith(1, GuestBlock.TrialExpired);
+    expect(send).toHaveBeenNthCalledWith(2, GuestBlock.TrialExpired);
+  });
+
+  it('evaluates many guard checks without mutating the gate object', () => {
+    const send = vi.fn();
+    const gate = guestGate({
+      createdAt: '2026-08-20T00:00:00.000Z',
+      groupCount: 1,
+      now: new Date('2026-08-21T00:00:00.000Z'),
+    });
+    const snapshot = { ...gate };
+    const guard = createGuestGuard(gate, send);
+
+    for (let i = 0; i < 1_000; i += 1) {
+      expect(guard.blockAddGroup()).toBe(true);
+    }
+
+    expect(gate).toEqual(snapshot);
+    expect(send).toHaveBeenCalledTimes(1_000);
+  });
+});

--- a/apps/mobile/test/qrScan.test.ts
+++ b/apps/mobile/test/qrScan.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const native = vi.hoisted(() => ({
+  platform: { OS: 'ios' },
+  requireOptionalNativeModule: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({ Platform: native.platform }));
+vi.mock('expo', () => ({ requireOptionalNativeModule: native.requireOptionalNativeModule }));
+
+const { cameraAvailable, tokenFromScan } = await import('../src/lib/qrScan');
+
+beforeEach(() => {
+  native.platform.OS = 'ios';
+  native.requireOptionalNativeModule.mockReset();
+});
+
+describe('cameraAvailable', () => {
+  it('requires an iOS or Android binary that actually includes ExpoCamera', () => {
+    native.requireOptionalNativeModule.mockReturnValue({});
+    native.platform.OS = 'ios';
+    expect(cameraAvailable()).toBe(true);
+
+    native.platform.OS = 'android';
+    expect(cameraAvailable()).toBe(true);
+
+    native.platform.OS = 'web';
+    expect(cameraAvailable()).toBe(false);
+    expect(native.requireOptionalNativeModule).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns false for native dev clients built without the camera module', () => {
+    native.platform.OS = 'android';
+    native.requireOptionalNativeModule.mockReturnValue(null);
+
+    expect(cameraAvailable()).toBe(false);
+  });
+});
+
+describe('tokenFromScan', () => {
+  it('extracts tokens from the supported HTTPS and app deep-link invite URLs', () => {
+    expect(tokenFromScan(' https://baaki.app/join?token=abc123 ')).toBe('abc123');
+    expect(tokenFromScan('https://BAAKI.app/join/?token=a%20b')).toBe('a b');
+    expect(tokenFromScan('waves://join?token=wave-token')).toBe('wave-token');
+    expect(tokenFromScan('baaki:///join?token=triple-slash')).toBe('triple-slash');
+  });
+
+  it('rejects unrelated hosts, paths, schemes and blank token values', () => {
+    for (const data of [
+      '',
+      'not a url',
+      'http://baaki.app/join?token=abc',
+      'https://evil.example/join?token=abc',
+      'https://baaki.app/not-join?token=abc',
+      'waves://evil.example/join?token=abc',
+      'mailto:test@example.com?token=abc',
+      'https://baaki.app/join?token=',
+      'https://baaki.app/join?token=%20%20',
+    ]) {
+      expect(tokenFromScan(data)).toBeNull();
+    }
+  });
+
+  it('does not let fragments leak into the invite token', () => {
+    expect(tokenFromScan('https://baaki.app/join?token=abc#token=evil')).toBe('abc');
+    expect(tokenFromScan('https://baaki.app/join?other=1&token=abc#frag')).toBe('abc');
+  });
+
+  it('keeps malformed percent-encoding as the raw non-empty token', () => {
+    expect(tokenFromScan('https://baaki.app/join?token=%E0%A4%A')).toBe('%E0%A4%A');
+  });
+
+  it('rejects non-invite QR payloads quickly even in a large scan batch', () => {
+    const payloads = Array.from({ length: 1_000 }, (_, index) =>
+      index === 999 ? 'https://baaki.app/join?token=last' : `https://example.com/${index}`,
+    );
+
+    const tokens = payloads.map(tokenFromScan).filter((token): token is string => token !== null);
+
+    expect(tokens).toEqual(['last']);
+  });
+});

--- a/apps/mobile/test/qrScan.test.ts
+++ b/apps/mobile/test/qrScan.test.ts
@@ -66,8 +66,9 @@ describe('tokenFromScan', () => {
     expect(tokenFromScan('https://baaki.app/join?other=1&token=abc#frag')).toBe('abc');
   });
 
-  it('keeps malformed percent-encoding as the raw non-empty token', () => {
+  it('keeps malformed percent-encoding as the trimmed raw non-empty token', () => {
     expect(tokenFromScan('https://baaki.app/join?token=%E0%A4%A')).toBe('%E0%A4%A');
+    expect(tokenFromScan('https://baaki.app/join?token=%E0%A4%A%20')).toBe('%E0%A4%A%20');
   });
 
   it('rejects non-invite QR payloads quickly even in a large scan batch', () => {

--- a/apps/mobile/test/recentCount.test.ts
+++ b/apps/mobile/test/recentCount.test.ts
@@ -1,0 +1,47 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_RECENT_COUNT } from '@waves/core';
+
+import { loadStoredRecentCount, saveStoredRecentCount } from '../src/lib/recentCount';
+
+const KEY = 'recent.count';
+
+describe('recent count storage', () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    await AsyncStorage.clear();
+  });
+
+  it('loads the default when storage is empty, invalid, or unavailable', async () => {
+    await expect(loadStoredRecentCount()).resolves.toBe(DEFAULT_RECENT_COUNT);
+
+    await AsyncStorage.setItem(KEY, '999');
+    await expect(loadStoredRecentCount()).resolves.toBe(DEFAULT_RECENT_COUNT);
+
+    vi.spyOn(AsyncStorage, 'getItem').mockRejectedValueOnce(new Error('storage unavailable'));
+    await expect(loadStoredRecentCount()).resolves.toBe(DEFAULT_RECENT_COUNT);
+  });
+
+  it('round-trips each allowed recent count through AsyncStorage', async () => {
+    for (const count of [3, 5, 10] as const) {
+      await saveStoredRecentCount(count);
+      await expect(AsyncStorage.getItem(KEY)).resolves.toBe(String(count));
+      await expect(loadStoredRecentCount()).resolves.toBe(count);
+    }
+  });
+
+  it('swallows write failures after the caller has already updated UI state', async () => {
+    vi.spyOn(AsyncStorage, 'setItem').mockRejectedValueOnce(new Error('disk full'));
+
+    await expect(saveStoredRecentCount(10)).resolves.toBeUndefined();
+  });
+
+  it('keeps repeated preference loads cheap and deterministic', async () => {
+    await AsyncStorage.setItem(KEY, '10');
+
+    const values = await Promise.all(Array.from({ length: 200 }, () => loadStoredRecentCount()));
+
+    expect(new Set(values)).toEqual(new Set([10]));
+  });
+});


### PR DESCRIPTION
## Summary
- harden QR invite parsing for custom-scheme hosts and blank decoded tokens
- extract testable guest guard and recent-count storage helpers without changing hook behavior
- add focused unit/e2e-style tests for QR scan parsing, guest guard blocking, and recent-count persistence
- add performance-style coverage for bulk QR scans, repeated guest checks, and repeated recent-count loads

## Validation
- pnpm --filter @waves/mobile exec vitest run test/qrScan.test.ts test/guestGuard.test.ts test/recentCount.test.ts --coverage
- pnpm coverage:app
- pnpm --filter @waves/mobile run typecheck
- pnpm --filter @waves/mobile run lint
- pnpm exec prettier --check apps/mobile/src/lib/qrScan.ts apps/mobile/src/lib/guestGuard.ts apps/mobile/src/lib/recentCount.tsx apps/mobile/test/qrScan.test.ts apps/mobile/test/guestGuard.test.ts apps/mobile/test/recentCount.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recent-item count preferences now persist between app sessions.
  - Guest access checks consistently enforce group limits and expired-trial restrictions with clear notifications.

- **Bug Fixes**
  - Improved QR invite scanning by accepting only valid invite URL formats.
  - Invite tokens are now safely trimmed, validated, and handled more reliably when links are malformed or contain fragments.

- **Tests**
  - Added coverage for guest access rules, QR scanning, invite validation, and recent-count persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->