### PR TITLE
feat(voice): draft-save when no group + activity-style review rows

### DIFF
--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -255,10 +255,22 @@ export default function VoiceScreen() {
     const unsub = navigation.addListener('beforeRemove', (event) => {
       if (committed.current) return;
       if (phase !== 'review' || dest.kind !== 'unassigned') return;
-      const hasSavable = drafts.some(
+      if (drafts.length === 0) return;
+      // A draft is only kept if the whole batch is savable. Persisting only the
+      // valid rows would silently drop the rest; leaving with an all-invalid
+      // batch would lose it entirely. So if any row lacks a real amount, hold
+      // the reader on the review with the batch intact and say why — they fix
+      // the amount or remove the row (dropping to an empty batch, which leaves
+      // freely). This mirrors the Save button, which is disabled on the same
+      // condition.
+      const allSavable = drafts.every(
         (draft) => toMinor(draft.amount, draft.currency ?? dc) !== null,
       );
-      if (!hasSavable) return;
+      if (!allSavable) {
+        event.preventDefault();
+        setError(t.voice.draftNeedsAmounts);
+        return;
+      }
       event.preventDefault();
       committed.current = true;
       void (async () => {
@@ -274,7 +286,16 @@ export default function VoiceScreen() {
       })();
     });
     return unsub;
-  }, [navigation, phase, dest, drafts, dc, persistDraftsToInbox, t.couldNotSave]);
+  }, [
+    navigation,
+    phase,
+    dest,
+    drafts,
+    dc,
+    persistDraftsToInbox,
+    t.couldNotSave,
+    t.voice.draftNeedsAmounts,
+  ]);
 
   const save = async (): Promise<void> => {
     setError(null);

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -19,10 +19,10 @@
  * shows a message instead of crashing.
  */
 
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
-import { router } from 'expo-router';
+import { router, useNavigation } from 'expo-router';
 import { ActivityIndicator, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -135,6 +135,12 @@ export default function VoiceScreen() {
   // A new group is created once, not again on a save retry after a partial
   // failure. Flipped true after the create lands; reset when a fresh parse comes.
   const groupCreated = useRef(false);
+  // A Save (or a close that persists the batch as a draft) has already taken
+  // over navigation — so the leave-guard below stands aside instead of writing
+  // the captures a second time.
+  const committed = useRef(false);
+
+  const navigation = useNavigation();
 
   const groupRows = groups.data ?? [];
   const groupRefs: VoiceGroupRef[] = groupRows.map((group) => ({ id: group.id, name: group.name }));
@@ -216,6 +222,60 @@ export default function VoiceScreen() {
     setDrafts((current) => current.filter((draft) => draft.key !== key));
   };
 
+  // Write the heard expenses into the capture inbox — the app's draft holding
+  // area. Each draft's own id is the capture id, so a retry (or the leave-guard
+  // firing after a Save that half-finished) re-uses it rather than minting a
+  // duplicate. Shared by the "Save as draft" button and the close-intercept, so
+  // the two land the same rows.
+  const persistDraftsToInbox = useCallback(async (): Promise<void> => {
+    const date = today();
+    const fallback = t.voice.anExpense;
+    for (const draft of drafts) {
+      const currency = draft.currency ?? dc;
+      const amount = toMinor(draft.amount, currency);
+      if (amount === null) continue;
+      await createCapture.mutateAsync({
+        captureId: draft.key,
+        description: draft.note.trim() || fallback,
+        expenseDate: date,
+        currency,
+        amount,
+        location,
+      });
+    }
+  }, [drafts, dc, location, t.voice.anExpense, createCapture]);
+
+  // Leaving the review with a draft batch and no group chosen must not throw the
+  // expenses away — an unassigned batch is a draft, and a draft survives a close
+  // (the user's rule). So intercept every way off the screen (the ✕, the OS back
+  // gesture, the hardware back key) and file the batch in the inbox first. A
+  // group destination is left to the explicit Save; closing it discards, as
+  // before. `committed` stands the guard down once a Save is already navigating.
+  useEffect(() => {
+    const unsub = navigation.addListener('beforeRemove', (event) => {
+      if (committed.current) return;
+      if (phase !== 'review' || dest.kind !== 'unassigned') return;
+      const hasSavable = drafts.some(
+        (draft) => toMinor(draft.amount, draft.currency ?? dc) !== null,
+      );
+      if (!hasSavable) return;
+      event.preventDefault();
+      committed.current = true;
+      void (async () => {
+        try {
+          await persistDraftsToInbox();
+          navigation.dispatch(event.data.action);
+        } catch (caught) {
+          // Keep the reader on the review with their batch intact rather than
+          // navigating away having lost it.
+          committed.current = false;
+          setError(friendlyError(caught, t.couldNotSave, 'voice.persistDraft'));
+        }
+      })();
+    });
+    return unsub;
+  }, [navigation, phase, dest, drafts, dc, persistDraftsToInbox, t.couldNotSave]);
+
   const save = async (): Promise<void> => {
     setError(null);
     setSaving(true);
@@ -224,21 +284,9 @@ export default function VoiceScreen() {
       const fallback = t.voice.anExpense;
 
       if (dest.kind === 'unassigned') {
-        for (const draft of drafts) {
-          const currency = draft.currency ?? dc;
-          const amount = toMinor(draft.amount, currency);
-          if (amount === null) continue;
-          // The draft's own id is the capture id, so a save retried after a
-          // partial failure re-uses it rather than minting a second capture.
-          await createCapture.mutateAsync({
-            captureId: draft.key,
-            description: draft.note.trim() || fallback,
-            expenseDate: date,
-            currency,
-            amount,
-            location,
-          });
-        }
+        // No group chosen: keep the batch as a draft in the capture inbox.
+        await persistDraftsToInbox();
+        committed.current = true;
         router.replace('/captures');
         return;
       }
@@ -303,6 +351,7 @@ export default function VoiceScreen() {
           location,
         });
       }
+      committed.current = true;
       router.replace({ pathname: '/group/[id]', params: { id: dest.groupId } });
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'voice.save'));
@@ -341,6 +390,12 @@ export default function VoiceScreen() {
   const singleTotal = draftTotals.size === 1 ? [...draftTotals.entries()][0] : null;
 
   const current = describeDest(dest, groupRows, t);
+
+  // With no group chosen the batch is a draft (it lands in the capture inbox),
+  // so the button says so; once a group is picked it writes real expenses and
+  // the label counts them.
+  const isDraft = dest.kind === 'unassigned';
+  const saveLabel = isDraft ? t.voice.saveDraft : plural(locale, drafts.length, t.voice.save);
 
   return (
     <Screen>
@@ -383,23 +438,33 @@ export default function VoiceScreen() {
           </View>
         ) : phase === 'review' ? (
           <View style={{ gap: theme.spacing.xl }}>
-            {/* The expenses are the hero: the receipt cards sit at the top, so
-                the first thing on the review is what you actually said, not a
-                column of destinations. */}
-            <View style={{ gap: theme.spacing.md }}>
-              {drafts.map((draft) => (
-                <DraftRow
-                  key={draft.key}
-                  draft={draft}
-                  onEdit={editDraft}
-                  onRemove={removeDraft}
-                  removeLabel={t.captures.delete}
-                  amountLabel={t.captures.amount}
-                  noteLabel={t.captures.description}
-                  notePlaceholder={t.captures.descriptionPlaceholder}
-                  theme={theme}
-                />
-              ))}
+            {/* The expenses are the hero, laid out the way the Activity feed
+                lays out its events: a soft tinted rounded-square node on the
+                left, the line beside it, hairlines between rows in one grouped
+                card — not a stack of separate cards. The tint is `sky`, the same
+                the feed gives a newly-added expense, so a draft here reads as the
+                same thing it will become once saved. */}
+            <View style={{ gap: theme.spacing.sm }}>
+              <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
+                {t.voice.review.toUpperCase()}
+              </Text>
+              <Card padded={false} flat style={{ overflow: 'hidden' }}>
+                {drafts.map((draft, index) => (
+                  <View key={draft.key}>
+                    <DraftRow
+                      draft={draft}
+                      onEdit={editDraft}
+                      onRemove={removeDraft}
+                      removeLabel={t.captures.delete}
+                      amountLabel={t.captures.amount}
+                      noteLabel={t.captures.description}
+                      notePlaceholder={t.captures.descriptionPlaceholder}
+                      theme={theme}
+                    />
+                    {index < drafts.length - 1 ? <Divider /> : null}
+                  </View>
+                ))}
+              </Card>
             </View>
 
             {/* Destination folded to one selector row — the whole group list
@@ -506,11 +571,7 @@ export default function VoiceScreen() {
               <Text variant="subheading">{plural(locale, drafts.length, t.voice.save)}</Text>
             )}
           </View>
-          <Button
-            label={plural(locale, drafts.length, t.voice.save)}
-            onPress={() => void save()}
-            disabled={!canSave}
-          />
+          <Button label={saveLabel} onPress={() => void save()} disabled={!canSave} />
         </View>
       ) : null}
 
@@ -776,61 +837,68 @@ function DraftRow({
   notePlaceholder: string;
   theme: ReturnType<typeof useTheme>;
 }) {
+  // The Activity feed's row shape: a soft rounded-square tile (radius md, not a
+  // full circle) in the `sky` tint the feed gives an added expense, the line
+  // beside it, a quiet trailing control. Here the line is editable — the amount
+  // is the hero with its currency, the note the muted line beneath — but the
+  // frame is the feed's, so review and activity read as one design.
+  const tile = theme.tint.sky;
   return (
-    // A receipt-glyph node (the same one the feeds use), the amount as the hero
-    // with its currency, and the note on the line beneath — a card that reads as
-    // one expense at a glance (Copilot / Expensify review rows), editable in
-    // place. Remove is a quiet trailing control, not a heavy grey disc.
-    <Card>
-      <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
-        <View
-          style={{
-            width: 40,
-            height: 40,
-            borderRadius: 20,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: theme.color.buttonPrimary,
-          }}
-        >
-          <Ionicons name="receipt-outline" size={iconSize.lg} color={theme.color.onBrand} />
-        </View>
+    <Row
+      style={{
+        alignItems: 'center',
+        gap: theme.spacing.md,
+        paddingVertical: theme.spacing.md,
+        paddingHorizontal: theme.spacing.lg,
+      }}
+    >
+      <View
+        style={{
+          width: 40,
+          height: 40,
+          borderRadius: theme.radius.md,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: tile.bg,
+        }}
+      >
+        <Ionicons name="receipt-outline" size={iconSize.lg} color={tile.ink} />
+      </View>
 
-        <View style={{ flex: 1, gap: theme.spacing.xs }}>
-          <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-            {draft.currency ? (
-              <Text variant="caption" tone="muted" style={{ fontWeight: '600' }}>
-                {draft.currency}
-              </Text>
-            ) : null}
-            <TextInput
-              value={draft.amount}
-              onChangeText={(value) => onEdit(draft.key, { amount: value })}
-              keyboardType="decimal-pad"
-              accessibilityLabel={amountLabel}
-              style={{
-                flex: 1,
-                fontSize: 24,
-                fontWeight: '700',
-                color: theme.color.text,
-                paddingVertical: 0,
-              }}
-            />
-          </Row>
+      <View style={{ flex: 1, gap: theme.spacing.xs }}>
+        <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+          {draft.currency ? (
+            <Text variant="caption" tone="muted" style={{ fontWeight: '600' }}>
+              {draft.currency}
+            </Text>
+          ) : null}
           <TextInput
-            value={draft.note}
-            onChangeText={(value) => onEdit(draft.key, { note: value })}
-            placeholder={notePlaceholder}
-            placeholderTextColor={theme.color.textFaint}
-            accessibilityLabel={noteLabel}
-            style={{ fontSize: 15, color: theme.color.textMuted, paddingVertical: 0 }}
+            value={draft.amount}
+            onChangeText={(value) => onEdit(draft.key, { amount: value })}
+            keyboardType="decimal-pad"
+            accessibilityLabel={amountLabel}
+            style={{
+              flex: 1,
+              fontSize: 24,
+              fontWeight: '700',
+              color: theme.color.text,
+              paddingVertical: 0,
+            }}
           />
-        </View>
+        </Row>
+        <TextInput
+          value={draft.note}
+          onChangeText={(value) => onEdit(draft.key, { note: value })}
+          placeholder={notePlaceholder}
+          placeholderTextColor={theme.color.textFaint}
+          accessibilityLabel={noteLabel}
+          style={{ fontSize: 15, color: theme.color.textMuted, paddingVertical: 0 }}
+        />
+      </View>
 
-        <IconButton label={removeLabel} onPress={() => onRemove(draft.key)}>
-          <Ionicons name="close" size={iconSize.md} color={theme.color.textFaint} />
-        </IconButton>
-      </Row>
-    </Card>
+      <IconButton label={removeLabel} onPress={() => onRemove(draft.key)}>
+        <Ionicons name="close" size={iconSize.md} color={theme.color.textFaint} />
+      </IconButton>
+    </Row>
   );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -791,6 +791,9 @@ export interface UiStrings {
     /** The Save button when no group is chosen: the batch is kept as a draft
         (the capture inbox) rather than written into a group. */
     saveDraft: string;
+    /** Shown when the reader tries to leave the review with a draft whose rows
+        do not all carry an amount — the batch is held rather than part-saved. */
+    draftNeedsAmounts: string;
   };
   /** Notification preferences, and what the phone will and will not allow. */
   notifications: {
@@ -2563,6 +2566,7 @@ const en: UiStrings = {
     thinking: 'Making sense of that…',
     save: { one: 'Save {n} expense', other: 'Save {n} expenses' },
     saveDraft: 'Save as draft',
+    draftNeedsAmounts: 'Enter an amount for each expense, or remove it, to keep this draft.',
   },
   notifications: {
     title: 'Notifications',
@@ -4355,6 +4359,8 @@ const ta: UiStrings = {
     thinking: 'புரிந்துகொள்கிறது…',
     save: { one: '{n} செலவைச் சேமி', other: '{n} செலவுகளைச் சேமி' },
     saveDraft: 'வரைவாகச் சேமி',
+    draftNeedsAmounts:
+      'இந்த வரைவைச் சேமிக்க ஒவ்வொரு செலவுக்கும் தொகையை உள்ளிடவும், அல்லது அதை நீக்கவும்.',
   },
   notifications: {
     title: 'அறிவிப்புகள்',
@@ -6199,6 +6205,7 @@ const hi: UiStrings = {
     thinking: 'समझा जा रहा है…',
     save: { one: '{n} खर्च सहेजें', other: '{n} खर्च सहेजें' },
     saveDraft: 'ड्राफ़्ट के रूप में सहेजें',
+    draftNeedsAmounts: 'यह ड्राफ़्ट रखने के लिए हर खर्च में राशि भरें, या उसे हटाएँ।',
   },
   notifications: {
     title: 'सूचनाएँ',
@@ -8021,6 +8028,7 @@ const ar: UiStrings = {
     thinking: 'جارٍ الفهم…',
     save: { one: 'حفظ مصروف', other: 'حفظ {n} مصاريف' },
     saveDraft: 'حفظ كمسودة',
+    draftNeedsAmounts: 'أدخل مبلغًا لكل مصروف، أو احذفه، للاحتفاظ بهذه المسودة.',
   },
   notifications: {
     title: 'الإشعارات',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -446,6 +446,10 @@ export interface UiStrings {
     couldNotAdd: string;
     /** Viewer counter, e.g. "2 of 5" — `{index}` and `{total}`. */
     counter: string;
+    /** Save-to-device action + outcomes. */
+    download: string;
+    saved: string;
+    couldNotSave: string;
   };
   /** The receipt markup editor (pen + text over an image). */
   annotate: {
@@ -784,6 +788,9 @@ export interface UiStrings {
     thinking: string;
     /** '{n}' is how many expenses will be saved. */
     save: PluralForms;
+    /** The Save button when no group is chosen: the batch is kept as a draft
+        (the capture inbox) rather than written into a group. */
+    saveDraft: string;
   };
   /** Notification preferences, and what the phone will and will not allow. */
   notifications: {
@@ -2242,6 +2249,9 @@ const en: UiStrings = {
     removeConfirm: 'Remove this receipt? The change is recorded.',
     couldNotAdd: "Couldn't add that — try again.",
     counter: '{index} of {total}',
+    download: 'Save to device',
+    saved: 'Saved to your device.',
+    couldNotSave: "Couldn't save the image — try again.",
   },
   annotate: {
     title: 'Markup',
@@ -2552,6 +2562,7 @@ const en: UiStrings = {
     newGroupNamed: 'New group “{name}”',
     thinking: 'Making sense of that…',
     save: { one: 'Save {n} expense', other: 'Save {n} expenses' },
+    saveDraft: 'Save as draft',
   },
   notifications: {
     title: 'Notifications',
@@ -4024,6 +4035,9 @@ const ta: UiStrings = {
     removeConfirm: 'இந்த ரசீதை அகற்றவா? இந்த மாற்றம் பதிவு செய்யப்படும்.',
     couldNotAdd: 'சேர்க்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
     counter: '{total} இல் {index}',
+    download: 'சாதனத்தில் சேமி',
+    saved: 'உங்கள் சாதனத்தில் சேமிக்கப்பட்டது.',
+    couldNotSave: 'படத்தைச் சேமிக்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
   },
   annotate: {
     title: 'குறிப்புகள்',
@@ -4340,6 +4354,7 @@ const ta: UiStrings = {
     newGroupNamed: 'புதிய குழு “{name}”',
     thinking: 'புரிந்துகொள்கிறது…',
     save: { one: '{n} செலவைச் சேமி', other: '{n} செலவுகளைச் சேமி' },
+    saveDraft: 'வரைவாகச் சேமி',
   },
   notifications: {
     title: 'அறிவிப்புகள்',
@@ -5871,6 +5886,9 @@ const hi: UiStrings = {
     removeConfirm: 'यह रसीद हटाएँ? यह बदलाव दर्ज किया जाएगा।',
     couldNotAdd: 'जोड़ा नहीं जा सका — फिर कोशिश करें।',
     counter: '{total} में से {index}',
+    download: 'डिवाइस पर सहेजें',
+    saved: 'आपके डिवाइस पर सहेज लिया गया।',
+    couldNotSave: 'छवि सहेजी नहीं जा सकी — फिर कोशिश करें।',
   },
   annotate: {
     title: 'मार्कअप',
@@ -6180,6 +6198,7 @@ const hi: UiStrings = {
     newGroupNamed: 'नया समूह “{name}”',
     thinking: 'समझा जा रहा है…',
     save: { one: '{n} खर्च सहेजें', other: '{n} खर्च सहेजें' },
+    saveDraft: 'ड्राफ़्ट के रूप में सहेजें',
   },
   notifications: {
     title: 'सूचनाएँ',
@@ -7668,6 +7687,9 @@ const ar: UiStrings = {
     removeConfirm: 'إزالة هذا الإيصال؟ سيُسجَّل هذا التغيير.',
     couldNotAdd: 'تعذّرت الإضافة — حاول مرة أخرى.',
     counter: '{index} من {total}',
+    download: 'حفظ على الجهاز',
+    saved: 'تم الحفظ على جهازك.',
+    couldNotSave: 'تعذّر حفظ الصورة — حاول مرة أخرى.',
   },
   annotate: {
     title: 'توصيف',
@@ -7998,6 +8020,7 @@ const ar: UiStrings = {
     newGroupNamed: 'مجموعة جديدة «{name}»',
     thinking: 'جارٍ الفهم…',
     save: { one: 'حفظ مصروف', other: 'حفظ {n} مصاريف' },
+    saveDraft: 'حفظ كمسودة',
   },
   notifications: {
     title: 'الإشعارات',


### PR DESCRIPTION
## What

Two changes to the spoken-expense **review** screen (`apps/mobile/src/app/voice.tsx`).

### 1. Save keyed to the destination
- **No group chosen** → the batch is a draft. Button reads **"Save as draft"**; expenses land in the capture inbox (the app's draft holding area). Leaving the review without saving no longer discards it — the ✕, the OS back gesture and the hardware back key are intercepted (`beforeRemove`) and file the drafts in the inbox first. An unassigned batch always survives a close.
- **A group chosen** → button counts them (**"Save 2 expenses"**) and writes into the group, as before. Closing a group destination still discards (an explicit write the reader hasn't confirmed).

A `committed` ref stands the leave-guard down once a Save is already navigating, so nothing is written twice.

### 2. Review rows match the Activity feed
Soft rounded-square node (radius `md`) in the `sky` tint the feed gives an added expense, hairlines between rows in one grouped card instead of a stack of separate cards. A draft reads as the same thing it becomes once saved.

## i18n
New `voice.saveDraft` across en / ta / hi / ar.

## Test
- typecheck + lint clean.
- `strings.test.ts` + `language.test.ts` pass (29).
- Manual: no-group → "Save as draft", close persists to inbox; group → "Save N expenses", writes to group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice review preserves valid unassigned drafts in the capture inbox when leaving the screen.
  * Draft saves are protected against duplicate entries and clearly distinguished from grouped expense saves.
  * Draft items appear in a streamlined feed-style layout with dividers.
  * Added localized labels for draft saving and receipt download status in English, Tamil, Hindi, and Arabic.

* **Bug Fixes**
  * Navigation is blocked when a draft expense is missing an amount.
  * Improved reliability during navigation and save retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->