### PR TITLE
feat(voice): auto-capture location on review + map by default

### DIFF
--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -57,6 +57,7 @@ import { aiEnabled, useAiAccess } from '@/lib/aiAccess';
 import { friendlyError } from '@/lib/errors';
 import { VoiceMicPanel } from '@/components/VoiceMicPanel';
 import { LocationField } from '@/components/LocationField';
+import { captureLocation, locationAvailable } from '@/lib/location';
 import { parseVoiceExpenses, type VoiceGroupRef, type VoiceParseResult } from '@/lib/voiceExpense';
 import { interpretVoiceExpenses } from '@/lib/voiceLlm';
 
@@ -139,6 +140,12 @@ export default function VoiceScreen() {
   // over navigation — so the leave-guard below stands aside instead of writing
   // the captures a second time.
   const committed = useRef(false);
+  // The review reads the current location once, on its own, so the batch is
+  // filed where it happened without the reader having to ask for it — a spoken
+  // expense is nearly always logged on the spot. Latched so the read fires once
+  // per batch (not on every render, and not again after the reader clears or
+  // adjusts the pin); reset when a fresh parse opens a new review.
+  const autoLocated = useRef(false);
 
   const navigation = useNavigation();
 
@@ -167,8 +174,10 @@ export default function VoiceScreen() {
         currency: item.currency,
       })),
     );
-    // A fresh parse is a fresh group to create.
+    // A fresh parse is a fresh group to create, and a fresh location to read.
     groupCreated.current = false;
+    autoLocated.current = false;
+    setLocation(null);
     // Default the destination to what was heard: a new group to make, an
     // existing group named, else the capture inbox.
     if (result.group?.kind === 'create') {
@@ -209,6 +218,7 @@ export default function VoiceScreen() {
     setError(null);
     setRequested(null);
     groupCreated.current = false;
+    autoLocated.current = false;
     setPhase('listening');
     setAttempt((current) => current + 1);
   };
@@ -296,6 +306,22 @@ export default function VoiceScreen() {
     t.couldNotSave,
     t.voice.draftNeedsAmounts,
   ]);
+
+  // On opening the review, read the current location once and pin the batch to
+  // it — so the map shows and the place is saved by default, no tap needed. It
+  // asks for permission just-in-time; a refusal or an unavailable fix leaves the
+  // field on its manual "Add location" / "Pick on map" buttons rather than
+  // failing loudly. Never overrides a pin the reader has since set or cleared:
+  // the latch runs it exactly once per parsed batch.
+  useEffect(() => {
+    if (phase !== 'review' || autoLocated.current) return;
+    autoLocated.current = true;
+    if (!locationAvailable()) return;
+    void (async () => {
+      const result = await captureLocation();
+      if (result.ok) setLocation(result.location);
+    })();
+  }, [phase]);
 
   const save = async (): Promise<void> => {
     setError(null);

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -146,6 +146,12 @@ export default function VoiceScreen() {
   // per batch (not on every render, and not again after the reader clears or
   // adjusts the pin); reset when a fresh parse opens a new review.
   const autoLocated = useRef(false);
+  // Guards the async auto-read from clobbering a later truth. `locationGen`
+  // ticks once per parsed batch, so a fix that arrives after a new utterance is
+  // dropped; `locationTouched` flips the moment the reader sets or clears the
+  // pin by hand, so an in-flight auto-read never overrides their choice.
+  const locationGen = useRef(0);
+  const locationTouched = useRef(false);
 
   const navigation = useNavigation();
 
@@ -177,6 +183,8 @@ export default function VoiceScreen() {
     // A fresh parse is a fresh group to create, and a fresh location to read.
     groupCreated.current = false;
     autoLocated.current = false;
+    locationGen.current += 1;
+    locationTouched.current = false;
     setLocation(null);
     // Default the destination to what was heard: a new group to make, an
     // existing group named, else the capture inbox.
@@ -219,6 +227,8 @@ export default function VoiceScreen() {
     setRequested(null);
     groupCreated.current = false;
     autoLocated.current = false;
+    locationGen.current += 1;
+    locationTouched.current = false;
     setPhase('listening');
     setAttempt((current) => current + 1);
   };
@@ -230,6 +240,13 @@ export default function VoiceScreen() {
   };
   const removeDraft = (key: string): void => {
     setDrafts((current) => current.filter((draft) => draft.key !== key));
+  };
+
+  // The reader set or cleared the pin by hand. Latch it so a still-pending
+  // auto-read cannot come back and overwrite their choice.
+  const handleLocationChange = (next: ExpenseLocation | null): void => {
+    locationTouched.current = true;
+    setLocation(next);
   };
 
   // Write the heard expenses into the capture inbox — the app's draft holding
@@ -317,9 +334,14 @@ export default function VoiceScreen() {
     if (phase !== 'review' || autoLocated.current) return;
     autoLocated.current = true;
     if (!locationAvailable()) return;
+    const gen = locationGen.current;
     void (async () => {
       const result = await captureLocation();
-      if (result.ok) setLocation(result.location);
+      if (!result.ok) return;
+      // Drop a fix that lost its race: the reader has since set or cleared the
+      // pin by hand, or a fresh utterance moved on to a new batch.
+      if (locationGen.current !== gen || locationTouched.current) return;
+      setLocation(result.location);
     })();
   }, [phase]);
 
@@ -565,7 +587,7 @@ export default function VoiceScreen() {
 
             {/* One place for the whole batch (A43) — opt-in, never a background
                 track. It rides onto every expense saved from this review. */}
-            <LocationField value={location} onChange={setLocation} />
+            <LocationField value={location} onChange={handleLocationChange} />
           </View>
         ) : (
           // Listening.


### PR DESCRIPTION
## What

On the spoken-expense **review**, the current location is now read automatically when the screen opens and pinned to the batch — so the map shows and the place is saved to the draft with **no tap**. A spoken expense is nearly always logged on the spot, so this is opt-out here rather than opt-in.

`apps/mobile/src/app/voice.tsx`:
- On entering `review`, `captureLocation()` runs once and sets the batch location. `LocationField` already renders `MapPreview` whenever a location is set, so the map appears by default.
- Latched (`autoLocated` ref) so it fires **once per parsed batch** — never overrides a pin the reader adjusts or clears, and re-runs for a fresh utterance (reset in `applyResult` / `retry`).
- Permission asked just-in-time; a refusal or unavailable fix falls back to the field's manual **Add location** / **Pick on map** buttons — no loud failure.
- The location already rides onto every saved expense/capture (draft included), so nothing else changed in the save path.

## Deviation

This makes the voice review **opt-out** for location, unlike the capture and group add-expense forms which stay opt-in (A43). Deliberate: the spoken flow is the on-the-spot one.

## Test
- typecheck + lint clean.
- Manual: open review → permission prompt (first time) → map appears with the current spot; close persists it to the inbox draft; clear/adjust is respected (no re-capture); new utterance re-reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice expense review can automatically capture and apply the current location when available.

* **Bug Fixes**
  * Manual location selections are no longer overwritten by delayed automatic capture results.
  * Location capture state resets correctly when starting a fresh parse or retrying.
  * Manual location controls remain unchanged when automatic capture is unavailable or unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->