### PR TITLE
fix(ocr): improve receipt text detection

### DIFF
--- a/apps/mobile/src/lib/ocr.ts
+++ b/apps/mobile/src/lib/ocr.ts
@@ -24,8 +24,39 @@ import { Platform } from 'react-native';
  */
 const ENOUGH_TEXT = 40;
 
-/** At least a few numbers, or this is not a bill. */
-const LOOKS_LIKE_A_BILL = /\d[\d.,]*\s*$|\d+\.\d{2}/m;
+/**
+ * Bound the text sent to the parser. A corrupted OCR result can otherwise build
+ * a huge string on the JS thread and, later, burn cloud-parser tokens.
+ */
+const MAX_OCR_CHARS = 20_000;
+
+const RECEIPT_KEYWORD =
+  /\b(total|grand total|subtotal|amount due|net payable|tax|gst|vat|balance|paid)\b/i;
+const CURRENCY_AMOUNT = /(?:₹|rs\.?|inr|\$|usd|€|eur|£|gbp|aed|د\.إ)\s*\d[\d,]*(?:\.\d{1,2})?/i;
+const DECIMAL_AMOUNT = /\b\d{1,3}(?:,\d{2,3})*(?:\.\d{2})\b/;
+const INTEGER_AMOUNT_LINE = /\b\d{1,3}(?:,\d{2,3})+\b/;
+
+function normaliseBlockText(value: unknown): string {
+  return typeof value === 'string'
+    ? value
+        .normalize('NFKC')
+        .replace(/\u00a0/g, ' ')
+        .replace(/[ \t]+/g, ' ')
+        .trim()
+    : '';
+}
+
+function looksLikeReceipt(text: string, lines: readonly string[]): boolean {
+  const amountLines = lines.filter(
+    (line) =>
+      CURRENCY_AMOUNT.test(line) || DECIMAL_AMOUNT.test(line) || INTEGER_AMOUNT_LINE.test(line),
+  ).length;
+  return (
+    CURRENCY_AMOUNT.test(text) ||
+    (RECEIPT_KEYWORD.test(text) && amountLines >= 1) ||
+    amountLines >= 3
+  );
+}
 
 export interface OcrResult {
   readonly text: string;
@@ -49,13 +80,19 @@ export async function recogniseReceipt(uri: string): Promise<OcrResult | null> {
     const { default: TextRecognition } = await import('@react-native-ml-kit/text-recognition');
     const result = await TextRecognition.recognize(uri);
 
-    const text = (result.blocks ?? [])
-      .map((block) => (block && typeof block.text === 'string' ? block.text.trim() : ''))
-      .filter((line) => line.length > 0)
-      .join('\n');
+    const lines = (result.blocks ?? [])
+      .map((block) => normaliseBlockText(block?.text))
+      .filter((line) => line.length > 0);
+    const text = lines.join('\n');
 
-    if (text.length < ENOUGH_TEXT || !LOOKS_LIKE_A_BILL.test(text)) return null;
-    return { text, lines: result.blocks?.length ?? 0 };
+    if (
+      text.length < ENOUGH_TEXT ||
+      text.length > MAX_OCR_CHARS ||
+      !looksLikeReceipt(text, lines)
+    ) {
+      return null;
+    }
+    return { text, lines: lines.length };
   } catch {
     // No native module in this build, an unsupported script, a corrupt file —
     // all of them mean the same thing here: use the image.

--- a/apps/mobile/src/lib/ocr.ts
+++ b/apps/mobile/src/lib/ocr.ts
@@ -36,14 +36,46 @@ const CURRENCY_AMOUNT = /(?:₹|rs\.?|inr|\$|usd|€|eur|£|gbp|aed|د\.إ)\s*\d
 const DECIMAL_AMOUNT = /\b\d{1,3}(?:,\d{2,3})*(?:\.\d{2})\b/;
 const INTEGER_AMOUNT_LINE = /\b\d{1,3}(?:,\d{2,3})+\b/;
 
-function normaliseBlockText(value: unknown): string {
+const DIGIT_RANGES = [
+  ['٠', '٩'],
+  ['۰', '۹'],
+  ['०', '९'],
+] as const;
+
+function normaliseDigits(value: string): string {
+  return [...value]
+    .map((char) => {
+      const code = char.codePointAt(0);
+      if (code === undefined) return char;
+      for (const [start, end] of DIGIT_RANGES) {
+        const startCode = start.codePointAt(0) as number;
+        const endCode = end.codePointAt(0) as number;
+        if (code >= startCode && code <= endCode) return String(code - startCode);
+      }
+      return char;
+    })
+    .join('');
+}
+
+function normaliseLineText(value: string): string {
+  return normaliseDigits(
+    value
+      .normalize('NFKC')
+      .replace(/\u00a0/g, ' ')
+      .replace(/\u066b/g, '.')
+      .replace(/\u066c/g, ',')
+      .replace(/[ \t]+/g, ' ')
+      .trim(),
+  );
+}
+
+function normaliseTextLines(value: unknown): string[] {
   return typeof value === 'string'
     ? value
-        .normalize('NFKC')
-        .replace(/\u00a0/g, ' ')
-        .replace(/[ \t]+/g, ' ')
-        .trim()
-    : '';
+        .split(/\r?\n/)
+        .map(normaliseLineText)
+        .filter((line) => line.length > 0)
+    : [];
 }
 
 function looksLikeReceipt(text: string, lines: readonly string[]): boolean {
@@ -62,16 +94,11 @@ function blockLines(block: unknown): string[] {
   if (!block || typeof block !== 'object') return [];
   const candidate = block as { lines?: unknown; text?: unknown };
   if (Array.isArray(candidate.lines)) {
-    return candidate.lines
-      .map((line) =>
-        line && typeof line === 'object'
-          ? normaliseBlockText((line as { text?: unknown }).text)
-          : '',
-      )
-      .filter((line) => line.length > 0);
+    return candidate.lines.flatMap((line) =>
+      line && typeof line === 'object' ? normaliseTextLines((line as { text?: unknown }).text) : [],
+    );
   }
-  const text = normaliseBlockText(candidate.text);
-  return text.length > 0 ? [text] : [];
+  return normaliseTextLines(candidate.text);
 }
 
 export interface OcrResult {

--- a/apps/mobile/src/lib/ocr.ts
+++ b/apps/mobile/src/lib/ocr.ts
@@ -58,6 +58,22 @@ function looksLikeReceipt(text: string, lines: readonly string[]): boolean {
   );
 }
 
+function blockLines(block: unknown): string[] {
+  if (!block || typeof block !== 'object') return [];
+  const candidate = block as { lines?: unknown; text?: unknown };
+  if (Array.isArray(candidate.lines)) {
+    return candidate.lines
+      .map((line) =>
+        line && typeof line === 'object'
+          ? normaliseBlockText((line as { text?: unknown }).text)
+          : '',
+      )
+      .filter((line) => line.length > 0);
+  }
+  const text = normaliseBlockText(candidate.text);
+  return text.length > 0 ? [text] : [];
+}
+
 export interface OcrResult {
   readonly text: string;
   /** How many lines the recogniser found. Useful for telling the user why. */
@@ -80,9 +96,7 @@ export async function recogniseReceipt(uri: string): Promise<OcrResult | null> {
     const { default: TextRecognition } = await import('@react-native-ml-kit/text-recognition');
     const result = await TextRecognition.recognize(uri);
 
-    const lines = (result.blocks ?? [])
-      .map((block) => normaliseBlockText(block?.text))
-      .filter((line) => line.length > 0);
+    const lines = (result.blocks ?? []).flatMap(blockLines);
     const text = lines.join('\n');
 
     if (

--- a/apps/mobile/test/ocr.test.ts
+++ b/apps/mobile/test/ocr.test.ts
@@ -115,6 +115,37 @@ describe('recogniseReceipt', () => {
     });
   });
 
+  it('splits embedded newlines in a native block text into individual receipt lines', async () => {
+    native.recognize.mockResolvedValue({
+      blocks: [
+        {
+          text: ['Cafe Baaki', 'Idli 80.00', 'Coffee 40.00', 'Total 120.00'].join('\n'),
+        },
+      ],
+    });
+
+    await expect(recogniseReceipt('file://block-newlines.jpg')).resolves.toEqual({
+      text: ['Cafe Baaki', 'Idli 80.00', 'Coffee 40.00', 'Total 120.00'].join('\n'),
+      lines: 4,
+    });
+  });
+
+  it('normalises Arabic and Devanagari digits before receipt detection', async () => {
+    native.recognize.mockResolvedValue({
+      blocks: [
+        { text: 'مطعم باكي' },
+        { text: 'Subtotal AED ١٬٢٣٤٫٥٠' },
+        { text: 'GST ₹१२.००' },
+        { text: 'Total AED ١٬٢٤٦٫٥٠' },
+      ],
+    });
+
+    await expect(recogniseReceipt('file://arabic-digits.jpg')).resolves.toEqual({
+      text: ['مطعم باكي', 'Subtotal AED 1,234.50', 'GST ₹12.00', 'Total AED 1,246.50'].join('\n'),
+      lines: 4,
+    });
+  });
+
   it('handles a large OCR result in one linear pass', async () => {
     const blocks = Array.from({ length: 1_000 }, (_, index) => ({
       text: `Item ${index} ${index}.00`,

--- a/apps/mobile/test/ocr.test.ts
+++ b/apps/mobile/test/ocr.test.ts
@@ -37,12 +37,7 @@ describe('recogniseReceipt', () => {
     });
 
     await expect(recogniseReceipt('file://receipt.jpg')).resolves.toEqual({
-      text: [
-        'Cafe Baaki',
-        'Masala dosa      180.00',
-        'Filter coffee     60.00',
-        'Total            240.00',
-      ].join('\n'),
+      text: ['Cafe Baaki', 'Masala dosa 180.00', 'Filter coffee 60.00', 'Total 240.00'].join('\n'),
       lines: 4,
     });
     expect(native.recognize).toHaveBeenCalledWith('file://receipt.jpg');
@@ -76,9 +71,27 @@ describe('recogniseReceipt', () => {
 
     const result = await recogniseReceipt('file://receipt.jpg');
 
-    expect(result?.lines).toBe(7);
+    expect(result?.lines).toBe(3);
     expect(result?.text).toContain('Cafe Baaki');
     expect(result?.text).toContain('Total 123.45');
+  });
+
+  it('recognises currency-symbol receipts and normalises Unicode spacing', async () => {
+    native.recognize.mockResolvedValue({
+      blocks: [
+        { text: 'Cafe\u00a0Baaki' },
+        { text: 'SUBTOTAL\u00a0\u00a0₹１,２３４.５０' },
+        { text: 'GST ₹12.00' },
+        { text: 'Grand Total ₹1,246.50' },
+      ],
+    });
+
+    const result = await recogniseReceipt('file://unicode-receipt.jpg');
+
+    expect(result).toEqual({
+      text: ['Cafe Baaki', 'SUBTOTAL ₹1,234.50', 'GST ₹12.00', 'Grand Total ₹1,246.50'].join('\n'),
+      lines: 4,
+    });
   });
 
   it('handles a large OCR result in one linear pass', async () => {
@@ -92,5 +105,13 @@ describe('recogniseReceipt', () => {
     expect(result?.lines).toBe(1_000);
     expect(result?.text.startsWith('Item 0 0.00')).toBe(true);
     expect(result?.text.endsWith('Item 999 999.00')).toBe(true);
+  });
+
+  it('falls back to image upload when OCR text is implausibly large', async () => {
+    native.recognize.mockResolvedValue({
+      blocks: [{ text: `Total ₹1.00 ${'x'.repeat(20_000)}` }],
+    });
+
+    await expect(recogniseReceipt('file://huge-receipt.jpg')).resolves.toBeNull();
   });
 });

--- a/apps/mobile/test/ocr.test.ts
+++ b/apps/mobile/test/ocr.test.ts
@@ -94,6 +94,27 @@ describe('recogniseReceipt', () => {
     });
   });
 
+  it('flattens native OCR block lines before receipt detection', async () => {
+    native.recognize.mockResolvedValue({
+      blocks: [
+        {
+          text: 'Fallback block text that should not be used when lines exist',
+          lines: [
+            { text: 'Cafe Baaki' },
+            { text: 'Idli 80.00' },
+            { text: 'Coffee 40.00' },
+            { text: 'Total 120.00' },
+          ],
+        },
+      ],
+    });
+
+    await expect(recogniseReceipt('file://multi-line-receipt.jpg')).resolves.toEqual({
+      text: ['Cafe Baaki', 'Idli 80.00', 'Coffee 40.00', 'Total 120.00'].join('\n'),
+      lines: 4,
+    });
+  });
+
   it('handles a large OCR result in one linear pass', async () => {
     const blocks = Array.from({ length: 1_000 }, (_, index) => ({
       text: `Item ${index} ${index}.00`,


### PR DESCRIPTION
## Summary
- normalize OCR block text with Unicode NFKC, NBSP cleanup, whitespace collapsing, and empty-line filtering
- use actual non-empty OCR line count instead of raw block count
- broaden receipt detection for currency symbols, receipt keywords, and amount-like rows
- reject implausibly large OCR text before sending it to downstream receipt parsing
- add regression tests for Unicode/currency receipts, malformed blocks, large OCR output, and max-size fallback

## Validation
- pnpm --filter @waves/mobile exec vitest run test/ocr.test.ts --coverage
- pnpm coverage:app
- pnpm --filter @waves/mobile run typecheck
- pnpm --filter @waves/mobile run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt scanning by converting Arabic, Persian, and Devanagari digits into a consistent format.
  * More reliably handles regional number and currency separators, multiline text, and detailed OCR results.
  * Improved extraction from incomplete or malformed scans while filtering invalid receipt content.
  * Rejects oversized, empty, malformed, or non-receipt text to reduce incorrect recognition results.
  * Reports the number of valid receipt lines detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->