### PR TITLE
feat(voice): mic from a group defaults the batch to that group

### DIFF
--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -201,10 +201,17 @@ export default function VoiceScreen() {
     } else if (result.group?.kind === 'existing') {
       setRequested(null);
       setDest({ kind: 'existing', groupId: result.group.groupId });
-    } else if (launchGroupId && groupRows.some((group) => group.id === launchGroupId)) {
+    } else if (
+      launchGroupId &&
+      (groups.data == null || groupRows.some((group) => group.id === launchGroupId))
+    ) {
       // No group named in the sentence, but the mic was opened from a group —
-      // default to it. Guarded against a stale id (a group left or deleted since
-      // the screen opened), which falls through to the inbox.
+      // default to it. The id came from a real group route, so it is trusted
+      // while the group mirror is still loading (`groups.data` null): a
+      // transcript that resolves before hydration must not fall to the inbox and
+      // then never re-evaluate. Once the mirror has loaded, a stale id (a group
+      // left or deleted since the screen opened) is no longer among the rows and
+      // falls through to the inbox below.
       setRequested(null);
       setDest({ kind: 'existing', groupId: launchGroupId });
     } else {

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -22,7 +22,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
-import { router, useNavigation } from 'expo-router';
+import { router, useLocalSearchParams, useNavigation } from 'expo-router';
 import { ActivityIndicator, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -104,6 +104,12 @@ export default function VoiceScreen() {
   const dc = useDefaultCurrency();
   const access = useAiAccess();
   const groups = useGroups();
+  // Opened from a group's own screens (the raised mic passes its id), so a
+  // spoken expense lands in that group by default rather than the unassigned
+  // inbox. The reader can still switch the destination on the review; and a
+  // sentence that names a different group ("…for the Goa trip") still wins.
+  const params = useLocalSearchParams<{ group?: string }>();
+  const launchGroupId = typeof params.group === 'string' ? params.group : null;
 
   const createCapture = useCreateCapture();
   const createGroup = useCreateGroup();
@@ -195,6 +201,12 @@ export default function VoiceScreen() {
     } else if (result.group?.kind === 'existing') {
       setRequested(null);
       setDest({ kind: 'existing', groupId: result.group.groupId });
+    } else if (launchGroupId && groupRows.some((group) => group.id === launchGroupId)) {
+      // No group named in the sentence, but the mic was opened from a group —
+      // default to it. Guarded against a stale id (a group left or deleted since
+      // the screen opened), which falls through to the inbox.
+      setRequested(null);
+      setDest({ kind: 'existing', groupId: launchGroupId });
     } else {
       setRequested(null);
       setDest({ kind: 'unassigned' });

--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -14,7 +14,7 @@
  */
 
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { router, useSegments } from 'expo-router';
+import { router, useGlobalSearchParams, useSegments } from 'expo-router';
 
 import { iconSize, PillTabBar, type PillTabItem } from '@waves/ui';
 
@@ -29,6 +29,12 @@ export function AppTabBar() {
   // past the first element trips the tuple bounds check under the CI tsconfig.
   // We only ever read positions generically, so widen to a plain string array.
   const segments = useSegments() as readonly string[];
+  // When the bar is showing over a group's own screens, the mic should speak
+  // *into that group*, not the unassigned inbox. `useSegments` gives the route
+  // shape (`group/[id]/…`); the id's value comes from the focused route's
+  // params. Any non-group screen leaves this null and the mic opens plain.
+  const params = useGlobalSearchParams<{ id?: string }>();
+  const groupId = segments[0] === 'group' && typeof params.id === 'string' ? params.id : null;
 
   // No session means no bar anywhere — the privacy page opened from the login
   // legal line is the one place it used to leak onto a signed-out screen.
@@ -82,7 +88,8 @@ export function AppTabBar() {
   // bar hands it.
   const voice = {
     accessibilityLabel: t.voice.speakExpense,
-    onPress: () => router.push('/voice'),
+    onPress: () =>
+      router.push(groupId ? { pathname: '/voice', params: { group: groupId } } : '/voice'),
     icon: (color: string) => <Ionicons name="mic" size={iconSize.lg} color={color} />,
   };
 


### PR DESCRIPTION
## What

Tapping the raised mic while viewing a group now speaks **into that group** by default, instead of the unassigned inbox.

- `apps/mobile/src/components/AppTabBar.tsx`: the bar renders over every screen; it now reads the focused route (`useSegments` + `useGlobalSearchParams`). On a `group/[id]/…` screen it passes `group=<id>` to `/voice`; every other screen opens the mic plain, as before.
- `apps/mobile/src/app/voice.tsx`: reads the `group` param and defaults the review's destination to it.

## Precedence on the review
1. A group named in the sentence wins ("…for the Goa trip").
2. Otherwise the launching group is the default.
3. Only with neither does it fall back to the inbox.

The launch id is validated against the loaded groups, so a group left/deleted since the screen opened falls through to the inbox rather than a dangling destination. The reader can still switch the destination on the review.

## Test
- typecheck + lint clean.
- Manual: open a group → mic → "60 rupees plus 30 rupees" → review destination = that group; from Home/other screens → inbox default unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice entries started from within a group are automatically assigned to that group when no group is explicitly mentioned.
  * Voice capture preserves the current group context when launched from group views.
  * Voice entries continue going to the unassigned inbox when the group is unavailable or no group context exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->