### PR TITLE
feat(map): Google Maps for the open link + keyed preview

### DIFF
--- a/apps/mobile/src/components/MapPreview.tsx
+++ b/apps/mobile/src/components/MapPreview.tsx
@@ -25,6 +25,7 @@ import { iconSize, Text, useTheme } from '@waves/ui';
 import {
   DEFAULT_TILE_URL,
   DEFAULT_ZOOM,
+  googleStaticMapUrl,
   TILE_ATTRIBUTION,
   TILE_HEADERS,
   TILE_SIZE,
@@ -56,7 +57,10 @@ export function MapPreview({
     setWidth(event.nativeEvent.layout.width);
   };
 
-  const tiles = width > 0 ? tileGrid(location, zoom, width, height) : [];
+  // Google Static Maps when a key is configured, else the CARTO tile grid. One
+  // composite image vs a mosaic of {z}/{x}/{y} tiles — see `googleStaticMapUrl`.
+  const googleUrl = width > 0 ? googleStaticMapUrl(location, zoom, width, height) : null;
+  const tiles = width > 0 && !googleUrl ? tileGrid(location, zoom, width, height) : [];
 
   const body = (
     <View
@@ -68,6 +72,15 @@ export function MapPreview({
         backgroundColor: theme.color.bg,
       }}
     >
+      {googleUrl ? (
+        <Image
+          source={{ uri: googleUrl }}
+          style={{ position: 'absolute', left: 0, top: 0, right: 0, bottom: 0 }}
+          contentFit="cover"
+          transition={120}
+          cachePolicy="memory-disk"
+        />
+      ) : null}
       {tiles.map((tile) => (
         <Image
           key={`${tile.x}-${tile.y}-${tile.left}`}
@@ -109,23 +122,26 @@ export function MapPreview({
       </View>
 
       {/* Attribution — required by the tile licence (OSM data, CARTO tiles).
-          Not translated: it is a fixed credit, like a copyright line. */}
-      <View
-        pointerEvents="none"
-        style={{
-          position: 'absolute',
-          right: 0,
-          bottom: 0,
-          paddingHorizontal: 4,
-          paddingVertical: 2,
-          backgroundColor: 'rgba(255, 255, 255, 0.7)',
-          borderTopLeftRadius: theme.radius.sm,
-        }}
-      >
-        <Text variant="micro" style={{ color: '#333', fontSize: 9 }}>
-          {TILE_ATTRIBUTION}
-        </Text>
-      </View>
+          Not translated: it is a fixed credit, like a copyright line. Hidden for
+          the Google image, which carries Google's own credit baked in. */}
+      {googleUrl ? null : (
+        <View
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            right: 0,
+            bottom: 0,
+            paddingHorizontal: 4,
+            paddingVertical: 2,
+            backgroundColor: 'rgba(255, 255, 255, 0.7)',
+            borderTopLeftRadius: theme.radius.sm,
+          }}
+        >
+          <Text variant="micro" style={{ color: '#333', fontSize: 9 }}>
+            {TILE_ATTRIBUTION}
+          </Text>
+        </View>
+      )}
     </View>
   );
 

--- a/apps/mobile/src/components/MapPreview.tsx
+++ b/apps/mobile/src/components/MapPreview.tsx
@@ -78,7 +78,10 @@ export function MapPreview({
           style={{ position: 'absolute', left: 0, top: 0, right: 0, bottom: 0 }}
           contentFit="cover"
           transition={120}
-          cachePolicy="memory-disk"
+          // Google Maps Platform Terms forbid caching Maps Static API images —
+          // each view must re-request. So no disk/memory cache here (unlike the
+          // CARTO tiles below, whose licence permits the normal image cache).
+          cachePolicy="none"
         />
       ) : null}
       {tiles.map((tile) => (

--- a/apps/mobile/src/lib/location.ts
+++ b/apps/mobile/src/lib/location.ts
@@ -244,13 +244,15 @@ export async function reverseGeocode(lat: number, lng: number): Promise<string |
   }
 }
 
-/** A deep link that opens the point in whatever maps app the phone prefers. */
+/**
+ * A deep link that opens the point in Google Maps — the Google Maps app when it
+ * is installed (this universal `/maps/search/` URL hands off to it on both iOS
+ * and Android), else Google Maps in the browser. One provider on every platform,
+ * rather than Apple Maps on iOS, so "open the map" is always the same place.
+ */
 export function mapsUrl(location: ExpenseLocation): string {
   const query = `${location.lat},${location.lng}`;
-  const label = location.name ? encodeURIComponent(location.name) : query;
-  return Platform.OS === 'ios'
-    ? `https://maps.apple.com/?q=${label}&ll=${query}`
-    : `https://www.google.com/maps/search/?api=1&query=${query}`;
+  return `https://www.google.com/maps/search/?api=1&query=${query}`;
 }
 
 /** What to show for a location that has no name: a trimmed coordinate pair. */

--- a/apps/mobile/src/lib/mapTiles.ts
+++ b/apps/mobile/src/lib/mapTiles.ts
@@ -67,6 +67,47 @@ export const TILE_HEADERS: Record<string, string> = {
   'User-Agent': 'WavesApp/1.0 (+https://waves.app; expense location map)',
 };
 
+/**
+ * Google Maps as the preview provider, when a key is configured. Google gives no
+ * keyless raster-tile endpoint (both built-in tile sources above are OSM-data
+ * CDNs), so a Google preview needs the Static Maps API — a single composite
+ * image, key-authenticated and billed. It is therefore opt-in: set
+ * `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY` and the preview switches to Google; leave it
+ * unset and the CARTO tile grid stands. (The "open in maps" deep link is always
+ * Google regardless — see `mapsUrl` — this only governs the inline thumbnail.)
+ */
+export const GOOGLE_MAPS_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY || '';
+
+/**
+ * A single Google Static Maps image covering a viewport, or null when no key is
+ * set (the caller then falls back to the raster tile grid). `scale: 2` serves a
+ * retina image; the caller draws its own centre pin over it, so no `markers`
+ * param is needed. The returned image already carries Google's own attribution
+ * baked in, so the caller hides the CARTO/OSM credit when this is used.
+ */
+export function googleStaticMapUrl(
+  center: LatLng,
+  zoom: number,
+  width: number,
+  height: number,
+): string | null {
+  if (!GOOGLE_MAPS_API_KEY) return null;
+  if (width <= 0 || height <= 0) return null;
+  const z = clampZoom(zoom);
+  // Static Maps caps a single (unscaled) dimension at 640; scale:2 doubles the
+  // delivered pixels. Clamp so an oversized frame never asks for a refused size.
+  const w = Math.max(1, Math.min(640, Math.round(width)));
+  const h = Math.max(1, Math.min(640, Math.round(height)));
+  const query = new URLSearchParams({
+    center: `${center.lat},${center.lng}`,
+    zoom: String(z),
+    size: `${w}x${h}`,
+    scale: '2',
+    key: GOOGLE_MAPS_API_KEY,
+  });
+  return `https://maps.googleapis.com/maps/api/staticmap?${query.toString()}`;
+}
+
 /** The latitudes Web Mercator can represent; beyond this the projection blows up. */
 export const MAX_MERCATOR_LAT = 85.05112878;
 

--- a/apps/mobile/src/lib/mapTiles.ts
+++ b/apps/mobile/src/lib/mapTiles.ts
@@ -75,6 +75,20 @@ export const TILE_HEADERS: Record<string, string> = {
  * `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY` and the preview switches to Google; leave it
  * unset and the CARTO tile grid stands. (The "open in maps" deep link is always
  * Google regardless — see `mapsUrl` — this only governs the inline thumbnail.)
+ *
+ * SECURITY — the key ships in the client. An `EXPO_PUBLIC_*` value is compiled
+ * into the app binary and appears in the Static Maps request, so it is
+ * extractable; it is not a secret. Google's sanctioned path for a Maps key that
+ * must live in a mobile app is Cloud-Console restriction, and a key put here
+ * MUST be locked down before release:
+ *   - Application restriction: Android package name + SHA-1, and/or iOS bundle
+ *     id, so another app cannot spend it.
+ *   - API restriction: the Maps Static API only, to bound the blast radius.
+ * For stricter control (hide the key entirely, add request signing) route the
+ * image through a server-side proxy that holds the credential and have this
+ * point at the proxy instead — a deliberate follow-up, not required to ship a
+ * properly-restricted key. Until a restricted key is supplied the feature stays
+ * dark (CARTO), so there is no exposure by default.
  */
 export const GOOGLE_MAPS_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY || '';
 


### PR DESCRIPTION
## What

"Instead of OpenStreetMap, use Google Maps."

- **Open in maps** (`lib/location.ts` `mapsUrl`): now Google Maps on every platform — was Apple Maps on iOS. The universal `/maps/search/?api=1` URL opens the Google Maps app when installed, else the browser.
- **Inline preview** (`MapPreview` + `lib/mapTiles.ts`): Google has no keyless raster-tile endpoint (both built-in sources are OSM-data CDNs), so a Google thumbnail uses the **Static Maps API** — one composite image, key-authenticated and billed. Opt-in via `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY`:
  - key set → `MapPreview` renders a Google Static Map (Google's attribution is baked into the image, so the CARTO/OSM credit badge is hidden);
  - key unset → the CARTO tile grid stands exactly as before.
  The app still draws its own centre pin over whichever base is shown.

## Why opt-in for the preview
The repo deliberately ships without native map modules or bundled API keys (see the `mapTiles.ts` header). Google's tiles require a billed key, so — like Clarity / Sentry / R2 in this app — the Google preview ships behind an env key the owner supplies; the deep link needs no key and switches now.

## Test
- typecheck + lint clean.
- Tap "open map" → Google Maps (app or browser) on both platforms.
- With `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY` set, preview shows Google tiles; without it, CARTO as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Static Maps previews when configured, with automatic fallback to existing map tiles.
  * Location links now consistently open in Google Maps.
* **Bug Fixes**
  * Preserved map attribution for tile-based previews while hiding it for Google imagery.
  * Improved preview loading by avoiding unnecessary tile generation for Google imagery.
* **Documentation**
  * Added guidance for securing Google Maps API keys with application and API restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->