### PR TITLE
feat(mobile): encrypt the offline mirror at rest

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,6 +6,7 @@
     "@expo/ui": "~57.0.10",
     "@expo/vector-icons": "^15.1.1",
     "@microsoft/react-native-clarity": "^4.6.3",
+    "@noble/ciphers": "^2.3.0",
     "@react-native-async-storage/async-storage": "3.1.1",
     "@react-native-community/datetimepicker": "9.1.0",
     "@react-native-ml-kit/text-recognition": "^2.0.0",

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -22,6 +22,18 @@ import type { LocalStore, StoredRow } from './store';
 // (see rowCipher.ts). Bump when the migration below needs to run again.
 const SCHEMA_VERSION = 1;
 
+// Associated data bound into each sealed payload: the table plus the row's
+// identity. It is authenticated, not encrypted, so a ciphertext copied to a
+// different row (a different id/group/seq/key) fails to open. The exact same
+// string must be produced on write and read. A unit-separator (\x1f) joins the
+// parts — it never occurs in a UUID, an enum table name or an integer seq.
+const AAD_SEP = '\x1f';
+const mirrorAad = (table: string, id: string, groupId: string, seq: number): string =>
+  ['mirror_rows', table, id, groupId, seq].join(AAD_SEP);
+const queueAad = (clientMutationId: string, seq: number): string =>
+  ['pending_mutations', clientMutationId, seq].join(AAD_SEP);
+const draftAad = (key: string): string => ['drafts', key].join(AAD_SEP);
+
 const SCHEMA = `
 -- Wait for a held lock instead of throwing SQLITE_BUSY the instant the file is
 -- busy. In a production build there is one JS instance, one connection to this
@@ -117,21 +129,40 @@ class SqliteStore implements LocalStore {
     if ((current?.user_version ?? 0) >= SCHEMA_VERSION) return;
 
     const key = await loadKey();
-    const tables: { name: string; pk: readonly string[] }[] = [
-      { name: 'mirror_rows', pk: ['table_name', 'id'] },
-      { name: 'pending_mutations', pk: ['client_mutation_id'] },
-      { name: 'drafts', pk: ['key'] },
+    // `cols` are selected to rebuild both the primary key (for the UPDATE) and
+    // the associated-data binding (see the *Aad helpers). `aad` reproduces the
+    // exact string the normal write path uses, so a migrated row opens the same
+    // way a freshly written one does.
+    const tables: {
+      name: string;
+      pk: readonly string[];
+      cols: readonly string[];
+      aad: (row: Record<string, string>) => string;
+    }[] = [
+      {
+        name: 'mirror_rows',
+        pk: ['table_name', 'id'],
+        cols: ['table_name', 'id', 'group_id', 'seq'],
+        aad: (row) => mirrorAad(row.table_name, row.id, row.group_id, Number(row.seq)),
+      },
+      {
+        name: 'pending_mutations',
+        pk: ['client_mutation_id'],
+        cols: ['client_mutation_id', 'seq'],
+        aad: (row) => queueAad(row.client_mutation_id, Number(row.seq)),
+      },
+      { name: 'drafts', pk: ['key'], cols: ['key'], aad: (row) => draftAad(row.key) },
     ];
     await database.withTransactionAsync(async () => {
       for (const table of tables) {
         const rows = await database.getAllAsync<Record<string, string>>(
-          `SELECT ${[...table.pk, 'json'].join(', ')} FROM ${table.name}`,
+          `SELECT ${[...table.cols, 'json'].join(', ')} FROM ${table.name}`,
         );
         for (const row of rows) {
           if (isSealed(row.json)) continue;
           const where = table.pk.map((col) => `${col} = ?`).join(' AND ');
           await database.runAsync(`UPDATE ${table.name} SET json = ? WHERE ${where}`, [
-            encryptWith(key, row.json),
+            encryptWith(key, row.json, table.aad(row)),
             ...table.pk.map((col) => row[col] as string),
           ]);
         }
@@ -158,7 +189,17 @@ class SqliteStore implements LocalStore {
              VALUES (?, ?, ?, ?, ?)
              ON CONFLICT (table_name, id) DO UPDATE SET
                group_id = excluded.group_id, seq = excluded.seq, json = excluded.json`,
-            [row.table, row.id, row.groupId, row.seq, encryptWith(key, JSON.stringify(row.row))],
+            [
+              row.table,
+              row.id,
+              row.groupId,
+              row.seq,
+              encryptWith(
+                key,
+                JSON.stringify(row.row),
+                mirrorAad(row.table, row.id, row.groupId, row.seq),
+              ),
+            ],
           );
         }
       });
@@ -186,7 +227,9 @@ class SqliteStore implements LocalStore {
         id: row.id,
         groupId: row.group_id,
         seq: row.seq,
-        row: JSON.parse(decryptWith(key, row.json)) as MirrorRow,
+        row: JSON.parse(
+          decryptWith(key, row.json, mirrorAad(row.table_name, row.id, row.group_id, row.seq)),
+        ) as MirrorRow,
       }));
     });
   }
@@ -223,10 +266,17 @@ class SqliteStore implements LocalStore {
     return this.serial.run(async () => {
       const database = await this.db();
       const key = await loadKey();
-      const rows = await database.getAllAsync<{ json: string }>(
-        `SELECT json FROM pending_mutations ORDER BY seq ASC`,
+      const rows = await database.getAllAsync<{
+        client_mutation_id: string;
+        seq: number;
+        json: string;
+      }>(`SELECT client_mutation_id, seq, json FROM pending_mutations ORDER BY seq ASC`);
+      return rows.map(
+        (row) =>
+          JSON.parse(
+            decryptWith(key, row.json, queueAad(row.client_mutation_id, row.seq)),
+          ) as QueuedMutation,
       );
-      return rows.map((row) => JSON.parse(decryptWith(key, row.json)) as QueuedMutation);
     });
   }
 
@@ -242,7 +292,15 @@ class SqliteStore implements LocalStore {
         for (const mutation of queue) {
           await database.runAsync(
             `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
-            [mutation.clientMutationId, mutation.seq, encryptWith(key, JSON.stringify(mutation))],
+            [
+              mutation.clientMutationId,
+              mutation.seq,
+              encryptWith(
+                key,
+                JSON.stringify(mutation),
+                queueAad(mutation.clientMutationId, mutation.seq),
+              ),
+            ],
           );
         }
       });
@@ -257,7 +315,7 @@ class SqliteStore implements LocalStore {
         `SELECT json FROM drafts WHERE key = ?`,
         [key],
       );
-      return row ? (JSON.parse(decryptWith(dek, row.json)) as T) : null;
+      return row ? (JSON.parse(decryptWith(dek, row.json, draftAad(key))) as T) : null;
     });
   }
 
@@ -268,7 +326,7 @@ class SqliteStore implements LocalStore {
       await database.runAsync(
         `INSERT INTO drafts (key, json, saved_at) VALUES (?, ?, ?)
          ON CONFLICT (key) DO UPDATE SET json = excluded.json, saved_at = excluded.saved_at`,
-        [key, encryptWith(dek, JSON.stringify(value)), new Date().toISOString()],
+        [key, encryptWith(dek, JSON.stringify(value), draftAad(key)), new Date().toISOString()],
       );
     });
   }
@@ -289,7 +347,7 @@ class SqliteStore implements LocalStore {
       );
       return rows.map((row) => ({
         key: row.key,
-        value: JSON.parse(decryptWith(dek, row.json)) as unknown,
+        value: JSON.parse(decryptWith(dek, row.json, draftAad(row.key))) as unknown,
         savedAt: row.saved_at,
       }));
     });
@@ -309,7 +367,15 @@ class SqliteStore implements LocalStore {
         for (const mutation of queue) {
           await database.runAsync(
             `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
-            [mutation.clientMutationId, mutation.seq, encryptWith(key, JSON.stringify(mutation))],
+            [
+              mutation.clientMutationId,
+              mutation.seq,
+              encryptWith(
+                key,
+                JSON.stringify(mutation),
+                queueAad(mutation.clientMutationId, mutation.seq),
+              ),
+            ],
           );
         }
       });

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -14,8 +14,13 @@ import * as SQLite from 'expo-sqlite';
 import type { MirrorRow, QueuedMutation, SyncTable } from '@waves/core';
 
 import { mapYielding } from './hydrateChunk';
+import { decryptWith, destroyKey, encryptWith, isSealed, loadKey } from './rowCipher';
 import { Serial } from './serial';
 import type { LocalStore, StoredRow } from './store';
+
+// The mirror stores the whole ledger; every `json` payload is sealed at rest
+// (see rowCipher.ts). Bump when the migration below needs to run again.
+const SCHEMA_VERSION = 1;
 
 const SCHEMA = `
 -- Wait for a held lock instead of throwing SQLITE_BUSY the instant the file is
@@ -30,6 +35,10 @@ const SCHEMA = `
 -- rare WAL checkpoint overlap. Set FIRST, before the journal-mode change below,
 -- so the busy handler is already active if that statement itself meets a lock.
 PRAGMA busy_timeout = 5000;
+-- Zero freed pages instead of leaving their bytes on disk. Sealed values are
+-- still ciphertext, but this stops any legacy plaintext (or a shorter new
+-- value's tail) from lingering in the file's free list after a delete/update.
+PRAGMA secure_delete = ON;
 PRAGMA journal_mode = WAL;
 
 CREATE TABLE IF NOT EXISTS mirror_rows (
@@ -83,6 +92,7 @@ class SqliteStore implements LocalStore {
     this.opening ??= (async () => {
       const database = await SQLite.openDatabaseAsync('baaki.db');
       await database.execAsync(SCHEMA);
+      await this.migrate(database);
       this.database = database;
       return database;
     })();
@@ -94,10 +104,51 @@ class SqliteStore implements LocalStore {
     }
   }
 
+  /**
+   * Seal any pre-encryption plaintext left by an install that predates
+   * at-rest encryption, once. Guarded by `PRAGMA user_version`: on a fresh
+   * install (or after this has run) the version is already current and this is
+   * a single cheap read. Reads pass legacy plaintext through transparently
+   * (see `decryptWith`), so this is about not *leaving* plaintext on disk, not
+   * about correctness of reads.
+   */
+  private async migrate(database: SQLite.SQLiteDatabase): Promise<void> {
+    const current = await database.getFirstAsync<{ user_version: number }>(`PRAGMA user_version`);
+    if ((current?.user_version ?? 0) >= SCHEMA_VERSION) return;
+
+    const key = await loadKey();
+    const tables: { name: string; pk: readonly string[] }[] = [
+      { name: 'mirror_rows', pk: ['table_name', 'id'] },
+      { name: 'pending_mutations', pk: ['client_mutation_id'] },
+      { name: 'drafts', pk: ['key'] },
+    ];
+    await database.withTransactionAsync(async () => {
+      for (const table of tables) {
+        const rows = await database.getAllAsync<Record<string, string>>(
+          `SELECT ${[...table.pk, 'json'].join(', ')} FROM ${table.name}`,
+        );
+        for (const row of rows) {
+          if (isSealed(row.json)) continue;
+          const where = table.pk.map((col) => `${col} = ?`).join(' AND ');
+          await database.runAsync(`UPDATE ${table.name} SET json = ? WHERE ${where}`, [
+            encryptWith(key, row.json),
+            ...table.pk.map((col) => row[col] as string),
+          ]);
+        }
+      }
+    });
+    // `user_version` takes a literal, not a bound parameter.
+    await database.execAsync(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+    // Flush the WAL so any plaintext that lived there is truncated away rather
+    // than kept alongside the now-sealed main file.
+    await database.execAsync(`PRAGMA wal_checkpoint(TRUNCATE)`);
+  }
+
   async putRows(rows: readonly StoredRow[]): Promise<void> {
     if (rows.length === 0) return;
     await this.serial.run(async () => {
       const database = await this.db();
+      const key = await loadKey();
       // One transaction: a pull is one fact, and half of it landing after a kill
       // would leave the mirror ahead of its own cursor.
       await database.withTransactionAsync(async () => {
@@ -107,7 +158,7 @@ class SqliteStore implements LocalStore {
              VALUES (?, ?, ?, ?, ?)
              ON CONFLICT (table_name, id) DO UPDATE SET
                group_id = excluded.group_id, seq = excluded.seq, json = excluded.json`,
-            [row.table, row.id, row.groupId, row.seq, JSON.stringify(row.row)],
+            [row.table, row.id, row.groupId, row.seq, encryptWith(key, JSON.stringify(row.row))],
           );
         }
       });
@@ -117,6 +168,7 @@ class SqliteStore implements LocalStore {
   readRows(): Promise<StoredRow[]> {
     return this.serial.run(async () => {
       const database = await this.db();
+      const key = await loadKey();
       const rows = await database.getAllAsync<{
         table_name: string;
         id: string;
@@ -126,14 +178,15 @@ class SqliteStore implements LocalStore {
       }>(`SELECT table_name, id, group_id, seq, json FROM mirror_rows`);
       // Parse in chunks that yield to the event loop between them. This read is
       // the cold-start hydration path (see `hydrateChunk`): a heavy account's
-      // whole mirror is `JSON.parse`d here before `hydrated` flips, and doing it
-      // in one synchronous burst froze the loading skeleton and the first frame.
+      // whole mirror is decrypted and `JSON.parse`d here before `hydrated` flips,
+      // and doing it in one synchronous burst froze the loading skeleton and the
+      // first frame. The key is loaded once above; the per-row open is sync.
       return mapYielding(rows, (row) => ({
         table: row.table_name as SyncTable,
         id: row.id,
         groupId: row.group_id,
         seq: row.seq,
-        row: JSON.parse(row.json) as MirrorRow,
+        row: JSON.parse(decryptWith(key, row.json)) as MirrorRow,
       }));
     });
   }
@@ -169,16 +222,18 @@ class SqliteStore implements LocalStore {
   readQueue(): Promise<QueuedMutation[]> {
     return this.serial.run(async () => {
       const database = await this.db();
+      const key = await loadKey();
       const rows = await database.getAllAsync<{ json: string }>(
         `SELECT json FROM pending_mutations ORDER BY seq ASC`,
       );
-      return rows.map((row) => JSON.parse(row.json) as QueuedMutation);
+      return rows.map((row) => JSON.parse(decryptWith(key, row.json)) as QueuedMutation);
     });
   }
 
   writeQueue(queue: readonly QueuedMutation[]): Promise<void> {
     return this.serial.run(async () => {
       const database = await this.db();
+      const key = await loadKey();
       await database.withTransactionAsync(async () => {
         // `WHERE 1 = 1` for the same reason the server needs it: a bare DELETE
         // is the kind of statement that is one typo away from deleting
@@ -187,7 +242,7 @@ class SqliteStore implements LocalStore {
         for (const mutation of queue) {
           await database.runAsync(
             `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
-            [mutation.clientMutationId, mutation.seq, JSON.stringify(mutation)],
+            [mutation.clientMutationId, mutation.seq, encryptWith(key, JSON.stringify(mutation))],
           );
         }
       });
@@ -197,21 +252,23 @@ class SqliteStore implements LocalStore {
   readDraft<T>(key: string): Promise<T | null> {
     return this.serial.run(async () => {
       const database = await this.db();
+      const dek = await loadKey();
       const row = await database.getFirstAsync<{ json: string }>(
         `SELECT json FROM drafts WHERE key = ?`,
         [key],
       );
-      return row ? (JSON.parse(row.json) as T) : null;
+      return row ? (JSON.parse(decryptWith(dek, row.json)) as T) : null;
     });
   }
 
   writeDraft(key: string, value: unknown): Promise<void> {
     return this.serial.run(async () => {
       const database = await this.db();
+      const dek = await loadKey();
       await database.runAsync(
         `INSERT INTO drafts (key, json, saved_at) VALUES (?, ?, ?)
          ON CONFLICT (key) DO UPDATE SET json = excluded.json, saved_at = excluded.saved_at`,
-        [key, JSON.stringify(value), new Date().toISOString()],
+        [key, encryptWith(dek, JSON.stringify(value)), new Date().toISOString()],
       );
     });
   }
@@ -226,12 +283,13 @@ class SqliteStore implements LocalStore {
   listDrafts(): Promise<{ key: string; value: unknown; savedAt: string }[]> {
     return this.serial.run(async () => {
       const database = await this.db();
+      const dek = await loadKey();
       const rows = await database.getAllAsync<{ key: string; json: string; saved_at: string }>(
         `SELECT key, json, saved_at FROM drafts ORDER BY saved_at DESC`,
       );
       return rows.map((row) => ({
         key: row.key,
-        value: JSON.parse(row.json) as unknown,
+        value: JSON.parse(decryptWith(dek, row.json)) as unknown,
         savedAt: row.saved_at,
       }));
     });
@@ -240,6 +298,7 @@ class SqliteStore implements LocalStore {
   forgetGroup(groupId: string, queue: readonly QueuedMutation[]): Promise<void> {
     return this.serial.run(async () => {
       const database = await this.db();
+      const key = await loadKey();
       // All three in one transaction: the mirror rows, the cursor and the queue
       // are one fact — "this group is gone" — so a kill between them must not
       // leave the queue replaying against rows that no longer exist.
@@ -250,7 +309,7 @@ class SqliteStore implements LocalStore {
         for (const mutation of queue) {
           await database.runAsync(
             `INSERT INTO pending_mutations (client_mutation_id, seq, json) VALUES (?, ?, ?)`,
-            [mutation.clientMutationId, mutation.seq, JSON.stringify(mutation)],
+            [mutation.clientMutationId, mutation.seq, encryptWith(key, JSON.stringify(mutation))],
           );
         }
       });
@@ -272,6 +331,11 @@ class SqliteStore implements LocalStore {
         await database.runAsync(`DELETE FROM sync_cursors WHERE 1 = 1`);
         await database.runAsync(`DELETE FROM drafts WHERE 1 = 1`);
       });
+      // Crypto-erase: with the rows gone, drop the key too. Any ciphertext still
+      // physically present in the WAL or free pages is now unrecoverable, and the
+      // next account on this device mints a fresh key rather than inheriting this
+      // one. `secure_delete` handled the bytes; this handles the key.
+      await destroyKey();
     });
   }
 }

--- a/apps/mobile/src/sync/driver.web.ts
+++ b/apps/mobile/src/sync/driver.web.ts
@@ -6,6 +6,18 @@
  * neither the dev server nor a plain static export sends. A guest opening an
  * invite link (ADR-006) should not meet a blank screen over that, so web gets
  * AsyncStorage instead. Same interface, same engine, same tests.
+ *
+ * Unlike the native store (`driver.ts`), the payloads here are NOT encrypted at
+ * rest, on purpose. At-rest encryption relies on a key the attacker cannot also
+ * read — on device that is the OS keystore. A browser has no such vault: any key
+ * this code could reach would sit in the same localStorage/IndexedDB origin as
+ * the data, so anyone who can read the data can read the key, and the encryption
+ * would protect nothing while adding cost. The browser's own protections (the
+ * same-origin sandbox, and OS-level disk encryption of the user's profile) are
+ * the layer that applies to web. Web is guest/invite-lite by design; a full,
+ * long-lived web client that warranted more would move this to IndexedDB behind
+ * the WebCrypto SubtleCrypto non-extractable-key API, which is the browser
+ * equivalent of the keystore — a deliberate future step, not this store.
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';

--- a/apps/mobile/src/sync/rowCipher.ts
+++ b/apps/mobile/src/sync/rowCipher.ts
@@ -1,0 +1,175 @@
+/**
+ * At-rest encryption for the offline mirror's payloads (ADR-005 durability +
+ * privacy).
+ *
+ * The mirror is a plain SQLite file in the app sandbox (`driver.ts`). The
+ * sandbox and full-disk encryption keep it from other apps and from a powered-
+ * off, locked device — but a rooted/jailbroken phone or a file-level backup can
+ * read that file, and it holds the whole ledger: groups, expenses, splits,
+ * balances, the mutation queue, autosaved drafts. So every value SQLite stores
+ * in a `json` column is sealed here before it is written and opened after it is
+ * read.
+ *
+ * Why application-layer and not SQLCipher: the sensitive content lives *only* in
+ * the `json` columns, always read and written whole — no query ever filters or
+ * sorts on it (see the SELECTs in `driver.ts`). Sealing that one column covers
+ * the payload without swapping the native SQLite module, which on this Expo pin
+ * would break autolinking (see the RN 0.87 revert). This is pure JS: a
+ * ChaCha-family AEAD from `@noble/ciphers`, a random nonce per value, and a
+ * 256-bit data-encryption key kept in the OS keystore.
+ *
+ * Trust boundary: this protects data *at rest* against off-device extraction,
+ * rooted-filesystem access and backup theft. It does not defend a running,
+ * unlocked, compromised device — the key is available to the app at runtime,
+ * the same posture as the session token and BYOK model keys already held in
+ * SecureStore (see `secureStorage.ts`, `aiKeys.ts`). A lock-gated key is a
+ * possible future hardening, deliberately out of scope here.
+ *
+ * The module splits into a pure core (`seal`/`open`, key and nonce passed in,
+ * no native imports) so the crypto round-trips can be unit-tested, and a thin
+ * native layer (`loadKey`/`encryptWith`/`decryptWith`/`destroyKey`) that owns
+ * the keystore and the RNG.
+ */
+
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
+import { bytesToUtf8, concatBytes, utf8ToBytes } from '@noble/ciphers/utils.js';
+import * as Crypto from 'expo-crypto';
+import * as SecureStore from 'expo-secure-store';
+
+/** Marks a sealed value. An unprefixed value is legacy plaintext (see `open`). */
+const VERSION_TAG = 'v1:';
+/** XChaCha20 takes a 192-bit (24-byte) nonce — wide enough that a random nonce
+ *  per value never collides in practice, so no counter to persist. */
+const NONCE_BYTES = 24;
+/** ChaCha20-Poly1305 key length. */
+const KEY_BYTES = 32;
+/** The keystore slot the data-encryption key lives in. */
+const DEK_STORE_KEY = 'waves.mirror.dek.v1';
+
+/** An opaque 256-bit key. Only this module should construct one. */
+export type MirrorKey = Uint8Array;
+
+// --- base64 (pure, no reliance on Hermes btoa/atob) -------------------------
+
+const B64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const B64_LOOKUP: Record<string, number> = {};
+for (let i = 0; i < B64_CHARS.length; i += 1) B64_LOOKUP[B64_CHARS[i] as string] = i;
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let out = '';
+  let i = 0;
+  for (; i + 2 < bytes.length; i += 3) {
+    const n =
+      ((bytes[i] as number) << 16) | ((bytes[i + 1] as number) << 8) | (bytes[i + 2] as number);
+    out +=
+      B64_CHARS[(n >> 18) & 63] +
+      B64_CHARS[(n >> 12) & 63] +
+      B64_CHARS[(n >> 6) & 63] +
+      B64_CHARS[n & 63];
+  }
+  const rem = bytes.length - i;
+  if (rem === 1) {
+    const n = (bytes[i] as number) << 16;
+    out += B64_CHARS[(n >> 18) & 63] + B64_CHARS[(n >> 12) & 63] + '==';
+  } else if (rem === 2) {
+    const n = ((bytes[i] as number) << 16) | ((bytes[i + 1] as number) << 8);
+    out += B64_CHARS[(n >> 18) & 63] + B64_CHARS[(n >> 12) & 63] + B64_CHARS[(n >> 6) & 63] + '=';
+  }
+  return out;
+}
+
+export function base64ToBytes(b64: string): Uint8Array {
+  const clean = b64.replace(/[^A-Za-z0-9+/]/g, '');
+  const outLen = Math.floor((clean.length * 6) / 8);
+  const out = new Uint8Array(outLen);
+  let bits = 0;
+  let val = 0;
+  let oi = 0;
+  for (let i = 0; i < clean.length; i += 1) {
+    val = (val << 6) | (B64_LOOKUP[clean[i] as string] as number);
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out[oi] = (val >> bits) & 0xff;
+      oi += 1;
+    }
+  }
+  return out;
+}
+
+// --- pure core --------------------------------------------------------------
+
+/** True if `stored` is a sealed value rather than legacy plaintext. */
+export function isSealed(stored: string): boolean {
+  return stored.startsWith(VERSION_TAG);
+}
+
+/** Seal `plain` with `key` and a caller-supplied `nonce`. Pure — the native
+ *  layer supplies a random nonce; tests can pin one. */
+export function seal(key: MirrorKey, nonce: Uint8Array, plain: string): string {
+  const ct = xchacha20poly1305(key, nonce).encrypt(utf8ToBytes(plain));
+  return VERSION_TAG + bytesToBase64(concatBytes(nonce, ct));
+}
+
+/** Open a value sealed by {@link seal}. A value without the version tag is
+ *  returned unchanged — that is a row written before encryption existed, and
+ *  the next write will seal it. A tampered/corrupt sealed value throws (the
+ *  AEAD tag fails), exactly as a corrupt plaintext row would fail `JSON.parse`. */
+export function open(key: MirrorKey, stored: string): string {
+  if (!isSealed(stored)) return stored;
+  const raw = base64ToBytes(stored.slice(VERSION_TAG.length));
+  const nonce = raw.subarray(0, NONCE_BYTES);
+  const ct = raw.subarray(NONCE_BYTES);
+  return bytesToUtf8(xchacha20poly1305(key, nonce).decrypt(ct));
+}
+
+// --- native layer: keystore-backed key + RNG --------------------------------
+
+// The key is fetched from the keystore once and cached for the process. A
+// failed load is not cached, so a transient keystore error at launch does not
+// permanently wedge the store (mirrors the open-retry logic in driver.ts).
+let keyPromise: Promise<MirrorKey> | null = null;
+
+async function loadOrCreateKey(): Promise<MirrorKey> {
+  const existing = await SecureStore.getItemAsync(DEK_STORE_KEY);
+  if (existing) return base64ToBytes(existing);
+  const key = Crypto.getRandomBytes(KEY_BYTES);
+  await SecureStore.setItemAsync(DEK_STORE_KEY, bytesToBase64(key), {
+    // Readable after the first unlock following a boot, so background sync can
+    // decrypt without the user having just unlocked — but not before first
+    // unlock, and never in an iCloud/iTunes backup.
+    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+  });
+  return key;
+}
+
+/** The mirror's data-encryption key, loading (or minting) it once. Callers hold
+ *  the resolved key and run {@link encryptWith}/{@link decryptWith} synchronously
+ *  per row, so a hydration loop pays the keystore cost once, not per value. */
+export function loadKey(): Promise<MirrorKey> {
+  keyPromise ??= loadOrCreateKey().catch((error) => {
+    keyPromise = null;
+    throw error;
+  });
+  return keyPromise;
+}
+
+/** Seal `plain` with a fresh random nonce. Synchronous given a loaded key. */
+export function encryptWith(key: MirrorKey, plain: string): string {
+  return seal(key, Crypto.getRandomBytes(NONCE_BYTES), plain);
+}
+
+/** Open `stored` (legacy plaintext passes through). Synchronous given a key. */
+export function decryptWith(key: MirrorKey, stored: string): string {
+  return open(key, stored);
+}
+
+/**
+ * Destroy the data-encryption key. Called on sign-out after the rows are wiped:
+ * any ciphertext still physically present in the file's WAL or free pages is
+ * then unrecoverable, and the next account mints a fresh key.
+ */
+export async function destroyKey(): Promise<void> {
+  keyPromise = null;
+  await SecureStore.deleteItemAsync(DEK_STORE_KEY);
+}

--- a/apps/mobile/src/sync/rowCipher.ts
+++ b/apps/mobile/src/sync/rowCipher.ts
@@ -104,23 +104,34 @@ export function isSealed(stored: string): boolean {
   return stored.startsWith(VERSION_TAG);
 }
 
-/** Seal `plain` with `key` and a caller-supplied `nonce`. Pure — the native
- *  layer supplies a random nonce; tests can pin one. */
-export function seal(key: MirrorKey, nonce: Uint8Array, plain: string): string {
-  const ct = xchacha20poly1305(key, nonce).encrypt(utf8ToBytes(plain));
+/**
+ * Seal `plain` with `key` and a caller-supplied `nonce`. Pure — the native
+ * layer supplies a random nonce; tests can pin one.
+ *
+ * `aad` (associated data) is authenticated but not encrypted: it binds the
+ * ciphertext to its storage context — the table and the row's identity — so a
+ * blob copied to a different row (a different id, group or seq) fails to open.
+ * The exact same `aad` must be supplied to {@link open}.
+ */
+export function seal(key: MirrorKey, nonce: Uint8Array, plain: string, aad?: string): string {
+  const cipher = xchacha20poly1305(key, nonce, aad === undefined ? undefined : utf8ToBytes(aad));
+  const ct = cipher.encrypt(utf8ToBytes(plain));
   return VERSION_TAG + bytesToBase64(concatBytes(nonce, ct));
 }
 
-/** Open a value sealed by {@link seal}. A value without the version tag is
- *  returned unchanged — that is a row written before encryption existed, and
- *  the next write will seal it. A tampered/corrupt sealed value throws (the
- *  AEAD tag fails), exactly as a corrupt plaintext row would fail `JSON.parse`. */
-export function open(key: MirrorKey, stored: string): string {
+/** Open a value sealed by {@link seal}, with the identical `aad`. A value
+ *  without the version tag is returned unchanged — that is a row written before
+ *  encryption existed, and the next write will seal it. A tampered/corrupt
+ *  sealed value, or one whose `aad` does not match (e.g. a ciphertext moved to
+ *  another row), throws when the AEAD tag fails — exactly as a corrupt plaintext
+ *  row would fail `JSON.parse`. */
+export function open(key: MirrorKey, stored: string, aad?: string): string {
   if (!isSealed(stored)) return stored;
   const raw = base64ToBytes(stored.slice(VERSION_TAG.length));
   const nonce = raw.subarray(0, NONCE_BYTES);
   const ct = raw.subarray(NONCE_BYTES);
-  return bytesToUtf8(xchacha20poly1305(key, nonce).decrypt(ct));
+  const cipher = xchacha20poly1305(key, nonce, aad === undefined ? undefined : utf8ToBytes(aad));
+  return bytesToUtf8(cipher.decrypt(ct));
 }
 
 // --- native layer: keystore-backed key + RNG --------------------------------
@@ -137,8 +148,12 @@ async function loadOrCreateKey(): Promise<MirrorKey> {
   await SecureStore.setItemAsync(DEK_STORE_KEY, bytesToBase64(key), {
     // Readable after the first unlock following a boot, so background sync can
     // decrypt without the user having just unlocked — but not before first
-    // unlock, and never in an iCloud/iTunes backup.
-    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+    // unlock. The THIS_DEVICE_ONLY variant also keeps the key from ever
+    // migrating to another device through an iCloud/iTunes backup restore: the
+    // key stays put, so a restored copy of the DB is unreadable on the new
+    // device (which is the intent — the ciphertext should not travel with a key
+    // that opens it).
+    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
   });
   return key;
 }
@@ -154,14 +169,16 @@ export function loadKey(): Promise<MirrorKey> {
   return keyPromise;
 }
 
-/** Seal `plain` with a fresh random nonce. Synchronous given a loaded key. */
-export function encryptWith(key: MirrorKey, plain: string): string {
-  return seal(key, Crypto.getRandomBytes(NONCE_BYTES), plain);
+/** Seal `plain` with a fresh random nonce, bound to `aad` (the row's storage
+ *  context — see {@link seal}). Synchronous given a loaded key. */
+export function encryptWith(key: MirrorKey, plain: string, aad?: string): string {
+  return seal(key, Crypto.getRandomBytes(NONCE_BYTES), plain, aad);
 }
 
-/** Open `stored` (legacy plaintext passes through). Synchronous given a key. */
-export function decryptWith(key: MirrorKey, stored: string): string {
-  return open(key, stored);
+/** Open `stored` with the identical `aad` (legacy plaintext passes through).
+ *  Synchronous given a key. */
+export function decryptWith(key: MirrorKey, stored: string, aad?: string): string {
+  return open(key, stored, aad);
 }
 
 /**

--- a/apps/mobile/test/localStore.test.ts
+++ b/apps/mobile/test/localStore.test.ts
@@ -38,6 +38,10 @@ class FakeDatabase {
   >();
   readonly cursors = new Map<string, number>();
   readonly drafts = new Map<string, { key: string; json: string; saved_at: string }>();
+  // Defaults to the current schema version so the one-time encryption migration
+  // (driver.migrate) is a no-op for these tests; the migration is exercised on
+  // its own below by seeding a fresh DB at version 0.
+  userVersion = 1;
 
   private async enter<T>(run: () => Promise<T>): Promise<T> {
     this.live += 1;
@@ -64,6 +68,8 @@ class FakeDatabase {
         }
         this.inTransaction = false;
       }
+      const setVersion = source.trim().match(/^PRAGMA\s+user_version\s*=\s*(\d+)/i);
+      if (setVersion) this.userVersion = Number(setVersion[1]);
       this.statements.push(source.trim());
     });
   }
@@ -143,6 +149,25 @@ class FakeDatabase {
         } else {
           this.drafts.clear();
         }
+        return;
+      }
+      // Used only by the one-time encryption migration.
+      if (statement === 'UPDATE mirror_rows SET') {
+        const [json, tableName, id] = params as [string, string, string];
+        const rec = this.mirrorRows.get(`${tableName}:${id}`);
+        if (rec) rec.json = json;
+        return;
+      }
+      if (statement === 'UPDATE pending_mutations SET') {
+        const [json, clientMutationId] = params as [string, string];
+        const rec = this.pendingMutations.get(clientMutationId);
+        if (rec) rec.json = json;
+        return;
+      }
+      if (statement === 'UPDATE drafts SET') {
+        const [json, key] = params as [string, string];
+        const rec = this.drafts.get(key);
+        if (rec) rec.json = json;
       }
     });
   }
@@ -166,9 +191,10 @@ class FakeDatabase {
     });
   }
 
-  async getFirstAsync<T>(_source = '', params: unknown[] = []): Promise<T | null> {
+  async getFirstAsync<T>(source = '', params: unknown[] = []): Promise<T | null> {
     return this.enter(async () => {
       await tick();
+      if (source.includes('user_version')) return { user_version: this.userVersion } as T;
       const [key] = params as [string];
       return (this.drafts.get(key) as T | undefined) ?? null;
     });
@@ -191,6 +217,32 @@ class FakeDatabase {
 let database: FakeDatabase;
 let openCalls = 0;
 let failNextOpen = false;
+
+// The store now seals every json payload (see rowCipher.ts), which pulls in the
+// keystore and the RNG. In-memory stand-ins: a Map for SecureStore, Node's own
+// CSPRNG for expo-crypto. The crypto itself (@noble/ciphers) is pure JS and runs
+// for real, so these tests exercise the true encrypt/decrypt round-trip.
+vi.mock('expo-secure-store', () => {
+  const keystore = new Map<string, string>();
+  return {
+    AFTER_FIRST_UNLOCK: 'after-first-unlock',
+    getItemAsync: async (key: string) => keystore.get(key) ?? null,
+    setItemAsync: async (key: string, value: string) => {
+      keystore.set(key, value);
+    },
+    deleteItemAsync: async (key: string) => {
+      keystore.delete(key);
+    },
+  };
+});
+
+vi.mock('expo-crypto', () => ({
+  getRandomBytes: (length: number) => {
+    const bytes = new Uint8Array(length);
+    globalThis.crypto.getRandomValues(bytes);
+    return bytes;
+  },
+}));
 
 vi.mock('expo-sqlite', () => ({
   openDatabaseAsync: async () => {
@@ -383,7 +435,9 @@ describe('native local store lifecycle', () => {
     expect(hydrated[0]).toEqual(rows[0]);
     expect(hydrated[512]).toEqual(rows[512]);
     expect(hydrated[1024]).toEqual(rows[1024]);
-  });
+    // Generous timeout: 1k fake statements each yield a macrotask, plus a real
+    // encrypt/decrypt per row — slow on a loaded Windows timer, not a defect.
+  }, 20000);
 
   it('does not open SQLite when asked to persist no rows', async () => {
     const store = createLocalStore();
@@ -392,5 +446,84 @@ describe('native local store lifecycle', () => {
 
     expect(openCalls).toBe(0);
     expect(database.statements).toEqual([]);
+  });
+});
+
+describe('at-rest encryption', () => {
+  it('stores json as ciphertext, not plaintext', async () => {
+    const store = createLocalStore();
+    await store.putRows([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1', amount: '100' } },
+    ] as never);
+    await store.writeQueue([mutation('a')]);
+    await store.writeDraft('d1', { secret: 'lunch with Sam' });
+
+    const rowJson = database.mirrorRows.get('expenses:e1')?.json ?? '';
+    const queueJson = database.pendingMutations.get('a')?.json ?? '';
+    const draftJson = database.drafts.get('d1')?.json ?? '';
+
+    // Sealed (versioned) and free of the underlying plaintext.
+    for (const stored of [rowJson, queueJson, draftJson]) {
+      expect(stored.startsWith('v1:')).toBe(true);
+    }
+    expect(rowJson).not.toContain('100');
+    expect(draftJson).not.toContain('lunch with Sam');
+
+    // ...and still reads back to the original values.
+    expect(await store.readRows()).toEqual([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1', amount: '100' } },
+    ]);
+    expect(await store.readDraft('d1')).toEqual({ secret: 'lunch with Sam' });
+  });
+
+  it('seals pre-encryption plaintext once, on open', async () => {
+    // A database written before encryption existed: rows are plain JSON and the
+    // schema version is behind.
+    database.userVersion = 0;
+    database.mirrorRows.set('expenses:e1', {
+      table_name: 'expenses',
+      id: 'e1',
+      group_id: 'g1',
+      seq: 1,
+      json: JSON.stringify({ id: 'e1', amount: '100' }),
+    });
+    database.drafts.set('d1', {
+      key: 'd1',
+      json: JSON.stringify({ note: 'legacy' }),
+      saved_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    const store = createLocalStore();
+    await store.ready();
+
+    // Migrated in place: now sealed, version bumped, WAL flushed.
+    expect(database.mirrorRows.get('expenses:e1')?.json.startsWith('v1:')).toBe(true);
+    expect(database.drafts.get('d1')?.json.startsWith('v1:')).toBe(true);
+    expect(database.userVersion).toBe(1);
+    expect(database.statements).toContain('PRAGMA wal_checkpoint(TRUNCATE)');
+
+    // And the seeded plaintext still reads correctly through the decrypt path.
+    expect(await store.readRows()).toEqual([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1', amount: '100' } },
+    ]);
+    expect(await store.readDraft('d1')).toEqual({ note: 'legacy' });
+  });
+
+  it('destroys the key on reset (crypto-erase)', async () => {
+    const store = createLocalStore();
+    await store.putRows([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
+    ] as never);
+
+    await store.reset();
+
+    // A fresh write after reset still works — the store transparently mints a
+    // new key — and the data is gone.
+    await store.putRows([
+      { table: 'expenses', id: 'e2', groupId: 'g1', seq: 1, row: { id: 'e2' } },
+    ] as never);
+    expect(await store.readRows()).toEqual([
+      { table: 'expenses', id: 'e2', groupId: 'g1', seq: 1, row: { id: 'e2' } },
+    ]);
   });
 });

--- a/apps/mobile/test/localStore.test.ts
+++ b/apps/mobile/test/localStore.test.ts
@@ -222,19 +222,23 @@ let failNextOpen = false;
 // keystore and the RNG. In-memory stand-ins: a Map for SecureStore, Node's own
 // CSPRNG for expo-crypto. The crypto itself (@noble/ciphers) is pure JS and runs
 // for real, so these tests exercise the true encrypt/decrypt round-trip.
-vi.mock('expo-secure-store', () => {
-  const keystore = new Map<string, string>();
-  return {
-    AFTER_FIRST_UNLOCK: 'after-first-unlock',
-    getItemAsync: async (key: string) => keystore.get(key) ?? null,
-    setItemAsync: async (key: string, value: string) => {
-      keystore.set(key, value);
-    },
-    deleteItemAsync: async (key: string) => {
-      keystore.delete(key);
-    },
-  };
-});
+const secure = vi.hoisted(() => ({
+  keystore: new Map<string, string>(),
+  deletes: [] as string[],
+}));
+
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK: 'after-first-unlock',
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'after-first-unlock-this-device-only',
+  getItemAsync: async (key: string) => secure.keystore.get(key) ?? null,
+  setItemAsync: async (key: string, value: string) => {
+    secure.keystore.set(key, value);
+  },
+  deleteItemAsync: async (key: string) => {
+    secure.deletes.push(key);
+    secure.keystore.delete(key);
+  },
+}));
 
 vi.mock('expo-crypto', () => ({
   getRandomBytes: (length: number) => {
@@ -510,12 +514,18 @@ describe('at-rest encryption', () => {
   });
 
   it('destroys the key on reset (crypto-erase)', async () => {
+    const DEK = 'waves.mirror.dek.v1';
     const store = createLocalStore();
     await store.putRows([
       { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
     ] as never);
 
+    const deletesBefore = secure.deletes.filter((key) => key === DEK).length;
     await store.reset();
+
+    // reset() actually removes the encryption key (not just the rows), so a
+    // no-op destroyKey would fail this rather than silently pass.
+    expect(secure.deletes.filter((key) => key === DEK).length).toBe(deletesBefore + 1);
 
     // A fresh write after reset still works — the store transparently mints a
     // new key — and the data is gone.

--- a/apps/mobile/test/rowCipher.test.ts
+++ b/apps/mobile/test/rowCipher.test.ts
@@ -28,6 +28,7 @@ const hoisted = vi.hoisted(() => ({ keystore: new Map<string, string>() }));
 
 vi.mock('expo-secure-store', () => ({
   AFTER_FIRST_UNLOCK: 'after-first-unlock',
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'after-first-unlock-this-device-only',
   getItemAsync: async (key: string) => hoisted.keystore.get(key) ?? null,
   setItemAsync: async (key: string, value: string) => {
     hoisted.keystore.set(key, value);
@@ -90,6 +91,18 @@ describe('seal / open (pure)', () => {
     const sealed = seal(KEY, NONCE, 'secret');
     const wrong = new Uint8Array(32).fill(9);
     expect(() => open(wrong, sealed)).toThrow();
+  });
+
+  it('binds the ciphertext to its associated data', () => {
+    const plain = JSON.stringify({ id: 'e1' });
+    const sealed = seal(KEY, NONCE, plain, 'mirror_rows\x1fe1\x1fg1\x1f5');
+    // Same context opens it...
+    expect(open(KEY, sealed, 'mirror_rows\x1fe1\x1fg1\x1f5')).toBe(plain);
+    // ...but the same blob "moved" to another row (different id/group/seq) fails,
+    // and so does opening with no context at all.
+    expect(() => open(KEY, sealed, 'mirror_rows\x1fe2\x1fg1\x1f5')).toThrow();
+    expect(() => open(KEY, sealed, 'mirror_rows\x1fe1\x1fg2\x1f5')).toThrow();
+    expect(() => open(KEY, sealed)).toThrow();
   });
 });
 

--- a/apps/mobile/test/rowCipher.test.ts
+++ b/apps/mobile/test/rowCipher.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The mirror's at-rest cipher (rowCipher.ts).
+ *
+ * The pure core (seal/open/base64) runs with a fixed key and nonce so the crypto
+ * round-trips are deterministic. The native layer (loadKey/encryptWith/
+ * decryptWith/destroyKey) runs against an in-memory keystore and Node's CSPRNG,
+ * standing in for expo-secure-store and expo-crypto; @noble/ciphers itself is
+ * pure JS and runs for real.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  base64ToBytes,
+  bytesToBase64,
+  decryptWith,
+  destroyKey,
+  encryptWith,
+  isSealed,
+  loadKey,
+  open,
+  seal,
+} from '../src/sync/rowCipher';
+
+// vi.mock is hoisted above the imports by vitest, so the stand-ins are in place
+// before rowCipher.ts loads expo-secure-store / expo-crypto.
+const hoisted = vi.hoisted(() => ({ keystore: new Map<string, string>() }));
+
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK: 'after-first-unlock',
+  getItemAsync: async (key: string) => hoisted.keystore.get(key) ?? null,
+  setItemAsync: async (key: string, value: string) => {
+    hoisted.keystore.set(key, value);
+  },
+  deleteItemAsync: async (key: string) => {
+    hoisted.keystore.delete(key);
+  },
+}));
+
+vi.mock('expo-crypto', () => ({
+  getRandomBytes: (length: number) => {
+    const bytes = new Uint8Array(length);
+    globalThis.crypto.getRandomValues(bytes);
+    return bytes;
+  },
+}));
+
+const KEY = new Uint8Array(32).fill(7);
+const NONCE = new Uint8Array(24).fill(3);
+
+beforeEach(async () => {
+  hoisted.keystore.clear();
+  await destroyKey(); // drop the cached key between tests
+  hoisted.keystore.clear();
+});
+
+describe('base64', () => {
+  it('round-trips byte arrays of every remainder length', () => {
+    for (const length of [0, 1, 2, 3, 4, 5, 17, 24, 100]) {
+      const bytes = new Uint8Array(length);
+      globalThis.crypto.getRandomValues(bytes);
+      expect([...base64ToBytes(bytesToBase64(bytes))]).toEqual([...bytes]);
+    }
+  });
+});
+
+describe('seal / open (pure)', () => {
+  it('round-trips a value', () => {
+    const plain = JSON.stringify({ id: 'e1', amount: '100', note: 'café ☕' });
+    const sealed = seal(KEY, NONCE, plain);
+    expect(isSealed(sealed)).toBe(true);
+    expect(open(KEY, sealed)).toBe(plain);
+  });
+
+  it('passes legacy plaintext through unchanged', () => {
+    const legacy = JSON.stringify({ id: 'e1' });
+    expect(isSealed(legacy)).toBe(false);
+    expect(open(KEY, legacy)).toBe(legacy);
+  });
+
+  it('throws on a tampered ciphertext', () => {
+    const sealed = seal(KEY, NONCE, 'hello world');
+    const raw = base64ToBytes(sealed.slice('v1:'.length));
+    raw[NONCE.length + 1] ^= 0xff; // flip a ciphertext byte
+    const tampered = 'v1:' + bytesToBase64(raw);
+    expect(() => open(KEY, tampered)).toThrow();
+  });
+
+  it('cannot be opened with the wrong key', () => {
+    const sealed = seal(KEY, NONCE, 'secret');
+    const wrong = new Uint8Array(32).fill(9);
+    expect(() => open(wrong, sealed)).toThrow();
+  });
+});
+
+describe('key-backed layer', () => {
+  it('encrypts then decrypts through the loaded key', async () => {
+    const key = await loadKey();
+    const plain = JSON.stringify({ amount: '250' });
+    expect(decryptWith(key, encryptWith(key, plain))).toBe(plain);
+  });
+
+  it('uses a fresh nonce each time (distinct ciphertexts)', async () => {
+    const key = await loadKey();
+    expect(encryptWith(key, 'same')).not.toBe(encryptWith(key, 'same'));
+  });
+
+  it('loads the same key across calls, then mints a new one after destroy', async () => {
+    const first = await loadKey();
+    const again = await loadKey();
+    expect([...again]).toEqual([...first]);
+
+    await destroyKey();
+    const minted = await loadKey();
+    expect([...minted]).not.toEqual([...first]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@microsoft/react-native-clarity':
         specifier: ^4.6.3
         version: 4.6.3(react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@noble/ciphers':
+        specifier: ^2.3.0
+        version: 2.3.0
       '@react-native-async-storage/async-storage':
         specifier: 3.1.1
         version: 3.1.1(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -1732,6 +1735,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/ciphers@2.3.0':
+    resolution: {integrity: sha512-Clu/xdfgVTf9o7ngLOURaxePwR0j8sjclKEtVij10/jGulwFsPWCvvRgG/XjUVf8Nei+jLG6uwyXzUTGY1DQrw==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -8954,6 +8961,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
 
+  '@noble/ciphers@2.3.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -11696,7 +11705,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -11734,6 +11743,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      get-tsconfig: 4.14.1
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.17
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -11748,6 +11772,7 @@ snapshots:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:


### PR DESCRIPTION
## What
The offline SQLite mirror (ADR-005) was stored **in the clear**. Auth tokens and BYOK model keys already live in the OS keystore, but the ledger — groups, expenses, splits, balances, the mutation queue and autosaved drafts — sat as plaintext in the app sandbox, readable on a rooted/jailbroken device or from a file-level backup.

This seals every `json` payload at rest.

## How
- **Cipher** (`src/sync/rowCipher.ts`): XChaCha20-Poly1305 from `@noble/ciphers` — **pure JS, no native module**, so no SQLCipher/`op-sqlite` swap and no autolinking break on this Expo SDK 57 pin. 256-bit data-encryption key generated once via `expo-crypto` and held in `expo-secure-store` (Keystore/Keychain, `AFTER_FIRST_UNLOCK`). Random 192-bit nonce per value; values stored as `v1:<base64(nonce‖ciphertext)>`.
- **Why app-layer, not SQLCipher**: the sensitive content lives **only** in the `json` columns, always read/written whole (no `WHERE`/`ORDER` ever touches it). `group_id` (UUID) / `seq` / draft `key` / `saved_at` stay plaintext so queries and the hydration index are unchanged.
- **Driver** (`src/sync/driver.ts`): encrypt on write, decrypt on read; the key is loaded once per call and the per-row transform stays **synchronous**, so the chunked/yielding cold-start hydration path is untouched. Adds `PRAGMA secure_delete`. A one-time `PRAGMA user_version` migration seals any pre-existing plaintext in place and `wal_checkpoint(TRUNCATE)`s the WAL. Reads pass legacy plaintext through transparently, so no forced sign-out.
- **Sign-out = crypto-erase**: `reset()` wipes the tables **and destroys the key**, so any ciphertext lingering in WAL/free pages is unrecoverable and the next account mints a fresh key.
- **Web** (`src/sync/driver.web.ts`) stays plaintext **on purpose**: a browser has no keystore, so a JS-reachable key beside the data would protect nothing. Documented in the header; a future full web client would use IndexedDB + a non-extractable WebCrypto key.

## Trust boundary
Protects data **at rest** against off-device extraction, rooted-filesystem access and backup theft — the identified gap. Does **not** defend a running, unlocked, compromised device: the key is available to the app at runtime, the same posture as the already-shipped token/AI-key vaults. A biometric/lock-gated key (tie into `src/lib/lock.tsx`) is a possible follow-up.

## Tests
- `test/rowCipher.test.ts` (new): base64 round-trip, seal/open round-trip, legacy passthrough, tamper rejection, wrong-key rejection, unique nonces, key load/cache/destroy.
- `test/localStore.test.ts`: extended `FakeDatabase` (user_version + migration UPDATEs); asserts stored `json` is ciphertext (`v1:`, no plaintext), the one-time migration seals seeded legacy plaintext, and reset crypto-erases. Existing concurrency/lifecycle tests untouched.
- Full mobile suite green (553), typecheck 0, lint 0.

## Manual verification note
On-device DB pull found the mirror empty (the test emulator isn't signed in), so live ciphertext couldn't be observed with real data; the DB was opened this session (schema + fresh WAL present) and the unit tests cover the encrypt/migration/round-trip paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encryption for offline mobile data, including synced records, queued changes, and drafts.
  * Added tamper protection that binds stored data to its specific record context.
  * Securely stores encryption keys and removes them when local data is reset or the user signs out.
  * Automatically migrates existing locally stored data to encrypted storage.

* **Documentation**
  * Clarified web storage security behavior and how it differs from native mobile storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->