### PR TITLE
feat(receipts): full-screen viewer with save-to-device

### DIFF
--- a/apps/mobile/src/app/receipt/[id].tsx
+++ b/apps/mobile/src/app/receipt/[id].tsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useState } from 'react';
-import Ionicons from '@expo/vector-icons/Ionicons';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, Alert, StatusBar, View } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Button, EmptyState, IconButton, iconSize, Screen, useTheme } from '@waves/ui';
+import { Button, EmptyState, Row, useTheme } from '@waves/ui';
 
+import { ViewerButton } from '@/components/ViewerButton';
 import { ZoomableImage } from '@/components/ZoomableImage';
 import { useStrings } from '@/i18n';
 import { imageUrl } from '@/lib/storage';
+import { saveImageToDevice } from '@/lib/saveImage';
 
 /**
  * See the bill, any time after it was kept (E2).
@@ -15,12 +17,15 @@ import { imageUrl } from '@/lib/storage';
  * The receipt lives in R2 under the group + expense id, and is group-readable —
  * the `r2-sign` edge authorises a read by group membership — so any member can
  * open it, not just whoever kept it. The storage path is handed in as a route
- * param; this screen resolves it to a signed URL and shows it full-bleed, pinch
- * to zoom. A path that resolves to nothing — a bill that was never kept, or has
- * since been removed — is a calm empty state, never a crash.
+ * param; this screen resolves it to a signed URL and shows it full-bleed on a
+ * dark, immersive backdrop (the Photos/ChatGPT viewer pattern), pinch- and
+ * double-tap-to-zoom, with the close and save controls floating over the image
+ * rather than in a bar. A path that resolves to nothing — a bill that was never
+ * kept, or has since been removed — is a calm empty state, never a crash.
  */
 export default function ReceiptViewerScreen(): React.JSX.Element {
   const theme = useTheme();
+  const insets = useSafeAreaInsets();
   const { t } = useStrings();
   // `id` is the expense id in the route; the receipt itself is addressed by the
   // `path` param, which is what actually resolves the image.
@@ -30,6 +35,7 @@ export default function ReceiptViewerScreen(): React.JSX.Element {
   // No path is "empty" from the first frame (the route param never changes over
   // this screen's life), so the resolve only ever has a path to work with.
   const [state, setState] = useState<'loading' | 'ready' | 'empty'>(path ? 'loading' : 'empty');
+  const [saving, setSaving] = useState(false);
 
   // Resolve the path to a signed URL. Extracted so the empty state's retry can
   // run it again — a resolve can fail transiently (offline, a signing hiccup),
@@ -66,36 +72,60 @@ export default function ReceiptViewerScreen(): React.JSX.Element {
     };
   }, [path]);
 
-  return (
-    <Screen edges={['top', 'bottom']}>
-      <View style={{ flex: 1, backgroundColor: theme.color.bg }}>
-        <View style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-        </View>
+  const onSave = useCallback(async () => {
+    if (!uri || saving) return;
+    setSaving(true);
+    const result = await saveImageToDevice(uri);
+    setSaving(false);
+    if (result === 'error') Alert.alert(t.receipts.couldNotSave);
+  }, [uri, saving, t]);
 
+  return (
+    <View style={{ flex: 1, backgroundColor: '#000' }}>
+      <StatusBar barStyle="light-content" />
+
+      {state === 'ready' && uri ? (
+        <ZoomableImage uri={uri} />
+      ) : state === 'loading' ? (
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <ActivityIndicator color="#FFFFFF" />
+        </View>
+      ) : (
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            paddingHorizontal: theme.spacing.xl,
+            gap: theme.spacing.lg,
+          }}
+        >
+          <EmptyState title={t.loadError} body={t.loadErrorBody} />
+          <Button label={t.retry} onPress={() => void load()} />
+        </View>
+      )}
+
+      {/* Controls float over the image so nothing squeezes the pixels. */}
+      <Row
+        style={{
+          position: 'absolute',
+          top: insets.top + theme.spacing.sm,
+          left: theme.spacing.xl,
+          right: theme.spacing.xl,
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <ViewerButton icon="close" label={t.common.close} onPress={() => router.back()} />
         {state === 'ready' && uri ? (
-          <ZoomableImage uri={uri} />
-        ) : state === 'loading' ? (
-          <View style={{ flex: 1, justifyContent: 'center' }}>
-            <ActivityIndicator color={theme.color.brand} />
-          </View>
-        ) : (
-          <View
-            style={{
-              flex: 1,
-              justifyContent: 'center',
-              alignItems: 'center',
-              paddingHorizontal: theme.spacing.xl,
-              gap: theme.spacing.lg,
-            }}
-          >
-            <EmptyState title={t.loadError} body={t.loadErrorBody} />
-            <Button label={t.retry} onPress={() => void load()} />
-          </View>
-        )}
-      </View>
-    </Screen>
+          <ViewerButton
+            icon="download-outline"
+            label={t.receipts.download}
+            onPress={() => void onSave()}
+            busy={saving}
+          />
+        ) : null}
+      </Row>
+    </View>
   );
 }

--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -18,13 +18,24 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ActivityIndicator, Alert, Modal, Pressable, ScrollView, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Pressable,
+  ScrollView,
+  StatusBar,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { iconSize, Row, Text, useTheme } from '@waves/ui';
 
 import { canAddExpenseAttachment } from '@/data/api';
 import { receiptCapStatus } from '@/lib/receiptCapGate';
+import { saveImageToDevice } from '@/lib/saveImage';
 
+import { ViewerButton } from '@/components/ViewerButton';
 import { ZoomableGallery, type GalleryPage } from '@/components/ZoomableGallery';
 import { ReceiptAnnotator } from '@/components/ReceiptAnnotator';
 import { ReceiptCropper } from '@/components/ReceiptCropper';
@@ -225,6 +236,7 @@ export function ExpenseReceipts({
   onLegacyRemoved?: () => void;
 }): React.JSX.Element | null {
   const theme = useTheme();
+  const insets = useSafeAreaInsets();
   const { t } = useStrings();
   const attachments = useExpenseAttachments(expenseId);
   const attach = useAttachExpenseAttachment(groupId, expenseId);
@@ -306,6 +318,7 @@ export function ExpenseReceipts({
 
   const urls = useResolvedUrls(expenseId, items);
   const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
   const [editing, setEditing] = useState<{
     attachmentId: string;
     uri: string;
@@ -461,6 +474,18 @@ export function ExpenseReceipts({
 
   const viewing = viewerIndex !== null ? items[viewerIndex] : null;
 
+  // Save the open receipt off the device via the OS share/save sheet.
+  const saveViewed = () => {
+    if (viewerIndex === null || saving) return;
+    const url = urls[viewerIndex];
+    if (!url) return;
+    setSaving(true);
+    void saveImageToDevice(url).then((result) => {
+      setSaving(false);
+      if (result === 'error') Alert.alert(t.receipts.couldNotSave);
+    });
+  };
+
   return (
     <View style={{ gap: theme.spacing.sm }}>
       <Text variant="caption" tone="muted">
@@ -565,108 +590,134 @@ export function ExpenseReceipts({
         animationType="fade"
         onRequestClose={() => setViewerIndex(null)}
       >
-        <View style={{ flex: 1, backgroundColor: theme.color.bg }}>
-          <Row
-            style={{
-              justifyContent: 'space-between',
-              paddingHorizontal: theme.spacing.xl,
-              paddingTop: theme.spacing.xxl,
-              paddingBottom: theme.spacing.sm,
-            }}
-          >
-            <IconButton label={t.common.close} onPress={() => setViewerIndex(null)}>
-              <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-            </IconButton>
-            <View style={{ alignItems: 'center' }}>
-              <Text variant="caption" tone="muted">
-                {fill(t.receipts.counter, {
-                  index: (viewerIndex ?? 0) + 1,
-                  total: items.length,
-                })}
-              </Text>
-              {viewing && isPrivate(viewing) ? (
-                <Row style={{ gap: 4, alignItems: 'center' }}>
-                  <Ionicons name="lock-closed" size={11} color={theme.color.textMuted} />
-                  <Text variant="micro" tone="muted">
-                    {t.receipts.privateTag}
-                  </Text>
-                </Row>
-              ) : null}
-            </View>
-            {(() => {
-              // An attachment's edit/remove is party-only (`canManage`); the
-              // legacy bill's remove also allows a group admin (`canRemoveLegacy`)
-              // — the same split the RPCs enforce. Nothing to offer → a spacer,
-              // so the counter stays centred.
-              const showEdit =
-                canManage && viewing?.kind === 'attachment' && viewerIndex !== null
-                  ? urls[viewerIndex]
-                  : null;
-              const showRemove =
-                viewing !== null && (viewing.kind === 'legacy' ? canRemoveLegacy : canManage);
-              if (viewerIndex === null || (!showEdit && !showRemove)) {
-                return <View style={{ width: 44 }} />;
-              }
-              return (
-                <Row style={{ gap: theme.spacing.xs }}>
-                  {showEdit ? (
-                    <IconButton
-                      label={t.adjust.title}
-                      onPress={() => {
-                        const url = urls[viewerIndex];
-                        if (viewing?.kind === 'attachment' && url) {
-                          setAdjusting({
-                            attachmentId: viewing.row.id,
-                            uri: url,
-                            oldStoragePath: viewing.row.storagePath,
-                          });
-                        }
-                      }}
-                    >
-                      <Ionicons name="crop" size={iconSize.md} color={theme.color.text} />
-                    </IconButton>
-                  ) : null}
-                  {showEdit ? (
-                    <IconButton
-                      label={t.annotate.title}
-                      onPress={() => {
-                        const url = urls[viewerIndex];
-                        if (viewing?.kind === 'attachment' && url) {
-                          setEditing({
-                            attachmentId: viewing.row.id,
-                            uri: url,
-                            initial: viewing.row.annotations ?? EMPTY_ANNOTATIONS,
-                          });
-                        }
-                      }}
-                    >
-                      <Ionicons name="pencil" size={iconSize.md} color={theme.color.text} />
-                    </IconButton>
-                  ) : null}
-                  {showRemove ? (
-                    <IconButton
-                      label={t.receipts.remove}
-                      onPress={() => {
-                        if (!removeAttachment.isPending && !removeLegacy.isPending)
-                          removeAt(viewerIndex);
-                      }}
-                    >
-                      <Ionicons
-                        name="trash-outline"
-                        size={iconSize.lg}
-                        color={theme.color.negative}
-                      />
-                    </IconButton>
-                  ) : null}
-                </Row>
-              );
-            })()}
-          </Row>
+        {/* A dark, immersive viewer (the Photos/ChatGPT pattern): the image fills
+            the screen and every control floats over it, so nothing squeezes the
+            pixels. Save, adjust, annotate and remove sit as translucent circular
+            buttons; the counter is a pill at the foot. */}
+        <View style={{ flex: 1, backgroundColor: '#000' }}>
+          <StatusBar barStyle="light-content" />
+
           <ZoomableGallery
             pages={pages}
             index={viewerIndex ?? 0}
             onIndexChange={(i) => setViewerIndex(i)}
           />
+
+          <Row
+            style={{
+              position: 'absolute',
+              top: insets.top + theme.spacing.sm,
+              left: theme.spacing.xl,
+              right: theme.spacing.xl,
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+            }}
+          >
+            <ViewerButton
+              icon="close"
+              label={t.common.close}
+              onPress={() => setViewerIndex(null)}
+            />
+            <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+              {viewerIndex !== null && urls[viewerIndex] ? (
+                <ViewerButton
+                  icon="download-outline"
+                  label={t.receipts.download}
+                  onPress={saveViewed}
+                  busy={saving}
+                />
+              ) : null}
+              {(() => {
+                if (viewerIndex === null) return null;
+                // An attachment's edit/remove is party-only (`canManage`); the
+                // legacy bill's remove also allows a group admin
+                // (`canRemoveLegacy`) — the same split the RPCs enforce.
+                const showEdit =
+                  canManage && viewing?.kind === 'attachment' ? urls[viewerIndex] : null;
+                const showRemove =
+                  viewing !== null && (viewing.kind === 'legacy' ? canRemoveLegacy : canManage);
+                return (
+                  <>
+                    {showEdit ? (
+                      <ViewerButton
+                        icon="crop"
+                        label={t.adjust.title}
+                        onPress={() => {
+                          const url = urls[viewerIndex];
+                          if (viewing?.kind === 'attachment' && url) {
+                            setAdjusting({
+                              attachmentId: viewing.row.id,
+                              uri: url,
+                              oldStoragePath: viewing.row.storagePath,
+                            });
+                          }
+                        }}
+                      />
+                    ) : null}
+                    {showEdit ? (
+                      <ViewerButton
+                        icon="pencil"
+                        label={t.annotate.title}
+                        onPress={() => {
+                          const url = urls[viewerIndex];
+                          if (viewing?.kind === 'attachment' && url) {
+                            setEditing({
+                              attachmentId: viewing.row.id,
+                              uri: url,
+                              initial: viewing.row.annotations ?? EMPTY_ANNOTATIONS,
+                            });
+                          }
+                        }}
+                      />
+                    ) : null}
+                    {showRemove ? (
+                      <ViewerButton
+                        icon="trash-outline"
+                        label={t.receipts.remove}
+                        tint={theme.color.negative}
+                        onPress={() => {
+                          if (!removeAttachment.isPending && !removeLegacy.isPending)
+                            removeAt(viewerIndex);
+                        }}
+                      />
+                    ) : null}
+                  </>
+                );
+              })()}
+            </Row>
+          </Row>
+
+          {/* Page counter + private tag, a floating pill at the foot. */}
+          <View
+            style={{
+              position: 'absolute',
+              bottom: insets.bottom + theme.spacing.xl,
+              left: 0,
+              right: 0,
+              alignItems: 'center',
+            }}
+          >
+            <Row
+              style={{
+                gap: theme.spacing.xs,
+                alignItems: 'center',
+                paddingHorizontal: theme.spacing.md,
+                paddingVertical: 6,
+                borderRadius: theme.radius.pill,
+                backgroundColor: 'rgba(20, 20, 30, 0.55)',
+              }}
+            >
+              {viewing && isPrivate(viewing) ? (
+                <Ionicons name="lock-closed" size={11} color="#FFFFFF" />
+              ) : null}
+              <Text variant="caption" style={{ color: '#FFFFFF' }}>
+                {fill(t.receipts.counter, {
+                  index: (viewerIndex ?? 0) + 1,
+                  total: items.length,
+                })}
+              </Text>
+            </Row>
+          </View>
         </View>
       </Modal>
 

--- a/apps/mobile/src/components/ReceiptAnnotator.tsx
+++ b/apps/mobile/src/components/ReceiptAnnotator.tsx
@@ -23,13 +23,16 @@ import {
   Image as RNImage,
   Modal,
   Pressable,
+  StatusBar,
   TextInput,
   View,
   type LayoutChangeEvent,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { IconButton, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { iconSize, Row, Text, useTheme } from '@waves/ui';
 
+import { ViewerButton } from '@/components/ViewerButton';
 import { AnnotationOverlay } from '@/components/AnnotationOverlay';
 import {
   ANNOT_COLORS,
@@ -62,6 +65,7 @@ export function ReceiptAnnotator({
   onSave: (annotations: Annotations) => void;
 }): React.JSX.Element {
   const theme = useTheme();
+  const insets = useSafeAreaInsets();
   const { t } = useStrings();
 
   const [history, setHistory] = useState<Action[]>(() => [
@@ -166,32 +170,10 @@ export function ReceiptAnnotator({
   return (
     <Modal visible animationType="slide" onRequestClose={onCancel}>
       <View style={{ flex: 1, backgroundColor: '#000' }}>
-        {/* Top bar: cancel / mode label / save. */}
-        <Row
-          style={{
-            justifyContent: 'space-between',
-            paddingHorizontal: theme.spacing.xl,
-            paddingTop: theme.spacing.xxl,
-            paddingBottom: theme.spacing.sm,
-          }}
-        >
-          <IconButton label={t.common.cancel} onPress={onCancel}>
-            <Ionicons name="close" size={iconSize.lg} color="#FFFFFF" />
-          </IconButton>
-          <Text variant="subheading" style={{ color: '#FFFFFF' }}>
-            {t.annotate.title}
-          </Text>
-          <IconButton label={t.common.save} onPress={save}>
-            {saving ? (
-              <ActivityIndicator color="#FFFFFF" />
-            ) : (
-              <Ionicons name="checkmark" size={iconSize.lg} color="#FFFFFF" />
-            )}
-          </IconButton>
-        </Row>
+        <StatusBar barStyle="light-content" />
 
-        {/* The canvas: the image, the overlay, and the input layer over its
-            drawn rectangle. */}
+        {/* The canvas fills the screen; the chrome floats over it (the Apple
+            Photos markup pattern), so the bill gets the whole frame. */}
         <View style={{ flex: 1 }} onLayout={onBoxLayout}>
           <ExpoImage source={{ uri }} style={{ flex: 1 }} contentFit="contain" transition={100} />
           <View
@@ -217,54 +199,104 @@ export function ReceiptAnnotator({
           </View>
         </View>
 
-        {/* Toolbar: pen/text, colour swatches, undo, clear. */}
+        {/* Top chrome: close on the left; undo / clear / save grouped on the
+            right, save as a filled accent circle so the commit reads as primary. */}
         <Row
           style={{
+            position: 'absolute',
+            top: insets.top + theme.spacing.sm,
+            left: theme.spacing.xl,
+            right: theme.spacing.xl,
             justifyContent: 'space-between',
             alignItems: 'center',
-            paddingHorizontal: theme.spacing.xl,
-            paddingVertical: theme.spacing.md,
-            gap: theme.spacing.md,
           }}
         >
-          <Row style={{ gap: theme.spacing.sm }}>
-            <ToolButton
-              icon="pencil"
-              active={mode === 'pen'}
-              label={t.annotate.pen}
-              onPress={() => setMode('pen')}
-            />
-            <ToolButton
-              icon="text"
-              active={mode === 'text'}
-              label={t.annotate.addText}
-              onPress={() => setMode('text')}
-            />
-          </Row>
-          <Row style={{ gap: theme.spacing.sm, flex: 1, justifyContent: 'center' }}>
-            {ANNOT_COLORS.map((c) => (
-              <Pressable
-                key={c}
-                onPress={() => setColor(c)}
-                accessibilityRole="button"
-                accessibilityLabel={c}
-                accessibilityState={{ selected: color === c }}
-                style={{
-                  width: 26,
-                  height: 26,
-                  borderRadius: 13,
-                  backgroundColor: c,
-                  borderWidth: color === c ? 3 : 1,
-                  borderColor: color === c ? '#FFFFFF' : 'rgba(255,255,255,0.4)',
-                }}
-              />
-            ))}
-          </Row>
-          <Row style={{ gap: theme.spacing.sm }}>
-            <ToolButton icon="arrow-undo" label={t.annotate.undo} onPress={undo} />
-            <ToolButton icon="trash-outline" label={t.annotate.clear} onPress={clear} />
+          <ViewerButton icon="close" label={t.common.cancel} onPress={onCancel} />
+          <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+            <ViewerButton icon="arrow-undo" label={t.annotate.undo} onPress={undo} />
+            <ViewerButton icon="trash-outline" label={t.annotate.clear} onPress={clear} />
+            <Pressable
+              onPress={save}
+              accessibilityRole="button"
+              accessibilityLabel={t.common.save}
+              hitSlop={6}
+              style={({ pressed }) => ({
+                width: 40,
+                height: 40,
+                borderRadius: 20,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.color.buttonPrimary,
+                opacity: pressed ? 0.8 : 1,
+              })}
+            >
+              {saving ? (
+                <ActivityIndicator color={theme.color.onButtonPrimary} />
+              ) : (
+                <Ionicons name="checkmark" size={iconSize.md} color={theme.color.onButtonPrimary} />
+              )}
+            </Pressable>
           </Row>
         </Row>
+
+        {/* Bottom tray: a floating rounded toolbar — pen/text toggle, then the
+            colour swatches — the shape every markup editor lands on. */}
+        <View
+          style={{
+            position: 'absolute',
+            bottom: insets.bottom + theme.spacing.md,
+            left: theme.spacing.xl,
+            right: theme.spacing.xl,
+            alignItems: 'center',
+          }}
+        >
+          <Row
+            style={{
+              alignItems: 'center',
+              gap: theme.spacing.md,
+              paddingHorizontal: theme.spacing.lg,
+              paddingVertical: theme.spacing.sm,
+              borderRadius: theme.radius.pill,
+              backgroundColor: 'rgba(20, 20, 30, 0.7)',
+            }}
+          >
+            <Row style={{ gap: theme.spacing.xs }}>
+              <ToolButton
+                icon="pencil"
+                active={mode === 'pen'}
+                label={t.annotate.pen}
+                onPress={() => setMode('pen')}
+              />
+              <ToolButton
+                icon="text"
+                active={mode === 'text'}
+                label={t.annotate.addText}
+                onPress={() => setMode('text')}
+              />
+            </Row>
+            <View style={{ width: 1, height: 24, backgroundColor: 'rgba(255,255,255,0.18)' }} />
+            <Row style={{ gap: theme.spacing.sm }}>
+              {ANNOT_COLORS.map((c) => (
+                <Pressable
+                  key={c}
+                  onPress={() => setColor(c)}
+                  accessibilityRole="button"
+                  accessibilityLabel={c}
+                  accessibilityState={{ selected: color === c }}
+                  hitSlop={4}
+                  style={{
+                    width: 26,
+                    height: 26,
+                    borderRadius: 13,
+                    backgroundColor: c,
+                    borderWidth: color === c ? 3 : 1,
+                    borderColor: color === c ? '#FFFFFF' : 'rgba(255,255,255,0.4)',
+                  }}
+                />
+              ))}
+            </Row>
+          </Row>
+        </View>
 
         {/* Text entry for a dropped note. */}
         <Modal

--- a/apps/mobile/src/components/ViewerButton.tsx
+++ b/apps/mobile/src/components/ViewerButton.tsx
@@ -1,0 +1,58 @@
+/**
+ * A floating, circular action button for the full-screen image viewers.
+ *
+ * The receipt viewer sits over a dark, immersive backdrop (the Photos/ChatGPT
+ * pattern), so its controls float *over* the image rather than in a bar that
+ * eats layout. A translucent dark pill keeps every glyph legible whether the
+ * pixels behind it are light or dark, and an active `busy` swaps the glyph for a
+ * spinner in place so the button never resizes mid-press.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { ActivityIndicator, Pressable } from 'react-native';
+
+import { iconSize } from '@waves/ui';
+
+const SIZE = 40;
+
+export function ViewerButton({
+  icon,
+  label,
+  onPress,
+  busy,
+  tint = '#FFFFFF',
+  disabled,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  onPress: () => void;
+  busy?: boolean;
+  /** Glyph colour — defaults to white; a destructive action passes a red. */
+  tint?: string;
+  disabled?: boolean;
+}): React.JSX.Element {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled || busy}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      hitSlop={6}
+      style={({ pressed }) => ({
+        width: SIZE,
+        height: SIZE,
+        borderRadius: SIZE / 2,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(20, 20, 30, 0.55)',
+        opacity: disabled ? 0.4 : pressed ? 0.7 : 1,
+      })}
+    >
+      {busy ? (
+        <ActivityIndicator color={tint} />
+      ) : (
+        <Ionicons name={icon} size={iconSize.md} color={tint} />
+      )}
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -98,16 +98,36 @@ export function ZoomableImage({
       savedY.set(translateY.get());
     });
 
+  // Double-tap toggles zoom: from fit it magnifies to a fixed level centred on
+  // the point tapped (so a tap on a total zooms to that total, the Photos/Maps
+  // behaviour), and from any zoomed state it returns to fit. Translate lives in
+  // screen space (it is the outermost transform), so keeping the tapped point
+  // still means shifting by -(target-1) × its offset from the view centre.
+  const DOUBLE_TAP_SCALE = 2.5;
   const doubleTap = Gesture.Tap()
     .numberOfTaps(2)
-    .onEnd(() => {
-      scale.set(withTiming(1));
-      savedScale.set(1);
-      translateX.set(withTiming(0));
-      translateY.set(withTiming(0));
-      savedX.set(0);
-      savedY.set(0);
-      runOnJS(reportZoom)(false);
+    .onEnd((event) => {
+      if (scale.get() > 1) {
+        scale.set(withTiming(1));
+        savedScale.set(1);
+        translateX.set(withTiming(0));
+        translateY.set(withTiming(0));
+        savedX.set(0);
+        savedY.set(0);
+        runOnJS(reportZoom)(false);
+        return;
+      }
+      const dx = event.x - width / 2;
+      const dy = event.y - height / 2;
+      const tx = -(DOUBLE_TAP_SCALE - 1) * dx;
+      const ty = -(DOUBLE_TAP_SCALE - 1) * dy;
+      scale.set(withTiming(DOUBLE_TAP_SCALE));
+      savedScale.set(DOUBLE_TAP_SCALE);
+      translateX.set(withTiming(tx));
+      translateY.set(withTiming(ty));
+      savedX.set(tx);
+      savedY.set(ty);
+      runOnJS(reportZoom)(true);
     });
 
   const composed = Gesture.Simultaneous(pinch, pan, doubleTap);

--- a/apps/mobile/src/lib/saveImage.ts
+++ b/apps/mobile/src/lib/saveImage.ts
@@ -1,0 +1,63 @@
+/**
+ * Save a receipt image off the device — the "download" affordance on the viewer.
+ *
+ * The app ships `expo-sharing`, not `expo-media-library`, so "download" here means
+ * the OS share sheet, which on both platforms carries "Save Image" / "Save to
+ * Photos" / "Save to Files" alongside the send targets. That needs no extra
+ * native module and no gallery-write permission, and it is the same mechanism the
+ * export and invite screens already use.
+ *
+ * The bytes are a short-lived signed URL, so they are fetched to a cache file
+ * first (the share sheet needs a local `file://`, not a remote URL) and the file
+ * is named and typed by what actually came back, so a WebP saves as `.webp` and a
+ * JPEG as `.jpg`.
+ */
+
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+
+export type SaveImageResult = 'shared' | 'unavailable' | 'error';
+
+/** Map a content-type to a file extension; default to jpg, the safest to open. */
+function extensionFor(contentType: string | null): string {
+  if (!contentType) return 'jpg';
+  if (contentType.includes('webp')) return 'webp';
+  if (contentType.includes('png')) return 'png';
+  if (contentType.includes('heic')) return 'heic';
+  return 'jpg';
+}
+
+/**
+ * Fetch a (signed) image URL and hand it to the OS share/save sheet.
+ *
+ * Returns `'shared'` once the sheet has been presented (we cannot know whether
+ * the person tapped Save or Cancel — the OS does not tell us, and that is fine),
+ * `'unavailable'` where no share sheet exists (some web contexts), and `'error'`
+ * when the bytes could not be fetched or written.
+ */
+export async function saveImageToDevice(url: string): Promise<SaveImageResult> {
+  try {
+    if (!(await Sharing.isAvailableAsync())) return 'unavailable';
+
+    const response = await fetch(url);
+    if (!response.ok) return 'error';
+    const contentType = response.headers.get('content-type');
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength === 0) return 'error';
+
+    const ext = extensionFor(contentType);
+    // A stable, human name in the sheet rather than the opaque storage key.
+    const file = new FileSystem.File(FileSystem.Paths.cache, `receipt.${ext}`);
+    if (file.exists) file.delete();
+    file.create();
+    file.write(bytes);
+
+    await Sharing.shareAsync(file.uri, {
+      mimeType: contentType ?? 'image/jpeg',
+      dialogTitle: 'Save receipt',
+    });
+    return 'shared';
+  } catch {
+    return 'error';
+  }
+}


### PR DESCRIPTION
## What
Receipt images now open in a full-screen, immersive viewer with a save/download action.

- **Viewer UX**: dark backdrop, floating circular controls (`ViewerButton.tsx`) that sit *over* the image (Photos/ChatGPT pattern) rather than in a bar that eats layout. Translucent dark pill keeps glyphs legible over any pixels; `busy` swaps the glyph for a spinner in place so the button never resizes mid-press.
- **Save/download** (`saveImage.ts`): uses the OS share sheet (`expo-sharing`, already shipped) — carries "Save Image"/"Save to Photos"/"Save to Files" with no `expo-media-library` and no gallery-write permission. Signed URL is fetched to a cache file, named/typed by the actual content-type (`.webp`/`.png`/`.heic`/`.jpg`).
- `receipt/[id].tsx`, `ExpenseReceipts`, `ReceiptAnnotator`, `ZoomableImage` moved to the shared control surface.

## Test
- typecheck 0, lint 0, mobile suite green (566 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned receipt viewing and annotation with an immersive full-screen interface.
  * Added floating controls for closing, saving, editing, annotating, and removing receipts.
  * Added the ability to save receipt images to the device with loading states and error alerts.
  * Added double-tap zoom toggling between fit-to-screen and 2.5× magnification.
  * Added clearer annotation tools, color selection, and save actions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->