### PR TITLE
fix(sync): carry baseVersionNo through the offline write queue

### DIFF
--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -91,6 +91,7 @@ import {
   type PersonContribution,
 } from './peopleBalances';
 import { totalsByCurrency } from './totals';
+import { serialiseExpense } from './serialiseExpense';
 import { putImage, removeRestrictedImage } from '@/lib/storage';
 import { pickAlbumPhoto, type PickedImage } from '@/lib/image';
 import { parseAnnotations, type Annotations } from '@/lib/annotations';
@@ -848,36 +849,6 @@ export function invalidateGroup(queryClient: QueryClient, groupId: string): void
 }
 
 // ─────────────────────────────────────────────────────────── mutations ──
-
-/**
- * bigint does not survive JSON, and the queue is JSON on disk. Amounts go as
- * decimal strings and come back exact — the one thing money may never do here
- * is round-trip through a float.
- */
-function serialiseExpense(input: Omit<WriteExpenseInput, 'groupId'>): Record<string, unknown> {
-  return {
-    description: input.description.trim(),
-    category: input.category ?? null,
-    expenseDate: input.expenseDate,
-    currency: input.currency,
-    amount: input.amount.toString(),
-    fx: input.fx ?? null,
-    splitParams: input.splitParams,
-    participants: input.participants,
-    payers: Object.fromEntries(
-      Object.entries(input.payers).map(([member, amount]) => [member, amount.toString()]),
-    ),
-    expectedShares: input.expectedShares
-      ? Object.fromEntries(
-          Object.entries(input.expectedShares).map(([member, share]) => [member, share.toString()]),
-        )
-      : undefined,
-    notes: input.notes ?? null,
-    paymentMethod: input.paymentMethod ?? null,
-    categoryMeta: input.categoryMeta ?? null,
-    location: input.location ?? null,
-  };
-}
 
 /**
  * Every write below queues rather than calls.

--- a/apps/mobile/src/data/serialiseExpense.ts
+++ b/apps/mobile/src/data/serialiseExpense.ts
@@ -1,0 +1,59 @@
+/**
+ * Serialise an expense write into the JSON envelope the `/sync` queue stores on
+ * disk (`driver.ts`) and later replays to the `sync` edge function.
+ *
+ * Kept in its own module — free of any React Native import — for two reasons:
+ * the mapping is the whole serialisation surface of `useWriteExpense`, and it can
+ * be unit-tested directly (importing `data/hooks.ts` pulls React Native through
+ * the graph and breaks the vitest/Rollup transform on Flow syntax, the same
+ * reason `expenseWriteBody.test.ts` tests the pure `@waves/core` builder). The
+ * only dependency here is the `WriteExpenseInput` *type*, imported type-only so
+ * it is erased at build and carries none of `api.ts`'s runtime deps.
+ *
+ * Every field the `sync` edge reads off the envelope (see `buildApplyExpenseArgs`
+ * in `@waves/core`, and the `payload.*` reads in `supabase/functions/sync`) must
+ * be produced here, or an offline write silently loses it relative to the direct
+ * `expense-write` path — the parity hole this contract exists to prevent.
+ */
+
+import type { WriteExpenseInput } from './api';
+
+/**
+ * bigint does not survive JSON, and the queue is JSON on disk. Amounts go as
+ * decimal strings and come back exact — the one thing money may never do here
+ * is round-trip through a float.
+ */
+export function serialiseExpense(
+  input: Omit<WriteExpenseInput, 'groupId'>,
+): Record<string, unknown> {
+  return {
+    description: input.description.trim(),
+    category: input.category ?? null,
+    expenseDate: input.expenseDate,
+    currency: input.currency,
+    amount: input.amount.toString(),
+    fx: input.fx ?? null,
+    splitParams: input.splitParams,
+    participants: input.participants,
+    payers: Object.fromEntries(
+      Object.entries(input.payers).map(([member, amount]) => [member, amount.toString()]),
+    ),
+    expectedShares: input.expectedShares
+      ? Object.fromEntries(
+          Object.entries(input.expectedShares).map(([member, share]) => [member, share.toString()]),
+        )
+      : undefined,
+    notes: input.notes ?? null,
+    paymentMethod: input.paymentMethod ?? null,
+    categoryMeta: input.categoryMeta ?? null,
+    location: input.location ?? null,
+    // The `/sync` edge reads all three off the queued envelope (buildApplyExpenseArgs
+    // in @waves/core), so they must survive the queue or an offline write silently
+    // loses them versus the direct path. baseVersionNo is the one an offline *edit*
+    // sets today (add-expense.tsx) — dropping it skipped the concurrent-edit conflict
+    // check (TDR §4.4); receiptId/receiptShareUrl are carried for the same parity.
+    baseVersionNo: input.baseVersionNo ?? null,
+    receiptId: input.receiptId ?? null,
+    receiptShareUrl: input.receiptShareUrl ?? null,
+  };
+}

--- a/apps/mobile/test/serialiseExpense.test.ts
+++ b/apps/mobile/test/serialiseExpense.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `serialiseExpense` is the whole serialisation surface of `useWriteExpense`: it
+ * turns an expense write into the JSON envelope the `/sync` queue stores and
+ * replays. Every field the `sync` edge reads back off that envelope
+ * (`buildApplyExpenseArgs` in `@waves/core`, and the `payload.*` reads in
+ * `supabase/functions/sync`) must be produced here, or an offline write silently
+ * loses it relative to the direct `expense-write` path.
+ *
+ * The regression this pins: the envelope used to drop `baseVersionNo`, so an
+ * offline *edit* skipped the concurrent-edit conflict check (TDR §4.4) that the
+ * direct path had; `receiptId`/`receiptShareUrl` were the same latent hole.
+ *
+ * Tested here (not through `data/hooks.ts`) on purpose: importing hooks pulls
+ * React Native through the graph and breaks the vitest/Rollup transform on Flow
+ * syntax — the same reason `expenseWriteBody.test.ts` tests the pure builder.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { serialiseExpense } from '../src/data/serialiseExpense';
+
+const base = {
+  description: '  Dinner  ',
+  expenseDate: '2026-03-01',
+  currency: 'INR',
+  amount: 2000n,
+  splitParams: { kind: 'equal' as const },
+  participants: ['m1', 'm2'],
+  payers: { m1: 2000n },
+} satisfies Parameters<typeof serialiseExpense>[0];
+
+describe('serialiseExpense', () => {
+  it('carries baseVersionNo, receiptId and receiptShareUrl through the queue (parity)', () => {
+    const out = serialiseExpense({
+      ...base,
+      baseVersionNo: 4,
+      receiptId: 'r1',
+      receiptShareUrl: 'https://drive.example/abc',
+    });
+    expect(out.baseVersionNo).toBe(4);
+    expect(out.receiptId).toBe('r1');
+    expect(out.receiptShareUrl).toBe('https://drive.example/abc');
+  });
+
+  it('defaults the parity fields to null when absent (a fresh create)', () => {
+    const out = serialiseExpense(base);
+    expect(out.baseVersionNo).toBeNull();
+    expect(out.receiptId).toBeNull();
+    expect(out.receiptShareUrl).toBeNull();
+  });
+
+  it('serialises money as decimal strings, never bigint or float', () => {
+    const out = serialiseExpense({
+      ...base,
+      payers: { m1: 1500n, m2: 500n },
+      expectedShares: { m1: 1000n, m2: 1000n },
+    });
+    expect(out.amount).toBe('2000');
+    expect(out.payers).toEqual({ m1: '1500', m2: '500' });
+    expect(out.expectedShares).toEqual({ m1: '1000', m2: '1000' });
+  });
+
+  it('trims the description and leaves expectedShares undefined when not given', () => {
+    const out = serialiseExpense(base);
+    expect(out.description).toBe('Dinner');
+    expect(out.expectedShares).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What
The mobile write queue's `serialiseExpense` dropped `baseVersionNo`, so an **offline edit** reached the `/sync` edge with no base version — skipping the concurrent-edit conflict check (TDR §4.4) that the direct `expense-write` path performs. Two devices editing the same expense offline would silently overwrite each other instead of logging a conflict.

`receiptId` and `receiptShareUrl` were the same latent hole: read by the sync edge (`payload.*` → `buildApplyExpenseArgs`) but never produced by the queue.

## Fix
- Add all three fields to the queued envelope.
- Extract `serialiseExpense` into its own **React Native-free** module (`data/serialiseExpense.ts`, type-only `WriteExpenseInput` import) so it can be unit-tested directly — importing `data/hooks.ts` pulls RN through the graph and breaks the vitest/Rollup transform on Flow syntax (the constraint `expenseWriteBody.test.ts` documents).
- New `test/serialiseExpense.test.ts`: pins the three parity fields (present + null default) and the bigint→decimal-string money contract.

## Context
Completes the follow-up noted when #459 landed the shared `expenseWrite.ts` builder — that closed the *direct* path's parity gap; this closes the *offline queue* side.

## Test
typecheck 0, lint 0, mobile suite 570 passed (+4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving expenses for later synchronization.
  * Preserved expense details, receipt information, edit versions, and payment data during queued writes.
  * Normalized amounts and optional fields to ensure consistent data handling.
* **Tests**
  * Added coverage for queued expense data, including trimmed descriptions, default values, and monetary formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->