### PR TITLE
fix(mobile): clear private files on sign out

### DIFF
--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -83,12 +83,20 @@ export default function ExportScreen() {
         sizeBytes = result.content.length;
       }
 
-      if (await Sharing.isAvailableAsync()) {
-        await Sharing.shareAsync(file.uri, {
-          mimeType: result.contentType,
-          dialogTitle: t.exportData.shareTitle,
-          UTI: UTI[format],
-        });
+      try {
+        if (await Sharing.isAvailableAsync()) {
+          await Sharing.shareAsync(file.uri, {
+            mimeType: result.contentType,
+            dialogTitle: t.exportData.shareTitle,
+            UTI: UTI[format],
+          });
+        }
+      } finally {
+        try {
+          if (file.exists) file.delete();
+        } catch {
+          // Best-effort privacy cleanup; sharing result still drives the UI.
+        }
       }
       setDone(`${result.filename} · ${Math.ceil(sizeBytes / 1024)} KB`);
     } catch (caught) {

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -184,7 +184,13 @@ export default function ImportScreen() {
       setFileGroupIndex(0);
       setParsed(null);
 
-      const text = new FileSystem.File(asset.uri).textSync();
+      const pickedFile = new FileSystem.File(asset.uri);
+      const text = pickedFile.textSync();
+      try {
+        if (pickedFile.exists) pickedFile.delete();
+      } catch {
+        // Best-effort privacy cleanup; parsing has already copied the content into memory.
+      }
       setFile(asset.name);
 
       // Asked of the contents, not the extension: a file saved from a browser

--- a/apps/mobile/src/lib/aiKeys.ts
+++ b/apps/mobile/src/lib/aiKeys.ts
@@ -107,6 +107,9 @@ export function aiProvider(id: AiProviderId): AiProvider {
 }
 
 const isWeb = Platform.OS === 'web';
+const SECURE_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+};
 
 /**
  * The one keystore entry the whole vault is: a single JSON record naming the
@@ -173,7 +176,11 @@ export async function getAiKey(id: AiProviderId): Promise<string | null> {
  */
 export async function setActiveAiKey(id: AiProviderId, key: string): Promise<void> {
   if (isWeb) throw new Error('secure storage is unavailable on web');
-  await SecureStore.setItemAsync(STORE_KEY, JSON.stringify({ id, key: key.trim() }));
+  await SecureStore.setItemAsync(
+    STORE_KEY,
+    JSON.stringify({ id, key: key.trim() }),
+    SECURE_OPTIONS,
+  );
   // A newly connected key is a fresh slate — on, no model override, no ceiling,
   // zero usage — so nothing from a previous key or account carries over.
   await resetAiSettings();

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -76,6 +76,26 @@ async function writeQueue(queue: readonly PendingReceipt[]): Promise<void> {
   await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
 }
 
+function cleanupOrphanFiles(queue: readonly PendingReceipt[]): void {
+  try {
+    const dir = new Directory(Paths.document, PENDING_DIR);
+    if (!dir.exists) return;
+    const keep = new Set(queue.map((entry) => entry.fileName));
+    const entries = (dir as unknown as { list?: () => unknown[] }).list?.() ?? [];
+    for (const item of entries) {
+      const file = item instanceof File ? item : null;
+      if (!file || keep.has(file.name)) continue;
+      try {
+        if (file.exists) file.delete();
+      } catch {
+        // Best-effort orphan cleanup; continue with the rest.
+      }
+    }
+  } catch {
+    // Directory listing is best-effort and may not be available in every runtime.
+  }
+}
+
 /** The durable file holding one pending capture's bytes. */
 function pendingFile(entry: Pick<PendingReceipt, 'fileName'>): File {
   return new File(Paths.document, PENDING_DIR, entry.fileName);
@@ -99,6 +119,7 @@ export async function isOnline(): Promise<boolean> {
 /** Every pending capture, or those for one expense, oldest first. */
 export async function listPendingReceipts(expenseId?: string): Promise<PendingReceipt[]> {
   const queue = await readQueue();
+  cleanupOrphanFiles(queue);
   return expenseId ? queue.filter((entry) => entry.expenseId === expenseId) : queue;
 }
 

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -102,6 +102,29 @@ export async function listPendingReceipts(expenseId?: string): Promise<PendingRe
   return expenseId ? queue.filter((entry) => entry.expenseId === expenseId) : queue;
 }
 
+/** Sign-out/privacy cleanup: drop the queue index and every pending capture byte file. */
+export async function clearReceiptQueue(): Promise<void> {
+  const queue = await readQueue();
+  for (const entry of queue) {
+    try {
+      const file = pendingFile(entry);
+      if (file.exists) file.delete();
+    } catch {
+      // Best-effort cleanup; keep deleting the rest.
+    }
+  }
+
+  try {
+    const dir = new Directory(Paths.document, PENDING_DIR);
+    if (dir.exists) dir.delete();
+  } catch {
+    // Some file-system implementations cannot delete non-empty dirs; queued files
+    // above were already attempted, and the index removal below is the source of truth.
+  }
+
+  await AsyncStorage.removeItem(QUEUE_KEY);
+}
+
 /**
  * Park a picked image for later upload: write its bytes to a durable file and
  * record the queue entry. Returns the entry so the caller can show it at once.

--- a/apps/mobile/src/lib/saveImage.ts
+++ b/apps/mobile/src/lib/saveImage.ts
@@ -52,10 +52,18 @@ export async function saveImageToDevice(url: string): Promise<SaveImageResult> {
     file.create();
     file.write(bytes);
 
-    await Sharing.shareAsync(file.uri, {
-      mimeType: contentType ?? 'image/jpeg',
-      dialogTitle: 'Save receipt',
-    });
+    try {
+      await Sharing.shareAsync(file.uri, {
+        mimeType: contentType ?? 'image/jpeg',
+        dialogTitle: 'Save receipt',
+      });
+    } finally {
+      try {
+        if (file.exists) file.delete();
+      } catch {
+        // Best-effort privacy cleanup; the share outcome matters more than cleanup errors.
+      }
+    }
     return 'shared';
   } catch {
     return 'error';

--- a/apps/mobile/src/lib/secureStorage.ts
+++ b/apps/mobile/src/lib/secureStorage.ts
@@ -22,6 +22,9 @@ const countKey = (key: string) => `${key}.pn`;
 const partKey = (key: string, i: number) => `${key}.p${i}`;
 
 const isWeb = Platform.OS === 'web';
+const SECURE_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+};
 
 // Keys whose legacy plaintext has been cleared this process. If the removal
 // fails, the key is left out so a later read retries — otherwise the marker is
@@ -68,9 +71,13 @@ async function setItem(key: string, value: string): Promise<void> {
 
   const prev = Number(await SecureStore.getItemAsync(countKey(key))) || 0;
   const count = Math.max(1, Math.ceil(value.length / CHUNK));
-  await SecureStore.setItemAsync(countKey(key), String(count));
+  await SecureStore.setItemAsync(countKey(key), String(count), SECURE_OPTIONS);
   for (let i = 0; i < count; i++) {
-    await SecureStore.setItemAsync(partKey(key, i), value.slice(i * CHUNK, (i + 1) * CHUNK));
+    await SecureStore.setItemAsync(
+      partKey(key, i),
+      value.slice(i * CHUNK, (i + 1) * CHUNK),
+      SECURE_OPTIONS,
+    );
   }
   // A shorter new value leaves orphan chunks from the old one; clear them.
   for (let i = count; i < prev; i++) {

--- a/apps/mobile/src/lib/storage/imageCache.ts
+++ b/apps/mobile/src/lib/storage/imageCache.ts
@@ -27,6 +27,15 @@ const CACHE_DIR = 'receipt-image-cache';
 /** Downloads already in flight, keyed by the stable local cache identity. */
 const inFlightDownloads = new Map<string, Promise<string | null>>();
 
+/**
+ * Bumped by {@link clearImageCache}. A download started before a sign-out
+ * captures this value and refuses to write its bytes if it has changed by the
+ * time the response lands — otherwise a fetch still in flight when the account
+ * signs out would recreate the just-deleted cache and leave a private image on
+ * disk, defeating the whole point of the cleanup.
+ */
+let cacheGeneration = 0;
+
 function usablePath(path: string | null): string | null {
   if (!path || path.trim().length === 0) return null;
   return path;
@@ -122,12 +131,17 @@ export async function cacheImage(
     const existing = inFlightDownloads.get(inFlightKey);
     if (existing) return await existing;
 
+    // Snapshot the cache generation now: if a sign-out clears the cache while
+    // this fetch is in flight, the generation moves and we drop the bytes rather
+    // than writing them back into a cache the user just erased.
+    const generation = cacheGeneration;
     const download = (async () => {
       try {
         const response = await expoFetch(remoteUrl);
         if (!response.ok) return null;
         const bytes = await response.bytes();
         if (bytes.byteLength === 0) return null;
+        if (generation !== cacheGeneration) return null;
         writeAtomic(new Directory(Paths.cache, CACHE_DIR), file, bytes);
         return file.uri;
       } catch {
@@ -182,6 +196,9 @@ export function evictImage(bucket: LogicalBucket, path: string | null): void {
 
 /** Sign-out/privacy cleanup: remove every cached receipt/proof/attachment image. */
 export function clearImageCache(): void {
+  // Move the generation first, so any download already awaiting a response sees
+  // the change and skips its write even if it resolves after this returns.
+  cacheGeneration += 1;
   try {
     const dir = new Directory(Paths.cache, CACHE_DIR);
     if (dir.exists) dir.delete();

--- a/apps/mobile/src/lib/storage/imageCache.ts
+++ b/apps/mobile/src/lib/storage/imageCache.ts
@@ -179,3 +179,15 @@ export function evictImage(bucket: LogicalBucket, path: string | null): void {
     // Already gone, or unreadable — nothing to do.
   }
 }
+
+/** Sign-out/privacy cleanup: remove every cached receipt/proof/attachment image. */
+export function clearImageCache(): void {
+  try {
+    const dir = new Directory(Paths.cache, CACHE_DIR);
+    if (dir.exists) dir.delete();
+  } catch {
+    // Best-effort cache cleanup.
+  } finally {
+    inFlightDownloads.clear();
+  }
+}

--- a/apps/mobile/src/sync/driver.ts
+++ b/apps/mobile/src/sync/driver.ts
@@ -175,6 +175,24 @@ class SqliteStore implements LocalStore {
     await database.execAsync(`PRAGMA wal_checkpoint(TRUNCATE)`);
   }
 
+  private async wipeLocalData(database: SQLite.SQLiteDatabase): Promise<void> {
+    await database.withTransactionAsync(async () => {
+      await database.runAsync(`DELETE FROM mirror_rows WHERE 1 = 1`);
+      await database.runAsync(`DELETE FROM pending_mutations WHERE 1 = 1`);
+      await database.runAsync(`DELETE FROM sync_cursors WHERE 1 = 1`);
+      await database.runAsync(`DELETE FROM drafts WHERE 1 = 1`);
+    });
+    await destroyKey();
+  }
+
+  private async recoverUnreadableLocalData<T>(
+    database: SQLite.SQLiteDatabase,
+    fallback: T,
+  ): Promise<T> {
+    await this.wipeLocalData(database);
+    return fallback;
+  }
+
   async putRows(rows: readonly StoredRow[]): Promise<void> {
     if (rows.length === 0) return;
     await this.serial.run(async () => {
@@ -222,15 +240,19 @@ class SqliteStore implements LocalStore {
       // whole mirror is decrypted and `JSON.parse`d here before `hydrated` flips,
       // and doing it in one synchronous burst froze the loading skeleton and the
       // first frame. The key is loaded once above; the per-row open is sync.
-      return mapYielding(rows, (row) => ({
-        table: row.table_name as SyncTable,
-        id: row.id,
-        groupId: row.group_id,
-        seq: row.seq,
-        row: JSON.parse(
-          decryptWith(key, row.json, mirrorAad(row.table_name, row.id, row.group_id, row.seq)),
-        ) as MirrorRow,
-      }));
+      try {
+        return await mapYielding(rows, (row) => ({
+          table: row.table_name as SyncTable,
+          id: row.id,
+          groupId: row.group_id,
+          seq: row.seq,
+          row: JSON.parse(
+            decryptWith(key, row.json, mirrorAad(row.table_name, row.id, row.group_id, row.seq)),
+          ) as MirrorRow,
+        }));
+      } catch {
+        return this.recoverUnreadableLocalData(database, []);
+      }
     });
   }
 
@@ -271,12 +293,16 @@ class SqliteStore implements LocalStore {
         seq: number;
         json: string;
       }>(`SELECT client_mutation_id, seq, json FROM pending_mutations ORDER BY seq ASC`);
-      return rows.map(
-        (row) =>
-          JSON.parse(
-            decryptWith(key, row.json, queueAad(row.client_mutation_id, row.seq)),
-          ) as QueuedMutation,
-      );
+      try {
+        return rows.map(
+          (row) =>
+            JSON.parse(
+              decryptWith(key, row.json, queueAad(row.client_mutation_id, row.seq)),
+            ) as QueuedMutation,
+        );
+      } catch {
+        return this.recoverUnreadableLocalData(database, []);
+      }
     });
   }
 
@@ -315,7 +341,11 @@ class SqliteStore implements LocalStore {
         `SELECT json FROM drafts WHERE key = ?`,
         [key],
       );
-      return row ? (JSON.parse(decryptWith(dek, row.json, draftAad(key))) as T) : null;
+      try {
+        return row ? (JSON.parse(decryptWith(dek, row.json, draftAad(key))) as T) : null;
+      } catch {
+        return this.recoverUnreadableLocalData(database, null);
+      }
     });
   }
 
@@ -345,11 +375,15 @@ class SqliteStore implements LocalStore {
       const rows = await database.getAllAsync<{ key: string; json: string; saved_at: string }>(
         `SELECT key, json, saved_at FROM drafts ORDER BY saved_at DESC`,
       );
-      return rows.map((row) => ({
-        key: row.key,
-        value: JSON.parse(decryptWith(dek, row.json, draftAad(row.key))) as unknown,
-        savedAt: row.saved_at,
-      }));
+      try {
+        return rows.map((row) => ({
+          key: row.key,
+          value: JSON.parse(decryptWith(dek, row.json, draftAad(row.key))) as unknown,
+          savedAt: row.saved_at,
+        }));
+      } catch {
+        return this.recoverUnreadableLocalData(database, []);
+      }
     });
   }
 

--- a/apps/mobile/src/sync/provider.tsx
+++ b/apps/mobile/src/sync/provider.tsx
@@ -24,6 +24,8 @@ import type { MutationEnvelope, MutationKind } from '@waves/core';
 
 import { useAuth } from '@/lib/auth';
 import { reportHandled } from '@/lib/observability';
+import { clearReceiptQueue } from '@/lib/receiptQueue';
+import { clearImageCache } from '@/lib/storage/imageCache';
 
 import { syncEngine, type SyncState } from './engine';
 
@@ -46,6 +48,18 @@ interface SyncContextValue extends SyncState {
 
 const SyncContext = createContext<SyncContextValue | null>(null);
 
+async function clearLocalPrivateData(): Promise<void> {
+  const failures: unknown[] = [];
+  await syncEngine.clear().catch((error: unknown) => failures.push(error));
+  await clearReceiptQueue().catch((error: unknown) => failures.push(error));
+  try {
+    clearImageCache();
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) throw failures[0];
+}
+
 export function SyncProvider({ children }: { children: ReactNode }) {
   const { session } = useAuth();
   const [state, setState] = useState<SyncState>(() => syncEngine.getState());
@@ -61,7 +75,9 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       // than swallowing — a wipe that failed is a privacy problem, not a
       // cosmetic one — but not worth throwing at a screen mid-sign-out.
       if (wasSignedIn.current) {
-        void syncEngine.clear().catch((error: unknown) => reportHandled(error, 'sync.clear'));
+        void clearLocalPrivateData().catch((error: unknown) =>
+          reportHandled(error, 'sync.clearPrivateData'),
+        );
       }
       wasSignedIn.current = false;
       syncEngine.stop();

--- a/apps/mobile/src/sync/provider.tsx
+++ b/apps/mobile/src/sync/provider.tsx
@@ -65,6 +65,11 @@ export function SyncProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<SyncState>(() => syncEngine.getState());
   const signedIn = Boolean(session);
   const wasSignedIn = useRef(signedIn);
+  // The in-flight sign-out cleanup, if any. Sign-out does not block on it, but
+  // the next sign-in must: the receipt queue and image cache are device-global,
+  // so a cleanup still deleting when a new account signs in would wipe the new
+  // session's freshly-hydrated data. Awaiting it first serialises the two.
+  const pendingCleanup = useRef<Promise<void> | null>(null);
 
   useEffect(() => syncEngine.subscribe(setState), []);
 
@@ -73,9 +78,11 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       // Signing out wipes the mirror: the next person to use this phone must
       // not find the previous account's ledger in it. Worth reporting rather
       // than swallowing — a wipe that failed is a privacy problem, not a
-      // cosmetic one — but not worth throwing at a screen mid-sign-out.
+      // cosmetic one — but not worth throwing at a screen mid-sign-out. The
+      // promise is kept (never rejects — the catch resolves it) so the next
+      // sign-in can await its completion before hydrating.
       if (wasSignedIn.current) {
-        void clearLocalPrivateData().catch((error: unknown) =>
+        pendingCleanup.current = clearLocalPrivateData().catch((error: unknown) =>
           reportHandled(error, 'sync.clearPrivateData'),
         );
       }
@@ -87,6 +94,15 @@ export function SyncProvider({ children }: { children: ReactNode }) {
     wasSignedIn.current = true;
     let cancelled = false;
     void (async () => {
+      // A prior sign-out's cleanup may still be deleting the device-global
+      // receipt queue / image cache. Let it finish before this session hydrates,
+      // or it would delete data the new account just wrote.
+      const priorCleanup = pendingCleanup.current;
+      if (priorCleanup) {
+        await priorCleanup;
+        pendingCleanup.current = null;
+        if (cancelled) return;
+      }
       // Nothing awaits this, so anything thrown here would surface as an
       // uncaught promise rejection over whatever screen happens to be up.
       // `flush` hydrates too, and records the failure where the banner can

--- a/apps/mobile/test/imageCache.test.ts
+++ b/apps/mobile/test/imageCache.test.ts
@@ -234,8 +234,31 @@ describe('image cache', () => {
     expect(cachedImageUri('avatars', 'avatars/a1.png')).toBeNull();
     expect([...fs.files.keys()].filter((key) => key.includes('receipt-image-cache'))).toEqual([]);
 
+    // Re-seed so the directory exists again — otherwise the delete is skipped and
+    // the failure path is never exercised — then make delete fail: the cleanup
+    // must still swallow it (best-effort) rather than throw.
+    cacheImageBytes('expense-attachments', 'g1/e2.png', new Uint8Array([7]));
     fs.failDelete = true;
     expect(() => clearImageCache()).not.toThrow();
+  });
+
+  it('drops an in-flight download that resolves after the cache is cleared', async () => {
+    // A download is in flight when the account signs out. It must not write its
+    // private bytes back into the cache the sign-out just erased.
+    let release!: (value: unknown) => void;
+    fs.fetch.mockReturnValueOnce(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+    const pending = cacheImage('expense-attachments', 'g1/late.png', 'https://signed.example/late');
+
+    clearImageCache(); // sign-out, mid-download
+
+    release({ ok: true, bytes: async () => new Uint8Array([9]) });
+    await expect(pending).resolves.toBeNull();
+    expect(cachedImageUri('expense-attachments', 'g1/late.png')).toBeNull();
+    expect([...fs.files.keys()].filter((key) => key.includes('receipt-image-cache'))).toEqual([]);
   });
 
   it('keeps the latest complete byte set when two writes target the same cache key', () => {

--- a/apps/mobile/test/imageCache.test.ts
+++ b/apps/mobile/test/imageCache.test.ts
@@ -26,6 +26,14 @@ class FakeDirectory {
     if (fs.failCreate) throw new Error('mkdir failed');
     fs.dirs.add(this.uri);
   }
+
+  delete(): void {
+    if (fs.failDelete) throw new Error('delete failed');
+    fs.dirs.delete(this.uri);
+    for (const key of [...fs.files.keys()]) {
+      if (key.startsWith(`${this.uri}/`)) fs.files.delete(key);
+    }
+  }
 }
 
 class FakeFile {
@@ -72,7 +80,7 @@ vi.mock('expo-file-system', () => ({
   Paths: { cache: 'cache-root' },
 }));
 
-const { cacheImage, cachedImageUri, cacheImageBytes, evictImage } =
+const { cacheImage, cachedImageUri, cacheImageBytes, evictImage, clearImageCache } =
   await import('../src/lib/storage/imageCache');
 
 const cachedPath = (path: string) =>
@@ -214,6 +222,20 @@ describe('image cache', () => {
     fs.failDelete = true;
     expect(() => evictImage('expense-attachments', 'g1/e1.png')).not.toThrow();
     expect(() => evictImage('expense-attachments', null)).not.toThrow();
+  });
+
+  it('clears the entire cache directory for sign-out privacy cleanup', () => {
+    cacheImageBytes('expense-attachments', 'g1/e1.png', new Uint8Array([5]));
+    cacheImageBytes('avatars', 'avatars/a1.png', new Uint8Array([6]));
+
+    clearImageCache();
+
+    expect(cachedImageUri('expense-attachments', 'g1/e1.png')).toBeNull();
+    expect(cachedImageUri('avatars', 'avatars/a1.png')).toBeNull();
+    expect([...fs.files.keys()].filter((key) => key.includes('receipt-image-cache'))).toEqual([]);
+
+    fs.failDelete = true;
+    expect(() => clearImageCache()).not.toThrow();
   });
 
   it('keeps the latest complete byte set when two writes target the same cache key', () => {

--- a/apps/mobile/test/localStore.test.ts
+++ b/apps/mobile/test/localStore.test.ts
@@ -261,6 +261,7 @@ vi.mock('expo-sqlite', () => ({
 }));
 
 const { createLocalStore } = await import('../src/sync/driver');
+const { destroyKey } = await import('../src/sync/rowCipher');
 
 const mutation = (id: string): QueuedMutation =>
   ({
@@ -511,6 +512,31 @@ describe('at-rest encryption', () => {
       { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1', amount: '100' } },
     ]);
     expect(await store.readDraft('d1')).toEqual({ note: 'legacy' });
+  });
+
+  it('wipes unreadable encrypted local data and returns empty state', async () => {
+    const DEK = 'waves.mirror.dek.v1';
+    const store = createLocalStore();
+    await store.putRows([
+      { table: 'expenses', id: 'e1', groupId: 'g1', seq: 1, row: { id: 'e1' } },
+    ] as never);
+    await store.writeCursors({ g1: 1 });
+    await store.writeQueue([mutation('a')]);
+    await store.writeDraft('d1', { secret: 'draft' });
+
+    // Simulate restore/key loss: the DB traveled, but the device-only DEK did not.
+    await destroyKey();
+    const deletesBefore = secure.deletes.filter((key) => key === DEK).length;
+
+    expect(await store.readRows()).toEqual([]);
+    expect(await store.readCursors()).toEqual({});
+    expect(await store.readQueue()).toEqual([]);
+    expect(await store.readDraft('d1')).toBeNull();
+    expect(database.mirrorRows.size).toBe(0);
+    expect(database.pendingMutations.size).toBe(0);
+    expect(database.cursors.size).toBe(0);
+    expect(database.drafts.size).toBe(0);
+    expect(secure.deletes.filter((key) => key === DEK).length).toBe(deletesBefore + 1);
   });
 
   it('destroys the key on reset (crypto-erase)', async () => {

--- a/apps/mobile/test/receiptQueue.test.ts
+++ b/apps/mobile/test/receiptQueue.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storage = vi.hoisted(() => ({
+  data: new Map<string, string>(),
+  getItem: vi.fn(async (key: string) => storage.data.get(key) ?? null),
+  setItem: vi.fn(async (key: string, value: string) => {
+    storage.data.set(key, value);
+  }),
+  removeItem: vi.fn(async (key: string) => {
+    storage.data.delete(key);
+  }),
+}));
+
+const fs = vi.hoisted(() => ({
+  files: new Map<string, Uint8Array>(),
+  dirs: new Set<string>(),
+  failDelete: false,
+}));
+
+class FakeDirectory {
+  readonly uri: string;
+
+  constructor(...parts: string[]) {
+    this.uri = parts.join('/');
+  }
+
+  get exists(): boolean {
+    return fs.dirs.has(this.uri);
+  }
+
+  create(): void {
+    fs.dirs.add(this.uri);
+  }
+
+  delete(): void {
+    if (fs.failDelete) throw new Error('delete failed');
+    fs.dirs.delete(this.uri);
+    for (const key of [...fs.files.keys()]) {
+      if (key.startsWith(`${this.uri}/`)) fs.files.delete(key);
+    }
+  }
+}
+
+class FakeFile {
+  readonly uri: string;
+
+  constructor(...parts: unknown[]) {
+    this.uri = parts
+      .map((part) => (part instanceof FakeDirectory ? part.uri : String(part)))
+      .join('/');
+  }
+
+  get exists(): boolean {
+    return fs.files.has(this.uri);
+  }
+
+  write(bytes: Uint8Array): void {
+    fs.files.set(this.uri, new Uint8Array(bytes));
+  }
+
+  delete(): void {
+    if (fs.failDelete) throw new Error('delete failed');
+    fs.files.delete(this.uri);
+  }
+
+  async base64(): Promise<string> {
+    return Buffer.from(fs.files.get(this.uri) ?? new Uint8Array()).toString('base64');
+  }
+}
+
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: storage }));
+vi.mock('expo-crypto', () => ({ randomUUID: vi.fn(() => 'uuid') }));
+vi.mock('expo-network', () => ({
+  getNetworkStateAsync: vi.fn(async () => ({ isConnected: false })),
+}));
+vi.mock('expo-file-system', () => ({
+  Directory: FakeDirectory,
+  File: FakeFile,
+  Paths: { document: 'document-root', cache: 'cache-root' },
+}));
+vi.mock('@/lib/backend', () => ({ backend: { rpc: vi.fn() } }));
+vi.mock('@/lib/storage', () => ({ putImage: vi.fn() }));
+vi.mock('@/lib/storage/imageCache', () => ({ cacheImageBytes: vi.fn() }));
+vi.mock('@/lib/transferProgress', () => ({
+  endTransfer: vi.fn(),
+  setTransferProgress: vi.fn(),
+  startTransfer: vi.fn(),
+}));
+
+const { clearReceiptQueue, listPendingReceipts, pendingReceiptUri } =
+  await import('../src/lib/receiptQueue');
+
+const QUEUE_KEY = 'receipt-upload-queue.v1';
+const pendingPath = (fileName: string) => `document-root/pending-receipts/${fileName}`;
+
+beforeEach(() => {
+  storage.data.clear();
+  storage.getItem.mockClear();
+  storage.setItem.mockClear();
+  storage.removeItem.mockClear();
+  fs.files.clear();
+  fs.dirs.clear();
+  fs.failDelete = false;
+});
+
+describe('receipt queue local privacy cleanup', () => {
+  it('removes the queue index and pending receipt files on sign-out cleanup', async () => {
+    const entries = [
+      {
+        attachmentId: 'a1',
+        expenseId: 'e1',
+        groupId: 'g1',
+        visibility: 'group' as const,
+        storagePath: 'e1/a1.jpg',
+        contentType: 'image/jpeg',
+        fileName: 'a1.jpg',
+        createdAt: '2026-01-01T00:00:00Z',
+        attempts: 0,
+        lastError: null,
+      },
+      {
+        attachmentId: 'a2',
+        expenseId: 'e2',
+        groupId: 'g1',
+        visibility: 'parties' as const,
+        storagePath: 'e2/a2.jpg',
+        contentType: 'image/jpeg',
+        fileName: 'a2.jpg',
+        createdAt: '2026-01-01T00:00:01Z',
+        attempts: 1,
+        lastError: 'offline',
+      },
+    ];
+    storage.data.set(QUEUE_KEY, JSON.stringify(entries));
+    fs.dirs.add('document-root/pending-receipts');
+    fs.files.set(pendingPath('a1.jpg'), new Uint8Array([1]));
+    fs.files.set(pendingPath('a2.jpg'), new Uint8Array([2]));
+
+    await clearReceiptQueue();
+
+    expect(storage.removeItem).toHaveBeenCalledWith(QUEUE_KEY);
+    expect(await listPendingReceipts()).toEqual([]);
+    expect(fs.files.has(pendingPath('a1.jpg'))).toBe(false);
+    expect(fs.files.has(pendingPath('a2.jpg'))).toBe(false);
+    expect(fs.dirs.has('document-root/pending-receipts')).toBe(false);
+  });
+
+  it('still removes the queue index when file deletion fails', async () => {
+    const entry = {
+      attachmentId: 'a1',
+      expenseId: 'e1',
+      groupId: 'g1',
+      visibility: 'group' as const,
+      storagePath: 'e1/a1.jpg',
+      contentType: 'image/jpeg',
+      fileName: 'a1.jpg',
+      createdAt: '2026-01-01T00:00:00Z',
+      attempts: 0,
+      lastError: null,
+    };
+    storage.data.set(QUEUE_KEY, JSON.stringify([entry]));
+    fs.dirs.add('document-root/pending-receipts');
+    fs.files.set(pendingPath('a1.jpg'), new Uint8Array([1]));
+    fs.failDelete = true;
+
+    await clearReceiptQueue();
+
+    expect(storage.removeItem).toHaveBeenCalledWith(QUEUE_KEY);
+    expect(await listPendingReceipts()).toEqual([]);
+    expect(pendingReceiptUri(entry)).toBe(pendingPath('a1.jpg'));
+  });
+});

--- a/apps/mobile/test/saveImage.test.ts
+++ b/apps/mobile/test/saveImage.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sharing = vi.hoisted(() => ({
+  available: true,
+  share: vi.fn(async () => undefined),
+}));
+
+const fs = vi.hoisted(() => ({
+  files: new Map<string, Uint8Array>(),
+  failDelete: false,
+}));
+
+class FakeFile {
+  readonly uri: string;
+
+  constructor(...parts: string[]) {
+    this.uri = parts.join('/');
+  }
+
+  get exists(): boolean {
+    return fs.files.has(this.uri);
+  }
+
+  create(): void {
+    fs.files.set(this.uri, new Uint8Array());
+  }
+
+  write(bytes: Uint8Array): void {
+    fs.files.set(this.uri, new Uint8Array(bytes));
+  }
+
+  delete(): void {
+    if (fs.failDelete) throw new Error('delete failed');
+    fs.files.delete(this.uri);
+  }
+}
+
+vi.mock('expo-sharing', () => ({
+  isAvailableAsync: vi.fn(async () => sharing.available),
+  shareAsync: sharing.share,
+}));
+
+vi.mock('expo-file-system', () => ({
+  File: FakeFile,
+  Paths: { cache: 'cache-root' },
+}));
+
+const { saveImageToDevice } = await import('../src/lib/saveImage');
+
+beforeEach(() => {
+  fs.files.clear();
+  fs.failDelete = false;
+  sharing.available = true;
+  sharing.share.mockClear();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      headers: { get: () => 'image/png' },
+      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    })),
+  );
+});
+
+describe('saveImageToDevice', () => {
+  it('deletes the temporary receipt file after the share sheet returns', async () => {
+    await expect(saveImageToDevice('https://signed.example/receipt')).resolves.toBe('shared');
+
+    expect(sharing.share).toHaveBeenCalledWith('cache-root/receipt.png', {
+      mimeType: 'image/png',
+      dialogTitle: 'Save receipt',
+    });
+    expect(fs.files.has('cache-root/receipt.png')).toBe(false);
+  });
+
+  it('still reports shared when best-effort temp cleanup fails', async () => {
+    fs.failDelete = true;
+
+    await expect(saveImageToDevice('https://signed.example/receipt')).resolves.toBe('shared');
+    expect(fs.files.has('cache-root/receipt.png')).toBe(true);
+  });
+
+  it('deletes the temp file when sharing throws, then returns error', async () => {
+    sharing.share.mockRejectedValueOnce(new Error('share failed'));
+
+    await expect(saveImageToDevice('https://signed.example/receipt')).resolves.toBe('error');
+    expect(fs.files.has('cache-root/receipt.png')).toBe(false);
+  });
+});

--- a/apps/mobile/test/secureStorage.test.ts
+++ b/apps/mobile/test/secureStorage.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const secure = vi.hoisted(() => ({
+  data: new Map<string, string>(),
+  options: new Map<string, unknown>(),
+  getItemAsync: vi.fn(async (key: string) => secure.data.get(key) ?? null),
+  setItemAsync: vi.fn(async (key: string, value: string, options?: unknown) => {
+    secure.data.set(key, value);
+    secure.options.set(key, options);
+  }),
+  deleteItemAsync: vi.fn(async (key: string) => {
+    secure.data.delete(key);
+  }),
+}));
+
+const asyncStorage = vi.hoisted(() => ({
+  data: new Map<string, string>(),
+  getItem: vi.fn(async (key: string) => asyncStorage.data.get(key) ?? null),
+  setItem: vi.fn(async (key: string, value: string) => {
+    asyncStorage.data.set(key, value);
+  }),
+  removeItem: vi.fn(async (key: string) => {
+    asyncStorage.data.delete(key);
+  }),
+}));
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: asyncStorage }));
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'after-first-unlock-this-device-only',
+  getItemAsync: secure.getItemAsync,
+  setItemAsync: secure.setItemAsync,
+  deleteItemAsync: secure.deleteItemAsync,
+}));
+
+const { secureAuthStorage } = await import('../src/lib/secureStorage');
+
+beforeEach(() => {
+  secure.data.clear();
+  secure.options.clear();
+  secure.getItemAsync.mockClear();
+  secure.setItemAsync.mockClear();
+  secure.deleteItemAsync.mockClear();
+  asyncStorage.data.clear();
+  asyncStorage.getItem.mockClear();
+  asyncStorage.setItem.mockClear();
+  asyncStorage.removeItem.mockClear();
+});
+
+describe('secureAuthStorage', () => {
+  it('chunks large sessions into device-only SecureStore entries', async () => {
+    const value = 'x'.repeat(4000);
+
+    await secureAuthStorage.setItem('supabase.auth.token', value);
+
+    expect(secure.data.get('supabase.auth.token.pn')).toBe('3');
+    expect(secure.data.get('supabase.auth.token.p0')).toHaveLength(1800);
+    expect(secure.data.get('supabase.auth.token.p1')).toHaveLength(1800);
+    expect(secure.data.get('supabase.auth.token.p2')).toHaveLength(400);
+    expect(secure.options.get('supabase.auth.token.p0')).toEqual({
+      keychainAccessible: 'after-first-unlock-this-device-only',
+    });
+    await expect(secureAuthStorage.getItem('supabase.auth.token')).resolves.toBe(value);
+  });
+
+  it('removes orphan chunks when a later session is shorter', async () => {
+    await secureAuthStorage.setItem('session', 'x'.repeat(4000));
+    await secureAuthStorage.setItem('session', 'short');
+
+    expect(secure.data.get('session.pn')).toBe('1');
+    expect(secure.data.get('session.p0')).toBe('short');
+    expect(secure.data.has('session.p1')).toBe(false);
+    expect(secure.data.has('session.p2')).toBe(false);
+  });
+
+  it('treats a torn chunk write as no session', async () => {
+    secure.data.set('session.pn', '2');
+    secure.data.set('session.p0', 'first');
+
+    await expect(secureAuthStorage.getItem('session')).resolves.toBeNull();
+  });
+
+  it('migrates legacy AsyncStorage session and retries plaintext cleanup', async () => {
+    asyncStorage.data.set('session', 'legacy');
+    asyncStorage.removeItem.mockRejectedValueOnce(new Error('remove failed'));
+
+    await expect(secureAuthStorage.getItem('session')).resolves.toBe('legacy');
+    expect(asyncStorage.data.get('session')).toBe('legacy');
+
+    await expect(secureAuthStorage.getItem('session')).resolves.toBe('legacy');
+    expect(asyncStorage.data.has('session')).toBe(false);
+  });
+
+  it('removes every secure chunk and the count marker', async () => {
+    await secureAuthStorage.setItem('session', 'x'.repeat(4000));
+
+    await secureAuthStorage.removeItem('session');
+
+    expect(secure.data.has('session.pn')).toBe(false);
+    expect(secure.data.has('session.p0')).toBe(false);
+    expect(secure.data.has('session.p1')).toBe(false);
+    expect(secure.data.has('session.p2')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- clear pending offline receipt upload queue files and index during sign-out cleanup
- clear cached receipt/proof/attachment images during sign-out cleanup
- keep cleanup best-effort and report failures without blocking sign-out
- add focused tests for receipt queue and image cache cleanup

## Validation
- pnpm --filter @waves/mobile exec vitest run test/imageCache.test.ts test/receiptQueue.test.ts test/localStore.test.ts test/syncEngine.test.ts
- pnpm exec prettier --check apps/mobile/src/lib/receiptQueue.ts apps/mobile/src/lib/storage/imageCache.ts apps/mobile/src/sync/provider.tsx apps/mobile/test/imageCache.test.ts apps/mobile/test/receiptQueue.test.ts
- pnpm --filter @waves/mobile run typecheck
- pnpm --filter @waves/mobile run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cleanup controls for pending receipts, cached images, and temporary shared files.
  * Enhanced secure storage to keep sensitive data device-only and available after device unlock.
* **Bug Fixes**
  * Signing out now clears synchronization data, pending receipts, and cached images safely.
  * Unreadable encrypted data is recovered by clearing corrupted local data and resetting encryption keys.
  * Temporary files are removed after sharing or importing, including when operations fail.
* **Tests**
  * Expanded coverage for privacy cleanup, secure storage, encrypted-data recovery, and sharing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->