### PR TITLE
ci(vercel): skip builds for commits that don't touch web/admin

### DIFF
--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "regions": ["sin1"]
+  "regions": ["sin1"],
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/apps/admin' ':/packages' ':/pnpm-lock.yaml' ':/package.json'"
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "regions": ["sin1"]
+  "regions": ["sin1"],
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/apps/web' ':/packages' ':/pnpm-lock.yaml' ':/package.json'"
 }


### PR DESCRIPTION
## Problem
Every push builds **both** Vercel projects (web + admin). On the free tier this exhausts the build **rate limit** (`ERR ... upgradeToPro=build-rate-limit`), so unrelated PRs — mobile, docs — get a red **Vercel** check even though they change nothing Vercel serves.

## Fix
Add an `ignoreCommand` to each project's `vercel.json`:

```
git diff --quiet HEAD^ HEAD -- ':/apps/web'  ':/packages' ':/pnpm-lock.yaml' ':/package.json'   # web
git diff --quiet HEAD^ HEAD -- ':/apps/admin' ':/packages' ':/pnpm-lock.yaml' ':/package.json'   # admin
```

`git diff --quiet` exits **0** when nothing in those paths changed → Vercel **skips** the build; exit **1** when they did → build proceeds (per Vercel's ignoreCommand contract). `:/`-rooted pathspecs because Vercel runs the command from each project's Root Directory (`apps/web` / `apps/admin`). `packages` + lockfile are included so a shared-package or dependency change still rebuilds the affected app.

Result: a mobile-only or docs-only push builds neither project; a web change builds only web; an admin change builds only admin.

## Note
Config-only; no app code. This PR itself touches `apps/web`/`apps/admin`, so it will (correctly) trigger a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment efficiency by skipping unnecessary builds when changes do not affect the relevant application, shared packages, or dependency configuration.
  * Applied optimized deployment checks to both the admin and web applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->