### PR TITLE
test(mobile): audit local privacy cleanup

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -457,11 +457,16 @@ function AuthGate() {
   // on the welcome and guest doorways can open it before anybody has an account.
   // Its open-source licenses screen is part of that same policy, opened from a
   // row inside it, so it has to be public as well — otherwise tapping it bounces
-  // a signed-out reader back to /welcome.
+  // a signed-out reader back to /welcome. The local privacy audit is dev-only
+  // and must stay reachable after sign-out so e2e can verify private local state
+  // was removed, but production builds must never expose that route signed-out.
   const onPublicRoute =
     onAuth ||
     segments[0] === 'join' ||
     segments[0] === 'language' ||
+    (__DEV__ &&
+      (segments as string[])[0] === 'dev' &&
+      (segments as string[])[1] === 'local-privacy') ||
     (segments[0] === 'settings' &&
       ((segments as string[])[1] === 'privacy' || (segments as string[])[1] === 'licenses'));
 

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -608,6 +608,7 @@ function AuthGate() {
           <Stack.Screen name="settings/feedback" />
           <Stack.Screen name="settings/privacy" />
           <Stack.Screen name="settings/delete-account" />
+          <Stack.Screen name="dev/local-privacy" />
           <Stack.Screen name="join" />
           <Stack.Screen name="inbox" />
           <Stack.Screen name="voice" options={slide} />

--- a/apps/mobile/src/app/dev/local-privacy.tsx
+++ b/apps/mobile/src/app/dev/local-privacy.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { ScrollView } from 'react-native';
+
+import { Card, Screen, Text, useTheme } from '@waves/ui';
+
+import { localPrivacyAudit, type LocalPrivacyAudit } from '@/lib/localPrivacyAudit';
+
+/**
+ * Dev/e2e-only local privacy audit surface. It exposes aggregate counts only —
+ * no file names, tokens, row ids or ledger contents — so Maestro can verify that
+ * sign-out cleanup removed private local state that is otherwise invisible to UI.
+ */
+export default function LocalPrivacyAuditScreen() {
+  const theme = useTheme();
+  const [audit, setAudit] = useState<LocalPrivacyAudit | null>(null);
+
+  useEffect(() => {
+    void localPrivacyAudit().then(setAudit);
+  }, []);
+
+  if (!__DEV__) {
+    return (
+      <Screen>
+        <Card>
+          <Text testID="local-privacy-audit-disabled">Not available</Text>
+        </Card>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen>
+      <ScrollView contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.md }}>
+        <Text variant="heading">Local privacy audit</Text>
+        <Card style={{ gap: theme.spacing.sm }}>
+          <Text testID="local-privacy-mirror-key">
+            mirrorKeyPresent:{audit?.mirrorKeyPresent ? 'true' : 'false'}
+          </Text>
+          <Text testID="local-privacy-receipt-queue">
+            receiptQueuePresent:{audit?.receiptQueuePresent ? 'true' : 'false'}
+          </Text>
+          <Text testID="local-privacy-pending-files">
+            pendingReceiptFiles:{audit?.pendingReceiptFiles ?? 0}
+          </Text>
+          <Text testID="local-privacy-cached-files">
+            cachedImageFiles:{audit?.cachedImageFiles ?? 0}
+          </Text>
+        </Card>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/dev/local-privacy.tsx
+++ b/apps/mobile/src/app/dev/local-privacy.tsx
@@ -28,23 +28,32 @@ export default function LocalPrivacyAuditScreen() {
     );
   }
 
+  if (!audit) {
+    return (
+      <Screen>
+        <Card>
+          <Text testID="local-privacy-audit-loading">Checking local privacy state…</Text>
+        </Card>
+      </Screen>
+    );
+  }
+
   return (
     <Screen>
       <ScrollView contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.md }}>
         <Text variant="heading">Local privacy audit</Text>
         <Card style={{ gap: theme.spacing.sm }}>
+          <Text testID="local-privacy-audit-ready">Audit complete</Text>
           <Text testID="local-privacy-mirror-key">
-            mirrorKeyPresent:{audit?.mirrorKeyPresent ? 'true' : 'false'}
+            mirrorKeyPresent:{audit.mirrorKeyPresent ? 'true' : 'false'}
           </Text>
           <Text testID="local-privacy-receipt-queue">
-            receiptQueuePresent:{audit?.receiptQueuePresent ? 'true' : 'false'}
+            receiptQueuePresent:{audit.receiptQueuePresent ? 'true' : 'false'}
           </Text>
           <Text testID="local-privacy-pending-files">
-            pendingReceiptFiles:{audit?.pendingReceiptFiles ?? 0}
+            pendingReceiptFiles:{audit.pendingReceiptFiles}
           </Text>
-          <Text testID="local-privacy-cached-files">
-            cachedImageFiles:{audit?.cachedImageFiles ?? 0}
-          </Text>
+          <Text testID="local-privacy-cached-files">cachedImageFiles:{audit.cachedImageFiles}</Text>
         </Card>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/lib/localPrivacyAudit.ts
+++ b/apps/mobile/src/lib/localPrivacyAudit.ts
@@ -1,0 +1,38 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Directory, Paths } from 'expo-file-system';
+import * as SecureStore from 'expo-secure-store';
+
+/**
+ * Local private-data audit used by tests/e2e debug tooling. It reports counts and
+ * key presence only, never file names, row ids, tokens, or other sensitive data.
+ */
+export interface LocalPrivacyAudit {
+  readonly mirrorKeyPresent: boolean;
+  readonly receiptQueuePresent: boolean;
+  readonly pendingReceiptFiles: number;
+  readonly cachedImageFiles: number;
+}
+
+function countDirectoryFiles(root: string | Directory, name: string): number {
+  try {
+    const dir = new Directory(root, name);
+    if (!dir.exists) return 0;
+    const entries = (dir as unknown as { list?: () => unknown[] }).list?.() ?? [];
+    return entries.length;
+  } catch {
+    return 0;
+  }
+}
+
+export async function localPrivacyAudit(): Promise<LocalPrivacyAudit> {
+  const [mirrorKey, receiptQueue] = await Promise.all([
+    SecureStore.getItemAsync('waves.mirror.dek.v1').catch(() => null),
+    AsyncStorage.getItem('receipt-upload-queue.v1').catch(() => null),
+  ]);
+  return {
+    mirrorKeyPresent: mirrorKey !== null,
+    receiptQueuePresent: receiptQueue !== null,
+    pendingReceiptFiles: countDirectoryFiles(Paths.document, 'pending-receipts'),
+    cachedImageFiles: countDirectoryFiles(Paths.cache, 'receipt-image-cache'),
+  };
+}

--- a/apps/mobile/test/aiKeys.test.ts
+++ b/apps/mobile/test/aiKeys.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const secure = vi.hoisted(() => ({
+  data: new Map<string, string>(),
+  options: new Map<string, unknown>(),
+  getItemAsync: vi.fn(async (key: string) => secure.data.get(key) ?? null),
+  setItemAsync: vi.fn(async (key: string, value: string, options?: unknown) => {
+    secure.data.set(key, value);
+    secure.options.set(key, options);
+  }),
+  deleteItemAsync: vi.fn(async (key: string) => {
+    secure.data.delete(key);
+  }),
+}));
+
+const aiSettings = vi.hoisted(() => ({ resetAiSettings: vi.fn(async () => undefined) }));
+const aiEvents = vi.hoisted(() => ({ emitAiConfigChanged: vi.fn() }));
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'after-first-unlock-this-device-only',
+  getItemAsync: secure.getItemAsync,
+  setItemAsync: secure.setItemAsync,
+  deleteItemAsync: secure.deleteItemAsync,
+}));
+vi.mock('@/lib/aiSettings', () => aiSettings);
+vi.mock('@/lib/aiEvents', () => aiEvents);
+
+const { configuredAiProviders, getActiveAiKey, getAiKey, removeAiKey, setActiveAiKey } =
+  await import('../src/lib/aiKeys');
+
+const STORE_KEY = 'baaki.aikey';
+
+beforeEach(() => {
+  secure.data.clear();
+  secure.options.clear();
+  secure.getItemAsync.mockClear();
+  secure.setItemAsync.mockClear();
+  secure.deleteItemAsync.mockClear();
+  aiSettings.resetAiSettings.mockClear();
+  aiEvents.emitAiConfigChanged.mockClear();
+});
+
+describe('AI key vault', () => {
+  it('stores the active key trimmed with device-only SecureStore options', async () => {
+    await setActiveAiKey('openai', '  sk-test  ');
+
+    expect(JSON.parse(secure.data.get(STORE_KEY) ?? '{}')).toEqual({
+      id: 'openai',
+      key: 'sk-test',
+    });
+    expect(secure.options.get(STORE_KEY)).toEqual({
+      keychainAccessible: 'after-first-unlock-this-device-only',
+    });
+    await expect(getActiveAiKey()).resolves.toEqual({ id: 'openai', key: 'sk-test' });
+    expect(aiSettings.resetAiSettings).toHaveBeenCalledTimes(1);
+    expect(aiEvents.emitAiConfigChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores corrupt records and unknown providers', async () => {
+    secure.data.set(STORE_KEY, '{not-json');
+    await expect(getActiveAiKey()).resolves.toBeNull();
+
+    secure.data.set(STORE_KEY, JSON.stringify({ id: 'unknown', key: 'sk-test' }));
+    await expect(getActiveAiKey()).resolves.toBeNull();
+    await expect(configuredAiProviders()).resolves.toEqual([]);
+  });
+
+  it('returns a key only for the connected provider', async () => {
+    await setActiveAiKey('anthropic', 'sk-ant-test');
+
+    await expect(getAiKey('anthropic')).resolves.toBe('sk-ant-test');
+    await expect(getAiKey('openai')).resolves.toBeNull();
+    await expect(configuredAiProviders()).resolves.toEqual(['anthropic']);
+  });
+
+  it('removes the active key and resets settings', async () => {
+    await setActiveAiKey('moonshot', 'sk-test');
+    aiSettings.resetAiSettings.mockClear();
+    aiEvents.emitAiConfigChanged.mockClear();
+
+    await removeAiKey();
+
+    expect(secure.deleteItemAsync).toHaveBeenCalledWith(STORE_KEY);
+    expect(secure.data.has(STORE_KEY)).toBe(false);
+    expect(aiSettings.resetAiSettings).toHaveBeenCalledTimes(1);
+    expect(aiEvents.emitAiConfigChanged).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/test/imageCache.test.ts
+++ b/apps/mobile/test/imageCache.test.ts
@@ -261,6 +261,19 @@ describe('image cache', () => {
     expect([...fs.files.keys()].filter((key) => key.includes('receipt-image-cache'))).toEqual([]);
   });
 
+  it('clears many cached images in one directory sweep', () => {
+    for (let index = 0; index < 500; index += 1) {
+      cacheImageBytes('expense-attachments', `g1/e${index}.png`, new Uint8Array([index % 255]));
+    }
+    expect([...fs.files.keys()].filter((key) => key.includes('receipt-image-cache')).length).toBe(
+      500,
+    );
+
+    clearImageCache();
+
+    expect([...fs.files.keys()].filter((key) => key.includes('receipt-image-cache'))).toEqual([]);
+  });
+
   it('keeps the latest complete byte set when two writes target the same cache key', () => {
     fs.uuid.mockReturnValueOnce('first').mockReturnValueOnce('second');
 

--- a/apps/mobile/test/localPrivacyAudit.test.ts
+++ b/apps/mobile/test/localPrivacyAudit.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storage = vi.hoisted(() => ({
+  data: new Map<string, string>(),
+  getItem: vi.fn(async (key: string) => storage.data.get(key) ?? null),
+}));
+
+const secure = vi.hoisted(() => ({
+  data: new Map<string, string>(),
+  getItemAsync: vi.fn(async (key: string) => secure.data.get(key) ?? null),
+}));
+
+const fs = vi.hoisted(() => ({
+  files: new Map<string, Uint8Array>(),
+  dirs: new Set<string>(),
+}));
+
+class FakeDirectory {
+  readonly uri: string;
+
+  constructor(...parts: string[]) {
+    this.uri = parts.join('/');
+  }
+
+  get exists(): boolean {
+    return fs.dirs.has(this.uri);
+  }
+
+  list(): unknown[] {
+    return [...fs.files.keys()]
+      .filter((key) => key.startsWith(`${this.uri}/`))
+      .map((key) => ({ uri: key }));
+  }
+}
+
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: storage }));
+vi.mock('expo-secure-store', () => ({ getItemAsync: secure.getItemAsync }));
+vi.mock('expo-file-system', () => ({
+  Directory: FakeDirectory,
+  Paths: { document: 'document-root', cache: 'cache-root' },
+}));
+
+const { localPrivacyAudit } = await import('../src/lib/localPrivacyAudit');
+
+beforeEach(() => {
+  storage.data.clear();
+  storage.getItem.mockClear();
+  secure.data.clear();
+  secure.getItemAsync.mockClear();
+  fs.files.clear();
+  fs.dirs.clear();
+});
+
+describe('localPrivacyAudit', () => {
+  it('reports only key/index presence and aggregate private file counts', async () => {
+    secure.data.set('waves.mirror.dek.v1', 'dek');
+    storage.data.set('receipt-upload-queue.v1', '[]');
+    fs.dirs.add('document-root/pending-receipts');
+    fs.dirs.add('cache-root/receipt-image-cache');
+    fs.files.set('document-root/pending-receipts/a.jpg', new Uint8Array([1]));
+    fs.files.set('cache-root/receipt-image-cache/b.jpg', new Uint8Array([2]));
+    fs.files.set('cache-root/receipt-image-cache/c.jpg', new Uint8Array([3]));
+
+    await expect(localPrivacyAudit()).resolves.toEqual({
+      mirrorKeyPresent: true,
+      receiptQueuePresent: true,
+      pendingReceiptFiles: 1,
+      cachedImageFiles: 2,
+    });
+  });
+
+  it('reports clean state after sign-out cleanup has removed private local data', async () => {
+    await expect(localPrivacyAudit()).resolves.toEqual({
+      mirrorKeyPresent: false,
+      receiptQueuePresent: false,
+      pendingReceiptFiles: 0,
+      cachedImageFiles: 0,
+    });
+  });
+});

--- a/apps/mobile/test/localStore.test.ts
+++ b/apps/mobile/test/localStore.test.ts
@@ -225,12 +225,16 @@ let failNextOpen = false;
 const secure = vi.hoisted(() => ({
   keystore: new Map<string, string>(),
   deletes: [] as string[],
+  gets: 0,
 }));
 
 vi.mock('expo-secure-store', () => ({
   AFTER_FIRST_UNLOCK: 'after-first-unlock',
   AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'after-first-unlock-this-device-only',
-  getItemAsync: async (key: string) => secure.keystore.get(key) ?? null,
+  getItemAsync: async (key: string) => {
+    secure.gets += 1;
+    return secure.keystore.get(key) ?? null;
+  },
   setItemAsync: async (key: string, value: string) => {
     secure.keystore.set(key, value);
   },
@@ -280,6 +284,9 @@ beforeEach(() => {
   database = new FakeDatabase();
   openCalls = 0;
   failNextOpen = false;
+  secure.keystore.clear();
+  secure.deletes = [];
+  secure.gets = 0;
 });
 
 describe('two callers, one connection', () => {
@@ -440,8 +447,23 @@ describe('native local store lifecycle', () => {
     expect(hydrated[0]).toEqual(rows[0]);
     expect(hydrated[512]).toEqual(rows[512]);
     expect(hydrated[1024]).toEqual(rows[1024]);
+    expect(openCalls).toBe(1);
+    expect(secure.gets).toBeLessThanOrEqual(2);
     // Generous timeout: 1k fake statements each yield a macrotask, plus a real
     // encrypt/decrypt per row — slow on a loaded Windows timer, not a defect.
+  }, 20000);
+
+  it('round-trips a large encrypted offline queue with one keystore load', async () => {
+    const store = createLocalStore();
+    const queue = Array.from({ length: 1_000 }, (_, index) => mutation(`m${index}`));
+
+    await store.writeQueue(queue);
+    const read = await store.readQueue();
+
+    expect(read).toHaveLength(queue.length);
+    expect(read[0]?.clientMutationId).toBe('m0');
+    expect(read[999]?.clientMutationId).toBe('m999');
+    expect(secure.gets).toBeLessThanOrEqual(2);
   }, 20000);
 
   it('does not open SQLite when asked to persist no rows', async () => {

--- a/apps/mobile/test/receiptQueue.test.ts
+++ b/apps/mobile/test/receiptQueue.test.ts
@@ -39,6 +39,12 @@ class FakeDirectory {
       if (key.startsWith(`${this.uri}/`)) fs.files.delete(key);
     }
   }
+
+  list(): FakeFile[] {
+    return [...fs.files.keys()]
+      .filter((key) => key.startsWith(`${this.uri}/`))
+      .map((key) => new FakeFile(key));
+  }
 }
 
 class FakeFile {
@@ -48,6 +54,10 @@ class FakeFile {
     this.uri = parts
       .map((part) => (part instanceof FakeDirectory ? part.uri : String(part)))
       .join('/');
+  }
+
+  get name(): string {
+    return this.uri.split('/').pop() ?? this.uri;
   }
 
   get exists(): boolean {
@@ -168,5 +178,29 @@ describe('receipt queue local privacy cleanup', () => {
     expect(storage.removeItem).toHaveBeenCalledWith(QUEUE_KEY);
     expect(await listPendingReceipts()).toEqual([]);
     expect(pendingReceiptUri(entry)).toBe(pendingPath('a1.jpg'));
+  });
+
+  it('removes orphan pending files when pending receipts are listed', async () => {
+    const entry = {
+      attachmentId: 'a1',
+      expenseId: 'e1',
+      groupId: 'g1',
+      visibility: 'group' as const,
+      storagePath: 'e1/a1.jpg',
+      contentType: 'image/jpeg',
+      fileName: 'a1.jpg',
+      createdAt: '2026-01-01T00:00:00Z',
+      attempts: 0,
+      lastError: null,
+    };
+    storage.data.set(QUEUE_KEY, JSON.stringify([entry]));
+    fs.dirs.add('document-root/pending-receipts');
+    fs.files.set(pendingPath('a1.jpg'), new Uint8Array([1]));
+    fs.files.set(pendingPath('orphan.jpg'), new Uint8Array([9]));
+
+    await expect(listPendingReceipts()).resolves.toEqual([entry]);
+
+    expect(fs.files.has(pendingPath('a1.jpg'))).toBe(true);
+    expect(fs.files.has(pendingPath('orphan.jpg'))).toBe(false);
   });
 });

--- a/e2e/README-e2e.md
+++ b/e2e/README-e2e.md
@@ -61,7 +61,7 @@ node e2e/seed-e2e.mjs
 #    each flow on its own, reseeding first, because the flows mutate the backend:
 for flow in home-to-add-expense edit-expense delete-restore-expense \
             change-logo capture-assign custom-tags locale-switch \
-            rename-archive-group sign-out-privacy clone-group \
+            rename-archive-group sign-out-privacy local-privacy-audit clone-group \
             group-photo-paid-gate friends-merge-guests leave-group; do
   node e2e/seed-e2e.mjs
   maestro test --env E2E_EMAIL="$E2E_EMAIL" --env E2E_PASSWORD="$E2E_PASSWORD" "e2e/$flow.yaml"
@@ -85,6 +85,7 @@ In CI this loop lives in `e2e/run-maestro.sh`.
 | `custom-tags.yaml`            | make a tag in Settings → tag an expense with it → the tag names the ledger row (A42) |
 | `locale-switch.yaml`          | Account → Language → switch to Hindi → strings re-render live (no restart)           |
 | `sign-out-privacy.yaml`       | sign out → back at the gateway, the ledger off screen                                |
+| `local-privacy-audit.yaml`    | dev-only route checks aggregate local private-data cleanup after sign-out            |
 | `clone-group.yaml`            | Duplicate → prefilled New Group → drop a member → Create → copy made, original kept  |
 | `group-photo-paid-gate.yaml`  | group photo is paid, cover emoji is free                                             |
 | `friends-merge-guests.yaml`   | merge the two seeded "Reeya" ghosts, with the irreversible-warning gate              |

--- a/e2e/local-privacy-audit.yaml
+++ b/e2e/local-privacy-audit.yaml
@@ -1,0 +1,16 @@
+# Dev/e2e-only audit of local private-data cleanup. This verifies aggregate
+# device-local state after sign-out through a route that exposes counts only.
+appId: app.waves.mobile
+---
+- runFlow: sign-out-privacy.yaml
+
+# Open the debug audit screen directly; the screen is disabled outside dev builds.
+- openLink: waves:///dev/local-privacy
+- extendedWaitUntilVisible:
+    element:
+      id: 'local-privacy-mirror-key'
+    timeout: 10000
+- assertVisible: 'mirrorKeyPresent:false'
+- assertVisible: 'receiptQueuePresent:false'
+- assertVisible: 'pendingReceiptFiles:0'
+- assertVisible: 'cachedImageFiles:0'

--- a/e2e/local-privacy-audit.yaml
+++ b/e2e/local-privacy-audit.yaml
@@ -8,7 +8,7 @@ appId: app.waves.mobile
 - openLink: waves:///dev/local-privacy
 - extendedWaitUntilVisible:
     element:
-      id: 'local-privacy-mirror-key'
+      id: 'local-privacy-audit-ready'
     timeout: 10000
 - assertVisible: 'mirrorKeyPresent:false'
 - assertVisible: 'receiptQueuePresent:false'

--- a/e2e/run-maestro.sh
+++ b/e2e/run-maestro.sh
@@ -29,6 +29,7 @@ FLOWS=(
   custom-tags
   locale-switch
   sign-out-privacy
+  local-privacy-audit
   clone-group
   group-photo-paid-gate
   friends-merge-guests


### PR DESCRIPTION
## Summary
- add a dev/e2e local privacy audit route exposing aggregate cleanup state only
- add Maestro flow for local privacy audit after sign-out
- add AI key vault SecureStore failure-mode tests
- add local privacy audit unit tests
- add stronger receipt orphan cleanup coverage
- add performance-style tests for encrypted hydration, offline queue round-trip, and image cache cleanup scale

## Validation
- pnpm --filter @waves/mobile exec vitest run test/saveImage.test.ts test/secureStorage.test.ts test/aiKeys.test.ts test/localPrivacyAudit.test.ts test/receiptQueue.test.ts test/imageCache.test.ts test/localStore.test.ts test/syncEngine.test.ts
- pnpm --filter @waves/mobile run typecheck
- pnpm --filter @waves/mobile run lint
- pnpm exec prettier --check apps/mobile/src/app/_layout.tsx apps/mobile/src/app/dev/local-privacy.tsx apps/mobile/src/lib/localPrivacyAudit.ts apps/mobile/test/aiKeys.test.ts apps/mobile/test/localPrivacyAudit.test.ts apps/mobile/test/imageCache.test.ts apps/mobile/test/localStore.test.ts apps/mobile/test/receiptQueue.test.ts e2e/local-privacy-audit.yaml e2e/README-e2e.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development-only local privacy audit screen showing aggregate counts for stored keys, receipt queues, pending files, and cached images.
  * Added an end-to-end flow to verify local private data is cleared after sign-out.
* **Tests**
  * Expanded coverage for secure key storage, encrypted queues, image-cache cleanup, receipt-file cleanup, and local privacy auditing.
* **Documentation**
  * Documented the new local privacy audit flow in the mobile end-to-end test guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->