### PR TITLE
fix(core): harden split validation

### DIFF
--- a/apps/mobile/src/data/serialiseExpense.ts
+++ b/apps/mobile/src/data/serialiseExpense.ts
@@ -16,6 +16,8 @@
  * `expense-write` path — the parity hole this contract exists to prevent.
  */
 
+import { serialiseSplitParams } from '@waves/core';
+
 import type { WriteExpenseInput } from './api';
 
 /**
@@ -33,7 +35,7 @@ export function serialiseExpense(
     currency: input.currency,
     amount: input.amount.toString(),
     fx: input.fx ?? null,
-    splitParams: input.splitParams,
+    splitParams: serialiseSplitParams(input.splitParams),
     participants: input.participants,
     payers: Object.fromEntries(
       Object.entries(input.payers).map(([member, amount]) => [member, amount.toString()]),

--- a/apps/mobile/test/serialiseExpense.test.ts
+++ b/apps/mobile/test/serialiseExpense.test.ts
@@ -60,6 +60,47 @@ describe('serialiseExpense', () => {
     expect(out.expectedShares).toEqual({ m1: '1000', m2: '1000' });
   });
 
+  it('serialises bigint-bearing split params before the JSON queue sees them', () => {
+    const out = serialiseExpense({
+      ...base,
+      amount: 3200n,
+      splitParams: {
+        kind: 'itemized',
+        items: [{ label: 'Room', total: 3000n }],
+        claims: { 0: ['m1', 'm2'] },
+        taxes: 200n,
+      },
+      expectedShares: { m1: 1600n, m2: 1600n },
+    });
+
+    expect(out.splitParams).toEqual({
+      kind: 'itemized',
+      items: [{ label: 'Room', total: '3000' }],
+      claims: { 0: ['m1', 'm2'] },
+      taxes: '200',
+    });
+    expect(() => JSON.stringify(out)).not.toThrow();
+  });
+
+  it('serialises exact and adjustment split params for offline travel presets', () => {
+    const exact = serialiseExpense({
+      ...base,
+      splitParams: { kind: 'exact', amounts: { m1: 2000n, m2: 0n } },
+    });
+    const adjustment = serialiseExpense({
+      ...base,
+      splitParams: { kind: 'adjustment', adjustments: { m1: 300n, m2: 0n } },
+    });
+
+    expect(exact.splitParams).toEqual({ kind: 'exact', amounts: { m1: '2000', m2: '0' } });
+    expect(adjustment.splitParams).toEqual({
+      kind: 'adjustment',
+      adjustments: { m1: '300', m2: '0' },
+    });
+    expect(() => JSON.stringify(exact)).not.toThrow();
+    expect(() => JSON.stringify(adjustment)).not.toThrow();
+  });
+
   it('trims the description and leaves expectedShares undefined when not given', () => {
     const out = serialiseExpense(base);
     expect(out.description).toBe('Dinner');

--- a/packages/core/src/split/computeShares.ts
+++ b/packages/core/src/split/computeShares.ts
@@ -31,11 +31,12 @@ export function splitTypeOf(params: SplitParams): SplitType {
 
 export function computeShares(input: ComputeSharesInput): ShareMap {
   const participants = validateParticipants(input.participants);
+  const participantSet = new Set<MemberId>(participants);
   if (input.amount < 0n) {
     throw new SplitError(SplitErrorCode.NegativeTotal, 'Expense total cannot be negative');
   }
 
-  const shares = computeByType(input, participants);
+  const shares = computeByType(input, participants, participantSet);
 
   // Every participant appears, even with a zero share, so the UI and the
   // expense_shares table agree on the row set.
@@ -47,7 +48,11 @@ export function computeShares(input: ComputeSharesInput): ShareMap {
   return shares;
 }
 
-function computeByType(input: ComputeSharesInput, participants: readonly MemberId[]): ShareMap {
+function computeByType(
+  input: ComputeSharesInput,
+  participants: readonly MemberId[],
+  participantSet: ReadonlySet<MemberId>,
+): ShareMap {
   switch (input.params.kind) {
     case 'equal':
       return splitEqually(input.amount, participants, input.seed);
@@ -56,7 +61,7 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
       const shares = new Map<MemberId, bigint>();
       let total = 0n;
       for (const [member, amount] of Object.entries(input.params.amounts)) {
-        requireParticipant(member, participants);
+        requireParticipant(member, participantSet);
         shares.set(member, amount);
         total += amount;
       }
@@ -73,7 +78,7 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
       const weights = new Map<MemberId, bigint>();
       let total = 0;
       for (const [member, basisPoints] of Object.entries(input.params.basisPoints)) {
-        requireParticipant(member, participants);
+        requireParticipant(member, participantSet);
         if (!Number.isInteger(basisPoints) || basisPoints < 0) {
           throw new SplitError(
             SplitErrorCode.InvalidWeight,
@@ -96,7 +101,7 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
       const weights = new Map<MemberId, bigint>();
       let positive = false;
       for (const [member, weight] of Object.entries(input.params.weights)) {
-        requireParticipant(member, participants);
+        requireParticipant(member, participantSet);
         if (!Number.isInteger(weight) || weight < 0) {
           throw new SplitError(
             SplitErrorCode.InvalidWeight,
@@ -119,7 +124,7 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
       let adjustmentTotal = 0n;
       const adjustments = new Map<MemberId, bigint>();
       for (const [member, adjustment] of Object.entries(input.params.adjustments)) {
-        requireParticipant(member, participants);
+        requireParticipant(member, participantSet);
         adjustments.set(member, adjustment);
         adjustmentTotal += adjustment;
       }
@@ -132,7 +137,7 @@ function computeByType(input: ComputeSharesInput, participants: readonly MemberI
     }
 
     case 'itemized':
-      return splitItemized(input.amount, input.params, participants, input.seed);
+      return splitItemized(input.amount, input.params, participants, participantSet, input.seed);
   }
 }
 
@@ -158,6 +163,7 @@ function splitItemized(
   amount: bigint,
   params: ItemizedParams,
   participants: readonly MemberId[],
+  participantSet: ReadonlySet<MemberId>,
   seed: string,
 ): ShareMap {
   if (params.items.length === 0) {
@@ -165,6 +171,16 @@ function splitItemized(
       SplitErrorCode.InvalidItem,
       'An itemized split needs at least one line item',
     );
+  }
+
+  for (const key of Object.keys(params.claims)) {
+    const index = Number(key);
+    if (!Number.isSafeInteger(index) || index < 0 || index >= params.items.length) {
+      throw new SplitError(
+        SplitErrorCode.InvalidItem,
+        `Claims include line ${key}, which does not exist`,
+      );
+    }
   }
 
   const subtotals = new Map<MemberId, bigint>();
@@ -184,7 +200,14 @@ function splitItemized(
         `Line ${index} ("${item.label ?? ''}") is unclaimed`,
       );
     }
-    for (const claimer of claimers) requireParticipant(claimer, participants);
+    const uniqueClaimers = new Set(claimers);
+    if (uniqueClaimers.size !== claimers.length) {
+      throw new SplitError(
+        SplitErrorCode.InvalidItem,
+        `Line ${index} has the same member claiming it more than once`,
+      );
+    }
+    for (const claimer of claimers) requireParticipant(claimer, participantSet);
 
     const lineShares = splitEqually(item.total, claimers, `${seed}:item:${index}`);
     for (const [member, share] of lineShares) {
@@ -193,11 +216,11 @@ function splitItemized(
     itemsTotal += item.total;
   });
 
-  const extras =
-    (params.taxes ?? 0n) +
-    (params.serviceCharge ?? 0n) +
-    (params.tip ?? 0n) -
-    (params.discounts ?? 0n);
+  const taxes = requireNonNegativeExtra('taxes', params.taxes);
+  const serviceCharge = requireNonNegativeExtra('serviceCharge', params.serviceCharge);
+  const tip = requireNonNegativeExtra('tip', params.tip);
+  const discounts = requireNonNegativeExtra('discounts', params.discounts);
+  const extras = taxes + serviceCharge + tip - discounts;
 
   if (itemsTotal + extras !== amount) {
     throw new SplitError(
@@ -222,6 +245,17 @@ function splitItemized(
   return shares;
 }
 
+function requireNonNegativeExtra(
+  field: 'taxes' | 'serviceCharge' | 'tip' | 'discounts',
+  value: bigint | undefined,
+): bigint {
+  if (value === undefined) return 0n;
+  if (value < 0n) {
+    throw new SplitError(SplitErrorCode.InvalidItem, `${field} cannot be negative`);
+  }
+  return value;
+}
+
 function validateParticipants(participants: readonly MemberId[]): MemberId[] {
   if (participants.length === 0) {
     throw new SplitError(
@@ -236,8 +270,8 @@ function validateParticipants(participants: readonly MemberId[]): MemberId[] {
   return [...participants];
 }
 
-function requireParticipant(member: MemberId, participants: readonly MemberId[]): void {
-  if (!participants.includes(member)) {
+function requireParticipant(member: MemberId, participants: ReadonlySet<MemberId>): void {
+  if (!participants.has(member)) {
     throw new SplitError(
       SplitErrorCode.UnknownMember,
       `"${member}" is not a participant in this expense`,
@@ -252,6 +286,15 @@ export function sumShares(shares: ShareMap): bigint {
 }
 
 function assertSumsTo(shares: ShareMap, amount: bigint): void {
+  for (const [member, share] of shares) {
+    if (share < 0n) {
+      throw new SplitError(
+        SplitErrorCode.NegativeShare,
+        `Computed share for ${member} is negative (${share})`,
+      );
+    }
+  }
+
   const total = sumShares(shares);
   if (total !== amount) {
     throw new SplitError(

--- a/packages/core/src/split/remainder.ts
+++ b/packages/core/src/split/remainder.ts
@@ -29,8 +29,10 @@ export function rotationOffset(seed: string, count: number): number {
 }
 
 /**
- * Hand out `remainder` minor units (may be negative) across `order`, one unit
- * per member per pass, starting at `offset`.
+ * Hand out `remainder` minor units (may be negative) across `order`, starting at
+ * `offset`. Normal split callers pass a remainder smaller than `order.length`,
+ * but this helper is exported for tests and SQL parity, so large direct inputs
+ * are handled in O(n) by applying full rounds before the rotated leftovers.
  */
 export function distributeRemainder(
   shares: Map<MemberId, bigint>,
@@ -39,14 +41,23 @@ export function distributeRemainder(
   offset: number,
 ): void {
   if (remainder === 0n || order.length === 0) return;
-  const step = remainder > 0n ? 1n : -1n;
-  let left = remainder > 0n ? remainder : -remainder;
+  const sign = remainder > 0n ? 1n : -1n;
+  const magnitude = remainder > 0n ? remainder : -remainder;
+  const count = BigInt(order.length);
+  const fullRounds = magnitude / count;
+  const leftovers = Number(magnitude % count);
+
+  if (fullRounds !== 0n) {
+    for (const member of order) {
+      shares.set(member, (shares.get(member) ?? 0n) + sign * fullRounds);
+    }
+  }
+
   let index = offset % order.length;
-  while (left > 0n) {
+  for (let left = 0; left < leftovers; left += 1) {
     const member = order[index] as MemberId;
-    shares.set(member, (shares.get(member) ?? 0n) + step);
+    shares.set(member, (shares.get(member) ?? 0n) + sign);
     index = (index + 1) % order.length;
-    left -= 1n;
   }
 }
 

--- a/packages/core/src/split/types.ts
+++ b/packages/core/src/split/types.ts
@@ -89,6 +89,7 @@ export enum SplitErrorCode {
   DuplicateParticipant = 'DUPLICATE_PARTICIPANT',
   UnknownMember = 'UNKNOWN_MEMBER',
   NegativeTotal = 'NEGATIVE_TOTAL',
+  NegativeShare = 'NEGATIVE_SHARE',
   ExactSumMismatch = 'EXACT_SUM_MISMATCH',
   PercentSumMismatch = 'PERCENT_SUM_MISMATCH',
   InvalidWeight = 'INVALID_WEIGHT',

--- a/packages/core/src/split/wire.ts
+++ b/packages/core/src/split/wire.ts
@@ -82,7 +82,7 @@ export function parseSplitParams(raw: unknown): SplitParams {
       requireRecord(basisPoints, 'basisPoints');
       return {
         kind: 'percent',
-        basisPoints: mapValues(basisPoints, (value) => Number(integer(value, 'basisPoints'))),
+        basisPoints: mapValues(basisPoints, (value) => safeNumberInteger(value, 'basisPoints')),
       };
     }
 
@@ -91,7 +91,7 @@ export function parseSplitParams(raw: unknown): SplitParams {
       requireRecord(weights, 'weights');
       return {
         kind: 'shares',
-        weights: mapValues(weights, (value) => Number(integer(value, 'weights'))),
+        weights: mapValues(weights, (value) => safeNumberInteger(value, 'weights')),
       };
     }
 
@@ -100,7 +100,6 @@ export function parseSplitParams(raw: unknown): SplitParams {
       if (!Array.isArray(items)) {
         throw new SplitWireError('BAD_SHAPE', 'An itemized split needs a list of items');
       }
-      requireRecord(params.claims, 'claims');
       return {
         kind: 'itemized',
         items: items.map((item, index) => {
@@ -113,7 +112,7 @@ export function parseSplitParams(raw: unknown): SplitParams {
             total: integer(line.total, `items[${index}].total`),
           };
         }),
-        claims: params.claims as ItemizedParams['claims'],
+        claims: itemizedClaims(params.claims, items.length),
         ...optionalBig('taxes', maybeInteger(params.taxes, 'taxes')),
         ...optionalBig('serviceCharge', maybeInteger(params.serviceCharge, 'serviceCharge')),
         ...optionalBig('tip', maybeInteger(params.tip, 'tip')),
@@ -153,7 +152,52 @@ function integer(value: unknown, field: string): bigint {
 }
 
 function maybeInteger(value: unknown, field: string): bigint | undefined {
-  return value === undefined || value === null ? undefined : integer(value, field);
+  return value === undefined ? undefined : integer(value, field);
+}
+
+function safeNumberInteger(value: unknown, field: string): number {
+  const parsed = integer(value, field);
+  if (parsed < 0n || parsed > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new SplitWireError(
+      'NOT_AN_INTEGER',
+      `${field}: ${parsed} is outside the safe integer range`,
+    );
+  }
+  return Number(parsed);
+}
+
+function itemizedClaims(raw: unknown, itemCount: number): ItemizedParams['claims'] {
+  requireRecord(raw, 'claims');
+  const claims: Record<number, MemberId[]> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (!/^\d+$/.test(key)) {
+      throw new SplitWireError('BAD_SHAPE', `claims key ${key} is not a line index`);
+    }
+    const index = Number(key);
+    if (!Number.isSafeInteger(index) || index >= itemCount) {
+      throw new SplitWireError('BAD_SHAPE', `claims key ${key} does not name an item`);
+    }
+    if (Object.prototype.hasOwnProperty.call(claims, index)) {
+      throw new SplitWireError('BAD_SHAPE', `claims key ${key} repeats an item index`);
+    }
+    if (!Array.isArray(value)) {
+      throw new SplitWireError('BAD_SHAPE', `claims[${key}] must be a list of member ids`);
+    }
+    const members: MemberId[] = [];
+    const seen = new Set<MemberId>();
+    for (const member of value) {
+      if (typeof member !== 'string' || member.length === 0) {
+        throw new SplitWireError('BAD_SHAPE', `claims[${key}] must contain member ids`);
+      }
+      if (seen.has(member)) {
+        throw new SplitWireError('BAD_SHAPE', `claims[${key}] repeats member ${member}`);
+      }
+      seen.add(member);
+      members.push(member);
+    }
+    claims[index] = members;
+  }
+  return claims;
 }
 
 function requireRecord(value: unknown, field: string): asserts value is Record<string, unknown> {
@@ -169,7 +213,7 @@ function mapValues<In, Out>(
   return Object.fromEntries(Object.entries(source).map(([key, value]) => [key, transform(value)]));
 }
 
-/** Absent stays absent. `{ tip: null }` would read as "no tip", which is not the same as "no tip line". */
+/** Absent stays absent. `{ tip: null }` is refused rather than treated as a missing receipt line. */
 function optionalString<K extends string>(
   key: K,
   value: bigint | undefined,

--- a/packages/core/test/split.combinations.test.ts
+++ b/packages/core/test/split.combinations.test.ts
@@ -25,6 +25,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { computeShares, sumShares } from '../src/split/computeShares.js';
+import { distributeRemainder } from '../src/split/remainder.js';
 import { verifyClientShares } from '../src/split/verify.js';
 import { SplitError, SplitErrorCode, type MemberId, type ShareMap } from '../src/split/types.js';
 
@@ -379,16 +380,18 @@ describe('fixed value splits — exact amounts per person', () => {
     expect(shares.get('m3')).toBe(0n);
   });
 
-  it('allows a negative share only as part of a set that still sums correctly', () => {
-    // Someone was credited back — the total is still the total.
-    const shares = computeShares({
-      amount: 1000n,
-      currency: INR,
-      params: { kind: 'exact', amounts: { m1: 1200n, m2: -200n } },
-      participants: members(2),
-      seed: SEED,
-    });
-    expect(sumShares(shares)).toBe(1000n);
+  it('rejects a negative share even when the exact amounts sum correctly', () => {
+    expectSplitError(
+      () =>
+        computeShares({
+          amount: 1000n,
+          currency: INR,
+          params: { kind: 'exact', amounts: { m1: 1200n, m2: -200n } },
+          participants: members(2),
+          seed: SEED,
+        }),
+      SplitErrorCode.NegativeShare,
+    );
   });
 });
 
@@ -495,6 +498,20 @@ describe('rules that apply to every split type', () => {
       for (const [member, share] of shares) if (share === 334n) absorbers.add(member);
     }
     expect(absorbers.size).toBe(3);
+  });
+});
+
+describe('remainder distribution helper', () => {
+  it('handles large direct remainders by full rounds plus rotated leftovers', () => {
+    const shares = new Map<MemberId, bigint>([
+      ['a', 0n],
+      ['b', 0n],
+      ['c', 0n],
+    ]);
+    distributeRemainder(shares, 1_000_000_000_001n, ['a', 'b', 'c'], 1);
+    expect(shares.get('a')).toBe(333_333_333_333n);
+    expect(shares.get('b')).toBe(333_333_333_334n);
+    expect(shares.get('c')).toBe(333_333_333_334n);
   });
 });
 

--- a/packages/core/test/split.property.test.ts
+++ b/packages/core/test/split.property.test.ts
@@ -104,7 +104,7 @@ describe('computeShares — Σ shares === amount', () => {
       fc.property(
         memberIds().chain((members) =>
           fc
-            .array(fc.bigInt({ min: -50_000n, max: 50_000n }), {
+            .array(fc.bigInt({ min: 0n, max: 50_000n }), {
               minLength: members.length,
               maxLength: members.length,
             })
@@ -116,17 +116,21 @@ describe('computeShares — Σ shares === amount', () => {
               return { members, adjustments };
             }),
         ),
-        amounts(),
+        amounts(1_000_000_000n),
         seeds(),
         ({ members, adjustments }, amount, seed) => {
+          const adjustmentTotal = Object.values(adjustments).reduce(
+            (sum, value) => sum + value,
+            0n,
+          );
           const shares = computeShares({
-            amount,
+            amount: amount + adjustmentTotal,
             currency: INR,
             params: { kind: 'adjustment', adjustments },
             participants: members,
             seed,
           });
-          expect(sumShares(shares)).toBe(amount);
+          expect(sumShares(shares)).toBe(amount + adjustmentTotal);
         },
       ),
     );
@@ -282,6 +286,67 @@ describe('computeShares — rejections', () => {
         seed: 'x',
       }),
     ).toThrowError(/total/i);
+  });
+
+  it('rejects duplicate itemized claimers before the line total can be lost', () => {
+    expect(() =>
+      computeShares({
+        amount: 100n,
+        currency: INR,
+        params: { kind: 'itemized', items: [{ total: 100n }], claims: { 0: ['a', 'a'] } },
+        participants: ['a', 'b'],
+        seed: 'x',
+      }),
+    ).toThrowError(/claiming it more than once/i);
+  });
+
+  it('rejects itemized claims for lines that do not exist', () => {
+    expect(() =>
+      computeShares({
+        amount: 100n,
+        currency: INR,
+        params: { kind: 'itemized', items: [{ total: 100n }], claims: { 0: ['a'], 1: ['b'] } },
+        participants: ['a', 'b'],
+        seed: 'x',
+      }),
+    ).toThrowError(/does not exist/i);
+  });
+
+  it('rejects negative itemized tax, service, tip and discount fields', () => {
+    const base = { kind: 'itemized' as const, items: [{ total: 100n }], claims: { 0: ['a'] } };
+    for (const field of ['taxes', 'serviceCharge', 'tip', 'discounts'] as const) {
+      expect(() =>
+        computeShares({
+          amount: 100n,
+          currency: INR,
+          params: { ...base, [field]: -1n },
+          participants: ['a'],
+          seed: 'x',
+        }),
+      ).toThrowError(/cannot be negative/i);
+    }
+  });
+
+  it('rejects negative final shares from exact and adjustment splits', () => {
+    expect(() =>
+      computeShares({
+        amount: 1000n,
+        currency: INR,
+        params: { kind: 'exact', amounts: { a: 1200n, b: -200n } },
+        participants: ['a', 'b'],
+        seed: 'x',
+      }),
+    ).toThrowError(/negative/i);
+
+    expect(() =>
+      computeShares({
+        amount: 1000n,
+        currency: INR,
+        params: { kind: 'adjustment', adjustments: { a: -2000n } },
+        participants: ['a', 'b'],
+        seed: 'x',
+      }),
+    ).toThrowError(/negative/i);
   });
 
   it('rejects unknown members and empty participant lists', () => {

--- a/packages/core/test/wire.test.ts
+++ b/packages/core/test/wire.test.ts
@@ -168,10 +168,54 @@ describe('parsing what an older or stranger client sent', () => {
   });
 
   it('keeps a negative adjustment negative', () => {
-    // Adjustments go both ways: Ravi had the extra beer, Asha skipped dessert.
+    // Adjustments go both ways at the wire boundary; computeShares rejects a
+    // final negative owed share if the credit would make spending nonsensical.
     expect(
       parseSplitParams({ kind: 'adjustment', adjustments: { ravi: '12000', asha: '-4000' } }),
     ).toEqual({ kind: 'adjustment', adjustments: { ravi: 12000n, asha: -4000n } });
+  });
+
+  it('refuses unsafe integer weights before a double can round them', () => {
+    expect(() =>
+      parseSplitParams({ kind: 'shares', weights: { asha: '9007199254740993' } }),
+    ).toThrow(/safe integer/);
+    expect(() =>
+      parseSplitParams({ kind: 'percent', basisPoints: { asha: '9007199254740993' } }),
+    ).toThrow(/safe integer/);
+  });
+
+  it('refuses negative wire weights before computeShares sees them', () => {
+    expect(() => parseSplitParams({ kind: 'shares', weights: { asha: '-1' } })).toThrow(
+      /safe integer/,
+    );
+    expect(() => parseSplitParams({ kind: 'percent', basisPoints: { asha: '-1' } })).toThrow(
+      /safe integer/,
+    );
+  });
+
+  it('refuses null itemized optionals instead of treating them as absent', () => {
+    expect(() =>
+      parseSplitParams({
+        kind: 'itemized',
+        items: [{ total: '100' }],
+        claims: { 0: ['asha'] },
+        tip: null,
+      }),
+    ).toThrow(SplitWireError);
+  });
+
+  it('validates itemized claims before computeShares uses them', () => {
+    const base = { kind: 'itemized', items: [{ total: '100' }] };
+    expect(() => parseSplitParams({ ...base, claims: { 0: 'asha' } })).toThrow(/list/);
+    expect(() => parseSplitParams({ ...base, claims: { 0: [123] } })).toThrow(/member ids/);
+    expect(() => parseSplitParams({ ...base, claims: { 0: ['asha', 'asha'] } })).toThrow(/repeats/);
+    expect(() => parseSplitParams({ ...base, claims: { 1: ['asha'] } })).toThrow(
+      /does not name an item/,
+    );
+    expect(() => parseSplitParams({ ...base, claims: { '-1': ['asha'] } })).toThrow(/line index/);
+    expect(() => parseSplitParams({ ...base, claims: { 0: ['asha'], '00': ['ravi'] } })).toThrow(
+      /repeats an item index/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- serialize bigint-bearing split params before mobile offline queue persistence
- harden split compute/wire validation for itemized claims, unsafe numeric weights, null optionals, negative extras, and negative final shares
- make exported remainder distribution bounded for large direct inputs

## Validation
- pnpm --filter @waves/core test -- split.property.test.ts split.combinations.test.ts wire.test.ts travelSplit.test.ts
- pnpm --filter @waves/mobile test -- serialiseExpense.test.ts
- pnpm --filter @waves/core typecheck
- pnpm --filter @waves/mobile typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved expense split validation by rejecting negative shares, charges, discounts, taxes, and adjustments.
  - Prevented invalid item claims, duplicate claimers, nonexistent item references, and malformed split data.
  - Fixed large remainder distributions to ensure amounts are allocated accurately and consistently.
  - Improved queued expense serialization so split values remain compatible with JSON, including large numeric amounts.

- **Improvements**
  - Added clearer handling for explicitly null optional split values and more precise split error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->