### PR TITLE
feat(captures): quiet cloud glyph for unsynced drafts

### DIFF
--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -18,7 +18,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
   Avatar,
-  Badge,
   Button,
   directionalIcon,
   EmptyState,
@@ -34,6 +33,7 @@ import {
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
+import { PendingMark } from '@/components/PendingMark';
 import { InboxSkeleton } from '@/components/Skeletons';
 import { capturePhotoUrl } from '@/data/api';
 import { useSignedUrl } from '@/lib/useSignedUrl';
@@ -139,7 +139,7 @@ function CaptureListRow({
             <Text variant="micro" tone="muted">
               {shortDate(capture.expense_date, locale)}
             </Text>
-            {capture.pending ? <Badge label={t.captures.notSynced} tone="brand" /> : null}
+            {capture.pending ? <PendingMark /> : null}
           </Row>
         </View>
 


### PR DESCRIPTION
On the drafts (captures inbox) screen, a queued row wore a brand-coloured **"Not synced yet"** Badge — louder than the row itself.

Swap it for **`PendingMark`**, the faint grey `cloud-upload-outline` glyph the group and dashboard screens already use for a pending row, so "not sent yet" reads the same quiet way everywhere. The a11y label preserves the meaning for screen readers.

- `app/captures.tsx` — Badge → PendingMark (drop the now-unused Badge import)

typecheck ✅. JS-only (OTA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated pending capture indicators to use a clearer pending-status mark instead of the previous “not synced” badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->