### PR TITLE
fix(nav): make the Inbox tab-bar destination switch instantly like the tabs

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -615,7 +615,12 @@ function AuthGate() {
           <Stack.Screen name="settings/delete-account" />
           <Stack.Screen name="dev/local-privacy" />
           <Stack.Screen name="join" />
-          <Stack.Screen name="inbox" />
+          {/* A primary tab-bar destination sitting beside Home/Friends/Activity,
+              so it switches instantly like they do rather than sliding in like a
+              pushed page. Without this it inherits the stack's slide, and the
+              inbox was the one bar destination that animated while the tabs cut
+              straight across — the inconsistency this `none` removes. */}
+          <Stack.Screen name="inbox" options={{ animation: 'none' }} />
           <Stack.Screen name="voice" options={slide} />
         </Stack>
         {/* One bar over the whole stack, so every screen keeps it — it hides


### PR DESCRIPTION
## Problem

Primary navigation was inconsistent: switching between the bottom bar's tabs (Friends -> Activity) is an instant cut, but opening **Inbox** from the same bar slid in with an animation.

## Root cause

The bottom bar (`AppTabBar` -> `PillTabBar`) presents Inbox as a peer of Home / Friends / Activity, but they are reached by two different navigation mechanisms:

- **Friends / Activity** live inside the `(tabs)` navigator and are reached with `router.navigate('/friends')` / `router.navigate('/activity')` — a **tab switch**. Both the `(tabs)/_layout.tsx` Tabs navigator and the root Stack's `(tabs)` screen set `animation: 'none'`, so the switch is instant.
- **Inbox** is a separate root **Stack** route reached with `router.push('/inbox')`. Its `<Stack.Screen name="inbox" />` had no `options`, so it inherited the root Stack's default `screenOptions.animation` (`slide_from_right` / `slide_from_left`, `animationDuration: TRANSITION_MS`) — hence it slid.

## Fix

Give the Inbox Stack screen `animation: 'none'`, aligning it with the instant tab switches (and matching the existing `animation: 'none'` opt-outs already on `welcome`, `sign-in`, and `(tabs)`).

Direction chosen: **align Inbox to the tabs (instant)**, not the other way round. Bottom-tab switching is instant on both iOS and Android; the tabs clearly intend an instant cut (the `(tabs)` layout comment spells this out). The slide is left untouched for genuine pushed pages (groups, settings, capture, etc.).

## Gates

- `pnpm --filter @waves/mobile typecheck` — exit 0
- `pnpm format` — exit 0
- `pnpm --filter @waves/mobile lint` — exit 0
- `bash scripts/check-filenames.sh` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Inbox tab to switch instantly without a slide animation, matching the behavior of other primary navigation destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->