### PR TITLE
fix(mobile): respect reduced motion and clamp zoom

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -46,6 +46,7 @@ import { LanguageProvider, useLanguage } from '@/i18n/language';
 import { LocaleSync } from '@/i18n/localeSync';
 import { LockProvider, useLock } from '@/lib/lock';
 import { TRANSITION_MS } from '@/lib/anim';
+import { ReducedMotionProvider, useReducedMotion } from '@/lib/reducedMotion';
 import { RecentCountProvider } from '@/lib/recentCount';
 import { ShortcutProvider } from '@/lib/shortcut';
 import { WatchBridgeProvider } from '@/lib/watch/bridge';
@@ -203,55 +204,57 @@ function RootLayout() {
                   <SyncNetworkProvider>
                     <UpdateProvider>
                       <ThemePreferenceProvider>
-                        <TourProvider>
-                          <PromptQueueProvider>
-                            <ShortcutProvider>
-                              <RecentCountProvider>
-                                <ThemedRoot>
-                                  <ThemedStatusBar />
-                                  {/* Outside the lock and the auth gate on purpose: a build
+                        <ReducedMotionProvider>
+                          <TourProvider>
+                            <PromptQueueProvider>
+                              <ShortcutProvider>
+                                <RecentCountProvider>
+                                  <ThemedRoot>
+                                    <ThemedStatusBar />
+                                    {/* Outside the lock and the auth gate on purpose: a build
                             we have stopped trusting should not be unlocking a
                             ledger or signing anybody in either. */}
-                                  <UpdateGate>
-                                    <PushRouting />
-                                    <LockGate>
-                                      {/* Below the lock and update gates so the watch
+                                    <UpdateGate>
+                                      <PushRouting />
+                                      <LockGate>
+                                        {/* Below the lock and update gates so the watch
                                 bridge never turns a wrist tap into a capture
                                 while the app is locked or on a build we have
                                 stopped trusting. */}
-                                      <WatchBridgeProvider />
-                                      {/* Inside the lock so the two-device gate never
+                                        <WatchBridgeProvider />
+                                        {/* Inside the lock so the two-device gate never
                                 paints over the lock screen, and past auth so it
                                 only ever asks a signed-in account. */}
-                                      <DeviceSessionProvider>
-                                        <AuthGate />
-                                        {/* Inside the lock on purpose: a promotion is not a
+                                        <DeviceSessionProvider>
+                                          <AuthGate />
+                                          {/* Inside the lock on purpose: a promotion is not a
                                   reason to show somebody's phone anything before
                                   they have unlocked it. */}
-                                        <CampaignPopup />
-                                        {/* The soft ask for push, once, to a
+                                          <CampaignPopup />
+                                          {/* The soft ask for push, once, to a
                                         signed-in person whose permission is
                                         still undetermined. */}
-                                        <NotificationPrompt />
-                                      </DeviceSessionProvider>
-                                    </LockGate>
-                                    {/* The coach-mark tour, over the whole app but
+                                          <NotificationPrompt />
+                                        </DeviceSessionProvider>
+                                      </LockGate>
+                                      {/* The coach-mark tour, over the whole app but
                                     only ever started from Home. Above the gate
                                     so its scrim covers the screen. */}
-                                    <TourOverlay />
-                                    {/* Last, so it paints over the screen rather than
+                                      <TourOverlay />
+                                      {/* Last, so it paints over the screen rather than
                               under it. */}
-                                    <UpdateBanner />
-                                  </UpdateGate>
-                                  {/* Topmost of all: the launch field, painting over
+                                      <UpdateBanner />
+                                    </UpdateGate>
+                                    {/* Topmost of all: the launch field, painting over
                                   the whole app until it fades itself out. Native
                                   only; renders nothing on web. */}
-                                  <AnimatedSplash />
-                                </ThemedRoot>
-                              </RecentCountProvider>
-                            </ShortcutProvider>
-                          </PromptQueueProvider>
-                        </TourProvider>
+                                    <AnimatedSplash />
+                                  </ThemedRoot>
+                                </RecentCountProvider>
+                              </ShortcutProvider>
+                            </PromptQueueProvider>
+                          </TourProvider>
+                        </ReducedMotionProvider>
                       </ThemePreferenceProvider>
                     </UpdateProvider>
                   </SyncNetworkProvider>
@@ -409,6 +412,7 @@ function AuthGate() {
   const segments = useSegments();
   const router = useRouter();
   const theme = useTheme();
+  const reduceMotion = useReducedMotion();
   // The paywall is an unwired placeholder (no store products, no purchase
   // handling), so its route is registered only where a flag turns it on —
   // otherwise a deep link cannot reach a screen that would only mislead.
@@ -419,7 +423,11 @@ function AuthGate() {
   // that opt out are the auth and tab roots below, which replace the whole tree
   // and mark themselves `animation: 'none'`. Screens that once rose as bottom
   // modals now slide too, so navigation reads the same everywhere.
-  const push = I18nManager.isRTL ? ('slide_from_left' as const) : ('slide_from_right' as const);
+  const push = reduceMotion
+    ? ('none' as const)
+    : I18nManager.isRTL
+      ? ('slide_from_left' as const)
+      : ('slide_from_right' as const);
   // A normal forward page: a plain horizontal translate (and back out the way it
   // came) rather than rising like a modal — the "went to a page", not "on top of"
   // feel. A bare translate is the cheapest native transition on the UI thread, so
@@ -428,7 +436,7 @@ function AuthGate() {
   // from the right in LTR, from the left in RTL (Arabic) — so it never slides the
   // wrong way.
   const slide = {
-    animation: I18nManager.isRTL ? ('slide_from_left' as const) : ('slide_from_right' as const),
+    animation: push,
   };
 
   // The two auth doors and the invite-accept screen are the only routes a
@@ -560,7 +568,7 @@ function AuthGate() {
             headerShown: false,
             contentStyle: { backgroundColor: 'transparent' },
             animation: push,
-            animationDuration: TRANSITION_MS,
+            animationDuration: reduceMotion ? 0 : TRANSITION_MS,
             gestureEnabled: true,
           }}
         >

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useMutation } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -273,30 +273,40 @@ export default function GroupScreen() {
   const ledger = useGroupLedger(groupId, profile?.id ?? null);
   const disputes = useDisputes(groupId);
   const openReceipts = useOpenReceipts(groupId);
-  const openDisputes = new Set(
-    (disputes.data ?? []).filter((row) => row.status === 'open').map((row) => row.expense_id),
+  const openDisputes = useMemo(
+    () =>
+      new Set(
+        (disputes.data ?? []).filter((row) => row.status === 'open').map((row) => row.expense_id),
+      ),
+    [disputes.data],
   );
   const confirmSettlement = useConfirmSettlement(groupId);
 
   const { blockedIds } = useBlockedUsers();
-  const lookup = memberLookup(members.data);
-  const nameOf = (memberId: string | null): string => {
-    const member = memberId ? lookup.get(memberId) : undefined;
-    return member ? displayName(member, profile?.id, blockedIds, t.misc.someone) : t.misc.someone;
-  };
+  const lookup = useMemo(() => memberLookup(members.data), [members.data]);
+  const nameOf = useCallback(
+    (memberId: string | null): string => {
+      const member = memberId ? lookup.get(memberId) : undefined;
+      return member ? displayName(member, profile?.id, blockedIds, t.misc.someone) : t.misc.someone;
+    },
+    [blockedIds, lookup, profile?.id, t.misc.someone],
+  );
   // The joined actor an activity row would carry on the cross-group feed, rebuilt
   // from this group's members — so the mirror-backed group feed can name who did
   // the thing rather than falling back to "someone".
-  const actorFor = (memberId: string | null): ActivityActor | null => {
-    const member = memberId ? lookup.get(memberId) : undefined;
-    if (!member) return null;
-    return {
-      id: member.id,
-      profile_id: member.profile_id,
-      ghost_name: member.ghost_name,
-      profile: member.profile ? { display_name: member.profile.display_name } : null,
-    };
-  };
+  const actorFor = useCallback(
+    (memberId: string | null): ActivityActor | null => {
+      const member = memberId ? lookup.get(memberId) : undefined;
+      if (!member) return null;
+      return {
+        id: member.id,
+        profile_id: member.profile_id,
+        ghost_name: member.ghost_name,
+        profile: member.profile ? { display_name: member.profile.display_name } : null,
+      };
+    },
+    [lookup],
+  );
 
   if (group.isLoading) {
     return <GroupSkeleton />;
@@ -378,7 +388,8 @@ export default function GroupScreen() {
     );
   }
 
-  const currency = group.data.default_currency;
+  const groupData = group.data;
+  const currency = groupData.default_currency;
   // The hero panel wears its verdict, the same rule the dashboard hero follows:
   // a blue wash when the group owes you, a red one when you owe it, the brand
   // indigo when all is settled. Every stop is dark enough to hold the white
@@ -417,7 +428,7 @@ export default function GroupScreen() {
   // a trip to plan; a flatshare has no use for the row.
   const menuItems: OverflowMenuItem[] = [
     { icon: 'pie-chart-outline', label: t.spending, route: `/group/${groupId}/insights` },
-    ...(group.data.type === 'trip'
+    ...(groupData.type === 'trip'
       ? [
           {
             icon: 'map-outline',

--- a/apps/mobile/src/components/ContactPicker.tsx
+++ b/apps/mobile/src/components/ContactPicker.tsx
@@ -163,18 +163,19 @@ export function ContactPicker({
     }
     if (cancelled.current) return;
 
-    setContacts(
-      rows
-        .map((row) => ({
-          name: (row.fullName ?? [row.givenName, row.familyName].filter(Boolean).join(' ')).trim(),
-          email: row.emails?.[0]?.address?.trim().toLowerCase() ?? null,
-          phone: normalisePhone(row.phones?.[0]?.number ?? null),
-        }))
-        // Somebody with neither an email nor a number cannot be invited, so
-        // showing them would only be an invitation to tap and be refused.
-        .filter((contact) => contact.name && (contact.email || contact.phone))
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    );
+    const unique = new Map<string, PickedContact>();
+    for (const contact of rows
+      .map((row) => ({
+        name: (row.fullName ?? [row.givenName, row.familyName].filter(Boolean).join(' ')).trim(),
+        email: row.emails?.[0]?.address?.trim().toLowerCase() ?? null,
+        phone: normalisePhone(row.phones?.[0]?.number ?? null),
+      }))
+      // Somebody with neither an email nor a number cannot be invited, so
+      // showing them would only be an invitation to tap and be refused.
+      .filter((contact) => contact.name && (contact.email || contact.phone))) {
+      unique.set(keyOf(contact), contact);
+    }
+    setContacts([...unique.values()].sort((a, b) => a.name.localeCompare(b.name)));
     setAccess(Access.Granted);
   }, []);
 
@@ -399,9 +400,7 @@ export function ContactPicker({
               // lets it recycle each against its own kind instead of throwing
               // away a row every time a letter goes by.
               getItemType={(entry) => (isHeading(entry) ? 'heading' : 'person')}
-              keyExtractor={(entry, index) =>
-                isHeading(entry) ? `letter-${entry.letter}` : `${keyOf(entry)}-${index}`
-              }
+              keyExtractor={(entry) => (isHeading(entry) ? `letter-${entry.letter}` : keyOf(entry))}
               keyboardShouldPersistTaps="handled"
               renderItem={({ item }) => {
                 if (isHeading(item)) return <Heading letter={item.letter} />;
@@ -693,10 +692,21 @@ function IndexRail({
       shown.length - 1,
       Math.max(0, Math.floor((y - top) / RAIL_LETTER_HEIGHT)),
     );
+    seekToIndex(index);
+  };
+
+  const seekToIndex = (index: number): void => {
     const letter = shown[index];
     if (letter === undefined || letter === active) return;
     setActive(letter);
     onSeek(letter);
+  };
+
+  const seekByStep = (step: -1 | 1): void => {
+    if (shown.length === 0) return;
+    const current = active ? shown.indexOf(active) : -1;
+    const next = Math.min(shown.length - 1, Math.max(0, current + step));
+    seekToIndex(next);
   };
 
   return (
@@ -714,6 +724,12 @@ function IndexRail({
       accessible
       accessibilityRole="adjustable"
       accessibilityLabel={t.pickers.jumpToLetter}
+      accessibilityValue={active ? { text: active } : undefined}
+      accessibilityActions={[{ name: 'increment' }, { name: 'decrement' }]}
+      onAccessibilityAction={(event) => {
+        if (event.nativeEvent.actionName === 'increment') seekByStep(1);
+        if (event.nativeEvent.actionName === 'decrement') seekByStep(-1);
+      }}
       style={{
         width: RAIL_WIDTH,
         justifyContent: 'center',

--- a/apps/mobile/src/components/SyncBanner.tsx
+++ b/apps/mobile/src/components/SyncBanner.tsx
@@ -16,6 +16,7 @@ import { Card, iconSize, Row, Text, useTheme } from '@waves/ui';
 import { plural, useStrings } from '@/i18n';
 
 import { isPhoneCountryError } from '@/lib/phone';
+import { useReducedMotion } from '@/lib/reducedMotion';
 import { SyncNetworkPreference, useSyncNetwork } from '@/lib/syncNetwork';
 import { SyncStatus, useSync } from '@/sync';
 
@@ -35,6 +36,7 @@ export function SyncStatusIcon({
   groupId,
 }: { onBrand?: boolean; groupId?: string } = {}) {
   const theme = useTheme();
+  const reduceMotion = useReducedMotion();
   const { t, locale } = useStrings();
   const { status, queue, rejected } = useSync();
 
@@ -47,7 +49,7 @@ export function SyncStatusIcon({
   const pending = groupId ? queue.filter((item) => item.groupId === groupId) : queue;
 
   const spin = useState(() => new Animated.Value(0))[0];
-  const spinning = status === SyncStatus.Syncing;
+  const spinning = status === SyncStatus.Syncing && !reduceMotion;
   useEffect(() => {
     if (!spinning) return;
     const loop = Animated.loop(
@@ -110,7 +112,7 @@ export function SyncStatusIcon({
       accessibilityLabel={state.label}
       style={{ padding: theme.spacing.xs }}
     >
-      {status === SyncStatus.Syncing ? (
+      {spinning ? (
         <Animated.View
           style={{
             transform: [

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -32,6 +32,7 @@ import { iconSize, Text, useTheme, type Theme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 import { dictationError, englishSpeechLocale } from '@/lib/dictation';
+import { useReducedMotion } from '@/lib/reducedMotion';
 
 const MIC_SIZE = 104;
 
@@ -343,6 +344,7 @@ export function VoiceCapture({
   autoStart = true,
 }: VoiceCaptureProps) {
   const theme = useTheme();
+  const reduceMotion = useReducedMotion();
   const { t, locale } = useStrings();
 
   const [available] = useState(recognitionAvailable);
@@ -495,8 +497,8 @@ export function VoiceCapture({
           justifyContent: 'center',
         }}
       >
-        <Halo active={listening} theme={theme} />
-        <PulseRings active={listening} theme={theme} />
+        <Halo active={listening && !reduceMotion} theme={theme} />
+        <PulseRings active={listening && !reduceMotion} theme={theme} />
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={
@@ -541,7 +543,7 @@ export function VoiceCapture({
         <Text tone={listening || showMiss ? 'brand' : 'muted'}>
           {listening ? t.misc.listening : showMiss ? t.voice.tapToRetry : t.voice.tapToSpeak}
         </Text>
-        {listening ? (
+        {listening && !reduceMotion ? (
           <Waveform active={listening} />
         ) : showMiss ? (
           <Text variant="caption" tone="faint" align="center">

--- a/apps/mobile/src/components/ZoomableGallery.tsx
+++ b/apps/mobile/src/components/ZoomableGallery.tsx
@@ -31,13 +31,22 @@ export function ZoomableGallery({
   onIndexChange: (index: number) => void;
 }): React.JSX.Element {
   const { width } = useWindowDimensions();
-  const [zoomed, setZoomed] = useState(false);
+  const [zoomState, setZoomState] = useState<{ url: string | null; zoomed: boolean }>({
+    url: null,
+    zoomed: false,
+  });
   const listRef = useRef<FlatList<GalleryPage>>(null);
+  const activeUrl = pages[index]?.url ?? null;
+  const zoomed = zoomState.url === activeUrl && zoomState.zoomed;
 
   const renderItem = ({ item }: ListRenderItemInfo<GalleryPage>) => (
     <View style={{ width, flex: 1, justifyContent: 'center' }}>
       {item.url ? (
-        <ZoomableImage uri={item.url} onZoomChange={setZoomed} annotations={item.annotations} />
+        <ZoomableImage
+          uri={item.url}
+          onZoomChange={(next) => setZoomState({ url: item.url, zoomed: next })}
+          annotations={item.annotations}
+        />
       ) : null}
     </View>
   );

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -43,11 +43,10 @@ export function ZoomableImage({
   const { width, height } = useWindowDimensions();
   const boxHeight = height * 0.8;
 
-  // The image's natural size, only needed to place an overlay on its exact fit
-  // rectangle. Resolved once per uri; until then the rect falls back to the box.
+  // The image's natural size anchors both pan bounds and, when present, overlay
+  // placement. Resolved once per uri; until then the rect falls back to the box.
   const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
   useEffect(() => {
-    if (!annotations) return;
     let active = true;
     RNImage.getSize(
       uri,
@@ -57,7 +56,9 @@ export function ZoomableImage({
     return () => {
       active = false;
     };
-  }, [uri, annotations]);
+  }, [uri]);
+
+  const rect = containRect({ w: width, h: boxHeight }, natural ?? { w: 0, h: 0 });
 
   const scale = useSharedValue(1);
   const savedScale = useSharedValue(1);
@@ -186,8 +187,6 @@ export function ZoomableImage({
       </GestureDetector>
     );
   }
-
-  const rect = containRect({ w: width, h: boxHeight }, natural ?? { w: 0, h: 0 });
 
   return (
     <GestureDetector gesture={composed}>

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -11,6 +11,7 @@ import Animated, {
 
 import { AnnotationOverlay } from '@/components/AnnotationOverlay';
 import { containRect, type Annotations } from '@/lib/annotations';
+import { clampZoomPoint } from '@/lib/zoomMath';
 
 const AnimatedImage = Animated.createAnimatedComponent(Image);
 
@@ -82,6 +83,15 @@ export function ZoomableImage({
         savedY.set(0);
         runOnJS(reportZoom)(false);
       } else {
+        const clamped = clampZoomPoint(
+          { x: translateX.get(), y: translateY.get() },
+          { width, height: boxHeight },
+          scale.get(),
+        );
+        translateX.set(withTiming(clamped.x));
+        translateY.set(withTiming(clamped.y));
+        savedX.set(clamped.x);
+        savedY.set(clamped.y);
         runOnJS(reportZoom)(true);
       }
     });
@@ -90,12 +100,24 @@ export function ZoomableImage({
     .onUpdate((event) => {
       // Panning only makes sense once zoomed in; at fit it stays put.
       if (scale.get() <= 1) return;
-      translateX.set(savedX.get() + event.translationX);
-      translateY.set(savedY.get() + event.translationY);
+      const clamped = clampZoomPoint(
+        { x: savedX.get() + event.translationX, y: savedY.get() + event.translationY },
+        { width, height: boxHeight },
+        scale.get(),
+      );
+      translateX.set(clamped.x);
+      translateY.set(clamped.y);
     })
     .onEnd(() => {
-      savedX.set(translateX.get());
-      savedY.set(translateY.get());
+      const clamped = clampZoomPoint(
+        { x: translateX.get(), y: translateY.get() },
+        { width, height: boxHeight },
+        scale.get(),
+      );
+      translateX.set(withTiming(clamped.x));
+      translateY.set(withTiming(clamped.y));
+      savedX.set(clamped.x);
+      savedY.set(clamped.y);
     });
 
   // Double-tap toggles zoom: from fit it magnifies to a fixed level centred on
@@ -119,14 +141,17 @@ export function ZoomableImage({
       }
       const dx = event.x - width / 2;
       const dy = event.y - height / 2;
-      const tx = -(DOUBLE_TAP_SCALE - 1) * dx;
-      const ty = -(DOUBLE_TAP_SCALE - 1) * dy;
+      const target = clampZoomPoint(
+        { x: -(DOUBLE_TAP_SCALE - 1) * dx, y: -(DOUBLE_TAP_SCALE - 1) * dy },
+        { width, height: boxHeight },
+        DOUBLE_TAP_SCALE,
+      );
       scale.set(withTiming(DOUBLE_TAP_SCALE));
       savedScale.set(DOUBLE_TAP_SCALE);
-      translateX.set(withTiming(tx));
-      translateY.set(withTiming(ty));
-      savedX.set(tx);
-      savedY.set(ty);
+      translateX.set(withTiming(target.x));
+      translateY.set(withTiming(target.y));
+      savedX.set(target.x);
+      savedY.set(target.y);
       runOnJS(reportZoom)(true);
     });
 

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -11,7 +11,7 @@ import Animated, {
 
 import { AnnotationOverlay } from '@/components/AnnotationOverlay';
 import { containRect, type Annotations } from '@/lib/annotations';
-import { clampZoomPoint } from '@/lib/zoomMath';
+import { clampZoomPoint, naturalSizeForUri, type NaturalImageSize } from '@/lib/zoomMath';
 
 const AnimatedImage = Animated.createAnimatedComponent(Image);
 
@@ -45,21 +45,7 @@ export function ZoomableImage({
 
   // The image's natural size anchors both pan bounds and, when present, overlay
   // placement. Resolved once per uri; until then the rect falls back to the box.
-  const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
-  useEffect(() => {
-    let active = true;
-    RNImage.getSize(
-      uri,
-      (w, h) => active && setNatural({ w, h }),
-      () => active && setNatural(null),
-    );
-    return () => {
-      active = false;
-    };
-  }, [uri]);
-
-  const rect = containRect({ w: width, h: boxHeight }, natural ?? { w: 0, h: 0 });
-
+  const [natural, setNatural] = useState<NaturalImageSize | null>(null);
   const scale = useSharedValue(1);
   const savedScale = useSharedValue(1);
   const translateX = useSharedValue(0);
@@ -68,6 +54,28 @@ export function ZoomableImage({
   const savedY = useSharedValue(0);
 
   const reportZoom = (zoomed: boolean) => onZoomChange?.(zoomed);
+
+  useEffect(() => {
+    let active = true;
+    scale.set(1);
+    savedScale.set(1);
+    translateX.set(0);
+    translateY.set(0);
+    savedX.set(0);
+    savedY.set(0);
+    onZoomChange?.(false);
+    RNImage.getSize(
+      uri,
+      (w, h) => active && setNatural({ uri, size: { w, h } }),
+      () => active && setNatural(null),
+    );
+    return () => {
+      active = false;
+    };
+  }, [onZoomChange, savedScale, savedX, savedY, scale, translateX, translateY, uri]);
+
+  const naturalSize = naturalSizeForUri(natural, uri);
+  const rect = containRect({ w: width, h: boxHeight }, naturalSize ?? { w: 0, h: 0 });
 
   const pinch = Gesture.Pinch()
     .onUpdate((event) => {

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -86,6 +86,7 @@ export function ZoomableImage({
         const clamped = clampZoomPoint(
           { x: translateX.get(), y: translateY.get() },
           { width, height: boxHeight },
+          { width: rect.w, height: rect.h },
           scale.get(),
         );
         translateX.set(withTiming(clamped.x));
@@ -103,6 +104,7 @@ export function ZoomableImage({
       const clamped = clampZoomPoint(
         { x: savedX.get() + event.translationX, y: savedY.get() + event.translationY },
         { width, height: boxHeight },
+        { width: rect.w, height: rect.h },
         scale.get(),
       );
       translateX.set(clamped.x);
@@ -112,6 +114,7 @@ export function ZoomableImage({
       const clamped = clampZoomPoint(
         { x: translateX.get(), y: translateY.get() },
         { width, height: boxHeight },
+        { width: rect.w, height: rect.h },
         scale.get(),
       );
       translateX.set(withTiming(clamped.x));
@@ -144,6 +147,7 @@ export function ZoomableImage({
       const target = clampZoomPoint(
         { x: -(DOUBLE_TAP_SCALE - 1) * dx, y: -(DOUBLE_TAP_SCALE - 1) * dy },
         { width, height: boxHeight },
+        { width: rect.w, height: rect.h },
         DOUBLE_TAP_SCALE,
       );
       scale.set(withTiming(DOUBLE_TAP_SCALE));

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Image } from 'expo-image';
 import { Image as RNImage, useWindowDimensions } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -55,6 +55,14 @@ export function ZoomableImage({
 
   const reportZoom = (zoomed: boolean) => onZoomChange?.(zoomed);
 
+  // Hold the latest callback so the uri-reset effect can report the return to
+  // fit without depending on onZoomChange (that would reset zoom whenever the
+  // caller re-creates the callback).
+  const onZoomChangeRef = useRef(onZoomChange);
+  useEffect(() => {
+    onZoomChangeRef.current = onZoomChange;
+  }, [onZoomChange]);
+
   useEffect(() => {
     let active = true;
     scale.set(1);
@@ -63,6 +71,9 @@ export function ZoomableImage({
     translateY.set(0);
     savedX.set(0);
     savedY.set(0);
+    // A reused page (the gallery keys pages by index) can swap uri while still
+    // zoomed; tell the pager we are back at fit so it re-enables paging.
+    onZoomChangeRef.current?.(false);
     RNImage.getSize(
       uri,
       (w, h) => active && setNatural({ uri, size: { w, h } }),

--- a/apps/mobile/src/components/ZoomableImage.tsx
+++ b/apps/mobile/src/components/ZoomableImage.tsx
@@ -63,7 +63,6 @@ export function ZoomableImage({
     translateY.set(0);
     savedX.set(0);
     savedY.set(0);
-    onZoomChange?.(false);
     RNImage.getSize(
       uri,
       (w, h) => active && setNatural({ uri, size: { w, h } }),
@@ -72,10 +71,23 @@ export function ZoomableImage({
     return () => {
       active = false;
     };
-  }, [onZoomChange, savedScale, savedX, savedY, scale, translateX, translateY, uri]);
+  }, [savedScale, savedX, savedY, scale, translateX, translateY, uri]);
 
   const naturalSize = naturalSizeForUri(natural, uri);
   const rect = containRect({ w: width, h: boxHeight }, naturalSize ?? { w: 0, h: 0 });
+
+  useEffect(() => {
+    const clamped = clampZoomPoint(
+      { x: translateX.get(), y: translateY.get() },
+      { width, height: boxHeight },
+      { width: rect.w, height: rect.h },
+      scale.get(),
+    );
+    translateX.set(clamped.x);
+    translateY.set(clamped.y);
+    savedX.set(clamped.x);
+    savedY.set(clamped.y);
+  }, [boxHeight, rect.h, rect.w, savedX, savedY, scale, translateX, translateY, width]);
 
   const pinch = Gesture.Pinch()
     .onUpdate((event) => {

--- a/apps/mobile/src/lib/anim.tsx
+++ b/apps/mobile/src/lib/anim.tsx
@@ -24,6 +24,7 @@ import Animated, {
 import { minorUnitScale } from '@waves/core';
 import { MoneyText, type MoneyTextProps } from '@waves/ui';
 
+import { useReducedMotion } from './reducedMotion';
 import { easeOutCubic, lerpBig, MAX_SAFE_MINOR, staggerDelay } from './motionMath';
 
 export { easeOutCubic, lerpBig, MAX_SAFE_MINOR, staggerDelay } from './motionMath';
@@ -49,8 +50,11 @@ const PRESS_SPRING = { damping: 18, stiffness: 280, mass: 0.5 } as const;
  * same keys does not remount, so the list does not re-stagger every pull.
  */
 export function Stagger({ index = 0, children }: { index?: number; children: ReactNode }) {
+  const reduceMotion = useReducedMotion();
   return (
-    <Animated.View entering={FadeInDown.duration(340).delay(staggerDelay(index))}>
+    <Animated.View
+      entering={reduceMotion ? undefined : FadeInDown.duration(340).delay(staggerDelay(index))}
+    >
       {children}
     </Animated.View>
   );
@@ -69,6 +73,7 @@ export function PressableScale({
   onPressOut,
   ...rest
 }: Omit<PressableProps, 'style'> & { children: ReactNode; style?: ViewStyle }) {
+  const reduceMotion = useReducedMotion();
   // `.get()`/`.set()` rather than `.value`: the same shared value, through the
   // method API Reanimated 4 added — a call, not an assignment to a property the
   // React compiler treats as immutable and refuses inside a handler.
@@ -79,11 +84,11 @@ export function PressableScale({
     <AnimatedPressable
       style={[animatedStyle, style]}
       onPressIn={(event) => {
-        scale.set(withSpring(0.96, PRESS_SPRING));
+        if (!reduceMotion) scale.set(withSpring(0.96, PRESS_SPRING));
         onPressIn?.(event);
       }}
       onPressOut={(event) => {
-        scale.set(withSpring(1, PRESS_SPRING));
+        if (!reduceMotion) scale.set(withSpring(1, PRESS_SPRING));
         onPressOut?.(event);
       }}
       {...rest}
@@ -103,8 +108,12 @@ export function PressableScale({
  * launched it, the tap and the arrival belong to each other.
  */
 export function DetailEnter({ children, style }: { children: ReactNode; style?: ViewStyle }) {
+  const reduceMotion = useReducedMotion();
   return (
-    <Animated.View style={[{ flex: 1 }, style]} entering={detailEntering}>
+    <Animated.View
+      style={[{ flex: 1 }, style]}
+      entering={reduceMotion ? undefined : detailEntering}
+    >
       {children}
     </Animated.View>
   );
@@ -137,7 +146,8 @@ const detailEntering: EntryExitAnimationFunction = () => {
  * is `MoneyText`'s, unchanged; this only feeds it a moving `amount`.
  */
 export function CountUpMoney(props: MoneyTextProps): ReactNode {
-  const shown = useCountUp(props.amount);
+  const reduceMotion = useReducedMotion();
+  const shown = useCountUp(props.amount, reduceMotion);
   // While the figure is still rolling, drop the fractional units — the paise
   // digits spinning past two at a time read as noise, not motion. The tween
   // always lands on the exact target on its last frame, so the settled number
@@ -158,16 +168,18 @@ const COUNT_MS = 650;
  * from whatever is on screen now, so a mid-flight change redirects smoothly
  * rather than jumping back to zero.
  */
-export function useCountUp(target: bigint): bigint {
+export function useCountUp(target: bigint, reduceMotion = false): bigint {
   // The start figure is decided here rather than in the effect: a number too
   // large to tween as a Number begins on the target and never moves.
-  const [value, setValue] = useState<bigint>(() => (tooLargeToTween(target) ? target : 0n));
+  const [value, setValue] = useState<bigint>(() =>
+    reduceMotion || tooLargeToTween(target) ? target : 0n,
+  );
   const frame = useRef<number | null>(null);
 
   useEffect(() => {
     // Snapping is a state change too, so it goes through a frame rather than
     // running synchronously in the effect body — the same reason the tween does.
-    if (tooLargeToTween(target)) {
+    if (reduceMotion || tooLargeToTween(target)) {
       frame.current = requestAnimationFrame(() => setValue(target));
       return () => {
         if (frame.current !== null) cancelAnimationFrame(frame.current);
@@ -193,7 +205,7 @@ export function useCountUp(target: bigint): bigint {
     return () => {
       if (frame.current !== null) cancelAnimationFrame(frame.current);
     };
-  }, [target]);
+  }, [target, reduceMotion]);
 
   return value;
 }

--- a/apps/mobile/src/lib/reducedMotion.tsx
+++ b/apps/mobile/src/lib/reducedMotion.tsx
@@ -11,7 +11,7 @@ const ReducedMotionContext = createContext(false);
  * whether to mount loops/entrances at all.
  */
 export function ReducedMotionProvider({ children }: { children: ReactNode }): React.JSX.Element {
-  const [reduceMotion, setReduceMotion] = useState(false);
+  const [reduceMotion, setReduceMotion] = useState(true);
 
   useEffect(() => {
     let mounted = true;

--- a/apps/mobile/src/lib/reducedMotion.tsx
+++ b/apps/mobile/src/lib/reducedMotion.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { AccessibilityInfo } from 'react-native';
 
+import { shouldApplyInitialReducedMotionPreference } from '@/lib/reducedMotionState';
+
 const ReducedMotionContext = createContext(false);
 
 /**
@@ -15,10 +17,15 @@ export function ReducedMotionProvider({ children }: { children: ReactNode }): Re
 
   useEffect(() => {
     let mounted = true;
+    let receivedEvent = false;
     void AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
-      if (mounted) setReduceMotion(enabled);
+      if (shouldApplyInitialReducedMotionPreference(mounted, receivedEvent))
+        setReduceMotion(enabled);
     });
-    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduceMotion);
+    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', (enabled) => {
+      receivedEvent = true;
+      setReduceMotion(enabled);
+    });
     return () => {
       mounted = false;
       subscription.remove();

--- a/apps/mobile/src/lib/reducedMotion.tsx
+++ b/apps/mobile/src/lib/reducedMotion.tsx
@@ -18,13 +18,13 @@ export function ReducedMotionProvider({ children }: { children: ReactNode }): Re
   useEffect(() => {
     let mounted = true;
     let receivedEvent = false;
-    void AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
-      if (shouldApplyInitialReducedMotionPreference(mounted, receivedEvent))
-        setReduceMotion(enabled);
-    });
     const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', (enabled) => {
       receivedEvent = true;
       setReduceMotion(enabled);
+    });
+    void AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
+      if (shouldApplyInitialReducedMotionPreference(mounted, receivedEvent))
+        setReduceMotion(enabled);
     });
     return () => {
       mounted = false;

--- a/apps/mobile/src/lib/reducedMotion.tsx
+++ b/apps/mobile/src/lib/reducedMotion.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+const ReducedMotionContext = createContext(false);
+
+/**
+ * App-wide reduced-motion preference from the OS accessibility setting.
+ *
+ * It is deliberately local to the app tree rather than read ad hoc in every
+ * component: animations need a synchronous boolean during render to choose
+ * whether to mount loops/entrances at all.
+ */
+export function ReducedMotionProvider({ children }: { children: ReactNode }): React.JSX.Element {
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    void AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
+      if (mounted) setReduceMotion(enabled);
+    });
+    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduceMotion);
+    return () => {
+      mounted = false;
+      subscription.remove();
+    };
+  }, []);
+
+  const value = useMemo(() => reduceMotion, [reduceMotion]);
+  return <ReducedMotionContext.Provider value={value}>{children}</ReducedMotionContext.Provider>;
+}
+
+/** Returns true when the user asked the OS to reduce non-essential motion. */
+export function useReducedMotion(): boolean {
+  return useContext(ReducedMotionContext);
+}

--- a/apps/mobile/src/lib/reducedMotionState.ts
+++ b/apps/mobile/src/lib/reducedMotionState.ts
@@ -1,0 +1,7 @@
+/** Returns whether the initial OS query should still seed the reduced-motion state. */
+export function shouldApplyInitialReducedMotionPreference(
+  mounted: boolean,
+  receivedEvent: boolean,
+): boolean {
+  return mounted && !receivedEvent;
+}

--- a/apps/mobile/src/lib/zoomMath.ts
+++ b/apps/mobile/src/lib/zoomMath.ts
@@ -3,23 +3,29 @@ export interface Size {
   readonly height: number;
 }
 
-/** Keeps a pan offset inside the image area visible at the current zoom scale. */
-export function clampZoomPan(value: number, viewport: number, scale: number): number {
+/** Keeps one zoomed axis inside the visible viewport without assuming the image fills it. */
+export function clampZoomPan(
+  value: number,
+  viewport: number,
+  content: number,
+  scale: number,
+): number {
   'worklet';
-  if (scale <= 1 || viewport <= 0) return 0;
-  const limit = ((scale - 1) * viewport) / 2;
+  if (scale <= 1 || viewport <= 0 || content <= 0) return 0;
+  const limit = Math.max(0, (scale * content - viewport) / 2);
   return Math.min(limit, Math.max(-limit, value));
 }
 
-/** Clamps both axes of a zoomed image pan to the current viewport and scale. */
+/** Clamps both axes of a zoomed image pan using contained image and viewport dimensions. */
 export function clampZoomPoint(
   point: { readonly x: number; readonly y: number },
-  size: Size,
+  viewport: Size,
+  content: Size,
   scale: number,
 ): { x: number; y: number } {
   'worklet';
   return {
-    x: clampZoomPan(point.x, size.width, scale),
-    y: clampZoomPan(point.y, size.height, scale),
+    x: clampZoomPan(point.x, viewport.width, content.width, scale),
+    y: clampZoomPan(point.y, viewport.height, content.height, scale),
   };
 }

--- a/apps/mobile/src/lib/zoomMath.ts
+++ b/apps/mobile/src/lib/zoomMath.ts
@@ -1,0 +1,25 @@
+export interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Keeps a pan offset inside the image area visible at the current zoom scale. */
+export function clampZoomPan(value: number, viewport: number, scale: number): number {
+  'worklet';
+  if (scale <= 1 || viewport <= 0) return 0;
+  const limit = ((scale - 1) * viewport) / 2;
+  return Math.min(limit, Math.max(-limit, value));
+}
+
+/** Clamps both axes of a zoomed image pan to the current viewport and scale. */
+export function clampZoomPoint(
+  point: { readonly x: number; readonly y: number },
+  size: Size,
+  scale: number,
+): { x: number; y: number } {
+  'worklet';
+  return {
+    x: clampZoomPan(point.x, size.width, scale),
+    y: clampZoomPan(point.y, size.height, scale),
+  };
+}

--- a/apps/mobile/src/lib/zoomMath.ts
+++ b/apps/mobile/src/lib/zoomMath.ts
@@ -3,6 +3,19 @@ export interface Size {
   readonly height: number;
 }
 
+export interface NaturalImageSize {
+  readonly uri: string;
+  readonly size: { readonly w: number; readonly h: number };
+}
+
+/** Selects dimensions only for the currently rendered image URI. */
+export function naturalSizeForUri(
+  natural: NaturalImageSize | null,
+  uri: string,
+): { w: number; h: number } | null {
+  return natural?.uri === uri ? natural.size : null;
+}
+
 /** Keeps one zoomed axis inside the visible viewport without assuming the image fills it. */
 export function clampZoomPan(
   value: number,

--- a/apps/mobile/test/reducedMotion.test.ts
+++ b/apps/mobile/test/reducedMotion.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldApplyInitialReducedMotionPreference } from '../src/lib/reducedMotionState';
+
+describe('shouldApplyInitialReducedMotionPreference', () => {
+  it('uses the initial OS query while the provider is mounted and no event arrived', () => {
+    expect(shouldApplyInitialReducedMotionPreference(true, false)).toBe(true);
+  });
+
+  it('ignores the initial query after a newer change event arrives first', () => {
+    expect(shouldApplyInitialReducedMotionPreference(true, true)).toBe(false);
+  });
+
+  it('ignores the initial query after unmount', () => {
+    expect(shouldApplyInitialReducedMotionPreference(false, false)).toBe(false);
+  });
+});

--- a/apps/mobile/test/zoomMath.test.ts
+++ b/apps/mobile/test/zoomMath.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { clampZoomPan, clampZoomPoint } from '../src/lib/zoomMath';
+import { clampZoomPan, clampZoomPoint, naturalSizeForUri } from '../src/lib/zoomMath';
+
+describe('naturalSizeForUri', () => {
+  it('ignores stale dimensions from a previously rendered image uri', () => {
+    const previous = { uri: 'file://old.jpg', size: { w: 1000, h: 500 } };
+
+    expect(naturalSizeForUri(previous, 'file://new.jpg')).toBeNull();
+    expect(naturalSizeForUri(previous, 'file://old.jpg')).toEqual({ w: 1000, h: 500 });
+  });
+});
 
 describe('clampZoomPan', () => {
   it('keeps fit-scale images centered', () => {

--- a/apps/mobile/test/zoomMath.test.ts
+++ b/apps/mobile/test/zoomMath.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { clampZoomPan, clampZoomPoint } from '../src/lib/zoomMath';
+
+describe('clampZoomPan', () => {
+  it('keeps fit-scale images centered', () => {
+    expect(clampZoomPan(120, 300, 1)).toBe(0);
+    expect(clampZoomPan(-120, 300, 0.8)).toBe(0);
+  });
+
+  it('clamps positive and negative pan to the scaled viewport bounds', () => {
+    expect(clampZoomPan(999, 300, 2)).toBe(150);
+    expect(clampZoomPan(-999, 300, 2)).toBe(-150);
+    expect(clampZoomPan(90, 300, 2)).toBe(90);
+  });
+});
+
+describe('clampZoomPoint', () => {
+  it('clamps each axis independently', () => {
+    expect(clampZoomPoint({ x: 500, y: -500 }, { width: 200, height: 400 }, 3)).toEqual({
+      x: 200,
+      y: -400,
+    });
+  });
+});

--- a/apps/mobile/test/zoomMath.test.ts
+++ b/apps/mobile/test/zoomMath.test.ts
@@ -4,21 +4,36 @@ import { clampZoomPan, clampZoomPoint } from '../src/lib/zoomMath';
 
 describe('clampZoomPan', () => {
   it('keeps fit-scale images centered', () => {
-    expect(clampZoomPan(120, 300, 1)).toBe(0);
-    expect(clampZoomPan(-120, 300, 0.8)).toBe(0);
+    expect(clampZoomPan(120, 300, 240, 1)).toBe(0);
+    expect(clampZoomPan(-120, 300, 240, 0.8)).toBe(0);
   });
 
-  it('clamps positive and negative pan to the scaled viewport bounds', () => {
-    expect(clampZoomPan(999, 300, 2)).toBe(150);
-    expect(clampZoomPan(-999, 300, 2)).toBe(-150);
-    expect(clampZoomPan(90, 300, 2)).toBe(90);
+  it('clamps positive and negative pan to the scaled content bounds', () => {
+    expect(clampZoomPan(999, 300, 300, 2)).toBe(150);
+    expect(clampZoomPan(-999, 300, 300, 2)).toBe(-150);
+    expect(clampZoomPan(90, 300, 300, 2)).toBe(90);
+  });
+
+  it('keeps a contained landscape image from panning into vertical blank space', () => {
+    expect(clampZoomPan(999, 400, 150, 2)).toBe(0);
+  });
+
+  it('allows pan once contained portrait content grows past the viewport', () => {
+    expect(clampZoomPan(999, 300, 260, 2)).toBe(110);
   });
 });
 
 describe('clampZoomPoint', () => {
-  it('clamps each axis independently', () => {
-    expect(clampZoomPoint({ x: 500, y: -500 }, { width: 200, height: 400 }, 3)).toEqual({
-      x: 200,
+  it('clamps each axis independently using contained content dimensions', () => {
+    expect(
+      clampZoomPoint(
+        { x: 500, y: -500 },
+        { width: 200, height: 400 },
+        { width: 160, height: 400 },
+        3,
+      ),
+    ).toEqual({
+      x: 140,
       y: -400,
     });
   });


### PR DESCRIPTION
## Summary
- add app-wide reduced-motion provider and disable non-essential navigation, press, count-up, voice, and sync animations when requested
- clamp zoomed image pan/double-tap translations to visible bounds with unit coverage
- improve ContactPicker stability/accessibility and memoize key group detail lookups

## Validation
- pnpm --filter @waves/mobile test -- motionMath.test.ts zoomMath.test.ts
- pnpm --filter @waves/mobile typecheck
- pnpm --filter @waves/mobile lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added app-wide support for reduced-motion accessibility preferences.
  - Reduced or disabled animations across navigation, syncing, voice capture, transitions, counters, and interactive elements when enabled.
  - Improved contact picker accessibility with letter-based navigation and duplicate contact removal.

- **Bug Fixes**
  - Improved zoom and pan behavior, including image boundary handling and page-specific zoom state.
  - Preserved group navigation and display behavior while improving screen responsiveness.

- **Tests**
  - Added coverage for zoom positioning, boundary constraints, and reduced-motion preference handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->