### PR TITLE
ci(vercel): manual-only deploys (disable git auto-deploy)

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,78 @@
+name: Vercel deploy (manual)
+
+# Vercel's git integration is turned off (git.deploymentEnabled: false in each
+# app's vercel.json), so no push or PR ever creates a deployment. This workflow
+# is the only way a deploy happens: run it by hand from the Actions tab, pick
+# the project (web / admin / both) and the target (preview / production).
+#
+# Required repository secrets (Settings → Secrets and variables → Actions):
+#   VERCEL_TOKEN            — a Vercel access token
+#   VERCEL_ORG_ID           — the Vercel team/org id (same for both projects)
+#   VERCEL_PROJECT_ID_WEB   — project id of baaki-web   (.vercel/project.json)
+#   VERCEL_PROJECT_ID_ADMIN — project id of baaki-admin (.vercel/project.json)
+
+on:
+  workflow_dispatch:
+    inputs:
+      project:
+        description: Which app to deploy
+        type: choice
+        default: both
+        options:
+          - web
+          - admin
+          - both
+      target:
+        description: Deployment environment
+        type: choice
+        default: preview
+        options:
+          - preview
+          - production
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.project }}-${{ github.event.inputs.target }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: deploy ${{ matrix.app }} (${{ github.event.inputs.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      # One deploy per selected app. `both` fans out to web then admin; a single
+      # app filters the matrix down to just that entry. fail-fast off so admin
+      # still runs if web fails (and vice versa).
+      fail-fast: false
+      matrix:
+        app: [web, admin]
+        exclude:
+          - app: ${{ github.event.inputs.project == 'admin' && 'web' || 'nothing' }}
+          - app: ${{ github.event.inputs.project == 'web' && 'admin' || 'nothing' }}
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ matrix.app == 'admin' && secrets.VERCEL_PROJECT_ID_ADMIN || secrets.VERCEL_PROJECT_ID_WEB }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install the Vercel CLI
+        run: npm i -g vercel@latest
+
+      # vercel pull reads VERCEL_ORG_ID / VERCEL_PROJECT_ID from the env above to
+      # fetch that project's settings. --prod when deploying to production so the
+      # right environment variables are pulled and built.
+      - name: Pull Vercel project settings
+        working-directory: apps/${{ matrix.app }}
+        run: vercel pull --yes --environment=${{ github.event.inputs.target == 'production' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build
+        working-directory: apps/${{ matrix.app }}
+        run: vercel build ${{ github.event.inputs.target == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy (prebuilt)
+        working-directory: apps/${{ matrix.app }}
+        run: vercel deploy --prebuilt ${{ github.event.inputs.target == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}

--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "regions": ["sin1"],
+  "git": { "deploymentEnabled": false },
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/apps/admin' ':/packages' ':/pnpm-lock.yaml' ':/package.json'"
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "regions": ["sin1"],
+  "git": { "deploymentEnabled": false },
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/apps/web' ':/packages' ':/pnpm-lock.yaml' ':/package.json'"
 }


### PR DESCRIPTION
## What

Stop Vercel from auto-deploying on every push / PR, and make deploys **on-demand only** via a manually-triggered GitHub Action.

### Changes
- **`apps/web/vercel.json` + `apps/admin/vercel.json`** — add `"git": { "deploymentEnabled": false }`. This is the current Vercel schema key (confirmed against Vercel's [git-configuration docs](https://vercel.com/docs/project-configuration/git-configuration); the old `github.enabled` is deprecated in favour of it). With deployments disabled at the source, no deployment is ever created, so the failing / rate-limited **"Vercel" PR check disappears**. Existing `$schema`, `framework`, `regions`, and `ignoreCommand` keys are untouched — the `ignoreCommand` stays as a harmless second guard.
- **`.github/workflows/vercel-deploy.yml`** — new `workflow_dispatch`-only workflow (no `push` / `pull_request` triggers). Inputs: `project` (web | admin | **both**, default both) and `target` (preview | **production**, default preview). A matrix fans `both` out to web then admin (fail-fast off); a single choice filters to that app. Each job installs `vercel@latest` and runs `vercel pull` → `vercel build` → `vercel deploy --prebuilt`, adding `--prod` when `target=production`, from the selected `apps/<app>` directory. Pinned `actions/checkout@v4` + `actions/setup-node@v4` (node 20), with `concurrency` and `permissions: contents: read` matching CI house style.

## Required repository secrets

The manual workflow will **fail until these are added** (Settings → Secrets and variables → Actions). Because it only runs when manually invoked, nothing breaks in the meantime:

| Secret | What it is |
| --- | --- |
| `VERCEL_TOKEN` | A Vercel access token |
| `VERCEL_ORG_ID` | The Vercel team/org id (same for both projects) |
| `VERCEL_PROJECT_ID_WEB` | Project id of **baaki-web** — from its Vercel Project Settings, or `apps/web/.vercel/project.json` |
| `VERCEL_PROJECT_ID_ADMIN` | Project id of **baaki-admin** — from its Vercel Project Settings, or `apps/admin/.vercel/project.json` |

`VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` are passed as env to `vercel pull` (the latter selected per-app from the two project-id secrets).

## Also do in the Vercel dashboard (belt-and-suspenders)

`vercel.json` governs git deployments, but **the dashboard is authoritative if the two ever differ**. Please also confirm auto-deploy is off for both projects under **Project Settings → Git** (disable the production/preview branch deployments / connected Git triggers).

## Testing / gates
- `vercel.json` files validated as schema-valid JSON.
- `prettier --check` passes on all three changed files.
- `scripts/check-filenames.sh` passes with no stray files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual deployment workflow for preview or production releases of the web app, admin app, or both.
* **Configuration**
  * Disabled automatic Git-triggered deployments for the web and admin applications, enabling deployments through the controlled workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->