### PR TITLE
feat(category): specific per-expense icons from the description

### DIFF
--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -129,7 +129,12 @@ function CaptureListRow({
         {capture.photo_path ? (
           <CaptureThumb path={capture.photo_path} size={46} />
         ) : (
-          <CategoryBadge category={capture.category} meta={capture.category_meta} size={46} />
+          <CategoryBadge
+            category={capture.category}
+            meta={capture.category_meta}
+            description={capture.description}
+            size={46}
+          />
         )}
 
         <View style={{ flex: 1, minWidth: 0 }}>
@@ -679,6 +684,7 @@ export default function CapturesScreen() {
                 <CategoryBadge
                   category={assigning.category}
                   meta={assigning.category_meta}
+                  description={assigning.description}
                   size={38}
                 />
                 <View style={{ flex: 1, minWidth: 0 }}>

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -345,7 +345,12 @@ export default function ExpenseDetailScreen() {
           </Row>
 
           <View style={{ alignItems: 'flex-start', gap: theme.spacing.sm }}>
-            <CategoryBadge category={version.category} meta={version.category_meta} size={48} />
+            <CategoryBadge
+              category={version.category}
+              meta={version.category_meta}
+              description={version.description}
+              size={48}
+            />
             <MoneyText
               amount={BigInt(version.amount)}
               currency={currency}

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -516,7 +516,12 @@ export default function GroupScreen() {
               paddingVertical: theme.spacing.md,
             }}
           >
-            <CategoryBadge category={version?.category} meta={version?.category_meta} size={40} />
+            <CategoryBadge
+              category={version?.category}
+              meta={version?.category_meta}
+              description={version?.description}
+              size={40}
+            />
             <View style={{ flex: 1 }}>
               <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
                 <Text variant="subheading" numberOfLines={1} style={{ flexShrink: 1 }}>

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -228,6 +228,7 @@ export default function SpendingMonthScreen() {
                             <CategoryBadge
                               category={version?.category}
                               meta={version?.category_meta}
+                              description={version?.description}
                               size={40}
                             />
                             <View style={{ flex: 1 }}>

--- a/apps/mobile/src/components/Category.tsx
+++ b/apps/mobile/src/components/Category.tsx
@@ -17,7 +17,7 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Pressable, ScrollView, View } from 'react-native';
 
-import { normaliseTint, resolveCategory, type CategoryMeta } from '@waves/core';
+import { guessIcon, normaliseTint, resolveCategory, type CategoryMeta } from '@waves/core';
 import { iconSize, Text, useTheme } from '@waves/ui';
 
 import { useCategoryCatalog } from '@/data/hooks';
@@ -26,16 +26,26 @@ import { useStrings } from '@/i18n';
 export function CategoryBadge({
   category,
   meta,
+  description,
   size = 42,
 }: {
   category: string | null | undefined;
   /** The custom tag's denormalised display, when the value is a custom tag. */
   meta?: CategoryMeta | null;
+  /** The expense's own words. When given, the badge draws the specific icon for
+   *  what was typed (a coffee cup for a chai) and falls back to the category
+   *  icon when nothing matches. Omit on aggregate badges (per-category rows in
+   *  insights/budgets), where only the category itself is meaningful. Never
+   *  overrides a custom tag's chosen icon. */
+  description?: string | null;
   size?: number;
 }) {
   const theme = useTheme();
   const resolved = resolveCategory(category, meta ?? null);
   const tint = theme.tint[resolved.tint];
+  // A custom tag keeps the icon its author picked; only built-ins get the
+  // description-specific refinement over their single category icon.
+  const icon = resolved.custom ? resolved.icon : (guessIcon(description) ?? resolved.icon);
   return (
     <View
       style={{
@@ -48,7 +58,7 @@ export function CategoryBadge({
       }}
     >
       <Ionicons
-        name={resolved.icon as keyof typeof Ionicons.glyphMap}
+        name={icon as keyof typeof Ionicons.glyphMap}
         size={Math.round(size * 0.5)}
         color={tint.ink}
       />

--- a/packages/core/src/category/icons.ts
+++ b/packages/core/src/category/icons.ts
@@ -1,0 +1,167 @@
+/**
+ * The *specific* icon for what an expense was for — a coffee cup for a chai, a
+ * bicycle for a bike ride, a plane for a flight — one step finer than the ten
+ * category icons.
+ *
+ * The category (categories.ts) exists for the charts: ten buckets, one icon
+ * each. That is the right grain for a pie slice, and the wrong grain for a list
+ * row, where "restaurant" for every meal and "car" for every ride throws away
+ * the one glance-able thing a person actually wrote. So the badge on a list row
+ * reads the description and, when a keyword lands, draws the exact Ionicon for
+ * it; when nothing lands it falls back to the category's own icon, and the chart
+ * grouping is untouched either way.
+ *
+ * Same discipline as `guessCategory`: lowercase whole tokens (never substrings,
+ * so `car` in `carton` is not a taxi), deterministic (same words, same icon on
+ * every device — ADR-009), and a real null when it has nothing to say. Every
+ * icon name below is verified present in the app's Ionicons glyphmap; adding one
+ * that is not renders a blank box, so keep new entries to names that exist.
+ *
+ * Order matters. The list is scanned top to bottom and the first entry with a
+ * matching keyword wins, so the more specific reading is placed above the more
+ * general one: "car rental" (car-sport) sits above a plain "cab" (car), and
+ * "breakfast" (egg) above "coffee" (cafe).
+ */
+
+/** Lowercased whole words, Unicode-aware so Tamil and Hindi survive intact —
+ *  the same tokenisation `guessCategory` uses, kept local so this module stays
+ *  self-contained. */
+function tokenise(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^\p{L}\p{N}]+/u)
+      .filter((token) => token.length > 0),
+  );
+}
+
+/**
+ * Each entry is one Ionicon and the whole words that mean it. Scanned in order;
+ * the first entry any description token hits is the icon. More specific readings
+ * are listed above the general ones they would otherwise be swallowed by.
+ */
+const ICON_KEYWORDS: ReadonlyArray<readonly [string, readonly string[]]> = [
+  // ---- Food & drink -------------------------------------------------------
+  ['egg-outline', ['breakfast', 'brunch', 'omelette', 'eggs']],
+  [
+    'cafe-outline',
+    [
+      'coffee',
+      'chai',
+      'tea',
+      'teatime',
+      'cafe',
+      'latte',
+      'cappuccino',
+      'espresso',
+      'barista',
+      'starbucks',
+      'ccd',
+    ],
+  ],
+  ['pizza-outline', ['pizza', 'dominos']],
+  [
+    'fast-food-outline',
+    ['burger', 'fries', 'snacks', 'snack', 'kfc', 'mcdonalds', 'shawarma', 'sandwich', 'fastfood'],
+  ],
+  ['ice-cream-outline', ['icecream', 'dessert', 'cake', 'sweets', 'gelato']],
+  ['beer-outline', ['beer', 'pub', 'brewery']],
+  ['wine-outline', ['wine', 'drinks', 'cocktail', 'cocktails', 'bar']],
+  [
+    'restaurant-outline',
+    [
+      'lunch',
+      'dinner',
+      'meal',
+      'meals',
+      'thali',
+      'biryani',
+      'dosa',
+      'idli',
+      'restaurant',
+      'tiffin',
+      'buffet',
+      'food',
+    ],
+  ],
+  // ---- Travel -------------------------------------------------------------
+  ['bicycle-outline', ['bike', 'cycle', 'bicycle', 'scooter', 'cycling', 'rapido']],
+  [
+    'airplane-outline',
+    ['flight', 'plane', 'airfare', 'airplane', 'indigo', 'vistara', 'airindia', 'emirates'],
+  ],
+  ['train-outline', ['train', 'railway', 'irctc', 'rail']],
+  ['subway-outline', ['metro', 'subway']],
+  ['bus-outline', ['bus', 'redbus', 'coach']],
+  ['boat-outline', ['ferry', 'boat', 'cruise', 'kayak']],
+  ['car-sport-outline', ['rental', 'carrental', 'zoomcar', 'revv']],
+  ['car-outline', ['cab', 'taxi', 'uber', 'ola', 'car', 'auto', 'rickshaw', 'drive']],
+  ['walk-outline', ['trek', 'trekking', 'hike', 'hiking', 'mountain', 'mountains', 'trail']],
+  ['sunny-outline', ['beach', 'pool']],
+  // ---- Stay ---------------------------------------------------------------
+  [
+    'bed-outline',
+    [
+      'hotel',
+      'room',
+      'rooms',
+      'stay',
+      'resort',
+      'oyo',
+      'lodge',
+      'airbnb',
+      'homestay',
+      'hostel',
+      'dorm',
+    ],
+  ],
+  // ---- Shopping / groceries ----------------------------------------------
+  [
+    'shirt-outline',
+    ['clothes', 'clothing', 'dress', 'shirt', 'tshirt', 'jeans', 'saree', 'kurta', 'apparel'],
+  ],
+  ['basket-outline', ['groceries', 'grocery', 'vegetables', 'sabzi', 'kirana', 'supermarket']],
+  ['cart-outline', ['amazon', 'flipkart', 'myntra', 'shopping', 'mall']],
+  // ---- Entertainment ------------------------------------------------------
+  ['film-outline', ['movie', 'movies', 'cinema', 'pvr', 'inox', 'netflix', 'film']],
+  ['game-controller-outline', ['game', 'gaming', 'arcade', 'bowling', 'playstation']],
+  ['musical-notes-outline', ['concert', 'music', 'spotify', 'gig', 'band']],
+  ['ticket-outline', ['ticket', 'tickets', 'show', 'bookmyshow']],
+  // ---- Home & bills -------------------------------------------------------
+  ['flash-outline', ['electricity', 'current', 'power']],
+  ['water-outline', ['water']],
+  ['flame-outline', ['gas', 'cylinder', 'lpg']],
+  ['wifi-outline', ['wifi', 'internet', 'broadband']],
+  [
+    'phone-portrait-outline',
+    ['recharge', 'mobile', 'airtel', 'jio', 'bsnl', 'postpaid', 'prepaid'],
+  ],
+  ['construct-outline', ['repair', 'plumber', 'electrician', 'maintenance']],
+  // ---- Health -------------------------------------------------------------
+  ['medical-outline', ['doctor', 'clinic', 'hospital', 'dentist']],
+  ['barbell-outline', ['gym', 'workout', 'fitness']],
+  ['medkit-outline', ['medicine', 'medicines', 'pharmacy', 'chemist']],
+  // ---- Gifts --------------------------------------------------------------
+  ['flower-outline', ['flowers', 'bouquet']],
+  ['gift-outline', ['gift', 'gifts', 'present']],
+];
+
+/**
+ * The specific Ionicon for a description, or null when no keyword lands.
+ *
+ * Null is not a blank icon — it means "no opinion", and the caller falls back to
+ * the category's icon. Keyword matching is whole-token and case-insensitive; the
+ * first entry (top to bottom) any token hits wins, which keeps the answer stable
+ * and lets the specific readings sit above the general ones.
+ */
+export function guessIcon(description: string | null | undefined): string | null {
+  if (!description) return null;
+  const tokens = tokenise(description);
+  if (tokens.size === 0) return null;
+  for (const [icon, keywords] of ICON_KEYWORDS) {
+    for (const keyword of keywords) {
+      if (tokens.has(keyword)) return icon;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/category/index.ts
+++ b/packages/core/src/category/index.ts
@@ -1,4 +1,5 @@
 export * from './categories';
 export * from './catalog';
+export * from './icons';
 export * from './markets';
 export * from './merchant';

--- a/packages/core/test/icons.test.ts
+++ b/packages/core/test/icons.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The specific-icon guess follows the same rules as the category guess: whole
+ * words only, deterministic, a real null when it has nothing to say — and the
+ * ordering promise that a more specific reading beats the general one it sits
+ * above.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { guessIcon } from '../src/category/icons.js';
+
+describe('guessIcon', () => {
+  it('draws the specific thing a person typed', () => {
+    expect(guessIcon('Morning coffee')).toBe('cafe-outline');
+    expect(guessIcon('Chai and vada')).toBe('cafe-outline');
+    expect(guessIcon('Breakfast at the hostel')).toBe('egg-outline');
+    expect(guessIcon('Bike ride to the point')).toBe('bicycle-outline');
+    expect(guessIcon('Flight to Hanoi')).toBe('airplane-outline');
+    expect(guessIcon('Dinner')).toBe('restaurant-outline');
+    expect(guessIcon('Movie night')).toBe('film-outline');
+    expect(guessIcon('Gym membership')).toBe('barbell-outline');
+  });
+
+  it('prefers the specific reading over the general one below it', () => {
+    // "car rental" must be the sportier car, not the plain cab that follows it.
+    expect(guessIcon('Car rental for the trip')).toBe('car-sport-outline');
+    expect(guessIcon('Cab to airport')).toBe('car-outline');
+    // "breakfast" outranks a "coffee" in the same line (egg sits above cafe).
+    expect(guessIcon('Breakfast coffee')).toBe('egg-outline');
+  });
+
+  it('matches whole words, never substrings', () => {
+    // 'car' inside 'carton', 'bar' inside 'barber' — neither should hit.
+    expect(guessIcon('Carton of juice')).not.toBe('car-outline');
+    expect(guessIcon('Barber shop')).not.toBe('wine-outline');
+  });
+
+  it('returns null when it has nothing to say, so the caller keeps the category icon', () => {
+    expect(guessIcon('Miscellaneous')).toBeNull();
+    expect(guessIcon('')).toBeNull();
+    expect(guessIcon(null)).toBeNull();
+    expect(guessIcon(undefined)).toBeNull();
+  });
+
+  it('is case-insensitive and Unicode-safe', () => {
+    expect(guessIcon('COFFEE')).toBe('cafe-outline');
+    expect(guessIcon('Coffee ☕ break')).toBe('cafe-outline');
+  });
+});


### PR DESCRIPTION
## What
The expense-row badge showed **one icon per category** — a restaurant for every meal, a car for every ride. This adds a description-keyed icon layer so the badge draws the *specific* thing typed: a coffee cup for a chai, a bicycle for a bike ride, a plane for a flight, a car-sport for a car rental, a walker for a trek.

## How
- New `guessIcon(description)` in `@waves/core` (`category/icons.ts`): whole-token, case-insensitive, deterministic keyword→Ionicon map. First matching entry wins, so specific readings sit above general ones (`car rental`→car-sport above plain `cab`→car; `breakfast`→egg above `coffee`→cafe). Returns `null` (no opinion) when nothing lands.
- `CategoryBadge` gains an optional `description` prop: for built-in categories it uses `guessIcon(description) ?? categoryIcon`; **custom tags keep the author's chosen icon**; badges with no description (per-category rows in insights/budgets/settings) are unchanged — the charts stay category-level.
- Wired into: group expense list, month view, expense detail header, drafts inbox row + assign sheet.
- Every icon name is **verified present** in the app's Ionicons glyphmap (blank-box guard). `airport` deliberately excluded from the plane keywords — a cab to the airport is ground transport.

## Tests / gates
- New `packages/core/test/icons.test.ts` — 5/5 (specific reading, priority ordering, whole-word matching, null fallback, case/Unicode).
- core + mobile typecheck 0, format 0, mobile lint 0, check-filenames 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Category icons now automatically reflect keywords found in expense and capture descriptions.
  - Improved icon matching recognizes specific terms, whole words, capitalization differences, and accented characters.
  - Custom category icons remain unchanged.
  - Updated category displays across capture lists, assignment previews, expense details, group views, and monthly views.

- **Bug Fixes**
  - More relevant category icons are shown when descriptions provide additional context.
  - Unrecognized or missing descriptions continue using the category’s default icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->