### PR TITLE
perf(mobile): render ahead so fast scroll doesn't flash blank rows

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -609,6 +609,10 @@ export default function GroupScreen() {
           keyExtractor={(item) => item.key}
           getItemType={(item) => item.kind}
           renderItem={renderFeedItem}
+          // Render well beyond the viewport so a fast fling down a long ledger
+          // never outruns recycling and flashes blank rows (default is 250px,
+          // which a hard fling clears in a frame). ~800px ≈ a dozen rows ahead.
+          drawDistance={800}
           contentContainerStyle={{
             paddingHorizontal: theme.spacing.xl,
             paddingBottom: clearance,

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -61,6 +61,8 @@ export default function AllGroupsScreen() {
       <FlashList
         data={list}
         keyExtractor={(group) => group.id}
+        // Render ahead of the viewport so a fast fling doesn't flash blank rows.
+        drawDistance={800}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,


### PR DESCRIPTION
## Problem
A hard fling down a long group ledger (e.g. the imported ~95-row group) outran FlashList's row recycling and left the screen **blank** until the scroll settled. FlashList v2's default `drawDistance` is 250px — one frame's worth at fling velocity.

## Fix
Set `drawDistance={800}` (~a dozen rows ahead) on the two long vertical lists:
- the group expense feed (`group/[id]/index.tsx`)
- the groups list (`groups.tsx`)

Recycled rows are now mounted before they scroll into view, so a fast fling stays filled. FlashList v2 prop only — no layout, data, or row-render change.

## Gates
mobile typecheck 0, format 0, mobile lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved scrolling in group lists by preloading content ahead of the visible area.
  * Reduced blank rows and visual gaps during fast scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->