### PR TITLE
fix(mobile): white flash mid-slide + missing OAuth avatar on account page

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -266,7 +266,16 @@ function ProfileForm() {
   const { t, locale } = useStrings();
   // Gate the bring-your-own AI-key vault behind a flag until it ships.
   const aiKeysEnabled = useFlagEnabled('ai_keys');
-  const { profile, isGuest, updateProfile, signOut } = useAuth();
+  const { session, profile, isGuest, updateProfile, signOut } = useAuth();
+  // A Google/Apple sign-in carries a photo in the session's user metadata, but
+  // the profile row only holds one if a trigger copied it across — older
+  // accounts have a null `avatar_url` and so showed initials here. Fall back to
+  // the provider photo (an https URL that resolves straight through) so the
+  // account page shows your face whether or not the column was ever filled.
+  const oauthAvatar =
+    (session?.user?.user_metadata?.avatar_url as string | undefined) ??
+    (session?.user?.user_metadata?.picture as string | undefined) ??
+    null;
 
   const { enabled: lockEnabled, supported: lockSupported, graceSeconds } = useLock();
   const { preference: syncNetwork } = useSyncNetwork();
@@ -413,7 +422,7 @@ function ProfileForm() {
         <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
           <ProfileAvatar
             name={profile?.display_name ?? t.account.you}
-            avatarUrl={profile?.avatar_url}
+            avatarUrl={profile?.avatar_url ?? oauthAvatar}
             size={92}
             onPress={profile ? photoOptions : undefined}
             busy={photoBusy}

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -272,9 +272,12 @@ function ProfileForm() {
   // accounts have a null `avatar_url` and so showed initials here. Fall back to
   // the provider photo (an https URL that resolves straight through) so the
   // account page shows your face whether or not the column was ever filled.
+  // `||`, not `??`: an empty-string avatar (a cleared column, or a provider that
+  // sends '') is "no photo", so it must fall through to the next source rather
+  // than be handed on as a blank URL.
   const oauthAvatar =
-    (session?.user?.user_metadata?.avatar_url as string | undefined) ??
-    (session?.user?.user_metadata?.picture as string | undefined) ??
+    (session?.user?.user_metadata?.avatar_url as string | undefined) ||
+    (session?.user?.user_metadata?.picture as string | undefined) ||
     null;
 
   const { enabled: lockEnabled, supported: lockSupported, graceSeconds } = useLock();
@@ -422,7 +425,7 @@ function ProfileForm() {
         <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
           <ProfileAvatar
             name={profile?.display_name ?? t.account.you}
-            avatarUrl={profile?.avatar_url ?? oauthAvatar}
+            avatarUrl={profile?.avatar_url || oauthAvatar}
             size={92}
             onPress={profile ? photoOptions : undefined}
             busy={photoBusy}

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -566,7 +566,11 @@ function AuthGate() {
         <Stack
           screenOptions={{
             headerShown: false,
-            contentStyle: { backgroundColor: 'transparent' },
+            // Paint the app background on the sliding card. A transparent card
+            // lets the bare window (white) show through mid-transition, which
+            // read as a white flash while a screen slid in. The heroes still
+            // paint their own gradient over this, so nothing else changes.
+            contentStyle: { backgroundColor: theme.color.bg },
             animation: push,
             animationDuration: reduceMotion ? 0 : TRANSITION_MS,
             gestureEnabled: true,


### PR DESCRIPTION
Two small account/navigation fixes reported from screen recordings.

## 1. White flash while a screen slides in
The root `Stack` used `contentStyle: { backgroundColor: 'transparent' }`, so during a native push the sliding card revealed the bare (white) window behind it — a white flash on every navigation. Now paints `theme.color.bg` on the card. The gradient heroes still draw over it, so nothing else changes.

## 2. Account page showed initials instead of the profile photo
Google/Apple sign-in carries the photo in the session's user metadata, but `profiles.avatar_url` only holds it if the signup trigger copied it across — older accounts have a null `avatar_url`, so the account hero fell back to initials ("MD"). Now falls back to the provider photo (`user_metadata.avatar_url ?? picture`, an https URL that resolves straight through `avatarPhotoUrl`) when the column is empty.

Render-only fallback — it does not write to the DB, so a deliberately removed photo stays removed. (Cross-user visibility of an un-uploaded OAuth photo, and coalescing `picture` in the signup trigger, are follow-ups.)

## Gates
mobile typecheck 0, format 0, lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile avatars now correctly fall back to available OAuth images when profile avatar data is empty or unavailable.
  * Screen transitions now maintain the active theme background, preventing unwanted flashes of the window background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->