### PR TITLE
fix(import): unfreeze ledger import, add progress, brand Splitwise default

### DIFF
--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -24,7 +24,7 @@ import { randomUUID } from 'expo-crypto';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
 import { router } from 'expo-router';
-import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
+import { Pressable, ScrollView, View } from 'react-native';
 
 import {
   importSplitwiseCsv,
@@ -45,6 +45,7 @@ import {
   IconButton,
   iconSize,
   MoneyText,
+  ProgressBar,
   Row,
   Screen,
   SectionHeader,
@@ -64,6 +65,18 @@ import { useAuth } from '@/lib/auth';
 type Mapping = { kind: 'me' } | { kind: 'member'; memberId: string } | { kind: 'ghost' };
 
 const NEW_GROUP = 'new';
+
+/**
+ * Yield one frame so React can flush a state change to the screen before the
+ * thread is tied up again. The file read is async, but the parse that follows
+ * runs on this thread and blocks it — without a paint in between, a large file
+ * freezes on a blank screen and looks like nothing happened.
+ */
+const nextFrame = (): Promise<void> =>
+  new Promise((resolve) => requestAnimationFrame(() => resolve()));
+
+/** Which slow step the screen is on, so it can name what it is waiting for. */
+type Stage = 'reading' | 'parsing' | 'importing';
 
 /**
  * The two file formats, flattened to what this screen needs.
@@ -112,7 +125,12 @@ function fromBaaki(group: BaakiImportGroup, fallbackName: string): Loaded {
 
 export default function ImportScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
+  // The last thing on this screen is a full-width primary CTA (Import / Open the
+  // group), not a line of text. A footer-like action needs more breath above the
+  // system nav bar than the default so its icon and label never sit under the
+  // gesture pill — so ask the clearance hook for a larger base (still the inset
+  // plus a token, never a magic pixel number).
+  const clearance = useScreenClearance(theme.spacing.xxxl * 2);
   const { t, locale } = useStrings();
   const groups = useGroups();
   const { profile } = useAuth();
@@ -138,6 +156,7 @@ export default function ImportScreen() {
   const [mutationIds, setMutationIds] = useState<string[]>([]);
 
   const [busy, setBusy] = useState(false);
+  const [stage, setStage] = useState<Stage | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState<{
     groupId: string;
@@ -184,14 +203,27 @@ export default function ImportScreen() {
       setFileGroupIndex(0);
       setParsed(null);
 
+      // Paint the "reading" bar before touching the file. The read below is
+      // async, but the parse after it is not — both run on this thread, so
+      // without a frame here a large file blocks before any progress shows.
+      setStage('reading');
+      await nextFrame();
+
       const pickedFile = new FileSystem.File(asset.uri);
-      const text = pickedFile.textSync();
+      // Async read (Blob.text) rather than the synchronous textSync: a large
+      // file no longer holds the JS thread while it comes off disk.
+      const text = await pickedFile.text();
       try {
         if (pickedFile.exists) pickedFile.delete();
       } catch {
         // Best-effort privacy cleanup; parsing has already copied the content into memory.
       }
       setFile(asset.name);
+
+      // The parse is synchronous and can be the slow part on a big file, so flush
+      // the "parsing" label to the screen before it blocks the thread.
+      setStage('parsing');
+      await nextFrame();
 
       // Asked of the contents, not the extension: a file saved from a browser
       // or shared through a chat app arrives named all sorts of things.
@@ -214,7 +246,10 @@ export default function ImportScreen() {
       const result = importSplitwiseCsv(text);
       load({
         origin: 'splitwise',
-        suggestedName: asset.name.replace(/\.csv$/i, '') || t.importLedger.importedGroup,
+        // A Splitwise CSV is named "export" more often than not and carries no
+        // group name of its own, so default to the source's own name rather than
+        // a filename that means nothing. The person can rename the group later.
+        suggestedName: t.importLedger.splitwiseGroupName,
         people: result.people,
         currency: result.currency,
         expenses: result.expenses,
@@ -227,6 +262,7 @@ export default function ImportScreen() {
       setError(friendlyError(caught, t.importLedger.importFailed, 'import.readFile'));
     } finally {
       setBusy(false);
+      setStage(null);
     }
   };
 
@@ -281,7 +317,11 @@ export default function ImportScreen() {
   const run = async (): Promise<void> => {
     if (!parsed) return;
     setBusy(true);
+    setStage('importing');
     setError(null);
+    // Let the progress bar and "Importing…" label paint before the single
+    // transactional write ties the thread up.
+    await nextFrame();
     try {
       let groupId = target;
       if (groupId === NEW_GROUP) {
@@ -351,6 +391,7 @@ export default function ImportScreen() {
       setError(friendlyError(caught, t.importLedger.importFailed, 'import.commit'));
     } finally {
       setBusy(false);
+      setStage(null);
     }
   };
 
@@ -404,7 +445,14 @@ export default function ImportScreen() {
           }
         />
 
-        {busy && !parsed ? <ActivityIndicator color={theme.color.brand} /> : null}
+        {stage === 'reading' || stage === 'parsing' ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <Text variant="caption" tone="muted">
+              {stage === 'reading' ? t.importLedger.reading : t.importLedger.parsing}
+            </Text>
+            <ProgressBar />
+          </View>
+        ) : null}
 
         {/* A file holding several groups: one at a time, chosen here. */}
         {fileGroups.length > 1 && !done ? (
@@ -559,6 +607,14 @@ export default function ImportScreen() {
                     />
                   }
                 />
+                {stage === 'importing' ? (
+                  <View style={{ gap: theme.spacing.sm }}>
+                    <ProgressBar />
+                    <Text variant="caption" tone="muted" align="center">
+                      {plural(locale, parsed.expenses.length, t.importLedger.importingCount)}
+                    </Text>
+                  </View>
+                ) : null}
                 {!claimedByMe ? (
                   <Text variant="caption" tone="muted" align="center">
                     {t.importLedger.tapYourNameFirst}

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -57,6 +57,7 @@ import {
 import { createGroup, fetchMembers, importLedger, type ImportPerson } from '@/data/api';
 import { friendlyError } from '@/lib/errors';
 import { plural, useStrings, type UiStrings } from '@/i18n';
+import { useReducedMotion } from '@/lib/reducedMotion';
 import { useGroups } from '@/data/hooks';
 import { displayName, groupLabel, GroupType, type MemberRow } from '@/data/types';
 import { useAuth } from '@/lib/auth';
@@ -132,6 +133,7 @@ export default function ImportScreen() {
   // plus a token, never a magic pixel number).
   const clearance = useScreenClearance(theme.spacing.xxxl * 2);
   const { t, locale } = useStrings();
+  const reduceMotion = useReducedMotion();
   const groups = useGroups();
   const { profile } = useAuth();
 
@@ -450,7 +452,7 @@ export default function ImportScreen() {
             <Text variant="caption" tone="muted">
               {stage === 'reading' ? t.importLedger.reading : t.importLedger.parsing}
             </Text>
-            <ProgressBar />
+            <ProgressBar animated={!reduceMotion} />
           </View>
         ) : null}
 
@@ -609,7 +611,7 @@ export default function ImportScreen() {
                 />
                 {stage === 'importing' ? (
                   <View style={{ gap: theme.spacing.sm }}>
-                    <ProgressBar />
+                    <ProgressBar animated={!reduceMotion} />
                     <Text variant="caption" tone="muted" align="center">
                       {plural(locale, parsed.expenses.length, t.importLedger.importingCount)}
                     </Text>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1801,6 +1801,14 @@ export interface UiStrings {
     noGroupsInFile: string;
     /** Rejects the import when the person marked "me" is not in the target group. */
     couldNotFindYou: string;
+    /** Shown while the picked file is being read off disk. */
+    reading: string;
+    /** Shown while the file's rows are being parsed into a preview. */
+    parsing: string;
+    /** Shown while the parsed rows are being written to the group. */
+    importingCount: PluralForms;
+    /** Default group name for a Splitwise import, since the CSV carries none. */
+    splitwiseGroupName: string;
   };
   /** Picking people, a country, and the dates a trip runs between. */
   pickers: {
@@ -3594,6 +3602,10 @@ const en: UiStrings = {
       'The amounts below are the {currency} ones. {others} come across too, and are never converted.',
     noGroupsInFile: 'That file has no groups to import.',
     couldNotFindYou: 'Could not find you in that group. Open it and try again.',
+    reading: 'Reading the file…',
+    parsing: 'Working through the rows…',
+    importingCount: { one: 'Importing {n} expense…', other: 'Importing {n} expenses…' },
+    splitwiseGroupName: 'Splitwise',
   },
   pickers: {
     contactsDeniedTitle: 'Contacts are switched off',
@@ -5471,6 +5483,13 @@ const ta: UiStrings = {
     noGroupsInFile: 'அந்தக் கோப்பில் இறக்குமதி செய்ய குழுக்கள் இல்லை.',
     couldNotFindYou:
       'அந்தக் குழுவில் உங்களைக் கண்டறிய முடியவில்லை. அதைத் திறந்து மீண்டும் முயற்சிக்கவும்.',
+    reading: 'கோப்பைப் படிக்கிறது…',
+    parsing: 'வரிசைகளைச் செயலாக்குகிறது…',
+    importingCount: {
+      one: '{n} செலவை இறக்குமதி செய்கிறது…',
+      other: '{n} செலவுகளை இறக்குமதி செய்கிறது…',
+    },
+    splitwiseGroupName: 'Splitwise',
   },
   pickers: {
     contactsDeniedTitle: 'தொடர்புகள் அணைக்கப்பட்டுள்ளன',
@@ -7286,6 +7305,10 @@ const hi: UiStrings = {
       'नीचे की रकमें {currency} वाली हैं। {others} भी आती हैं, और कभी बदली नहीं जातीं।',
     noGroupsInFile: 'उस फ़ाइल में आयात करने के लिए कोई समूह नहीं है।',
     couldNotFindYou: 'उस समूह में आप नहीं मिले। उसे खोलकर फिर कोशिश करें।',
+    reading: 'फ़ाइल पढ़ी जा रही है…',
+    parsing: 'पंक्तियाँ संसाधित हो रही हैं…',
+    importingCount: { one: '{n} खर्च आयात हो रहा है…', other: '{n} खर्च आयात हो रहे हैं…' },
+    splitwiseGroupName: 'Splitwise',
   },
   pickers: {
     contactsDeniedTitle: 'संपर्क बंद हैं',
@@ -9261,6 +9284,17 @@ const ar: UiStrings = {
       'المبالغ أدناه هي مبالغ {currency}. وتأتي {others} أيضًا، ولا تُحوَّل أبدًا.',
     noGroupsInFile: 'لا توجد مجموعات في ذلك الملف لاستيرادها.',
     couldNotFindYou: 'تعذّر العثور عليك في تلك المجموعة. افتحها وحاول مرة أخرى.',
+    reading: 'جارٍ قراءة الملف…',
+    parsing: 'جارٍ معالجة الصفوف…',
+    importingCount: {
+      zero: 'لا شيء لاستيراده…',
+      one: 'جارٍ استيراد مصروف واحد…',
+      two: 'جارٍ استيراد مصروفين…',
+      few: 'جارٍ استيراد {n} مصاريف…',
+      many: 'جارٍ استيراد {n} مصروفًا…',
+      other: 'جارٍ استيراد {n} مصروف…',
+    },
+    splitwiseGroupName: 'Splitwise',
   },
   pickers: {
     contactsDeniedTitle: 'جهات الاتصال مُوقَفة',

--- a/packages/ui/src/components/ProgressBar.tsx
+++ b/packages/ui/src/components/ProgressBar.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from 'react';
+import { Animated, View, type ViewStyle } from 'react-native';
+
+import { useTheme } from '../theme';
+
+export interface ProgressBarProps {
+  /**
+   * `0..1` for a determinate bar. Leave it out (or pass `null`) for an
+   * indeterminate one — a segment that slides back and forth for work whose
+   * length is not known ahead of time, like reading and parsing a file.
+   */
+  progress?: number | null;
+  /**
+   * Whether the bar moves. Off (reduce motion) leaves a static fill: a
+   * determinate bar rests at its value, an indeterminate one shows a faint full
+   * track so "working" still reads without motion. The screen threads its own
+   * motion preference in here; this primitive holds no opinion about where the
+   * answer comes from — the same contract as {@link Skeleton}.
+   */
+  animated?: boolean;
+  /** Track thickness in pixels. */
+  height?: number;
+  style?: ViewStyle;
+}
+
+/** How much of the track the sliding segment fills while indeterminate. */
+const INDETERMINATE_FRACTION = 0.4;
+
+/**
+ * A slim progress track.
+ *
+ * Determinate when handed a `progress`, indeterminate otherwise. The moving
+ * part is a transform on the native driver, so it keeps sliding even while the
+ * JS thread is busy — which is the whole reason this bar is on screen: it is the
+ * one thing telling a person that a frozen-looking import is in fact working.
+ */
+export function ProgressBar({
+  progress = null,
+  animated = true,
+  height = 6,
+  style,
+}: ProgressBarProps) {
+  const theme = useTheme();
+  const indeterminate = progress == null;
+  const [trackWidth, setTrackWidth] = useState(0);
+  const slide = useRef(new Animated.Value(0)).current;
+  const fill = useRef(new Animated.Value(0)).current;
+  const clamped = Math.max(0, Math.min(1, progress ?? 0));
+
+  // Determinate: ease the fill toward the reported fraction.
+  useEffect(() => {
+    if (indeterminate) return;
+    if (!animated) {
+      fill.setValue(clamped);
+      return;
+    }
+    const run = Animated.timing(fill, {
+      toValue: clamped,
+      duration: 240,
+      useNativeDriver: false,
+    });
+    run.start();
+    return () => run.stop();
+  }, [indeterminate, clamped, animated, fill]);
+
+  // Indeterminate: loop a segment across the measured track.
+  useEffect(() => {
+    if (!indeterminate || !animated || trackWidth === 0) return;
+    slide.setValue(0);
+    const loop = Animated.loop(
+      Animated.timing(slide, {
+        toValue: 1,
+        duration: 1100,
+        useNativeDriver: true,
+      }),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [indeterminate, animated, trackWidth, slide]);
+
+  const segmentWidth = Math.max(1, trackWidth * INDETERMINATE_FRACTION);
+
+  return (
+    <View
+      accessible
+      accessibilityRole="progressbar"
+      accessibilityValue={
+        indeterminate ? undefined : { min: 0, max: 100, now: Math.round(clamped * 100) }
+      }
+      onLayout={(event) => setTrackWidth(event.nativeEvent.layout.width)}
+      style={[
+        {
+          height,
+          borderRadius: height / 2,
+          backgroundColor: theme.color.skeleton,
+          overflow: 'hidden',
+        },
+        style,
+      ]}
+    >
+      {indeterminate ? (
+        animated && trackWidth > 0 ? (
+          <Animated.View
+            style={{
+              position: 'absolute',
+              top: 0,
+              bottom: 0,
+              width: segmentWidth,
+              borderRadius: height / 2,
+              backgroundColor: theme.color.brand,
+              transform: [
+                {
+                  translateX: slide.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [-segmentWidth, trackWidth],
+                  }),
+                },
+              ],
+            }}
+          />
+        ) : (
+          <View
+            style={{
+              flex: 1,
+              borderRadius: height / 2,
+              backgroundColor: theme.color.brand,
+              opacity: 0.5,
+            }}
+          />
+        )
+      ) : (
+        <Animated.View
+          style={{
+            height: '100%',
+            borderRadius: height / 2,
+            backgroundColor: theme.color.brand,
+            width: fill.interpolate({ inputRange: [0, 1], outputRange: ['0%', '100%'] }),
+          }}
+        />
+      )}
+    </View>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -20,6 +20,7 @@ export * from './components/Avatar';
 export * from './components/MoneyText';
 export * from './components/ListRow';
 export * from './components/Skeleton';
+export * from './components/ProgressBar';
 export * from './components/Toggle';
 export * from './components/PillTabBar';
 export * from './components/SegmentedTabs';


### PR DESCRIPTION
## Why
On the ledger-import screen (`apps/mobile/src/app/settings/import.tsx`), a large file made the app appear to hang: the picked file was read with the **synchronous** `pickedFile.textSync()` and then parsed on the JS thread, so nothing painted — even `setBusy(true)` never flushed a spinner before the block.

## What changed

**1. File read no longer freezes the UI**
- Read asynchronously with `File.text()` (`Blob.text(): Promise<string>`, verified against expo-file-system `~57.0.2`) instead of `textSync()`.
- Yield a frame (`requestAnimationFrame`) after setting the progress stage, before both the read and the still-synchronous parse, so the progress UI paints before the thread is tied up. Best-effort file delete + privacy behaviour preserved.

**2. Progress / interactivity**
- New theme-aware `ProgressBar` primitive in `@waves/ui` (determinate `0..1` or indeterminate). The moving segment runs on the **native driver**, so it keeps sliding even while the JS thread is busy — which is exactly when it's on screen. Reduce-motion falls back to a static fill, same contract as `Skeleton`.
- Reading/parsing shows a labelled indeterminate bar ("Reading the file…" / "Working through the rows…").
- Committing shows a labelled indeterminate bar ("Importing N expenses…").

**Idempotency finding (why indeterminate, not batched-determinate):** I read the `importLedger` wrapper (`apps/mobile/src/data/api.ts`) and the `baaki_import_ledger` SQL (squashed baseline migration). Expenses and settlements are idempotent across repeated calls (per-row `clientMutationId` → `replayed`, and a `client_mutation_id` existence check). **Ghost members are not**: they are created with a plain `INSERT INTO group_members (…) VALUES (…)` with **no `ON CONFLICT` and no `(group_id, ghost_name)` unique constraint**, so calling the RPC per chunk with the full people list would mint duplicate ghosts each call. Per the task's explicit safety rule, I did **not** batch — the commit stays a single transactional call with an animated indeterminate bar.

**3. Splitwise default group name**
- A Splitwise import now defaults its group name to the branded **"Splitwise"** (new i18n key `splitwiseGroupName`) instead of the CSV filename (usually "export"). The Splitwise parser exposes no group name, so there is nothing truer to prefer; the user can still rename later.

**4. Bottom CTA clipped by the nav bar**
- The screen draws edge-to-edge (`<Screen edges={['top']}>`), so the Android system nav/gesture bar sits over the bottom of the scroll content. The last element here is a full-width **primary CTA** (Import / Open the group, with a cloud-upload icon), not a line of text like on comparable pushed screens (`group/[id]/month.tsx`). The default `useScreenClearance()` breath (`insets.bottom + spacing.xxxl`) let that button/icon crowd under the gesture pill. Fixed by asking the hook for a larger footer-sized base — `useScreenClearance(theme.spacing.xxxl * 2)` — still inset + a token, no magic pixel number.

## i18n
New keys under `importLedger`, added to the interface and all four locales (en/ta/hi/ar): `reading`, `parsing`, `importingCount` (PluralForms), `splitwiseGroupName`.

## Gates (all exit 0, Windows PowerShell)
- `pnpm --filter @waves/mobile typecheck`
- `pnpm format` (+ `prettier --check` on the touched file)
- `pnpm --filter @waves/mobile lint`
- `pnpm --filter @waves/mobile exec vitest run import` — 1 file, 7 tests pass
- `pnpm --filter @waves/ui typecheck`
- `bash scripts/check-filenames.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added progress feedback for file reading, parsing, and importing.
  * Progress indicators support animated, accessibility-friendly, and reduced-motion states.
  * Added localized import status messages in English, Tamil, Hindi, and Arabic.
* **Bug Fixes**
  * Improved responsiveness during large imports.
  * Import progress now clears after success or failure.
  * Splitwise imports use the localized default group name instead of the CSV filename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->