### PR TITLE
feat(expense): show "not involved" instead of a false "all settled"

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -10,6 +10,7 @@ import {
   Avatar,
   Badge,
   Button,
+  Callout,
   Card,
   directionalIcon,
   EmptyState,
@@ -148,6 +149,16 @@ export default function ExpenseDetailScreen() {
     (version.author_member_id === myMemberId ||
       version.payers.some((p) => p.member_id === myMemberId)),
   );
+  // Whether *you* have any stake in this bill — money you put in, or a share you
+  // owe of it. A member who is on the group but not on this split (or written into
+  // it with a zero share) has no stake, so the screen frames itself as someone
+  // else's bill: an observer banner up top, and the split shown in neutral ink
+  // instead of the owe-red that would imply the debt is yours. This is money-only
+  // on purpose — being the author but not a party still reads as not involved.
+  const myPaidHere = version?.payers.find((p) => p.member_id === myMemberId)?.amount;
+  const myShareHere = version?.shares.find((s) => s.member_id === myMemberId)?.amount;
+  const notInvolved =
+    Boolean(version) && BigInt(myPaidHere ?? 0) === 0n && BigInt(myShareHere ?? 0) === 0n;
   // Admin of this group — the moderation lever on the comment thread (delete
   // anyone's, resolve a report). The server re-checks; this only shows controls.
   const iAmAdmin =
@@ -400,6 +411,20 @@ export default function ExpenseDetailScreen() {
           />
         ) : (
           <>
+            {/* You are looking at a bill you have no stake in — not a payer, no
+            share. Say so plainly up top so the split below reads as someone
+            else's ledger, the way Splitwise marks it "not involved" rather than
+            letting a zero balance masquerade as "all settled". */}
+            {notInvolved ? (
+              <Callout
+                tone="info"
+                icon={(color) => <Ionicons name="eye-outline" size={iconSize.md} color={color} />}
+                title={t.expense.notInvolvedTitle}
+              >
+                {t.expense.notInvolvedBody}
+              </Callout>
+            ) : null}
+
             {/* Receipts — one gallery, many images, each group-visible or private.
             Folds in the legacy single bill (E2) as its first item. A party can
             add (scan or library) and remove; anyone sees the group images. */}
@@ -526,8 +551,11 @@ export default function ExpenseDetailScreen() {
                             // same owe colour the balances do across the app — not the
                             // neutral ink of a total. Forced (not sign-derived): every
                             // share is a positive owe, so mode="balance" would read it
-                            // as "owed to you" (green) instead.
-                            tone="negative"
+                            // as "owed to you" (green) instead. But when *you* are not
+                            // in this split, none of these owes are yours to read as
+                            // debt — the whole list drops to muted ink so it reads as
+                            // someone else's ledger, matching the observer banner.
+                            tone={notInvolved ? 'muted' : 'negative'}
                           />
                         }
                       />

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -157,8 +157,17 @@ export default function ExpenseDetailScreen() {
   // on purpose — being the author but not a party still reads as not involved.
   const myPaidHere = version?.payers.find((p) => p.member_id === myMemberId)?.amount;
   const myShareHere = version?.shares.find((s) => s.member_id === myMemberId)?.amount;
+  // Only classify once we know who the viewer is. An unresolved `myMemberId` (the
+  // members mirror still hydrating, or a viewer with no membership row yet) would
+  // otherwise read as zero-paid/zero-share and flash the "not involved" banner
+  // over a bill the viewer may well be in. Null → leave it involved (no banner)
+  // until resolution; a resolved member genuinely not in the split still gets the
+  // zero-stake treatment.
   const notInvolved =
-    Boolean(version) && BigInt(myPaidHere ?? 0) === 0n && BigInt(myShareHere ?? 0) === 0n;
+    Boolean(version) &&
+    myMemberId !== null &&
+    BigInt(myPaidHere ?? 0) === 0n &&
+    BigInt(myShareHere ?? 0) === 0n;
   // Admin of this group — the moderation lever on the comment thread (delete
   // anyone's, resolve a report). The server re-checks; this only shows controls.
   const iAmAdmin =

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -167,8 +167,15 @@ function myStake(
   if (!version || !memberId) return null;
   const paid = version.payers.find((row) => row.member_id === memberId)?.amount;
   const share = version.shares.find((row) => row.member_id === memberId)?.amount;
-  if (paid === undefined && share === undefined) return null;
-  return BigInt(paid ?? 0) - BigInt(share ?? 0);
+  const paidN = BigInt(paid ?? 0);
+  const shareN = BigInt(share ?? 0);
+  // Not involved is "put nothing in, owe nothing" — which covers both the member
+  // absent from the bill entirely AND a member written into the split with a zero
+  // share (an excluded party some imports still list). Either way there is no
+  // stake, so the row must read "not involved", not "all settled" — a settled
+  // square is what you get when you paid and owed the *same non-zero* amount.
+  if (paidN === 0n && shareN === 0n) return null;
+  return paidN - shareN;
 }
 
 /**

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1470,6 +1470,10 @@ export interface UiStrings {
     youBorrowed: string;
     /** An expense you neither paid for nor have a share of. */
     notInvolved: string;
+    /** Detail-screen banner title when you are not a party to the bill. */
+    notInvolvedTitle: string;
+    /** Detail-screen banner body: this bill does not touch your balance. */
+    notInvolvedBody: string;
     /** "edited twice" — the count is edits, so it starts at one. */
     editedTimes: PluralForms;
     /** "In 4 expenses" over the list on a member. */
@@ -3241,6 +3245,8 @@ const en: UiStrings = {
     youLent: 'you lent',
     youBorrowed: 'you borrowed',
     notInvolved: 'not involved',
+    notInvolvedTitle: "You're not in this split",
+    notInvolvedBody: "You're viewing this as a group member — nothing here touches your balance.",
     editedTimes: { one: 'edited once', other: 'edited {n} times' },
     inCount: { one: 'In {n} expense', other: 'In {n} expenses' },
     whoOwesWhat: 'Who owes what',
@@ -5100,6 +5106,9 @@ const ta: UiStrings = {
     youLent: 'நீங்கள் கொடுத்தது',
     youBorrowed: 'நீங்கள் வாங்கியது',
     notInvolved: 'உங்களுக்கு தொடர்பில்லை',
+    notInvolvedTitle: 'இந்த பங்கீட்டில் நீங்கள் இல்லை',
+    notInvolvedBody:
+      'நீங்கள் குழு உறுப்பினராக இதைப் பார்க்கிறீர்கள் — இதில் எதுவும் உங்கள் இருப்பைத் தொடாது.',
     editedTimes: { one: 'ஒருமுறை திருத்தப்பட்டது', other: '{n} முறை திருத்தப்பட்டது' },
     inCount: { one: '{n} செலவில்', other: '{n} செலவுகளில்' },
     whoOwesWhat: 'யார் என்ன தர வேண்டும்',
@@ -6940,6 +6949,9 @@ const hi: UiStrings = {
     youLent: 'आपने दिए',
     youBorrowed: 'आपने लिए',
     notInvolved: 'आप इसमें नहीं',
+    notInvolvedTitle: 'आप इस बँटवारे में नहीं हैं',
+    notInvolvedBody:
+      'आप इसे समूह सदस्य के रूप में देख रहे हैं — इसमें कुछ भी आपके बैलेंस को नहीं बदलता।',
     editedTimes: { one: 'एक बार संपादित', other: '{n} बार संपादित' },
     inCount: { one: '{n} खर्च में', other: '{n} खर्चों में' },
     whoOwesWhat: 'किस पर क्या बाकी',
@@ -8800,6 +8812,8 @@ const ar: UiStrings = {
     youLent: 'أقرضت',
     youBorrowed: 'اقترضت',
     notInvolved: 'لست ضمنها',
+    notInvolvedTitle: 'أنت لست ضمن هذه القسمة',
+    notInvolvedBody: 'أنت تشاهدها كعضو في المجموعة — لا شيء هنا يؤثّر على رصيدك.',
     editedTimes: {
       zero: 'لم يُعدّل',
       one: 'عُدّل مرة واحدة',


### PR DESCRIPTION
## Problem

An expense you have **no stake in** (paid nothing, owe no share) was showing as **"all settled"** — the green *done* verdict — on the group feed, and gave **no signal at all** on the opened expense detail. That reads as "you paid your share", when the truth is you were never on the bill. Splitwise marks these **"not involved"**.

## Fix

**Feed row** (`group/[id]/index.tsx`) — `myStake()` now returns `null` (→ "not involved") when you put in `0` and owe `0`. Folds in both the member absent from the split entirely *and* a member written into it with a zero share (some imports list excluded parties that way). A genuine settled square — `paid == share`, both non-zero — still reads "all settled".

**Expense detail** (`group/[id]/expense/[expenseId].tsx`) — the innovative part:
- An **observer `Callout`** up top ("You're not in this split", eye icon) when you have no stake.
- The **"Who owes what" amounts drop from owe-red to muted ink**, so the split reads as *someone else's ledger* rather than a debt of yours.

**i18n** — new `expense.notInvolvedTitle` / `notInvolvedBody` in en/ta/hi/ar.

## Verification

- `pnpm format`, `pnpm lint`, `pnpm -C apps/mobile typecheck` — all green.
- Not device-run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an informational banner for viewers with no financial involvement in an expense.
  * Updated expense details to display uninvolved amounts with muted styling.
  * Improved detection of members with zero paid and owed amounts.
  * Added translations for the new messaging in English, Tamil, Hindi, and Arabic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->