### PR TITLE
perf+feat: dashboard/voice/activity UX polish + import rename

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { Pressable, RefreshControl, SectionList, View } from 'react-native';
@@ -38,6 +38,120 @@ import { usePullRefresh } from '@/lib/pullRefresh';
 import { SyncStatus, useSync } from '@/sync';
 
 type DaySection = { key: string; first: RecentActivityRow; data: RecentActivityRow[] };
+
+/**
+ * One row of the virtualized activity feed, memoized so a recycled row that
+ * lands on the same entry does no work when the parent re-renders — the same
+ * pattern the expense feed uses. Every prop is a primitive or a reference the
+ * screen keeps stable (`t`/`theme` from context, `rtf` hoisted per locale), so
+ * the shallow `memo` compare holds on a fast fling.
+ *
+ * `describeActivity` is called once here, not twice (spoken label + visible
+ * line), and `relativeTime` is handed the hoisted `rtf` instead of building an
+ * `Intl.RelativeTimeFormat` per row — the two allocations that made this feed
+ * heavier to scroll than the expense feed it mirrors.
+ */
+const ActivityFeedRow = memo(function ActivityFeedRow({
+  entry,
+  locale,
+  t,
+  theme,
+  myProfileId,
+  blockedIds,
+  rtf,
+}: {
+  entry: RecentActivityRow;
+  locale: string;
+  t: ReturnType<typeof useStrings>['t'];
+  theme: ReturnType<typeof useTheme>;
+  myProfileId: string | null;
+  blockedIds: ReturnType<typeof useBlockedUsers>['blockedIds'];
+  rtf: Intl.RelativeTimeFormat | undefined;
+}) {
+  const money = parseMoney(entry.payload);
+  // A soft rounded-square tile whose tint leans with the verb — the same row the
+  // group's Activity tab and the Expenses tab use, so activity reads one way
+  // everywhere. No timeline rail; the day headings above do the sectioning,
+  // hairlines do the between-row separation.
+  const tint = theme.tint[verbTint(entry.verb)];
+  const g = entry.group;
+  const groupLabel = g
+    ? [g.cover_emoji, g.name].filter(Boolean).join(' ').trim() || t.captures.group
+    : null;
+  const label = describeActivity(entry, myProfileId, blockedIds, t.misc.someone);
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={() => router.push(`/group/${entry.group_id}`)}
+      style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+    >
+      <Row
+        style={{
+          gap: theme.spacing.md,
+          alignItems: 'center',
+          paddingVertical: theme.spacing.md,
+        }}
+      >
+        <View
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: theme.radius.md,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: tint.bg,
+          }}
+        >
+          <Ionicons name={verbIcon(entry.verb)} size={iconSize.lg} color={tint.ink} />
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text variant="body" numberOfLines={2}>
+            {label}
+          </Text>
+          {/* The relative time, plus which group the entry belongs to — this is a
+              cross-group feed, so the row would otherwise not say. An archived
+              group, or one no longer on this device (left or deleted), gets a
+              badge so it is recognisable without opening it. */}
+          <Row
+            style={{
+              gap: theme.spacing.sm,
+              alignItems: 'center',
+              marginTop: 2,
+              flexWrap: 'wrap',
+            }}
+          >
+            <Text variant="caption" tone="muted">
+              {relativeTime(locale, entry.created_at, undefined, rtf)}
+            </Text>
+            {groupLabel ? (
+              <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
+                {`· ${groupLabel}`}
+              </Text>
+            ) : null}
+            {g?.archived_at ? (
+              <Badge label={t.misc.archivedGroup} tone="neutral" />
+            ) : !g ? (
+              <Badge label={t.misc.unavailableGroup} tone="neutral" />
+            ) : null}
+          </Row>
+        </View>
+        {/* `payload` is an untyped JSON blob, so a bad amount must render as no
+            amount, not as a crashed tab. Red like the shares and balances — one
+            money colour across every screen. */}
+        {money ? (
+          <MoneyText
+            amount={money.amount}
+            currency={money.currency}
+            locale={locale}
+            variant="subheading"
+            tone="negative"
+          />
+        ) : null}
+      </Row>
+    </Pressable>
+  );
+});
 
 export default function ActivityScreen() {
   const theme = useTheme();
@@ -102,6 +216,17 @@ export default function ActivityScreen() {
       ? showDay(range.start)
       : `${showDay(range.start)} – ${showDay(range.end)}`
     : '';
+
+  // One relative-time formatter for the whole feed, rebuilt only when the locale
+  // changes — handed to every row so a fast scroll never constructs an
+  // `Intl.RelativeTimeFormat` per recycled row.
+  const rtf = useMemo(
+    () =>
+      typeof Intl.RelativeTimeFormat === 'function'
+        ? new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+        : undefined,
+    [locale],
+  );
 
   const notifications = useNotifications();
   const unread = (notifications.data ?? []).filter((row) => row.read_at === null).length;
@@ -297,96 +422,17 @@ export default function ActivityScreen() {
         ItemSeparatorComponent={() => (
           <View style={{ height: 1, backgroundColor: theme.color.border }} />
         )}
-        renderItem={({ item: entry }) => {
-          const money = parseMoney(entry.payload);
-          // A soft rounded-square tile whose tint leans with the verb — the same
-          // row the group's Activity tab and the Expenses tab use, so activity
-          // reads one way everywhere. No timeline rail; the day headings above
-          // do the sectioning, hairlines do the between-row separation.
-          const tint = theme.tint[verbTint(entry.verb)];
-          const g = entry.group;
-          const groupLabel = g
-            ? [g.cover_emoji, g.name].filter(Boolean).join(' ').trim() || t.captures.group
-            : null;
-          return (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={describeActivity(entry, myProfileId, blockedIds, t.misc.someone)}
-              onPress={() => router.push(`/group/${entry.group_id}`)}
-              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-            >
-              <Row
-                style={{
-                  gap: theme.spacing.md,
-                  alignItems: 'center',
-                  paddingVertical: theme.spacing.md,
-                }}
-              >
-                <View
-                  style={{
-                    width: 40,
-                    height: 40,
-                    borderRadius: theme.radius.md,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    backgroundColor: tint.bg,
-                  }}
-                >
-                  <Ionicons name={verbIcon(entry.verb)} size={iconSize.lg} color={tint.ink} />
-                </View>
-                <View style={{ flex: 1 }}>
-                  <Text variant="body" numberOfLines={2}>
-                    {describeActivity(entry, myProfileId, blockedIds, t.misc.someone)}
-                  </Text>
-                  {/* The relative time, plus which group the entry belongs to —
-                      this is a cross-group feed, so the row would otherwise not
-                      say. An archived group, or one no longer on this device
-                      (left or deleted), gets a badge so it is recognisable
-                      without opening it. */}
-                  <Row
-                    style={{
-                      gap: theme.spacing.sm,
-                      alignItems: 'center',
-                      marginTop: 2,
-                      flexWrap: 'wrap',
-                    }}
-                  >
-                    <Text variant="caption" tone="muted">
-                      {relativeTime(locale, entry.created_at)}
-                    </Text>
-                    {groupLabel ? (
-                      <Text
-                        variant="caption"
-                        tone="muted"
-                        numberOfLines={1}
-                        style={{ flexShrink: 1 }}
-                      >
-                        {`· ${groupLabel}`}
-                      </Text>
-                    ) : null}
-                    {g?.archived_at ? (
-                      <Badge label={t.misc.archivedGroup} tone="neutral" />
-                    ) : !g ? (
-                      <Badge label={t.misc.unavailableGroup} tone="neutral" />
-                    ) : null}
-                  </Row>
-                </View>
-                {/* `payload` is an untyped JSON blob, so a bad amount must render
-                    as no amount, not as a crashed tab. Red like the shares and
-                    balances — one money colour across every screen. */}
-                {money ? (
-                  <MoneyText
-                    amount={money.amount}
-                    currency={money.currency}
-                    locale={locale}
-                    variant="subheading"
-                    tone="negative"
-                  />
-                ) : null}
-              </Row>
-            </Pressable>
-          );
-        }}
+        renderItem={({ item }) => (
+          <ActivityFeedRow
+            entry={item}
+            locale={locale}
+            t={t}
+            theme={theme}
+            myProfileId={myProfileId}
+            blockedIds={blockedIds}
+            rtf={rtf}
+          />
+        )}
       />
       {/* The range picker, over the feed. Rendered only when open and only when
           there is a span to clamp to, so it can seed the picker from real dates. */}

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -23,6 +23,7 @@ import {
   EmptyState,
   Gradient,
   iconSize,
+  MoneyText,
   Row,
   Screen,
   Text,
@@ -31,7 +32,6 @@ import {
 } from '@waves/ui';
 
 import { useCaptures, useGroups, useHomeSummary } from '@/data/hooks';
-import { CountUpMoney } from '@/lib/anim';
 import { useFlagEnabled } from '@/lib/flags';
 import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -91,9 +91,6 @@ export default function HomeScreen() {
   const heroInner = width - theme.spacing.xl * 2;
   const heroGap = theme.spacing.md;
   const heroSnap = heroInner + heroGap;
-  // Which balance slide is centred — owned here so the dot pager can sit below
-  // the action buttons rather than under the balance.
-  const [heroPage, setHeroPage] = useState(0);
   // The time-of-day line under the name. The *bucket* is sampled once on mount
   // (lazy init, never a bare Date in render — the React Compiler lints that),
   // then the localised word is read at render so it follows a language change.
@@ -381,7 +378,6 @@ export default function HomeScreen() {
                 cardWidth={heroInner}
                 gap={heroGap}
                 snap={heroSnap}
-                onPageChange={setHeroPage}
                 // The mirror hydrates instantly, so the balance shows at once.
                 // Until this session's first sync settles it is provisional —
                 // "updating" rather than an owe/owed verdict, so the sub line
@@ -425,7 +421,7 @@ export default function HomeScreen() {
               </Row>
 
               {/* The swipe pager, right under the buttons. */}
-              <HeroDots count={SLIDE_GRADIENTS.length} page={heroPage} />
+              <HeroDots count={SLIDE_GRADIENTS.length} scrollX={heroScrollX} snap={heroSnap} />
             </View>
           </View>
         </TourTarget>
@@ -1224,7 +1220,6 @@ function HeroBalance({
   cardWidth,
   gap,
   snap,
-  onPageChange,
 }: {
   primary: CurrencyTotal;
   /** My share of this month's spend, per currency (from useHomeSummary). */
@@ -1243,9 +1238,6 @@ function HeroBalance({
   cardWidth: number;
   gap: number;
   snap: number;
-  /** Which slide is now centred — the screen renders the dot pager below the
-   *  action buttons, so it owns the page. */
-  onPageChange: (page: number) => void;
 }) {
   // The three balance views the dashboard leads with, one per swipe: where you
   // stand overall (net), what is owed to you, and what you have spent this month
@@ -1324,9 +1316,6 @@ function HeroBalance({
       decelerationRate="fast"
       disableIntervalMomentum
       scrollEventThrottle={16}
-      onMomentumScrollEnd={(event) =>
-        onPageChange(Math.round(event.nativeEvent.contentOffset.x / snap))
-      }
       contentContainerStyle={{ gap }}
       onScroll={Animated.event([{ nativeEvent: { contentOffset: { x: scrollX } } }], {
         useNativeDriver: true,
@@ -1365,24 +1354,74 @@ function HeroBalance({
 
 /**
  * The dot pager — the "swipe me" signal, rendered by the screen below the action
- * buttons rather than under the balance. The active dot is solid white and wider;
- * the rest sit faint white so they read against any of the slide washes.
+ * buttons rather than under the balance. A wide white pill marks the active slide
+ * over a row of faint dots that read against any of the slide washes.
+ *
+ * The pill slides off the carousel's live `scrollX`, native-driven, so it tracks
+ * the finger at 60fps exactly like the hero colour crossfade — not off a React
+ * state that only lands at `onMomentumScrollEnd`, which is what made the dots lag
+ * a beat behind the swipe. Native driver animates transform/opacity only (never
+ * width or colour), so the active mark is a fixed-width pill that *translates*
+ * across static dots rather than one dot growing and the row reflowing.
  */
-function HeroDots({ count, page }: { count: number; page: number }) {
+const DOT_SIZE = 6;
+const DOT_ACTIVE_WIDTH = 18;
+
+function HeroDots({
+  count,
+  scrollX,
+  snap,
+}: {
+  count: number;
+  scrollX: Animated.Value;
+  snap: number;
+}) {
   const theme = useTheme();
+  const gap = theme.spacing.xs;
+  const step = DOT_SIZE + gap; // centre-to-centre distance between dots
+  const trackWidth = count * DOT_SIZE + Math.max(0, count - 1) * gap;
+  // Map scroll offset (0, snap, 2·snap, …) to the pill's position over each dot.
+  // interpolate needs ≥2 strictly-ascending inputs, so a lone slide is a static
+  // pill with no interpolation.
+  const translateX =
+    count > 1
+      ? scrollX.interpolate({
+          inputRange: Array.from({ length: count }, (_, i) => i * snap),
+          outputRange: Array.from({ length: count }, (_, i) => i * step),
+          extrapolate: 'clamp',
+        })
+      : 0;
   return (
-    <Row style={{ justifyContent: 'center', gap: theme.spacing.xs }}>
-      {Array.from({ length: count }, (_, index) => (
-        <View
-          key={index}
+    <Row style={{ justifyContent: 'center' }}>
+      <View style={{ width: trackWidth, height: DOT_SIZE }}>
+        <Row style={{ position: 'absolute', left: 0, top: 0, gap }}>
+          {Array.from({ length: count }, (_, index) => (
+            <View
+              key={index}
+              style={{
+                width: DOT_SIZE,
+                height: DOT_SIZE,
+                borderRadius: DOT_SIZE / 2,
+                backgroundColor: 'rgba(255, 255, 255, 0.35)',
+              }}
+            />
+          ))}
+        </Row>
+        <Animated.View
           style={{
-            width: index === page ? 18 : 6,
-            height: 6,
-            borderRadius: 3,
-            backgroundColor: index === page ? '#FFFFFF' : 'rgba(255, 255, 255, 0.35)',
+            position: 'absolute',
+            top: 0,
+            // Seat the wide pill centred on the first dot; the translate then
+            // carries that centre from dot to dot.
+            left: (DOT_SIZE - DOT_ACTIVE_WIDTH) / 2,
+            width: DOT_ACTIVE_WIDTH,
+            height: DOT_SIZE,
+            borderRadius: DOT_SIZE / 2,
+            backgroundColor: '#FFFFFF',
+            transform: [{ translateX }],
           }}
         />
-      ))}
+      </View>
     </Row>
   );
 }
@@ -1504,7 +1543,7 @@ function MetricSlide({
             {'••••••'}
           </Text>
         ) : (
-          <CountUpMoney
+          <MoneyText
             amount={amount}
             currency={currency as never}
             locale={locale}
@@ -1615,7 +1654,7 @@ function GroupRow({
           {pendingLabel ?? `${memberLabel} · ${statusLabel}`}
         </Text>
       </View>
-      <CountUpMoney
+      <MoneyText
         amount={balance < 0n ? -balance : balance}
         currency={currency as never}
         locale={locale}

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -577,10 +577,6 @@ function ProfileForm() {
             },
           ]}
         />
-
-        <Text variant="micro" tone="muted" align="center">
-          {t.account.footnote}
-        </Text>
       </ScrollView>
     </Screen>
   );

--- a/apps/mobile/src/app/inbox.tsx
+++ b/apps/mobile/src/app/inbox.tsx
@@ -100,7 +100,18 @@ export default function InboxScreen() {
           screens sit together, so the inbox reads as the sibling it is. No
           back chevron: the title sits at the left edge exactly like Activity,
           and the bottom bar carries the way back. */}
-      <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center', gap: theme.spacing.sm }}>
+      {/* minHeight matches Activity's header, whose two IconButtons stand it at
+          44 — without it this button-less title row is ~14px shorter, so the
+          title and the whole body jump up when you cross from Activity to here
+          and back. */}
+      <Row
+        style={{
+          paddingTop: theme.spacing.md,
+          minHeight: 44 + theme.spacing.md,
+          alignItems: 'center',
+          gap: theme.spacing.sm,
+        }}
+      >
         <Ionicons name="notifications-outline" size={iconSize.xl} color={theme.color.brand} />
         <Text variant="title">{t.inbox.title}</Text>
       </Row>

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -178,22 +178,29 @@ export default function ImportScreen() {
     setMembers([]);
   };
 
-  const choose = async (): Promise<void> => {
+  const choose = async (source: 'splitwise' | 'other' = 'other'): Promise<void> => {
     setError(null);
     setDone(null);
     setBusy(true);
     try {
+      // The format is decided by sniffing the file contents (isBaakiExport),
+      // never the picker — so both sources funnel through here. The `source`
+      // only narrows what the picker offers: a Splitwise export is a CSV, so
+      // that option leads with CSV; "other data" (a Waves JSON, or anything
+      // else) leads with JSON. Both keep the text/octet-stream fallbacks, since
+      // some Android providers mislabel a .csv as `application/octet-stream`.
+      const type =
+        source === 'splitwise'
+          ? ['text/csv', 'text/comma-separated-values', 'text/plain', 'application/octet-stream']
+          : [
+              'application/json',
+              'text/csv',
+              'text/comma-separated-values',
+              'text/plain',
+              'application/octet-stream',
+            ];
       const picked = await DocumentPicker.getDocumentAsync({
-        // Some Android file providers hand back `application/octet-stream` for a
-        // .csv, so text/* is allowed too rather than hiding the file the person
-        // came here to select.
-        type: [
-          'text/csv',
-          'text/comma-separated-values',
-          'text/plain',
-          'application/json',
-          'application/octet-stream',
-        ],
+        type,
         copyToCacheDirectory: true,
       });
       if (picked.canceled) return;
@@ -431,21 +438,38 @@ export default function ImportScreen() {
           </Text>
         </Card>
 
-        <Button
-          label={file ? t.importLedger.chooseDifferentFile : t.importLedger.chooseFile}
-          size="lg"
-          fullWidth
-          variant={file ? 'secondary' : 'primary'}
-          disabled={busy}
-          onPress={() => void choose()}
-          icon={
-            <Ionicons
-              name="document-attach-outline"
-              size={iconSize.md}
-              color={file ? theme.color.brand : theme.color.onBrand}
-            />
-          }
-        />
+        {/* Two ways in, one flow: the file's contents decide the format either
+            way (see choose()), so these only set the picker's expectation and
+            the wording the person reads. Once a file is loaded, the block below
+            takes over; the buttons stay as the way to pick a different one. */}
+        <View style={{ gap: theme.spacing.md }}>
+          <Button
+            label={t.importLedger.fromSplitwise}
+            size="lg"
+            fullWidth
+            variant="primary"
+            disabled={busy}
+            onPress={() => void choose('splitwise')}
+            icon={
+              <Ionicons
+                name="document-attach-outline"
+                size={iconSize.md}
+                color={theme.color.onBrand}
+              />
+            }
+          />
+          <Button
+            label={t.importLedger.fromOther}
+            size="lg"
+            fullWidth
+            variant="secondary"
+            disabled={busy}
+            onPress={() => void choose('other')}
+            icon={
+              <Ionicons name="folder-open-outline" size={iconSize.md} color={theme.color.brand} />
+            }
+          />
+        </View>
 
         {stage === 'reading' || stage === 'parsing' ? (
           <View style={{ gap: theme.spacing.sm }}>

--- a/apps/mobile/src/components/Skeletons.tsx
+++ b/apps/mobile/src/components/Skeletons.tsx
@@ -215,60 +215,49 @@ export function PeopleSkeleton() {
 }
 
 /**
- * The activity tab: the vertical timeline — a tinted node on a connector line
- * running down the left, the sentence and its amount beside it, the relative
- * time beneath. Shaped to the real feed to the pixel so the swap is a fill, not
- * a jump: an earlier version drew day headings over full-width rounded cards, a
- * layout the feed no longer has, so the whole shape lurched when the timeline
- * arrived. The rail node, the 2px connector, the `md` gap to the text and the
- * `xl` drop between rows all match `ActivityScreen`'s timeline. Shown in place
- * of the "nothing yet" empty state, which is a verdict the query has not
- * returned yet.
+ * The activity tab, shaped to the real feed so the swap is a fill, not a jump.
+ * The feed is now a flat list of rows under day headings — a 40×40 tinted tile,
+ * the sentence and its trailing amount beside it, the relative time beneath —
+ * with hairline separators between rows. No timeline rail (an earlier design had
+ * one; drawing it here made the whole shape lurch when the railless feed
+ * arrived). The leading day-heading bar, the tile size, the `md` vertical
+ * padding and the hairline all match `ActivityScreen`'s row so nothing moves
+ * when the query returns. Shown in place of the "nothing yet" empty state, which
+ * is a verdict the query has not returned yet.
  */
-export function FeedSkeleton({ rows = 5 }: { rows?: number }) {
+export function FeedSkeleton({ rows = 6 }: { rows?: number }) {
   const theme = useTheme();
   return (
     <LoadingRegion>
+      {/* Stands in for the uppercase day heading the first section renders, at
+          its 11px height and the same lg/md margins — so the first real heading
+          does not push the rows down. */}
+      <Skeleton
+        width="28%"
+        height={11}
+        style={{ marginTop: theme.spacing.lg, marginBottom: theme.spacing.md }}
+      />
       {Array.from({ length: rows }, (_, index) => {
         const isLast = index === rows - 1;
         return (
-          <Row key={index} style={{ alignItems: 'stretch' }}>
-            {/* The rail: the node circle, then the connector running down to the
-                next node — dropped on the last row so it stops, not dangles. */}
-            <View style={{ width: 38, alignItems: 'center' }}>
-              <Skeleton width={38} height={38} radius={theme.radius.pill} />
-              {!isLast ? (
-                <View
-                  style={{
-                    flex: 1,
-                    width: 2,
-                    marginVertical: 2,
-                    backgroundColor: theme.color.border,
-                  }}
-                />
-              ) : null}
-            </View>
-
-            <View
+          <View key={index}>
+            <Row
               style={{
-                flex: 1,
-                paddingStart: theme.spacing.md,
-                paddingBottom: isLast ? 0 : theme.spacing.xl,
+                gap: theme.spacing.md,
+                alignItems: 'center',
+                paddingVertical: theme.spacing.md,
               }}
             >
-              <Row style={{ gap: theme.spacing.sm, alignItems: 'flex-start' }}>
-                {/* Two lines standing in for the wrapped sentence, and the
-                    amount that rides at its end. */}
-                <View style={{ flex: 1, gap: theme.spacing.sm }}>
-                  <Skeleton width="92%" height={15} />
-                  <Skeleton width="58%" height={15} />
-                </View>
-                <Skeleton width={56} height={16} />
-              </Row>
-              {/* The relative time, at its 11px height and the same 2px drop. */}
-              <Skeleton width="26%" height={11} style={{ marginTop: 2 }} />
-            </View>
-          </Row>
+              <Skeleton width={40} height={40} radius={theme.radius.md} />
+              <View style={{ flex: 1, gap: theme.spacing.sm }}>
+                {/* The sentence line, then the smaller relative-time line. */}
+                <Skeleton width="86%" height={15} />
+                <Skeleton width="34%" height={11} />
+              </View>
+              <Skeleton width={56} height={16} />
+            </Row>
+            {!isLast ? <View style={{ height: 1, backgroundColor: theme.color.border }} /> : null}
+          </View>
         );
       })}
     </LoadingRegion>

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -186,12 +186,16 @@ const AnimatedPath = Reanimated.createAnimatedComponent(Path);
  * hairline between them, tapering to a point at both ends like the reference.
  * Runs on the UI thread — the body of a `useAnimatedProps` worklet.
  */
-function wavePath(phase: number, layer: WaveLayerSpec): string {
+function wavePath(phase: number, level: number, layer: WaveLayerSpec): string {
   'worklet';
   const points = 72;
   const cy = WAVE_H / 2;
   const breath = 0.85 + 0.15 * Math.sin(phase * 2 + layer.phase);
-  const reach = (WAVE_H / 2 - 1) * layer.amp * breath;
+  // Loudness drives the height: a quiet mic keeps a low idling ribbon (40%), a
+  // loud voice pushes it to full. `level` is the eased 0…1 metering; when the
+  // platform sends no volume events it stays 0 and the wave simply idles.
+  const loud = 0.4 + 0.6 * level;
+  const reach = (WAVE_H / 2 - 1) * layer.amp * breath * loud;
   let top = '';
   let bottom = '';
   for (let i = 0; i <= points; i++) {
@@ -209,9 +213,18 @@ function wavePath(phase: number, layer: WaveLayerSpec): string {
   return `${top}${bottom}Z`;
 }
 
-/** One translucent filled ribbon, its path recomputed each frame from `phase`. */
-function WaveLayer({ phase, layer }: { phase: SharedValue<number>; layer: WaveLayerSpec }) {
-  const animatedProps = useAnimatedProps(() => ({ d: wavePath(phase.value, layer) }));
+/** One translucent filled ribbon, its path recomputed each frame from `phase`
+ *  and the live loudness `level`. */
+function WaveLayer({
+  phase,
+  level,
+  layer,
+}: {
+  phase: SharedValue<number>;
+  level: SharedValue<number>;
+  layer: WaveLayerSpec;
+}) {
+  const animatedProps = useAnimatedProps(() => ({ d: wavePath(phase.value, level.value, layer) }));
   return <AnimatedPath animatedProps={animatedProps} fill={layer.fill} opacity={layer.opacity} />;
 }
 
@@ -223,7 +236,7 @@ function WaveLayer({ phase, layer }: { phase: SharedValue<number>; layer: WaveLa
  * the wave reads as one living body. Only mounted while listening, so the loop is
  * torn down the moment it stops.
  */
-function Waveform({ active }: { active: boolean }) {
+function Waveform({ active, level }: { active: boolean; level: SharedValue<number> }) {
   const phase = useSharedValue(0);
 
   useEffect(() => {
@@ -254,7 +267,7 @@ function Waveform({ active }: { active: boolean }) {
         </LinearGradient>
       </Defs>
       {WAVE_LAYERS.map((layer) => (
-        <WaveLayer key={layer.id} phase={phase} layer={layer} />
+        <WaveLayer key={layer.id} phase={phase} level={level} layer={layer} />
       ))}
     </Svg>
   );
@@ -357,6 +370,11 @@ export function VoiceCapture({
   // read as one calm state rather than two different dead ends.
   const [emptyMiss, setEmptyMiss] = useState(false);
 
+  // Live input loudness, 0…1, eased from the recogniser's volume events. The
+  // waveform rides this so it answers the actual voice instead of looping on a
+  // fixed clock; it stays 0 when the mic is shut.
+  const level = useSharedValue(0);
+
   // The latest transcript, kept in a ref so the 'end' handler reads the final
   // one without waiting on a state update.
   const latest = useRef('');
@@ -370,14 +388,26 @@ export function VoiceCapture({
     setLive(transcript);
   });
 
+  // The recogniser's own metering (enabled via volumeChangeEventOptions in
+  // start). `value` runs −2…10, where below 0 is inaudible; normalise to 0…1 and
+  // ease so the wave tracks loudness without twitching on every packet.
+  useSpeechRecognitionEvent('volumechange', (event) => {
+    const norm = Math.max(0, Math.min(1, event.value / 10));
+    // `.set()`, not `.value =`: Reanimated 4's method API, the one the React
+    // compiler allows off the UI thread (see PressableScale in lib/anim).
+    level.set(withTiming(norm, { duration: 90 }));
+  });
+
   useSpeechRecognitionEvent('error', (event) => {
     const message = dictationError(event.error, t.misc.dictationErrors);
     if (message) setError(message);
     setListening(false);
+    level.set(withTiming(0, { duration: 150 }));
   });
 
   useSpeechRecognitionEvent('end', () => {
     setListening(false);
+    level.set(withTiming(0, { duration: 150 }));
     const said = latest.current.trim();
     if (said) onDone(said);
     // Heard nothing usable — surface the same calm recovery a parsed miss shows,
@@ -394,6 +424,7 @@ export function VoiceCapture({
     onListen?.();
     latest.current = '';
     setLive('');
+    level.set(0);
 
     const permission = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
     if (!mounted.current) return;
@@ -421,6 +452,9 @@ export function VoiceCapture({
         continuous: false,
         requiresOnDeviceRecognition: onDevice,
         addsPunctuation: onDevice,
+        // Meter the input so the waveform can ride real loudness (~10 Hz is
+        // plenty for a smooth wave and cheap to ease over).
+        volumeChangeEventOptions: { enabled: true, intervalMillis: 100 },
         contextualStrings: hints && hints.length > 0 ? [...hints] : undefined,
         iosTaskHint: 'dictation',
         // People start with a greeting and a beat of thought — "hello… uh… add
@@ -439,7 +473,7 @@ export function VoiceCapture({
       setListening(false);
       setError(t.misc.dictationFailed);
     }
-  }, [hints, locale, onListen, t]);
+  }, [hints, level, locale, onListen, t]);
 
   const stop = useCallback((): void => {
     ExpoSpeechRecognitionModule.stop();
@@ -535,21 +569,18 @@ export function VoiceCapture({
         </Pressable>
       </View>
 
-      {/* Listening: the status word over a live waveform. Recovering: the mic is
-          the retry, so the line invites the tap and a worked example sits under it
-          to fix the phrasing. At rest: the same example under a plain prompt. One
-          line and one supporting line — never a third. */}
+      {/* Listening: the status word over a live waveform. Recovering: the title
+          already says what was missed, so the mic just invites the tap — no
+          second warning under it. At rest: a worked example under the prompt.
+          The miss is stated once (the title), never a warning stacked on a
+          warning. */}
       <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
         <Text tone={listening || showMiss ? 'brand' : 'muted'}>
           {listening ? t.misc.listening : showMiss ? t.voice.tapToRetry : t.voice.tapToSpeak}
         </Text>
         {listening && !reduceMotion ? (
-          <Waveform active={listening} />
-        ) : showMiss ? (
-          <Text variant="caption" tone="faint" align="center">
-            {t.voice.missHint}
-          </Text>
-        ) : !live ? (
+          <Waveform active={listening} level={level} />
+        ) : !listening && !showMiss && !live ? (
           <Text variant="caption" tone="faint" align="center">
             {t.voice.example}
           </Text>

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -331,15 +331,25 @@ export function filterByDayRange<T extends { created_at: string }>(
   });
 }
 
-export function relativeTime(locale: string, iso: string, now: number = Date.now()): string {
+export function relativeTime(
+  locale: string,
+  iso: string,
+  now: number = Date.now(),
+  // A pre-built formatter the caller can hand in. Constructing an
+  // `Intl.RelativeTimeFormat` is dear, and a virtualized feed re-runs this per
+  // row as it recycles — so a screen builds one per locale and passes it, the
+  // same hoist the expense feed's date formatter uses. Omitted, it builds one.
+  formatter?: Intl.RelativeTimeFormat,
+): string {
   const parsed = Date.parse(iso);
   if (!Number.isFinite(parsed)) return iso;
   const seconds = Math.round((parsed - now) / 1000);
   const abs = Math.abs(seconds);
 
   const RTF = Intl.RelativeTimeFormat as typeof Intl.RelativeTimeFormat | undefined;
-  if (typeof RTF === 'function') {
-    const rtf = new RTF(locale, { numeric: 'auto' });
+  const rtf =
+    formatter ?? (typeof RTF === 'function' ? new RTF(locale, { numeric: 'auto' }) : undefined);
+  if (rtf) {
     if (abs < 60) return rtf.format(Math.round(seconds), 'second');
     if (abs < 3600) return rtf.format(Math.round(seconds / 60), 'minute');
     if (abs < 86400) return rtf.format(Math.round(seconds / 3600), 'hour');

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -774,7 +774,6 @@ export interface UiStrings {
     noAmount: string;
     /** Miss recovery headline: nothing intelligible was heard at all. */
     missedNothing: string;
-    /** The one supporting line under a miss — a concrete sentence to copy. */
     /** The status line under the mic on a miss: the mic itself is the retry. */
     tapToRetry: string;
     tryAgain: string;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -714,7 +714,6 @@ export interface UiStrings {
     lockOff: string;
     signOutGuestHint: string;
     signOutHint: string;
-    footnote: string;
   };
   /** Bring your own model key — held on the device, used on your own account. */
   aiKeys: {
@@ -776,7 +775,6 @@ export interface UiStrings {
     /** Miss recovery headline: nothing intelligible was heard at all. */
     missedNothing: string;
     /** The one supporting line under a miss — a concrete sentence to copy. */
-    missHint: string;
     /** The status line under the mic on a miss: the mic itself is the retry. */
     tapToRetry: string;
     tryAgain: string;
@@ -1762,6 +1760,9 @@ export interface UiStrings {
     free: string;
     ledgerHowTo: string;
     chooseFile: string;
+    /** Source-picker options on the import screen. */
+    fromSplitwise: string;
+    fromOther: string;
     chosenFile: string;
     chooseDifferentFile: string;
     whichGroup: string;
@@ -2529,8 +2530,8 @@ const en: UiStrings = {
     notificationsHint: 'Only what involves me',
     exportDataRow: 'Export data',
     exportHint: 'JSON + CSV, lossless, free',
-    importSplitwise: 'Import from Splitwise',
-    importHint: 'Bring a group across from a CSV export',
+    importSplitwise: 'Import your data',
+    importHint: 'Bring your history across from another app',
     themeRow: 'Appearance',
     languageFollowingPhone: 'Following your phone — {language}',
     languageRestartHint: '{language} · reopen Waves to mirror it',
@@ -2550,7 +2551,6 @@ const en: UiStrings = {
     lockOff: 'Off — anyone holding your phone can read the ledger',
     signOutGuestHint: 'This guest account lives on this device only',
     signOutHint: 'Nothing is deleted; sign back in whenever',
-    footnote: 'Waves · the ledger is free forever. We only ever charge for convenience.',
   },
   aiKeys: {
     title: 'Bring your own key',
@@ -2595,7 +2595,6 @@ const en: UiStrings = {
     tapToSpeak: 'Tap to speak',
     noAmount: 'Didn’t catch an amount',
     missedNothing: 'Didn’t catch that',
-    missHint: 'Try saying an amount, like “add 500 to Goa trip”',
     tapToRetry: 'Tap to try again',
     tryAgain: 'Try again',
     chooseGroup: 'Which group?',
@@ -3552,6 +3551,8 @@ const en: UiStrings = {
     ledgerHowTo:
       'From Splitwise: open a group → the ⚙ menu → Export as spreadsheet, and choose that CSV here. From Waves: choose a JSON file you exported from Settings. Everyone named in it becomes a member of the group — they do not need the app, and they can claim their history whenever they join.',
     chooseFile: 'Choose a file',
+    fromSplitwise: 'Import from Splitwise',
+    fromOther: 'Import from other data',
     chosenFile: 'Chosen: {name}',
     chooseDifferentFile: 'Choose a different file',
     whichGroup: 'Which group',
@@ -4346,8 +4347,8 @@ const ta: UiStrings = {
     notificationsHint: 'என்னைச் சார்ந்தவை மட்டும்',
     exportDataRow: 'தரவை ஏற்றுமதி செய்',
     exportHint: 'JSON + CSV, முழுமையானது, இலவசம்',
-    importSplitwise: 'Splitwise இலிருந்து இறக்குமதி',
-    importHint: 'CSV ஏற்றுமதியிலிருந்து ஒரு குழுவைக் கொண்டுவா',
+    importSplitwise: 'உங்கள் தரவை இறக்குமதி செய்',
+    importHint: 'மற்றொரு செயலியிலிருந்து உங்கள் வரலாற்றைக் கொண்டுவா',
     themeRow: 'தோற்றம்',
     languageFollowingPhone: 'உங்கள் ஃபோனைப் பின்பற்றுகிறது — {language}',
     languageRestartHint: '{language} · பிரதிபலிக்க பாக்கியை மீண்டும் திற',
@@ -4367,7 +4368,6 @@ const ta: UiStrings = {
     lockOff: 'நிறுத்தத்தில் — உங்கள் ஃபோனை வைத்திருப்பவர் யாரும் கணக்கைப் படிக்கலாம்',
     signOutGuestHint: 'இந்த விருந்தினர் கணக்கு இந்தச் சாதனத்தில் மட்டுமே உள்ளது',
     signOutHint: 'எதுவும் அழிக்கப்படாது; எப்போது வேண்டுமானாலும் மீண்டும் உள்நுழையலாம்',
-    footnote: 'பாக்கி · கணக்கு எப்போதும் இலவசம். வசதிக்கு மட்டுமே நாங்கள் கட்டணம் வாங்குவோம்.',
   },
   aiKeys: {
     title: 'உங்கள் சொந்த விசையைச் சேர்',
@@ -4415,7 +4415,6 @@ const ta: UiStrings = {
     tapToSpeak: 'பேச தட்டு',
     noAmount: 'தொகை புரியவில்லை',
     missedNothing: 'புரியவில்லை',
-    missHint: 'ஒரு தொகையைச் சொல்லுங்கள் (ஆங்கிலத்தில்), உ.தா. “add 500 to Goa trip”',
     tapToRetry: 'மீண்டும் முயற்சிக்க தட்டு',
     tryAgain: 'மீண்டும் முயற்சி செய்',
     chooseGroup: 'எந்த குழு?',
@@ -5428,6 +5427,8 @@ const ta: UiStrings = {
     ledgerHowTo:
       'Splitwise இலிருந்து: குழுவைத் திறந்து → ⚙ மெனு → Export as spreadsheet, அந்த CSV ஐ இங்கே தேர்வு செய்யுங்கள். பாக்கியிலிருந்து: அமைப்புகளிலிருந்து ஏற்றுமதி செய்த JSON கோப்பைத் தேர்வு செய்யுங்கள். அதில் பெயர் உள்ள அனைவரும் குழுவின் உறுப்பினராகிவிடுவார்கள் — அவர்களுக்குச் செயலி தேவையில்லை, சேரும்போது தங்கள் வரலாற்றைக் கோரலாம்.',
     chooseFile: 'ஒரு கோப்பைத் தேர்வு செய்',
+    fromSplitwise: 'Splitwise இலிருந்து இறக்குமதி',
+    fromOther: 'மற்ற தரவிலிருந்து இறக்குமதி',
     chosenFile: 'தேர்ந்தெடுத்தது: {name}',
     chooseDifferentFile: 'வேறு கோப்பைத் தேர்வு செய்',
     whichGroup: 'எந்தக் குழு',
@@ -6224,8 +6225,8 @@ const hi: UiStrings = {
     notificationsHint: 'सिर्फ़ वही जिनसे मेरा वास्ता है',
     exportDataRow: 'डेटा निर्यात',
     exportHint: 'JSON + CSV, कुछ छूटता नहीं, मुफ़्त',
-    importSplitwise: 'Splitwise से आयात',
-    importHint: 'CSV निर्यात से कोई समूह ले आएँ',
+    importSplitwise: 'अपना डेटा आयात करें',
+    importHint: 'किसी दूसरे ऐप से अपना इतिहास ले आएँ',
     themeRow: 'रूप-रंग',
     languageFollowingPhone: 'आपके फ़ोन के अनुसार — {language}',
     languageRestartHint: '{language} · दिशा बदलने के लिए बाकी दोबारा खोलें',
@@ -6245,7 +6246,6 @@ const hi: UiStrings = {
     lockOff: 'बंद — आपका फ़ोन पकड़े कोई भी हिसाब पढ़ सकता है',
     signOutGuestHint: 'यह मेहमान खाता सिर्फ़ इसी डिवाइस पर है',
     signOutHint: 'कुछ मिटता नहीं; जब चाहें दोबारा साइन इन करें',
-    footnote: 'बाकी · हिसाब हमेशा मुफ़्त है। हम सिर्फ़ सुविधा के पैसे लेते हैं।',
   },
   aiKeys: {
     title: 'अपनी कुंजी लाएँ',
@@ -6291,7 +6291,6 @@ const hi: UiStrings = {
     tapToSpeak: 'बोलने के लिए टैप करें',
     noAmount: 'रकम समझ नहीं आई',
     missedNothing: 'समझ नहीं आया',
-    missHint: 'रकम बोलें (अंग्रेज़ी में), जैसे “add 500 to Goa trip”',
     tapToRetry: 'दोबारा कोशिश के लिए टैप करें',
     tryAgain: 'फिर कोशिश करें',
     chooseGroup: 'कौन सा ग्रुप?',
@@ -7253,6 +7252,8 @@ const hi: UiStrings = {
     ledgerHowTo:
       'Splitwise से: समूह खोलें → ⚙ मेनू → Export as spreadsheet, और वही CSV यहाँ चुनें। बाकी से: सेटिंग्स से निर्यात की गई JSON फ़ाइल चुनें। उसमें जिनका नाम है वे सब समूह के सदस्य बन जाते हैं — उन्हें ऐप की ज़रूरत नहीं, और जब वे जुड़ेंगे तब अपना इतिहास ले सकते हैं।',
     chooseFile: 'फ़ाइल चुनें',
+    fromSplitwise: 'Splitwise से आयात',
+    fromOther: 'दूसरे डेटा से आयात',
     chosenFile: 'चुनी गई: {name}',
     chooseDifferentFile: 'दूसरी फ़ाइल चुनें',
     whichGroup: 'कौन-सा समूह',
@@ -8072,8 +8073,8 @@ const ar: UiStrings = {
     notificationsHint: 'ما يخصّني فقط',
     exportDataRow: 'تصدير البيانات',
     exportHint: 'JSON + CSV، بلا فقدان، مجانًا',
-    importSplitwise: 'استيراد من Splitwise',
-    importHint: 'أحضر مجموعة من ملف CSV مُصدَّر',
+    importSplitwise: 'استيراد بياناتك',
+    importHint: 'أحضر سجلّك من تطبيق آخر',
     themeRow: 'المظهر',
     languageFollowingPhone: 'يتبع هاتفك — {language}',
     languageRestartHint: '{language} · أعد فتح باقي لعكس الاتجاه',
@@ -8093,7 +8094,6 @@ const ar: UiStrings = {
     lockOff: 'متوقف — أي شخص يمسك هاتفك يمكنه قراءة الدفتر',
     signOutGuestHint: 'حساب الضيف هذا موجود على هذا الجهاز فقط',
     signOutHint: 'لا يُحذف شيء؛ سجّل الدخول متى شئت',
-    footnote: 'باقي · الدفتر مجاني إلى الأبد. لا نتقاضى إلا مقابل الراحة.',
   },
   aiKeys: {
     title: 'أحضر مفتاحك الخاص',
@@ -8138,7 +8138,6 @@ const ar: UiStrings = {
     tapToSpeak: 'انقر للتحدث',
     noAmount: 'لم أفهم المبلغ',
     missedNothing: 'لم أفهم ذلك',
-    missHint: 'قل مبلغًا بالإنجليزية، مثل «add 500 to Goa trip»',
     tapToRetry: 'انقر لإعادة المحاولة',
     tryAgain: 'أعد المحاولة',
     chooseGroup: 'أي مجموعة؟',
@@ -9185,6 +9184,8 @@ const ar: UiStrings = {
     ledgerHowTo:
       'من Splitwise: افتح مجموعة ← قائمة ⚙ ← Export as spreadsheet، ثم اختر ملف CSV هنا. من باقي: اختر ملف JSON صدّرته من الإعدادات. كل من ورد اسمه فيه يصبح عضوًا في المجموعة — لا يحتاجون التطبيق، ويمكنهم المطالبة بسجلّهم متى انضمّوا.',
     chooseFile: 'اختر ملفًا',
+    fromSplitwise: 'استيراد من Splitwise',
+    fromOther: 'استيراد من بيانات أخرى',
     chosenFile: 'المختار: {name}',
     chooseDifferentFile: 'اختر ملفًا آخر',
     whichGroup: 'أي مجموعة',

--- a/apps/mobile/src/lib/anim.tsx
+++ b/apps/mobile/src/lib/anim.tsx
@@ -10,7 +10,7 @@
  * a test rather than by watching the screen.
  */
 
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { Pressable, type PressableProps, type ViewStyle } from 'react-native';
 import Animated, {
   FadeInDown,
@@ -21,11 +21,8 @@ import Animated, {
   type EntryExitAnimationFunction,
 } from 'react-native-reanimated';
 
-import { minorUnitScale } from '@waves/core';
-import { MoneyText, type MoneyTextProps } from '@waves/ui';
-
 import { useReducedMotion } from './reducedMotion';
-import { easeOutCubic, lerpBig, MAX_SAFE_MINOR, staggerDelay } from './motionMath';
+import { staggerDelay } from './motionMath';
 
 export { easeOutCubic, lerpBig, MAX_SAFE_MINOR, staggerDelay } from './motionMath';
 
@@ -136,81 +133,3 @@ const detailEntering: EntryExitAnimationFunction = () => {
     },
   };
 };
-
-/**
- * A money value that rolls up to its figure instead of printing at once.
- *
- * Wraps `MoneyText` and animates the amount from where it was to where it is,
- * so a balance counts up on first load and slides to the new number when it
- * changes. Everything else — the currency, the faded paise, the spoken label —
- * is `MoneyText`'s, unchanged; this only feeds it a moving `amount`.
- */
-export function CountUpMoney(props: MoneyTextProps): ReactNode {
-  const reduceMotion = useReducedMotion();
-  const shown = useCountUp(props.amount, reduceMotion);
-  // While the figure is still rolling, drop the fractional units — the paise
-  // digits spinning past two at a time read as noise, not motion. The tween
-  // always lands on the exact target on its last frame, so the settled number
-  // keeps its decimals; only the in-flight frames are rounded to whole units.
-  const rolling = shown !== props.amount;
-  const display = rolling ? shown - (shown % minorUnitScale(props.currency)) : shown;
-  return <MoneyText {...props} amount={display} />;
-}
-
-/** Roughly the length of a screen transition — long enough to read, short enough to trust. */
-const COUNT_MS = 650;
-
-/**
- * Tween a bigint towards `target`, easing out, on the JS thread.
- *
- * A figure too large to hold in a Number without losing paise snaps straight to
- * the target — a wrong number is worse than a still one. Otherwise it animates
- * from whatever is on screen now, so a mid-flight change redirects smoothly
- * rather than jumping back to zero.
- */
-export function useCountUp(target: bigint, reduceMotion = false): bigint {
-  // The start figure is decided here rather than in the effect: a number too
-  // large to tween as a Number begins on the target and never moves.
-  const [value, setValue] = useState<bigint>(() =>
-    reduceMotion || tooLargeToTween(target) ? target : 0n,
-  );
-  const frame = useRef<number | null>(null);
-
-  useEffect(() => {
-    // Snapping is a state change too, so it goes through a frame rather than
-    // running synchronously in the effect body — the same reason the tween does.
-    if (reduceMotion || tooLargeToTween(target)) {
-      frame.current = requestAnimationFrame(() => setValue(target));
-      return () => {
-        if (frame.current !== null) cancelAnimationFrame(frame.current);
-      };
-    }
-
-    const started = Date.now();
-    // The figure on screen when this frame first fires is where the tween starts,
-    // read through the updater so a mid-flight target change redirects from the
-    // current number rather than jumping back to zero — and without a ref written
-    // during render to carry it.
-    let from: bigint | null = null;
-    const step = (): void => {
-      const progress = Math.min(1, (Date.now() - started) / COUNT_MS);
-      setValue((current) => {
-        if (from === null) from = current;
-        return lerpBig(from, target, easeOutCubic(progress));
-      });
-      if (progress < 1) frame.current = requestAnimationFrame(step);
-    };
-    frame.current = requestAnimationFrame(step);
-
-    return () => {
-      if (frame.current !== null) cancelAnimationFrame(frame.current);
-    };
-  }, [target, reduceMotion]);
-
-  return value;
-}
-
-/** A magnitude past the Number safe-integer ceiling would lose paise mid-tween. */
-function tooLargeToTween(target: bigint): boolean {
-  return (target < 0n ? -target : target) > MAX_SAFE_MINOR;
-}


### PR DESCRIPTION
A batch of UX/perf polish from one review pass. Four independent commits.

## 1. Dashboard motion felt slow (`perf(mobile)`)
- **Number count-up removed.** Balances animated up from zero on every load (`CountUpMoney`, a JS-thread rAF tween). Swapped to plain `MoneyText` at both the hero figure and the group rows; deleted the dead `CountUpMoney`/`useCountUp` from `lib/anim`.
- **Hero dots synced to the swipe.** Colour/scale tracked the live native `scrollX` at 60fps, but the active dot switched off a React state updated only at `onMomentumScrollEnd`, so the dots lagged the finger. `HeroDots` now rides the same `scrollX` — a fixed-width pill translating across static dots, native driver. Removed the lagging `heroPage` plumbing.

## 2. Import rename + two sources (`feat(settings)`)
- Settings row **"Import from Splitwise" → "Import your data"** (all 4 languages).
- The import screen already handled both a Splitwise CSV and a Waves JSON (it sniffs the file); it now shows a **two-option entry** — "Import from Splitwise" / "Import from other data" — which only narrow the file picker. The content sniff still decides the format.
- Removed the bottom **"free forever" tagline** from settings.

## 3. Voice screen (`feat(voice)`)
- **One warning, not two.** A miss stacked a headline + "tap to try again" + a hint. Now the headline states the miss once and the mic invites the retry — no second warning.
- **Live waveform.** It looped on a fixed clock; it now rides the recogniser's own metering (`volumeChangeEventOptions` + the `volumechange` event, eased into a shared value), so the wave answers real loudness and idles low when quiet. No new dependency.

## 4. Activity feed perf + two layout jumps (`perf(activity)`)
- **Memoized row.** The feed re-ran every visible row per parent render, built a fresh `Intl.RelativeTimeFormat` per row, and called `describeActivity` twice — the cost the expense feed already fixed. Extracted a memoized `ActivityFeedRow`, hoisted one formatter per locale, describe once.
- **Skeleton jump.** `FeedSkeleton` still drew the old timeline rail, so the feed lurched when the railless rows landed. Reshaped to match the current row + a day-heading placeholder.
- **Header jump.** The button-less Inbox header sat ~14px shorter than Activity's (two `IconButton`s), so the title jumped on navigation; gave Inbox's header a matching min height.

## Verification
- `pnpm format`, `pnpm lint`, `pnpm -C apps/mobile typecheck` — all green.
- Not device-run. Voice metering + waveform amplitude and the carousel dot sync want a real device to confirm feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate import options for Splitwise files and other data sources.
  * File selection now prioritizes suitable formats for each import type.
  * Voice waveform visuals now respond to live speaking volume.
  * Balance carousel indicators animate continuously with scrolling.

* **Improvements**
  * Refined activity feed rendering and loading placeholders.
  * Improved inbox header spacing and balance amount display.
  * Simplified voice recognition recovery messaging.
  * Removed outdated profile and account footnotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->