### PR TITLE
feat(expense): reorganize detail hero + add-receipt under the amount

### DIFF
--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ScrollView as RNScrollView } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
@@ -106,6 +106,23 @@ export default function ExpenseDetailScreen() {
   // The page has two faces: its breakdown, and its edit history. The hero stays
   // above both; only the body below the tab bar swaps.
   const [tab, setTab] = useState<'details' | 'history'>('details');
+  // The receipts section (and so its ref) is mounted only under the details tab,
+  // but the hero — with the "add receipt" button — stays above both tabs. A tap
+  // from the history tab would hit a null ref and do nothing, so it flips to
+  // details and parks the intent here; this effect fires it once the section has
+  // mounted.
+  const [pendingAdd, setPendingAdd] = useState(false);
+  useEffect(() => {
+    if (!pendingAdd || tab !== 'details') return undefined;
+    // Through a frame, not synchronously in the effect body: a bare setState here
+    // cascades renders (the lint the compiler enforces), and the extra tick also
+    // lets the just-switched-to receipts section finish mounting so its ref is set.
+    const frame = requestAnimationFrame(() => {
+      setPendingAdd(false);
+      receiptsRef.current?.openAdd();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [pendingAdd, tab]);
   const deleteExpense = useDeleteExpense(groupId);
   const restoreExpense = useRestoreExpense(groupId);
 
@@ -396,7 +413,14 @@ export default function ExpenseDetailScreen() {
                 adding; the button drives the receipts section through its ref. */}
             {isExpenseParty ? (
               <Pressable
-                onPress={() => receiptsRef.current?.openAdd()}
+                onPress={() => {
+                  if (tab === 'details') receiptsRef.current?.openAdd();
+                  else {
+                    // Switch to where the receipts live, then add once mounted.
+                    setTab('details');
+                    setPendingAdd(true);
+                  }
+                }}
                 accessibilityRole="button"
                 accessibilityLabel={t.receipts.add}
                 style={({ pressed }) => ({
@@ -463,7 +487,7 @@ export default function ExpenseDetailScreen() {
             <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
               <DetailLine
                 label={t.expense.detailGroup}
-                value={groupLabel(group.data, members.data ?? [])}
+                value={groupLabel(group.data, members.data ?? [], profile?.id)}
               />
               <View style={{ height: 1, backgroundColor: theme.color.border }} />
               <DetailLine

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -30,7 +30,7 @@ import {
 
 import { CategoryBadge } from '@/components/Category';
 import { MapPreview } from '@/components/MapPreview';
-import { ExpenseReceipts } from '@/components/ExpenseReceipts';
+import { ExpenseReceipts, type ExpenseReceiptsHandle } from '@/components/ExpenseReceipts';
 import { ExpenseComments } from '@/components/ExpenseComments';
 import { ExpenseHistory } from '@/components/ExpenseHistory';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
@@ -45,7 +45,7 @@ import {
 import { expenseTitle } from '@/data/expenseTitle';
 import { useBlockedUsers } from '@/data/blocked';
 import { displayName, groupLabel, isBlockedMember, isGhost } from '@/data/types';
-import { fill, plural, useStrings, type UiStrings } from '@/i18n';
+import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { expenseReceiptPath, expenseReceiptUrl } from '@/data/api';
 import { coordLabel, mapsUrl } from '@/lib/location';
@@ -61,24 +61,27 @@ function splitLabels(t: UiStrings): Record<string, string> {
   };
 }
 
-/** A small translucent-white pill for the meta tags on the hero wash (split
- *  type, "edited N times") — the on-panel equivalent of a Badge, legible on the
- *  saturated colour where a filled Badge would blend. */
-function HeroTag({ label }: { label: string }): React.JSX.Element {
+/** One labelled row of the bill's detail card — a muted label on the left, its
+ *  value on the right. The stacked "paid by · date · split" caption the hero
+ *  used to carry, given room to breathe as a proper key/value list. */
+function DetailLine({ label, value }: { label: string; value: string }): React.JSX.Element {
   const theme = useTheme();
   return (
-    <View
+    <Row
       style={{
-        paddingVertical: 3,
-        paddingHorizontal: theme.spacing.sm,
-        borderRadius: theme.radius.pill,
-        backgroundColor: 'rgba(255, 255, 255, 0.18)',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: theme.spacing.md,
+        paddingVertical: theme.spacing.md,
       }}
     >
-      <Text variant="micro" tone="onBrand">
+      <Text variant="caption" tone="muted">
         {label}
       </Text>
-    </View>
+      <Text variant="body" numberOfLines={1} style={{ flexShrink: 1, textAlign: 'right' }}>
+        {value}
+      </Text>
+    </Row>
   );
 }
 
@@ -95,6 +98,10 @@ export default function ExpenseDetailScreen() {
   const versions = useExpenseVersions(expenseId ?? '');
   const imageEvents = useExpenseImageEvents(expenseId ?? '');
   const scrollRef = useRef<RNScrollView>(null);
+  // The receipts section owns the add flow (scan/choose, cap gate); the hero
+  // renders the button and calls into it through this handle, so the "add
+  // receipt" action sits under the amount like the dashboard's "add expense".
+  const receiptsRef = useRef<ExpenseReceiptsHandle>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   // The page has two faces: its breakdown, and its edit history. The hero stays
   // above both; only the body below the tab bar swaps.
@@ -341,14 +348,10 @@ export default function ExpenseDetailScreen() {
                 color={theme.color.onBrand}
               />
             </Pressable>
-            <View style={{ flex: 1, alignItems: 'flex-start' }}>
-              <Text variant="heading" tone="onBrand" numberOfLines={1}>
-                {expenseTitle(version.description, version.category, t, version.category_meta)}
-              </Text>
-              <Text variant="micro" tone="onBrand" style={{ opacity: 0.85 }}>
-                {groupLabel(group.data, members.data ?? [])}
-              </Text>
-            </View>
+            {/* The title moves out of this row and into the hero body beside the
+                category badge, so the description reads as the heading of the
+                bill rather than a cramped line between two glyphs. */}
+            <View style={{ flex: 1 }} />
             {/* Every action on this bill lives behind one three-dot menu, the same
                 trailing control the group and dashboard headers carry — Edit and
                 Delete (or Restore) instead of a full-width button stacked at the
@@ -364,13 +367,23 @@ export default function ExpenseDetailScreen() {
             </Pressable>
           </Row>
 
-          <View style={{ alignItems: 'flex-start', gap: theme.spacing.sm }}>
-            <CategoryBadge
-              category={version.category}
-              meta={version.category_meta}
-              description={version.description}
-              size={48}
-            />
+          <View style={{ alignItems: 'flex-start', gap: theme.spacing.md }}>
+            {/* Badge + description as one line: the category icon, then what the
+                bill is called (the description, or the category name when none
+                was typed) reads as the heading — this is the "I don't see the
+                description" fix. */}
+            <Row style={{ alignItems: 'center', gap: theme.spacing.sm, alignSelf: 'stretch' }}>
+              <CategoryBadge
+                category={version.category}
+                meta={version.category_meta}
+                description={version.description}
+                size={40}
+              />
+              <Text variant="heading" tone="onBrand" numberOfLines={2} style={{ flex: 1 }}>
+                {expenseTitle(version.description, version.category, t, version.category_meta)}
+              </Text>
+              {deleted ? <Badge label={t.expense.deleted} tone="negative" /> : null}
+            </Row>
             <MoneyText
               amount={BigInt(version.amount)}
               currency={currency}
@@ -378,23 +391,32 @@ export default function ExpenseDetailScreen() {
               variant="display"
               style={{ color: theme.color.onBrand }}
             />
-            <Text variant="caption" tone="onBrand" style={{ opacity: 0.85 }}>
-              {`${fill(t.expense.paidByName, {
-                name: nameOf(version.payers[0]?.member_id ?? null),
-              })} · ${new Intl.DateTimeFormat(locale, {
-                day: 'numeric',
-                month: 'long',
-                year: 'numeric',
-                timeZone: 'UTC',
-              }).format(new Date(version.expense_date))}`}
-            </Text>
-            <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap', justifyContent: 'flex-start' }}>
-              <HeroTag label={splitLabels(t)[version.split_type] ?? version.split_type} />
-              {version.version_no > 1 ? (
-                <HeroTag label={plural(locale, version.version_no - 1, t.expense.editedTimes)} />
-              ) : null}
-              {deleted ? <Badge label={t.expense.deleted} tone="negative" /> : null}
-            </Row>
+            {/* Add receipt, right under the amount — the same "primary action sits
+                under the number" the dashboard and group heros use. A party owns
+                adding; the button drives the receipts section through its ref. */}
+            {isExpenseParty ? (
+              <Pressable
+                onPress={() => receiptsRef.current?.openAdd()}
+                accessibilityRole="button"
+                accessibilityLabel={t.receipts.add}
+                style={({ pressed }) => ({
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: theme.spacing.sm,
+                  alignSelf: 'flex-start',
+                  paddingHorizontal: theme.spacing.lg,
+                  paddingVertical: theme.spacing.sm,
+                  borderRadius: theme.radius.pill,
+                  backgroundColor: '#FFFFFF',
+                  opacity: pressed ? 0.85 : 1,
+                })}
+              >
+                <Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />
+                <Text style={{ color: theme.color.brand, fontWeight: '700' }}>
+                  {t.receipts.add}
+                </Text>
+              </Pressable>
+            ) : null}
           </View>
         </Gradient>
 
@@ -434,10 +456,48 @@ export default function ExpenseDetailScreen() {
               </Callout>
             ) : null}
 
+            {/* The bill's facts as a tidy labelled card — who paid, when, and how
+                it was split — in place of the stacked caption and chips the hero
+                used to wear. The group it belongs to leads the list so the bill
+                is placed without crowding the hero. */}
+            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+              <DetailLine
+                label={t.expense.detailGroup}
+                value={groupLabel(group.data, members.data ?? [])}
+              />
+              <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              <DetailLine
+                label={t.paidBy}
+                value={
+                  version.payers.length > 1
+                    ? plural(locale, version.payers.length, t.misc.peopleCount)
+                    : nameOf(version.payers[0]?.member_id ?? null)
+                }
+              />
+              <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              <DetailLine
+                label={t.expense.detailDate}
+                value={new Intl.DateTimeFormat(locale, {
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric',
+                  timeZone: 'UTC',
+                }).format(new Date(version.expense_date))}
+              />
+              <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              <DetailLine
+                label={t.expense.detailSplit}
+                value={splitLabels(t)[version.split_type] ?? version.split_type}
+              />
+            </Card>
+
             {/* Receipts — one gallery, many images, each group-visible or private.
-            Folds in the legacy single bill (E2) as its first item. A party can
-            add (scan or library) and remove; anyone sees the group images. */}
+            Folds in the legacy single bill (E2) as its first item. Adding is now
+            the hero button (externalAdd), driven through the ref; this section
+            shows the gallery of what is already kept. */}
             <ExpenseReceipts
+              ref={receiptsRef}
+              externalAdd
               groupId={groupId}
               expenseId={expense.id}
               canManage={isExpenseParty}

--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -13,7 +13,7 @@
  * orphaned; new images are all attachment rows.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
@@ -210,14 +210,13 @@ function Thumb({
   );
 }
 
-export function ExpenseReceipts({
-  groupId,
-  expenseId,
-  canManage,
-  canRemoveLegacy,
-  legacyReceiptPath,
-  onLegacyRemoved,
-}: {
+/** Imperative handle so a parent (the expense-detail hero) can own the add
+ *  button while this component keeps the add flow and the gallery. */
+export interface ExpenseReceiptsHandle {
+  openAdd: () => void;
+}
+
+interface ExpenseReceiptsProps {
   groupId: string;
   expenseId: string;
   /** Whether the viewer may add and manage attachments — a party to the expense
@@ -234,539 +233,573 @@ export function ExpenseReceipts({
   legacyReceiptPath: string | null;
   /** Called after the legacy bill is removed, so the parent can hide its item. */
   onLegacyRemoved?: () => void;
-}): React.JSX.Element | null {
-  const theme = useTheme();
-  const insets = useSafeAreaInsets();
-  const { t } = useStrings();
-  const attachments = useExpenseAttachments(expenseId);
-  const attach = useAttachExpenseAttachment(groupId, expenseId);
-  const removeAttachment = useRemoveExpenseAttachment(expenseId);
-  const removeLegacy = useRemoveExpenseReceipt(groupId, expenseId);
-  const annotate = useAnnotateExpenseAttachment();
-  const replace = useReplaceExpenseAttachmentImage(groupId, expenseId);
-  const queryClient = useQueryClient();
-  const { status, flush } = useSync();
+  /** When true, this section renders no add affordance of its own — the parent
+   *  drives adding through the ref (`openAdd`), and an empty gallery renders
+   *  nothing rather than an add row. The gallery of existing receipts still
+   *  shows, minus its inline "+" tile. */
+  externalAdd?: boolean;
+}
 
-  // Captures taken while offline (or when an upload could not reach R2), held on
-  // the device until they can be sent. They show in the gallery straight away
-  // from their local file, and a flush uploads them the moment there is network.
-  const [pending, setPending] = useState<PendingReceipt[]>([]);
-  const refreshPending = useCallback(async () => {
-    setPending(await listPendingReceipts(expenseId));
-  }, [expenseId]);
-  useEffect(() => {
-    // An async load from AsyncStorage — the setState lands after an await, not
-    // synchronously, so the cascading-render rule does not apply here.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    void refreshPending();
-  }, [refreshPending]);
+export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceiptsProps>(
+  function ExpenseReceipts(
+    {
+      groupId,
+      expenseId,
+      canManage,
+      canRemoveLegacy,
+      legacyReceiptPath,
+      onLegacyRemoved,
+      externalAdd = false,
+    },
+    ref,
+  ) {
+    const theme = useTheme();
+    const insets = useSafeAreaInsets();
+    const { t } = useStrings();
+    const attachments = useExpenseAttachments(expenseId);
+    const attach = useAttachExpenseAttachment(groupId, expenseId);
+    const removeAttachment = useRemoveExpenseAttachment(expenseId);
+    const removeLegacy = useRemoveExpenseReceipt(groupId, expenseId);
+    const annotate = useAnnotateExpenseAttachment();
+    const replace = useReplaceExpenseAttachmentImage(groupId, expenseId);
+    const queryClient = useQueryClient();
+    const { status, flush } = useSync();
 
-  // The per-expense receipt ceiling (A46): a free group keeps a small number of
-  // gallery images per expense; paid lifts it. This is the affordance — the
-  // attach RPC enforces the same limit — so a failed fetch defaults to "allowed"
-  // and lets the server be the boundary, the same stance as the scan cap.
-  const cap = useQuery({
-    queryKey: ['attachmentCap', expenseId],
-    queryFn: () => canAddExpenseAttachment(expenseId),
-    staleTime: 30_000,
-  });
-  const capLocked = !cap.isError && receiptCapStatus(cap.data, cap.isLoading) === 'locked';
-  const refreshCap = () =>
-    void queryClient.invalidateQueries({ queryKey: ['attachmentCap', expenseId] });
+    // Captures taken while offline (or when an upload could not reach R2), held on
+    // the device until they can be sent. They show in the gallery straight away
+    // from their local file, and a flush uploads them the moment there is network.
+    const [pending, setPending] = useState<PendingReceipt[]>([]);
+    const refreshPending = useCallback(async () => {
+      setPending(await listPendingReceipts(expenseId));
+    }, [expenseId]);
+    useEffect(() => {
+      // An async load from AsyncStorage — the setState lands after an await, not
+      // synchronously, so the cascading-render rule does not apply here.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      void refreshPending();
+    }, [refreshPending]);
 
-  // Try to send any parked captures when there is a usable network — on mount
-  // and whenever the connection comes back. A success pulls the freshly-recorded
-  // rows into the mirror (so the optimistic tile becomes the real attachment) and
-  // re-asks the cap; a permanent refusal (cap reached, not a party) just clears
-  // the stuck entry. All best-effort — a flush never throws into the screen.
-  useEffect(() => {
-    if (status === SyncStatus.Offline || status === SyncStatus.Metered) return;
-    void (async () => {
-      const result = await flushReceiptQueue();
-      if (result.uploadedExpenseIds.length > 0) {
-        await refreshPending();
-        await flush();
-        refreshCap();
-      } else if (result.hadPermanentFailure) {
-        await refreshPending();
-        refreshCap();
-      }
-    })();
-    // Re-run when the connection state flips; refreshers are stable.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status]);
-
-  const items = useMemo<GalleryItem[]>(() => {
-    const list: GalleryItem[] = [];
-    if (legacyReceiptPath) {
-      list.push({ kind: 'legacy', key: 'legacy', path: legacyReceiptPath, visibility: 'group' });
-    }
-    for (const row of attachments.data) {
-      list.push({ kind: 'attachment', key: row.id, row });
-    }
-    // Show a parked capture only until its real row lands — once the upload has
-    // been pulled into the mirror, the entry shares that row's id, so drop it
-    // here to avoid a duplicate tile for the same receipt.
-    const uploaded = new Set(attachments.data.map((row) => row.id));
-    for (const entry of pending) {
-      if (!uploaded.has(entry.attachmentId)) {
-        list.push({ kind: 'pending', key: `pending-${entry.attachmentId}`, entry });
-      }
-    }
-    return list;
-  }, [legacyReceiptPath, attachments.data, pending]);
-
-  const urls = useResolvedUrls(expenseId, items);
-  const [viewerIndex, setViewerIndex] = useState<number | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [editing, setEditing] = useState<{
-    attachmentId: string;
-    uri: string;
-    initial: Annotations;
-  } | null>(null);
-  const [adjusting, setAdjusting] = useState<{
-    attachmentId: string;
-    uri: string;
-    oldStoragePath: string;
-  } | null>(null);
-
-  const pages = useMemo<GalleryPage[]>(
-    () =>
-      items.map((it, i) => ({
-        url: urls[i] ?? null,
-        annotations: it.kind === 'attachment' ? (it.row.annotations ?? undefined) : undefined,
-      })),
-    [items, urls],
-  );
-
-  // Nothing to show and cannot add → render nothing, so a non-party's bill is
-  // not cluttered with an empty section.
-  if (items.length === 0 && !canManage) return null;
-
-  const isPrivate = (it: GalleryItem) =>
-    (it.kind === 'attachment' && it.row.visibility === 'parties') ||
-    (it.kind === 'pending' && it.entry.visibility === 'parties');
-
-  // The free per-expense limit is reached (and the group is not paid): point the
-  // person at the upgrade rather than open the add sheet. Reuses the scan cap's
-  // strings and upgrade route so both ceilings read and route the same.
-  const showCapUpsell = () => {
-    Alert.alert(t.expense.capReachedTitle, t.expense.capReachedBody, [
-      { text: t.common.cancel, style: 'cancel' },
-      { text: t.expense.capUpgrade, onPress: () => router.push('/settings/upgrade') },
-    ]);
-  };
-
-  // The server may still refuse over the cap even when the local gate allowed it
-  // (another party filled the last slot from another device); surface that as the
-  // upgrade prompt, not a generic failure. Anything else is the generic message.
-  const onAddError = (error: unknown) => {
-    const message = error instanceof Error ? error.message : '';
-    if (message.includes('ATTACHMENT_CAP')) {
-      showCapUpsell();
-      refreshCap();
-    } else {
-      Alert.alert(t.receipts.couldNotAdd);
-    }
-  };
-
-  // Add at a chosen visibility. Online it uploads now; offline (or if the upload
-  // cannot reach R2) the capture is parked on the device and shown at once, to
-  // be sent automatically on reconnect — the receipt equivalent of ADR-005's
-  // offline writes.
-  const commitAdd = (
-    picked: NonNullable<Awaited<ReturnType<typeof captureReceipt>>>,
-    visibility: 'group' | 'parties',
-  ) => {
-    const contentType = picked.mimeType ?? 'image/jpeg';
-    const park = async () => {
-      await enqueueReceipt({ expenseId, groupId, visibility, base64: picked.base64, contentType });
-      await refreshPending();
-    };
-    void (async () => {
-      if (!(await isOnline())) {
-        await park();
-        return;
-      }
-      attach.mutate(
-        { picked, visibility },
-        {
-          onSuccess: refreshCap,
-          onError: (error) =>
-            void (async () => {
-              // The connection dropped mid-upload → park it rather than fail.
-              if (!(await isOnline())) {
-                await park();
-                return;
-              }
-              onAddError(error);
-            })(),
-        },
-      );
-    })();
-  };
-
-  const add = (picked: Awaited<ReturnType<typeof captureReceipt>>) => {
-    if (!picked) return; // Cancelled/declined.
-    Alert.alert(t.receipts.chooseVisibility, undefined, [
-      { text: t.receipts.everyone, onPress: () => commitAdd(picked, 'group') },
-      { text: t.receipts.payersOnly, onPress: () => commitAdd(picked, 'parties') },
-      { text: t.common.cancel, style: 'cancel' },
-    ]);
-  };
-
-  const startAdd = () => {
-    Alert.alert(t.receipts.add, undefined, [
-      { text: t.receipts.scan, onPress: () => void captureReceipt().then(add) },
-      { text: t.receipts.choosePhoto, onPress: () => void pickReceiptImage().then(add) },
-      { text: t.common.cancel, style: 'cancel' },
-    ]);
-  };
-
-  // The add affordance's tap: locked → upsell, otherwise the scan/choose sheet.
-  const handleAddPress = () => {
-    if (capLocked) showCapUpsell();
-    else startAdd();
-  };
-
-  const removeAt = (index: number) => {
-    const it = items[index];
-    if (!it) return;
-    Alert.alert(t.receipts.removeConfirm, undefined, [
-      { text: t.common.cancel, style: 'cancel' },
-      {
-        text: t.receipts.remove,
-        style: 'destructive',
-        onPress: () => {
-          setViewerIndex(null);
-          const onError = () => Alert.alert(t.imageAudit.couldNotRemove);
-          if (it.kind === 'pending') {
-            // Not uploaded yet: just drop the parked capture and its local bytes.
-            void discardPendingReceipt(it.entry.attachmentId).then(refreshPending);
-          } else if (it.kind === 'legacy') {
-            // Only clear the parent's receipt state on a confirmed delete — if the
-            // byte removal throws, the bill is still there and must keep showing.
-            removeLegacy.mutate(undefined, {
-              onSuccess: () => {
-                evictImage('receipts', it.path);
-                onLegacyRemoved?.();
-              },
-              onError,
-            });
-          } else {
-            const storagePath = it.row.storagePath;
-            removeAttachment.mutate(
-              { attachmentId: it.row.id, storagePath },
-              // Removing a live attachment frees a slot, so re-ask the cap gate.
-              {
-                onError,
-                onSuccess: () => {
-                  evictImage('expense-attachments', storagePath);
-                  refreshCap();
-                },
-              },
-            );
-          }
-        },
-      },
-    ]);
-  };
-
-  const viewing = viewerIndex !== null ? items[viewerIndex] : null;
-
-  // Save the open receipt off the device via the OS share/save sheet.
-  const saveViewed = () => {
-    if (viewerIndex === null || saving) return;
-    const url = urls[viewerIndex];
-    if (!url) return;
-    setSaving(true);
-    void saveImageToDevice(url).then((result) => {
-      setSaving(false);
-      if (result === 'error') Alert.alert(t.receipts.couldNotSave);
+    // The per-expense receipt ceiling (A46): a free group keeps a small number of
+    // gallery images per expense; paid lifts it. This is the affordance — the
+    // attach RPC enforces the same limit — so a failed fetch defaults to "allowed"
+    // and lets the server be the boundary, the same stance as the scan cap.
+    const cap = useQuery({
+      queryKey: ['attachmentCap', expenseId],
+      queryFn: () => canAddExpenseAttachment(expenseId),
+      staleTime: 30_000,
     });
-  };
+    const capLocked = !cap.isError && receiptCapStatus(cap.data, cap.isLoading) === 'locked';
+    const refreshCap = () =>
+      void queryClient.invalidateQueries({ queryKey: ['attachmentCap', expenseId] });
 
-  return (
-    <View style={{ gap: theme.spacing.sm }}>
-      <Text variant="caption" tone="muted">
-        {t.receipts.title}
-      </Text>
-      {items.length === 0 ? (
-        // No receipt yet (and, per the guard above, the viewer may add one). A
-        // lone 96px tile left a wide empty band under it; a full-width row that
-        // reads "Add receipt" fills the space and makes the affordance obvious.
-        <Pressable
-          onPress={handleAddPress}
-          disabled={attach.isPending}
-          accessibilityRole="button"
-          accessibilityLabel={t.receipts.add}
-          style={({ pressed }) => ({
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: theme.spacing.md,
-            paddingVertical: theme.spacing.md,
-            paddingHorizontal: theme.spacing.lg,
-            borderRadius: theme.radius.lg,
-            borderWidth: 1,
-            borderColor: theme.color.border,
-            borderStyle: 'dashed',
-            backgroundColor: theme.color.surfaceMuted,
-            opacity: pressed ? 0.6 : 1,
-          })}
-        >
-          <View
-            style={{
-              width: 40,
-              height: 40,
-              borderRadius: theme.radius.md,
+    // Try to send any parked captures when there is a usable network — on mount
+    // and whenever the connection comes back. A success pulls the freshly-recorded
+    // rows into the mirror (so the optimistic tile becomes the real attachment) and
+    // re-asks the cap; a permanent refusal (cap reached, not a party) just clears
+    // the stuck entry. All best-effort — a flush never throws into the screen.
+    useEffect(() => {
+      if (status === SyncStatus.Offline || status === SyncStatus.Metered) return;
+      void (async () => {
+        const result = await flushReceiptQueue();
+        if (result.uploadedExpenseIds.length > 0) {
+          await refreshPending();
+          await flush();
+          refreshCap();
+        } else if (result.hadPermanentFailure) {
+          await refreshPending();
+          refreshCap();
+        }
+      })();
+      // Re-run when the connection state flips; refreshers are stable.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [status]);
+
+    const items = useMemo<GalleryItem[]>(() => {
+      const list: GalleryItem[] = [];
+      if (legacyReceiptPath) {
+        list.push({ kind: 'legacy', key: 'legacy', path: legacyReceiptPath, visibility: 'group' });
+      }
+      for (const row of attachments.data) {
+        list.push({ kind: 'attachment', key: row.id, row });
+      }
+      // Show a parked capture only until its real row lands — once the upload has
+      // been pulled into the mirror, the entry shares that row's id, so drop it
+      // here to avoid a duplicate tile for the same receipt.
+      const uploaded = new Set(attachments.data.map((row) => row.id));
+      for (const entry of pending) {
+        if (!uploaded.has(entry.attachmentId)) {
+          list.push({ kind: 'pending', key: `pending-${entry.attachmentId}`, entry });
+        }
+      }
+      return list;
+    }, [legacyReceiptPath, attachments.data, pending]);
+
+    const urls = useResolvedUrls(expenseId, items);
+    const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+    const [saving, setSaving] = useState(false);
+    const [editing, setEditing] = useState<{
+      attachmentId: string;
+      uri: string;
+      initial: Annotations;
+    } | null>(null);
+    const [adjusting, setAdjusting] = useState<{
+      attachmentId: string;
+      uri: string;
+      oldStoragePath: string;
+    } | null>(null);
+
+    const pages = useMemo<GalleryPage[]>(
+      () =>
+        items.map((it, i) => ({
+          url: urls[i] ?? null,
+          annotations: it.kind === 'attachment' ? (it.row.annotations ?? undefined) : undefined,
+        })),
+      [items, urls],
+    );
+
+    const isPrivate = (it: GalleryItem) =>
+      (it.kind === 'attachment' && it.row.visibility === 'parties') ||
+      (it.kind === 'pending' && it.entry.visibility === 'parties');
+
+    // The free per-expense limit is reached (and the group is not paid): point the
+    // person at the upgrade rather than open the add sheet. Reuses the scan cap's
+    // strings and upgrade route so both ceilings read and route the same.
+    const showCapUpsell = () => {
+      Alert.alert(t.expense.capReachedTitle, t.expense.capReachedBody, [
+        { text: t.common.cancel, style: 'cancel' },
+        { text: t.expense.capUpgrade, onPress: () => router.push('/settings/upgrade') },
+      ]);
+    };
+
+    // The server may still refuse over the cap even when the local gate allowed it
+    // (another party filled the last slot from another device); surface that as the
+    // upgrade prompt, not a generic failure. Anything else is the generic message.
+    const onAddError = (error: unknown) => {
+      const message = error instanceof Error ? error.message : '';
+      if (message.includes('ATTACHMENT_CAP')) {
+        showCapUpsell();
+        refreshCap();
+      } else {
+        Alert.alert(t.receipts.couldNotAdd);
+      }
+    };
+
+    // Add at a chosen visibility. Online it uploads now; offline (or if the upload
+    // cannot reach R2) the capture is parked on the device and shown at once, to
+    // be sent automatically on reconnect — the receipt equivalent of ADR-005's
+    // offline writes.
+    const commitAdd = (
+      picked: NonNullable<Awaited<ReturnType<typeof captureReceipt>>>,
+      visibility: 'group' | 'parties',
+    ) => {
+      const contentType = picked.mimeType ?? 'image/jpeg';
+      const park = async () => {
+        await enqueueReceipt({
+          expenseId,
+          groupId,
+          visibility,
+          base64: picked.base64,
+          contentType,
+        });
+        await refreshPending();
+      };
+      void (async () => {
+        if (!(await isOnline())) {
+          await park();
+          return;
+        }
+        attach.mutate(
+          { picked, visibility },
+          {
+            onSuccess: refreshCap,
+            onError: (error) =>
+              void (async () => {
+                // The connection dropped mid-upload → park it rather than fail.
+                if (!(await isOnline())) {
+                  await park();
+                  return;
+                }
+                onAddError(error);
+              })(),
+          },
+        );
+      })();
+    };
+
+    const add = (picked: Awaited<ReturnType<typeof captureReceipt>>) => {
+      if (!picked) return; // Cancelled/declined.
+      Alert.alert(t.receipts.chooseVisibility, undefined, [
+        { text: t.receipts.everyone, onPress: () => commitAdd(picked, 'group') },
+        { text: t.receipts.payersOnly, onPress: () => commitAdd(picked, 'parties') },
+        { text: t.common.cancel, style: 'cancel' },
+      ]);
+    };
+
+    const startAdd = () => {
+      Alert.alert(t.receipts.add, undefined, [
+        { text: t.receipts.scan, onPress: () => void captureReceipt().then(add) },
+        { text: t.receipts.choosePhoto, onPress: () => void pickReceiptImage().then(add) },
+        { text: t.common.cancel, style: 'cancel' },
+      ]);
+    };
+
+    // The add affordance's tap: locked → upsell, otherwise the scan/choose sheet.
+    const handleAddPress = () => {
+      if (capLocked) showCapUpsell();
+      else startAdd();
+    };
+
+    // Hand the add action up to a parent that renders its own button (the detail
+    // hero). Defined here, after handleAddPress and before the sole early return
+    // below, so the hook runs on every render and reads the current handler.
+    useImperativeHandle(ref, () => ({ openAdd: handleAddPress }));
+
+    // Nothing to show and cannot add here → render nothing, so a non-party's bill
+    // is not cluttered with an empty section. `externalAdd` also counts as "cannot
+    // add here": the parent's button owns adding, so an empty gallery is nothing.
+    if (items.length === 0 && (!canManage || externalAdd)) return null;
+
+    const removeAt = (index: number) => {
+      const it = items[index];
+      if (!it) return;
+      Alert.alert(t.receipts.removeConfirm, undefined, [
+        { text: t.common.cancel, style: 'cancel' },
+        {
+          text: t.receipts.remove,
+          style: 'destructive',
+          onPress: () => {
+            setViewerIndex(null);
+            const onError = () => Alert.alert(t.imageAudit.couldNotRemove);
+            if (it.kind === 'pending') {
+              // Not uploaded yet: just drop the parked capture and its local bytes.
+              void discardPendingReceipt(it.entry.attachmentId).then(refreshPending);
+            } else if (it.kind === 'legacy') {
+              // Only clear the parent's receipt state on a confirmed delete — if the
+              // byte removal throws, the bill is still there and must keep showing.
+              removeLegacy.mutate(undefined, {
+                onSuccess: () => {
+                  evictImage('receipts', it.path);
+                  onLegacyRemoved?.();
+                },
+                onError,
+              });
+            } else {
+              const storagePath = it.row.storagePath;
+              removeAttachment.mutate(
+                { attachmentId: it.row.id, storagePath },
+                // Removing a live attachment frees a slot, so re-ask the cap gate.
+                {
+                  onError,
+                  onSuccess: () => {
+                    evictImage('expense-attachments', storagePath);
+                    refreshCap();
+                  },
+                },
+              );
+            }
+          },
+        },
+      ]);
+    };
+
+    const viewing = viewerIndex !== null ? items[viewerIndex] : null;
+
+    // Save the open receipt off the device via the OS share/save sheet.
+    const saveViewed = () => {
+      if (viewerIndex === null || saving) return;
+      const url = urls[viewerIndex];
+      if (!url) return;
+      setSaving(true);
+      void saveImageToDevice(url).then((result) => {
+        setSaving(false);
+        if (result === 'error') Alert.alert(t.receipts.couldNotSave);
+      });
+    };
+
+    return (
+      <View style={{ gap: theme.spacing.sm }}>
+        <Text variant="caption" tone="muted">
+          {t.receipts.title}
+        </Text>
+        {items.length === 0 ? (
+          // No receipt yet (and, per the guard above, the viewer may add one). A
+          // lone 96px tile left a wide empty band under it; a full-width row that
+          // reads "Add receipt" fills the space and makes the affordance obvious.
+          <Pressable
+            onPress={handleAddPress}
+            disabled={attach.isPending}
+            accessibilityRole="button"
+            accessibilityLabel={t.receipts.add}
+            style={({ pressed }) => ({
+              flexDirection: 'row',
               alignItems: 'center',
-              justifyContent: 'center',
-              backgroundColor: theme.color.surface,
-            }}
+              gap: theme.spacing.md,
+              paddingVertical: theme.spacing.md,
+              paddingHorizontal: theme.spacing.lg,
+              borderRadius: theme.radius.lg,
+              borderWidth: 1,
+              borderColor: theme.color.border,
+              borderStyle: 'dashed',
+              backgroundColor: theme.color.surfaceMuted,
+              opacity: pressed ? 0.6 : 1,
+            })}
           >
-            {attach.isPending ? (
-              <ActivityIndicator color={theme.color.brand} />
-            ) : (
-              <Ionicons name="camera-outline" size={iconSize.lg} color={theme.color.brand} />
-            )}
-          </View>
-          <View style={{ flex: 1, minWidth: 0 }}>
-            <Text variant="subheading">{t.receipts.add}</Text>
-            <Text variant="micro" tone="muted">
-              {`${t.receipts.scan} · ${t.receipts.choosePhoto}`}
-            </Text>
-          </View>
-          <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
-        </Pressable>
-      ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={{ gap: theme.spacing.sm }}
-        >
-          {canManage ? (
-            <Pressable
-              onPress={handleAddPress}
-              disabled={attach.isPending}
-              accessibilityRole="button"
-              accessibilityLabel={t.receipts.add}
+            <View
               style={{
-                width: THUMB,
-                height: THUMB,
+                width: 40,
+                height: 40,
                 borderRadius: theme.radius.md,
-                borderWidth: 1,
-                borderColor: theme.color.border,
                 alignItems: 'center',
                 justifyContent: 'center',
-                backgroundColor: theme.color.surfaceMuted,
+                backgroundColor: theme.color.surface,
               }}
             >
               {attach.isPending ? (
                 <ActivityIndicator color={theme.color.brand} />
               ) : (
-                <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
+                <Ionicons name="camera-outline" size={iconSize.lg} color={theme.color.brand} />
               )}
-            </Pressable>
-          ) : null}
+            </View>
+            <View style={{ flex: 1, minWidth: 0 }}>
+              <Text variant="subheading">{t.receipts.add}</Text>
+              <Text variant="micro" tone="muted">
+                {`${t.receipts.scan} · ${t.receipts.choosePhoto}`}
+              </Text>
+            </View>
+            <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
+          </Pressable>
+        ) : (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={{ gap: theme.spacing.sm }}
+          >
+            {canManage && !externalAdd ? (
+              <Pressable
+                onPress={handleAddPress}
+                disabled={attach.isPending}
+                accessibilityRole="button"
+                accessibilityLabel={t.receipts.add}
+                style={{
+                  width: THUMB,
+                  height: THUMB,
+                  borderRadius: theme.radius.md,
+                  borderWidth: 1,
+                  borderColor: theme.color.border,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: theme.color.surfaceMuted,
+                }}
+              >
+                {attach.isPending ? (
+                  <ActivityIndicator color={theme.color.brand} />
+                ) : (
+                  <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
+                )}
+              </Pressable>
+            ) : null}
 
-          {items.map((it, index) => (
-            <Thumb
-              key={it.key}
-              url={urls[index] ?? null}
-              resolved={urls[index] !== undefined}
-              isPrivate={isPrivate(it)}
-              pending={it.kind === 'pending'}
-              label={
-                isPrivate(it) ? `${t.receipts.title} — ${t.receipts.privateTag}` : t.receipts.title
-              }
-              onPress={() => setViewerIndex(index)}
-            />
-          ))}
-        </ScrollView>
-      )}
+            {items.map((it, index) => (
+              <Thumb
+                key={it.key}
+                url={urls[index] ?? null}
+                resolved={urls[index] !== undefined}
+                isPrivate={isPrivate(it)}
+                pending={it.kind === 'pending'}
+                label={
+                  isPrivate(it)
+                    ? `${t.receipts.title} — ${t.receipts.privateTag}`
+                    : t.receipts.title
+                }
+                onPress={() => setViewerIndex(index)}
+              />
+            ))}
+          </ScrollView>
+        )}
 
-      <Modal
-        visible={viewing !== null}
-        animationType="fade"
-        onRequestClose={() => setViewerIndex(null)}
-      >
-        {/* A dark, immersive viewer (the Photos/ChatGPT pattern): the image fills
+        <Modal
+          visible={viewing !== null}
+          animationType="fade"
+          onRequestClose={() => setViewerIndex(null)}
+        >
+          {/* A dark, immersive viewer (the Photos/ChatGPT pattern): the image fills
             the screen and every control floats over it, so nothing squeezes the
             pixels. Save, adjust, annotate and remove sit as translucent circular
             buttons; the counter is a pill at the foot. */}
-        <View style={{ flex: 1, backgroundColor: '#000' }}>
-          <StatusBar barStyle="light-content" />
+          <View style={{ flex: 1, backgroundColor: '#000' }}>
+            <StatusBar barStyle="light-content" />
 
-          <ZoomableGallery
-            pages={pages}
-            index={viewerIndex ?? 0}
-            onIndexChange={(i) => setViewerIndex(i)}
-          />
-
-          <Row
-            style={{
-              position: 'absolute',
-              top: insets.top + theme.spacing.sm,
-              left: theme.spacing.xl,
-              right: theme.spacing.xl,
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-            }}
-          >
-            <ViewerButton
-              icon="close"
-              label={t.common.close}
-              onPress={() => setViewerIndex(null)}
+            <ZoomableGallery
+              pages={pages}
+              index={viewerIndex ?? 0}
+              onIndexChange={(i) => setViewerIndex(i)}
             />
-            <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
-              {viewerIndex !== null && urls[viewerIndex] ? (
-                <ViewerButton
-                  icon="download-outline"
-                  label={t.receipts.download}
-                  onPress={saveViewed}
-                  busy={saving}
-                />
-              ) : null}
-              {(() => {
-                if (viewerIndex === null) return null;
-                // An attachment's edit/remove is party-only (`canManage`); the
-                // legacy bill's remove also allows a group admin
-                // (`canRemoveLegacy`) — the same split the RPCs enforce.
-                const showEdit =
-                  canManage && viewing?.kind === 'attachment' ? urls[viewerIndex] : null;
-                const showRemove =
-                  viewing !== null && (viewing.kind === 'legacy' ? canRemoveLegacy : canManage);
-                return (
-                  <>
-                    {showEdit ? (
-                      <ViewerButton
-                        icon="crop"
-                        label={t.adjust.title}
-                        onPress={() => {
-                          const url = urls[viewerIndex];
-                          if (viewing?.kind === 'attachment' && url) {
-                            setAdjusting({
-                              attachmentId: viewing.row.id,
-                              uri: url,
-                              oldStoragePath: viewing.row.storagePath,
-                            });
-                          }
-                        }}
-                      />
-                    ) : null}
-                    {showEdit ? (
-                      <ViewerButton
-                        icon="pencil"
-                        label={t.annotate.title}
-                        onPress={() => {
-                          const url = urls[viewerIndex];
-                          if (viewing?.kind === 'attachment' && url) {
-                            setEditing({
-                              attachmentId: viewing.row.id,
-                              uri: url,
-                              initial: viewing.row.annotations ?? EMPTY_ANNOTATIONS,
-                            });
-                          }
-                        }}
-                      />
-                    ) : null}
-                    {showRemove ? (
-                      <ViewerButton
-                        icon="trash-outline"
-                        label={t.receipts.remove}
-                        tint={theme.color.negative}
-                        onPress={() => {
-                          if (!removeAttachment.isPending && !removeLegacy.isPending)
-                            removeAt(viewerIndex);
-                        }}
-                      />
-                    ) : null}
-                  </>
-                );
-              })()}
-            </Row>
-          </Row>
 
-          {/* Page counter + private tag, a floating pill at the foot. */}
-          <View
-            style={{
-              position: 'absolute',
-              bottom: insets.bottom + theme.spacing.xl,
-              left: 0,
-              right: 0,
-              alignItems: 'center',
-            }}
-          >
             <Row
               style={{
-                gap: theme.spacing.xs,
-                alignItems: 'center',
-                paddingHorizontal: theme.spacing.md,
-                paddingVertical: 6,
-                borderRadius: theme.radius.pill,
-                backgroundColor: 'rgba(20, 20, 30, 0.55)',
+                position: 'absolute',
+                top: insets.top + theme.spacing.sm,
+                left: theme.spacing.xl,
+                right: theme.spacing.xl,
+                justifyContent: 'space-between',
+                alignItems: 'flex-start',
               }}
             >
-              {viewing && isPrivate(viewing) ? (
-                <Ionicons name="lock-closed" size={11} color="#FFFFFF" />
-              ) : null}
-              <Text variant="caption" style={{ color: '#FFFFFF' }}>
-                {fill(t.receipts.counter, {
-                  index: (viewerIndex ?? 0) + 1,
-                  total: items.length,
-                })}
-              </Text>
+              <ViewerButton
+                icon="close"
+                label={t.common.close}
+                onPress={() => setViewerIndex(null)}
+              />
+              <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+                {viewerIndex !== null && urls[viewerIndex] ? (
+                  <ViewerButton
+                    icon="download-outline"
+                    label={t.receipts.download}
+                    onPress={saveViewed}
+                    busy={saving}
+                  />
+                ) : null}
+                {(() => {
+                  if (viewerIndex === null) return null;
+                  // An attachment's edit/remove is party-only (`canManage`); the
+                  // legacy bill's remove also allows a group admin
+                  // (`canRemoveLegacy`) — the same split the RPCs enforce.
+                  const showEdit =
+                    canManage && viewing?.kind === 'attachment' ? urls[viewerIndex] : null;
+                  const showRemove =
+                    viewing !== null && (viewing.kind === 'legacy' ? canRemoveLegacy : canManage);
+                  return (
+                    <>
+                      {showEdit ? (
+                        <ViewerButton
+                          icon="crop"
+                          label={t.adjust.title}
+                          onPress={() => {
+                            const url = urls[viewerIndex];
+                            if (viewing?.kind === 'attachment' && url) {
+                              setAdjusting({
+                                attachmentId: viewing.row.id,
+                                uri: url,
+                                oldStoragePath: viewing.row.storagePath,
+                              });
+                            }
+                          }}
+                        />
+                      ) : null}
+                      {showEdit ? (
+                        <ViewerButton
+                          icon="pencil"
+                          label={t.annotate.title}
+                          onPress={() => {
+                            const url = urls[viewerIndex];
+                            if (viewing?.kind === 'attachment' && url) {
+                              setEditing({
+                                attachmentId: viewing.row.id,
+                                uri: url,
+                                initial: viewing.row.annotations ?? EMPTY_ANNOTATIONS,
+                              });
+                            }
+                          }}
+                        />
+                      ) : null}
+                      {showRemove ? (
+                        <ViewerButton
+                          icon="trash-outline"
+                          label={t.receipts.remove}
+                          tint={theme.color.negative}
+                          onPress={() => {
+                            if (!removeAttachment.isPending && !removeLegacy.isPending)
+                              removeAt(viewerIndex);
+                          }}
+                        />
+                      ) : null}
+                    </>
+                  );
+                })()}
+              </Row>
             </Row>
+
+            {/* Page counter + private tag, a floating pill at the foot. */}
+            <View
+              style={{
+                position: 'absolute',
+                bottom: insets.bottom + theme.spacing.xl,
+                left: 0,
+                right: 0,
+                alignItems: 'center',
+              }}
+            >
+              <Row
+                style={{
+                  gap: theme.spacing.xs,
+                  alignItems: 'center',
+                  paddingHorizontal: theme.spacing.md,
+                  paddingVertical: 6,
+                  borderRadius: theme.radius.pill,
+                  backgroundColor: 'rgba(20, 20, 30, 0.55)',
+                }}
+              >
+                {viewing && isPrivate(viewing) ? (
+                  <Ionicons name="lock-closed" size={11} color="#FFFFFF" />
+                ) : null}
+                <Text variant="caption" style={{ color: '#FFFFFF' }}>
+                  {fill(t.receipts.counter, {
+                    index: (viewerIndex ?? 0) + 1,
+                    total: items.length,
+                  })}
+                </Text>
+              </Row>
+            </View>
           </View>
-        </View>
-      </Modal>
+        </Modal>
 
-      {editing ? (
-        <ReceiptAnnotator
-          uri={editing.uri}
-          initial={editing.initial}
-          saving={annotate.isPending}
-          onCancel={() => setEditing(null)}
-          onSave={(next) =>
-            annotate.mutate(
-              {
-                attachmentId: editing.attachmentId,
-                annotations: isEmptyAnnotations(next) ? null : next,
-              },
-              {
-                onSuccess: () => setEditing(null),
-                onError: () => Alert.alert(t.annotate.couldNotSave),
-              },
-            )
-          }
-        />
-      ) : null}
-
-      {adjusting ? (
-        <ReceiptCropper
-          uri={adjusting.uri}
-          saving={replace.isPending}
-          onCancel={() => setAdjusting(null)}
-          onSave={(picked) =>
-            replace.mutate(
-              {
-                attachmentId: adjusting.attachmentId,
-                oldStoragePath: adjusting.oldStoragePath,
-                picked,
-              },
-              {
-                onSuccess: () => {
-                  // The row now points at fresh bytes under a new path; drop the
-                  // old cached copy so a later view fetches the replacement.
-                  evictImage('expense-attachments', adjusting.oldStoragePath);
-                  setAdjusting(null);
+        {editing ? (
+          <ReceiptAnnotator
+            uri={editing.uri}
+            initial={editing.initial}
+            saving={annotate.isPending}
+            onCancel={() => setEditing(null)}
+            onSave={(next) =>
+              annotate.mutate(
+                {
+                  attachmentId: editing.attachmentId,
+                  annotations: isEmptyAnnotations(next) ? null : next,
                 },
-                onError: () => Alert.alert(t.adjust.couldNotSave),
-              },
-            )
-          }
-        />
-      ) : null}
-    </View>
-  );
-}
+                {
+                  onSuccess: () => setEditing(null),
+                  onError: () => Alert.alert(t.annotate.couldNotSave),
+                },
+              )
+            }
+          />
+        ) : null}
+
+        {adjusting ? (
+          <ReceiptCropper
+            uri={adjusting.uri}
+            saving={replace.isPending}
+            onCancel={() => setAdjusting(null)}
+            onSave={(picked) =>
+              replace.mutate(
+                {
+                  attachmentId: adjusting.attachmentId,
+                  oldStoragePath: adjusting.oldStoragePath,
+                  picked,
+                },
+                {
+                  onSuccess: () => {
+                    // The row now points at fresh bytes under a new path; drop the
+                    // old cached copy so a later view fetches the replacement.
+                    evictImage('expense-attachments', adjusting.oldStoragePath);
+                    setAdjusting(null);
+                  },
+                  onError: () => Alert.alert(t.adjust.couldNotSave),
+                },
+              )
+            }
+          />
+        ) : null}
+      </View>
+    );
+  },
+);

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1476,6 +1476,11 @@ export interface UiStrings {
     /** "In 4 expenses" over the list on a member. */
     inCount: PluralForms;
     whoOwesWhat: string;
+    /** Labels on the expense detail card: the group it belongs to, its date, and
+     *  how it was split. */
+    detailGroup: string;
+    detailDate: string;
+    detailSplit: string;
     history: string;
     restore: string;
     deleteAction: string;
@@ -3248,6 +3253,9 @@ const en: UiStrings = {
     editedTimes: { one: 'edited once', other: 'edited {n} times' },
     inCount: { one: 'In {n} expense', other: 'In {n} expenses' },
     whoOwesWhat: 'Who owes what',
+    detailGroup: 'Group',
+    detailDate: 'Date',
+    detailSplit: 'Split',
     history: 'History',
     restore: 'Restore this expense',
     deleteAction: 'Delete expense',
@@ -5110,6 +5118,9 @@ const ta: UiStrings = {
     editedTimes: { one: 'ஒருமுறை திருத்தப்பட்டது', other: '{n} முறை திருத்தப்பட்டது' },
     inCount: { one: '{n} செலவில்', other: '{n} செலவுகளில்' },
     whoOwesWhat: 'யார் என்ன தர வேண்டும்',
+    detailGroup: 'குழு',
+    detailDate: 'தேதி',
+    detailSplit: 'பிரிப்பு',
     history: 'வரலாறு',
     restore: 'இந்தச் செலவை மீட்டெடு',
     deleteAction: 'செலவை நீக்கு',
@@ -6953,6 +6964,9 @@ const hi: UiStrings = {
     editedTimes: { one: 'एक बार संपादित', other: '{n} बार संपादित' },
     inCount: { one: '{n} खर्च में', other: '{n} खर्चों में' },
     whoOwesWhat: 'किस पर क्या बाकी',
+    detailGroup: 'समूह',
+    detailDate: 'तारीख़',
+    detailSplit: 'बँटवारा',
     history: 'इतिहास',
     restore: 'यह खर्च वापस लाएँ',
     deleteAction: 'खर्च मिटाएँ',
@@ -8829,6 +8843,9 @@ const ar: UiStrings = {
       other: 'في {n} مصروف',
     },
     whoOwesWhat: 'من عليه ماذا',
+    detailGroup: 'المجموعة',
+    detailDate: 'التاريخ',
+    detailSplit: 'التقسيم',
     history: 'السجل',
     restore: 'استرجاع هذا المصروف',
     deleteAction: 'حذف المصروف',


### PR DESCRIPTION
## Problem
The expense detail hero read as unorganized: a category icon, the amount, a stacked "you paid · date" caption and a row of chips — and the **description hid** as a one-line header squeezed between the back and ⋮ glyphs, so it was easy to miss.

## Change (the "Amount hero + detail card" direction)
- **Description leads the hero** beside the category badge, as the heading of the bill — the "I don't see the description" fix.
- **Amount is the centrepiece**, and an **"Add receipt" button sits right under it** — the same "primary action under the number" the dashboard and group heros use. `ExpenseReceipts` is now a `forwardRef` exposing `openAdd()`; the hero button drives it, and the section shows the gallery of existing receipts without its own inline add (`externalAdd`).
- **"Paid by / Date / Split"** (plus the group) move into a tidy **labelled detail card** below, replacing the stacked caption and floating chips.

## i18n
New `expense.detailGroup` / `detailDate` / `detailSplit` in en/ta/hi/ar.

## Verification
`pnpm format`, `pnpm lint`, `pnpm -C apps/mobile typecheck` — all green. Not device-run.

> Note: touches the same screen as #502 (the "not involved" observer banner). Small, resolvable overlap if both land — the banner sits in the details-tab body, this reworks the hero + adds the detail card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the expense detail screen with clearer expense, payment, date, split, and group information.
  * Added a prominent “Add receipt” action for eligible expenses.
  * Improved receipt management, including browsing, adding, editing, removing, saving, and offline handling.
  * Add-receipt actions now work consistently when switching between expense detail tabs.
  * Added translated labels for expense details in English, Tamil, Hindi, and Arabic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->