### PR TITLE
feat(onboarding): sequence first-run prompts, end the double tour

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -527,7 +527,7 @@ export default function HomeScreen() {
       {/* Guests are nudged to secure their account as an animated popup rather
           than an inline banner — once a day, dismissible. Held back while the
           tour is up so the two do not stack on a guest's first run. */}
-      {isGuest && !tour.active ? (
+      {isGuest ? (
         <GuestPopup gate={guard.gate} t={t} onAction={() => router.push('/settings/account')} />
       ) : null}
 
@@ -866,7 +866,14 @@ function GuestPopup({
 }) {
   const theme = useTheme();
   const { hidden, ready, dismiss } = useDailyDismiss(GUEST_PROMPT_DISMISS_KEY);
-  const visible = ready && !hidden;
+  // Take a turn in the shared prompt queue rather than firing on its own: the
+  // guest card waits behind the tour and the push/campaign asks and only shows
+  // when it is the live winner. `active` is exactly "would show today" (ready and
+  // not dismissed), so it never holds the queue — and blocks the lower-priority
+  // tip — while it is hidden for the day.
+  const wants = ready && !hidden;
+  const granted = usePromptSlot({ id: 'guest', priority: 40, active: wants, delayMs: 300 });
+  const visible = wants && granted;
 
   // A gentle scale-and-fade in, the way the reference presents this card. RN
   // Animated (not reanimated) since this file already drives its counters with

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -51,7 +51,7 @@ import { RecentCountProvider } from '@/lib/recentCount';
 import { ShortcutProvider } from '@/lib/shortcut';
 import { WatchBridgeProvider } from '@/lib/watch/bridge';
 import { ShortcutGesture } from '@/components/ShortcutGesture';
-import { TourProvider } from '@/lib/tour';
+import { TourProvider, useTour } from '@/lib/tour';
 import { PromptQueueProvider } from '@/lib/promptQueue';
 import { SyncNetworkProvider } from '@/lib/syncNetwork';
 import { ThemePreferenceProvider, useThemePreference } from '@/lib/theme';
@@ -413,6 +413,10 @@ function AuthGate() {
   const router = useRouter();
   const theme = useTheme();
   const reduceMotion = useReducedMotion();
+  // Finishing the 3-card intro also marks the coach tour seen, so a new person
+  // is not toured twice back-to-back (the intro, then the coach-marks). The
+  // coach tour stays available on demand from the Home overflow menu.
+  const tour = useTour();
   // The paywall is an unwired placeholder (no store products, no purchase
   // handling), so its route is registered only where a flag turns it on —
   // otherwise a deep link cannot reach a screen that would only mislead.
@@ -555,6 +559,9 @@ function AuthGate() {
           // Not awaited: the tour is over the moment they say so, and a write
           // that fails costs them one repeat, not a stuck screen.
           void AsyncStorage.setItem(TOUR_KEY, 'yes').catch(() => {});
+          // One onboarding, not two: mark the coach tour seen as well so it does
+          // not autostart on the Home screen the intro just handed them to.
+          tour.finish();
         }}
       />
     );

--- a/apps/mobile/src/components/CampaignPopup.tsx
+++ b/apps/mobile/src/components/CampaignPopup.tsx
@@ -24,6 +24,7 @@ import { Button, Text, useTheme } from '@waves/ui';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { backend } from '@/lib/backend';
+import { usePromptSlot } from '@/lib/promptQueue';
 
 interface Campaign {
   id: string;
@@ -67,16 +68,23 @@ export function CampaignPopup() {
     onSettled: () => queryClient.invalidateQueries({ queryKey: ['campaign'] }),
   });
 
-  // On show, not on dismiss: somebody who reads this and force-quits has still
-  // been reached, and the funnel would otherwise never know.
-  useEffect(() => {
-    if (campaign && !dismissed) seen.mutate({ id: campaign.id, acted: false });
-    // Only when the campaign itself changes — re-running on every render of the
-    // mutation object would report the same impression forever.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [campaign?.id]);
+  // Wait its turn behind the tour and the push ask rather than stacking on them:
+  // the announcement claims a queue slot while there is one to show and only
+  // renders when it is the live winner.
+  const wants = Boolean(campaign) && !dismissed;
+  const granted = usePromptSlot({ id: 'campaign', priority: 60, active: wants, delayMs: 300 });
 
-  if (!campaign || dismissed) return null;
+  // On show, not on dismiss, and only once it is actually granted the screen:
+  // somebody who reads this and force-quits has still been reached, but one that
+  // never surfaced (a higher-priority prompt held the queue) has not.
+  useEffect(() => {
+    if (campaign && !dismissed && granted) seen.mutate({ id: campaign.id, acted: false });
+    // Only when the campaign changes or it is first granted — re-running on every
+    // render of the mutation object would report the same impression forever.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [campaign?.id, granted]);
+
+  if (!campaign || dismissed || !granted) return null;
 
   const close = () => setDismissed(true);
 

--- a/apps/mobile/src/components/NotificationPrompt.tsx
+++ b/apps/mobile/src/components/NotificationPrompt.tsx
@@ -23,6 +23,7 @@ import { Button, Text, useTheme } from '@waves/ui';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { enablePush, PushPermission, pushPermission, pushSupported } from '@/lib/push';
+import { usePromptSlot } from '@/lib/promptQueue';
 
 const SEEN_KEY = 'waves.push_prompt_seen';
 
@@ -81,7 +82,13 @@ export function NotificationPrompt() {
     }
   };
 
-  if (!visible) return null;
+  // Sits in the shared prompt queue so the soft ask never lands on top of the
+  // tour or the 3-card intro — it waits its turn and shows only when it is the
+  // live winner. It outranks the campaign and guest asks (a permission the OS
+  // will only offer once is worth more than an announcement).
+  const granted = usePromptSlot({ id: 'notifPrompt', priority: 80, active: visible, delayMs: 300 });
+
+  if (!visible || !granted) return null;
 
   return (
     <Modal visible transparent animationType="fade" onRequestClose={dismiss}>


### PR DESCRIPTION
## Problem
On a new user's first launch, **six overlays** could appear with nothing sequencing them — the 3-card intro, the coach tour, the daily tip, the guest card, the push ask, and a server campaign. Only the tour and tip shared the `PromptQueue`; the **guest card, push ask, and campaign each decided independently**, so they stacked on the tour and on each other ("everything comes together"). New users were also **toured twice**: the 3-card intro, then coach-marks immediately after.

## Change
- **One queue for all of them.** The push ask (priority **80**), campaign (**60**), and guest card (**40**) now take a slot in the same `PromptQueue` as the tour (**100**) and tip (**10**). Exactly one shows at a time; the next only after the previous is dismissed.
  - Each claims its slot **only while it would actually show** — the guest card stays out of the queue while hidden for the day (so it never blocks the tip), and the campaign records its impression **only once it's actually granted** the screen, not merely fetched.
- **End the double tour.** Finishing the 3-card intro now also marks the coach tour seen (`tour.finish()`), so it doesn't autostart on the Home screen the intro just handed over to. The coach tour stays available on demand from the **Home overflow → Replay**.

Priority order, highest first: tour → push ask → campaign → guest → tip. (The 3-card intro is unchanged — it's a hard gate before the app tree mounts, so it's inherently first.)

## Verification
`pnpm format`, `pnpm lint`, `pnpm -C apps/mobile typecheck` — green. Not device-run; the sequencing wants a real first-launch to feel end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt sequencing to prevent guest, campaign, and notification popups from overlapping.
  * Guest prompts now appear only when eligible and are correctly suppressed after dismissal for the day.
  * Campaign impressions are recorded only when the campaign is actually displayed.
  * Completed onboarding no longer immediately triggers the coach tour.
  * Notification prompts now wait for their turn before appearing.
  * Carousel indicators now accurately reflect the current slide.
  * Improved dashboard and group navigation behavior.
  * Updated displayed amounts for smoother, more consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->