### PR TITLE
fix(splitwise): harden import parser

### DIFF
--- a/packages/core/src/import/splitwise.ts
+++ b/packages/core/src/import/splitwise.ts
@@ -30,6 +30,8 @@ export enum ImportProblemKind {
   UnparseableRow = 'unparseable_row',
   RowDoesNotBalance = 'row_does_not_balance',
   UnknownCurrency = 'unknown_currency',
+  DuplicatePerson = 'duplicate_person',
+  NonPositiveCost = 'non_positive_cost',
   NoPeople = 'no_people',
   NoRows = 'no_rows',
 }
@@ -70,6 +72,17 @@ export interface SplitwiseImport {
 
 /** Columns Splitwise writes before the per-person ones. */
 const FIXED_COLUMNS = ['date', 'description', 'category', 'cost', 'currency'];
+
+function normaliseHeaderName(name: string): string {
+  return name
+    .replace(/^\uFEFF/, '')
+    .trim()
+    .toLowerCase();
+}
+
+function normalisePersonName(name: string): string {
+  return name.replace(/^\uFEFF/, '').trim();
+}
 
 /**
  * The trailing summary row Splitwise appends. It is not an expense, and
@@ -210,16 +223,20 @@ export function importSplitwiseCsv(csv: string): SplitwiseImport {
 
   const header = lines[0] ? parseCsvRow(lines[0]) : [];
   const fixedCount = FIXED_COLUMNS.filter((name) =>
-    header.some((column) => column.toLowerCase() === name),
+    header.some((column) => normaliseHeaderName(column) === name),
   ).length;
   // Keep the field index beside each name: a blank person column in the header
   // shifts the people list without shifting the field positions, so reading by
   // list index would attribute every net after the gap to the wrong person.
   const personColumns = header
     .slice(FIXED_COLUMNS.length)
-    .map((name, offset) => ({ name, column: FIXED_COLUMNS.length + offset }))
+    .map((name, offset) => ({
+      name: normalisePersonName(name),
+      column: FIXED_COLUMNS.length + offset,
+    }))
     .filter((entry) => entry.name !== '');
   const people = personColumns.map((entry) => entry.name);
+  const duplicatePeople = people.filter((person, index) => people.indexOf(person) !== index);
 
   if (fixedCount < FIXED_COLUMNS.length || people.length === 0) {
     problems.push({
@@ -227,6 +244,15 @@ export function importSplitwiseCsv(csv: string): SplitwiseImport {
       row: 1,
       message:
         'This does not look like a Splitwise export — expected Date, Description, Category, Cost, Currency and then one column per person.',
+    });
+    return { people: [], expenses: [], balances: {}, currency: 'INR', problems };
+  }
+
+  if (duplicatePeople.length > 0) {
+    problems.push({
+      kind: ImportProblemKind.DuplicatePerson,
+      row: 1,
+      message: `Splitwise export has duplicate person columns: ${[...new Set(duplicatePeople)].join(', ')}.`,
     });
     return { people: [], expenses: [], balances: {}, currency: 'INR', problems };
   }
@@ -264,13 +290,37 @@ export function importSplitwiseCsv(csv: string): SplitwiseImport {
       });
       continue;
     }
+    if (amount <= 0n) {
+      problems.push({
+        kind: ImportProblemKind.NonPositiveCost,
+        row: rowNumber,
+        message: `Row ${rowNumber} ("${description}"): Splitwise cost must be greater than zero.`,
+      });
+      continue;
+    }
 
     const nets = new Map<string, bigint>();
     let net = 0n;
+    let malformedNet: string | null = null;
     for (const entry of personColumns) {
-      const value = parseCsvAmount(fields[entry.column] ?? '', rowCurrency) ?? 0n;
+      const raw = fields[entry.column] ?? '';
+      const parsed = parseCsvAmount(raw, rowCurrency);
+      if (parsed === null && raw.trim() !== '') {
+        malformedNet = entry.name;
+        break;
+      }
+      const value = parsed ?? 0n;
       nets.set(entry.name, value);
       net += value;
+    }
+
+    if (malformedNet) {
+      problems.push({
+        kind: ImportProblemKind.UnparseableRow,
+        row: rowNumber,
+        message: `Row ${rowNumber} ("${description}"): could not read ${malformedNet}'s amount.`,
+      });
+      continue;
     }
 
     // Every row in a correct export sums to zero across people. A row that does

--- a/packages/core/test/splitwise.test.ts
+++ b/packages/core/test/splitwise.test.ts
@@ -12,7 +12,12 @@
 import { describe, expect, it } from 'vitest';
 import fc from 'fast-check';
 
-import { importSplitwiseCsv, parseCsvAmount, parseCsvRow } from '../src/index.js';
+import {
+  ImportProblemKind,
+  importSplitwiseCsv,
+  parseCsvAmount,
+  parseCsvRow,
+} from '../src/index.js';
 
 const HEADER = 'Date,Description,Category,Cost,Currency,Asha,Bharath,Chitra';
 
@@ -65,6 +70,70 @@ describe('reading the file', () => {
       file('2026-03-01,Dinner,Food and drink,300.00,INR,200.00,-100.00,-100.00'),
     );
     expect(result.expenses[0]?.category).toBe('Food and drink');
+  });
+
+  it('accepts Splitwise headers with extra spaces, casing differences, and BOMs', () => {
+    const result = importSplitwiseCsv(
+      [
+        '\uFEFF Date , Description , Category , Cost , Currency , Asha , Bharath ',
+        '2026-03-01,Dinner,Food and drink,300.00,INR,200.00,-200.00',
+      ].join('\n'),
+    );
+
+    expect(result.problems).toEqual([]);
+    expect(result.people).toEqual(['Asha', 'Bharath']);
+    expect(result.expenses).toHaveLength(1);
+  });
+
+  it('rejects duplicate person columns after trimming', () => {
+    const result = importSplitwiseCsv(
+      [
+        'Date,Description,Category,Cost,Currency,Asha, Asha ',
+        '2026-03-01,Dinner,Food and drink,300.00,INR,200.00,-100.00',
+      ].join('\n'),
+    );
+
+    expect(result.problems).toMatchObject([{ kind: ImportProblemKind.DuplicatePerson, row: 1 }]);
+    expect(result.expenses).toEqual([]);
+  });
+
+  it('rejects zero, negative, and malformed person amounts', () => {
+    const result = importSplitwiseCsv(
+      [
+        'Date,Description,Category,Cost,Currency,Asha,Bharath',
+        '2026-03-01,Zero,Food,0.00,INR,0.00,0.00',
+        '2026-03-02,Refund,Food,-300.00,INR,-200.00,100.00',
+        '2026-03-03,Broken,Food,300.00,INR,not-a-number,-100.00',
+      ].join('\n'),
+    );
+
+    expect(result.expenses).toEqual([]);
+    expect(result.problems.map((problem) => problem.kind)).toEqual([
+      ImportProblemKind.NonPositiveCost,
+      ImportProblemKind.NonPositiveCost,
+      ImportProblemKind.UnparseableRow,
+    ]);
+  });
+
+  it('parses non-INR currencies with their own minor-unit precision', () => {
+    const result = importSplitwiseCsv(
+      [
+        'Date,Description,Category,Cost,Currency,Asha,Bharath',
+        '2026-03-01,Sushi,Food,1234,JPY,617,-617',
+      ].join('\n'),
+    );
+
+    expect(result.problems).toEqual([]);
+    expect(result.currency).toBe('JPY');
+    expect(result.expenses).toMatchObject([
+      {
+        currency: 'JPY',
+        amount: 1234n,
+        payers: { Asha: 1234n },
+        shares: { Asha: 617n, Bharath: 617n },
+      },
+    ]);
+    expect(result.balances).toEqual({ Asha: 617n, Bharath: -617n });
   });
 });
 

--- a/packages/db/src/import/splitwise.ts
+++ b/packages/db/src/import/splitwise.ts
@@ -48,6 +48,8 @@ export enum SplitwiseProblemKind {
   UnparseableRow = 'unparseable_row',
   RowDoesNotBalance = 'row_does_not_balance',
   UnexpectedSettlement = 'unexpected_settlement',
+  DuplicatePerson = 'duplicate_person',
+  NonPositiveCost = 'non_positive_cost',
   NoPeople = 'no_people',
   NoRows = 'no_rows',
 }
@@ -109,6 +111,17 @@ export interface SplitwiseParse {
 
 /** Columns Splitwise writes before the per-person ones. */
 const FIXED_COLUMNS = ['date', 'description', 'category', 'cost', 'currency'];
+
+function normaliseHeaderName(name: string): string {
+  return name
+    .replace(/^\uFEFF/, '')
+    .trim()
+    .toLowerCase();
+}
+
+function normalisePersonName(name: string): string {
+  return name.replace(/^\uFEFF/, '').trim();
+}
 
 /** The trailing summary row Splitwise appends — not an expense. */
 const TOTAL_ROW = /^total\s+balance$/i;
@@ -199,16 +212,20 @@ export function parseSplitwiseCsv(csv: string): SplitwiseParse {
 
   const header = lines[0] ? parseCsvRow(lines[0]) : [];
   const fixedCount = FIXED_COLUMNS.filter((name) =>
-    header.some((column) => column.toLowerCase() === name),
+    header.some((column) => normaliseHeaderName(column) === name),
   ).length;
   // Keep the field index beside each name: a blank person column in the header
   // shifts the people list without shifting the field positions, so reading by
   // list index would attribute every net after the gap to the wrong person.
   const personColumns = header
     .slice(FIXED_COLUMNS.length)
-    .map((name, offset) => ({ name, column: FIXED_COLUMNS.length + offset }))
+    .map((name, offset) => ({
+      name: normalisePersonName(name),
+      column: FIXED_COLUMNS.length + offset,
+    }))
     .filter((entry) => entry.name !== '');
   const people = personColumns.map((entry) => entry.name);
+  const duplicatePeople = people.filter((person, index) => people.indexOf(person) !== index);
 
   if (fixedCount < FIXED_COLUMNS.length || people.length === 0) {
     errors.push({
@@ -216,6 +233,22 @@ export function parseSplitwiseCsv(csv: string): SplitwiseParse {
       row: 1,
       message:
         'This does not look like a Splitwise export — expected Date, Description, Category, Cost, Currency and then one column per person.',
+    });
+    return {
+      people: [],
+      expenses: [],
+      settlements: [],
+      errors,
+      currency: 'INR',
+      netByPerson: {},
+    };
+  }
+
+  if (duplicatePeople.length > 0) {
+    errors.push({
+      kind: SplitwiseProblemKind.DuplicatePerson,
+      row: 1,
+      message: `Splitwise export has duplicate person columns: ${[...new Set(duplicatePeople)].join(', ')}.`,
     });
     return {
       people: [],
@@ -260,12 +293,37 @@ export function parseSplitwiseCsv(csv: string): SplitwiseParse {
     }
     currency = rowCurrency;
 
+    if (amount <= 0n) {
+      errors.push({
+        kind: SplitwiseProblemKind.NonPositiveCost,
+        row: rowNumber,
+        message: `Row ${rowNumber} ("${description}"): Splitwise cost must be greater than zero.`,
+      });
+      continue;
+    }
+
     const nets = new Map<string, bigint>();
     let netTotal = 0n;
+    let malformedNet: string | null = null;
     for (const entry of personColumns) {
-      const value = parseCsvAmount(fields[entry.column] ?? '', rowCurrency) ?? 0n;
+      const raw = fields[entry.column] ?? '';
+      const parsed = parseCsvAmount(raw, rowCurrency);
+      if (parsed === null && raw.trim() !== '') {
+        malformedNet = entry.name;
+        break;
+      }
+      const value = parsed ?? 0n;
       nets.set(entry.name, value);
       netTotal += value;
+    }
+
+    if (malformedNet) {
+      errors.push({
+        kind: SplitwiseProblemKind.UnparseableRow,
+        row: rowNumber,
+        message: `Row ${rowNumber} ("${description}"): could not read ${malformedNet}'s amount.`,
+      });
+      continue;
     }
 
     // Every row in a correct export sums to zero across people. A row that does

--- a/packages/db/test/splitwise-parser.test.ts
+++ b/packages/db/test/splitwise-parser.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSplitwiseCsv, SplitwiseProblemKind } from '../src/import/splitwise.js';
+
+const newline = String.fromCharCode(10);
+
+describe('Splitwise parser hardening', () => {
+  it('accepts Splitwise headers with extra spaces, casing differences, and BOMs', () => {
+    const parsed = parseSplitwiseCsv(
+      [
+        '\uFEFF Date , Description , Category , Cost , Currency , Asha , Ravi ',
+        '2026-08-01,Dinner,Dining out,100.00,INR,50.00,-50.00',
+      ].join(newline),
+    );
+
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.people).toEqual(['Asha', 'Ravi']);
+    expect(parsed.expenses).toHaveLength(1);
+  });
+
+  it('rejects duplicate person columns after trimming', () => {
+    const parsed = parseSplitwiseCsv(
+      [
+        'Date,Description,Category,Cost,Currency,Asha, Asha ',
+        '2026-08-01,Dinner,Dining out,100.00,INR,50.00,-50.00',
+      ].join(newline),
+    );
+
+    expect(parsed.errors).toMatchObject([{ kind: SplitwiseProblemKind.DuplicatePerson, row: 1 }]);
+    expect(parsed.expenses).toEqual([]);
+    expect(parsed.settlements).toEqual([]);
+  });
+
+  it('reports zero and negative costs instead of importing nonsensical rows', () => {
+    const parsed = parseSplitwiseCsv(
+      [
+        'Date,Description,Category,Cost,Currency,Asha,Ravi',
+        '2026-08-01,Zero,Dining out,0.00,INR,0.00,0.00',
+        '2026-08-02,Refund,Dining out,-100.00,INR,-50.00,50.00',
+      ].join(newline),
+    );
+
+    expect(parsed.expenses).toEqual([]);
+    expect(parsed.errors.map((error) => error.kind)).toEqual([
+      SplitwiseProblemKind.NonPositiveCost,
+      SplitwiseProblemKind.NonPositiveCost,
+    ]);
+  });
+
+  it('rejects malformed person amounts instead of silently treating them as zero', () => {
+    const parsed = parseSplitwiseCsv(
+      [
+        'Date,Description,Category,Cost,Currency,Asha,Ravi',
+        '2026-08-01,Dinner,Dining out,100.00,INR,not-a-number,-50.00',
+      ].join(newline),
+    );
+
+    expect(parsed.expenses).toEqual([]);
+    expect(parsed.errors).toMatchObject([{ kind: SplitwiseProblemKind.UnparseableRow, row: 2 }]);
+  });
+
+  it('parses non-INR currencies with their own minor-unit precision', () => {
+    const parsed = parseSplitwiseCsv(
+      [
+        'Date,Description,Category,Cost,Currency,Asha,Ravi',
+        '2026-08-01,Sushi,Dining out,1234,JPY,617,-617',
+      ].join(newline),
+    );
+
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.currency).toBe('JPY');
+    expect(parsed.expenses).toMatchObject([
+      {
+        currency: 'JPY',
+        amount: 1234n,
+        payers: { Asha: 1234n },
+        shares: { Asha: 617n, Ravi: 617n },
+      },
+    ]);
+    expect(parsed.netByPerson).toEqual({ Asha: 617n, Ravi: -617n });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize Splitwise headers/person names, including BOMs and extra whitespace
- reject duplicate person columns, non-positive row costs, and malformed non-blank person amounts
- mirror the hardening in both core/mobile parser and db importer
- add non-INR currency regression coverage

## Validation
- pnpm --filter @waves/core test -- splitwise.test.ts
- pnpm --dir packages/db exec vitest run test/splitwise-parser.test.ts
- pnpm --filter @waves/core typecheck
- pnpm --filter @waves/db typecheck

## Note
- Existing db integration test `pnpm --filter @waves/db test -- import-splitwise.test.ts` could not run locally because Postgres on 127.0.0.1:54330 / ::1:54330 is not running in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Splitwise import handling for BOMs, extra whitespace, and inconsistent casing.
  * Detects duplicate person columns and reports clear import errors.
  * Rejects expenses with zero or negative costs.
  * Reports malformed person amounts at the affected row instead of treating them as zero.
  * Correctly handles currency-specific minor units, including currencies such as JPY.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->