### PR TITLE
perf(mobile): instant tab switches + no hero balance layout shift

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -17,10 +17,20 @@ export default function TabsLayout() {
         // scene, and on a busy tab that dropped frames and read as slow — an
         // instant switch is the fastest a tab can feel.
         animation: 'none',
+        // Mount every tab up front instead of building it the first time it is
+        // focused. Lazy tabs (the default) construct the whole screen tree on
+        // first tap — the few-hundred-ms lag before the destination paints, the
+        // thing that reads as sluggish next to WhatsApp. WhatsApp keeps all of
+        // its tabs mounted, so a tap is a pure visibility swap; this does the
+        // same. The cost is a little more work at cold start, paid once behind
+        // the splash, and `freezeOnBlur` keeps the pre-mounted tabs idle so they
+        // do not burn the JS thread while off-screen.
+        lazy: false,
         // Suspend an off-screen tab's rendering while it is blurred, so its
         // queries and realtime subscriptions stop competing for the JS thread
-        // with the foreground tab's paint. It re-renders from cache on return,
-        // which is instant.
+        // with the foreground tab's paint. Combined with `lazy: false` this is
+        // the WhatsApp shape: mounted once, frozen while away, unfrozen on
+        // return — which is instant, no rebuild.
         freezeOnBlur: true,
       }}
     >

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1428,32 +1428,50 @@ function HeroDots({
 }
 
 /**
- * The balance area while it loads — two translucent-white bars on the green, a
- * label bar over a taller figure bar, sized to the same block the real balance
- * fills so the swap in is a settle, not a jump. Plain `Skeleton` is themed for
- * light surfaces and would vanish on the green, so these are hand-drawn washes.
+ * The balance area while it loads — translucent-white bars on the green that
+ * stand in for a `MetricSlide`: a label bar, the big figure, and the sub line.
+ *
+ * The whole point is that the swap-in is a settle, not a jump, so the skeleton
+ * is built to the *exact* height a loaded slide fills. Each bar rides inside a
+ * wrapper sized to the real line's height — the label and sub to the caption's
+ * 18px line, the figure to the money's 46px line — so the block is 92px tall
+ * either way and the number lands in place instead of shoving the Add-expense
+ * button and the group list down (the layout shift the user flagged). A gentle
+ * pulse reads as "loading" rather than a dead placeholder. Plain `Skeleton` is
+ * themed for light surfaces and would vanish on the green, so these are
+ * hand-drawn washes.
  */
 function HeroBalanceSkeleton() {
   const theme = useTheme();
+  // A slow breathe so the bars read as loading. Lazy-init state, never through a
+  // ref in render (the React Compiler lints that), native-driven opacity.
+  const [pulse] = useState(() => new Animated.Value(0.5));
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, { toValue: 1, duration: 650, useNativeDriver: true }),
+        Animated.timing(pulse, { toValue: 0.5, duration: 650, useNativeDriver: true }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [pulse]);
+  const bar = (width: number, height: number) => (
+    <View
+      style={{ width, height, borderRadius: height / 2, backgroundColor: 'rgba(255,255,255,0.28)' }}
+    />
+  );
   return (
-    <View style={{ gap: theme.spacing.sm }}>
-      <View
-        style={{
-          width: 120,
-          height: 14,
-          borderRadius: 7,
-          backgroundColor: 'rgba(255, 255, 255, 0.25)',
-        }}
-      />
-      <View
-        style={{
-          width: 200,
-          height: 40,
-          borderRadius: 10,
-          backgroundColor: 'rgba(255, 255, 255, 0.25)',
-        }}
-      />
-    </View>
+    <Animated.View style={{ gap: theme.spacing.sm, opacity: pulse }}>
+      {/* Label line — the caption+eye row rides an 18px line height. */}
+      <View style={{ height: 18, justifyContent: 'center' }}>{bar(120, 12)}</View>
+      <View style={{ gap: 2 }}>
+        {/* The figure — the money sits on a 46px line (fontSize 40). */}
+        <View style={{ height: 46, justifyContent: 'center' }}>{bar(200, 34)}</View>
+        {/* The sub caption — another 18px line. */}
+        <View style={{ height: 18, justifyContent: 'center' }}>{bar(90, 12)}</View>
+      </View>
+    </Animated.View>
   );
 }
 


### PR DESCRIPTION
### What & why
On arriving at the dashboard the app felt janky in two ways (screen recording from the reporter). Both fixed here.

**1. Tab switches lagged (WhatsApp-instant ask)**
The `(tabs)` navigator mounted screens lazily — the react-navigation default — so the first tap on a tab built the whole screen tree before painting: the few-hundred-ms lag the user compared unfavourably to WhatsApp. WhatsApp keeps all tabs mounted and a tap is a pure visibility swap.

- `lazy: false` → all four tabs (home/friends/activity/profile) mount once, behind the splash.
- `freezeOnBlur: true` (already on) keeps the pre-mounted tabs idle while off-screen, so a switch is an instant *unfreeze*, no rebuild.

Note: the **Inbox** item is a stacked route (`/inbox`), not a tab screen, so it is still pushed fresh — out of scope here.

**2. Hero balance layout shift**
The loading skeleton was 62px tall; a loaded `MetricSlide` is 92px (eye row + taller 40/46 figure + the "you are owed overall" sub-line). When the number landed the hero grew ~30px and pushed Add-expense and the group list down.

- Rebuilt `HeroBalanceSkeleton` to the exact 92px, one bar per line, each inside a wrapper matching the real line height (18 / 46 / 18), so the number settles in place instead of jumping.
- Added a gentle native-driven pulse so it reads as loading, not a dead placeholder.

### Testing
- `tsc --noEmit`, `pnpm lint`, `pnpm format` — all green (Windows node).
- Manual: verify tab switches paint instantly and the hero number no longer nudges the list on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Tab screens now load immediately when opening the tab area, providing smoother navigation between tabs.

- **User Experience**
  - Improved balance loading placeholders now better match the final balance layout.
  - Added animated loading feedback while balance information is being retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->