### PR TITLE
perf(mobile): make the inbox a tab so inbox→activity is instant

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -39,6 +39,11 @@ export default function TabsLayout() {
       <Tabs.Screen name="index" />
       <Tabs.Screen name="friends" />
       <Tabs.Screen name="activity" />
+      {/* The inbox is a bar destination like the three above it, so it lives in
+          the tab navigator too — a tap from Activity is then an instant tab swap,
+          not a stack push that re-reveals (and thaws) the whole tab tree. It is
+          not shown in the hidden native bar; the root `AppTabBar` draws it. */}
+      <Tabs.Screen name="inbox" />
       <Tabs.Screen name="profile" />
     </Tabs>
   );

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -256,7 +256,7 @@ export default function ActivityScreen() {
           {/* The feed is what happened in the groups; the inbox is what Baaki
               said to you. Related enough to sit together, different enough not
               to be interleaved. */}
-          <IconButton label={t.tabs.inbox} onPress={() => router.push('/inbox' as never)}>
+          <IconButton label={t.tabs.inbox} onPress={() => router.navigate('/inbox')}>
             <Ionicons name="notifications-outline" size={iconSize.lg} color={theme.color.text} />
             {unread > 0 ? (
               <View

--- a/apps/mobile/src/app/(tabs)/inbox.tsx
+++ b/apps/mobile/src/app/(tabs)/inbox.tsx
@@ -12,9 +12,9 @@
  * stored English as the fallback for a kind this build has never heard of.
  */
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { router } from 'expo-router';
+import { router, useFocusEffect } from 'expo-router';
 import { Pressable, RefreshControl, ScrollView, SectionList, View } from 'react-native';
 
 import { renderNotification } from '@waves/core';
@@ -81,18 +81,26 @@ export default function InboxScreen() {
   const captureCount = useCaptures().data?.length ?? 0;
 
   const rows = notifications.data ?? EMPTY_NOTIFICATIONS;
-  const unread = rows.filter((row) => row.read_at === null);
   const sections = useMemo(() => groupNotificationsByDay(rows), [rows]);
 
-  // Opening the inbox is reading it. Leaving a badge up after somebody has
-  // looked is how a badge stops meaning anything.
+  // The latest rows, held in a ref so the focus effect below reads a snapshot
+  // without taking `rows` as a dependency (which would re-fire it on every
+  // background refetch and fight the user's scroll). The ref is updated in an
+  // effect, never during render — the React Compiler forbids ref writes there.
+  const rowsRef = useRef(rows);
   useEffect(() => {
-    if (unread.length === 0) return;
-    markRead.mutate(unread.map((row) => row.id));
-    // Only on the ids present when the screen opened; re-running as the list
-    // refetches would fight the user's scroll.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [notifications.isSuccess]);
+    rowsRef.current = rows;
+  }, [rows]);
+
+  // Opening the inbox is reading it. Leaving a badge up after somebody has
+  // looked is how a badge stops meaning anything. Gated on *focus*, not mount:
+  // the inbox is a pre-mounted tab now (lazy: false mounts every tab at launch),
+  // so marking read on mount would clear the badge before anybody looked at it.
+  // The unread snapshot is taken at the moment of focus.
+  useFocusEffect(() => {
+    const ids = rowsRef.current.filter((row) => row.read_at === null).map((row) => row.id);
+    if (ids.length > 0) markRead.mutate(ids);
+  });
 
   const header = (
     <View style={{ gap: theme.spacing.xl }}>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -634,12 +634,10 @@ function AuthGate() {
           <Stack.Screen name="settings/delete-account" />
           <Stack.Screen name="dev/local-privacy" />
           <Stack.Screen name="join" />
-          {/* A primary tab-bar destination sitting beside Home/Friends/Activity,
-              so it switches instantly like they do rather than sliding in like a
-              pushed page. Without this it inherits the stack's slide, and the
-              inbox was the one bar destination that animated while the tabs cut
-              straight across — the inconsistency this `none` removes. */}
-          <Stack.Screen name="inbox" options={{ animation: 'none' }} />
+          {/* The inbox is a tab-navigator destination now (see `(tabs)/inbox`),
+              so it is no longer a screen on this root stack — a tap on it from
+              anywhere is an instant tab swap rather than a push that re-reveals
+              and thaws the whole tab tree. */}
           <Stack.Screen name="voice" options={slide} />
         </Stack>
         {/* One bar over the whole stack, so every screen keeps it — it hides


### PR DESCRIPTION
### What & why
Reported: **inbox → activity** navigation lags, while **home → friends** is instant.

Cause: the inbox was a **stack route pushed on top of the whole `(tabs)` navigator**. Leaving it for a tab isn't a tab swap — it pops the inbox card and re-reveals `(tabs)`, which the native stack **freezes while it's covered**, so the return has to *thaw the entire tab tree*. Tab→tab (home→friends) never covers/freezes anything, so it stayed instant.

### Fix
Make the inbox a real tab, so every bar destination is a sibling and switching between any two is an instant visibility swap. The inbox never covers — and never freezes — the other tabs.

- `app/inbox.tsx` → `app/(tabs)/inbox.tsx` (route stays `/inbox`).
- Registered as a `Tabs.Screen`; removed its root `Stack.Screen`.
- Activity's inbox bell now `navigate`s (tab swap) instead of `push`ing.
- **Mark-read gated on focus, not mount.** `lazy: false` (from #510) pre-mounts every tab at launch, so marking on mount would clear the badge before anybody looked. Unread ids are snapshotted at focus via a ref, so a later refetch doesn't re-fire it or fight the scroll.

`resolveTabBar` needs no change — `/inbox` under `(tabs)` resolves to `activeKey: 'inbox'` through the existing `(tabs)` branch (legacy `['inbox']` branch stays, still test-covered).

### Behaviour notes
- From a pushed screen (a group), tapping inbox pops to tabs and selects the inbox tab — same as tapping Home/Friends/Activity already does.
- Android hardware-back on the inbox tab now follows tab semantics (→ Home) instead of popping a card. Consistent with the other tabs.

### Testing
- `tsc --noEmit`, `pnpm lint`, `pnpm format` — green (Windows node).
- `vitest test/tabBar.test.ts` — 9/9.
- Manual (owed): confirm inbox↔activity is now instant, the inbox badge only clears when the tab is actually opened, and the bar highlights Inbox on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Inbox as a tab destination for smoother navigation.
  * Inbox notifications are marked as read when the Inbox tab is opened.
* **Bug Fixes**
  * Updated activity navigation so Inbox opens by switching tabs instead of adding a new screen to the navigation stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->