### PR TITLE
perf(mobile): instant nav off the drafts screen (no slide-out)

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -599,7 +599,12 @@ function AuthGate() {
           <Stack.Screen name="clone-group" options={slide} />
           {paywallEnabled ? <Stack.Screen name="paywall" options={slide} /> : null}
           <Stack.Screen name="capture" options={slide} />
-          <Stack.Screen name="captures" />
+          {/* The drafts screen keeps the bottom bar, so a person leaves it by
+              tapping a tab — which should cut straight across the way a tab does,
+              not slide the draft card out first. `none` makes leaving it (and
+              arriving on it) instant, the same treatment the inbox destination
+              had before it became a tab. */}
+          <Stack.Screen name="captures" options={{ animation: 'none' }} />
           <Stack.Screen name="groups" options={slide} />
           <Stack.Screen name="group/[id]/index" options={slide} />
           <Stack.Screen name="group/[id]/add-expense" options={slide} />


### PR DESCRIPTION
### What & why
Leaving the **drafts (captures)** screen by tapping a bottom-bar tab felt slow / "not native." The drafts screen keeps the bar (you leave it by tapping a tab), but it was a plain pushed stack screen with the **default slide** — so a tab tap first slid the draft card out (~300ms) before the destination tab appeared.

### Fix
`animation: 'none'` on the `captures` stack screen, so leaving it (and arriving on it) **cuts straight across** like a tab does — the exact treatment the inbox destination had before it became a tab (#513).

The screen itself is already virtualized (FlashList, #505), so there's no heavy render involved — this was purely the transition animation.

### Testing
- `tsc --noEmit`, `pnpm lint` — green (Windows node).
- Manual (owed): from the drafts screen, tapping Home/Friends/Activity/Inbox now cuts instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Captures screen transition to be immediate, removing navigation animations when entering or leaving the route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->