### PR TITLE
perf(mobile): reduce tab bar navigation work

### DIFF
--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -13,14 +13,15 @@
  * it is not one of the bar's destinations.
  */
 
+import { useCallback, useMemo } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, useGlobalSearchParams, useSegments } from 'expo-router';
 
-import { iconSize, PillTabBar, type PillTabItem } from '@waves/ui';
+import { iconSize, PillTabBar, type PillTabAction, type PillTabItem } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
-import { resolveTabBar } from '@/lib/tabBar';
+import { resolveTabBar, tabBarRouteForSelection } from '@/lib/tabBar';
 
 /** Renders the persistent bottom navigation bar and routes tab selections without stacking duplicates. */
 export function AppTabBar() {
@@ -40,59 +41,58 @@ export function AppTabBar() {
   // No session means no bar anywhere — the privacy page opened from the login
   // legal line is the one place it used to leak onto a signed-out screen.
   const { hidden, activeKey } = resolveTabBar(segments, !session);
-  if (hidden) return null;
 
-  const items: PillTabItem[] = [
-    {
-      key: 'index',
-      label: t.home,
-      icon: (color) => <Ionicons name="home" size={iconSize.lg} color={color} />,
-    },
-    {
-      key: 'friends',
-      label: t.friends,
-      icon: (color) => <Ionicons name="people" size={iconSize.lg} color={color} />,
-    },
-    {
-      key: 'activity',
-      label: t.activity,
-      icon: (color) => <Ionicons name="pulse" size={iconSize.lg} color={color} />,
-    },
-    {
-      key: 'inbox',
-      label: t.tabs.inbox,
-      icon: (color) => <Ionicons name="file-tray-outline" size={iconSize.lg} color={color} />,
-    },
-  ];
+  const items = useMemo<PillTabItem[]>(
+    () => [
+      {
+        key: 'index',
+        label: t.home,
+        icon: (color) => <Ionicons name="home" size={iconSize.lg} color={color} />,
+      },
+      {
+        key: 'friends',
+        label: t.friends,
+        icon: (color) => <Ionicons name="people" size={iconSize.lg} color={color} />,
+      },
+      {
+        key: 'activity',
+        label: t.activity,
+        icon: (color) => <Ionicons name="pulse" size={iconSize.lg} color={color} />,
+      },
+      {
+        key: 'inbox',
+        label: t.tabs.inbox,
+        icon: (color) => <Ionicons name="file-tray-outline" size={iconSize.lg} color={color} />,
+      },
+    ],
+    [t.activity, t.friends, t.home, t.tabs.inbox],
+  );
 
-  // The inbox is a stacked route, so it is pushed; the tabs are navigated to,
-  // which switches the tab rather than stacking a second copy. Home is the
-  // group's default route, reached at '/'.
-  const go = (key: string): void => {
-    switch (key) {
-      case 'inbox':
-        router.navigate('/inbox');
-        break;
-      case 'friends':
-        router.navigate('/friends');
-        break;
-      case 'activity':
-        router.navigate('/activity');
-        break;
-      default:
-        router.navigate('/');
-    }
-  };
+  // All bar destinations are tabs now. `navigate` switches to the existing tab
+  // route instead of stacking a second copy; tapping the active tab is a no-op
+  // so repeated taps do not schedule redundant router work.
+  const go = useCallback(
+    (key: string): void => {
+      const route = tabBarRouteForSelection(activeKey, key);
+      if (route) router.navigate(route);
+    },
+    [activeKey],
+  );
 
   // The raised mic: speak an expense from anywhere the bar is showing. The
   // button is a black circle, so the mic wears the on-brand (white) colour the
   // bar hands it.
-  const voice = {
-    accessibilityLabel: t.voice.speakExpense,
-    onPress: () =>
-      router.push(groupId ? { pathname: '/voice', params: { group: groupId } } : '/voice'),
-    icon: (color: string) => <Ionicons name="mic" size={iconSize.lg} color={color} />,
-  };
+  const voice = useMemo<PillTabAction>(
+    () => ({
+      accessibilityLabel: t.voice.speakExpense,
+      onPress: () =>
+        router.push(groupId ? { pathname: '/voice', params: { group: groupId } } : '/voice'),
+      icon: (color: string) => <Ionicons name="mic" size={iconSize.lg} color={color} />,
+    }),
+    [groupId, t.voice.speakExpense],
+  );
+
+  if (hidden) return null;
 
   return (
     <PillTabBar items={items} activeKey={activeKey} onSelect={go} animated centerAction={voice} />

--- a/apps/mobile/src/lib/tabBar.ts
+++ b/apps/mobile/src/lib/tabBar.ts
@@ -43,6 +43,31 @@ export interface TabBarState {
   readonly activeKey: string;
 }
 
+export type TabBarRoute = '/' | '/friends' | '/activity' | '/inbox';
+
+/**
+ * The route a bottom-bar tap should navigate to, or null when the destination is
+ * already current. The null is intentional: a repeated tap on the highlighted
+ * tab should not schedule router work or rebuild the same scene.
+ */
+export function tabBarRouteForSelection(
+  activeKey: string,
+  selectedKey: string,
+): TabBarRoute | null {
+  if (selectedKey === activeKey) return null;
+
+  switch (selectedKey) {
+    case 'inbox':
+      return '/inbox';
+    case 'friends':
+      return '/friends';
+    case 'activity':
+      return '/activity';
+    default:
+      return '/';
+  }
+}
+
 /**
  * Resolve the bar's state from the current route segments.
  *

--- a/apps/mobile/test/tabBar.test.ts
+++ b/apps/mobile/test/tabBar.test.ts
@@ -1,19 +1,36 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveTabBar } from '../src/lib/tabBar';
+import { resolveTabBar, tabBarRouteForSelection } from '../src/lib/tabBar';
+
+describe('tabBarRouteForSelection', () => {
+  it('does not navigate when the selected tab is already active', () => {
+    expect(tabBarRouteForSelection('index', 'index')).toBeNull();
+    expect(tabBarRouteForSelection('friends', 'friends')).toBeNull();
+    expect(tabBarRouteForSelection('activity', 'activity')).toBeNull();
+    expect(tabBarRouteForSelection('inbox', 'inbox')).toBeNull();
+  });
+
+  it('maps inactive tab selections to their routes', () => {
+    expect(tabBarRouteForSelection('friends', 'index')).toBe('/');
+    expect(tabBarRouteForSelection('index', 'friends')).toBe('/friends');
+    expect(tabBarRouteForSelection('index', 'activity')).toBe('/activity');
+    expect(tabBarRouteForSelection('index', 'inbox')).toBe('/inbox');
+  });
+});
 
 describe('resolveTabBar', () => {
   it('lights the current tab inside the tabs group', () => {
     expect(resolveTabBar(['(tabs)', 'index'])).toEqual({ hidden: false, activeKey: 'index' });
     expect(resolveTabBar(['(tabs)', 'friends'])).toEqual({ hidden: false, activeKey: 'friends' });
     expect(resolveTabBar(['(tabs)', 'activity'])).toEqual({ hidden: false, activeKey: 'activity' });
+    expect(resolveTabBar(['(tabs)', 'inbox'])).toEqual({ hidden: false, activeKey: 'inbox' });
   });
 
   it('defaults to home when the tabs group has no leaf yet', () => {
     expect(resolveTabBar(['(tabs)'])).toEqual({ hidden: false, activeKey: 'index' });
   });
 
-  it('lights the inbox on its pushed route', () => {
+  it('keeps compatibility for the old pushed inbox route', () => {
     expect(resolveTabBar(['inbox'])).toEqual({ hidden: false, activeKey: 'inbox' });
   });
 

--- a/packages/ui/src/components/PillTabBar.tsx
+++ b/packages/ui/src/components/PillTabBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactNode } from 'react';
+import { memo, useRef, type ReactNode } from 'react';
 import { Animated, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -134,7 +134,7 @@ export function PillTabBar({
 }
 
 /** The raised round action in the middle of the bar. */
-function CenterButton({ action }: { action: PillTabAction }) {
+const CenterButton = memo(function CenterButton({ action }: { action: PillTabAction }) {
   const theme = useTheme();
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
@@ -164,9 +164,9 @@ function CenterButton({ action }: { action: PillTabAction }) {
       </Pressable>
     </View>
   );
-}
+});
 
-function TabItem({
+const TabItem = memo(function TabItem({
   item,
   focused,
   animated,
@@ -202,7 +202,9 @@ function TabItem({
       accessibilityRole="tab"
       accessibilityState={{ selected: focused }}
       accessibilityLabel={item.label}
-      onPress={() => onSelect(item.key)}
+      onPress={() => {
+        if (!focused) onSelect(item.key);
+      }}
       onPressIn={() => press(0.9)}
       onPressOut={() => press(1)}
       style={{ flex: 1 }}
@@ -241,4 +243,4 @@ function TabItem({
       </Animated.View>
     </Pressable>
   );
-}
+});


### PR DESCRIPTION
## Summary
- skip redundant bottom-tab navigation when tapping the active tab
- memoize AppTabBar tab items, handlers, and center action
- memoize PillTabBar leaf components and avoid active-tab onSelect work
- add pure tab-route mapping coverage plus inbox tab resolver coverage

## Validation
- pnpm --filter @waves/mobile test -- tabBar.test.ts
- pnpm --filter @waves/ui typecheck
- pnpm --filter @waves/mobile typecheck
- pnpm --filter @waves/mobile lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab navigation so selecting the currently active tab does not trigger unnecessary navigation.
  * Added the Inbox tab to the tab bar while preserving existing Inbox navigation behavior.

* **Performance**
  * Reduced unnecessary tab bar updates and repeated selection handling for smoother interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->