### PR TITLE
fix(mobile): honor named voice splits

### DIFF
--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -62,7 +62,7 @@ import {
   useWriteExpense,
   type DestinationUsage,
 } from '@/data/hooks';
-import { groupLabel, GroupType, type GroupRow } from '@/data/types';
+import { displayName, groupLabel, GroupType, type GroupRow } from '@/data/types';
 import { plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useDefaultCurrency } from '@/lib/currency';
@@ -71,7 +71,12 @@ import { friendlyError } from '@/lib/errors';
 import { VoiceMicPanel } from '@/components/VoiceMicPanel';
 import { LocationField } from '@/components/LocationField';
 import { captureLocation, locationAvailable } from '@/lib/location';
-import { parseVoiceExpenses, type VoiceGroupRef, type VoiceParseResult } from '@/lib/voiceExpense';
+import {
+  parseVoiceExpenses,
+  resolveVoiceParticipants,
+  type VoiceGroupRef,
+  type VoiceParseResult,
+} from '@/lib/voiceExpense';
 import { interpretVoiceExpenses } from '@/lib/voiceLlm';
 import { logVoiceAttempt } from '@/lib/voiceLog';
 
@@ -188,6 +193,8 @@ export default function VoiceScreen() {
   // capture, "add more", or a single row's re-dictation), read when it returns.
   const [micMode, setMicMode] = useState<MicMode>('replace');
   const [drafts, setDrafts] = useState<Draft[]>([]);
+  const [voicePeopleText, setVoicePeopleText] = useState<string | null>(null);
+  const [voiceSplitCount, setVoiceSplitCount] = useState<number | null>(null);
   // One place for the whole spoken batch — a run of "coffee, then the taxi" all
   // happened where you are standing (A43). Optional and opt-in; null until the
   // reader taps "Add location" on the review.
@@ -331,6 +338,8 @@ export default function VoiceScreen() {
         currency: item.currency,
       })),
     );
+    setVoicePeopleText(result.peopleText);
+    setVoiceSplitCount(result.splitCount);
     // A fresh parse is a fresh group to create, and a fresh location to read.
     groupCreated.current = false;
     ghostMemberId.current = null;
@@ -427,6 +436,8 @@ export default function VoiceScreen() {
       return;
     }
     setDrafts((current) => [...current, ...toDrafts(result)]);
+    if (result.peopleText) setVoicePeopleText(result.peopleText);
+    if (result.splitCount !== null) setVoiceSplitCount(result.splitCount);
     setNoAmount(false);
     setMicMode('replace');
     setPhase('review');
@@ -676,19 +687,30 @@ export default function VoiceScreen() {
 
       const groupCurrency =
         dest.kind === 'existing' ? (target.group.data?.default_currency ?? dc) : dc;
+      const groupMembers = target.members.data ?? [];
+      const payer =
+        dest.kind === 'existing'
+          ? (groupMembers.find((member) => member.profile_id === profile?.id)?.id ??
+            groupMembers[0]?.id)
+          : dest.memberId;
+      if (!payer) throw new Error('no members to split among');
       const participants =
         dest.kind === 'existing'
-          ? (target.members.data ?? []).map((member) => member.id)
+          ? resolveVoiceParticipants({
+              all: groupMembers.map((member) => member.id),
+              payer,
+              members: groupMembers.map((member) => ({
+                id: member.id,
+                name: displayName(member, profile?.id),
+              })),
+              peopleText: voicePeopleText,
+              splitCount: voiceSplitCount,
+            })
           : dest.kind === 'person'
             ? [dest.memberId, ghostMemberId.current!]
             : [dest.memberId];
-      const payer =
-        dest.kind === 'existing'
-          ? ((target.members.data ?? []).find((member) => member.profile_id === profile?.id)?.id ??
-            participants[0])
-          : dest.memberId;
 
-      if (participants.length === 0 || !payer) throw new Error('no members to split among');
+      if (participants.length === 0) throw new Error('no members to split among');
 
       for (const draft of drafts) {
         const amount = toMinor(draft.amount, groupCurrency);

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -26,8 +26,10 @@ export const MAX_VOICE_NOTE_CHARS = 160;
 const UNSUPPORTED_EXPENSE_INTENT =
   /\b(?:do\s+not|don['’]t|dont|did\s+not\s+pay|didn['’]t\s+pay|didnt\s+pay|not\s+paid|cancel|remove|delete|ignore|refund(?:ed|s|ing)?|reimburse(?:d|ment|ments|s|ing)?|repay(?:ment|ments|s|ing)?|repaid|pay\s*back|paid\s+(?:me\s+)?back|got\s+(?:paid\s+)?back|received\s+(?:money\s+)?back|not\s+an\s+expense)\b/i;
 
+const SPOKEN_NEGATIVE_AMOUNT = /\b(?:minus|negative)\s+(?=\S)/i;
+
 export function isUnsupportedVoiceExpenseIntent(text: string): boolean {
-  return UNSUPPORTED_EXPENSE_INTENT.test(text);
+  return UNSUPPORTED_EXPENSE_INTENT.test(text) || SPOKEN_NEGATIVE_AMOUNT.test(text);
 }
 
 export function isSafeVoiceAmount(amountMajor: number): boolean {
@@ -480,6 +482,7 @@ function buildNote(transcript: string, matchedGroupName: string | null): string 
   const currencyWord = new RegExp(`\\b(?:${CURRENCY_WORD_ALT})\\b`, 'gi');
 
   return transcript
+    .replace(/\bsplit\s+(?:it\s+)?(?:with|between|among|amongst)\b.*$/iu, ' ')
     .replace(currencyWord, ' ')
     .replace(new RegExp(CURRENCY_SYMBOL_RE, 'g'), ' ')
     .replace(/\d[\d,]*(?:\.\d+)?/g, ' ')
@@ -527,7 +530,7 @@ export function parseVoiceExpense(
   transcript: string,
   groups: readonly VoiceGroupRef[],
 ): ParsedVoiceExpense {
-  if (UNSUPPORTED_EXPENSE_INTENT.test(transcript)) {
+  if (isUnsupportedVoiceExpenseIntent(transcript)) {
     return {
       amountMinor: null,
       amountMajor: null,
@@ -614,6 +617,20 @@ export function stripMemberNames(
     .trim();
 }
 
+export function resolveVoiceParticipants(params: {
+  all: readonly string[];
+  payer: string;
+  members: readonly { id: string; name: string }[];
+  peopleText: string | null;
+  splitCount: number | null;
+}): string[] {
+  const named = params.peopleText ? matchMemberNames(params.peopleText, params.members) : [];
+  if (named.length === 0) return [...params.all];
+  const chosen = named.includes(params.payer) ? [...named] : [...named, params.payer];
+  if (params.splitCount !== null && params.splitCount !== chosen.length) return [...params.all];
+  return chosen;
+}
+
 /* ─────────────────────────────────────────────────────────────────────────
  * Several expenses in one breath, an optional "make a group", and a nudge
  * toward other languages.
@@ -649,6 +666,8 @@ export interface VoiceParseResult {
   group: VoiceGroupTarget;
   /** A split count, when one was heard — carried through for the group case. */
   splitCount: number | null;
+  /** The cleaned transcript fragment that may name split participants. */
+  peopleText: string | null;
 }
 
 /**
@@ -1216,8 +1235,8 @@ export function parseVoiceExpenses(
   transcript: string,
   groups: readonly VoiceGroupRef[],
 ): VoiceParseResult {
-  if (UNSUPPORTED_EXPENSE_INTENT.test(transcript))
-    return { items: [], group: null, splitCount: null };
+  if (isUnsupportedVoiceExpenseIntent(transcript))
+    return { items: [], group: null, splitCount: null, peopleText: null };
 
   const normalized = normalizeSpokenNumbers(
     collapseAdditionRuns(normalizeCurrencyPrefixes(normalizeDigits(transcript))),
@@ -1273,5 +1292,5 @@ export function parseVoiceExpenses(
     }
   }
 
-  return { items, group, splitCount: extractSplitCount(body) };
+  return { items, group, splitCount: extractSplitCount(body), peopleText: body.trim() || null };
 }

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -26,7 +26,8 @@ export const MAX_VOICE_NOTE_CHARS = 160;
 const UNSUPPORTED_EXPENSE_INTENT =
   /\b(?:do\s+not|don['’]t|dont|did\s+not\s+pay|didn['’]t\s+pay|didnt\s+pay|not\s+paid|cancel|remove|delete|ignore|refund(?:ed|s|ing)?|reimburse(?:d|ment|ments|s|ing)?|repay(?:ment|ments|s|ing)?|repaid|pay\s*back|paid\s+(?:me\s+)?back|got\s+(?:paid\s+)?back|received\s+(?:money\s+)?back|not\s+an\s+expense)\b/i;
 
-const SPOKEN_NEGATIVE_AMOUNT = /\b(?:minus|negative)\s+(?=\S)/i;
+const SPOKEN_NEGATIVE_AMOUNT =
+  /\b(?:minus|negative)\s+(?=(?:\d|zero\b|one\b|two\b|three\b|four\b|five\b|six\b|seven\b|eight\b|nine\b|ten\b|eleven\b|twelve\b|thirteen\b|fourteen\b|fifteen\b|sixteen\b|seventeen\b|eighteen\b|nineteen\b|twenty\b|thirty\b|forty\b|fourty\b|fifty\b|sixty\b|seventy\b|eighty\b|ninety\b|hundred\b|thousand\b|lakh\b|lakhs\b|crore\b|crores\b))/i;
 
 export function isUnsupportedVoiceExpenseIntent(text: string): boolean {
   return UNSUPPORTED_EXPENSE_INTENT.test(text) || SPOKEN_NEGATIVE_AMOUNT.test(text);
@@ -477,12 +478,24 @@ function matchGroup(tokens: readonly string[], groups: readonly VoiceGroupRef[])
  * description someone would have typed. Numbers, currency words, the stopwords,
  * and any word from the matched group's name are all dropped.
  */
+const SPLIT_COUNT_WORD_AFTER_PREPOSITION =
+  '(?:\\d|zero\\b|one\\b|two\\b|three\\b|four\\b|five\\b|six\\b|seven\\b|eight\\b|nine\\b|ten\\b|eleven\\b|twelve\\b|people\\b|persons\\b|ways\\b)';
+const SPLIT_WITH_CLAUSE = new RegExp(
+  `\\bsplit\\b(?:(?!\\bwith\\b|\\bbetween\\b|\\bamong\\b|\\bamongst\\b).)*` +
+    `\\b(?:with|between|among|amongst)\\b\\s+(?!${SPLIT_COUNT_WORD_AFTER_PREPOSITION})(.*)$`,
+  'iu',
+);
+
+function splitParticipantClause(text: string | null): string | null {
+  return text?.match(SPLIT_WITH_CLAUSE)?.[1]?.trim() || null;
+}
+
 function buildNote(transcript: string, matchedGroupName: string | null): string {
   const nameTokens = new Set(matchedGroupName ? tokenize(matchedGroupName) : []);
   const currencyWord = new RegExp(`\\b(?:${CURRENCY_WORD_ALT})\\b`, 'gi');
 
   return transcript
-    .replace(/\bsplit\s+(?:it\s+)?(?:with|between|among|amongst)\b.*$/iu, ' ')
+    .replace(SPLIT_WITH_CLAUSE, ' ')
     .replace(currencyWord, ' ')
     .replace(new RegExp(CURRENCY_SYMBOL_RE, 'g'), ' ')
     .replace(/\d[\d,]*(?:\.\d+)?/g, ' ')
@@ -624,7 +637,8 @@ export function resolveVoiceParticipants(params: {
   peopleText: string | null;
   splitCount: number | null;
 }): string[] {
-  const named = params.peopleText ? matchMemberNames(params.peopleText, params.members) : [];
+  const clause = splitParticipantClause(params.peopleText);
+  const named = clause ? matchMemberNames(clause, params.members) : [];
   if (named.length === 0) return [...params.all];
   const chosen = named.includes(params.payer) ? [...named] : [...named, params.payer];
   if (params.splitCount !== null && params.splitCount !== chosen.length) return [...params.all];

--- a/apps/mobile/src/lib/voiceLlm.ts
+++ b/apps/mobile/src/lib/voiceLlm.ts
@@ -507,7 +507,8 @@ export async function interpretVoiceExpenses(
     // The call earned its cost only once we know it produced something usable.
     await noteUsage(reply.totalTokens);
 
-    return { items, group, splitCount: parseVoiceExpenses(trimmed, ctx.groups).splitCount };
+    const heuristic = parseVoiceExpenses(trimmed, ctx.groups);
+    return { items, group, splitCount: heuristic.splitCount, peopleText: heuristic.peopleText };
   } catch (caught) {
     // Network error, abort/timeout, malformed body — all of it is a fallback, not
     // a crash. The raw error (scrubbed) goes to Sentry; the key and transcript do

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -442,6 +442,28 @@ describe('matchMemberNames', () => {
         splitCount: 3,
       }),
     ).toEqual(['m-ravi', 'm-priya', 'm-me']);
+    expect(
+      resolveVoiceParticipants({
+        all: members.map((member) => member.id),
+        payer: 'm-me',
+        members,
+        peopleText: 'split 800 dinner with Ravi and Priya',
+        splitCount: 3,
+      }),
+    ).toEqual(['m-ravi', 'm-priya', 'm-me']);
+  });
+
+  it('does not narrow participants when names appear outside an explicit split clause', () => {
+    const all = members.map((member) => member.id);
+    expect(
+      resolveVoiceParticipants({
+        all,
+        payer: 'm-me',
+        members,
+        peopleText: "1000 rupees for Priya's birthday dinner",
+        splitCount: null,
+      }),
+    ).toEqual(all);
   });
 
   it('falls back to all members when a split count names nobody or conflicts', () => {
@@ -563,7 +585,10 @@ describe('parseVoiceExpenses (several in one breath)', () => {
   });
 
   it('carries split names for downstream matching without leaking them into the note', () => {
-    const result = parseVoiceExpenses('800 rupees dinner on Goa trip split with Ravi and Priya', groups);
+    const result = parseVoiceExpenses(
+      '800 rupees dinner on Goa trip split with Ravi and Priya',
+      groups,
+    );
     expect(result.peopleText).toBe('800 rupees dinner on Goa trip split with Ravi and Priya');
     expect(result.items[0].note).toBe('dinner');
   });
@@ -605,6 +630,15 @@ describe('parseVoiceExpenses (several in one breath)', () => {
       expect(parseVoiceExpenses(sentence, groups).items, sentence).toEqual([]);
     }
     expect(parseVoiceExpenses('+500 rupees dinner', groups).items[0]?.amountMajor).toBe(500);
+  });
+
+  it('does not reject non-amount uses of negative or minus', () => {
+    expect(parseVoiceExpenses('500 rupees negative test kit', groups).items[0]?.note).toBe(
+      'negative test kit',
+    );
+    expect(parseVoiceExpenses('300 rupees minus screwdriver', groups).items[0]?.note).toBe(
+      'minus screwdriver',
+    );
   });
 
   it('does not sum mixed-currency plus runs into one cross-currency amount', () => {

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { matchMemberNames, parseVoiceExpense, type VoiceGroupRef } from '@/lib/voiceExpense';
+import {
+  matchMemberNames,
+  parseVoiceExpense,
+  resolveVoiceParticipants,
+  type VoiceGroupRef,
+} from '@/lib/voiceExpense';
 
 const groups: VoiceGroupRef[] = [
   { id: 'g-goa', name: 'Goa Trip' },
@@ -271,8 +276,14 @@ describe('parseVoiceExpense', () => {
     }
   });
 
-  it('rejects negative signed amounts in currency-adjacent and fallback positions', () => {
-    for (const sentence of ['-500 rupees dinner', '₹-500 dinner', 'minus -500 dinner']) {
+  it('rejects negative signed and spoken amounts in currency-adjacent and fallback positions', () => {
+    for (const sentence of [
+      '-500 rupees dinner',
+      '₹-500 dinner',
+      'minus -500 dinner',
+      'minus five hundred rupees dinner',
+      'negative twenty dollars cab',
+    ]) {
       const parsed = parseVoiceExpense(sentence, groups);
       expect(parsed.amountMajor, sentence).toBeNull();
       expect(parsed.amountMinor, sentence).toBeNull();
@@ -420,6 +431,34 @@ describe('matchMemberNames', () => {
   it('returns nothing when no one is named', () => {
     expect(matchMemberNames('add 500 for dinner', members)).toEqual([]);
   });
+
+  it('resolves named voice participants and keeps the payer included', () => {
+    expect(
+      resolveVoiceParticipants({
+        all: members.map((member) => member.id),
+        payer: 'm-me',
+        members,
+        peopleText: '800 dinner split with Ravi and Priya',
+        splitCount: 3,
+      }),
+    ).toEqual(['m-ravi', 'm-priya', 'm-me']);
+  });
+
+  it('falls back to all members when a split count names nobody or conflicts', () => {
+    const all = members.map((member) => member.id);
+    expect(
+      resolveVoiceParticipants({ all, payer: 'm-me', members, peopleText: null, splitCount: 2 }),
+    ).toEqual(all);
+    expect(
+      resolveVoiceParticipants({
+        all,
+        payer: 'm-me',
+        members,
+        peopleText: '800 dinner split with Ravi and Priya',
+        splitCount: 2,
+      }),
+    ).toEqual(all);
+  });
 });
 
 import { detectCreateGroup, normalizeDigits, parseVoiceExpenses } from '@/lib/voiceExpense';
@@ -523,6 +562,12 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     expect(result.items[0].amountMajor).toBe(1000);
   });
 
+  it('carries split names for downstream matching without leaking them into the note', () => {
+    const result = parseVoiceExpenses('800 rupees dinner on Goa trip split with Ravi and Priya', groups);
+    expect(result.peopleText).toBe('800 rupees dinner on Goa trip split with Ravi and Priya');
+    expect(result.items[0].note).toBe('dinner');
+  });
+
   it('carries non-rupee currencies through the multi-expense path', () => {
     const result = parseVoiceExpenses('20 euros coffee, 15 euros cake', groups);
     expect(result.items.map((item) => item.currency)).toEqual(['EUR', 'EUR']);
@@ -549,8 +594,14 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     }
   });
 
-  it('does not create items from signed negative amounts', () => {
-    for (const sentence of ['-500 rupees dinner', '₹-500 dinner', 'minus -500 dinner']) {
+  it('does not create items from signed or spoken negative amounts', () => {
+    for (const sentence of [
+      '-500 rupees dinner',
+      '₹-500 dinner',
+      'minus -500 dinner',
+      'minus five hundred rupees dinner',
+      'negative twenty dollars cab',
+    ]) {
       expect(parseVoiceExpenses(sentence, groups).items, sentence).toEqual([]);
     }
     expect(parseVoiceExpenses('+500 rupees dinner', groups).items[0]?.amountMajor).toBe(500);

--- a/apps/mobile/test/voiceLlm.test.ts
+++ b/apps/mobile/test/voiceLlm.test.ts
@@ -313,6 +313,7 @@ describe('interpretVoiceExpenses', () => {
       items: [],
       group: { kind: 'create', name: 'Goa' },
       splitCount: null,
+      peopleText: null,
     });
   });
 
@@ -374,7 +375,7 @@ describe('interpretVoiceExpenses', () => {
     expect(result?.items[0]?.note).toBe('x'.repeat(160));
   });
 
-  it('keeps heuristic split-count information when the model returns usable items', async () => {
+  it('keeps the heuristic split metadata alongside model items', async () => {
     getActiveAiKeyMock.mockResolvedValue({ id: 'openai', key: 'sk-test' });
     const content = JSON.stringify({
       items: [{ amount: 1000, currency: 'INR', note: 'dinner' }],
@@ -385,8 +386,12 @@ describe('interpretVoiceExpenses', () => {
       vi.fn(async () => openAiReply(content)),
     );
 
-    const result = await interpretVoiceExpenses('split 1000 rupees among 4 people for dinner', ctx);
+    const result = await interpretVoiceExpenses(
+      'split 1000 rupees among 4 people for dinner with Ravi',
+      ctx,
+    );
     expect(result?.splitCount).toBe(4);
+    expect(result?.peopleText).toBe('split 1000 rupees among 4 people for dinner with Ravi');
   });
 
   it('rejects unsupported negative or refund intents before key lookup or network calls', async () => {


### PR DESCRIPTION
## Summary

- carry voice split metadata (`peopleText`) through heuristic and LLM parsing
- apply named voice split participants when saving voice batches into existing groups
- keep the payer included in named splits and fall back to all members when split counts conflict
- strip `split with ...` participant names from saved expense notes
- reject spoken negative amounts like “minus five hundred rupees” consistently

## Tests

- `pnpm --filter @waves/mobile test -- voiceExpense.test.ts voiceLlm.test.ts --run`
- `pnpm --filter @waves/mobile typecheck`
- `pnpm --filter @waves/mobile lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice expense entry now recognizes named participants and includes the payer when splitting expenses.
  * Group expense splits use spoken participant details, with a fallback when names or counts don’t match.
* **Bug Fixes**
  * Negative amounts are rejected when clearly expressed as numeric values.
  * Participant details are removed from expense notes while remaining available for split matching.
  * Empty participant selections now show an error instead of creating an invalid split.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->