### PR TITLE
feat(import): background ledger import with a Home progress banner

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -26,6 +26,7 @@ import {
   MoneyText,
   Row,
   Screen,
+  Skeleton,
   Text,
   useTabBarClearance,
   useTheme,
@@ -43,7 +44,7 @@ import { TourTarget, useTour } from '@/lib/tour';
 import { SyncStatusIcon } from '@/components/SyncBanner';
 import { ImportProgressBanner } from '@/components/ImportProgressBanner';
 import { SkeletonList } from '@/components/Skeletons';
-import { useImportProgress } from '@/lib/importProgress';
+import { useImportedGroupId } from '@/lib/importProgress';
 import { useReducedMotion } from '@/lib/reducedMotion';
 import { useDefaultCurrency } from '@/lib/currency';
 import { QuickAddSheet, useQuickAddActions } from '@/components/QuickAddSheet';
@@ -109,10 +110,11 @@ export default function HomeScreen() {
 
   // A ledger import running in the background (see `@/lib/importProgress`): its
   // banner sits above the group list, and when it lands the just-added group
-  // slides into the list. `justAddedId` is that group while the success banner
-  // is up, so its row animates in the moment the mirror gains it.
-  const imp = useImportProgress();
-  const justAddedId = imp.phase === 'success' ? imp.groupId : null;
+  // slides into the list. This reads *only* the landed group id (a primitive),
+  // so the dashboard re-renders on the success transition alone — never on the
+  // running/waiting churn, which would otherwise re-render this heavy screen and
+  // make the app crawl while an import ran. The banner owns the running state.
+  const justAddedId = useImportedGroupId();
 
   // First time on Home, once the "seen" flag has been read *and the data has
   // loaded*, run the tour. Waiting on the data matters: the coach-marks anchor
@@ -531,6 +533,10 @@ export default function HomeScreen() {
                       // The just-imported group slides and fades into place
                       // rather than blinking in under the success banner.
                       enter={group.id === justAddedId}
+                      // Its balance materialises a beat after the group row does,
+                      // so mask the amount until the ledger lands rather than show
+                      // a confident wrong ₹0 that then jumps to the real figure.
+                      pendingBalance={group.id === justAddedId && !summary.hasLedger(group.id)}
                       onPress={() => router.push(`/group/${group.id}`)}
                     />
                   );
@@ -1620,6 +1626,7 @@ function GroupRow({
   tagTone,
   divider,
   enter = false,
+  pendingBalance = false,
   onPress,
 }: {
   title: string;
@@ -1632,6 +1639,9 @@ function GroupRow({
   pendingLabel: string | null;
   tag: string | null;
   tagTone: 'positive' | 'brand';
+  /** True while this group's balance is still materialising (just after an
+      import): the amount is masked with a skeleton instead of a wrong zero. */
+  pendingBalance?: boolean;
   /** A hairline above the row — every row but the first, so the card reads as
       one divided list rather than a stack of loose cards. */
   divider: boolean;
@@ -1727,13 +1737,17 @@ function GroupRow({
             {pendingLabel ?? `${memberLabel} · ${statusLabel}`}
           </Text>
         </View>
-        <MoneyText
-          amount={balance < 0n ? -balance : balance}
-          currency={currency as never}
-          locale={locale}
-          tone={tone}
-          style={{ fontWeight: '700' }}
-        />
+        {pendingBalance ? (
+          <Skeleton width={64} height={16} radius={6} animated={!reduceMotion} />
+        ) : (
+          <MoneyText
+            amount={balance < 0n ? -balance : balance}
+            currency={currency as never}
+            locale={locale}
+            tone={tone}
+            style={{ fontWeight: '700' }}
+          />
+        )}
       </Pressable>
     </Animated.View>
   );

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -41,7 +41,10 @@ import { usePromptSlot } from '@/lib/promptQueue';
 import { useDashboardTips } from '@/lib/tips';
 import { TourTarget, useTour } from '@/lib/tour';
 import { SyncStatusIcon } from '@/components/SyncBanner';
+import { ImportProgressBanner } from '@/components/ImportProgressBanner';
 import { SkeletonList } from '@/components/Skeletons';
+import { useImportProgress } from '@/lib/importProgress';
+import { useReducedMotion } from '@/lib/reducedMotion';
 import { useDefaultCurrency } from '@/lib/currency';
 import { QuickAddSheet, useQuickAddActions } from '@/components/QuickAddSheet';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
@@ -103,6 +106,13 @@ export default function HomeScreen() {
 
   const list = groups.data ?? [];
   const loading = groups.isLoading || summary.isLoading;
+
+  // A ledger import running in the background (see `@/lib/importProgress`): its
+  // banner sits above the group list, and when it lands the just-added group
+  // slides into the list. `justAddedId` is that group while the success banner
+  // is up, so its row animates in the moment the mirror gains it.
+  const imp = useImportProgress();
+  const justAddedId = imp.phase === 'success' ? imp.groupId : null;
 
   // First time on Home, once the "seen" flag has been read *and the data has
   // loaded*, run the tour. Waiting on the data matters: the coach-marks anchor
@@ -438,6 +448,10 @@ export default function HomeScreen() {
             flexGrow: 1,
           }}
         >
+          {/* A background import's progress lands here, just above the groups —
+              the person tapped Import, came home, and watches it fill. */}
+          <ImportProgressBanner />
+
           {loading ? (
             <SkeletonList rows={3} />
           ) : list.length === 0 ? (
@@ -514,6 +528,9 @@ export default function HomeScreen() {
                       tag={tag}
                       tagTone={onTrip ? 'positive' : 'brand'}
                       divider={index > 0}
+                      // The just-imported group slides and fades into place
+                      // rather than blinking in under the success banner.
+                      enter={group.id === justAddedId}
                       onPress={() => router.push(`/group/${group.id}`)}
                     />
                   );
@@ -1602,6 +1619,7 @@ function GroupRow({
   tag,
   tagTone,
   divider,
+  enter = false,
   onPress,
 }: {
   title: string;
@@ -1617,76 +1635,106 @@ function GroupRow({
   /** A hairline above the row — every row but the first, so the card reads as
       one divided list rather than a stack of loose cards. */
   divider: boolean;
+  /** True for a row that has just arrived (a fresh import): it fades and slides
+      into place on mount rather than blinking in. */
+  enter?: boolean;
   onPress: () => void;
 }) {
   const theme = useTheme();
+  const reduceMotion = useReducedMotion();
   // Money's own colour, kept for the ledger even though the hero is green:
   // owed-to-you positive, you-owe negative, square is quiet.
   const tone = balance === 0n ? 'muted' : balance > 0n ? 'positive' : 'negative';
+
+  // The entrance: start dropped and clear, settle into place. Only for a row
+  // flagged `enter` (a just-imported group), and never under reduce motion —
+  // otherwise the row is static at rest. Lazy-init state, never a ref read in
+  // render (the React Compiler lints that), transform+opacity native-driven.
+  const shouldAnimate = enter && !reduceMotion;
+  const anim = useState(() => new Animated.Value(shouldAnimate ? 0 : 1))[0];
+  useEffect(() => {
+    if (!shouldAnimate) return;
+    const run = Animated.spring(anim, {
+      toValue: 1,
+      friction: 8,
+      tension: 60,
+      useNativeDriver: true,
+    });
+    run.start();
+    return () => run.stop();
+  }, [shouldAnimate, anim]);
+
   return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={`${title}. ${statusLabel}`}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: theme.spacing.md,
-        paddingVertical: theme.spacing.md,
-        paddingHorizontal: theme.spacing.lg,
-        borderTopWidth: divider ? 1 : 0,
-        borderTopColor: theme.color.border,
-        opacity: pressed ? 0.6 : 1,
-      })}
+    <Animated.View
+      style={{
+        opacity: anim,
+        transform: [{ translateY: anim.interpolate({ inputRange: [0, 1], outputRange: [12, 0] }) }],
+      }}
     >
-      <View
-        style={{
-          width: 44,
-          height: 44,
-          borderRadius: 22,
-          backgroundColor: theme.color.surfaceMuted,
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${title}. ${statusLabel}`}
+        onPress={onPress}
+        style={({ pressed }) => ({
+          flexDirection: 'row',
           alignItems: 'center',
-          justifyContent: 'center',
-        }}
+          gap: theme.spacing.md,
+          paddingVertical: theme.spacing.md,
+          paddingHorizontal: theme.spacing.lg,
+          borderTopWidth: divider ? 1 : 0,
+          borderTopColor: theme.color.border,
+          opacity: pressed ? 0.6 : 1,
+        })}
       >
-        <Text style={{ fontSize: 20 }}>{coverEmoji ?? '👥'}</Text>
-      </View>
-      <View style={{ flex: 1, gap: 2 }}>
-        <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-          <Text variant="body" numberOfLines={1} style={{ flexShrink: 1, fontWeight: '600' }}>
-            {title}
-          </Text>
-          {tag ? (
-            <View
-              style={{
-                paddingHorizontal: 6,
-                paddingVertical: 1,
-                borderRadius: 6,
-                backgroundColor:
-                  tagTone === 'positive' ? theme.color.positiveSoft : theme.color.brandSoft,
-              }}
-            >
-              <Text
-                variant="micro"
-                tone={tagTone === 'positive' ? 'positive' : 'brand'}
-                style={{ fontWeight: '700' }}
+        <View
+          style={{
+            width: 44,
+            height: 44,
+            borderRadius: 22,
+            backgroundColor: theme.color.surfaceMuted,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontSize: 20 }}>{coverEmoji ?? '👥'}</Text>
+        </View>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            <Text variant="body" numberOfLines={1} style={{ flexShrink: 1, fontWeight: '600' }}>
+              {title}
+            </Text>
+            {tag ? (
+              <View
+                style={{
+                  paddingHorizontal: 6,
+                  paddingVertical: 1,
+                  borderRadius: 6,
+                  backgroundColor:
+                    tagTone === 'positive' ? theme.color.positiveSoft : theme.color.brandSoft,
+                }}
               >
-                {tag}
-              </Text>
-            </View>
-          ) : null}
-        </Row>
-        <Text variant="caption" tone="muted" numberOfLines={1}>
-          {pendingLabel ?? `${memberLabel} · ${statusLabel}`}
-        </Text>
-      </View>
-      <MoneyText
-        amount={balance < 0n ? -balance : balance}
-        currency={currency as never}
-        locale={locale}
-        tone={tone}
-        style={{ fontWeight: '700' }}
-      />
-    </Pressable>
+                <Text
+                  variant="micro"
+                  tone={tagTone === 'positive' ? 'positive' : 'brand'}
+                  style={{ fontWeight: '700' }}
+                >
+                  {tag}
+                </Text>
+              </View>
+            ) : null}
+          </Row>
+          <Text variant="caption" tone="muted" numberOfLines={1}>
+            {pendingLabel ?? `${memberLabel} · ${statusLabel}`}
+          </Text>
+        </View>
+        <MoneyText
+          amount={balance < 0n ? -balance : balance}
+          currency={currency as never}
+          locale={locale}
+          tone={tone}
+          style={{ fontWeight: '700' }}
+        />
+      </Pressable>
+    </Animated.View>
   );
 }

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -55,6 +55,7 @@ import {
 } from '@waves/ui';
 
 import { createGroup, fetchMembers, importLedger, type ImportPerson } from '@/data/api';
+import { beginImport } from '@/lib/importProgress';
 import { friendlyError } from '@/lib/errors';
 import { plural, useStrings, type UiStrings } from '@/i18n';
 import { useReducedMotion } from '@/lib/reducedMotion';
@@ -323,85 +324,110 @@ export default function ImportScreen() {
 
   const claimedByMe = Object.values(mapping).some((value) => value.kind === 'me');
 
-  const run = async (): Promise<void> => {
+  /**
+   * Hand the import to the background store and walk home. The write itself no
+   * longer happens on this screen: the moment it is kicked, we replace this
+   * screen with the dashboard, where a banner above the group list tracks the
+   * percentage and the finished group animates into the list. The job below
+   * closes over everything it needs, so it runs to completion whether or not
+   * this screen is still mounted (see `@/lib/importProgress`).
+   */
+  const run = (): void => {
     if (!parsed) return;
-    setBusy(true);
-    setStage('importing');
-    setError(null);
-    // Let the progress bar and "Importing…" label paint before the single
-    // transactional write ties the thread up.
-    await nextFrame();
-    try {
-      let groupId = target;
-      if (groupId === NEW_GROUP) {
-        groupId = await createGroup({
-          name: parsed.suggestedName || t.importLedger.importedGroup,
-          type: GroupType.Other,
-          currency: parsed.currency,
-        });
-      }
+    const snapshot = parsed;
+    const chosenMapping = mapping;
+    const chosenTarget = target;
+    const ids = mutationIds;
+    const iClaimedAColumn = claimedByMe;
+    const name = snapshot.suggestedName || t.importLedger.importedGroup;
 
-      // Whoever is "you" maps to your own membership in the target group; the
-      // server resolves the rest, so a null memberId means "make a ghost".
-      const mine = (await fetchMembers(groupId)).find(
-        (member) => member.profile_id === profile?.id,
-      );
-
-      // Somebody claimed a column as themselves, but their own membership is not
-      // in the target group — importing would file their history under a ghost.
-      // Refuse rather than quietly drop them into a stranger's row.
-      if (claimedByMe && !mine) {
-        setError(t.importLedger.couldNotFindYou);
-        return;
-      }
-
-      const people: ImportPerson[] = parsed.people.map((person) => {
-        const chosen = mapping[person] ?? { kind: 'ghost' };
-        if (chosen.kind === 'me') return { name: person, memberId: mine?.id ?? null };
-        if (chosen.kind === 'member') return { name: person, memberId: chosen.memberId };
-        return { name: person, memberId: null };
-      });
-
-      const result = await importLedger({
-        groupId,
-        people,
-        origin: parsed.origin,
-        expenses: parsed.expenses.map((expense, index) => ({
-          clientMutationId: mutationIds[index] ?? randomUUID(),
-          description: expense.description,
-          category: expense.category,
-          date: expense.date,
-          currency: expense.currency,
-          amount: expense.amount,
-          payers: expense.payers,
-          shares: expense.shares,
-        })),
-        settlements: parsed.settlements.map((settlement, index) => ({
-          clientMutationId: mutationIds[parsed.expenses.length + index] ?? randomUUID(),
-          from: settlement.from,
-          to: settlement.to,
-          currency: settlement.currency,
-          amount: settlement.amount,
-          method: settlement.method,
-          status: settlement.status,
-          note: settlement.note,
-          at: settlement.at,
-        })),
-      });
-
-      setDone({
-        groupId,
-        expenses: result.expenses,
-        ghosts: result.ghosts,
-        settlements: result.settlements ?? 0,
-      });
-      void groups.refetch();
-    } catch (caught) {
-      setError(friendlyError(caught, t.importLedger.importFailed, 'import.commit'));
-    } finally {
-      setBusy(false);
-      setStage(null);
+    // The one precondition we can settle before leaving: claiming yourself in an
+    // existing group you are not a member of would file your history under a
+    // ghost. A new group makes you a member, so this only bites an existing
+    // target — and there we already hold its members, so the check is local.
+    if (
+      chosenTarget !== NEW_GROUP &&
+      iClaimedAColumn &&
+      !members.some((member) => member.profile_id === profile?.id)
+    ) {
+      setError(t.importLedger.couldNotFindYou);
+      return;
     }
+
+    beginImport({
+      name,
+      run: async () => {
+        try {
+          let groupId = chosenTarget;
+          if (groupId === NEW_GROUP) {
+            groupId = await createGroup({
+              name,
+              type: GroupType.Other,
+              currency: snapshot.currency,
+            });
+          }
+
+          // Whoever is "you" maps to your own membership in the target group; the
+          // server resolves the rest, so a null memberId means "make a ghost".
+          const mine = (await fetchMembers(groupId)).find(
+            (member) => member.profile_id === profile?.id,
+          );
+          if (iClaimedAColumn && !mine) throw new Error(t.importLedger.couldNotFindYou);
+
+          const people: ImportPerson[] = snapshot.people.map((person) => {
+            const chosen = chosenMapping[person] ?? { kind: 'ghost' };
+            if (chosen.kind === 'me') return { name: person, memberId: mine?.id ?? null };
+            if (chosen.kind === 'member') return { name: person, memberId: chosen.memberId };
+            return { name: person, memberId: null };
+          });
+
+          const result = await importLedger({
+            groupId,
+            people,
+            origin: snapshot.origin,
+            expenses: snapshot.expenses.map((expense, index) => ({
+              clientMutationId: ids[index] ?? randomUUID(),
+              description: expense.description,
+              category: expense.category,
+              date: expense.date,
+              currency: expense.currency,
+              amount: expense.amount,
+              payers: expense.payers,
+              shares: expense.shares,
+            })),
+            settlements: snapshot.settlements.map((settlement, index) => ({
+              clientMutationId: ids[snapshot.expenses.length + index] ?? randomUUID(),
+              from: settlement.from,
+              to: settlement.to,
+              currency: settlement.currency,
+              amount: settlement.amount,
+              method: settlement.method,
+              status: settlement.status,
+              note: settlement.note,
+              at: settlement.at,
+            })),
+          });
+
+          // Pull the new group into the mirror so Home can show (and animate) it.
+          groups.refetch();
+          return {
+            groupId,
+            expenses: result.expenses,
+            ghosts: result.ghosts,
+            settlements: result.settlements ?? 0,
+          };
+        } catch (caught) {
+          // Keep the one precondition message as-is; wrap everything else in a
+          // people-facing line. The store shows whichever we throw verbatim.
+          if (caught instanceof Error && caught.message === t.importLedger.couldNotFindYou) {
+            throw caught;
+          }
+          throw new Error(friendlyError(caught, t.importLedger.importFailed, 'import.commit'));
+        }
+      },
+    });
+
+    router.replace('/');
   };
 
   return (
@@ -624,7 +650,7 @@ export default function ImportScreen() {
                   size="lg"
                   fullWidth
                   disabled={busy || !claimedByMe}
-                  onPress={() => void run()}
+                  onPress={() => run()}
                   icon={
                     <Ionicons
                       name="cloud-upload-outline"
@@ -633,14 +659,6 @@ export default function ImportScreen() {
                     />
                   }
                 />
-                {stage === 'importing' ? (
-                  <View style={{ gap: theme.spacing.sm }}>
-                    <ProgressBar animated={!reduceMotion} />
-                    <Text variant="caption" tone="muted" align="center">
-                      {plural(locale, parsed.expenses.length, t.importLedger.importingCount)}
-                    </Text>
-                  </View>
-                ) : null}
                 {!claimedByMe ? (
                   <Text variant="caption" tone="muted" align="center">
                     {t.importLedger.tapYourNameFirst}

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -369,7 +369,7 @@ export default function ImportScreen() {
       return;
     }
 
-    beginImport({
+    const scheduled = beginImport({
       name,
       run: async () => {
         try {
@@ -444,6 +444,13 @@ export default function ImportScreen() {
       },
     });
 
+    // Only leave once the job is actually on. If another import is already
+    // running, the store refused this one — staying put with a message beats
+    // walking home to watch a different import and silently losing this file.
+    if (!scheduled) {
+      setError(t.importLedger.alreadyImporting);
+      return;
+    }
     router.replace('/');
   };
 

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -350,6 +350,11 @@ export default function ImportScreen() {
     // What the person typed, falling back to the file's suggestion and then a
     // generic label — a new group never lands nameless.
     const name = newGroupName.trim() || snapshot.suggestedName || t.importLedger.importedGroup;
+    // A client-chosen id for a brand-new group, fixed here so the whole job is a
+    // safe replay: if the store re-runs it after an offline wait, createGroup is
+    // idempotent on this id (returns the same group, never a second one) and the
+    // ledger write dedups on its mutation ids. Unused for an existing target.
+    const newGroupId = randomUUID();
 
     // The one precondition we can settle before leaving: claiming yourself in an
     // existing group you are not a member of would file your history under a
@@ -370,7 +375,9 @@ export default function ImportScreen() {
         try {
           let groupId = chosenTarget;
           if (groupId === NEW_GROUP) {
-            groupId = await createGroup({
+            groupId = newGroupId;
+            await createGroup({
+              groupId: newGroupId,
               name,
               type: GroupType.Other,
               currency: snapshot.currency,
@@ -817,6 +824,11 @@ export default function ImportScreen() {
               </Text>
               <Text variant="caption" tone="muted">
                 {t.importLedger.fromBaakiNote}
+              </Text>
+              <Divider />
+              {/* Offline: parked and run on reconnect (see `@/lib/importProgress`). */}
+              <Text variant="caption" tone="muted">
+                {t.importLedger.helpOffline}
               </Text>
             </ScrollView>
             <Button label={t.misc.gotIt} fullWidth onPress={() => setHelpOpen(false)} />

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -24,7 +24,8 @@ import { randomUUID } from 'expo-crypto';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
 import { router } from 'expo-router';
-import { Pressable, ScrollView, View } from 'react-native';
+import { Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
   importSplitwiseCsv,
@@ -50,8 +51,8 @@ import {
   Screen,
   SectionHeader,
   Text,
+  useTabBarClearance,
   useTheme,
-  useScreenClearance,
 } from '@waves/ui';
 
 import { createGroup, fetchMembers, importLedger, type ImportPerson } from '@/data/api';
@@ -127,12 +128,13 @@ function fromBaaki(group: BaakiImportGroup, fallbackName: string): Loaded {
 
 export default function ImportScreen() {
   const theme = useTheme();
-  // The last thing on this screen is a full-width primary CTA (Import / Open the
-  // group), not a line of text. A footer-like action needs more breath above the
-  // system nav bar than the default so its icon and label never sit under the
-  // gesture pill — so ask the clearance hook for a larger base (still the inset
-  // plus a token, never a magic pixel number).
-  const clearance = useScreenClearance(theme.spacing.xxxl * 2);
+  // The bottom bar shows on this screen (it is a settings page, not a modal), and
+  // it is opaque — so the scroll has to clear the *bar*, not just the system
+  // inset. `useScreenClearance` only cleared the inset, which left the Import CTA
+  // jammed under the bar. `useTabBarClearance` is the bar-aware room the other
+  // settings screens use; a token more on top gives the footer CTA its breath.
+  const clearance = useTabBarClearance() + theme.spacing.xl;
+  const insets = useSafeAreaInsets();
   const { t, locale } = useStrings();
   const reduceMotion = useReducedMotion();
   const groups = useGroups();
@@ -149,6 +151,10 @@ export default function ImportScreen() {
   const [fileGroups, setFileGroups] = useState<readonly BaakiImportGroup[]>([]);
   const [fileGroupIndex, setFileGroupIndex] = useState(0);
   const [target, setTarget] = useState<string>(NEW_GROUP);
+  // The name a new group is created with. Seeded from the file (the Splitwise
+  // default, or the export's own name) and then the person's to change — they no
+  // longer have to accept "Splitwise" or rename it afterwards.
+  const [newGroupName, setNewGroupName] = useState('');
   const [members, setMembers] = useState<MemberRow[]>([]);
   const [mapping, setMapping] = useState<Record<string, Mapping>>({});
   /**
@@ -159,6 +165,7 @@ export default function ImportScreen() {
   const [mutationIds, setMutationIds] = useState<string[]>([]);
 
   const [busy, setBusy] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
   const [stage, setStage] = useState<Stage | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState<{
@@ -171,6 +178,7 @@ export default function ImportScreen() {
   /** Everyone starts as somebody new — see `load`. */
   const load = (loaded: Loaded): void => {
     setParsed(loaded);
+    setNewGroupName(loaded.suggestedName);
     setMutationIds([...loaded.expenses, ...loaded.settlements].map(() => randomUUID()));
     // Claiming a name as yourself is a deliberate act. Guessing by name would
     // silently merge your ledger with a stranger who shares your first name.
@@ -339,7 +347,9 @@ export default function ImportScreen() {
     const chosenTarget = target;
     const ids = mutationIds;
     const iClaimedAColumn = claimedByMe;
-    const name = snapshot.suggestedName || t.importLedger.importedGroup;
+    // What the person typed, falling back to the file's suggestion and then a
+    // generic label — a new group never lands nameless.
+    const name = newGroupName.trim() || snapshot.suggestedName || t.importLedger.importedGroup;
 
     // The one precondition we can settle before leaving: claiming yourself in an
     // existing group you are not a member of would file your history under a
@@ -451,7 +461,9 @@ export default function ImportScreen() {
           <View style={{ flex: 1, alignItems: 'center' }}>
             <Text variant="heading">{t.importLedger.ledgerTitle}</Text>
           </View>
-          <View style={{ width: 44 }} />
+          <IconButton label={t.importLedger.helpTitle} onPress={() => setHelpOpen(true)}>
+            <Ionicons name="help-circle-outline" size={iconSize.lg} color={theme.color.text} />
+          </IconButton>
         </Row>
 
         <Card style={{ gap: theme.spacing.sm }}>
@@ -585,7 +597,7 @@ export default function ImportScreen() {
                 <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
                   <TargetRow
                     label={t.importLedger.aNewGroup}
-                    hint={t.importLedger.namedAfterFile}
+                    hint={t.importLedger.nameItBelow}
                     selected={target === NEW_GROUP}
                     onPress={() => void chooseTarget(NEW_GROUP)}
                   />
@@ -599,6 +611,59 @@ export default function ImportScreen() {
                     />
                   ))}
                 </Card>
+
+                {/* Name the new group here rather than accept the file's default.
+                    Only for a new group — an existing target already has a name. */}
+                {target === NEW_GROUP ? (
+                  <View style={{ marginTop: theme.spacing.md, gap: theme.spacing.xs }}>
+                    <Text
+                      variant="micro"
+                      tone="muted"
+                      style={{ paddingHorizontal: theme.spacing.sm }}
+                    >
+                      {t.group.groupName}
+                    </Text>
+                    <Card style={{ paddingVertical: theme.spacing.md }}>
+                      <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+                        <Ionicons
+                          name="people-outline"
+                          size={iconSize.md}
+                          color={theme.color.textFaint}
+                        />
+                        <TextInput
+                          value={newGroupName}
+                          onChangeText={setNewGroupName}
+                          placeholder={parsed.suggestedName}
+                          placeholderTextColor={theme.color.textFaint}
+                          accessibilityLabel={t.group.groupName}
+                          returnKeyType="done"
+                          style={{
+                            flex: 1,
+                            fontSize: 16,
+                            fontWeight: '600',
+                            color: theme.color.text,
+                            paddingVertical: 0,
+                          }}
+                        />
+                        {newGroupName.length > 0 ? (
+                          <Pressable
+                            accessibilityRole="button"
+                            accessibilityLabel={t.entry.clear}
+                            onPress={() => setNewGroupName('')}
+                            hitSlop={8}
+                            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+                          >
+                            <Ionicons
+                              name="close-circle"
+                              size={iconSize.md}
+                              color={theme.color.textFaint}
+                            />
+                          </Pressable>
+                        ) : null}
+                      </Row>
+                    </Card>
+                  </View>
+                ) : null}
               </View>
             ) : null}
 
@@ -693,6 +758,71 @@ export default function ImportScreen() {
 
         {error ? <Callout tone="negative">{error}</Callout> : null}
       </ScrollView>
+
+      {/* How it works, on tap of the header's help glyph — a bottom sheet that
+          walks through the two file types and what does and does not come
+          across, plus that it can be done with no connection. */}
+      <Modal
+        transparent
+        animationType="fade"
+        visible={helpOpen}
+        onRequestClose={() => setHelpOpen(false)}
+      >
+        <Pressable
+          onPress={() => setHelpOpen(false)}
+          accessibilityLabel={t.common.close}
+          style={{
+            flex: 1,
+            backgroundColor: 'rgba(10, 10, 26, 0.55)',
+            justifyContent: 'flex-end',
+          }}
+        >
+          {/* Swallows the tap so pressing the sheet does not dismiss it. */}
+          <Pressable
+            onPress={() => {}}
+            style={{
+              backgroundColor: theme.color.surface,
+              borderTopLeftRadius: theme.radius.xxl,
+              borderTopRightRadius: theme.radius.xxl,
+              paddingHorizontal: theme.spacing.xxl,
+              paddingTop: theme.spacing.xl,
+              paddingBottom: theme.spacing.xxl + insets.bottom,
+              gap: theme.spacing.lg,
+            }}
+          >
+            <View
+              style={{
+                alignSelf: 'center',
+                width: 40,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: theme.color.border,
+              }}
+            />
+            <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+              <Ionicons name="help-circle-outline" size={iconSize.xl} color={theme.color.brand} />
+              <Text variant="title">{t.importLedger.helpTitle}</Text>
+            </Row>
+            <ScrollView
+              style={{ maxHeight: 340 }}
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={{ gap: theme.spacing.md }}
+            >
+              <Text variant="body" tone="muted">
+                {t.importLedger.ledgerHowTo}
+              </Text>
+              <Divider />
+              <Text variant="caption" tone="muted">
+                {t.importLedger.fromSplitwiseNote}
+              </Text>
+              <Text variant="caption" tone="muted">
+                {t.importLedger.fromBaakiNote}
+              </Text>
+            </ScrollView>
+            <Button label={t.misc.gotIt} fullWidth onPress={() => setHelpOpen(false)} />
+          </Pressable>
+        </Pressable>
+      </Modal>
     </Screen>
   );
 }

--- a/apps/mobile/src/components/ImportProgressBanner.tsx
+++ b/apps/mobile/src/components/ImportProgressBanner.tsx
@@ -50,32 +50,43 @@ export function ImportProgressBanner(): React.JSX.Element | null {
   if (!visible) return null;
 
   const running = imp.phase === 'running';
+  const waiting = imp.phase === 'waiting';
   const success = imp.phase === 'success';
+  const error = imp.phase === 'error';
   const percent = Math.round(imp.fraction * 100);
 
   // The title and its sub line, per phase. Running: the group name and the live
-  // percent. Success: "added" and the count. Error: the failure and its reason.
+  // percent. Waiting: parked offline, with the reassurance it will land. Success:
+  // "added" and the count. Error: the failure and its reason.
   const title = running
     ? t.importLedger.importingNamed.replace('{name}', imp.groupName)
-    : success
-      ? t.importLedger.addedNamed.replace('{name}', imp.groupName)
-      : t.importLedger.importFailed;
+    : waiting
+      ? t.importLedger.waitingNamed.replace('{name}', imp.groupName)
+      : success
+        ? t.importLedger.addedNamed.replace('{name}', imp.groupName)
+        : t.importLedger.importFailed;
   const sub = running
     ? `${percent}%`
-    : success && imp.summary
-      ? plural(locale, imp.summary.expenses, t.importLedger.expenseCount)
-      : imp.error;
+    : waiting
+      ? t.importLedger.waitingHint
+      : success && imp.summary
+        ? plural(locale, imp.summary.expenses, t.importLedger.expenseCount)
+        : imp.error;
 
   const icon: keyof typeof Ionicons.glyphMap = running
     ? 'cloud-upload-outline'
-    : success
-      ? 'checkmark-circle'
-      : 'alert-circle';
+    : waiting
+      ? 'cloud-offline-outline'
+      : success
+        ? 'checkmark-circle'
+        : 'alert-circle';
   const accent = success
     ? theme.color.positive
-    : imp.phase === 'error'
+    : error
       ? theme.color.negative
-      : theme.color.brand;
+      : waiting
+        ? theme.color.warning
+        : theme.color.brand;
 
   // Success opens the group on tap; the rest of the time the card is inert.
   const onPress =
@@ -126,7 +137,7 @@ export function ImportProgressBanner(): React.JSX.Element | null {
             <Text variant="subheading" tone="brand" style={{ fontWeight: '700' }}>
               {`${percent}%`}
             </Text>
-          ) : imp.phase === 'error' ? (
+          ) : error || waiting ? (
             <Pressable
               onPress={dismissImport}
               accessibilityRole="button"

--- a/apps/mobile/src/components/ImportProgressBanner.tsx
+++ b/apps/mobile/src/components/ImportProgressBanner.tsx
@@ -2,13 +2,16 @@
  * The import banner that sits above the group list on Home.
  *
  * It is the visible half of {@link ../lib/importProgress}: while a ledger is
- * being brought in it shows the group's name, a live percentage and a
- * determinate bar; on success it flips to a check and the count it added, then
- * clears itself (the store lingers a beat, then goes idle); on failure it holds
- * the people-facing reason with a way to dismiss. Idle, it renders nothing.
+ * being brought in it names the group and shows a slim indeterminate bar; parked
+ * offline it says it is waiting for a connection; on success it flips to a check
+ * and the count it added, then clears itself; on failure it holds the
+ * people-facing reason with a way to dismiss. Idle, it renders nothing.
  *
- * The whole card eases in — a short fade and drop — so it arrives as the person
- * lands on Home from the import screen rather than snapping into the layout.
+ * No percentage. The import is one atomic write with no honest fraction to show,
+ * and a ticking number meant re-rendering the dashboard many times a second — so
+ * the running state is an indeterminate bar that slides on the *native* driver:
+ * it costs the JS thread nothing, so a slow or stalled import never makes the app
+ * feel slow. The whole card eases in once as the person lands on Home.
  */
 
 import { useEffect, useState } from 'react';
@@ -53,11 +56,10 @@ export function ImportProgressBanner(): React.JSX.Element | null {
   const waiting = imp.phase === 'waiting';
   const success = imp.phase === 'success';
   const error = imp.phase === 'error';
-  const percent = Math.round(imp.fraction * 100);
 
-  // The title and its sub line, per phase. Running: the group name and the live
-  // percent. Waiting: parked offline, with the reassurance it will land. Success:
-  // "added" and the count. Error: the failure and its reason.
+  // The title and its sub line, per phase. Running: just the group name (the bar
+  // below carries "in progress"). Waiting: parked offline, with the reassurance
+  // it will land. Success: "added" and the count. Error: the failure and reason.
   const title = running
     ? t.importLedger.importingNamed.replace('{name}', imp.groupName)
     : waiting
@@ -66,7 +68,7 @@ export function ImportProgressBanner(): React.JSX.Element | null {
         ? t.importLedger.addedNamed.replace('{name}', imp.groupName)
         : t.importLedger.importFailed;
   const sub = running
-    ? `${percent}%`
+    ? null
     : waiting
       ? t.importLedger.waitingHint
       : success && imp.summary
@@ -131,13 +133,9 @@ export function ImportProgressBanner(): React.JSX.Element | null {
               </Text>
             ) : null}
           </View>
-          {/* Running: the percent, big and to the right. Success: a chevron into
-              the group. Error: a dismiss. */}
-          {running ? (
-            <Text variant="subheading" tone="brand" style={{ fontWeight: '700' }}>
-              {`${percent}%`}
-            </Text>
-          ) : error || waiting ? (
+          {/* Success: a chevron into the group. Waiting/error: a dismiss. Running
+              carries no trailing control — just the bar below. */}
+          {error || waiting ? (
             <Pressable
               onPress={dismissImport}
               accessibilityRole="button"
@@ -146,7 +144,7 @@ export function ImportProgressBanner(): React.JSX.Element | null {
             >
               <Ionicons name="close" size={iconSize.lg} color={theme.color.textMuted} />
             </Pressable>
-          ) : imp.groupId ? (
+          ) : success && imp.groupId ? (
             <Ionicons
               name={directionalIcon('chevron-forward')}
               size={iconSize.lg}
@@ -154,7 +152,9 @@ export function ImportProgressBanner(): React.JSX.Element | null {
             />
           ) : null}
         </Row>
-        {running ? <ProgressBar progress={imp.fraction} animated={!reduceMotion} /> : null}
+        {/* A slim indeterminate bar while the write is in flight — no `progress`,
+            so it slides on the native driver and never re-renders per frame. */}
+        {running ? <ProgressBar animated={!reduceMotion} height={3} /> : null}
       </Pressable>
     </Animated.View>
   );

--- a/apps/mobile/src/components/ImportProgressBanner.tsx
+++ b/apps/mobile/src/components/ImportProgressBanner.tsx
@@ -1,0 +1,150 @@
+/**
+ * The import banner that sits above the group list on Home.
+ *
+ * It is the visible half of {@link ../lib/importProgress}: while a ledger is
+ * being brought in it shows the group's name, a live percentage and a
+ * determinate bar; on success it flips to a check and the count it added, then
+ * clears itself (the store lingers a beat, then goes idle); on failure it holds
+ * the people-facing reason with a way to dismiss. Idle, it renders nothing.
+ *
+ * The whole card eases in — a short fade and drop — so it arrives as the person
+ * lands on Home from the import screen rather than snapping into the layout.
+ */
+
+import { useEffect, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Animated, Pressable, View } from 'react-native';
+
+import { directionalIcon, iconSize, ProgressBar, Row, Text, useTheme } from '@waves/ui';
+
+import { dismissImport, useImportProgress } from '@/lib/importProgress';
+import { plural, useStrings } from '@/i18n';
+import { useReducedMotion } from '@/lib/reducedMotion';
+
+export function ImportProgressBanner(): React.JSX.Element | null {
+  const imp = useImportProgress();
+  const theme = useTheme();
+  const { t, locale } = useStrings();
+  const reduceMotion = useReducedMotion();
+
+  // Stable Animated values via useState (not useRef) so reading them in render
+  // is not a ref access — the pattern the rest of the app's animations use.
+  const opacity = useState(() => new Animated.Value(0))[0];
+  const translateY = useState(() => new Animated.Value(-8))[0];
+
+  const visible = imp.phase !== 'idle';
+  useEffect(() => {
+    if (!visible) return;
+    if (reduceMotion) {
+      opacity.setValue(1);
+      translateY.setValue(0);
+      return;
+    }
+    Animated.parallel([
+      Animated.timing(opacity, { toValue: 1, duration: 200, useNativeDriver: true }),
+      Animated.spring(translateY, { toValue: 0, friction: 8, useNativeDriver: true }),
+    ]).start();
+  }, [visible, reduceMotion, opacity, translateY]);
+
+  if (!visible) return null;
+
+  const running = imp.phase === 'running';
+  const success = imp.phase === 'success';
+  const percent = Math.round(imp.fraction * 100);
+
+  // The title and its sub line, per phase. Running: the group name and the live
+  // percent. Success: "added" and the count. Error: the failure and its reason.
+  const title = running
+    ? t.importLedger.importingNamed.replace('{name}', imp.groupName)
+    : success
+      ? t.importLedger.addedNamed.replace('{name}', imp.groupName)
+      : t.importLedger.importFailed;
+  const sub = running
+    ? `${percent}%`
+    : success && imp.summary
+      ? plural(locale, imp.summary.expenses, t.importLedger.expenseCount)
+      : imp.error;
+
+  const icon: keyof typeof Ionicons.glyphMap = running
+    ? 'cloud-upload-outline'
+    : success
+      ? 'checkmark-circle'
+      : 'alert-circle';
+  const accent = success
+    ? theme.color.positive
+    : imp.phase === 'error'
+      ? theme.color.negative
+      : theme.color.brand;
+
+  // Success opens the group on tap; the rest of the time the card is inert.
+  const onPress =
+    success && imp.groupId ? () => router.replace(`/group/${imp.groupId}`) : undefined;
+
+  return (
+    <Animated.View style={{ opacity, transform: [{ translateY }] }}>
+      <Pressable
+        onPress={onPress}
+        accessibilityRole={onPress ? 'button' : undefined}
+        accessibilityLabel={`${title}${sub ? `. ${sub}` : ''}`}
+        style={({ pressed }) => ({
+          gap: theme.spacing.md,
+          padding: theme.spacing.lg,
+          borderRadius: theme.radius.lg,
+          borderWidth: 1,
+          borderColor: theme.color.border,
+          backgroundColor: theme.color.surface,
+          opacity: pressed && onPress ? 0.7 : 1,
+        })}
+      >
+        <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+          <View
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 20,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.color.surfaceMuted,
+            }}
+          >
+            <Ionicons name={icon} size={iconSize.lg} color={accent} />
+          </View>
+          <View style={{ flex: 1, gap: 2 }}>
+            <Text variant="subheading" numberOfLines={1}>
+              {title}
+            </Text>
+            {sub ? (
+              <Text variant="caption" tone="muted" numberOfLines={2}>
+                {sub}
+              </Text>
+            ) : null}
+          </View>
+          {/* Running: the percent, big and to the right. Success: a chevron into
+              the group. Error: a dismiss. */}
+          {running ? (
+            <Text variant="subheading" tone="brand" style={{ fontWeight: '700' }}>
+              {`${percent}%`}
+            </Text>
+          ) : imp.phase === 'error' ? (
+            <Pressable
+              onPress={dismissImport}
+              accessibilityRole="button"
+              accessibilityLabel={t.common.close}
+              hitSlop={10}
+            >
+              <Ionicons name="close" size={iconSize.lg} color={theme.color.textMuted} />
+            </Pressable>
+          ) : imp.groupId ? (
+            <Ionicons
+              name={directionalIcon('chevron-forward')}
+              size={iconSize.lg}
+              color={theme.color.textFaint}
+            />
+          ) : null}
+        </Row>
+        {running ? <ProgressBar progress={imp.fraction} animated={!reduceMotion} /> : null}
+      </Pressable>
+    </Animated.View>
+  );
+}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -288,6 +288,11 @@ export function useHomeSummary(profileId: string | null) {
     // `snapshot.date` comes from `expense_date`, a local date, so a UTC prefix
     // is the wrong month for the hours either side of the 1st.
     const monthByCurrency = new Map<string, bigint>();
+    // Groups that already have a materialised ledger (any expense or settlement).
+    // A freshly imported group lands in the mirror a beat before its expenses do,
+    // so its balance reads a confident 0 until they arrive; this lets the row mask
+    // that amount rather than flash a wrong zero (see the dashboard's GroupRow).
+    const withLedger = new Set<string>();
 
     for (const group of materialiseGroups(mirror, queue) as unknown as GroupRow[]) {
       const currency = group.default_currency ?? 'INR';
@@ -302,6 +307,8 @@ export function useHomeSummary(profileId: string | null) {
       const snapshots = materialiseExpenses(mirror, queue, { groupId: group.id })
         .map((expense) => toSnapshot(expense as unknown as ExpenseRow))
         .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
+
+      if (snapshots.length > 0 || settlements.length > 0) withLedger.add(group.id);
 
       const net = computeNetBalances(snapshots, settlements.map(toSettlementSnapshot));
       const mine = (membersByGroup.get(group.id) ?? []).find(
@@ -341,7 +348,7 @@ export function useHomeSummary(profileId: string | null) {
       .map(([currency, amount]) => ({ currency, amount }))
       .sort((a, b) => (b.amount > a.amount ? 1 : b.amount < a.amount ? -1 : 0));
 
-    return { byGroup, membersByGroup, awaiting, totals, monthSpent };
+    return { byGroup, membersByGroup, awaiting, totals, monthSpent, withLedger };
   }, [mirror, queue, profileId, monthPrefix]);
 
   return {
@@ -349,6 +356,9 @@ export function useHomeSummary(profileId: string | null) {
     membersFor: (groupId: string) => summary.membersByGroup.get(groupId) ?? [],
     memberCountFor: (groupId: string) => summary.membersByGroup.get(groupId)?.length ?? 0,
     hasPending: (groupId: string) => summary.awaiting.has(groupId),
+    /** Whether this group's ledger has materialised yet — false for the brief
+     *  window after an import lands the group but before its expenses arrive. */
+    hasLedger: (groupId: string) => summary.withLedger.has(groupId),
     totals: summary.totals,
     /** My share of this month's expenses, per currency, biggest first. */
     monthSpent: summary.monthSpent,

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1831,6 +1831,10 @@ export interface UiStrings {
     importingCount: PluralForms;
     /** Default group name for a Splitwise import, since the CSV carries none. */
     splitwiseGroupName: string;
+    /** Home-screen banner while a background import runs — carries the group name. */
+    importingNamed: string;
+    /** Home-screen banner once a background import has landed the group. */
+    addedNamed: string;
   };
   /** Picking people, a country, and the dates a trip runs between. */
   pickers: {
@@ -3644,6 +3648,8 @@ const en: UiStrings = {
     parsing: 'Working through the rows…',
     importingCount: { one: 'Importing {n} expense…', other: 'Importing {n} expenses…' },
     splitwiseGroupName: 'Splitwise',
+    importingNamed: 'Importing {name}…',
+    addedNamed: '{name} added',
   },
   pickers: {
     contactsDeniedTitle: 'Contacts are switched off',
@@ -5545,6 +5551,8 @@ const ta: UiStrings = {
       other: '{n} செலவுகளை இறக்குமதி செய்கிறது…',
     },
     splitwiseGroupName: 'Splitwise',
+    importingNamed: '{name} இறக்குமதி ஆகிறது…',
+    addedNamed: '{name} சேர்க்கப்பட்டது',
   },
   pickers: {
     contactsDeniedTitle: 'தொடர்புகள் அணைக்கப்பட்டுள்ளன',
@@ -7381,6 +7389,8 @@ const hi: UiStrings = {
     parsing: 'पंक्तियाँ संसाधित हो रही हैं…',
     importingCount: { one: '{n} खर्च आयात हो रहा है…', other: '{n} खर्च आयात हो रहे हैं…' },
     splitwiseGroupName: 'Splitwise',
+    importingNamed: '{name} इंपोर्ट हो रहा है…',
+    addedNamed: '{name} जोड़ा गया',
   },
   pickers: {
     contactsDeniedTitle: 'संपर्क बंद हैं',
@@ -9390,6 +9400,8 @@ const ar: UiStrings = {
       other: 'جارٍ استيراد {n} مصروف…',
     },
     splitwiseGroupName: 'Splitwise',
+    importingNamed: 'جارٍ استيراد {name}…',
+    addedNamed: 'تمت إضافة {name}',
   },
   pickers: {
     contactsDeniedTitle: 'جهات الاتصال مُوقَفة',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1839,6 +1839,12 @@ export interface UiStrings {
     helpTitle: string;
     /** Hint on the "A new group" row, now the name is editable below it. */
     nameItBelow: string;
+    /** Banner title when an import is parked offline, awaiting a connection. */
+    waitingNamed: string;
+    /** Banner sub line under a parked import — the reassurance it will land. */
+    waitingHint: string;
+    /** Help-sheet line: what happens to an import started with no connection. */
+    helpOffline: string;
   };
   /** Picking people, a country, and the dates a trip runs between. */
   pickers: {
@@ -3656,6 +3662,9 @@ const en: UiStrings = {
     addedNamed: '{name} added',
     helpTitle: 'How importing works',
     nameItBelow: 'Name it below',
+    waitingNamed: '{name} — waiting for a connection',
+    waitingHint: 'It will import the moment you are back online.',
+    helpOffline: 'No connection? The import is saved and runs the moment you are back online.',
   },
   pickers: {
     contactsDeniedTitle: 'Contacts are switched off',
@@ -5561,6 +5570,10 @@ const ta: UiStrings = {
     addedNamed: '{name} சேர்க்கப்பட்டது',
     helpTitle: 'இறக்குமதி எப்படி வேலை செய்கிறது',
     nameItBelow: 'கீழே பெயரிடுங்கள்',
+    waitingNamed: '{name} — இணைப்புக்காக காத்திருக்கிறது',
+    waitingHint: 'நீங்கள் மீண்டும் ஆன்லைனுக்கு வந்ததும் இறக்குமதி ஆகும்.',
+    helpOffline:
+      'இணைப்பு இல்லையா? இறக்குமதி சேமிக்கப்பட்டு, நீங்கள் ஆன்லைனுக்கு வந்ததும் இயங்கும்.',
   },
   pickers: {
     contactsDeniedTitle: 'தொடர்புகள் அணைக்கப்பட்டுள்ளன',
@@ -7401,6 +7414,9 @@ const hi: UiStrings = {
     addedNamed: '{name} जोड़ा गया',
     helpTitle: 'इंपोर्ट कैसे काम करता है',
     nameItBelow: 'नीचे नाम दें',
+    waitingNamed: '{name} — कनेक्शन का इंतज़ार',
+    waitingHint: 'ऑनलाइन आते ही यह इंपोर्ट हो जाएगा।',
+    helpOffline: 'कनेक्शन नहीं? इंपोर्ट सेव हो जाता है और ऑनलाइन आते ही चल जाता है।',
   },
   pickers: {
     contactsDeniedTitle: 'संपर्क बंद हैं',
@@ -9414,6 +9430,9 @@ const ar: UiStrings = {
     addedNamed: 'تمت إضافة {name}',
     helpTitle: 'كيف يعمل الاستيراد',
     nameItBelow: 'سمِّها بالأسفل',
+    waitingNamed: '{name} — بانتظار الاتصال',
+    waitingHint: 'سيُستورد فور عودتك للاتصال.',
+    helpOffline: 'لا يوجد اتصال؟ يُحفظ الاستيراد ويعمل فور عودتك للاتصال.',
   },
   pickers: {
     contactsDeniedTitle: 'جهات الاتصال مُوقَفة',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1845,6 +1845,8 @@ export interface UiStrings {
     waitingHint: string;
     /** Help-sheet line: what happens to an import started with no connection. */
     helpOffline: string;
+    /** Shown when a second import is started while one is already in progress. */
+    alreadyImporting: string;
   };
   /** Picking people, a country, and the dates a trip runs between. */
   pickers: {
@@ -3665,6 +3667,7 @@ const en: UiStrings = {
     waitingNamed: '{name} — waiting for a connection',
     waitingHint: 'It will import the moment you are back online.',
     helpOffline: 'No connection? The import is saved and runs the moment you are back online.',
+    alreadyImporting: 'An import is already running. Give it a moment to finish.',
   },
   pickers: {
     contactsDeniedTitle: 'Contacts are switched off',
@@ -5574,6 +5577,7 @@ const ta: UiStrings = {
     waitingHint: 'நீங்கள் மீண்டும் ஆன்லைனுக்கு வந்ததும் இறக்குமதி ஆகும்.',
     helpOffline:
       'இணைப்பு இல்லையா? இறக்குமதி சேமிக்கப்பட்டு, நீங்கள் ஆன்லைனுக்கு வந்ததும் இயங்கும்.',
+    alreadyImporting: 'ஏற்கனவே ஒரு இறக்குமதி நடக்கிறது. முடிய சிறிது நேரம் கொடுங்கள்.',
   },
   pickers: {
     contactsDeniedTitle: 'தொடர்புகள் அணைக்கப்பட்டுள்ளன',
@@ -7417,6 +7421,7 @@ const hi: UiStrings = {
     waitingNamed: '{name} — कनेक्शन का इंतज़ार',
     waitingHint: 'ऑनलाइन आते ही यह इंपोर्ट हो जाएगा।',
     helpOffline: 'कनेक्शन नहीं? इंपोर्ट सेव हो जाता है और ऑनलाइन आते ही चल जाता है।',
+    alreadyImporting: 'एक इंपोर्ट पहले से चल रहा है। इसे पूरा होने का थोड़ा समय दें।',
   },
   pickers: {
     contactsDeniedTitle: 'संपर्क बंद हैं',
@@ -9433,6 +9438,7 @@ const ar: UiStrings = {
     waitingNamed: '{name} — بانتظار الاتصال',
     waitingHint: 'سيُستورد فور عودتك للاتصال.',
     helpOffline: 'لا يوجد اتصال؟ يُحفظ الاستيراد ويعمل فور عودتك للاتصال.',
+    alreadyImporting: 'هناك استيراد قيد التنفيذ بالفعل. امنحه لحظة حتى ينتهي.',
   },
   pickers: {
     contactsDeniedTitle: 'جهات الاتصال مُوقَفة',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1835,6 +1835,10 @@ export interface UiStrings {
     importingNamed: string;
     /** Home-screen banner once a background import has landed the group. */
     addedNamed: string;
+    /** Title of the header help sheet on the import screen. */
+    helpTitle: string;
+    /** Hint on the "A new group" row, now the name is editable below it. */
+    nameItBelow: string;
   };
   /** Picking people, a country, and the dates a trip runs between. */
   pickers: {
@@ -3650,6 +3654,8 @@ const en: UiStrings = {
     splitwiseGroupName: 'Splitwise',
     importingNamed: 'Importing {name}…',
     addedNamed: '{name} added',
+    helpTitle: 'How importing works',
+    nameItBelow: 'Name it below',
   },
   pickers: {
     contactsDeniedTitle: 'Contacts are switched off',
@@ -5553,6 +5559,8 @@ const ta: UiStrings = {
     splitwiseGroupName: 'Splitwise',
     importingNamed: '{name} இறக்குமதி ஆகிறது…',
     addedNamed: '{name} சேர்க்கப்பட்டது',
+    helpTitle: 'இறக்குமதி எப்படி வேலை செய்கிறது',
+    nameItBelow: 'கீழே பெயரிடுங்கள்',
   },
   pickers: {
     contactsDeniedTitle: 'தொடர்புகள் அணைக்கப்பட்டுள்ளன',
@@ -7391,6 +7399,8 @@ const hi: UiStrings = {
     splitwiseGroupName: 'Splitwise',
     importingNamed: '{name} इंपोर्ट हो रहा है…',
     addedNamed: '{name} जोड़ा गया',
+    helpTitle: 'इंपोर्ट कैसे काम करता है',
+    nameItBelow: 'नीचे नाम दें',
   },
   pickers: {
     contactsDeniedTitle: 'संपर्क बंद हैं',
@@ -9402,6 +9412,8 @@ const ar: UiStrings = {
     splitwiseGroupName: 'Splitwise',
     importingNamed: 'جارٍ استيراد {name}…',
     addedNamed: 'تمت إضافة {name}',
+    helpTitle: 'كيف يعمل الاستيراد',
+    nameItBelow: 'سمِّها بالأسفل',
   },
   pickers: {
     contactsDeniedTitle: 'جهات الاتصال مُوقَفة',

--- a/apps/mobile/src/lib/importProgress.ts
+++ b/apps/mobile/src/lib/importProgress.ts
@@ -195,14 +195,17 @@ function park(job: ImportJob, mine: number): void {
 }
 
 /**
- * Start an import. A second call while one is already running or waiting is
- * ignored, so a double tap cannot fan out two writes.
+ * Start an import. Returns whether the job was scheduled: `false` when one is
+ * already running or waiting (a second import is refused so a double tap cannot
+ * fan out two writes), `true` once this job is on. The caller uses that to
+ * decide whether to leave the import screen — dropping the job *and* navigating
+ * away would strand the person's mapping unimported.
  *
  * If the phone is offline at the tap, the job is parked straight into `waiting`
  * rather than run and failed.
  */
-export function beginImport(job: ImportJob): void {
-  if (snapshot.phase === 'running' || snapshot.phase === 'waiting') return;
+export function beginImport(job: ImportJob): boolean {
+  if (snapshot.phase === 'running' || snapshot.phase === 'waiting') return false;
   stopClear();
   stopNetWatch();
   pendingJob = null;
@@ -216,6 +219,7 @@ export function beginImport(job: ImportJob): void {
     if (online) attempt(job, mine);
     else park(job, mine);
   });
+  return true;
 }
 
 /** Clear the banner — the error/waiting dismiss, and the guard against a late

--- a/apps/mobile/src/lib/importProgress.ts
+++ b/apps/mobile/src/lib/importProgress.ts
@@ -1,0 +1,195 @@
+/**
+ * A tiny global store for an in-flight ledger import, so the work survives the
+ * screen that started it.
+ *
+ * The import screen used to run the write itself and hold the person there
+ * watching a bar. Now the tap hands the job here and walks home: this store
+ * keeps running the import from plain module code — not tied to any component —
+ * and the dashboard subscribes through {@link useImportProgress} to show one
+ * banner above the group list. When it finishes, the new group animates into
+ * that list on its own; the banner says its piece and clears itself.
+ *
+ * Built framework-free on the same shape as {@link ./transferProgress}: the job
+ * is kicked from a callback and the UI reads it through `useSyncExternalStore`,
+ * so nothing about the import depends on the import screen still being mounted.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+export type ImportPhase = 'idle' | 'running' | 'success' | 'error';
+
+/** What a finished import brought in — the counts the banner reads back. */
+export interface ImportSummary {
+  expenses: number;
+  ghosts: number;
+  settlements: number;
+}
+
+/** The result an import job resolves with: where it landed, and what it added. */
+export type ImportResult = { groupId: string } & ImportSummary;
+
+/** The unit of work the store runs: a display name and the async import itself. */
+export interface ImportJob {
+  /** The group's name, shown in the banner while the write is in flight. */
+  name: string;
+  /**
+   * The whole import — create/target the group, resolve members, write the
+   * ledger, and pull it into the mirror — resolving with the group id and the
+   * counts. It should throw an Error whose message is already people-facing
+   * (via friendlyError); the store shows that message verbatim on failure.
+   */
+  run: () => Promise<ImportResult>;
+}
+
+export interface ImportProgressSnapshot {
+  phase: ImportPhase;
+  /** 0‑1. Simulated while running (see below); exactly 1 only once it is done. */
+  fraction: number;
+  groupName: string;
+  /** The imported group, known only once it has succeeded. */
+  groupId: string | null;
+  summary: ImportSummary | null;
+  /** A people-facing message, set only in the error phase. */
+  error: string | null;
+}
+
+const IDLE: ImportProgressSnapshot = {
+  phase: 'idle',
+  fraction: 0,
+  groupName: '',
+  groupId: null,
+  summary: null,
+  error: null,
+};
+
+let snapshot: ImportProgressSnapshot = IDLE;
+const listeners = new Set<() => void>();
+
+// The easing ticker while running, and the timer that clears a finished banner.
+let ease: ReturnType<typeof setInterval> | null = null;
+let clearTimer: ReturnType<typeof setTimeout> | null = null;
+// Bumped on every start and dismiss, so a job that resolves after a newer one
+// has begun (or after the banner was dismissed) cannot write stale state.
+let token = 0;
+
+function emit(next: ImportProgressSnapshot): void {
+  snapshot = next;
+  for (const listener of listeners) listener();
+}
+
+function stopEase(): void {
+  if (ease) {
+    clearInterval(ease);
+    ease = null;
+  }
+}
+
+function stopClear(): void {
+  if (clearTimer) {
+    clearTimeout(clearTimer);
+    clearTimer = null;
+  }
+}
+
+/** Where the simulated bar tops out before completion, and how fast it decays
+ *  toward it — a bar that eases to ~92% then waits reads as "almost there"
+ *  without ever claiming to be done before it is. */
+const EASE_CEILING = 0.92;
+const EASE_RATE = 0.06;
+const EASE_MS = 140;
+/** How long a success banner lingers before it clears itself. */
+const SUCCESS_LINGER_MS = 4200;
+
+/**
+ * Start an import. A second call while one is already running is ignored, so a
+ * double tap on the import button cannot fan out two writes.
+ *
+ * The bar is simulated on purpose: the import is a single transactional RPC with
+ * no streaming, so there is no real fraction to report mid-flight. It eases
+ * toward {@link EASE_CEILING} on a decaying curve and only reaches a true 100%
+ * when the write actually resolves — honest about the one thing that matters
+ * (done or not) while still feeling alive.
+ */
+export function beginImport(job: ImportJob): void {
+  if (snapshot.phase === 'running') return;
+  stopEase();
+  stopClear();
+  const mine = ++token;
+
+  emit({
+    phase: 'running',
+    fraction: 0,
+    groupName: job.name,
+    groupId: null,
+    summary: null,
+    error: null,
+  });
+
+  ease = setInterval(() => {
+    if (token !== mine || snapshot.phase !== 'running') return;
+    const next = snapshot.fraction + (EASE_CEILING - snapshot.fraction) * EASE_RATE;
+    emit({ ...snapshot, fraction: next });
+  }, EASE_MS);
+
+  job.run().then(
+    (result) => {
+      if (token !== mine) return;
+      stopEase();
+      emit({
+        phase: 'success',
+        fraction: 1,
+        groupName: job.name,
+        groupId: result.groupId,
+        summary: {
+          expenses: result.expenses,
+          ghosts: result.ghosts,
+          settlements: result.settlements,
+        },
+        error: null,
+      });
+      // Leave the "added" banner up for a beat, then clear it. The new group row
+      // on Home animates itself in the moment the mirror gains the group; the
+      // banner does not have to stay for that.
+      clearTimer = setTimeout(() => {
+        if (token === mine) emit(IDLE);
+      }, SUCCESS_LINGER_MS);
+    },
+    (caught: unknown) => {
+      if (token !== mine) return;
+      stopEase();
+      const message = caught instanceof Error ? caught.message : String(caught);
+      emit({
+        phase: 'error',
+        fraction: 0,
+        groupName: job.name,
+        groupId: null,
+        summary: null,
+        error: message,
+      });
+    },
+  );
+}
+
+/** Clear the banner — the error dismiss, and the guard against a late resolve. */
+export function dismissImport(): void {
+  token++;
+  stopEase();
+  stopClear();
+  emit(IDLE);
+}
+
+export function subscribeImport(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getImportSnapshot(): ImportProgressSnapshot {
+  return snapshot;
+}
+
+/** React binding: the current import state, re-rendered as it advances. */
+export function useImportProgress(): ImportProgressSnapshot {
+  return useSyncExternalStore(subscribeImport, getImportSnapshot, getImportSnapshot);
+}

--- a/apps/mobile/src/lib/importProgress.ts
+++ b/apps/mobile/src/lib/importProgress.ts
@@ -1,23 +1,27 @@
 /**
  * A tiny global store for an in-flight ledger import, so the work survives the
- * screen that started it — and now survives being offline.
+ * screen that started it — and never ties up the app while it runs.
  *
- * The import screen used to run the write itself and hold the person there
- * watching a bar. Now the tap hands the job here and walks home: this store
- * keeps running the import from plain module code — not tied to any component —
- * and the dashboard subscribes through {@link useImportProgress} to show one
- * banner above the group list. When it finishes, the new group animates into
- * that list on its own; the banner says its piece and clears itself.
+ * The import screen hands the job here and walks home: this store runs the
+ * import from plain module code (not tied to any component), and the dashboard
+ * shows one banner above the group list through {@link useImportProgress}. When
+ * it finishes, the new group animates into that list on its own.
  *
- * Offline (Option B — deferred): the import is one direct RPC, so with no
- * connection it cannot land. Rather than fail, the store parks the job in a
- * `waiting` phase and watches for connectivity; the moment the phone is back
- * online it runs the same job (idempotent — the group id and every mutation id
- * are fixed by the caller, so a replay is a replay, never a duplicate). The
- * pending job lives in memory: it survives navigation, not the app being killed.
+ * It reports *phases*, not a percentage. The import is a single transactional
+ * RPC with no streaming, so there is no honest fraction to tick — and ticking a
+ * fake one meant emitting many times a second, which re-rendered a heavy
+ * dashboard on every tick and made the whole app crawl while a large import ran.
+ * Now the store emits only on a real transition (running → success, or into the
+ * offline wait), a handful of times total; the banner shows an indeterminate bar
+ * that animates on the native driver, so a slow or stalled import costs the JS
+ * thread nothing.
  *
- * Built framework-free on the same shape as {@link ./transferProgress}: the job
- * is kicked from a callback and the UI reads it through `useSyncExternalStore`.
+ * Offline (Option B — deferred): with no connection the RPC cannot land, so the
+ * store parks the job in a `waiting` phase and watches for connectivity; the
+ * moment the phone is back online it runs the same job. The job is idempotent —
+ * the group id and every mutation id are fixed by the caller — so a replay is a
+ * replay, never a duplicate. The pending job lives in memory: it survives
+ * navigation, not the app being killed.
  */
 
 import { useSyncExternalStore } from 'react';
@@ -53,8 +57,6 @@ export interface ImportJob {
 
 export interface ImportProgressSnapshot {
   phase: ImportPhase;
-  /** 0‑1. Simulated while running (see below); exactly 1 only once it is done. */
-  fraction: number;
   groupName: string;
   /** The imported group, known only once it has succeeded. */
   groupId: string | null;
@@ -65,7 +67,6 @@ export interface ImportProgressSnapshot {
 
 const IDLE: ImportProgressSnapshot = {
   phase: 'idle',
-  fraction: 0,
   groupName: '',
   groupId: null,
   summary: null,
@@ -75,9 +76,8 @@ const IDLE: ImportProgressSnapshot = {
 let snapshot: ImportProgressSnapshot = IDLE;
 const listeners = new Set<() => void>();
 
-// The easing ticker while running, the timer that clears a finished banner, and
-// the poll that watches for connectivity while a job is parked offline.
-let ease: ReturnType<typeof setInterval> | null = null;
+// The timer that clears a finished banner, and the poll that watches for
+// connectivity while a job is parked offline.
 let clearTimer: ReturnType<typeof setTimeout> | null = null;
 let netWatch: ReturnType<typeof setInterval> | null = null;
 // The job held for a reconnect while `phase === 'waiting'`.
@@ -90,13 +90,6 @@ let token = 0;
 function emit(next: ImportProgressSnapshot): void {
   snapshot = next;
   for (const listener of listeners) listener();
-}
-
-function stopEase(): void {
-  if (ease) {
-    clearInterval(ease);
-    ease = null;
-  }
 }
 
 function stopClear(): void {
@@ -113,12 +106,6 @@ function stopNetWatch(): void {
   }
 }
 
-/** Where the simulated bar tops out before completion, and how fast it decays
- *  toward it — a bar that eases to ~92% then waits reads as "almost there"
- *  without ever claiming to be done before it is. */
-const EASE_CEILING = 0.92;
-const EASE_RATE = 0.06;
-const EASE_MS = 140;
 /** How long a success banner lingers before it clears itself. */
 const SUCCESS_LINGER_MS = 4200;
 /** How often, while parked offline, to check whether the phone is back online. */
@@ -136,32 +123,19 @@ async function isOnline(): Promise<boolean> {
   }
 }
 
-/** Run the job now: ease the bar, then resolve to success, park (offline), or
- *  fail. `mine` is the start token this attempt belongs to. */
+function toRunning(job: ImportJob): void {
+  emit({ phase: 'running', groupName: job.name, groupId: null, summary: null, error: null });
+}
+
+/** Run the job now: resolve to success, park (offline), or fail. `mine` is the
+ *  start token this attempt belongs to. */
 function attempt(job: ImportJob, mine: number): void {
-  stopEase();
-  emit({
-    phase: 'running',
-    fraction: 0,
-    groupName: job.name,
-    groupId: null,
-    summary: null,
-    error: null,
-  });
-
-  ease = setInterval(() => {
-    if (token !== mine || snapshot.phase !== 'running') return;
-    const next = snapshot.fraction + (EASE_CEILING - snapshot.fraction) * EASE_RATE;
-    emit({ ...snapshot, fraction: next });
-  }, EASE_MS);
-
+  toRunning(job);
   job.run().then(
     (result) => {
       if (token !== mine) return;
-      stopEase();
       emit({
         phase: 'success',
-        fraction: 1,
         groupName: job.name,
         groupId: result.groupId,
         summary: {
@@ -179,7 +153,6 @@ function attempt(job: ImportJob, mine: number): void {
     },
     (caught: unknown) => {
       if (token !== mine) return;
-      stopEase();
       // A write that failed because we dropped offline is not an error — it is a
       // wait. Anything else, online, is a real failure to show.
       void isOnline().then((online) => {
@@ -190,7 +163,6 @@ function attempt(job: ImportJob, mine: number): void {
           const message = caught instanceof Error ? caught.message : String(caught);
           emit({
             phase: 'error',
-            fraction: 0,
             groupName: job.name,
             groupId: null,
             summary: null,
@@ -204,16 +176,8 @@ function attempt(job: ImportJob, mine: number): void {
 
 /** Hold the job for a reconnect, and start watching for one. */
 function park(job: ImportJob, mine: number): void {
-  stopEase();
   pendingJob = job;
-  emit({
-    phase: 'waiting',
-    fraction: 0,
-    groupName: job.name,
-    groupId: null,
-    summary: null,
-    error: null,
-  });
+  emit({ phase: 'waiting', groupName: job.name, groupId: null, summary: null, error: null });
   stopNetWatch();
   netWatch = setInterval(() => {
     if (token !== mine) {
@@ -234,31 +198,19 @@ function park(job: ImportJob, mine: number): void {
  * Start an import. A second call while one is already running or waiting is
  * ignored, so a double tap cannot fan out two writes.
  *
- * The bar is simulated on purpose: the import is a single transactional RPC with
- * no streaming, so there is no real fraction to report mid-flight. It eases
- * toward {@link EASE_CEILING} and only reaches a true 100% when the write
- * actually resolves. If the phone is offline at the tap, the job is parked
- * straight into `waiting` rather than run and failed.
+ * If the phone is offline at the tap, the job is parked straight into `waiting`
+ * rather than run and failed.
  */
 export function beginImport(job: ImportJob): void {
   if (snapshot.phase === 'running' || snapshot.phase === 'waiting') return;
-  stopEase();
   stopClear();
   stopNetWatch();
   pendingJob = null;
   const mine = ++token;
 
   // Show the banner at once, then decide: run if online, park if not. The
-  // reachability check is a fast local call, so any "running → waiting" flip is
-  // within a frame or two.
-  emit({
-    phase: 'running',
-    fraction: 0,
-    groupName: job.name,
-    groupId: null,
-    summary: null,
-    error: null,
-  });
+  // reachability check is a fast local call.
+  toRunning(job);
   void isOnline().then((online) => {
     if (token !== mine) return;
     if (online) attempt(job, mine);
@@ -270,7 +222,6 @@ export function beginImport(job: ImportJob): void {
  *  resolve. Drops any parked job. */
 export function dismissImport(): void {
   token++;
-  stopEase();
   stopClear();
   stopNetWatch();
   pendingJob = null;
@@ -288,7 +239,19 @@ export function getImportSnapshot(): ImportProgressSnapshot {
   return snapshot;
 }
 
+/** The group a just-finished import landed, or null. A primitive so a subscriber
+ *  that only wants this (the dashboard, to animate the new row) re-renders on the
+ *  success transition alone, not on every phase change. */
+export function getImportedGroupId(): string | null {
+  return snapshot.phase === 'success' ? snapshot.groupId : null;
+}
+
 /** React binding: the current import state, re-rendered as it advances. */
 export function useImportProgress(): ImportProgressSnapshot {
   return useSyncExternalStore(subscribeImport, getImportSnapshot, getImportSnapshot);
+}
+
+/** React binding for just the landed group id (see {@link getImportedGroupId}). */
+export function useImportedGroupId(): string | null {
+  return useSyncExternalStore(subscribeImport, getImportedGroupId, getImportedGroupId);
 }

--- a/apps/mobile/src/lib/importProgress.ts
+++ b/apps/mobile/src/lib/importProgress.ts
@@ -1,6 +1,6 @@
 /**
  * A tiny global store for an in-flight ledger import, so the work survives the
- * screen that started it.
+ * screen that started it — and now survives being offline.
  *
  * The import screen used to run the write itself and hold the person there
  * watching a bar. Now the tap hands the job here and walks home: this store
@@ -9,14 +9,21 @@
  * banner above the group list. When it finishes, the new group animates into
  * that list on its own; the banner says its piece and clears itself.
  *
+ * Offline (Option B — deferred): the import is one direct RPC, so with no
+ * connection it cannot land. Rather than fail, the store parks the job in a
+ * `waiting` phase and watches for connectivity; the moment the phone is back
+ * online it runs the same job (idempotent — the group id and every mutation id
+ * are fixed by the caller, so a replay is a replay, never a duplicate). The
+ * pending job lives in memory: it survives navigation, not the app being killed.
+ *
  * Built framework-free on the same shape as {@link ./transferProgress}: the job
- * is kicked from a callback and the UI reads it through `useSyncExternalStore`,
- * so nothing about the import depends on the import screen still being mounted.
+ * is kicked from a callback and the UI reads it through `useSyncExternalStore`.
  */
 
 import { useSyncExternalStore } from 'react';
+import * as Network from 'expo-network';
 
-export type ImportPhase = 'idle' | 'running' | 'success' | 'error';
+export type ImportPhase = 'idle' | 'running' | 'waiting' | 'success' | 'error';
 
 /** What a finished import brought in — the counts the banner reads back. */
 export interface ImportSummary {
@@ -30,13 +37,16 @@ export type ImportResult = { groupId: string } & ImportSummary;
 
 /** The unit of work the store runs: a display name and the async import itself. */
 export interface ImportJob {
-  /** The group's name, shown in the banner while the write is in flight. */
+  /** The group's name, shown in the banner. */
   name: string;
   /**
    * The whole import — create/target the group, resolve members, write the
    * ledger, and pull it into the mirror — resolving with the group id and the
-   * counts. It should throw an Error whose message is already people-facing
-   * (via friendlyError); the store shows that message verbatim on failure.
+   * counts. It MUST be idempotent: the store may run it more than once (a
+   * reconnect after an offline wait), so the caller fixes the group id and every
+   * clientMutationId up front, making a re-run a replay. It should throw an
+   * Error whose message is already people-facing (via friendlyError); the store
+   * shows that message verbatim on a real failure.
    */
   run: () => Promise<ImportResult>;
 }
@@ -65,11 +75,16 @@ const IDLE: ImportProgressSnapshot = {
 let snapshot: ImportProgressSnapshot = IDLE;
 const listeners = new Set<() => void>();
 
-// The easing ticker while running, and the timer that clears a finished banner.
+// The easing ticker while running, the timer that clears a finished banner, and
+// the poll that watches for connectivity while a job is parked offline.
 let ease: ReturnType<typeof setInterval> | null = null;
 let clearTimer: ReturnType<typeof setTimeout> | null = null;
-// Bumped on every start and dismiss, so a job that resolves after a newer one
-// has begun (or after the banner was dismissed) cannot write stale state.
+let netWatch: ReturnType<typeof setInterval> | null = null;
+// The job held for a reconnect while `phase === 'waiting'`.
+let pendingJob: ImportJob | null = null;
+// Bumped on every start and dismiss, so a job that resolves (or a net poll that
+// fires) after a newer start — or after the banner was dismissed — cannot write
+// stale state.
 let token = 0;
 
 function emit(next: ImportProgressSnapshot): void {
@@ -91,6 +106,13 @@ function stopClear(): void {
   }
 }
 
+function stopNetWatch(): void {
+  if (netWatch) {
+    clearInterval(netWatch);
+    netWatch = null;
+  }
+}
+
 /** Where the simulated bar tops out before completion, and how fast it decays
  *  toward it — a bar that eases to ~92% then waits reads as "almost there"
  *  without ever claiming to be done before it is. */
@@ -99,23 +121,25 @@ const EASE_RATE = 0.06;
 const EASE_MS = 140;
 /** How long a success banner lingers before it clears itself. */
 const SUCCESS_LINGER_MS = 4200;
+/** How often, while parked offline, to check whether the phone is back online. */
+const NET_POLL_MS = 4000;
 
-/**
- * Start an import. A second call while one is already running is ignored, so a
- * double tap on the import button cannot fan out two writes.
- *
- * The bar is simulated on purpose: the import is a single transactional RPC with
- * no streaming, so there is no real fraction to report mid-flight. It eases
- * toward {@link EASE_CEILING} on a decaying curve and only reaches a true 100%
- * when the write actually resolves — honest about the one thing that matters
- * (done or not) while still feeling alive.
- */
-export function beginImport(job: ImportJob): void {
-  if (snapshot.phase === 'running') return;
+/** The engine's own reachability check, kept in step with `sync/engine`: a
+ *  reachable interface is online; unknown fails open (a genuinely bad request is
+ *  caught below and parks the job anyway). */
+async function isOnline(): Promise<boolean> {
+  try {
+    const state = await Network.getNetworkStateAsync();
+    return state.isInternetReachable ?? state.isConnected ?? true;
+  } catch {
+    return true;
+  }
+}
+
+/** Run the job now: ease the bar, then resolve to success, park (offline), or
+ *  fail. `mine` is the start token this attempt belongs to. */
+function attempt(job: ImportJob, mine: number): void {
   stopEase();
-  stopClear();
-  const mine = ++token;
-
   emit({
     phase: 'running',
     fraction: 0,
@@ -148,8 +172,7 @@ export function beginImport(job: ImportJob): void {
         error: null,
       });
       // Leave the "added" banner up for a beat, then clear it. The new group row
-      // on Home animates itself in the moment the mirror gains the group; the
-      // banner does not have to stay for that.
+      // on Home animates itself in the moment the mirror gains the group.
       clearTimer = setTimeout(() => {
         if (token === mine) emit(IDLE);
       }, SUCCESS_LINGER_MS);
@@ -157,24 +180,100 @@ export function beginImport(job: ImportJob): void {
     (caught: unknown) => {
       if (token !== mine) return;
       stopEase();
-      const message = caught instanceof Error ? caught.message : String(caught);
-      emit({
-        phase: 'error',
-        fraction: 0,
-        groupName: job.name,
-        groupId: null,
-        summary: null,
-        error: message,
+      // A write that failed because we dropped offline is not an error — it is a
+      // wait. Anything else, online, is a real failure to show.
+      void isOnline().then((online) => {
+        if (token !== mine) return;
+        if (!online) {
+          park(job, mine);
+        } else {
+          const message = caught instanceof Error ? caught.message : String(caught);
+          emit({
+            phase: 'error',
+            fraction: 0,
+            groupName: job.name,
+            groupId: null,
+            summary: null,
+            error: message,
+          });
+        }
       });
     },
   );
 }
 
-/** Clear the banner — the error dismiss, and the guard against a late resolve. */
+/** Hold the job for a reconnect, and start watching for one. */
+function park(job: ImportJob, mine: number): void {
+  stopEase();
+  pendingJob = job;
+  emit({
+    phase: 'waiting',
+    fraction: 0,
+    groupName: job.name,
+    groupId: null,
+    summary: null,
+    error: null,
+  });
+  stopNetWatch();
+  netWatch = setInterval(() => {
+    if (token !== mine) {
+      stopNetWatch();
+      return;
+    }
+    void isOnline().then((online) => {
+      if (!online || token !== mine || snapshot.phase !== 'waiting' || !pendingJob) return;
+      stopNetWatch();
+      const job2 = pendingJob;
+      pendingJob = null;
+      attempt(job2, mine);
+    });
+  }, NET_POLL_MS);
+}
+
+/**
+ * Start an import. A second call while one is already running or waiting is
+ * ignored, so a double tap cannot fan out two writes.
+ *
+ * The bar is simulated on purpose: the import is a single transactional RPC with
+ * no streaming, so there is no real fraction to report mid-flight. It eases
+ * toward {@link EASE_CEILING} and only reaches a true 100% when the write
+ * actually resolves. If the phone is offline at the tap, the job is parked
+ * straight into `waiting` rather than run and failed.
+ */
+export function beginImport(job: ImportJob): void {
+  if (snapshot.phase === 'running' || snapshot.phase === 'waiting') return;
+  stopEase();
+  stopClear();
+  stopNetWatch();
+  pendingJob = null;
+  const mine = ++token;
+
+  // Show the banner at once, then decide: run if online, park if not. The
+  // reachability check is a fast local call, so any "running → waiting" flip is
+  // within a frame or two.
+  emit({
+    phase: 'running',
+    fraction: 0,
+    groupName: job.name,
+    groupId: null,
+    summary: null,
+    error: null,
+  });
+  void isOnline().then((online) => {
+    if (token !== mine) return;
+    if (online) attempt(job, mine);
+    else park(job, mine);
+  });
+}
+
+/** Clear the banner — the error/waiting dismiss, and the guard against a late
+ *  resolve. Drops any parked job. */
 export function dismissImport(): void {
   token++;
   stopEase();
   stopClear();
+  stopNetWatch();
+  pendingJob = null;
   emit(IDLE);
 }
 

--- a/apps/mobile/test/importProgress.test.ts
+++ b/apps/mobile/test/importProgress.test.ts
@@ -165,9 +165,11 @@ describe('importProgress store', () => {
     const first = vi.fn(() => deferred<ImportResult>().promise);
     const second = vi.fn(() => deferred<ImportResult>().promise);
 
-    beginImport({ name: 'One', run: first });
+    expect(beginImport({ name: 'One', run: first })).toBe(true);
     await flush();
-    beginImport({ name: 'Two', run: second });
+    // Refused while one is running — and the caller is told, so it can stay put
+    // rather than navigate away and strand this file.
+    expect(beginImport({ name: 'Two', run: second })).toBe(false);
     await flush();
 
     expect(first).toHaveBeenCalledTimes(1);

--- a/apps/mobile/test/importProgress.test.ts
+++ b/apps/mobile/test/importProgress.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The background-import store's state machine (src/lib/importProgress).
+ *
+ * These assert the transitions the dashboard banner relies on — run → success,
+ * the offline park-and-retry, real failures, and the token guards that stop a
+ * stale job writing over a newer one — with `expo-network` mocked so "online"
+ * and "offline" are ours to drive, and fake timers so the reconnect poll and the
+ * success linger do not make the suite wait in real seconds.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as Network from 'expo-network';
+
+import {
+  beginImport,
+  dismissImport,
+  getImportedGroupId,
+  getImportSnapshot,
+  type ImportResult,
+} from '@/lib/importProgress';
+
+// Hoisted above the imports by vitest, so the store sees the mock — we drive
+// "online" / "offline" from each test through `netMock`.
+vi.mock('expo-network', () => ({
+  getNetworkStateAsync: vi.fn(),
+}));
+
+// The store's NET_POLL_MS — the reconnect poll interval. Kept in step with the
+// module; the test advances past it to fire a poll.
+const NET_POLL_MS = 4000;
+
+const ONLINE = { isInternetReachable: true, isConnected: true } as const;
+const OFFLINE = { isInternetReachable: false, isConnected: false } as const;
+
+const netMock = Network.getNetworkStateAsync as unknown as ReturnType<typeof vi.fn>;
+
+/** A promise whose settling this test controls. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+} {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const result = (groupId: string): ImportResult => ({
+  groupId,
+  expenses: 3,
+  ghosts: 1,
+  settlements: 0,
+});
+
+/** Let every pending microtask (awaited isOnline / job.run continuations) run. */
+async function flush(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  netMock.mockReset();
+  netMock.mockResolvedValue(ONLINE);
+});
+
+afterEach(() => {
+  // Return the module singleton to idle between tests (bumps the guard token,
+  // clears any timers), then hand real timers back.
+  dismissImport();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('importProgress store', () => {
+  it('runs online: idle → running → success, exposing the landed group', async () => {
+    const d = deferred<ImportResult>();
+    const run = vi.fn(() => d.promise);
+
+    beginImport({ name: 'Goa', run });
+    // Shows the banner synchronously, before the reachability check resolves.
+    expect(getImportSnapshot().phase).toBe('running');
+
+    await flush(); // isOnline resolves → attempt runs the job
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(getImportSnapshot().phase).toBe('running');
+    expect(getImportedGroupId()).toBeNull();
+
+    d.resolve(result('g1'));
+    await flush();
+
+    const snap = getImportSnapshot();
+    expect(snap.phase).toBe('success');
+    expect(snap.groupId).toBe('g1');
+    expect(snap.summary).toEqual({ expenses: 3, ghosts: 1, settlements: 0 });
+    expect(getImportedGroupId()).toBe('g1');
+  });
+
+  it('clears itself a beat after success', async () => {
+    const d = deferred<ImportResult>();
+    beginImport({ name: 'Goa', run: () => d.promise });
+    await flush();
+    d.resolve(result('g1'));
+    await flush();
+    expect(getImportSnapshot().phase).toBe('success');
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(getImportSnapshot().phase).toBe('idle');
+    expect(getImportedGroupId()).toBeNull();
+  });
+
+  it('parks offline, then runs on reconnect', async () => {
+    netMock.mockResolvedValue(OFFLINE);
+    const d = deferred<ImportResult>();
+    const run = vi.fn(() => d.promise);
+
+    beginImport({ name: 'Goa', run });
+    await flush(); // isOnline resolves false → park
+    expect(getImportSnapshot().phase).toBe('waiting');
+    expect(run).not.toHaveBeenCalled();
+
+    // Connection returns; the next poll picks it up and runs the job.
+    netMock.mockResolvedValue(ONLINE);
+    await vi.advanceTimersByTimeAsync(NET_POLL_MS);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(getImportSnapshot().phase).toBe('running');
+
+    d.resolve(result('g2'));
+    await flush();
+    expect(getImportSnapshot().phase).toBe('success');
+    expect(getImportedGroupId()).toBe('g2');
+  });
+
+  it('surfaces a real (online) failure as an error with its message', async () => {
+    const d = deferred<ImportResult>();
+    beginImport({ name: 'Goa', run: () => d.promise });
+    await flush();
+
+    d.reject(new Error('That group id is already taken'));
+    await flush(); // onFail → isOnline (online) → error
+
+    const snap = getImportSnapshot();
+    expect(snap.phase).toBe('error');
+    expect(snap.error).toBe('That group id is already taken');
+    expect(getImportedGroupId()).toBeNull();
+  });
+
+  it('treats a failure while offline as a wait, not an error', async () => {
+    const d = deferred<ImportResult>();
+    beginImport({ name: 'Goa', run: () => d.promise });
+    await flush(); // online → running
+
+    // The connection drops, then the in-flight write rejects.
+    netMock.mockResolvedValue(OFFLINE);
+    d.reject(new Error('Network request failed'));
+    await flush(); // onFail → isOnline (offline) → park
+
+    expect(getImportSnapshot().phase).toBe('waiting');
+  });
+
+  it('ignores a second start while one is already running', async () => {
+    const first = vi.fn(() => deferred<ImportResult>().promise);
+    const second = vi.fn(() => deferred<ImportResult>().promise);
+
+    beginImport({ name: 'One', run: first });
+    await flush();
+    beginImport({ name: 'Two', run: second });
+    await flush();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+    expect(getImportSnapshot().groupName).toBe('One');
+  });
+
+  it('drops a job dismissed before it resolves — a stale resolve cannot win', async () => {
+    const d = deferred<ImportResult>();
+    beginImport({ name: 'Goa', run: () => d.promise });
+    await flush();
+    expect(getImportSnapshot().phase).toBe('running');
+
+    dismissImport();
+    expect(getImportSnapshot().phase).toBe('idle');
+
+    // The old job settles late; its token is stale, so nothing changes.
+    d.resolve(result('g3'));
+    await flush();
+    expect(getImportSnapshot().phase).toBe('idle');
+    expect(getImportedGroupId()).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Reworks the Splitwise/Waves import so tapping **Import** no longer traps you on the import screen. The tap hands the work to a background store and takes you **straight home**, where a banner above the group list tracks the percentage and the finished group **animates into the list**.

## Flow

1. Tap Import → `router.replace('/')` immediately.
2. Home shows `ImportProgressBanner` just above the groups: group name + live **percent** + determinate bar while running.
3. On success → check + count, tappable to open the group, auto-clears after a beat.
4. The just-imported group **fades and slides** into the list (`GroupRow` `enter` flag, reduce-motion aware).
5. On failure → the people-facing reason with a dismiss.

## How

- **`lib/importProgress.ts`** — framework-free store on the same `useSyncExternalStore` pattern as `transferProgress`. Runs the import from module code so it survives the import screen unmounting. The bar is *simulated* (eased toward ~92%) because the import is one atomic RPC with no streaming; only 100% is real, on resolve. A `token` guards against a stale job resolving after a newer start/dismiss.
- **`settings/import.tsx`** — `run()` now builds the entire import as a closure (create/target group, resolve members, write ledger, `groups.refetch()` to pull into the mirror), hands it to `beginImport`, and navigates home. The one pre-navigation guard (claiming yourself in an existing group you're not a member of) is kept.
- **`(tabs)/index.tsx`** — renders the banner above the list; `justAddedId` marks the success group so its row animates in.
- **i18n** — `importingNamed` / `addedNamed` in en/ta/hi/ar.

## Notes

- The import screen's old inline `done` card / `importing` bar are superseded by the Home banner (the `done` branch is now unreached; left in place to keep the diff focused).
- The new-row animation only fires for a group visible in the capped Home preview; the banner success state covers the rest.

## Checks

- `pnpm --filter @waves/mobile typecheck` — clean
- `eslint` on all changed files — clean
- `prettier --write` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added background ledger importing so processing can continue after leaving the import screen.
  - Users can name new groups before importing and access format and data guidance.
  - Added Home-screen import status banners with completion details, errors, dismissal, and navigation.
  - Added animated balance loading states with reduced-motion support.
  - Added offline waiting, automatic retry, duplicate-import alerts, and localized messaging in English, Tamil, Hindi, and Arabic.
- **Bug Fixes**
  - Improved handling of concurrent imports, stale results, and failed imports.
  - Import progress now reflects actual processing phases without simulated percentages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->