### PR TITLE
feat(mobile): expand voice expense parsing

### DIFF
--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -86,6 +86,7 @@ interface Draft {
   amount: string;
   note: string;
   currency: string | null;
+  category: string | null;
 }
 
 /** Where the reviewed expenses will be written. */
@@ -337,6 +338,7 @@ export default function VoiceScreen() {
         amount: String(item.amountMajor),
         note: item.note,
         currency: item.currency,
+        category: item.category,
       })),
     );
     setVoicePeopleText(result.peopleText);
@@ -415,6 +417,7 @@ export default function VoiceScreen() {
       amount: String(item.amountMajor),
       note: item.note,
       currency: item.currency,
+      category: item.category,
     }));
 
   const editDraft = (key: string, patch: Partial<Draft>): void => {
@@ -550,7 +553,7 @@ export default function VoiceScreen() {
       await createCapture.mutateAsync({
         captureId: draft.key,
         description,
-        category: guessCategory(description),
+        category: draft.category ?? guessCategory(description),
         expenseDate: date,
         currency,
         amount,
@@ -737,7 +740,7 @@ export default function VoiceScreen() {
         await writeExpense.mutateAsync({
           expenseId,
           description,
-          category: guessCategory(description),
+          category: draft.category ?? guessCategory(description),
           expenseDate: date,
           currency: groupCurrency,
           amount,

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -195,6 +195,7 @@ export default function VoiceScreen() {
   const [drafts, setDrafts] = useState<Draft[]>([]);
   const [voicePeopleText, setVoicePeopleText] = useState<string | null>(null);
   const [voiceSplitCount, setVoiceSplitCount] = useState<number | null>(null);
+  const [voiceExpenseDate, setVoiceExpenseDate] = useState<string | null>(null);
   // One place for the whole spoken batch — a run of "coffee, then the taxi" all
   // happened where you are standing (A43). Optional and opt-in; null until the
   // reader taps "Add location" on the review.
@@ -340,6 +341,7 @@ export default function VoiceScreen() {
     );
     setVoicePeopleText(result.peopleText);
     setVoiceSplitCount(result.splitCount);
+    setVoiceExpenseDate(result.expenseDate);
     // A fresh parse is a fresh group to create, and a fresh location to read.
     groupCreated.current = false;
     ghostMemberId.current = null;
@@ -438,6 +440,7 @@ export default function VoiceScreen() {
     setDrafts((current) => [...current, ...toDrafts(result)]);
     if (result.peopleText) setVoicePeopleText(result.peopleText);
     if (result.splitCount !== null) setVoiceSplitCount(result.splitCount);
+    if (result.expenseDate) setVoiceExpenseDate(result.expenseDate);
     setNoAmount(false);
     setMicMode('replace');
     setPhase('review');
@@ -529,7 +532,7 @@ export default function VoiceScreen() {
   // duplicate. Shared by the "Save as draft" button and the close-intercept, so
   // the two land the same rows.
   const persistDraftsToInbox = useCallback(async (): Promise<void> => {
-    const date = today();
+    const date = voiceExpenseDate ?? today();
     const fallback = t.voice.anExpense;
     // Several expenses spoken in one breath stay one thing in the inbox: they
     // share a batch id (carried in the capture's `parsed`, so no schema change),
@@ -555,7 +558,7 @@ export default function VoiceScreen() {
         parsed: batchId ? { voiceBatchId: batchId } : undefined,
       });
     }
-  }, [drafts, dc, location, t.voice.anExpense, createCapture]);
+  }, [drafts, dc, location, voiceExpenseDate, t.voice.anExpense, createCapture]);
 
   // Leaving the review with a draft batch and no group chosen must not throw the
   // expenses away — an unassigned batch is a draft, and a draft survives a close
@@ -653,7 +656,7 @@ export default function VoiceScreen() {
     setError(null);
     setSaving(true);
     try {
-      const date = today();
+      const date = voiceExpenseDate ?? today();
       const fallback = t.voice.anExpense;
 
       if (dest.kind === 'unassigned') {

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -22,20 +22,28 @@ export const MAX_VOICE_AMOUNT_MAJOR = 1_000_000_000;
 /** Bound model-supplied notes before they reach the review UI. */
 export const MAX_VOICE_NOTE_CHARS = 160;
 
-/** Unsupported intent words that must not be converted into normal expenses. */
-const UNSUPPORTED_EXPENSE_INTENT =
-  /\b(?:do\s+not|don['’]t|dont|did\s+not\s+pay|didn['’]t\s+pay|didnt\s+pay|not\s+paid|cancel|remove|delete|ignore|refund(?:ed|s|ing)?|reimburse(?:d|ment|ments|s|ing)?|repay(?:ment|ments|s|ing)?|repaid|pay\s*back|paid\s+(?:me\s+)?back|got\s+(?:paid\s+)?back|received\s+(?:money\s+)?back|not\s+an\s+expense)\b/i;
+/** Whole-command intents that must not be converted into expenses. */
+const UNSUPPORTED_GLOBAL_EXPENSE_INTENT =
+  /\b(?:do\s+not|don['’]t|dont|did\s+not\s+pay|didn['’]t\s+pay|didnt\s+pay|not\s+paid|cancel|remove|delete|ignore|not\s+an\s+expense)\b/i;
+
+/** Clause-level intents that can be skipped without discarding neighbouring safe expenses. */
+const UNSUPPORTED_EXPENSE_CLAUSE =
+  /\b(?:refund(?:ed|s|ing)?|reimburse(?:d|ment|ments|s|ing)?|repay(?:ment|ments|s|ing)?|repaid|pay\s*back|paid\s+(?:me\s+)?back|got\s+(?:paid\s+)?back|received\s+(?:money\s+)?back)\b/i;
 
 const SPOKEN_NEGATIVE_AMOUNT =
   /\b(?:minus|negative)\s+(?=(?:\d|zero\b|one\b|two\b|three\b|four\b|five\b|six\b|seven\b|eight\b|nine\b|ten\b|eleven\b|twelve\b|thirteen\b|fourteen\b|fifteen\b|sixteen\b|seventeen\b|eighteen\b|nineteen\b|twenty\b|thirty\b|forty\b|fourty\b|fifty\b|sixty\b|seventy\b|eighty\b|ninety\b|hundred\b|thousand\b|lakh\b|lakhs\b|crore\b|crores\b))/i;
 const THIRD_PARTY_PAYER_INTENT = /\b(?!(?:i|we|you)\b)[\p{L}][\p{L}'’.-]*\s+paid\b/iu;
 
-export function isUnsupportedVoiceExpenseIntent(text: string): boolean {
+function isUnsupportedVoiceExpenseClause(text: string): boolean {
   return (
-    UNSUPPORTED_EXPENSE_INTENT.test(text) ||
+    UNSUPPORTED_EXPENSE_CLAUSE.test(text) ||
     SPOKEN_NEGATIVE_AMOUNT.test(text) ||
     THIRD_PARTY_PAYER_INTENT.test(text)
   );
+}
+
+export function isUnsupportedVoiceExpenseIntent(text: string): boolean {
+  return UNSUPPORTED_GLOBAL_EXPENSE_INTENT.test(text) || isUnsupportedVoiceExpenseClause(text);
 }
 
 export function isSafeVoiceAmount(amountMajor: number): boolean {
@@ -718,7 +726,10 @@ export function parseVoiceCategory(text: string): CategoryId | null {
 
 function stripCategoryPhrase(text: string): string {
   CATEGORY_PHRASE.lastIndex = 0;
-  return text.replace(CATEGORY_PHRASE, ' ').replace(/[ \t]{2,}/g, ' ').trim();
+  return text
+    .replace(CATEGORY_PHRASE, ' ')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
 }
 
 /* ─────────────────────────────────────────────────────────────────────────
@@ -1328,7 +1339,7 @@ export function parseVoiceExpenses(
   transcript: string,
   groups: readonly VoiceGroupRef[],
 ): VoiceParseResult {
-  if (isUnsupportedVoiceExpenseIntent(transcript))
+  if (UNSUPPORTED_GLOBAL_EXPENSE_INTENT.test(transcript))
     return { items: [], group: null, splitCount: null, peopleText: null, expenseDate: null };
 
   const normalized = normalizeSpokenNumbers(
@@ -1361,6 +1372,7 @@ export function parseVoiceExpenses(
   let carriedCurrency: string | null = null;
 
   for (const segment of segments) {
+    if (isUnsupportedVoiceExpenseClause(segment)) continue;
     const amountMajor = extractAmount(segment);
     if (amountMajor === null) continue;
     const currency: string | null = detectCurrency(segment) ?? carriedCurrency;
@@ -1377,7 +1389,7 @@ export function parseVoiceExpenses(
 
   // Nothing segmented out but there is still a single amount — treat the whole
   // sentence as one expense, matching the single-expense parser's reach.
-  if (items.length === 0) {
+  if (items.length === 0 && !isUnsupportedVoiceExpenseClause(body)) {
     const one = parseVoiceExpense(body, groups);
     if (one.amountMinor !== null && one.amountMajor !== null) {
       items.push({
@@ -1390,7 +1402,9 @@ export function parseVoiceExpenses(
     }
   }
 
-  const namedCurrencies = new Set(items.map((item) => item.currency).filter((currency) => currency));
+  const namedCurrencies = new Set(
+    items.map((item) => item.currency).filter((currency) => currency),
+  );
   const finalItems =
     namedCurrencies.size === 1
       ? items.map((item) => {

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -702,23 +702,23 @@ const CATEGORY_WORDS = new Map<string, CategoryId>(
   ]),
 );
 
+const CATEGORY_PHRASE =
+  /\b(?:category|tag|label)\s+(?:as\s+)?([\p{L}\p{N}][\p{L}\p{N}& -]{0,40}?)(?=\s+(?:and|then|with|split|on|for|category|tag|label)\b|\s*[,;]|\s*$)/giu;
+
 export function parseVoiceCategory(text: string): CategoryId | null {
-  const match = text.match(/\b(?:category|tag|label)\s+(?:as\s+)?([\p{L}\p{N}][\p{L}\p{N}& -]{0,40})/iu);
-  if (!match) return null;
-  const phrase = match[1]
-    .trim()
-    .toLowerCase()
-    .replace(/\s+(?:and|then|with|split|on|for)\b.*$/u, '')
-    .trim();
-  if (!phrase) return null;
-  return CATEGORY_WORDS.get(phrase) ?? null;
+  CATEGORY_PHRASE.lastIndex = 0;
+  for (let match = CATEGORY_PHRASE.exec(text); match !== null; match = CATEGORY_PHRASE.exec(text)) {
+    const phrase = match[1].trim().toLowerCase();
+    if (!phrase) continue;
+    const category = CATEGORY_WORDS.get(phrase);
+    if (category) return category;
+  }
+  return null;
 }
 
 function stripCategoryPhrase(text: string): string {
-  return text
-    .replace(/\b(?:category|tag|label)\s+(?:as\s+)?[\p{L}\p{N}][\p{L}\p{N}& -]{0,40}(?=\s+(?:and|then|with|split|on|for)\b|\s*$)/giu, ' ')
-    .replace(/[ \t]{2,}/g, ' ')
-    .trim();
+  CATEGORY_PHRASE.lastIndex = 0;
+  return text.replace(CATEGORY_PHRASE, ' ').replace(/[ \t]{2,}/g, ' ').trim();
 }
 
 /* ─────────────────────────────────────────────────────────────────────────
@@ -1340,9 +1340,7 @@ export function parseVoiceExpenses(
   // Strip the routing lead-in ("assign to group …", "put it in …") after any
   // create-group clause is lifted, so the destination name and the notes are
   // read from the clean remainder.
-  const body = stripCategoryPhrase(
-    stripDatePhrases(stripAssignmentLeadIn(created ? created.rest : normalized)),
-  );
+  const body = stripDatePhrases(stripAssignmentLeadIn(created ? created.rest : normalized));
 
   // The group is settled before the notes are built, so each note can have the
   // named group's words taken out ("dinner on the Goa trip" → note "dinner").
@@ -1367,12 +1365,13 @@ export function parseVoiceExpenses(
     if (amountMajor === null) continue;
     const currency: string | null = detectCurrency(segment) ?? carriedCurrency;
     if (currency) carriedCurrency = currency;
+    const itemCategory = parseVoiceCategory(segment) ?? category;
     items.push({
       amountMajor,
       amountMinor: toVoiceMinorUnits(amountMajor, currency),
       currency,
-      note: buildNote(segment, matchedName),
-      category,
+      note: stripCategoryPhrase(buildNote(segment, matchedName)),
+      category: itemCategory,
     });
   }
 
@@ -1402,11 +1401,12 @@ export function parseVoiceExpenses(
         })
       : items;
 
+  const peopleText = stripCategoryPhrase(body).trim();
   return {
     items: finalItems,
     group,
     splitCount: extractSplitCount(body),
-    peopleText: body.trim() || null,
+    peopleText: peopleText || null,
     expenseDate,
   };
 }

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -28,9 +28,14 @@ const UNSUPPORTED_EXPENSE_INTENT =
 
 const SPOKEN_NEGATIVE_AMOUNT =
   /\b(?:minus|negative)\s+(?=(?:\d|zero\b|one\b|two\b|three\b|four\b|five\b|six\b|seven\b|eight\b|nine\b|ten\b|eleven\b|twelve\b|thirteen\b|fourteen\b|fifteen\b|sixteen\b|seventeen\b|eighteen\b|nineteen\b|twenty\b|thirty\b|forty\b|fourty\b|fifty\b|sixty\b|seventy\b|eighty\b|ninety\b|hundred\b|thousand\b|lakh\b|lakhs\b|crore\b|crores\b))/i;
+const THIRD_PARTY_PAYER_INTENT = /\b(?!(?:i|we|you)\b)[\p{L}][\p{L}'’.-]*\s+paid\b/iu;
 
 export function isUnsupportedVoiceExpenseIntent(text: string): boolean {
-  return UNSUPPORTED_EXPENSE_INTENT.test(text) || SPOKEN_NEGATIVE_AMOUNT.test(text);
+  return (
+    UNSUPPORTED_EXPENSE_INTENT.test(text) ||
+    SPOKEN_NEGATIVE_AMOUNT.test(text) ||
+    THIRD_PARTY_PAYER_INTENT.test(text)
+  );
 }
 
 export function isSafeVoiceAmount(amountMajor: number): boolean {
@@ -645,6 +650,46 @@ export function resolveVoiceParticipants(params: {
   return chosen;
 }
 
+function localIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+export function parseVoiceExpenseDate(text: string, now: Date = new Date()): string | null {
+  if (/\bday\s+before\s+yesterday\b/i.test(text)) return localIsoDate(addDays(now, -2));
+  if (/\byesterday\b/i.test(text)) return localIsoDate(addDays(now, -1));
+  if (/\btomorrow\b/i.test(text)) return localIsoDate(addDays(now, 1));
+  if (/\btoday\b/i.test(text)) return localIsoDate(now);
+
+  const iso = text.match(/\b(?:on\s+)?(\d{4})-(\d{1,2})-(\d{1,2})\b/);
+  if (!iso) return null;
+  const year = Number(iso[1]);
+  const month = Number(iso[2]);
+  const day = Number(iso[3]);
+  const date = new Date(year, month - 1, day);
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null;
+  }
+  return localIsoDate(date);
+}
+
+function stripDatePhrases(text: string): string {
+  return text
+    .replace(/\b(?:on\s+)?\d{4}-\d{1,2}-\d{1,2}\b/gi, ' ')
+    .replace(/\bday\s+before\s+yesterday\b/gi, ' ')
+    .replace(/\b(?:today|yesterday|tomorrow)\b/gi, ' ')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
 /* ─────────────────────────────────────────────────────────────────────────
  * Several expenses in one breath, an optional "make a group", and a nudge
  * toward other languages.
@@ -682,6 +727,8 @@ export interface VoiceParseResult {
   splitCount: number | null;
   /** The cleaned transcript fragment that may name split participants. */
   peopleText: string | null;
+  /** A deterministic spoken expense date, when one was heard. */
+  expenseDate: string | null;
 }
 
 /**
@@ -1250,16 +1297,17 @@ export function parseVoiceExpenses(
   groups: readonly VoiceGroupRef[],
 ): VoiceParseResult {
   if (isUnsupportedVoiceExpenseIntent(transcript))
-    return { items: [], group: null, splitCount: null, peopleText: null };
+    return { items: [], group: null, splitCount: null, peopleText: null, expenseDate: null };
 
   const normalized = normalizeSpokenNumbers(
     collapseAdditionRuns(normalizeCurrencyPrefixes(normalizeDigits(transcript))),
   );
+  const expenseDate = parseVoiceExpenseDate(normalized);
   const created = detectCreateGroup(normalized);
   // Strip the routing lead-in ("assign to group …", "put it in …") after any
   // create-group clause is lifted, so the destination name and the notes are
   // read from the clean remainder.
-  const body = stripAssignmentLeadIn(created ? created.rest : normalized);
+  const body = stripDatePhrases(stripAssignmentLeadIn(created ? created.rest : normalized));
 
   // The group is settled before the notes are built, so each note can have the
   // named group's words taken out ("dinner on the Goa trip" → note "dinner").
@@ -1306,5 +1354,22 @@ export function parseVoiceExpenses(
     }
   }
 
-  return { items, group, splitCount: extractSplitCount(body), peopleText: body.trim() || null };
+  const namedCurrencies = new Set(items.map((item) => item.currency).filter((currency) => currency));
+  const finalItems =
+    namedCurrencies.size === 1
+      ? items.map((item) => {
+          const currency = item.currency ?? [...namedCurrencies][0] ?? null;
+          return currency === item.currency
+            ? item
+            : { ...item, currency, amountMinor: toVoiceMinorUnits(item.amountMajor, currency) };
+        })
+      : items;
+
+  return {
+    items: finalItems,
+    group,
+    splitCount: extractSplitCount(body),
+    peopleText: body.trim() || null,
+    expenseDate,
+  };
 }

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -14,7 +14,7 @@
  * and the group are cheap and certain here, and everyone gets them.
  */
 
-import { isCurrencyCode, minorUnitScale } from '@waves/core';
+import { CATEGORIES, isCurrencyCode, minorUnitScale, type CategoryId } from '@waves/core';
 
 /** Above this, a voice parse is more likely corrupted or misheard than safe to book. */
 export const MAX_VOICE_AMOUNT_MAJOR = 1_000_000_000;
@@ -690,6 +690,37 @@ function stripDatePhrases(text: string): string {
     .trim();
 }
 
+const CATEGORY_WORDS = new Map<string, CategoryId>(
+  CATEGORIES.flatMap((category) => [
+    [category.id, category.id],
+    [category.label.toLowerCase(), category.id],
+    ...category.label
+      .toLowerCase()
+      .split(/[^\p{L}\p{N}]+/u)
+      .filter(Boolean)
+      .map((word) => [word, category.id] as const),
+  ]),
+);
+
+export function parseVoiceCategory(text: string): CategoryId | null {
+  const match = text.match(/\b(?:category|tag|label)\s+(?:as\s+)?([\p{L}\p{N}][\p{L}\p{N}& -]{0,40})/iu);
+  if (!match) return null;
+  const phrase = match[1]
+    .trim()
+    .toLowerCase()
+    .replace(/\s+(?:and|then|with|split|on|for)\b.*$/u, '')
+    .trim();
+  if (!phrase) return null;
+  return CATEGORY_WORDS.get(phrase) ?? null;
+}
+
+function stripCategoryPhrase(text: string): string {
+  return text
+    .replace(/\b(?:category|tag|label)\s+(?:as\s+)?[\p{L}\p{N}][\p{L}\p{N}& -]{0,40}(?=\s+(?:and|then|with|split|on|for)\b|\s*$)/giu, ' ')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
 /* ─────────────────────────────────────────────────────────────────────────
  * Several expenses in one breath, an optional "make a group", and a nudge
  * toward other languages.
@@ -709,6 +740,7 @@ export interface VoiceExpenseItem {
   amountMajor: number;
   currency: string | null;
   note: string;
+  category: CategoryId | null;
 }
 
 /**
@@ -1303,11 +1335,14 @@ export function parseVoiceExpenses(
     collapseAdditionRuns(normalizeCurrencyPrefixes(normalizeDigits(transcript))),
   );
   const expenseDate = parseVoiceExpenseDate(normalized);
+  const category = parseVoiceCategory(normalized);
   const created = detectCreateGroup(normalized);
   // Strip the routing lead-in ("assign to group …", "put it in …") after any
   // create-group clause is lifted, so the destination name and the notes are
   // read from the clean remainder.
-  const body = stripDatePhrases(stripAssignmentLeadIn(created ? created.rest : normalized));
+  const body = stripCategoryPhrase(
+    stripDatePhrases(stripAssignmentLeadIn(created ? created.rest : normalized)),
+  );
 
   // The group is settled before the notes are built, so each note can have the
   // named group's words taken out ("dinner on the Goa trip" → note "dinner").
@@ -1337,6 +1372,7 @@ export function parseVoiceExpenses(
       amountMinor: toVoiceMinorUnits(amountMajor, currency),
       currency,
       note: buildNote(segment, matchedName),
+      category,
     });
   }
 
@@ -1349,7 +1385,8 @@ export function parseVoiceExpenses(
         amountMinor: one.amountMinor,
         amountMajor: one.amountMajor,
         currency: one.currency,
-        note: one.note,
+        note: stripCategoryPhrase(one.note),
+        category,
       });
     }
   }

--- a/apps/mobile/src/lib/voiceLlm.ts
+++ b/apps/mobile/src/lib/voiceLlm.ts
@@ -508,7 +508,13 @@ export async function interpretVoiceExpenses(
     await noteUsage(reply.totalTokens);
 
     const heuristic = parseVoiceExpenses(trimmed, ctx.groups);
-    return { items, group, splitCount: heuristic.splitCount, peopleText: heuristic.peopleText };
+    return {
+      items,
+      group,
+      splitCount: heuristic.splitCount,
+      peopleText: heuristic.peopleText,
+      expenseDate: heuristic.expenseDate,
+    };
   } catch (caught) {
     // Network error, abort/timeout, malformed body — all of it is a fallback, not
     // a crash. The raw error (scrubbed) goes to Sentry; the key and transcript do

--- a/apps/mobile/src/lib/voiceLlm.ts
+++ b/apps/mobile/src/lib/voiceLlm.ts
@@ -382,6 +382,7 @@ function mapItems(rawItems: unknown): VoiceExpenseItem[] {
       note: String(entry?.note ?? '')
         .trim()
         .slice(0, MAX_VOICE_NOTE_CHARS),
+      category: null,
     });
   }
   return items;
@@ -508,8 +509,12 @@ export async function interpretVoiceExpenses(
     await noteUsage(reply.totalTokens);
 
     const heuristic = parseVoiceExpenses(trimmed, ctx.groups);
+    const categorizedItems = items.map((item, index) => ({
+      ...item,
+      category: heuristic.items[index]?.category ?? null,
+    }));
     return {
-      items,
+      items: categorizedItems,
       group,
       splitCount: heuristic.splitCount,
       peopleText: heuristic.peopleText,

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -670,6 +670,21 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     expect(parseVoiceExpenses('I paid 500 rupees for dinner', groups).items).toHaveLength(1);
   });
 
+  it('keeps safe expenses while skipping unsupported neighbouring clauses', () => {
+    const result = parseVoiceExpenses(
+      '500 rupees dinner, Ravi paid me back 200 rupees, 300 rupees cab, Priya paid 50 rupees snacks',
+      groups,
+    );
+    expect(result.items.map((item) => item.amountMajor)).toEqual([500, 300]);
+    expect(result.items.map((item) => item.note)).toEqual(['dinner', 'cab']);
+  });
+
+  it('still rejects global removal commands instead of partially parsing them', () => {
+    expect(parseVoiceExpenses('delete 500 rupees dinner and 300 rupees cab', groups).items).toEqual(
+      [],
+    );
+  });
+
   it('does not create items from signed or spoken negative amounts', () => {
     for (const sentence of [
       '-500 rupees dinner',

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   matchMemberNames,
   parseVoiceExpense,
+  parseVoiceExpenseDate,
   resolveVoiceParticipants,
   type VoiceGroupRef,
 } from '@/lib/voiceExpense';
@@ -599,13 +600,34 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     expect(result.items.map((item) => item.amountMajor)).toEqual([20, 15]);
   });
 
-  it('does not create items from unsupported negative, repayment, or refund intents', () => {
+  it('backfills a single named currency to earlier bare items', () => {
+    const result = parseVoiceExpenses('5 snacks, 10 rupees tea', groups);
+    expect(result.items.map((item) => item.currency)).toEqual(['INR', 'INR']);
+    expect(result.items.map((item) => item.amountMinor)).toEqual([500n, 1000n]);
+  });
+
+  it('carries deterministic spoken dates without leaking them into notes', () => {
+    const result = parseVoiceExpenses('500 rupees dinner yesterday', groups);
+    expect(result.expenseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.items[0].note).toBe('dinner');
+  });
+
+  it('reads explicit ISO dates and rejects impossible dates', () => {
+    const result = parseVoiceExpenses('500 rupees dinner on 2026-08-12', groups);
+    expect(result.expenseDate).toBe('2026-08-12');
+    expect(result.items[0].note).toBe('dinner');
+    expect(parseVoiceExpenseDate('dinner on 2026-02-30')).toBeNull();
+  });
+
+  it('does not create items from unsupported negative, repayment, refund, or third-party payer intents', () => {
     for (const sentence of [
       "don't add 500 rupees for dinner",
       'don’t add 500 rupees for dinner',
       'delete 500 rupees dinner',
       'refund 200 rupees hotel',
       'Ravi paid me back 500 rupees',
+      'Ravi paid 500 rupees for dinner',
+      'Priya paid twenty dollars for cab',
       'I did not pay 500 rupees for dinner',
       "I didn't pay 500 rupees for dinner",
       'I didn’t pay 500 rupees for dinner',
@@ -617,6 +639,7 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     ]) {
       expect(parseVoiceExpenses(sentence, groups).items, sentence).toEqual([]);
     }
+    expect(parseVoiceExpenses('I paid 500 rupees for dinner', groups).items).toHaveLength(1);
   });
 
   it('does not create items from signed or spoken negative amounts', () => {

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -627,6 +627,20 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     expect(parseVoiceCategory('tag as food')).toBe('food');
   });
 
+  it('keeps explicit categories item-specific in multi-expense transcripts', () => {
+    const result = parseVoiceExpenses(
+      '500 rupees airport cab category travel, 300 rupees dinner tag food',
+      groups,
+    );
+    expect(result.items.map((item) => item.category)).toEqual(['travel', 'food']);
+    expect(result.items.map((item) => item.note)).toEqual(['airport cab', 'dinner']);
+  });
+
+  it('uses a trailing category as a global fallback when items do not name one', () => {
+    const result = parseVoiceExpenses('500 rupees cab, 300 rupees bus category travel', groups);
+    expect(result.items.map((item) => item.category)).toEqual(['travel', 'travel']);
+  });
+
   it('ignores unknown category phrases safely', () => {
     const result = parseVoiceExpenses('500 rupees dinner category crypto', groups);
     expect(result.items[0].category).toBeNull();

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   matchMemberNames,
+  parseVoiceCategory,
   parseVoiceExpense,
   parseVoiceExpenseDate,
   resolveVoiceParticipants,
@@ -617,6 +618,19 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     expect(result.expenseDate).toBe('2026-08-12');
     expect(result.items[0].note).toBe('dinner');
     expect(parseVoiceExpenseDate('dinner on 2026-02-30')).toBeNull();
+  });
+
+  it('reads explicit built-in category phrases without leaking them into notes', () => {
+    const result = parseVoiceExpenses('500 rupees airport cab category travel', groups);
+    expect(result.items[0].category).toBe('travel');
+    expect(result.items[0].note).toBe('airport cab');
+    expect(parseVoiceCategory('tag as food')).toBe('food');
+  });
+
+  it('ignores unknown category phrases safely', () => {
+    const result = parseVoiceExpenses('500 rupees dinner category crypto', groups);
+    expect(result.items[0].category).toBeNull();
+    expect(result.items[0].note).toBe('dinner');
   });
 
   it('does not create items from unsupported negative, repayment, refund, or third-party payer intents', () => {

--- a/apps/mobile/test/voiceLlm.test.ts
+++ b/apps/mobile/test/voiceLlm.test.ts
@@ -274,8 +274,8 @@ describe('interpretVoiceExpenses', () => {
 
     expect(result).not.toBeNull();
     expect(result?.items).toEqual([
-      { amountMajor: 500, amountMinor: 50000n, currency: 'INR', note: 'dinner' },
-      { amountMajor: 20, amountMinor: 2000n, currency: null, note: 'tea' },
+      { amountMajor: 500, amountMinor: 50000n, currency: 'INR', note: 'dinner', category: null },
+      { amountMajor: 20, amountMinor: 2000n, currency: null, note: 'tea', category: null },
     ]);
     expect(result?.group).toEqual({ kind: 'existing', groupId: 'g-goa' });
     expect(result?.splitCount).toBeNull();
@@ -336,7 +336,7 @@ describe('interpretVoiceExpenses', () => {
 
     const result = await interpretVoiceExpenses('snack 12.5 dollars', ctx);
     expect(result?.items).toEqual([
-      { amountMajor: 12.5, amountMinor: 1250n, currency: 'USD', note: 'snack' },
+      { amountMajor: 12.5, amountMinor: 1250n, currency: 'USD', note: 'snack', category: null },
     ]);
   });
 
@@ -357,9 +357,9 @@ describe('interpretVoiceExpenses', () => {
 
     const result = await interpretVoiceExpenses('3000 yen ramen, 100000 rupiah dinner', ctx);
     expect(result?.items).toEqual([
-      { amountMajor: 3000, amountMinor: 3000n, currency: 'JPY', note: 'ramen' },
-      { amountMajor: 100000, amountMinor: 10000000n, currency: 'IDR', note: 'dinner' },
-      { amountMajor: 9, amountMinor: 900n, currency: null, note: 'unknown code' },
+      { amountMajor: 3000, amountMinor: 3000n, currency: 'JPY', note: 'ramen', category: null },
+      { amountMajor: 100000, amountMinor: 10000000n, currency: 'IDR', note: 'dinner', category: null },
+      { amountMajor: 9, amountMinor: 900n, currency: null, note: 'unknown code', category: null },
     ]);
   });
 
@@ -388,12 +388,13 @@ describe('interpretVoiceExpenses', () => {
     );
 
     const result = await interpretVoiceExpenses(
-      'split 1000 rupees among 4 people for dinner with Ravi yesterday',
+      'split 1000 rupees among 4 people for dinner with Ravi yesterday category travel',
       ctx,
     );
     expect(result?.splitCount).toBe(4);
     expect(result?.peopleText).toBe('split 1000 rupees among 4 people for dinner with Ravi');
     expect(result?.expenseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result?.items[0].category).toBe('travel');
   });
 
   it('rejects unsupported negative or refund intents before key lookup or network calls', async () => {
@@ -431,7 +432,7 @@ describe('interpretVoiceExpenses', () => {
 
     const result = await interpretVoiceExpenses('chai 5', ctx);
     expect(result?.items).toEqual([
-      { amountMajor: 5, amountMinor: 500n, currency: null, note: 'chai' },
+      { amountMajor: 5, amountMinor: 500n, currency: null, note: 'chai', category: null },
     ]);
   });
 
@@ -504,7 +505,7 @@ describe('interpretVoiceExpenses', () => {
 
     const result = await interpretVoiceExpenses('bus 7', ctx);
     expect(result?.items).toEqual([
-      { amountMajor: 7, amountMinor: 700n, currency: null, note: 'bus' },
+      { amountMajor: 7, amountMinor: 700n, currency: null, note: 'bus', category: null },
     ]);
     // The recording was attempted, but its failure did not sink the parse.
     expect(addAiTokensUsedMock).toHaveBeenCalled();
@@ -530,7 +531,7 @@ describe('interpretVoiceExpenses — the Anthropic tool path', () => {
     const result = await interpretVoiceExpenses('cab 40 goa trip', ctx);
     // Contract parity with the OpenAI path: same VoiceParseResult shape.
     expect(result?.items).toEqual([
-      { amountMajor: 40, amountMinor: 4000n, currency: 'INR', note: 'cab' },
+      { amountMajor: 40, amountMinor: 4000n, currency: 'INR', note: 'cab', category: null },
     ]);
     expect(result?.group).toEqual({ kind: 'existing', groupId: 'g-goa' });
 
@@ -559,7 +560,7 @@ describe('interpretVoiceExpenses — the Anthropic tool path', () => {
 
     const result = await interpretVoiceExpenses('tea 3', ctx);
     expect(result?.items).toEqual([
-      { amountMajor: 3, amountMinor: 300n, currency: null, note: 'tea' },
+      { amountMajor: 3, amountMinor: 300n, currency: null, note: 'tea', category: null },
     ]);
   });
 
@@ -709,7 +710,7 @@ describe('interpretVoiceExpenses — abort timeout', () => {
 
     const result = await promise;
     expect(result?.items).toEqual([
-      { amountMajor: 5, amountMinor: 500n, currency: null, note: 'chai' },
+      { amountMajor: 5, amountMinor: 500n, currency: null, note: 'chai', category: null },
     ]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(reportHandledMock).not.toHaveBeenCalled();

--- a/apps/mobile/test/voiceLlm.test.ts
+++ b/apps/mobile/test/voiceLlm.test.ts
@@ -358,7 +358,13 @@ describe('interpretVoiceExpenses', () => {
     const result = await interpretVoiceExpenses('3000 yen ramen, 100000 rupiah dinner', ctx);
     expect(result?.items).toEqual([
       { amountMajor: 3000, amountMinor: 3000n, currency: 'JPY', note: 'ramen', category: null },
-      { amountMajor: 100000, amountMinor: 10000000n, currency: 'IDR', note: 'dinner', category: null },
+      {
+        amountMajor: 100000,
+        amountMinor: 10000000n,
+        currency: 'IDR',
+        note: 'dinner',
+        category: null,
+      },
       { amountMajor: 9, amountMinor: 900n, currency: null, note: 'unknown code', category: null },
     ]);
   });

--- a/apps/mobile/test/voiceLlm.test.ts
+++ b/apps/mobile/test/voiceLlm.test.ts
@@ -314,6 +314,7 @@ describe('interpretVoiceExpenses', () => {
       group: { kind: 'create', name: 'Goa' },
       splitCount: null,
       peopleText: null,
+      expenseDate: null,
     });
   });
 
@@ -387,11 +388,12 @@ describe('interpretVoiceExpenses', () => {
     );
 
     const result = await interpretVoiceExpenses(
-      'split 1000 rupees among 4 people for dinner with Ravi',
+      'split 1000 rupees among 4 people for dinner with Ravi yesterday',
       ctx,
     );
     expect(result?.splitCount).toBe(4);
     expect(result?.peopleText).toBe('split 1000 rupees among 4 people for dinner with Ravi');
+    expect(result?.expenseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
   it('rejects unsupported negative or refund intents before key lookup or network calls', async () => {


### PR DESCRIPTION
## Summary

- carry deterministic voice expense dates through parsing, LLM fallback metadata, and voice review saves
- strip simple date phrases from generated expense notes
- backfill a single named currency to earlier bare items in the same utterance
- reject explicit third-party payer phrasing rather than saving it as if the current user paid

## Tests

- `pnpm --filter @waves/mobile test -- voiceExpense.test.ts voiceLlm.test.ts --run`
- `pnpm --filter @waves/mobile typecheck`
- `pnpm --filter @waves/mobile lint`

## Stacking

Stacked on #518 (`voice-named-splits`). Retarget this PR to `main` after #518 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice-entered expenses can now recognize spoken dates and categories.
  * Expense drafts preserve recognized dates and categories when saved to the inbox or groups.
  * Multi-expense voice entries support individual categories, shared currencies, and more accurate amounts.
  * Category phrases are removed from expense notes for cleaner descriptions.

* **Bug Fixes**
  * Unsupported voice commands and invalid expense clauses are handled more safely without discarding valid expenses.
  * Invalid dates and unknown categories no longer produce incorrect expense details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->