### PR TITLE
fix(mobile): stop activity/inbox feeds blanking on fast scroll

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -391,9 +391,11 @@ export default function ActivityScreen() {
           flexGrow: 1,
         }}
         showsVerticalScrollIndicator={false}
-        // Recycle offscreen rows rather than keep every scrolled-past one
-        // mounted — the point of moving off the old ScrollView.
-        removeClippedSubviews
+        // No `removeClippedSubviews`: on Android it detaches off-screen subviews
+        // and, on a fast fling of this SectionList, fails to re-attach them —
+        // the whole viewport blanks out mid-scroll (rows vanish, only the
+        // scrollbar remains). `windowSize` already bounds how much is mounted, so
+        // virtualization holds without the clipping that caused the blanking.
         initialNumToRender={12}
         windowSize={9}
         ListHeaderComponent={header}

--- a/apps/mobile/src/app/(tabs)/inbox.tsx
+++ b/apps/mobile/src/app/(tabs)/inbox.tsx
@@ -220,7 +220,10 @@ export default function InboxScreen() {
           keyExtractor={(row) => row.id}
           showsVerticalScrollIndicator={false}
           stickySectionHeadersEnabled={false}
-          removeClippedSubviews
+          // No `removeClippedSubviews`: on Android it can leave off-screen rows
+          // detached after a fast fling, blanking the viewport mid-scroll (the
+          // same failure the activity feed hit). `windowSize` bounds what is
+          // mounted without the clipping that caused it.
           initialNumToRender={12}
           maxToRenderPerBatch={10}
           windowSize={7}


### PR DESCRIPTION
## Symptom

On the activity feed, a fast scroll blanks the **entire viewport** mid-fling — rows vanish, only the scrollbar remains — then it repaints once scrolling settles. (Reported on device; screen recording shows the feed going fully empty on a fling.)

## Cause

Both the activity feed and the inbox set `removeClippedSubviews` on their `SectionList` (added when they moved off a plain `ScrollView` to virtualize). On Android that prop detaches off-screen subviews and, on a fast fling, fails to re-attach them — the well-known VirtualizedList "blank cells / blank viewport on Android" pathology.

## Fix

Drop `removeClippedSubviews` from both `SectionList`s. `windowSize` (plus the initial/batch counts) already bounds how many rows are mounted, so virtualization and row recycling are unaffected — it's only the Android clipping pass that caused the blanking, and it isn't needed for the memory win.

## Scope

Two files, prop removal + comment: `apps/mobile/src/app/(tabs)/activity.tsx`, `apps/mobile/src/app/(tabs)/inbox.tsx`. No behaviour/string changes.

## Checks
- `pnpm --filter @waves/mobile typecheck` — clean
- `eslint` both files — clean
- `prettier --write` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity and inbox list scrolling on Android by preventing blank rows during fast scrolling.
  * Preserved efficient list performance through controlled virtualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->