### PR TITLE
fix(mobile): allow with in voice group names

### DIFF
--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -1249,10 +1249,10 @@ export function collapseAdditionRuns(text: string): string {
  * A spoken "make a group" and the name it gives.
  *
  * Matches "create/make/start/new/open [a] [new] group [called/named/for] X",
- * where X runs to the first joining word ("and", "then", ",", "with") or the
- * end. Returns the trimmed name and the sentence with that whole clause cut out,
- * so what remains can still be parsed for expenses ("make a group Goa and add
- * 500 for lunch" leaves "add 500 for lunch"). Null when no such intent is heard.
+ * where X runs to the first joining word ("and", "then", ",") or the end.
+ * Returns the trimmed name and the sentence with that whole clause cut out, so
+ * what remains can still be parsed for expenses ("make a group Goa and add 500
+ * for lunch" leaves "add 500 for lunch"). Null when no such intent is heard.
  */
 export function detectCreateGroup(transcript: string): { name: string; rest: string } | null {
   const pattern =
@@ -1262,13 +1262,13 @@ export function detectCreateGroup(transcript: string): { name: string; rest: str
 
   const after = transcript.slice(head.index + head[0].length);
   // The name is everything up to a joining word that starts the next clause, or
-  // the end. "and/then/with/plus" and a comma each end the name.
-  const nameMatch = after.match(/^(.*?)(?:\s+(?:and|then|with|plus|also)\b|\s*[,;]|$)/i);
+  // the end. "with" is allowed inside names ("Friends with Kids").
+  const nameMatch = after.match(/^(.*?)(?:\s+(?:and|then|plus|also)\b|\s*[,;]|$)/i);
   const name = (nameMatch?.[1] ?? after).trim().replace(/[.\s]+$/, '');
   if (!name) return null;
   // A name that opens with a joining word is not a name: "create a group and add
   // 100" names nothing. Treat the clause as missing so the rest parses normally.
-  if (/^(?:and|then|with|plus|also)\b/i.test(name)) return null;
+  if (/^(?:and|then|plus|also)\b/i.test(name)) return null;
 
   // Consume the whole name match — name *and* the joining word that ended it
   // ("and", a comma) — so the joiner does not lead the leftover sentence.

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -518,6 +518,16 @@ describe('parseVoiceExpenses (several in one breath)', () => {
     expect(result.items[0].note).toBe('lunch');
   });
 
+  it('keeps with inside a created group name', () => {
+    const result = parseVoiceExpenses(
+      'make a group called Friends with Kids and add 200 for lunch',
+      groups,
+    );
+    expect(result.group).toEqual({ kind: 'create', name: 'Friends with Kids' });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].note).toBe('lunch');
+  });
+
   it('drops segments that carry no amount', () => {
     const result = parseVoiceExpenses('hello, 50 for coffee, um', groups);
     expect(result.items.map((item) => item.amountMajor)).toEqual([50]);
@@ -812,6 +822,13 @@ describe('detectCreateGroup', () => {
   it('lifts the name and returns the rest', () => {
     expect(detectCreateGroup('create a group named Goa Trip and add 100')).toEqual({
       name: 'Goa Trip',
+      rest: 'add 100',
+    });
+  });
+
+  it('allows with inside the created group name', () => {
+    expect(detectCreateGroup('create a group named Friends with Kids and add 100')).toEqual({
+      name: 'Friends with Kids',
       rest: 'add 100',
     });
   });


### PR DESCRIPTION
## Summary

- allow `with` inside voice-created group names, e.g. “Friends with Kids”
- keep existing `and`/`then`/comma handling so following expense clauses still parse
- add direct and end-to-end parser regression tests

## Tests

- `pnpm --filter @waves/mobile test -- voiceExpense.test.ts --run`
- `pnpm --filter @waves/mobile typecheck`
- `pnpm --filter @waves/mobile lint`
- `pnpm exec prettier --check apps/mobile/src/lib/voiceExpense.ts apps/mobile/test/voiceExpense.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice expense parsing to preserve “with” in group names, such as “Friends with Kids.”
  * Continued to correctly identify expenses and trailing commands after group names.
  * Invalid group names beginning with joining words remain rejected.

* **Tests**
  * Added coverage for group names containing “with” and related voice input patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->