### PR TITLE
fix(group): surface delete refusals + lock delete against concurrent writer (A49 review)

### DIFF
--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -280,11 +280,19 @@ export default function GroupSettingsScreen() {
           if (deleteGroup.isPending) return;
           deleteGroup.mutate(undefined, {
             onSuccess: () => router.replace('/'),
-            onError: (caught) =>
-              Alert.alert(
-                t.group.deleteGroup,
-                friendlyError(caught, t.misc.tryAgainMoment, 'groupSettings.delete'),
-              ),
+            onError: (caught) => {
+              // The two coded refusals carry a `code` (set in api.deleteGroup);
+              // show their localized line directly. Anything else is unknown and
+              // goes through friendlyError, which never echoes raw backend text.
+              const code = (caught as { code?: string } | null)?.code;
+              const body =
+                code === 'NOT_SETTLED'
+                  ? t.group.settleAllFirstBody
+                  : code === 'NOT_ADMIN'
+                    ? t.group.deleteAdminOnly
+                    : friendlyError(caught, t.misc.tryAgainMoment, 'groupSettings.delete');
+              Alert.alert(t.group.deleteGroup, body);
+            },
           });
         },
       },

--- a/apps/mobile/src/data/api.ts
+++ b/apps/mobile/src/data/api.ts
@@ -997,13 +997,22 @@ export async function deleteGroup(groupId: string): Promise<void> {
   if (error) {
     const code = /^([A-Z_]+):/.exec(error.message)?.[1];
     const strings = activeStrings();
-    throw new Error(
+    // Carry the coded reason on the Error so the caller can pick the right
+    // localized line in the render locale. The message is still a sentence (not
+    // raw PostgREST) for any non-UI consumer / crash report; the unknown case
+    // keeps the raw message, which the UI runs through friendlyError so it is
+    // never shown verbatim.
+    const thrown = new Error(
       code === 'NOT_SETTLED'
         ? strings.group.settleAllFirstBody
         : code === 'NOT_ADMIN'
           ? strings.group.deleteAdminOnly
           : error.message,
     );
+    if (code === 'NOT_SETTLED' || code === 'NOT_ADMIN') {
+      (thrown as { code?: string }).code = code;
+    }
+    throw thrown;
   }
 }
 

--- a/baaki-tdr.md
+++ b/baaki-tdr.md
@@ -69,7 +69,8 @@ profiles(id UUID PK ↔ auth.users, display_name TEXT, avatar_url TEXT,
 -- Groups & membership
 groups(id, name, type TEXT CHECK (type IN ('trip','home','couple','event','other')),
        default_currency CHAR(3), simplify_debts BOOL DEFAULT true,
-       cover_emoji TEXT, archived_at TIMESTAMPTZ NULL)
+       cover_emoji TEXT, archived_at TIMESTAMPTZ NULL,
+       deleted_at TIMESTAMPTZ NULL)             -- A49 group-wide tombstone (admin, settled-gated)
 
 group_members(id, group_id FK, profile_id FK NULL,      -- NULL ⇒ ghost member
               ghost_name TEXT NULL,                     -- exactly one of profile_id/ghost_name

--- a/packages/db/prisma/migrations/20260827000000_group_delete/migration.sql
+++ b/packages/db/prisma/migrations/20260827000000_group_delete/migration.sql
@@ -23,7 +23,13 @@ BEGIN
       USING ERRCODE = 'insufficient_privilege';
   END IF;
 
-  SELECT deleted_at INTO v_deleted_at FROM public.groups WHERE id = p_group_id;
+  -- Lock the group row up front (FOR UPDATE), before the settled check, so the
+  -- settlement validation and the tombstone that follows read and write the same
+  -- serialized view of the row. This closes the delete-vs-delete window and gives
+  -- a single coordination point a balance-mutating writer can share (take the
+  -- same row lock) to be serialized against a delete; on its own it does not stop
+  -- a writer that never locks this row (see A49 review notes).
+  SELECT deleted_at INTO v_deleted_at FROM public.groups WHERE id = p_group_id FOR UPDATE;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'NOT_FOUND: no such group' USING ERRCODE = 'no_data_found';
   END IF;

--- a/packages/db/test/group-delete.test.ts
+++ b/packages/db/test/group-delete.test.ts
@@ -111,4 +111,41 @@ describe('deleting a group', () => {
     await asUser(profileIds[0]!, () => client.query(`SELECT baaki_delete_group($1)`, [groupId]));
     expect(await deletedAt(groupId)).toBe(first);
   });
+
+  it('holds the group row lock while deleting, serializing a concurrent writer', async () => {
+    // The delete takes `FOR UPDATE` on the group row before it validates the
+    // balances, so a balance-mutating writer that shares that lock cannot slip a
+    // change in between the settled check and the tombstone. Prove it with a
+    // second connection: while the delete's transaction is open, a `FOR UPDATE
+    // NOWAIT` on the same row is refused (55P03) rather than interleaving.
+    const { groupId, profileIds, memberIds } = await seedGroup(client, { memberCount: 2 });
+    await addEqualSplitExpense(client, {
+      groupId,
+      amount: 1000n,
+      participants: [memberIds[0]!, memberIds[1]!],
+      payers: { [memberIds[0]!]: 500n, [memberIds[1]!]: 500n },
+    });
+
+    const other = await connect();
+    try {
+      // Connection A: run the delete inside an open transaction — it locks the
+      // group row and does not commit yet.
+      await client.query('BEGIN');
+      await asUser(profileIds[0]!, () => client.query(`SELECT baaki_delete_group($1)`, [groupId]));
+
+      // Connection B: the same row lock is unavailable while A holds it.
+      let refused = false;
+      try {
+        await other.query(`SELECT 1 FROM groups WHERE id = $1 FOR UPDATE NOWAIT`, [groupId]);
+      } catch (caught) {
+        const err = caught as { code?: string; message?: string };
+        refused = err.code === '55P03' || /could not obtain lock|lock/i.test(err.message ?? '');
+      }
+      expect(refused).toBe(true);
+    } finally {
+      // Undo the uncommitted delete; the group is left as it was.
+      await client.query('ROLLBACK');
+      await other.end();
+    }
+  });
 });


### PR DESCRIPTION
CodeRabbit review follow-up to #524. Each finding verified against current code; fixed the valid ones minimally, skipped the rest with reasons.

## Findings

**1. Delete errors never reached the user — VALID (real bug), fixed.**
`api.deleteGroup` already mapped `NOT_SETTLED`/`NOT_ADMIN` to localized strings, but `settings.tsx` then re-ran the thrown Error through `friendlyError`, which matches none of its regexes for a localized sentence and returns the generic `tryAgainMoment` fallback — so every delete error showed "try again in a moment". Now the Error carries a stable `code`, the component maps it to the localized line, and unknown errors still go through `friendlyError` (which never echoes raw backend text).

**2. Canonical groups schema missing `deleted_at` — VALID intent, fixed.**
The review pointed at line 426 (the A49 prose row); the canonical §2 groups DDL is line 72 and lacked `deleted_at`. Added it there.

**3. Concurrent writer race — PARTIAL, fixed on the delete side.**
`baaki_delete_group` now takes `SELECT … FOR UPDATE` on the group row before the settled check, so the balance validation and the tombstone share one serialized view (closes delete-vs-delete and gives a shared lock point). Added a **deterministic** two-connection test: `FOR UPDATE NOWAIT` is refused (`55P03`) while the delete's transaction is open — no timing flakiness.

**4. "Apply the same lock in `schema.prisma` 238–241" — SKIPPED.**
That file is the declarative Prisma model; it holds no procedural lock or writer code. The real balance writers are `baaki_apply_expense` (service_role) and `baaki_record_settlement` in the squashed baseline. Making them share the delete lock means editing core money RPCs — disproportionate/high-risk for a **recoverable** tombstone (ledger rows are preserved per ADR-004; a stray-balance delete is undone by clearing `deleted_at`). Out of scope for this follow-up; the shared lock point is now in place for them to adopt later without re-touching delete.

## Validation (Windows node)
- mobile typecheck ✅ · eslint (changed files) ✅ · prettier ✅
- `@waves/db` `group-delete.test.ts` 5/5 ✅ (incl. new lock test)

Migration `20260827000000_group_delete` edited in place (undeployed, never reached prod) — one clean migration for the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Group deletion now displays clearer localized messages when the group cannot be deleted because it is unsettled or the requester lacks administrator access.
  - Improved deletion reliability by preventing conflicting deletion operations from proceeding simultaneously.
  - Existing handling for unexpected deletion errors remains unchanged.

- **Tests**
  - Added coverage to verify safe behavior when multiple deletion-related operations occur at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->