### PR TITLE
feat(voice): header add-more mic + per-item mic is plain dictation

### DIFF
--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -115,8 +115,8 @@ interface PersonChoice {
  *  - 'replace'   the opening capture: the heard batch becomes the review list.
  *  - 'append'    "+ Add more": the heard expenses are pushed onto the current
  *                list, keeping the existing items and the chosen destination.
- *  - redescribe  a single row's mic: only that row's description is re-dictated;
- *                the amounts and every other row stay put.
+ *  - redescribe  a single row's mic: plain dictation appended to only that row's
+ *                description (no parsing); the amounts and every other row stay put.
  */
 type MicMode = 'replace' | 'append' | { kind: 'redescribe'; key: string };
 
@@ -451,14 +451,24 @@ export default function VoiceScreen() {
 
   const handleTranscript = (transcript: string): void => {
     const mode = micMode;
-    // A single row's re-dictation replaces only that description — no thinking
-    // phase, no destination change; the amounts and the other rows stand.
+    // A single row's mic is plain dictation: the spoken words are appended to
+    // that row's description verbatim — no parsing, so amounts/currency/group
+    // words are NOT stripped and no thinking phase, destination change, or other
+    // row is touched. It only ever adds text to the one note.
     if (typeof mode === 'object') {
-      const parsed = parseVoiceExpenses(transcript, groupRefs);
-      // Prefer the cleaned note (amount/currency/group words stripped); fall back
-      // to the raw sentence when nothing parsed out of it.
-      const note = parsed.items[0]?.note.trim() || transcript.trim();
-      if (note) editDraft(mode.key, { note });
+      const spoken = transcript.trim();
+      if (spoken) {
+        setDrafts((current) =>
+          current.map((draft) =>
+            draft.key === mode.key
+              ? {
+                  ...draft,
+                  note: draft.note.trim() ? `${draft.note.trim()} ${spoken}` : spoken,
+                }
+              : draft,
+          ),
+        );
+      }
       setNoAmount(false);
       setMicMode('replace');
       setPhase('review');
@@ -502,7 +512,7 @@ export default function VoiceScreen() {
     setPhase('listening');
   };
 
-  // The per-row mic — reopen to re-dictate just this expense's description.
+  // The per-row mic — reopen to dictate more text onto just this expense's note.
   const startRedescribe = (key: string): void => {
     setMicMode({ kind: 'redescribe', key });
     setNoAmount(false);
@@ -829,9 +839,19 @@ export default function VoiceScreen() {
             <Ionicons name="mic" size={iconSize.xl} color={theme.color.brand} />
             <Text variant="title">{phase === 'review' ? t.voice.review : t.voice.title}</Text>
           </Row>
-          <IconButton label={t.common.close} onPress={dismiss}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
+          {/* On the review, a mic sits before the ✕ so another expense (or
+              several) can be spoken and appended without hunting for the inline
+              "+ Add more" — same append job (`startAddMore`), header-reachable. */}
+          <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            {phase === 'review' ? (
+              <IconButton label={t.voice.addMore} onPress={startAddMore}>
+                <Ionicons name="mic-outline" size={iconSize.lg} color={theme.color.brand} />
+              </IconButton>
+            ) : null}
+            <IconButton label={t.common.close} onPress={dismiss}>
+              <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+            </IconButton>
+          </Row>
         </Row>
 
         {error ? <Callout tone="negative">{error}</Callout> : null}
@@ -861,7 +881,7 @@ export default function VoiceScreen() {
                       onRemove={removeDraft}
                       onRedescribe={startRedescribe}
                       removeLabel={t.captures.delete}
-                      redescribeLabel={t.voice.redescribe}
+                      dictateLabel={t.voice.dictate}
                       amountLabel={t.captures.amount}
                       noteLabel={t.captures.description}
                       notePlaceholder={t.captures.descriptionPlaceholder}
@@ -1560,7 +1580,7 @@ function DraftRow({
   onRemove,
   onRedescribe,
   removeLabel,
-  redescribeLabel,
+  dictateLabel,
   amountLabel,
   noteLabel,
   notePlaceholder,
@@ -1571,7 +1591,7 @@ function DraftRow({
   onRemove: (key: string) => void;
   onRedescribe: (key: string) => void;
   removeLabel: string;
-  redescribeLabel: string;
+  dictateLabel: string;
   amountLabel: string;
   noteLabel: string;
   notePlaceholder: string;
@@ -1639,7 +1659,7 @@ function DraftRow({
               this row's note, leaving its amount and the other rows untouched. */}
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel={redescribeLabel}
+            accessibilityLabel={dictateLabel}
             onPress={() => onRedescribe(draft.key)}
             hitSlop={8}
             style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}

--- a/apps/mobile/src/app/voice.tsx
+++ b/apps/mobile/src/app/voice.tsx
@@ -249,6 +249,13 @@ export default function VoiceScreen() {
   // that lands after they have returned to the review (a cancelled append) is
   // dropped rather than mutating the batch they went back to.
   const interpretToken = useRef(0);
+  // True only while a mic capture the reader actually started is live. The mic's
+  // `abort()` on unmount (a dismiss, or the switch back to the review) fires a
+  // final `end` that calls `onDone` with the last transcript — so a dismissed
+  // capture would otherwise still append its words to a row or replace the batch.
+  // Set on every real listen start (via `onListen`), cleared on dismiss and the
+  // moment a transcript is consumed, so a post-dismiss `onDone` is ignored.
+  const captureActive = useRef(false);
 
   const navigation = useNavigation();
 
@@ -450,6 +457,13 @@ export default function VoiceScreen() {
   };
 
   const handleTranscript = (transcript: string): void => {
+    // Ignore a callback from a capture the reader has already dismissed: the
+    // mic's abort-on-unmount emits a final `end` → `onDone`, and without this a
+    // stale transcript would land after the dismiss. Consuming one live capture
+    // also clears the flag, so a second `end` from the same abort cannot
+    // double-apply.
+    if (!captureActive.current) return;
+    captureActive.current = false;
     const mode = micMode;
     // A single row's mic is plain dictation: the spoken words are appended to
     // that row's description verbatim — no parsing, so amounts/currency/group
@@ -525,6 +539,9 @@ export default function VoiceScreen() {
   // batch intact, rather than leaving the screen. Otherwise it leaves as before
   // (the leave-guard below still files an unassigned batch as a draft on the way).
   const dismiss = (): void => {
+    // Abandon any live capture: the mic's abort-on-unmount will fire a final
+    // `onDone`, and this flag makes handleTranscript drop it.
+    captureActive.current = false;
     // A sub-capture over an existing batch — the mic (listening) or its pending
     // interpretation (thinking). Either way, back out to the review with the
     // batch intact and cancel any interpretation still in flight, rather than
@@ -588,6 +605,7 @@ export default function VoiceScreen() {
       // pending ('thinking'). A late interpretation is cancelled with the token.
       if ((phase === 'listening' || phase === 'thinking') && drafts.length > 0) {
         event.preventDefault();
+        captureActive.current = false;
         interpretToken.current += 1;
         setNoAmount(false);
         setMicMode('replace');
@@ -1014,7 +1032,12 @@ export default function VoiceScreen() {
               hints={hints}
               missed={noAmount}
               autoStart={!noAmount}
-              onListen={() => setNoAmount(false)}
+              onListen={() => {
+                // A capture the reader actually started — mark it live so its
+                // transcript is accepted (and a dismissed one's is not).
+                captureActive.current = true;
+                setNoAmount(false);
+              }}
             />
           </View>
         )}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -818,8 +818,8 @@ export interface UiStrings {
     addPersonPlaceholder: string;
     /** The affordance under the review items to speak and append more expenses. */
     addMore: string;
-    /** The per-item mic that re-dictates just that expense's description. */
-    redescribe: string;
+    /** The per-item mic: plain voice dictation appended to that expense's note. */
+    dictate: string;
     /** The two destination tabs in the "Save to" picker. */
     groupsTab: string;
     peopleTab: string;
@@ -2672,7 +2672,7 @@ const en: UiStrings = {
     addPerson: 'Add a person',
     addPersonPlaceholder: 'Their name',
     addMore: 'Add more',
-    redescribe: 'Say the description again',
+    dictate: 'Add text by voice',
     groupsTab: 'Groups',
     peopleTab: 'People',
     badgeNew: 'New',
@@ -4525,7 +4525,7 @@ const ta: UiStrings = {
     addPerson: 'ஒரு நபரைச் சேர்',
     addPersonPlaceholder: 'அவர்களின் பெயர்',
     addMore: 'மேலும் சேர்',
-    redescribe: 'விளக்கத்தை மீண்டும் பேசு',
+    dictate: 'குரல் மூலம் உரை சேர்',
     groupsTab: 'குழுக்கள்',
     peopleTab: 'நபர்கள்',
     badgeNew: 'புதியது',
@@ -6434,7 +6434,7 @@ const hi: UiStrings = {
     addPerson: 'व्यक्ति जोड़ें',
     addPersonPlaceholder: 'उनका नाम',
     addMore: 'और जोड़ें',
-    redescribe: 'विवरण दोबारा बोलें',
+    dictate: 'आवाज़ से टेक्स्ट जोड़ें',
     groupsTab: 'ग्रुप',
     peopleTab: 'लोग',
     badgeNew: 'नया',
@@ -8321,7 +8321,7 @@ const ar: UiStrings = {
     addPerson: 'إضافة شخص',
     addPersonPlaceholder: 'اسمه',
     addMore: 'أضف المزيد',
-    redescribe: 'انطق الوصف مرة أخرى',
+    dictate: 'إضافة نص بالصوت',
     groupsTab: 'المجموعات',
     peopleTab: 'الأشخاص',
     badgeNew: 'جديد',


### PR DESCRIPTION
On the voice multi-expense **review** screen.

## 1. Header add-more mic
A mic now sits in the top-right header, **before the close ✕**, shown only in the review phase. It runs the same append job as the inline "+ Add more" (`startAddMore`): speak another expense (or several), it is pushed onto the batch, destination untouched — now reachable from the header without scrolling to the inline button. The inline "+ Add more" stays.

## 2. Per-item mic → plain dictation (no parsing)
Each draft row's mic was "redescribe": it re-ran `parseVoiceExpenses` and **replaced** the note with the cleaned text (amount/currency/group words stripped). Now it is plain speech-to-text: the spoken words are **appended** to that row's note verbatim, with **no parsing** — nothing is stripped, and no other row or the destination is touched. It only ever adds text.

## i18n
Renamed `voice.redescribe` → `voice.dictate` ("Add text by voice") across en/ta/hi/ar to match the new behavior. Internal mechanism names (`startRedescribe`, `MicMode: 'redescribe'`) kept — still "the single-row mic".

## Validation (Windows node)
- mobile typecheck ✅ · eslint (voice.tsx, i18n) ✅ · prettier ✅
- No stale `redescribe` references remain.

Mobile-only — ships via OTA, no migration, no Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Dictate” action to append spoken text directly to an existing expense note.
  - Added a microphone button to start the expense entry flow from the review screen.

- **Bug Fixes**
  - Prevented stale or duplicate voice transcripts from appearing after leaving dictation or navigating back to review.

- **Localization**
  - Updated voice expense labels in English, Tamil, Hindi, and Arabic to reflect the new dictation action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->