### PR TITLE
fix(voice): second capture stuck on "listening" after the first

### DIFF
--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -381,6 +381,12 @@ export function VoiceCapture({
   const mounted = useRef(true);
   // Guards the one auto-start so a re-render never reopens the mic.
   const started = useRef(false);
+  // Mirrors `listening` for the unmount cleanup to read. The panel is remounted
+  // (via a changing `key`) to start each new capture; its cleanup must abort a
+  // mic that is still open, but must NOT abort an already-idle recogniser — a
+  // needless abort() races the next mount's start() on the Android singleton and
+  // leaves the second capture stuck on "listening" with nothing happening.
+  const listeningRef = useRef(false);
 
   useSpeechRecognitionEvent('result', (event) => {
     const transcript = event.results[0]?.transcript ?? '';
@@ -490,11 +496,20 @@ export function VoiceCapture({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [available, autoStart]);
 
-  // Leaving mid-sentence must not leave the microphone open.
+  // Keep the cleanup's view of "is the mic open" current.
+  useEffect(() => {
+    listeningRef.current = listening;
+  }, [listening]);
+
+  // Leaving mid-sentence must not leave the microphone open — but only abort when
+  // the mic is actually open. On a remount to start the next capture the previous
+  // instance has usually already finished (idle); aborting it then needlessly
+  // disrupts the singleton recogniser and the next start() does nothing, leaving
+  // the second capture stuck on "listening".
   useEffect(() => {
     return () => {
       mounted.current = false;
-      ExpoSpeechRecognitionModule.abort();
+      if (listeningRef.current) ExpoSpeechRecognitionModule.abort();
     };
   }, []);
 

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -387,6 +387,15 @@ export function VoiceCapture({
   // needless abort() races the next mount's start() on the Android singleton and
   // leaves the second capture stuck on "listening" with nothing happening.
   const listeningRef = useRef(false);
+  // Set the listening flag and its ref together, synchronously, at every
+  // transition — so the unmount cleanup below always reads the true state. A
+  // passive effect mirroring the ref could still be pending when a fast remount
+  // unmounts this instance, leaving the ref stale (an open mic not aborted, or an
+  // idle one needlessly aborted).
+  const setListeningState = useCallback((next: boolean): void => {
+    listeningRef.current = next;
+    setListening(next);
+  }, []);
 
   useSpeechRecognitionEvent('result', (event) => {
     const transcript = event.results[0]?.transcript ?? '';
@@ -407,12 +416,12 @@ export function VoiceCapture({
   useSpeechRecognitionEvent('error', (event) => {
     const message = dictationError(event.error, t.misc.dictationErrors);
     if (message) setError(message);
-    setListening(false);
+    setListeningState(false);
     level.set(withTiming(0, { duration: 150 }));
   });
 
   useSpeechRecognitionEvent('end', () => {
-    setListening(false);
+    setListeningState(false);
     level.set(withTiming(0, { duration: 150 }));
     const said = latest.current.trim();
     if (said) onDone(said);
@@ -445,7 +454,7 @@ export function VoiceCapture({
     const onDevice = await englishInstalledOnDevice();
     if (!mounted.current) return;
 
-    setListening(true);
+    setListeningState(true);
     try {
       ExpoSpeechRecognitionModule.start({
         // Recognition is English-only — the surface each speaker reads is still
@@ -476,10 +485,10 @@ export function VoiceCapture({
         },
       });
     } catch {
-      setListening(false);
+      setListeningState(false);
       setError(t.misc.dictationFailed);
     }
-  }, [hints, level, locale, onListen, t]);
+  }, [hints, level, locale, onListen, setListeningState, t]);
 
   const stop = useCallback((): void => {
     ExpoSpeechRecognitionModule.stop();
@@ -495,11 +504,6 @@ export function VoiceCapture({
     void start();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [available, autoStart]);
-
-  // Keep the cleanup's view of "is the mic open" current.
-  useEffect(() => {
-    listeningRef.current = listening;
-  }, [listening]);
 
   // Leaving mid-sentence must not leave the microphone open — but only abort when
   // the mic is actually open. On a remount to start the next capture the previous


### PR DESCRIPTION
## Bug
On the Speak-an-expense screen, the first capture works; the **second** one (add-more, a per-row re-dictation, or a retry) shows "listening" and never captures anything.

## Cause
The mic panel (`VoiceCapture`) is remounted via a changing `key` to start each new capture. Its unmount cleanup always called `ExpoSpeechRecognitionModule.abort()` — but after a *completed* capture the previous instance is already idle. Aborting an idle recogniser races the next mount's `start()` on the Android speech singleton, so the second `start()` silently no-ops and the UI is stuck on "listening".

## Fix
Track whether the mic is actually open (`listeningRef`, mirrored from the `listening` state) and abort on unmount **only when it is**. A capture dismissed mid-sentence still stops the mic; a completed one no longer disrupts the next `start()`.

Minimal, targeted; no change to the capture/parse/append flow.

## Validation (Windows node)
- mobile typecheck ✅ · eslint ✅ · prettier ✅

(Device-verify the reported repro after OTA: speak → review → add-more → speak again.)

Mobile-only — OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved voice capture cleanup to prevent inactive microphone sessions from interrupting future recordings.
  - Voice recognition now stops more reliably when leaving the capture screen while actively listening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->