### PR TITLE
feat(voice): parse localized expense amounts

### DIFF
--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -568,11 +568,11 @@ export function parseVoiceExpense(
   }
 
   // Spoken numbers become digits first; every pattern below is digit-based. A
-  // "plus"-joined run of amounts is summed into one before that.
+  // "plus"-joined run of amounts is summed into one before that. Common Hindi,
+  // Tamil and Arabic amount/currency words are folded into the same vocabulary
+  // before this step, so the deterministic path works offline in the app locales.
   const said = stripAssignmentLeadIn(
-    normalizeSpokenNumbers(
-      collapseAdditionRuns(normalizeCurrencyPrefixes(normalizeDigits(transcript))),
-    ),
+    normalizeSpokenNumbers(collapseAdditionRuns(normalizeVoiceInput(transcript))),
   );
   const tokens = tokenize(said);
   const amountMajor = extractAmount(said);
@@ -793,6 +793,140 @@ export function normalizeDigits(text: string): string {
 
 function normalizeCurrencyPrefixes(text: string): string {
   return text.replace(/\b(rp|idr)\.?\s*(?=\d)/gi, '$1 ');
+}
+
+/**
+ * Localized number and currency words from the app's non-English locales, folded
+ * into the English vocabulary the parser already understands. This is deliberately
+ * a small deterministic bridge, not a translation system: the model remains the
+ * broad answer for arbitrary language, while common Hindi/Tamil/Arabic amount
+ * commands work even offline.
+ */
+const LOCALIZED_VOICE_WORDS: ReadonlyMap<string, string> = new Map([
+  // Hindi currency and common amount words.
+  ['रुपये', 'rupees'],
+  ['रुपया', 'rupees'],
+  ['रुपए', 'rupees'],
+  ['रूपये', 'rupees'],
+  ['रूपया', 'rupees'],
+  ['रूपए', 'rupees'],
+  ['पैसे', 'paise'],
+  ['पैसा', 'paise'],
+  ['शून्य', 'zero'],
+  ['एक', 'one'],
+  ['दो', 'two'],
+  ['तीन', 'three'],
+  ['चार', 'four'],
+  ['पांच', 'five'],
+  ['पाँच', 'five'],
+  ['छह', 'six'],
+  ['सात', 'seven'],
+  ['आठ', 'eight'],
+  ['नौ', 'nine'],
+  ['दस', 'ten'],
+  ['बीस', 'twenty'],
+  ['तीस', 'thirty'],
+  ['चालीस', 'forty'],
+  ['पचास', 'fifty'],
+  ['साठ', 'sixty'],
+  ['सत्तर', 'seventy'],
+  ['अस्सी', 'eighty'],
+  ['नब्बे', 'ninety'],
+  ['सौ', 'hundred'],
+  ['हजार', 'thousand'],
+  ['लाख', 'lakh'],
+  ['करोड़', 'crore'],
+  // Tamil currency and common amount words.
+  ['ரூபாய்', 'rupees'],
+  ['ரூபாய்கள்', 'rupees'],
+  ['பைசா', 'paise'],
+  ['பைசே', 'paise'],
+  ['பூஜ்யம்', 'zero'],
+  ['ஒன்று', 'one'],
+  ['இரண்டு', 'two'],
+  ['மூன்று', 'three'],
+  ['நான்கு', 'four'],
+  ['ஐந்து', 'five'],
+  ['ஆறு', 'six'],
+  ['ஏழு', 'seven'],
+  ['எட்டு', 'eight'],
+  ['ஒன்பது', 'nine'],
+  ['பத்து', 'ten'],
+  ['இருபது', 'twenty'],
+  ['முப்பது', 'thirty'],
+  ['நாற்பது', 'forty'],
+  ['ஐம்பது', 'fifty'],
+  ['அறுபது', 'sixty'],
+  ['எழுபது', 'seventy'],
+  ['எண்பது', 'eighty'],
+  ['தொண்ணூறு', 'ninety'],
+  ['நூறு', 'hundred'],
+  ['ஆயிரம்', 'thousand'],
+  ['லட்சம்', 'lakh'],
+  ['கோடி', 'crore'],
+  // Arabic currency and common amount words.
+  ['روبية', 'rupees'],
+  ['روبيات', 'rupees'],
+  ['روبيه', 'rupees'],
+  ['روبي', 'rupees'],
+  ['درهم', 'dirhams'],
+  ['دراهم', 'dirhams'],
+  ['فلس', 'fils'],
+  ['فلوس', 'fils'],
+  ['صفر', 'zero'],
+  ['واحد', 'one'],
+  ['واحدة', 'one'],
+  ['اثنان', 'two'],
+  ['اثنين', 'two'],
+  ['اثنتان', 'two'],
+  ['اثنتين', 'two'],
+  ['ثلاثة', 'three'],
+  ['ثلاث', 'three'],
+  ['أربعة', 'four'],
+  ['اربعة', 'four'],
+  ['أربع', 'four'],
+  ['اربع', 'four'],
+  ['خمسة', 'five'],
+  ['خمس', 'five'],
+  ['ستة', 'six'],
+  ['ست', 'six'],
+  ['سبعة', 'seven'],
+  ['سبع', 'seven'],
+  ['ثمانية', 'eight'],
+  ['ثمان', 'eight'],
+  ['تسعة', 'nine'],
+  ['تسع', 'nine'],
+  ['عشرة', 'ten'],
+  ['عشر', 'ten'],
+  ['عشرون', 'twenty'],
+  ['ثلاثون', 'thirty'],
+  ['أربعون', 'forty'],
+  ['اربعون', 'forty'],
+  ['خمسون', 'fifty'],
+  ['ستون', 'sixty'],
+  ['سبعون', 'seventy'],
+  ['ثمانون', 'eighty'],
+  ['تسعون', 'ninety'],
+  ['مئة', 'hundred'],
+  ['مائة', 'hundred'],
+  ['ألف', 'thousand'],
+  ['الف', 'thousand'],
+  ['مليون', 'million'],
+]);
+
+function normalizeLocalizedVoiceWords(text: string): string {
+  return text
+    .split(/(\s+)/)
+    .map((part) => {
+      if (/^\s+$/u.test(part)) return part;
+      const replacement = LOCALIZED_VOICE_WORDS.get(part.normalize('NFKC'));
+      return replacement ?? part;
+    })
+    .join('');
+}
+
+function normalizeVoiceInput(text: string): string {
+  return normalizeLocalizedVoiceWords(normalizeCurrencyPrefixes(normalizeDigits(text)));
 }
 
 /** Words for numbers, and the Indian/Western multipliers that scale them. */
@@ -1342,9 +1476,7 @@ export function parseVoiceExpenses(
   if (UNSUPPORTED_GLOBAL_EXPENSE_INTENT.test(transcript))
     return { items: [], group: null, splitCount: null, peopleText: null, expenseDate: null };
 
-  const normalized = normalizeSpokenNumbers(
-    collapseAdditionRuns(normalizeCurrencyPrefixes(normalizeDigits(transcript))),
-  );
+  const normalized = normalizeSpokenNumbers(collapseAdditionRuns(normalizeVoiceInput(transcript)));
   const expenseDate = parseVoiceExpenseDate(normalized);
   const category = parseVoiceCategory(normalized);
   const created = detectCreateGroup(normalized);

--- a/apps/mobile/src/lib/voiceExpense.ts
+++ b/apps/mobile/src/lib/voiceExpense.ts
@@ -919,8 +919,17 @@ function normalizeLocalizedVoiceWords(text: string): string {
     .split(/(\s+)/)
     .map((part) => {
       if (/^\s+$/u.test(part)) return part;
-      const replacement = LOCALIZED_VOICE_WORDS.get(part.normalize('NFKC'));
-      return replacement ?? part;
+      // A token often carries leading/trailing punctuation — a comma, the Arabic
+      // comma (،), a Devanagari danda (।), a full stop — as in "रुपये," or
+      // "روبية،". Split that off, translate the bare word, then restore the
+      // punctuation, so the currency/number word is still recognised (an exact
+      // lookup of "रुपये," would miss and leave the token untranslated).
+      const match = /^([\p{P}\p{S}]*)(.*?)([\p{P}\p{S}]*)$/u.exec(part);
+      if (!match) return part;
+      const [, prefix, core, suffix] = match;
+      if (!core) return part;
+      const replacement = LOCALIZED_VOICE_WORDS.get(core.normalize('NFKC'));
+      return replacement ? `${prefix}${replacement}${suffix}` : part;
     })
     .join('');
 }

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -851,6 +851,44 @@ describe('normalizeDigits', () => {
   });
 });
 
+describe('parseVoiceExpenses in the app languages', () => {
+  it('reads Hindi rupee commands with native numerals and spoken numbers', () => {
+    const numeric = parseVoiceExpenses('५०० रुपये चाय', groups);
+    expect(numeric.items[0]?.amountMajor).toBe(500);
+    expect(numeric.items[0]?.currency).toBe('INR');
+    expect(numeric.items[0]?.note).toBe('चाय');
+
+    const spoken = parseVoiceExpenses('पांच सौ रुपये खाना', groups);
+    expect(spoken.items[0]?.amountMajor).toBe(500);
+    expect(spoken.items[0]?.currency).toBe('INR');
+    expect(spoken.items[0]?.note).toBe('खाना');
+  });
+
+  it('reads Tamil rupee commands with native numerals and spoken numbers', () => {
+    const numeric = parseVoiceExpenses('௫௦௦ ரூபாய் தேநீர்', groups);
+    expect(numeric.items[0]?.amountMajor).toBe(500);
+    expect(numeric.items[0]?.currency).toBe('INR');
+    expect(numeric.items[0]?.note).toBe('தேநீர்');
+
+    const spoken = parseVoiceExpenses('ஐந்து நூறு ரூபாய் சாப்பாடு', groups);
+    expect(spoken.items[0]?.amountMajor).toBe(500);
+    expect(spoken.items[0]?.currency).toBe('INR');
+    expect(spoken.items[0]?.note).toBe('சாப்பாடு');
+  });
+
+  it('reads Arabic currency commands with native numerals and spoken numbers', () => {
+    const numeric = parseVoiceExpenses('٥٠٠ روبية شاي', groups);
+    expect(numeric.items[0]?.amountMajor).toBe(500);
+    expect(numeric.items[0]?.currency).toBe('INR');
+    expect(numeric.items[0]?.note).toBe('شاي');
+
+    const spoken = parseVoiceExpenses('خمسة مئة درهم قهوة', groups);
+    expect(spoken.items[0]?.amountMajor).toBe(500);
+    expect(spoken.items[0]?.currency).toBe('AED');
+    expect(spoken.items[0]?.note).toBe('قهوة');
+  });
+});
+
 describe('parseVoiceExpenses — split count and unnamed create-group', () => {
   it('reads a split count without turning it into an extra expense', () => {
     const result = parseVoiceExpenses('split 1000 among 4 people', groups);

--- a/apps/mobile/test/voiceExpense.test.ts
+++ b/apps/mobile/test/voiceExpense.test.ts
@@ -887,6 +887,23 @@ describe('parseVoiceExpenses in the app languages', () => {
     expect(spoken.items[0]?.currency).toBe('AED');
     expect(spoken.items[0]?.note).toBe('قهوة');
   });
+
+  it('recognises a currency word carrying trailing punctuation', () => {
+    // "रुपये," / "روبية،" — a comma (ASCII or the Arabic comma) stuck to the
+    // currency word must not stop it being recognised: the token is looked up
+    // without its punctuation, so the currency still resolves and the word is not
+    // left behind in the note. (Singular parse: the multi-expense path treats a
+    // comma as a separator, which is a different concern.)
+    const hindi = parseVoiceExpense('५०० रुपये, चाय', groups);
+    expect(hindi.amountMajor).toBe(500);
+    expect(hindi.currency).toBe('INR');
+    expect(hindi.note).toBe('चाय');
+
+    const arabic = parseVoiceExpense('٥٠٠ روبية، شاي', groups);
+    expect(arabic.amountMajor).toBe(500);
+    expect(arabic.currency).toBe('INR');
+    expect(arabic.note).toBe('شاي');
+  });
 });
 
 describe('parseVoiceExpenses — split count and unnamed create-group', () => {


### PR DESCRIPTION
## Summary
- normalize common Hindi, Tamil, and Arabic amount/currency words before deterministic voice parsing
- route both single-expense and multi-expense voice flows through the localized normalization path
- add regression coverage for native numerals and spoken localized currency commands

## Validation
- pnpm --filter @waves/mobile exec vitest run test/voiceExpense.test.ts
- pnpm --filter @waves/mobile run typecheck
- pnpm --filter @waves/mobile run lint

Note: unrelated untracked mobile native/watch/widget files were left unstaged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice expense entry now supports Hindi, Tamil, and Arabic currency and number words.
  * Multilingual commands with native numerals can detect amounts, currencies, and expense notes.
  * Single- and multi-expense voice entries are supported across these languages.

* **Tests**
  * Added coverage for multilingual voice expense parsing and non-Latin notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->