### PR TITLE
refactor(mobile): bring notification settings to the screen standard

### DIFF
--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -6,6 +6,7 @@ import { ActivityIndicator, ScrollView, View } from 'react-native';
 import {
   Badge,
   Button,
+  Callout,
   Card,
   directionalIcon,
   Divider,
@@ -192,28 +193,23 @@ export default function NotificationSettingsScreen() {
         </Row>
 
         {/* ADR-010: the competition is simultaneously spammy and silent. These
-            defaults are the fix, and they are all off-switchable. */}
-        <Card
-          flat
-          style={{ backgroundColor: theme.color.buttonPrimary, paddingVertical: theme.spacing.lg }}
+            defaults are the fix, and they are all off-switchable. The promise is
+            a "read this" note, so it wears the app's canonical Callout shape
+            (info tone) rather than a hand-rolled brand banner. */}
+        <Callout
+          tone="info"
+          icon={(color) => (
+            <Ionicons name="shield-checkmark-outline" size={iconSize.md} color={color} />
+          )}
         >
-          <Row gap={theme.spacing.md}>
-            <Ionicons
-              name="shield-checkmark-outline"
-              size={iconSize.xl}
-              color={theme.color.onBrand}
-            />
-            <Text variant="caption" tone="onBrand" style={{ flex: 1 }}>
-              {t.notifications.neverSpam}
-            </Text>
-          </Row>
-        </Card>
+          {t.notifications.neverSpam}
+        </Callout>
 
         {/* The master switch: nothing below fires until the phone itself is
             allowed to deliver, so this device-permission state leads. */}
         <Card style={{ gap: theme.spacing.md }}>
           <Row gap={theme.spacing.md}>
-            <IconChip icon="phone-portrait-outline" />
+            <Ionicons name="phone-portrait-outline" size={iconSize.xl} color={theme.color.text} />
             <View style={{ flex: 1 }}>
               <Text variant="subheading">{t.notifications.onThisPhone}</Text>
               <Text variant="caption" tone="muted">
@@ -249,11 +245,11 @@ export default function NotificationSettingsScreen() {
           <ActivityIndicator color={theme.color.brand} />
         ) : (
           <>
-            <View>
+            <View style={{ gap: theme.spacing.sm }}>
               <SectionHeader title={t.notifications.pushSection} />
               <PrefSection rows={pushRows(t)} prefs={prefs} onToggle={toggle} />
             </View>
-            <View>
+            <View style={{ gap: theme.spacing.sm }}>
               <SectionHeader title={t.notifications.emailSection} />
               <PrefSection rows={emailRows(t)} prefs={prefs} onToggle={toggle} />
             </View>
@@ -275,30 +271,16 @@ export default function NotificationSettingsScreen() {
 }
 
 /**
- * A soft round badge that carries a row's glyph. Purely decorative — the
- * screen reader ignores it and reads the row title instead — but it gives each
- * preference a fixed anchor on the left, the way the reference notification
- * lists lean on a leading icon column.
+ * One grouped card of preference toggles, shared by the push and email
+ * sections. Built from the same primitives the other settings lists use: a
+ * `Card` holding a stack of `Row`s with a hairline `Divider` between each, a
+ * quiet leading glyph anchoring the left, and a `Toggle` as the trailing
+ * control (the pattern the devices and sync screens share).
+ *
+ * The bodies run to two lines, so each row is a plain `Row` with a
+ * full-wrapping caption rather than a single-line `ListRow` that would clip the
+ * explanation — the same reason the devices list rolls its own row.
  */
-function IconChip({ icon }: { icon: IconName }) {
-  const theme = useTheme();
-  return (
-    <View
-      style={{
-        width: 40,
-        height: 40,
-        borderRadius: theme.radius.pill,
-        backgroundColor: theme.color.buttonPrimary,
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <Ionicons name={icon} size={iconSize.lg} color={theme.color.onBrand} />
-    </View>
-  );
-}
-
-/** One card of preference toggles, shared by the push and email sections. */
 function PrefSection({
   rows,
   prefs,
@@ -310,12 +292,12 @@ function PrefSection({
 }) {
   const theme = useTheme();
   return (
-    <Card padded={false} style={{ paddingHorizontal: theme.spacing.xl }}>
+    <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
       {rows.map((row, index) => (
         <View key={row.key}>
           {index > 0 ? <Divider /> : null}
-          <Row gap={theme.spacing.md} style={{ paddingVertical: theme.spacing.lg }}>
-            <IconChip icon={row.icon} />
+          <Row gap={theme.spacing.md} style={{ paddingVertical: theme.spacing.md }}>
+            <Ionicons name={row.icon} size={iconSize.xl} color={theme.color.textMuted} />
             <View style={{ flex: 1 }}>
               <Text variant="subheading">{row.title}</Text>
               <Text variant="caption" tone="muted">


### PR DESCRIPTION
## What & why

The notification settings screen (`apps/mobile/src/app/settings/notifications.tsx`) had drifted from the app's shared settings-screen grammar and read as "off" next to its siblings. This is a **visual/structure refresh only** — no setting, toggle, permission prompt, hook, or mutation changed.

## What was non-standard

- **Bespoke `IconChip`** — a filled-brand *pill* (`radius.pill` + `buttonPrimary` bg + white `onBrand` icon) behind every preference row *and* the master switch. No sibling screen uses a filled-brand pill; it made every row shout. Siblings use plain leading `Ionicons` (or, at most, a soft neutral tinted square in devices).
- **Hand-rolled brand banner** — the "never spam" promise was a `Card flat` in `buttonPrimary`/`onBrand`, a one-off shape. The app's canonical "read this" component is `Callout`.
- **Section spacing** — `SectionHeader` + card groups sat in a bare `<View>` with no `gap`; the standard wraps them in `View gap: spacing.sm`.
- **Card padding** — the list cards padded at `spacing.xl`; the sibling list cards pad at `spacing.lg`.

## The standard I matched (sibling references)

- `apps/mobile/src/app/settings/privacy.tsx`
- `apps/mobile/src/app/settings/devices.tsx`
- `apps/mobile/src/app/settings/sync.tsx`
- `apps/mobile/src/app/settings/account.tsx`
- `apps/mobile/src/app/group/[id]/settings.tsx`

Grammar applied: standard header (back chevron via `directionalIcon('chevron-back')` + optically-centred `Text variant="heading"` + 44pt trailing spacer) — already correct and kept; scroll container `paddingHorizontal: xl / paddingBottom: clearance / gap: xl`; `useTabBarClearance()` (matches every pushed settings screen); grouped `Card` sections each under a muted `SectionHeader`; rows built from shared `Row` + `Toggle` with a quiet leading `Ionicon`; `Divider` between rows; `Callout tone="info"` for the intro note; centred muted `micro` footnote.

## Before / after structure

**Before**
- Brand `Callout`-lookalike banner (bespoke `Card flat`, buttonPrimary)
- Master `Card` — `IconChip` + text + Badge + Button
- `<View>` → `SectionHeader` + `PrefSection` (Card, `IconChip` per row, xl padding)  ×2

**After**
- `Callout tone="info"` (shield icon) — the standard note shape
- Master `Card` — plain `Ionicon` + text + Badge + Button
- `<View gap: sm>` → `SectionHeader` + `PrefSection` (Card, plain leading `Ionicon`, lg padding)  ×2

Preference rows stay a custom `Row` (not `ListRow`) on purpose: the bodies wrap to two lines and `ListRow`'s subtitle is single-line/truncated — the same reason `devices.tsx` rolls its own row.

## i18n

No new strings — the redesign reuses the existing `notifications.*` keys, so no locale files were touched.

## Gates (Windows node v24)

- `pnpm --filter @waves/mobile typecheck` — PASS
- `pnpm --filter @waves/mobile exec eslint src/app/settings/notifications.tsx` — PASS (0 warnings)
- `pnpm exec prettier --check apps/mobile/src/app/settings/notifications.tsx` — PASS
- Tests not required (no i18n/shared-code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated notification settings with a consistent informational callout.
  - Refined icons, spacing, padding, and preference rows for a cleaner, more compact layout.
  - Improved visual consistency across push and email notification sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->