### PR TITLE
feat(mobile): colorful script-badge language picker

### DIFF
--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -4,7 +4,13 @@
  * Four languages and "follow my phone", which is the default and stays first.
  * Each one is written in its own script, because somebody who has opened the
  * app in a language they cannot read is scanning for the *shape* of their own
- * writing — "Tamil" spelled in Latin letters is not that shape.
+ * writing — "Tamil" spelled in Latin letters is not that shape. The same
+ * reasoning drives the coloured badge on each row: a round chip carrying the
+ * language's own script initial — "A", "அ", "अ", "ع" — in a distinct brand
+ * tint, so the row is recognised by shape and colour before a single word of a
+ * foreign UI is read. A national flag would be worse than useless here: two of
+ * the four languages (Tamil, Hindi) share one country, so a flag names the
+ * state, not the tongue.
  *
  * Choosing Arabic changes the words at once and the direction only after the
  * app is opened again. React Native decides right-to-left natively, before any
@@ -14,7 +20,7 @@
 
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { ScrollView, View } from 'react-native';
+import { Pressable, ScrollView, View } from 'react-native';
 
 import {
   Button,
@@ -22,17 +28,78 @@ import {
   directionalIcon,
   IconButton,
   iconSize,
-  ListRow,
   Row,
   Screen,
   Text,
   useTabBarClearance,
   useTheme,
+  type TintName,
 } from '@waves/ui';
 
-import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES, useStrings, type Language } from '@/i18n';
+import { isRtlLanguage, Language, LANGUAGE_NAMES, LANGUAGES, useStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
 import { canRestart, restartApp } from '@/lib/restart';
+
+/**
+ * The script-initial glyph and the brand tint each language wears.
+ *
+ * The glyphs are literals in this file, not translated strings: a badge shows
+ * *that language's* own script regardless of the app's current locale, so it is
+ * a fixed property of the language, not UI copy. Tints are hand-picked from the
+ * app's pastel family (never new hex) so the four hues stay maximally distinct —
+ * a cool blue, a warm coral, an amber, a violet — rather than colliding the way
+ * a hash-based assignment eventually would across only four keys.
+ */
+const LANGUAGE_BADGE: Readonly<Record<Language, { glyph: string; tint: TintName }>> = {
+  [Language.En]: { glyph: 'A', tint: 'sky' },
+  [Language.Ta]: { glyph: 'அ', tint: 'coral' },
+  [Language.Hi]: { glyph: 'अ', tint: 'peach' },
+  [Language.Ar]: { glyph: 'ع', tint: 'lilac' },
+};
+
+/** The diameter of the leading badge — matched to the default Avatar size. */
+const BADGE_SIZE = 44;
+
+/**
+ * A round, brand-tinted chip carrying either a language's script initial or the
+ * "follow my phone" glyph. It reuses the theme's tint pairs (bg + AA-safe ink),
+ * so the letter always clears contrast on its own colour.
+ */
+function LanguageBadge({
+  glyph,
+  tint,
+  icon,
+}: {
+  glyph?: string;
+  tint?: TintName;
+  /** Used for "follow my phone", which stands for a setting, not a script. */
+  icon?: keyof typeof Ionicons.glyphMap;
+}) {
+  const theme = useTheme();
+  // The phone row wears the brand's own soft wash rather than a language tint —
+  // it is the app's default, not a fifth language, and reads that way.
+  const background = tint ? theme.tint[tint].bg : theme.color.brandSoft;
+  const foreground = tint ? theme.tint[tint].ink : theme.color.brand;
+
+  return (
+    <View
+      style={{
+        width: BADGE_SIZE,
+        height: BADGE_SIZE,
+        borderRadius: BADGE_SIZE / 2,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: background,
+      }}
+    >
+      {icon ? (
+        <Ionicons name={icon} size={iconSize.xl} color={foreground} />
+      ) : (
+        <Text style={{ fontSize: 20, fontWeight: '700', color: foreground }}>{glyph}</Text>
+      )}
+    </View>
+  );
+}
 
 export default function LanguageSettingsScreen() {
   const theme = useTheme();
@@ -40,12 +107,19 @@ export default function LanguageSettingsScreen() {
   const { t } = useStrings();
   const { stored, language, phoneLanguage, setLanguage, restartNeeded } = useLanguage();
 
-  const rows: { key: string; title: string; subtitle: string; value: Language | null }[] = [
+  const rows: {
+    key: string;
+    title: string;
+    subtitle: string;
+    value: Language | null;
+    badge: { glyph?: string; tint?: TintName; icon?: keyof typeof Ionicons.glyphMap };
+  }[] = [
     {
       key: 'phone',
       title: t.misc.followMyPhone,
       subtitle: t.misc.currentlyLanguage.replace('{language}', LANGUAGE_NAMES[phoneLanguage].own),
       value: null,
+      badge: { icon: 'phone-portrait-outline' },
     },
     ...LANGUAGES.map((entry) => ({
       key: entry,
@@ -54,6 +128,7 @@ export default function LanguageSettingsScreen() {
         ? `${LANGUAGE_NAMES[entry].english} · ${t.misc.rightToLeft}`
         : LANGUAGE_NAMES[entry].english,
       value: entry as Language | null,
+      badge: LANGUAGE_BADGE[entry],
     })),
   ];
 
@@ -110,26 +185,59 @@ export default function LanguageSettingsScreen() {
           </Card>
         ) : null}
 
-        <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-          {rows.map((row, index) => {
+        {/* One tap-target per row. The list behaves as a radio group: the whole
+            list is `radiogroup`, each row a `radio` carrying its selected state,
+            so a screen reader announces "2 of 5, selected" rather than reading a
+            loose checkmark glyph. */}
+        <Card padded={false} style={{ padding: theme.spacing.xs }} accessibilityRole="radiogroup">
+          {rows.map((row) => {
             const chosen = stored === row.value;
             return (
-              <View key={row.key}>
-                <ListRow
-                  title={row.title}
-                  subtitle={row.subtitle}
-                  onPress={() => void setLanguage(row.value)}
-                  accessibilityLabel={`${row.title}${chosen ? ', selected' : ''}`}
-                  trailing={
-                    chosen ? (
-                      <Ionicons name="checkmark" size={iconSize.lg} color={theme.color.brand} />
-                    ) : null
-                  }
+              <Pressable
+                key={row.key}
+                accessibilityRole="radio"
+                // The chosen state rides on `accessibilityState`, which the OS
+                // announces natively for a radio ("selected"); spelling it into
+                // the label as well would say it twice.
+                accessibilityState={{ selected: chosen }}
+                accessibilityLabel={`${row.title}, ${row.subtitle}`}
+                onPress={() => void setLanguage(row.value)}
+                style={({ pressed }) => ({
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: theme.spacing.md,
+                  paddingVertical: theme.spacing.sm,
+                  paddingHorizontal: theme.spacing.md,
+                  borderRadius: theme.radius.md,
+                  // The chosen row lifts onto the brand's soft wash — a quiet
+                  // fill rather than a loud border, so the colour lives with the
+                  // badges and not against them.
+                  backgroundColor: chosen ? theme.color.brandSoft : 'transparent',
+                  opacity: pressed ? 0.7 : 1,
+                })}
+              >
+                <LanguageBadge
+                  glyph={row.badge.glyph}
+                  tint={row.badge.tint}
+                  icon={row.badge.icon}
                 />
-                {index < rows.length - 1 ? (
-                  <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                ) : null}
-              </View>
+                <View style={{ flex: 1 }}>
+                  <Text variant="subheading" numberOfLines={1}>
+                    {row.title}
+                  </Text>
+                  <Text variant="caption" tone="muted" numberOfLines={1}>
+                    {row.subtitle}
+                  </Text>
+                </View>
+                {/* The radio mark the refs use: a filled brand check-circle when
+                    chosen, a hollow ring otherwise — present on every row so the
+                    trailing column never jumps as the selection moves. */}
+                <Ionicons
+                  name={chosen ? 'checkmark-circle' : 'ellipse-outline'}
+                  size={iconSize.jumbo}
+                  color={chosen ? theme.color.brand : theme.color.border}
+                />
+              </Pressable>
             );
           })}
         </Card>


### PR DESCRIPTION
## What & why

Redesign the **Language** settings screen (`apps/mobile/src/app/settings/language.tsx`) to feel world-class and colorful while staying strictly on-brand and preserving every behavior.

### Before
Plain `ListRow`s (native name / English subtitle) with a bare trailing checkmark on the selected one — visually indistinguishable from every other settings list, no per-language identity.

### After
Each row now leads with a **round, brand-tinted chip carrying that language's own script initial** — `A` / `அ` / `अ` / `ع` — each in a distinct pastel from the app's existing tint palette:

| Language | Glyph | Tint |
|---|---|---|
| English | `A` | sky (blue) |
| தமிழ் | `அ` | coral |
| हिन्दी | `अ` | peach (amber) |
| العربية | `ع` | lilac (violet) |
| Follow my phone | phone glyph | brand-soft wash |

The row shows the **native name in bold over the English name muted**, a **radio mark** (filled brand `checkmark-circle` when chosen, hollow `ellipse-outline` ring otherwise), and a **brand-soft wash on the selected row**. This follows the Mobbin references:

- **Vivid** — https://mobbin.com/screens/8d44e1ab-19ff-439e-aad3-c7ebed982e06 (circular chip + native name bold over English + trailing mark)
- **inDrive** — https://mobbin.com/screens/61ec11bc-74d7-49f2-9b77-ee1b36f8f892 (native bold + English subtitle + check)
- **Agoda** — https://mobbin.com/screens/6280032b-3b04-4134-a6db-84a11f7be94f / **Calm** — https://mobbin.com/screens/4dd89625-1d8b-4915-8079-9c43f3730c7f (pill rows, colorful backdrop)

Script badges (not flags) are deliberate: Tamil and Hindi share one country, so a national flag would name the state, not the tongue.

## Constraints honored
- **Behavior preserved:** same `setLanguage` setter, same `stored` / `phoneLanguage` / `restartNeeded` state, selected reflects current state. The **RTL restart banner is kept verbatim** (direction is decided natively at launch — a real constraint).
- **RTL:** row mirrors correctly via `flexDirection: 'row'` auto-flip; back chevron stays on `directionalIcon`.
- **On-system:** reuses `Card`, `Row`, `Text`, `Ionicons`, `iconSize`, `useTheme`, `useTabBarClearance`, and the `theme.tint` pairs — **no new hex colors**. Tint pairs carry AA-safe ink, so each glyph clears contrast on its own chip.
- **A11y:** list is now a proper `radiogroup` of `radio` rows with `accessibilityState={{ selected }}` — the OS announces selection natively instead of via a loose checkmark string.
- **React Compiler:** no `Date.now()`/`new Date()` in render, no ref writes, no Animated values; `LanguageBadge` is pure, badge map is a module constant.
- **No new user-facing strings** — script glyphs are in-component literals (a fixed property of each language, rendered regardless of the app's current locale).

## Gates (Windows node)
- `pnpm --filter @waves/mobile typecheck` — pass (`tsc --noEmit`, no errors)
- `pnpm --filter @waves/mobile exec eslint src/app/settings/language.tsx` — pass (clean)
- `pnpm exec prettier --check apps/mobile/src/app/settings/language.tsx` — pass

No i18n/shared files touched, so no test gate triggered. Mobile-only (OTA); no migration, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated language settings with script-specific tinted badges.
  - Added a phone icon for the “Follow my phone” option.
  - Added clearer selected-state visuals, including highlighted rows and check/radio indicators.
  - Improved accessibility feedback for selected language options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->