### PR TITLE
fix(settings): show real profile photo on Your account + Mobbin redesign

### DIFF
--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -13,7 +13,6 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 
 import {
-  Avatar,
   Badge,
   Button,
   Callout,
@@ -24,7 +23,6 @@ import {
   iconSize,
   Row,
   Screen,
-  SectionHeader,
   Text,
   useTabBarClearance,
   useTheme,
@@ -34,6 +32,7 @@ import { currencyForCountry, currencySymbol, dialingCodeForCountry } from '@wave
 
 import { CountryCodePicker } from '@/components/CountryCodePicker';
 import { CountryRow } from '@/components/CountryPicker';
+import { ProfileAvatar } from '@/components/ProfileAvatar';
 import { friendlyError } from '@/lib/errors';
 import { confirmContact, startAddingContact, ContactChannel } from '@/data/api';
 import { deviceCountry, useStrings } from '@/i18n';
@@ -113,6 +112,22 @@ function AccountForm() {
   // independent of which channel the form below is currently pointed at, so it
   // does not flip as the chips are toggled. Purely a label.
   const accountContact = session?.user.email ?? session?.user.phone ?? null;
+
+  // The portrait's photo. A Google/Apple sign-in carries a photo in the
+  // session's user metadata, but the profile row only holds one if a trigger
+  // copied it across — older accounts have a null `avatar_url` and so showed
+  // initials here. Fall back to the provider photo (an https URL that resolves
+  // straight through) so the header shows the real face whether or not the
+  // column was ever filled. `||`, not `??`: an empty-string avatar (a cleared
+  // column, or a provider that sends '') is "no photo", so it must fall through
+  // to the next source rather than be handed on as a blank URL. This mirrors the
+  // derivation on (tabs)/profile deliberately — kept local so this screen does
+  // not depend on that one (a separate change is in flight there).
+  const oauthAvatar =
+    (session?.user?.user_metadata?.avatar_url as string | undefined) ||
+    (session?.user?.user_metadata?.picture as string | undefined) ||
+    null;
+  const avatarUrl = profile?.avatar_url || oauthAvatar;
 
   // The name shown in the header portrait, never blank — the same "You"
   // fallback the save path already uses, so the header agrees with the row.
@@ -270,20 +285,31 @@ function AccountForm() {
         </Row>
 
         {/* A calm identity header: the avatar and name give the screen a focal
-            point that names whose account this is (Mobbin — Todoist, TheFork).
-            It is a portrait, not a control — the name is edited in the field
-            just below, and the initials fall back cleanly when there is no
-            display name yet. */}
+            point that names whose account this is (Mobbin — Slopes, Tesla, Me+,
+            Vivino: a centred portrait over the name and contact). It is a
+            portrait, not a control — the name is edited in the field just below,
+            and the photo owner is (tabs)/profile, so there is no camera badge
+            here. `ProfileAvatar` shows the uploaded photo, or the provider
+            photo, and falls back to initials only when there is neither. */}
         <View
           style={{
             alignItems: 'center',
-            gap: theme.spacing.sm,
+            gap: theme.spacing.md,
             paddingTop: theme.spacing.sm,
           }}
         >
-          <Avatar name={displayName} size={88} />
+          <ProfileAvatar name={displayName} avatarUrl={avatarUrl} size={96} />
           <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-            <Text variant="title">{displayName}</Text>
+            <Row style={{ gap: theme.spacing.sm }}>
+              <Text variant="title">{displayName}</Text>
+              {/* The badge says the account has no email or phone on it. When
+                  somebody has not renamed themselves it repeats the name they
+                  were given, which reads as a bug rather than a fact — so it is
+                  held back for the untouched "Guest" name. */}
+              {isGuest && profile?.display_name !== 'Guest' ? (
+                <Badge label={t.common.guest} />
+              ) : null}
+            </Row>
             {accountContact ? (
               <Text variant="caption" tone="muted">
                 {accountContact}
@@ -296,7 +322,7 @@ function AccountForm() {
             old "You" screen so the whole account lives on one page. Save appears
             only once the name has changed, so the resting screen is calm. */}
         <View style={{ gap: theme.spacing.md }}>
-          <SectionHeader title={t.account.displayName} />
+          <GroupLabel icon="person-outline" title={t.account.displayName} />
           <Card style={{ gap: theme.spacing.lg }}>
             <TextInput
               value={name}
@@ -324,7 +350,7 @@ function AccountForm() {
             expense starts on, and the settle rails you are offered. Required —
             an address may follow, but it never has to. */}
         <View style={{ gap: theme.spacing.md }}>
-          <SectionHeader title={t.account.regionTitle} />
+          <GroupLabel icon="location-outline" title={t.account.regionTitle} />
           <Card style={{ gap: theme.spacing.lg }}>
             <CountryRow countryCode={country} onChange={(next) => void saveCountry(next)} />
 
@@ -399,7 +425,7 @@ function AccountForm() {
         ) : null}
 
         <View style={{ gap: theme.spacing.md }}>
-          <SectionHeader title={t.contact.signInMethodsTitle} />
+          <GroupLabel icon="log-in-outline" title={t.contact.signInMethodsTitle} />
           {/* An email or phone, or a linked account — any of them signs you back
               in on another phone. */}
           <Card style={{ gap: theme.spacing.lg }}>
@@ -571,6 +597,39 @@ function AccountForm() {
         </Text>
       </ScrollView>
     </Screen>
+  );
+}
+
+/**
+ * A section label in the settings grammar: a leading glyph in a soft brand
+ * circle beside the heading, matching the rows on (tabs)/profile so this screen
+ * reads as one of the settings family rather than a bespoke form. It replaces
+ * the bare `SectionHeader` here — the icon gives each grouped card a fast,
+ * scannable anchor (Mobbin — Me+, Vivino: grouped rows led by an icon). No
+ * chevron: every group below is edited in place, so there is nowhere to go.
+ */
+function GroupLabel({ icon, title }: { icon: keyof typeof Ionicons.glyphMap; title: string }) {
+  const theme = useTheme();
+  return (
+    <Row style={{ gap: theme.spacing.md, marginBottom: theme.spacing.xs }}>
+      <View
+        style={{
+          width: 34,
+          height: 34,
+          borderRadius: theme.radius.pill,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: theme.color.brandSoft,
+        }}
+      >
+        <Ionicons name={icon} size={iconSize.md} color={theme.color.brand} />
+      </View>
+      {/* Marked as a header so a screen reader's heading navigation can still
+          jump between sections, exactly as the `SectionHeader` it replaced did. */}
+      <Text variant="heading" accessibilityRole="header">
+        {title}
+      </Text>
+    </Row>
   );
 }
 

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -306,9 +306,7 @@ function AccountForm() {
                   somebody has not renamed themselves it repeats the name they
                   were given, which reads as a bug rather than a fact — so it is
                   held back for the untouched "Guest" name. */}
-              {isGuest && profile?.display_name !== 'Guest' ? (
-                <Badge label={t.common.guest} />
-              ) : null}
+              {isGuest && displayName !== 'Guest' ? <Badge label={t.common.guest} /> : null}
             </Row>
             {accountContact ? (
               <Text variant="caption" tone="muted">


### PR DESCRIPTION
## The bug

The Your account screen's identity header (`apps/mobile/src/app/settings/account.tsx`) rendered `<Avatar name={displayName} size={88} />` — an **initials-only** avatar. So anyone with a profile photo (uploaded, or a Google/Apple sign-in photo) saw their initials instead of their picture.

### Fix

Derive the avatar exactly the way `(tabs)/profile.tsx` already does, and render `ProfileAvatar` instead of `Avatar`:

- uploaded `profile.avatar_url` first,
- fall back to the provider photo in `session.user.user_metadata.avatar_url` / `.picture` (a Google/Apple https URL) — using `||`, not `??`, so a cleared/empty-string avatar falls through rather than being handed on as a blank URL,
- initials only as the final fallback.

`ProfileAvatar` resolves signed storage paths (private bucket, ADR-013) and passes OAuth https URLs straight through. The derivation is **duplicated locally** — profile.tsx is intentionally left untouched (a separate change is in flight there).

## Redesign (Mobbin-grounded)

Refs: [Slopes](https://mobbin.com/screens/7de0978c-1d94-4baf-b324-ef907f33d971), [Me+](https://mobbin.com/screens/eb011a11-3a79-48ba-b81a-833bebb06216), [Vivino](https://mobbin.com/screens/18edd215-4978-455e-9c37-703f65a02973), [Tesla](https://mobbin.com/screens/77306280-9f47-4bc1-8d25-3846156d89f2).

- **Premium identity header**: larger real avatar (88 → 96), centred over the name and email/phone, with a guest badge (consistent with `(tabs)/profile`).
- **Grouped, labelled cards**: each control group now leads with a soft brand-circle leading icon (`person-outline` / `location-outline` / `log-in-outline`) via a new local `GroupLabel`, matching the settings grammar of the sibling screens — replacing the bare `SectionHeader`. The `accessibilityRole="header"` is preserved so screen-reader heading navigation still works.

### Deliberate omissions
- **No camera/edit affordance on the avatar**: photo upload is owned by `(tabs)/profile.tsx`, not this screen. Per the brief, the photo is shown but no upload is added here.
- **No chevrons**: every group on this screen is edited *in place* (name field, country picker, verification form) — none navigate — so a chevron would falsely imply navigation.

## Before / after structure

| Before | After |
| --- | --- |
| `<Avatar>` initials, size 88 | `<ProfileAvatar>` real photo (uploaded → provider → initials), size 96 |
| name over contact | name + guest badge over contact |
| `SectionHeader` (bare title) × 3 | `GroupLabel` (leading soft-circle icon + title) × 3 |

Every existing control and behaviour is preserved: name edit + save + status, region / currency / optional address + save, guest & gate callout, email/phone chip + OTP send/confirm + "use a different", Google account linking, footnote.

## New i18n keys

None. All copy reuses existing strings (`t.account.displayName`, `t.account.regionTitle`, `t.contact.signInMethodsTitle`, `t.common.guest`, …).

## Gates (Windows node v24.18.0)

- `pnpm --filter @waves/mobile typecheck` — pass (tsc exit 0)
- `pnpm --filter @waves/mobile exec eslint src/app/settings/account.tsx` — pass (exit 0)
- `pnpm exec prettier --check apps/mobile/src/app/settings/account.tsx` — pass
- i18n/shared untouched → no test run required.

Mobile-only (OTA). No migration, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account profiles display uploaded or connected-provider photos, with initials shown when no photo is available.
  * Guest accounts are clearly identified with a badge.
  * Account settings sections use clearer icon-based labels while retaining accessibility support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->