### PR TITLE
feat(tags): drag-and-drop reorder in tags & categories

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -58,6 +58,7 @@
     "react-dom": "19.2.8",
     "react-native": "0.86.2",
     "react-native-document-scanner-plugin": "^2.0.4",
+    "react-native-draggable-flatlist": "4.0.3",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-get-sms-android": "^2.1.0",
     "react-native-qrcode-styled": "^0.4.0",

--- a/apps/mobile/src/app/settings/categories.tsx
+++ b/apps/mobile/src/app/settings/categories.tsx
@@ -3,7 +3,7 @@
  *
  * One ordered list of everything the pickers show: the ten built-ins and the
  * tags you have made yourself. From here you can make a new tag, edit or delete
- * your own, hide a built-in you never use, and move any of them up or down so
+ * your own, hide a built-in you never use, and drag any of them up or down so
  * the ones you reach for sit first.
  *
  * The order and the hidden state live on the same per-user `category_tags` rows
@@ -15,7 +15,11 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { Pressable, ScrollView, View } from 'react-native';
+import { Pressable, View } from 'react-native';
+import DraggableFlatList, {
+  ScaleDecorator,
+  type RenderItemParams,
+} from 'react-native-draggable-flatlist';
 
 import type { CatalogEntry } from '@waves/core';
 import {
@@ -34,7 +38,7 @@ import {
 
 import { CategoryBadge } from '@/components/Category';
 import { TagEditorSheet } from '@/components/TagEditorSheet';
-import { useCategoryCatalog, useUpsertTag } from '@/data/hooks';
+import { useCategoryCatalog, useUpsertTag, type TagUpsertInput } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 
 export default function CategoriesSettingsScreen() {
@@ -49,196 +53,200 @@ export default function CategoriesSettingsScreen() {
   const [editing, setEditing] = useState<CatalogEntry | null>(null);
   const [creating, setCreating] = useState(false);
 
+  // The list drives its own order while a drag is in flight, then commits and
+  // lets the catalog read (the source of truth) flow back in. When the catalog
+  // itself changes (a tag added, hidden, a reorder synced) we resnap to it —
+  // done during render off a remembered reference, the sanctioned alternative to
+  // a setState-in-effect sync.
+  const [order, setOrder] = useState<CatalogEntry[]>(() => [...all]);
+  const [catalogRef, setCatalogRef] = useState(all);
+  if (catalogRef !== all) {
+    setCatalogRef(all);
+    setOrder([...all]);
+  }
+
+  // One drag settles at a time. A reorder that touches a built-in with no
+  // override row yet mints a fresh row for it; letting a second drag start
+  // before the first's rows have landed in the queue could mint a duplicate for
+  // the same built-in and trip the (owner, builtin_id) unique index at sync.
+  const [savingOrder, setSavingOrder] = useState(false);
+
   // The upsert payload for one entry, with a field or two overridden. A custom
   // tag carries its whole display so a re-save never blanks it; a built-in
   // carries only its place and hidden flag (its label is in the string table).
+  const payloadFor = (
+    entry: CatalogEntry,
+    over: { sortOrder?: number; hidden?: boolean },
+  ): TagUpsertInput =>
+    entry.custom
+      ? {
+          tagId: entry.tagId ?? undefined,
+          label: entry.label,
+          icon: entry.icon,
+          tint: entry.tint,
+          sortOrder: over.sortOrder ?? entry.sortOrder,
+          hidden: over.hidden ?? entry.hidden,
+        }
+      : {
+          tagId: entry.tagId ?? undefined,
+          builtinId: entry.builtinId,
+          sortOrder: over.sortOrder ?? entry.sortOrder,
+          hidden: over.hidden ?? entry.hidden,
+        };
+
   const persist = (entry: CatalogEntry, over: { sortOrder?: number; hidden?: boolean }): void => {
-    if (entry.custom) {
-      upsertTag.mutate({
-        tagId: entry.tagId ?? undefined,
-        label: entry.label,
-        icon: entry.icon,
-        tint: entry.tint,
-        sortOrder: over.sortOrder ?? entry.sortOrder,
-        hidden: over.hidden ?? entry.hidden,
-      });
-    } else {
-      upsertTag.mutate({
-        tagId: entry.tagId ?? undefined,
-        builtinId: entry.builtinId,
-        sortOrder: over.sortOrder ?? entry.sortOrder,
-        hidden: over.hidden ?? entry.hidden,
-      });
+    upsertTag.mutate(payloadFor(entry, over));
+  };
+
+  // Commit a dropped order. Each entry's new place is its index in the list, so
+  // the stored `sort_order` (an integer) matches what the eye sees. Only the
+  // rows whose place actually changed are written — after one full pass the
+  // orders are already 0..n-1, so a later single drag touches just the span it
+  // crossed. Each built-in is written at most once per drop, so no two writes
+  // race for the same override row.
+  const commitOrder = async (next: CatalogEntry[]): Promise<void> => {
+    const changed = next
+      .map((entry, index) => ({ entry, index }))
+      .filter(({ entry, index }) => entry.sortOrder !== index);
+    if (changed.length === 0) return;
+    setSavingOrder(true);
+    try {
+      for (const { entry, index } of changed) {
+        await upsertTag.mutateAsync(payloadFor(entry, { sortOrder: index }));
+      }
+    } finally {
+      setSavingOrder(false);
     }
   };
 
-  // Move an entry up or down by swapping its order with its neighbour. Both
-  // rows are persisted with the other's sort_order; a built-in with no override
-  // yet gains one here.
-  const move = (index: number, direction: -1 | 1): void => {
-    // Reordering a built-in that has no override row yet mints a fresh id for
-    // it. Two taps fired inside one render frame would mint two rows for the
-    // same built-in, and the second trips the (owner, builtin_id) unique index
-    // at sync. Ignore a move while the previous one is still in flight: the
-    // arrows settle one reorder at a time, so no two rows race for one built-in.
-    if (upsertTag.isPending) return;
-    const other = index + direction;
-    if (other < 0 || other >= all.length) return;
-    const a = all[index]!;
-    const b = all[other]!;
-    persist(a, { sortOrder: b.sortOrder });
-    persist(b, { sortOrder: a.sortOrder });
-  };
+  const renderItem = ({ item: entry, drag, isActive }: RenderItemParams<CatalogEntry>) => (
+    <ScaleDecorator>
+      <Card
+        padded={false}
+        style={{
+          paddingHorizontal: theme.spacing.md,
+          paddingVertical: theme.spacing.sm,
+          marginBottom: theme.spacing.sm,
+          // The lifted row reads as picked-up: a touch brighter, a touch raised.
+          ...(isActive ? { borderColor: theme.color.brand, elevation: 4, opacity: 0.97 } : null),
+        }}
+      >
+        <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+          {/* The grip is the one thing that starts a drag: press and hold it,
+              then move. Disabled while a previous reorder is still saving so two
+              drops can't race to mint the same built-in's override row. */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`${entry.label} — ${t.tags.dragHandle}`}
+            accessibilityState={{ disabled: savingOrder }}
+            disabled={savingOrder || isActive}
+            onLongPress={drag}
+            delayLongPress={120}
+            style={({ pressed }) => ({
+              paddingVertical: theme.spacing.xs,
+              paddingRight: theme.spacing.xs,
+              opacity: savingOrder ? 0.4 : pressed ? 0.5 : 1,
+            })}
+          >
+            <Ionicons name="reorder-three" size={iconSize.lg} color={theme.color.textMuted} />
+          </Pressable>
+
+          <CategoryBadge
+            category={entry.key}
+            meta={entry.custom ? { label: entry.label, icon: entry.icon, tint: entry.tint } : null}
+            size={32}
+          />
+
+          <Text
+            variant="body"
+            numberOfLines={1}
+            style={{ flex: 1, opacity: entry.hidden ? 0.5 : 1 }}
+          >
+            {entry.label}
+          </Text>
+
+          {/* A custom tag is edited (and deleted) in the sheet; a built-in is
+              only ever hidden or shown. */}
+          {entry.custom ? (
+            <IconButton label={t.common.edit} onPress={() => setEditing(entry)}>
+              <Ionicons name="pencil" size={iconSize.md} color={theme.color.textMuted} />
+            </IconButton>
+          ) : (
+            <Toggle
+              value={!entry.hidden}
+              onValueChange={(shown) => persist(entry, { hidden: !shown })}
+              accessibilityLabel={entry.hidden ? t.tags.show : t.tags.hide}
+            />
+          )}
+        </Row>
+      </Card>
+    </ScaleDecorator>
+  );
 
   return (
     <Screen>
-      <ScrollView
-        // A tighter vertical rhythm than the old blanket `xl` gap: the header,
-        // the intro line, the card and the hint each carry their own margin so
-        // the intro can hug the header while the card still breathes. Denser
-        // overall, so the list starts higher up the screen.
+      <DraggableFlatList
+        data={order}
+        keyExtractor={(entry) => entry.key}
+        renderItem={renderItem}
+        onDragEnd={({ data }) => {
+          setOrder(data);
+          void commitOrder(data);
+        }}
+        containerStyle={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
         }}
         showsVerticalScrollIndicator={false}
-      >
-        <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.tags.manageTitle}</Text>
+        ListHeaderComponent={
+          <View>
+            <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
+              <IconButton label={t.common.back} onPress={() => router.back()}>
+                <Ionicons
+                  name={directionalIcon('chevron-back')}
+                  size={iconSize.lg}
+                  color={theme.color.text}
+                />
+              </IconButton>
+              <View style={{ flex: 1, alignItems: 'center' }}>
+                <Text variant="heading">{t.tags.manageTitle}</Text>
+              </View>
+              <IconButton label={t.tags.newTag} onPress={() => setCreating(true)}>
+                <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
+              </IconButton>
+            </Row>
+
+            {/* Hugs the header (small top margin) rather than sitting a full gap
+                below it, so the intro reads as a subtitle of the title above. */}
+            <Text
+              variant="caption"
+              tone="muted"
+              align="center"
+              style={{ marginTop: theme.spacing.sm, marginBottom: theme.spacing.lg }}
+            >
+              {t.tags.manageSubtitle}
+            </Text>
           </View>
-          <IconButton label={t.tags.newTag} onPress={() => setCreating(true)}>
-            <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
-          </IconButton>
-        </Row>
-
-        {/* Hugs the header (small top margin) rather than sitting a full gap
-            below it, so the intro reads as a subtitle of the title above. */}
-        <Text variant="caption" tone="muted" align="center" style={{ marginTop: theme.spacing.sm }}>
-          {t.tags.manageSubtitle}
-        </Text>
-
-        {all.length === 0 ? (
+        }
+        ListEmptyComponent={
           <View style={{ paddingTop: theme.spacing.xxxl }}>
             <EmptyState title={t.tags.noCustomTags} />
           </View>
-        ) : (
-          <Card
-            padded={false}
-            style={{ paddingHorizontal: theme.spacing.lg, marginTop: theme.spacing.lg }}
-          >
-            {all.map((entry, index) => (
-              <View key={entry.key}>
-                {index > 0 ? (
-                  <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                ) : null}
-                <Row
-                  style={{
-                    alignItems: 'center',
-                    paddingVertical: theme.spacing.sm,
-                    gap: theme.spacing.sm,
-                  }}
-                >
-                  {/* Reorder controls. Compact chevrons stacked up-over-down:
-                      the tap target is real padding on each Pressable (kept
-                      small), so it stays inside the control's own bounds — a
-                      `hitSlop` would extend past this wrapper and be clipped on
-                      Android — while the badge and label still set the row height.
-                      A `move` that can't go anywhere (the first row's up, the last
-                      row's down, or any while a reorder is still saving) is
-                      disabled: the arrow dims, gives no pressed feedback, and
-                      announces its disabled state. */}
-                  <View style={{ gap: 2 }}>
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel={`${entry.label} ▲`}
-                      accessibilityState={{ disabled: index === 0 || upsertTag.isPending }}
-                      disabled={index === 0 || upsertTag.isPending}
-                      onPress={() => move(index, -1)}
-                      style={({ pressed }) => ({
-                        paddingHorizontal: theme.spacing.sm,
-                        paddingVertical: 3,
-                        opacity: pressed ? 0.5 : 1,
-                      })}
-                    >
-                      <Ionicons
-                        name="chevron-up"
-                        size={iconSize.md}
-                        color={index === 0 ? theme.color.textFaint : theme.color.textMuted}
-                      />
-                    </Pressable>
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel={`${entry.label} ▼`}
-                      accessibilityState={{
-                        disabled: index === all.length - 1 || upsertTag.isPending,
-                      }}
-                      disabled={index === all.length - 1 || upsertTag.isPending}
-                      onPress={() => move(index, 1)}
-                      style={({ pressed }) => ({
-                        paddingHorizontal: theme.spacing.sm,
-                        paddingVertical: 3,
-                        opacity: pressed ? 0.5 : 1,
-                      })}
-                    >
-                      <Ionicons
-                        name="chevron-down"
-                        size={iconSize.md}
-                        color={
-                          index === all.length - 1 ? theme.color.textFaint : theme.color.textMuted
-                        }
-                      />
-                    </Pressable>
-                  </View>
-
-                  <CategoryBadge
-                    category={entry.key}
-                    meta={
-                      entry.custom
-                        ? { label: entry.label, icon: entry.icon, tint: entry.tint }
-                        : null
-                    }
-                    size={32}
-                  />
-
-                  <Text
-                    variant="body"
-                    numberOfLines={1}
-                    style={{ flex: 1, opacity: entry.hidden ? 0.5 : 1 }}
-                  >
-                    {entry.label}
-                  </Text>
-
-                  {/* A custom tag is edited (and deleted) in the sheet; a
-                      built-in is only ever hidden or shown. */}
-                  {entry.custom ? (
-                    <IconButton label={t.common.edit} onPress={() => setEditing(entry)}>
-                      <Ionicons name="pencil" size={iconSize.md} color={theme.color.textMuted} />
-                    </IconButton>
-                  ) : (
-                    <Toggle
-                      value={!entry.hidden}
-                      onValueChange={(shown) => persist(entry, { hidden: !shown })}
-                      accessibilityLabel={entry.hidden ? t.tags.show : t.tags.hide}
-                    />
-                  )}
-                </Row>
-              </View>
-            ))}
-          </Card>
-        )}
-
-        <Text variant="micro" tone="muted" align="center" style={{ marginTop: theme.spacing.md }}>
-          {t.tags.reorderHint}
-        </Text>
-      </ScrollView>
+        }
+        ListFooterComponent={
+          order.length > 0 ? (
+            <Text
+              variant="micro"
+              tone="muted"
+              align="center"
+              style={{ marginTop: theme.spacing.md }}
+            >
+              {t.tags.reorderHint}
+            </Text>
+          ) : null
+        }
+      />
 
       <TagEditorSheet open={creating} onClose={() => setCreating(false)} />
       <TagEditorSheet open={editing !== null} editing={editing} onClose={() => setEditing(null)} />

--- a/apps/mobile/src/app/settings/categories.tsx
+++ b/apps/mobile/src/app/settings/categories.tsx
@@ -166,7 +166,9 @@ export default function CategoriesSettingsScreen() {
           </Text>
 
           {/* A custom tag is edited (and deleted) in the sheet; a built-in is
-              only ever hidden or shown. */}
+              only ever hidden or shown. Hiding a built-in also mints its override
+              row, so it is held while a reorder is still saving — same reason the
+              grip is — so the two can't race to create the one built-in's row. */}
           {entry.custom ? (
             <IconButton label={t.common.edit} onPress={() => setEditing(entry)}>
               <Ionicons name="pencil" size={iconSize.md} color={theme.color.textMuted} />
@@ -175,6 +177,7 @@ export default function CategoriesSettingsScreen() {
             <Toggle
               value={!entry.hidden}
               onValueChange={(shown) => persist(entry, { hidden: !shown })}
+              disabled={savingOrder}
               accessibilityLabel={entry.hidden ? t.tags.show : t.tags.hide}
             />
           )}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1306,6 +1306,7 @@ export interface UiStrings {
     builtinSection: string;
     noCustomTags: string;
     reorderHint: string;
+    dragHandle: string;
     hide: string;
     show: string;
     deleteConfirm: string;
@@ -3209,7 +3210,8 @@ const en: UiStrings = {
     yourTags: 'Your tags',
     builtinSection: 'Built-in',
     noCustomTags: 'No tags of your own yet. Make one to sort spending your way.',
-    reorderHint: 'Use the arrows to move a tag up or down.',
+    reorderHint: 'Press and hold the handle, then drag to reorder.',
+    dragHandle: 'Drag to reorder',
     hide: 'Hide',
     show: 'Show',
     deleteConfirm: 'Delete this tag? Past expenses keep it; it just leaves the list.',
@@ -5154,7 +5156,8 @@ const ta: UiStrings = {
     builtinSection: 'உள்ளமைந்தவை',
     noCustomTags:
       'இன்னும் சொந்தக் குறிச்சொற்கள் இல்லை. உங்கள் வழியில் செலவுகளை வகைப்படுத்த ஒன்றை உருவாக்குங்கள்.',
-    reorderHint: 'அம்புக்குறிகளால் ஒரு குறிச்சொல்லை மேலே அல்லது கீழே நகர்த்துங்கள்.',
+    reorderHint: 'கைப்பிடியை அழுத்திப் பிடித்து, இழுத்து வரிசைப்படுத்துங்கள்.',
+    dragHandle: 'இழுத்து வரிசைப்படுத்து',
     hide: 'மறை',
     show: 'காட்டு',
     deleteConfirm:
@@ -7114,7 +7117,8 @@ const hi: UiStrings = {
     yourTags: 'आपके टैग',
     builtinSection: 'पहले से मौजूद',
     noCustomTags: 'अभी आपका कोई टैग नहीं है। अपने तरीके से खर्च बाँटने के लिए एक बनाएँ।',
-    reorderHint: 'तीरों से किसी टैग को ऊपर या नीचे ले जाएँ।',
+    reorderHint: 'हैंडल को दबाकर रखें, फिर खींचकर क्रम बदलें।',
+    dragHandle: 'क्रम बदलने के लिए खींचें',
     hide: 'छिपाएँ',
     show: 'दिखाएँ',
     deleteConfirm: 'यह टैग हटाएँ? पुराने खर्च इसे रखेंगे; यह बस सूची से हटेगा।',
@@ -9074,7 +9078,8 @@ const ar: UiStrings = {
     yourTags: 'وسومك',
     builtinSection: 'جاهزة',
     noCustomTags: 'لا توجد وسوم خاصة بك بعد. أنشئ واحدًا لتصنيف المصروفات بطريقتك.',
-    reorderHint: 'استخدم الأسهم لتحريك وسم لأعلى أو لأسفل.',
+    reorderHint: 'اضغط مطولاً على المقبض ثم اسحب لإعادة الترتيب.',
+    dragHandle: 'اسحب لإعادة الترتيب',
     hide: 'إخفاء',
     show: 'إظهار',
     deleteConfirm: 'حذف هذا الوسم؟ ستحتفظ به المصروفات السابقة؛ يختفي من القائمة فقط.',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,9 @@ importers:
       react-native-document-scanner-plugin:
         specifier: ^2.0.4
         version: 2.0.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      react-native-draggable-flatlist:
+        specifier: 4.0.3
+        version: 4.0.3(88be7f83f53966fcbf6670bb51604ecf)
       react-native-gesture-handler:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -6361,6 +6364,13 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-draggable-flatlist@4.0.3:
+    resolution: {integrity: sha512-2F4x5BFieWdGq9SetD2nSAR7s7oQCSgNllYgERRXXtNfSOuAGAVbDb/3H3lP0y5f7rEyNwabKorZAD/SyyNbDw==}
+    peerDependencies:
+      react-native: '>=0.64.0'
+      react-native-gesture-handler: '>=2.0.0'
+      react-native-reanimated: '>=2.8.0'
+
   react-native-drawer-layout@4.2.9:
     resolution: {integrity: sha512-ETOxvlhhb4LmuuG3RN7A3qwt9jr9AZ2it+1G2kNE4g2fTyxxay7QQkPm1HfKi/JzmMSWC5+YTepGSgZNpJIDGg==}
     peerDependencies:
@@ -11723,7 +11733,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -11761,6 +11771,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      get-tsconfig: 4.14.1
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.17
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -11775,6 +11800,7 @@ snapshots:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
@@ -14099,6 +14125,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  react-native-draggable-flatlist@4.0.3(88be7f83f53966fcbf6670bb51604ecf):
+    dependencies:
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      react-native: 0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
+      react-native-gesture-handler: 2.32.0(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native-reanimated: 4.5.3(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   react-native-drawer-layout@4.2.9(ca4fcd713756e400fb5bdb52687c423a):
     dependencies:


### PR DESCRIPTION
## What

Replaces the up/down arrow buttons in the **Tags & categories** settings manager with proper **drag-and-drop** reordering — the arrows didn't look good and reordering a long way meant many taps.

- Each tag is its own card with a **grip handle** (`reorder-three`). Press and hold the handle, then drag to reorder; the lifted row scales and highlights (`ScaleDecorator`).
- On drop, each entry's new place becomes its list index, written back to the integer `sort_order`. Only rows whose place actually changed are persisted; each built-in override is written **at most once per drop**, so no two writes race for the same `(owner, builtin_id)` row. A second drag is held off until the previous reorder settles (same reason the old code guarded on `isPending`).
- List order resnaps to the catalog when it changes, via the sanctioned setState-during-render pattern (no setState-in-effect).

## Implementation

- `react-native-draggable-flatlist@4.0.3` — JS-only, rides the app's existing `react-native-reanimated` + `react-native-gesture-handler`. Verified it **bundles through the worklets transform** (`expo export --platform android` succeeded).
- i18n for en / ta / hi / ar: reorder hint reworded to describe dragging; new `dragHandle` label.

## Verification

- `tsc --noEmit` clean, `eslint` clean, `prettier` clean.
- Android bundle export succeeds (Hermes bytecode produced).
- Not yet run on a device — drag interaction unverified on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorder categories by pressing and dragging them into position.
  * Category order changes are saved automatically after rearranging.
  * Drag-and-drop controls provide clear accessibility states and updated guidance across supported languages.
  * Category visibility controls are temporarily disabled while changes are being saved.
  * Existing category editing and visibility controls remain available.
  * The categories list now provides improved empty-list, header, and footer states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->