### PR TITLE
fix(voice): per-item dictation on the review screen (silence + stuck mic)

### DIFF
--- a/apps/mobile/src/components/DictateVoice.tsx
+++ b/apps/mobile/src/components/DictateVoice.tsx
@@ -30,7 +30,12 @@ import { Linking, Pressable, View } from 'react-native';
 import { iconSize, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
-import { dictationError, mergeTranscript, speechLocale } from '@/lib/dictation';
+import {
+  dictationError,
+  mergeTranscript,
+  onDeviceLocaleInstalled,
+  speechLocale,
+} from '@/lib/dictation';
 
 export interface DictateProps {
   /** What is in the field now. Dictation adds to it, never replaces it. */
@@ -85,9 +90,6 @@ async function installedOnDeviceFor(langTag: string): Promise<boolean> {
     }
     if (!supportsOnDevice) return false;
 
-    const primary = langTag.trim().split(/[-_]/)[0]?.toLowerCase();
-    if (!primary) return false;
-
     let androidRecognitionServicePackage: string | undefined;
     try {
       const pkg = ExpoSpeechRecognitionModule.getDefaultRecognitionService?.().packageName;
@@ -98,9 +100,9 @@ async function installedOnDeviceFor(langTag: string): Promise<boolean> {
     const { installedLocales } = await ExpoSpeechRecognitionModule.getSupportedLocales(
       androidRecognitionServicePackage ? { androidRecognitionServicePackage } : {},
     );
-    return (installedLocales ?? []).some(
-      (tag) => tag.trim().split(/[-_]/)[0]?.toLowerCase() === primary,
-    );
+    // Match the whole tag, region and all: a phone with only en-US installed
+    // must not be told it has the en-IN model (that returns silence).
+    return onDeviceLocaleInstalled(langTag, installedLocales);
   } catch {
     return false;
   }
@@ -162,10 +164,13 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
   });
 
   const stop = useCallback(() => {
+    // Ask the recogniser to finish — but hold the lock and the listening flag.
+    // stop() (unlike abort()) still delivers one last `result` and then `end`,
+    // and it is the `end`/`error` handlers that clear ownership. Clearing it
+    // here would make that final result's `if (!listeningRef.current) return`
+    // drop the last words the person spoke before tapping stop.
     ExpoSpeechRecognitionModule.stop();
-    micOwner = null;
-    setListeningState(false);
-  }, [setListeningState]);
+  }, []);
 
   const start = useCallback(async () => {
     // The mic is a single global object. If another field is mid-dictation,
@@ -189,6 +194,12 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
     // network recogniser unless the language's model is actually installed.
     const onDevice = await installedOnDeviceFor(lang);
     if (!mounted.current) return;
+
+    // Re-check the lock right before taking it. The two awaits above (the
+    // permission prompt, the installed-model probe) give another field a window
+    // to claim the mic between the first check and here; without this recheck
+    // two overlapping starts could both reach ExpoSpeechRecognitionModule.start.
+    if (micOwner !== null && micOwner !== id) return;
 
     before.current = value;
     micOwner = id;

--- a/apps/mobile/src/components/DictateVoice.tsx
+++ b/apps/mobile/src/components/DictateVoice.tsx
@@ -12,6 +12,14 @@
  * `DictateButton`, which loads it inside a `try`, because the import below
  * throws on any binary built before the native module existed — see the note
  * there.
+ *
+ * The native recogniser is a single global object with one event stream: every
+ * mounted `DictateVoice` (a review screen shows one per expense row) subscribes
+ * to the *same* `result`/`error`/`end` events. So a module-level lock hands the
+ * mic to one field at a time, and each instance acts on an event only while it
+ * is the one listening — otherwise idle rows cross-write the transcript, and a
+ * row unmounting (the list changing after "add more") aborts a capture some
+ * other surface just started.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -36,10 +44,63 @@ export interface DictateProps {
   hints?: readonly string[];
 }
 
+/**
+ * Which field currently owns the single native recogniser, or `null` when no
+ * dictation is running. Module-level on purpose: it is shared across every
+ * mounted `DictateVoice` so a second field cannot start a capture on top of the
+ * first, and so only the owning field reacts to the global events.
+ */
+let micOwner: symbol | null = null;
+
 /** Whether this phone has a recogniser at all. A phone without one gets no mic. */
 function recognitionAvailable(): boolean {
   try {
     return ExpoSpeechRecognitionModule.isRecognitionAvailable();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether an on-device model for `langTag` is actually installed on this phone.
+ *
+ * `supportsOnDeviceRecognition()` only says the phone can do on-device work at
+ * all — not that the model for the language we are about to ask for is present.
+ * Requiring on-device for a locale whose model is not downloaded is a quiet
+ * failure: the recogniser starts, hears the words, and returns nothing, because
+ * it was told to use a model that is not there (the "did not catch anything"
+ * this field used to hit). So on-device is requested only when this language is
+ * in `installedLocales`; otherwise the mic falls back to network recognition,
+ * which is what the keyboard's mic key uses. An empty or throwing probe
+ * (Android 12 and below, a missing service) resolves to `false` and the network
+ * path, which works, rather than the on-device path, which may not.
+ */
+async function installedOnDeviceFor(langTag: string): Promise<boolean> {
+  try {
+    let supportsOnDevice = false;
+    try {
+      supportsOnDevice = ExpoSpeechRecognitionModule.supportsOnDeviceRecognition();
+    } catch {
+      supportsOnDevice = false;
+    }
+    if (!supportsOnDevice) return false;
+
+    const primary = langTag.trim().split(/[-_]/)[0]?.toLowerCase();
+    if (!primary) return false;
+
+    let androidRecognitionServicePackage: string | undefined;
+    try {
+      const pkg = ExpoSpeechRecognitionModule.getDefaultRecognitionService?.().packageName;
+      if (pkg) androidRecognitionServicePackage = pkg;
+    } catch {
+      // iOS / older builds have no Android service concept — query without one.
+    }
+    const { installedLocales } = await ExpoSpeechRecognitionModule.getSupportedLocales(
+      androidRecognitionServicePackage ? { androidRecognitionServicePackage } : {},
+    );
+    return (installedLocales ?? []).some(
+      (tag) => tag.trim().split(/[-_]/)[0]?.toLowerCase() === primary,
+    );
   } catch {
     return false;
   }
@@ -55,6 +116,20 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
   const [listening, setListening] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // This instance's identity in the module-level `micOwner` lock. Stable for the
+  // life of the component (lazy-initialised so it is minted once).
+  const [id] = useState(() => Symbol('dictate'));
+
+  // Whether *this* field is the one currently listening, read synchronously
+  // inside the global event handlers. The single-owner lock guarantees at most
+  // one field has this set at a time, so it is a safe stand-in for "this event
+  // is mine" — and it avoids reacting to an event another field's session fired.
+  const listeningRef = useRef(false);
+  const setListeningState = useCallback((next: boolean): void => {
+    listeningRef.current = next;
+    setListening(next);
+  }, []);
+
   // What the field held when the mic was tapped. Interim results are re-issued
   // in full, so every one of them is merged onto this rather than onto the
   // field's current contents.
@@ -65,23 +140,39 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
   const mounted = useRef(true);
 
   useSpeechRecognitionEvent('result', (event) => {
+    // Only the field that started this capture takes the words — otherwise the
+    // other rows' mics would each merge the transcript into their own note too.
+    if (!listeningRef.current) return;
     const transcript = event.results[0]?.transcript ?? '';
     onChange(mergeTranscript(before.current, transcript));
   });
 
   useSpeechRecognitionEvent('error', (event) => {
+    if (!listeningRef.current) return;
+    micOwner = null;
+    setListeningState(false);
     const message = dictationError(event.error, t.misc.dictationErrors);
     if (message) setError(message);
   });
 
-  useSpeechRecognitionEvent('end', () => setListening(false));
+  useSpeechRecognitionEvent('end', () => {
+    if (!listeningRef.current) return;
+    micOwner = null;
+    setListeningState(false);
+  });
 
   const stop = useCallback(() => {
     ExpoSpeechRecognitionModule.stop();
-    setListening(false);
-  }, []);
+    micOwner = null;
+    setListeningState(false);
+  }, [setListeningState]);
 
   const start = useCallback(async () => {
+    // The mic is a single global object. If another field is mid-dictation,
+    // ignore the tap rather than aborting it: an abort would race that field's
+    // next event and wedge the recogniser for both.
+    if (micOwner !== null && micOwner !== id) return;
+
     setError(null);
 
     const permission = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
@@ -91,22 +182,21 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
       return;
     }
 
+    const lang = speechLocale(language, locale);
+
     // Best effort, not a requirement: asking for on-device recognition on a
-    // phone that has no model for this language would fail outright, and a
-    // failed note is worse than a note the OS transcribed over the network.
-    let onDevice = false;
-    try {
-      onDevice = ExpoSpeechRecognitionModule.supportsOnDeviceRecognition();
-    } catch {
-      onDevice = false;
-    }
+    // phone that has no model for this language returns silence, so fall to the
+    // network recogniser unless the language's model is actually installed.
+    const onDevice = await installedOnDeviceFor(lang);
+    if (!mounted.current) return;
 
     before.current = value;
-    setListening(true);
+    micOwner = id;
+    setListeningState(true);
 
     try {
       ExpoSpeechRecognitionModule.start({
-        lang: speechLocale(language, locale),
+        lang,
         interimResults: true,
         maxAlternatives: 1,
         // A note is one short utterance. Continuous listening would leave the
@@ -120,16 +210,27 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
         iosTaskHint: 'dictation',
       });
     } catch {
-      setListening(false);
+      micOwner = null;
+      setListeningState(false);
       setError(t.misc.dictationFailed);
     }
-  }, [hints, language, locale, value, t]);
+  }, [hints, id, language, locale, value, t, setListeningState]);
 
-  // Leaving the screen mid-sentence must not leave the microphone open.
+  // Leaving the screen mid-sentence must not leave the microphone open — but
+  // only this field may abort, and only while it is the one listening. An idle
+  // row unmounting (the list changing after "add more") must not abort a capture
+  // another surface just started.
   useEffect(() => {
     return () => {
       mounted.current = false;
-      ExpoSpeechRecognitionModule.abort();
+      if (listeningRef.current) {
+        try {
+          ExpoSpeechRecognitionModule.abort();
+        } catch {
+          // Recogniser already torn down — nothing to abort.
+        }
+        micOwner = null;
+      }
     };
   }, []);
 

--- a/apps/mobile/src/lib/dictation.ts
+++ b/apps/mobile/src/lib/dictation.ts
@@ -49,6 +49,44 @@ export function englishSpeechLocale(deviceLocale: string): string {
 }
 
 /**
+ * Whether an on-device model for `langTag` is covered by the phone's list of
+ * installed locales — kept pure (no native module) so the matching itself can be
+ * tested without a device.
+ *
+ * The trap this avoids: matching on the language subtag alone treats every
+ * regional model as interchangeable, so a phone with only `en-US` installed
+ * would be told it has `en-IN` — and asking the recogniser for an on-device
+ * model that is not there returns silence (the "did not catch anything" bug).
+ * So two *regioned* tags must match in full: `en-US` does not satisfy `en-IN`.
+ *
+ * A language-only entry is the one wildcard: Android commonly lists an installed
+ * model as just `en`, meaning the generic English model, which does cover any
+ * region of English. So `en` (installed) covers `en-IN` (wanted), and a bare
+ * `en` request is covered by any installed English. Only when both sides name a
+ * region must those regions agree.
+ */
+export function onDeviceLocaleInstalled(
+  langTag: string,
+  installedLocales: readonly string[] | null | undefined,
+): boolean {
+  const norm = (tag: string): string => tag.trim().replace(/_/g, '-').toLowerCase();
+  const want = norm(langTag);
+  if (!want) return false;
+  const wantLang = want.split('-')[0];
+  const wantHasRegion = want.includes('-');
+  return (installedLocales ?? []).some((raw) => {
+    const tag = norm(raw);
+    if (!tag) return false;
+    if (tag.split('-')[0] !== wantLang) return false;
+    const tagHasRegion = tag.includes('-');
+    // A language-only entry on either side is the generic model: it covers the
+    // whole language. Only when both carry a region must the regions match.
+    if (!tagHasRegion || !wantHasRegion) return true;
+    return tag === want;
+  });
+}
+
+/**
  * What the field should read while somebody is speaking.
  *
  * `before` is whatever was in the field when the mic was tapped, and it is

--- a/apps/mobile/test/dictation.test.ts
+++ b/apps/mobile/test/dictation.test.ts
@@ -12,6 +12,7 @@ import {
   dictationError,
   englishSpeechLocale,
   mergeTranscript,
+  onDeviceLocaleInstalled,
   speechLocale,
 } from '@/lib/dictation';
 import { Language, STRINGS_BY_LANGUAGE } from '@/i18n';
@@ -129,5 +130,34 @@ describe('dictationError', () => {
     for (const code of codes) {
       expect(dictationError(code, messages)).toMatch(/try again|Type the note|speak again/i);
     }
+  });
+});
+
+describe('onDeviceLocaleInstalled', () => {
+  it('does not let one region stand in for another', () => {
+    // The bug this guards: asking for the en-IN on-device model on a phone that
+    // only has en-US returns silence. Two regioned tags must match in full.
+    expect(onDeviceLocaleInstalled('en-IN', ['en-US'])).toBe(false);
+    expect(onDeviceLocaleInstalled('en-IN', ['en-US', 'en-GB'])).toBe(false);
+    expect(onDeviceLocaleInstalled('en-IN', ['en-IN'])).toBe(true);
+  });
+
+  it('treats a language-only installed entry as the whole language', () => {
+    // Android commonly lists an installed model as just `en` — the generic
+    // model, which does cover any English region.
+    expect(onDeviceLocaleInstalled('en-IN', ['en'])).toBe(true);
+    expect(onDeviceLocaleInstalled('ta-IN', ['ta'])).toBe(true);
+  });
+
+  it('covers a language-only request with any installed region of it', () => {
+    expect(onDeviceLocaleInstalled('en', ['en-US'])).toBe(true);
+    expect(onDeviceLocaleInstalled('en', ['fr-FR'])).toBe(false);
+  });
+
+  it('normalises separators and case, and handles an empty probe', () => {
+    expect(onDeviceLocaleInstalled('en_IN', ['EN-in'])).toBe(true);
+    expect(onDeviceLocaleInstalled('en-IN', [])).toBe(false);
+    expect(onDeviceLocaleInstalled('en-IN', null)).toBe(false);
+    expect(onDeviceLocaleInstalled('', ['en'])).toBe(false);
   });
 });


### PR DESCRIPTION
## The bug

On the voice **Review** screen, the mic on each expense row (inline note dictation) did nothing — speak, stop, and it showed **"Did not catch anything. Tap the mic and speak again."** Worse, afterwards the header **Add more** mic was dead too, so you couldn't add anything.

## Root causes (all in `DictateVoice`)

1. **Silence.** It requested on-device recognition off `supportsOnDeviceRecognition()`, which only says the phone *can* do on-device work — not that the model for the spoken language is installed. Requiring an absent model makes the recogniser hear the words and return nothing (the same [voice-ondevice gotcha] the capture flow already fixed via `installedLocales`). Now it probes `installedLocales` for the target language and falls back to the network recogniser otherwise.
2. **Stuck "Add more".** The native recogniser is a single global object; every row's `DictateVoice` called the global `abort()` on unmount. When the row list changed (after add-more), an idle row unmounting aborted the recogniser a different surface had just started. Now a field aborts on unmount **only while it is the one actually listening**.
3. **Cross-write.** Every mounted row subscribed to the shared `result`/`error`/`end` events, so dictating into one row merged the transcript into the others and flipped their state. A module-level **single-owner lock** now hands the mic to one field at a time; each instance acts on an event only while it is the listener.

## Verification

- `tsc --noEmit`, `eslint`, `prettier` clean.
- Mirrors the proven capture-flow gate (`installedLocales`) and the single-owner `listeningRef` pattern already used in `VoiceCapture`.
- Not yet run on a device — mic behaviour unverified on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice dictation when multiple fields are present, ensuring only the active field receives recognition results.
  * Prevented inactive or unmounted fields from interrupting ongoing dictation.
  * Added automatic fallback to network-based recognition when the requested on-device language model is unavailable.
  * Improved language matching for on-device recognition across regional variants, capitalization, and separator formats.
  * Improved consistency when starting, stopping, or recovering from dictation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->