### PR TITLE
feat(personal): private personal-finance ledger — the "Me" tab (A48)

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -44,6 +44,7 @@ export default function TabsLayout() {
           not a stack push that re-reveals (and thaws) the whole tab tree. It is
           not shown in the hidden native bar; the root `AppTabBar` draws it. */}
       <Tabs.Screen name="inbox" />
+      <Tabs.Screen name="me" />
       <Tabs.Screen name="profile" />
     </Tabs>
   );

--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -43,6 +43,7 @@ import {
   useUpsertPersonalRecord,
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
+import { useSync } from '@/sync';
 import { useStrings } from '@/i18n';
 
 export default function MeScreen() {
@@ -50,6 +51,7 @@ export default function MeScreen() {
   const clearance = useScreenClearance();
   const { t, locale } = useStrings();
   const dc = useDefaultCurrency();
+  const { hydrated } = useSync();
   const ledger = usePersonalLedger();
   const upsert = useUpsertPersonalRecord();
 
@@ -57,23 +59,27 @@ export default function MeScreen() {
   const [today] = useState(() => todayIso());
   const month = today.slice(0, 7);
 
-  // Post due auto-recurring entries when the ledger first has any recurring
-  // rules to act on. Waiting for that readiness (rather than firing on the raw
-  // mount) means a screen that mounts before the mirror hydrates still posts
-  // once the rules arrive. It runs at most once per session, and even if it ran
-  // early against a partial ledger the occurrence ids are deterministic
-  // (recurringOccurrenceId), so a later real run upserts the same rows — never a
-  // duplicate.
+  // Post due auto-recurring entries once the mirror has hydrated from disk and
+  // there are recurring rules to act on. Gating on `hydrated` (not the raw mount)
+  // means we never latch against a still-loading, empty ledger; gating on
+  // local hydration — not a network round-trip — keeps it working offline, which
+  // is the whole point of the local-first ledger. `posted` is set only after the
+  // catch-up resolves and cleared on failure, so a transient write error can
+  // retry on a later run rather than being swallowed for the session. Even a
+  // double-fire is harmless: occurrence ids are deterministic
+  // (recurringOccurrenceId), so a repeat upserts the same rows, never a dupe.
   const posted = useRef(false);
-  const hasRules = ledger.recurrings.length > 0;
+  const ready = hydrated && ledger.recurrings.length > 0;
   useEffect(() => {
-    if (posted.current || !hasRules) return;
+    if (posted.current || !ready) return;
     posted.current = true;
-    void postDueRecurring(ledger, today, (input) => upsert.mutateAsync(input));
-    // Intentionally keyed on readiness only; `ledger`/`today`/`upsert` are read
-    // at fire time and the ref makes it one-shot.
+    postDueRecurring(ledger, today, (input) => upsert.mutateAsync(input)).catch(() => {
+      posted.current = false;
+    });
+    // Keyed on readiness only; `ledger`/`today`/`upsert` are read at fire time
+    // and the ref makes it one-shot per successful run.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasRules]);
+  }, [ready]);
 
   const summary = monthlySummary(ledger.txns, month, dc);
   const recent = ledger.txns.slice(0, 6);

--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -1,0 +1,369 @@
+/**
+ * The "Me" tab — the private personal-finance ledger (A48).
+ *
+ * A person's own money, nothing shared: this month's income, spend and net at
+ * the top; quick ways to add an expense or income; the last few entries; and the
+ * doors to the recurring rules, loans and budgets. Everything is read local-first
+ * from the mirror and every figure is computed on the device.
+ *
+ * Opening the tab also posts any auto-recurring entries that have come due since
+ * it was last open (idempotent — see `postDueRecurring`).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, ScrollView, View } from 'react-native';
+
+import {
+  format,
+  isRecurringDue,
+  loanOutstanding,
+  money,
+  monthlySummary,
+  personalBudgetProgress,
+  type PersonalTxn,
+} from '@waves/core';
+import {
+  Card,
+  Divider,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { CategoryBadge } from '@/components/Category';
+import {
+  postDueRecurring,
+  todayIso,
+  usePersonalLedger,
+  useUpsertPersonalRecord,
+} from '@/data/personal';
+import { useDefaultCurrency } from '@/lib/currency';
+import { useStrings } from '@/i18n';
+
+export default function MeScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const dc = useDefaultCurrency();
+  const ledger = usePersonalLedger();
+  const upsert = useUpsertPersonalRecord();
+
+  // Read the clock once, off render (the React Compiler forbids it inline).
+  const [today] = useState(() => todayIso());
+  const month = today.slice(0, 7);
+
+  // Post due auto-recurring entries once per mount. Idempotent, so a re-run
+  // never double-posts; guarded so it fires only after the ledger has loaded and
+  // not again on every re-render.
+  const posted = useRef(false);
+  useEffect(() => {
+    if (posted.current) return;
+    posted.current = true;
+    void postDueRecurring(ledger, today, (input) => upsert.mutateAsync(input));
+    // Deliberately runs against the first-loaded ledger only; new rules added
+    // later post on the next open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const summary = monthlySummary(ledger.txns, month, dc);
+  const recent = ledger.txns.slice(0, 6);
+
+  const dueCount = ledger.recurrings.filter((rule) => isRecurringDue(rule, today)).length;
+  const activeLoans = ledger.loans.filter((loan) => loan.status === 'active');
+  const overBudgets = ledger.budgets.filter(
+    (budget) => personalBudgetProgress(budget, ledger.txns, month).remaining < 0n,
+  ).length;
+  const outstanding = activeLoans
+    .filter((loan) => loan.currency === dc)
+    .reduce((sum, loan) => sum + loanOutstanding(loan, ledger.txns), 0n);
+
+  const fmt = (amount: bigint): string =>
+    format(money(amount, dc), { locale, compactFraction: true });
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={{ paddingTop: theme.spacing.md, gap: 2 }}>
+          <Text variant="title">{t.personal.title}</Text>
+          <Text variant="caption" tone="muted">
+            {t.personal.subtitle}
+          </Text>
+        </View>
+
+        {/* This month: income, spend, net — the headline of the ledger. */}
+        <Card style={{ gap: theme.spacing.lg }}>
+          <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
+            {t.personal.thisMonth.toUpperCase()}
+          </Text>
+          <Row style={{ justifyContent: 'space-between' }}>
+            <Metric label={t.personal.income} value={fmt(summary.income)} tone="positive" />
+            <Metric label={t.personal.expenses} value={fmt(summary.expense)} tone="text" />
+            <Metric
+              label={t.personal.net}
+              value={fmt(summary.net < 0n ? -summary.net : summary.net)}
+              tone={summary.net < 0n ? 'negative' : 'positive'}
+            />
+          </Row>
+        </Card>
+
+        <Row style={{ gap: theme.spacing.md }}>
+          <QuickAdd
+            label={t.personal.addExpense}
+            icon="remove-circle-outline"
+            tint={theme.color.negative}
+            onPress={() =>
+              router.push({ pathname: '/personal/entry', params: { kind: 'expense' } })
+            }
+          />
+          <QuickAdd
+            label={t.personal.addIncome}
+            icon="add-circle-outline"
+            tint={theme.color.positive}
+            onPress={() => router.push({ pathname: '/personal/entry', params: { kind: 'income' } })}
+          />
+        </Row>
+
+        {/* Recent entries. */}
+        <View style={{ gap: theme.spacing.sm }}>
+          <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
+              {t.personal.recent.toUpperCase()}
+            </Text>
+            {ledger.txns.length > recent.length ? (
+              <Pressable
+                accessibilityRole="button"
+                onPress={() => router.push('/personal/transactions')}
+              >
+                <Text variant="caption" tone="brand">
+                  {t.personal.seeAll}
+                </Text>
+              </Pressable>
+            ) : null}
+          </Row>
+
+          {recent.length === 0 ? (
+            <Card>
+              <Text tone="muted" align="center">
+                {t.personal.empty}
+              </Text>
+            </Card>
+          ) : (
+            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+              {recent.map((txn, index) => (
+                <View key={txn.id}>
+                  {index > 0 ? <Divider /> : null}
+                  <TxnRow txn={txn} locale={locale} theme={theme} labelFor={labelForCategory(t)} />
+                </View>
+              ))}
+            </Card>
+          )}
+        </View>
+
+        {/* The three management areas. */}
+        <View style={{ gap: theme.spacing.md }}>
+          <SectionLink
+            label={t.personal.recurring}
+            icon="repeat"
+            hint={dueCount > 0 ? `${dueCount} ${t.personal.due}` : t.personal.recurringSub}
+            emphasise={dueCount > 0}
+            onPress={() => router.push('/personal/recurring')}
+          />
+          <SectionLink
+            label={t.personal.loans}
+            icon="cash-outline"
+            hint={
+              activeLoans.length > 0
+                ? `${t.personal.outstanding} ${fmt(outstanding)}`
+                : t.personal.loansSub
+            }
+            onPress={() => router.push('/personal/loans')}
+          />
+          <SectionLink
+            label={t.personal.budgets}
+            icon="pie-chart-outline"
+            hint={overBudgets > 0 ? `${overBudgets} ${t.personal.over}` : t.personal.budgetsSub}
+            emphasise={overBudgets > 0}
+            onPress={() => router.push('/personal/budgets')}
+          />
+        </View>
+      </ScrollView>
+    </Screen>
+  );
+}
+
+// The translated label for a category id (built-in key or custom tag id). Custom
+// tags fall back to their own stored label via the badge; here we only need the
+// built-in names, so an unknown id returns null and the row shows its note.
+function labelForCategory(t: ReturnType<typeof useStrings>['t']) {
+  return (id: string | null): string | null =>
+    id ? (t.categories[id as keyof typeof t.categories] ?? null) : null;
+}
+
+function Metric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone: 'positive' | 'negative' | 'text';
+}) {
+  const theme = useTheme();
+  const color =
+    tone === 'positive'
+      ? theme.color.positive
+      : tone === 'negative'
+        ? theme.color.negative
+        : theme.color.text;
+  return (
+    <View style={{ gap: 4 }}>
+      <Text variant="caption" tone="muted">
+        {label}
+      </Text>
+      <Text variant="heading" style={{ color }}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+function QuickAdd({
+  label,
+  icon,
+  tint,
+  onPress,
+}: {
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  tint: string;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: theme.spacing.sm,
+        paddingVertical: theme.spacing.lg,
+        borderRadius: theme.radius.lg,
+        backgroundColor: theme.color.surface,
+        borderWidth: 1,
+        borderColor: theme.color.border,
+        opacity: pressed ? 0.6 : 1,
+      })}
+    >
+      <Ionicons name={icon} size={iconSize.md} color={tint} />
+      <Text variant="caption" style={{ fontWeight: '600' }}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function SectionLink({
+  label,
+  icon,
+  hint,
+  emphasise,
+  onPress,
+}: {
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  hint: string;
+  emphasise?: boolean;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  return (
+    <Pressable accessibilityRole="button" onPress={onPress}>
+      <Card>
+        <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+          <View
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: theme.radius.md,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.color.brandSoft,
+            }}
+          >
+            <Ionicons name={icon} size={iconSize.md} color={theme.color.brand} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text variant="body" style={{ fontWeight: '600' }}>
+              {label}
+            </Text>
+            <Text variant="caption" tone={emphasise ? 'brand' : 'muted'}>
+              {hint}
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={iconSize.md} color={theme.color.textFaint} />
+        </Row>
+      </Card>
+    </Pressable>
+  );
+}
+
+function TxnRow({
+  txn,
+  locale,
+  theme,
+  labelFor,
+}: {
+  txn: PersonalTxn;
+  locale: string;
+  theme: ReturnType<typeof useTheme>;
+  labelFor: (id: string | null) => string | null;
+}) {
+  const income = txn.kind === 'income';
+  const title = txn.note?.trim() || labelFor(txn.category) || '—';
+  const amount = format(money(txn.amount, txn.currency), { locale, compactFraction: true });
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={() => router.push({ pathname: '/personal/entry', params: { id: txn.id } })}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: theme.spacing.md,
+        paddingVertical: theme.spacing.md,
+      }}
+    >
+      <CategoryBadge category={txn.category ?? 'other'} meta={null} size={32} />
+      <View style={{ flex: 1 }}>
+        <Text variant="body" numberOfLines={1}>
+          {title}
+        </Text>
+        <Text variant="micro" tone="muted">
+          {txn.date}
+        </Text>
+      </View>
+      <Text
+        variant="body"
+        style={{ fontWeight: '700', color: income ? theme.color.positive : theme.color.text }}
+      >
+        {income ? '+' : '−'}
+        {amount}
+      </Text>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -57,18 +57,23 @@ export default function MeScreen() {
   const [today] = useState(() => todayIso());
   const month = today.slice(0, 7);
 
-  // Post due auto-recurring entries once per mount. Idempotent, so a re-run
-  // never double-posts; guarded so it fires only after the ledger has loaded and
-  // not again on every re-render.
+  // Post due auto-recurring entries when the ledger first has any recurring
+  // rules to act on. Waiting for that readiness (rather than firing on the raw
+  // mount) means a screen that mounts before the mirror hydrates still posts
+  // once the rules arrive. It runs at most once per session, and even if it ran
+  // early against a partial ledger the occurrence ids are deterministic
+  // (recurringOccurrenceId), so a later real run upserts the same rows — never a
+  // duplicate.
   const posted = useRef(false);
+  const hasRules = ledger.recurrings.length > 0;
   useEffect(() => {
-    if (posted.current) return;
+    if (posted.current || !hasRules) return;
     posted.current = true;
     void postDueRecurring(ledger, today, (input) => upsert.mutateAsync(input));
-    // Deliberately runs against the first-loaded ledger only; new rules added
-    // later post on the next open.
+    // Intentionally keyed on readiness only; `ledger`/`today`/`upsert` are read
+    // at fire time and the ref makes it one-shot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [hasRules]);
 
   const summary = monthlySummary(ledger.txns, month, dc);
   const recent = ledger.txns.slice(0, 6);
@@ -112,7 +117,7 @@ export default function MeScreen() {
             <Metric label={t.personal.expenses} value={fmt(summary.expense)} tone="text" />
             <Metric
               label={t.personal.net}
-              value={fmt(summary.net < 0n ? -summary.net : summary.net)}
+              value={`${summary.net < 0n ? '−' : ''}${fmt(summary.net < 0n ? -summary.net : summary.net)}`}
               tone={summary.net < 0n ? 'negative' : 'positive'}
             />
           </Row>

--- a/apps/mobile/src/app/personal/budgets.tsx
+++ b/apps/mobile/src/app/personal/budgets.tsx
@@ -8,9 +8,15 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { Modal, Pressable, ScrollView, View } from 'react-native';
+import { Alert, Modal, Pressable, ScrollView, View } from 'react-native';
 
-import { format, money, personalBudgetProgress, type PersonalBudget } from '@waves/core';
+import {
+  encodeBudget,
+  format,
+  money,
+  personalBudgetProgress,
+  type PersonalBudget,
+} from '@waves/core';
 import {
   AmountField,
   Button,
@@ -191,11 +197,11 @@ function BudgetEditor({
       {
         recordId: budget?.id,
         recordKind: 'budget',
-        data: {
+        data: encodeBudget({
           category: chosenCategory,
-          limit: limit.toString(),
+          limit,
           currency: budget?.currency ?? currency,
-        },
+        }),
       },
       { onSuccess: onClose },
     );
@@ -262,7 +268,16 @@ function BudgetEditor({
                 label={t.common.delete}
                 variant="danger"
                 fullWidth
-                onPress={() => remove.mutate(budget.id, { onSuccess: onClose })}
+                onPress={() =>
+                  Alert.alert(t.common.delete, t.personal.deleteConfirm, [
+                    { text: t.common.cancel, style: 'cancel' },
+                    {
+                      text: t.common.delete,
+                      style: 'destructive',
+                      onPress: () => remove.mutate(budget.id, { onSuccess: onClose }),
+                    },
+                  ])
+                }
               />
             ) : null}
           </ScrollView>

--- a/apps/mobile/src/app/personal/budgets.tsx
+++ b/apps/mobile/src/app/personal/budgets.tsx
@@ -1,0 +1,273 @@
+/**
+ * Budgets (A48): a monthly cap on spending, overall or per category, with this
+ * month's spend measured against it. Loan repayments do not count — a budget is
+ * about everyday spending (see personalBudgetProgress). The editor is an inline
+ * sheet.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Modal, Pressable, ScrollView, View } from 'react-native';
+
+import { format, money, personalBudgetProgress, type PersonalBudget } from '@waves/core';
+import {
+  AmountField,
+  Button,
+  Card,
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  SegmentedTabs,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { CategoryBadge, CategoryPicker } from '@/components/Category';
+import {
+  todayIso,
+  usePersonalLedger,
+  useDeletePersonalRecord,
+  useUpsertPersonalRecord,
+} from '@/data/personal';
+import { useDefaultCurrency } from '@/lib/currency';
+import { useStrings } from '@/i18n';
+
+export default function BudgetsScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const dc = useDefaultCurrency();
+  const { budgets, txns } = usePersonalLedger();
+
+  const [month] = useState(() => todayIso().slice(0, 7));
+  const [editing, setEditing] = useState<PersonalBudget | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const labelFor = (id: string | null): string =>
+    id ? (t.categories[id as keyof typeof t.categories] ?? id) : t.personal.overall;
+
+  return (
+    <Screen>
+      <Row
+        style={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.md,
+          alignItems: 'center',
+        }}
+      >
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.personal.budgets}</Text>
+        </View>
+        <IconButton label={t.personal.addBudget} onPress={() => setCreating(true)}>
+          <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
+        </IconButton>
+      </Row>
+
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.md,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text
+          variant="caption"
+          tone="muted"
+          align="center"
+          style={{ marginBottom: theme.spacing.sm }}
+        >
+          {t.personal.budgetsSub}
+        </Text>
+
+        {budgets.length === 0 ? (
+          <View style={{ paddingTop: theme.spacing.xxxl }}>
+            <EmptyState title={t.personal.noBudgets} />
+          </View>
+        ) : (
+          budgets.map((budget) => {
+            const progress = personalBudgetProgress(budget, txns, month);
+            const over = progress.remaining < 0n;
+            const pct = Math.min(1, Math.max(0, progress.ratio));
+            const barColor = over
+              ? theme.color.negative
+              : pct > 0.85
+                ? theme.color.warning
+                : theme.color.brand;
+            return (
+              <Pressable
+                key={budget.id}
+                accessibilityRole="button"
+                onPress={() => setEditing(budget)}
+              >
+                <Card style={{ gap: theme.spacing.sm }}>
+                  <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+                    <CategoryBadge category={budget.category ?? 'other'} meta={null} size={28} />
+                    <Text variant="body" style={{ flex: 1, fontWeight: '600' }} numberOfLines={1}>
+                      {labelFor(budget.category)}
+                    </Text>
+                    <Text variant="caption" tone={over ? 'negative' : 'muted'}>
+                      {format(money(progress.spent, budget.currency), {
+                        locale,
+                        compactFraction: true,
+                      })}
+                      {' / '}
+                      {format(money(budget.limit, budget.currency), {
+                        locale,
+                        compactFraction: true,
+                      })}
+                    </Text>
+                  </Row>
+                  <View
+                    style={{
+                      height: 8,
+                      borderRadius: 4,
+                      backgroundColor: theme.color.surfaceMuted,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <View
+                      style={{ width: `${pct * 100}%`, height: 8, backgroundColor: barColor }}
+                    />
+                  </View>
+                  <Text variant="micro" tone={over ? 'negative' : 'muted'}>
+                    {over
+                      ? `${format(money(-progress.remaining, budget.currency), { locale, compactFraction: true })} ${t.personal.over}`
+                      : `${format(money(progress.remaining, budget.currency), { locale, compactFraction: true })} ${t.personal.left}`}
+                  </Text>
+                </Card>
+              </Pressable>
+            );
+          })
+        )}
+      </ScrollView>
+
+      {creating ? <BudgetEditor currency={dc} onClose={() => setCreating(false)} /> : null}
+      {editing ? (
+        <BudgetEditor budget={editing} currency={dc} onClose={() => setEditing(null)} />
+      ) : null}
+    </Screen>
+  );
+}
+
+function BudgetEditor({
+  budget,
+  currency,
+  onClose,
+}: {
+  budget?: PersonalBudget;
+  currency: string;
+  onClose: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const upsert = useUpsertPersonalRecord();
+  const remove = useDeletePersonalRecord();
+
+  const [scope, setScope] = useState<'overall' | 'category'>(
+    budget?.category ? 'category' : 'overall',
+  );
+  const [category, setCategory] = useState<string | null>(budget?.category ?? null);
+  const [limit, setLimit] = useState<bigint>(budget?.limit ?? 0n);
+
+  const chosenCategory = scope === 'category' ? category : null;
+  const canSave = limit > 0n && (scope === 'overall' || category !== null) && !upsert.isPending;
+
+  const onSave = (): void => {
+    if (!canSave) return;
+    upsert.mutate(
+      {
+        recordId: budget?.id,
+        recordKind: 'budget',
+        data: {
+          category: chosenCategory,
+          limit: limit.toString(),
+          currency: budget?.currency ?? currency,
+        },
+      },
+      { onSuccess: onClose },
+    );
+  };
+
+  return (
+    <Modal visible transparent animationType="slide" onRequestClose={onClose}>
+      <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
+        <View
+          style={{
+            backgroundColor: theme.color.surface,
+            borderTopLeftRadius: theme.radius.xl,
+            borderTopRightRadius: theme.radius.xl,
+            maxHeight: '90%',
+          }}
+        >
+          <ScrollView
+            contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+              <Text variant="heading">{budget ? t.personal.editBudget : t.personal.addBudget}</Text>
+              <IconButton label={t.common.close} onPress={onClose}>
+                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+              </IconButton>
+            </Row>
+
+            <SegmentedTabs
+              value={scope}
+              onChange={setScope}
+              tabs={[
+                { value: 'overall', label: t.personal.overall },
+                { value: 'category', label: t.personal.category },
+              ]}
+            />
+
+            {scope === 'category' ? (
+              <CategoryPicker value={category} onChange={(picked) => setCategory(picked)} />
+            ) : null}
+
+            <View style={{ gap: theme.spacing.sm }}>
+              <Text variant="caption" tone="muted">
+                {t.personal.monthlyLimit}
+              </Text>
+              <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
+                <AmountField
+                  currency={budget?.currency ?? currency}
+                  value={limit}
+                  onChange={setLimit}
+                />
+              </View>
+            </View>
+
+            <Button
+              label={t.personal.save}
+              size="lg"
+              fullWidth
+              onPress={onSave}
+              disabled={!canSave}
+            />
+
+            {budget ? (
+              <Button
+                label={t.common.delete}
+                variant="danger"
+                fullWidth
+                onPress={() => remove.mutate(budget.id, { onSuccess: onClose })}
+              />
+            ) : null}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/app/personal/entry.tsx
+++ b/apps/mobile/src/app/personal/entry.tsx
@@ -43,6 +43,7 @@ import {
   useUpsertPersonalRecord,
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
+import { useSync } from '@/sync';
 import { useStrings } from '@/i18n';
 
 export default function PersonalEntryScreen() {
@@ -50,18 +51,38 @@ export default function PersonalEntryScreen() {
   const { t } = useStrings();
   const dc = useDefaultCurrency();
   const params = useLocalSearchParams<{ kind?: string; id?: string; loanId?: string }>();
+  const { hydrated } = useSync();
   const { txns } = usePersonalLedger();
 
   const editing = params.id ? txns.find((txn) => txn.id === params.id) : undefined;
 
-  // Editing an id that has not resolved yet (the ledger is still hydrating): hold
-  // a spinner rather than render a blank form whose initial state would be wrong
-  // and whose Save would overwrite the real record with empties.
+  // Editing an id that has not resolved. Two very different cases:
+  //  - the mirror is still loading from disk (`!hydrated`): hold a spinner rather
+  //    than render a blank form whose Save would overwrite the record with empties;
+  //  - hydration is done and the id still isn't there (deleted, or a stale link):
+  //    say so and offer a way back, instead of a spinner that never ends.
   if (params.id && !editing) {
     return (
       <Screen>
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-          <ActivityIndicator color={theme.color.brand} />
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: theme.spacing.lg,
+            padding: theme.spacing.xl,
+          }}
+        >
+          {hydrated ? (
+            <>
+              <Text tone="muted" align="center">
+                {t.personal.entryMissing}
+              </Text>
+              <Button label={t.common.back} variant="secondary" onPress={() => router.back()} />
+            </>
+          ) : (
+            <ActivityIndicator color={theme.color.brand} />
+          )}
         </View>
       </Screen>
     );

--- a/apps/mobile/src/app/personal/entry.tsx
+++ b/apps/mobile/src/app/personal/entry.tsx
@@ -9,9 +9,17 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { router, useLocalSearchParams } from 'expo-router';
-import { Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  Platform,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+} from 'react-native';
 
-import { encodeTxn, type CategoryMeta, type TxnKind } from '@waves/core';
+import { encodeTxn, type CategoryMeta, type PersonalTxn, type TxnKind } from '@waves/core';
 import {
   AmountField,
   Button,
@@ -28,30 +36,69 @@ import {
 
 import { CategoryPicker } from '@/components/Category';
 import {
+  localIsoDate,
+  todayIso,
   useDeletePersonalRecord,
   usePersonalLedger,
   useUpsertPersonalRecord,
-  todayIso,
 } from '@/data/personal';
 import { useDefaultCurrency } from '@/lib/currency';
 import { useStrings } from '@/i18n';
 
 export default function PersonalEntryScreen() {
   const theme = useTheme();
-  const clearance = useScreenClearance();
   const { t } = useStrings();
   const dc = useDefaultCurrency();
   const params = useLocalSearchParams<{ kind?: string; id?: string; loanId?: string }>();
-
   const { txns } = usePersonalLedger();
+
   const editing = params.id ? txns.find((txn) => txn.id === params.id) : undefined;
 
+  // Editing an id that has not resolved yet (the ledger is still hydrating): hold
+  // a spinner rather than render a blank form whose initial state would be wrong
+  // and whose Save would overwrite the real record with empties.
+  if (params.id && !editing) {
+    return (
+      <Screen>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={theme.color.brand} />
+        </View>
+      </Screen>
+    );
+  }
+
+  // Keyed so a create and each distinct edited record mount their own fresh form.
+  return (
+    <EntryForm
+      key={editing?.id ?? 'new'}
+      editing={editing}
+      defaultKind={params.kind === 'income' ? 'income' : 'expense'}
+      paramLoanId={typeof params.loanId === 'string' ? params.loanId : null}
+      currency={editing?.currency ?? dc}
+      t={t}
+    />
+  );
+}
+
+function EntryForm({
+  editing,
+  defaultKind,
+  paramLoanId,
+  currency,
+  t,
+}: {
+  editing?: PersonalTxn;
+  defaultKind: TxnKind;
+  paramLoanId: string | null;
+  currency: string;
+  t: ReturnType<typeof useStrings>['t'];
+}) {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
   const upsert = useUpsertPersonalRecord();
   const remove = useDeletePersonalRecord();
 
-  const [kind, setKind] = useState<TxnKind>(
-    editing?.kind ?? (params.kind === 'income' ? 'income' : 'expense'),
-  );
+  const [kind, setKind] = useState<TxnKind>(editing?.kind ?? defaultKind);
   const [amount, setAmount] = useState<bigint>(editing?.amount ?? 0n);
   const [note, setNote] = useState(editing?.note ?? '');
   const [category, setCategory] = useState<string | null>(editing?.category ?? null);
@@ -59,9 +106,8 @@ export default function PersonalEntryScreen() {
   const [showDate, setShowDate] = useState(false);
   // A repayment carries the loan it settles through from the loans screen; kept
   // as-is on an edit so the link survives.
-  const loanId = editing?.loanId ?? (typeof params.loanId === 'string' ? params.loanId : null);
+  const loanId = editing?.loanId ?? paramLoanId;
 
-  const currency = editing?.currency ?? dc;
   const canSave = amount > 0n && !upsert.isPending;
 
   const onSave = (): void => {
@@ -87,7 +133,14 @@ export default function PersonalEntryScreen() {
 
   const onDelete = (): void => {
     if (!editing) return;
-    remove.mutate(editing.id, { onSuccess: () => router.back() });
+    Alert.alert(t.common.delete, t.personal.deleteConfirm, [
+      { text: t.common.cancel, style: 'cancel' },
+      {
+        text: t.common.delete,
+        style: 'destructive',
+        onPress: () => remove.mutate(editing.id, { onSuccess: () => router.back() }),
+      },
+    ]);
   };
 
   const title = editing
@@ -203,9 +256,7 @@ export default function PersonalEntryScreen() {
               onChange={(event, picked) => {
                 // Android fires once and dismisses itself; iOS stays open.
                 if (Platform.OS !== 'ios') setShowDate(false);
-                if (event.type === 'set' && picked) {
-                  setDate(picked.toISOString().slice(0, 10));
-                }
+                if (event.type === 'set' && picked) setDate(localIsoDate(picked));
               }}
             />
           ) : null}

--- a/apps/mobile/src/app/personal/entry.tsx
+++ b/apps/mobile/src/app/personal/entry.tsx
@@ -1,0 +1,218 @@
+/**
+ * Add or edit one personal-finance entry (A48) — an expense or income line in
+ * your own private ledger. No group, no split, no members: just an amount, what
+ * it was for, and when. Reached from the "Me" tab's add buttons, and (with a
+ * `loanId`) as a loan repayment.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { router, useLocalSearchParams } from 'expo-router';
+import { Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+
+import { encodeTxn, type CategoryMeta, type TxnKind } from '@waves/core';
+import {
+  AmountField,
+  Button,
+  directionalIcon,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  SegmentedTabs,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { CategoryPicker } from '@/components/Category';
+import {
+  useDeletePersonalRecord,
+  usePersonalLedger,
+  useUpsertPersonalRecord,
+  todayIso,
+} from '@/data/personal';
+import { useDefaultCurrency } from '@/lib/currency';
+import { useStrings } from '@/i18n';
+
+export default function PersonalEntryScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t } = useStrings();
+  const dc = useDefaultCurrency();
+  const params = useLocalSearchParams<{ kind?: string; id?: string; loanId?: string }>();
+
+  const { txns } = usePersonalLedger();
+  const editing = params.id ? txns.find((txn) => txn.id === params.id) : undefined;
+
+  const upsert = useUpsertPersonalRecord();
+  const remove = useDeletePersonalRecord();
+
+  const [kind, setKind] = useState<TxnKind>(
+    editing?.kind ?? (params.kind === 'income' ? 'income' : 'expense'),
+  );
+  const [amount, setAmount] = useState<bigint>(editing?.amount ?? 0n);
+  const [note, setNote] = useState(editing?.note ?? '');
+  const [category, setCategory] = useState<string | null>(editing?.category ?? null);
+  const [date, setDate] = useState(editing?.date ?? todayIso());
+  const [showDate, setShowDate] = useState(false);
+  // A repayment carries the loan it settles through from the loans screen; kept
+  // as-is on an edit so the link survives.
+  const loanId = editing?.loanId ?? (typeof params.loanId === 'string' ? params.loanId : null);
+
+  const currency = editing?.currency ?? dc;
+  const canSave = amount > 0n && !upsert.isPending;
+
+  const onSave = (): void => {
+    if (!canSave) return;
+    upsert.mutate(
+      {
+        recordId: editing?.id,
+        recordKind: 'txn',
+        data: encodeTxn({
+          kind,
+          amount,
+          currency,
+          category,
+          note: note.trim() || null,
+          date,
+          loanId,
+          recurringId: editing?.recurringId ?? null,
+        }),
+      },
+      { onSuccess: () => router.back() },
+    );
+  };
+
+  const onDelete = (): void => {
+    if (!editing) return;
+    remove.mutate(editing.id, { onSuccess: () => router.back() });
+  };
+
+  const title = editing
+    ? t.personal.transactions
+    : kind === 'income'
+      ? t.personal.addIncome
+      : t.personal.addExpense;
+
+  return (
+    <Screen>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.xl,
+        }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{title}</Text>
+          </View>
+          {editing ? (
+            <IconButton label={t.common.delete} onPress={onDelete}>
+              <Ionicons name="trash-outline" size={iconSize.md} color={theme.color.negative} />
+            </IconButton>
+          ) : (
+            <View style={{ width: iconSize.lg }} />
+          )}
+        </Row>
+
+        {/* A repayment's kind is fixed by the loan, so only a plain entry chooses. */}
+        {loanId ? null : (
+          <SegmentedTabs
+            value={kind}
+            onChange={setKind}
+            tabs={[
+              { value: 'expense', label: t.personal.expense },
+              { value: 'income', label: t.personal.incomeKind },
+            ]}
+          />
+        )}
+
+        <View style={{ alignItems: 'center', paddingVertical: theme.spacing.lg }}>
+          <AmountField currency={currency} value={amount} onChange={setAmount} />
+        </View>
+
+        <View style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            {t.personal.note}
+          </Text>
+          <TextInput
+            value={note}
+            onChangeText={setNote}
+            placeholder={t.personal.notePlaceholder}
+            placeholderTextColor={theme.color.textFaint}
+            style={{
+              fontSize: 16,
+              color: theme.color.text,
+              paddingVertical: theme.spacing.md,
+              paddingHorizontal: theme.spacing.lg,
+              backgroundColor: theme.color.surfaceMuted,
+              borderRadius: theme.radius.md,
+            }}
+          />
+        </View>
+
+        {/* A repayment is not everyday spend, so it carries no category. */}
+        {loanId ? null : (
+          <View style={{ gap: theme.spacing.sm }}>
+            <Text variant="caption" tone="muted">
+              {t.personal.category}
+            </Text>
+            <CategoryPicker
+              value={category}
+              onChange={(picked: string, _meta: CategoryMeta | null) => setCategory(picked)}
+            />
+          </View>
+        )}
+
+        <View style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            {t.personal.date}
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => setShowDate(true)}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              paddingVertical: theme.spacing.md,
+              paddingHorizontal: theme.spacing.lg,
+              backgroundColor: theme.color.surfaceMuted,
+              borderRadius: theme.radius.md,
+            }}
+          >
+            <Text variant="body">{date}</Text>
+            <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
+          </Pressable>
+          {showDate ? (
+            <DateTimePicker
+              value={new Date(`${date}T00:00:00`)}
+              mode="date"
+              onChange={(event, picked) => {
+                // Android fires once and dismisses itself; iOS stays open.
+                if (Platform.OS !== 'ios') setShowDate(false);
+                if (event.type === 'set' && picked) {
+                  setDate(picked.toISOString().slice(0, 10));
+                }
+              }}
+            />
+          ) : null}
+        </View>
+
+        <Button label={t.personal.save} size="lg" fullWidth onPress={onSave} disabled={!canSave} />
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/app/personal/loans.tsx
+++ b/apps/mobile/src/app/personal/loans.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { router } from 'expo-router';
-import { Modal, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { Alert, Modal, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
   encodeLoan,
@@ -37,6 +37,7 @@ import {
 } from '@waves/ui';
 
 import {
+  localIsoDate,
   todayIso,
   usePersonalLedger,
   useDeletePersonalRecord,
@@ -327,8 +328,7 @@ function LoanEditor({
                 mode="date"
                 onChange={(event, picked) => {
                   if (Platform.OS !== 'ios') setShowDate(false);
-                  if (event.type === 'set' && picked)
-                    setStartDate(picked.toISOString().slice(0, 10));
+                  if (event.type === 'set' && picked) setStartDate(localIsoDate(picked));
                 }}
               />
             ) : null}
@@ -358,7 +358,16 @@ function LoanEditor({
                 label={t.common.delete}
                 variant="danger"
                 fullWidth
-                onPress={() => remove.mutate(loan.id, { onSuccess: onClose })}
+                onPress={() =>
+                  Alert.alert(t.common.delete, t.personal.deleteConfirm, [
+                    { text: t.common.cancel, style: 'cancel' },
+                    {
+                      text: t.common.delete,
+                      style: 'destructive',
+                      onPress: () => remove.mutate(loan.id, { onSuccess: onClose }),
+                    },
+                  ])
+                }
               />
             ) : null}
           </ScrollView>

--- a/apps/mobile/src/app/personal/loans.tsx
+++ b/apps/mobile/src/app/personal/loans.tsx
@@ -1,0 +1,369 @@
+/**
+ * Loans (A48): money you owe or are owed, tracked with a running balance. A loan
+ * carries its principal; each repayment is a normal ledger entry linked to it
+ * ("Record payment" opens the entry form pre-linked), and what is left is the
+ * principal less those payments. The editor is an inline sheet.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { router } from 'expo-router';
+import { Modal, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+
+import {
+  encodeLoan,
+  format,
+  loanOutstanding,
+  money,
+  type LoanDirection,
+  type PersonalLoan,
+} from '@waves/core';
+import {
+  AmountField,
+  Button,
+  Card,
+  directionalIcon,
+  Divider,
+  EmptyState,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  SegmentedTabs,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import {
+  todayIso,
+  usePersonalLedger,
+  useDeletePersonalRecord,
+  useUpsertPersonalRecord,
+} from '@/data/personal';
+import { useDefaultCurrency } from '@/lib/currency';
+import { useStrings } from '@/i18n';
+
+export default function LoansScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const dc = useDefaultCurrency();
+  const { loans, txns } = usePersonalLedger();
+
+  const [today] = useState(() => todayIso());
+  const [editing, setEditing] = useState<PersonalLoan | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const sorted = [...loans].sort((a, b) => {
+    if (a.status !== b.status) return a.status === 'active' ? -1 : 1;
+    return a.startDate < b.startDate ? 1 : -1;
+  });
+
+  return (
+    <Screen>
+      <Row
+        style={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.md,
+          alignItems: 'center',
+        }}
+      >
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.personal.loans}</Text>
+        </View>
+        <IconButton label={t.personal.addLoan} onPress={() => setCreating(true)}>
+          <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
+        </IconButton>
+      </Row>
+
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.md,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text
+          variant="caption"
+          tone="muted"
+          align="center"
+          style={{ marginBottom: theme.spacing.sm }}
+        >
+          {t.personal.loansSub}
+        </Text>
+
+        {sorted.length === 0 ? (
+          <View style={{ paddingTop: theme.spacing.xxxl }}>
+            <EmptyState title={t.personal.noLoans} />
+          </View>
+        ) : (
+          sorted.map((loan) => {
+            const left = loanOutstanding(loan, txns);
+            const borrowed = loan.direction === 'borrowed';
+            const settled = loan.status === 'closed' || left === 0n;
+            return (
+              <Card key={loan.id} style={{ gap: theme.spacing.sm }}>
+                <Pressable accessibilityRole="button" onPress={() => setEditing(loan)}>
+                  <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+                    <View
+                      style={{
+                        width: 40,
+                        height: 40,
+                        borderRadius: theme.radius.md,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        backgroundColor: theme.color.brandSoft,
+                      }}
+                    >
+                      <Ionicons
+                        name={borrowed ? 'arrow-down' : 'arrow-up'}
+                        size={iconSize.md}
+                        color={theme.color.brand}
+                      />
+                    </View>
+                    <View style={{ flex: 1 }}>
+                      <Text variant="body" numberOfLines={1} style={{ fontWeight: '600' }}>
+                        {loan.counterpart || (borrowed ? t.personal.borrowed : t.personal.lent)}
+                      </Text>
+                      <Text variant="micro" tone="muted">
+                        {borrowed ? t.personal.borrowed : t.personal.lent} ·{' '}
+                        {format(money(loan.principal, loan.currency), {
+                          locale,
+                          compactFraction: true,
+                        })}
+                      </Text>
+                    </View>
+                    <View style={{ alignItems: 'flex-end' }}>
+                      <Text variant="micro" tone="faint">
+                        {settled ? t.personal.paidOff : t.personal.outstanding}
+                      </Text>
+                      <Text variant="body" style={{ fontWeight: '700' }}>
+                        {format(money(left, loan.currency), { locale, compactFraction: true })}
+                      </Text>
+                    </View>
+                  </Row>
+                </Pressable>
+                {!settled ? (
+                  <>
+                    <Divider />
+                    <Button
+                      label={t.personal.recordPayment}
+                      size="sm"
+                      variant="secondary"
+                      onPress={() =>
+                        router.push({
+                          pathname: '/personal/entry',
+                          params: { loanId: loan.id, kind: borrowed ? 'expense' : 'income' },
+                        })
+                      }
+                    />
+                  </>
+                ) : null}
+              </Card>
+            );
+          })
+        )}
+      </ScrollView>
+
+      {creating ? (
+        <LoanEditor currency={dc} today={today} onClose={() => setCreating(false)} />
+      ) : null}
+      {editing ? (
+        <LoanEditor loan={editing} currency={dc} today={today} onClose={() => setEditing(null)} />
+      ) : null}
+    </Screen>
+  );
+}
+
+function LoanEditor({
+  loan,
+  currency,
+  today,
+  onClose,
+}: {
+  loan?: PersonalLoan;
+  currency: string;
+  today: string;
+  onClose: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const upsert = useUpsertPersonalRecord();
+  const remove = useDeletePersonalRecord();
+
+  const [direction, setDirection] = useState<LoanDirection>(loan?.direction ?? 'borrowed');
+  const [counterpart, setCounterpart] = useState(loan?.counterpart ?? '');
+  const [principal, setPrincipal] = useState<bigint>(loan?.principal ?? 0n);
+  const [note, setNote] = useState(loan?.note ?? '');
+  const [startDate, setStartDate] = useState(loan?.startDate ?? today);
+  const [showDate, setShowDate] = useState(false);
+  const [closed, setClosed] = useState(loan?.status === 'closed');
+
+  const canSave = principal > 0n && counterpart.trim().length > 0 && !upsert.isPending;
+
+  const onSave = (): void => {
+    if (!canSave) return;
+    upsert.mutate(
+      {
+        recordId: loan?.id,
+        recordKind: 'loan',
+        data: encodeLoan({
+          direction,
+          counterpart: counterpart.trim(),
+          principal,
+          currency: loan?.currency ?? currency,
+          note: note.trim() || null,
+          startDate,
+          status: closed ? 'closed' : 'active',
+        }),
+      },
+      { onSuccess: onClose },
+    );
+  };
+
+  return (
+    <Modal visible transparent animationType="slide" onRequestClose={onClose}>
+      <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
+        <View
+          style={{
+            backgroundColor: theme.color.surface,
+            borderTopLeftRadius: theme.radius.xl,
+            borderTopRightRadius: theme.radius.xl,
+            maxHeight: '90%',
+          }}
+        >
+          <ScrollView
+            contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+              <Text variant="heading">{loan ? t.personal.editLoan : t.personal.addLoan}</Text>
+              <IconButton label={t.common.close} onPress={onClose}>
+                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+              </IconButton>
+            </Row>
+
+            <SegmentedTabs
+              value={direction}
+              onChange={setDirection}
+              tabs={[
+                { value: 'borrowed', label: t.personal.borrowed },
+                { value: 'lent', label: t.personal.lent },
+              ]}
+            />
+
+            <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
+              <AmountField
+                currency={loan?.currency ?? currency}
+                value={principal}
+                onChange={setPrincipal}
+              />
+            </View>
+
+            <View style={{ gap: theme.spacing.sm }}>
+              <Text variant="caption" tone="muted">
+                {t.personal.counterpart}
+              </Text>
+              <TextInput
+                value={counterpart}
+                onChangeText={setCounterpart}
+                placeholder={t.personal.counterpartPlaceholder}
+                placeholderTextColor={theme.color.textFaint}
+                style={{
+                  fontSize: 16,
+                  color: theme.color.text,
+                  paddingVertical: theme.spacing.md,
+                  paddingHorizontal: theme.spacing.lg,
+                  backgroundColor: theme.color.surfaceMuted,
+                  borderRadius: theme.radius.md,
+                }}
+              />
+            </View>
+
+            <TextInput
+              value={note}
+              onChangeText={setNote}
+              placeholder={t.personal.notePlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              style={{
+                fontSize: 16,
+                color: theme.color.text,
+                paddingVertical: theme.spacing.md,
+                paddingHorizontal: theme.spacing.lg,
+                backgroundColor: theme.color.surfaceMuted,
+                borderRadius: theme.radius.md,
+              }}
+            />
+
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => setShowDate(true)}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingVertical: theme.spacing.md,
+                paddingHorizontal: theme.spacing.lg,
+                backgroundColor: theme.color.surfaceMuted,
+                borderRadius: theme.radius.md,
+              }}
+            >
+              <Text variant="body">{startDate}</Text>
+              <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
+            </Pressable>
+            {showDate ? (
+              <DateTimePicker
+                value={new Date(`${startDate}T00:00:00`)}
+                mode="date"
+                onChange={(event, picked) => {
+                  if (Platform.OS !== 'ios') setShowDate(false);
+                  if (event.type === 'set' && picked)
+                    setStartDate(picked.toISOString().slice(0, 10));
+                }}
+              />
+            ) : null}
+
+            {loan ? (
+              <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                <Text variant="body">{t.personal.closeLoan}</Text>
+                <Button
+                  label={closed ? t.personal.reopenLoan : t.personal.closeLoan}
+                  size="sm"
+                  variant="secondary"
+                  onPress={() => setClosed((prev) => !prev)}
+                />
+              </Row>
+            ) : null}
+
+            <Button
+              label={t.personal.save}
+              size="lg"
+              fullWidth
+              onPress={onSave}
+              disabled={!canSave}
+            />
+
+            {loan ? (
+              <Button
+                label={t.common.delete}
+                variant="danger"
+                fullWidth
+                onPress={() => remove.mutate(loan.id, { onSuccess: onClose })}
+              />
+            ) : null}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/app/personal/recurring.tsx
+++ b/apps/mobile/src/app/personal/recurring.tsx
@@ -1,0 +1,415 @@
+/**
+ * Recurring rules (A48): bills and income that repeat — a phone bill, a salary,
+ * a subscription. A rule set to "add automatically" posts its entry on its own
+ * when due (handled on the Me tab's open); a manual one just shows as due here,
+ * to add with one tap. The editor is an inline sheet.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { router } from 'expo-router';
+import { Modal, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+
+import {
+  addToDate,
+  encodeRecurring,
+  format,
+  isRecurringDue,
+  money,
+  type Cadence,
+  type PersonalRecurring,
+  type TxnKind,
+} from '@waves/core';
+import {
+  AmountField,
+  Button,
+  Card,
+  directionalIcon,
+  Divider,
+  EmptyState,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  SegmentedTabs,
+  Text,
+  Toggle,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { CategoryPicker } from '@/components/Category';
+import {
+  todayIso,
+  usePersonalLedger,
+  useDeletePersonalRecord,
+  useUpsertPersonalRecord,
+} from '@/data/personal';
+import { useDefaultCurrency } from '@/lib/currency';
+import { useStrings } from '@/i18n';
+
+export default function RecurringScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const dc = useDefaultCurrency();
+  const { recurrings } = usePersonalLedger();
+  const upsert = useUpsertPersonalRecord();
+
+  const [today] = useState(() => todayIso());
+  const [editing, setEditing] = useState<PersonalRecurring | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const cadenceLabel = (rule: PersonalRecurring): string => {
+    const base =
+      rule.cadence === 'weekly'
+        ? t.personal.weekly
+        : rule.cadence === 'yearly'
+          ? t.personal.yearly
+          : t.personal.monthly;
+    return rule.interval > 1 ? `${t.personal.every} ${rule.interval} · ${base}` : base;
+  };
+
+  // Post one occurrence of a manual rule now, and advance its next date.
+  const postOnce = async (rule: PersonalRecurring): Promise<void> => {
+    await upsert.mutateAsync({
+      recordKind: 'txn',
+      data: {
+        kind: rule.txnKind,
+        amount: rule.amount.toString(),
+        currency: rule.currency,
+        category: rule.category,
+        note: rule.note,
+        date: rule.nextDate,
+        loanId: null,
+        recurringId: rule.id,
+      },
+    });
+    await upsert.mutateAsync({
+      recordId: rule.id,
+      recordKind: 'recurring',
+      data: encodeRecurring({
+        ...rule,
+        nextDate: addToDate(rule.nextDate, rule.cadence, rule.interval),
+      }),
+    });
+  };
+
+  return (
+    <Screen>
+      <Row
+        style={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.md,
+          alignItems: 'center',
+        }}
+      >
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.personal.recurring}</Text>
+        </View>
+        <IconButton label={t.personal.addRecurring} onPress={() => setCreating(true)}>
+          <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
+        </IconButton>
+      </Row>
+
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.md,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text
+          variant="caption"
+          tone="muted"
+          align="center"
+          style={{ marginBottom: theme.spacing.sm }}
+        >
+          {t.personal.recurringSub}
+        </Text>
+
+        {recurrings.length === 0 ? (
+          <View style={{ paddingTop: theme.spacing.xxxl }}>
+            <EmptyState title={t.personal.noRecurring} />
+          </View>
+        ) : (
+          recurrings.map((rule) => {
+            const due = isRecurringDue(rule, today);
+            const income = rule.txnKind === 'income';
+            return (
+              <Card key={rule.id} style={{ gap: theme.spacing.sm }}>
+                <Pressable accessibilityRole="button" onPress={() => setEditing(rule)}>
+                  <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+                    <View style={{ flex: 1 }}>
+                      <Text variant="body" numberOfLines={1} style={{ fontWeight: '600' }}>
+                        {rule.note?.trim() || (income ? t.personal.incomeKind : t.personal.expense)}
+                      </Text>
+                      <Text variant="micro" tone="muted">
+                        {cadenceLabel(rule)} · {t.personal.nextDue} {rule.nextDate}
+                        {rule.active ? '' : ` · ${t.personal.paused}`}
+                      </Text>
+                    </View>
+                    <Text
+                      variant="body"
+                      style={{
+                        fontWeight: '700',
+                        color: income ? theme.color.positive : theme.color.text,
+                      }}
+                    >
+                      {income ? '+' : '−'}
+                      {format(money(rule.amount, rule.currency), { locale, compactFraction: true })}
+                    </Text>
+                  </Row>
+                </Pressable>
+                {due && !rule.autoPost && rule.active ? (
+                  <>
+                    <Divider />
+                    <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                      <Text variant="caption" tone="brand" style={{ fontWeight: '600' }}>
+                        {t.personal.due}
+                      </Text>
+                      <Button
+                        label={t.personal.postNow}
+                        size="sm"
+                        onPress={() => void postOnce(rule)}
+                        disabled={upsert.isPending}
+                      />
+                    </Row>
+                  </>
+                ) : null}
+              </Card>
+            );
+          })
+        )}
+      </ScrollView>
+
+      {creating ? (
+        <RecurringEditor currency={dc} today={today} onClose={() => setCreating(false)} />
+      ) : null}
+      {editing ? (
+        <RecurringEditor
+          rule={editing}
+          currency={dc}
+          today={today}
+          onClose={() => setEditing(null)}
+        />
+      ) : null}
+    </Screen>
+  );
+}
+
+function RecurringEditor({
+  rule,
+  currency,
+  today,
+  onClose,
+}: {
+  rule?: PersonalRecurring;
+  currency: string;
+  today: string;
+  onClose: () => void;
+}) {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const upsert = useUpsertPersonalRecord();
+  const remove = useDeletePersonalRecord();
+
+  const [txnKind, setTxnKind] = useState<TxnKind>(rule?.txnKind ?? 'expense');
+  const [amount, setAmount] = useState<bigint>(rule?.amount ?? 0n);
+  const [note, setNote] = useState(rule?.note ?? '');
+  const [category, setCategory] = useState<string | null>(rule?.category ?? null);
+  const [cadence, setCadence] = useState<Cadence>(rule?.cadence ?? 'monthly');
+  const [startDate, setStartDate] = useState(rule?.anchorDate ?? today);
+  const [showDate, setShowDate] = useState(false);
+  const [autoPost, setAutoPost] = useState(rule?.autoPost ?? false);
+  const [active, setActive] = useState(rule?.active ?? true);
+
+  const canSave = amount > 0n && !upsert.isPending;
+
+  const onSave = (): void => {
+    if (!canSave) return;
+    upsert.mutate(
+      {
+        recordId: rule?.id,
+        recordKind: 'recurring',
+        data: encodeRecurring({
+          txnKind,
+          amount,
+          currency: rule?.currency ?? currency,
+          category,
+          note: note.trim() || null,
+          cadence,
+          interval: rule?.interval ?? 1,
+          anchorDate: startDate,
+          // A new rule is next due on its start date; an edit keeps its schedule.
+          nextDate: rule?.nextDate ?? startDate,
+          endDate: rule?.endDate ?? null,
+          autoPost,
+          active,
+        }),
+      },
+      { onSuccess: onClose },
+    );
+  };
+
+  return (
+    <Modal visible transparent animationType="slide" onRequestClose={onClose}>
+      <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
+        <View
+          style={{
+            backgroundColor: theme.color.surface,
+            borderTopLeftRadius: theme.radius.xl,
+            borderTopRightRadius: theme.radius.xl,
+            maxHeight: '90%',
+          }}
+        >
+          <ScrollView
+            contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+              <Text variant="heading">
+                {rule ? t.personal.editRecurring : t.personal.addRecurring}
+              </Text>
+              <IconButton label={t.common.close} onPress={onClose}>
+                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+              </IconButton>
+            </Row>
+
+            <SegmentedTabs
+              value={txnKind}
+              onChange={setTxnKind}
+              tabs={[
+                { value: 'expense', label: t.personal.expense },
+                { value: 'income', label: t.personal.incomeKind },
+              ]}
+            />
+
+            <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
+              <AmountField
+                currency={rule?.currency ?? currency}
+                value={amount}
+                onChange={setAmount}
+              />
+            </View>
+
+            <TextInput
+              value={note}
+              onChangeText={setNote}
+              placeholder={t.personal.notePlaceholder}
+              placeholderTextColor={theme.color.textFaint}
+              style={{
+                fontSize: 16,
+                color: theme.color.text,
+                paddingVertical: theme.spacing.md,
+                paddingHorizontal: theme.spacing.lg,
+                backgroundColor: theme.color.surfaceMuted,
+                borderRadius: theme.radius.md,
+              }}
+            />
+
+            {txnKind === 'expense' ? (
+              <CategoryPicker value={category} onChange={(picked) => setCategory(picked)} />
+            ) : null}
+
+            <View style={{ gap: theme.spacing.sm }}>
+              <Text variant="caption" tone="muted">
+                {t.personal.repeats}
+              </Text>
+              <SegmentedTabs
+                value={cadence}
+                onChange={setCadence}
+                tabs={[
+                  { value: 'weekly', label: t.personal.weekly },
+                  { value: 'monthly', label: t.personal.monthly },
+                  { value: 'yearly', label: t.personal.yearly },
+                ]}
+              />
+            </View>
+
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => setShowDate(true)}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingVertical: theme.spacing.md,
+                paddingHorizontal: theme.spacing.lg,
+                backgroundColor: theme.color.surfaceMuted,
+                borderRadius: theme.radius.md,
+              }}
+            >
+              <Text variant="body">
+                {t.personal.nextDue}: {rule?.nextDate ?? startDate}
+              </Text>
+              <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
+            </Pressable>
+            {showDate ? (
+              <DateTimePicker
+                value={new Date(`${startDate}T00:00:00`)}
+                mode="date"
+                onChange={(event, picked) => {
+                  if (Platform.OS !== 'ios') setShowDate(false);
+                  if (event.type === 'set' && picked)
+                    setStartDate(picked.toISOString().slice(0, 10));
+                }}
+              />
+            ) : null}
+
+            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+              <View style={{ flex: 1, paddingRight: theme.spacing.md }}>
+                <Text variant="body">{t.personal.autoPost}</Text>
+                <Text variant="micro" tone="muted">
+                  {t.personal.autoPostHint}
+                </Text>
+              </View>
+              <Toggle
+                value={autoPost}
+                onValueChange={setAutoPost}
+                accessibilityLabel={t.personal.autoPost}
+              />
+            </Row>
+
+            {rule ? (
+              <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                <Text variant="body">{t.personal.active}</Text>
+                <Toggle
+                  value={active}
+                  onValueChange={setActive}
+                  accessibilityLabel={t.personal.active}
+                />
+              </Row>
+            ) : null}
+
+            <Button
+              label={t.personal.save}
+              size="lg"
+              fullWidth
+              onPress={onSave}
+              disabled={!canSave}
+            />
+
+            {rule ? (
+              <Button
+                label={t.common.delete}
+                variant="danger"
+                fullWidth
+                onPress={() => remove.mutate(rule.id, { onSuccess: onClose })}
+              />
+            ) : null}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/app/personal/recurring.tsx
+++ b/apps/mobile/src/app/personal/recurring.tsx
@@ -9,14 +9,16 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { router } from 'expo-router';
-import { Modal, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { Alert, Modal, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
   addToDate,
   encodeRecurring,
+  encodeTxn,
   format,
   isRecurringDue,
   money,
+  recurringOccurrenceId,
   type Cadence,
   type PersonalRecurring,
   type TxnKind,
@@ -41,6 +43,7 @@ import {
 
 import { CategoryPicker } from '@/components/Category';
 import {
+  localIsoDate,
   todayIso,
   usePersonalLedger,
   useDeletePersonalRecord,
@@ -71,20 +74,23 @@ export default function RecurringScreen() {
     return rule.interval > 1 ? `${t.personal.every} ${rule.interval} · ${base}` : base;
   };
 
-  // Post one occurrence of a manual rule now, and advance its next date.
+  // Post one occurrence of a manual rule now, and advance its next date. The
+  // occurrence id is deterministic per (rule, date), so this posting the same
+  // date the auto catch-up also posts collapses to one row rather than two.
   const postOnce = async (rule: PersonalRecurring): Promise<void> => {
     await upsert.mutateAsync({
+      recordId: recurringOccurrenceId(rule.id, rule.nextDate),
       recordKind: 'txn',
-      data: {
+      data: encodeTxn({
         kind: rule.txnKind,
-        amount: rule.amount.toString(),
+        amount: rule.amount,
         currency: rule.currency,
         category: rule.category,
         note: rule.note,
         date: rule.nextDate,
         loanId: null,
         recurringId: rule.id,
-      },
+      }),
     });
     await upsert.mutateAsync({
       recordId: rule.id,
@@ -228,7 +234,10 @@ function RecurringEditor({
   const [note, setNote] = useState(rule?.note ?? '');
   const [category, setCategory] = useState<string | null>(rule?.category ?? null);
   const [cadence, setCadence] = useState<Cadence>(rule?.cadence ?? 'monthly');
-  const [startDate, setStartDate] = useState(rule?.anchorDate ?? today);
+  // The editable "next due" date: a new rule starts on it; an existing rule is
+  // rescheduled to it. Seeded from the rule's current next date, not its anchor,
+  // so opening and saving an unchanged rule never rewinds its schedule.
+  const [startDate, setStartDate] = useState(rule?.nextDate ?? today);
   const [showDate, setShowDate] = useState(false);
   const [autoPost, setAutoPost] = useState(rule?.autoPost ?? false);
   const [active, setActive] = useState(rule?.active ?? true);
@@ -249,9 +258,11 @@ function RecurringEditor({
           note: note.trim() || null,
           cadence,
           interval: rule?.interval ?? 1,
-          anchorDate: startDate,
-          // A new rule is next due on its start date; an edit keeps its schedule.
-          nextDate: rule?.nextDate ?? startDate,
+          // Keep the original anchor on an edit; a new rule anchors on its start.
+          anchorDate: rule?.anchorDate ?? startDate,
+          // The picker holds the next-due date for both a new rule and an edit,
+          // so a rescheduled date actually takes effect.
+          nextDate: startDate,
           endDate: rule?.endDate ?? null,
           autoPost,
           active,
@@ -350,7 +361,7 @@ function RecurringEditor({
               }}
             >
               <Text variant="body">
-                {t.personal.nextDue}: {rule?.nextDate ?? startDate}
+                {t.personal.nextDue}: {startDate}
               </Text>
               <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
             </Pressable>
@@ -360,8 +371,7 @@ function RecurringEditor({
                 mode="date"
                 onChange={(event, picked) => {
                   if (Platform.OS !== 'ios') setShowDate(false);
-                  if (event.type === 'set' && picked)
-                    setStartDate(picked.toISOString().slice(0, 10));
+                  if (event.type === 'set' && picked) setStartDate(localIsoDate(picked));
                 }}
               />
             ) : null}
@@ -404,7 +414,16 @@ function RecurringEditor({
                 label={t.common.delete}
                 variant="danger"
                 fullWidth
-                onPress={() => remove.mutate(rule.id, { onSuccess: onClose })}
+                onPress={() =>
+                  Alert.alert(t.common.delete, t.personal.deleteConfirm, [
+                    { text: t.common.cancel, style: 'cancel' },
+                    {
+                      text: t.common.delete,
+                      style: 'destructive',
+                      onPress: () => remove.mutate(rule.id, { onSuccess: onClose }),
+                    },
+                  ])
+                }
               />
             ) : null}
           </ScrollView>

--- a/apps/mobile/src/app/personal/transactions.tsx
+++ b/apps/mobile/src/app/personal/transactions.tsx
@@ -1,0 +1,134 @@
+/**
+ * The full personal ledger (A48): every entry, newest first, grouped by day.
+ * Tapping one opens it to edit; the header "+" adds a new one.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, SectionList, View } from 'react-native';
+
+import { format, money, type PersonalTxn } from '@waves/core';
+import {
+  Card,
+  directionalIcon,
+  EmptyState,
+  IconButton,
+  iconSize,
+  Row,
+  Screen,
+  Text,
+  useScreenClearance,
+  useTheme,
+} from '@waves/ui';
+
+import { CategoryBadge } from '@/components/Category';
+import { usePersonalLedger } from '@/data/personal';
+import { useStrings } from '@/i18n';
+
+export default function PersonalTransactionsScreen() {
+  const theme = useTheme();
+  const clearance = useScreenClearance();
+  const { t, locale } = useStrings();
+  const { txns } = usePersonalLedger();
+
+  // Group by day; the ledger already comes newest first, so days do too.
+  const sections: { title: string; data: PersonalTxn[] }[] = [];
+  for (const txn of txns) {
+    const last = sections[sections.length - 1];
+    if (last && last.title === txn.date) last.data.push(txn);
+    else sections.push({ title: txn.date, data: [txn] });
+  }
+
+  const labelFor = (id: string | null): string | null =>
+    id ? (t.categories[id as keyof typeof t.categories] ?? null) : null;
+
+  return (
+    <Screen>
+      <Row
+        style={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.md,
+          alignItems: 'center',
+        }}
+      >
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.personal.transactions}</Text>
+        </View>
+        <IconButton
+          label={t.personal.add}
+          onPress={() => router.push({ pathname: '/personal/entry', params: { kind: 'expense' } })}
+        >
+          <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
+        </IconButton>
+      </Row>
+
+      <SectionList
+        sections={sections}
+        keyExtractor={(txn) => txn.id}
+        contentContainerStyle={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingBottom: clearance,
+          gap: theme.spacing.sm,
+        }}
+        showsVerticalScrollIndicator={false}
+        ListEmptyComponent={
+          <View style={{ paddingTop: theme.spacing.xxxl }}>
+            <EmptyState title={t.personal.empty} />
+          </View>
+        }
+        renderSectionHeader={({ section }) => (
+          <Text
+            variant="micro"
+            tone="faint"
+            style={{
+              letterSpacing: 0.8,
+              paddingTop: theme.spacing.lg,
+              paddingBottom: theme.spacing.xs,
+            }}
+          >
+            {section.title}
+          </Text>
+        )}
+        renderItem={({ item: txn }) => {
+          const income = txn.kind === 'income';
+          const title = txn.note?.trim() || labelFor(txn.category) || '—';
+          return (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => router.push({ pathname: '/personal/entry', params: { id: txn.id } })}
+            >
+              <Card
+                padded={false}
+                style={{ paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.md }}
+              >
+                <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+                  <CategoryBadge category={txn.category ?? 'other'} meta={null} size={32} />
+                  <Text variant="body" numberOfLines={1} style={{ flex: 1 }}>
+                    {title}
+                  </Text>
+                  <Text
+                    variant="body"
+                    style={{
+                      fontWeight: '700',
+                      color: income ? theme.color.positive : theme.color.text,
+                    }}
+                  >
+                    {income ? '+' : '−'}
+                    {format(money(txn.amount, txn.currency), { locale, compactFraction: true })}
+                  </Text>
+                </Row>
+              </Card>
+            </Pressable>
+          );
+        }}
+      />
+    </Screen>
+  );
+}

--- a/apps/mobile/src/components/AppTabBar.tsx
+++ b/apps/mobile/src/components/AppTabBar.tsx
@@ -64,8 +64,13 @@ export function AppTabBar() {
         label: t.tabs.inbox,
         icon: (color) => <Ionicons name="file-tray-outline" size={iconSize.lg} color={color} />,
       },
+      {
+        key: 'me',
+        label: t.personal.tab,
+        icon: (color) => <Ionicons name="wallet-outline" size={iconSize.lg} color={color} />,
+      },
     ],
-    [t.activity, t.friends, t.home, t.tabs.inbox],
+    [t.activity, t.friends, t.home, t.tabs.inbox, t.personal.tab],
   );
 
   // All bar destinations are tabs now. `navigate` switches to the existing tab

--- a/apps/mobile/src/data/personal.ts
+++ b/apps/mobile/src/data/personal.ts
@@ -23,6 +23,7 @@ import {
   MutationKind,
   personalScope,
   recurringCatchUp,
+  recurringOccurrenceId,
   type PersonalBudget,
   type PersonalLoan,
   type PersonalRecordKind,
@@ -33,10 +34,21 @@ import {
 import { useAuth } from '@/lib/auth';
 import { useSync } from '@/sync';
 
-/** Today as YYYY-MM-DD. Call outside render (an effect or a lazy initialiser);
- *  a bare `new Date()` in render trips the React Compiler lint. */
+/** A Date as a LOCAL YYYY-MM-DD — the calendar day the person is looking at, not
+ *  the UTC one. `toISOString().slice(0,10)` shifts the day for anyone east or
+ *  west of UTC (a local-midnight pick in IST reads as the day before), so the
+ *  date maths must read the local parts instead. */
+export function localIsoDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** Today as a LOCAL YYYY-MM-DD. Call outside render (an effect or a lazy
+ *  initialiser); a bare `new Date()` in render trips the React Compiler lint. */
 export function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
+  return localIsoDate(new Date());
 }
 
 export interface PersonalLedger {
@@ -151,7 +163,10 @@ export async function postDueRecurring(
     for (const date of dates) {
       const already = ledger.txns.some((txn) => txn.recurringId === rule.id && txn.date === date);
       if (already) continue;
+      // A deterministic id per (rule, date), so two posts of the same occurrence
+      // — a race, or a manual "add now" crossing this catch-up — upsert one row.
       await upsert({
+        recordId: recurringOccurrenceId(rule.id, date),
         recordKind: 'txn',
         data: encodeTxn({
           kind: rule.txnKind,

--- a/apps/mobile/src/data/personal.ts
+++ b/apps/mobile/src/data/personal.ts
@@ -1,0 +1,178 @@
+/**
+ * The private personal-finance ledger (A48), read and written local-first.
+ *
+ * Everything here rides the same offline mirror the rest of the app does, on the
+ * personal scope (the owner's own user id, suffixed): a record made offline is
+ * in the queue and shows immediately; the server is only a relay. All the sums
+ * the screens show are computed from these rows by the pure helpers in
+ * `@waves/core` (personal/compute), never on the server.
+ */
+
+import { useMemo } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { randomUUID } from 'expo-crypto';
+
+import {
+  decodeBudget,
+  decodeLoan,
+  decodeRecurring,
+  decodeTxn,
+  encodeRecurring,
+  encodeTxn,
+  materialisePersonalRecords,
+  MutationKind,
+  personalScope,
+  recurringCatchUp,
+  type PersonalBudget,
+  type PersonalLoan,
+  type PersonalRecordKind,
+  type PersonalRecurring,
+  type PersonalTxn,
+} from '@waves/core';
+
+import { useAuth } from '@/lib/auth';
+import { useSync } from '@/sync';
+
+/** Today as YYYY-MM-DD. Call outside render (an effect or a lazy initialiser);
+ *  a bare `new Date()` in render trips the React Compiler lint. */
+export function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export interface PersonalLedger {
+  readonly txns: readonly PersonalTxn[];
+  readonly recurrings: readonly PersonalRecurring[];
+  readonly loans: readonly PersonalLoan[];
+  readonly budgets: readonly PersonalBudget[];
+}
+
+const EMPTY: PersonalLedger = { txns: [], recurrings: [], loans: [], budgets: [] };
+
+/**
+ * The whole ledger, decoded by kind and read local-first. Txns come back newest
+ * first. Empty (not an error) when signed out — personal finance is per-account.
+ */
+export function usePersonalLedger(): PersonalLedger {
+  const { mirror, queue } = useSync();
+  const { session } = useAuth();
+  const ownerId = session?.user?.id ?? '';
+
+  return useMemo(() => {
+    if (!ownerId) return EMPTY;
+    const records = materialisePersonalRecords(mirror, queue, { ownerId });
+    const txns: PersonalTxn[] = [];
+    const recurrings: PersonalRecurring[] = [];
+    const loans: PersonalLoan[] = [];
+    const budgets: PersonalBudget[] = [];
+    for (const record of records) {
+      switch (record.record_kind) {
+        case 'txn':
+          txns.push(decodeTxn(record.id, record.data));
+          break;
+        case 'recurring':
+          recurrings.push(decodeRecurring(record.id, record.data));
+          break;
+        case 'loan':
+          loans.push(decodeLoan(record.id, record.data));
+          break;
+        case 'budget':
+          budgets.push(decodeBudget(record.id, record.data));
+          break;
+        default:
+          break;
+      }
+    }
+    txns.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+    return { txns, recurrings, loans, budgets };
+  }, [mirror, queue, ownerId]);
+}
+
+export interface UpsertPersonalInput {
+  /** Omit to create (a fresh id is minted); pass to edit an existing record. */
+  readonly recordId?: string;
+  readonly recordKind: PersonalRecordKind;
+  readonly data: Record<string, unknown>;
+}
+
+/**
+ * Create or edit one personal-finance record. One upsert covers every kind — the
+ * caller supplies `recordKind` and the encoded `data` (see the `encode*` helpers
+ * in core). Returns the record id, minted here on a create.
+ */
+export function useUpsertPersonalRecord() {
+  const { mutate } = useSync();
+  const { session } = useAuth();
+  return useMutation({
+    mutationFn: async (input: UpsertPersonalInput): Promise<string> => {
+      const ownerId = session?.user?.id;
+      if (!ownerId) throw new Error('Sign in first');
+      const recordId = input.recordId ?? randomUUID();
+      await mutate(MutationKind.PersonalUpsert, personalScope(ownerId), {
+        recordId,
+        recordKind: input.recordKind,
+        data: input.data,
+      });
+      return recordId;
+    },
+  });
+}
+
+/** Soft-delete one personal-finance record (the tombstone rides the pull). */
+export function useDeletePersonalRecord() {
+  const { mutate } = useSync();
+  const { session } = useAuth();
+  return useMutation({
+    mutationFn: async (recordId: string): Promise<string> => {
+      const ownerId = session?.user?.id;
+      if (!ownerId) throw new Error('Sign in first');
+      await mutate(MutationKind.PersonalDelete, personalScope(ownerId), { recordId });
+      return recordId;
+    },
+  });
+}
+
+/**
+ * Post every occurrence an auto-posting recurring rule owes up to `today`, and
+ * advance each rule's `nextDate`. Idempotent: an occurrence whose txn already
+ * exists (matched by rule id + date) is skipped, so running this on every open
+ * never double-posts. Manual (non-auto) rules are left for the user to confirm.
+ * Returns how many txns were posted. Call from an effect, not render.
+ */
+export async function postDueRecurring(
+  ledger: PersonalLedger,
+  today: string,
+  upsert: (input: UpsertPersonalInput) => Promise<string>,
+): Promise<number> {
+  let posted = 0;
+  for (const rule of ledger.recurrings) {
+    if (!rule.autoPost || !rule.active) continue;
+    const { dates, nextDate } = recurringCatchUp(rule, today);
+    if (dates.length === 0) continue;
+    for (const date of dates) {
+      const already = ledger.txns.some((txn) => txn.recurringId === rule.id && txn.date === date);
+      if (already) continue;
+      await upsert({
+        recordKind: 'txn',
+        data: encodeTxn({
+          kind: rule.txnKind,
+          amount: rule.amount,
+          currency: rule.currency,
+          category: rule.category,
+          note: rule.note,
+          date,
+          loanId: null,
+          recurringId: rule.id,
+        }),
+      });
+      posted += 1;
+    }
+    if (nextDate !== rule.nextDate) {
+      await upsert({
+        recordId: rule.id,
+        recordKind: 'recurring',
+        data: encodeRecurring({ ...rule, nextDate }),
+      });
+    }
+  }
+  return posted;
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2224,6 +2224,80 @@ export interface UiStrings {
     body: string;
     action: string;
   };
+  /** The private personal-finance ledger (A48): the "Me" tab and its screens —
+   *  solo expenses/income, recurring rules, loans and monthly budgets. */
+  personal: {
+    tab: string;
+    title: string;
+    subtitle: string;
+    thisMonth: string;
+    income: string;
+    expenses: string;
+    net: string;
+    add: string;
+    addExpense: string;
+    addIncome: string;
+    amount: string;
+    note: string;
+    notePlaceholder: string;
+    date: string;
+    category: string;
+    save: string;
+    recent: string;
+    seeAll: string;
+    empty: string;
+    transactions: string;
+    expense: string;
+    incomeKind: string;
+    recurring: string;
+    recurringSub: string;
+    addRecurring: string;
+    editRecurring: string;
+    repeats: string;
+    weekly: string;
+    monthly: string;
+    yearly: string;
+    every: string;
+    nextDue: string;
+    endDate: string;
+    noEnd: string;
+    autoPost: string;
+    autoPostHint: string;
+    active: string;
+    paused: string;
+    due: string;
+    postNow: string;
+    noRecurring: string;
+    loans: string;
+    loansSub: string;
+    addLoan: string;
+    editLoan: string;
+    borrowed: string;
+    lent: string;
+    counterpart: string;
+    counterpartPlaceholder: string;
+    principal: string;
+    outstanding: string;
+    recordPayment: string;
+    closeLoan: string;
+    reopenLoan: string;
+    paidOff: string;
+    closed: string;
+    noLoans: string;
+    budgets: string;
+    budgetsSub: string;
+    addBudget: string;
+    editBudget: string;
+    overall: string;
+    monthlyLimit: string;
+    spent: string;
+    left: string;
+    over: string;
+    noBudgets: string;
+    justMe: string;
+    justMeHint: string;
+    deleteConfirm: string;
+  };
 }
 
 const en: UiStrings = {
@@ -4130,6 +4204,78 @@ const en: UiStrings = {
     title: 'Something went wrong',
     body: 'That screen hit an error. Nothing you saved is lost — go back and try again.',
     action: 'Back to home',
+  },
+  personal: {
+    tab: 'Me',
+    title: 'Personal',
+    subtitle: 'Your own money — private to you.',
+    thisMonth: 'This month',
+    income: 'Income',
+    expenses: 'Expenses',
+    net: 'Net',
+    add: 'Add',
+    addExpense: 'Add expense',
+    addIncome: 'Add income',
+    amount: 'Amount',
+    note: 'Note',
+    notePlaceholder: 'What was it for?',
+    date: 'Date',
+    category: 'Category',
+    save: 'Save',
+    recent: 'Recent',
+    seeAll: 'See all',
+    empty: 'Nothing yet. Add your first entry.',
+    transactions: 'Transactions',
+    expense: 'Expense',
+    incomeKind: 'Income',
+    recurring: 'Recurring',
+    recurringSub: 'Bills and income that repeat.',
+    addRecurring: 'Add recurring',
+    editRecurring: 'Edit recurring',
+    repeats: 'Repeats',
+    weekly: 'Weekly',
+    monthly: 'Monthly',
+    yearly: 'Yearly',
+    every: 'Every',
+    nextDue: 'Next',
+    endDate: 'Ends',
+    noEnd: 'No end',
+    autoPost: 'Add automatically',
+    autoPostHint: 'Post the entry on its own when due. Off just reminds you.',
+    active: 'Active',
+    paused: 'Paused',
+    due: 'Due',
+    postNow: 'Add now',
+    noRecurring: 'No recurring items yet.',
+    loans: 'Loans',
+    loansSub: 'Money you owe or are owed.',
+    addLoan: 'Add loan',
+    editLoan: 'Edit loan',
+    borrowed: 'I borrowed',
+    lent: 'I lent',
+    counterpart: 'With',
+    counterpartPlaceholder: 'A name — a friend, a bank, anyone',
+    principal: 'Amount',
+    outstanding: 'Outstanding',
+    recordPayment: 'Record payment',
+    closeLoan: 'Close',
+    reopenLoan: 'Reopen',
+    paidOff: 'Paid off',
+    closed: 'Closed',
+    noLoans: 'No loans yet.',
+    budgets: 'Budgets',
+    budgetsSub: 'Monthly caps by category.',
+    addBudget: 'Add budget',
+    editBudget: 'Edit budget',
+    overall: 'Overall',
+    monthlyLimit: 'Monthly limit',
+    spent: 'Spent',
+    left: 'left',
+    over: 'over',
+    noBudgets: 'No budgets yet.',
+    justMe: 'Just me',
+    justMeHint: 'A private entry in your own ledger — not shared with anyone.',
+    deleteConfirm: 'Delete this entry? This cannot be undone.',
   },
 };
 
@@ -6132,6 +6278,78 @@ const ta: UiStrings = {
     body: 'அந்தத் திரையில் பிழை ஏற்பட்டது. நீங்கள் சேமித்தது எதுவும் இழக்கப்படவில்லை — திரும்பிச் சென்று மீண்டும் முயலுங்கள்.',
     action: 'முகப்புக்குத் திரும்பு',
   },
+  personal: {
+    tab: 'நான்',
+    title: 'தனிப்பட்டது',
+    subtitle: 'உங்கள் சொந்தப் பணம் — உங்களுக்கு மட்டும் தனிப்பட்டது.',
+    thisMonth: 'இந்த மாதம்',
+    income: 'வருமானம்',
+    expenses: 'செலவுகள்',
+    net: 'நிகரம்',
+    add: 'சேர்',
+    addExpense: 'செலவைச் சேர்',
+    addIncome: 'வருமானத்தைச் சேர்',
+    amount: 'தொகை',
+    note: 'குறிப்பு',
+    notePlaceholder: 'எதற்காக?',
+    date: 'தேதி',
+    category: 'வகை',
+    save: 'சேமி',
+    recent: 'சமீபத்தியவை',
+    seeAll: 'அனைத்தையும் காண்',
+    empty: 'இன்னும் எதுவும் இல்லை. முதல் பதிவைச் சேருங்கள்.',
+    transactions: 'பரிவர்த்தனைகள்',
+    expense: 'செலவு',
+    incomeKind: 'வருமானம்',
+    recurring: 'மீண்டும் வருபவை',
+    recurringSub: 'மீண்டும் வரும் பில்கள், வருமானம்.',
+    addRecurring: 'மீண்டும் வருவதைச் சேர்',
+    editRecurring: 'மீண்டும் வருவதைத் திருத்து',
+    repeats: 'திரும்பும்',
+    weekly: 'வாராந்திரம்',
+    monthly: 'மாதந்தோறும்',
+    yearly: 'ஆண்டுதோறும்',
+    every: 'ஒவ்வொரு',
+    nextDue: 'அடுத்தது',
+    endDate: 'முடிவு',
+    noEnd: 'முடிவு இல்லை',
+    autoPost: 'தானாகச் சேர்',
+    autoPostHint: 'நேரம் வரும்போது பதிவைத் தானாகச் சேர்க்கும். இல்லையெனில் நினைவூட்டும்.',
+    active: 'செயலில்',
+    paused: 'இடைநிறுத்தம்',
+    due: 'நிலுவை',
+    postNow: 'இப்போது சேர்',
+    noRecurring: 'மீண்டும் வரும் பதிவுகள் இல்லை.',
+    loans: 'கடன்கள்',
+    loansSub: 'நீங்கள் தர வேண்டியது அல்லது வர வேண்டியது.',
+    addLoan: 'கடனைச் சேர்',
+    editLoan: 'கடனைத் திருத்து',
+    borrowed: 'நான் வாங்கினேன்',
+    lent: 'நான் கொடுத்தேன்',
+    counterpart: 'யாருடன்',
+    counterpartPlaceholder: 'ஒரு பெயர் — நண்பர், வங்கி, யாரும்',
+    principal: 'தொகை',
+    outstanding: 'நிலுவைத் தொகை',
+    recordPayment: 'கட்டணத்தைப் பதிவு செய்',
+    closeLoan: 'மூடு',
+    reopenLoan: 'மீண்டும் திற',
+    paidOff: 'அடைக்கப்பட்டது',
+    closed: 'மூடப்பட்டது',
+    noLoans: 'கடன்கள் இல்லை.',
+    budgets: 'பட்ஜெட்டுகள்',
+    budgetsSub: 'வகை வாரியான மாதவரம்பு.',
+    addBudget: 'பட்ஜெட்டைச் சேர்',
+    editBudget: 'பட்ஜெட்டைத் திருத்து',
+    overall: 'மொத்தம்',
+    monthlyLimit: 'மாத வரம்பு',
+    spent: 'செலவழித்தது',
+    left: 'மீதம்',
+    over: 'அதிகம்',
+    noBudgets: 'பட்ஜெட்டுகள் இல்லை.',
+    justMe: 'எனக்கு மட்டும்',
+    justMeHint: 'உங்கள் சொந்தக் கணக்கில் தனிப்பட்ட பதிவு — யாருடனும் பகிரப்படாது.',
+    deleteConfirm: 'இந்தப் பதிவை நீக்கவா? இதை மீட்க முடியாது.',
+  },
 };
 
 const hi: UiStrings = {
@@ -8043,6 +8261,78 @@ const hi: UiStrings = {
     title: 'कुछ गड़बड़ हो गई',
     body: 'उस स्क्रीन में कोई त्रुटि आ गई। आपका सहेजा हुआ कुछ भी नहीं खोया — वापस जाकर फिर कोशिश करें।',
     action: 'होम पर वापस',
+  },
+  personal: {
+    tab: 'मैं',
+    title: 'निजी',
+    subtitle: 'आपका अपना पैसा — सिर्फ़ आपके लिए निजी।',
+    thisMonth: 'इस महीने',
+    income: 'आय',
+    expenses: 'खर्च',
+    net: 'शुद्ध',
+    add: 'जोड़ें',
+    addExpense: 'खर्च जोड़ें',
+    addIncome: 'आय जोड़ें',
+    amount: 'राशि',
+    note: 'टिप्पणी',
+    notePlaceholder: 'किसके लिए था?',
+    date: 'तारीख़',
+    category: 'श्रेणी',
+    save: 'सहेजें',
+    recent: 'हाल के',
+    seeAll: 'सभी देखें',
+    empty: 'अभी कुछ नहीं। अपनी पहली प्रविष्टि जोड़ें।',
+    transactions: 'लेन-देन',
+    expense: 'खर्च',
+    incomeKind: 'आय',
+    recurring: 'आवर्ती',
+    recurringSub: 'दोहराए जाने वाले बिल और आय।',
+    addRecurring: 'आवर्ती जोड़ें',
+    editRecurring: 'आवर्ती संपादित करें',
+    repeats: 'दोहराव',
+    weekly: 'साप्ताहिक',
+    monthly: 'मासिक',
+    yearly: 'वार्षिक',
+    every: 'हर',
+    nextDue: 'अगला',
+    endDate: 'समाप्ति',
+    noEnd: 'कोई अंत नहीं',
+    autoPost: 'अपने आप जोड़ें',
+    autoPostHint: 'देय होने पर प्रविष्टि अपने आप जुड़ेगी। बंद रहने पर सिर्फ़ याद दिलाएगा।',
+    active: 'सक्रिय',
+    paused: 'रुका हुआ',
+    due: 'देय',
+    postNow: 'अभी जोड़ें',
+    noRecurring: 'अभी कोई आवर्ती मद नहीं।',
+    loans: 'ऋण',
+    loansSub: 'जो आप देते हैं या आपको मिलना है।',
+    addLoan: 'ऋण जोड़ें',
+    editLoan: 'ऋण संपादित करें',
+    borrowed: 'मैंने उधार लिया',
+    lent: 'मैंने उधार दिया',
+    counterpart: 'किसके साथ',
+    counterpartPlaceholder: 'एक नाम — दोस्त, बैंक, कोई भी',
+    principal: 'राशि',
+    outstanding: 'बकाया',
+    recordPayment: 'भुगतान दर्ज करें',
+    closeLoan: 'बंद करें',
+    reopenLoan: 'फिर खोलें',
+    paidOff: 'चुका दिया',
+    closed: 'बंद',
+    noLoans: 'अभी कोई ऋण नहीं।',
+    budgets: 'बजट',
+    budgetsSub: 'श्रेणी के अनुसार मासिक सीमाएँ।',
+    addBudget: 'बजट जोड़ें',
+    editBudget: 'बजट संपादित करें',
+    overall: 'कुल',
+    monthlyLimit: 'मासिक सीमा',
+    spent: 'ख़र्च',
+    left: 'बचा',
+    over: 'अधिक',
+    noBudgets: 'अभी कोई बजट नहीं।',
+    justMe: 'सिर्फ़ मैं',
+    justMeHint: 'आपके अपने खाते में निजी प्रविष्टि — किसी के साथ साझा नहीं।',
+    deleteConfirm: 'यह प्रविष्टि हटाएँ? इसे वापस नहीं किया जा सकता।',
   },
 };
 
@@ -10168,6 +10458,78 @@ const ar: UiStrings = {
     title: 'حدث خطأ ما',
     body: 'واجهت تلك الشاشة خطأ. لم يُفقد أي شيء حفظته — ارجع وحاول مرة أخرى.',
     action: 'العودة إلى الرئيسية',
+  },
+  personal: {
+    tab: 'أنا',
+    title: 'الشخصي',
+    subtitle: 'أموالك الخاصة — خاصة بك وحدك.',
+    thisMonth: 'هذا الشهر',
+    income: 'الدخل',
+    expenses: 'المصروفات',
+    net: 'الصافي',
+    add: 'إضافة',
+    addExpense: 'إضافة مصروف',
+    addIncome: 'إضافة دخل',
+    amount: 'المبلغ',
+    note: 'ملاحظة',
+    notePlaceholder: 'لماذا كان؟',
+    date: 'التاريخ',
+    category: 'الفئة',
+    save: 'حفظ',
+    recent: 'الأخيرة',
+    seeAll: 'عرض الكل',
+    empty: 'لا شيء بعد. أضف أول إدخال.',
+    transactions: 'المعاملات',
+    expense: 'مصروف',
+    incomeKind: 'دخل',
+    recurring: 'متكرر',
+    recurringSub: 'فواتير ودخل يتكرران.',
+    addRecurring: 'إضافة متكرر',
+    editRecurring: 'تعديل المتكرر',
+    repeats: 'يتكرر',
+    weekly: 'أسبوعياً',
+    monthly: 'شهرياً',
+    yearly: 'سنوياً',
+    every: 'كل',
+    nextDue: 'التالي',
+    endDate: 'ينتهي',
+    noEnd: 'بلا نهاية',
+    autoPost: 'إضافة تلقائية',
+    autoPostHint: 'يضيف الإدخال تلقائياً عند استحقاقه. عند الإيقاف يذكّرك فقط.',
+    active: 'نشط',
+    paused: 'متوقف',
+    due: 'مستحق',
+    postNow: 'أضف الآن',
+    noRecurring: 'لا عناصر متكررة بعد.',
+    loans: 'القروض',
+    loansSub: 'أموال تدين بها أو مستحقة لك.',
+    addLoan: 'إضافة قرض',
+    editLoan: 'تعديل القرض',
+    borrowed: 'اقترضت',
+    lent: 'أقرضت',
+    counterpart: 'مع',
+    counterpartPlaceholder: 'اسم — صديق، بنك، أي أحد',
+    principal: 'المبلغ',
+    outstanding: 'المتبقي',
+    recordPayment: 'تسجيل دفعة',
+    closeLoan: 'إغلاق',
+    reopenLoan: 'إعادة فتح',
+    paidOff: 'مسدَّد',
+    closed: 'مغلق',
+    noLoans: 'لا قروض بعد.',
+    budgets: 'الميزانيات',
+    budgetsSub: 'حدود شهرية حسب الفئة.',
+    addBudget: 'إضافة ميزانية',
+    editBudget: 'تعديل الميزانية',
+    overall: 'الإجمالي',
+    monthlyLimit: 'الحد الشهري',
+    spent: 'المنفَق',
+    left: 'متبقٍ',
+    over: 'تجاوز',
+    noBudgets: 'لا ميزانيات بعد.',
+    justMe: 'أنا فقط',
+    justMeHint: 'إدخال خاص في دفترك أنت — غير مشارَك مع أحد.',
+    deleteConfirm: 'حذف هذا الإدخال؟ لا يمكن التراجع.',
   },
 };
 

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2230,6 +2230,7 @@ export interface UiStrings {
     tab: string;
     title: string;
     subtitle: string;
+    entryMissing: string;
     thisMonth: string;
     income: string;
     expenses: string;
@@ -4209,6 +4210,7 @@ const en: UiStrings = {
     tab: 'Me',
     title: 'Personal',
     subtitle: 'Your own money — private to you.',
+    entryMissing: 'That entry is no longer here.',
     thisMonth: 'This month',
     income: 'Income',
     expenses: 'Expenses',
@@ -6282,6 +6284,7 @@ const ta: UiStrings = {
     tab: 'நான்',
     title: 'தனிப்பட்டது',
     subtitle: 'உங்கள் சொந்தப் பணம் — உங்களுக்கு மட்டும் தனிப்பட்டது.',
+    entryMissing: 'அந்தப் பதிவு இப்போது இல்லை.',
     thisMonth: 'இந்த மாதம்',
     income: 'வருமானம்',
     expenses: 'செலவுகள்',
@@ -8266,6 +8269,7 @@ const hi: UiStrings = {
     tab: 'मैं',
     title: 'निजी',
     subtitle: 'आपका अपना पैसा — सिर्फ़ आपके लिए निजी।',
+    entryMissing: 'वह प्रविष्टि अब यहाँ नहीं है।',
     thisMonth: 'इस महीने',
     income: 'आय',
     expenses: 'खर्च',
@@ -10463,6 +10467,7 @@ const ar: UiStrings = {
     tab: 'أنا',
     title: 'الشخصي',
     subtitle: 'أموالك الخاصة — خاصة بك وحدك.',
+    entryMissing: 'هذا القيد لم يعد موجودًا.',
     thisMonth: 'هذا الشهر',
     income: 'الدخل',
     expenses: 'المصروفات',

--- a/apps/mobile/src/lib/tabBar.ts
+++ b/apps/mobile/src/lib/tabBar.ts
@@ -43,7 +43,7 @@ export interface TabBarState {
   readonly activeKey: string;
 }
 
-export type TabBarRoute = '/' | '/friends' | '/activity' | '/inbox';
+export type TabBarRoute = '/' | '/friends' | '/activity' | '/inbox' | '/me';
 
 /**
  * The route a bottom-bar tap should navigate to, or null when the destination is
@@ -63,6 +63,8 @@ export function tabBarRouteForSelection(
       return '/friends';
     case 'activity':
       return '/activity';
+    case 'me':
+      return '/me';
     default:
       return '/';
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,5 +26,6 @@ export * from './version/index';
 export * from './billing/index';
 export * from './session/index';
 export * from './trip/index';
+export * from './personal/index';
 export * from './watch/index';
 export * from './export/index';

--- a/packages/core/src/personal/compute.ts
+++ b/packages/core/src/personal/compute.ts
@@ -1,0 +1,193 @@
+/**
+ * The sums the personal-finance ledger shows, and the date maths behind a
+ * recurring rule. All pure and side-effect free — `today` is passed in, never
+ * read from the clock here — so the whole thing is unit-testable without a
+ * device, which is the point of keeping it in core.
+ */
+
+import type { CurrencyCode } from '../money/currency';
+import type {
+  Cadence,
+  PersonalBudget,
+  PersonalLoan,
+  PersonalRecurring,
+  PersonalTxn,
+} from './types';
+
+// ─────────────────────────────────────────────────────── date helpers ──
+
+interface Ymd {
+  readonly y: number;
+  readonly m: number;
+  readonly d: number;
+}
+
+function parseYmd(date: string): Ymd | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) return null;
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  if (m < 1 || m > 12 || d < 1 || d > 31) return null;
+  return { y, m, d };
+}
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function fmtYmd(y: number, m: number, d: number): string {
+  return `${y}-${pad(m)}-${pad(d)}`;
+}
+
+/** Days in month `m` (1-12) of year `y`, leap years handled. */
+function daysInMonth(y: number, m: number): number {
+  return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
+/**
+ * `date` advanced by `interval` cadence units. Month/year steps clamp the day to
+ * the target month's length (Jan 31 + 1 month → Feb 28/29), so a rule anchored
+ * on the 31st never skips a short month. Weekly steps are exact 7-day hops.
+ */
+export function addToDate(date: string, cadence: Cadence, interval: number): string {
+  const p = parseYmd(date);
+  if (!p) return date;
+  const step = interval > 0 ? Math.floor(interval) : 1;
+
+  if (cadence === 'weekly') {
+    const t = new Date(Date.UTC(p.y, p.m - 1, p.d + 7 * step));
+    return fmtYmd(t.getUTCFullYear(), t.getUTCMonth() + 1, t.getUTCDate());
+  }
+  if (cadence === 'yearly') {
+    const y = p.y + step;
+    return fmtYmd(y, p.m, Math.min(p.d, daysInMonth(y, p.m)));
+  }
+  // monthly
+  const total = p.m - 1 + step;
+  const y = p.y + Math.floor(total / 12);
+  const m = (total % 12) + 1;
+  return fmtYmd(y, m, Math.min(p.d, daysInMonth(y, m)));
+}
+
+/** The YYYY-MM a date falls in. */
+export function monthKey(date: string): string {
+  return date.slice(0, 7);
+}
+
+// ────────────────────────────────────────────────────────── recurring ──
+
+/** Whether a rule is live and its next occurrence is on or before `today`. */
+export function isRecurringDue(rule: PersonalRecurring, today: string): boolean {
+  if (!rule.active) return false;
+  if (rule.endDate !== null && rule.nextDate > rule.endDate) return false;
+  return rule.nextDate <= today;
+}
+
+export interface RecurringCatchUp {
+  /** Every occurrence date from `nextDate` up to and including `today`. */
+  readonly dates: readonly string[];
+  /** Where the rule's `nextDate` should move to after these post. */
+  readonly nextDate: string;
+}
+
+/**
+ * Every occurrence a rule owes between its `nextDate` and `today` — more than
+ * one when the app has not been opened in a while — plus where `nextDate` lands
+ * afterwards. Capped so a far-past anchor can never mint an unbounded run.
+ */
+export function recurringCatchUp(
+  rule: PersonalRecurring,
+  today: string,
+  cap = 60,
+): RecurringCatchUp {
+  const dates: string[] = [];
+  let cursor = rule.nextDate;
+  let guard = 0;
+  while (cursor <= today && guard < cap) {
+    if (rule.endDate !== null && cursor > rule.endDate) break;
+    dates.push(cursor);
+    cursor = addToDate(cursor, rule.cadence, rule.interval);
+    guard += 1;
+  }
+  return { dates, nextDate: cursor };
+}
+
+// ─────────────────────────────────────────────────────────── summaries ──
+
+export interface MonthlySummary {
+  readonly income: bigint;
+  readonly expense: bigint;
+  /** income − expense; negative means you spent more than you took in. */
+  readonly net: bigint;
+}
+
+/** Income, expense and net for one month and currency. */
+export function monthlySummary(
+  txns: readonly PersonalTxn[],
+  month: string,
+  currency: CurrencyCode,
+): MonthlySummary {
+  let income = 0n;
+  let expense = 0n;
+  for (const txn of txns) {
+    if (txn.currency !== currency) continue;
+    if (monthKey(txn.date) !== month) continue;
+    if (txn.kind === 'income') income += txn.amount;
+    else expense += txn.amount;
+  }
+  return { income, expense, net: income - expense };
+}
+
+// ─────────────────────────────────────────────────────────────── loans ──
+
+/**
+ * What is still outstanding on a loan: the principal less every repayment linked
+ * to it (a txn carrying its `loanId`), floored at zero. A `borrowed` loan is
+ * repaid with expense txns, a `lent` one with income txns; either way the linked
+ * amounts reduce what remains, so the sum is over both.
+ */
+export function loanOutstanding(loan: PersonalLoan, txns: readonly PersonalTxn[]): bigint {
+  let paid = 0n;
+  for (const txn of txns) {
+    if (txn.loanId === loan.id) paid += txn.amount;
+  }
+  const remaining = loan.principal - paid;
+  return remaining > 0n ? remaining : 0n;
+}
+
+// ───────────────────────────────────────────────────────────── budgets ──
+
+export interface PersonalBudgetProgress {
+  readonly spent: bigint;
+  readonly limit: bigint;
+  /** limit − spent; negative means over budget. */
+  readonly remaining: bigint;
+  /** 0–1+ share of the cap used (0 when the cap is 0). */
+  readonly ratio: number;
+}
+
+/**
+ * Spend against one budget for a month: everyday expense txns in the budget's
+ * currency, in that month, matching its category (or all categories for an
+ * overall budget). Loan repayments are excluded — a budget is about spending,
+ * not paying down a debt.
+ */
+export function personalBudgetProgress(
+  budget: PersonalBudget,
+  txns: readonly PersonalTxn[],
+  month: string,
+): PersonalBudgetProgress {
+  let spent = 0n;
+  for (const txn of txns) {
+    if (txn.kind !== 'expense') continue;
+    if (txn.loanId !== null) continue;
+    if (txn.currency !== budget.currency) continue;
+    if (monthKey(txn.date) !== month) continue;
+    if (budget.category !== null && txn.category !== budget.category) continue;
+    spent += txn.amount;
+  }
+  const remaining = budget.limit - spent;
+  const ratio = budget.limit > 0n ? Number(spent) / Number(budget.limit) : 0;
+  return { spent, limit: budget.limit, remaining, ratio };
+}

--- a/packages/core/src/personal/compute.ts
+++ b/packages/core/src/personal/compute.ts
@@ -113,6 +113,29 @@ export function recurringCatchUp(
   return { dates, nextDate: cursor };
 }
 
+/**
+ * A stable record id for one occurrence of a recurring rule, derived from the
+ * rule and the occurrence date. Deterministic on purpose: whichever path posts
+ * an occurrence — the auto catch-up on open, or a manual "add now", even racing
+ * — writes the *same* id, so the upsert-by-id collapses them to one row instead
+ * of minting two UUIDs for the same date. Two FNV-1a passes fill a uuid-shaped
+ * 32 hex string; Postgres's `uuid` accepts the grouping and a per-user ledger
+ * makes a collision vanishingly unlikely.
+ */
+export function recurringOccurrenceId(ruleId: string, date: string): string {
+  const seed = `${ruleId}:${date}`;
+  const pass = (offset: number): string => {
+    let hash = offset >>> 0;
+    for (let i = 0; i < seed.length; i += 1) {
+      hash ^= seed.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash.toString(16).padStart(8, '0');
+  };
+  const hex = pass(0x811c9dc5) + pass(0x7ee3a5b1) + pass(0x243f6a88) + pass(0x9e3779b9);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
 // ─────────────────────────────────────────────────────────── summaries ──
 
 export interface MonthlySummary {

--- a/packages/core/src/personal/index.ts
+++ b/packages/core/src/personal/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './compute';

--- a/packages/core/src/personal/types.ts
+++ b/packages/core/src/personal/types.ts
@@ -1,0 +1,208 @@
+/**
+ * The private personal-finance ledger (A48): the shapes the app works in, and
+ * the codecs between them and the opaque `data` blob a `personal_records` row
+ * carries on the wire.
+ *
+ * Four record kinds share one table (see PersonalRecord in the schema): a `txn`
+ * (an expense or income line), a `recurring` rule that mints txns, a `loan` owed
+ * either way, and a monthly `budget` cap. Money is a `bigint` of minor units in
+ * the app and a decimal string on the wire, like everywhere else; the decoders
+ * are defensive so a malformed blob degrades to a sane default rather than
+ * throwing in a list render.
+ */
+
+import type { CurrencyCode } from '../money/currency';
+import { parseAmount, serialiseAmount, type PersonalRecordKind } from '../sync/protocol';
+
+export type { PersonalRecordKind };
+
+/** An expense leaves the wallet; income comes into it. */
+export type TxnKind = 'expense' | 'income';
+/** How often a recurring rule fires. Interval multiplies it ("every 2 weeks"). */
+export type Cadence = 'weekly' | 'monthly' | 'yearly';
+/** `borrowed` = money you owe; `lent` = money owed to you. */
+export type LoanDirection = 'borrowed' | 'lent';
+
+export interface PersonalTxn {
+  readonly id: string;
+  readonly kind: TxnKind;
+  readonly amount: bigint;
+  readonly currency: CurrencyCode;
+  readonly category: string | null;
+  readonly note: string | null;
+  /** YYYY-MM-DD. */
+  readonly date: string;
+  /** Set when this txn is a repayment on a loan; links the two. */
+  readonly loanId: string | null;
+  /** Set when a recurring rule minted this txn (idempotency: rule id + date). */
+  readonly recurringId: string | null;
+}
+
+export interface PersonalRecurring {
+  readonly id: string;
+  readonly txnKind: TxnKind;
+  readonly amount: bigint;
+  readonly currency: CurrencyCode;
+  readonly category: string | null;
+  readonly note: string | null;
+  readonly cadence: Cadence;
+  /** Every `interval` cadence units (1 = every week/month/year). */
+  readonly interval: number;
+  /** First occurrence. */
+  readonly anchorDate: string;
+  /** The next date this rule is due to fire. Advanced as occurrences post. */
+  readonly nextDate: string;
+  /** Stop firing after this date; null runs forever. */
+  readonly endDate: string | null;
+  /** True → mint the txn automatically when due; false → only remind. */
+  readonly autoPost: boolean;
+  readonly active: boolean;
+}
+
+export interface PersonalLoan {
+  readonly id: string;
+  readonly direction: LoanDirection;
+  /** Who the loan is with — a free-text name, not a member id. */
+  readonly counterpart: string;
+  readonly principal: bigint;
+  readonly currency: CurrencyCode;
+  readonly note: string | null;
+  readonly startDate: string;
+  readonly status: 'active' | 'closed';
+}
+
+export interface PersonalBudget {
+  readonly id: string;
+  /** The category this caps, or null for an overall monthly cap. */
+  readonly category: string | null;
+  readonly limit: bigint;
+  readonly currency: CurrencyCode;
+}
+
+// ───────────────────────────────────────────────── defensive readers ──
+
+const str = (v: unknown): string | null => (typeof v === 'string' && v.length > 0 ? v : null);
+const bool = (v: unknown): boolean => v === true;
+const int = (v: unknown, fallback: number): number =>
+  typeof v === 'number' && Number.isFinite(v) && v > 0 ? Math.floor(v) : fallback;
+const money = (v: unknown): bigint => {
+  try {
+    return parseAmount(String(v ?? '0'));
+  } catch {
+    return 0n;
+  }
+};
+const oneOf = <T extends string>(v: unknown, allowed: readonly T[], fallback: T): T =>
+  typeof v === 'string' && (allowed as readonly string[]).includes(v) ? (v as T) : fallback;
+
+// ─────────────────────────────────────────────────────────── decoders ──
+
+export function decodeTxn(id: string, data: Record<string, unknown>): PersonalTxn {
+  return {
+    id,
+    kind: oneOf(data.kind, ['expense', 'income'] as const, 'expense'),
+    amount: money(data.amount),
+    currency: str(data.currency) ?? 'INR',
+    category: str(data.category),
+    note: str(data.note),
+    date: str(data.date) ?? '',
+    loanId: str(data.loanId),
+    recurringId: str(data.recurringId),
+  };
+}
+
+export function decodeRecurring(id: string, data: Record<string, unknown>): PersonalRecurring {
+  const anchor = str(data.anchorDate) ?? '';
+  return {
+    id,
+    txnKind: oneOf(data.txnKind, ['expense', 'income'] as const, 'expense'),
+    amount: money(data.amount),
+    currency: str(data.currency) ?? 'INR',
+    category: str(data.category),
+    note: str(data.note),
+    cadence: oneOf(data.cadence, ['weekly', 'monthly', 'yearly'] as const, 'monthly'),
+    interval: int(data.interval, 1),
+    anchorDate: anchor,
+    nextDate: str(data.nextDate) ?? anchor,
+    endDate: str(data.endDate),
+    autoPost: bool(data.autoPost),
+    active: data.active === undefined ? true : bool(data.active),
+  };
+}
+
+export function decodeLoan(id: string, data: Record<string, unknown>): PersonalLoan {
+  return {
+    id,
+    direction: oneOf(data.direction, ['borrowed', 'lent'] as const, 'borrowed'),
+    counterpart: str(data.counterpart) ?? '',
+    principal: money(data.principal),
+    currency: str(data.currency) ?? 'INR',
+    note: str(data.note),
+    startDate: str(data.startDate) ?? '',
+    status: oneOf(data.status, ['active', 'closed'] as const, 'active'),
+  };
+}
+
+export function decodeBudget(id: string, data: Record<string, unknown>): PersonalBudget {
+  return {
+    id,
+    category: str(data.category),
+    limit: money(data.limit),
+    currency: str(data.currency) ?? 'INR',
+  };
+}
+
+// ─────────────────────────────────────────────────────────── encoders ──
+// The `data` blob for an upsert payload. Money is serialised to a decimal
+// string; nulls are kept explicit so an edit that clears a field really clears
+// it in the mirror overlay.
+
+export function encodeTxn(txn: Omit<PersonalTxn, 'id'>): Record<string, unknown> {
+  return {
+    kind: txn.kind,
+    amount: serialiseAmount(txn.amount),
+    currency: txn.currency,
+    category: txn.category,
+    note: txn.note,
+    date: txn.date,
+    loanId: txn.loanId,
+    recurringId: txn.recurringId,
+  };
+}
+
+export function encodeRecurring(rule: Omit<PersonalRecurring, 'id'>): Record<string, unknown> {
+  return {
+    txnKind: rule.txnKind,
+    amount: serialiseAmount(rule.amount),
+    currency: rule.currency,
+    category: rule.category,
+    note: rule.note,
+    cadence: rule.cadence,
+    interval: rule.interval,
+    anchorDate: rule.anchorDate,
+    nextDate: rule.nextDate,
+    endDate: rule.endDate,
+    autoPost: rule.autoPost,
+    active: rule.active,
+  };
+}
+
+export function encodeLoan(loan: Omit<PersonalLoan, 'id'>): Record<string, unknown> {
+  return {
+    direction: loan.direction,
+    counterpart: loan.counterpart,
+    principal: serialiseAmount(loan.principal),
+    currency: loan.currency,
+    note: loan.note,
+    startDate: loan.startDate,
+    status: loan.status,
+  };
+}
+
+export function encodeBudget(budget: Omit<PersonalBudget, 'id'>): Record<string, unknown> {
+  return {
+    category: budget.category,
+    limit: serialiseAmount(budget.limit),
+    currency: budget.currency,
+  };
+}

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -20,7 +20,7 @@ import type { MemberId, SplitParams, SplitType } from '../split/types';
 import type { CurrencyCode } from '../money/currency';
 import type { ExpenseSnapshot } from '../balances/types';
 
-import { categoryTagsScope, parseAmount, SyncTable } from './protocol';
+import { categoryTagsScope, parseAmount, personalScope, SyncTable } from './protocol';
 import type { CategoryMeta } from '../category/catalog';
 import type {
   CaptureAssignPayload,
@@ -31,6 +31,9 @@ import type {
   ExpenseLocation,
   MemberBudgetSetPayload,
   MutationEnvelope,
+  PersonalDeletePayload,
+  PersonalRecordKind,
+  PersonalUpsertPayload,
   PlanItemCreatePayload,
   PlanItemDeletePayload,
   PlanItemUpdatePayload,
@@ -68,6 +71,7 @@ const TABLES: readonly SyncTable[] = [
   SyncTable.ExpenseAttachments,
   SyncTable.ExpenseComments,
   SyncTable.ExpenseImageEvents,
+  SyncTable.PersonalRecords,
 ];
 
 export function emptyMirror(): MirrorState {
@@ -852,6 +856,74 @@ export function materialiseCategoryTags(
   }
 
   return [...byId.values()].filter((tag) => tag.deleted_at === null);
+}
+
+// ─────────────────────────────────────── the personal-finance ledger ──
+// Personal scope (A48), exactly like captures/tags but under `personalScope`.
+// One generic row per record; `record_kind` says which of the four it is and
+// `data` carries that kind's fields (money as minor-unit strings). A record made
+// offline is only in the queue, so the same server+pending overlay applies.
+
+export interface MirrorPersonalRecord extends MirrorRow {
+  readonly id: string;
+  readonly owner_user_id: string;
+  readonly record_kind: PersonalRecordKind;
+  readonly data: Record<string, unknown>;
+  readonly created_at: string;
+  readonly deleted_at: string | null;
+  readonly pending?: boolean;
+}
+
+/**
+ * The personal-finance records to read: the server's rows for this owner with
+ * the queue replayed on top. `ownerId` is the personal scope; every queued
+ * personal mutation carries `personalScope(ownerId)` in the envelope's group
+ * slot. Deleted rows are dropped — the caller sees only live records.
+ */
+export function materialisePersonalRecords(
+  state: MirrorState,
+  queue: readonly QueuedMutation[],
+  options: { readonly ownerId: string },
+): MirrorPersonalRecord[] {
+  const scope = personalScope(options.ownerId);
+  const byId = new Map<string, MirrorPersonalRecord>();
+  for (const row of rowsFor(state, SyncTable.PersonalRecords) as MirrorPersonalRecord[]) {
+    if (row.owner_user_id !== options.ownerId) continue;
+    byId.set(row.id, row);
+  }
+
+  for (const mutation of [...queue].sort((a, b) => a.seq - b.seq)) {
+    if (mutation.groupId !== scope) continue;
+
+    switch (mutation.kind) {
+      case 'personal.upsert': {
+        const payload = mutation.payload as PersonalUpsertPayload;
+        const existing = byId.get(payload.recordId);
+        byId.set(payload.recordId, {
+          id: payload.recordId,
+          owner_user_id: options.ownerId,
+          record_kind: payload.recordKind,
+          data: { ...payload.data },
+          created_at: existing?.created_at ?? mutation.clientCreatedAt,
+          deleted_at: existing?.deleted_at ?? null,
+          pending: true,
+        });
+        break;
+      }
+      case 'personal.delete': {
+        const { recordId } = mutation.payload as PersonalDeletePayload;
+        const existing = byId.get(recordId);
+        if (existing) {
+          byId.set(recordId, { ...existing, deleted_at: mutation.clientCreatedAt, pending: true });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return [...byId.values()].filter((record) => record.deleted_at === null);
 }
 
 /**

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -54,6 +54,14 @@ export enum MutationKind {
   MemberBudgetClear = 'member_budget.clear',
   GroupBudgetSet = 'group_budget.set',
   CategoryBudgetSet = 'category_budget.set',
+  // Personal-scope kinds for the private personal-finance ledger (A48): solo
+  // expenses/income, recurring rules, loans and monthly budgets. Like captures
+  // they ride a personal scope, under their own suffixed cursor
+  // (`personalScope`). One generic upsert/delete pair covers all four record
+  // kinds; `recordKind` in the payload says which, and the `data` blob is opaque
+  // to the server, which only relays it. A delete is a soft tombstone.
+  PersonalUpsert = 'personal.upsert',
+  PersonalDelete = 'personal.delete',
 }
 
 export interface MutationEnvelope<K extends MutationKind = MutationKind, P = unknown> {
@@ -284,6 +292,27 @@ export interface CategoryBudgetSetPayload {
   readonly currency?: CurrencyCode | null;
 }
 
+/** The four kinds of row the personal-finance ledger holds (A48). */
+export type PersonalRecordKind = 'txn' | 'recurring' | 'loan' | 'budget';
+
+/**
+ * An upsert of one personal-finance record (A48). `recordId` is client-chosen
+ * and the idempotency key. `data` carries the record's fields shaped by
+ * `recordKind` — money fields are minor-unit decimal strings, like everywhere
+ * on the wire — and is opaque to the server, which stores and relays it without
+ * reading it (all summaries and balances are computed on the device).
+ */
+export interface PersonalUpsertPayload {
+  readonly recordId: string;
+  readonly recordKind: PersonalRecordKind;
+  readonly data: Readonly<Record<string, unknown>>;
+}
+
+/** Soft-deletes one personal-finance record; the tombstone rides the pull. */
+export interface PersonalDeletePayload {
+  readonly recordId: string;
+}
+
 export interface SyncRequest {
   readonly deviceId: string;
   readonly mutations: readonly MutationEnvelope[];
@@ -371,6 +400,10 @@ export enum SyncTable {
    * log RPC and the attachment RPCs, which stamp the actor from the session; a
    * `parties` row is RLS-filtered so a non-party never receives it. */
   ExpenseImageEvents = 'expense_image_events',
+  /** Personal scope (A48): the caller's own personal-finance ledger — solo
+   * expenses/income, recurring rules, loans and budgets. Read + write, one
+   * generic row per record, keyed by the owner's user id under `personalScope`. */
+  PersonalRecords = 'personal_records',
 }
 
 /**
@@ -390,6 +423,15 @@ export function ghostMergesScope(profileId: string): string {
  */
 export function categoryTagsScope(profileId: string): string {
   return `${profileId}:category_tags`;
+}
+
+/**
+ * The sync scope key for a user's personal-finance ledger (A48). Suffixed, so it
+ * keeps its own cursor apart from captures, ghost merges and the tag catalog.
+ * The edge and the client must agree on this string.
+ */
+export function personalScope(profileId: string): string {
+  return `${profileId}:personal`;
 }
 
 /** bigint ↔ string at the wire boundary; JSON has no integers this size. */

--- a/packages/core/test/personal.test.ts
+++ b/packages/core/test/personal.test.ts
@@ -15,6 +15,7 @@ import {
   monthlySummary,
   personalBudgetProgress,
   recurringCatchUp,
+  recurringOccurrenceId,
   type PersonalBudget,
   type PersonalLoan,
   type PersonalRecurring,
@@ -93,6 +94,24 @@ describe('recurringCatchUp', () => {
     expect(isRecurringDue(base, '2026-05-31')).toBe(false);
     expect(isRecurringDue({ ...base, active: false }, '2026-08-01')).toBe(false);
     expect(isRecurringDue({ ...base, endDate: '2026-05-01' }, '2026-08-01')).toBe(false);
+  });
+});
+
+describe('recurringOccurrenceId', () => {
+  it('is deterministic per rule and date, and a valid uuid shape', () => {
+    const a = recurringOccurrenceId('r1', '2026-08-01');
+    const b = recurringOccurrenceId('r1', '2026-08-01');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it('differs by date and by rule', () => {
+    expect(recurringOccurrenceId('r1', '2026-08-01')).not.toBe(
+      recurringOccurrenceId('r1', '2026-09-01'),
+    );
+    expect(recurringOccurrenceId('r1', '2026-08-01')).not.toBe(
+      recurringOccurrenceId('r2', '2026-08-01'),
+    );
   });
 });
 

--- a/packages/core/test/personal.test.ts
+++ b/packages/core/test/personal.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The personal-finance maths (A48). All of it is pure, so the sums the "Me" tab
+ * shows — a month's net, a loan's outstanding balance, a budget's remaining, and
+ * when a recurring rule is next due — are pinned here without a device.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  addToDate,
+  decodeTxn,
+  encodeTxn,
+  isRecurringDue,
+  loanOutstanding,
+  monthlySummary,
+  personalBudgetProgress,
+  recurringCatchUp,
+  type PersonalBudget,
+  type PersonalLoan,
+  type PersonalRecurring,
+  type PersonalTxn,
+} from '../src/personal/index.js';
+
+const txn = (over: Partial<PersonalTxn>): PersonalTxn => ({
+  id: over.id ?? crypto.randomUUID(),
+  kind: over.kind ?? 'expense',
+  amount: over.amount ?? 0n,
+  currency: over.currency ?? 'INR',
+  category: over.category ?? null,
+  note: over.note ?? null,
+  date: over.date ?? '2026-08-15',
+  loanId: over.loanId ?? null,
+  recurringId: over.recurringId ?? null,
+});
+
+describe('addToDate', () => {
+  it('hops exact weeks', () => {
+    expect(addToDate('2026-08-15', 'weekly', 1)).toBe('2026-08-22');
+    expect(addToDate('2026-08-28', 'weekly', 1)).toBe('2026-09-04');
+  });
+
+  it('clamps a month step to the shorter month', () => {
+    // Jan 31 + 1 month is Feb 28, not an invalid Feb 31 that rolls into March.
+    expect(addToDate('2026-01-31', 'monthly', 1)).toBe('2026-02-28');
+    expect(addToDate('2028-01-31', 'monthly', 1)).toBe('2028-02-29'); // leap year
+  });
+
+  it('rolls a month step across the year boundary', () => {
+    expect(addToDate('2026-12-10', 'monthly', 1)).toBe('2027-01-10');
+    expect(addToDate('2026-11-15', 'monthly', 3)).toBe('2027-02-15');
+  });
+
+  it('clamps a yearly step off Feb 29', () => {
+    expect(addToDate('2028-02-29', 'yearly', 1)).toBe('2029-02-28');
+  });
+});
+
+describe('recurringCatchUp', () => {
+  const base: PersonalRecurring = {
+    id: 'r1',
+    txnKind: 'expense',
+    amount: 50000n,
+    currency: 'INR',
+    category: null,
+    note: 'Phone',
+    cadence: 'monthly',
+    interval: 1,
+    anchorDate: '2026-06-01',
+    nextDate: '2026-06-01',
+    endDate: null,
+    autoPost: true,
+    active: true,
+  };
+
+  it('returns every missed occurrence up to today, then the new next date', () => {
+    const { dates, nextDate } = recurringCatchUp(base, '2026-08-15');
+    expect(dates).toEqual(['2026-06-01', '2026-07-01', '2026-08-01']);
+    expect(nextDate).toBe('2026-09-01');
+  });
+
+  it('stops at the end date', () => {
+    const { dates } = recurringCatchUp({ ...base, endDate: '2026-07-01' }, '2026-12-01');
+    expect(dates).toEqual(['2026-06-01', '2026-07-01']);
+  });
+
+  it('caps a far-past anchor rather than minting forever', () => {
+    const { dates } = recurringCatchUp({ ...base, cadence: 'weekly' }, '2030-01-01', 10);
+    expect(dates).toHaveLength(10);
+  });
+
+  it('isRecurringDue tracks active, end date and today', () => {
+    expect(isRecurringDue(base, '2026-06-01')).toBe(true);
+    expect(isRecurringDue(base, '2026-05-31')).toBe(false);
+    expect(isRecurringDue({ ...base, active: false }, '2026-08-01')).toBe(false);
+    expect(isRecurringDue({ ...base, endDate: '2026-05-01' }, '2026-08-01')).toBe(false);
+  });
+});
+
+describe('monthlySummary', () => {
+  it('nets income against expense within one month and currency', () => {
+    const txns = [
+      txn({ kind: 'income', amount: 100000n, date: '2026-08-01' }),
+      txn({ kind: 'expense', amount: 30000n, date: '2026-08-10' }),
+      txn({ kind: 'expense', amount: 20000n, date: '2026-08-20' }),
+      txn({ kind: 'expense', amount: 99999n, date: '2026-07-31' }), // other month
+      txn({ kind: 'expense', amount: 99999n, currency: 'USD', date: '2026-08-05' }), // other currency
+    ];
+    const s = monthlySummary(txns, '2026-08', 'INR');
+    expect(s.income).toBe(100000n);
+    expect(s.expense).toBe(50000n);
+    expect(s.net).toBe(50000n);
+  });
+});
+
+describe('loanOutstanding', () => {
+  const loan: PersonalLoan = {
+    id: 'L1',
+    direction: 'borrowed',
+    counterpart: 'Bank',
+    principal: 100000n,
+    currency: 'INR',
+    note: null,
+    startDate: '2026-01-01',
+    status: 'active',
+  };
+
+  it('is the principal less linked repayments, floored at zero', () => {
+    const txns = [
+      txn({ amount: 40000n, loanId: 'L1' }),
+      txn({ amount: 70000n, loanId: 'L1' }), // over-pays
+      txn({ amount: 99999n, loanId: 'other' }), // not this loan
+    ];
+    expect(loanOutstanding(loan, txns)).toBe(0n);
+    expect(loanOutstanding(loan, [txn({ amount: 25000n, loanId: 'L1' })])).toBe(75000n);
+  });
+});
+
+describe('personalBudgetProgress', () => {
+  const budget: PersonalBudget = { id: 'B1', category: 'food', limit: 50000n, currency: 'INR' };
+
+  it('counts matching-category expenses in the month, not income or loan repayments', () => {
+    const txns = [
+      txn({ kind: 'expense', category: 'food', amount: 20000n, date: '2026-08-02' }),
+      txn({ kind: 'expense', category: 'food', amount: 15000n, date: '2026-08-09' }),
+      txn({ kind: 'expense', category: 'travel', amount: 9999n, date: '2026-08-09' }), // other category
+      txn({ kind: 'income', category: 'food', amount: 9999n, date: '2026-08-09' }), // income
+      txn({ kind: 'expense', category: 'food', amount: 9999n, loanId: 'L1', date: '2026-08-09' }), // repayment
+      txn({ kind: 'expense', category: 'food', amount: 9999n, date: '2026-07-31' }), // other month
+    ];
+    const p = personalBudgetProgress(budget, txns, '2026-08');
+    expect(p.spent).toBe(35000n);
+    expect(p.remaining).toBe(15000n);
+  });
+
+  it('an overall budget (null category) counts every everyday expense', () => {
+    const overall: PersonalBudget = { id: 'B2', category: null, limit: 40000n, currency: 'INR' };
+    const txns = [
+      txn({ kind: 'expense', category: 'food', amount: 20000n, date: '2026-08-02' }),
+      txn({ kind: 'expense', category: 'travel', amount: 30000n, date: '2026-08-02' }),
+    ];
+    const p = personalBudgetProgress(overall, txns, '2026-08');
+    expect(p.spent).toBe(50000n);
+    expect(p.remaining).toBe(-10000n); // over budget
+  });
+});
+
+describe('txn codec', () => {
+  it('round-trips through the wire blob', () => {
+    const original = txn({
+      kind: 'income',
+      amount: 123456n,
+      currency: 'INR',
+      category: 'salary',
+      note: 'August pay',
+      date: '2026-08-01',
+      loanId: null,
+      recurringId: 'r9',
+    });
+    const decoded = decodeTxn(original.id, encodeTxn(original));
+    expect(decoded).toEqual(original);
+  });
+
+  it('decodes a malformed blob to safe defaults rather than throwing', () => {
+    const decoded = decodeTxn('x', { amount: 'not-a-number', kind: 'weird' });
+    expect(decoded.amount).toBe(0n);
+    expect(decoded.kind).toBe('expense');
+    expect(decoded.currency).toBe('INR');
+  });
+});

--- a/packages/db/prisma/migrations/20260828120000_personal_finance/migration.sql
+++ b/packages/db/prisma/migrations/20260828120000_personal_finance/migration.sql
@@ -1,0 +1,91 @@
+-- Personal finance (A48): a private, single-owner ledger — solo expenses and
+-- income, recurring rules, loans, and monthly budgets. None of it is shared, has
+-- members, or touches a group balance, so it does not go near the group expense
+-- machinery. It rides the offline mirror on a personal scope (like captures and
+-- the tag catalog): a per-owner `updated_seq`, owner-only RLS, soft delete.
+--
+-- One generic table holds all four record kinds. The server is only a relay for
+-- this data — every summary, loan balance and budget figure is computed on the
+-- device — so it never needs to read the shape of a record. Keeping it one table
+-- (a `record_kind` discriminator + a `data` json blob) keeps the sync surface
+-- tiny: one scope, one cursor, one pull, two mutation kinds.
+
+-- The per-owner cursor behind the `:personal` sync scope, stamped onto every
+-- personal_records row by the trigger below (the personal mirror of the group
+-- counter, exactly like captures_seq / category_tags_seq).
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS personal_seq bigint DEFAULT 0 NOT NULL;
+
+CREATE FUNCTION public.baaki_next_personal_seq(p_owner uuid) RETURNS bigint
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_seq bigint;
+BEGIN
+  UPDATE public.profiles
+     SET personal_seq = personal_seq + 1
+   WHERE id = p_owner
+   RETURNING personal_seq INTO v_seq;
+  RETURN COALESCE(v_seq, 0);
+END
+$$;
+
+CREATE FUNCTION public.baaki_stamp_personal_seq() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  NEW.updated_seq := public.baaki_next_personal_seq(NEW.owner_user_id);
+  RETURN NEW;
+END
+$$;
+
+CREATE TABLE public.personal_records (
+    id uuid NOT NULL,
+    owner_user_id uuid NOT NULL,
+    -- One of: 'txn' (an expense or income line), 'recurring' (a rule that mints
+    -- txns), 'loan' (a debt owed either way), 'budget' (a monthly category cap).
+    -- The shape of `data` follows from this; the client validates it.
+    record_kind text NOT NULL,
+    data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    updated_seq bigint DEFAULT 0 NOT NULL,
+    created_at timestamp(6) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp(6) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    deleted_at timestamp(6) with time zone,
+    CONSTRAINT personal_records_kind_known
+      CHECK ((record_kind = ANY (ARRAY['txn'::text, 'recurring'::text, 'loan'::text, 'budget'::text])))
+);
+
+ALTER TABLE ONLY public.personal_records
+    ADD CONSTRAINT personal_records_pkey PRIMARY KEY (id);
+
+CREATE INDEX personal_records_owner_user_id_updated_seq_idx
+    ON public.personal_records USING btree (owner_user_id, updated_seq);
+
+ALTER TABLE ONLY public.personal_records
+    ADD CONSTRAINT personal_records_owner_user_id_fkey
+    FOREIGN KEY (owner_user_id) REFERENCES public.profiles(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+CREATE TRIGGER personal_records_stamp_seq
+    BEFORE INSERT OR UPDATE ON public.personal_records
+    FOR EACH ROW EXECUTE FUNCTION public.baaki_stamp_personal_seq();
+
+ALTER TABLE public.personal_records ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY personal_records_own ON public.personal_records
+    TO authenticated
+    USING ((owner_user_id = public.baaki_current_profile_id()))
+    WITH CHECK ((owner_user_id = public.baaki_current_profile_id()));
+
+-- No hard DELETE for authenticated: a delete is the `deleted_at` tombstone, set
+-- through /sync as the caller, so the removal rides the pull to other devices.
+GRANT SELECT,INSERT,UPDATE ON TABLE public.personal_records TO authenticated;
+GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.personal_records TO service_role;
+
+REVOKE ALL ON FUNCTION public.baaki_next_personal_seq(p_owner uuid) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.baaki_next_personal_seq(p_owner uuid) TO authenticated;
+GRANT ALL ON FUNCTION public.baaki_next_personal_seq(p_owner uuid) TO service_role;
+
+GRANT ALL ON FUNCTION public.baaki_stamp_personal_seq() TO anon;
+GRANT ALL ON FUNCTION public.baaki_stamp_personal_seq() TO authenticated;
+GRANT ALL ON FUNCTION public.baaki_stamp_personal_seq() TO service_role;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -155,12 +155,16 @@ model Profile {
   /// Per-owner counter behind the personal category-tag catalog scope, the
   /// captures equivalent for `category_tags`. Bumped by `baaki_next_category_tag_seq`.
   categoryTagsSeq   BigInt   @default(0) @map("category_tags_seq")
+  /// Per-owner counter behind the personal-finance scope (A48), covering every
+  /// `personal_records` row. Bumped by `baaki_next_personal_seq`.
+  personalSeq       BigInt   @default(0) @map("personal_seq")
   createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt         DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   memberships         GroupMember[]
   captures            Capture[]
   categoryTags        CategoryTag[]
+  personalRecords     PersonalRecord[]
   pushTokens          PushToken[]
   notifications       Notification[]
   emailEvents         EmailEvent[]
@@ -955,6 +959,34 @@ model CategoryTag {
 
   @@index([ownerUserId, updatedSeq], map: "category_tags_owner_user_id_updated_seq_idx")
   @@map("category_tags")
+  @@schema("public")
+}
+
+/// The private personal-finance ledger (A48): a person's own expenses, income,
+/// recurring rules, loans and monthly budgets — none of it shared, no members,
+/// never a group balance. Syncs under the owner exactly like `Capture`: a
+/// per-owner `updatedSeq`, owner-only RLS, soft delete.
+///
+/// One table for all four record kinds. The server only relays this data (every
+/// summary, loan balance and budget figure is computed on the device), so it
+/// never reads the shape of a row: `recordKind` says which of the four it is and
+/// `data` carries that kind's fields, validated on the client.
+model PersonalRecord {
+  id          String    @id @db.Uuid
+  ownerUserId String    @map("owner_user_id") @db.Uuid
+  /// 'txn' | 'recurring' | 'loan' | 'budget'.
+  recordKind  String    @map("record_kind")
+  /// The record's fields, shaped by `recordKind`. Opaque to the server.
+  data        Json      @default("{}")
+  updatedSeq  BigInt    @default(0) @map("updated_seq")
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz(6)
+
+  owner Profile @relation(fields: [ownerUserId], references: [id], onDelete: Cascade)
+
+  @@index([ownerUserId, updatedSeq], map: "personal_records_owner_user_id_updated_seq_idx")
+  @@map("personal_records")
   @@schema("public")
 }
 

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -870,7 +870,11 @@ class SyncSession {
   // scope. owner_user_id is set from the identity, never the payload.
   private requirePersonalScope(mutation: MutationEnvelope): void {
     if (mutation.groupId !== personalScope(this.profileId)) {
-      throw new HttpError(403, 'NOT_OWNER', 'A personal record may only be written under its own owner');
+      throw new HttpError(
+        403,
+        'NOT_OWNER',
+        'A personal record may only be written under its own owner',
+      );
     }
   }
 
@@ -1146,7 +1150,8 @@ async function pull(
     .gt('updated_seq', pfSince)
     .order('updated_seq', { ascending: true })
     .limit(MAX_ROWS_PER_TABLE);
-  if (personalError) throw new HttpError(500, 'PULL_FAILED', `personal_records: ${personalError.message}`);
+  if (personalError)
+    throw new HttpError(500, 'PULL_FAILED', `personal_records: ${personalError.message}`);
 
   let pfHighWater = pfSince;
   for (const row of personal ?? []) {

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -68,6 +68,10 @@ type MutationKind =
   | 'tag.create'
   | 'tag.update'
   | 'tag.delete'
+  // The private personal-finance ledger (A48): personal like captures, under its
+  // own suffixed scope. One generic upsert/delete covers all four record kinds.
+  | 'personal.upsert'
+  | 'personal.delete'
   // Trip plan + budgets (A23) — group-scoped, authorised by membership, so NOT
   // in isPersonalKind below.
   | 'plan_item.create'
@@ -87,7 +91,9 @@ function isPersonalKind(kind: MutationKind): boolean {
     kind === 'capture.assign' ||
     kind === 'tag.create' ||
     kind === 'tag.update' ||
-    kind === 'tag.delete'
+    kind === 'tag.delete' ||
+    kind === 'personal.upsert' ||
+    kind === 'personal.delete'
   );
 }
 
@@ -96,6 +102,12 @@ function isPersonalKind(kind: MutationKind): boolean {
  *  suffixed, so the two personal scopes keep separate cursors. */
 function categoryTagsScope(profileId: string): string {
   return `${profileId}:category_tags`;
+}
+
+/** The personal-scope key for a user's personal-finance ledger (A48). Must match
+ *  the client's `personalScope`; suffixed so it keeps its own cursor. */
+function personalScope(profileId: string): string {
+  return `${profileId}:personal`;
 }
 
 interface MutationEnvelope {
@@ -422,6 +434,10 @@ class SyncSession {
         return await this.upsertTag(mutation);
       case 'tag.delete':
         return await this.deleteTag(mutation);
+      case 'personal.upsert':
+        return await this.upsertPersonal(mutation);
+      case 'personal.delete':
+        return await this.deletePersonal(mutation);
       case 'plan_item.create':
         return await this.rpcAsCaller('baaki_add_plan_item', {
           p_group_id: mutation.groupId,
@@ -846,6 +862,62 @@ class SyncSession {
     if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
     return { tagId };
   }
+
+  // ────────────────────────────────── personal finance (A48) ──
+  // A personal record's scope is suffixed (`<profileId>:personal`). The server
+  // is only a relay: `data` is stored as sent (all sums are computed on the
+  // device), so there is nothing to validate beyond the record kind and the
+  // scope. owner_user_id is set from the identity, never the payload.
+  private requirePersonalScope(mutation: MutationEnvelope): void {
+    if (mutation.groupId !== personalScope(this.profileId)) {
+      throw new HttpError(403, 'NOT_OWNER', 'A personal record may only be written under its own owner');
+    }
+  }
+
+  private async upsertPersonal(mutation: MutationEnvelope): Promise<unknown> {
+    this.requirePersonalScope(mutation);
+    const payload = mutation.payload as {
+      recordId?: string;
+      recordKind?: string;
+      data?: Record<string, unknown> | null;
+    };
+    const recordId = requireString(payload.recordId, 'recordId');
+    const recordKind = requireString(payload.recordKind, 'recordKind');
+    if (!['txn', 'recurring', 'loan', 'budget'].includes(recordKind)) {
+      throw new HttpError(400, 'VALIDATION_FAILED', `Unknown personal record kind: ${recordKind}`);
+    }
+    const data =
+      payload.data && typeof payload.data === 'object' && !Array.isArray(payload.data)
+        ? payload.data
+        : {};
+    // Upsert by id, so a create and its edits are one row and a replay is
+    // harmless. `deleted_at: null` lets an upsert un-delete (an edit after a
+    // remove), matching the tag path.
+    const { error } = await this.caller.from('personal_records').upsert(
+      {
+        id: recordId,
+        owner_user_id: this.profileId,
+        record_kind: recordKind,
+        data,
+        deleted_at: null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' },
+    );
+    if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
+    return { recordId };
+  }
+
+  private async deletePersonal(mutation: MutationEnvelope): Promise<unknown> {
+    this.requirePersonalScope(mutation);
+    const recordId = requireString(mutation.payload.recordId, 'recordId');
+    const { error } = await this.caller
+      .from('personal_records')
+      .update({ deleted_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .eq('id', recordId);
+    if (error) throw new HttpError(400, 'VALIDATION_FAILED', error.message);
+    return { recordId };
+  }
 }
 
 /**
@@ -889,6 +961,11 @@ async function pull(
   // merges. Must equal `categoryTagsScope(profileId)` in @waves/core.
   const tagScope = `${profileId}:category_tags`;
   groupIds.delete(tagScope);
+
+  // The personal-finance ledger (A48) rides a fourth personal scope, its own
+  // suffixed key. Must equal `personalScope(profileId)` in @waves/core.
+  const pfScope = `${profileId}:personal`;
+  groupIds.delete(pfScope);
 
   for (const groupId of groupIds) {
     const since = cursors[groupId] ?? 0;
@@ -1057,6 +1134,29 @@ async function pull(
   }
   nextCursors[tagScope] = tagsHighWater;
   if ((tags ?? []).length === MAX_ROWS_PER_TABLE) hasMore = true;
+
+  // Personal scope (A48): the caller's own personal-finance ledger, its own
+  // suffixed cursor. Read as the caller so owner-only RLS guarantees the rows
+  // are theirs. Tombstones (deleted_at set) ride the pull like every soft delete.
+  const pfSince = cursors[pfScope] ?? 0;
+  const { data: personal, error: personalError } = await caller
+    .from('personal_records')
+    .select('*')
+    .eq('owner_user_id', profileId)
+    .gt('updated_seq', pfSince)
+    .order('updated_seq', { ascending: true })
+    .limit(MAX_ROWS_PER_TABLE);
+  if (personalError) throw new HttpError(500, 'PULL_FAILED', `personal_records: ${personalError.message}`);
+
+  let pfHighWater = pfSince;
+  for (const row of personal ?? []) {
+    const record = row as Record<string, unknown>;
+    const seq = Number(record.updated_seq ?? 0);
+    changes.push({ table: 'personal_records', groupId: pfScope, seq, row: record });
+    if (seq > pfHighWater) pfHighWater = seq;
+  }
+  nextCursors[pfScope] = pfHighWater;
+  if ((personal ?? []).length === MAX_ROWS_PER_TABLE) hasMore = true;
 
   return { changes, cursors: nextCursors, hasMore };
 }


### PR DESCRIPTION
## What

A new **Personal Finance** pillar — a private ledger, per-account and never shared, reached from a new **"Me"** bottom tab. It covers what you asked for: add expenses and income **just for yourself**, plus **recurring** bills/income, **loans**, and **monthly budgets**, and see your own money alone.

- **Me tab** — this month's income / expenses / net, quick add expense/income, recent entries, and doors to Recurring, Loans, Budgets.
- **Entries** — an expense or income line with amount, note, category, date. Full add/edit/delete.
- **Recurring** — a rule (phone bill, salary) that repeats weekly/monthly/yearly; "add automatically" posts the entry on its own when due (idempotent, on tab open), or it shows as due to add with one tap.
- **Loans** — money you borrowed or lent, with a running **outstanding** balance; a repayment is a normal entry linked to the loan ("Record payment").
- **Budgets** — a monthly cap overall or per category, with this month's spend measured against it (loan repayments excluded).

## Architecture

- **One generic `personal_records` table** — a `record_kind` discriminator (`txn` / `recurring` / `loan` / `budget`) + a `data` json blob. The server is only a relay (all sums are computed on the device), so it never reads a record's shape.
- **Offline-first on a new personal scope** (`personalScope` → `<userId>:personal`), exactly like captures / the tag catalog: per-owner `updated_seq`, owner-only RLS, soft-delete tombstones, and — like every mirror row — **encrypted at rest** on the device. Sync surface is one scope, one cursor, one pull, two mutation kinds (`personal.upsert` / `personal.delete`).
- **Pure core** (`@waves/core` `personal/`): record shapes + wire codecs, and the sums — monthly net, loan outstanding, budget progress, and recurring date maths (month/leap clamping, catch-up of missed occurrences). **14 unit tests.**

## Decisions (from you)

Everything at once · new "Me" bottom tab · a separate private ledger (not a hidden self-group).

## Verification

- `tsc` (mobile + core), `eslint` (mobile), `prettier` clean.
- Core: 14 tests pass (`packages/core/test/personal.test.ts`).
- **Deploy-gated**: the migration (`personal_records` + `personal_seq` counter) and the `/sync` edge change ship on the next deploy.
- **Not yet run on a device.**

## Deliberately deferred (follow-ups)

- A **"Just me"** destination on the main add-expense / voice-review flow (route a shared-flow entry into the personal ledger). The Me tab's own add already covers adding for yourself; wiring the other entry points is a focused follow-up.
- Recurring **end-date** UI and per-rule interval editing (schema already supports both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a personal finance “Me” tab for managing private financial activity.
  - Track categorized income and expenses with notes, dates, currencies, and loan repayments.
  - Create and manage recurring entries, including automatic posting and manual due entries.
  - Monitor borrowed or lent loans, balances, repayments, and open/closed status.
  - Set monthly overall or category budgets with progress and over-limit indicators.
  - View transactions by date and edit or delete existing entries.
  - Added English, Tamil, Hindi, and Arabic translations.
  - Personal finance data synchronizes securely across supported sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->