### PR TITLE
design: one WhatsApp-density padding across every list

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -90,7 +90,7 @@ const ActivityFeedRow = memo(function ActivityFeedRow({
         style={{
           gap: theme.spacing.md,
           alignItems: 'center',
-          paddingVertical: theme.spacing.md,
+          paddingVertical: theme.spacing.sm,
         }}
       >
         <View

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -536,7 +536,7 @@ function FriendCard({
         );
 
   const body = (
-    <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
+    <Row style={{ paddingVertical: theme.spacing.sm, alignItems: 'center' }}>
       <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
         <Avatar name={shownName} size={44} ghost={row.is_ghost || blocked} />
         <View style={{ flex: 1 }}>

--- a/apps/mobile/src/app/(tabs)/inbox.tsx
+++ b/apps/mobile/src/app/(tabs)/inbox.tsx
@@ -276,8 +276,8 @@ export default function InboxScreen() {
                   opacity: pressed ? 0.6 : 1,
                   borderRadius: theme.radius.lg,
                   backgroundColor: unreadRow ? theme.color.brandSoft : 'transparent',
-                  paddingHorizontal: theme.spacing.sm,
-                  paddingVertical: theme.spacing.md,
+                  paddingHorizontal: theme.spacing.lg,
+                  paddingVertical: theme.spacing.sm,
                 })}
               >
                 <Row style={{ gap: theme.spacing.md, alignItems: 'flex-start' }}>

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1687,7 +1687,7 @@ function GroupRow({
           flexDirection: 'row',
           alignItems: 'center',
           gap: theme.spacing.md,
-          paddingVertical: theme.spacing.md,
+          paddingVertical: theme.spacing.sm,
           paddingHorizontal: theme.spacing.lg,
           borderTopWidth: divider ? 1 : 0,
           borderTopColor: theme.color.border,

--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -517,7 +517,7 @@ function TxnRow({
         flexDirection: 'row',
         alignItems: 'center',
         gap: theme.spacing.md,
-        paddingVertical: theme.spacing.md,
+        paddingVertical: theme.spacing.sm,
       }}
     >
       <CategoryBadge category={txn.category ?? 'other'} meta={null} size={32} />

--- a/apps/mobile/src/app/clone-group.tsx
+++ b/apps/mobile/src/app/clone-group.tsx
@@ -93,7 +93,7 @@ export default function CloneGroupScreen() {
                   style={{
                     gap: theme.spacing.md,
                     alignItems: 'center',
-                    paddingVertical: theme.spacing.md,
+                    paddingVertical: theme.spacing.sm,
                   }}
                 >
                   <Avatar

--- a/apps/mobile/src/app/friends/person/[key].tsx
+++ b/apps/mobile/src/app/friends/person/[key].tsx
@@ -195,7 +195,7 @@ export default function PersonDetailScreen() {
                       onPress={() => router.push(`/group/${group.groupId}`)}
                       style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
                     >
-                      <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
+                      <Row style={{ paddingVertical: theme.spacing.sm, alignItems: 'center' }}>
                         <View
                           style={{
                             width: 44,

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -403,7 +403,7 @@ const ExpenseFeedRow = memo(function ExpenseFeedRow({
           style={{
             gap: theme.spacing.md,
             alignItems: 'center',
-            paddingVertical: theme.spacing.md,
+            paddingVertical: theme.spacing.sm,
           }}
         >
           <CategoryBadge
@@ -836,7 +836,7 @@ export default function GroupScreen() {
     return (
       <View>
         <Row
-          style={{ gap: theme.spacing.md, alignItems: 'center', paddingVertical: theme.spacing.md }}
+          style={{ gap: theme.spacing.md, alignItems: 'center', paddingVertical: theme.spacing.sm }}
         >
           <View
             style={{

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -786,7 +786,7 @@ export default function GroupScreen() {
             style={{
               gap: theme.spacing.md,
               alignItems: 'center',
-              paddingVertical: theme.spacing.md,
+              paddingVertical: theme.spacing.sm,
             }}
           >
             <Avatar

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -222,7 +222,7 @@ export default function SpendingMonthScreen() {
                             style={{
                               gap: theme.spacing.md,
                               alignItems: 'center',
-                              paddingVertical: theme.spacing.md,
+                              paddingVertical: theme.spacing.sm,
                             }}
                           >
                             <CategoryBadge

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -105,7 +105,7 @@ export default function AllGroupsScreen() {
                 style={{
                   gap: theme.spacing.md,
                   alignItems: 'center',
-                  paddingVertical: theme.spacing.md,
+                  paddingVertical: theme.spacing.sm,
                 }}
               >
                 <View

--- a/apps/mobile/src/app/personal/transactions.tsx
+++ b/apps/mobile/src/app/personal/transactions.tsx
@@ -106,7 +106,7 @@ export default function PersonalTransactionsScreen() {
             >
               <Card
                 padded={false}
-                style={{ paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.md }}
+                style={{ paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.sm }}
               >
                 <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
                   <CategoryBadge category={txn.category ?? 'other'} meta={null} size={32} />

--- a/apps/mobile/src/app/settings/blocked.tsx
+++ b/apps/mobile/src/app/settings/blocked.tsx
@@ -111,7 +111,7 @@ function BlockedRow({
   const name = user.name.trim() || t.misc.someone;
 
   return (
-    <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center', gap: theme.spacing.md }}>
+    <Row style={{ paddingVertical: theme.spacing.sm, alignItems: 'center', gap: theme.spacing.md }}>
       <Avatar name={name} size={44} photoUrl={url} />
       <Text variant="subheading" numberOfLines={1} style={{ flex: 1 }}>
         {name}

--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -207,7 +207,7 @@ export default function LanguageSettingsScreen() {
                   alignItems: 'center',
                   gap: theme.spacing.md,
                   paddingVertical: theme.spacing.sm,
-                  paddingHorizontal: theme.spacing.md,
+                  paddingHorizontal: theme.spacing.lg,
                   borderRadius: theme.radius.md,
                   // The chosen row lifts onto the brand's soft wash — a quiet
                   // fill rather than a loud border, so the colour lives with the

--- a/packages/ui/src/components/ListRow.tsx
+++ b/packages/ui/src/components/ListRow.tsx
@@ -43,8 +43,11 @@ export function ListRow({
         gap: theme.spacing.md,
         // WhatsApp-density list rows across the app: a tight vertical rhythm
         // (the leading avatar/badge sets the height), one shared value so every
-        // list reads the same.
+        // list reads the same. `minHeight` floors a leading-less, single-line
+        // row at the 44pt touch target — a tall avatar row already clears it, so
+        // this only lifts the short ones the tight padding would leave too small.
         paddingVertical: theme.spacing.sm,
+        minHeight: 44,
       }}
     >
       {leading}

--- a/packages/ui/src/components/ListRow.tsx
+++ b/packages/ui/src/components/ListRow.tsx
@@ -41,7 +41,10 @@ export function ListRow({
         flexDirection: 'row',
         alignItems: 'center',
         gap: theme.spacing.md,
-        paddingVertical: theme.spacing.md,
+        // WhatsApp-density list rows across the app: a tight vertical rhythm
+        // (the leading avatar/badge sets the height), one shared value so every
+        // list reads the same.
+        paddingVertical: theme.spacing.sm,
       }}
     >
       {leading}


### PR DESCRIPTION
Standardizes list-row density across the whole app to a single WhatsApp-like value, taking the [WhatsApp chats list](https://mobbin.com/screens/14fcc4ed-fecf-4f61-b99a-2b2b76b7332b) as the reference: a tight, avatar-led rhythm where the leading avatar/badge sets the row height and the padding stays out of the way.

## What changed
- **Shared `ListRow`** (`packages/ui`) — `paddingVertical` `md`→`sm` (12→8). This alone retightens every settings / menu / picker list that uses the component.
- **Bespoke rows** swept to the same `spacing.sm`:
  - Dashboard groups list; the **Me** ledger rows + full transactions list
  - Activity feed, Friends, Inbox
  - Groups list + clone-group picker
  - Group **expense feed / balances / activity / month** rows
  - Per-person ledger rows, blocked list
  - Language picker row — horizontal padding aligned to `lg`

Only padding **values** changed. No logic, no layout restructure. Buttons, chips, inputs, sheets/modals, headers, cards and section headers were deliberately left untouched.

## Notes
- Chosen density: **8px vertical / 16px horizontal** (denser than WhatsApp's measured ~12, matching the tighter dashboard you approved).
- Supersedes the standalone dashboard-padding tweak branch.
- Gates green locally: `@waves/ui` + `@waves/mobile` tsc, eslint, prettier, 660 mobile tests.
- Not device-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Tightened vertical spacing across activity, friends, groups, expenses, transactions, notifications, and settings lists for more compact screens.
  - Increased horizontal padding for notification and language-selection rows.
  - Applied consistent compact spacing to shared list rows throughout the mobile app while preserving a minimum touch-target height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->