### PR TITLE
feat(friends): multiselect merge from the Friends tab

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -762,8 +762,15 @@ function FriendCard({
       onPress={onPress}
       onLongPress={onLongPress}
       delayLongPress={250}
-      accessibilityRole={selectMode && selectable ? 'checkbox' : 'button'}
-      accessibilityState={selectMode && selectable ? { checked: selected } : undefined}
+      // In selection mode a selectable row is a checkbox; a non-selectable one
+      // (a real account — already one identity, nothing to merge) is inert, so
+      // it announces neither role nor tap and reads as disabled. Outside
+      // selection mode every row is the usual button into the person.
+      disabled={selectMode && !selectable}
+      accessibilityRole={selectMode ? (selectable ? 'checkbox' : 'none') : 'button'}
+      accessibilityState={
+        selectMode ? (selectable ? { checked: selected } : { disabled: true }) : undefined
+      }
       accessibilityLabel={shownName}
       style={({ pressed }) => ({
         opacity: pressed ? 0.9 : 1,

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -14,12 +14,13 @@
  * account are followed across groups, because a profile id is proof.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useMutation } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import {
   ActivityIndicator,
+  BackHandler,
   Modal,
   Pressable,
   RefreshControl,
@@ -31,6 +32,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   Avatar,
   Badge,
+  Button,
   Card,
   EmptyState,
   iconSize,
@@ -45,6 +47,7 @@ import {
 
 import { nudgeToSettle, type PersonBalanceRow } from '@/data/api';
 import { useBlockedUsers } from '@/data/blocked';
+import { defaultMergeName } from '@/data/mergePeople';
 import { useKnownPeopleCount, usePeopleBalances } from '@/data/hooks';
 import { useAuth } from '@/lib/auth';
 import { PeopleSkeleton } from '@/components/Skeletons';
@@ -148,6 +151,66 @@ export default function FriendsScreen() {
     }
   };
 
+  // Multiselect merge: long-press a guest to start picking, tap to add/remove,
+  // then Merge folds them into one person through the very flow the header's
+  // merge entry uses (rename + optional contact + the irreversibility warning),
+  // only pre-selected. Only guests (ghosts) are mergeable, so only they are
+  // selectable — a real account is already one identity across every group.
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedKeys, setSelectedKeys] = useState<ReadonlySet<string>>(new Set());
+
+  const exitSelect = (): void => {
+    setSelectMode(false);
+    setSelectedKeys(new Set());
+  };
+
+  const enterSelect = (personKey: string): void => {
+    setSelectMode(true);
+    setSelectedKeys(new Set([personKey]));
+  };
+
+  const toggleSelect = (personKey: string): void => {
+    const next = new Set(selectedKeys);
+    if (next.has(personKey)) next.delete(personKey);
+    else next.add(personKey);
+    // Dropping the last pick leaves selection mode — an empty selection is no
+    // selection.
+    if (next.size === 0) exitSelect();
+    else setSelectedKeys(next);
+  };
+
+  const startMerge = (): void => {
+    const keys = [...selectedKeys];
+    // The Merge action is only enabled at two or more, but guard anyway.
+    if (keys.length < 2) return;
+    // Pre-fill the merge screen's name from the picked people — one display name
+    // per person (a person unsettled in two currencies is two rows but one
+    // name), most-common wins, exactly as the merge screen's own default does.
+    const nameByKey = new Map<string, string>();
+    for (const row of rows) {
+      if (selectedKeys.has(row.person_key) && !nameByKey.has(row.person_key)) {
+        nameByKey.set(row.person_key, row.display_name);
+      }
+    }
+    const suggestedName = defaultMergeName(
+      [...nameByKey.values()].map((display_name) => ({ display_name })),
+    );
+    const keyParam = keys.map(encodeURIComponent).join(',');
+    const nameParam = encodeURIComponent(suggestedName);
+    exitSelect();
+    router.push(`/friends/merge?keys=${keyParam}&name=${nameParam}` as never);
+  };
+
+  // Android hardware back leaves selection mode rather than the tab.
+  useEffect(() => {
+    if (!selectMode) return;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      exitSelect();
+      return true;
+    });
+    return () => sub.remove();
+  }, [selectMode]);
+
   // The two lists are a filter plus an O(n log n) sort each, and every render —
   // opening or closing the sort menu, a pull-to-refresh tick — used to run both
   // again and hand back freshly allocated arrays. They only actually change when
@@ -191,75 +254,111 @@ export default function FriendsScreen() {
           />
         }
       >
-        <Row style={{ justifyContent: 'space-between', paddingTop: theme.spacing.md }}>
-          <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
-            <Ionicons name="people" size={iconSize.xl} color={theme.color.brand} />
-            <Text variant="title">{t.friends}</Text>
-          </Row>
-          <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
-            {/* Merge same-person guests into one — only once there are at least
-                two guests to merge, so the control never leads to a dead end. */}
-            {mergeableGuestCount >= 2 ? (
+        {selectMode ? (
+          // Selection header: leave the mode, the running count, and Merge —
+          // enabled only at two or more, since one person is nothing to merge.
+          <Row
+            style={{
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              paddingTop: theme.spacing.md,
+            }}
+          >
+            <Row style={{ alignItems: 'center', gap: theme.spacing.sm, flex: 1 }}>
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel={t.mergePeople.entry}
-                onPress={() => router.push('/friends/merge' as never)}
+                accessibilityLabel={t.common.close}
+                onPress={exitSelect}
                 hitSlop={10}
                 style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
               >
-                <Ionicons name="git-merge-outline" size={iconSize.xl} color={theme.color.text} />
+                <Ionicons name="close" size={iconSize.xl} color={theme.color.text} />
               </Pressable>
-            ) : null}
-            {/* Add somebody who is not in your contacts — just a name and the
+              <Text variant="heading" numberOfLines={1}>
+                {plural(locale, selectedKeys.size, t.mergePeople.selected)}
+              </Text>
+            </Row>
+            <Button
+              label={t.mergePeople.entry}
+              size="sm"
+              disabled={selectedKeys.size < 2}
+              onPress={startMerge}
+            />
+          </Row>
+        ) : (
+          <Row style={{ justifyContent: 'space-between', paddingTop: theme.spacing.md }}>
+            <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+              <Ionicons name="people" size={iconSize.xl} color={theme.color.brand} />
+              <Text variant="title">{t.friends}</Text>
+            </Row>
+            <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+              {/* Merge same-person guests into one — only once there are at least
+                two guests to merge, so the control never leads to a dead end. */}
+              {mergeableGuestCount >= 2 ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={t.mergePeople.entry}
+                  onPress={() => router.push('/friends/merge' as never)}
+                  hitSlop={10}
+                  style={({ pressed }) => ({
+                    opacity: pressed ? 0.5 : 1,
+                    padding: theme.spacing.xs,
+                  })}
+                >
+                  <Ionicons name="git-merge-outline" size={iconSize.xl} color={theme.color.text} />
+                </Pressable>
+              ) : null}
+              {/* Add somebody who is not in your contacts — just a name and the
                 amount between you. A person icon, bare like the rest of the row. */}
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t.addPerson.title}
-              onPress={() => router.push('/friends/add-person' as never)}
-              hitSlop={10}
-              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
-            >
-              {/* Optically one step down: Ionicons draws `person-add-outline`'s
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.addPerson.title}
+                onPress={() => router.push('/friends/add-person' as never)}
+                hitSlop={10}
+                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+              >
+                {/* Optically one step down: Ionicons draws `person-add-outline`'s
                   single figure larger in its viewbox than `people-outline` and
                   the three-dot, so at an equal nominal size it reads bigger.
                   lg here makes the three header icons appear the same size. */}
-              <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.text} />
-            </Pressable>
-            {/* Pull people from the phone's address book — icon only, no button
+                <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.text} />
+              </Pressable>
+              {/* Pull people from the phone's address book — icon only, no button
                 chrome, so the header reads as a title row not a toolbar. */}
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t.tabs.fromContacts}
-              onPress={() => router.push('/friends/contacts')}
-              hitSlop={10}
-              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
-            >
-              <Ionicons name="people-outline" size={iconSize.xl} color={theme.color.text} />
-            </Pressable>
-            {/* Point the camera at a group's invite QR to join it — the read
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.tabs.fromContacts}
+                onPress={() => router.push('/friends/contacts')}
+                hitSlop={10}
+                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+              >
+                <Ionicons name="people-outline" size={iconSize.xl} color={theme.color.text} />
+              </Pressable>
+              {/* Point the camera at a group's invite QR to join it — the read
                 lands in the same join flow an invite link opens. */}
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t.misc.scanToJoin}
-              onPress={() => router.push('/scan')}
-              hitSlop={10}
-              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
-            >
-              <Ionicons name="qr-code-outline" size={iconSize.lg} color={theme.color.text} />
-            </Pressable>
-            {/* The sort control — a bare vertical three-dot beside the button,
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.misc.scanToJoin}
+                onPress={() => router.push('/scan')}
+                hitSlop={10}
+                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+              >
+                <Ionicons name="qr-code-outline" size={iconSize.lg} color={theme.color.text} />
+              </Pressable>
+              {/* The sort control — a bare vertical three-dot beside the button,
                 opening the same corner dropdown the rest of the app uses. */}
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t.sort.by}
-              onPress={() => setSortOpen(true)}
-              hitSlop={10}
-              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
-            >
-              <Ionicons name="ellipsis-vertical" size={iconSize.xl} color={theme.color.text} />
-            </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t.sort.by}
+                onPress={() => setSortOpen(true)}
+                hitSlop={10}
+                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+              >
+                <Ionicons name="ellipsis-vertical" size={iconSize.xl} color={theme.color.text} />
+              </Pressable>
+            </Row>
           </Row>
-        </Row>
+        )}
 
         <SortMenu
           open={sortOpen}
@@ -283,6 +382,10 @@ export default function FriendsScreen() {
               multiCurrencyKeys={multiCurrencyKeys}
               emptyBody={t.tabs.nobodyOwesYou}
               emptyIcon="people-outline"
+              selectMode={selectMode}
+              selectedKeys={selectedKeys}
+              onEnterSelect={enterSelect}
+              onToggleSelect={toggleSelect}
             />
             <FriendsSection
               title={t.tabs.youOweThem}
@@ -291,6 +394,10 @@ export default function FriendsScreen() {
               multiCurrencyKeys={multiCurrencyKeys}
               emptyBody={t.tabs.youAreNotBehind}
               emptyIcon="checkmark-circle-outline"
+              selectMode={selectMode}
+              selectedKeys={selectedKeys}
+              onEnterSelect={enterSelect}
+              onToggleSelect={toggleSelect}
             />
           </>
         )}
@@ -431,6 +538,10 @@ function FriendsSection({
   multiCurrencyKeys,
   emptyBody,
   emptyIcon,
+  selectMode,
+  selectedKeys,
+  onEnterSelect,
+  onToggleSelect,
 }: {
   title: string;
   rows: PersonBalanceRow[];
@@ -440,6 +551,13 @@ function FriendsSection({
   emptyBody: string;
   /** Glyph for the empty card — says "state, not error" before the line is read. */
   emptyIcon: React.ComponentProps<typeof Ionicons>['name'];
+  /** Whether the screen is in multiselect-merge mode (rows tap to (de)select). */
+  selectMode: boolean;
+  selectedKeys: ReadonlySet<string>;
+  /** Long-press a selectable (guest) row to begin selecting from it. */
+  onEnterSelect: (personKey: string) => void;
+  /** Tap a selectable row while selecting to add/remove it. */
+  onToggleSelect: (personKey: string) => void;
 }): React.JSX.Element {
   const theme = useTheme();
   const { t } = useStrings();
@@ -485,6 +603,10 @@ function FriendsSection({
                 locale={locale}
                 t={t}
                 showCurrency={multiCurrencyKeys.has(row.person_key)}
+                selectMode={selectMode}
+                selected={selectedKeys.has(row.person_key)}
+                onEnterSelect={onEnterSelect}
+                onToggleSelect={onToggleSelect}
               />
               {index < rows.length - 1 ? (
                 <View style={{ height: 1, backgroundColor: theme.color.border }} />
@@ -502,6 +624,10 @@ function FriendCard({
   locale,
   t,
   showCurrency,
+  selectMode,
+  selected,
+  onEnterSelect,
+  onToggleSelect,
 }: {
   row: PersonBalanceRow;
   locale: string;
@@ -509,6 +635,11 @@ function FriendCard({
   /** When this person has balances in more than one currency, name the currency
       in the subtitle so two rows for them do not read as two different people. */
   showCurrency: boolean;
+  /** Whether the screen is picking people to merge. */
+  selectMode: boolean;
+  selected: boolean;
+  onEnterSelect: (personKey: string) => void;
+  onToggleSelect: (personKey: string) => void;
 }): React.JSX.Element {
   const theme = useTheme();
   const { isBlocked } = useBlockedUsers();
@@ -521,10 +652,15 @@ function FriendCard({
   // reads in ordinary ink, and the owed/owe meaning is carried by the sign and
   // the section this row sits under. The avatar keeps the person's own colour.
   const owed = BigInt(row.net) > 0n;
+  // Only a guest can be merged — a real account is already one identity across
+  // every group — so only guest rows take part in a selection. A real-account
+  // row stays inert (and dimmed) while a merge selection is running.
+  const selectable = row.is_ghost;
+
   // One group explains the balance: open it. Several do: the amount is a sum, so
   // open the person instead — a screen that splits it back out per group. Either
   // way the row is now a doorway; it used to be a dead end once it spanned two.
-  const onPress = row.only_group_id
+  const navigate = row.only_group_id
     ? () => router.push(`/group/${row.only_group_id}`)
     : () =>
         router.push(
@@ -535,8 +671,32 @@ function FriendCard({
           )}` as never,
         );
 
+  // In a selection, a tap toggles a guest and does nothing on a non-guest; out
+  // of one, a tap opens the row and a long-press on a guest starts a selection.
+  const onPress = selectMode
+    ? selectable
+      ? () => onToggleSelect(row.person_key)
+      : undefined
+    : navigate;
+  const onLongPress = !selectMode && selectable ? () => onEnterSelect(row.person_key) : undefined;
+
   const body = (
-    <Row style={{ paddingVertical: theme.spacing.sm, alignItems: 'center' }}>
+    <Row
+      style={{
+        paddingVertical: theme.spacing.sm,
+        alignItems: 'center',
+        gap: theme.spacing.sm,
+        // A non-selectable row reads as unavailable while a selection runs.
+        opacity: selectMode && !selectable ? 0.4 : 1,
+      }}
+    >
+      {selectMode ? (
+        <Ionicons
+          name={selected ? 'checkmark-circle' : 'ellipse-outline'}
+          size={iconSize.xl}
+          color={selected ? theme.color.brand : theme.color.textFaint}
+        />
+      ) : null}
       <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
         <Avatar name={shownName} size={44} ghost={row.is_ghost || blocked} />
         <View style={{ flex: 1 }}>
@@ -567,7 +727,7 @@ function FriendCard({
           variant="subheading"
           mode="balance"
         />
-        {row.is_ghost ? (
+        {selectMode ? null : row.is_ghost ? (
           // A ghost is somebody you added who has no Baaki account yet, so the
           // badge is the useful action rather than a verdict: send them this
           // group's invite link, which is the same link that lets them claim
@@ -600,9 +760,16 @@ function FriendCard({
   return (
     <Pressable
       onPress={onPress}
-      accessibilityRole="button"
+      onLongPress={onLongPress}
+      delayLongPress={250}
+      accessibilityRole={selectMode && selectable ? 'checkbox' : 'button'}
+      accessibilityState={selectMode && selectable ? { checked: selected } : undefined}
       accessibilityLabel={shownName}
-      style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
+      style={({ pressed }) => ({
+        opacity: pressed ? 0.9 : 1,
+        // A tick alone can be missed; a picked row also wears a soft fill.
+        backgroundColor: selected ? theme.color.surfaceMuted : 'transparent',
+      })}
     >
       {body}
     </Pressable>

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -25,7 +25,7 @@
 import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -102,6 +102,22 @@ export default function MergePeopleScreen() {
   const queryClient = useQueryClient();
   const { flush } = useSync();
 
+  // People pre-picked on the Friends tab (its multiselect merge) arrive as a
+  // comma-joined, encoded list of person_keys, plus the name to pre-fill. They
+  // seed the selection and name here so this screen opens on the confirm step
+  // rather than an empty pick.
+  const params = useLocalSearchParams<{ keys?: string; name?: string }>();
+  const initialKeys = useMemo(
+    () =>
+      new Set(
+        (typeof params.keys === 'string' ? params.keys : '')
+          .split(',')
+          .map((key) => decodeURIComponent(key))
+          .filter((key) => key.length > 0),
+      ),
+    [params.keys],
+  );
+
   const people = useQuery({ queryKey: ['people', 'balances'], queryFn: fetchPeopleBalances });
 
   // One selectable row per guest. A guest unsettled in two currencies is two
@@ -116,13 +132,15 @@ export default function MergePeopleScreen() {
     return [...byKey.values()];
   }, [people.data]);
 
-  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set(initialKeys));
   // Guests materialised from a device contact that was new to the app. They
   // never had a balance to appear in `guests`, so they live beside it rather
   // than in it — always part of the selection once added (removable, not
   // untickable, since there is no unmerged state to go back to).
   const [contactTargets, setContactTargets] = useState<readonly ContactMergeTarget[]>([]);
-  const [name, setName] = useState('');
+  const [name, setName] = useState(() =>
+    decodeURIComponent(typeof params.name === 'string' ? params.name : ''),
+  );
   const [nameTouched, setNameTouched] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -112,7 +112,8 @@ export default function MergePeopleScreen() {
       new Set(
         (typeof params.keys === 'string' ? params.keys : '')
           .split(',')
-          .map((key) => decodeURIComponent(key))
+          // useLocalSearchParams already URL-decodes params, so the keys arrive
+          // decoded — decoding again would corrupt any key containing a %.
           .filter((key) => key.length > 0),
       ),
     [params.keys],


### PR DESCRIPTION
Adds an in-place multiselect merge to the **Friends** tab, so folding same-person guests no longer requires opening the separate merge screen first.

## Flow
- **Long-press** a guest row → enter selection mode (that person is selected).
- **Tap** other guest rows to add/remove them. Selected rows show a check + a soft fill.
- The header becomes a selection bar: an **X** to leave, a running **count**, and a **Merge** action (enabled at ≥2).
- **Merge** opens the existing merge screen at its confirm step — rename the result, optionally assign to a device contact, and the irreversibility warning — only **pre-selected**.
- Android hardware back leaves selection mode; dropping the last pick exits it.

## Approach — reused, not reinvented
The per-viewer ghost-merge path is used end to end. `mergeGhosts(memberIds, name)` **already takes N member ids**, so there was **no server or schema change** — the Friends tab just seeds `merge.tsx`'s selection (`person_key`s) and a suggested name via route params. All ledger-safety rules (union-not-overwrite, advisory-lock serialization, ghost-only) stay in the one place that enforces them.

- Only **guests** are selectable — a real account is one identity across every group already; non-guest rows stay inert and dimmed while a selection runs.
- **No new i18n strings**: the count reuses `mergePeople.selected` and the button reuses `mergePeople.entry` (all four locales already present).

## Files
- `apps/mobile/src/app/(tabs)/friends.tsx` — selection mode, selection header, per-row select behavior, back-handler, `startMerge` (encodes picks + suggested name).
- `apps/mobile/src/app/friends/merge.tsx` — reads `keys`/`name` params; seeds selection and name (lazy init, no effect).

## Notes
- Gates green: `@waves/mobile` tsc, eslint, repo `pnpm lint`, `pnpm format`, `check-filenames.sh`, 660 mobile tests.
- Mobile-only; nothing deployed. Not device-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guest selection mode in Friends, activated by long-pressing a guest.
  - Select or deselect multiple guests and exit selection with Android back.
  - Added merge controls with suggested names; merging requires at least two guests.
  - Added clear selection indicators and accessibility support.
  - Disabled invite and reminder actions while selecting guests.
  - Dimmed and disabled non-guest accounts during selection.
  - Carried selected guests and suggested merge names into the merge screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->