### PR TITLE
feat(friends): multiselect merge — fix selection + redesigned Merge screen

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -164,7 +164,16 @@ export default function FriendsScreen() {
     setSelectedKeys(new Set());
   };
 
+  // A long press fires onLongPress (this), then the SAME touch fires the row's
+  // onPress on release — which in selection mode is a toggle. Left alone, that
+  // release toggles right back off the person the long press just picked, the
+  // set empties, and selection mode vanishes the instant you lift your finger.
+  // So the long press arms a one-shot guard that the very next toggle consumes
+  // and ignores. Any later tap is a real pick.
+  const swallowNextToggleRef = useRef(false);
+
   const enterSelect = (personKey: string): void => {
+    swallowNextToggleRef.current = true;
     setSelectMode(true);
     setSelectedKeys(new Set([personKey]));
   };
@@ -182,6 +191,12 @@ export default function FriendsScreen() {
   }, [selectedKeys]);
 
   const toggleSelect = (personKey: string): void => {
+    // The release of the long press that just entered selection — ignore it once
+    // so the picked person stays picked.
+    if (swallowNextToggleRef.current) {
+      swallowNextToggleRef.current = false;
+      return;
+    }
     const next = new Set(selectedKeysRef.current);
     if (next.has(personKey)) next.delete(personKey);
     else next.add(personKey);

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -14,7 +14,7 @@
  * account are followed across groups, because a profile id is proof.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useMutation } from '@tanstack/react-query';
 import { router } from 'expo-router';
@@ -169,8 +169,20 @@ export default function FriendsScreen() {
     setSelectedKeys(new Set([personKey]));
   };
 
+  // A live mirror of the selection, read through a ref so a tap always folds
+  // into the very latest set — not a snapshot captured at some earlier render.
+  // Two taps in quick succession (add A, then add B) previously worked off a
+  // stale `selectedKeys` closure, so the second tap dropped the first pick and
+  // selection mode appeared to fall apart the moment you chose a second person.
+  // The ref is current on every commit, so even a memoised row's handler sees
+  // the real set.
+  const selectedKeysRef = useRef(selectedKeys);
+  useEffect(() => {
+    selectedKeysRef.current = selectedKeys;
+  }, [selectedKeys]);
+
   const toggleSelect = (personKey: string): void => {
-    const next = new Set(selectedKeys);
+    const next = new Set(selectedKeysRef.current);
     if (next.has(personKey)) next.delete(personKey);
     else next.add(personKey);
     // Dropping the last pick leaves selection mode — an empty selection is no

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -16,7 +16,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useMutation } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import {
@@ -361,7 +361,11 @@ export default function FriendsScreen() {
                 hitSlop={10}
                 style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
               >
-                <MaterialIcons name="import-contacts" size={iconSize.xl} color={theme.color.text} />
+                <MaterialCommunityIcons
+                  name="book-account-outline"
+                  size={iconSize.xl}
+                  color={theme.color.text}
+                />
               </Pressable>
               {/* Point the camera at a group's invite QR to join it — the read
                 lands in the same join flow an invite link opens. */}

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useMutation } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import {
@@ -350,8 +351,9 @@ export default function FriendsScreen() {
                   lg here makes the three header icons appear the same size. */}
                 <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.text} />
               </Pressable>
-              {/* Pull people from the phone's address book — icon only, no button
-                chrome, so the header reads as a title row not a toolbar. */}
+              {/* Pull people from the phone's address book — an address-book
+                glyph, icon only, no button chrome, so the header reads as a
+                title row not a toolbar. */}
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={t.tabs.fromContacts}
@@ -359,7 +361,7 @@ export default function FriendsScreen() {
                 hitSlop={10}
                 style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
               >
-                <Ionicons name="people-outline" size={iconSize.xl} color={theme.color.text} />
+                <MaterialIcons name="import-contacts" size={iconSize.xl} color={theme.color.text} />
               </Pressable>
               {/* Point the camera at a group's invite QR to join it — the read
                 lands in the same join flow an invite link opens. */}

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -160,9 +160,20 @@ export default function FriendsScreen() {
   const [selectMode, setSelectMode] = useState(false);
   const [selectedKeys, setSelectedKeys] = useState<ReadonlySet<string>>(new Set());
 
+  // A live mirror of the selection, read by `toggleSelect` so a tap always folds
+  // into the very latest set — not a snapshot captured at some earlier render,
+  // and not a value that lags behind a passive effect. It is written in the same
+  // helper that schedules the state, so a second tap that lands before React has
+  // flushed still sees the real set (picking A then B keeps both, never just B).
+  const selectedKeysRef = useRef<ReadonlySet<string>>(selectedKeys);
+  const applySelection = (next: ReadonlySet<string>): void => {
+    selectedKeysRef.current = next;
+    setSelectedKeys(next);
+  };
+
   const exitSelect = (): void => {
     setSelectMode(false);
-    setSelectedKeys(new Set());
+    applySelection(new Set());
   };
 
   // A long press fires onLongPress (this), then the SAME touch fires the row's
@@ -176,20 +187,8 @@ export default function FriendsScreen() {
   const enterSelect = (personKey: string): void => {
     swallowNextToggleRef.current = true;
     setSelectMode(true);
-    setSelectedKeys(new Set([personKey]));
+    applySelection(new Set([personKey]));
   };
-
-  // A live mirror of the selection, read through a ref so a tap always folds
-  // into the very latest set — not a snapshot captured at some earlier render.
-  // Two taps in quick succession (add A, then add B) previously worked off a
-  // stale `selectedKeys` closure, so the second tap dropped the first pick and
-  // selection mode appeared to fall apart the moment you chose a second person.
-  // The ref is current on every commit, so even a memoised row's handler sees
-  // the real set.
-  const selectedKeysRef = useRef(selectedKeys);
-  useEffect(() => {
-    selectedKeysRef.current = selectedKeys;
-  }, [selectedKeys]);
 
   const toggleSelect = (personKey: string): void => {
     // The release of the long press that just entered selection — ignore it once
@@ -204,7 +203,7 @@ export default function FriendsScreen() {
     // Dropping the last pick leaves selection mode — an empty selection is no
     // selection.
     if (next.size === 0) exitSelect();
-    else setSelectedKeys(next);
+    else applySelection(next);
   };
 
   const startMerge = (): void => {

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -31,7 +31,6 @@ import {
   KeyboardAvoidingView,
   Modal,
   Platform,
-  Pressable,
   ScrollView,
   TextInput,
   View,
@@ -145,6 +144,10 @@ export default function MergePeopleScreen() {
   const [nameTouched, setNameTouched] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // The "add another person" sheet — the only way more guests join the merge
+  // now that the main list shows the chosen people rather than the whole roster.
+  const [addOpen, setAddOpen] = useState(false);
+
   const [contactStep, setContactStep] = useState<ContactStep>('closed');
   const [pendingContact, setPendingContact] = useState<PickedContact | null>(null);
   const [contactBusy, setContactBusy] = useState(false);
@@ -158,7 +161,15 @@ export default function MergePeopleScreen() {
     enabled: contactStep !== 'closed',
   });
 
-  const selectedRows = [...guests.filter((row) => selected.has(row.person_key)), ...contactTargets];
+  const selectedGuestRows = guests.filter((row) => selected.has(row.person_key));
+  const selectedRows = [...selectedGuestRows, ...contactTargets];
+  // Guests not yet in the merge — what the "add another person" sheet offers.
+  const remainingGuests = guests.filter((row) => !selected.has(row.person_key));
+
+  const openContacts = (): void => {
+    setAddOpen(false);
+    setContactStep('pick');
+  };
 
   const toggle = (personKey: string): void => {
     setError(null);
@@ -350,88 +361,89 @@ export default function MergePeopleScreen() {
             />
           ) : (
             <>
-              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-                {guests.map((row, index) => {
-                  const isSelected = selected.has(row.person_key);
-                  const isLastRow = index === guests.length - 1 && contactTargets.length === 0;
-                  return (
-                    <View key={row.person_key}>
-                      <Pressable
-                        accessibilityRole="checkbox"
-                        accessibilityState={{ checked: isSelected }}
-                        accessibilityLabel={row.display_name}
-                        onPress={() => toggle(row.person_key)}
-                        style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
-                      >
-                        <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
-                          <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
-                            <Avatar name={row.display_name} size={44} ghost />
-                            <View style={{ flex: 1 }}>
-                              <Text variant="subheading" numberOfLines={1}>
-                                {row.display_name}
-                              </Text>
-                              <Text variant="caption" tone="muted" numberOfLines={1}>
-                                {row.group_count === 1
-                                  ? t.tabs.inOneGroup
-                                  : plural(locale, row.group_count, t.tabs.acrossGroups)}
-                              </Text>
-                            </View>
-                          </Row>
-                          <Ionicons
-                            name={isSelected ? 'checkmark-circle' : 'ellipse-outline'}
-                            size={iconSize.xl}
-                            color={isSelected ? theme.color.brand : theme.color.textFaint}
-                          />
-                        </Row>
-                      </Pressable>
-                      {!isLastRow ? (
-                        <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                      ) : null}
-                    </View>
-                  );
-                })}
-                {contactTargets.map((row, index) => {
-                  const isLastRow = index === contactTargets.length - 1;
-                  return (
-                    <View key={row.member_id}>
-                      <Row style={{ paddingVertical: theme.spacing.md, alignItems: 'center' }}>
-                        <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
-                          <Avatar name={row.display_name} size={44} ghost />
-                          <View style={{ flex: 1 }}>
-                            <Text variant="subheading" numberOfLines={1}>
-                              {row.display_name}
-                            </Text>
-                            <Text variant="caption" tone="muted" numberOfLines={1}>
-                              {t.mergePeople.fromContactsTag}
-                            </Text>
-                          </View>
-                        </Row>
-                        <IconButton
-                          label={fill(t.pickers.removeName, { name: row.display_name })}
-                          onPress={() => removeContactTarget(row.member_id)}
-                        >
-                          <Ionicons
-                            name="close-circle"
-                            size={iconSize.xl}
-                            color={theme.color.textFaint}
-                          />
-                        </IconButton>
-                      </Row>
-                      {!isLastRow ? (
-                        <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                      ) : null}
-                    </View>
-                  );
-                })}
-              </Card>
+              {/* The identity these people become: their faces folded into one,
+                  and the name that one person will carry on the Friends list.
+                  This is the whole point of the screen, so it leads. */}
+              <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
+                <MergedAvatars names={selectedRows.map((row) => row.display_name)} />
+                <View style={{ alignSelf: 'stretch', alignItems: 'center', gap: theme.spacing.xs }}>
+                  <TextInput
+                    value={name}
+                    onChangeText={(value) => {
+                      setNameTouched(true);
+                      setName(value);
+                    }}
+                    editable={selectedRows.length > 0}
+                    accessibilityLabel={t.mergePeople.nameLabel}
+                    placeholder={t.mergePeople.namePlaceholder}
+                    placeholderTextColor={theme.color.textFaint}
+                    textAlign="center"
+                    style={{
+                      fontSize: 24,
+                      fontWeight: '800',
+                      color: theme.color.text,
+                      minWidth: 180,
+                      maxWidth: '100%',
+                      paddingVertical: theme.spacing.xs,
+                      paddingHorizontal: theme.spacing.md,
+                      borderBottomWidth: 1,
+                      borderBottomColor: theme.color.border,
+                    }}
+                  />
+                  <Text variant="caption" tone="muted" align="center">
+                    {t.mergePeople.heroCaption}
+                  </Text>
+                </View>
+              </View>
+
+              {/* Only the people actually being merged — not the whole roster.
+                  Each one is removable; more are added through the sheet below. */}
+              <View style={{ gap: theme.spacing.sm }}>
+                <Text variant="caption" tone="muted">
+                  {selectedRows.length > 0
+                    ? plural(locale, selectedRows.length, t.mergePeople.peopleHeader)
+                    : t.mergePeople.needTwo}
+                </Text>
+                {selectedRows.length > 0 ? (
+                  <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                    {selectedGuestRows.map((row, index) => (
+                      <View key={row.person_key}>
+                        <MergeMemberRow
+                          name={row.display_name}
+                          subtitle={
+                            row.group_count === 1
+                              ? t.tabs.inOneGroup
+                              : plural(locale, row.group_count, t.tabs.acrossGroups)
+                          }
+                          removeLabel={fill(t.pickers.removeName, { name: row.display_name })}
+                          onRemove={() => toggle(row.person_key)}
+                        />
+                        {index < selectedGuestRows.length - 1 || contactTargets.length > 0 ? (
+                          <Divider />
+                        ) : null}
+                      </View>
+                    ))}
+                    {contactTargets.map((row, index) => (
+                      <View key={row.member_id}>
+                        <MergeMemberRow
+                          name={row.display_name}
+                          subtitle={t.mergePeople.fromContactsTag}
+                          removeLabel={fill(t.pickers.removeName, { name: row.display_name })}
+                          onRemove={() => removeContactTarget(row.member_id)}
+                        />
+                        {index < contactTargets.length - 1 ? <Divider /> : null}
+                      </View>
+                    ))}
+                  </Card>
+                ) : null}
+              </View>
 
               <Button
-                label={t.tabs.fromContacts}
+                label={t.mergePeople.addPerson}
                 variant="secondary"
-                size="sm"
                 fullWidth
                 disabled={merge.isPending}
-                onPress={() => setContactStep('pick')}
+                onPress={() => setAddOpen(true)}
                 icon={
                   <Ionicons
                     name="person-add-outline"
@@ -440,28 +452,6 @@ export default function MergePeopleScreen() {
                   />
                 }
               />
-
-              <Card style={{ gap: theme.spacing.xs }}>
-                <Text variant="caption" tone="muted">
-                  {t.mergePeople.nameLabel}
-                </Text>
-                <TextInput
-                  value={name}
-                  onChangeText={(value) => {
-                    setNameTouched(true);
-                    setName(value);
-                  }}
-                  accessibilityLabel={t.mergePeople.nameLabel}
-                  placeholder={t.mergePeople.namePlaceholder}
-                  placeholderTextColor={theme.color.textFaint}
-                  style={{
-                    fontSize: 20,
-                    fontWeight: '700',
-                    color: theme.color.text,
-                    paddingVertical: theme.spacing.sm,
-                  }}
-                />
-              </Card>
 
               {/* The irreversibility, spelled out before the button rather than
                 buried in a toast after the fact. Title + body go through Callout's
@@ -472,12 +462,6 @@ export default function MergePeopleScreen() {
               </Callout>
 
               {error ? <Callout tone="negative">{error}</Callout> : null}
-
-              {selectedRows.length > 0 ? (
-                <Text variant="caption" tone="muted" align="center">
-                  {plural(locale, memberIdsForMerge(selectedRows).length, t.mergePeople.selected)}
-                </Text>
-              ) : null}
 
               <Button
                 label={t.mergePeople.cta}
@@ -491,6 +475,80 @@ export default function MergePeopleScreen() {
           )}
         </ScrollView>
       </KeyboardAvoidingView>
+
+      {/* Add another person to the merge: pick from the guests not already in
+          it, or reach for a device contact. Kept a plain sheet — the roster is
+          usually short — with the contact door at the top for the case the
+          person you mean is not a guest yet. */}
+      <Modal visible={addOpen} animationType="slide" onRequestClose={() => setAddOpen(false)}>
+        <Screen edges={['top', 'bottom']} inModal>
+          <View
+            style={{
+              flex: 1,
+              paddingHorizontal: theme.spacing.xl,
+              paddingBottom: theme.spacing.md,
+              gap: theme.spacing.lg,
+            }}
+          >
+            <Row style={{ paddingTop: theme.spacing.md }}>
+              <IconButton label={t.common.close} onPress={() => setAddOpen(false)}>
+                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+              </IconButton>
+              <View style={{ flex: 1, alignItems: 'center' }}>
+                <Text variant="heading">{t.mergePeople.addGuestTitle}</Text>
+              </View>
+              <View style={{ width: 44 }} />
+            </Row>
+
+            <Button
+              label={t.tabs.fromContacts}
+              variant="secondary"
+              fullWidth
+              onPress={openContacts}
+              icon={
+                <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.brand} />
+              }
+            />
+
+            <ScrollView
+              contentContainerStyle={{ paddingBottom: theme.spacing.xl, gap: theme.spacing.sm }}
+              showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+            >
+              {remainingGuests.length === 0 ? (
+                <Text variant="caption" tone="muted" align="center">
+                  {t.mergePeople.noMoreGuests}
+                </Text>
+              ) : (
+                <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                  {remainingGuests.map((row, index) => (
+                    <View key={row.person_key}>
+                      <ListRow
+                        title={row.display_name}
+                        subtitle={
+                          row.group_count === 1
+                            ? t.tabs.inOneGroup
+                            : plural(locale, row.group_count, t.tabs.acrossGroups)
+                        }
+                        leading={<Avatar name={row.display_name} size={40} ghost />}
+                        trailing={
+                          <Ionicons
+                            name="add-circle"
+                            size={iconSize.xl}
+                            color={theme.color.brand}
+                          />
+                        }
+                        onPress={() => toggle(row.person_key)}
+                      />
+                      {index < remainingGuests.length - 1 ? <Divider /> : null}
+                    </View>
+                  ))}
+                </Card>
+              )}
+            </ScrollView>
+          </View>
+        </Screen>
+      </Modal>
 
       {/* Picking a device contact as a merge target: step one is the contact
           itself, step two (only when the contact is new to the app) is which
@@ -647,5 +705,74 @@ function ChooseGroupForContact({
 
       <Button label={t.common.cancel} variant="ghost" onPress={onCancel} />
     </ScrollView>
+  );
+}
+
+/**
+ * The people being merged, shown as one overlapping cluster of faces — the
+ * visual promise of "these become one." Up to four; a ring in the page colour
+ * keeps them legible where they overlap. Empty (nothing picked yet) shows a
+ * single placeholder so the hero never collapses.
+ */
+function MergedAvatars({ names }: { names: readonly string[] }): React.JSX.Element {
+  const theme = useTheme();
+  const shown = names.slice(0, 4);
+  if (shown.length === 0) {
+    return <Avatar name="?" size={72} ghost />;
+  }
+  return (
+    <Row style={{ alignItems: 'center' }}>
+      {shown.map((name, index) => (
+        <View
+          key={`${name}-${index}`}
+          style={{
+            marginLeft: index === 0 ? 0 : -20,
+            borderRadius: 999,
+            borderWidth: 3,
+            borderColor: theme.color.bg,
+          }}
+        >
+          <Avatar name={name} size={64} ghost />
+        </View>
+      ))}
+    </Row>
+  );
+}
+
+/**
+ * One person in the merge selection: face, name, where their balance sits, and
+ * a remove control. Removing is the only edit here — there is no "unpick to
+ * unmerged," only "not part of this merge," so it reads as a delete, not a
+ * toggle.
+ */
+function MergeMemberRow({
+  name,
+  subtitle,
+  removeLabel,
+  onRemove,
+}: {
+  name: string;
+  subtitle: string;
+  removeLabel: string;
+  onRemove: () => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Row style={{ paddingVertical: theme.spacing.sm, alignItems: 'center', minHeight: 44 }}>
+      <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
+        <Avatar name={name} size={44} ghost />
+        <View style={{ flex: 1 }}>
+          <Text variant="subheading" numberOfLines={1}>
+            {name}
+          </Text>
+          <Text variant="caption" tone="muted" numberOfLines={1}>
+            {subtitle}
+          </Text>
+        </View>
+      </Row>
+      <IconButton label={removeLabel} onPress={onRemove}>
+        <Ionicons name="close-circle" size={iconSize.xl} color={theme.color.textFaint} />
+      </IconButton>
+    </Row>
   );
 }

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -24,11 +24,12 @@
  */
 import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import {
   ActivityIndicator,
+  Alert,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -215,12 +216,12 @@ export default function MergePeopleScreen() {
       setSelected((prev) => {
         const next = new Set(prev);
         for (const row of matches) next.add(row.person_key);
-        if (!nameTouched) {
-          const rows = guests.filter((row) => next.has(row.person_key));
-          setName(defaultMergeName([...rows, ...contactTargets]));
-        }
         return next;
       });
+      // Assigning a contact is naming the merged person: the contact's name
+      // wins, and it stops auto-tracking the picks from here on.
+      setNameTouched(true);
+      setName(contact.name);
       closeContactFlow();
       return;
     }
@@ -258,7 +259,10 @@ export default function MergePeopleScreen() {
         display_name: pendingContact.name,
       };
       setContactTargets((prev) => [...prev, newTarget]);
-      if (!nameTouched) setName(defaultMergeName([...selectedRows, newTarget]));
+      // The assigned contact's name is the merged person's name (preferred over
+      // the auto-name), and it stays put once chosen.
+      setNameTouched(true);
+      setName(pendingContact.name);
       setError(null);
       closeContactFlow();
     } catch (caught) {
@@ -289,6 +293,17 @@ export default function MergePeopleScreen() {
     },
     onError: (caught) => setError(mergeErrorMessage(caught, t.mergePeople)),
   });
+
+  // Merging is permanent, so the "this can't be undone" warning is a dialog on
+  // tap — the person confirms it deliberately — rather than a line they may
+  // skim past. Only the confirm proceeds to the write.
+  const confirmMerge = (): void => {
+    if (!ready || merge.isPending) return;
+    Alert.alert(t.mergePeople.warningTitle, t.mergePeople.warningBody, [
+      { text: t.common.cancel, style: 'cancel' },
+      { text: t.mergePeople.cta, style: 'destructive', onPress: () => merge.mutate() },
+    ]);
+  };
 
   return (
     <Screen>
@@ -386,9 +401,6 @@ export default function MergePeopleScreen() {
                   />
                   <Ionicons name="pencil" size={iconSize.md} color={theme.color.textFaint} />
                 </Row>
-                <Text variant="caption" tone="muted">
-                  {t.mergePeople.heroCaption}
-                </Text>
               </View>
 
               {/* Only the people actually being merged — not the whole roster.
@@ -433,8 +445,10 @@ export default function MergePeopleScreen() {
                 ) : null}
               </View>
 
-              {/* Another person joins from your device contacts — a name matches
-                  an existing guest and ticks it, or is added as a new one. */}
+              {/* Give the merged person a real identity: assign them a device
+                  contact. A contact whose name matches a guest ticks it; a new
+                  one is added — and either way the contact's name becomes the
+                  merged name (see onPickContact / attachContact). */}
               <Button
                 label={t.mergePeople.addPerson}
                 variant="secondary"
@@ -442,25 +456,25 @@ export default function MergePeopleScreen() {
                 disabled={merge.isPending}
                 onPress={() => setContactStep('pick')}
                 icon={
-                  <MaterialIcons
-                    name="import-contacts"
+                  <MaterialCommunityIcons
+                    name="book-account-outline"
                     size={iconSize.md}
                     color={theme.color.brand}
                   />
                 }
               />
 
-              {/* Irreversible — one quiet line before the button, not a block. */}
-              <Callout tone="negative">{t.mergePeople.warningTitle}</Callout>
-
               {error ? <Callout tone="negative">{error}</Callout> : null}
 
+              {/* The irreversibility is confirmed in a dialog on tap rather than
+                  shouted inline — one clear "are you sure, this can't be undone"
+                  before anything is written. */}
               <Button
                 label={t.mergePeople.cta}
                 size="lg"
                 fullWidth
                 disabled={!ready || merge.isPending}
-                onPress={() => merge.mutate()}
+                onPress={confirmMerge}
               />
               {merge.isPending ? <ActivityIndicator color={theme.color.brand} /> : null}
             </>

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -24,6 +24,7 @@
  */
 import { useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import {
@@ -144,10 +145,6 @@ export default function MergePeopleScreen() {
   const [nameTouched, setNameTouched] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // The "add another person" sheet — the only way more guests join the merge
-  // now that the main list shows the chosen people rather than the whole roster.
-  const [addOpen, setAddOpen] = useState(false);
-
   const [contactStep, setContactStep] = useState<ContactStep>('closed');
   const [pendingContact, setPendingContact] = useState<PickedContact | null>(null);
   const [contactBusy, setContactBusy] = useState(false);
@@ -163,13 +160,6 @@ export default function MergePeopleScreen() {
 
   const selectedGuestRows = guests.filter((row) => selected.has(row.person_key));
   const selectedRows = [...selectedGuestRows, ...contactTargets];
-  // Guests not yet in the merge — what the "add another person" sheet offers.
-  const remainingGuests = guests.filter((row) => !selected.has(row.person_key));
-
-  const openContacts = (): void => {
-    setAddOpen(false);
-    setContactStep('pick');
-  };
 
   const toggle = (personKey: string): void => {
     setError(null);
@@ -361,12 +351,21 @@ export default function MergePeopleScreen() {
             />
           ) : (
             <>
-              {/* The identity these people become: their faces folded into one,
-                  and the name that one person will carry on the Friends list.
-                  This is the whole point of the screen, so it leads. */}
-              <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
-                <MergedAvatars names={selectedRows.map((row) => row.display_name)} />
-                <View style={{ alignSelf: 'stretch', alignItems: 'center', gap: theme.spacing.xs }}>
+              {/* The one thing this screen decides: the name the merged person
+                  carries on Friends. Editable inline — a plain underlined field
+                  with a pencil so it reads as "tap to change." */}
+              <View style={{ gap: theme.spacing.xs }}>
+                <Text variant="caption" tone="muted">
+                  {t.mergePeople.nameLabel}
+                </Text>
+                <Row
+                  style={{
+                    alignItems: 'center',
+                    gap: theme.spacing.sm,
+                    borderBottomWidth: 1,
+                    borderBottomColor: theme.color.border,
+                  }}
+                >
                   <TextInput
                     value={name}
                     onChangeText={(value) => {
@@ -377,27 +376,23 @@ export default function MergePeopleScreen() {
                     accessibilityLabel={t.mergePeople.nameLabel}
                     placeholder={t.mergePeople.namePlaceholder}
                     placeholderTextColor={theme.color.textFaint}
-                    textAlign="center"
                     style={{
-                      fontSize: 24,
+                      flex: 1,
+                      fontSize: 22,
                       fontWeight: '800',
                       color: theme.color.text,
-                      minWidth: 180,
-                      maxWidth: '100%',
                       paddingVertical: theme.spacing.xs,
-                      paddingHorizontal: theme.spacing.md,
-                      borderBottomWidth: 1,
-                      borderBottomColor: theme.color.border,
                     }}
                   />
-                  <Text variant="caption" tone="muted" align="center">
-                    {t.mergePeople.heroCaption}
-                  </Text>
-                </View>
+                  <Ionicons name="pencil" size={iconSize.md} color={theme.color.textFaint} />
+                </Row>
+                <Text variant="caption" tone="muted">
+                  {t.mergePeople.heroCaption}
+                </Text>
               </View>
 
               {/* Only the people actually being merged — not the whole roster.
-                  Each one is removable; more are added through the sheet below. */}
+                  Each is removable; more come in through the button below. */}
               <View style={{ gap: theme.spacing.sm }}>
                 <Text variant="caption" tone="muted">
                   {selectedRows.length > 0
@@ -438,28 +433,25 @@ export default function MergePeopleScreen() {
                 ) : null}
               </View>
 
+              {/* Another person joins from your device contacts — a name matches
+                  an existing guest and ticks it, or is added as a new one. */}
               <Button
                 label={t.mergePeople.addPerson}
                 variant="secondary"
                 fullWidth
                 disabled={merge.isPending}
-                onPress={() => setAddOpen(true)}
+                onPress={() => setContactStep('pick')}
                 icon={
-                  <Ionicons
-                    name="person-add-outline"
+                  <MaterialIcons
+                    name="import-contacts"
                     size={iconSize.md}
                     color={theme.color.brand}
                   />
                 }
               />
 
-              {/* The irreversibility, spelled out before the button rather than
-                buried in a toast after the fact. Title + body go through Callout's
-                own props: it wraps children in a single Text, so passing two Text
-                nodes made the heading and body run together as inline spans. */}
-              <Callout tone="negative" title={t.mergePeople.warningTitle}>
-                {t.mergePeople.warningBody}
-              </Callout>
+              {/* Irreversible — one quiet line before the button, not a block. */}
+              <Callout tone="negative">{t.mergePeople.warningTitle}</Callout>
 
               {error ? <Callout tone="negative">{error}</Callout> : null}
 
@@ -475,80 +467,6 @@ export default function MergePeopleScreen() {
           )}
         </ScrollView>
       </KeyboardAvoidingView>
-
-      {/* Add another person to the merge: pick from the guests not already in
-          it, or reach for a device contact. Kept a plain sheet — the roster is
-          usually short — with the contact door at the top for the case the
-          person you mean is not a guest yet. */}
-      <Modal visible={addOpen} animationType="slide" onRequestClose={() => setAddOpen(false)}>
-        <Screen edges={['top', 'bottom']} inModal>
-          <View
-            style={{
-              flex: 1,
-              paddingHorizontal: theme.spacing.xl,
-              paddingBottom: theme.spacing.md,
-              gap: theme.spacing.lg,
-            }}
-          >
-            <Row style={{ paddingTop: theme.spacing.md }}>
-              <IconButton label={t.common.close} onPress={() => setAddOpen(false)}>
-                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-              </IconButton>
-              <View style={{ flex: 1, alignItems: 'center' }}>
-                <Text variant="heading">{t.mergePeople.addGuestTitle}</Text>
-              </View>
-              <View style={{ width: 44 }} />
-            </Row>
-
-            <Button
-              label={t.tabs.fromContacts}
-              variant="secondary"
-              fullWidth
-              onPress={openContacts}
-              icon={
-                <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.brand} />
-              }
-            />
-
-            <ScrollView
-              contentContainerStyle={{ paddingBottom: theme.spacing.xl, gap: theme.spacing.sm }}
-              showsVerticalScrollIndicator={false}
-              keyboardShouldPersistTaps="handled"
-            >
-              {remainingGuests.length === 0 ? (
-                <Text variant="caption" tone="muted" align="center">
-                  {t.mergePeople.noMoreGuests}
-                </Text>
-              ) : (
-                <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-                  {remainingGuests.map((row, index) => (
-                    <View key={row.person_key}>
-                      <ListRow
-                        title={row.display_name}
-                        subtitle={
-                          row.group_count === 1
-                            ? t.tabs.inOneGroup
-                            : plural(locale, row.group_count, t.tabs.acrossGroups)
-                        }
-                        leading={<Avatar name={row.display_name} size={40} ghost />}
-                        trailing={
-                          <Ionicons
-                            name="add-circle"
-                            size={iconSize.xl}
-                            color={theme.color.brand}
-                          />
-                        }
-                        onPress={() => toggle(row.person_key)}
-                      />
-                      {index < remainingGuests.length - 1 ? <Divider /> : null}
-                    </View>
-                  ))}
-                </Card>
-              )}
-            </ScrollView>
-          </View>
-        </Screen>
-      </Modal>
 
       {/* Picking a device contact as a merge target: step one is the contact
           itself, step two (only when the contact is new to the app) is which
@@ -709,41 +627,11 @@ function ChooseGroupForContact({
 }
 
 /**
- * The people being merged, shown as one overlapping cluster of faces — the
- * visual promise of "these become one." Up to four; a ring in the page colour
- * keeps them legible where they overlap. Empty (nothing picked yet) shows a
- * single placeholder so the hero never collapses.
- */
-function MergedAvatars({ names }: { names: readonly string[] }): React.JSX.Element {
-  const theme = useTheme();
-  const shown = names.slice(0, 4);
-  if (shown.length === 0) {
-    return <Avatar name="?" size={72} ghost />;
-  }
-  return (
-    <Row style={{ alignItems: 'center' }}>
-      {shown.map((name, index) => (
-        <View
-          key={`${name}-${index}`}
-          style={{
-            marginLeft: index === 0 ? 0 : -20,
-            borderRadius: 999,
-            borderWidth: 3,
-            borderColor: theme.color.bg,
-          }}
-        >
-          <Avatar name={name} size={64} ghost />
-        </View>
-      ))}
-    </Row>
-  );
-}
-
-/**
- * One person in the merge selection: face, name, where their balance sits, and
- * a remove control. Removing is the only edit here — there is no "unpick to
- * unmerged," only "not part of this merge," so it reads as a delete, not a
- * toggle.
+ * One person in the merge selection: their name, where their balance sits, and
+ * a remove control. No avatar — the identity being built is the name at the top,
+ * so the rows stay a compact, glanceable list rather than a stack of circles.
+ * Removing is the only edit here — there is no "unpick to unmerged," only "not
+ * part of this merge," so it reads as a delete, not a toggle.
  */
 function MergeMemberRow({
   name,
@@ -759,17 +647,14 @@ function MergeMemberRow({
   const theme = useTheme();
   return (
     <Row style={{ paddingVertical: theme.spacing.sm, alignItems: 'center', minHeight: 44 }}>
-      <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
-        <Avatar name={name} size={44} ghost />
-        <View style={{ flex: 1 }}>
-          <Text variant="subheading" numberOfLines={1}>
-            {name}
-          </Text>
-          <Text variant="caption" tone="muted" numberOfLines={1}>
-            {subtitle}
-          </Text>
-        </View>
-      </Row>
+      <View style={{ flex: 1 }}>
+        <Text variant="subheading" numberOfLines={1}>
+          {name}
+        </Text>
+        <Text variant="caption" tone="muted" numberOfLines={1}>
+          {subtitle}
+        </Text>
+      </View>
       <IconButton label={removeLabel} onPress={onRemove}>
         <Ionicons name="close-circle" size={iconSize.xl} color={theme.color.textFaint} />
       </IconButton>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -3206,7 +3206,7 @@ const en: UiStrings = {
     heroCaption: 'They’ll appear as one person on Friends.',
     peopleHeader: { one: '{n} person to merge', other: '{n} people to merge' },
     needTwo: 'Add at least two people to merge them into one.',
-    addPerson: 'Add another person',
+    addPerson: 'Assign to a contact',
     addGuestTitle: 'Add a person',
     noMoreGuests:
       'Everyone you can merge is already added. Add someone from your contacts instead.',
@@ -5237,7 +5237,7 @@ const ta: UiStrings = {
     heroCaption: 'நண்பர்கள் பட்டியலில் அவர்கள் ஒரே நபராகத் தோன்றுவார்கள்.',
     peopleHeader: { one: 'இணைக்க {n} நபர்', other: 'இணைக்க {n} நபர்கள்' },
     needTwo: 'ஒரே நபராக இணைக்க குறைந்தது இரண்டு நபர்களைச் சேர்க்கவும்.',
-    addPerson: 'மற்றொரு நபரைச் சேர்க்கவும்',
+    addPerson: 'தொடர்பிற்கு ஒதுக்கு',
     addGuestTitle: 'ஒரு நபரைச் சேர்க்கவும்',
     noMoreGuests:
       'இணைக்கக்கூடிய அனைவரும் ஏற்கனவே சேர்க்கப்பட்டுள்ளனர். பதிலாக உங்கள் தொடர்புகளிலிருந்து ஒருவரைச் சேர்க்கவும்.',
@@ -7296,7 +7296,7 @@ const hi: UiStrings = {
     heroCaption: 'वे Friends सूची में एक ही व्यक्ति के रूप में दिखेंगे.',
     peopleHeader: { one: 'मर्ज करने के लिए {n} व्यक्ति', other: 'मर्ज करने के लिए {n} लोग' },
     needTwo: 'एक व्यक्ति में मर्ज करने के लिए कम से कम दो लोगों को जोड़ें.',
-    addPerson: 'एक और व्यक्ति जोड़ें',
+    addPerson: 'संपर्क से लिंक करें',
     addGuestTitle: 'एक व्यक्ति जोड़ें',
     noMoreGuests:
       'जिन्हें आप मर्ज कर सकते हैं वे सभी पहले से जुड़े हैं. इसके बजाय अपने संपर्कों से किसी को जोड़ें.',
@@ -9337,7 +9337,7 @@ const ar: UiStrings = {
     heroCaption: 'سيظهرون كشخص واحد في قائمة الأصدقاء.',
     peopleHeader: { one: 'شخص واحد للدمج', other: '{n} أشخاص للدمج' },
     needTwo: 'أضف شخصين على الأقل لدمجهما في شخص واحد.',
-    addPerson: 'إضافة شخص آخر',
+    addPerson: 'ربطه بجهة اتصال',
     addGuestTitle: 'إضافة شخص',
     noMoreGuests: 'كل من يمكنك دمجهم مُضافون بالفعل. أضِف شخصًا من جهات اتصالك بدلاً من ذلك.',
   },

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1195,6 +1195,18 @@ export interface UiStrings {
     /** Fallback when adding a contact as a new guest fails. `{name}` is the
      *  contact's name. */
     errorContactAdd: string;
+    /** Caption under the merged name, on the confirm hero. */
+    heroCaption: string;
+    /** Header over the list of people currently in the merge. `{n}` is the count. */
+    peopleHeader: PluralForms;
+    /** Hint shown in place of the list until two people are picked. */
+    needTwo: string;
+    /** Button that opens the sheet to add another person to the merge. */
+    addPerson: string;
+    /** Title of that add sheet. */
+    addGuestTitle: string;
+    /** Empty state of the add sheet when every mergeable guest is already in. */
+    noMoreGuests: string;
   };
   /** Group photos are a paid feature; the cover emoji stays free for everyone. */
   groupPhoto: {
@@ -3191,6 +3203,13 @@ const en: UiStrings = {
     newContactBody:
       '{name} isn’t on Waves yet. Add them to a group first, then merge them in below.',
     errorContactAdd: 'Could not add {name}. Please try again.',
+    heroCaption: 'They’ll appear as one person on Friends.',
+    peopleHeader: { one: '{n} person to merge', other: '{n} people to merge' },
+    needTwo: 'Add at least two people to merge them into one.',
+    addPerson: 'Add another person',
+    addGuestTitle: 'Add a person',
+    noMoreGuests:
+      'Everyone you can merge is already added. Add someone from your contacts instead.',
   },
   groupPhoto: {
     paidHint: 'Group photos are a Plus feature. Pick an icon, or upgrade to add a photo.',
@@ -5215,6 +5234,13 @@ const ta: UiStrings = {
     newContactBody:
       '{name} இன்னும் Waves-இல் இல்லை. முதலில் அவர்களை ஒரு குழுவில் சேர்க்கவும், பிறகு கீழே இணைக்கவும்.',
     errorContactAdd: '{name} ஐச் சேர்க்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.',
+    heroCaption: 'நண்பர்கள் பட்டியலில் அவர்கள் ஒரே நபராகத் தோன்றுவார்கள்.',
+    peopleHeader: { one: 'இணைக்க {n} நபர்', other: 'இணைக்க {n} நபர்கள்' },
+    needTwo: 'ஒரே நபராக இணைக்க குறைந்தது இரண்டு நபர்களைச் சேர்க்கவும்.',
+    addPerson: 'மற்றொரு நபரைச் சேர்க்கவும்',
+    addGuestTitle: 'ஒரு நபரைச் சேர்க்கவும்',
+    noMoreGuests:
+      'இணைக்கக்கூடிய அனைவரும் ஏற்கனவே சேர்க்கப்பட்டுள்ளனர். பதிலாக உங்கள் தொடர்புகளிலிருந்து ஒருவரைச் சேர்க்கவும்.',
   },
   groupPhoto: {
     paidHint:
@@ -7267,6 +7293,13 @@ const hi: UiStrings = {
     newContactBody:
       '{name} अभी Waves पर नहीं है. पहले उन्हें किसी समूह में जोड़ें, फिर नीचे मर्ज करें.',
     errorContactAdd: '{name} को नहीं जोड़ा जा सका. कृपया फिर कोशिश करें.',
+    heroCaption: 'वे Friends सूची में एक ही व्यक्ति के रूप में दिखेंगे.',
+    peopleHeader: { one: 'मर्ज करने के लिए {n} व्यक्ति', other: 'मर्ज करने के लिए {n} लोग' },
+    needTwo: 'एक व्यक्ति में मर्ज करने के लिए कम से कम दो लोगों को जोड़ें.',
+    addPerson: 'एक और व्यक्ति जोड़ें',
+    addGuestTitle: 'एक व्यक्ति जोड़ें',
+    noMoreGuests:
+      'जिन्हें आप मर्ज कर सकते हैं वे सभी पहले से जुड़े हैं. इसके बजाय अपने संपर्कों से किसी को जोड़ें.',
   },
   groupPhoto: {
     paidHint: 'ग्रुप फ़ोटो एक Plus सुविधा है। कोई आइकन चुनें, या फ़ोटो जोड़ने के लिए अपग्रेड करें।',
@@ -9301,6 +9334,12 @@ const ar: UiStrings = {
     fromContactsTag: 'أُضيف من جهات الاتصال',
     newContactBody: '{name} ليس على Waves بعد. أضفه إلى مجموعة أولاً، ثم ادمجه أدناه.',
     errorContactAdd: 'تعذّرت إضافة {name}. يرجى المحاولة مرة أخرى.',
+    heroCaption: 'سيظهرون كشخص واحد في قائمة الأصدقاء.',
+    peopleHeader: { one: 'شخص واحد للدمج', other: '{n} أشخاص للدمج' },
+    needTwo: 'أضف شخصين على الأقل لدمجهما في شخص واحد.',
+    addPerson: 'إضافة شخص آخر',
+    addGuestTitle: 'إضافة شخص',
+    noMoreGuests: 'كل من يمكنك دمجهم مُضافون بالفعل. أضِف شخصًا من جهات اتصالك بدلاً من ذلك.',
   },
   groupPhoto: {
     paidHint: 'صور المجموعة ميزة Plus. اختر أيقونة، أو قم بالترقية لإضافة صورة.',


### PR DESCRIPTION
End-to-end fixes and redesign for the Friends multiselect-merge flow.

## 1. Long-press selection (fixed)
Long-pressing a guest showed the checkbox, but it vanished the instant you lifted your finger: the long press's release fired the row's `onPress`, which in select mode toggled the just-picked person back off, emptied the set, and exited. A one-shot guard now ignores that release, so the pick stands. (Also hardened the toggle to read the latest committed set via a ref, so rapid taps don't drop earlier picks.)

## 2. Merge screen — rebuilt as review & confirm
Previously showed the entire guest roster as a checklist even when you'd already picked people. Now:
- **Merged-identity hero** — the picked faces overlapped into one cluster, the merged name editable beneath, and a caption ("they'll appear as one person on Friends").
- **People to merge** — a list of only the selected people, each **removable** (not a roster to re-pick).
- **Add another person** sheet — the guests not yet in the merge, or someone from device contacts (existing contact→ghost flow untouched).

Merge logic underneath (`canMerge` / `mergeGhosts` / ledger-safety) is unchanged; UI restructure plus six new i18n strings across en/ta/hi/ar. Mobbin-informed (Mesh "Merge Profile", Trip.com contact-merge).

Gates green: tsc, eslint, prettier, filenames. Selection fix confirmed working on device; merge-screen redesign not yet device-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the merge-people experience with contact-based name assignment, editable details, clearer selected-member lists, removable members, and direct contact selection.
  * Added confirmation before permanently merging people.
  * Updated merge-people labels in English, Tamil, Hindi, and Arabic to clarify contact linking.

* **Bug Fixes**
  * Fixed friend selection after a long press so the initial selection remains unchanged while subsequent taps work normally.
  * Improved contact action icons throughout the friends and merge flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->