### PR TITLE
design(dashboard): sync spinner beside the eye + tighter groups list

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import {
+  ActivityIndicator,
   Animated,
   Modal,
   Pressable,
@@ -441,11 +442,12 @@ export default function HomeScreen() {
 
         <OverflowMenu visible={menuOpen} onClose={() => setMenuOpen(false)} items={menuItems} />
 
-        {/* The white body beneath the hero: the groups list. */}
+        {/* The white body beneath the hero: the groups list. Tightened to a
+            WhatsApp-style side margin (lg) so the list reads dense, not floaty. */}
         <View
           style={{
-            paddingHorizontal: theme.spacing.xl,
-            paddingTop: theme.spacing.xl,
+            paddingHorizontal: theme.spacing.lg,
+            paddingTop: theme.spacing.lg,
             gap: theme.spacing.md,
             flexGrow: 1,
           }}
@@ -1280,15 +1282,12 @@ function HeroBalance({
   // carries meaning. We fold that verdict into the label itself (a Title-case
   // phrase that matches the other slides' headings) so a single line still
   // tells you which way you stand, now that the old third "sub" line is gone.
-  // Held at "updating" until the first sync settles, so it never flips owe↔owed
-  // as the sync reconciles.
-  const netDirection = provisional
-    ? t.dashHero.updating
-    : primary.net === 0n
-      ? t.allSettled
-      : primary.net > 0n
-        ? t.dashHero.netOwed
-        : t.dashHero.netOwe;
+  // The real owe↔owed verdict, shown even before the first sync settles: rather
+  // than masking it behind an "updating" label, each slide carries a small
+  // spinner (see `busy` on MetricSlide) while the sync is still in flight, so
+  // the direction is there to read and the spinner says it may yet change.
+  const netDirection =
+    primary.net === 0n ? t.allSettled : primary.net > 0n ? t.dashHero.netOwed : t.dashHero.netOwe;
 
   const slides = [
     {
@@ -1301,6 +1300,7 @@ function HeroBalance({
           locale={locale}
           hidden={hidden}
           onToggleHide={onToggleHide}
+          busy={provisional}
         />
       ),
     },
@@ -1314,6 +1314,7 @@ function HeroBalance({
           locale={locale}
           hidden={hidden}
           onToggleHide={onToggleHide}
+          busy={provisional}
         />
       ),
     },
@@ -1327,6 +1328,7 @@ function HeroBalance({
           locale={locale}
           hidden={hidden}
           onToggleHide={onToggleHide}
+          busy={provisional}
         />
       ),
     },
@@ -1559,6 +1561,7 @@ function MetricSlide({
   locale,
   hidden,
   onToggleHide,
+  busy = false,
 }: {
   label: string;
   amount: bigint;
@@ -1566,6 +1569,9 @@ function MetricSlide({
   locale: string;
   hidden: boolean;
   onToggleHide: () => void;
+  /** Sync still in flight — a small spinner beside the eye says the figure may
+   *  yet change, without hiding the real label behind an "updating" placeholder. */
+  busy?: boolean;
 }) {
   const theme = useTheme();
   const { t } = useStrings();
@@ -1588,6 +1594,13 @@ function MetricSlide({
             color={theme.color.onBrand}
           />
         </Pressable>
+        {busy ? (
+          <ActivityIndicator
+            size="small"
+            color={theme.color.onBrand}
+            accessibilityLabel={t.dashHero.updating}
+          />
+        ) : null}
       </Row>
       {hidden ? (
         <Text tone="onBrand" style={{ fontSize: 40, lineHeight: 46, fontWeight: '700' }}>


### PR DESCRIPTION
Two Home tweaks from device feedback.

## Sync spinner instead of an "updating" label
The balance hero used to replace the owe/owed verdict with the word "updating" until the first sync settled. Now it shows the **real** direction and puts a small spinner next to the eye toggle on each slide while the sync is still in flight — the figure stays readable and the spinner signals it may still change. ("updating" survives as the spinner's accessibility label.)

## Tighter groups list
The groups list's outer inset dropped from `xl` (20) to `lg` (16) — a WhatsApp-style side margin, so the list reads dense rather than floating in whitespace.

Mobile-only UI; ships via OTA/native. Gates green (tsc, eslint, prettier, filenames). Not device-verified by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators for provisional balance values while synchronization is in progress.
  * Balance cards now show whether amounts are owed or owed to you during loading.

* **Style**
  * Reduced spacing in the groups list for a more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->