### PR TITLE
feat(personal): monthly breakdown, budget/recurring/cashflow insights

### DIFF
--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -157,17 +157,33 @@ export default function MeScreen() {
     format(money(amount, dc), { locale, compactFraction: true });
 
   // Where the month's money went — the biggest categories, each with its share,
-  // capped so the list stays a glance rather than a scroll.
+  // capped so the list stays a glance rather than a scroll. Personal txns carry
+  // no category-meta snapshot, so unknown/custom-tag ids all resolve to the same
+  // built-in "Other"; fold them into one bucket (summing spend and share) BEFORE
+  // sorting and slicing, or several look-alike "Other" rows would crowd real
+  // categories out of the top six.
   const catLabel = labelForCategory(t);
-  const breakdownBars: BarDatum[] = categoryBreakdown(ledger.txns, month, dc)
+  const buckets = new Map<string, { spent: bigint; share: number }>();
+  for (const row of categoryBreakdown(ledger.txns, month, dc)) {
+    const key = resolveCategory(row.category, null).builtinId ?? 'other';
+    const prev = buckets.get(key);
+    buckets.set(key, {
+      spent: (prev?.spent ?? 0n) + row.spent,
+      share: (prev?.share ?? 0) + row.share,
+    });
+  }
+  const breakdownBars: BarDatum[] = [...buckets]
+    .sort((a, b) =>
+      b[1].spent === a[1].spent ? (a[0] < b[0] ? -1 : 1) : b[1].spent > a[1].spent ? 1 : -1,
+    )
     .slice(0, 6)
-    .map((row) => ({
-      key: row.category ?? '__none',
-      label: catLabel(row.category) ?? t.categories.other,
-      value: row.spent,
-      formatted: `${fmt(row.spent)} · ${Math.round(row.share * 100)}%`,
-      tint: resolveCategory(row.category, null).tint,
-      leading: <CategoryBadge category={row.category} meta={null} size={26} />,
+    .map(([key, agg]) => ({
+      key,
+      label: catLabel(key) ?? t.categories.other,
+      value: agg.spent,
+      formatted: `${fmt(agg.spent)} · ${Math.round(agg.share * 100)}%`,
+      tint: resolveCategory(key, null).tint,
+      leading: <CategoryBadge category={key} meta={null} size={26} />,
     }));
 
   // The soonest upcoming recurring item, previewed by name and when.
@@ -180,7 +196,7 @@ export default function MeScreen() {
     : '';
 
   // The single worst over-budget category, named — more useful than the count.
-  const worstOver = worstOverBudget(ledger.budgets, ledger.txns, month);
+  const worstOver = worstOverBudget(ledger.budgets, ledger.txns, month, dc);
   const overName = worstOver
     ? worstOver.budget.category
       ? (catLabel(worstOver.budget.category) ?? t.categories.other)

--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -31,16 +31,25 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
+  cashflowTrend,
+  categoryBreakdown,
+  dayDelta,
   format,
   isRecurringDue,
   loanOutstanding,
   money,
   monthlySummary,
+  nextRecurring,
   personalBudgetProgress,
+  recentMonths,
+  resolveCategory,
   savingsRate,
+  worstOverBudget,
+  type MonthCashflow,
   type PersonalTxn,
 } from '@waves/core';
 import {
+  BarList,
   Card,
   directionalIcon,
   Divider,
@@ -51,6 +60,7 @@ import {
   Text,
   useScreenClearance,
   useTheme,
+  type BarDatum,
 } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
@@ -146,6 +156,42 @@ export default function MeScreen() {
   const fmt = (amount: bigint): string =>
     format(money(amount, dc), { locale, compactFraction: true });
 
+  // Where the month's money went — the biggest categories, each with its share,
+  // capped so the list stays a glance rather than a scroll.
+  const catLabel = labelForCategory(t);
+  const breakdownBars: BarDatum[] = categoryBreakdown(ledger.txns, month, dc)
+    .slice(0, 6)
+    .map((row) => ({
+      key: row.category ?? '__none',
+      label: catLabel(row.category) ?? t.categories.other,
+      value: row.spent,
+      formatted: `${fmt(row.spent)} · ${Math.round(row.share * 100)}%`,
+      tint: resolveCategory(row.category, null).tint,
+      leading: <CategoryBadge category={row.category} meta={null} size={26} />,
+    }));
+
+  // The soonest upcoming recurring item, previewed by name and when.
+  const upcoming = nextRecurring(ledger.recurrings, today);
+  const upcomingName = upcoming
+    ? upcoming.rule.note?.trim() || catLabel(upcoming.rule.category) || t.personal.recurring
+    : '';
+  const upcomingWhen = upcoming
+    ? whenLabel(dayDelta(today, upcoming.date), upcoming.date, locale, t)
+    : '';
+
+  // The single worst over-budget category, named — more useful than the count.
+  const worstOver = worstOverBudget(ledger.budgets, ledger.txns, month);
+  const overName = worstOver
+    ? worstOver.budget.category
+      ? (catLabel(worstOver.budget.category) ?? t.categories.other)
+      : t.personal.overall
+    : '';
+
+  // The last three months of cash flow, ending on the browsed month. Hidden
+  // until there is something in the window to draw.
+  const trend = cashflowTrend(ledger.txns, recentMonths(month, 3), dc);
+  const trendActive = trend.some((m) => m.income > 0n || m.expense > 0n);
+
   return (
     <Screen edges={[]}>
       <ScrollView
@@ -198,6 +244,60 @@ export default function MeScreen() {
               onPress={() => router.push('/personal/budgets')}
             />
           </Row>
+
+          {/* Two quiet contextual lines: what recurring item is next, and the
+              category that has run furthest past its cap this month. */}
+          {upcoming || worstOver ? (
+            <View style={{ gap: theme.spacing.sm }}>
+              {upcoming ? (
+                <SignalRow
+                  icon="repeat"
+                  tone="brand"
+                  label={t.personal.upcoming}
+                  title={upcomingName}
+                  value={upcomingWhen}
+                  onPress={() => router.push('/personal/recurring')}
+                />
+              ) : null}
+              {worstOver ? (
+                <SignalRow
+                  icon="alert-circle-outline"
+                  tone="negative"
+                  label={t.personal.overBudget}
+                  title={overName}
+                  value={`+${fmt(worstOver.over)}`}
+                  onPress={() => router.push('/personal/budgets')}
+                />
+              ) : null}
+            </View>
+          ) : null}
+
+          {/* Where the money went — a ranked bar list of the month's categories. */}
+          {breakdownBars.length > 0 ? (
+            <View style={{ gap: theme.spacing.sm }}>
+              <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
+                {t.personal.whereMoneyWent.toUpperCase()}
+              </Text>
+              <Card>
+                <BarList
+                  data={breakdownBars}
+                  accessibilityLabelFor={(d) => `${d.label}, ${d.formatted}`}
+                />
+              </Card>
+            </View>
+          ) : null}
+
+          {/* Cash flow over the last three months — a small saved/spent trend. */}
+          {trendActive ? (
+            <View style={{ gap: theme.spacing.sm }}>
+              <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
+                {t.personal.last3Months.toUpperCase()}
+              </Text>
+              <Card>
+                <CashflowStrip trend={trend} currency={dc} locale={locale} />
+              </Card>
+            </View>
+          ) : null}
 
           {/* The month's entries, grouped by day like a statement. */}
           <View style={{ gap: theme.spacing.sm }}>
@@ -259,6 +359,14 @@ export default function MeScreen() {
               ))
             )}
           </View>
+
+          {/* A quiet reassurance: this ledger is the person's alone. */}
+          <Row style={{ justifyContent: 'center', gap: theme.spacing.xs }}>
+            <Ionicons name="lock-closed-outline" size={iconSize.xs} color={theme.color.textFaint} />
+            <Text variant="micro" tone="faint">
+              {t.personal.privateNote}
+            </Text>
+          </Row>
         </View>
       </ScrollView>
     </Screen>
@@ -292,6 +400,26 @@ function monthLabel(month: string, locale: string): string {
     );
   } catch {
     return month;
+  }
+}
+
+// When an upcoming item falls, in words: overdue / today / tomorrow, else the
+// short calendar date (Sep 3). `days` is signed days from today to the date.
+function whenLabel(
+  days: number,
+  date: string,
+  locale: string,
+  t: ReturnType<typeof useStrings>['t'],
+): string {
+  if (days < 0) return t.personal.overdue;
+  if (days === 0) return t.personal.today;
+  if (days === 1) return t.personal.tomorrow;
+  try {
+    return new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' }).format(
+      new Date(`${date}T00:00:00`),
+    );
+  } catch {
+    return date;
   }
 }
 
@@ -805,6 +933,139 @@ function StatTile({
       </Card>
     </Pressable>
   );
+}
+
+/** A compact contextual line under the stat tiles: a tinted glyph, a small label
+ *  (Upcoming / Over budget), the thing it names, and a trailing value — tappable
+ *  through to the area it belongs to. Kept quiet, one row, never a card of its
+ *  own weight. */
+function SignalRow({
+  icon,
+  tone,
+  label,
+  title,
+  value,
+  onPress,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  tone: 'brand' | 'negative';
+  label: string;
+  title: string;
+  value: string;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  const accent = tone === 'negative' ? theme.color.negative : theme.color.brand;
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${label}. ${title}. ${value}`}
+      onPress={onPress}
+      style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+    >
+      <Card flat style={{ backgroundColor: theme.color.surfaceMuted }}>
+        <Row style={{ gap: theme.spacing.md }}>
+          <Ionicons name={icon} size={iconSize.md} color={accent} />
+          <View style={{ flex: 1 }}>
+            <Text variant="micro" tone="faint" numberOfLines={1}>
+              {label}
+            </Text>
+            <Text variant="body" numberOfLines={1}>
+              {title}
+            </Text>
+          </View>
+          <Text variant="body" style={{ fontWeight: '700', color: accent }} numberOfLines={1}>
+            {value}
+          </Text>
+        </Row>
+      </Card>
+    </Pressable>
+  );
+}
+
+/** The last-three-months trend: one column per month, its height the size of the
+ *  month's net and its colour the verdict (kept when in the black, spent when in
+ *  the red), with the signed net and the month beneath. Heights scale to the
+ *  largest absolute net in the window so the three read against each other. */
+function CashflowStrip({
+  trend,
+  currency,
+  locale,
+}: {
+  trend: readonly MonthCashflow[];
+  currency: string;
+  locale: string;
+}) {
+  const theme = useTheme();
+  const abs = (n: bigint): bigint => (n < 0n ? -n : n);
+  const largest = trend.reduce((max, m) => (abs(m.net) > max ? abs(m.net) : max), 0n);
+  const barsHeight = 72;
+  const fmt = (amount: bigint): string =>
+    format(money(amount, currency), { locale, compactFraction: true });
+
+  return (
+    <View style={{ gap: theme.spacing.sm }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'flex-end',
+          gap: theme.spacing.md,
+          height: barsHeight,
+        }}
+      >
+        {trend.map((m) => {
+          const saved = m.net >= 0n;
+          const percent = largest > 0n ? Number((abs(m.net) * 100n) / largest) : 0;
+          return (
+            <View
+              key={m.month}
+              accessible
+              accessibilityLabel={`${monthShort(m.month, locale)}: ${saved ? '' : '−'}${fmt(abs(m.net))}`}
+              style={{ flex: 1, justifyContent: 'flex-end', alignItems: 'center' }}
+            >
+              <View
+                style={{
+                  width: '100%',
+                  maxWidth: 44,
+                  height: Math.max((percent / 100) * barsHeight, abs(m.net) > 0n ? 4 : 0),
+                  borderRadius: theme.radius.sm,
+                  backgroundColor: saved ? theme.color.positive : theme.color.negative,
+                }}
+              />
+            </View>
+          );
+        })}
+      </View>
+      <Row style={{ gap: theme.spacing.md }}>
+        {trend.map((m) => (
+          <View key={m.month} style={{ flex: 1, alignItems: 'center', gap: 2 }}>
+            <Text
+              variant="micro"
+              numberOfLines={1}
+              style={{ color: m.net < 0n ? theme.color.negative : theme.color.text }}
+            >
+              {m.net < 0n ? '−' : ''}
+              {fmt(abs(m.net))}
+            </Text>
+            <Text variant="micro" tone="faint" numberOfLines={1}>
+              {monthShort(m.month, locale)}
+            </Text>
+          </View>
+        ))}
+      </Row>
+    </View>
+  );
+}
+
+// A month's short name (Sep) for the trend axis, timezone-safe.
+function monthShort(month: string, locale: string): string {
+  try {
+    return new Intl.DateTimeFormat(locale, { month: 'short' }).format(
+      new Date(`${month}-01T00:00:00`),
+    );
+  } catch {
+    return month;
+  }
 }
 
 interface Day {

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2324,6 +2324,13 @@ export interface UiStrings {
     justMe: string;
     justMeHint: string;
     deleteConfirm: string;
+    whereMoneyWent: string;
+    last3Months: string;
+    upcoming: string;
+    overBudget: string;
+    overdue: string;
+    tomorrow: string;
+    privateNote: string;
   };
 }
 
@@ -4322,6 +4329,13 @@ const en: UiStrings = {
     justMe: 'Just me',
     justMeHint: 'A private entry in your own ledger — not shared with anyone.',
     deleteConfirm: 'Delete this entry? This cannot be undone.',
+    whereMoneyWent: 'Where your money went',
+    last3Months: 'Last 3 months',
+    upcoming: 'Upcoming',
+    overBudget: 'Over budget',
+    overdue: 'Overdue',
+    tomorrow: 'Tomorrow',
+    privateNote: 'Private to you · Not shared with groups',
   },
 };
 
@@ -6414,6 +6428,13 @@ const ta: UiStrings = {
     justMe: 'எனக்கு மட்டும்',
     justMeHint: 'உங்கள் சொந்தக் கணக்கில் தனிப்பட்ட பதிவு — யாருடனும் பகிரப்படாது.',
     deleteConfirm: 'இந்தப் பதிவை நீக்கவா? இதை மீட்க முடியாது.',
+    whereMoneyWent: 'உங்கள் பணம் எங்கே போனது',
+    last3Months: 'கடந்த 3 மாதங்கள்',
+    upcoming: 'வரவிருப்பது',
+    overBudget: 'பட்ஜெட்டைத் தாண்டியது',
+    overdue: 'தாமதம்',
+    tomorrow: 'நாளை',
+    privateNote: 'உங்களுக்கு மட்டும் தனிப்பட்டது · குழுக்களுடன் பகிரப்படாது',
   },
 };
 
@@ -8417,6 +8438,13 @@ const hi: UiStrings = {
     justMe: 'सिर्फ़ मैं',
     justMeHint: 'आपके अपने खाते में निजी प्रविष्टि — किसी के साथ साझा नहीं।',
     deleteConfirm: 'यह प्रविष्टि हटाएँ? इसे वापस नहीं किया जा सकता।',
+    whereMoneyWent: 'आपका पैसा कहाँ गया',
+    last3Months: 'पिछले 3 महीने',
+    upcoming: 'आने वाला',
+    overBudget: 'बजट से अधिक',
+    overdue: 'बकाया',
+    tomorrow: 'कल',
+    privateNote: 'सिर्फ़ आपके लिए निजी · समूहों के साथ साझा नहीं',
   },
 };
 
@@ -10632,6 +10660,13 @@ const ar: UiStrings = {
     justMe: 'أنا فقط',
     justMeHint: 'إدخال خاص في دفترك أنت — غير مشارَك مع أحد.',
     deleteConfirm: 'حذف هذا الإدخال؟ لا يمكن التراجع.',
+    whereMoneyWent: 'أين ذهبت أموالك',
+    last3Months: 'آخر 3 أشهر',
+    upcoming: 'القادم',
+    overBudget: 'تجاوز الميزانية',
+    overdue: 'متأخر',
+    tomorrow: 'غداً',
+    privateNote: 'خاص بك وحدك · غير مشارَك مع المجموعات',
   },
 };
 

--- a/packages/core/src/personal/compute.ts
+++ b/packages/core/src/personal/compute.ts
@@ -75,6 +75,44 @@ export function monthKey(date: string): string {
   return date.slice(0, 7);
 }
 
+/**
+ * Whole days from `from` to `to` (both YYYY-MM-DD); negative when `to` precedes
+ * `from`. Counted on the UTC calendar so a DST change never makes a day 23 or 25
+ * hours — the same reason the recurring maths uses `Date.UTC`. 0 for a malformed
+ * date, so a caller can render a fallback rather than crash. (Named `dayDelta`,
+ * not `daysBetween`, to avoid colliding with the trip helper of that name, which
+ * returns a range of dates.)
+ */
+export function dayDelta(from: string, to: string): number {
+  const a = parseYmd(from);
+  const b = parseYmd(to);
+  if (!a || !b) return 0;
+  const ta = Date.UTC(a.y, a.m - 1, a.d);
+  const tb = Date.UTC(b.y, b.m - 1, b.d);
+  return Math.round((tb - ta) / 86_400_000);
+}
+
+/**
+ * The `count` month keys (YYYY-MM) ending at `month`, oldest first — the window
+ * a short trend reads over. `recentMonths('2026-08', 3)` → `['2026-06',
+ * '2026-07', '2026-08']`. Pure integer maths on the year/month, so it rolls year
+ * boundaries without a `Date`. A malformed `month` or `count < 1` yields
+ * `[month]` so a caller always has at least the anchor to show.
+ */
+export function recentMonths(month: string, count: number): string[] {
+  const p = /^(\d{4})-(\d{2})$/.exec(month);
+  if (!p || count < 1) return [month];
+  const base = Number(p[1]) * 12 + (Number(p[2]) - 1);
+  const out: string[] = [];
+  for (let k = count - 1; k >= 0; k -= 1) {
+    const idx = base - k;
+    const y = Math.floor(idx / 12);
+    const m = (idx % 12) + 1;
+    out.push(`${y}-${pad(m)}`);
+  }
+  return out;
+}
+
 // ────────────────────────────────────────────────────────── recurring ──
 
 /** Whether a rule is live and its next occurrence is on or before `today`. */
@@ -136,6 +174,43 @@ export function recurringOccurrenceId(ruleId: string, date: string): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 }
 
+export interface UpcomingRecurring {
+  readonly rule: PersonalRecurring;
+  /** The rule's next occurrence date (its `nextDate`). May be on or before
+   *  `today` for a manual rule that has come due but not been posted. */
+  readonly date: string;
+}
+
+/**
+ * The soonest recurring occurrence still ahead — the "Upcoming: rent tomorrow"
+ * the Me tab previews above the plain due count. The active, not-yet-ended rule
+ * with the earliest `nextDate` wins; ties break on the rule id so the pick is
+ * stable. `null` when nothing is scheduled. `today` bounds nothing here (the
+ * soonest is shown whether it is future or an unposted overdue) — the caller
+ * turns the gap into words with `dayDelta`.
+ */
+export function nextRecurring(
+  recurrings: readonly PersonalRecurring[],
+  // `today` is part of the signature so the caller reads naturally and a future
+  // "only ahead of today" rule has a home; the current pick is the soonest
+  // regardless, so it is not read yet.
+  _today: string,
+): UpcomingRecurring | null {
+  let best: UpcomingRecurring | null = null;
+  for (const rule of recurrings) {
+    if (!rule.active) continue;
+    if (rule.endDate !== null && rule.nextDate > rule.endDate) continue;
+    if (
+      best === null ||
+      rule.nextDate < best.date ||
+      (rule.nextDate === best.date && rule.id < best.rule.id)
+    ) {
+      best = { rule, date: rule.nextDate };
+    }
+  }
+  return best;
+}
+
 // ─────────────────────────────────────────────────────────── summaries ──
 
 export interface MonthlySummary {
@@ -171,6 +246,73 @@ export function monthlySummary(
 export function savingsRate(income: bigint, expense: bigint): number | null {
   if (income <= 0n) return null;
   return Number(income - expense) / Number(income);
+}
+
+export interface CategorySpend {
+  /** The stored category value — a built-in key, a custom-tag id, or null for an
+   *  uncategorised entry. The UI resolves it to a name and a colour. */
+  readonly category: string | null;
+  readonly spent: bigint;
+  /** This category's share of the month's total spend, 0–1 (0 when nothing was
+   *  spent). Kept as a float for a bar width; the money itself stays bigint. */
+  readonly share: number;
+}
+
+/**
+ * "Where did my money go" — one month's expense split by category, in a single
+ * currency, sorted biggest spend first. Every expense txn counts (loan
+ * repayments included, an uncategorised one under `null`) so the totals add up to
+ * the month's `expense` in `monthlySummary` — the figure the hero shows. Ties
+ * break on the category key so the order is stable between renders.
+ */
+export function categoryBreakdown(
+  txns: readonly PersonalTxn[],
+  month: string,
+  currency: CurrencyCode,
+): CategorySpend[] {
+  const totals = new Map<string | null, bigint>();
+  let total = 0n;
+  for (const txn of txns) {
+    if (txn.kind !== 'expense') continue;
+    if (txn.currency !== currency) continue;
+    if (monthKey(txn.date) !== month) continue;
+    totals.set(txn.category, (totals.get(txn.category) ?? 0n) + txn.amount);
+    total += txn.amount;
+  }
+  return [...totals]
+    .sort((a, b) => (b[1] === a[1] ? keyOrder(a[0], b[0]) : b[1] > a[1] ? 1 : -1))
+    .map(([category, spent]) => ({
+      category,
+      spent,
+      // Integer maths first, then one divide — no float ever touches the money.
+      share: total > 0n ? Number((spent * 10_000n) / total) / 10_000 : 0,
+    }));
+}
+
+// Stable order for two category keys, nulls last.
+function keyOrder(a: string | null, b: string | null): number {
+  if (a === b) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return a < b ? -1 : 1;
+}
+
+export interface MonthCashflow extends MonthlySummary {
+  readonly month: string;
+}
+
+/**
+ * Income, expense and net for each of `months` (in the order given) in one
+ * currency — the shape a short saved-vs-spent trend reads over. Each month is
+ * just a `monthlySummary`, so the figures match the hero exactly. Pair it with
+ * `recentMonths` to get the last N months ending at the browsed month.
+ */
+export function cashflowTrend(
+  txns: readonly PersonalTxn[],
+  months: readonly string[],
+  currency: CurrencyCode,
+): MonthCashflow[] {
+  return months.map((month) => ({ month, ...monthlySummary(txns, month, currency) }));
 }
 
 // ─────────────────────────────────────────────────────────────── loans ──
@@ -224,4 +366,37 @@ export function personalBudgetProgress(
   const remaining = budget.limit - spent;
   const ratio = budget.limit > 0n ? Number(spent) / Number(budget.limit) : 0;
   return { spent, limit: budget.limit, remaining, ratio };
+}
+
+export interface OverBudget {
+  readonly budget: PersonalBudget;
+  /** How far past the cap this month's spend ran, in minor units (always > 0). */
+  readonly over: bigint;
+}
+
+/**
+ * The single worst over-budget category this month — the one whose spend runs
+ * furthest past its cap — so the Me tab can name it, not just count how many are
+ * over. `null` when nothing is over budget. Ties break on the budget id so the
+ * pick is stable.
+ */
+export function worstOverBudget(
+  budgets: readonly PersonalBudget[],
+  txns: readonly PersonalTxn[],
+  month: string,
+): OverBudget | null {
+  let worst: OverBudget | null = null;
+  for (const budget of budgets) {
+    const { remaining } = personalBudgetProgress(budget, txns, month);
+    if (remaining >= 0n) continue;
+    const over = -remaining;
+    if (
+      worst === null ||
+      over > worst.over ||
+      (over === worst.over && budget.id < worst.budget.id)
+    ) {
+      worst = { budget, over };
+    }
+  }
+  return worst;
 }

--- a/packages/core/src/personal/compute.ts
+++ b/packages/core/src/personal/compute.ts
@@ -28,7 +28,11 @@ function parseYmd(date: string): Ymd | null {
   const y = Number(match[1]);
   const m = Number(match[2]);
   const d = Number(match[3]);
-  if (m < 1 || m > 12 || d < 1 || d > 31) return null;
+  // Reject impossible calendar dates (Feb 30, Apr 31, …). Checking against the
+  // real month length — not a flat 1–31 — matters because callers feed the day
+  // straight into `Date.UTC`, which silently rolls an impossible day into the
+  // next month rather than treating it as the malformed input it is.
+  if (m < 1 || m > 12 || d < 1 || d > daysInMonth(y, m)) return null;
   return { y, m, d };
 }
 
@@ -102,7 +106,11 @@ export function dayDelta(from: string, to: string): number {
 export function recentMonths(month: string, count: number): string[] {
   const p = /^(\d{4})-(\d{2})$/.exec(month);
   if (!p || count < 1) return [month];
-  const base = Number(p[1]) * 12 + (Number(p[2]) - 1);
+  const mm = Number(p[2]);
+  // The regex admits `2026-00` / `2026-13`; reject an out-of-range month so a bad
+  // anchor falls back to itself rather than generating skewed keys.
+  if (mm < 1 || mm > 12) return [month];
+  const base = Number(p[1]) * 12 + (mm - 1);
   const out: string[] = [];
   for (let k = count - 1; k >= 0; k -= 1) {
     const idx = base - k;
@@ -379,14 +387,22 @@ export interface OverBudget {
  * furthest past its cap — so the Me tab can name it, not just count how many are
  * over. `null` when nothing is over budget. Ties break on the budget id so the
  * pick is stable.
+ *
+ * Scoped to one `currency`: overages live in different currencies' minor units,
+ * which do not compare (₹500 over is not "less" than $6 over), and the caller
+ * formats the winner in a single display currency. Budgets in another currency
+ * are skipped rather than silently mislabelled — pass the same currency the
+ * screen formats with.
  */
 export function worstOverBudget(
   budgets: readonly PersonalBudget[],
   txns: readonly PersonalTxn[],
   month: string,
+  currency: CurrencyCode,
 ): OverBudget | null {
   let worst: OverBudget | null = null;
   for (const budget of budgets) {
+    if (budget.currency !== currency) continue;
     const { remaining } = personalBudgetProgress(budget, txns, month);
     if (remaining >= 0n) continue;
     const over = -remaining;

--- a/packages/core/test/personal.test.ts
+++ b/packages/core/test/personal.test.ts
@@ -241,6 +241,18 @@ describe('dayDelta', () => {
   it('is 0 for a malformed date rather than NaN', () => {
     expect(dayDelta('nope', '2026-08-28')).toBe(0);
   });
+
+  it('treats an impossible calendar date as malformed (0), not a rolled-over one', () => {
+    // Feb 30 does not exist; without a days-in-month check Date.UTC would roll it
+    // into March and yield a nonzero delta.
+    expect(dayDelta('2026-02-30', '2026-03-02')).toBe(0);
+    expect(dayDelta('2026-04-31', '2026-05-01')).toBe(0);
+    expect(dayDelta('2027-02-29', '2027-03-01')).toBe(0); // 2027 is not a leap year
+  });
+
+  it('accepts a real leap-year Feb 29', () => {
+    expect(dayDelta('2028-02-29', '2028-03-01')).toBe(1); // 2028 is a leap year
+  });
 });
 
 describe('recentMonths', () => {
@@ -255,6 +267,11 @@ describe('recentMonths', () => {
   it('falls back to the anchor for a bad month or count', () => {
     expect(recentMonths('2026-08', 0)).toEqual(['2026-08']);
     expect(recentMonths('nope', 3)).toEqual(['nope']);
+  });
+
+  it('rejects an out-of-range month (00 / 13) rather than skewing the keys', () => {
+    expect(recentMonths('2026-00', 3)).toEqual(['2026-00']);
+    expect(recentMonths('2026-13', 3)).toEqual(['2026-13']);
   });
 });
 
@@ -367,9 +384,40 @@ describe('worstOverBudget', () => {
       txn({ kind: 'expense', category: 'food', amount: 60000n, date: '2026-08-02' }), // 10000 over
       txn({ kind: 'expense', category: 'travel', amount: 55000n, date: '2026-08-03' }), // 35000 over
     ];
-    const worst = worstOverBudget(budgets, txns, '2026-08');
+    const worst = worstOverBudget(budgets, txns, '2026-08', 'INR');
     expect(worst?.budget.id).toBe('travel');
     expect(worst?.over).toBe(35000n);
+  });
+
+  it('compares only budgets in the requested currency', () => {
+    // A larger USD overage must NOT be picked when the screen formats in INR —
+    // minor units across currencies do not compare, and the winner would be
+    // mislabelled. The INR budget wins even though its raw overage is smaller.
+    const budgets: PersonalBudget[] = [
+      { id: 'rent-inr', category: 'rent', limit: 100000n, currency: 'INR' },
+      { id: 'trip-usd', category: 'travel', limit: 1000n, currency: 'USD' },
+    ];
+    const txns = [
+      txn({
+        kind: 'expense',
+        category: 'rent',
+        amount: 150000n,
+        currency: 'INR',
+        date: '2026-08-02',
+      }), // 50000 over (INR)
+      txn({
+        kind: 'expense',
+        category: 'travel',
+        amount: 900000n,
+        currency: 'USD',
+        date: '2026-08-03',
+      }), // 899000 over (USD)
+    ];
+    const worst = worstOverBudget(budgets, txns, '2026-08', 'INR');
+    expect(worst?.budget.id).toBe('rent-inr');
+    expect(worst?.over).toBe(50000n);
+    // And scoping to USD picks the USD budget instead.
+    expect(worstOverBudget(budgets, txns, '2026-08', 'USD')?.budget.id).toBe('trip-usd');
   });
 
   it('is null when everything is within its cap', () => {
@@ -377,7 +425,7 @@ describe('worstOverBudget', () => {
       { id: 'food', category: 'food', limit: 50000n, currency: 'INR' },
     ];
     const txns = [txn({ kind: 'expense', category: 'food', amount: 10000n, date: '2026-08-02' })];
-    expect(worstOverBudget(budgets, txns, '2026-08')).toBeNull();
-    expect(worstOverBudget([], txns, '2026-08')).toBeNull();
+    expect(worstOverBudget(budgets, txns, '2026-08', 'INR')).toBeNull();
+    expect(worstOverBudget([], txns, '2026-08', 'INR')).toBeNull();
   });
 });

--- a/packages/core/test/personal.test.ts
+++ b/packages/core/test/personal.test.ts
@@ -8,15 +8,21 @@ import { describe, expect, it } from 'vitest';
 
 import {
   addToDate,
+  cashflowTrend,
+  categoryBreakdown,
+  dayDelta,
   decodeTxn,
   encodeTxn,
   isRecurringDue,
   loanOutstanding,
   monthlySummary,
+  nextRecurring,
   personalBudgetProgress,
+  recentMonths,
   recurringCatchUp,
   recurringOccurrenceId,
   savingsRate,
+  worstOverBudget,
   type PersonalBudget,
   type PersonalLoan,
   type PersonalRecurring,
@@ -221,5 +227,157 @@ describe('savingsRate', () => {
   it('is null when there was no income to measure against', () => {
     expect(savingsRate(0n, 500n)).toBeNull();
     expect(savingsRate(-10n, 0n)).toBeNull();
+  });
+});
+
+describe('dayDelta', () => {
+  it('counts whole days, signed, and across a month boundary', () => {
+    expect(dayDelta('2026-08-28', '2026-08-28')).toBe(0);
+    expect(dayDelta('2026-08-28', '2026-08-29')).toBe(1);
+    expect(dayDelta('2026-08-28', '2026-08-27')).toBe(-1);
+    expect(dayDelta('2026-08-28', '2026-09-01')).toBe(4);
+  });
+
+  it('is 0 for a malformed date rather than NaN', () => {
+    expect(dayDelta('nope', '2026-08-28')).toBe(0);
+  });
+});
+
+describe('recentMonths', () => {
+  it('returns the count months ending at the anchor, oldest first', () => {
+    expect(recentMonths('2026-08', 3)).toEqual(['2026-06', '2026-07', '2026-08']);
+  });
+
+  it('rolls the year boundary', () => {
+    expect(recentMonths('2027-01', 3)).toEqual(['2026-11', '2026-12', '2027-01']);
+  });
+
+  it('falls back to the anchor for a bad month or count', () => {
+    expect(recentMonths('2026-08', 0)).toEqual(['2026-08']);
+    expect(recentMonths('nope', 3)).toEqual(['nope']);
+  });
+});
+
+describe('categoryBreakdown', () => {
+  it('splits a month by category, biggest first, with shares that sum to one', () => {
+    const txns = [
+      txn({ kind: 'expense', category: 'food', amount: 30000n, date: '2026-08-02' }),
+      txn({ kind: 'expense', category: 'food', amount: 10000n, date: '2026-08-10' }),
+      txn({ kind: 'expense', category: 'travel', amount: 60000n, date: '2026-08-05' }),
+      txn({ kind: 'income', category: 'salary', amount: 99999n, date: '2026-08-01' }), // income excluded
+      txn({ kind: 'expense', category: 'food', amount: 99999n, date: '2026-07-31' }), // other month
+      txn({
+        kind: 'expense',
+        category: 'food',
+        amount: 99999n,
+        currency: 'USD',
+        date: '2026-08-01',
+      }), // other currency
+    ];
+    const rows = categoryBreakdown(txns, '2026-08', 'INR');
+    expect(rows.map((r) => r.category)).toEqual(['travel', 'food']);
+    expect(rows[0]!.spent).toBe(60000n);
+    expect(rows[1]!.spent).toBe(40000n);
+    expect(rows[0]!.share).toBeCloseTo(0.6);
+    expect(rows[1]!.share).toBeCloseTo(0.4);
+  });
+
+  it('folds uncategorised expenses under a null key and reconciles with the month expense', () => {
+    const txns = [
+      txn({ kind: 'expense', category: null, amount: 25000n, date: '2026-08-02' }),
+      txn({ kind: 'expense', category: 'food', amount: 25000n, date: '2026-08-03' }),
+    ];
+    const rows = categoryBreakdown(txns, '2026-08', 'INR');
+    const total = rows.reduce((sum, r) => sum + r.spent, 0n);
+    expect(total).toBe(monthlySummary(txns, '2026-08', 'INR').expense);
+    expect(rows.some((r) => r.category === null)).toBe(true);
+  });
+
+  it('is empty when nothing was spent that month', () => {
+    expect(categoryBreakdown([], '2026-08', 'INR')).toEqual([]);
+  });
+});
+
+describe('cashflowTrend', () => {
+  it('gives income, expense and net per month in order', () => {
+    const txns = [
+      txn({ kind: 'income', amount: 100000n, date: '2026-06-01' }),
+      txn({ kind: 'expense', amount: 40000n, date: '2026-06-10' }),
+      txn({ kind: 'expense', amount: 20000n, date: '2026-08-05' }),
+    ];
+    const trend = cashflowTrend(txns, recentMonths('2026-08', 3), 'INR');
+    expect(trend.map((m) => m.month)).toEqual(['2026-06', '2026-07', '2026-08']);
+    expect(trend[0]).toMatchObject({ income: 100000n, expense: 40000n, net: 60000n });
+    expect(trend[1]).toMatchObject({ income: 0n, expense: 0n, net: 0n });
+    expect(trend[2]).toMatchObject({ income: 0n, expense: 20000n, net: -20000n });
+  });
+});
+
+describe('nextRecurring', () => {
+  const rule = (over: Partial<PersonalRecurring>): PersonalRecurring => ({
+    id: over.id ?? 'r1',
+    txnKind: over.txnKind ?? 'expense',
+    amount: over.amount ?? 50000n,
+    currency: over.currency ?? 'INR',
+    category: over.category ?? null,
+    note: over.note ?? null,
+    cadence: over.cadence ?? 'monthly',
+    interval: over.interval ?? 1,
+    anchorDate: over.anchorDate ?? '2026-08-01',
+    nextDate: over.nextDate ?? '2026-08-01',
+    endDate: over.endDate ?? null,
+    autoPost: over.autoPost ?? true,
+    active: over.active ?? true,
+  });
+
+  it('picks the soonest active rule', () => {
+    const picked = nextRecurring(
+      [rule({ id: 'rent', nextDate: '2026-09-01' }), rule({ id: 'phone', nextDate: '2026-08-29' })],
+      '2026-08-28',
+    );
+    expect(picked?.rule.id).toBe('phone');
+    expect(picked?.date).toBe('2026-08-29');
+  });
+
+  it('skips paused and past-their-end rules', () => {
+    const picked = nextRecurring(
+      [
+        rule({ id: 'a', nextDate: '2026-08-29', active: false }),
+        rule({ id: 'b', nextDate: '2026-09-05', endDate: '2026-08-01' }),
+        rule({ id: 'c', nextDate: '2026-09-10' }),
+      ],
+      '2026-08-28',
+    );
+    expect(picked?.rule.id).toBe('c');
+  });
+
+  it('is null when nothing is scheduled', () => {
+    expect(nextRecurring([], '2026-08-28')).toBeNull();
+    expect(nextRecurring([rule({ active: false })], '2026-08-28')).toBeNull();
+  });
+});
+
+describe('worstOverBudget', () => {
+  it('names the category furthest past its cap', () => {
+    const budgets: PersonalBudget[] = [
+      { id: 'food', category: 'food', limit: 50000n, currency: 'INR' },
+      { id: 'travel', category: 'travel', limit: 20000n, currency: 'INR' },
+    ];
+    const txns = [
+      txn({ kind: 'expense', category: 'food', amount: 60000n, date: '2026-08-02' }), // 10000 over
+      txn({ kind: 'expense', category: 'travel', amount: 55000n, date: '2026-08-03' }), // 35000 over
+    ];
+    const worst = worstOverBudget(budgets, txns, '2026-08');
+    expect(worst?.budget.id).toBe('travel');
+    expect(worst?.over).toBe(35000n);
+  });
+
+  it('is null when everything is within its cap', () => {
+    const budgets: PersonalBudget[] = [
+      { id: 'food', category: 'food', limit: 50000n, currency: 'INR' },
+    ];
+    const txns = [txn({ kind: 'expense', category: 'food', amount: 10000n, date: '2026-08-02' })];
+    expect(worstOverBudget(budgets, txns, '2026-08')).toBeNull();
+    expect(worstOverBudget([], txns, '2026-08')).toBeNull();
   });
 });


### PR DESCRIPTION
## What & why

Enriches the private **"Me" tab** (personal finance, A48) with five insight features. Everything is derived on-device from the existing `personal_records` mirror — **no server columns, no migrations, the relay model is untouched.**

## Features (all 5 implemented)

1. **Monthly category breakdown** — "Where your money went": a ranked `BarList` of the selected month's categories, each with amount + share. Shares reconcile to the hero's expense figure (every expense txn counts).
2. **Budget: worst over-budget category** — beyond the existing over-budget count, a quiet signal row names the single category furthest past its cap (name + how far over).
3. **Recurring upcoming preview** — a signal row previewing the soonest upcoming recurring item ("Upcoming: Rent · Tomorrow") instead of only a due count.
4. **Cashflow trend** — a small 3-bar saved/spent trend over the last three months, ending on the browsed month, coloured by verdict.
5. **Privacy note** — a quiet "Private to you · Not shared with groups" line with a lock glyph.

Search/filter and export were deferred per the brief.

## Core (pure, unit-tested)

New helpers in `packages/core/src/personal/compute.ts`:
- `categoryBreakdown(txns, month, currency)` — per-category spend + share, biggest first.
- `worstOverBudget(budgets, txns, month)` — the single worst over-budget category.
- `nextRecurring(recurrings, today)` — the soonest scheduled recurring occurrence.
- `cashflowTrend(txns, months, currency)` + `recentMonths(month, count)` — per-month income/expense/net over a window.
- `dayDelta(from, to)` — signed whole-day gap (named `dayDelta`, not `daysBetween`, to avoid the existing trip helper of that name).

14 new unit tests (`packages/core/test/personal.test.ts`), covering ties, currency/month isolation, reconciliation with `monthlySummary`, year-boundary rollover, and null/empty cases.

## i18n

7 new keys added to the type block **and** all four locales (en / ta / hi / ar).

## Gates (all green, Windows node v24)

- `pnpm format` — clean
- `pnpm lint` — clean (the one mobile warning is pre-existing in `friends.tsx`, untouched here)
- `pnpm --filter @waves/mobile exec tsc --noEmit` — passes
- `pnpm --filter @waves/core test` — 741 passing (incl. 14 new)

## Notes

- The hero deck (3-slide carousel) is intentionally left intact; the trend rides the body as a card to avoid destabilising the wash/pager coupling.
- Custom-tag personal expenses (which carry no meta snapshot) fold to "Other" in the breakdown label — documented; personal ledgers rarely use custom tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added personal finance insights, including spending by category, upcoming recurring entries, over-budget alerts, and three-month cash-flow trends.
  * Added ranked spending categories, contextual overdue and upcoming indicators, and a private-ledger reassurance note.
  * Added English, Tamil, Hindi, and Arabic translations for the new insights.

* **Bug Fixes**
  * Improved date handling for invalid and leap-year dates.
  * Over-budget insights now accurately reflect the selected currency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->