### PR TITLE
fix(personal): reject non-integer recentMonths count

### DIFF
--- a/packages/core/src/personal/compute.ts
+++ b/packages/core/src/personal/compute.ts
@@ -100,12 +100,15 @@ export function dayDelta(from: string, to: string): number {
  * The `count` month keys (YYYY-MM) ending at `month`, oldest first — the window
  * a short trend reads over. `recentMonths('2026-08', 3)` → `['2026-06',
  * '2026-07', '2026-08']`. Pure integer maths on the year/month, so it rolls year
- * boundaries without a `Date`. A malformed `month` or `count < 1` yields
- * `[month]` so a caller always has at least the anchor to show.
+ * boundaries without a `Date`. A malformed `month`, or a `count` that is not a
+ * positive integer (rejecting `0`, negatives, fractions, `NaN`, and `Infinity`),
+ * yields `[month]` so a caller always has at least the anchor to show.
  */
 export function recentMonths(month: string, count: number): string[] {
   const p = /^(\d{4})-(\d{2})$/.exec(month);
-  if (!p || count < 1) return [month];
+  // `count < 1` alone lets `NaN` (loop never runs → `[]`), `Infinity` (runaway
+  // loop), and fractions (skewed keys) slip through, so require a safe integer.
+  if (!p || !Number.isInteger(count) || count < 1) return [month];
   const mm = Number(p[2]);
   // The regex admits `2026-00` / `2026-13`; reject an out-of-range month so a bad
   // anchor falls back to itself rather than generating skewed keys.

--- a/packages/core/test/personal.test.ts
+++ b/packages/core/test/personal.test.ts
@@ -273,6 +273,12 @@ describe('recentMonths', () => {
     expect(recentMonths('2026-00', 3)).toEqual(['2026-00']);
     expect(recentMonths('2026-13', 3)).toEqual(['2026-13']);
   });
+
+  it('rejects a count that is not a positive integer (NaN / fractional / Infinity)', () => {
+    expect(recentMonths('2026-08', Number.NaN)).toEqual(['2026-08']);
+    expect(recentMonths('2026-08', 2.5)).toEqual(['2026-08']);
+    expect(recentMonths('2026-08', Number.POSITIVE_INFINITY)).toEqual(['2026-08']);
+  });
 });
 
 describe('categoryBreakdown', () => {


### PR DESCRIPTION
Follow-up to #561, addressing a CodeRabbit review comment on `recentMonths`.

### Problem
The guard `if (!p || count < 1)` only rejected `count` values *less than 1*. Three non-integer inputs slipped through:
- **`NaN`** — `NaN < 1` is false, so it passed; the loop condition `k >= 0` is immediately false, returning `[]` instead of the documented `[month]`.
- **`Infinity`** — passed the guard, then `idx = base - Infinity` drove a runaway loop.
- **fractional** (e.g. `2.5`) — passed, producing fractional `idx` and skewed month keys.

### Fix
Require a positive **safe integer**: `!Number.isInteger(count) || count < 1`. `Number.isInteger` is false for `NaN`, `Infinity`, and fractions, so all three fall back to `[month]` — the same contract already documented for a bad `month` or `count < 1`. Minimal, no behavior change for valid counts.

### Tests
Added a case asserting `NaN`, `2.5`, and `Infinity` each return `[month]`. `@waves/core` — 746 passing; `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid values when calculating recent months.
  * Invalid counts—including zero, negative, fractional, `NaN`, and infinite values—now consistently return the anchor month.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->