### PR TITLE
feat(friends): Splitwise-model balance list — headline + one row per person

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -35,16 +35,18 @@ import {
   Badge,
   Button,
   Card,
+  directionalIcon,
   EmptyState,
   iconSize,
   MoneyText,
   Row,
   Screen,
-  SectionHeader,
   Text,
   useTabBarClearance,
   useTheme,
 } from '@waves/ui';
+
+import { balanceDirection, copyFor, moneyAccessibilityLabel } from '@waves/core';
 
 import { nudgeToSettle, type PersonBalanceRow } from '@/data/api';
 import { useBlockedUsers } from '@/data/blocked';
@@ -75,23 +77,104 @@ const SORT_META: Record<SortKey, { icon: keyof typeof Ionicons.glyphMap; default
 
 const SORT_ORDER: readonly SortKey[] = [SortKey.Amount, SortKey.Date, SortKey.Name];
 
-/** Sort a section by the chosen key; asc/desc flips whatever the key means. */
-function sortPeople(rows: PersonBalanceRow[], key: SortKey, dir: SortDir): PersonBalanceRow[] {
+/** The human name of a sort key — shared by the menu row and the header's
+ *  now-stateful sort control's spoken label. */
+function sortLabel(key: SortKey, t: UiStrings): string {
+  if (key === SortKey.Amount) return t.sort.amount;
+  if (key === SortKey.Date) return t.sort.date;
+  return t.sort.name;
+}
+
+/**
+ * One person and every currency they are unsettled with you in.
+ *
+ * The mirror returns a row per (person, currency) — currencies never sum
+ * (ADR-003), so a person owed in rupees and owing in dollars is two rows. This
+ * folds them back into the one human the list shows, keeping each currency's net
+ * as its own entry for the row's right edge to stack.
+ */
+interface PersonGroup {
+  person_key: string;
+  display_name: string;
+  profile_id: string | null;
+  /** A ghost only if every one of their rows is — a real account is proof. */
+  is_ghost: boolean;
+  entries: PersonBalanceRow[];
+  /** The largest single-currency balance, for the amount sort. */
+  topAbs: bigint;
+  /** Newest activity across their rows, for the recent sort. */
+  lastActivityAt: string | null;
+}
+
+function absBig(v: bigint): bigint {
+  return v < 0n ? -v : v;
+}
+
+/** Later of two ISO timestamps, ignoring null. */
+function laterDate(a: string | null, b: string | null): string | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return b > a ? b : a;
+}
+
+/** Fold the per-currency rows into one entry per person. */
+function groupByPerson(rows: PersonBalanceRow[]): PersonGroup[] {
+  const map = new Map<string, PersonGroup>();
+  for (const row of rows) {
+    let g = map.get(row.person_key);
+    if (!g) {
+      g = {
+        person_key: row.person_key,
+        display_name: row.display_name,
+        profile_id: row.profile_id,
+        is_ghost: true,
+        entries: [],
+        topAbs: 0n,
+        lastActivityAt: null,
+      };
+      map.set(row.person_key, g);
+    }
+    g.entries.push(row);
+    g.is_ghost = g.is_ghost && row.is_ghost;
+    if (row.profile_id) g.profile_id = row.profile_id;
+    const abs = absBig(BigInt(row.net));
+    if (abs > g.topAbs) g.topAbs = abs;
+    g.lastActivityAt = laterDate(g.lastActivityAt, row.last_activity_at);
+  }
+  return [...map.values()];
+}
+
+/** Sort people by the chosen key; asc/desc flips whatever the key means. A
+ *  person's amount is their biggest single-currency balance (never a
+ *  cross-currency sum), their date the newest activity across their rows. */
+function sortPersons(people: PersonGroup[], key: SortKey, dir: SortDir): PersonGroup[] {
   const sign = dir === SortDir.Asc ? 1 : -1;
-  const cmp = (a: PersonBalanceRow, b: PersonBalanceRow): number => {
+  const cmp = (a: PersonGroup, b: PersonGroup): number => {
     if (key === SortKey.Name) return a.display_name.localeCompare(b.display_name) * sign;
     if (key === SortKey.Date) {
-      const at = a.last_activity_at ? Date.parse(a.last_activity_at) : 0;
-      const bt = b.last_activity_at ? Date.parse(b.last_activity_at) : 0;
+      const at = a.lastActivityAt ? Date.parse(a.lastActivityAt) : 0;
+      const bt = b.lastActivityAt ? Date.parse(b.lastActivityAt) : 0;
       return (at < bt ? -1 : at > bt ? 1 : 0) * sign;
     }
-    const av = BigInt(a.net);
-    const aAbs = av < 0n ? -av : av;
-    const bv = BigInt(b.net);
-    const bAbs = bv < 0n ? -bv : bv;
-    return (aAbs < bAbs ? -1 : aAbs > bAbs ? 1 : 0) * sign;
+    return (a.topAbs < b.topAbs ? -1 : a.topAbs > b.topAbs ? 1 : 0) * sign;
   };
-  return [...rows].sort(cmp);
+  return [...people].sort(cmp);
+}
+
+export interface CurrencyTotal {
+  currency: string;
+  net: bigint;
+}
+
+/** The net you are up or down in each currency, summed over everyone. Positive:
+ *  owed to you. Never summed across currencies (ADR-003). Biggest first. */
+function currencyTotals(rows: PersonBalanceRow[]): CurrencyTotal[] {
+  const m = new Map<string, bigint>();
+  for (const row of rows) m.set(row.currency, (m.get(row.currency) ?? 0n) + BigInt(row.net));
+  return [...m.entries()]
+    .filter(([, net]) => net !== 0n)
+    .map(([currency, net]) => ({ currency, net }))
+    .sort((a, b) => (absBig(a.net) < absBig(b.net) ? 1 : absBig(a.net) > absBig(b.net) ? -1 : 0));
 }
 
 export default function FriendsScreen() {
@@ -118,30 +201,17 @@ export default function FriendsScreen() {
     rows.filter((row) => row.is_ghost).map((row) => row.person_key),
   ).size;
 
-  // A person unsettled in two currencies shows up as two rows (currencies never
-  // mix — ADR-003/004), which reads as a duplicate when both rows carry the same
-  // "in one group" subtitle. These are the person_keys that appear in more than
-  // one currency, so their rows can name the currency and stop looking like two
-  // different people. Computed once over the whole list, not per section — the
-  // two currencies can land in opposite sections (owed in one, owe in the other).
-  const multiCurrencyKeys = useMemo(() => {
-    const byPerson = new Map<string, Set<string>>();
-    for (const row of rows) {
-      const set = byPerson.get(row.person_key) ?? new Set<string>();
-      set.add(row.currency);
-      byPerson.set(row.person_key, set);
-    }
-    return new Set(
-      [...byPerson.entries()].filter(([, currencies]) => currencies.size > 1).map(([key]) => key),
-    );
-  }, [rows]);
-
   // The sort the whole list obeys. Tapping a key in the menu switches to it;
   // tapping the key already chosen flips its direction — amount and recent
   // activity open biggest/newest first, name A→Z, and either can be reversed.
   const [sortKey, setSortKey] = useState<SortKey>(SortKey.Amount);
   const [sortDir, setSortDir] = useState<SortDir>(SortDir.Desc);
   const [sortOpen, setSortOpen] = useState(false);
+
+  // The "add someone" family — add a person, pull from contacts, scan an invite
+  // QR — folded behind one `+` so the header reads as a title row, not a
+  // five-icon toolbar of mystery glyphs.
+  const [addOpen, setAddOpen] = useState(false);
 
   const pickSort = (key: SortKey): void => {
     if (key === sortKey) {
@@ -238,28 +308,20 @@ export default function FriendsScreen() {
     return () => sub.remove();
   }, [selectMode]);
 
-  // The two lists are a filter plus an O(n log n) sort each, and every render —
-  // opening or closing the sort menu, a pull-to-refresh tick — used to run both
-  // again and hand back freshly allocated arrays. They only actually change when
-  // the rows or the chosen sort change, so memoise on exactly those.
-  const owedToYou = useMemo(
-    () =>
-      sortPeople(
-        rows.filter((row) => BigInt(row.net) > 0n),
-        sortKey,
-        sortDir,
-      ),
+  // One row per person, not per (person, currency). The mirror hands back a row
+  // for each currency a person is unsettled in (currencies never mix — ADR-003);
+  // folding them into one person is what lets the list read the Splitwise way —
+  // a single row whose right edge stacks each currency's net — instead of the
+  // same face twice. Memoised on rows + sort, which is all that moves it.
+  const persons = useMemo(
+    () => sortPersons(groupByPerson(rows), sortKey, sortDir),
     [rows, sortKey, sortDir],
   );
-  const youOwe = useMemo(
-    () =>
-      sortPeople(
-        rows.filter((row) => BigInt(row.net) < 0n),
-        sortKey,
-        sortDir,
-      ),
-    [rows, sortKey, sortDir],
-  );
+
+  // The headline's figures: the net you are up or down in each currency, summed
+  // across everyone. Never across currencies — there is no honest single number
+  // without a rate (ADR-003), so a mixed wallet shows one line per currency.
+  const totals = useMemo(() => currencyTotals(rows), [rows]);
 
   return (
     <Screen>
@@ -318,79 +380,53 @@ export default function FriendsScreen() {
               <Ionicons name="people" size={iconSize.xl} color={theme.color.brand} />
               <Text variant="title">{t.friends}</Text>
             </Row>
-            <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
-              {/* Merge same-person guests into one — only once there are at least
-                two guests to merge, so the control never leads to a dead end. */}
-              {mergeableGuestCount >= 2 ? (
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={t.mergePeople.entry}
-                  onPress={() => router.push('/friends/merge' as never)}
-                  hitSlop={10}
-                  style={({ pressed }) => ({
-                    opacity: pressed ? 0.5 : 1,
-                    padding: theme.spacing.xs,
-                  })}
-                >
-                  <Ionicons name="git-merge-outline" size={iconSize.xl} color={theme.color.text} />
-                </Pressable>
-              ) : null}
-              {/* Add somebody who is not in your contacts — just a name and the
-                amount between you. A person icon, bare like the rest of the row. */}
+            <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+              {/* One primary action — everything that adds a person (type a name,
+                pull from contacts, scan an invite QR) lives behind this `+` so a
+                first-timer has one obvious door instead of four bare glyphs to
+                guess between. Merge is not here: it is a fix, not an add, and it
+                gets its own contextual card once there are duplicates. */}
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel={t.addPerson.title}
-                onPress={() => router.push('/friends/add-person' as never)}
+                accessibilityLabel={t.tabs.addSomeone}
+                onPress={() => setAddOpen(true)}
                 hitSlop={10}
                 style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
               >
-                {/* Optically one step down: Ionicons draws `person-add-outline`'s
-                  single figure larger in its viewbox than `people-outline` and
-                  the three-dot, so at an equal nominal size it reads bigger.
-                  lg here makes the three header icons appear the same size. */}
-                <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.text} />
+                <Ionicons name="add" size={iconSize.xxxl} color={theme.color.text} />
               </Pressable>
-              {/* Pull people from the phone's address book — an address-book
-                glyph, icon only, no button chrome, so the header reads as a
-                title row not a toolbar. */}
+              {/* The sort control now wears its own state: the active key's glyph
+                and the direction arrow, so a glance says how the list is ordered
+                without opening the menu (fixes the invisible-sort complaint). */}
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel={t.tabs.fromContacts}
-                onPress={() => router.push('/friends/contacts')}
-                hitSlop={10}
-                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
-              >
-                <MaterialCommunityIcons
-                  name="book-account-outline"
-                  size={iconSize.xl}
-                  color={theme.color.text}
-                />
-              </Pressable>
-              {/* Point the camera at a group's invite QR to join it — the read
-                lands in the same join flow an invite link opens. */}
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t.misc.scanToJoin}
-                onPress={() => router.push('/scan')}
-                hitSlop={10}
-                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
-              >
-                <Ionicons name="qr-code-outline" size={iconSize.lg} color={theme.color.text} />
-              </Pressable>
-              {/* The sort control — a bare vertical three-dot beside the button,
-                opening the same corner dropdown the rest of the app uses. */}
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t.sort.by}
+                accessibilityLabel={`${t.sort.by}: ${sortLabel(sortKey, t)}`}
                 onPress={() => setSortOpen(true)}
                 hitSlop={10}
-                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, padding: theme.spacing.xs })}
+                style={({ pressed }) => ({
+                  opacity: pressed ? 0.5 : 1,
+                  padding: theme.spacing.xs,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 2,
+                })}
               >
-                <Ionicons name="ellipsis-vertical" size={iconSize.xl} color={theme.color.text} />
+                <Ionicons
+                  name={SORT_META[sortKey].icon}
+                  size={iconSize.lg}
+                  color={theme.color.textMuted}
+                />
+                <Ionicons
+                  name={sortDir === SortDir.Asc ? 'arrow-up' : 'arrow-down'}
+                  size={iconSize.sm}
+                  color={theme.color.textMuted}
+                />
               </Pressable>
             </Row>
           </Row>
         )}
+
+        <AddMenu open={addOpen} onClose={() => setAddOpen(false)} t={t} />
 
         <SortMenu
           open={sortOpen}
@@ -407,30 +443,41 @@ export default function FriendsScreen() {
           <EmptyFriends hasPeople={known.data > 0} t={t} />
         ) : (
           <>
-            <FriendsSection
-              title={t.tabs.owesYou}
-              rows={owedToYou}
-              locale={locale}
-              multiCurrencyKeys={multiCurrencyKeys}
-              emptyBody={t.tabs.nobodyOwesYou}
-              emptyIcon="people-outline"
-              selectMode={selectMode}
-              selectedKeys={selectedKeys}
-              onEnterSelect={enterSelect}
-              onToggleSelect={toggleSelect}
-            />
-            <FriendsSection
-              title={t.tabs.youOweThem}
-              rows={youOwe}
-              locale={locale}
-              multiCurrencyKeys={multiCurrencyKeys}
-              emptyBody={t.tabs.youAreNotBehind}
-              emptyIcon="checkmark-circle-outline"
-              selectMode={selectMode}
-              selectedKeys={selectedKeys}
-              onEnterSelect={enterSelect}
-              onToggleSelect={toggleSelect}
-            />
+            {/* Overall headline — am I up or down, and by how much, before a
+              single row is read. This is the one thing group-by-group
+              navigation could never answer. One line per currency; never a
+              summed cross-currency total (ADR-003). It steps aside mid-merge,
+              where the running selection owns the top of the screen. */}
+            {!selectMode ? <BalanceHeadline totals={totals} locale={locale} t={t} /> : null}
+            {/* Merge used to hide behind a bare header glyph and a long-press
+              nobody discovers. When two or more guests could be the same person,
+              say so in words with a way in — a stable place to learn the concept
+              (hidden in selection mode, where merging is already under way). */}
+            {mergeableGuestCount >= 2 && !selectMode ? (
+              <MergeHint onPress={() => router.push('/friends/merge' as never)} t={t} />
+            ) : null}
+            {/* One list, one row per person (Splitwise model). Direction lives on
+              the row — a "you owe"/"owes you" micro-label and the money's own
+              colour — so no owes/owed tab, and a person unsettled in two
+              currencies is one row with both nets stacked, not two faces. */}
+            <View>
+              {persons.map((person, index) => (
+                <View key={person.person_key}>
+                  <PersonRow
+                    person={person}
+                    locale={locale}
+                    t={t}
+                    selectMode={selectMode}
+                    selected={selectedKeys.has(person.person_key)}
+                    onEnterSelect={enterSelect}
+                    onToggleSelect={toggleSelect}
+                  />
+                  {index < persons.length - 1 ? (
+                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
+                  ) : null}
+                </View>
+              ))}
+            </View>
           </>
         )}
       </ScrollView>
@@ -525,6 +572,25 @@ function NoFriendsHero({ t }: { t: UiStrings }): React.JSX.Element {
       <Text variant="heading" align="center">
         {t.tabs.noFriends}
       </Text>
+      <Text variant="body" tone="muted" align="center" style={{ maxWidth: 300 }}>
+        {t.tabs.noFriendsBody}
+      </Text>
+      {/* Both ways in, where a first-timer is actually looking — the header `+`
+          is easy to miss on an otherwise blank page. Primary types a name;
+          secondary pulls from the phone's contacts. */}
+      <View style={{ alignSelf: 'stretch', gap: theme.spacing.sm, marginTop: theme.spacing.lg }}>
+        <Button
+          label={t.tabs.addSomeone}
+          onPress={() => router.push('/friends/add-person' as never)}
+          fullWidth
+        />
+        <Button
+          label={t.tabs.fromContacts}
+          variant="secondary"
+          onPress={() => router.push('/friends/contacts')}
+          fullWidth
+        />
+      </View>
     </View>
   );
 }
@@ -563,111 +629,74 @@ function Face({
   );
 }
 
-function FriendsSection({
-  title,
-  rows,
+/**
+ * The one figure group-by-group navigation can never show: across every group
+ * and person, am I up or down — and by how much. One line per currency, because
+ * there is no honest single number across currencies without a rate (ADR-003).
+ * Nets to nothing overall? Then it says nothing and the rows below carry it.
+ */
+function BalanceHeadline({
+  totals,
   locale,
-  multiCurrencyKeys,
-  emptyBody,
-  emptyIcon,
-  selectMode,
-  selectedKeys,
-  onEnterSelect,
-  onToggleSelect,
+  t,
 }: {
-  title: string;
-  rows: PersonBalanceRow[];
+  totals: readonly CurrencyTotal[];
   locale: string;
-  /** person_keys that appear in more than one currency — their rows name it. */
-  multiCurrencyKeys: ReadonlySet<string>;
-  emptyBody: string;
-  /** Glyph for the empty card — says "state, not error" before the line is read. */
-  emptyIcon: React.ComponentProps<typeof Ionicons>['name'];
-  /** Whether the screen is in multiselect-merge mode (rows tap to (de)select). */
-  selectMode: boolean;
-  selectedKeys: ReadonlySet<string>;
-  /** Long-press a selectable (guest) row to begin selecting from it. */
-  onEnterSelect: (personKey: string) => void;
-  /** Tap a selectable row while selecting to add/remove it. */
-  onToggleSelect: (personKey: string) => void;
-}): React.JSX.Element {
+  t: UiStrings;
+}): React.JSX.Element | null {
   const theme = useTheme();
-  const { t } = useStrings();
-
+  if (totals.length === 0) return null;
   return (
-    <View style={{ gap: theme.spacing.md }}>
-      <SectionHeader title={title} />
-      {rows.length === 0 ? (
-        <Card>
-          {/* Mobbin pass: an empty section is mostly air; a lone grey sentence
-              reads as a screen that failed. A tinted glyph over the line names
-              it as a resting state (cf. Zip "all paid up", Splitwise settled). */}
-          <View
+    <Card>
+      <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
+        {t.tabs.overall.toUpperCase()}
+      </Text>
+      <View style={{ gap: theme.spacing.xs, marginTop: theme.spacing.xs }}>
+        {totals.map((total) => (
+          <Row
+            key={total.currency}
             style={{
-              alignItems: 'center',
-              gap: theme.spacing.xs,
-              paddingVertical: theme.spacing.sm,
+              justifyContent: 'space-between',
+              alignItems: 'baseline',
+              gap: theme.spacing.md,
             }}
           >
-            <View
-              style={{
-                width: 44,
-                height: 44,
-                borderRadius: 22,
-                alignItems: 'center',
-                justifyContent: 'center',
-                backgroundColor: theme.color.buttonPrimary,
-              }}
-            >
-              <Ionicons name={emptyIcon} size={22} color={theme.color.onBrand} />
-            </View>
-            <Text variant="caption" tone="muted" align="center">
-              {emptyBody}
+            <Text variant="body" tone="muted">
+              {total.net > 0n ? t.tabs.youAreOwed : t.tabs.youOweThem}
             </Text>
-          </View>
-        </Card>
-      ) : (
-        <View>
-          {rows.map((row, index) => (
-            <View key={`${row.person_key}-${row.currency}`}>
-              <FriendCard
-                row={row}
-                locale={locale}
-                t={t}
-                showCurrency={multiCurrencyKeys.has(row.person_key)}
-                selectMode={selectMode}
-                selected={selectedKeys.has(row.person_key)}
-                onEnterSelect={onEnterSelect}
-                onToggleSelect={onToggleSelect}
-              />
-              {index < rows.length - 1 ? (
-                <View style={{ height: 1, backgroundColor: theme.color.border }} />
-              ) : null}
-            </View>
-          ))}
-        </View>
-      )}
-    </View>
+            <MoneyText
+              amount={total.net}
+              currency={total.currency}
+              locale={locale}
+              variant="heading"
+              mode="balance"
+            />
+          </Row>
+        ))}
+      </View>
+    </Card>
   );
 }
 
-function FriendCard({
-  row,
+/**
+ * One person, one row — every group and currency they are unsettled with you in,
+ * folded into a single line (the Splitwise model). Direction lives on the row: a
+ * "you owe" / "owes you" micro-label and the money's own colour, so no owes/owed
+ * tab is needed. A person unsettled in two currencies shows both nets stacked at
+ * the right edge rather than appearing as two different people.
+ */
+function PersonRow({
+  person,
   locale,
   t,
-  showCurrency,
   selectMode,
   selected,
   onEnterSelect,
   onToggleSelect,
 }: {
-  row: PersonBalanceRow;
+  person: PersonGroup;
   locale: string;
   t: ReturnType<typeof useStrings>['t'];
-  /** When this person has balances in more than one currency, name the currency
-      in the subtitle so two rows for them do not read as two different people. */
-  showCurrency: boolean;
-  /** Whether the screen is picking people to merge. */
   selectMode: boolean;
   selected: boolean;
   onEnterSelect: (personKey: string) => void;
@@ -675,42 +704,73 @@ function FriendCard({
 }): React.JSX.Element {
   const theme = useTheme();
   const { isBlocked } = useBlockedUsers();
-  // A blocked person is hidden behind the ghost name and the ghost avatar here
-  // too, so their identity never surfaces on the Friends list — the amount and
-  // everything the row does with it are unchanged; only who it names is.
-  const blocked = isBlocked(row.profile_id);
-  const shownName = blocked ? t.misc.someone : row.display_name;
-  // Flat WhatsApp row: the money colour is gone from the background, the amount
-  // reads in ordinary ink, and the owed/owe meaning is carried by the sign and
-  // the section this row sits under. The avatar keeps the person's own colour.
-  const owed = BigInt(row.net) > 0n;
+  // A blocked person is hidden behind the ghost name and avatar here too, so
+  // their identity never surfaces on the list — the amounts are unchanged; only
+  // who the row names is.
+  const blocked = isBlocked(person.profile_id);
+  const shownName = blocked ? t.misc.someone : person.display_name;
   // Only a guest can be merged — a real account is already one identity across
-  // every group — so only guest rows take part in a selection. A real-account
-  // row stays inert (and dimmed) while a merge selection is running.
-  const selectable = row.is_ghost;
+  // every group — so only guest rows take part in a selection.
+  const selectable = person.is_ghost;
 
-  // One group explains the balance: open it. Several do: the amount is a sum, so
-  // open the person instead — a screen that splits it back out per group. Either
-  // way the row is now a doorway; it used to be a dead end once it spanned two.
-  const navigate = row.only_group_id
-    ? () => router.push(`/group/${row.only_group_id}`)
+  const entries = person.entries;
+  // The common case: a person with a single balance. It carries the micro-label,
+  // the group scope and the badges; a multi-currency person leans on the stacked
+  // amounts instead.
+  const single = entries.length === 1 ? entries[0] : null;
+  const soloGroup = single?.only_group_id ?? null;
+
+  // One group and one currency explains it: open that group. Otherwise the
+  // person page splits the balance back out per group and currency.
+  const navigate = soloGroup
+    ? () => router.push(`/group/${soloGroup}`)
     : () =>
         router.push(
-          // The route is typed once expo regenerates its route map; `as never`
-          // matches how the other friends/* pushes bridge that gap.
-          `/friends/person/${encodeURIComponent(row.person_key)}?name=${encodeURIComponent(
+          `/friends/person/${encodeURIComponent(person.person_key)}?name=${encodeURIComponent(
             shownName,
           )}` as never,
         );
 
-  // In a selection, a tap toggles a guest and does nothing on a non-guest; out
-  // of one, a tap opens the row and a long-press on a guest starts a selection.
   const onPress = selectMode
     ? selectable
-      ? () => onToggleSelect(row.person_key)
+      ? () => onToggleSelect(person.person_key)
       : undefined
     : navigate;
-  const onLongPress = !selectMode && selectable ? () => onEnterSelect(row.person_key) : undefined;
+  const onLongPress =
+    !selectMode && selectable ? () => onEnterSelect(person.person_key) : undefined;
+
+  const subtitle = single
+    ? single.group_count === 1
+      ? t.tabs.inOneGroup
+      : plural(locale, single.group_count, t.tabs.acrossGroups)
+    : null;
+
+  // What a screen reader hears: who, then each currency's spoken direction and
+  // amount, the group scope, and — for a guest — that they have not joined.
+  const moneyLabels = entries.map((e) =>
+    moneyAccessibilityLabel(
+      { minor: BigInt(e.net), currency: e.currency },
+      balanceDirection(BigInt(e.net)),
+      copyFor(locale).money,
+      { locale },
+    ),
+  );
+  const statusPart = person.is_ghost ? (soloGroup ? t.people.invite : t.tabs.notJoined) : '';
+  const rowA11yLabel = [shownName, ...moneyLabels, subtitle ?? '', statusPart]
+    .filter(Boolean)
+    .join('. ');
+
+  // Biggest currency first when a person spans several.
+  const sortedEntries =
+    entries.length > 1
+      ? [...entries].sort((a, b) =>
+          absBig(BigInt(a.net)) < absBig(BigInt(b.net))
+            ? 1
+            : absBig(BigInt(a.net)) > absBig(BigInt(b.net))
+              ? -1
+              : 0,
+        )
+      : entries;
 
   const body = (
     <Row
@@ -730,45 +790,56 @@ function FriendCard({
         />
       ) : null}
       <Row style={{ flex: 1, gap: theme.spacing.md, alignItems: 'center' }}>
-        <Avatar name={shownName} size={44} ghost={row.is_ghost || blocked} />
+        <Avatar name={shownName} size={44} ghost={person.is_ghost || blocked} />
         <View style={{ flex: 1 }}>
           <Text variant="subheading" numberOfLines={1}>
             {shownName}
           </Text>
-          <Text variant="caption" tone="muted" numberOfLines={1}>
-            {(() => {
-              const groupPart =
-                row.group_count === 1
-                  ? t.tabs.inOneGroup
-                  : plural(locale, row.group_count, t.tabs.acrossGroups);
-              // The currency is what tells this row apart from the same person's
-              // other-currency row; a middot keeps it one glanceable line.
-              return showCurrency ? `${groupPart} · ${row.currency}` : groupPart;
-            })()}
-          </Text>
+          {subtitle ? (
+            <Text variant="caption" tone="muted" numberOfLines={1}>
+              {subtitle}
+            </Text>
+          ) : null}
         </View>
       </Row>
       <View style={{ alignItems: 'flex-end', gap: 2 }}>
-        {/* Semantic money colour (owed green, owe red) is the one signal that
-            tells direction at a glance — the section header alone is lost the
-            moment it scrolls off. Sign is spoken via the balance a11y label. */}
-        <MoneyText
-          amount={BigInt(row.net)}
-          currency={row.currency}
-          locale={locale}
-          variant="subheading"
-          mode="balance"
-        />
-        {selectMode ? null : row.is_ghost ? (
-          // A ghost is somebody you added who has no Baaki account yet, so the
-          // badge is the useful action rather than a verdict: send them this
-          // group's invite link, which is the same link that lets them claim
-          // this very row (A25). Only offered when a single group explains the
-          // balance — otherwise there is no one link to share. Its own
-          // Pressable so tapping it invites rather than opening the group.
-          row.only_group_id ? (
+        {single ? (
+          <>
+            {/* The one place the row says the direction in words — over the
+                coloured amount — so a glance reads owed-vs-owe without leaning on
+                red/green alone. */}
+            <Text variant="micro" tone="faint">
+              {BigInt(single.net) > 0n ? t.tabs.owesYou : t.tabs.youOweThem}
+            </Text>
+            <MoneyText
+              amount={BigInt(single.net)}
+              currency={single.currency}
+              locale={locale}
+              variant="subheading"
+              mode="balance"
+            />
+          </>
+        ) : (
+          // Multi-currency: one small coloured line per currency — never summed.
+          sortedEntries.map((e) => (
+            <MoneyText
+              key={e.currency}
+              amount={BigInt(e.net)}
+              currency={e.currency}
+              locale={locale}
+              variant="caption"
+              mode="balance"
+            />
+          ))
+        )}
+        {selectMode ? null : person.is_ghost ? (
+          // A ghost is somebody you added who has no account yet, so the badge is
+          // the useful action: send them this group's invite link — the same link
+          // that lets them claim this balance (A25). Offered only when a single
+          // group explains it, otherwise there is no one link to share.
+          soloGroup ? (
             <Pressable
-              onPress={() => router.push(`/group/${row.only_group_id}/invite`)}
+              onPress={() => router.push(`/group/${soloGroup}/invite`)}
               accessibilityRole="button"
               accessibilityLabel={t.people.invite}
               hitSlop={12}
@@ -779,11 +850,10 @@ function FriendCard({
           ) : (
             <Badge label={t.tabs.notJoined} />
           )
-        ) : owed && row.only_group_id ? (
-          // They owe you and one group explains it, so there is a single pair
-          // to nudge. The server keeps it honest — one a day, never to a
-          // ghost, never for nothing — so the button only has to ask (ADR-010).
-          <RemindButton row={row} />
+        ) : single && BigInt(single.net) > 0n && single.only_group_id ? (
+          // They owe you and one group explains it, so there is a single pair to
+          // nudge. The server keeps it honest — one a day (ADR-010).
+          <RemindButton row={single} />
         ) : null}
       </View>
     </Row>
@@ -795,15 +865,15 @@ function FriendCard({
       onLongPress={onLongPress}
       delayLongPress={250}
       // In selection mode a selectable row is a checkbox; a non-selectable one
-      // (a real account — already one identity, nothing to merge) is inert, so
-      // it announces neither role nor tap and reads as disabled. Outside
-      // selection mode every row is the usual button into the person.
+      // (a real account — already one identity, nothing to merge) is inert, so it
+      // announces neither role nor tap and reads as disabled. Outside selection
+      // mode every row is the usual button into the person.
       disabled={selectMode && !selectable}
       accessibilityRole={selectMode ? (selectable ? 'checkbox' : 'none') : 'button'}
       accessibilityState={
         selectMode ? (selectable ? { checked: selected } : { disabled: true }) : undefined
       }
-      accessibilityLabel={shownName}
+      accessibilityLabel={selectMode ? shownName : rowA11yLabel}
       style={({ pressed }) => ({
         opacity: pressed ? 0.9 : 1,
         // A tick alone can be missed; a picked row also wears a soft fill.
@@ -928,12 +998,7 @@ function SortMenu({
             </Text>
             {SORT_ORDER.map((key) => {
               const active = key === sortKey;
-              const label =
-                key === SortKey.Amount
-                  ? t.sort.amount
-                  : key === SortKey.Date
-                    ? t.sort.date
-                    : t.sort.name;
+              const label = sortLabel(key, t);
               return (
                 <Pressable
                   key={key}
@@ -971,6 +1036,169 @@ function SortMenu({
                 </Pressable>
               );
             })}
+          </View>
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+/**
+ * The contextual merge nudge — a card, not a bare header glyph.
+ *
+ * Merge used to live behind an icon that appeared only when it was usable and a
+ * long-press nobody stumbles onto. This says the concept in words and offers the
+ * way in, so a user learns "duplicate guests can be merged" at the one moment it
+ * is true and actionable. It disappears the instant the duplicates are gone.
+ */
+function MergeHint({ onPress, t }: { onPress: () => void; t: UiStrings }): React.JSX.Element {
+  const theme = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={t.mergePeople.entry}
+      accessibilityHint={t.mergePeople.hint}
+      style={({ pressed }) => ({ opacity: pressed ? 0.85 : 1 })}
+    >
+      <Card>
+        <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+          <View
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 20,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.color.brandSoft,
+            }}
+          >
+            <Ionicons name="git-merge-outline" size={iconSize.xl} color={theme.color.brand} />
+          </View>
+          <Text variant="caption" tone="muted" style={{ flex: 1 }}>
+            {t.mergePeople.hint}
+          </Text>
+          <Ionicons
+            name={directionalIcon('chevron-forward')}
+            size={iconSize.lg}
+            color={theme.color.textFaint}
+          />
+        </Row>
+      </Card>
+    </Pressable>
+  );
+}
+
+/**
+ * The `+` menu — the same corner dropdown SortMenu uses, holding the three ways
+ * to add a person: type a name, pull from contacts, scan an invite QR. One door
+ * in place of the header's former row of bare glyphs.
+ */
+function AddMenu({
+  open,
+  onClose,
+  t,
+}: {
+  open: boolean;
+  onClose: () => void;
+  t: UiStrings;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const go = (path: string): void => {
+    onClose();
+    router.push(path as never);
+  };
+
+  const items: {
+    key: string;
+    label: string;
+    icon: React.ReactNode;
+    onPress: () => void;
+  }[] = [
+    {
+      key: 'add',
+      label: t.addPerson.title,
+      icon: <Ionicons name="person-add-outline" size={iconSize.lg} color={theme.color.text} />,
+      onPress: () => go('/friends/add-person'),
+    },
+    {
+      key: 'contacts',
+      label: t.tabs.fromContacts,
+      icon: (
+        <MaterialCommunityIcons
+          name="book-account-outline"
+          size={iconSize.lg}
+          color={theme.color.text}
+        />
+      ),
+      onPress: () => go('/friends/contacts'),
+    },
+    {
+      key: 'scan',
+      label: t.misc.scanToJoin,
+      icon: <Ionicons name="qr-code-outline" size={iconSize.lg} color={theme.color.text} />,
+      onPress: () => go('/scan'),
+    },
+  ];
+
+  return (
+    <Modal visible={open} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel={t.common.close}
+        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.12)' }}
+      >
+        <View
+          style={{
+            position: 'absolute',
+            top: insets.top + 56,
+            right: theme.spacing.xl,
+            minWidth: 220,
+            borderRadius: theme.radius.lg,
+            ...theme.shadow.lifted,
+          }}
+        >
+          <View
+            style={{
+              borderRadius: theme.radius.lg,
+              borderWidth: 1,
+              borderColor: theme.color.border,
+              backgroundColor: theme.color.surface,
+              paddingVertical: theme.spacing.xs,
+              overflow: 'hidden',
+            }}
+          >
+            <Text
+              variant="micro"
+              tone="faint"
+              style={{ paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.xs }}
+            >
+              {t.tabs.addSomeone}
+            </Text>
+            {items.map((item) => (
+              <Pressable
+                key={item.key}
+                onPress={item.onPress}
+                accessibilityRole="button"
+                accessibilityLabel={item.label}
+                style={({ pressed }) => ({
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: theme.spacing.md,
+                  paddingHorizontal: theme.spacing.lg,
+                  paddingVertical: theme.spacing.md,
+                  backgroundColor: pressed ? theme.color.surfaceMuted : 'transparent',
+                })}
+              >
+                {item.icon}
+                <Text variant="body" style={{ flex: 1 }}>
+                  {item.label}
+                </Text>
+              </Pressable>
+            ))}
           </View>
         </View>
       </Pressable>

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1109,6 +1109,9 @@ export interface UiStrings {
     inbox: string;
     fromContacts: string;
     addFromContacts: string;
+    /** Title of the header `+` menu and its primary empty-state button — the
+        umbrella verb over add-a-person / from-contacts / scan. */
+    addSomeone: string;
     /** The Friends screen with nobody in it yet — not the same state as being
         square with people you do have, which is `allSquare` below. */
     noFriends: string;
@@ -1117,6 +1120,10 @@ export interface UiStrings {
     allSquareBody: string;
     owesYou: string;
     youOweThem: string;
+    /** Headline card label over the overall per-currency balances. */
+    overall: string;
+    /** Headline line when a currency's overall net is in your favour. */
+    youAreOwed: string;
     nobodyOwesYou: string;
     youAreNotBehind: string;
     inOneGroup: string;
@@ -1207,6 +1214,8 @@ export interface UiStrings {
     addGuestTitle: string;
     /** Empty state of the add sheet when every mergeable guest is already in. */
     noMoreGuests: string;
+    /** Contextual card on Friends when duplicate guests exist, inviting a merge. */
+    hint: string;
   };
   /** Group photos are a paid feature; the cover emoji stays free for everyone. */
   groupPhoto: {
@@ -3140,6 +3149,7 @@ const en: UiStrings = {
     inbox: 'Inbox',
     fromContacts: 'From contacts',
     addFromContacts: 'Add from contacts',
+    addSomeone: 'Add someone',
     noFriends: 'Your circle starts here',
     noFriendsBody:
       'Add the people you share costs with. They do not need the app — a name is enough to start.',
@@ -3147,6 +3157,8 @@ const en: UiStrings = {
     allSquareBody: 'Nobody owes you and you owe nobody. New balances show up here.',
     owesYou: 'Owes you',
     youOweThem: 'You owe',
+    overall: 'Overall',
+    youAreOwed: 'You’re owed',
     nobodyOwesYou: 'Nobody owes you anything right now.',
     youAreNotBehind: 'All settled up — you owe nobody right now.',
     inOneGroup: 'in one group',
@@ -3217,6 +3229,7 @@ const en: UiStrings = {
     addGuestTitle: 'Add a person',
     noMoreGuests:
       'Everyone you can merge is already added. Add someone from your contacts instead.',
+    hint: 'Seeing the same guest in more than one group? Merge the duplicates into one person.',
   },
   groupPhoto: {
     paidHint: 'Group photos are a Plus feature. Pick an icon, or upgrade to add a photo.',
@@ -5174,6 +5187,7 @@ const ta: UiStrings = {
     inbox: 'அஞ்சல் பெட்டி',
     fromContacts: 'தொடர்புகளிலிருந்து',
     addFromContacts: 'தொடர்புகளிலிருந்து சேர்',
+    addSomeone: 'ஒருவரைச் சேர்',
     noFriends: 'உங்கள் வட்டம் இங்கே தொடங்குகிறது',
     noFriendsBody:
       'நீங்கள் செலவுகளைப் பகிர்பவர்களைச் சேருங்கள். அவர்களுக்கு ஆப் தேவையில்லை — ஒரு பெயர் போதும்.',
@@ -5182,6 +5196,8 @@ const ta: UiStrings = {
       'உங்களுக்கு யாரும் தர வேண்டியதில்லை, நீங்களும் யாருக்கும் தர வேண்டியதில்லை. புதிய பாக்கிகள் இங்கே தோன்றும்.',
     owesYou: 'உங்களுக்குத் தர வேண்டியவர்கள்',
     youOweThem: 'நீங்கள் தர வேண்டியவர்கள்',
+    overall: 'மொத்தம்',
+    youAreOwed: 'உங்களுக்கு வர வேண்டியது',
     nobodyOwesYou: 'இப்போது உங்களுக்கு யாரும் தர வேண்டியதில்லை.',
     youAreNotBehind: 'நீங்கள் யாருக்கும் பாக்கி வைத்திருக்கவில்லை.',
     inOneGroup: 'ஒரு குழுவில்',
@@ -5255,6 +5271,7 @@ const ta: UiStrings = {
     addGuestTitle: 'ஒரு நபரைச் சேர்க்கவும்',
     noMoreGuests:
       'இணைக்கக்கூடிய அனைவரும் ஏற்கனவே சேர்க்கப்பட்டுள்ளனர். பதிலாக உங்கள் தொடர்புகளிலிருந்து ஒருவரைச் சேர்க்கவும்.',
+    hint: 'ஒரே விருந்தினர் ஒன்றுக்கு மேற்பட்ட குழுக்களில் தெரிகிறாரா? நகல்களை ஒரே நபராக இணைக்கவும்.',
   },
   groupPhoto: {
     paidHint:
@@ -7242,6 +7259,7 @@ const hi: UiStrings = {
     inbox: 'इनबॉक्स',
     fromContacts: 'संपर्कों से',
     addFromContacts: 'संपर्कों से जोड़ें',
+    addSomeone: 'किसी को जोड़ें',
     noFriends: 'आपका सर्कल यहाँ से शुरू होता है',
     noFriendsBody:
       'जिनके साथ आप खर्च बाँटते हैं उन्हें जोड़ें। उन्हें ऐप की ज़रूरत नहीं — बस एक नाम काफ़ी है।',
@@ -7249,6 +7267,8 @@ const hi: UiStrings = {
     allSquareBody: 'न किसी पर आपका बाकी है, न आप पर किसी का। नए हिसाब यहाँ दिखेंगे।',
     owesYou: 'आपको देने हैं',
     youOweThem: 'आपको देने हैं जिन्हें',
+    overall: 'कुल मिलाकर',
+    youAreOwed: 'आपको मिलने हैं',
     nobodyOwesYou: 'अभी किसी पर आपका कुछ बाकी नहीं है।',
     youAreNotBehind: 'आप पर किसी का कुछ बाकी नहीं है।',
     inOneGroup: 'एक समूह में',
@@ -7321,6 +7341,7 @@ const hi: UiStrings = {
     addGuestTitle: 'एक व्यक्ति जोड़ें',
     noMoreGuests:
       'जिन्हें आप मर्ज कर सकते हैं वे सभी पहले से जुड़े हैं. इसके बजाय अपने संपर्कों से किसी को जोड़ें.',
+    hint: 'एक ही मेहमान कई समूहों में दिख रहा है? डुप्लिकेट को एक व्यक्ति में मर्ज करें.',
   },
   groupPhoto: {
     paidHint: 'ग्रुप फ़ोटो एक Plus सुविधा है। कोई आइकन चुनें, या फ़ोटो जोड़ने के लिए अपग्रेड करें।',
@@ -9289,12 +9310,15 @@ const ar: UiStrings = {
     inbox: 'صندوق الوارد',
     fromContacts: 'من جهات الاتصال',
     addFromContacts: 'أضف من جهات الاتصال',
+    addSomeone: 'إضافة شخص',
     noFriends: 'دائرتك تبدأ من هنا',
     noFriendsBody: 'أضف من تتشارك معهم المصاريف. لا يحتاجون إلى التطبيق — يكفي اسم للبدء.',
     allSquare: 'كل شيء متساوٍ',
     allSquareBody: 'لا أحد يدين لك ولا أنت تدين لأحد. ستظهر هنا أي مبالغ جديدة.',
     owesYou: 'لك عندهم',
     youOweThem: 'عليك لهم',
+    overall: 'الإجمالي',
+    youAreOwed: 'لك عندهم',
     nobodyOwesYou: 'لا أحد يدين لك بشيء الآن.',
     youAreNotBehind: 'لست متأخرًا مع أحد.',
     inOneGroup: 'في مجموعة واحدة',
@@ -9368,6 +9392,7 @@ const ar: UiStrings = {
     addPerson: 'ربطه بجهة اتصال',
     addGuestTitle: 'إضافة شخص',
     noMoreGuests: 'كل من يمكنك دمجهم مُضافون بالفعل. أضِف شخصًا من جهات اتصالك بدلاً من ذلك.',
+    hint: 'هل ترى نفس الضيف في أكثر من مجموعة؟ ادمج المكرَّرين في شخص واحد.',
   },
   groupPhoto: {
     paidHint: 'صور المجموعة ميزة Plus. اختر أيقونة، أو قم بالترقية لإضافة صورة.',


### PR DESCRIPTION
## What

Rebuilds the Friends screen on the pattern Splitwise uses for the exact question this tab answers — *"who do I need to settle with?"* — after a UX roast and a [Mobbin](https://mobbin.com/screens/b458ec73-3848-4060-b5c4-158e960dd49b) review.

## The pivot

- **Overall headline** — net per currency across everyone, up top. One line per currency; never a summed cross-currency total (ADR-003). Silent when overall-flat, so the rows carry it.
- **One row per person** — folds the mirror's per-`(person, currency)` rows via `groupByPerson`. A single balance shows a **"owes you" / "you owe" micro-label** + coloured amount; a **multi-currency** person **stacks each net** at the right edge instead of appearing as two different people (kills the duplicate-row problem).
- **Direction lives on the row**, so the owes/owed split needs no navigation — the `SegmentedTabs` experiment was removed.

## Also in this branch (earlier UX pass)

- **Header de-cluttered** — add-person / contacts / scan collapsed behind one `+` menu; the sort control now shows its active key + direction (was an invisible ellipsis).
- **`NoFriendsHero`** gains its promised add CTAs — it was rendering title-only, a first-run dead end.
- **Merge** surfaced as a contextual hint card, not a bare git-merge glyph + undiscoverable long-press.
- **Richer per-row a11y labels** — name, spoken direction + amount, group scope, guest status (was name-only).

## Notes

- Merge selection is keyed by person, which retires the "select one currency, both rows select" edge case.
- New i18n across **en / ta / hi / ar**: `overall`, `youAreOwed`, `addSomeone`, `mergePeople.hint`.
- Gates: `typecheck` clean, `lint` clean bar one pre-existing `exitSelect` exhaustive-deps warning (untouched selection effect). **Not device-tested.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Friends are now grouped by person, with balances shown separately by currency.
  * Added overall totals for each currency and sorting by balance, recent activity, or name.
  * Added a unified add menu and clearer merge and empty-state actions.
  * Improved balance direction labels, accessibility descriptions, and person-level navigation.
  * Selection and merging now apply to entire people rather than individual currency entries.

* **Localization**
  * Added translations for new balance, add-person, and merge guidance text in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->