### PR TITLE
feat(trip): offer to plan a trip after it is created, not before

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -477,12 +477,16 @@ export default function GroupScreen() {
   const clearance = useScreenClearance(112);
   const pull = usePullRefresh();
   const { t, locale } = useStrings();
-  const { id } = useLocalSearchParams<{ id: string }>();
+  // `?welcome=trip` is set once, by the create screen, when a trip is made
+  // without dates — it opens this group with a one-time plan-your-trip nudge.
+  // The param is gone on any later visit, so the nudge is a moment, not a nag.
+  const { id, welcome } = useLocalSearchParams<{ id: string; welcome?: string }>();
   const groupId = id ?? '';
   const { profile } = useAuth();
   const [tab, setTab] = useState<Tab>(Tab.Expenses);
   const [showDeleted, setShowDeleted] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [tripNudgeDismissed, setTripNudgeDismissed] = useState(false);
 
   // Live updates from the other devices in this group (TDR §1).
   useGroupRealtime(groupId);
@@ -678,6 +682,12 @@ export default function GroupScreen() {
   // The overflow: the same three-dot dropdown the dashboard uses, not a bottom
   // sheet, so the two headers behave alike. Planner only appears where there is
   // a trip to plan; a flatshare has no use for the row.
+  // The one-time trip nudge: a trip opened straight from create, with no dates
+  // on it yet, until it is dismissed. Dates being the tell — a dated trip was
+  // already planned at create, and a nudge would be noise.
+  const showTripNudge =
+    welcome === 'trip' && groupData.type === 'trip' && !groupData.start_date && !tripNudgeDismissed;
+
   const menuItems: OverflowMenuItem[] = [
     { icon: 'pie-chart-outline', label: t.spending, route: `/group/${groupId}/insights` },
     ...(groupData.type === 'trip'
@@ -1118,6 +1128,43 @@ export default function GroupScreen() {
                     <Text variant="caption" tone="muted">
                       {t.group.mismatchBody}
                     </Text>
+                  </Card>
+                ) : null}
+
+                {/* The one-time nudge to plan a fresh trip. Dates and budget were
+            moved off the create screen to keep it short; this is where a trip
+            gets offered them, once, on its own group. Later dismisses it for
+            this visit; the param is gone next time regardless. */}
+                {showTripNudge ? (
+                  <Card style={{ gap: theme.spacing.md }}>
+                    <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+                      <Ionicons name="airplane" size={iconSize.md} color={theme.color.brand} />
+                      <Text variant="subheading" style={{ flex: 1 }}>
+                        {t.extras.tripWelcomeTitle}
+                      </Text>
+                    </Row>
+                    <Text variant="caption" tone="muted">
+                      {t.extras.tripWelcomeBody}
+                    </Text>
+                    <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
+                      <Button
+                        label={t.extras.tripWelcomeAddDates}
+                        size="sm"
+                        onPress={() => router.push(`/group/${groupId}/settings`)}
+                      />
+                      <Button
+                        label={t.extras.tripWelcomeSetBudget}
+                        size="sm"
+                        variant="secondary"
+                        onPress={() => router.push(`/group/${groupId}/plan`)}
+                      />
+                      <Button
+                        label={t.extras.tripWelcomeLater}
+                        size="sm"
+                        variant="ghost"
+                        onPress={() => setTripNudgeDismissed(true)}
+                      />
+                    </Row>
                   </Card>
                 ) : null}
 

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -445,7 +445,13 @@ export default function NewGroupScreen() {
         });
       }
 
-      router.replace(`/group/${groupId}`);
+      // A trip made without dates lands on its group with a one-time nudge to
+      // plan it — dates turn on the daily reminders, a budget the cap. Only when
+      // neither was set here, since the point of moving them off the create
+      // screen is that most trips skip them there. Any other kind, or a trip
+      // already dated, opens plain.
+      const nudgeTrip = type === GroupType.Trip && !(tripDates.start_date && tripDates.end_date);
+      router.replace(nudgeTrip ? `/group/${groupId}?welcome=trip` : `/group/${groupId}`);
     } catch (caught) {
       setError(
         isPhoneCountryError(caught)

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -7,6 +7,7 @@ import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react
 import {
   currencySymbol,
   guessGroupEmoji,
+  guessGroupType,
   minorUnitExponent,
   minorUnitScale,
   MutationKind,
@@ -17,7 +18,6 @@ import {
   Callout,
   Card,
   ChipRow,
-  directionalIcon,
   Divider,
   IconButton,
   iconSize,
@@ -232,10 +232,17 @@ export default function NewGroupScreen() {
   // The group cover is an emoji icon, chosen by tapping the avatar. Photos are
   // a paid feature edited from group settings, not part of creating one.
   const [iconOpen, setIconOpen] = useState(false);
-  const [type, setType] = useState<GroupType>(GroupType.Trip);
+  // Null until somebody picks a kind — until then it is read from the name, the
+  // same bargain the icon strikes. So the screen never opens assuming a trip: a
+  // group called "Goa" still becomes one, "Dinner" does not, and an untyped
+  // name falls back to Other rather than dragging trip fields in behind it.
+  const [pickedType, setPickedType] = useState<GroupType | null>(null);
+  // Kind, dates, budget and simplify all live behind one collapsed row: the
+  // shortest path is name, people, create, and everything here is optional.
+  const [showMore, setShowMore] = useState(false);
   // Which attribute row of the combined card is unfolded, if any — one at a
   // time, so the card stays a short list until you open the one you want.
-  const [openAttr, setOpenAttr] = useState<'kind' | 'dates' | 'budget' | null>(null);
+  const [openAttr, setOpenAttr] = useState<'dates' | 'budget' | null>(null);
   const [ghostName, setGhostName] = useState('');
   // People to add on Create — a typed name carries no address, a contact carries
   // whatever the phone had. Same shape either way, so the create loop treats
@@ -297,7 +304,7 @@ export default function NewGroupScreen() {
     // same shape GroupPhoto's signed-URL fetch uses).
     void Promise.resolve().then(() => {
       setName(group.name ? fill(t.clone.copyOf, { name: group.name }) : '');
-      setType(group.type);
+      setPickedType(group.type);
       setPickedEmoji(group.cover_emoji ?? null);
       setSimplify(group.simplify_debts);
       if (budgetMinor !== null) setBudget(budgetMinor);
@@ -316,6 +323,11 @@ export default function NewGroupScreen() {
     });
   }, [cloning, sourceGroup, sourceMembers, profile?.id, t]);
 
+  // The kind is a reading of the name, unless somebody has chosen one, and
+  // Other when the name says nothing — never Trip by default, so the trip-only
+  // dates and budget stay out of the way of a dinner or a flat.
+  const type: GroupType =
+    pickedType ?? (guessGroupType(name) as GroupType | null) ?? GroupType.Other;
   // The icon is a reading of the name, unless somebody has chosen one; it
   // changes under the caret as they type "Goa" and again if they change the
   // kind of group.
@@ -542,36 +554,6 @@ export default function NewGroupScreen() {
           </Row>
         </Card>
 
-        {/* Seed the whole form from a group you already have. Hidden once you
-            are already cloning — you are past the choosing. */}
-        {!cloning ? (
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.clone.startFromExisting}
-            onPress={() => router.push('/clone-group')}
-            style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-          >
-            <Card style={{ paddingVertical: theme.spacing.md }}>
-              <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
-                <IconTile tint="lilac" icon="copy-outline" />
-                <View style={{ flex: 1 }}>
-                  <Text variant="subheading" style={{ fontWeight: '600' }}>
-                    {t.clone.startFromExisting}
-                  </Text>
-                  <Text variant="caption" tone="muted">
-                    {t.clone.startFromExistingHint}
-                  </Text>
-                </View>
-                <Ionicons
-                  name={directionalIcon('chevron-forward')}
-                  size={iconSize.base}
-                  color={theme.color.textFaint}
-                />
-              </Row>
-            </Card>
-          </Pressable>
-        ) : null}
-
         {/* Controlled by the avatar tap above — no trigger of its own. */}
         <CoverEmojiPicker
           value={emoji}
@@ -580,133 +562,23 @@ export default function NewGroupScreen() {
           onOpenChange={setIconOpen}
         />
 
-        {/* Kind, dates, budget and simplify as one card of attribute rows —
-            each a label with a value pill that unfolds its editor beneath, so
-            the whole shape of a group is set from one short list rather than
-            four stacked cards. Dates and budget are trip-only.
-
-            The budget, left at zero, sets nothing; entered, it seeds the
-            planner's overall cap on create so the Plan screen opens with the
-            number already in it. ADR-009: simplification is presentation only —
-            the pairwise ledger underneath is untouched. */}
-        <Card
-          flat
-          padded={false}
-          style={{ backgroundColor: theme.color.surfaceMuted, overflow: 'hidden' }}
-        >
-          <AttrRow tint="lilac" icon={currentType.icon} label={t.extras.groupKind}>
-            <Pill
-              label={currentType.label}
-              expanded={openAttr === 'kind'}
-              accessibilityLabel={t.extras.whatKindOfGroup}
-              onPress={() => setOpenAttr((current) => (current === 'kind' ? null : 'kind'))}
-            />
-          </AttrRow>
-          {openAttr === 'kind' ? (
-            <View style={{ paddingHorizontal: theme.spacing.lg, paddingBottom: theme.spacing.md }}>
-              <ChipRow<GroupType>
-                value={type}
-                onChange={(next) => {
-                  setType(next);
-                  setOpenAttr(null);
-                }}
-                options={typeOptions.map((option) => ({
-                  value: option.value,
-                  label: option.label,
-                  icon: iconFor(option.icon),
-                }))}
-              />
-            </View>
-          ) : null}
-
-          {type === GroupType.Trip ? (
-            <>
-              <InsetDivider />
-              <AttrRow tint="sky" icon="calendar-outline" label={t.misc.tripDatesTitle}>
-                <Pill
-                  label={dateSummary}
-                  placeholder={!tripDates.start_date || !tripDates.end_date}
-                  expanded={openAttr === 'dates'}
-                  accessibilityLabel={t.misc.tripDatesTitle}
-                  onPress={() => setOpenAttr((current) => (current === 'dates' ? null : 'dates'))}
-                />
-              </AttrRow>
-              {openAttr === 'dates' ? (
-                <View
-                  style={{ paddingHorizontal: theme.spacing.lg, paddingBottom: theme.spacing.md }}
-                >
-                  <TripDates
-                    group={tripDates}
-                    locale={locale}
-                    embedded
-                    onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
-                  />
-                </View>
-              ) : null}
-
-              <InsetDivider />
-              <AttrRow tint="mint" icon="wallet-outline" label={t.extras.tripBudget}>
-                <Pill
-                  label={budgetSummary}
-                  placeholder={budget <= 0n}
-                  expanded={openAttr === 'budget'}
-                  accessibilityLabel={t.extras.tripBudgetOptional}
-                  onPress={() => setOpenAttr((current) => (current === 'budget' ? null : 'budget'))}
-                />
-              </AttrRow>
-              {openAttr === 'budget' ? (
-                <View
-                  style={{ paddingHorizontal: theme.spacing.lg, paddingBottom: theme.spacing.md }}
-                >
-                  <AmountField currency={currency} value={budget} onChange={setBudget} />
-                </View>
-              ) : null}
-            </>
-          ) : null}
-
-          <InsetDivider />
-          <AttrRow
-            tint="peach"
-            icon="flash-outline"
-            label={t.group.simplifyDebts}
-            subtitle={t.group.simplifyDebtsHint}
-          >
-            <Toggle
-              value={effectiveSimplify}
-              onValueChange={setSimplify}
-              accessibilityLabel={t.group.simplifyDebts}
-            />
-          </AttrRow>
-        </Card>
-
+        {/* People sit directly under the name — they are the group, so nothing
+            optional (kind, dates, budget) comes between naming it and saying who
+            is in it. Contacts is a real button, not a corner link; a typed name
+            is the quieter second way. Nobody's address book is uploaded
+            (ADR-006). */}
         <Card style={{ gap: theme.spacing.md }}>
           <InfoDisclosure
             title={t.extras.addPeopleByName}
             info={t.extras.ghostNote}
             titleVariant="caption"
-            right={
-              // Opens the address book on its own screen rather than unfolding
-              // it inline — a thousand-name list needs the whole height. Nobody's
-              // book is uploaded (ADR-006). The picker hands its answer back
-              // through the bridge into `addContacts`.
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t.people.browseContacts}
-                hitSlop={8}
-                onPress={openContactPicker}
-                style={({ pressed }) => ({
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: 6,
-                  opacity: pressed ? 0.6 : 1,
-                })}
-              >
-                <Ionicons name="people-outline" size={iconSize.base} color={theme.color.brand} />
-                <Text variant="caption" style={{ color: theme.color.brand }}>
-                  {t.people.contacts}
-                </Text>
-              </Pressable>
-            }
+          />
+          <Button
+            label={t.people.browseContacts}
+            variant="secondary"
+            fullWidth
+            onPress={openContactPicker}
+            icon={<Ionicons name="people-outline" size={iconSize.base} color={theme.color.brand} />}
           />
           <Row>
             <TextInput
@@ -758,6 +630,172 @@ export default function NewGroupScreen() {
             </Row>
           ) : null}
         </Card>
+
+        {/* Everything that is not name-people-create folds behind one row, so
+            the screen opens as a short path and the settings are there for who
+            wants them. The collapsed row still shows the current kind, so a
+            wrong guess from the name is visible without opening it.
+
+            Dates and budget are trip-only; the budget, left at zero, sets
+            nothing; entered, it seeds the planner's overall cap on create.
+            ADR-009: simplification is presentation only — the pairwise ledger
+            underneath is untouched. */}
+        <Card
+          flat
+          padded={false}
+          style={{ backgroundColor: theme.color.surfaceMuted, overflow: 'hidden' }}
+        >
+          <Pressable
+            accessibilityRole="button"
+            accessibilityState={{ expanded: showMore }}
+            accessibilityLabel={t.extras.moreOptions}
+            onPress={() => setShowMore((current) => !current)}
+            style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+          >
+            <Row
+              style={{
+                alignItems: 'center',
+                gap: theme.spacing.md,
+                paddingHorizontal: theme.spacing.lg,
+                paddingVertical: theme.spacing.md,
+              }}
+            >
+              <IconTile tint="lilac" icon="options-outline" />
+              <View style={{ flex: 1, gap: 2 }}>
+                <Text variant="subheading" style={{ fontWeight: '600' }}>
+                  {t.extras.moreOptions}
+                </Text>
+                <Text variant="caption" tone="muted">
+                  {t.extras.moreOptionsHint}
+                </Text>
+              </View>
+              {!showMore ? (
+                <Text variant="caption" tone="muted">
+                  {currentType.label}
+                </Text>
+              ) : null}
+              <Ionicons
+                name={showMore ? 'chevron-up' : 'chevron-down'}
+                size={iconSize.base}
+                color={theme.color.textFaint}
+              />
+            </Row>
+          </Pressable>
+
+          {showMore ? (
+            <>
+              <InsetDivider />
+              <AttrRow tint="lilac" icon={currentType.icon} label={t.extras.groupKind}>
+                <View />
+              </AttrRow>
+              <View
+                style={{ paddingHorizontal: theme.spacing.lg, paddingBottom: theme.spacing.md }}
+              >
+                <ChipRow<GroupType>
+                  value={type}
+                  onChange={setPickedType}
+                  options={typeOptions.map((option) => ({
+                    value: option.value,
+                    label: option.label,
+                    icon: iconFor(option.icon),
+                  }))}
+                />
+              </View>
+
+              {type === GroupType.Trip ? (
+                <>
+                  <InsetDivider />
+                  <AttrRow tint="sky" icon="calendar-outline" label={t.misc.tripDatesTitle}>
+                    <Pill
+                      label={dateSummary}
+                      placeholder={!tripDates.start_date || !tripDates.end_date}
+                      expanded={openAttr === 'dates'}
+                      accessibilityLabel={t.misc.tripDatesTitle}
+                      onPress={() =>
+                        setOpenAttr((current) => (current === 'dates' ? null : 'dates'))
+                      }
+                    />
+                  </AttrRow>
+                  {openAttr === 'dates' ? (
+                    <View
+                      style={{
+                        paddingHorizontal: theme.spacing.lg,
+                        paddingBottom: theme.spacing.md,
+                      }}
+                    >
+                      <TripDates
+                        group={tripDates}
+                        locale={locale}
+                        embedded
+                        onChange={(patch) => setTripDates((current) => ({ ...current, ...patch }))}
+                      />
+                    </View>
+                  ) : null}
+
+                  <InsetDivider />
+                  <AttrRow tint="mint" icon="wallet-outline" label={t.extras.tripBudget}>
+                    <Pill
+                      label={budgetSummary}
+                      placeholder={budget <= 0n}
+                      expanded={openAttr === 'budget'}
+                      accessibilityLabel={t.extras.tripBudgetOptional}
+                      onPress={() =>
+                        setOpenAttr((current) => (current === 'budget' ? null : 'budget'))
+                      }
+                    />
+                  </AttrRow>
+                  {openAttr === 'budget' ? (
+                    <View
+                      style={{
+                        paddingHorizontal: theme.spacing.lg,
+                        paddingBottom: theme.spacing.md,
+                      }}
+                    >
+                      <AmountField currency={currency} value={budget} onChange={setBudget} />
+                    </View>
+                  ) : null}
+                </>
+              ) : null}
+
+              <InsetDivider />
+              <AttrRow
+                tint="peach"
+                icon="flash-outline"
+                label={t.group.simplifyDebts}
+                subtitle={t.group.simplifyDebtsHint}
+              >
+                <Toggle
+                  value={effectiveSimplify}
+                  onValueChange={setSimplify}
+                  accessibilityLabel={t.group.simplifyDebts}
+                />
+              </AttrRow>
+            </>
+          ) : null}
+        </Card>
+
+        {/* Seed the whole form from a group you already have — a power move, so
+            it is a quiet link at the foot, not a card above the real work.
+            Hidden once you are already cloning: you are past the choosing. */}
+        {!cloning ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.clone.startFromExisting}
+            onPress={() => router.push('/clone-group')}
+            style={({ pressed }) => ({
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: theme.spacing.sm,
+              opacity: pressed ? 0.6 : 1,
+            })}
+          >
+            <Ionicons name="copy-outline" size={iconSize.base} color={theme.color.brand} />
+            <Text variant="subheading" style={{ color: theme.color.brand, fontWeight: '600' }}>
+              {t.clone.startFromExisting}
+            </Text>
+          </Pressable>
+        ) : null}
       </ScrollView>
 
       {/* The primary action is pinned rather than parked at the foot of a long

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -3407,7 +3407,7 @@ const en: UiStrings = {
     saveName: 'Save name',
     chooseIcon: 'Choose an icon',
     removePhoto: 'Remove photo',
-    simplifyDebts: 'Simplify debts',
+    simplifyDebts: 'Fewer repayments',
     simplifyDebtsBody:
       'Suggest the fewest payments that settle the group. The real who-owes-whom ledger is never rewritten.',
     simplifyDebtsHint: 'Fewest payments to settle up',
@@ -5460,7 +5460,7 @@ const ta: UiStrings = {
     saveName: 'பெயரைச் சேமி',
     chooseIcon: 'ஐகானைத் தேர்ந்தெடு',
     removePhoto: 'புகைப்படத்தை நீக்கு',
-    simplifyDebts: 'கடன்களை எளிமையாக்கு',
+    simplifyDebts: 'குறைந்த திருப்பிச் செலுத்தல்கள்',
     simplifyDebtsBody:
       'குழுவைத் தீர்க்கும் மிகக் குறைந்த பணப்பரிமாற்றங்களைப் பரிந்துரைக்கும். யார் யாருக்குத் தர வேண்டும் என்ற உண்மையான கணக்கு மாற்றப்படுவதே இல்லை.',
     simplifyDebtsHint: 'தீர்க குறைந்தபட்ச பணம் செலுத்தல்கள்',
@@ -7513,7 +7513,7 @@ const hi: UiStrings = {
     saveName: 'नाम सेव करें',
     chooseIcon: 'आइकन चुनें',
     removePhoto: 'फ़ोटो हटाएँ',
-    simplifyDebts: 'हिसाब सरल करें',
+    simplifyDebts: 'कम भुगतान',
     simplifyDebtsBody:
       'समूह को निपटाने के सबसे कम भुगतान सुझाता है। किस पर किसका बाकी है, वह असली हिसाब कभी नहीं बदला जाता।',
     simplifyDebtsHint: 'सेटल करने के लिए कम से कम भुगतान',
@@ -9580,7 +9580,7 @@ const ar: UiStrings = {
     saveName: 'حفظ الاسم',
     chooseIcon: 'اختر أيقونة',
     removePhoto: 'إزالة الصورة',
-    simplifyDebts: 'تبسيط الديون',
+    simplifyDebts: 'مدفوعات أقل',
     simplifyDebtsBody:
       'يقترح أقل عدد من الدفعات لتسوية المجموعة. أما دفتر من يدين لمن فلا يُعاد كتابته أبدًا.',
     simplifyDebtsHint: 'أقل عدد من المدفوعات للتسوية',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2202,6 +2202,11 @@ export interface UiStrings {
     tripBudgetOptional: string;
     moreOptions: string;
     moreOptionsHint: string;
+    tripWelcomeTitle: string;
+    tripWelcomeBody: string;
+    tripWelcomeAddDates: string;
+    tripWelcomeSetBudget: string;
+    tripWelcomeLater: string;
     groupKind: string;
     tripBudget: string;
     whatKindOfGroup: string;
@@ -4202,6 +4207,11 @@ const en: UiStrings = {
     tripBudgetOptional: 'Trip budget (optional)',
     moreOptions: 'More options',
     moreOptionsHint: 'Type, dates, budget',
+    tripWelcomeTitle: 'Want to plan this trip?',
+    tripWelcomeBody: 'Add dates to turn on daily reminders, or set a budget to track spending.',
+    tripWelcomeAddDates: 'Add dates',
+    tripWelcomeSetBudget: 'Set budget',
+    tripWelcomeLater: 'Later',
     groupKind: 'Kind',
     tripBudget: 'Budget',
     whatKindOfGroup: 'What kind of group?',
@@ -6299,6 +6309,12 @@ const ta: UiStrings = {
     tripBudgetOptional: 'பயண பட்ஜெட் (விருப்பம்)',
     moreOptions: 'மேலும் விருப்பங்கள்',
     moreOptionsHint: 'வகை, தேதிகள், பட்ஜெட்',
+    tripWelcomeTitle: 'இந்தப் பயணத்தைத் திட்டமிடலாமா?',
+    tripWelcomeBody:
+      'தினசரி நினைவூட்டல்களை இயக்க தேதிகளைச் சேர்க்கவும், அல்லது செலவைக் கண்காணிக்க பட்ஜெட் அமைக்கவும்.',
+    tripWelcomeAddDates: 'தேதிகளைச் சேர்',
+    tripWelcomeSetBudget: 'பட்ஜெட் அமை',
+    tripWelcomeLater: 'பிறகு',
     groupKind: 'வகை',
     tripBudget: 'பட்ஜெட்',
     whatKindOfGroup: 'என்ன வகைக் குழு?',
@@ -8312,6 +8328,12 @@ const hi: UiStrings = {
     tripBudgetOptional: 'ट्रिप बजट (वैकल्पिक)',
     moreOptions: 'और विकल्प',
     moreOptionsHint: 'प्रकार, तारीखें, बजट',
+    tripWelcomeTitle: 'इस ट्रिप की योजना बनाएँ?',
+    tripWelcomeBody:
+      'रोज़ाना रिमाइंडर चालू करने के लिए तारीखें जोड़ें, या खर्च देखने के लिए बजट सेट करें।',
+    tripWelcomeAddDates: 'तारीखें जोड़ें',
+    tripWelcomeSetBudget: 'बजट सेट करें',
+    tripWelcomeLater: 'बाद में',
     groupKind: 'प्रकार',
     tripBudget: 'बजट',
     whatKindOfGroup: 'किस तरह का समूह?',
@@ -10540,6 +10562,11 @@ const ar: UiStrings = {
     tripBudgetOptional: 'ميزانية الرحلة (اختياري)',
     moreOptions: 'خيارات إضافية',
     moreOptionsHint: 'النوع، التواريخ، الميزانية',
+    tripWelcomeTitle: 'هل تريد التخطيط لهذه الرحلة؟',
+    tripWelcomeBody: 'أضِف التواريخ لتشغيل التذكيرات اليومية، أو حدّد ميزانية لتتبّع الإنفاق.',
+    tripWelcomeAddDates: 'أضف التواريخ',
+    tripWelcomeSetBudget: 'حدّد الميزانية',
+    tripWelcomeLater: 'لاحقًا',
     groupKind: 'النوع',
     tripBudget: 'الميزانية',
     whatKindOfGroup: 'أي نوع من المجموعات؟',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2200,6 +2200,8 @@ export interface UiStrings {
   extras: {
     blankNameHint: string;
     tripBudgetOptional: string;
+    moreOptions: string;
+    moreOptionsHint: string;
     groupKind: string;
     tripBudget: string;
     whatKindOfGroup: string;
@@ -4198,6 +4200,8 @@ const en: UiStrings = {
   extras: {
     blankNameHint: 'Leave it blank and the group is named after whoever is in it.',
     tripBudgetOptional: 'Trip budget (optional)',
+    moreOptions: 'More options',
+    moreOptionsHint: 'Type, dates, budget',
     groupKind: 'Kind',
     tripBudget: 'Budget',
     whatKindOfGroup: 'What kind of group?',
@@ -6293,6 +6297,8 @@ const ta: UiStrings = {
   extras: {
     blankNameHint: 'காலியாக விட்டால், குழுவில் உள்ளவர்களின் பெயரில் குழு அமையும்.',
     tripBudgetOptional: 'பயண பட்ஜெட் (விருப்பம்)',
+    moreOptions: 'மேலும் விருப்பங்கள்',
+    moreOptionsHint: 'வகை, தேதிகள், பட்ஜெட்',
     groupKind: 'வகை',
     tripBudget: 'பட்ஜெட்',
     whatKindOfGroup: 'என்ன வகைக் குழு?',
@@ -8304,6 +8310,8 @@ const hi: UiStrings = {
   extras: {
     blankNameHint: 'खाली छोड़ दें तो समूह का नाम उसमें शामिल लोगों पर रख दिया जाएगा।',
     tripBudgetOptional: 'ट्रिप बजट (वैकल्पिक)',
+    moreOptions: 'और विकल्प',
+    moreOptionsHint: 'प्रकार, तारीखें, बजट',
     groupKind: 'प्रकार',
     tripBudget: 'बजट',
     whatKindOfGroup: 'किस तरह का समूह?',
@@ -10530,6 +10538,8 @@ const ar: UiStrings = {
   extras: {
     blankNameHint: 'اتركه فارغًا فتُسمّى المجموعة بأسماء من فيها.',
     tripBudgetOptional: 'ميزانية الرحلة (اختياري)',
+    moreOptions: 'خيارات إضافية',
+    moreOptionsHint: 'النوع، التواريخ، الميزانية',
     groupKind: 'النوع',
     tripBudget: 'الميزانية',
     whatKindOfGroup: 'أي نوع من المجموعات؟',

--- a/packages/core/src/group/icon.ts
+++ b/packages/core/src/group/icon.ts
@@ -306,3 +306,41 @@ export function guessGroupEmoji(name: string): string | null {
   }
   return best;
 }
+
+/** The kind of group its name suggests. String values, not an app enum, so core
+ *  stays free of the mobile `GroupType` — the caller casts. Matches the enum's
+ *  string values exactly ('trip' | 'home' | ...). */
+export type GuessedGroupType = 'trip' | 'home' | 'couple' | 'event' | 'friends' | 'other';
+
+/**
+ * The picture the name-guesser lands on, mapped to a kind of group. One source
+ * of truth: whatever emoji `guessGroupEmoji` picks decides the kind, so "Goa"
+ * (a beach) is a trip and "Flat 402" (a house) is a home. Every icon that means
+ * "somebody is going somewhere" maps to Trip; the rest to the nearest kind.
+ */
+const EMOJI_TO_TYPE: Record<string, GuessedGroupType> = {
+  '🏖️': 'trip',
+  '⛰️': 'trip',
+  '✈️': 'trip',
+  '🏠': 'home',
+  '🛒': 'home',
+  '💜': 'couple',
+  '🎉': 'event',
+  '🎓': 'friends',
+  '🏏': 'friends',
+  '🍽️': 'friends',
+  '🎬': 'friends',
+  '🏢': 'other',
+  '🚗': 'other',
+};
+
+/**
+ * The kind of group a name suggests, or null when it suggests nothing — the
+ * caller (which opens on a sensible default) decides what "nothing" means. Lets
+ * the new-group screen keep Trip out of the default while still catching the
+ * "Goa trip" that genuinely is one, from the same word list the icon reads.
+ */
+export function guessGroupType(name: string): GuessedGroupType | null {
+  const emoji = guessGroupEmoji(name);
+  return emoji ? (EMOJI_TO_TYPE[emoji] ?? null) : null;
+}

--- a/packages/core/test/groupIcon.test.ts
+++ b/packages/core/test/groupIcon.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { GROUP_ICONS, guessGroupEmoji } from '../src/index';
+import { GROUP_ICONS, guessGroupEmoji, guessGroupType } from '../src/index';
 
 describe('a group name suggests a picture', () => {
   it('reads the ordinary names people give groups', () => {
@@ -62,6 +62,43 @@ describe('a group name suggests a picture', () => {
     expect(guessGroupEmoji('GOA!!')).toBe('🏖️');
     expect(guessGroupEmoji('flat-402')).toBe('🏠');
     expect(guessGroupEmoji('  Wedding  ')).toBe('🎉');
+  });
+});
+
+describe('a group name suggests a kind', () => {
+  it('catches the names that really are a trip', () => {
+    expect(guessGroupType('Goa December')).toBe('trip');
+    expect(guessGroupType('Manali trek')).toBe('trip');
+    expect(guessGroupType('Europe trip')).toBe('trip');
+  });
+
+  it('reads the non-trip kinds too', () => {
+    expect(guessGroupType('Flat 402')).toBe('home');
+    expect(guessGroupType('Grocery run')).toBe('home');
+    expect(guessGroupType('Priya wedding')).toBe('event');
+    expect(guessGroupType('Honeymoon')).toBe('couple');
+    expect(guessGroupType('Friday dinner')).toBe('friends');
+    expect(guessGroupType('Office offsite')).toBe('other');
+  });
+
+  it('says nothing when the name says nothing, so the caller keeps its default', () => {
+    // The screen opens on Other, not Trip — null here is what lets a bare name
+    // stay Other instead of dragging trip fields in.
+    expect(guessGroupType('')).toBeNull();
+    expect(guessGroupType('Ravi and Asha')).toBeNull();
+    expect(guessGroupType('Group 3')).toBeNull();
+  });
+
+  it('maps every icon in the table to a kind', () => {
+    // A picture with no kind would silently fall through to the caller's
+    // default even when the name clearly meant something.
+    for (const icon of GROUP_ICONS) {
+      const name = `test ${icon.keywords[0]}`;
+      expect(
+        guessGroupType(name),
+        `${icon.emoji} (${icon.keywords[0]}) has no kind`,
+      ).not.toBeNull();
+    }
   });
 });
 


### PR DESCRIPTION
Trip dates and budget were moved off the create screen (#567) to keep it short — but a trip with no dates gets no daily reminders and no cap. This catches that with a one-time nudge on the new group instead.

## Changes
- A trip created without dates redirects to `/group/{id}?welcome=trip`.
- The group shows a dismissible card — ✈️ "Want to plan this trip?" with **Add dates** (→ settings), **Set budget** (→ plan), **Later** (dismiss) — only while the trip has no start date and the param is present.
- The param is gone on any later visit, so it is a moment, not a recurring nag.

## Notes
- Pure UI. No migration, no deploy.
- Known rough edge: **Add dates** routes to full group settings (where the dates editor lives), not a focused date sheet — works, slightly heavy; a focused sheet is a later polish.

**Stacked on #568** (base `feat/simplify-debts-rename`). Merge order: #567 → #568 → #569.