### PR TITLE
feat(trip): offer to plan a trip after it is created, not before

### DIFF
--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -477,12 +477,16 @@ export default function GroupScreen() {
   const clearance = useScreenClearance(112);
   const pull = usePullRefresh();
   const { t, locale } = useStrings();
-  const { id } = useLocalSearchParams<{ id: string }>();
+  // `?welcome=trip` is set once, by the create screen, when a trip is made
+  // without dates — it opens this group with a one-time plan-your-trip nudge.
+  // The param is gone on any later visit, so the nudge is a moment, not a nag.
+  const { id, welcome } = useLocalSearchParams<{ id: string; welcome?: string }>();
   const groupId = id ?? '';
   const { profile } = useAuth();
   const [tab, setTab] = useState<Tab>(Tab.Expenses);
   const [showDeleted, setShowDeleted] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [tripNudgeDismissed, setTripNudgeDismissed] = useState(false);
 
   // Live updates from the other devices in this group (TDR §1).
   useGroupRealtime(groupId);
@@ -678,6 +682,12 @@ export default function GroupScreen() {
   // The overflow: the same three-dot dropdown the dashboard uses, not a bottom
   // sheet, so the two headers behave alike. Planner only appears where there is
   // a trip to plan; a flatshare has no use for the row.
+  // The one-time trip nudge: a trip opened straight from create, with no dates
+  // on it yet, until it is dismissed. Dates being the tell — a dated trip was
+  // already planned at create, and a nudge would be noise.
+  const showTripNudge =
+    welcome === 'trip' && groupData.type === 'trip' && !groupData.start_date && !tripNudgeDismissed;
+
   const menuItems: OverflowMenuItem[] = [
     { icon: 'pie-chart-outline', label: t.spending, route: `/group/${groupId}/insights` },
     ...(groupData.type === 'trip'
@@ -1118,6 +1128,43 @@ export default function GroupScreen() {
                     <Text variant="caption" tone="muted">
                       {t.group.mismatchBody}
                     </Text>
+                  </Card>
+                ) : null}
+
+                {/* The one-time nudge to plan a fresh trip. Dates and budget were
+            moved off the create screen to keep it short; this is where a trip
+            gets offered them, once, on its own group. Later dismisses it for
+            this visit; the param is gone next time regardless. */}
+                {showTripNudge ? (
+                  <Card style={{ gap: theme.spacing.md }}>
+                    <Row style={{ gap: theme.spacing.sm, alignItems: 'center' }}>
+                      <Ionicons name="airplane" size={iconSize.md} color={theme.color.brand} />
+                      <Text variant="subheading" style={{ flex: 1 }}>
+                        {t.extras.tripWelcomeTitle}
+                      </Text>
+                    </Row>
+                    <Text variant="caption" tone="muted">
+                      {t.extras.tripWelcomeBody}
+                    </Text>
+                    <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
+                      <Button
+                        label={t.extras.tripWelcomeAddDates}
+                        size="sm"
+                        onPress={() => router.push(`/group/${groupId}/settings`)}
+                      />
+                      <Button
+                        label={t.extras.tripWelcomeSetBudget}
+                        size="sm"
+                        variant="secondary"
+                        onPress={() => router.push(`/group/${groupId}/plan`)}
+                      />
+                      <Button
+                        label={t.extras.tripWelcomeLater}
+                        size="sm"
+                        variant="ghost"
+                        onPress={() => setTripNudgeDismissed(true)}
+                      />
+                    </Row>
                   </Card>
                 ) : null}
 

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -445,7 +445,13 @@ export default function NewGroupScreen() {
         });
       }
 
-      router.replace(`/group/${groupId}`);
+      // A trip made without dates lands on its group with a one-time nudge to
+      // plan it — dates turn on the daily reminders, a budget the cap. Only when
+      // neither was set here, since the point of moving them off the create
+      // screen is that most trips skip them there. Any other kind, or a trip
+      // already dated, opens plain.
+      const nudgeTrip = type === GroupType.Trip && !(tripDates.start_date && tripDates.end_date);
+      router.replace(nudgeTrip ? `/group/${groupId}?welcome=trip` : `/group/${groupId}`);
     } catch (caught) {
       setError(
         isPhoneCountryError(caught)

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2202,6 +2202,11 @@ export interface UiStrings {
     tripBudgetOptional: string;
     moreOptions: string;
     moreOptionsHint: string;
+    tripWelcomeTitle: string;
+    tripWelcomeBody: string;
+    tripWelcomeAddDates: string;
+    tripWelcomeSetBudget: string;
+    tripWelcomeLater: string;
     groupKind: string;
     tripBudget: string;
     whatKindOfGroup: string;
@@ -4202,6 +4207,11 @@ const en: UiStrings = {
     tripBudgetOptional: 'Trip budget (optional)',
     moreOptions: 'More options',
     moreOptionsHint: 'Type, dates, budget',
+    tripWelcomeTitle: 'Want to plan this trip?',
+    tripWelcomeBody: 'Add dates to turn on daily reminders, or set a budget to track spending.',
+    tripWelcomeAddDates: 'Add dates',
+    tripWelcomeSetBudget: 'Set budget',
+    tripWelcomeLater: 'Later',
     groupKind: 'Kind',
     tripBudget: 'Budget',
     whatKindOfGroup: 'What kind of group?',
@@ -6299,6 +6309,12 @@ const ta: UiStrings = {
     tripBudgetOptional: 'பயண பட்ஜெட் (விருப்பம்)',
     moreOptions: 'மேலும் விருப்பங்கள்',
     moreOptionsHint: 'வகை, தேதிகள், பட்ஜெட்',
+    tripWelcomeTitle: 'இந்தப் பயணத்தைத் திட்டமிடலாமா?',
+    tripWelcomeBody:
+      'தினசரி நினைவூட்டல்களை இயக்க தேதிகளைச் சேர்க்கவும், அல்லது செலவைக் கண்காணிக்க பட்ஜெட் அமைக்கவும்.',
+    tripWelcomeAddDates: 'தேதிகளைச் சேர்',
+    tripWelcomeSetBudget: 'பட்ஜெட் அமை',
+    tripWelcomeLater: 'பிறகு',
     groupKind: 'வகை',
     tripBudget: 'பட்ஜெட்',
     whatKindOfGroup: 'என்ன வகைக் குழு?',
@@ -8312,6 +8328,12 @@ const hi: UiStrings = {
     tripBudgetOptional: 'ट्रिप बजट (वैकल्पिक)',
     moreOptions: 'और विकल्प',
     moreOptionsHint: 'प्रकार, तारीखें, बजट',
+    tripWelcomeTitle: 'इस ट्रिप की योजना बनाएँ?',
+    tripWelcomeBody:
+      'रोज़ाना रिमाइंडर चालू करने के लिए तारीखें जोड़ें, या खर्च देखने के लिए बजट सेट करें।',
+    tripWelcomeAddDates: 'तारीखें जोड़ें',
+    tripWelcomeSetBudget: 'बजट सेट करें',
+    tripWelcomeLater: 'बाद में',
     groupKind: 'प्रकार',
     tripBudget: 'बजट',
     whatKindOfGroup: 'किस तरह का समूह?',
@@ -10540,6 +10562,11 @@ const ar: UiStrings = {
     tripBudgetOptional: 'ميزانية الرحلة (اختياري)',
     moreOptions: 'خيارات إضافية',
     moreOptionsHint: 'النوع، التواريخ، الميزانية',
+    tripWelcomeTitle: 'هل تريد التخطيط لهذه الرحلة؟',
+    tripWelcomeBody: 'أضِف التواريخ لتشغيل التذكيرات اليومية، أو حدّد ميزانية لتتبّع الإنفاق.',
+    tripWelcomeAddDates: 'أضف التواريخ',
+    tripWelcomeSetBudget: 'حدّد الميزانية',
+    tripWelcomeLater: 'لاحقًا',
     groupKind: 'النوع',
     tripBudget: 'الميزانية',
     whatKindOfGroup: 'أي نوع من المجموعات؟',


### PR DESCRIPTION
Trip dates and budget were moved off the create screen (#567) to keep it short — but a trip with no dates gets no daily reminders and no cap. This catches that with a one-time nudge on the new group instead.

## Changes
- A trip created without dates redirects to `/group/{id}?welcome=trip`.
- The group shows a dismissible card — ✈️ "Want to plan this trip?" with **Add dates** (→ settings), **Set budget** (→ plan), **Later** (dismiss) — only while the trip has no start date and the param is present.
- The param is gone on any later visit, so it is a moment, not a recurring nag.

## Notes
- Pure UI. No migration, no deploy.
- Known rough edge: **Add dates** routes to full group settings (where the dates editor lives), not a focused date sheet.

Rebased on latest main. (Supersedes #569, auto-closed when its stacked base branch was deleted.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a welcome planning card for newly created trips without dates.
  * Offers quick actions to add trip dates, set a budget, or continue later.
  * The card appears once and can be dismissed.
  * Added translations for the new trip-planning prompts in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->