### PR TITLE
feat(settings): simplify the settings hub into five plain-language groups

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -24,7 +24,7 @@ import { friendlyError } from '@/lib/errors';
 import { SkeletonList } from '@/components/Skeletons';
 import { removeAvatar, uploadAvatar } from '@/data/api';
 import { useSettledTotals } from '@/data/hooks';
-import { isRtlLanguage, LANGUAGE_NAMES, plural, useStrings, type UiStrings } from '@/i18n';
+import { isRtlLanguage, LANGUAGE_NAMES, plural, useStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
 import { useAuth } from '@/lib/auth';
 import { pickAvatarPhoto } from '@/lib/image';
@@ -44,11 +44,11 @@ interface SettingsRow {
   destructive?: boolean;
 }
 
-function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }) {
+function SettingsSection({ title, rows }: { title?: string; rows: SettingsRow[] }) {
   const theme = useTheme();
   return (
     <View>
-      <SectionHeader title={title} />
+      {title ? <SectionHeader title={title} /> : null}
       <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
         {rows.map((item, index) => {
           const live = Boolean(item.route ?? item.onPress);
@@ -108,80 +108,6 @@ function SettingsSection({ title, rows }: { title: string; rows: SettingsRow[] }
       </Card>
     </View>
   );
-}
-
-/**
- * A function of the strings rather than a constant, because the labels are no
- * longer knowable at module load — they depend on which language the reader
- * has chosen, and that can change while the app is open.
- */
-function settingsRows(t: UiStrings): SettingsRow[] {
-  return [
-    {
-      icon: 'notifications-outline',
-      label: t.account.notifications,
-      hint: t.account.notificationsHint,
-      route: '/settings/notifications',
-    },
-    {
-      icon: 'pricetags-outline',
-      label: t.tags.settingsRow,
-      hint: t.tags.manageSubtitle,
-      route: '/settings/categories',
-    },
-    {
-      icon: 'download-outline',
-      label: t.account.exportDataRow,
-      hint: t.account.exportHint,
-      route: '/settings/export',
-    },
-    {
-      icon: 'cloud-upload-outline',
-      label: t.account.importSplitwise,
-      hint: t.account.importHint,
-      route: '/settings/import',
-    },
-    {
-      icon: 'chatbubble-ellipses-outline',
-      label: t.privacy.feedbackRow,
-      hint: t.privacy.feedbackRowHint,
-      route: '/settings/feedback',
-    },
-    {
-      icon: 'shield-checkmark-outline',
-      label: t.privacy.row,
-      hint: t.privacy.rowHint,
-      route: '/settings/privacy',
-    },
-  ];
-}
-
-/**
- * Your account and Paying used to be two faces of this screen, switched with a
- * segmented control that sat between the hero and the settings. They are the
- * two things a person edits about themselves rather than about the app, so they
- * now lead the settings list as their own rows — each a page of its own,
- * reached the same way every other setting is.
- *
- * "You" (just the name) and "Your account" (email, phone, sign-in links) were
- * one thing split across two screens, so they are folded into a single "Your
- * account" page that carries the name too.
- */
-function profileRows(t: UiStrings): SettingsRow[] {
-  return [
-    {
-      icon: 'person-circle-outline',
-      label: t.account.yourAccount,
-      hint: t.account.yourAccountHint,
-      route: '/settings/account',
-    },
-    {
-      icon: 'card-outline',
-      label: t.account.facePaying,
-      hint: t.account.howPeoplePayYou,
-      route: '/settings/paying',
-    },
-  ];
 }
 
 /**
@@ -450,20 +376,32 @@ function ProfileForm() {
           </View>
         </View>
 
-        {/* You and Paying lead: the two things you edit about yourself, above
-            everything you set about the app. */}
-        <SettingsSection title={t.account.sectionProfile} rows={profileRows(t)} />
-
-        {/* Its own section, above the settings rather than among them. Paying
-            for something is not a preference, and a row that sells you something
-            sitting between Notifications and Export is a row dressed up as a
-            setting. */}
+        {/* Account: who you are, how people pay you, what plan you're on. The
+            things you edit about *yourself*, above everything you set about the
+            app. Storage and your AI keys belong to the account too, so they sit
+            here rather than each claiming a section of its own. Only their
+            state-bearing rows keep a subtitle; the rest say enough in the label. */}
         <SettingsSection
-          title={t.account.sectionBaaki}
+          title={t.account.sectionAccount}
           rows={[
             {
+              icon: 'person-circle-outline',
+              label: t.account.yourAccount,
+              hint: t.account.yourAccountHint,
+              route: '/settings/account',
+            },
+            {
+              icon: 'card-outline',
+              label: t.account.facePaying,
+              hint: t.account.howPeoplePayYou,
+              route: '/settings/paying',
+            },
+            // "Plan", not "Upgrade": the row opened a page that sells nothing, so
+            // its old name promised a purchase the app doesn't have. The honest
+            // label states what it is; the hint says the plan is free.
+            {
               icon: 'rocket-outline',
-              label: t.upgrade,
+              label: t.account.planRow,
               hint: t.account.upgradeHint,
               route: '/settings/upgrade',
             },
@@ -474,38 +412,31 @@ function ProfileForm() {
                   {
                     icon: 'cloud-outline' as const,
                     label: t.storage.row,
-                    hint: t.storage.rowHint,
                     route: '/settings/storage',
+                  },
+                ]
+              : []),
+            // Bring your own model key — a credential you supply, held on the
+            // device. Flagged off until it ships.
+            ...(aiKeysEnabled
+              ? [
+                  {
+                    icon: 'key-outline' as const,
+                    label: t.account.aiKeysRow,
+                    route: '/settings/ai-keys',
                   },
                 ]
               : []),
           ]}
         />
 
-        {/* Bring your own model key. Its own section because it is neither a
-            preference nor a Baaki purchase — it is a credential the reader
-            supplies, held on the device, to run the model-powered features on
-            their own account. */}
-        {aiKeysEnabled ? (
-          <SettingsSection
-            title={t.account.sectionAi}
-            rows={[
-              {
-                icon: 'key-outline',
-                label: t.account.aiKeysRow,
-                hint: t.account.aiKeysHint,
-                route: '/settings/ai-keys',
-              },
-            ]}
-          />
-        ) : null}
-
-        {/* Language leads. It was fifth, under Import, and it is the one setting
-            somebody may have to reach *before* they can read the four above it —
-            a row you can only find by reading past rows you cannot read is a row
-            that is not there. */}
+        {/* Preferences: how the app looks and speaks to you. Language leads — it
+            is the one setting somebody may have to reach *before* they can read
+            the rows below it, so it cannot sit under them. Shortcut and the
+            watch are neither everyday nor state-bearing, so they trail the
+            section, quiet, rather than sit among the primary rows. */}
         <SettingsSection
-          title={t.account.sectionSettings}
+          title={t.account.sectionPreferences}
           rows={[
             {
               icon: 'language-outline',
@@ -513,12 +444,16 @@ function ProfileForm() {
               hint: languageSummary,
               route: '/settings/language',
             },
-            ...settingsRows(t),
             {
               icon: 'contrast-outline',
               label: t.account.themeRow,
               hint: themeSummary,
               route: '/settings/theme',
+            },
+            {
+              icon: 'notifications-outline',
+              label: t.account.notifications,
+              route: '/settings/notifications',
             },
             {
               icon: 'flash-outline',
@@ -530,17 +465,50 @@ function ProfileForm() {
               label: t.recent.title,
               route: '/settings/recent',
             },
+          ]}
+        />
+
+        {/* Data & privacy: your records, and who can reach them. Export and
+            import used to sit up among Language and Notifications, which made
+            the screen read like an admin console; they belong with the data
+            they move. */}
+        <SettingsSection
+          title={t.account.sectionData}
+          rows={[
+            {
+              icon: 'pricetags-outline',
+              label: t.tags.settingsRow,
+              route: '/settings/categories',
+            },
+            {
+              icon: 'download-outline',
+              label: t.account.exportDataRow,
+              route: '/settings/export',
+            },
+            {
+              icon: 'cloud-upload-outline',
+              label: t.account.importSplitwise,
+              route: '/settings/import',
+            },
             {
               icon: 'cloud-outline',
               label: t.sync.title,
               hint: syncNetworkSummary,
               route: '/settings/sync',
             },
+            {
+              icon: 'shield-checkmark-outline',
+              label: t.privacy.row,
+              route: '/settings/privacy',
+            },
           ]}
         />
 
-        {/* Security is its own section rather than one row among many: it is the
-            only group of settings somebody comes looking for. */}
+        {/* Security: the one group somebody comes to Settings looking *for*.
+            Sign out and Delete used to live here too — but ending a session and
+            ending an account are not security settings, and burying an
+            irreversible act in a list is how it gets tapped by accident. They
+            are pulled out below. */}
         <SettingsSection
           title={t.account.sectionSecurity}
           rows={[
@@ -553,9 +521,38 @@ function ProfileForm() {
             {
               icon: 'phone-portrait-outline',
               label: t.devices.row,
-              hint: t.devices.rowHint,
               route: '/settings/devices',
             },
+          ]}
+        />
+
+        {/* Help: not settings — support and the fine print. Feedback was a row
+            dressed as a preference; licenses were buried on the privacy page.
+            Both are things you look for at the bottom, so that is where they
+            are. */}
+        <SettingsSection
+          title={t.account.sectionHelp}
+          rows={[
+            {
+              icon: 'chatbubble-ellipses-outline',
+              label: t.privacy.feedbackRow,
+              route: '/settings/feedback',
+            },
+            {
+              icon: 'document-text-outline',
+              label: t.privacy.licensesRow,
+              route: '/settings/licenses',
+            },
+          ]}
+        />
+
+        {/* The two irreversible acts, each alone on its own card at the very
+            bottom, split from every section and from each other by the same gap
+            that separates sections. No header — a danger zone announces itself
+            by standing apart, not by a title. Sign out ends the session; Delete
+            ends the account. */}
+        <SettingsSection
+          rows={[
             {
               icon: 'log-out-outline',
               label: t.lock.signOut,
@@ -563,11 +560,10 @@ function ProfileForm() {
               onPress: confirmSignOut,
               destructive: true,
             },
-            // Last row of the last section, under Sign out. It first sat in the
-            // middle of the settings list, because `settingsRows` is spread
-            // before Motion is appended — which put an irreversible action
-            // between "import a spreadsheet" and "animations on". Running it on
-            // a device is what showed that.
+          ]}
+        />
+        <SettingsSection
+          rows={[
             {
               icon: 'trash-outline',
               label: t.privacy.deleteRow,

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -781,13 +781,14 @@ export interface UiStrings {
     railLinkNote: string;
     railManualNote: string;
     nothingToAdd: string;
-    sectionProfile: string;
-    sectionBaaki: string;
-    sectionSettings: string;
+    sectionAccount: string;
+    sectionHelp: string;
+    sectionPreferences: string;
     sectionSecurity: string;
-    sectionAi: string;
+    sectionData: string;
     aiKeysRow: string;
     aiKeysHint: string;
+    planRow: string;
     upgradeHint: string;
     yourAccount: string;
     yourAccountHint: string;
@@ -2861,14 +2862,15 @@ const en: UiStrings = {
     railManualNote:
       'People settling with you see this to pay you from their own bank app. Waves never handles the money.',
     nothingToAdd: 'Nothing to add — people will record what they paid you by hand.',
-    sectionProfile: 'Profile',
-    sectionBaaki: 'Waves',
-    sectionSettings: 'Settings',
+    sectionAccount: 'Account',
+    sectionHelp: 'Help',
+    sectionPreferences: 'Preferences',
     sectionSecurity: 'Security',
-    sectionAi: 'AI',
+    sectionData: 'Data & privacy',
     aiKeysRow: 'Your AI keys',
     aiKeysHint: 'Bring your own OpenAI, Claude or Kimi key',
-    upgradeHint: 'Nothing to buy yet — the ledger stays free',
+    planRow: 'Plan',
+    upgradeHint: 'Free plan — everything included, nothing to buy',
     yourAccount: 'Your account',
     yourAccountHint: 'Email, phone, or a linked account',
     notifications: 'Notifications',
@@ -4890,14 +4892,15 @@ const ta: UiStrings = {
     railManualNote:
       'உங்களுடன் தீர்ப்பவர்கள் இதைப் பார்த்து தங்கள் வங்கி ஆப்பிலிருந்து பணம் அனுப்புவார்கள். பாக்கி பணத்தைக் கையாள்வதே இல்லை.',
     nothingToAdd: 'சேர்க்க ஒன்றுமில்லை — கொடுத்ததை மற்றவர்கள் கையால் பதிவு செய்வார்கள்.',
-    sectionProfile: 'சுயவிவரம்',
-    sectionBaaki: 'பாக்கி',
-    sectionSettings: 'அமைப்புகள்',
+    sectionAccount: 'கணக்கு',
+    sectionHelp: 'உதவி',
+    sectionPreferences: 'விருப்பங்கள்',
     sectionSecurity: 'பாதுகாப்பு',
-    sectionAi: 'AI',
+    sectionData: 'தரவு & தனியுரிமை',
     aiKeysRow: 'உங்கள் AI விசைகள்',
     aiKeysHint: 'உங்கள் சொந்த OpenAI, Claude அல்லது Kimi விசையைச் சேர்',
-    upgradeHint: 'வாங்க இன்னும் ஒன்றுமில்லை — கணக்கு இலவசமாகவே இருக்கும்',
+    planRow: 'திட்டம்',
+    upgradeHint: 'இலவசத் திட்டம் — எல்லாம் உள்ளடக்கம், வாங்க எதுவுமில்லை',
     yourAccount: 'உங்கள் கணக்கு',
     yourAccountHint: 'மின்னஞ்சல், தொலைபேசி, அல்லது இணைத்த கணக்கு',
     notifications: 'அறிவிப்புகள்',
@@ -6982,14 +6985,15 @@ const hi: UiStrings = {
     railManualNote:
       'आपसे हिसाब करने वाले इसे देखकर अपने बैंक ऐप से भुगतान करते हैं। बाकी पैसा कभी नहीं छूता।',
     nothingToAdd: 'जोड़ने को कुछ नहीं — लोग जो चुकाया है उसे खुद दर्ज करेंगे।',
-    sectionProfile: 'प्रोफ़ाइल',
-    sectionBaaki: 'बाकी',
-    sectionSettings: 'सेटिंग्स',
+    sectionAccount: 'खाता',
+    sectionHelp: 'सहायता',
+    sectionPreferences: 'प्राथमिकताएँ',
     sectionSecurity: 'सुरक्षा',
-    sectionAi: 'AI',
+    sectionData: 'डेटा और गोपनीयता',
     aiKeysRow: 'आपकी AI कुंजियाँ',
     aiKeysHint: 'अपनी OpenAI, Claude या Kimi कुंजी जोड़ें',
-    upgradeHint: 'अभी खरीदने को कुछ नहीं — हिसाब मुफ़्त ही रहेगा',
+    planRow: 'प्लान',
+    upgradeHint: 'मुफ़्त प्लान — सब कुछ शामिल, खरीदने को कुछ नहीं',
     yourAccount: 'आपका खाता',
     yourAccountHint: 'ईमेल, फ़ोन, या कोई लिंक किया खाता',
     notifications: 'सूचनाएँ',
@@ -9043,14 +9047,15 @@ const ar: UiStrings = {
     railLinkNote: 'من يسوّي معك يدفع بضغطة واحدة. باقي لا يلمس المال أبدًا.',
     railManualNote: 'من يسوّي معك يرى هذا ليدفع لك من تطبيق مصرفه. باقي لا يلمس المال أبدًا.',
     nothingToAdd: 'لا شيء تضيفه — سيسجّل الناس ما دفعوه لك يدويًا.',
-    sectionProfile: 'الملف الشخصي',
-    sectionBaaki: 'باقي',
-    sectionSettings: 'الإعدادات',
+    sectionAccount: 'الحساب',
+    sectionHelp: 'المساعدة',
+    sectionPreferences: 'التفضيلات',
     sectionSecurity: 'الأمان',
-    sectionAi: 'الذكاء الاصطناعي',
+    sectionData: 'البيانات والخصوصية',
     aiKeysRow: 'مفاتيح الذكاء الاصطناعي',
     aiKeysHint: 'أضف مفتاح OpenAI أو Claude أو Kimi الخاص بك',
-    upgradeHint: 'لا شيء للشراء بعد — الدفتر يبقى مجانيًا',
+    planRow: 'الخطة',
+    upgradeHint: 'خطة مجانية — كل شيء مُتضمَّن، لا شيء للشراء',
     yourAccount: 'حسابك',
     yourAccountHint: 'بريد، هاتف، أو حساب مرتبط',
     notifications: 'الإشعارات',


### PR DESCRIPTION
Acts on a UX roast of the settings hub: it read like an engineer's feature inventory, not a place to find one setting.

## Before → after
Five internal-model sections (Profile, Waves, AI, Settings, Security) collapse into five user-facing groups, with the two irreversible acts pulled out below:

| Group | Rows |
|---|---|
| **Account** | Your account, Paying, Plan, (Storage), (AI keys) |
| **Preferences** | Language, Appearance, Notifications, Quick shortcut, Watch |
| **Data & privacy** | Tags, Export, Import, Sync, Privacy |
| **Security** | App lock, Devices |
| **Help** | Feedback, Licenses |
| *— danger —* | Sign out (own card), Delete account (own card, very bottom) |

## What changed
- **Waves/AI sections gone** — Plan, Storage, AI keys fold into Account.
- Inner "Settings" → **Preferences**; Quick shortcut + Watch demoted to the tail, quiet.
- Export/Import/Sync moved down into **Data & privacy**, off the primary list.
- **Feedback** out of the settings list, **Licenses** off the privacy page — both into a new **Help** section.
- **Sign out** and **Delete account** leave Security; each alone on its own card at the very bottom, split from every section and from each other.
- `"Upgrade"` → **`"Plan"`**: the row sells nothing, so the old label promised a purchase the app doesn't have. Hint reworded to "Free plan — everything included, nothing to buy".
- Subtitles trimmed to state-bearing/warning rows only.

## i18n
Section keys renamed, `planRow` added, `upgradeHint` reworded — across **en / ta / hi / ar**. Dead row-builder helpers and the unused `UiStrings` import removed. No new screens; existing routes only.

Gates: `tsc` 0 errors, eslint clean, prettier clean. Not device-tested (emulator).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Reorganized Profile settings into clearer sections for Account, Preferences, Data & Privacy, Security, and Help.
  - Improved grouping for AI keys, data tools, feedback, licenses, sign-out, and account deletion.
  - Updated plan messaging to clearly describe what’s included in the free plan.
  - Removed unnecessary row subtitles for a cleaner settings experience.
- **Localization**
  - Updated English, Tamil, Hindi, and Arabic translations for the revised settings sections and plan information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->