### PR TITLE
feat(groups): make the groups list a money screen, not a directory

### DIFF
--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -60,7 +60,12 @@ export default function AllGroupsScreen() {
 
   const [query, setQuery] = useState('');
   const searchRef = useRef<TextInput>(null);
-  const trimmed = query.trim().toLowerCase();
+  // The search field only appears once the roster is long enough to need one.
+  // If it later shrinks back under that line the field vanishes — so the query
+  // has to stop filtering along with it, or the list could sit empty behind a
+  // stale query with no visible control left to clear it.
+  const showSearch = list.length >= SEARCH_THRESHOLD;
+  const trimmed = showSearch ? query.trim().toLowerCase() : '';
 
   // Decorate every group with the three facts a row shows — balance, whether a
   // settlement is pending, the member count — then split into the ones needing
@@ -107,8 +112,6 @@ export default function AllGroupsScreen() {
 
     return out;
   }, [list, summary, profile?.id, trimmed, t.settledHeader]);
-
-  const showSearch = list.length >= SEARCH_THRESHOLD;
 
   const header = (
     <View style={{ paddingTop: theme.spacing.md, gap: theme.spacing.lg }}>
@@ -217,6 +220,10 @@ export default function AllGroupsScreen() {
           paddingBottom: clearance,
         }}
         showsVerticalScrollIndicator={false}
+        // With the search keyboard open, a tap on a result row should open it in
+        // one go, not be eaten by the keyboard dismiss (FlashList defaults this
+        // to "never").
+        keyboardShouldPersistTaps="handled"
         ListHeaderComponent={header}
         ListEmptyComponent={empty}
         ItemSeparatorComponent={() => (
@@ -251,7 +258,10 @@ export default function AllGroupsScreen() {
           return (
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel={`${row.item.label}. ${statusLabel}`}
+              // The full subtitle, not just the status word: a pending group at a
+              // zero balance would otherwise be read out as "All settled",
+              // hiding the very state that needs attention.
+              accessibilityLabel={`${row.item.label}. ${subtitle}`}
               onPress={() => router.push(`/group/${group.id}`)}
               style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
             >

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -113,6 +113,13 @@ export default function AllGroupsScreen() {
     return out;
   }, [list, summary, profile?.id, trimmed, t.settledHeader]);
 
+  // What a rendered row reads from outside its own data: the locale (money and
+  // member-count formatting) and the theme (its colours). Both hold identity
+  // between renders and move only when they truly change, so this memo is a
+  // stable extraData that re-renders rows on a language or light/dark switch
+  // without the per-render churn an inline array would cause.
+  const listExtraData = useMemo(() => ({ locale, theme }), [locale, theme]);
+
   const header = (
     <View style={{ paddingTop: theme.spacing.md, gap: theme.spacing.lg }}>
       <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
@@ -210,11 +217,11 @@ export default function AllGroupsScreen() {
         // The group-ledger settings: render well ahead of the viewport so a fast
         // fling doesn't flash blank rows. The row items already carry their own
         // balance/pending/count (baked in the memo above), so a money change
-        // flows through `data`; the only external a row reads is `locale`, so
-        // that alone — a stable string — is the extraData. Passing an array
-        // literal here would allocate every render and re-render every row.
+        // flows through `data`; the outside a row reads — locale and theme —
+        // rides the memoised `listExtraData`, which changes identity only on a
+        // real language or light/dark switch, not every render.
         drawDistance={1500}
-        extraData={locale}
+        extraData={listExtraData}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -1,11 +1,14 @@
+import { useMemo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { Pressable, View } from 'react-native';
+import { Pressable, TextInput, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 
 import {
+  Button,
   directionalIcon,
   EmptyState,
+  IconButton,
   iconSize,
   MoneyText,
   Row,
@@ -22,10 +25,28 @@ import { useAuth } from '@/lib/auth';
 import { SkeletonList } from '@/components/Skeletons';
 
 /**
+ * Below this many groups a search field is ceremony — the list is short enough
+ * to take in at a glance, and a box asking "which one?" over four rows reads as
+ * clutter, not help.
+ */
+const SEARCH_THRESHOLD = 6;
+
+const absBig = (n: bigint): bigint => (n < 0n ? -n : n);
+
+/**
  * The full, browsable list of every group — the "All groups" door off the
- * dashboard's capped preview. Built in the Activity feed's shape: a plain
- * hairline-divided list of soft-tile rows, not the dashboard's single card,
- * so a long roster reads the same skimmable way the activity timeline does.
+ * dashboard's capped preview.
+ *
+ * It used to be a flat directory: every row equal, newest-first, no way in but
+ * to read the whole thing. A money screen has a sharper job than a directory —
+ * it should answer "where do I need to act?" before it answers "what do I
+ * have?". So the groups that owe or are owed (or are waiting on a confirmation)
+ * sort to the top, biggest balances first; the settled ones fall below a quiet
+ * "Settled" divider, dimmed, present but not competing. A search field appears
+ * once the roster is long enough to need one, and the door to a new group sits
+ * where a new-thing button belongs — top-right, and again inside the empty
+ * state, so the first-time reader is never staring at "No groups yet" with no
+ * way forward.
  */
 export default function AllGroupsScreen() {
   const theme = useTheme();
@@ -34,70 +55,200 @@ export default function AllGroupsScreen() {
   const { profile } = useAuth();
   const summary = useHomeSummary(profile?.id ?? null);
   const groups = useGroups();
-  const list = groups.data ?? [];
+  const list = useMemo(() => groups.data ?? [], [groups.data]);
   const loading = groups.isLoading || summary.isLoading;
 
+  const [query, setQuery] = useState('');
+  const searchRef = useRef<TextInput>(null);
+  const trimmed = query.trim().toLowerCase();
+
+  // Decorate every group with the three facts a row shows — balance, whether a
+  // settlement is pending, the member count — then split into the ones needing
+  // action and the ones settled, each sorted, and thread a "Settled" divider
+  // between them. Rebuilt as one memo so a fast scroll isn't recomputing per
+  // frame.
+  const rows = useMemo(() => {
+    const decorated = list.map((group) => {
+      const members = summary.membersFor(group.id);
+      const balance = summary.balanceFor(group.id);
+      const pending = summary.hasPending(group.id);
+      return {
+        group,
+        label: groupLabel(group, members, profile?.id),
+        balance,
+        pending,
+        count: summary.memberCountFor(group.id),
+        needsAction: pending || balance !== 0n,
+      };
+    });
+
+    const filtered = trimmed
+      ? decorated.filter((d) => d.label.toLowerCase().includes(trimmed))
+      : decorated;
+
+    // Biggest balances first among the ones needing action; a pending-but-zero
+    // group still belongs in the action block, just after the real debts.
+    const active = filtered
+      .filter((d) => d.needsAction)
+      .sort((a, b) => {
+        const x = absBig(a.balance);
+        const y = absBig(b.balance);
+        return x === y ? 0 : y > x ? 1 : -1;
+      });
+    const settled = filtered.filter((d) => !d.needsAction);
+
+    type Entry = (typeof decorated)[number];
+    type Row = { kind: 'group'; item: Entry } | { kind: 'header'; label: string };
+    const out: Row[] = active.map((item) => ({ kind: 'group', item }));
+    // Only announce "Settled" when there's a mix above it — a screen that is all
+    // settled doesn't need a header telling it so.
+    if (settled.length && active.length) out.push({ kind: 'header', label: t.settledHeader });
+    for (const item of settled) out.push({ kind: 'group', item });
+
+    return out;
+  }, [list, summary, profile?.id, trimmed, t.settledHeader]);
+
+  const showSearch = list.length >= SEARCH_THRESHOLD;
+
   const header = (
-    <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center', gap: theme.spacing.sm }}>
-      <Pressable
-        onPress={() => router.back()}
-        accessibilityRole="button"
-        accessibilityLabel={t.common.back}
-        hitSlop={10}
-        style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
-      >
-        <Ionicons
-          name={directionalIcon('chevron-back')}
-          size={iconSize.xxl}
-          color={theme.color.text}
-        />
-      </Pressable>
-      <Text variant="title">{t.allGroups}</Text>
-    </Row>
+    <View style={{ paddingTop: theme.spacing.md, gap: theme.spacing.lg }}>
+      <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.xxl}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <Text variant="title" style={{ flex: 1 }}>
+          {t.groupsTitle}
+        </Text>
+        {/* The new-group door, where a new-thing button belongs. It repeats in
+            the empty state below, so it's reachable whether or not any group
+            exists yet. */}
+        <IconButton label={t.newGroup} onPress={() => router.push('/new-group')}>
+          <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
+        </IconButton>
+      </Row>
+
+      {showSearch ? (
+        <Pressable
+          onPress={() => searchRef.current?.focus()}
+          accessible={false}
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+            height: 44,
+            paddingHorizontal: theme.spacing.lg,
+            borderRadius: theme.radius.pill,
+            backgroundColor: theme.color.surfaceMuted,
+          }}
+        >
+          <Ionicons name="search" size={iconSize.md} color={theme.color.textFaint} />
+          <TextInput
+            ref={searchRef}
+            value={query}
+            onChangeText={setQuery}
+            autoCapitalize="none"
+            accessibilityRole="search"
+            accessibilityLabel={t.searchGroups}
+            placeholder={t.searchGroups}
+            placeholderTextColor={theme.color.textFaint}
+            style={{ flex: 1, fontSize: 16, color: theme.color.text, paddingVertical: 0 }}
+          />
+          {query ? (
+            <Pressable
+              onPress={() => setQuery('')}
+              accessibilityRole="button"
+              accessibilityLabel={t.pickers.clearSearch}
+              hitSlop={8}
+            >
+              <Ionicons name="close-circle" size={iconSize.md} color={theme.color.textFaint} />
+            </Pressable>
+          ) : null}
+        </Pressable>
+      ) : null}
+    </View>
+  );
+
+  const empty = loading ? (
+    <View style={{ paddingTop: theme.spacing.xl }}>
+      <SkeletonList rows={5} />
+    </View>
+  ) : trimmed ? (
+    // A search that matched nothing — the reason the list is empty is the query,
+    // so the mark and words say "nothing matched", not "you have no groups".
+    <View style={{ paddingTop: theme.spacing.xxxl }}>
+      <EmptyState
+        icon={<Ionicons name="search-outline" size={iconSize.xxl} color={theme.color.brand} />}
+        title={t.noGroupsMatch}
+      />
+    </View>
+  ) : (
+    // The true first-run empty: reassure, explain lightly what a "group" is for,
+    // and hand over the one action that moves you off this screen.
+    <View style={{ paddingTop: theme.spacing.xxxl }}>
+      <EmptyState
+        icon={<Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.brand} />}
+        title={t.tabs.noGroups}
+        body={t.noGroupsBody}
+        action={<Button label={t.newGroup} onPress={() => router.push('/new-group')} />}
+      />
+    </View>
   );
 
   return (
     <Screen>
       <FlashList
-        data={list}
-        keyExtractor={(group) => group.id}
-        // Render ahead of the viewport so a fast fling doesn't flash blank rows.
-        drawDistance={800}
+        data={rows}
+        keyExtractor={(row) => (row.kind === 'header' ? 'settled-header' : row.item.group.id)}
+        getItemType={(row) => row.kind}
+        // The group-ledger settings: render well ahead of the viewport so a fast
+        // fling doesn't flash blank rows, and re-render rows when the money,
+        // language or search behind them changes.
+        drawDistance={1500}
+        extraData={[summary, locale, trimmed]}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
         }}
         showsVerticalScrollIndicator={false}
         ListHeaderComponent={header}
-        ListEmptyComponent={
-          loading ? (
-            <View style={{ paddingTop: theme.spacing.xl }}>
-              <SkeletonList rows={5} />
-            </View>
-          ) : (
-            <View style={{ paddingTop: theme.spacing.xxxl }}>
-              <EmptyState
-                title={t.tabs.noGroups}
-                icon={
-                  <Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.brand} />
-                }
-              />
-            </View>
-          )
-        }
+        ListEmptyComponent={empty}
         ItemSeparatorComponent={() => (
           <View style={{ height: 1, backgroundColor: theme.color.border }} />
         )}
-        renderItem={({ item: group }) => {
-          const members = summary.membersFor(group.id);
-          const balance = summary.balanceFor(group.id);
-          const pending = summary.hasPending(group.id);
+        renderItem={({ item: row }) => {
+          if (row.kind === 'header') {
+            return (
+              <Text
+                variant="caption"
+                tone="muted"
+                style={{ paddingTop: theme.spacing.lg, paddingBottom: theme.spacing.xs }}
+              >
+                {row.label}
+              </Text>
+            );
+          }
+
+          const { group, balance, pending, count } = row.item;
           const statusLabel =
             balance === 0n ? t.allSettled : balance > 0n ? t.youAreOwed : t.youOwe;
+          // Status first, member count second: the reader's question is "do I
+          // owe or am I owed?", not "how many people". Pending keeps its context
+          // rather than replacing it — it used to swallow the member count whole.
+          const subtitle = pending
+            ? `${t.pendingConfirmation} · ${plural(locale, count, t.memberCount)}`
+            : `${statusLabel} · ${plural(locale, count, t.memberCount)}`;
+          // Settled groups are present, not urgent: dimmed so the eye lands on
+          // the rows that still need something.
+          const dim = !row.item.needsAction;
+
           return (
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel={`${groupLabel(group, members, profile?.id)}. ${statusLabel}`}
+              accessibilityLabel={`${row.item.label}. ${statusLabel}`}
               onPress={() => router.push(`/group/${group.id}`)}
               style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
             >
@@ -106,6 +257,7 @@ export default function AllGroupsScreen() {
                   gap: theme.spacing.md,
                   alignItems: 'center',
                   paddingVertical: theme.spacing.sm,
+                  opacity: dim ? 0.55 : 1,
                 }}
               >
                 <View
@@ -126,12 +278,10 @@ export default function AllGroupsScreen() {
                     numberOfLines={1}
                     style={{ flexShrink: 1, fontWeight: '600' }}
                   >
-                    {groupLabel(group, members, profile?.id)}
+                    {row.item.label}
                   </Text>
                   <Text variant="caption" tone="muted" numberOfLines={1}>
-                    {pending
-                      ? t.pendingConfirmation
-                      : `${plural(locale, summary.memberCountFor(group.id), t.memberCount)} · ${statusLabel}`}
+                    {subtitle}
                   </Text>
                 </View>
                 <MoneyText

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -205,10 +205,13 @@ export default function AllGroupsScreen() {
         keyExtractor={(row) => (row.kind === 'header' ? 'settled-header' : row.item.group.id)}
         getItemType={(row) => row.kind}
         // The group-ledger settings: render well ahead of the viewport so a fast
-        // fling doesn't flash blank rows, and re-render rows when the money,
-        // language or search behind them changes.
+        // fling doesn't flash blank rows. The row items already carry their own
+        // balance/pending/count (baked in the memo above), so a money change
+        // flows through `data`; the only external a row reads is `locale`, so
+        // that alone — a stable string — is the extraData. Passing an array
+        // literal here would allocate every render and re-render every row.
         drawDistance={1500}
-        extraData={[summary, locale, trimmed]}
+        extraData={locale}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -402,37 +402,46 @@ export function useHomeSummary(profileId: string | null) {
     return { byGroup, membersByGroup, awaiting, totals, monthSpent, withLedger };
   }, [mirror, queue, profileId, monthPrefix]);
 
-  return {
-    balanceFor: (groupId: string) => summary.byGroup.get(groupId) ?? 0n,
-    membersFor: (groupId: string) => summary.membersByGroup.get(groupId) ?? [],
-    memberCountFor: (groupId: string) => summary.membersByGroup.get(groupId)?.length ?? 0,
-    hasPending: (groupId: string) => summary.awaiting.has(groupId),
-    /** Whether this group's ledger has materialised yet — false for the brief
-     *  window after an import lands the group but before its expenses arrive. */
-    hasLedger: (groupId: string) => summary.withLedger.has(groupId),
-    totals: summary.totals,
-    /** My share of this month's expenses, per currency, biggest first. */
-    monthSpent: summary.monthSpent,
-    isLoading: !hydrated,
-    isFetching: status === 'syncing',
-    // The mirror hydrates from disk instantly (ADR-005), but that snapshot can
-    // be behind the server — a settlement that cleared your debt may only exist
-    // server-side until the session's first pull lands. Painting a confident,
-    // colour-coded balance from stale local data means the card can read "you
-    // owe" (red) and then flip once the sync reconciles — the exact jump the
-    // hero skeleton exists to hide. So the balance is only trustworthy once the
-    // first sync of the session has settled. `lastSyncedAt` is in-memory and
-    // starts null each launch, so it marks *this session's* first success.
-    //
-    // Bounded, never a hang: the provider kicks one `flush` on mount, which
-    // resolves to either `lastSyncedAt` set (success) or a can't-sync status
-    // (offline/metered/error). In those states there is nothing better than the
-    // local snapshot, so fall through and show it at once rather than shimmer
-    // forever — local-first still wins whenever the network can't answer.
-    pendingFirstSync:
-      hydrated && lastSyncedAt === null && (status === 'idle' || status === 'syncing'),
-    refetch: () => void flush(),
-  };
+  // Memoised so the returned object keeps a stable identity across renders that
+  // didn't change the underlying data. Without this every consumer got a fresh
+  // object (and fresh selector closures) every render — which, on the groups
+  // list, made `extraData` churn and re-render the whole FlashList each frame,
+  // janking the transition when you navigated away. Identity now changes only
+  // when the memoised `summary` or a sync flag actually moves.
+  return useMemo(
+    () => ({
+      balanceFor: (groupId: string) => summary.byGroup.get(groupId) ?? 0n,
+      membersFor: (groupId: string) => summary.membersByGroup.get(groupId) ?? [],
+      memberCountFor: (groupId: string) => summary.membersByGroup.get(groupId)?.length ?? 0,
+      hasPending: (groupId: string) => summary.awaiting.has(groupId),
+      /** Whether this group's ledger has materialised yet — false for the brief
+       *  window after an import lands the group but before its expenses arrive. */
+      hasLedger: (groupId: string) => summary.withLedger.has(groupId),
+      totals: summary.totals,
+      /** My share of this month's expenses, per currency, biggest first. */
+      monthSpent: summary.monthSpent,
+      isLoading: !hydrated,
+      isFetching: status === 'syncing',
+      // The mirror hydrates from disk instantly (ADR-005), but that snapshot can
+      // be behind the server — a settlement that cleared your debt may only exist
+      // server-side until the session's first pull lands. Painting a confident,
+      // colour-coded balance from stale local data means the card can read "you
+      // owe" (red) and then flip once the sync reconciles — the exact jump the
+      // hero skeleton exists to hide. So the balance is only trustworthy once the
+      // first sync of the session has settled. `lastSyncedAt` is in-memory and
+      // starts null each launch, so it marks *this session's* first success.
+      //
+      // Bounded, never a hang: the provider kicks one `flush` on mount, which
+      // resolves to either `lastSyncedAt` set (success) or a can't-sync status
+      // (offline/metered/error). In those states there is nothing better than the
+      // local snapshot, so fall through and show it at once rather than shimmer
+      // forever — local-first still wins whenever the network can't answer.
+      pendingFirstSync:
+        hydrated && lastSyncedAt === null && (status === 'idle' || status === 'syncing'),
+      refetch: () => void flush(),
+    }),
+    [summary, hydrated, status, lastSyncedAt, flush],
+  );
 }
 
 /**

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -190,6 +190,16 @@ export interface UiStrings {
   allSettled: string;
   yourGroups: string;
   allGroups: string;
+  /** Title of the full groups screen — plainer than "All groups", which read like a database view. */
+  groupsTitle: string;
+  /** Placeholder in the groups search field. */
+  searchGroups: string;
+  /** Empty result when a search matches no group. */
+  noGroupsMatch: string;
+  /** Body under "No groups yet" on the groups screen, with its Create-group button. */
+  noGroupsBody: string;
+  /** Divider above the settled groups, once they're sorted below the ones needing action. */
+  settledHeader: string;
   /** The "show every category" chip at the head of the group filter strip. */
   filterAll: string;
   /** A small tag on a just-created group row. */
@@ -2365,6 +2375,11 @@ const en: UiStrings = {
   allSettled: 'All settled',
   yourGroups: 'Your groups',
   allGroups: 'All groups',
+  groupsTitle: 'Groups',
+  searchGroups: 'Search groups',
+  noGroupsMatch: 'No groups match your search',
+  noGroupsBody: 'Create a group for a trip, rent, dinner — anything you split.',
+  settledHeader: 'Settled',
   filterAll: 'All',
   tagNew: 'New',
   tagOnTrip: 'On trip',
@@ -4389,6 +4404,11 @@ const ta: UiStrings = {
   allSettled: 'எல்லாம் சரி',
   yourGroups: 'உங்கள் குழுக்கள்',
   allGroups: 'அனைத்து குழுக்கள்',
+  groupsTitle: 'குழுக்கள்',
+  searchGroups: 'குழுக்களைத் தேடு',
+  noGroupsMatch: 'உங்கள் தேடலுக்கு எந்தக் குழுவும் இல்லை',
+  noGroupsBody: 'பயணம், வாடகை, இரவு உணவு — நீங்கள் பகிர்வது எதற்கும் ஒரு குழுவை உருவாக்குங்கள்.',
+  settledHeader: 'தீர்க்கப்பட்டவை',
   filterAll: 'அனைத்தும்',
   tagNew: 'புதியது',
   tagOnTrip: 'பயணத்தில்',
@@ -6490,6 +6510,11 @@ const hi: UiStrings = {
   allSettled: 'सब बराबर',
   yourGroups: 'आपके समूह',
   allGroups: 'सभी समूह',
+  groupsTitle: 'समूह',
+  searchGroups: 'समूह खोजें',
+  noGroupsMatch: 'आपकी खोज से कोई समूह मेल नहीं खाता',
+  noGroupsBody: 'यात्रा, किराया, डिनर — जो कुछ भी आप बाँटते हैं, उसके लिए एक समूह बनाएँ।',
+  settledHeader: 'निपटाए गए',
   filterAll: 'सभी',
   tagNew: 'नया',
   tagOnTrip: 'यात्रा जारी',
@@ -8523,6 +8548,11 @@ const ar: UiStrings = {
   allSettled: 'تمت التسوية',
   yourGroups: 'مجموعاتك',
   allGroups: 'كل المجموعات',
+  groupsTitle: 'المجموعات',
+  searchGroups: 'ابحث في المجموعات',
+  noGroupsMatch: 'لا توجد مجموعات تطابق بحثك',
+  noGroupsBody: 'أنشئ مجموعة لرحلة أو إيجار أو عشاء — أي شيء تتقاسمه.',
+  settledHeader: 'مُسوَّاة',
   filterAll: 'الكل',
   tagNew: 'جديد',
   tagOnTrip: 'في رحلة',


### PR DESCRIPTION
Acts on a UX roast of the "All groups" screen: clean, but a passive directory — it didn't answer *"where do I need to act?"* or *"how do I make a group?"*.

## What changed
- **Action-first sorting.** Groups that owe, are owed, or await a confirmation sort to the top, biggest balances first. Settled groups drop below a quiet **Settled** divider, dimmed — present, not competing.
- **Search.** A pill search field appears once you pass six groups; filters by name, with a clear button. A search matching nothing gets its own "No groups match" empty state (distinct from having no groups).
- **New-group CTA.** A `+` top-right, and again as a button inside the first-run empty state.
- **Richer empty state.** "No groups yet" now carries a line — *"Create a group for a trip, rent, dinner — anything you split."* — and the Create button, so a first-timer is never staring at a dead end.
- **Clearer rows.** Subtitle leads with the status (`You owe · 4 members`), member count second. A pending settlement keeps its member-count context instead of swallowing it. Balance stays on the right, color-coded, where users expect it.
- **Title** `All groups` → **`Groups`** (new key; the dashboard's "All groups" link is unchanged).

## Notes
- FlashList carries the group-ledger settings (`drawDistance` 1500, `extraData`) and mixed row/header item types via `getItemType`.
- New i18n keys across **en / ta / hi / ar**.
- Gates: `tsc` 0 errors, eslint clean, prettier clean. Not device-tested (emulator).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added group search for lists with six or more groups.
  - Added options to create a group from the top-right action or empty state.
  - Group lists now prioritize groups requiring action and separate settled groups.
  - Group rows show settlement status and member count, with settled groups visually dimmed.

- **Localization**
  - Added translations for group titles, search, empty states, no-match results, and settled-group sections in English, Tamil, Hindi, and Arabic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->