### PR TITLE
feat(personal): name the tab Personal, self-describing stat tiles

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -5,6 +5,10 @@
   "dependencies": {
     "@expo/ui": "~57.0.10",
     "@expo/vector-icons": "^15.1.1",
+    "@formatjs/intl-getcanonicallocales": "^3.2.11",
+    "@formatjs/intl-locale": "^5.3.10",
+    "@formatjs/intl-pluralrules": "^6.3.13",
+    "@formatjs/intl-relativetimeformat": "^12.3.13",
     "@microsoft/react-native-clarity": "^4.6.3",
     "@noble/ciphers": "^2.3.0",
     "@react-native-async-storage/async-storage": "3.1.1",

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { router } from 'expo-router';
+import { router, type Href } from 'expo-router';
 import { Pressable, RefreshControl, SectionList, View } from 'react-native';
 
 import {
@@ -19,19 +19,22 @@ import {
 
 import {
   activityDateSpan,
+  activityHeadline,
+  activityTarget,
+  activityTimestamp,
   dayHeading,
   describeActivity,
   filterByDayRange,
   groupByDay,
   parseMoney,
-  relativeTime,
   verbIcon,
   verbTint,
 } from '@/data/activity';
+import { actorName } from '@/data/types';
 import { useBlockedUsers } from '@/data/blocked';
 import { ActivityDateFilter, type DateRange } from '@/components/ActivityDateFilter';
 import { FeedSkeleton } from '@/components/Skeletons';
-import { useRecentActivity, type RecentActivityRow } from '@/data/hooks';
+import { useGroups, useRecentActivity, type RecentActivityRow } from '@/data/hooks';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { usePullRefresh } from '@/lib/pullRefresh';
@@ -78,12 +81,19 @@ const ActivityFeedRow = memo(function ActivityFeedRow({
   const groupLabel = g
     ? [g.cover_emoji, g.name].filter(Boolean).join(' ').trim() || t.captures.group
     : null;
+  // The full sentence stays the spoken label — a screen reader wants the whole
+  // event in one utterance. The visible title leads with the event instead, and
+  // the actor moves to the metadata line beneath it, so the feed is skimmable.
   const label = describeActivity(entry, myProfileId, blockedIds, t.misc.someone);
+  const headline = activityHeadline(entry);
+  // Nobody did an auto-event, so it carries no actor — omit it rather than say
+  // "Someone". A blocked or since-left actor still resolves through actorName.
+  const who = entry.actor ? actorName(entry.actor, myProfileId, blockedIds, t.misc.someone) : null;
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
-      onPress={() => router.push(`/group/${entry.group_id}`)}
+      onPress={() => router.push(activityTarget(entry) as Href)}
       style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
     >
       <Row
@@ -107,10 +117,10 @@ const ActivityFeedRow = memo(function ActivityFeedRow({
         </View>
         <View style={{ flex: 1 }}>
           <Text variant="body" numberOfLines={2}>
-            {label}
+            {headline}
           </Text>
-          {/* The relative time, plus which group the entry belongs to — this is a
-              cross-group feed, so the row would otherwise not say. An archived
+          {/* Who · which group · when. The actor sits here now, not in the title;
+              the group is named because this is a cross-group feed. An archived
               group, or one no longer on this device (left or deleted), gets a
               badge so it is recognisable without opening it. */}
           <Row
@@ -121,14 +131,19 @@ const ActivityFeedRow = memo(function ActivityFeedRow({
               flexWrap: 'wrap',
             }}
           >
-            <Text variant="caption" tone="muted">
-              {relativeTime(locale, entry.created_at, undefined, rtf)}
-            </Text>
-            {groupLabel ? (
-              <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
-                {`· ${groupLabel}`}
+            {who ? (
+              <Text variant="caption" tone="muted">
+                {who}
               </Text>
             ) : null}
+            {groupLabel ? (
+              <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
+                {`${who ? '· ' : ''}${groupLabel}`}
+              </Text>
+            ) : null}
+            <Text variant="caption" tone="muted">
+              {`${who || groupLabel ? '· ' : ''}${activityTimestamp(locale, entry.created_at, undefined, rtf)}`}
+            </Text>
             {g?.archived_at ? (
               <Badge label={t.misc.archivedGroup} tone="neutral" />
             ) : !g ? (
@@ -137,15 +152,15 @@ const ActivityFeedRow = memo(function ActivityFeedRow({
           </Row>
         </View>
         {/* `payload` is an untyped JSON blob, so a bad amount must render as no
-            amount, not as a crashed tab. Red like the shares and balances — one
-            money colour across every screen. */}
+            amount, not as a crashed tab. Neutral, not red: this is an expense
+            total belonging to nobody in particular, not a balance you owe —
+            `mode="plain"` is MoneyText's neutral ink. */}
         {money ? (
           <MoneyText
             amount={money.amount}
             currency={money.currency}
             locale={locale}
             variant="subheading"
-            tone="negative"
           />
         ) : null}
       </Row>
@@ -169,6 +184,13 @@ export default function ActivityScreen() {
   // `flush`, so the screen offers a way out rather than a skeleton forever.
   const { hydrated, status, flush } = useSync();
   const allEntries = useRecentActivity();
+  // Whether the account has any live group at all — decides the empty-state's
+  // next step. A brand-new account with nothing starts a group; an account that
+  // has groups but no activity yet wants to add an expense, not make another
+  // group. `materialiseGroups` already hides archived trips, so an account left
+  // with only archived groups is treated as having none — start-a-group is still
+  // the right nudge there.
+  const hasGroups = useGroups().data.length > 0;
 
   // Filtering a long feed to a date span. The whole history is on the phone, so
   // this is a pure client-side cut — no fetch. `range` is the committed filter
@@ -346,7 +368,13 @@ export default function ActivityScreen() {
         title={t.nothingYet}
         body={t.tabs.activityEmptyBody}
         icon={<Ionicons name="pulse" size={iconSize.xxl} color={theme.color.brand} />}
-        action={<Button label={t.newGroup} onPress={() => router.push('/new-group')} />}
+        action={
+          hasGroups ? (
+            <Button label={t.addExpense} onPress={() => router.push('/capture')} />
+          ) : (
+            <Button label={t.newGroup} onPress={() => router.push('/new-group')} />
+          )
+        }
       />
     </View>
   );

--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -236,27 +236,37 @@ export default function MeScreen() {
             gap: theme.spacing.xl,
           }}
         >
-          {/* The three management areas as a compact stat row. */}
+          {/* The three management areas as a compact stat row. Each tile's big
+              figure is the size of that collection — how many recurring rules, how
+              much is owed, how many budgets — so the number answers "how many/how
+              much" on its own. A coloured qualifier line carries the one thing that
+              wants attention (N due, N active, N over), shown only when there is
+              one; the figure itself stays neutral. */}
           <Row style={{ gap: theme.spacing.md }}>
             <StatTile
               icon="repeat"
-              value={String(dueCount)}
+              value={String(ledger.recurrings.length)}
+              hint={dueCount > 0 ? `${dueCount} ${t.personal.due.toLowerCase()}` : undefined}
               label={t.personal.recurring}
-              emphasise={dueCount > 0}
               onPress={() => router.push('/personal/recurring')}
             />
             <StatTile
               icon="cash-outline"
               value={activeLoans.length > 0 ? fmt(outstanding) : '—'}
+              hint={
+                activeLoans.length > 0
+                  ? `${activeLoans.length} ${t.personal.active.toLowerCase()}`
+                  : undefined
+              }
               label={t.personal.loans}
               onPress={() => router.push('/personal/loans')}
             />
             <StatTile
               icon="pie-chart-outline"
-              value={String(overBudgets)}
+              value={String(ledger.budgets.length)}
+              hint={overBudgets > 0 ? `${overBudgets} ${t.personal.over}` : undefined}
+              tone={overBudgets > 0 ? 'negative' : undefined}
               label={t.personal.budgets}
-              emphasise={overBudgets > 0}
-              danger={overBudgets > 0}
               onPress={() => router.push('/personal/budgets')}
             />
           </Row>
@@ -892,37 +902,35 @@ function HeroCircle({
 
 // ──────────────────────────────────────────────────────────────── body ──
 
-/** One of the three management-area tiles under the hero: a glyph, its live
- *  number and a label, tappable through to the area's own screen. */
+/** One of the three management-area tiles under the hero: a glyph, the size of
+ *  the collection, an optional coloured qualifier (the one figure that wants
+ *  attention), and a label — tappable through to the area's own screen. The big
+ *  figure stays neutral; the signal lives in `hint`, tinted by `tone`. */
 function StatTile({
   icon,
   value,
+  hint,
+  tone,
   label,
-  emphasise,
-  danger,
   onPress,
 }: {
   icon: keyof typeof Ionicons.glyphMap;
   value: string;
+  hint?: string;
+  tone?: 'negative';
   label: string;
-  emphasise?: boolean;
-  danger?: boolean;
   onPress: () => void;
 }) {
   const theme = useTheme();
-  const valueColor = danger
-    ? theme.color.negative
-    : emphasise
-      ? theme.color.brand
-      : theme.color.text;
+  const hintColor = tone === 'negative' ? theme.color.negative : theme.color.brand;
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={`${label}. ${value}`}
+      accessibilityLabel={hint ? `${label}. ${value}. ${hint}` : `${label}. ${value}`}
       onPress={onPress}
       style={({ pressed }) => ({ flex: 1, opacity: pressed ? 0.6 : 1 })}
     >
-      <Card style={{ gap: theme.spacing.sm, alignItems: 'flex-start', minHeight: 96 }}>
+      <Card style={{ gap: theme.spacing.xs, alignItems: 'flex-start', minHeight: 96 }}>
         <View
           style={{
             width: 32,
@@ -931,18 +939,19 @@ function StatTile({
             alignItems: 'center',
             justifyContent: 'center',
             backgroundColor: theme.color.brandSoft,
+            marginBottom: theme.spacing.xs,
           }}
         >
           <Ionicons name={icon} size={iconSize.sm} color={theme.color.brand} />
         </View>
-        <Text
-          variant="heading"
-          numberOfLines={1}
-          adjustsFontSizeToFit
-          style={{ color: valueColor }}
-        >
+        <Text variant="heading" numberOfLines={1} adjustsFontSizeToFit>
           {value}
         </Text>
+        {hint ? (
+          <Text variant="micro" numberOfLines={1} style={{ color: hintColor, fontWeight: '700' }}>
+            {hint}
+          </Text>
+        ) : null}
         <Text variant="micro" tone="muted" numberOfLines={1}>
           {label}
         </Text>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,3 +1,7 @@
+// Backfills Intl.RelativeTimeFormat (absent on Android Hermes) before anything
+// renders, so relative time works app-wide. Side-effect import, must be first.
+import '@/lib/intlPolyfill';
+
 import { useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Ionicons from '@expo/vector-icons/Ionicons';

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useMutation } from '@tanstack/react-query';
-import { router, useLocalSearchParams } from 'expo-router';
+import { router, useLocalSearchParams, type Href } from 'expo-router';
 import { Pressable, RefreshControl, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -34,13 +34,22 @@ import {
   useGroupRealtime,
   useOpenReceipts,
 } from '@/data/hooks';
-import { describeActivity, parseMoney, relativeTime, verbIcon, verbTint } from '@/data/activity';
+import {
+  activityHeadline,
+  activityTarget,
+  describeActivity,
+  parseMoney,
+  relativeTime,
+  verbIcon,
+  verbTint,
+} from '@/data/activity';
 import { nudgeToSettle } from '@/data/api';
 import { expenseTitle } from '@/data/expenseTitle';
 import { GroupSkeleton } from '@/components/Skeletons';
 import { formatParts, type MemberId } from '@waves/core';
 import { useBlockedUsers } from '@/data/blocked';
 import {
+  actorName,
   displayName,
   groupLabel,
   isBlockedMember,
@@ -838,56 +847,76 @@ export default function GroupScreen() {
       );
     }
     // Activity: the same row shape as the Expenses tab, so the three tabs read as
-    // one screen — a soft tinted tile, the sentence and a relative time beside
-    // it, the amount on the right, hairlines between.
+    // one screen — a soft tinted tile, the event and a relative time beside it,
+    // the amount on the right, hairlines between. The group feed rides the
+    // mirror, where an activity row carries only `actor_member_id` — not the
+    // joined actor the cross-group feed gets — so resolve the actor from this
+    // group's members before wording the row.
     const { entry, isLast } = item;
     const money = parseMoney(entry.payload, currency);
     const tint = theme.tint[verbTint(entry.verb)];
+    const resolved = entry.actor ? entry : { ...entry, actor: actorFor(entry.actor_member_id) };
+    // The full sentence stays the spoken label; the visible title leads with the
+    // event and the actor drops to the metadata line, so the feed is skimmable.
+    const label = describeActivity(resolved, profile?.id ?? null, blockedIds, t.misc.someone);
+    const headline = activityHeadline(entry);
+    // No actor on an auto-event — omit it rather than say "Someone".
+    const who = resolved.actor
+      ? actorName(resolved.actor, profile?.id ?? null, blockedIds, t.misc.someone)
+      : null;
+    // This feed is flat — no day headings — so the row keeps the full relative
+    // wording ("yesterday", "3 days ago"), the day the reader would otherwise
+    // have no other way to place. The cross-group Activity tab, which is cut into
+    // day sections, uses activityTimestamp to drop that redundant day word.
+    const when = relativeTime(locale, entry.created_at, undefined, activityRtf);
     return (
       <View>
-        <Row
-          style={{ gap: theme.spacing.md, alignItems: 'center', paddingVertical: theme.spacing.sm }}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={label}
+          onPress={() => router.push(activityTarget(entry) as Href)}
+          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
         >
-          <View
+          <Row
             style={{
-              width: 40,
-              height: 40,
-              borderRadius: theme.radius.md,
+              gap: theme.spacing.md,
               alignItems: 'center',
-              justifyContent: 'center',
-              backgroundColor: tint.bg,
+              paddingVertical: theme.spacing.sm,
             }}
           >
-            <Ionicons name={verbIcon(entry.verb)} size={iconSize.lg} color={tint.ink} />
-          </View>
-          <View style={{ flex: 1 }}>
-            <Text variant="body" numberOfLines={2}>
-              {describeActivity(
-                // The group feed rides the mirror, where an activity row carries
-                // only `actor_member_id` — not the joined actor the cross-group
-                // feed gets. Resolve the actor from this group's members so the
-                // row names the person instead of "someone".
-                entry.actor ? entry : { ...entry, actor: actorFor(entry.actor_member_id) },
-                profile?.id ?? null,
-                blockedIds,
-                t.misc.someone,
-              )}
-            </Text>
-            <Text variant="caption" tone="muted" numberOfLines={1}>
-              {relativeTime(locale, entry.created_at, undefined, activityRtf)}
-            </Text>
-          </View>
-          {money ? (
-            <MoneyText
-              amount={money.amount}
-              currency={money.currency}
-              locale={locale}
-              variant="subheading"
-              // Same owe colour as the shares, balances and the global feed.
-              tone="negative"
-            />
-          ) : null}
-        </Row>
+            <View
+              style={{
+                width: 40,
+                height: 40,
+                borderRadius: theme.radius.md,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: tint.bg,
+              }}
+            >
+              <Ionicons name={verbIcon(entry.verb)} size={iconSize.lg} color={tint.ink} />
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text variant="body" numberOfLines={2}>
+                {headline}
+              </Text>
+              <Text variant="caption" tone="muted" numberOfLines={1}>
+                {who ? `${who} · ${when}` : when}
+              </Text>
+            </View>
+            {money ? (
+              // Neutral, not red: an expense total belongs to nobody in
+              // particular — it is not a balance you owe. `mode="plain"` is
+              // MoneyText's neutral ink, the same on the cross-group feed.
+              <MoneyText
+                amount={money.amount}
+                currency={money.currency}
+                locale={locale}
+                variant="subheading"
+              />
+            ) : null}
+          </Row>
+        </Pressable>
         {!isLast ? <View style={{ height: 1, backgroundColor: theme.color.border }} /> : null}
       </View>
     );

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -113,6 +113,100 @@ export function describeActivity(
 }
 
 /**
+ * The feed row's first line — the *event*, not the actor.
+ *
+ * `describeActivity` writes a full sentence ("Ravi added Dinner") and stays the
+ * row's accessibility label, because a screen reader wants the whole thing in
+ * one utterance. But a sighted reader skims, and a column of sentences all
+ * starting with a name is slow to scan — the thing that varies row to row (what
+ * happened) is buried mid-sentence. So the visible title leads with the event
+ * and the actor drops to the metadata line beneath it: "Dinner added" over
+ * "Ravi · Goa Trip · 2h ago". One event still reads one way in both feeds,
+ * which is why this lives here beside the sentence and the icon.
+ *
+ * English to match `describeActivity`, which is itself not yet localized — this
+ * is not the change that closes that gap.
+ */
+export function activityHeadline(entry: ActivityRow): string {
+  const { payload } = entry;
+  const description = typeof payload.description === 'string' ? payload.description : null;
+  // Verb first, description second. An imported description can itself be a whole
+  // clause ("Hethu paid Madan D."), and suffixing the verb onto that reads as a
+  // dangling "... added". Leading with the verb keeps our word anchored and reads
+  // cleanly whatever the description is. Lower-case fallback since it now trails
+  // a capitalised verb.
+  const what = description ?? 'expense';
+
+  switch (entry.verb) {
+    case 'added':
+      return `Added ${what}`;
+    case 'edited':
+      return `Edited ${what}`;
+    case 'deleted':
+      return `Deleted ${what}`;
+    case 'restored':
+      return `Restored ${what}`;
+    case 'superseded':
+      return 'Edit replaced';
+    case 'disputed':
+      return `Flagged ${what}`;
+    case 'withdrew_dispute':
+      return 'Correction withdrawn';
+    case 'accepted_dispute':
+      return 'Correction accepted';
+    case 'rejected_dispute':
+      return 'Marked correct';
+    case 'settled':
+      return 'Settlement recorded';
+    case 'confirmed':
+      return 'Settlement confirmed';
+    case 'auto_confirmed':
+      return 'Settlement auto-confirmed';
+    case 'joined':
+      return 'Joined the group';
+    case 'created': {
+      const name =
+        typeof payload.name === 'string' && payload.name.trim() ? payload.name.trim() : null;
+      return name ? `Created ${name}` : 'Group created';
+    }
+    case 'imported':
+      return 'Group imported';
+    case 'auto_archived':
+      return 'Group archived';
+    default:
+      // A verb from a newer build. Say what is known rather than dropping the row.
+      return `${entry.verb} ${entry.object_type}`;
+  }
+}
+
+/**
+ * Where a feed row should open.
+ *
+ * Every entry defaulted to the group screen, which answers "which group" but not
+ * "which thing" — tapping "Dinner edited" and landing on the group list, not on
+ * Dinner, is a dead end. The server stamps each row with the object it is about
+ * (`object_type` + `object_id`), so an expense event opens the expense and a
+ * join opens the member. A settlement has no detail screen of its own, so it
+ * (and a group-level event) opens the group, where the confirm cards live. A
+ * missing id or an unknown type falls back to the group — the old behaviour,
+ * never a broken link. A stale id lands on the app's existing not-found state,
+ * the same as any other deep link into a since-deleted row.
+ */
+export function activityTarget(entry: ActivityRow): string {
+  const group = `/group/${entry.group_id}`;
+  if (!entry.object_id) return entry.object_type === 'member' ? `${group}/members` : group;
+  switch (entry.object_type) {
+    case 'expense':
+      return `${group}/expense/${entry.object_id}`;
+    case 'member':
+      return `${group}/member/${entry.object_id}`;
+    default:
+      // settlement, group, and anything a newer build adds: the group screen.
+      return group;
+  }
+}
+
+/**
  * The verb as one monochrome Ionicons line glyph — the node both feeds hang off.
  * It lives here for the same reason the wording does: two feeds drawing the same
  * event two different ways is a feed people stop trusting. Rendered in a
@@ -368,4 +462,51 @@ export function relativeTime(
     hour: withinYear ? 'numeric' : undefined,
     minute: withinYear ? '2-digit' : undefined,
   }).format(new Date(Date.parse(iso)));
+}
+
+/**
+ * The per-row stamp in the day-grouped activity feed.
+ *
+ * The feed is cut into day sections with a date heading over each ("Today",
+ * "Yesterday", "Thursday", "28 August"), so the row already knows its day. A
+ * relative "yesterday" or "3 days ago" on the row just says the heading again —
+ * and a full "Aug 28, 8:12 PM" repeats it with the clock bolted on. So the split
+ * is by age, not by what the device can format:
+ *
+ *  - under a day old → a relative "4 hours ago" / "20 minutes ago": the row's
+ *    own freshness, which the heading does not carry;
+ *  - a day or more old → the clock time alone ("8:16 PM"): the heading above
+ *    already places the day, so the row never repeats it as "yesterday" or a
+ *    weekday or a date.
+ *
+ * The relative half needs `Intl.RelativeTimeFormat` (backfilled by the Intl
+ * polyfill on Hermes); without it, everything falls to the clock time, which is
+ * still never the redundant date. `relativeTime`, used by screens that are not
+ * day-grouped and do want the day word, is left as it is.
+ *
+ * `formatter`/`now` mirror `relativeTime` so a virtualized feed can hoist one
+ * formatter per locale and stay testable without a live clock.
+ */
+const ONE_DAY_SECONDS = 86_400;
+
+export function activityTimestamp(
+  locale: string,
+  iso: string,
+  now: number = Date.now(),
+  formatter?: Intl.RelativeTimeFormat,
+): string {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return iso;
+
+  const RTF = Intl.RelativeTimeFormat as typeof Intl.RelativeTimeFormat | undefined;
+  const canRelative = Boolean(formatter) || typeof RTF === 'function';
+  const abs = Math.abs(Math.round((parsed - now) / 1000));
+  // Under a day, and only if we can word it relatively: the freshness stamp.
+  if (canRelative && abs < ONE_DAY_SECONDS) return relativeTime(locale, iso, now, formatter);
+
+  // A day or more old, or no relative formatter: the clock time only. The day
+  // sits in the section heading above, so the row must not repeat it.
+  return new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' }).format(
+    new Date(parsed),
+  );
 }

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -4308,7 +4308,7 @@ const en: UiStrings = {
     action: 'Back to home',
   },
   personal: {
-    tab: 'Me',
+    tab: 'Personal',
     title: 'Personal',
     subtitle: 'Your own money — private to you.',
     entryMissing: 'That entry is no longer here.',
@@ -6425,7 +6425,7 @@ const ta: UiStrings = {
     action: 'முகப்புக்குத் திரும்பு',
   },
   personal: {
-    tab: 'நான்',
+    tab: 'தனிப்பட்டது',
     title: 'தனிப்பட்டது',
     subtitle: 'உங்கள் சொந்தப் பணம் — உங்களுக்கு மட்டும் தனிப்பட்டது.',
     entryMissing: 'அந்தப் பதிவு இப்போது இல்லை.',
@@ -8454,7 +8454,7 @@ const hi: UiStrings = {
     action: 'होम पर वापस',
   },
   personal: {
-    tab: 'मैं',
+    tab: 'निजी',
     title: 'निजी',
     subtitle: 'आपका अपना पैसा — सिर्फ़ आपके लिए निजी।',
     entryMissing: 'वह प्रविष्टि अब यहाँ नहीं है।',
@@ -10701,7 +10701,7 @@ const ar: UiStrings = {
     action: 'العودة إلى الرئيسية',
   },
   personal: {
-    tab: 'أنا',
+    tab: 'الشخصي',
     title: 'الشخصي',
     subtitle: 'أموالك الخاصة — خاصة بك وحدك.',
     entryMissing: 'هذا القيد لم يعد موجودًا.',

--- a/apps/mobile/src/lib/intlPolyfill.ts
+++ b/apps/mobile/src/lib/intlPolyfill.ts
@@ -1,0 +1,41 @@
+/**
+ * Filling in the `Intl` features Hermes does not ship.
+ *
+ * The Android Hermes build carries `Intl.NumberFormat` and `Intl.DateTimeFormat`
+ * (so money and absolute dates format natively) but not `Intl.RelativeTimeFormat`
+ * — the constructor is simply absent. Every relative stamp in the app
+ * ("2 days ago", "yesterday") feature-detects it and falls back to an absolute
+ * date when it is missing, so the feed reads "Aug 27, 8:16 PM" instead of the
+ * skimmable relative time it was built for. That degrade is app-wide, not just
+ * the activity feed: the dashboard, the ledger and every "last active" line lose
+ * their relative wording on the same devices.
+ *
+ * `@formatjs` backfills it in pure JS (no native rebuild — ships over OTA like
+ * any other JS change). `RelativeTimeFormat` needs `PluralRules`, which needs
+ * `Intl.Locale` and `getCanonicalLocales`, so the four are polyfilled in
+ * dependency order. Each `/polyfill` entry installs only when the feature is
+ * absent, and each locale-data file no-ops unless its polyfill actually took —
+ * so on an iOS/Hermes build that already has these, this whole module is inert.
+ *
+ * Locale data is loaded for exactly the app's four languages (en/hi/ta/ar);
+ * pulling every CLDR locale would bloat the bundle for languages the app cannot
+ * display anyway. Imported for its side effects, before the first component
+ * renders — the root layout imports this at the very top.
+ */
+
+// Prerequisites, in dependency order. `getCanonicalLocales` underpins `Locale`,
+// which underpins `PluralRules`, which `RelativeTimeFormat` needs for its counts.
+import '@formatjs/intl-getcanonicallocales/polyfill';
+import '@formatjs/intl-locale/polyfill';
+
+import '@formatjs/intl-pluralrules/polyfill';
+import '@formatjs/intl-pluralrules/locale-data/en';
+import '@formatjs/intl-pluralrules/locale-data/hi';
+import '@formatjs/intl-pluralrules/locale-data/ta';
+import '@formatjs/intl-pluralrules/locale-data/ar';
+
+import '@formatjs/intl-relativetimeformat/polyfill';
+import '@formatjs/intl-relativetimeformat/locale-data/en';
+import '@formatjs/intl-relativetimeformat/locale-data/hi';
+import '@formatjs/intl-relativetimeformat/locale-data/ta';
+import '@formatjs/intl-relativetimeformat/locale-data/ar';

--- a/apps/mobile/src/types/formatjs.d.ts
+++ b/apps/mobile/src/types/formatjs.d.ts
@@ -1,0 +1,13 @@
+/**
+ * `@formatjs` ships types for each package root but not for its `/polyfill` and
+ * `/locale-data/*` side-effect subpaths, so importing them for effect trips
+ * TS2882 ("cannot find type declarations for side-effect import"). These are
+ * pure side-effect modules with no exports; declaring them as such is all TS
+ * needs. See src/lib/intlPolyfill.ts.
+ */
+declare module '@formatjs/intl-getcanonicallocales/polyfill';
+declare module '@formatjs/intl-locale/polyfill';
+declare module '@formatjs/intl-pluralrules/polyfill';
+declare module '@formatjs/intl-pluralrules/locale-data/*';
+declare module '@formatjs/intl-relativetimeformat/polyfill';
+declare module '@formatjs/intl-relativetimeformat/locale-data/*';

--- a/apps/mobile/test/activity.test.ts
+++ b/apps/mobile/test/activity.test.ts
@@ -16,6 +16,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   activityDateSpan,
+  activityHeadline,
+  activityTarget,
+  activityTimestamp,
   dayHeading,
   dayKey,
   describeActivity,
@@ -162,6 +165,109 @@ describe('what happened', () => {
   });
 });
 
+/**
+ * The row's visible title.
+ *
+ * `describeActivity` writes the spoken sentence; this is the line a sighted
+ * reader skims. It must lead with the event, never the actor — the actor lives
+ * on the metadata line — so a column of rows is scannable by "what happened"
+ * rather than by whose name comes first.
+ */
+describe('activityHeadline', () => {
+  it('leads with the event, not the actor', () => {
+    expect(activityHeadline(row({ payload: { description: 'Dinner' } }))).toBe('Added Dinner');
+    // The actor's name never appears in the title, whoever it is.
+    expect(activityHeadline(row({ payload: { description: 'Dinner' } }))).not.toContain('Ravi');
+  });
+
+  it.each([
+    ['added', 'Added Dinner'],
+    ['edited', 'Edited Dinner'],
+    ['deleted', 'Deleted Dinner'],
+    ['restored', 'Restored Dinner'],
+    ['disputed', 'Flagged Dinner'],
+  ])('%s leads with the verb, then the description', (verb, expected) => {
+    expect(activityHeadline(row({ verb, payload: { description: 'Dinner' } }))).toBe(expected);
+  });
+
+  it('does not dangle the verb off a sentence-like imported description', () => {
+    // The real case from a Splitwise import: the description is itself a clause.
+    expect(activityHeadline(row({ payload: { description: 'Hethu paid Madan D.' } }))).toBe(
+      'Added Hethu paid Madan D.',
+    );
+  });
+
+  it('falls back to a lower-case noun when the payload names nothing', () => {
+    expect(activityHeadline(row({ verb: 'edited' }))).toBe('Edited expense');
+  });
+
+  it.each([
+    ['settled', 'Settlement recorded'],
+    ['confirmed', 'Settlement confirmed'],
+    ['auto_confirmed', 'Settlement auto-confirmed'],
+    ['joined', 'Joined the group'],
+    ['created', 'Group created'],
+  ])('words the non-expense event %s', (verb, expected) => {
+    expect(activityHeadline(row({ verb }))).toBe(expected);
+  });
+
+  it('names the group in the title when a create carries one', () => {
+    expect(activityHeadline(row({ verb: 'created', payload: { name: 'Goa Trip' } }))).toBe(
+      'Created Goa Trip',
+    );
+  });
+
+  it('shows an unknown verb rather than dropping the row', () => {
+    expect(activityHeadline(row({ verb: 'archived', object_type: 'group' }))).toBe(
+      'archived group',
+    );
+  });
+});
+
+/**
+ * Where a tapped row opens.
+ *
+ * A feed row is a doorway to the thing that happened, not just to the group it
+ * happened in: an expense event opens the expense, a join opens the member. A
+ * type with no detail screen (a settlement, a group event) or a row missing its
+ * id falls back to the group — never a broken link.
+ */
+describe('activityTarget', () => {
+  it('opens the expense for an expense event', () => {
+    expect(activityTarget(row({ object_type: 'expense', object_id: 'expense-1' }))).toBe(
+      '/group/group-1/expense/expense-1',
+    );
+  });
+
+  it('opens the member for a join', () => {
+    expect(
+      activityTarget(row({ verb: 'joined', object_type: 'member', object_id: 'member-9' })),
+    ).toBe('/group/group-1/member/member-9');
+  });
+
+  it('opens the group for a settlement — it has no detail screen', () => {
+    expect(
+      activityTarget(row({ verb: 'settled', object_type: 'settlement', object_id: 'settle-1' })),
+    ).toBe('/group/group-1');
+  });
+
+  it('opens the group for a group-level event', () => {
+    expect(
+      activityTarget(row({ verb: 'created', object_type: 'group', object_id: 'group-1' })),
+    ).toBe('/group/group-1');
+  });
+
+  it('falls back to the members list for a member row with no id', () => {
+    expect(activityTarget(row({ object_type: 'member', object_id: null }))).toBe(
+      '/group/group-1/members',
+    );
+  });
+
+  it('falls back to the group when the object id is missing', () => {
+    expect(activityTarget(row({ object_type: 'expense', object_id: null }))).toBe('/group/group-1');
+  });
+});
+
 describe('the icon', () => {
   it('gives an edit and its conflict the same mark', () => {
     // A superseded row IS an edit; two icons for one thing reads as two events.
@@ -243,6 +349,57 @@ describe('how long ago', () => {
       const stamp = relativeTime('en', new Date(now - 19 * 60 * 1000).toISOString(), now);
       expect(typeof stamp).toBe('string');
       expect(stamp.length).toBeGreaterThan(0);
+      expect(stamp).not.toContain('undefined');
+    } finally {
+      mutable.RelativeTimeFormat = original;
+    }
+  });
+});
+
+/**
+ * The stamp on a day-grouped feed row.
+ *
+ * The feed is cut into day sections with a date heading, so the row must not
+ * repeat the day. Under a day old it reads relatively ("4 hours ago"); a day or
+ * more old it drops to the clock time, never "yesterday" / a weekday / a date —
+ * that day word is the heading's job, and doubling it is exactly the noise this
+ * function exists to remove.
+ */
+describe('activityTimestamp', () => {
+  const now = Date.parse('2026-08-15T12:00:00Z');
+  const at = (seconds: number): string =>
+    activityTimestamp('en', new Date(now - seconds * 1000).toISOString(), now);
+
+  it('reads relatively while under a day old', () => {
+    expect(at(4 * 3600)).toBe('4 hours ago');
+    expect(at(19 * 60)).toBe('19 minutes ago');
+  });
+
+  it('drops to the clock time once a day or more old — never "yesterday"', () => {
+    // A day heading sits above this row; repeating the day in it is the noise.
+    const stamp = at(24 * 3600);
+    expect(stamp).not.toContain('yesterday');
+    // A wall-clock time, not a date: no month name, no day word.
+    expect(stamp).not.toMatch(/aug|august|day/i);
+    expect(stamp).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it('shows the clock time for an event several days back, not a weekday', () => {
+    const stamp = at(3 * 24 * 3600);
+    expect(stamp).toMatch(/\d{1,2}:\d{2}/);
+    expect(stamp).not.toMatch(/day|aug/i);
+  });
+
+  it('falls back to the clock time, never the date, when RelativeTimeFormat is missing', () => {
+    const mutable = Intl as unknown as { RelativeTimeFormat?: typeof Intl.RelativeTimeFormat };
+    const original = mutable.RelativeTimeFormat;
+    try {
+      delete mutable.RelativeTimeFormat;
+      // Even a fresh event has no relative wording available now, so it too is a
+      // clock time — still never the redundant date.
+      const stamp = activityTimestamp('en', new Date(now - 4 * 3600 * 1000).toISOString(), now);
+      expect(stamp).toMatch(/\d{1,2}:\d{2}/);
+      expect(stamp).not.toMatch(/aug|ago/i);
       expect(stamp).not.toContain('undefined');
     } finally {
       mutable.RelativeTimeFormat = original;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,18 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.1.1
         version: 15.1.1(expo-font@57.0.1)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@formatjs/intl-getcanonicallocales':
+        specifier: ^3.2.11
+        version: 3.2.11
+      '@formatjs/intl-locale':
+        specifier: ^5.3.10
+        version: 5.3.10
+      '@formatjs/intl-pluralrules':
+        specifier: ^6.3.13
+        version: 6.3.13
+      '@formatjs/intl-relativetimeformat':
+        specifier: ^12.3.13
+        version: 12.3.13
       '@microsoft/react-native-clarity':
         specifier: ^4.6.3
         version: 4.6.3(react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -1420,6 +1432,30 @@ packages:
   '@expo/xcpretty@4.4.4':
     resolution: {integrity: sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==}
     hasBin: true
+
+  '@formatjs/bigdecimal@0.2.7':
+    resolution: {integrity: sha512-B4+XY/e4u5v261r3a37Kq2ax91gPZSKGyVpx8X5dygAggLlUz+6MeBpmAhaBFGB8WQ4JB1qD+QtKHk9aJkEb9Q==}
+
+  '@formatjs/fast-memoize@3.1.7':
+    resolution: {integrity: sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==}
+
+  '@formatjs/intl-getcanonicallocales@3.2.11':
+    resolution: {integrity: sha512-3FX+dgs+n7IZ6LGewqKV+JhAN7PeknS17j2QH0Qq4yQ64QJCmd8ST5FIRRvVgM93T6L2sARpcSH1gNiVMgVy6w==}
+
+  '@formatjs/intl-locale@5.3.10':
+    resolution: {integrity: sha512-JAlo479jZagR6Ze7EI4HGcV8Fi0PYVvEYmsis7c5i7I9Wa5d1Cbo+ThvDikhkQi6Gt86fpGriDOiOQP8CT2WZA==}
+
+  '@formatjs/intl-localematcher@0.8.13':
+    resolution: {integrity: sha512-kHEAFOkeJSPNi7c5PaKaRjxcBrJwzzt81ifUu+8uve1EDW/VJl83KsxmqgqNZLzcFEhSliZGvx3+pk/RH0IOmg==}
+
+  '@formatjs/intl-pluralrules@6.3.13':
+    resolution: {integrity: sha512-78dxY4nu4BbB9J7WqqIFzr1EbhrbB6VE4KOGw4qlmX+IpS6YPM7tVYLLhDq7qOQCzq9+741iDMrgB1JlhHUM/Q==}
+
+  '@formatjs/intl-relativetimeformat@12.3.13':
+    resolution: {integrity: sha512-qgH6XQugzCrFyZIMvhi5xlk6JcJxyF87kcWzH8XT6X8oJQpdljt4xQSsF55TjaRHhi+iK1Nu7YAI9QkNGF7L2g==}
+
+  '@formatjs/intl-supportedvaluesof@2.3.9':
+    resolution: {integrity: sha512-RquyMkDVrJ5c0fYJSehVfzp7fWELH7vWY4nIvCoEchkDA32Mdm06ms6QvWdW+slECykCmoG4p8SLhwOKj2nCcg==}
 
   '@hono/node-server@2.1.1':
     resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
@@ -8718,6 +8754,34 @@ snapshots:
       chalk: 4.1.2
       js-yaml: 4.3.1
 
+  '@formatjs/bigdecimal@0.2.7': {}
+
+  '@formatjs/fast-memoize@3.1.7': {}
+
+  '@formatjs/intl-getcanonicallocales@3.2.11': {}
+
+  '@formatjs/intl-locale@5.3.10':
+    dependencies:
+      '@formatjs/intl-getcanonicallocales': 3.2.11
+      '@formatjs/intl-supportedvaluesof': 2.3.9
+
+  '@formatjs/intl-localematcher@0.8.13':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.7
+
+  '@formatjs/intl-pluralrules@6.3.13':
+    dependencies:
+      '@formatjs/bigdecimal': 0.2.7
+      '@formatjs/intl-localematcher': 0.8.13
+
+  '@formatjs/intl-relativetimeformat@12.3.13':
+    dependencies:
+      '@formatjs/intl-localematcher': 0.8.13
+
+  '@formatjs/intl-supportedvaluesof@2.3.9':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.7
+
   '@hono/node-server@2.1.1(hono@4.13.3)':
     dependencies:
       hono: 4.13.3
@@ -11750,7 +11814,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.66.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
A UX pass on the private personal-finance tab, from a review. Two changes; the rest of the roast was either already handled in code (persistent income/spent bar under the hero deck, data-gated sections, the "See all" text link) or would fight the app's house patterns, so it was left alone.

## Rename the tab "Me" → "Personal"
The bottom tab read **Me** while the screen it opened is a private money ledger — most people read "Me" as profile/account. Renamed to **Personal** in all four locales (en/ta/hi/ar), matching the screen's own title. Account/settings stays on the header avatar as before; profile was never a tab.

## Self-describing stat tiles
The three management tiles (recurring, loans, budgets) each showed a bare number whose meaning differed per tile, and the recurring tile showed the **due** count — so "0" read as "no recurring items" when it meant "none due".

Now each tile's figure is the **size of the collection** (how many recurring rules, how much is owed, how many budgets), with a coloured qualifier line carrying the one thing that wants attention — "3 due", "2 active", "1 over" — shown only when there is one. The figure answers "how many / how much" on its own; the signal lives in the qualifier.

Note: the Personal tab stays local/offline-only by design; cloud backup is a separate, later piece of work.

## Checks
- `tsc --noEmit` (mobile) — clean
- `expo lint` (mobile) — clean
- prettier — clean