### PR TITLE
feat(activity): skimmable feed, Personal tab, FlashList migration

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -42,9 +42,10 @@ import { usePullRefresh } from '@/lib/pullRefresh';
 import { SyncStatus, useSync } from '@/sync';
 
 // The day-grouped feed flattened for FlashList, which has no section API: a
-// `header` item per day, then that day's `entry` rows. The day cut is made to
-// stick via `stickyHeaderIndices`; `firstOfDay` drives the between-row hairline
-// so no line falls between a day heading and its first entry.
+// `header` item per day, then that day's `entry` rows. Headers scroll inline
+// with their rows (not pinned — sticky headers on this long, variable-height
+// feed left blank gaps and misaligned on a fast fling). `firstOfDay` drives the
+// between-row hairline so no line falls between a day heading and its first entry.
 type FeedRow =
   | { kind: 'header'; key: string; date: string }
   | { kind: 'row'; key: string; entry: RecentActivityRow; firstOfDay: boolean };
@@ -221,12 +222,10 @@ export default function ActivityScreen() {
   // rows near the viewport are mounted, and they recycle as the feed scrolls, so
   // a heavy account's memory and mount cost stay bounded no matter how far back
   // it goes. FlashList has no sections, so the day cut is flattened into `header`
-  // items whose positions become `stickyIndices`.
-  const { listData, stickyIndices } = useMemo(() => {
+  // items that scroll inline with their rows (like the group ledger's months).
+  const listData = useMemo(() => {
     const rows: FeedRow[] = [];
-    const sticky: number[] = [];
     for (const section of groupByDay(visibleEntries)) {
-      sticky.push(rows.length);
       rows.push({
         kind: 'header',
         key: `day-${section.key}`,
@@ -236,7 +235,7 @@ export default function ActivityScreen() {
         rows.push({ kind: 'row', key: entry.id, entry, firstOfDay: index === 0 });
       });
     }
-    return { listData: rows, stickyIndices: sticky };
+    return rows;
   }, [visibleEntries]);
 
   // The active range worded for the chip: one date when start and end share a
@@ -427,9 +426,8 @@ export default function ActivityScreen() {
     <Screen>
       {/* A feed broken into days: each event is an icon in a soft tile, the
           sentence beside it and the actor/group/time beneath. The day headings
-          are what make a long feed skimmable — they stick to the top so the day
-          in view is always named — without them every row had to be read to
-          place it in time. */}
+          are what make a long feed skimmable — without them every row had to be
+          read to place it in time. */}
       <View style={{ flex: 1 }}>
         <FlashList
           data={listData}
@@ -440,7 +438,6 @@ export default function ActivityScreen() {
           // Day headings and event rows are structurally different subtrees;
           // typing them lets FlashList recycle like with like.
           getItemType={(item) => item.kind}
-          stickyHeaderIndices={stickyIndices}
           // Render well beyond the viewport so a fast fling never outruns
           // recycling into blank rows (default 250px clears in a frame).
           drawDistance={1500}
@@ -466,8 +463,6 @@ export default function ActivityScreen() {
                   textTransform: 'uppercase',
                   marginTop: theme.spacing.lg,
                   marginBottom: theme.spacing.md,
-                  // Opaque, so rows scrolling under the stuck heading are masked.
-                  backgroundColor: theme.color.bg,
                 }}
               >
                 {dayHeading(locale, item.date)}

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -46,62 +46,94 @@ import { SyncStatus, useSync } from '@/sync';
 // with their rows (not pinned — sticky headers on this long, variable-height
 // feed left blank gaps and misaligned on a fast fling). `firstOfDay` drives the
 // between-row hairline so no line falls between a day heading and its first entry.
+//
+// A row carries a fully pre-computed `RowView`, not the raw entry: the localized
+// sentence, actor, group label, relative time, tint and parsed amount are all
+// resolved once when the list is built (see `toRowView`), never per render. On a
+// fast fling FlashList recycles a cell onto a new row constantly, so the mount
+// has to be near-free — recomputing all of that per mount is what let a hard
+// fling outrun the recycler into a blank screen.
+type RowView = {
+  href: Href;
+  /** The whole event as one sentence — the spoken (screen-reader) label. */
+  label: string;
+  /** The visible title, event-first so the feed is skimmable. */
+  headline: string;
+  who: string | null;
+  groupLabel: string | null;
+  timestamp: string;
+  tintKey: ReturnType<typeof verbTint>;
+  icon: ReturnType<typeof verbIcon>;
+  money: ReturnType<typeof parseMoney>;
+  archived: boolean;
+  unavailable: boolean;
+};
+
 type FeedRow =
   | { kind: 'header'; key: string; date: string }
-  | { kind: 'row'; key: string; entry: RecentActivityRow; firstOfDay: boolean };
+  | { kind: 'row'; key: string; firstOfDay: boolean; view: RowView };
 
-/**
- * One row of the virtualized activity feed, memoized so a recycled row that
- * lands on the same entry does no work when the parent re-renders — the same
- * pattern the expense feed uses. Every prop is a primitive or a reference the
- * screen keeps stable (`t`/`theme` from context, `rtf` hoisted per locale), so
- * the shallow `memo` compare holds on a fast fling.
- *
- * `describeActivity` is called once here, not twice (spoken label + visible
- * line), and `relativeTime` is handed the hoisted `rtf` instead of building an
- * `Intl.RelativeTimeFormat` per row — the two allocations that made this feed
- * heavier to scroll than the expense feed it mirrors.
- */
-const ActivityFeedRow = memo(function ActivityFeedRow({
-  entry,
-  locale,
-  t,
-  theme,
-  myProfileId,
-  blockedIds,
-  rtf,
-}: {
-  entry: RecentActivityRow;
+type RowContext = {
   locale: string;
   t: ReturnType<typeof useStrings>['t'];
-  theme: ReturnType<typeof useTheme>;
   myProfileId: string | null;
   blockedIds: ReturnType<typeof useBlockedUsers>['blockedIds'];
   rtf: Intl.RelativeTimeFormat | undefined;
+};
+
+// Resolve everything a row shows, once, at list-build time. `describeActivity`
+// is called once for the spoken label; the visible title uses the lighter
+// `activityHeadline`; `rtf` is the hoisted formatter, never rebuilt per row.
+function toRowView(entry: RecentActivityRow, ctx: RowContext): RowView {
+  const g = entry.group;
+  return {
+    href: activityTarget(entry) as Href,
+    label: describeActivity(entry, ctx.myProfileId, ctx.blockedIds, ctx.t.misc.someone),
+    headline: activityHeadline(entry),
+    // Nobody did an auto-event, so it carries no actor — omit it rather than say
+    // "Someone". A blocked or since-left actor still resolves through actorName.
+    who: entry.actor
+      ? actorName(entry.actor, ctx.myProfileId, ctx.blockedIds, ctx.t.misc.someone)
+      : null,
+    groupLabel: g
+      ? [g.cover_emoji, g.name].filter(Boolean).join(' ').trim() || ctx.t.captures.group
+      : null,
+    timestamp: activityTimestamp(ctx.locale, entry.created_at, undefined, ctx.rtf),
+    tintKey: verbTint(entry.verb),
+    icon: verbIcon(entry.verb),
+    money: parseMoney(entry.payload),
+    archived: !!g?.archived_at,
+    unavailable: !g,
+  };
+}
+
+/**
+ * One row of the virtualized activity feed — purely presentational over a
+ * pre-computed `RowView`, and memoized so a recycled cell that lands on the same
+ * row does no work. The render is just JSX assembly (no string-building, no
+ * parsing), which is what keeps a hard fling from outrunning the recycler.
+ */
+const ActivityFeedRow = memo(function ActivityFeedRow({
+  view,
+  locale,
+  t,
+  theme,
+}: {
+  view: RowView;
+  locale: string;
+  t: ReturnType<typeof useStrings>['t'];
+  theme: ReturnType<typeof useTheme>;
 }) {
-  const money = parseMoney(entry.payload);
   // A soft rounded-square tile whose tint leans with the verb — the same row the
   // group's Activity tab and the Expenses tab use, so activity reads one way
   // everywhere. No timeline rail; the day headings above do the sectioning,
   // hairlines do the between-row separation.
-  const tint = theme.tint[verbTint(entry.verb)];
-  const g = entry.group;
-  const groupLabel = g
-    ? [g.cover_emoji, g.name].filter(Boolean).join(' ').trim() || t.captures.group
-    : null;
-  // The full sentence stays the spoken label — a screen reader wants the whole
-  // event in one utterance. The visible title leads with the event instead, and
-  // the actor moves to the metadata line beneath it, so the feed is skimmable.
-  const label = describeActivity(entry, myProfileId, blockedIds, t.misc.someone);
-  const headline = activityHeadline(entry);
-  // Nobody did an auto-event, so it carries no actor — omit it rather than say
-  // "Someone". A blocked or since-left actor still resolves through actorName.
-  const who = entry.actor ? actorName(entry.actor, myProfileId, blockedIds, t.misc.someone) : null;
+  const tint = theme.tint[view.tintKey];
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={label}
-      onPress={() => router.push(activityTarget(entry) as Href)}
+      accessibilityLabel={view.label}
+      onPress={() => router.push(view.href)}
       style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
     >
       <Row
@@ -121,11 +153,11 @@ const ActivityFeedRow = memo(function ActivityFeedRow({
             backgroundColor: tint.bg,
           }}
         >
-          <Ionicons name={verbIcon(entry.verb)} size={iconSize.lg} color={tint.ink} />
+          <Ionicons name={view.icon} size={iconSize.lg} color={tint.ink} />
         </View>
         <View style={{ flex: 1 }}>
           <Text variant="body" numberOfLines={2}>
-            {headline}
+            {view.headline}
           </Text>
           {/* Who · which group · when. The actor sits here now, not in the title;
               the group is named because this is a cross-group feed. An archived
@@ -139,22 +171,22 @@ const ActivityFeedRow = memo(function ActivityFeedRow({
               flexWrap: 'wrap',
             }}
           >
-            {who ? (
+            {view.who ? (
               <Text variant="caption" tone="muted">
-                {who}
+                {view.who}
               </Text>
             ) : null}
-            {groupLabel ? (
+            {view.groupLabel ? (
               <Text variant="caption" tone="muted" numberOfLines={1} style={{ flexShrink: 1 }}>
-                {`${who ? '· ' : ''}${groupLabel}`}
+                {`${view.who ? '· ' : ''}${view.groupLabel}`}
               </Text>
             ) : null}
             <Text variant="caption" tone="muted">
-              {`${who || groupLabel ? '· ' : ''}${activityTimestamp(locale, entry.created_at, undefined, rtf)}`}
+              {`${view.who || view.groupLabel ? '· ' : ''}${view.timestamp}`}
             </Text>
-            {g?.archived_at ? (
+            {view.archived ? (
               <Badge label={t.misc.archivedGroup} tone="neutral" />
-            ) : !g ? (
+            ) : view.unavailable ? (
               <Badge label={t.misc.unavailableGroup} tone="neutral" />
             ) : null}
           </Row>
@@ -163,10 +195,10 @@ const ActivityFeedRow = memo(function ActivityFeedRow({
             amount, not as a crashed tab. Neutral, not red: this is an expense
             total belonging to nobody in particular, not a balance you owe —
             `mode="plain"` is MoneyText's neutral ink. */}
-        {money ? (
+        {view.money ? (
           <MoneyText
-            amount={money.amount}
-            currency={money.currency}
+            amount={view.money.amount}
+            currency={view.money.currency}
             locale={locale}
             variant="subheading"
           />
@@ -217,13 +249,29 @@ export default function ActivityScreen() {
     [allEntries, range],
   );
 
+  // One relative-time formatter for the whole feed, rebuilt only when the locale
+  // changes — handed to `toRowView` so no `Intl.RelativeTimeFormat` is ever built
+  // per row. Declared before the list so the build below can use it.
+  const rtf = useMemo(
+    () =>
+      typeof Intl.RelativeTimeFormat === 'function'
+        ? new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+        : undefined,
+    [locale],
+  );
+
   // The whole history is already on the phone (the mirror), so there is no page
   // to fetch — the list is fully known. `FlashList` virtualizes it: only the
   // rows near the viewport are mounted, and they recycle as the feed scrolls, so
   // a heavy account's memory and mount cost stay bounded no matter how far back
   // it goes. FlashList has no sections, so the day cut is flattened into `header`
   // items that scroll inline with their rows (like the group ledger's months).
+  //
+  // Each row's display is pre-computed here via `toRowView` so a recycled cell
+  // mounts with no work. This whole pass only reruns when the data, filter or
+  // locale changes — never on scroll — so the up-front cost is paid off-fling.
   const listData = useMemo(() => {
+    const ctx: RowContext = { locale, t, myProfileId, blockedIds, rtf };
     const rows: FeedRow[] = [];
     for (const section of groupByDay(visibleEntries)) {
       rows.push({
@@ -232,11 +280,16 @@ export default function ActivityScreen() {
         date: section.entries[0]!.created_at,
       });
       section.entries.forEach((entry, index) => {
-        rows.push({ kind: 'row', key: entry.id, entry, firstOfDay: index === 0 });
+        rows.push({
+          kind: 'row',
+          key: entry.id,
+          firstOfDay: index === 0,
+          view: toRowView(entry, ctx),
+        });
       });
     }
     return rows;
-  }, [visibleEntries]);
+  }, [visibleEntries, locale, t, myProfileId, blockedIds, rtf]);
 
   // The active range worded for the chip: one date when start and end share a
   // day, "start – end" otherwise. Formatted in the current locale.
@@ -251,17 +304,6 @@ export default function ActivityScreen() {
       ? showDay(range.start)
       : `${showDay(range.start)} – ${showDay(range.end)}`
     : '';
-
-  // One relative-time formatter for the whole feed, rebuilt only when the locale
-  // changes — handed to every row so a fast scroll never constructs an
-  // `Intl.RelativeTimeFormat` per recycled row.
-  const rtf = useMemo(
-    () =>
-      typeof Intl.RelativeTimeFormat === 'function'
-        ? new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
-        : undefined,
-    [locale],
-  );
 
   const header = (
     <View>
@@ -477,15 +519,7 @@ export default function ActivityScreen() {
                     : { borderTopWidth: 1, borderTopColor: theme.color.border }
                 }
               >
-                <ActivityFeedRow
-                  entry={item.entry}
-                  locale={locale}
-                  t={t}
-                  theme={theme}
-                  myProfileId={myProfileId}
-                  blockedIds={blockedIds}
-                  rtf={rtf}
-                />
+                <ActivityFeedRow view={item.view} locale={locale} t={t} theme={theme} />
               </View>
             )
           }

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -1,7 +1,8 @@
 import { memo, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, type Href } from 'expo-router';
-import { Pressable, RefreshControl, SectionList, View } from 'react-native';
+import { Pressable, RefreshControl, View } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
 
 import {
   Badge,
@@ -40,7 +41,13 @@ import { useAuth } from '@/lib/auth';
 import { usePullRefresh } from '@/lib/pullRefresh';
 import { SyncStatus, useSync } from '@/sync';
 
-type DaySection = { key: string; first: RecentActivityRow; data: RecentActivityRow[] };
+// The day-grouped feed flattened for FlashList, which has no section API: a
+// `header` item per day, then that day's `entry` rows. The day cut is made to
+// stick via `stickyHeaderIndices`; `firstOfDay` drives the between-row hairline
+// so no line falls between a day heading and its first entry.
+type FeedRow =
+  | { kind: 'header'; key: string; date: string }
+  | { kind: 'row'; key: string; entry: RecentActivityRow; firstOfDay: boolean };
 
 /**
  * One row of the virtualized activity feed, memoized so a recycled row that
@@ -210,20 +217,27 @@ export default function ActivityScreen() {
   );
 
   // The whole history is already on the phone (the mirror), so there is no page
-  // to fetch — the list is fully known. `SectionList` virtualizes it: only the
+  // to fetch — the list is fully known. `FlashList` virtualizes it: only the
   // rows near the viewport are mounted, and they recycle as the feed scrolls, so
   // a heavy account's memory and mount cost stay bounded no matter how far back
-  // it goes. (This replaced a plain `ScrollView` that grew a window but never
-  // recycled a mounted row.)
-  const sections: DaySection[] = useMemo(
-    () =>
-      groupByDay(visibleEntries).map((section) => ({
-        key: section.key,
-        first: section.entries[0]!,
-        data: section.entries,
-      })),
-    [visibleEntries],
-  );
+  // it goes. FlashList has no sections, so the day cut is flattened into `header`
+  // items whose positions become `stickyIndices`.
+  const { listData, stickyIndices } = useMemo(() => {
+    const rows: FeedRow[] = [];
+    const sticky: number[] = [];
+    for (const section of groupByDay(visibleEntries)) {
+      sticky.push(rows.length);
+      rows.push({
+        kind: 'header',
+        key: `day-${section.key}`,
+        date: section.entries[0]!.created_at,
+      });
+      section.entries.forEach((entry, index) => {
+        rows.push({ kind: 'row', key: entry.id, entry, firstOfDay: index === 0 });
+      });
+    }
+    return { listData: rows, stickyIndices: sticky };
+  }, [visibleEntries]);
 
   // The active range worded for the chip: one date when start and end share a
   // day, "start – end" otherwise. Formatted in the current locale.
@@ -379,82 +393,110 @@ export default function ActivityScreen() {
     </View>
   );
 
+  // The range picker, over the feed. Rendered only when open and only when there
+  // is a span to clamp to, so it can seed the picker from real dates.
+  const picker =
+    filterOpen && span ? (
+      <ActivityDateFilter
+        earliest={span.earliest}
+        latest={span.latest}
+        locale={locale}
+        initial={range}
+        onApply={setRange}
+        onClear={() => setRange(null)}
+        onClose={() => setFilterOpen(false)}
+      />
+    ) : null;
+
+  // With no rows, FlashList's empty slot renders inside an unbounded scroll view,
+  // so a `flex: 1` centre is meaningless there — the header and the centred empty
+  // state are laid out directly instead, keeping the same padding the feed uses.
+  if (listData.length === 0) {
+    return (
+      <Screen>
+        <View style={{ flex: 1, paddingHorizontal: theme.spacing.xl }}>
+          {header}
+          {empty}
+        </View>
+        {picker}
+      </Screen>
+    );
+  }
+
   return (
     <Screen>
-      {/* A vertical timeline broken into days: each event is a node on a
-          connector line running down the left, its icon in a soft circle, the
-          sentence beside it and the time beneath. The day headings are what make
-          a long feed skimmable — without them every row had to be read to place
-          it in time. */}
-      <SectionList<RecentActivityRow, DaySection>
-        sections={sections}
-        keyExtractor={(entry) => entry.id}
-        contentContainerStyle={{
-          paddingHorizontal: theme.spacing.xl,
-          paddingBottom: clearance,
-          // So the empty and error states can take the room the feed is not
-          // using and sit centred. With a feed present this changes nothing.
-          flexGrow: 1,
-        }}
-        showsVerticalScrollIndicator={false}
-        // No `removeClippedSubviews`: on Android it detaches off-screen subviews
-        // and, on a fast fling of this SectionList, fails to re-attach them —
-        // the whole viewport blanks out mid-scroll (rows vanish, only the
-        // scrollbar remains). `windowSize` already bounds how much is mounted, so
-        // virtualization holds without the clipping that caused the blanking.
-        initialNumToRender={12}
-        windowSize={9}
-        ListHeaderComponent={header}
-        ListEmptyComponent={empty}
-        refreshControl={
-          <RefreshControl
-            refreshing={pull.refreshing}
-            onRefresh={pull.onRefresh}
-            tintColor={theme.color.brand}
-          />
-        }
-        renderSectionHeader={({ section }) => (
-          <Text
-            variant="micro"
-            tone="muted"
-            style={{
-              textTransform: 'uppercase',
-              marginTop: theme.spacing.lg,
-              marginBottom: theme.spacing.md,
-              backgroundColor: theme.color.bg,
-            }}
-          >
-            {dayHeading(locale, section.first.created_at)}
-          </Text>
-        )}
-        ItemSeparatorComponent={() => (
-          <View style={{ height: 1, backgroundColor: theme.color.border }} />
-        )}
-        renderItem={({ item }) => (
-          <ActivityFeedRow
-            entry={item}
-            locale={locale}
-            t={t}
-            theme={theme}
-            myProfileId={myProfileId}
-            blockedIds={blockedIds}
-            rtf={rtf}
-          />
-        )}
-      />
-      {/* The range picker, over the feed. Rendered only when open and only when
-          there is a span to clamp to, so it can seed the picker from real dates. */}
-      {filterOpen && span ? (
-        <ActivityDateFilter
-          earliest={span.earliest}
-          latest={span.latest}
-          locale={locale}
-          initial={range}
-          onApply={setRange}
-          onClear={() => setRange(null)}
-          onClose={() => setFilterOpen(false)}
+      {/* A feed broken into days: each event is an icon in a soft tile, the
+          sentence beside it and the actor/group/time beneath. The day headings
+          are what make a long feed skimmable — they stick to the top so the day
+          in view is always named — without them every row had to be read to
+          place it in time. */}
+      <View style={{ flex: 1 }}>
+        <FlashList
+          data={listData}
+          // The row text is locale-formatted, so a language change has to re-run
+          // renderItem even though the data array is unchanged.
+          extraData={locale}
+          keyExtractor={(item) => item.key}
+          // Day headings and event rows are structurally different subtrees;
+          // typing them lets FlashList recycle like with like.
+          getItemType={(item) => item.kind}
+          stickyHeaderIndices={stickyIndices}
+          // Render well beyond the viewport so a fast fling never outruns
+          // recycling into blank rows (default 250px clears in a frame).
+          drawDistance={1500}
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: clearance,
+          }}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl
+              refreshing={pull.refreshing}
+              onRefresh={pull.onRefresh}
+              tintColor={theme.color.brand}
+            />
+          }
+          ListHeaderComponent={header}
+          renderItem={({ item }) =>
+            item.kind === 'header' ? (
+              <Text
+                variant="micro"
+                tone="muted"
+                style={{
+                  textTransform: 'uppercase',
+                  marginTop: theme.spacing.lg,
+                  marginBottom: theme.spacing.md,
+                  // Opaque, so rows scrolling under the stuck heading are masked.
+                  backgroundColor: theme.color.bg,
+                }}
+              >
+                {dayHeading(locale, item.date)}
+              </Text>
+            ) : (
+              // The between-row hairline rides on the row itself — above every row
+              // but the day's first, so no line falls under a day heading.
+              <View
+                style={
+                  item.firstOfDay
+                    ? undefined
+                    : { borderTopWidth: 1, borderTopColor: theme.color.border }
+                }
+              >
+                <ActivityFeedRow
+                  entry={item.entry}
+                  locale={locale}
+                  t={t}
+                  theme={theme}
+                  myProfileId={myProfileId}
+                  blockedIds={blockedIds}
+                  rtf={rtf}
+                />
+              </View>
+            )
+          }
         />
-      ) : null}
+      </View>
+      {picker}
     </Screen>
   );
 }


### PR DESCRIPTION
## What

Three changes on the activity-feed line:

- **Skimmable feed** (`770d1e1`) — event-first rows, honest amount colour, deep links into the target.
- **Personal tab** (`b84daea`) — name the tab Personal; the stat tiles self-describe.
- **FlashList migration** (`ddafb88`) — the feed was the last scrollable row list on `SectionList`; moved to FlashList v2 to match the group-ledger standard.

## FlashList migration notes

- Day-grouped feed flattened to one typed `FeedRow[]` (`header` + `row` items).
- Sticky day headings via `stickyHeaderIndices` (indices are in the data array; `ListHeaderComponent` sits outside that index space in v2).
- `getItemType` = `header|row` for like-with-like recycling; `drawDistance={1500}`, `extraData={locale}` — same settings as the group ledger and Friends.
- Between-row hairline moved onto each row (`firstOfDay` → `border-top` on all but a day's first) so no line falls under a heading.
- Empty / skeleton / error states laid out **outside** the list: FlashList's empty slot renders in an unbounded scroll view, where `flex:1` centring is inert. Same shape Friends uses.

## Checks

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Not yet device-tested (sticky-header stick + fast-fling recycling worth an eyeball).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved activity feeds with clearer event titles, actor details, timestamps, sticky day headings, and context-aware navigation.
  * Added helpful empty-state actions for adding expenses or creating a group.
  * Management tiles now highlight collection totals with attention details shown separately.
* **Bug Fixes**
  * Relative timestamps now work reliably on Android and support all available languages.
  * Updated the personal-ledger tab label across supported translations.
* **Tests**
  * Added coverage for activity titles, navigation, and timestamp formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->