### PR TITLE
feat(expense): progressive add-expense — quick-add first, details folded

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -19,7 +19,9 @@ import {
   CategoryId,
   computeShares,
   currencySymbol,
+  format,
   guessCategory,
+  money,
   MutationKind,
   ridersSplit,
   splitByUnits,
@@ -40,7 +42,6 @@ import {
   ChipRow,
   directionalIcon,
   EmptyState,
-  IconButton,
   iconSize,
   MoneyText,
   Row,
@@ -551,6 +552,12 @@ export default function AddExpenseScreen() {
   const [splitOpen, setSplitOpen] = useState(false);
   const showSplit = splitOpen || !isDefaultSplit || splitIssue !== null;
 
+  // "More details" folds category, payment method, location and the FX rate off
+  // the common path — the same collapse the split summary uses. It opens itself
+  // whenever one of those carries a non-default value, so an edit (or a foreign
+  // currency, whose rate must be typed to save) is never hidden behind the fold.
+  const [detailsOpen, setDetailsOpen] = useState(false);
+
   const isTrip = group.data?.type === 'trip';
   const groupCurrency = group.data?.default_currency ?? 'INR';
   // The expense keeps the currency it was paid in; the group's is only the
@@ -1017,6 +1024,55 @@ export default function AddExpenseScreen() {
         : null;
   const canSave = amount > 0n && participants.length > 0 && splitIssue === null;
 
+  // A foreign currency must show its rate card (it cannot be saved without one),
+  // and any detail somebody has already set is a decision that must not hide.
+  const detailsNonDefault =
+    currency !== groupCurrency || location !== null || paymentMethod !== 'cash' || categoryChosen;
+  const showDetails = detailsOpen || detailsNonDefault;
+
+  // The split, as the outcome rather than the machinery: "You paid · split
+  // equally with everyone". The payer leads (you, or the person who did); the
+  // tail is the preset's own words, or "split equally with everyone" for the
+  // default, or the split kind and headcount for anything hand-tuned.
+  const payerMember =
+    payer && payer !== myMemberId
+      ? (members.data ?? []).find((member) => member.id === payer)
+      : undefined;
+  const payerName = payerMember
+    ? t.expense.paidByName.replace('{name}', displayName(payerMember, profile?.id))
+    : t.expense.youPaid;
+  const splitTail =
+    presetLabel ??
+    (isDefaultSplit
+      ? t.expense.splitEquallyEveryone
+      : [
+          splitKind === SplitKind.Equal
+            ? t.expense.equally
+            : splitKind === SplitKind.Shares
+              ? t.expense.shares
+              : t.expense.percent,
+          plural(locale, participants.length, t.memberCount),
+        ].join(' · '));
+  const splitSummary = `${payerName} · ${splitTail}`;
+
+  // The bottom-bar sub-line. When an equal split lands the same amount on every
+  // head, say it in money — "3 people owe ₹200 each" — which is the number
+  // people actually care about; otherwise the plain headcount.
+  const previewValues = preview ? [...preview.values()] : [];
+  const evenEach =
+    previewValues.length > 0 && previewValues.every((value) => value === previewValues[0])
+      ? previewValues[0]
+      : null;
+  const savePreview =
+    participants.length === 0
+      ? t.extras.savedStraightAway
+      : evenEach !== null && amount > 0n
+        ? plural(locale, participants.length, t.expense.oweEach).replace(
+            '{amount}',
+            format(money(evenEach, currency), { locale, compactFraction: true }),
+          )
+        : plural(locale, participants.length, t.memberCount);
+
   return (
     <Screen edges={['top', 'bottom']}>
       {/* The action bar is pinned to the bottom edge, outside the scroll, and a
@@ -1046,12 +1102,21 @@ export default function AddExpenseScreen() {
             subtitle={groupLabel(group.data, members.data ?? [], profile?.id)}
             right={
               editing ? undefined : (
-                <IconButton
-                  label={t.expense.splitByItem}
+                // A bare list glyph read as nothing in particular; the words say
+                // what it does — split the bill line by line.
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={t.expense.splitByItem}
                   onPress={() => router.replace(`/group/${groupId}/itemize`)}
+                  hitSlop={8}
                 >
-                  <Ionicons name="list-outline" size={iconSize.lg} color={theme.color.brand} />
-                </IconButton>
+                  <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+                    <Ionicons name="list-outline" size={iconSize.md} color={theme.color.brand} />
+                    <Text variant="caption" tone="brand" style={{ fontWeight: '700' }}>
+                      {t.expense.splitByItem}
+                    </Text>
+                  </Row>
+                </Pressable>
               )
             }
           />
@@ -1073,28 +1138,32 @@ export default function AddExpenseScreen() {
             onPressCurrency={() => setPickingCurrency(true)}
           />
 
-          {/* Below the amount, not above it. Typing a number is the fast path and
-            stays the first thing on the screen; the camera is for the bill that
-            is easier to point at than to read. Attach sits beside Scan for the
-            bill that is already a picture, or the scan that would not read. */}
-          <Card style={{ gap: theme.spacing.md }}>
-            <View>
-              <Text variant="subheading">
-                {capLocked ? t.expense.capReachedTitle : t.expense.scanBillTitle}
-              </Text>
-              <Text variant="caption" tone="muted">
-                {capLocked ? t.expense.capReachedBody : t.expense.scanBillBody}
-              </Text>
-            </View>
+          {/* "How much" and "what for" are the whole of the common case, so the
+            description sits directly under the amount — nothing between the two
+            fields somebody came here to fill and the split below them. The names
+            are handed to the recogniser as hints; a general model guesses at
+            Indian names and the note is where they turn up. */}
+          <DescriptionField
+            value={description}
+            onChange={setDescription}
+            placeholder={t.expense.descriptionPlaceholder}
+            accessibilityLabel={t.description}
+            hints={nameHints}
+            multiline
+          />
 
-            {/* Scan is metered and gives way when the group is capped; Attach is
-              not — it keeps a photo on the device and never records a receipt
-              server-side, so it is offered even at the cap. */}
+          {/* The bill is a shortcut, not the screen: two small actions rather
+            than a card that makes this look like a receipt scanner. Scan is
+            metered and gives way when the group is capped; Add photo keeps an
+            image on the device and never records a receipt server-side, so it
+            is offered even at the cap. */}
+          <View style={{ gap: theme.spacing.sm }}>
             <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
               {!capLocked ? (
                 <Button
-                  label={scanning ? t.expense.reading : t.expense.scan}
-                  variant="secondary"
+                  label={scanning ? t.expense.reading : t.expense.scanReceipt}
+                  variant="ghost"
+                  size="sm"
                   disabled={scanning || saving || capStatus === 'loading'}
                   onPress={() => void scan()}
                   icon={
@@ -1103,8 +1172,9 @@ export default function AddExpenseScreen() {
                 />
               ) : null}
               <Button
-                label={t.expense.attach}
-                variant="secondary"
+                label={t.expense.addPhoto}
+                variant="ghost"
+                size="sm"
                 disabled={scanning || saving}
                 onPress={() => void attach()}
                 icon={
@@ -1113,9 +1183,13 @@ export default function AddExpenseScreen() {
               />
             </Row>
             {capLocked ? (
-              <Row style={{ gap: theme.spacing.sm }}>
+              <Row style={{ gap: theme.spacing.sm, alignItems: 'center', flexWrap: 'wrap' }}>
+                <Text variant="caption" tone="muted" style={{ flex: 1, minWidth: 0 }}>
+                  {t.expense.capReachedBody}
+                </Text>
                 <Button
                   label={t.expense.capUpgrade}
+                  size="sm"
                   onPress={() => router.push('/settings/upgrade')}
                 />
               </Row>
@@ -1176,62 +1250,38 @@ export default function AddExpenseScreen() {
                 </Text>
               </Pressable>
             ) : null}
-          </Card>
+          </View>
 
-          {/* Currency is chosen from the header pill; this now collapses to the FX
-            rate alone — nothing while the expense is in the group's currency,
-            the rate methods once it is foreign (ADR-003). */}
-          <CurrencyRate
-            groupCurrency={groupCurrency}
-            currency={currency}
-            onCurrencyChange={setExpenseCurrency}
-            amount={amount}
-            fx={fx}
-            onFxChange={setFx}
-            showCurrencyPicker={false}
-          />
-
-          {/* Description field shared with capture. Kept multiline here for the
-            longer notes a group expense sometimes carries. The member names are
-            handed to the recogniser as hints — a general model guesses at Indian
-            names and gets them wrong, and the note is where they turn up. */}
-          <DescriptionField
-            value={description}
-            onChange={setDescription}
-            placeholder={t.expense.descriptionPlaceholder}
-            accessibilityLabel={t.description}
-            hints={nameHints}
-            multiline
-          />
-
-          {/* Pre-picked from the description, because a menu between somebody and
-            saving a dinner is how a column ends up empty — and an empty column
-            is a spending chart nobody can draw (TDR §8). */}
-          <View style={{ gap: theme.spacing.md }}>
-            <Text variant="caption" tone="muted">
-              {t.whatFor}
-            </Text>
-            <CategoryPicker
-              value={category}
-              onChange={(picked, meta) => {
-                setCategory(picked);
-                setCategoryMeta(meta);
-                setCategoryChosen(true);
+          {/* The escape hatch, up on the common path where it is found before the
+            whole shared form is filled — not after. Some spend is nobody else's;
+            this hands the amount and note already typed to the personal captures
+            inbox, which never touches a group balance (plan §5). Only on a new
+            expense; converting an existing shared row is a different act. */}
+          {!editing ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t.expense.justForMe}
+              onPress={() => {
+                const params: Record<string, string> = { cur: currency };
+                if (amount > 0n) params.amount = amount.toString();
+                const note = description.trim();
+                if (note) params.desc = note;
+                router.replace({ pathname: '/capture', params });
               }}
-              onCreate={() => setEditingTag(true)}
-            />
-          </View>
-
-          {/* How it was paid — a tag on the expense, defaulting to cash. */}
-          <View style={{ gap: theme.spacing.md }}>
-            <Text variant="caption" tone="muted">
-              {t.captures.paidWith}
-            </Text>
-            <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} />
-          </View>
-
-          {/* Where it happened (A43) — optional, opt-in, never a background track. */}
-          <LocationField value={location} onChange={setLocation} />
+            >
+              <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                <Ionicons name="lock-closed-outline" size={iconSize.md} color={theme.color.brand} />
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text variant="subheading" tone="brand">
+                    {t.expense.justForMe}
+                  </Text>
+                  <Text variant="micro" tone="muted">
+                    {t.expense.justForMeBody}
+                  </Text>
+                </View>
+              </Row>
+            </Pressable>
+          ) : null}
 
           {/* The one-line answer to "who pays what", tappable to open the three
             controls that decide it. */}
@@ -1250,15 +1300,7 @@ export default function AddExpenseScreen() {
                     {t.expense.howToSplit}
                   </Text>
                   <Text variant="subheading" numberOfLines={2}>
-                    {[
-                      presetLabel ??
-                        (splitKind === SplitKind.Equal
-                          ? t.expense.equally
-                          : splitKind === SplitKind.Shares
-                            ? t.expense.shares
-                            : t.expense.percent),
-                      plural(locale, participants.length, t.memberCount),
-                    ].join(' · ')}
+                    {splitSummary}
                   </Text>
                 </View>
                 <Row style={{ gap: theme.spacing.xs, alignItems: 'center', flexShrink: 0 }}>
@@ -1481,39 +1523,73 @@ export default function AddExpenseScreen() {
             />
           </Card>
 
-          {/* The way out of splitting. Some spend on a trip is nobody else's —
-              a souvenir, a private treat — and forcing it onto the shared ledger
-              (even split 1:1 with yourself) is noise in everyone's balances. This
-              hands the amount and note already typed to the personal captures
-              inbox, which never touches a group balance (plan §5). Only offered
-              on a new expense; converting an existing shared row is a different,
-              destructive act. `replace` so the abandoned split form is not left
-              on the back stack behind the capture. */}
-          {!editing ? (
-            <View style={{ gap: theme.spacing.xs, alignItems: 'flex-start' }}>
-              <Button
-                label={t.expense.justForMe}
-                variant="ghost"
-                onPress={() => {
-                  const params: Record<string, string> = { cur: currency };
-                  if (amount > 0n) params.amount = amount.toString();
-                  const note = description.trim();
-                  if (note) params.desc = note;
-                  router.replace({ pathname: '/capture', params });
-                }}
-                icon={
-                  <Ionicons
-                    name="lock-closed-outline"
-                    size={iconSize.md}
-                    color={theme.color.brand}
-                  />
-                }
-              />
-              <Text variant="micro" tone="muted">
-                {t.expense.justForMeBody}
+          {/* Everything most expenses never need — the category (already guessed
+            from the note), how it was paid, where, and a foreign rate — folded
+            off the common path. It opens itself the moment one of them carries a
+            value, so an edit or a foreign currency is never hidden behind it. */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityState={{ expanded: showDetails }}
+            accessibilityLabel={t.expense.moreDetails}
+            onPress={() => setDetailsOpen((open) => !open)}
+            // A detail that is already set must not be foldable away.
+            disabled={detailsNonDefault}
+          >
+            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+              <Text variant="caption" tone="brand" style={{ fontWeight: '700' }}>
+                {showDetails ? t.expense.fewerDetails : t.expense.moreDetails}
               </Text>
+              <Ionicons
+                name={showDetails ? 'chevron-up' : 'chevron-down'}
+                size={iconSize.md}
+                color={theme.color.brand}
+              />
+            </Row>
+          </Pressable>
+
+          <View style={{ gap: theme.spacing.xl, display: showDetails ? 'flex' : 'none' }}>
+            {/* Pre-picked from the description, because a menu between somebody and
+              saving a dinner is how a column ends up empty — and an empty column
+              is a spending chart nobody can draw (TDR §8). */}
+            <View style={{ gap: theme.spacing.md }}>
+              <Text variant="caption" tone="muted">
+                {t.whatFor}
+              </Text>
+              <CategoryPicker
+                value={category}
+                onChange={(picked, meta) => {
+                  setCategory(picked);
+                  setCategoryMeta(meta);
+                  setCategoryChosen(true);
+                }}
+                onCreate={() => setEditingTag(true)}
+              />
             </View>
-          ) : null}
+
+            {/* How it was paid — a tag on the expense, defaulting to cash. */}
+            <View style={{ gap: theme.spacing.md }}>
+              <Text variant="caption" tone="muted">
+                {t.captures.paidWith}
+              </Text>
+              <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} />
+            </View>
+
+            {/* Where it happened (A43) — optional, opt-in, never a background track. */}
+            <LocationField value={location} onChange={setLocation} />
+
+            {/* Currency is chosen from the header pill; this collapses to the FX
+              rate alone — nothing while the expense is in the group's currency,
+              the rate methods once it is foreign (ADR-003). */}
+            <CurrencyRate
+              groupCurrency={groupCurrency}
+              currency={currency}
+              onCurrencyChange={setExpenseCurrency}
+              amount={amount}
+              fx={fx}
+              onFxChange={setFx}
+              showCurrencyPicker={false}
+            />
+          </View>
         </ScrollView>
 
         {/* The one action, pinned. The screen is tall — keypad, scan, currency,
@@ -1538,16 +1614,14 @@ export default function AddExpenseScreen() {
           <Row style={{ justifyContent: 'space-between', gap: theme.spacing.lg }}>
             <View style={{ flex: 1, minWidth: 0 }}>
               <MoneyText amount={amount} currency={currency} locale={locale} variant="heading" />
-              <Text variant="micro" tone="muted">
-                {participants.length > 0
-                  ? plural(locale, participants.length, t.memberCount)
-                  : t.extras.savedStraightAway}
+              <Text variant="micro" tone="muted" numberOfLines={1}>
+                {savePreview}
               </Text>
             </View>
             <Row style={{ gap: theme.spacing.md, flexGrow: 0, flexShrink: 0 }}>
               {saving ? <ActivityIndicator color={theme.color.brand} /> : null}
               <Button
-                label={editing ? t.expense.saveChanges : t.save}
+                label={editing ? t.expense.saveChanges : t.expense.saveExpense}
                 size="lg"
                 disabled={!canSave || saving}
                 onPress={() => void submit()}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1606,6 +1606,19 @@ export interface UiStrings {
     splitBetween: string;
     ofCount: string;
     saveChanges: string;
+    /** Bottom-bar Save on a new expense — more than a bare "Save". */
+    saveExpense: string;
+    /** Compact receipt actions under the amount. */
+    scanReceipt: string;
+    addPhoto: string;
+    /** The collapsible that folds category, payment, location and FX away. */
+    moreDetails: string;
+    fewerDetails: string;
+    /** Split summary, outcome-first: "You paid · split equally with everyone". */
+    youPaid: string;
+    splitEquallyEveryone: string;
+    /** Bottom-bar preview for an even split: "3 people owe ₹200 each". */
+    oweEach: PluralForms;
     notFound: string;
     notFoundBody: string;
     deleteQuestion: string;
@@ -3618,6 +3631,14 @@ const en: UiStrings = {
     splitBetween: 'Split between',
     ofCount: '{chosen} of {total}',
     saveChanges: 'Save changes',
+    saveExpense: 'Save expense',
+    scanReceipt: 'Scan receipt',
+    addPhoto: 'Add photo',
+    moreDetails: 'More details',
+    fewerDetails: 'Fewer details',
+    youPaid: 'You paid',
+    splitEquallyEveryone: 'split equally with everyone',
+    oweEach: { one: '{n} person owes {amount}', other: '{n} people owe {amount} each' },
     notFound: 'Expense not found',
     notFoundBody: 'It may have been deleted more than 30 days ago.',
     deleteQuestion: 'Delete this expense?',
@@ -5697,6 +5718,17 @@ const ta: UiStrings = {
     splitBetween: 'யாருக்கிடையே',
     ofCount: '{total} இல் {chosen}',
     saveChanges: 'மாற்றங்களைச் சேமி',
+    saveExpense: 'செலவைச் சேமி',
+    scanReceipt: 'ரசீதை ஸ்கேன் செய்',
+    addPhoto: 'படத்தைச் சேர்',
+    moreDetails: 'மேலும் விவரங்கள்',
+    fewerDetails: 'விவரங்களை மறை',
+    youPaid: 'நீங்கள் கொடுத்தீர்கள்',
+    splitEquallyEveryone: 'அனைவருடனும் சமமாகப் பிரிக்கப்படும்',
+    oweEach: {
+      one: '{n} நபர் {amount} செலுத்த வேண்டும்',
+      other: '{n} பேர் தலா {amount} செலுத்த வேண்டும்',
+    },
     notFound: 'செலவு கிடைக்கவில்லை',
     notFoundBody: '30 நாட்களுக்கு முன்பே அது நீக்கப்பட்டிருக்கலாம்.',
     deleteQuestion: 'இந்தச் செலவை நீக்கவா?',
@@ -7760,6 +7792,17 @@ const hi: UiStrings = {
     splitBetween: 'किनके बीच',
     ofCount: '{total} में से {chosen}',
     saveChanges: 'बदलाव सेव करें',
+    saveExpense: 'खर्च सेव करें',
+    scanReceipt: 'बिल स्कैन करें',
+    addPhoto: 'फ़ोटो जोड़ें',
+    moreDetails: 'और जानकारी',
+    fewerDetails: 'जानकारी छिपाएँ',
+    youPaid: 'आपने चुकाया',
+    splitEquallyEveryone: 'सबके साथ बराबर बँटेगा',
+    oweEach: {
+      one: '{n} व्यक्ति को {amount} देना है',
+      other: '{n} लोगों को प्रत्येक {amount} देना है',
+    },
     notFound: 'खर्च नहीं मिला',
     notFoundBody: 'हो सकता है इसे 30 दिन से पहले हटा दिया गया हो।',
     deleteQuestion: 'यह खर्च मिटाएँ?',
@@ -9855,6 +9898,20 @@ const ar: UiStrings = {
     splitBetween: 'التقسيم بين',
     ofCount: '{chosen} من {total}',
     saveChanges: 'حفظ التغييرات',
+    saveExpense: 'احفظ المصروف',
+    scanReceipt: 'امسح الفاتورة',
+    addPhoto: 'أضف صورة',
+    moreDetails: 'المزيد من التفاصيل',
+    fewerDetails: 'إخفاء التفاصيل',
+    youPaid: 'أنت دفعت',
+    splitEquallyEveryone: 'يُقسَّم بالتساوي مع الجميع',
+    oweEach: {
+      one: 'على شخص واحد دفع {amount}',
+      two: 'على شخصين دفع {amount} لكلٍّ',
+      few: 'على {n} أشخاص دفع {amount} لكل واحد',
+      many: 'على {n} شخصًا دفع {amount} لكل واحد',
+      other: 'على {n} شخص دفع {amount} لكل واحد',
+    },
     notFound: 'المصروف غير موجود',
     notFoundBody: 'ربما حُذف قبل أكثر من 30 يومًا.',
     deleteQuestion: 'حذف هذا المصروف؟',


### PR DESCRIPTION
## What

Reworks Add Expense after a UX roast: it read as a full accounting form for the common case ("I paid ₹800 for dinner, split it"). Reorder to lead with the quick path and fold everything else. Progressive disclosure only — no split-math or data-model changes.

### Screen order
- **Amount** → **description** directly under it.
- Receipt **scan / photo** collapse to two small ghost actions (was a full card) + thumbnail + itemize CTA.
- A small **"Just for me"** link near the top (not `editing`).
- **Split summary** reads *"You paid · Split equally with everyone"*; the split controls (presets, paid-by, split-between) fold behind it.
- **"More details"** fold holds category, payment method, location, FX rate. Auto-opens when any is non-default — e.g. a foreign currency whose rate must be typed to save — so a required input is never hidden.

### Save bar
- Sub-line previews the outcome: *"3 people owe ₹200 each"* (even split) / person count otherwise.
- Button label **"Save expense"** (was a bare glyph); **"Save changes"** when editing.
- Itemize is a **labeled action**, not an icon-only button.

### i18n
New keys in **en/ta/hi/ar**: `saveExpense`, `scanReceipt`, `addPhoto`, `moreDetails`/`fewerDetails`, `youPaid`, `splitEquallyEveryone`, `oweEach` (plural).

## Deferred
Exact-amount split mode (roast #10) — needs a new `SplitKind` in `@waves/core` + split lib + tests. Separate task.

## Checks
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Not device-tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized the add-expense form for a clearer, faster entry flow.
  * Added dedicated “Scan receipt” and “Add photo” actions.
  * Added an expandable “More details” section for optional expense information.
  * Improved split summaries with payer names and per-person amounts.
  * Added a convenient “Just for me” option and clearer itemization access.

* **Localization**
  * Added translated labels and messages for the new expense-entry features in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->