### PR TITLE
feat(friends): shimmering balance in the hero on cold launch

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -49,6 +49,7 @@ import {
   MoneyText,
   Row,
   Screen,
+  Skeleton,
   Text,
   tintForKey,
   useTabBarClearance,
@@ -422,6 +423,7 @@ export default function FriendsScreen() {
         selectedCount={selectedKeys.size}
         onExitSelect={exitSelect}
         onMerge={startMerge}
+        loading={people.isLoading}
       />
 
       <AddMenu open={addOpen} onClose={() => setAddOpen(false)} t={t} />
@@ -559,6 +561,7 @@ function FriendsHero({
   selectedCount,
   onExitSelect,
   onMerge,
+  loading,
 }: {
   totals: readonly CurrencyTotal[];
   locale: string;
@@ -573,6 +576,10 @@ function FriendsHero({
   selectedCount: number;
   onExitSelect: () => void;
   onMerge: () => void;
+  /** Cold launch, mirror not read yet — the hero paints a shimmering balance so
+      the panel reads as a full Friends header rather than a bare title bar over
+      an empty screen while the rows hydrate. */
+  loading: boolean;
 }): React.JSX.Element {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
@@ -737,7 +744,28 @@ function FriendsHero({
         </Reanimated.View>
       </View>
 
-      {!selectMode && totals.length > 0 ? (
+      {!selectMode && loading ? (
+        // Cold launch: a shimmering stand-in for the OVERALL balance, tinted
+        // translucent-white so it reads on the indigo (the grey skeleton default
+        // is overridden by the trailing style). Keeps the hero a full header
+        // while the mirror hydrates instead of a bare title bar over blank.
+        <View style={{ gap: theme.spacing.sm }}>
+          <Skeleton width="30%" height={12} style={{ backgroundColor: 'rgba(255,255,255,0.20)' }} />
+          <Row style={{ justifyContent: 'space-between', alignItems: 'flex-end' }}>
+            <Skeleton
+              width="28%"
+              height={18}
+              style={{ backgroundColor: 'rgba(255,255,255,0.14)' }}
+            />
+            <Skeleton
+              width="52%"
+              height={34}
+              radius={theme.radius.sm}
+              style={{ backgroundColor: 'rgba(255,255,255,0.22)' }}
+            />
+          </Row>
+        </View>
+      ) : !selectMode && totals.length > 0 ? (
         <Reanimated.View
           entering={reduceMotion ? undefined : FadeIn.duration(160)}
           exiting={reduceMotion ? undefined : FadeOut.duration(100)}


### PR DESCRIPTION
## What

On a cold launch the local mirror hasn't been read yet, so the Friends `totals` are empty and the indigo hero rendered as a bare title bar sitting over the skeleton list — a sparse, half-empty top. Follow-up to #582.

The hero now paints a shimmering stand-in for the OVERALL balance (an uppercase label bar + a big number bar) while `loading`, so the panel reads as a **full Friends header** the whole time. Cold screen = hero + list, never a title over blank.

- Skeleton bars tinted **translucent-white** via the trailing `style` (the grey `theme.color.skeleton` default is for light surfaces, wrong on the indigo wash — the primitive's later style wins).
- Gated on `people.isLoading` (`!hydrated`), i.e. cold only. A warm tab switch already has the rows on disk and stays instant — this never becomes fake loading.

## Scope / risk

- Mobile only, one file. Uses the existing `Skeleton` primitive. **OTA-safe, no native rebuild.**
- No data / RPC / schema changes.

## Verification

- `tsc --noEmit`, `eslint`, `prettier` clean.
- Not device-tested (cold-launch state; author reviewed against the shared `Skeleton` behavior).