### PR TITLE
feat(mobile): tighten row horizontal padding on Friends and dashboard

### DIFF
--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -1154,7 +1154,7 @@ const PersonRow = memo(function PersonRow({
     <Row
       style={{
         paddingVertical: theme.spacing.sm,
-        paddingHorizontal: theme.spacing.lg,
+        paddingHorizontal: theme.spacing.xs,
         alignItems: 'center',
         gap: theme.spacing.md,
         borderTopWidth: divider ? 1 : 0,

--- a/apps/mobile/src/app/(tabs)/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/friends.tsx
@@ -1154,7 +1154,7 @@ const PersonRow = memo(function PersonRow({
     <Row
       style={{
         paddingVertical: theme.spacing.sm,
-        paddingHorizontal: theme.spacing.xs,
+        paddingHorizontal: theme.spacing.sm,
         alignItems: 'center',
         gap: theme.spacing.md,
         borderTopWidth: divider ? 1 : 0,

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1703,7 +1703,7 @@ function GroupRow({
           alignItems: 'center',
           gap: theme.spacing.md,
           paddingVertical: theme.spacing.sm,
-          paddingHorizontal: theme.spacing.xs,
+          paddingHorizontal: theme.spacing.sm,
           borderTopWidth: divider ? 1 : 0,
           borderTopColor: theme.color.border,
           opacity: pressed ? 0.6 : 1,

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1703,7 +1703,7 @@ function GroupRow({
           alignItems: 'center',
           gap: theme.spacing.md,
           paddingVertical: theme.spacing.sm,
-          paddingHorizontal: theme.spacing.lg,
+          paddingHorizontal: theme.spacing.xs,
           borderTopWidth: divider ? 1 : 0,
           borderTopColor: theme.color.border,
           opacity: pressed ? 0.6 : 1,


### PR DESCRIPTION
## What

The list rows on **Friends** and the **dashboard** groups card carried `lg` (16) horizontal padding *inside* a card that already sits an `lg` margin off the screen edge — a double inset that read as too much air on the leading/trailing side.

Dropped each row's own `paddingHorizontal` to `sm` (8) on both screens, so the avatar and the amount sit closer to the card edge and the two lists stay visually identical. Vertical padding unchanged.

## Scope / risk

- Two one-line style changes, mobile only. **OTA-safe, no native rebuild.**
- No data / RPC / schema changes.

## Verification

- `eslint`, `prettier` clean.
- Not device-tested; iterated against screen recordings.