### PR TITLE
fix(voice): keep on-device recognition on second capture; match group list to activity

### DIFF
--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -280,11 +280,15 @@ export default function AllGroupsScreen() {
                   opacity: dim ? 0.55 : 1,
                 }}
               >
+                {/* The activity feed's row tile — a 40×40 rounded square — so the
+                    two lists read as one family. Activity tints its tile by the
+                    verb; a group carries an emoji cover instead, so the tile stays
+                    neutral and the emoji is the identity. */}
                 <View
                   style={{
-                    width: 44,
-                    height: 44,
-                    borderRadius: 22,
+                    width: 40,
+                    height: 40,
+                    borderRadius: theme.radius.md,
                     backgroundColor: theme.color.surfaceMuted,
                     alignItems: 'center',
                     justifyContent: 'center',
@@ -292,15 +296,11 @@ export default function AllGroupsScreen() {
                 >
                   <Text style={{ fontSize: 20 }}>{group.cover_emoji ?? '👥'}</Text>
                 </View>
-                <View style={{ flex: 1, gap: 2 }}>
-                  <Text
-                    variant="body"
-                    numberOfLines={1}
-                    style={{ flexShrink: 1, fontWeight: '600' }}
-                  >
+                <View style={{ flex: 1 }}>
+                  <Text variant="body" numberOfLines={2}>
                     {row.item.label}
                   </Text>
-                  <Text variant="caption" tone="muted" numberOfLines={1}>
+                  <Text variant="caption" tone="muted" numberOfLines={1} style={{ marginTop: 2 }}>
                     {subtitle}
                   </Text>
                 </View>

--- a/apps/mobile/src/components/DictateVoice.tsx
+++ b/apps/mobile/src/components/DictateVoice.tsx
@@ -67,6 +67,20 @@ function recognitionAvailable(): boolean {
 }
 
 /**
+ * Languages already confirmed on-device this session — kept so a flaky re-probe
+ * cannot downgrade one to the network path.
+ *
+ * `getSupportedLocales` is unreliable when called right after a recognition
+ * session ends: Android's RecognitionService is briefly busy and the query
+ * throws or returns empty, so the `catch` reports `false`. That flipped a second
+ * dictation to the network recogniser — which, offline, fails with a "needs a
+ * connection" error even though the model that served the first is still there.
+ * A model is not uninstalled between two utterances, so the positive signal is
+ * reliable and a re-probe's negative is not: latch each confirmed tag.
+ */
+const onDeviceConfirmed = new Set<string>();
+
+/**
  * Whether an on-device model for `langTag` is actually installed on this phone.
  *
  * `supportsOnDeviceRecognition()` only says the phone can do on-device work at
@@ -81,6 +95,7 @@ function recognitionAvailable(): boolean {
  * path, which works, rather than the on-device path, which may not.
  */
 async function installedOnDeviceFor(langTag: string): Promise<boolean> {
+  if (onDeviceConfirmed.has(langTag)) return true;
   try {
     let supportsOnDevice = false;
     try {
@@ -102,7 +117,9 @@ async function installedOnDeviceFor(langTag: string): Promise<boolean> {
     );
     // Match the whole tag, region and all: a phone with only en-US installed
     // must not be told it has the en-IN model (that returns silence).
-    return onDeviceLocaleInstalled(langTag, installedLocales);
+    const installed = onDeviceLocaleInstalled(langTag, installedLocales);
+    if (installed) onDeviceConfirmed.add(langTag);
+    return installed;
   } catch {
     return false;
   }

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -308,6 +308,20 @@ function recognitionAvailable(): boolean {
 }
 
 /**
+ * Once English has been confirmed on-device, keep that answer for the session.
+ *
+ * The probe below (`getSupportedLocales`) is flaky when called right after a
+ * recognition session ends: Android's RecognitionService is briefly busy and the
+ * query throws or returns empty, so the `catch` reports `false`. That flipped the
+ * *second* capture to the network recogniser — which, offline, fails with a
+ * "needs a connection" error even though the very model that served the first
+ * capture is still installed. A model is not uninstalled between two utterances,
+ * so the positive signal is reliable and a re-probe's negative is not: latch the
+ * true and never re-probe once it lands.
+ */
+let englishOnDeviceConfirmed = false;
+
+/**
  * Whether an on-device English model is actually installed on this phone.
  *
  * `supportsOnDeviceRecognition()` only says the phone can do on-device work at
@@ -322,6 +336,7 @@ function recognitionAvailable(): boolean {
  * not.)
  */
 async function englishInstalledOnDevice(): Promise<boolean> {
+  if (englishOnDeviceConfirmed) return true;
   try {
     let supportsOnDevice = false;
     try {
@@ -341,9 +356,11 @@ async function englishInstalledOnDevice(): Promise<boolean> {
     const { installedLocales } = await ExpoSpeechRecognitionModule.getSupportedLocales(
       androidRecognitionServicePackage ? { androidRecognitionServicePackage } : {},
     );
-    return (installedLocales ?? []).some(
+    const installed = (installedLocales ?? []).some(
       (tag) => tag.trim().split(/[-_]/)[0]?.toLowerCase() === 'en',
     );
+    if (installed) englishOnDeviceConfirmed = true;
+    return installed;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Voice: second capture failed offline

Reported: first speak-an-expense works, the **second** errors with *"needs a connection on this phone."*

That string is the Web Speech `network` error. On-device recognition uses **no** network, so a network error means the second capture ran on the **network** recogniser — which fails offline. It flipped because the on-device probe (`getSupportedLocales`) is flaky right after a recognition session ends: Android's `RecognitionService` is briefly busy, the query throws, the `catch` returned `false`, and `requiresOnDeviceRecognition` went false. First capture probed clean → on-device → worked offline; the second (remounted via `key={attempt}`) hit the busy probe → network → error.

**Fix:** latch the positive probe result. A model is not uninstalled between two utterances, so once on-device is confirmed the probe is never re-run and a flaky re-probe can't downgrade to the network path.

- `VoiceCapture.tsx` (speak-an-expense) — sticky `englishOnDeviceConfirmed`
- `DictateVoice.tsx` (note dictation, same pattern) — `onDeviceConfirmed` set, per language

## Group list matches activity list

`groups.tsx` rows adopt the activity feed's row chrome — 40×40 rounded-square tile (`radius.md`), non-bold two-line title, same subtitle/spacing. Kept two group truths that can't literally match: the emoji cover (a group has no verb-tint icon) and balance-coloured money (semantic red/green is the rule; activity's money is neutral because it belongs to nobody).

## Testing

`pnpm format` + `pnpm lint` clean (exit 0). Not device-tested — the emulator can't do a live mic.