### PR TITLE
feat(web): intent-first dashboard — loud Add expense, one hero answer, Waves brand

### DIFF
--- a/apps/web/src/app/add/page.tsx
+++ b/apps/web/src/app/add/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+/**
+ * The global "Add expense" lands here.
+ *
+ * An expense still belongs to a group, but the reader should not have to open
+ * one first to reach the form — that is the friction the roast named. So this
+ * route holds the choice, not the dashboard: one group means no choice at all
+ * (straight through to its form), several means a short pick, none means there
+ * is nothing to add to yet. The form itself is unchanged — this only decides
+ * which group's `/g/[id]/add` to open.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { groupLabel, type GroupRow, type MemberRow } from '@waves/api-client';
+
+import { baaki } from '@/lib/baaki';
+import { AppFrame } from '@/components/AppFrame';
+import { Section } from '@/components/Shell';
+import { SkeletonRows } from '@/components/Skeleton';
+import { plural } from '@/i18n';
+import { useStrings } from '@/i18n-context';
+
+export default function AddPage() {
+  return (
+    <AppFrame current={Section.Overview}>
+      {({ profileId }) => <Picker profileId={profileId} />}
+    </AppFrame>
+  );
+}
+
+function Picker({ profileId }: { profileId: string }) {
+  const router = useRouter();
+  const { t, locale } = useStrings();
+
+  const [groups, setGroups] = useState<GroupRow[]>([]);
+  const [membersByGroup, setMembersByGroup] = useState<Map<string, MemberRow[]>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      // Set when we hand off to a group's form, so the `finally` does not drop
+      // the skeleton and flash the picker for the single-group case.
+      let forwarding = false;
+      try {
+        const [g, m] = await Promise.all([baaki.myGroups(), baaki.membersByGroup()]);
+        if (!active) return;
+        const only = g.length === 1 ? g[0] : null;
+        if (only) {
+          forwarding = true;
+          router.replace(`/g/${only.id}/add`);
+          return;
+        }
+        setGroups(g);
+        setMembersByGroup(m);
+      } catch (caught) {
+        if (active) setError(caught instanceof Error ? caught.message : String(caught));
+      } finally {
+        if (active && !forwarding) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  if (loading) {
+    return (
+      <div className="app-body">
+        <div className="app-main">
+          <div className="page-head">
+            <div>
+              <h1>{t.dash.addExpense}</h1>
+              <div className="sub">{t.dash.addPickGroup}</div>
+            </div>
+          </div>
+          <section className="panel">
+            <SkeletonRows rows={4} />
+          </section>
+        </div>
+        <aside className="detail" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="app-body">
+      <div className="app-main">
+        <div className="page-head">
+          <div>
+            <h1>{t.dash.addExpense}</h1>
+            <div className="sub">{t.dash.addPickGroup}</div>
+          </div>
+        </div>
+
+        <section className="panel">
+          {error ? (
+            <p className="error">{error}</p>
+          ) : groups.length === 0 ? (
+            <p className="muted">{t.dash.noGroups}</p>
+          ) : (
+            <div className="list">
+              {groups.map((group) => {
+                const members = membersByGroup.get(group.id) ?? [];
+                return (
+                  <Link key={group.id} href={`/g/${group.id}/add`} className="item">
+                    <span className="tile-emoji" aria-hidden>
+                      {group.cover_emoji ?? '💫'}
+                    </span>
+                    <span className="grow">
+                      <span className="title">{groupLabel(group, members, profileId)}</span>
+                      <span className="meta">
+                        {plural(locale, members.length, t.dash.membersCount)}
+                      </span>
+                    </span>
+                    <span className="item-go" aria-hidden>
+                      →
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </div>
+      <aside className="detail" />
+    </div>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -388,6 +388,48 @@
     @apply text-[12px] text-ink-faint [font-variant-numeric:tabular-nums];
   }
 
+  /* The dashboard's one loud answer: are you up, down, or square. One big tinted
+     card, so the eye lands on the number that matters instead of comparing a row
+     of equal boxes. Owed reads mint, owe reads rose, settled celebrates. */
+  .hero {
+    @apply mb-[22px] flex flex-col gap-[5px] rounded-card border border-line px-[24px] py-[22px] shadow-card;
+  }
+  .hero-owed {
+    background: var(--tint-mint);
+  }
+  .hero-owe {
+    background: var(--tint-rose);
+  }
+  .hero-flat {
+    background: var(--tint-mint);
+  }
+  .hero-label {
+    @apply text-[13px] font-semibold uppercase [letter-spacing:0.4px] text-ink-muted;
+  }
+  .hero-amount {
+    @apply text-[40px] font-extrabold [font-variant-numeric:tabular-nums] [letter-spacing:-1px] text-ink;
+  }
+  .hero-owed .hero-amount {
+    @apply text-owed;
+  }
+  .hero-owe .hero-amount {
+    @apply text-owe;
+  }
+  .hero-flat-line {
+    @apply text-[28px] text-ink;
+  }
+  .hero-extra {
+    @apply text-[13px] text-ink-muted [font-variant-numeric:tabular-nums];
+  }
+
+  /* The primary action, sitting in the top bar of every page. */
+  .topbar-add {
+    @apply flex-none;
+  }
+  .item-go {
+    @apply flex-none text-[16px] text-ink-faint;
+  }
+
   .panel {
     @apply mb-[18px] rounded-card border border-line bg-app-surface px-[18px] py-[14px] shadow-card;
   }
@@ -408,7 +450,7 @@
     @apply flex flex-col;
   }
   .item {
-    @apply flex w-full cursor-pointer items-center gap-3 rounded-[10px] border-0 bg-transparent px-2 py-[11px] text-start text-inherit;
+    @apply flex w-full cursor-pointer items-center gap-3 rounded-[10px] border-0 bg-transparent px-2 py-[11px] text-start text-inherit no-underline;
   }
   .item:hover,
   .item[aria-pressed='true'] {
@@ -725,5 +767,13 @@
   }
   .stat-value {
     font-size: 23px;
+  }
+  .hero-amount {
+    font-size: 32px;
+  }
+  /* On a phone the bar is tight: the action keeps its ＋ but sheds its label so
+     the title and search still fit without wrapping. */
+  .topbar-add-label {
+    display: none;
   }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { isRtlLanguage, localeFor, pickLanguage, stringsFor } from '@/i18n';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'Baaki',
+  title: 'Waves',
   description: 'Split expenses without the argument at the end.',
 };
 

--- a/apps/web/src/app/settle/page.tsx
+++ b/apps/web/src/app/settle/page.tsx
@@ -429,7 +429,7 @@ function SettleForm({
             payeeName: memberName(payee),
             amount,
             currency: currency as CurrencyCode,
-            note: `Baaki ${group.name ?? ''}`.trim(),
+            note: `Waves ${group.name ?? ''}`.trim(),
           },
           (value, code) => toMajorString({ minor: value, currency: code }),
         )

--- a/apps/web/src/components/Overview.tsx
+++ b/apps/web/src/components/Overview.tsx
@@ -111,6 +111,18 @@ export function Overview({ profileId, query }: { profileId: string; query: strin
     [myBalances],
   );
 
+  // The hero's single answer: the currency the reader is furthest from square
+  // in leads, the rest fold into "+N more". Net, never a sum across currencies
+  // (ADR-004) — the largest |net| just decides which one gets the big line.
+  const heroTotals = useMemo(() => {
+    const abs = (n: bigint) => (n < 0n ? -n : n);
+    return overall
+      .filter((e) => e.net !== 0n)
+      .sort((a, b) => (abs(a.net) > abs(b.net) ? -1 : abs(a.net) < abs(b.net) ? 1 : 0));
+  }, [overall]);
+  const heroTop = heroTotals[0] ?? null;
+  const heroRest = Math.max(heroTotals.length - 1, 0);
+
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return groupNets;
@@ -159,49 +171,27 @@ export function Overview({ profileId, query }: { profileId: string; query: strin
           </div>
         </div>
 
-        <div className="stat-grid">
-          <StatCard
-            tint="tint-mint"
-            icon="📈"
-            label={t.dash.youreOwed}
-            entries={overall
-              .filter((e) => e.owed > 0n)
-              .map((e) => ({ currency: e.currency, amount: e.owed }))}
-            locale={locale}
-            emptyLabel={t.dash.allSettled}
-            moreForms={t.dash.moreCurrencies}
-          />
-          <StatCard
-            tint="tint-rose"
-            icon="📉"
-            label={t.dash.youOwe}
-            entries={overall
-              .filter((e) => e.owing > 0n)
-              .map((e) => ({ currency: e.currency, amount: e.owing }))}
-            locale={locale}
-            emptyLabel={t.dash.allSettled}
-            moreForms={t.dash.moreCurrencies}
-          />
-          <StatCard
-            tint="tint-blue"
-            icon="⚖️"
-            label={t.dash.net}
-            entries={overall.map((e) => ({ currency: e.currency, amount: e.net }))}
-            locale={locale}
-            signed
-            emptyLabel={t.dash.allSettled}
-            moreForms={t.dash.moreCurrencies}
-          />
-          <div className="stat tint-lilac">
-            <div className="stat-top">
-              <span className="stat-badge" aria-hidden>
-                👥
-              </span>
-              {t.dash.activeGroups}
-            </div>
-            <div className="stat-value">{groups.length}</div>
-          </div>
-        </div>
+        {/* One dominant answer instead of four boxes of equal weight: are you
+            up, down, or square. The per-group rows below carry the detail. */}
+        {groups.length > 0 ? (
+          heroTop ? (
+            <section className={`hero ${heroTop.net > 0n ? 'hero-owed' : 'hero-owe'}`}>
+              <div className="hero-label">
+                {heroTop.net > 0n ? t.dash.youGetBack : t.dash.youNeedToPay}
+              </div>
+              <div className="hero-amount">
+                {money(heroTop.net < 0n ? -heroTop.net : heroTop.net, heroTop.currency, locale)}
+              </div>
+              {heroRest > 0 ? (
+                <div className="hero-extra">{plural(locale, heroRest, t.dash.moreCurrencies)}</div>
+              ) : null}
+            </section>
+          ) : (
+            <section className="hero hero-flat">
+              <div className="hero-amount hero-flat-line">🎉 {t.dash.allSettled}</div>
+            </section>
+          )
+        ) : null}
 
         <section className="panel">
           <div className="panel-head">
@@ -257,7 +247,7 @@ export function Overview({ profileId, query }: { profileId: string; query: strin
             <p className="muted">{t.dash.noActivity}</p>
           ) : (
             <div className="list">
-              {filteredActivity.slice(0, 12).map((entry) => (
+              {filteredActivity.slice(0, 6).map((entry) => (
                 <div key={entry.id} className="item" style={{ cursor: 'default' }}>
                   <span className="tile-emoji" aria-hidden>
                     {verbEmoji(entry.verb)}
@@ -308,16 +298,9 @@ function OverviewSkeleton() {
           <span className="sk sk-sub" />
         </div>
 
-        <div className="stat-grid">
-          {[0, 1, 2, 3].map((i) => (
-            <div key={i} className="stat">
-              <div className="stat-top">
-                <span className="sk sk-badge" />
-                <span className="sk sk-line" style={{ width: 84 }} />
-              </div>
-              <span className="sk sk-value" />
-            </div>
-          ))}
+        <div className="hero">
+          <span className="sk sk-line" style={{ width: 96 }} />
+          <span className="sk sk-line" style={{ height: 38, width: 190, marginTop: 6 }} />
         </div>
 
         {[0, 1].map((panel) => (
@@ -342,54 +325,6 @@ function OverviewSkeleton() {
           </div>
         ))}
       </aside>
-    </div>
-  );
-}
-
-function StatCard({
-  tint,
-  icon,
-  label,
-  entries,
-  locale,
-  emptyLabel,
-  moreForms,
-  signed = false,
-}: {
-  tint: string;
-  icon: string;
-  label: string;
-  entries: { currency: string; amount: bigint }[];
-  locale: string;
-  emptyLabel: string;
-  moreForms: PluralForms;
-  signed?: boolean;
-}) {
-  const shown = entries.filter((e) => e.amount !== 0n);
-  const top = shown[0] ?? null;
-  const rest = shown.length - 1;
-
-  return (
-    <div className={`stat ${tint}`}>
-      <div className="stat-top">
-        <span className="stat-badge" aria-hidden>
-          {icon}
-        </span>
-        {label}
-      </div>
-      {top ? (
-        <>
-          <div className="stat-value">
-            {signed && top.amount < 0n ? '−' : ''}
-            {money(top.amount < 0n ? -top.amount : top.amount, top.currency, locale)}
-          </div>
-          {rest > 0 ? <div className="stat-extra">{plural(locale, rest, moreForms)}</div> : null}
-        </>
-      ) : (
-        <div className="stat-value" style={{ fontSize: 18, opacity: 0.7 }}>
-          {emptyLabel}
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -79,7 +79,7 @@ export function Shell({
             <span className="brand-mark" aria-hidden>
               ₹
             </span>
-            Baaki
+            Waves
           </div>
 
           <nav className="side-nav">
@@ -146,6 +146,13 @@ export function Shell({
         <div className="main-col">
           <header className="topbar">
             <h1 className="topbar-title">{pageTitle}</h1>
+            {/* The one action a split app is for, present on every page — no
+                need to open a group first to reach it (the picker at /add does
+                that). This is the loudest thing in the bar on purpose. */}
+            <Link href="/add" className="btn topbar-add">
+              <span aria-hidden>＋</span>
+              <span className="topbar-add-label">{t.dash.addExpense}</span>
+            </Link>
             <label className="search">
               <span aria-hidden>🔍</span>
               <input

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -205,6 +205,12 @@ export interface WebStrings {
     youOwe: string;
     net: string;
     activeGroups: string;
+    /** The one-line answer the dashboard hero gives: are you up or down. */
+    youGetBack: string;
+    youNeedToPay: string;
+    /** The always-present primary action, and the group picker it opens. */
+    addExpense: string;
+    addPickGroup: string;
     allSettled: string;
     moreCurrencies: PluralForms;
     yourGroups: string;
@@ -298,7 +304,7 @@ export interface WebStrings {
 
 const en: WebStrings = {
   home: {
-    title: 'Baaki',
+    title: 'Waves',
     description:
       'Split expenses without the argument at the end. This page is only for opening an invite link — if somebody shared a group with you, open their link rather than this address.',
     elsewhere: 'Everything else lives in the app.',
@@ -349,7 +355,7 @@ const en: WebStrings = {
     recent: 'Recent',
     addAnExpense: 'Add an expense',
     installNote:
-      'Install Baaki to scan receipts, settle over UPI and keep this working without a signal.',
+      'Install Waves to scan receipts, settle over UPI and keep this working without a signal.',
   },
   add: {
     title: 'Add an expense',
@@ -389,7 +395,7 @@ const en: WebStrings = {
       settle: 'Settle',
     },
     searchPlaceholder: 'Search groups, people, expenses',
-    signInTitle: 'Baaki',
+    signInTitle: 'Waves',
     signInBody: 'Split expenses without the argument at the end.',
     continueWithGoogle: 'Continue with Google',
     orDivider: 'or',
@@ -414,6 +420,10 @@ const en: WebStrings = {
     youOwe: 'You owe',
     net: 'Net position',
     activeGroups: 'Active groups',
+    youGetBack: 'You get back',
+    youNeedToPay: 'You need to pay',
+    addExpense: 'Add expense',
+    addPickGroup: 'Which group?',
     allSettled: 'All settled',
     moreCurrencies: { one: '+{n} more currency', other: '+{n} more currencies' },
     yourGroups: 'Your groups',
@@ -503,7 +513,7 @@ const en: WebStrings = {
 
 const ta: WebStrings = {
   home: {
-    title: 'பாக்கி',
+    title: 'Waves',
     description:
       'கடைசியில் வாக்குவாதம் இல்லாமல் செலவுகளைப் பிரியுங்கள். இந்தப் பக்கம் அழைப்புச் சுட்டியைத் திறக்க மட்டுமே — யாராவது ஒரு குழுவை உங்களுடன் பகிர்ந்திருந்தால், இந்த முகவரிக்குப் பதிலாக அவர்களின் சுட்டியைத் திறக்கவும்.',
     elsewhere: 'மற்ற அனைத்தும் செயலியில் உள்ளது.',
@@ -556,7 +566,7 @@ const ta: WebStrings = {
     recent: 'சமீபத்தியவை',
     addAnExpense: 'ஒரு செலவைச் சேர்',
     installNote:
-      'ரசீதுகளை ஸ்கேன் செய்ய, UPI மூலம் தீர்க்க, சிக்னல் இல்லாமலும் இது வேலை செய்ய — பாக்கியை நிறுவுங்கள்.',
+      'ரசீதுகளை ஸ்கேன் செய்ய, UPI மூலம் தீர்க்க, சிக்னல் இல்லாமலும் இது வேலை செய்ய — Waves ஐ நிறுவுங்கள்.',
   },
   add: {
     title: 'ஒரு செலவைச் சேர்',
@@ -598,7 +608,7 @@ const ta: WebStrings = {
       settle: 'தீர்வு',
     },
     searchPlaceholder: 'குழுக்கள், நபர்கள், செலவுகளைத் தேடுங்கள்',
-    signInTitle: 'பாக்கி',
+    signInTitle: 'Waves',
     signInBody: 'கடைசியில் வாக்குவாதம் இல்லாமல் செலவுகளைப் பிரியுங்கள்.',
     continueWithGoogle: 'Google மூலம் தொடரவும்',
     orDivider: 'அல்லது',
@@ -623,6 +633,10 @@ const ta: WebStrings = {
     youOwe: 'நீங்கள் தர வேண்டியது',
     net: 'நிகர நிலை',
     activeGroups: 'செயலில் உள்ள குழுக்கள்',
+    youGetBack: 'உங்களுக்கு வர வேண்டியது',
+    youNeedToPay: 'நீங்கள் தர வேண்டியது',
+    addExpense: 'செலவைச் சேர்',
+    addPickGroup: 'எந்தக் குழு?',
     allSettled: 'அனைத்தும் தீர்ந்தது',
     moreCurrencies: { one: '+இன்னும் {n} நாணயம்', other: '+இன்னும் {n} நாணயங்கள்' },
     yourGroups: 'உங்கள் குழுக்கள்',
@@ -716,7 +730,7 @@ const ta: WebStrings = {
 
 const hi: WebStrings = {
   home: {
-    title: 'बाकी',
+    title: 'Waves',
     description:
       'आख़िर में बहस किए बिना खर्च बाँटें। यह पेज सिर्फ़ न्योते का लिंक खोलने के लिए है — अगर किसी ने आपके साथ कोई समूह साझा किया है, तो इस पते के बजाय उनका लिंक खोलें।',
     elsewhere: 'बाकी सब कुछ ऐप में है।',
@@ -768,7 +782,7 @@ const hi: WebStrings = {
     recent: 'हाल के',
     addAnExpense: 'खर्च जोड़ें',
     installNote:
-      'रसीदें स्कैन करने, UPI से निपटाने और बिना सिग्नल भी यह चलाने के लिए बाकी इंस्टॉल करें।',
+      'रसीदें स्कैन करने, UPI से निपटाने और बिना सिग्नल भी यह चलाने के लिए Waves इंस्टॉल करें।',
   },
   add: {
     title: 'खर्च जोड़ें',
@@ -808,7 +822,7 @@ const hi: WebStrings = {
       settle: 'हिसाब',
     },
     searchPlaceholder: 'समूह, लोग, खर्च खोजें',
-    signInTitle: 'बाकी',
+    signInTitle: 'Waves',
     signInBody: 'आख़िर में बहस किए बिना खर्च बाँटें।',
     continueWithGoogle: 'Google से जारी रखें',
     orDivider: 'या',
@@ -833,6 +847,10 @@ const hi: WebStrings = {
     youOwe: 'आपको देने हैं',
     net: 'कुल स्थिति',
     activeGroups: 'सक्रिय समूह',
+    youGetBack: 'आपको मिलने हैं',
+    youNeedToPay: 'आपको देने हैं',
+    addExpense: 'खर्च जोड़ें',
+    addPickGroup: 'कौन सा समूह?',
     allSettled: 'सब हिसाब बराबर',
     moreCurrencies: { one: '+{n} और मुद्रा', other: '+{n} और मुद्राएँ' },
     yourGroups: 'आपके समूह',
@@ -923,7 +941,7 @@ const hi: WebStrings = {
 
 const ar: WebStrings = {
   home: {
-    title: 'باقي',
+    title: 'Waves',
     description:
       'قسّموا المصاريف دون خلاف في النهاية. هذه الصفحة لفتح رابط دعوة فقط — إن شاركك أحدهم مجموعة، فافتح رابطه بدل هذا العنوان.',
     elsewhere: 'كل ما عدا ذلك في التطبيق.',
@@ -989,7 +1007,7 @@ const ar: WebStrings = {
       'أقل عدد من الدفعات يسوّي حساب الجميع. ولا يُطلب من أحد أن يدفع لشخص لم يقسّم معه شيئًا قط.',
     recent: 'الأحدث',
     addAnExpense: 'أضف مصروفًا',
-    installNote: 'ثبّت باقي لمسح الإيصالات والتسوية عبر UPI ولكي يعمل هذا دون اتصال.',
+    installNote: 'ثبّت Waves لمسح الإيصالات والتسوية عبر UPI ولكي يعمل هذا دون اتصال.',
   },
   add: {
     title: 'أضف مصروفًا',
@@ -1029,7 +1047,7 @@ const ar: WebStrings = {
       settle: 'التسوية',
     },
     searchPlaceholder: 'ابحث في المجموعات والأشخاص والمصاريف',
-    signInTitle: 'باقي',
+    signInTitle: 'Waves',
     signInBody: 'قسّموا المصاريف دون خلاف في النهاية.',
     continueWithGoogle: 'المتابعة عبر Google',
     orDivider: 'أو',
@@ -1061,6 +1079,10 @@ const ar: WebStrings = {
     youOwe: 'عليك',
     net: 'الصافي',
     activeGroups: 'المجموعات النشطة',
+    youGetBack: 'لك',
+    youNeedToPay: 'عليك',
+    addExpense: 'أضف مصروفًا',
+    addPickGroup: 'أي مجموعة؟',
     allSettled: 'كل الحسابات مسوّاة',
     moreCurrencies: {
       one: '+عملة أخرى',


### PR DESCRIPTION
Addresses a first-impression roast: the web app read like a finance portal (dark sidebar, four equal stat cards, net/owed/owing, activity), organized around data tables rather than the handful of things people actually arrive to do. Reorganizes around intent.

## What changed

**1. Add expense is now the loud, global action.**
A filled "Add expense" button sits in the top bar of every signed-in page, opening a new `/add` route:
- one group → forwards straight to its expense form (no choice to make)
- several → a short group picker
- none → says there's nothing to add to yet

Previously the only way to add an expense was to open a group first — intent #1 buried two clicks deep.

**2. The dashboard leads with one answer, not four boxes.**
Replaced the owed / owe / net / active-groups grid with a single dominant hero:
- **You get back {amount}** (mint) when you're net up
- **You need to pay {amount}** (rose) when you're net down
- **🎉 All settled** when square

It leads on the currency you're furthest from square in and folds the rest into "+N more currencies" (still never sums across currencies, ADR-004). "Net" survives in the detail panel where the word belongs; the hero speaks plainly.

**3. Recent activity demoted** to six rows, below the groups — the screen answers "where do I act" before "what happened".

**4. Brand Baaki → Waves** across the shell, sign-in, install note, document `<title>` and the settlement payment memo. Left the Hindi common word बाकी ("the rest") alone; native-script transliteration of the brand stays deferred, so the Latin "Waves" is used in ta/hi/ar titles.

## Notes
- `/add` empty state is honest: the web client has no create-group capability, so zero groups points to invite/app rather than pretending.
- New i18n keys (`addExpense`, `addPickGroup`, `youGetBack`, `youNeedToPay`) added across en/ta/hi/ar; unused `net`/`youreOwed`/`youOwe`/`activeGroups` keys kept.

## Verification
- `pnpm --filter @waves/web typecheck` — clean
- `pnpm --filter @waves/web lint` — clean
- `pnpm --filter @waves/web test` — 24 passed (incl. the >90%-translated i18n proportion check)
- Not device/browser-run; no deploy (web-only change ships via Vercel on merge).