### PR TITLE
fix(mobile): pin the header/hero on every scrolling screen (+ settlement payload typing)

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -471,6 +471,9 @@ export default function ActivityScreen() {
           are what make a long feed skimmable — without them every row had to be
           read to place it in time. */}
       <View style={{ flex: 1 }}>
+        {/* The nav header is a fixed sibling above the feed, so only the rows
+            scroll under it. Padded to line up with the feed rows below. */}
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>{header}</View>
         <FlashList
           data={listData}
           // The row text is locale-formatted, so a language change has to re-run
@@ -495,7 +498,6 @@ export default function ActivityScreen() {
               tintColor={theme.color.brand}
             />
           }
-          ListHeaderComponent={header}
           renderItem={({ item }) =>
             item.kind === 'header' ? (
               <Text

--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -238,25 +238,25 @@ export default function MeScreen() {
 
   return (
     <Screen edges={[]}>
+      <MeHero
+        net={summary.net}
+        income={summary.income}
+        expense={summary.expense}
+        rate={rate}
+        currency={dc}
+        locale={locale}
+        t={t}
+        monthLabel={monthLabel(month, locale)}
+        canGoForward={monthsBack > 0}
+        canGoBack={monthsBack < maxBack}
+        onPrevMonth={() => setMonthsBack((back) => Math.min(maxBack, back + 1))}
+        onNextMonth={() => setMonthsBack((back) => Math.max(0, back - 1))}
+      />
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{ paddingBottom: clearance }}
         showsVerticalScrollIndicator={false}
       >
-        <MeHero
-          net={summary.net}
-          income={summary.income}
-          expense={summary.expense}
-          rate={rate}
-          currency={dc}
-          locale={locale}
-          t={t}
-          monthLabel={monthLabel(month, locale)}
-          canGoForward={monthsBack > 0}
-          canGoBack={monthsBack < maxBack}
-          onPrevMonth={() => setMonthsBack((back) => Math.min(maxBack, back + 1))}
-          onNextMonth={() => setMonthsBack((back) => Math.max(0, back - 1))}
-        />
-
         <View
           style={{
             paddingHorizontal: theme.spacing.xl,

--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -315,34 +315,36 @@ function ProfileForm() {
 
   return (
     <Screen>
+      {/* A titled bar, like every other pushed screen and every settings
+          screen worth copying. Without it the avatar sat against the status
+          bar with no word for what the page was, and no way back but the
+          gesture. Back on the left, the title centred, an equal spacer on the
+          right so the title is centred on the screen, not on the gap. */}
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.account.faceSettings}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
-        {/* A titled bar, like every other pushed screen and every settings
-            screen worth copying. Without it the avatar sat against the status
-            bar with no word for what the page was, and no way back but the
-            gesture. Back on the left, the title centred, an equal spacer on the
-            right so the title is centred on the screen, not on the gap. */}
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.account.faceSettings}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {/* The hero. No card behind it: the avatar, the name and the one number
             are the page's title, and a title does not sit in a box. */}
         <View style={{ alignItems: 'center', gap: theme.spacing.md }}>

--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -508,18 +508,20 @@ export default function CaptureScreen() {
 
   return (
     <Screen edges={['top', 'bottom']}>
+      <View style={{ paddingHorizontal: theme.spacing.xl }}>
+        <ExpenseHeader title={isEditing ? t.captures.editTitle : t.captures.newTitle} />
+      </View>
       <ScrollView
         style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: theme.spacing.xl,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <ExpenseHeader title={isEditing ? t.captures.editTitle : t.captures.newTitle} />
-
         {/* Amount-forward hero: the number is the point of this screen, so it
             leads — big and centred, with the currency it is counted in a tap
             below it (the Splitwise/PayPal amount-first pattern). Shared with

--- a/apps/mobile/src/app/friends/add-person.tsx
+++ b/apps/mobile/src/app/friends/add-person.tsx
@@ -233,32 +233,33 @@ export default function AddPersonScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+            <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.brand} />
+            <Text variant="heading">{t.addPerson.title}</Text>
+          </Row>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
-              <Ionicons name="person-add-outline" size={iconSize.md} color={theme.color.brand} />
-              <Text variant="heading">{t.addPerson.title}</Text>
-            </Row>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {/* The person is the subject of this screen, so the card leads with
             them: an avatar that fills in with the name's own colour and initial
             as it is typed, the name as the field beside it, and picking from

--- a/apps/mobile/src/app/friends/merge.tsx
+++ b/apps/mobile/src/app/friends/merge.tsx
@@ -297,29 +297,30 @@ export default function MergePeopleScreen() {
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={{ flex: 1 }}
       >
+        <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+          <IconButton label={t.common.back} onPress={() => router.back()}>
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.lg}
+              color={theme.color.text}
+            />
+          </IconButton>
+          <View style={{ flex: 1, alignItems: 'center' }}>
+            <Text variant="heading">{t.mergePeople.title}</Text>
+          </View>
+          <View style={{ width: 44 }} />
+        </Row>
         <ScrollView
+          style={{ flex: 1 }}
           contentContainerStyle={{
             paddingHorizontal: theme.spacing.xl,
+            paddingTop: theme.spacing.lg,
             paddingBottom: clearance,
             gap: theme.spacing.xl,
           }}
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
-          <Row style={{ paddingTop: theme.spacing.md }}>
-            <IconButton label={t.common.back} onPress={() => router.back()}>
-              <Ionicons
-                name={directionalIcon('chevron-back')}
-                size={iconSize.lg}
-                color={theme.color.text}
-              />
-            </IconButton>
-            <View style={{ flex: 1, alignItems: 'center' }}>
-              <Text variant="heading">{t.mergePeople.title}</Text>
-            </View>
-            <View style={{ width: 44 }} />
-          </Row>
-
           {people.isLoading ? (
             <PeopleSkeleton />
           ) : people.isError ? (

--- a/apps/mobile/src/app/friends/person/[key].tsx
+++ b/apps/mobile/src/app/friends/person/[key].tsx
@@ -109,43 +109,44 @@ export default function PersonDetailScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading" numberOfLines={1}>
+            {title}
+          </Text>
+        </View>
+        {isRealPerson ? (
+          <IconButton
+            label={blocked ? t.blocked.unblock : t.blocked.action}
+            onPress={blocked ? () => unblock(key) : confirmBlock}
+          >
+            <Ionicons
+              name={blocked ? 'person-add-outline' : 'person-remove-outline'}
+              size={iconSize.md}
+              color={blocked ? theme.color.brand : theme.color.negative}
+            />
+          </IconButton>
+        ) : (
+          <View style={{ width: 44 }} />
+        )}
+      </Row>
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading" numberOfLines={1}>
-              {title}
-            </Text>
-          </View>
-          {isRealPerson ? (
-            <IconButton
-              label={blocked ? t.blocked.unblock : t.blocked.action}
-              onPress={blocked ? () => unblock(key) : confirmBlock}
-            >
-              <Ionicons
-                name={blocked ? 'person-add-outline' : 'person-remove-outline'}
-                size={iconSize.md}
-                color={blocked ? theme.color.brand : theme.color.negative}
-              />
-            </IconButton>
-          ) : (
-            <View style={{ width: 44 }} />
-          )}
-        </Row>
-
         {person.isLoading ? (
           <PeopleSkeleton />
         ) : person.isError ? (

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1086,16 +1086,7 @@ export default function AddExpenseScreen() {
         style={{ flex: 1 }}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <ScrollView
-          style={{ flex: 1 }}
-          contentContainerStyle={{
-            paddingHorizontal: theme.spacing.xl,
-            paddingBottom: theme.spacing.xl,
-            gap: theme.spacing.xl,
-          }}
-          keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
-        >
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>
           <ExpenseHeader
             leading="back"
             title={editing ? t.expense.edit : t.addExpense}
@@ -1120,7 +1111,18 @@ export default function AddExpenseScreen() {
               )
             }
           />
-
+        </View>
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingTop: theme.spacing.lg,
+            paddingBottom: theme.spacing.xl,
+            gap: theme.spacing.xl,
+          }}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
           {editing ? (
             <Card style={{ backgroundColor: theme.color.buttonPrimary }}>
               <Text variant="caption" tone="onBrand">

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -316,11 +316,126 @@ export default function ExpenseDetailScreen() {
       {/* The hero runs dark under the status bar, so its icons must be light —
           overriding the app's theme-driven default for this route. */}
       <StatusBar style="light" />
+      {/* The expense hero, built like the group and dashboard panels: one
+          saturated wash edge to edge and up under the status bar, carrying the
+          back/edit controls, the category badge, the amount and its "paid by"
+          line — all in white. Neutral brand indigo, never a money colour: the
+          amount is a total that is nobody's balance. A fixed header: it sits as a
+          sibling before the scroll so only the body below it scrolls, then re-pads
+          and rounds only its bottom corners. */}
+      <Gradient
+        radius={0}
+        colors={theme.gradient.brand}
+        style={{
+          paddingTop: insets.top + theme.spacing.md,
+          paddingHorizontal: theme.spacing.xl,
+          // Match the dashboard/group hero height: lg bottom padding, not xl.
+          paddingBottom: theme.spacing.lg,
+          borderBottomLeftRadius: theme.radius.xxl,
+          borderBottomRightRadius: theme.radius.xxl,
+          gap: theme.spacing.lg,
+        }}
+      >
+        <Row style={{ alignItems: 'center' }}>
+          {/* Back and overflow match the dashboard/group hero: a chip-less xxl
+                white glyph, not the smaller boxed IconButton. */}
+          <Pressable
+            onPress={() => router.back()}
+            accessibilityRole="button"
+            accessibilityLabel={t.common.back}
+            hitSlop={10}
+            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+          >
+            <Ionicons
+              name={directionalIcon('chevron-back')}
+              size={iconSize.xxl}
+              color={theme.color.onBrand}
+            />
+          </Pressable>
+          {/* The title moves out of this row and into the hero body beside the
+                category badge, so the description reads as the heading of the
+                bill rather than a cramped line between two glyphs. */}
+          <View style={{ flex: 1 }} />
+          {/* Every action on this bill lives behind one three-dot menu, the same
+                trailing control the group and dashboard headers carry — Edit and
+                Delete (or Restore) instead of a full-width button stacked at the
+                bottom of a long scroll. */}
+          <Pressable
+            onPress={() => setMenuOpen(true)}
+            accessibilityRole="button"
+            accessibilityLabel={t.group.more}
+            hitSlop={10}
+            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+          >
+            <Ionicons name="ellipsis-vertical" size={iconSize.xxl} color={theme.color.onBrand} />
+          </Pressable>
+        </Row>
+
+        <View style={{ alignItems: 'flex-start', gap: theme.spacing.md }}>
+          {/* Badge + description as one line: the category icon, then what the
+                bill is called (the description, or the category name when none
+                was typed) reads as the heading — this is the "I don't see the
+                description" fix. */}
+          <Row style={{ alignItems: 'center', gap: theme.spacing.sm, alignSelf: 'stretch' }}>
+            <CategoryBadge
+              category={version.category}
+              meta={version.category_meta}
+              description={version.description}
+              size={40}
+            />
+            <Text variant="heading" tone="onBrand" numberOfLines={2} style={{ flex: 1 }}>
+              {expenseTitle(version.description, version.category, t, version.category_meta)}
+            </Text>
+            {deleted ? <Badge label={t.expense.deleted} tone="negative" /> : null}
+          </Row>
+          <MoneyText
+            amount={BigInt(version.amount)}
+            currency={currency}
+            locale={locale}
+            variant="display"
+            style={{ color: theme.color.onBrand }}
+          />
+          {/* Add receipt, right under the amount — the same "primary action sits
+                under the number" the dashboard and group heros use. A party owns
+                adding; the button drives the receipts section through its ref. */}
+          {isExpenseParty ? (
+            <Pressable
+              onPress={() => {
+                if (tab === 'details') receiptsRef.current?.openAdd();
+                else {
+                  // Switch to where the receipts live, then add once mounted.
+                  setTab('details');
+                  setPendingAdd(true);
+                }
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={t.receipts.add}
+              style={({ pressed }) => ({
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: theme.spacing.sm,
+                alignSelf: 'flex-start',
+                paddingHorizontal: theme.spacing.lg,
+                paddingVertical: theme.spacing.sm,
+                borderRadius: theme.radius.pill,
+                backgroundColor: '#FFFFFF',
+                opacity: pressed ? 0.85 : 1,
+              })}
+            >
+              <Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />
+              <Text style={{ color: theme.color.brand, fontWeight: '700' }}>{t.receipts.add}</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </Gradient>
+
       <ScrollView
         ref={scrollRef}
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.xl,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
@@ -329,121 +444,6 @@ export default function ExpenseDetailScreen() {
         keyboardShouldPersistTaps="handled"
         automaticallyAdjustKeyboardInsets
       >
-        {/* The expense hero, built like the group and dashboard panels: one
-            saturated wash edge to edge and up under the status bar, carrying the
-            back/edit controls, the category badge, the amount and its "paid by"
-            line — all in white. Neutral brand indigo, never a money colour: the
-            amount is a total that is nobody's balance. Breaks out of the
-            scroll's padding, then re-pads and rounds only its bottom corners. */}
-        <Gradient
-          radius={0}
-          colors={theme.gradient.brand}
-          style={{
-            marginHorizontal: -theme.spacing.xl,
-            paddingTop: insets.top + theme.spacing.md,
-            paddingHorizontal: theme.spacing.xl,
-            // Match the dashboard/group hero height: lg bottom padding, not xl.
-            paddingBottom: theme.spacing.lg,
-            borderBottomLeftRadius: theme.radius.xxl,
-            borderBottomRightRadius: theme.radius.xxl,
-            gap: theme.spacing.lg,
-          }}
-        >
-          <Row style={{ alignItems: 'center' }}>
-            {/* Back and overflow match the dashboard/group hero: a chip-less xxl
-                white glyph, not the smaller boxed IconButton. */}
-            <Pressable
-              onPress={() => router.back()}
-              accessibilityRole="button"
-              accessibilityLabel={t.common.back}
-              hitSlop={10}
-              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
-            >
-              <Ionicons
-                name={directionalIcon('chevron-back')}
-                size={iconSize.xxl}
-                color={theme.color.onBrand}
-              />
-            </Pressable>
-            {/* The title moves out of this row and into the hero body beside the
-                category badge, so the description reads as the heading of the
-                bill rather than a cramped line between two glyphs. */}
-            <View style={{ flex: 1 }} />
-            {/* Every action on this bill lives behind one three-dot menu, the same
-                trailing control the group and dashboard headers carry — Edit and
-                Delete (or Restore) instead of a full-width button stacked at the
-                bottom of a long scroll. */}
-            <Pressable
-              onPress={() => setMenuOpen(true)}
-              accessibilityRole="button"
-              accessibilityLabel={t.group.more}
-              hitSlop={10}
-              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
-            >
-              <Ionicons name="ellipsis-vertical" size={iconSize.xxl} color={theme.color.onBrand} />
-            </Pressable>
-          </Row>
-
-          <View style={{ alignItems: 'flex-start', gap: theme.spacing.md }}>
-            {/* Badge + description as one line: the category icon, then what the
-                bill is called (the description, or the category name when none
-                was typed) reads as the heading — this is the "I don't see the
-                description" fix. */}
-            <Row style={{ alignItems: 'center', gap: theme.spacing.sm, alignSelf: 'stretch' }}>
-              <CategoryBadge
-                category={version.category}
-                meta={version.category_meta}
-                description={version.description}
-                size={40}
-              />
-              <Text variant="heading" tone="onBrand" numberOfLines={2} style={{ flex: 1 }}>
-                {expenseTitle(version.description, version.category, t, version.category_meta)}
-              </Text>
-              {deleted ? <Badge label={t.expense.deleted} tone="negative" /> : null}
-            </Row>
-            <MoneyText
-              amount={BigInt(version.amount)}
-              currency={currency}
-              locale={locale}
-              variant="display"
-              style={{ color: theme.color.onBrand }}
-            />
-            {/* Add receipt, right under the amount — the same "primary action sits
-                under the number" the dashboard and group heros use. A party owns
-                adding; the button drives the receipts section through its ref. */}
-            {isExpenseParty ? (
-              <Pressable
-                onPress={() => {
-                  if (tab === 'details') receiptsRef.current?.openAdd();
-                  else {
-                    // Switch to where the receipts live, then add once mounted.
-                    setTab('details');
-                    setPendingAdd(true);
-                  }
-                }}
-                accessibilityRole="button"
-                accessibilityLabel={t.receipts.add}
-                style={({ pressed }) => ({
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: theme.spacing.sm,
-                  alignSelf: 'flex-start',
-                  paddingHorizontal: theme.spacing.lg,
-                  paddingVertical: theme.spacing.sm,
-                  borderRadius: theme.radius.pill,
-                  backgroundColor: '#FFFFFF',
-                  opacity: pressed ? 0.85 : 1,
-                })}
-              >
-                <Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />
-                <Text style={{ color: theme.color.brand, fontWeight: '700' }}>
-                  {t.receipts.add}
-                </Text>
-              </Pressable>
-            ) : null}
-          </View>
-        </Gradient>
-
         {/* The two faces of the page — its breakdown and its edit history —
             sectioned so the audit is its own place rather than the tail of a
             long scroll. */}

--- a/apps/mobile/src/app/group/[id]/export.tsx
+++ b/apps/mobile/src/app/group/[id]/export.tsx
@@ -288,28 +288,30 @@ export default function GroupExportScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.groupExport.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.groupExport.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Card style={{ gap: theme.spacing.sm }}>
           <Text variant="subheading" numberOfLines={1}>
             {groupData?.cover_emoji ? `${groupData.cover_emoji} ` : ''}

--- a/apps/mobile/src/app/group/[id]/insights.tsx
+++ b/apps/mobile/src/app/group/[id]/insights.tsx
@@ -104,31 +104,33 @@ export default function InsightsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.spending}</Text>
+          <Text variant="micro" tone="muted">
+            {group.data?.name}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.spending}</Text>
-            <Text variant="micro" tone="muted">
-              {group.data?.name}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <ChipRow<Scope>
           value={scope}
           onChange={setScope}

--- a/apps/mobile/src/app/group/[id]/invite.tsx
+++ b/apps/mobile/src/app/group/[id]/invite.tsx
@@ -202,27 +202,29 @@ export default function InviteScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.close} onPress={() => router.back()}>
+          <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.people.inviteTitle}</Text>
+          <Text variant="micro" tone="muted">
+            {label}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.people.inviteTitle}</Text>
-            <Text variant="micro" tone="muted">
-              {label}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Card style={{ gap: theme.spacing.md }}>
           <Text variant="subheading">{t.people.anyoneWithLink}</Text>
           <Text variant="caption" tone="muted">

--- a/apps/mobile/src/app/group/[id]/itemize.tsx
+++ b/apps/mobile/src/app/group/[id]/itemize.tsx
@@ -470,28 +470,30 @@ export default function ItemizeScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.close} onPress={() => router.back()}>
+          <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.itemize.title}</Text>
+          <Text variant="micro" tone="muted">
+            {groupLabel(group.data, members.data ?? [])}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.itemize.title}</Text>
-            <Text variant="micro" tone="muted">
-              {groupLabel(group.data, members.data ?? [])}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {isShared ? (
           /* A shared bill: the lines are settled, and the only thing left to do
              is say who had what. Everybody sees everybody else's taps. */

--- a/apps/mobile/src/app/group/[id]/map.tsx
+++ b/apps/mobile/src/app/group/[id]/map.tsx
@@ -85,31 +85,33 @@ export default function PlacesScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.tripMap.title}</Text>
+          <Text variant="micro" tone="muted">
+            {group.data?.name}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.tripMap.title}</Text>
-            <Text variant="micro" tone="muted">
-              {group.data?.name}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {loading ? (
           <InsightsSkeleton />
         ) : places.length === 0 ? (

--- a/apps/mobile/src/app/group/[id]/member/[memberId].tsx
+++ b/apps/mobile/src/app/group/[id]/member/[memberId].tsx
@@ -137,32 +137,34 @@ export default function MemberScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{shownName}</Text>
+          <Text variant="micro" tone="muted">
+            {groupLabel(group.data, members.data ?? [])}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{shownName}</Text>
-            <Text variant="micro" tone="muted">
-              {groupLabel(group.data, members.data ?? [])}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <TintCard
           tint={heroTint}
           style={{

--- a/apps/mobile/src/app/group/[id]/members.tsx
+++ b/apps/mobile/src/app/group/[id]/members.tsx
@@ -188,37 +188,36 @@ export default function MembersScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.members}</Text>
+          <Text variant="micro" tone="muted">
+            {groupLabel(group.data, members.data ?? [])}
+          </Text>
+        </View>
+        <IconButton label={t.people.invite} onPress={() => router.push(`/group/${groupId}/invite`)}>
+          <Ionicons name="share-outline" size={iconSize.md} color={theme.color.brand} />
+        </IconButton>
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.members}</Text>
-            <Text variant="micro" tone="muted">
-              {groupLabel(group.data, members.data ?? [])}
-            </Text>
-          </View>
-          <IconButton
-            label={t.people.invite}
-            onPress={() => router.push(`/group/${groupId}/invite`)}
-          >
-            <Ionicons name="share-outline" size={iconSize.md} color={theme.color.brand} />
-          </IconButton>
-        </Row>
-
         {/* Above the member list, because it is a question and the list is not.
             Only admins ever see anything here: the function returns no rows to
             anybody else, so the screen does not have to know who is one. */}

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -134,34 +134,36 @@ export default function SpendingMonthScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{monthTitle}</Text>
+          <Text variant="micro" tone="muted">
+            {`${mine ? t.extras.justMe : t.extras.theGroup} · ${groupLabel(
+              group.data,
+              members.data ?? [],
+            )}`}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{monthTitle}</Text>
-            <Text variant="micro" tone="muted">
-              {`${mine ? t.extras.justMe : t.extras.theGroup} · ${groupLabel(
-                group.data,
-                members.data ?? [],
-              )}`}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {expenses.isLoading ? (
           <View style={{ padding: theme.spacing.xl }}>
             <ActivityIndicator color={theme.color.brand} />

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -432,34 +432,39 @@ export default function PlanScreen() {
 
   return (
     <Screen>
+      <Row
+        style={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.md,
+          gap: theme.spacing.sm,
+        }}
+      >
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <Text variant="heading">{t.plan}</Text>
+        <View style={{ flex: 1 }} />
+        {group.data?.type === 'trip' ? (
+          <IconButton label={t.tripMap.title} onPress={() => router.push(`/group/${groupId}/map`)}>
+            <Ionicons name="location-outline" size={iconSize.lg} color={theme.color.text} />
+          </IconButton>
+        ) : null}
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.lg,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md, gap: theme.spacing.sm }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <Text variant="heading">{t.plan}</Text>
-          <View style={{ flex: 1 }} />
-          {group.data?.type === 'trip' ? (
-            <IconButton
-              label={t.tripMap.title}
-              onPress={() => router.push(`/group/${groupId}/map`)}
-            >
-              <Ionicons name="location-outline" size={iconSize.lg} color={theme.color.text} />
-            </IconButton>
-          ) : null}
-        </Row>
-
         {error ? <Callout tone="negative">{error}</Callout> : null}
 
         {/* Planned against actual, per currency and never added together. */}

--- a/apps/mobile/src/app/group/[id]/recap.tsx
+++ b/apps/mobile/src/app/group/[id]/recap.tsx
@@ -99,31 +99,33 @@ export default function RecapScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.tripInsights.recap}</Text>
+          <Text variant="micro" tone="muted">
+            {group.data?.name}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.tripInsights.recap}</Text>
-            <Text variant="micro" tone="muted">
-              {group.data?.name}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {loading ? (
           <InsightsSkeleton />
         ) : recapData.byCurrency.length === 0 ? (

--- a/apps/mobile/src/app/group/[id]/settings.tsx
+++ b/apps/mobile/src/app/group/[id]/settings.tsx
@@ -301,35 +301,37 @@ export default function GroupSettingsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            <Ionicons name="settings-outline" size={iconSize.md} color={theme.color.brand} />
+            <Text variant="heading">{t.group.settings}</Text>
+          </Row>
+          <Text variant="micro" tone="muted">
+            {groupLabel(group.data, members.data ?? [])}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-              <Ionicons name="settings-outline" size={iconSize.md} color={theme.color.brand} />
-              <Text variant="heading">{t.group.settings}</Text>
-            </Row>
-            <Text variant="micro" tone="muted">
-              {groupLabel(group.data, members.data ?? [])}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Card style={{ gap: theme.spacing.lg }}>
           <Row style={{ gap: theme.spacing.lg }}>
             <GroupPhoto

--- a/apps/mobile/src/app/group/[id]/settle.tsx
+++ b/apps/mobile/src/app/group/[id]/settle.tsx
@@ -260,27 +260,29 @@ export default function SettleScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.close} onPress={() => router.back()}>
+          <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.settleUp}</Text>
+          <Text variant="micro" tone="muted">
+            {group.data?.name}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.settleUp}</Text>
-            <Text variant="micro" tone="muted">
-              {group.data?.name}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {counterparties.length === 0 || !counterparty ? (
           <EmptyState
             title={t.allSettled}

--- a/apps/mobile/src/app/group/[id]/simplify.tsx
+++ b/apps/mobile/src/app/group/[id]/simplify.tsx
@@ -42,31 +42,33 @@ export default function SimplifyScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.whoPaysWhom}</Text>
+          <Text variant="micro" tone="muted">
+            {group.data?.name}
+          </Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.whoPaysWhom}</Text>
-            <Text variant="micro" tone="muted">
-              {group.data?.name}
-            </Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Card style={{ gap: theme.spacing.sm }}>
           <Row style={{ justifyContent: 'space-between' }}>
             <Text variant="subheading">

--- a/apps/mobile/src/app/groups.tsx
+++ b/apps/mobile/src/app/groups.tsx
@@ -210,112 +210,116 @@ export default function AllGroupsScreen() {
 
   return (
     <Screen>
-      <FlashList
-        data={rows}
-        keyExtractor={(row) => (row.kind === 'header' ? 'settled-header' : row.item.group.id)}
-        getItemType={(row) => row.kind}
-        // The group-ledger settings: render well ahead of the viewport so a fast
-        // fling doesn't flash blank rows. The row items already carry their own
-        // balance/pending/count (baked in the memo above), so a money change
-        // flows through `data`; the outside a row reads — locale and theme —
-        // rides the memoised `listExtraData`, which changes identity only on a
-        // real language or light/dark switch, not every render.
-        drawDistance={1500}
-        extraData={listExtraData}
-        contentContainerStyle={{
-          paddingHorizontal: theme.spacing.xl,
-          paddingBottom: clearance,
-        }}
-        showsVerticalScrollIndicator={false}
-        // With the search keyboard open, a tap on a result row should open it in
-        // one go, not be eaten by the keyboard dismiss (FlashList defaults this
-        // to "never").
-        keyboardShouldPersistTaps="handled"
-        ListHeaderComponent={header}
-        ListEmptyComponent={empty}
-        ItemSeparatorComponent={() => (
-          <View style={{ height: 1, backgroundColor: theme.color.border }} />
-        )}
-        renderItem={({ item: row }) => {
-          if (row.kind === 'header') {
+      <View style={{ flex: 1 }}>
+        {/* The nav header is a fixed sibling above the list, so only the roster
+            scrolls under it. Padded to line up with the list rows below. */}
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>{header}</View>
+        <FlashList
+          data={rows}
+          keyExtractor={(row) => (row.kind === 'header' ? 'settled-header' : row.item.group.id)}
+          getItemType={(row) => row.kind}
+          // The group-ledger settings: render well ahead of the viewport so a fast
+          // fling doesn't flash blank rows. The row items already carry their own
+          // balance/pending/count (baked in the memo above), so a money change
+          // flows through `data`; the outside a row reads — locale and theme —
+          // rides the memoised `listExtraData`, which changes identity only on a
+          // real language or light/dark switch, not every render.
+          drawDistance={1500}
+          extraData={listExtraData}
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: clearance,
+          }}
+          showsVerticalScrollIndicator={false}
+          // With the search keyboard open, a tap on a result row should open it in
+          // one go, not be eaten by the keyboard dismiss (FlashList defaults this
+          // to "never").
+          keyboardShouldPersistTaps="handled"
+          ListEmptyComponent={empty}
+          ItemSeparatorComponent={() => (
+            <View style={{ height: 1, backgroundColor: theme.color.border }} />
+          )}
+          renderItem={({ item: row }) => {
+            if (row.kind === 'header') {
+              return (
+                <Text
+                  variant="caption"
+                  tone="muted"
+                  style={{ paddingTop: theme.spacing.lg, paddingBottom: theme.spacing.xs }}
+                >
+                  {row.label}
+                </Text>
+              );
+            }
+
+            const { group, balance, pending, count } = row.item;
+            const statusLabel =
+              balance === 0n ? t.allSettled : balance > 0n ? t.youAreOwed : t.youOwe;
+            // Status first, member count second: the reader's question is "do I
+            // owe or am I owed?", not "how many people". Pending keeps its context
+            // rather than replacing it — it used to swallow the member count whole.
+            const subtitle = pending
+              ? `${t.pendingConfirmation} · ${plural(locale, count, t.memberCount)}`
+              : `${statusLabel} · ${plural(locale, count, t.memberCount)}`;
+            // Settled groups are present, not urgent: dimmed so the eye lands on
+            // the rows that still need something.
+            const dim = !row.item.needsAction;
+
             return (
-              <Text
-                variant="caption"
-                tone="muted"
-                style={{ paddingTop: theme.spacing.lg, paddingBottom: theme.spacing.xs }}
+              <Pressable
+                accessibilityRole="button"
+                // The full subtitle, not just the status word: a pending group at a
+                // zero balance would otherwise be read out as "All settled",
+                // hiding the very state that needs attention.
+                accessibilityLabel={`${row.item.label}. ${subtitle}`}
+                onPress={() => router.push(`/group/${group.id}`)}
+                style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
               >
-                {row.label}
-              </Text>
-            );
-          }
-
-          const { group, balance, pending, count } = row.item;
-          const statusLabel =
-            balance === 0n ? t.allSettled : balance > 0n ? t.youAreOwed : t.youOwe;
-          // Status first, member count second: the reader's question is "do I
-          // owe or am I owed?", not "how many people". Pending keeps its context
-          // rather than replacing it — it used to swallow the member count whole.
-          const subtitle = pending
-            ? `${t.pendingConfirmation} · ${plural(locale, count, t.memberCount)}`
-            : `${statusLabel} · ${plural(locale, count, t.memberCount)}`;
-          // Settled groups are present, not urgent: dimmed so the eye lands on
-          // the rows that still need something.
-          const dim = !row.item.needsAction;
-
-          return (
-            <Pressable
-              accessibilityRole="button"
-              // The full subtitle, not just the status word: a pending group at a
-              // zero balance would otherwise be read out as "All settled",
-              // hiding the very state that needs attention.
-              accessibilityLabel={`${row.item.label}. ${subtitle}`}
-              onPress={() => router.push(`/group/${group.id}`)}
-              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-            >
-              <Row
-                style={{
-                  gap: theme.spacing.md,
-                  alignItems: 'center',
-                  paddingVertical: theme.spacing.sm,
-                  opacity: dim ? 0.55 : 1,
-                }}
-              >
-                {/* The activity feed's row tile — a 40×40 rounded square — so the
+                <Row
+                  style={{
+                    gap: theme.spacing.md,
+                    alignItems: 'center',
+                    paddingVertical: theme.spacing.sm,
+                    opacity: dim ? 0.55 : 1,
+                  }}
+                >
+                  {/* The activity feed's row tile — a 40×40 rounded square — so the
                     two lists read as one family. Activity tints its tile by the
                     verb; a group carries an emoji cover instead, so the tile stays
                     neutral and the emoji is the identity. */}
-                <View
-                  style={{
-                    width: 40,
-                    height: 40,
-                    borderRadius: theme.radius.md,
-                    backgroundColor: theme.color.surfaceMuted,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <Text style={{ fontSize: 20 }}>{group.cover_emoji ?? '👥'}</Text>
-                </View>
-                <View style={{ flex: 1 }}>
-                  <Text variant="body" numberOfLines={2}>
-                    {row.item.label}
-                  </Text>
-                  <Text variant="caption" tone="muted" numberOfLines={1} style={{ marginTop: 2 }}>
-                    {subtitle}
-                  </Text>
-                </View>
-                <MoneyText
-                  amount={balance}
-                  currency={group.default_currency as never}
-                  locale={locale}
-                  mode="balance"
-                  variant="subheading"
-                />
-              </Row>
-            </Pressable>
-          );
-        }}
-      />
+                  <View
+                    style={{
+                      width: 40,
+                      height: 40,
+                      borderRadius: theme.radius.md,
+                      backgroundColor: theme.color.surfaceMuted,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <Text style={{ fontSize: 20 }}>{group.cover_emoji ?? '👥'}</Text>
+                  </View>
+                  <View style={{ flex: 1 }}>
+                    <Text variant="body" numberOfLines={2}>
+                      {row.item.label}
+                    </Text>
+                    <Text variant="caption" tone="muted" numberOfLines={1} style={{ marginTop: 2 }}>
+                      {subtitle}
+                    </Text>
+                  </View>
+                  <MoneyText
+                    amount={balance}
+                    currency={group.default_currency as never}
+                    locale={locale}
+                    mode="balance"
+                    variant="subheading"
+                  />
+                </Row>
+              </Pressable>
+            );
+          }}
+        />
+      </View>
     </Screen>
   );
 }

--- a/apps/mobile/src/app/language.tsx
+++ b/apps/mobile/src/app/language.tsx
@@ -60,41 +60,42 @@ export default function LanguageScreen() {
 
   return (
     <Screen>
+      {/* Back to the gateway, the chevron in the primary ink. */}
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t.common.back}
+          hitSlop={12}
+          onPress={() => (router.canGoBack() ? router.back() : router.replace('/welcome'))}
+          style={({ pressed }) => ({
+            width: 44,
+            height: 44,
+            alignItems: 'center',
+            justifyContent: 'center',
+            opacity: pressed ? 0.6 : 1,
+          })}
+        >
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.buttonPrimary}
+          />
+        </Pressable>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.language}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: insets.bottom + theme.spacing.xxxl,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        {/* Back to the gateway, the chevron in the primary ink. */}
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t.common.back}
-            hitSlop={12}
-            onPress={() => (router.canGoBack() ? router.back() : router.replace('/welcome'))}
-            style={({ pressed }) => ({
-              width: 44,
-              height: 44,
-              alignItems: 'center',
-              justifyContent: 'center',
-              opacity: pressed ? 0.6 : 1,
-            })}
-          >
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.buttonPrimary}
-            />
-          </Pressable>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.language}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {/* Choosing Arabic mirrors the layout only after a restart, so the note
             sits above the list, where the eyes already are. */}
         {restartNeeded ? (

--- a/apps/mobile/src/app/new-group.tsx
+++ b/apps/mobile/src/app/new-group.tsx
@@ -523,25 +523,26 @@ export default function NewGroupScreen() {
 
   return (
     <Screen edges={['top', 'bottom']}>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.close} onPress={() => router.back()}>
+          <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{cloning ? t.clone.duplicateTitle : t.newGroup}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: theme.spacing.xl,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.close} onPress={() => router.back()}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{cloning ? t.clone.duplicateTitle : t.newGroup}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {/* One compact row: the cover — tapped to choose an icon — with the
             name inline beside it and a clear (×) once there is a name. */}
         <Card style={{ paddingVertical: theme.spacing.md }}>

--- a/apps/mobile/src/app/paywall.tsx
+++ b/apps/mobile/src/app/paywall.tsx
@@ -87,25 +87,33 @@ export default function PaywallScreen() {
 
   return (
     <Screen edges={['top', 'bottom']}>
+      {/* Header: close on the left, title centred, a spacer to balance it. */}
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.sm,
+        }}
+      >
+        <IconButton label="Close" onPress={() => router.back()}>
+          <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">Choose your plan</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </View>
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: theme.spacing.xxxl,
           gap: theme.spacing.xxl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        {/* Header: close on the left, title centred, a spacer to balance it. */}
-        <View style={{ flexDirection: 'row', alignItems: 'center', paddingTop: theme.spacing.sm }}>
-          <IconButton label="Close" onPress={() => router.back()}>
-            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">Choose your plan</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </View>
-
         {/* The plans. Tapping one selects it; the selected card wears the brand
             border and a green check. */}
         <View accessibilityRole="radiogroup" style={{ gap: theme.spacing.lg }}>

--- a/apps/mobile/src/app/personal/entry.tsx
+++ b/apps/mobile/src/app/personal/entry.tsx
@@ -172,35 +172,42 @@ function EntryForm({
 
   return (
     <Screen>
+      <Row
+        style={{
+          paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.md,
+          alignItems: 'center',
+        }}
+      >
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{title}</Text>
+        </View>
+        {editing ? (
+          <IconButton label={t.common.delete} onPress={onDelete}>
+            <Ionicons name="trash-outline" size={iconSize.md} color={theme.color.negative} />
+          </IconButton>
+        ) : (
+          <View style={{ width: iconSize.lg }} />
+        )}
+      </Row>
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
+          paddingTop: theme.spacing.lg,
           paddingBottom: clearance,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{title}</Text>
-          </View>
-          {editing ? (
-            <IconButton label={t.common.delete} onPress={onDelete}>
-              <Ionicons name="trash-outline" size={iconSize.md} color={theme.color.negative} />
-            </IconButton>
-          ) : (
-            <View style={{ width: iconSize.lg }} />
-          )}
-        </Row>
-
         {/* A repayment's kind is fixed by the loan, so only a plain entry chooses. */}
         {loanId ? null : (
           <SegmentedTabs

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -262,28 +262,30 @@ function AccountForm() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.contact.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.contact.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {/* A calm identity header: the avatar and name give the screen a focal
             point that names whose account this is (Mobbin — Slopes, Tesla, Me+,
             Vivino: a centred portrait over the name and contact). It is a

--- a/apps/mobile/src/app/settings/archived.tsx
+++ b/apps/mobile/src/app/settings/archived.tsx
@@ -61,28 +61,30 @@ export default function ArchivedGroupsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.group.archivedTitle}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.group.archivedTitle}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {groups.length === 0 ? (
           <EmptyState title={t.group.archivedEmpty} body={t.group.archivedEmptyBody} />
         ) : (

--- a/apps/mobile/src/app/settings/blocked.tsx
+++ b/apps/mobile/src/app/settings/blocked.tsx
@@ -41,28 +41,30 @@ export default function BlockedScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.blocked.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.blocked.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Text variant="caption" tone="muted">
           {t.blocked.note}
         </Text>

--- a/apps/mobile/src/app/settings/categories.tsx
+++ b/apps/mobile/src/app/settings/categories.tsx
@@ -188,40 +188,43 @@ export default function CategoriesSettingsScreen() {
 
   return (
     <Screen>
-      <DraggableFlatList
-        data={order}
-        keyExtractor={(entry) => entry.key}
-        renderItem={renderItem}
-        onDragEnd={({ data }) => {
-          setOrder(data);
-          void commitOrder(data);
-        }}
-        containerStyle={{ flex: 1 }}
-        contentContainerStyle={{
-          paddingHorizontal: theme.spacing.xl,
-          paddingBottom: clearance,
-        }}
-        showsVerticalScrollIndicator={false}
-        ListHeaderComponent={
-          <View>
-            <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
-              <IconButton label={t.common.back} onPress={() => router.back()}>
-                <Ionicons
-                  name={directionalIcon('chevron-back')}
-                  size={iconSize.lg}
-                  color={theme.color.text}
-                />
-              </IconButton>
-              <View style={{ flex: 1, alignItems: 'center' }}>
-                <Text variant="heading">{t.tags.manageTitle}</Text>
-              </View>
-              <IconButton label={t.tags.newTag} onPress={() => setCreating(true)}>
-                <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
-              </IconButton>
-            </Row>
-
-            {/* Hugs the header (small top margin) rather than sitting a full gap
-                below it, so the intro reads as a subtitle of the title above. */}
+      <View style={{ flex: 1 }}>
+        {/* The nav header is a fixed sibling above the drag list, so only the
+            tags scroll under it. Padded to line up with the rows below. */}
+        <View style={{ paddingHorizontal: theme.spacing.xl }}>
+          <Row style={{ paddingTop: theme.spacing.md, alignItems: 'center' }}>
+            <IconButton label={t.common.back} onPress={() => router.back()}>
+              <Ionicons
+                name={directionalIcon('chevron-back')}
+                size={iconSize.lg}
+                color={theme.color.text}
+              />
+            </IconButton>
+            <View style={{ flex: 1, alignItems: 'center' }}>
+              <Text variant="heading">{t.tags.manageTitle}</Text>
+            </View>
+            <IconButton label={t.tags.newTag} onPress={() => setCreating(true)}>
+              <Ionicons name="add" size={iconSize.xxl} color={theme.color.brand} />
+            </IconButton>
+          </Row>
+        </View>
+        <DraggableFlatList
+          data={order}
+          keyExtractor={(entry) => entry.key}
+          renderItem={renderItem}
+          onDragEnd={({ data }) => {
+            setOrder(data);
+            void commitOrder(data);
+          }}
+          containerStyle={{ flex: 1 }}
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: clearance,
+          }}
+          showsVerticalScrollIndicator={false}
+          ListHeaderComponent={
+            // Hugs the (now fixed) header rather than sitting a full gap below it,
+            // so the intro reads as a subtitle of the title above.
             <Text
               variant="caption"
               tone="muted"
@@ -230,26 +233,26 @@ export default function CategoriesSettingsScreen() {
             >
               {t.tags.manageSubtitle}
             </Text>
-          </View>
-        }
-        ListEmptyComponent={
-          <View style={{ paddingTop: theme.spacing.xxxl }}>
-            <EmptyState title={t.tags.noCustomTags} />
-          </View>
-        }
-        ListFooterComponent={
-          order.length > 0 ? (
-            <Text
-              variant="micro"
-              tone="muted"
-              align="center"
-              style={{ marginTop: theme.spacing.md }}
-            >
-              {t.tags.reorderHint}
-            </Text>
-          ) : null
-        }
-      />
+          }
+          ListEmptyComponent={
+            <View style={{ paddingTop: theme.spacing.xxxl }}>
+              <EmptyState title={t.tags.noCustomTags} />
+            </View>
+          }
+          ListFooterComponent={
+            order.length > 0 ? (
+              <Text
+                variant="micro"
+                tone="muted"
+                align="center"
+                style={{ marginTop: theme.spacing.md }}
+              >
+                {t.tags.reorderHint}
+              </Text>
+            ) : null
+          }
+        />
+      </View>
 
       <TagEditorSheet open={creating} onClose={() => setCreating(false)} />
       <TagEditorSheet open={editing !== null} editing={editing} onClose={() => setEditing(null)} />

--- a/apps/mobile/src/app/settings/delete-account.tsx
+++ b/apps/mobile/src/app/settings/delete-account.tsx
@@ -89,29 +89,31 @@ export default function DeleteAccountScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.privacy.deleteTitle}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.privacy.deleteTitle}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Text variant="body" tone="muted">
           {t.privacy.deleteIntro}
         </Text>

--- a/apps/mobile/src/app/settings/devices.tsx
+++ b/apps/mobile/src/app/settings/devices.tsx
@@ -100,28 +100,30 @@ export default function DevicesScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.devices.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.devices.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Text variant="caption" tone="muted">
           {t.devices.intro}
         </Text>

--- a/apps/mobile/src/app/settings/export.tsx
+++ b/apps/mobile/src/app/settings/export.tsx
@@ -108,28 +108,30 @@ export default function ExportScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.exportData.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.exportData.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Card style={{ gap: theme.spacing.sm }}>
           <Row style={{ justifyContent: 'space-between' }}>
             <Text variant="subheading">{t.exportData.everythingFree}</Text>

--- a/apps/mobile/src/app/settings/feedback.tsx
+++ b/apps/mobile/src/app/settings/feedback.tsx
@@ -72,29 +72,31 @@ export default function FeedbackScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.privacy.feedbackTitle}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.privacy.feedbackTitle}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {sent ? (
           <Card style={{ gap: theme.spacing.md, alignItems: 'center' }}>
             <Ionicons name="checkmark-circle" size={iconSize.hero} color={theme.color.positive} />

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -456,30 +456,32 @@ export default function ImportScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.importLedger.ledgerTitle}</Text>
+        </View>
+        <IconButton label={t.importLedger.helpTitle} onPress={() => setHelpOpen(true)}>
+          <Ionicons name="help-circle-outline" size={iconSize.lg} color={theme.color.text} />
+        </IconButton>
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.importLedger.ledgerTitle}</Text>
-          </View>
-          <IconButton label={t.importLedger.helpTitle} onPress={() => setHelpOpen(true)}>
-            <Ionicons name="help-circle-outline" size={iconSize.lg} color={theme.color.text} />
-          </IconButton>
-        </Row>
-
         <Card style={{ gap: theme.spacing.sm }}>
           <Row style={{ justifyContent: 'space-between' }}>
             <Text variant="subheading">{t.importLedger.bringHistory}</Text>

--- a/apps/mobile/src/app/settings/language.tsx
+++ b/apps/mobile/src/app/settings/language.tsx
@@ -134,28 +134,30 @@ export default function LanguageSettingsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.language}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.language}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {/* Above the list, not below it: somebody who has just chosen Arabic and
             is looking at a screen that did not mirror needs the explanation
             where their eyes already are. */}

--- a/apps/mobile/src/app/settings/licenses.tsx
+++ b/apps/mobile/src/app/settings/licenses.tsx
@@ -99,28 +99,30 @@ export default function LicensesScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.privacy.licensesTitle}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.privacy.licensesTitle}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Text variant="body" tone="muted">
           {t.privacy.licensesIntro}
         </Text>

--- a/apps/mobile/src/app/settings/lock.tsx
+++ b/apps/mobile/src/app/settings/lock.tsx
@@ -56,27 +56,29 @@ export default function LockSettingsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.lock.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.lock.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Card>
           <Row style={{ justifyContent: 'space-between' }}>
             <View style={{ flex: 1, paddingRight: theme.spacing.lg }}>

--- a/apps/mobile/src/app/settings/notifications.tsx
+++ b/apps/mobile/src/app/settings/notifications.tsx
@@ -170,28 +170,30 @@ export default function NotificationSettingsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.notifications.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.notifications.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {/* ADR-010: the competition is simultaneously spammy and silent. These
             defaults are the fix, and they are all off-switchable. The promise is
             a "read this" note, so it wears the app's canonical Callout shape

--- a/apps/mobile/src/app/settings/paying.tsx
+++ b/apps/mobile/src/app/settings/paying.tsx
@@ -111,29 +111,31 @@ function PayingForm() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.account.facePaying}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.account.facePaying}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {/* The country decides which rails exist below, so it sits above them
             and is changeable here — the device guess is only a start. */}
         <CountryRow countryCode={country} onChange={onCountry} />

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -99,29 +99,31 @@ export default function PrivacyScreen() {
 
   return (
     <Screen>
+      {/* Back on the left, the title lifted out of the bar into the hero
+          below — the policy leads with a symbol and a heading centred on the
+          page, the way Apple's own privacy sheets open. */}
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1 }} />
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        {/* Back on the left, the title lifted out of the bar into the hero
-            below — the policy leads with a symbol and a heading centred on the
-            page, the way Apple's own privacy sheets open. */}
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1 }} />
-          <View style={{ width: 44 }} />
-        </Row>
-
         <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
           <Ionicons name="people" size={64} color={theme.color.text} />
           <Text

--- a/apps/mobile/src/app/settings/recent.tsx
+++ b/apps/mobile/src/app/settings/recent.tsx
@@ -35,28 +35,30 @@ export default function RecentSettingsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.recent.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.recent.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Text variant="body" tone="muted">
           {t.recent.intro}
         </Text>

--- a/apps/mobile/src/app/settings/redeem.tsx
+++ b/apps/mobile/src/app/settings/redeem.tsx
@@ -86,29 +86,31 @@ export default function RedeemScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.promo.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.promo.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         {granted ? (
           <Card style={{ gap: theme.spacing.md, alignItems: 'center' }}>
             <Ionicons name="checkmark-circle" size={iconSize.hero} color={theme.color.positive} />

--- a/apps/mobile/src/app/settings/shortcut.tsx
+++ b/apps/mobile/src/app/settings/shortcut.tsx
@@ -42,28 +42,30 @@ export default function ShortcutSettingsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.shortcut.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.shortcut.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Text variant="body" tone="muted">
           {t.shortcut.intro}
         </Text>

--- a/apps/mobile/src/app/settings/storage.tsx
+++ b/apps/mobile/src/app/settings/storage.tsx
@@ -73,7 +73,7 @@ export default function StorageUsageScreen() {
   });
 
   const header = (
-    <Row style={{ paddingTop: theme.spacing.md }}>
+    <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
       <IconButton label={t.common.back} onPress={() => router.back()}>
         <Ionicons
           name={directionalIcon('chevron-back')}
@@ -181,15 +181,17 @@ export default function StorageUsageScreen() {
 
   return (
     <Screen>
+      {header}
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        {header}
         {body()}
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/app/settings/sync.tsx
+++ b/apps/mobile/src/app/settings/sync.tsx
@@ -65,28 +65,30 @@ export default function SyncSettingsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.sync.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.sync.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
           {rows.map((row, index) => {
             const chosen = preference === row.value;

--- a/apps/mobile/src/app/settings/theme.tsx
+++ b/apps/mobile/src/app/settings/theme.tsx
@@ -69,28 +69,30 @@ export default function ThemeSettingsScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.theme.title}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.theme.title}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
           {rows.map((row, index) => {
             const chosen = preference === row.value;

--- a/apps/mobile/src/app/settings/upgrade.tsx
+++ b/apps/mobile/src/app/settings/upgrade.tsx
@@ -57,28 +57,30 @@ export default function UpgradeScreen() {
 
   return (
     <Screen>
+      <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
+        <IconButton label={t.common.back} onPress={() => router.back()}>
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.lg}
+            color={theme.color.text}
+          />
+        </IconButton>
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text variant="heading">{t.upgrade}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </Row>
+
       <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: theme.spacing.xl,
           paddingBottom: clearance,
+          paddingTop: theme.spacing.lg,
           gap: theme.spacing.xl,
         }}
         showsVerticalScrollIndicator={false}
       >
-        <Row style={{ paddingTop: theme.spacing.md }}>
-          <IconButton label={t.common.back} onPress={() => router.back()}>
-            <Ionicons
-              name={directionalIcon('chevron-back')}
-              size={iconSize.lg}
-              color={theme.color.text}
-            />
-          </IconButton>
-          <View style={{ flex: 1, alignItems: 'center' }}>
-            <Text variant="heading">{t.upgrade}</Text>
-          </View>
-          <View style={{ width: 44 }} />
-        </Row>
-
         <Card style={{ backgroundColor: theme.color.buttonPrimary, gap: theme.spacing.md }}>
           {/* No badge saying "coming later". A brand badge on a brand-soft card
               is text with an invisible pill behind it, and the heading is

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -49,6 +49,7 @@ import {
   type MirrorCategoryTag,
   type MirrorExpense,
   type SettlementSnapshot,
+  type SettlementTransitionPayload,
   type Transfer,
 } from '@waves/core';
 
@@ -1103,7 +1104,10 @@ export function useConfirmSettlement(groupId: string) {
   const { mutate } = useSync();
   return useMutation({
     mutationFn: (settlementId: string) =>
-      mutate(MutationKind.SettlementTransition, groupId, { settlementId, to: 'confirmed' }),
+      mutate(MutationKind.SettlementTransition, groupId, {
+        settlementId,
+        to: SettlementStatus.Confirmed,
+      } satisfies SettlementTransitionPayload),
   });
 }
 
@@ -1112,7 +1116,10 @@ export function useCancelSettlement(groupId: string) {
   const { mutate } = useSync();
   return useMutation({
     mutationFn: (settlementId: string) =>
-      mutate(MutationKind.SettlementTransition, groupId, { settlementId, to: 'cancelled' }),
+      mutate(MutationKind.SettlementTransition, groupId, {
+        settlementId,
+        to: SettlementStatus.Cancelled,
+      } satisfies SettlementTransitionPayload),
   });
 }
 
@@ -1121,7 +1128,10 @@ export function useDisputeSettlement(groupId: string) {
   const { mutate } = useSync();
   return useMutation({
     mutationFn: (settlementId: string) =>
-      mutate(MutationKind.SettlementTransition, groupId, { settlementId, to: 'disputed' }),
+      mutate(MutationKind.SettlementTransition, groupId, {
+        settlementId,
+        to: SettlementStatus.Disputed,
+      } satisfies SettlementTransitionPayload),
   });
 }
 


### PR DESCRIPTION
## What

Two follow-ups to #591 (which merged before these landed):

1. **Fixed headers everywhere.** On 49 screens the header/hero rode the scroll and slid off the top. Each is now lifted out of its `ScrollView`/`FlashList` to a sibling before it, with the surrounding container flexed so only the body scrolls — mirroring the already-fixed dashboard, friends, group and captures screens. Matches the existing look (no new divider); DOM position + padding only, no logic/i18n/data change. Covers all `settings/*`, the `group/[id]/*` subscreens, the `me` and `expense` heroes, the three `ListHeaderComponent` cases (`groups`, `activity`, `categories`) lifted out of their lists, and assorted others (`profile`, `capture`, `add-expense`, `new-group`, `paywall`, `friends/*`, `personal/entry`, root `language`).

2. **Settlement transition payload typing (CodeRabbit nitpick).** The `settlement.transition` mutate payloads used loose string literals for `to`; typed now with `satisfies SettlementTransitionPayload` and `SettlementStatus` enum members (same wire values) so a bad target is a compile error.

## Gates
`pnpm format`, mobile typecheck, mobile lint, and mobile tests (669) all green locally.