### PR TITLE
test(settlement): db + live coverage for cancel and dispute (A50)

### DIFF
--- a/e2e/m4-live.mjs
+++ b/e2e/m4-live.mjs
@@ -10,6 +10,8 @@
  *
  * Run: node e2e/m4-live.mjs   (needs ANON_KEY)
  */
+import { randomUUID } from 'node:crypto';
+
 import { createClient } from '@supabase/supabase-js';
 
 const URL = process.env.SUPABASE_URL ?? 'https://xvjzbpgcmotoahtqcxve.supabase.co';
@@ -178,6 +180,25 @@ for (const [name, args] of [
   check(
     `${name} is not something a signed-in person can run`,
     Boolean(attempt.error),
+    attempt.error?.message?.slice(0, 60) ?? 'ALLOWED',
+  );
+}
+
+// ── cancel / dispute a pending settlement (A50) ─────────────────────────────
+// A live run cannot stage a real pending settlement without a second account,
+// but it can prove the two hand-transition RPCs are DEPLOYED and grant-reachable
+// by an authenticated caller, and that their own party guard runs at all: a
+// random id belongs to no settlement, so each must answer with its own NOT_FOUND
+// — not PostgREST's "could not find the function", which is exactly how a missing
+// migration or a lost grant would show up instead.
+for (const [name, args] of [
+  ['baaki_cancel_settlement', { p_settlement_id: randomUUID() }],
+  ['baaki_dispute_settlement', { p_settlement_id: randomUUID(), p_reason: null }],
+]) {
+  const attempt = await client.rpc(name, args);
+  check(
+    `${name} is deployed and its guard runs`,
+    /NOT_FOUND/i.test(attempt.error?.message ?? ''),
     attempt.error?.message?.slice(0, 60) ?? 'ALLOWED',
   );
 }

--- a/packages/db/test/m4-cancel-dispute.test.ts
+++ b/packages/db/test/m4-cancel-dispute.test.ts
@@ -1,0 +1,212 @@
+/**
+ * The two ends of a pending settlement the payer and payee can reach by hand.
+ *
+ * A recorded UPI payment sits at `initiated` until the payee confirms it or the
+ * seven-day clock does (m4-auto-confirm). Between those, two people can act:
+ *
+ *   * the PAYER can cancel a claim they should not have made — a duplicate, or a
+ *     payment that never actually went through;
+ *   * the PAYEE can dispute a claim — "that money never reached me".
+ *
+ * Both are party-scoped `SECURITY DEFINER` RPCs (baaki_cancel_settlement /
+ * baaki_dispute_settlement), so the check for *who* may do it lives in the
+ * database, not the client (ADR-013). This proves the who, the idempotency, and
+ * that disputing an auto-confirmed settlement is allowed — the recovery path
+ * ADR-007 promises when the clock confirmed something the payee denies.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, seedGroup } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+interface Pending {
+  groupId: string;
+  settlementId: string;
+  payerProfile: string;
+  payeeProfile: string;
+}
+
+/** A recorded payment the payee has not answered yet. */
+async function initiate(daysAgo = 0): Promise<Pending> {
+  const { groupId, profileIds, memberIds } = await seedGroup(client, { memberCount: 2 });
+  const settlementId = randomUUID();
+  await client.query(
+    `INSERT INTO settlements
+       (id, group_id, from_member_id, to_member_id, currency, amount, method, status, initiated_at)
+     VALUES ($1, $2, $3, $4, 'INR', 42000, 'upi', 'initiated', now() - ($5 || ' days')::interval)`,
+    [settlementId, groupId, memberIds[0], memberIds[1], String(daysAgo)],
+  );
+  return {
+    groupId,
+    settlementId,
+    payerProfile: profileIds[0] ?? '',
+    payeeProfile: profileIds[1] ?? '',
+  };
+}
+
+const statusOf = async (settlementId: string): Promise<string> => {
+  const { rows } = await client.query(`SELECT status FROM settlements WHERE id = $1`, [
+    settlementId,
+  ]);
+  return String(rows[0]?.status);
+};
+
+const setStatus = async (settlementId: string, status: string): Promise<void> => {
+  await client.query(`UPDATE settlements SET status = $2 WHERE id = $1`, [settlementId, status]);
+};
+
+const activityOf = async (
+  groupId: string,
+): Promise<{ verb: string; payload: Record<string, unknown> | null }[]> => {
+  const { rows } = await client.query(
+    `SELECT verb, payload FROM activity_log
+       WHERE group_id = $1 AND object_type = 'settlement' ORDER BY created_at`,
+    [groupId],
+  );
+  return rows as { verb: string; payload: Record<string, unknown> | null }[];
+};
+
+/**
+ * Call one of the transition RPCs as a specific person, exactly as the sync edge
+ * does (`rpcAsCaller`): a signed-in `authenticated` role whose JWT `sub` is that
+ * profile. The party check inside the definer function reads that `sub`.
+ */
+async function callAs<T = unknown>(
+  profileId: string,
+  sql: string,
+  params: unknown[],
+): Promise<T | { error: string }> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query(`SET ROLE authenticated`);
+  try {
+    const { rows } = await client.query(sql, params);
+    return rows[0] as T;
+  } catch (error) {
+    return { error: (error as Error).message };
+  } finally {
+    await client.query(`RESET ROLE`);
+    await client.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  }
+}
+
+const cancel = (profileId: string, settlementId: string) =>
+  callAs(profileId, `SELECT baaki_cancel_settlement($1)`, [settlementId]);
+
+const dispute = (profileId: string, settlementId: string, reason: string | null = null) =>
+  callAs(profileId, `SELECT baaki_dispute_settlement($1, $2)`, [settlementId, reason]);
+
+describe('the payer cancels a claim they should not have made', () => {
+  it('moves a pending settlement to cancelled', async () => {
+    const { settlementId, payerProfile } = await initiate();
+    await cancel(payerProfile, settlementId);
+    expect(await statusOf(settlementId)).toBe('cancelled');
+  });
+
+  it('writes it to the activity log so the group can see it', async () => {
+    const { groupId, settlementId, payerProfile } = await initiate();
+    await cancel(payerProfile, settlementId);
+    const log = await activityOf(groupId);
+    expect(log.map((entry) => entry.verb)).toContain('cancelled');
+  });
+
+  it('refuses the payee — cancel is the payer tool, dispute is theirs', async () => {
+    const { settlementId, payeeProfile } = await initiate();
+    const result = await cancel(payeeProfile, settlementId);
+    expect(result).toMatchObject({ error: expect.stringMatching(/NOT_THE_PAYER/) });
+    expect(await statusOf(settlementId)).toBe('initiated');
+  });
+
+  it('refuses a stranger who is not in the group at all', async () => {
+    const { settlementId } = await initiate();
+    const result = await cancel(randomUUID(), settlementId);
+    expect(result).toMatchObject({ error: expect.stringMatching(/NOT_THE_PAYER/) });
+    expect(await statusOf(settlementId)).toBe('initiated');
+  });
+
+  it('is idempotent — a replayed offline cancel is a no-op, not a second log row', async () => {
+    const { groupId, settlementId, payerProfile } = await initiate();
+    await cancel(payerProfile, settlementId);
+    const again = await cancel(payerProfile, settlementId);
+    expect(again).not.toMatchObject({ error: expect.anything() });
+    expect(await statusOf(settlementId)).toBe('cancelled');
+    const cancels = (await activityOf(groupId)).filter((entry) => entry.verb === 'cancelled');
+    expect(cancels).toHaveLength(1);
+  });
+
+  it('will not unwind a settlement somebody already confirmed', async () => {
+    const { settlementId, payerProfile } = await initiate();
+    await setStatus(settlementId, 'confirmed');
+    const result = await cancel(payerProfile, settlementId);
+    expect(result).toMatchObject({ error: expect.stringMatching(/NOT_CANCELLABLE/) });
+    expect(await statusOf(settlementId)).toBe('confirmed');
+  });
+});
+
+describe('the payee disputes a claim that never reached them', () => {
+  it('moves a pending settlement to disputed', async () => {
+    const { settlementId, payeeProfile } = await initiate();
+    await dispute(payeeProfile, settlementId);
+    expect(await statusOf(settlementId)).toBe('disputed');
+  });
+
+  it('reopens an auto-confirmed one — the clock confirmed what the payee denies', async () => {
+    // The whole reason auto-confirm is acceptable: a week of silence can be
+    // undone by the person it was assumed for. `auto_confirmed → disputed` is a
+    // permitted transition precisely so the debt comes back until it is settled
+    // for real.
+    const { settlementId, payeeProfile } = await initiate();
+    await setStatus(settlementId, 'auto_confirmed');
+    const result = await dispute(payeeProfile, settlementId);
+    expect(result).not.toMatchObject({ error: expect.anything() });
+    expect(await statusOf(settlementId)).toBe('disputed');
+  });
+
+  it('records the reason when one is given', async () => {
+    const { groupId, settlementId, payeeProfile } = await initiate();
+    await dispute(payeeProfile, settlementId, 'never got it');
+    const disputed = (await activityOf(groupId)).find((entry) => entry.verb === 'settle_disputed');
+    expect(disputed?.payload?.reason).toBe('never got it');
+  });
+
+  it('refuses the payer — only the person who was paid can say it never arrived', async () => {
+    const { settlementId, payerProfile } = await initiate();
+    const result = await dispute(payerProfile, settlementId);
+    expect(result).toMatchObject({ error: expect.stringMatching(/NOT_THE_PAYEE/) });
+    expect(await statusOf(settlementId)).toBe('initiated');
+  });
+
+  it('is idempotent — a replayed dispute is a no-op, not a second log row', async () => {
+    const { groupId, settlementId, payeeProfile } = await initiate();
+    await dispute(payeeProfile, settlementId);
+    const again = await dispute(payeeProfile, settlementId);
+    expect(again).not.toMatchObject({ error: expect.anything() });
+    expect(await statusOf(settlementId)).toBe('disputed');
+    const disputes = (await activityOf(groupId)).filter(
+      (entry) => entry.verb === 'settle_disputed',
+    );
+    expect(disputes).toHaveLength(1);
+  });
+
+  it('will not dispute a settlement somebody manually confirmed', async () => {
+    const { settlementId, payeeProfile } = await initiate();
+    await setStatus(settlementId, 'confirmed');
+    const result = await dispute(payeeProfile, settlementId);
+    expect(result).toMatchObject({ error: expect.stringMatching(/NOT_DISPUTABLE/) });
+    expect(await statusOf(settlementId)).toBe('confirmed');
+  });
+});


### PR DESCRIPTION
Follow-up test coverage for the settlement cancel/dispute RPCs (#591).

## DB test — `packages/db/test/m4-cancel-dispute.test.ts`
Runs against real Postgres in the `db.yml` job, calling the two `SECURITY DEFINER` RPCs **as the party** (JWT `sub` + `SET ROLE authenticated`), covering:
- payer cancels `initiated → cancelled`, with an `activity_log` row
- cancel refused for the payee and for a non-member (`NOT_THE_PAYER`)
- cancel is idempotent; refuses a `confirmed` row (`NOT_CANCELLABLE`)
- payee disputes `initiated → disputed`, and **reopens an `auto_confirmed`** one (the ADR-007 recovery path)
- dispute records its reason, is idempotent, refused for the payer (`NOT_THE_PAYEE`) and for a `confirmed` row (`NOT_DISPUTABLE`)

## Live e2e — `e2e/m4-live.mjs`
Asserts both RPCs are **deployed and their party guard runs**: a random id answers with the function's own `NOT_FOUND`, not PostgREST's missing-function error — the shape a lost migration or grant would take. (Runs post-deploy; the migration is still deploy-gated.)

## Remind
Already covered by the existing `packages/db/test/m4-nudge-to-settle.test.ts` — the "remind" action reuses that nudge RPC, unchanged here.

Gates: format + db typecheck green locally; the DB test itself runs in CI (no local Postgres here).