### PR TITLE
fix(mobile): raise bottom sheets above raised cards, fold the plan add into the day heading

### DIFF
--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -777,9 +777,19 @@ export default function PlanScreen() {
               }}
               accessibilityRole="button"
               accessibilityLabel={`${t.add} — ${dayLabel(day.day, locale)}`}
-              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+              accessibilityHint={t.addPlanHint}
+              // A heading is a line of text, and a line of text is a shorter
+              // target than a finger. Now that this line is the only way to add
+              // to a day it has to be reachable like a button: a full-height row
+              // to aim at, and slop around it for the miss.
+              hitSlop={8}
+              style={({ pressed }) => ({
+                minHeight: 44,
+                justifyContent: 'center',
+                opacity: pressed ? 0.6 : 1,
+              })}
             >
-              <Row style={{ justifyContent: 'space-between' }}>
+              <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
                 <Text variant="subheading" tone={day.day === today ? 'brand' : 'default'}>
                   {dayLabel(day.day, locale)}
                 </Text>

--- a/apps/mobile/src/app/group/[id]/plan.tsx
+++ b/apps/mobile/src/app/group/[id]/plan.tsx
@@ -762,139 +762,153 @@ export default function PlanScreen() {
 
         {timeline.days.map((day) => (
           <View key={day.day} style={{ gap: theme.spacing.sm }}>
-            <Row style={{ justifyContent: 'space-between' }}>
-              <Text variant="subheading" tone={day.day === today ? 'brand' : 'default'}>
-                {dayLabel(day.day, locale)}
-              </Text>
-              {Object.entries(day.spentByCurrency).map(([code, amount]) => (
-                <MoneyText
-                  key={code}
-                  amount={amount}
-                  currency={code}
-                  locale={locale}
-                  variant="caption"
-                />
-              ))}
-            </Row>
+            {/* The day heading is the day's add button.
 
-            <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-              {day.items.map((item) => (
-                <Row
-                  key={item.id}
-                  style={{ paddingVertical: theme.spacing.md, gap: theme.spacing.md }}
-                >
-                  <Pressable
-                    onPress={() => void toggle(item)}
-                    accessibilityRole="checkbox"
-                    accessibilityState={{ checked: item.done }}
-                    accessibilityLabel={item.title}
-                    hitSlop={10}
-                  >
-                    <Ionicons
-                      name={item.done ? 'checkmark-circle' : 'ellipse-outline'}
-                      size={iconSize.xl}
-                      color={item.done ? theme.color.positive : theme.color.textFaint}
-                    />
-                  </Pressable>
-                  <View style={{ flex: 1 }}>
-                    <Text variant="body" tone={item.done ? 'faint' : 'default'}>
-                      {item.startsAt ? `${item.startsAt}  ` : ''}
-                      {item.title}
-                    </Text>
-                    {item.note ? (
-                      <Text variant="micro" tone="muted">
-                        {item.note}
-                      </Text>
-                    ) : null}
-                  </View>
-                  {item.plannedMinor !== null ? (
-                    <MoneyText
-                      amount={item.plannedMinor}
-                      currency={item.currency}
-                      locale={locale}
-                      variant="caption"
-                    />
-                  ) : null}
-                  <Pressable
-                    onPress={() => void remove(item)}
-                    accessibilityRole="button"
-                    accessibilityLabel={fill(t.itemize.removeItem, { label: item.title })}
-                    hitSlop={10}
-                  >
-                    <Ionicons name="close" size={iconSize.md} color={theme.color.textFaint} />
-                  </Pressable>
-                </Row>
-              ))}
-
-              {/* What was actually spent that day, so the plan and the ledger
-                  are read in one place rather than two screens apart. */}
-              {day.expenses.map((expense) => (
-                <Row
-                  key={expense.id}
-                  style={{ paddingVertical: theme.spacing.sm, gap: theme.spacing.md }}
-                >
-                  <Ionicons
-                    name="receipt-outline"
-                    size={iconSize.md}
-                    color={theme.color.textFaint}
-                  />
-                  <Text variant="caption" tone="muted" style={{ flex: 1 }} numberOfLines={1}>
-                    {expense.description}
-                  </Text>
+                Every day used to carry a standing "+ Add" row beneath its
+                items, which meant a screen of eight days wore eight identical
+                buttons — the affordance repeated far more loudly than the plan
+                it belonged to. The heading was already the thing being pointed
+                at when somebody wanted to add to that day, so it does the job:
+                tapping it opens the same inline field the row used to. */}
+            <Pressable
+              onPress={() => {
+                setAddingTo(day.day);
+                setTitle('');
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`${t.add} — ${dayLabel(day.day, locale)}`}
+              style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+            >
+              <Row style={{ justifyContent: 'space-between' }}>
+                <Text variant="subheading" tone={day.day === today ? 'brand' : 'default'}>
+                  {dayLabel(day.day, locale)}
+                </Text>
+                {Object.entries(day.spentByCurrency).map(([code, amount]) => (
                   <MoneyText
-                    amount={expense.amountMinor}
-                    currency={expense.currency}
+                    key={code}
+                    amount={amount}
+                    currency={code}
                     locale={locale}
                     variant="caption"
                   />
-                </Row>
-              ))}
+                ))}
+              </Row>
+            </Pressable>
 
-              {addingTo === day.day ? (
-                <View style={{ paddingVertical: theme.spacing.md, gap: theme.spacing.sm }}>
-                  <TextInput
-                    value={title}
-                    onChangeText={setTitle}
-                    placeholder={t.whatIsPlanned}
-                    placeholderTextColor={theme.color.textFaint}
-                    autoFocus
-                    onSubmitEditing={() => void submit(day.day)}
-                    style={{ fontSize: 16, color: theme.color.text, paddingVertical: 4 }}
-                  />
-                  <Row style={{ gap: theme.spacing.sm }}>
-                    <Button
-                      label={t.add}
-                      size="sm"
-                      disabled={busy}
-                      onPress={() => void submit(day.day)}
+            {/* A day with nothing planned, nothing spent and no open field has
+                an empty card to show, and an empty card is a sliver of surface
+                that reads as a rendering fault. It used to always hold at least
+                the "+ Add" row; now that the heading carries that, the card
+                only appears once there is something in it. */}
+            {day.items.length > 0 || day.expenses.length > 0 || addingTo === day.day ? (
+              <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
+                {day.items.map((item) => (
+                  <Row
+                    key={item.id}
+                    style={{ paddingVertical: theme.spacing.md, gap: theme.spacing.md }}
+                  >
+                    <Pressable
+                      onPress={() => void toggle(item)}
+                      accessibilityRole="checkbox"
+                      accessibilityState={{ checked: item.done }}
+                      accessibilityLabel={item.title}
+                      hitSlop={10}
+                    >
+                      <Ionicons
+                        name={item.done ? 'checkmark-circle' : 'ellipse-outline'}
+                        size={iconSize.xl}
+                        color={item.done ? theme.color.positive : theme.color.textFaint}
+                      />
+                    </Pressable>
+                    <View style={{ flex: 1 }}>
+                      <Text variant="body" tone={item.done ? 'faint' : 'default'}>
+                        {item.startsAt ? `${item.startsAt}  ` : ''}
+                        {item.title}
+                      </Text>
+                      {item.note ? (
+                        <Text variant="micro" tone="muted">
+                          {item.note}
+                        </Text>
+                      ) : null}
+                    </View>
+                    {item.plannedMinor !== null ? (
+                      <MoneyText
+                        amount={item.plannedMinor}
+                        currency={item.currency}
+                        locale={locale}
+                        variant="caption"
+                      />
+                    ) : null}
+                    <Pressable
+                      onPress={() => void remove(item)}
+                      accessibilityRole="button"
+                      accessibilityLabel={fill(t.itemize.removeItem, { label: item.title })}
+                      hitSlop={10}
+                    >
+                      <Ionicons name="close" size={iconSize.md} color={theme.color.textFaint} />
+                    </Pressable>
+                  </Row>
+                ))}
+
+                {/* What was actually spent that day, so the plan and the ledger
+                  are read in one place rather than two screens apart. */}
+                {day.expenses.map((expense) => (
+                  <Row
+                    key={expense.id}
+                    style={{ paddingVertical: theme.spacing.sm, gap: theme.spacing.md }}
+                  >
+                    <Ionicons
+                      name="receipt-outline"
+                      size={iconSize.md}
+                      color={theme.color.textFaint}
                     />
-                    <Button
-                      label={t.cancel}
-                      size="sm"
-                      variant="ghost"
-                      onPress={() => {
-                        setAddingTo(null);
-                        setTitle('');
-                      }}
+                    <Text variant="caption" tone="muted" style={{ flex: 1 }} numberOfLines={1}>
+                      {expense.description}
+                    </Text>
+                    <MoneyText
+                      amount={expense.amountMinor}
+                      currency={expense.currency}
+                      locale={locale}
+                      variant="caption"
                     />
                   </Row>
-                </View>
-              ) : (
-                <Pressable
-                  onPress={() => {
-                    setAddingTo(day.day);
-                    setTitle('');
-                  }}
-                  accessibilityRole="button"
-                  accessibilityLabel={`${t.add} — ${dayLabel(day.day, locale)}`}
-                  style={{ paddingVertical: theme.spacing.md }}
-                >
-                  <Text variant="caption" tone="brand">
-                    + {t.add}
-                  </Text>
-                </Pressable>
-              )}
-            </Card>
+                ))}
+
+                {/* Opened by the day's heading above. Nothing stands in its place
+                  when closed: an empty day is already an invitation, and the
+                  heading is the way in. */}
+                {addingTo === day.day ? (
+                  <View style={{ paddingVertical: theme.spacing.md, gap: theme.spacing.sm }}>
+                    <TextInput
+                      value={title}
+                      onChangeText={setTitle}
+                      placeholder={t.whatIsPlanned}
+                      placeholderTextColor={theme.color.textFaint}
+                      autoFocus
+                      onSubmitEditing={() => void submit(day.day)}
+                      style={{ fontSize: 16, color: theme.color.text, paddingVertical: 4 }}
+                    />
+                    <Row style={{ gap: theme.spacing.sm }}>
+                      <Button
+                        label={t.add}
+                        size="sm"
+                        disabled={busy}
+                        onPress={() => void submit(day.day)}
+                      />
+                      <Button
+                        label={t.cancel}
+                        size="sm"
+                        variant="ghost"
+                        onPress={() => {
+                          setAddingTo(null);
+                          setTitle('');
+                        }}
+                      />
+                    </Row>
+                  </View>
+                ) : null}
+              </Card>
+            ) : null}
           </View>
         ))}
       </ScrollView>

--- a/apps/mobile/src/components/expense/SheetOverlay.tsx
+++ b/apps/mobile/src/components/expense/SheetOverlay.tsx
@@ -133,6 +133,15 @@ export function SheetOverlay({
         bottom: 0,
         backgroundColor: 'rgba(10, 10, 26, 0.55)',
         justifyContent: 'flex-end',
+        // Being last in the tree is enough on iOS, but not on Android: there a
+        // raised view paints above every unraised sibling whatever the order,
+        // and this app's cards are raised (`shadow.soft` is elevation 4,
+        // `shadow.lifted` 10, the pill tab bar 6). A sheet with no elevation of
+        // its own therefore opened *underneath* the content it covers — the
+        // Activity feed's cards showed through the backdrop. Sit above all of
+        // them, with the matching zIndex so the web build orders it the same.
+        zIndex: 100,
+        elevation: 24,
       }}
     >
       <Animated.View

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -492,6 +492,8 @@ export interface UiStrings {
   nothingPlannedYet: string;
   planEmptyBody: string;
   whatIsPlanned: string;
+  /** Screen-reader hint on a day heading, which is that day's add button. */
+  addPlanHint: string;
   add: string;
   cancel: string;
   whichGroup: string;
@@ -2689,6 +2691,7 @@ const en: UiStrings = {
   nothingPlannedYet: 'Nothing planned yet',
   planEmptyBody: 'Add the days and what you mean to do. What it actually costs fills itself in.',
   whatIsPlanned: 'What are you doing?',
+  addPlanHint: 'Opens a field to add a plan to this day',
   add: 'Add',
   cancel: 'Cancel',
   whichGroup: 'Which group is this for?',
@@ -4772,6 +4775,7 @@ const ta: UiStrings = {
   planEmptyBody:
     'நாட்களையும் செய்யப் போவதையும் சேருங்கள். உண்மையில் ஆன செலவு தானே நிரம்பிக்கொள்ளும்.',
   whatIsPlanned: 'என்ன செய்யப் போகிறீர்கள்?',
+  addPlanHint: 'இந்த நாளுக்குத் திட்டம் சேர்க்கும் புலத்தைத் திறக்கும்',
   add: 'சேர்',
   cancel: 'ரத்து',
   whichGroup: 'எந்தக் குழுவுக்கு?',
@@ -6930,6 +6934,7 @@ const hi: UiStrings = {
   nothingPlannedYet: 'अभी कोई योजना नहीं',
   planEmptyBody: 'दिन और जो करना है वह जोड़िए। असल में जो लगा वह अपने आप भर जाएगा।',
   whatIsPlanned: 'क्या करना है?',
+  addPlanHint: 'इस दिन में योजना जोड़ने का फ़ील्ड खोलता है',
   add: 'जोड़ें',
   cancel: 'रद्द',
   whichGroup: 'किस समूह के लिए?',
@@ -9032,6 +9037,7 @@ const ar: UiStrings = {
   nothingPlannedYet: 'لا خطة بعد',
   planEmptyBody: 'أضف الأيام وما تنوي فعله. أما التكلفة الفعلية فتُملأ من تلقاء نفسها.',
   whatIsPlanned: 'ماذا ستفعل؟',
+  addPlanHint: 'يفتح حقلاً لإضافة خطة إلى هذا اليوم',
   add: 'إضافة',
   cancel: 'إلغاء',
   whichGroup: 'لأي مجموعة؟',


### PR DESCRIPTION
Two reported UI bugs, both an affordance sitting in the wrong place in the stack.

### The Activity date filter opened behind the feed

Tapping "filter by date" on Activity showed the sheet *underneath* the activity cards.

Being last in the tree is enough on iOS, but not on Android: there a raised view paints above every unraised sibling whatever the tree order. This app's cards are raised — `shadow.soft` is elevation 4, `shadow.lifted` is 10, the pill tab bar is 6 — and `SheetOverlay` had no elevation of its own, so the feed painted straight through the backdrop.

`SheetOverlay` now sits at `elevation: 24` with a matching `zIndex: 100` so the web build orders it the same way. Because it is the shared sheet primitive, this fixes the same latent bug in the currency and group pickers on the capture and add-expense screens.

### The trip plan repeated "+ Add" once per day

Every day section carried a standing `+ Add` row beneath its items, so a screen of eight days wore eight identical buttons — the affordance repeating far more loudly than the plan it belonged to.

The day heading was already the thing being pointed at when somebody wanted to add to that day, so it now does the job: tapping the heading opens the same inline field the row used to. A day with nothing planned, nothing spent and no open field renders no card at all, rather than the empty sliver of surface the add row used to fill.

### Checks

- `tsc --noEmit` clean (the pre-existing `fileURLToPath(URL)` errors in the two vitest configs are untouched and unrelated)
- eslint clean, prettier applied
- full mobile suite: 694 tests / 55 files pass

Not device-tested — the elevation fix in particular is worth a look on a real Android build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily plan headings are now tappable controls for adding items.
  * Empty day cards are hidden unless they contain planned items, expenses, or an active add form.

* **Bug Fixes**
  * Fixed expense sheets appearing behind cards and navigation elements on Android and web.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->