### PR TITLE
fix(voice): one arbiter for the one microphone, so a second capture opens

### DIFF
--- a/apps/mobile/src/components/DictateVoice.tsx
+++ b/apps/mobile/src/components/DictateVoice.tsx
@@ -15,11 +15,13 @@
  *
  * The native recogniser is a single global object with one event stream: every
  * mounted `DictateVoice` (a review screen shows one per expense row) subscribes
- * to the *same* `result`/`error`/`end` events. So a module-level lock hands the
- * mic to one field at a time, and each instance acts on an event only while it
- * is the one listening — otherwise idle rows cross-write the transcript, and a
- * row unmounting (the list changing after "add more") aborts a capture some
- * other surface just started.
+ * to the *same* `result`/`error`/`end` events — and so does the voice quick-add
+ * panel on the other side of the app. So the mic is handed out by the shared
+ * arbiter in `lib/speechMic`, one holder at a time, and each instance acts on an
+ * event only while it is the holder: otherwise idle rows cross-write the
+ * transcript, a row unmounting (the list changing after "add more") aborts a
+ * capture some other surface just started, and the trailing events of a
+ * torn-down session close the one that replaced it.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -36,6 +38,15 @@ import {
   onDeviceLocaleInstalled,
   speechLocale,
 } from '@/lib/dictation';
+import { speechMic } from '@/lib/speechMic';
+
+// Hand the shared arbiter the real recogniser. Safe at module scope: this file
+// is only reached through `DictateButton`'s guarded require, so getting here at
+// all means the native module imported cleanly.
+speechMic.attach({
+  stop: () => ExpoSpeechRecognitionModule.stop(),
+  abort: () => ExpoSpeechRecognitionModule.abort(),
+});
 
 export interface DictateProps {
   /** What is in the field now. Dictation adds to it, never replaces it. */
@@ -48,14 +59,6 @@ export interface DictateProps {
    */
   hints?: readonly string[];
 }
-
-/**
- * Which field currently owns the single native recogniser, or `null` when no
- * dictation is running. Module-level on purpose: it is shared across every
- * mounted `DictateVoice` so a second field cannot start a capture on top of the
- * first, and so only the owning field reacts to the global events.
- */
-let micOwner: symbol | null = null;
 
 /** Whether this phone has a recogniser at all. A phone without one gets no mic. */
 function recognitionAvailable(): boolean {
@@ -135,19 +138,16 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
   const [listening, setListening] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // This instance's identity in the module-level `micOwner` lock. Stable for the
-  // life of the component (lazy-initialised so it is minted once).
-  const [id] = useState(() => Symbol('dictate'));
+  // This instance's claim on the single recogniser. Minted once for the life of
+  // the component, and the answer to "is this event mine?" — the events are
+  // global, so a field that does not hold the mic must ignore every one of them.
+  const [session] = useState(() => Symbol('dictate'));
 
-  // Whether *this* field is the one currently listening, read synchronously
-  // inside the global event handlers. The single-owner lock guarantees at most
-  // one field has this set at a time, so it is a safe stand-in for "this event
-  // is mine" — and it avoids reacting to an event another field's session fired.
-  const listeningRef = useRef(false);
-  const setListeningState = useCallback((next: boolean): void => {
-    listeningRef.current = next;
-    setListening(next);
-  }, []);
+  // A start is already on its way: the mic is claimed but the native call has
+  // not been made yet, because a permission check and an installed-model probe
+  // are awaited first. Without this a double tap would issue two native starts,
+  // the second tearing down the recogniser the first had only just created.
+  const starting = useRef(false);
 
   // What the field held when the mic was tapped. Interim results are re-issued
   // in full, so every one of them is merged onto this rather than onto the
@@ -161,47 +161,78 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
   useSpeechRecognitionEvent('result', (event) => {
     // Only the field that started this capture takes the words — otherwise the
     // other rows' mics would each merge the transcript into their own note too.
-    if (!listeningRef.current) return;
+    if (!speechMic.owns(session)) return;
     const transcript = event.results[0]?.transcript ?? '';
     onChange(mergeTranscript(before.current, transcript));
   });
 
   useSpeechRecognitionEvent('error', (event) => {
-    if (!listeningRef.current) return;
-    micOwner = null;
-    setListeningState(false);
+    if (!speechMic.owns(session)) return;
+    setListening(false);
     const message = dictationError(event.error, t.misc.dictationErrors);
     if (message) setError(message);
+    // The mic is given up by the `end` that follows, so a stop's final result
+    // still lands; the arbiter guards against an `end` that never comes.
+    speechMic.errored(session);
   });
 
   useSpeechRecognitionEvent('end', () => {
-    if (!listeningRef.current) return;
-    micOwner = null;
-    setListeningState(false);
+    const mine = speechMic.owns(session);
+    // Told either way: the recogniser really has finished, and whatever is
+    // waiting to open it next needs exactly this to know it may. A field that
+    // does not own the session is ignored by the arbiter, so this cannot close
+    // another field's capture out from under it.
+    speechMic.ended(session);
+    if (!mine) return;
+    starting.current = false;
+    setListening(false);
   });
 
   const stop = useCallback(() => {
-    // Ask the recogniser to finish — but hold the lock and the listening flag.
-    // stop() (unlike abort()) still delivers one last `result` and then `end`,
-    // and it is the `end`/`error` handlers that clear ownership. Clearing it
-    // here would make that final result's `if (!listeningRef.current) return`
-    // drop the last words the person spoke before tapping stop.
-    ExpoSpeechRecognitionModule.stop();
-  }, []);
+    // Ask the recogniser to finish — but keep the session. stop() (unlike
+    // abort()) still delivers one last `result` and then `end`, and it is the
+    // `end` handler that gives the mic back. Giving it up here would make that
+    // final result's ownership check drop the last words the person spoke
+    // before tapping stop.
+    speechMic.stop(session);
+  }, [session]);
 
   const start = useCallback(async () => {
-    // The mic is a single global object. If another field is mid-dictation,
-    // ignore the tap rather than aborting it: an abort would race that field's
-    // next event and wedge the recogniser for both.
-    if (micOwner !== null && micOwner !== id) return;
-
+    // One start at a time from this field, and one capture at a time in the app.
+    if (starting.current) return;
+    starting.current = true;
     setError(null);
+    // Still holding the mic from a session this field has already given up on —
+    // an error whose `end` never arrived, say. The tap is a deliberate retry, so
+    // let go of the old session here; the claim below then waits for its
+    // teardown rather than opening a second recogniser on top of it.
+    if (speechMic.owns(session)) speechMic.release(session);
+
+    // Claim the mic before the awaits below, and wait here for any previous
+    // session's teardown to land — opening a new one on top of a teardown that
+    // has not run yet is what leaves the next capture silent. If another field
+    // is mid-dictation the claim is refused and the tap does nothing, rather
+    // than aborting them: an abort would race that field's next event and wedge
+    // the recogniser for both.
+    const claimed = await speechMic.acquire(session);
+    if (!mounted.current || !claimed) {
+      starting.current = false;
+      if (claimed) speechMic.release(session);
+      return;
+    }
+
+    // Every path from here gives the mic back. A claim nobody releases is a
+    // recogniser nothing can reopen.
+    const give = (): void => {
+      starting.current = false;
+      speechMic.release(session);
+    };
 
     const permission = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
-    if (!mounted.current) return;
+    if (!mounted.current) return give();
     if (!permission.granted) {
       setError(permission.canAskAgain ? t.misc.micPermission : t.misc.micBlocked);
-      return;
+      return give();
     }
 
     const lang = speechLocale(language, locale);
@@ -210,17 +241,10 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
     // phone that has no model for this language returns silence, so fall to the
     // network recogniser unless the language's model is actually installed.
     const onDevice = await installedOnDeviceFor(lang);
-    if (!mounted.current) return;
-
-    // Re-check the lock right before taking it. The two awaits above (the
-    // permission prompt, the installed-model probe) give another field a window
-    // to claim the mic between the first check and here; without this recheck
-    // two overlapping starts could both reach ExpoSpeechRecognitionModule.start.
-    if (micOwner !== null && micOwner !== id) return;
+    if (!mounted.current) return give();
 
     before.current = value;
-    micOwner = id;
-    setListeningState(true);
+    setListening(true);
 
     try {
       ExpoSpeechRecognitionModule.start({
@@ -237,30 +261,33 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
         contextualStrings: hints && hints.length > 0 ? [...hints] : undefined,
         iosTaskHint: 'dictation',
       });
+      speechMic.opened(session);
+      starting.current = false;
     } catch {
-      micOwner = null;
-      setListeningState(false);
+      setListening(false);
       setError(t.misc.dictationFailed);
+      give();
     }
-  }, [hints, id, language, locale, value, t, setListeningState]);
+  }, [hints, language, locale, session, value, t]);
 
-  // Leaving the screen mid-sentence must not leave the microphone open — but
-  // only this field may abort, and only while it is the one listening. An idle
-  // row unmounting (the list changing after "add more") must not abort a capture
-  // another surface just started.
+  // Leaving the screen mid-sentence must not leave the microphone open — and
+  // must not leave it claimed either. `release` is the one call for both: it
+  // aborts a session this field actually opened, hands back a claim that never
+  // got as far as the native start, and does nothing at all when the mic belongs
+  // to another field (an idle row unmounting as the list changes must not abort
+  // a capture some other surface just started).
+  //
+  // `mounted` is re-armed on the way in, not only cleared on the way out: this
+  // effect is re-run whole by a Fast Refresh, and a flag that only ever goes
+  // false would leave every later start() bailing out after its first await.
   useEffect(() => {
+    mounted.current = true;
     return () => {
       mounted.current = false;
-      if (listeningRef.current) {
-        try {
-          ExpoSpeechRecognitionModule.abort();
-        } catch {
-          // Recogniser already torn down — nothing to abort.
-        }
-        micOwner = null;
-      }
+      starting.current = false;
+      speechMic.release(session);
     };
-  }, []);
+  }, [session]);
 
   if (!available) return null;
 

--- a/apps/mobile/src/components/DictateVoice.tsx
+++ b/apps/mobile/src/components/DictateVoice.tsx
@@ -177,13 +177,13 @@ export function DictateVoice({ value, onChange, hints }: DictateProps) {
   });
 
   useSpeechRecognitionEvent('end', () => {
-    const mine = speechMic.owns(session);
     // Told either way: the recogniser really has finished, and whatever is
-    // waiting to open it next needs exactly this to know it may. A field that
-    // does not own the session is ignored by the arbiter, so this cannot close
-    // another field's capture out from under it.
-    speechMic.ended(session);
-    if (!mine) return;
+    // waiting to open it next needs exactly this to know it may. The answer
+    // decides whether the ending was *this* field's — which is not the same as
+    // owning the mic right now, because a previous session's teardown can
+    // report in after the guard timer settled it and this field opened. Acting
+    // on that late ending would close a dictation that has barely started.
+    if (!speechMic.ended(session)) return;
     starting.current = false;
     setListening(false);
   });

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -33,8 +33,29 @@ import { iconSize, Text, useTheme, type Theme } from '@waves/ui';
 import { useStrings } from '@/i18n';
 import { dictationError, englishSpeechLocale } from '@/lib/dictation';
 import { useReducedMotion } from '@/lib/reducedMotion';
+import { speechMic } from '@/lib/speechMic';
 
 const MIC_SIZE = 104;
+
+// Hand the shared arbiter the real recogniser. Safe at module scope: this file
+// is only ever loaded through `VoiceMicPanel`'s guarded require, so reaching it
+// at all means the native module imported cleanly.
+speechMic.attach({
+  stop: () => ExpoSpeechRecognitionModule.stop(),
+  abort: () => ExpoSpeechRecognitionModule.abort(),
+});
+
+/**
+ * How long a session may stay completely inert before it is written off.
+ *
+ * A live recogniser says so within a beat — `start` (ready for speech) lands
+ * well under a second, and `volumechange` follows it continuously. A session
+ * that has produced *nothing at all* after this long is not listening: its
+ * recogniser was destroyed under it, which the platform reports by saying
+ * nothing whatsoever. Generous on purpose, because the only cost of waiting is
+ * a slower error and the cost of firing early is cutting somebody off.
+ */
+const STALL_MS = 8000;
 
 /**
  * A soft halo that breathes behind the mic while it listens — a slow, low-opacity
@@ -398,23 +419,39 @@ export function VoiceCapture({
   const mounted = useRef(true);
   // Guards the one auto-start so a re-render never reopens the mic.
   const started = useRef(false);
-  // Mirrors `listening` for the unmount cleanup to read. The panel is remounted
-  // (via a changing `key`) to start each new capture; its cleanup must abort a
-  // mic that is still open, but must NOT abort an already-idle recogniser — a
-  // needless abort() races the next mount's start() on the Android singleton and
-  // leaves the second capture stuck on "listening" with nothing happening.
-  const listeningRef = useRef(false);
-  // Set the listening flag and its ref together, synchronously, at every
-  // transition — so the unmount cleanup below always reads the true state. A
-  // passive effect mirroring the ref could still be pending when a fast remount
-  // unmounts this instance, leaving the ref stale (an open mic not aborted, or an
-  // idle one needlessly aborted).
-  const setListeningState = useCallback((next: boolean): void => {
-    listeningRef.current = next;
-    setListening(next);
+
+  // This instance's claim on the single recogniser (see lib/speechMic). Minted
+  // once per mount, and the answer to "is this event mine?" — the events are
+  // global, so a panel that does not hold the mic must ignore every one of them.
+  // In particular the `end` a *previous* panel's abort still owes belongs to
+  // nobody, and closing this capture on it is what left the second attempt dead.
+  const [session] = useState(() => Symbol('voice-capture'));
+
+  // A start is already on its way — the mic is claimed but the native call has
+  // not been made yet, because a permission check and an installed-model probe
+  // are awaited first. Two taps inside that window would otherwise both see an
+  // idle mic and issue two native starts, the second destroying the first.
+  const starting = useRef(false);
+
+  // Nothing at all has come back from this session yet. Armed when the native
+  // start is issued, disarmed by the first event of any kind; if it fires, the
+  // recogniser never woke up and the panel says so instead of sitting on
+  // "listening" forever.
+  const stall = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearStall = useCallback((): void => {
+    if (stall.current === null) return;
+    clearTimeout(stall.current);
+    stall.current = null;
   }, []);
 
+  useSpeechRecognitionEvent('start', () => {
+    if (!speechMic.owns(session)) return;
+    clearStall();
+  });
+
   useSpeechRecognitionEvent('result', (event) => {
+    if (!speechMic.owns(session)) return;
+    clearStall();
     const transcript = event.results[0]?.transcript ?? '';
     latest.current = transcript;
     setLive(transcript);
@@ -424,6 +461,8 @@ export function VoiceCapture({
   // start). `value` runs −2…10, where below 0 is inaudible; normalise to 0…1 and
   // ease so the wave tracks loudness without twitching on every packet.
   useSpeechRecognitionEvent('volumechange', (event) => {
+    if (!speechMic.owns(session)) return;
+    clearStall();
     const norm = Math.max(0, Math.min(1, event.value / 10));
     // `.set()`, not `.value =`: Reanimated 4's method API, the one the React
     // compiler allows off the UI thread (see PressableScale in lib/anim).
@@ -431,14 +470,28 @@ export function VoiceCapture({
   });
 
   useSpeechRecognitionEvent('error', (event) => {
+    if (!speechMic.owns(session)) return;
+    clearStall();
     const message = dictationError(event.error, t.misc.dictationErrors);
     if (message) setError(message);
-    setListeningState(false);
+    setListening(false);
     level.set(withTiming(0, { duration: 150 }));
+    // Ownership is held for the `end` that follows, so it is still recognised as
+    // this session's; the arbiter arms its own guard in case that `end` never
+    // comes.
+    speechMic.errored(session);
   });
 
   useSpeechRecognitionEvent('end', () => {
-    setListeningState(false);
+    const mine = speechMic.owns(session);
+    // Told either way: the recogniser really has finished, and the next capture
+    // is waiting on exactly this to know it may open. A panel that does not own
+    // the session is ignored by the arbiter, so this cannot close somebody
+    // else's capture.
+    speechMic.ended(session);
+    if (!mine) return;
+    clearStall();
+    setListening(false);
     level.set(withTiming(0, { duration: 150 }));
     const said = latest.current.trim();
     if (said) onDone(said);
@@ -449,6 +502,14 @@ export function VoiceCapture({
   });
 
   const start = useCallback(async (): Promise<void> => {
+    // One start at a time from this panel, and one capture at a time in the app.
+    if (starting.current) return;
+    starting.current = true;
+    // Still holding the mic from a session the panel has already given up on —
+    // an error whose `end` never arrived, say. The tap is a deliberate retry, so
+    // let go of the old session here; the claim below then waits for its
+    // teardown rather than opening a second recogniser on top of it.
+    if (speechMic.owns(session)) speechMic.release(session);
     setError(null);
     // Speaking again is the retry: clear both miss states as the mic opens, and
     // let the screen drop any parsed miss it is still holding.
@@ -458,20 +519,40 @@ export function VoiceCapture({
     setLive('');
     level.set(0);
 
+    // Claim the recogniser first, and wait here for any previous session's
+    // teardown to land. Everything below must give it back — a claimed mic that
+    // is never released is one nothing can reopen.
+    const claimed = await speechMic.acquire(session);
+    if (!mounted.current) {
+      starting.current = false;
+      if (claimed) speechMic.release(session);
+      return;
+    }
+    if (!claimed) {
+      starting.current = false;
+      setError(t.misc.dictationFailed);
+      return;
+    }
+
+    const give = (): void => {
+      starting.current = false;
+      speechMic.release(session);
+    };
+
     const permission = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
-    if (!mounted.current) return;
+    if (!mounted.current) return give();
     if (!permission.granted) {
       setError(permission.canAskAgain ? t.misc.micPermission : t.misc.micBlocked);
-      return;
+      return give();
     }
 
     // On-device only when an English model is actually installed; otherwise the
     // recogniser is left to use the network, which speaks English on every phone.
     // Requiring on-device for a model that is not there is what returned silence.
     const onDevice = await englishInstalledOnDevice();
-    if (!mounted.current) return;
+    if (!mounted.current) return give();
 
-    setListeningState(true);
+    setListening(true);
     try {
       ExpoSpeechRecognitionModule.start({
         // Recognition is English-only — the surface each speaker reads is still
@@ -501,15 +582,32 @@ export function VoiceCapture({
           EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS: 2000,
         },
       });
+      speechMic.opened(session);
+      starting.current = false;
+      // Nothing has come back yet; if nothing ever does, the recogniser was
+      // torn down under us and the panel must say so rather than pretend.
+      clearStall();
+      stall.current = setTimeout(() => {
+        stall.current = null;
+        if (!mounted.current || !speechMic.owns(session)) return;
+        setListening(false);
+        level.set(withTiming(0, { duration: 150 }));
+        setError(t.misc.dictationFailed);
+        speechMic.release(session);
+      }, STALL_MS);
     } catch {
-      setListeningState(false);
+      setListening(false);
       setError(t.misc.dictationFailed);
+      give();
     }
-  }, [hints, level, locale, onListen, setListeningState, t]);
+  }, [clearStall, hints, level, locale, onListen, session, t]);
 
   const stop = useCallback((): void => {
-    ExpoSpeechRecognitionModule.stop();
-  }, []);
+    // Ask the recogniser to finish, but keep the session: `stop()` (unlike
+    // `abort()`) still delivers one last `result`, and giving the mic up here
+    // would make the handler above drop the words spoken before the tap.
+    speechMic.stop(session);
+  }, [session]);
 
   // Open the mic as the screen appears — the reader tapped a mic to get here, so
   // making them tap a second one to start would be a step too many. Suppressed
@@ -522,17 +620,24 @@ export function VoiceCapture({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [available, autoStart]);
 
-  // Leaving mid-sentence must not leave the microphone open — but only abort when
-  // the mic is actually open. On a remount to start the next capture the previous
-  // instance has usually already finished (idle); aborting it then needlessly
-  // disrupts the singleton recogniser and the next start() does nothing, leaving
-  // the second capture stuck on "listening".
+  // Leaving mid-sentence must not leave the microphone open, and must not leave
+  // it claimed either: the panel is remounted (via a changing `key`) to start
+  // each new capture, and a claim nobody gives back is a mic the next mount can
+  // never open. `release` is the one call for both — it aborts a live session
+  // and simply hands back a claim that never got as far as the native start.
+  //
+  // `mounted` is re-armed on the way in, not just cleared on the way out: this
+  // effect is re-run whole by a Fast Refresh, and a flag that only ever goes
+  // false would leave every later `start()` bailing out after its first await.
   useEffect(() => {
+    mounted.current = true;
     return () => {
       mounted.current = false;
-      if (listeningRef.current) ExpoSpeechRecognitionModule.abort();
+      clearStall();
+      starting.current = false;
+      speechMic.release(session);
     };
-  }, []);
+  }, [clearStall, session]);
 
   if (!available) {
     return (

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -483,13 +483,14 @@ export function VoiceCapture({
   });
 
   useSpeechRecognitionEvent('end', () => {
-    const mine = speechMic.owns(session);
     // Told either way: the recogniser really has finished, and the next capture
-    // is waiting on exactly this to know it may open. A panel that does not own
-    // the session is ignored by the arbiter, so this cannot close somebody
-    // else's capture.
-    speechMic.ended(session);
-    if (!mine) return;
+    // is waiting on exactly this to know it may open. The answer decides whether
+    // the ending was *this* capture's — which is not the same as owning the mic
+    // right now. A previous session's teardown can report in late, after the
+    // guard timer settled it and this panel opened; the arbiter swallows it, and
+    // this panel must not act on it either, or it closes a capture that has
+    // barely started.
+    if (!speechMic.ended(session)) return;
     clearStall();
     setListening(false);
     level.set(withTiming(0, { duration: 150 }));

--- a/apps/mobile/src/lib/speechMic.ts
+++ b/apps/mobile/src/lib/speechMic.ts
@@ -201,7 +201,8 @@ export class SpeechMic {
   }
 
   /**
-   * The recogniser reported `end`.
+   * The recogniser reported `end`. **Returns whether `token`'s capture is the
+   * one that just ended** — and so whether the caller should act on it.
    *
    * Every mounted surface hears the event, so each passes its own token and only
    * the owner's word is taken — otherwise an idle panel's handler, running first
@@ -209,20 +210,35 @@ export class SpeechMic {
    * and the owner would drop the final transcript. When there is no owner (the
    * trailing `end` of an aborted session) anybody may settle it, which is what
    * lets the next capture stop waiting.
+   *
+   * The return value is not a convenience. Asking `owns(token)` *before* calling
+   * this is not the same question and gets the dangerous answer: once the guard
+   * timer has settled an aborted session and a new capture has opened, the new
+   * capture owns the mic, so `owns` says yes — and then the old session's late
+   * `end` arrives and the caller closes a capture that has barely started. That
+   * is the original "the mic only works once" bug reaching the screen by the
+   * back door, with the arbiter's own state perfectly correct underneath. Only
+   * this method knows the ending was somebody else's, so only this method can
+   * answer, and it must be the single call the caller branches on.
    */
-  ended(token?: symbol): void {
+  ended(token?: symbol): boolean {
     const owed = this.owed !== 0 && Date.now() < this.owed;
     if (owed) {
       this.owed = 0;
-      // This is the aborted session finally reporting in. If the mic has moved
-      // on to somebody else in the meantime, that is all it is — swallow it.
-      if (this.phase !== 'closing') return;
+      // This is the aborted session finally reporting in. Either way it is not
+      // the caller's ending: it settles a teardown still in progress, or — if
+      // the mic has moved on to somebody else in the meantime — it is swallowed.
+      if (this.phase !== 'closing') return false;
       this.settle();
-      return;
+      return false;
     }
-    if (this.phase === 'idle') return;
-    if (this.owner !== null && this.owner !== token) return;
+    if (this.phase === 'idle') return false;
+    if (this.owner !== null && this.owner !== token) return false;
+    // Null owner here is the trailing `end` of a session already given up on:
+    // worth settling so the next capture may open, but nobody's to act on.
+    const mine = this.owner === token;
     this.settle();
+    return mine;
   }
 
   private settle(): void {

--- a/apps/mobile/src/lib/speechMic.ts
+++ b/apps/mobile/src/lib/speechMic.ts
@@ -1,0 +1,262 @@
+/**
+ * Who is holding the one microphone, and when the next capture may open it.
+ *
+ * Both platforms give the app a *single* recogniser object with a *single*
+ * global event stream — `ExpoSpeechRecognitionModule.start/stop/abort` and the
+ * `result`/`error`/`end` events are the same recogniser no matter which screen
+ * asked. Every surface that dictates (the note mic on an expense, the quick-add
+ * panel on the voice screen) therefore hears every other surface's events, and
+ * a second `start()` issued before the previous session has finished tearing
+ * down does not queue — it lands on top of it.
+ *
+ * That is the whole family of "the mic worked once and then went dead":
+ *
+ *  - **A stale `end` closes the new session.** `abort()` does not end the
+ *    session there and then; it queues a teardown (Android posts it to the main
+ *    looper, iOS runs it in a `Task`) and the `end` arrives some milliseconds
+ *    later. By then the panel that aborted has usually been replaced by a fresh
+ *    one, which — hearing an `end` it never asked for — decides its own capture
+ *    is over before it has begun.
+ *  - **The teardown eats the new recogniser.** That queued teardown calls
+ *    `cancel()`/`destroy()` on whatever the recogniser field happens to hold
+ *    when it finally runs. Start a new session first and it destroys *that* one,
+ *    silently: no result, no error, no `end`, a mic stuck on "listening".
+ *  - **Two starts at once.** Opening the mic is not instant on our side either
+ *    — there is a permission call and an installed-model probe to await first —
+ *    so two taps (or a tap racing the auto-start) can both get past a
+ *    `listening` check and issue two native starts, with the same outcome.
+ *
+ * So one object owns the recogniser at a time, and the next owner waits for the
+ * previous one's `end` before opening it. Kept free of React and of the native
+ * module so the sequencing can be tested without a device — the microphone
+ * itself is injected as a two-call driver.
+ */
+
+/**
+ * How long to wait for the `end` a torn-down session still owes us before
+ * assuming it will never come.
+ *
+ * A guard, not a schedule: `end` normally lands within a frame or two of the
+ * teardown. But it is emitted by the native side, and if the app navigates away
+ * while a capture is open there may be no component mounted to hand it to us at
+ * all. Without the timer the mic would be locked shut for the rest of the
+ * session — a far worse failure than the race it is protecting against.
+ */
+const SETTLE_MS = 1500;
+
+/**
+ * The phase of the one recogniser.
+ *
+ * `held` is the gap our own code opens: the owner has the mic but has not
+ * issued the native start yet (it is still awaiting permission and the
+ * on-device probe). Nothing is running natively, so giving the mic up from
+ * `held` needs no teardown and no wait.
+ */
+export type SpeechMicPhase = 'idle' | 'held' | 'open' | 'stopping' | 'closing';
+
+/** The two calls this needs from the native recogniser. */
+export interface SpeechMicDriver {
+  /** Finish the utterance and deliver a last result. */
+  stop: () => void;
+  /** Drop the session; no final result. */
+  abort: () => void;
+}
+
+export class SpeechMic {
+  private driver: SpeechMicDriver | null = null;
+  private owner: symbol | null = null;
+  private phase: SpeechMicPhase = 'idle';
+  private waiting: (() => void)[] = [];
+  private guard: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * When the `end` an aborted session still owes stops being believable —
+   * epoch milliseconds, or 0 when nothing is owed. See {@link release}.
+   */
+  private owed = 0;
+
+  constructor(private readonly settleMs: number = SETTLE_MS) {}
+
+  /**
+   * Point this at the real recogniser.
+   *
+   * Called at module load by each surface that owns a mic, because those files
+   * are the only ones allowed to touch `expo-speech-recognition` (its import
+   * throws on binaries built before the native module existed, so it is reached
+   * through a guarded `require`). Every caller attaches the same two calls, so
+   * attaching twice is harmless.
+   */
+  attach(driver: SpeechMicDriver): void {
+    this.driver = driver;
+  }
+
+  /** What the recogniser is doing — for tests and for reasoning, not for UI. */
+  get state(): SpeechMicPhase {
+    return this.phase;
+  }
+
+  /** Whether `token` is the session the recogniser's events belong to. */
+  owns(token: symbol): boolean {
+    return this.owner === token;
+  }
+
+  /**
+   * Take the mic for `token`, waiting out a previous session's teardown.
+   *
+   * Resolves `false` when somebody else is mid-capture — the caller should do
+   * nothing rather than abort them, because an abort would race that session's
+   * next event and wedge the recogniser for both. Resolves `true` with the mic
+   * held, which the caller **must** eventually give back through
+   * {@link release}, on every path including the ones that never open it (a
+   * refused permission, an unmount while the permission sheet is up). A `held`
+   * mic nobody releases is a mic nobody can use again.
+   */
+  async acquire(token: symbol): Promise<boolean> {
+    if (this.owner !== null) return false;
+    // A session that has been aborted still owes us an `end`; opening the next
+    // one before it lands is exactly what lets the old teardown destroy the new
+    // recogniser. Wait it out (or wait out the guard timer).
+    if (this.phase === 'closing') await this.settled();
+    // Somebody else may have taken it while we waited.
+    if (this.owner !== null) return false;
+    this.owner = token;
+    this.phase = 'held';
+    return true;
+  }
+
+  /**
+   * The native `start()` has been issued for `token` — events from here on
+   * belong to it.
+   */
+  opened(token: symbol): void {
+    if (this.owner !== token) return;
+    this.phase = 'open';
+  }
+
+  /**
+   * Ask the recogniser to finish, keeping ownership until `end`.
+   *
+   * Ownership is deliberately held across the stop: `stop()` (unlike `abort()`)
+   * still delivers one last `result`, and dropping ownership here would make the
+   * owner ignore the very words somebody spoke before tapping stop.
+   */
+  stop(token: symbol): void {
+    if (this.owner !== token || this.phase !== 'open') return;
+    this.phase = 'stopping';
+    // A recogniser that answers a stop with silence must not hold the mic shut.
+    this.arm();
+    try {
+      this.driver?.stop();
+    } catch {
+      // Already torn down natively — the guard timer settles it.
+    }
+  }
+
+  /**
+   * Give the mic back.
+   *
+   * Ownership is dropped *first* and synchronously, so the `error: aborted` that
+   * `abort()` emits on the spot — and the `end` that follows it a few
+   * milliseconds later — belong to nobody and are ignored by whichever panel is
+   * mounted by then, rather than ending its capture for it.
+   */
+  release(token: symbol): void {
+    if (this.owner !== token) return;
+    const live = this.phase === 'open' || this.phase === 'stopping';
+    this.owner = null;
+    if (!live) {
+      // Nothing was ever started natively (`held`): there is no teardown to wait
+      // for, so the next capture may open immediately.
+      this.settle();
+      return;
+    }
+    this.phase = 'closing';
+    // One `end` is now owed. Normally it lands while we are still `closing` and
+    // settles it; if the guard timer gets there first and the next capture has
+    // already opened, that late `end` must be swallowed rather than mistaken for
+    // the new session's — which is the "second capture dies on somebody else's
+    // ending" bug, arriving by the back door. The debt expires so a teardown
+    // that never reports at all cannot swallow a genuine ending forever.
+    this.owed = Date.now() + this.settleMs * 2;
+    this.arm();
+    try {
+      this.driver?.abort();
+    } catch {
+      // Already torn down — the guard timer settles it.
+    }
+  }
+
+  /**
+   * The recogniser reported `error` on the owner's session.
+   *
+   * Every native error path is supposed to emit an `end` behind it, and holding
+   * ownership until it lands is what lets the owner recognise its own ending.
+   * But "supposed to" is not a guarantee across two platforms and several error
+   * codes, so the guard timer is armed here too: a session that errors and then
+   * says nothing more settles on its own instead of holding the mic shut.
+   */
+  errored(token: symbol): void {
+    if (this.owner !== token || this.phase !== 'open') return;
+    this.phase = 'stopping';
+    this.arm();
+  }
+
+  /**
+   * The recogniser reported `end`.
+   *
+   * Every mounted surface hears the event, so each passes its own token and only
+   * the owner's word is taken — otherwise an idle panel's handler, running first
+   * in the subscription order, would close the session out from under the owner
+   * and the owner would drop the final transcript. When there is no owner (the
+   * trailing `end` of an aborted session) anybody may settle it, which is what
+   * lets the next capture stop waiting.
+   */
+  ended(token?: symbol): void {
+    const owed = this.owed !== 0 && Date.now() < this.owed;
+    if (owed) {
+      this.owed = 0;
+      // This is the aborted session finally reporting in. If the mic has moved
+      // on to somebody else in the meantime, that is all it is — swallow it.
+      if (this.phase !== 'closing') return;
+      this.settle();
+      return;
+    }
+    if (this.phase === 'idle') return;
+    if (this.owner !== null && this.owner !== token) return;
+    this.settle();
+  }
+
+  private settle(): void {
+    if (this.guard !== null) {
+      clearTimeout(this.guard);
+      this.guard = null;
+    }
+    this.owner = null;
+    this.phase = 'idle';
+    const waiting = this.waiting;
+    this.waiting = [];
+    for (const resolve of waiting) resolve();
+  }
+
+  private arm(): void {
+    if (this.guard !== null) clearTimeout(this.guard);
+    this.guard = setTimeout(() => {
+      this.guard = null;
+      this.settle();
+    }, this.settleMs);
+  }
+
+  private settled(): Promise<void> {
+    if (this.phase === 'idle') return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.waiting.push(resolve);
+    });
+  }
+}
+
+/**
+ * The app's one microphone.
+ *
+ * A module singleton because the thing it stands for is a singleton: there is
+ * one recogniser in the process, whatever is on screen.
+ */
+export const speechMic = new SpeechMic();

--- a/apps/mobile/test/speechMic.test.ts
+++ b/apps/mobile/test/speechMic.test.ts
@@ -125,9 +125,68 @@ describe('whose event is this', () => {
 
     // The first session's `end` finally lands. It is not the second's, and
     // closing the second on it is exactly the bug being fixed.
-    mic.ended(second);
+    expect(mic.ended(second)).toBe(false);
     expect(mic.owns(second)).toBe(true);
     expect(mic.state).toBe('open');
+  });
+
+  /**
+   * The arbiter keeping the session is only half the fix.
+   *
+   * A caller that asks `owns(token)` and *then* reports the ending gets `true`
+   * here — it does own the mic, the new capture is live — and goes on to close
+   * its own capture on somebody else's ending. The arbiter's state stays
+   * perfectly correct while the screen shows the original bug. So the answer
+   * the caller branches on has to come from `ended` itself.
+   */
+  it('tells the new capture that a late ending was not its own', async () => {
+    const first = Symbol('first');
+    await mic.acquire(first);
+    mic.opened(first);
+    mic.release(first);
+
+    const second = Symbol('second');
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    await mic.acquire(second);
+    mic.opened(second);
+
+    // What the old code asked, and the answer that misled it.
+    expect(mic.owns(second)).toBe(true);
+    // What the caller must ask instead.
+    expect(mic.ended(second)).toBe(false);
+  });
+
+  it('tells a capture when the ending really is its own', async () => {
+    const only = Symbol('only');
+    await mic.acquire(only);
+    mic.opened(only);
+
+    expect(mic.ended(only)).toBe(true);
+    expect(mic.state).toBe('idle');
+  });
+
+  it('tells a bystander the ending was not its own', async () => {
+    const owner = Symbol('owner');
+    const bystander = Symbol('bystander');
+    await mic.acquire(owner);
+    mic.opened(owner);
+
+    expect(mic.ended(bystander)).toBe(false);
+    // The owner's own ending still reaches it afterwards.
+    expect(mic.ended(owner)).toBe(true);
+  });
+
+  it('tells nobody to act on the trailing ending of an abandoned session', async () => {
+    const gone = Symbol('gone');
+    const watcher = Symbol('watcher');
+    await mic.acquire(gone);
+    mic.opened(gone);
+    mic.release(gone);
+
+    // Still `closing`: this ending settles the teardown so the next capture may
+    // open, but it belongs to a session nobody is rendering any more.
+    expect(mic.ended(watcher)).toBe(false);
+    expect(mic.state).toBe('idle');
   });
 
   it('will not let an idle surface close the capture somebody else is running', async () => {

--- a/apps/mobile/test/speechMic.test.ts
+++ b/apps/mobile/test/speechMic.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Handing the one microphone from one capture to the next.
+ *
+ * The device bug these are written against is always the same shape: the first
+ * utterance is heard and the second one is not. Every case below is a way that
+ * used to happen — a previous session's ending closing the new one, a teardown
+ * running after the new start and destroying it, two starts issued at once, or a
+ * claim nobody ever gave back. None of it can be seen on the emulator (no live
+ * mic), so the sequencing is tested here instead of asserted on a device.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { SpeechMic } from '@/lib/speechMic';
+
+const SETTLE = 1000;
+
+let driver: { stop: Mock<() => void>; abort: Mock<() => void> };
+let mic: SpeechMic;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  driver = { stop: vi.fn<() => void>(), abort: vi.fn<() => void>() };
+  mic = new SpeechMic(SETTLE);
+  mic.attach(driver);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** A capture that runs to completion: claimed, opened, and ended by the mic. */
+async function fullCapture(token: symbol): Promise<void> {
+  await mic.acquire(token);
+  mic.opened(token);
+  mic.ended(token);
+}
+
+describe('one capture after another', () => {
+  it('hands the mic straight to the next capture when the last one ended', async () => {
+    const first = Symbol('first');
+    await fullCapture(first);
+
+    expect(mic.state).toBe('idle');
+    expect(mic.owns(first)).toBe(false);
+    // The completed session is already torn down natively; aborting it again is
+    // what used to race the next start and leave the second capture silent.
+    expect(driver.abort).not.toHaveBeenCalled();
+
+    const second = Symbol('second');
+    await expect(mic.acquire(second)).resolves.toBe(true);
+    expect(mic.owns(second)).toBe(true);
+  });
+
+  it('gives the mic back on unmount without aborting a session that ended', async () => {
+    const first = Symbol('first');
+    await fullCapture(first);
+    // The panel unmounts a moment later, as the screen moves on.
+    mic.release(first);
+
+    expect(driver.abort).not.toHaveBeenCalled();
+    expect(mic.state).toBe('idle');
+  });
+
+  it('makes the next capture wait for an aborted one to finish tearing down', async () => {
+    const first = Symbol('first');
+    await mic.acquire(first);
+    mic.opened(first);
+
+    // The panel is dismissed mid-sentence: it gives the mic back, which aborts.
+    mic.release(first);
+    expect(driver.abort).toHaveBeenCalledTimes(1);
+    expect(mic.state).toBe('closing');
+
+    // The replacement panel asks for the mic straight away. It must not get it
+    // yet: the abort's teardown has not run, and it would destroy whatever
+    // recogniser it finds when it does — including one started in between.
+    const second = Symbol('second');
+    let claimed: boolean | null = null;
+    void mic.acquire(second).then((granted) => {
+      claimed = granted;
+    });
+    await Promise.resolve();
+    expect(claimed).toBeNull();
+
+    // The teardown reports in. Now, and only now, the next capture may open.
+    mic.ended();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(claimed).toBe(true);
+    expect(mic.owns(second)).toBe(true);
+  });
+
+  it('stops waiting on a teardown that never reports', async () => {
+    const first = Symbol('first');
+    await mic.acquire(first);
+    mic.opened(first);
+    // Nobody is left mounted to hear the `end` — the screen was left entirely.
+    mic.release(first);
+
+    const second = Symbol('second');
+    let claimed: boolean | null = null;
+    void mic.acquire(second).then((granted) => {
+      claimed = granted;
+    });
+    await vi.advanceTimersByTimeAsync(SETTLE - 1);
+    expect(claimed).toBeNull();
+    // A missing event must cost a pause, never the microphone.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(claimed).toBe(true);
+  });
+});
+
+describe('whose event is this', () => {
+  it('ignores the ending a torn-down session reports late', async () => {
+    const first = Symbol('first');
+    await mic.acquire(first);
+    mic.opened(first);
+    mic.release(first);
+
+    // The teardown is slow; the guard timer gives up and the next capture opens.
+    const second = Symbol('second');
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    await mic.acquire(second);
+    mic.opened(second);
+
+    // The first session's `end` finally lands. It is not the second's, and
+    // closing the second on it is exactly the bug being fixed.
+    mic.ended(second);
+    expect(mic.owns(second)).toBe(true);
+    expect(mic.state).toBe('open');
+  });
+
+  it('will not let an idle surface close the capture somebody else is running', async () => {
+    const owner = Symbol('owner');
+    const bystander = Symbol('bystander');
+    await mic.acquire(owner);
+    mic.opened(owner);
+
+    // Every mounted surface hears every event; a bystander reporting the ending
+    // first must not clear ownership, or the owner drops its final transcript.
+    mic.ended(bystander);
+    expect(mic.owns(owner)).toBe(true);
+
+    mic.ended(owner);
+    expect(mic.owns(owner)).toBe(false);
+  });
+
+  it('refuses the mic to a second surface while one is capturing', async () => {
+    const owner = Symbol('owner');
+    const other = Symbol('other');
+    await mic.acquire(owner);
+    mic.opened(owner);
+
+    await expect(mic.acquire(other)).resolves.toBe(false);
+    // Refused, not stolen: aborting the live capture would race its next event.
+    expect(driver.abort).not.toHaveBeenCalled();
+    expect(mic.owns(owner)).toBe(true);
+  });
+});
+
+describe('the paths that never open the mic', () => {
+  it('frees a claim that never reached the recogniser, with nothing to abort', async () => {
+    // A refused permission, or an unmount while the permission sheet is up: the
+    // mic was claimed but never started. A claim nobody gives back is a mic
+    // nothing can reopen.
+    const first = Symbol('first');
+    await mic.acquire(first);
+    mic.release(first);
+
+    expect(driver.abort).not.toHaveBeenCalled();
+    expect(mic.state).toBe('idle');
+
+    const second = Symbol('second');
+    await expect(mic.acquire(second)).resolves.toBe(true);
+  });
+
+  it('ignores a release from a surface that does not hold the mic', async () => {
+    const owner = Symbol('owner');
+    const bystander = Symbol('bystander');
+    await mic.acquire(owner);
+    mic.opened(owner);
+
+    // An idle row unmounting as a list changes must not abort somebody's capture.
+    mic.release(bystander);
+    expect(driver.abort).not.toHaveBeenCalled();
+    expect(mic.owns(owner)).toBe(true);
+  });
+});
+
+describe('stopping', () => {
+  it('keeps the session across a stop so the last words still land', async () => {
+    const owner = Symbol('owner');
+    await mic.acquire(owner);
+    mic.opened(owner);
+
+    mic.stop(owner);
+    expect(driver.stop).toHaveBeenCalledTimes(1);
+    // stop() still delivers one final result; dropping ownership here would make
+    // the owner ignore the very words spoken before the tap.
+    expect(mic.owns(owner)).toBe(true);
+
+    mic.ended(owner);
+    expect(mic.state).toBe('idle');
+  });
+
+  it('settles a stop the recogniser never answers', async () => {
+    const owner = Symbol('owner');
+    await mic.acquire(owner);
+    mic.opened(owner);
+    mic.stop(owner);
+
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(mic.state).toBe('idle');
+  });
+
+  it('settles an error whose ending never follows it', async () => {
+    const owner = Symbol('owner');
+    await mic.acquire(owner);
+    mic.opened(owner);
+
+    mic.errored(owner);
+    // Ownership is held for the `end` that is supposed to follow…
+    expect(mic.owns(owner)).toBe(true);
+    // …but a platform that never sends one must not hold the mic shut.
+    await vi.advanceTimersByTimeAsync(SETTLE);
+    expect(mic.state).toBe('idle');
+  });
+});
+
+describe('two taps at once', () => {
+  it('gives the mic to one of two simultaneous claims, not both', async () => {
+    const first = Symbol('first');
+    const second = Symbol('second');
+    const [a, b] = await Promise.all([mic.acquire(first), mic.acquire(second)]);
+
+    expect([a, b]).toEqual([true, false]);
+    expect(mic.owns(first)).toBe(true);
+  });
+
+  it('survives a claim released while a second one is still waiting', async () => {
+    const first = Symbol('first');
+    await mic.acquire(first);
+    mic.opened(first);
+    mic.release(first);
+
+    const second = Symbol('second');
+    const third = Symbol('third');
+    const pending = Promise.all([mic.acquire(second), mic.acquire(third)]);
+    mic.ended();
+    const [a, b] = await pending;
+
+    // Exactly one of them opens the recogniser; the other is told no rather than
+    // starting a second one on top of it.
+    expect([a, b].filter(Boolean)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Reported: in speech-to-expense, the first time you speak it works; if you want to speak again, the mic is dead.

### Root cause

Both platforms give the app a **single** recogniser object with a **single** global event stream — `ExpoSpeechRecognitionModule.start/stop/abort` and the `result`/`error`/`end` events are the same recogniser no matter which screen asked. And `abort()` does not end a session synchronously: it queues a teardown (Android posts it to the main looper, iOS runs it in a `Task`) whose `end` arrives some milliseconds later.

Nothing attributed events to a session, so on the second attempt the freshly-keyed panel would either:

- receive the previous session's trailing `end` and close its own capture before it had begun, or
- issue its native `start()` before that queued teardown ran — and the teardown then calls `cancel()`/`destroy()` on whatever the recogniser field holds, which is now the *new* one. Silently: no result, no error, no `end`, a mic stuck on "listening".

Two further holes fed the same symptom:

- `start()` was re-entrant. There are two awaits before `listening` flips (permission, installed-model probe), so a double tap — or a tap racing the auto-start — issued two native starts, the second destroying the first.
- `mounted.current` was set `false` on cleanup but never re-armed, so after a Fast Refresh every later `start()` bailed out after its first await.

PR #529 removed the *needless* abort of an already-idle recogniser, but the case where the panel unmounts while genuinely listening still raced, and nothing attributed events to a session.

### The fix

`apps/mobile/src/lib/speechMic.ts` — a React-free, native-module-free arbiter for the one recogniser (the microphone is injected as a two-call driver, so the sequencing is testable without a device). One owner token per session:

- ownership is dropped **synchronously before** `abort()`, so the `error: aborted` and the `end` that follow belong to nobody and are ignored by whichever panel is mounted by then;
- the next `acquire` **waits for the previous session's `end`** rather than opening on top of its teardown;
- a 1.5s guard timer means a missing `end` costs a pause, never the microphone;
- a bounded "owed end" debt swallows a late teardown ending so it cannot close the session that replaced it;
- ownership is deliberately held across `stop()`, which unlike `abort()` still delivers one last `result` — dropping it there would discard the words spoken before the tap.

`VoiceCapture` now gates all five event handlers on `speechMic.owns(session)`, makes `start()` non-re-entrant (claim, then await, release on every exit path including a refused permission and an unmount during the permission sheet), adds a watchdog for a native start that emits nothing at all, and re-arms `mounted` on the way in. The `listeningRef` mirror from #529 is gone — the arbiter is the synchronous source of truth.

`DictateVoice` had its own module-level `micOwner` lock over the same native recogniser — two independent locks on one device is its own bug class — and now shares the arbiter.

### Lifecycle paths covered

Success → immediate restart; user-stop; error; no-speech/timeout; unmount mid-session; unmount during the permission sheet; rapid double-tap; a claim refused because another surface holds the mic (ignored, never stolen); a teardown that never reports; a teardown that reports late after a new capture opened; a native `start()` that produces no events; Fast Refresh.

### Checks

- 14 new tests in `apps/mobile/test/speechMic.test.ts`; full mobile suite 694 tests / 55 files pass
- `tsc --noEmit` clean, eslint clean
- no new user-facing strings, so no i18n change

**Not device-tested** — the emulator has no live mic, so this is verified by reasoning over the sequencing plus unit tests. The restart path is what to exercise first on real hardware.
