### PR TITLE
feat(receipts): keep every bill on the phone first, show it going up, resume it after a restart

### DIFF
--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -13,7 +13,7 @@
  * orphaned; new images are all attachment rows.
  */
 
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
@@ -41,7 +41,6 @@ import { ReceiptAnnotator } from '@/components/ReceiptAnnotator';
 import { ReceiptCropper } from '@/components/ReceiptCropper';
 import {
   useAnnotateExpenseAttachment,
-  useAttachExpenseAttachment,
   useExpenseAttachments,
   useRemoveExpenseAttachment,
   useRemoveExpenseReceipt,
@@ -56,10 +55,12 @@ import {
   discardPendingReceipt,
   enqueueReceipt,
   flushReceiptQueue,
-  isOnline,
-  listPendingReceipts,
   pendingReceiptUri,
-  type PendingReceipt,
+  retryPendingReceipts,
+  usePendingReceipts,
+  type FlushResult,
+  type PendingReceiptStatus,
+  type PendingReceiptView,
 } from '@/lib/receiptQueue';
 import { SyncStatus, useSync } from '@/sync';
 import { fill, useStrings } from '@/i18n';
@@ -67,11 +68,11 @@ import { fill, useStrings } from '@/i18n';
 const THUMB = 96;
 
 /** One gallery entry: the legacy kept bill, an uploaded attachment, or a capture
- *  that was taken offline and is still waiting to upload. */
+ *  still on its way up — parked on the device, sending, or refused. */
 type GalleryItem =
   | { kind: 'legacy'; key: string; path: string; visibility: 'group' }
   | { kind: 'attachment'; key: string; row: ExpenseAttachmentRow }
-  | { kind: 'pending'; key: string; entry: PendingReceipt };
+  | { kind: 'pending'; key: string; entry: PendingReceiptView };
 
 /**
  * Resolve every item to a displayable URL, each through its own backend (the
@@ -140,15 +141,20 @@ function Thumb({
   url,
   resolved,
   isPrivate,
-  pending,
+  status,
   onPress,
   label,
 }: {
   url: string | null;
   resolved: boolean;
   isPrivate: boolean;
-  /** A capture not yet uploaded — wears an upload glyph so the wait is visible. */
-  pending?: boolean;
+  /**
+   * Set for a capture that has not finished uploading, so the tile says which
+   * of the three it is. This is the whole answer to "did that work?": the image
+   * is on screen either way, and the badge is what separates a receipt that is
+   * safely on the server from one that is still on the phone.
+   */
+  status?: PendingReceiptStatus;
   onPress: () => void;
   label: string;
 }): React.JSX.Element {
@@ -191,9 +197,14 @@ function Thumb({
           <Ionicons name="lock-closed" size={12} color={theme.color.text} />
         </View>
       ) : null}
-      {pending ? (
-        // A soft scrim plus a cloud-upload glyph, so an unsent capture reads as
-        // "saved, waiting to send" rather than a finished receipt.
+      {status ? (
+        // A soft scrim over the image, with the state drawn on top of it: a
+        // spinner while the bytes are in the air, a cloud glyph while they wait
+        // for a connection, and a filled red disc when the send failed. The
+        // failure is a disc rather than a bare glyph because a red line drawn
+        // straight onto an arbitrary photograph is exactly as legible as the
+        // photograph lets it be, which is not enough for the one state somebody
+        // has to notice.
         <View
           style={{
             position: 'absolute',
@@ -203,7 +214,24 @@ function Thumb({
             backgroundColor: 'rgba(10, 10, 26, 0.35)',
           }}
         >
-          <Ionicons name="cloud-upload-outline" size={iconSize.lg} color="#FFFFFF" />
+          {status === 'uploading' ? <ActivityIndicator color="#FFFFFF" /> : null}
+          {status === 'queued' ? (
+            <Ionicons name="cloud-upload-outline" size={iconSize.lg} color="#FFFFFF" />
+          ) : null}
+          {status === 'failed' ? (
+            <View
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: theme.radius.pill,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.color.negative,
+              }}
+            >
+              <Ionicons name="alert" size={iconSize.md} color="#FFFFFF" />
+            </View>
+          ) : null}
         </View>
       ) : null}
     </Pressable>
@@ -257,7 +285,6 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
     const insets = useSafeAreaInsets();
     const { t } = useStrings();
     const attachments = useExpenseAttachments(expenseId);
-    const attach = useAttachExpenseAttachment(groupId, expenseId);
     const removeAttachment = useRemoveExpenseAttachment(expenseId);
     const removeLegacy = useRemoveExpenseReceipt(groupId, expenseId);
     const annotate = useAnnotateExpenseAttachment();
@@ -265,19 +292,18 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
     const queryClient = useQueryClient();
     const { status, flush } = useSync();
 
-    // Captures taken while offline (or when an upload could not reach R2), held on
-    // the device until they can be sent. They show in the gallery straight away
-    // from their local file, and a flush uploads them the moment there is network.
-    const [pending, setPending] = useState<PendingReceipt[]>([]);
-    const refreshPending = useCallback(async () => {
-      setPending(await listPendingReceipts(expenseId));
-    }, [expenseId]);
-    useEffect(() => {
-      // An async load from AsyncStorage — the setState lands after an await, not
-      // synchronously, so the cascading-render rule does not apply here.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      void refreshPending();
-    }, [refreshPending]);
+    // Every capture on this expense that has not finished uploading, with the
+    // state it is in. This is a subscription to the device-wide queue, not this
+    // screen's copy of it: an upload that finishes while the person is on another
+    // screen still updates these tiles when they come back, and a capture parked
+    // by a run of the app that was killed is here on the next launch.
+    const pending = usePendingReceipts(expenseId);
+
+    // The brief moment between choosing a photo and it being written to disk.
+    // Short, but not free — the bytes can be a couple of megabytes — and it is
+    // the one window in which nothing is on screen yet, so the add affordance
+    // holds a spinner rather than looking like it ignored the tap.
+    const [adding, setAdding] = useState(false);
 
     // The per-expense receipt ceiling (A46): a free group keeps a small number of
     // gallery images per expense; paid lifts it. This is the affordance — the
@@ -292,25 +318,54 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
     const refreshCap = () =>
       void queryClient.invalidateQueries({ queryKey: ['attachmentCap', expenseId] });
 
-    // Try to send any parked captures when there is a usable network — on mount
-    // and whenever the connection comes back. A success pulls the freshly-recorded
-    // rows into the mirror (so the optimistic tile becomes the real attachment) and
-    // re-asks the cap; a permanent refusal (cap reached, not a party) just clears
-    // the stuck entry. All best-effort — a flush never throws into the screen.
+    // The free per-expense limit is reached (and the group is not paid): point the
+    // person at the upgrade rather than open the add sheet. Reuses the scan cap's
+    // strings and upgrade route so both ceilings read and route the same.
+    const showCapUpsell = () => {
+      Alert.alert(t.expense.capReachedTitle, t.expense.capReachedBody, [
+        { text: t.common.cancel, style: 'cancel' },
+        { text: t.expense.capUpgrade, onPress: () => router.push('/settings/upgrade') },
+      ]);
+    };
+
+    // What a flush of the receipt queue means for this screen. A success pulls
+    // the freshly-recorded rows into the mirror, so the optimistic tile is
+    // replaced by the real attachment rather than sitting beside it, and either
+    // outcome moves the cap, so the gate is re-asked.
+    const applyFlushResult = async (result: FlushResult) => {
+      if (result.uploadedExpenseIds.length > 0) await flush();
+      if (result.uploadedExpenseIds.length > 0 || result.hadPermanentFailure) refreshCap();
+      // The one refusal somebody can act on: another party filled the last slot
+      // from another device, so the local gate let this through and the server
+      // did not. Offer the upgrade rather than leave a red tile unexplained.
+      if (result.capReached) showCapUpsell();
+    };
+
+    // Send whatever is parked.
+    //
+    // The queue is flushed from the sync provider too — on launch, on foreground,
+    // on reconnect — so this is not the only thing keeping uploads moving; it is
+    // the copy that runs while this screen is the one being looked at, and the
+    // only one in a position to answer with the cap upsell. Best-effort
+    // throughout: a capture that could not be sent stays in the gallery wearing
+    // its failure rather than throwing anything at the screen.
+    const sendPending = async () => {
+      await applyFlushResult(await flushReceiptQueue());
+    };
+
+    // Send failed captures again at the person's asking, ignoring the backoff and
+    // the refusal mark the automatic path respects.
+    const retryFailed = (attachmentIds: readonly string[]) => {
+      void (async () => {
+        await applyFlushResult(await retryPendingReceipts(attachmentIds));
+      })();
+    };
+
+    // Try to send on mount and whenever the connection comes back.
     useEffect(() => {
       if (status === SyncStatus.Offline || status === SyncStatus.Metered) return;
-      void (async () => {
-        const result = await flushReceiptQueue();
-        if (result.uploadedExpenseIds.length > 0) {
-          await refreshPending();
-          await flush();
-          refreshCap();
-        } else if (result.hadPermanentFailure) {
-          await refreshPending();
-          refreshCap();
-        }
-      })();
-      // Re-run when the connection state flips; refreshers are stable.
+      void sendPending();
+      // Re-run when the connection state flips; the sender reads current values.
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [status]);
 
@@ -361,78 +416,65 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
       (it.kind === 'attachment' && it.row.visibility === 'parties') ||
       (it.kind === 'pending' && it.entry.visibility === 'parties');
 
-    // The free per-expense limit is reached (and the group is not paid): point the
-    // person at the upgrade rather than open the add sheet. Reuses the scan cap's
-    // strings and upgrade route so both ceilings read and route the same.
-    const showCapUpsell = () => {
-      Alert.alert(t.expense.capReachedTitle, t.expense.capReachedBody, [
-        { text: t.common.cancel, style: 'cancel' },
-        { text: t.expense.capUpgrade, onPress: () => router.push('/settings/upgrade') },
-      ]);
-    };
-
-    // The server may still refuse over the cap even when the local gate allowed it
-    // (another party filled the last slot from another device); surface that as the
-    // upgrade prompt, not a generic failure. Anything else is the generic message.
-    const onAddError = (error: unknown) => {
-      const message = error instanceof Error ? error.message : '';
-      if (message.includes('ATTACHMENT_CAP')) {
-        showCapUpsell();
-        refreshCap();
-      } else {
-        Alert.alert(t.receipts.couldNotAdd);
-      }
-    };
-
-    // Add at a chosen visibility. Online it uploads now; offline (or if the upload
-    // cannot reach R2) the capture is parked on the device and shown at once, to
-    // be sent automatically on reconnect — the receipt equivalent of ADR-005's
-    // offline writes.
+    /**
+     * Add at a chosen visibility.
+     *
+     * There is one path here now, and it is the durable one: the bytes are
+     * written to a file and recorded in the receipt queue *before* anything is
+     * sent, and the queue does the sending. This used to branch — upload now if
+     * online, park it if not — and the online branch was the one that hurt.
+     * Nothing appeared while it ran, so a slow upload and a failed one looked
+     * identical; leaving the screen took its callbacks with it; and an app killed
+     * mid-upload lost the photograph, which by then was the only copy of a bill
+     * already in the bin. Parking first costs one file write and buys all three
+     * back — the tile is on screen the moment the write lands, and the upload is
+     * the queue's problem from then on, not this screen's.
+     */
     const commitAdd = (
       picked: NonNullable<Awaited<ReturnType<typeof captureReceipt>>>,
       visibility: 'group' | 'parties',
     ) => {
       const contentType = picked.mimeType ?? 'image/jpeg';
-      const park = async () => {
-        await enqueueReceipt({
-          expenseId,
-          groupId,
-          visibility,
-          base64: picked.base64,
-          contentType,
-        });
-        await refreshPending();
-      };
+      setAdding(true);
       void (async () => {
-        if (!(await isOnline())) {
-          await park();
+        try {
+          await enqueueReceipt({
+            expenseId,
+            groupId,
+            visibility,
+            base64: picked.base64,
+            contentType,
+          });
+        } catch {
+          // The bytes never reached the disk (a full device, a revoked path), so
+          // there is no tile to carry the failure and this is the only chance to
+          // say so. Everything past this point has somewhere to show it instead.
+          Alert.alert(t.receipts.couldNotKeep);
           return;
+        } finally {
+          setAdding(false);
         }
-        attach.mutate(
-          { picked, visibility },
-          {
-            onSuccess: refreshCap,
-            onError: (error) =>
-              void (async () => {
-                // The connection dropped mid-upload → park it rather than fail.
-                if (!(await isOnline())) {
-                  await park();
-                  return;
-                }
-                onAddError(error);
-              })(),
-          },
-        );
+        await sendPending();
       })();
     };
 
+    /**
+     * A bill added here belongs to the group that is splitting it.
+     *
+     * This used to stop and ask who could see it, between the whole group and
+     * the people on the bill. The question came a beat after the photograph,
+     * when the person was done, and the answer was the group's every time — a
+     * receipt for a bill everybody is paying a share of is not a private
+     * document. So it is no longer asked: the bill lands group-readable, which
+     * is what the R2 group path already authorises by membership.
+     *
+     * The narrower 'parties' visibility stays in {@link commitAdd} and in the
+     * storage rules — payment proofs still use it, and a receipt already added
+     * that way keeps its Private tag.
+     */
     const add = (picked: Awaited<ReturnType<typeof captureReceipt>>) => {
       if (!picked) return; // Cancelled/declined.
-      Alert.alert(t.receipts.chooseVisibility, undefined, [
-        { text: t.receipts.everyone, onPress: () => commitAdd(picked, 'group') },
-        { text: t.receipts.payersOnly, onPress: () => commitAdd(picked, 'parties') },
-        { text: t.common.cancel, style: 'cancel' },
-      ]);
+      commitAdd(picked, 'group');
     };
 
     const startAdd = () => {
@@ -472,7 +514,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
             const onError = () => Alert.alert(t.imageAudit.couldNotRemove);
             if (it.kind === 'pending') {
               // Not uploaded yet: just drop the parked capture and its local bytes.
-              void discardPendingReceipt(it.entry.attachmentId).then(refreshPending);
+              void discardPendingReceipt(it.entry.attachmentId);
             } else if (it.kind === 'legacy') {
               // Only clear the parent's receipt state on a confirmed delete — if the
               // byte removal throws, the bill is still there and must keep showing.
@@ -502,6 +544,51 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
       ]);
     };
 
+    // What the strip as a whole is doing, for the line under it. Sending wins
+    // over failed, and failed over waiting: the line reports the most active
+    // thing happening, and the per-tile badges say which capture is which.
+    const unsent = items.flatMap((it) => (it.kind === 'pending' ? [it.entry] : []));
+    const failedIds = unsent
+      .filter((entry) => entry.status === 'failed')
+      .map((entry) => entry.attachmentId);
+    const stripStatus: PendingReceiptStatus | null = unsent.some(
+      (entry) => entry.status === 'uploading',
+    )
+      ? 'uploading'
+      : failedIds.length > 0
+        ? 'failed'
+        : unsent.length > 0
+          ? 'queued'
+          : null;
+
+    /** The state in words, for the tile's accessibility label and the strip line. */
+    const statusWord = (state: PendingReceiptStatus): string =>
+      state === 'uploading'
+        ? t.receipts.sending
+        : state === 'failed'
+          ? t.receipts.notSent
+          : t.receipts.waitingToSend;
+
+    // A capture that did not go up: say what that means and offer the two things
+    // worth doing about it. Removing here does not go through `removeAt`'s
+    // confirmation — nothing was ever sent, so there is no change to record and
+    // nothing for anybody else to see disappear.
+    const showUnsent = (entry: PendingReceiptView) => {
+      Alert.alert(
+        t.receipts.notSent,
+        entry.permanent ? t.receipts.notSentBlockedBody : t.receipts.notSentBody,
+        [
+          { text: t.common.cancel, style: 'cancel' },
+          {
+            text: t.receipts.remove,
+            style: 'destructive',
+            onPress: () => void discardPendingReceipt(entry.attachmentId),
+          },
+          { text: t.receipts.tryAgain, onPress: () => retryFailed([entry.attachmentId]) },
+        ],
+      );
+    };
+
     const viewing = viewerIndex !== null ? items[viewerIndex] : null;
 
     // Save the open receipt off the device via the OS share/save sheet.
@@ -527,7 +614,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
           // reads "Add receipt" fills the space and makes the affordance obvious.
           <Pressable
             onPress={handleAddPress}
-            disabled={attach.isPending}
+            disabled={adding}
             accessibilityRole="button"
             accessibilityLabel={t.receipts.add}
             style={({ pressed }) => ({
@@ -554,7 +641,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
                 backgroundColor: theme.color.surface,
               }}
             >
-              {attach.isPending ? (
+              {adding ? (
                 <ActivityIndicator color={theme.color.brand} />
               ) : (
                 <Ionicons name="camera-outline" size={iconSize.lg} color={theme.color.brand} />
@@ -577,7 +664,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
             {canManage && !externalAdd ? (
               <Pressable
                 onPress={handleAddPress}
-                disabled={attach.isPending}
+                disabled={adding}
                 accessibilityRole="button"
                 accessibilityLabel={t.receipts.add}
                 style={{
@@ -591,7 +678,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
                   backgroundColor: theme.color.surfaceMuted,
                 }}
               >
-                {attach.isPending ? (
+                {adding ? (
                   <ActivityIndicator color={theme.color.brand} />
                 ) : (
                   <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
@@ -605,17 +692,63 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
                 url={urls[index] ?? null}
                 resolved={urls[index] !== undefined}
                 isPrivate={isPrivate(it)}
-                pending={it.kind === 'pending'}
-                label={
+                status={it.kind === 'pending' ? it.entry.status : undefined}
+                label={[
                   isPrivate(it)
                     ? `${t.receipts.title} — ${t.receipts.privateTag}`
-                    : t.receipts.title
-                }
-                onPress={() => setViewerIndex(index)}
+                    : t.receipts.title,
+                  it.kind === 'pending' ? statusWord(it.entry.status) : null,
+                ]
+                  .filter(Boolean)
+                  .join(' — ')}
+                onPress={() => {
+                  // A failed capture's tap is about the failure, not the picture
+                  // — the picture is already the thumbnail, and what the person
+                  // needs is the reason and a way out of it.
+                  if (it.kind === 'pending' && it.entry.status === 'failed') showUnsent(it.entry);
+                  else setViewerIndex(index);
+                }}
               />
             ))}
           </ScrollView>
         )}
+
+        {stripStatus ? (
+          // One line under the strip saying what is happening to the receipts
+          // that are not up yet. The tiles carry badges, but a badge is 20px on
+          // a photograph — this is the sentence somebody can actually read, and
+          // the only place a retry is offered without opening anything.
+          <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
+            {stripStatus === 'uploading' ? (
+              <ActivityIndicator size="small" color={theme.color.textMuted} />
+            ) : (
+              <Ionicons
+                name={stripStatus === 'failed' ? 'alert-circle' : 'cloud-upload-outline'}
+                size={iconSize.sm}
+                color={stripStatus === 'failed' ? theme.color.negative : theme.color.textMuted}
+              />
+            )}
+            <Text
+              variant="micro"
+              tone={stripStatus === 'failed' ? undefined : 'muted'}
+              style={stripStatus === 'failed' ? { color: theme.color.negative } : undefined}
+            >
+              {statusWord(stripStatus)}
+            </Text>
+            {stripStatus === 'failed' ? (
+              <Pressable
+                onPress={() => retryFailed(failedIds)}
+                accessibilityRole="button"
+                accessibilityLabel={t.receipts.tryAgain}
+                hitSlop={8}
+              >
+                <Text variant="micro" style={{ color: theme.color.brand }}>
+                  {t.receipts.tryAgain}
+                </Text>
+              </Pressable>
+            ) : null}
+          </Row>
+        ) : null}
 
         <Modal
           visible={viewing !== null}

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -1766,48 +1766,17 @@ export function useAnnotateExpenseAttachment() {
   });
 }
 
-/**
- * Attach an already-picked image to an expense at a chosen visibility. The
- * caller does the picking (scan or library), so one hook serves every entry
- * point and the gallery can offer both. Upload → RPC → flush; throws on a real
- * failure and cleans up the R2 object if the RPC rejected after the upload
- * committed. The caller surfaces the throw.
+/*
+ * There is deliberately no "attach this image now" mutation here.
+ *
+ * There was one — upload → RPC → flush, driven straight from the gallery — and
+ * it is gone because a mutation is the wrong shape for this particular job. It
+ * lived and died with the screen that started it, so walking away mid-upload
+ * dropped its result on the floor, and it held the only copy of the photograph
+ * in memory, so an app killed mid-upload lost a bill somebody had already
+ * thrown away. Adding a receipt now always goes through `lib/receiptQueue`,
+ * which writes the bytes down first and sends them from outside React.
  */
-export function useAttachExpenseAttachment(groupId: string, expenseId: string) {
-  const { flush } = useSync();
-  return useMutation({
-    mutationFn: async (input: { picked: PickedImage; visibility: 'group' | 'parties' }) => {
-      const { picked, visibility } = input;
-      const ext = picked.mimeType === 'image/webp' ? 'webp' : 'jpg';
-      const path = `${expenseId}/${randomUUID()}.${ext}`;
-      let committed: string | null = null;
-      try {
-        await putImage({
-          bucket: 'expense-attachments',
-          path,
-          base64: picked.base64,
-          contentType: picked.mimeType,
-          groupId,
-          subjectId: expenseId,
-        });
-        committed = path;
-        const { error } = await backend.rpc('baaki_attach_expense_attachment', {
-          p_expense_id: expenseId,
-          p_storage_path: path,
-          p_visibility: visibility,
-          p_attachment_id: randomUUID(),
-        });
-        if (error) throw new Error(error.message);
-        committed = null;
-      } catch (caught) {
-        if (committed)
-          await removeRestrictedImage('expense-attachments', expenseId, committed).catch(() => {});
-        throw caught;
-      }
-    },
-    onSuccess: () => void flush(),
-  });
-}
 
 /**
  * Replace an attachment's image with an adjusted (rotated/cropped) one: upload

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -445,7 +445,6 @@ export interface UiStrings {
     /** Add-source choices. */
     scan: string;
     choosePhoto: string;
-    /** Visibility sheet. */
     /** Lock-badge label on a private image. */
     privateTag: string;
     remove: string;

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -446,14 +446,24 @@ export interface UiStrings {
     scan: string;
     choosePhoto: string;
     /** Visibility sheet. */
-    chooseVisibility: string;
-    everyone: string;
-    payersOnly: string;
     /** Lock-badge label on a private image. */
     privateTag: string;
     remove: string;
     removeConfirm: string;
     couldNotAdd: string;
+    /** The photo could not even be saved on the device — nothing was queued. */
+    couldNotKeep: string;
+    /** Upload states shown on a receipt tile and under the gallery: in the air,
+     *  saved but not sent yet, and sent-and-refused/failed. */
+    sending: string;
+    waitingToSend: string;
+    notSent: string;
+    /** What a failed upload means, for the tile's tap: a transient failure the
+     *  app will retry by itself, and a refusal that needs the person to act. */
+    notSentBody: string;
+    notSentBlockedBody: string;
+    /** Retry an unsent receipt now. */
+    tryAgain: string;
     /** Viewer counter, e.g. "2 of 5" — `{index}` and `{total}`. */
     counter: string;
     /** Save-to-device action + outcomes. */
@@ -2649,13 +2659,19 @@ const en: UiStrings = {
     add: 'Add receipt',
     scan: 'Scan',
     choosePhoto: 'Choose photo',
-    chooseVisibility: 'Who can see this receipt?',
-    everyone: 'Everyone in the group',
-    payersOnly: 'Only the payers',
     privateTag: 'Private',
     remove: 'Remove',
     removeConfirm: 'Remove this receipt? The change is recorded.',
     couldNotAdd: "Couldn't add that — try again.",
+    couldNotKeep: "Couldn't keep that photo on your phone — try again.",
+    sending: 'Sending…',
+    waitingToSend: 'Waiting to send',
+    notSent: "Didn't send",
+    notSentBody:
+      "This receipt is saved on your phone and hasn't been sent yet. It will keep trying on its own, or you can try again now.",
+    notSentBlockedBody:
+      "This receipt was refused, so it hasn't been sent. It is still saved on your phone.",
+    tryAgain: 'Try again',
     counter: '{index} of {total}',
     download: 'Save to device',
     saved: 'Saved to your device.',
@@ -4731,13 +4747,20 @@ const ta: UiStrings = {
     add: 'ரசீது சேர்',
     scan: 'ஸ்கேன்',
     choosePhoto: 'படத்தைத் தேர்ந்தெடு',
-    chooseVisibility: 'இந்த ரசீதை யார் பார்க்கலாம்?',
-    everyone: 'குழுவில் உள்ள அனைவரும்',
-    payersOnly: 'செலுத்தியவர்கள் மட்டும்',
     privateTag: 'தனிப்பட்டது',
     remove: 'அகற்று',
     removeConfirm: 'இந்த ரசீதை அகற்றவா? இந்த மாற்றம் பதிவு செய்யப்படும்.',
     couldNotAdd: 'சேர்க்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
+    couldNotKeep:
+      'அந்தப் படத்தை உங்கள் தொலைபேசியில் வைத்திருக்க முடியவில்லை — மீண்டும் முயற்சிக்கவும்.',
+    sending: 'அனுப்பப்படுகிறது…',
+    waitingToSend: 'அனுப்பக் காத்திருக்கிறது',
+    notSent: 'அனுப்பப்படவில்லை',
+    notSentBody:
+      'இந்த ரசீது உங்கள் தொலைபேசியில் சேமிக்கப்பட்டுள்ளது, இன்னும் அனுப்பப்படவில்லை. இது தானாகவே மீண்டும் முயற்சிக்கும், அல்லது நீங்கள் இப்போதே மீண்டும் முயற்சிக்கலாம்.',
+    notSentBlockedBody:
+      'இந்த ரசீது மறுக்கப்பட்டது, எனவே அனுப்பப்படவில்லை. இது இன்னும் உங்கள் தொலைபேசியில் சேமிக்கப்பட்டுள்ளது.',
+    tryAgain: 'மீண்டும் முயற்சிக்கவும்',
     counter: '{total} இல் {index}',
     download: 'சாதனத்தில் சேமி',
     saved: 'உங்கள் சாதனத்தில் சேமிக்கப்பட்டது.',
@@ -6890,13 +6913,19 @@ const hi: UiStrings = {
     add: 'रसीद जोड़ें',
     scan: 'स्कैन',
     choosePhoto: 'फ़ोटो चुनें',
-    chooseVisibility: 'यह रसीद कौन देख सकता है?',
-    everyone: 'ग्रुप में सभी',
-    payersOnly: 'केवल भुगतानकर्ता',
     privateTag: 'निजी',
     remove: 'हटाएँ',
     removeConfirm: 'यह रसीद हटाएँ? यह बदलाव दर्ज किया जाएगा।',
     couldNotAdd: 'जोड़ा नहीं जा सका — फिर कोशिश करें।',
+    couldNotKeep: 'यह फ़ोटो आपके फ़ोन पर रखी नहीं जा सकी — फिर कोशिश करें।',
+    sending: 'भेजी जा रही है…',
+    waitingToSend: 'भेजने की प्रतीक्षा में',
+    notSent: 'नहीं भेजी गई',
+    notSentBody:
+      'यह रसीद आपके फ़ोन पर सहेजी है और अभी भेजी नहीं गई है। यह अपने आप फिर कोशिश करती रहेगी, या आप अभी फिर कोशिश कर सकते हैं।',
+    notSentBlockedBody:
+      'यह रसीद अस्वीकार कर दी गई, इसलिए भेजी नहीं गई। यह अब भी आपके फ़ोन पर सहेजी है।',
+    tryAgain: 'फिर कोशिश करें',
     counter: '{total} में से {index}',
     download: 'डिवाइस पर सहेजें',
     saved: 'आपके डिवाइस पर सहेज लिया गया।',
@@ -8992,13 +9021,18 @@ const ar: UiStrings = {
     add: 'إضافة إيصال',
     scan: 'مسح ضوئي',
     choosePhoto: 'اختيار صورة',
-    chooseVisibility: 'من يمكنه رؤية هذا الإيصال؟',
-    everyone: 'كل أعضاء المجموعة',
-    payersOnly: 'الدافعون فقط',
     privateTag: 'خاص',
     remove: 'إزالة',
     removeConfirm: 'إزالة هذا الإيصال؟ سيُسجَّل هذا التغيير.',
     couldNotAdd: 'تعذّرت الإضافة — حاول مرة أخرى.',
+    couldNotKeep: 'تعذّر الاحتفاظ بالصورة على هاتفك — حاول مرة أخرى.',
+    sending: 'جارٍ الإرسال…',
+    waitingToSend: 'في انتظار الإرسال',
+    notSent: 'لم يُرسَل',
+    notSentBody:
+      'هذا الإيصال محفوظ على هاتفك ولم يُرسَل بعد. ستستمر المحاولة تلقائيًا، أو يمكنك المحاولة الآن.',
+    notSentBlockedBody: 'رُفض هذا الإيصال، لذلك لم يُرسَل. وهو لا يزال محفوظًا على هاتفك.',
+    tryAgain: 'حاول مرة أخرى',
     counter: '{index} من {total}',
     download: 'حفظ على الجهاز',
     saved: 'تم الحفظ على جهازك.',

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -1,13 +1,21 @@
 /**
- * The offline half of adding a receipt (ADR-005 for images).
+ * Every receipt an expense gains goes through here (ADR-005 for images).
  *
- * Attaching a receipt online is upload → RPC → done. Offline, both steps need
- * the network, so instead of failing this parks the capture: the bytes are
- * written to a durable file, a queue entry is recorded, and the gallery shows
- * the image straight away from that local file. When the device is back online
- * a flush walks the queue — uploading each capture to R2 and recording the
- * attachment row exactly as the online path would, then seeding the view cache
- * so the receipt keeps showing with no network and dropping the queue entry.
+ * Adding a receipt used to be two different things depending on the weather:
+ * online it was upload → RPC → done, driven by a mutation living on the expense
+ * screen; offline the capture was parked on the device and sent on reconnect.
+ * The online half had three problems the person could feel. Nothing appeared
+ * while the bytes were in the air, so there was no way to tell a slow upload
+ * from one that had quietly failed. Walking away from the screen took the
+ * mutation's callbacks with it. And an app killed mid-upload lost the photograph
+ * outright — it only ever existed in memory and in the picker's cache.
+ *
+ * So there is one path now, the durable one: a picked image is written to a file
+ * and recorded in a queue *before* anything is sent, and the queue is what
+ * uploads it. The gallery shows the capture from its local file the instant it
+ * is parked, wearing the state it is actually in — waiting, sending, or not
+ * sent — and a flush that finishes while the person is three screens away still
+ * lands. Nothing about that is tied to a component being mounted.
  *
  * The queue index lives in AsyncStorage (small, structured); the image bytes
  * live under the OS *document* directory — not the cache — because a pending
@@ -17,8 +25,14 @@
  * The entry's `attachmentId` is the eventual row id, chosen up front, so the
  * optimistic gallery item and the real row that arrives after the flush share
  * one identity — the gallery de-dupes on it, and a retry never doubles a row.
+ *
+ * Views subscribe rather than poll: the queue publishes a snapshot on every
+ * change (parked, sending, sent, failed) through `usePendingReceipts`, the same
+ * `useSyncExternalStore` shape `transferProgress` uses, because the work that
+ * changes it happens in plain library code with no React around it.
  */
 
+import { useEffect, useMemo, useSyncExternalStore } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { decode } from 'base64-arraybuffer';
 import { randomUUID } from 'expo-crypto';
@@ -39,7 +53,23 @@ const QUEUE_KEY = 'receipt-upload-queue.v1';
 /** Durable subdirectory (under the document dir) holding unsent capture bytes. */
 const PENDING_DIR = 'pending-receipts';
 
-/** A capture waiting to be uploaded. */
+/**
+ * How long a failed capture waits before a background flush tries it again,
+ * indexed by how many attempts it has already cost. A flush only runs on an
+ * event — a screen mounting, the connection returning, the app coming forward —
+ * so this is not guarding against a hot loop; it is stopping a capture that
+ * fails for a durable reason (a server having a bad hour) from burning the
+ * radio every time the person switches apps. The last value is the ceiling.
+ * A person who taps "try again" bypasses all of it — see {@link retryPendingReceipts}.
+ */
+const RETRY_BACKOFF_MS = [30_000, 2 * 60_000, 10 * 60_000, 30 * 60_000] as const;
+
+function backoffFor(attempts: number): number {
+  const index = Math.min(Math.max(attempts, 1), RETRY_BACKOFF_MS.length) - 1;
+  return RETRY_BACKOFF_MS[index] ?? RETRY_BACKOFF_MS[RETRY_BACKOFF_MS.length - 1] ?? 0;
+}
+
+/** A capture waiting to be uploaded. This is the persisted shape. */
 export interface PendingReceipt {
   /** The eventual attachment row id — the optimistic item and the real row share it. */
   attachmentId: string;
@@ -53,7 +83,33 @@ export interface PendingReceipt {
   fileName: string;
   createdAt: string;
   attempts: number;
+  /** The last failure's raw message. Kept for diagnosis; never shown to anybody. */
   lastError: string | null;
+  /**
+   * The server refused this capture for a reason a retry will not change (the
+   * per-expense ceiling, not being a party). Background flushes skip it, so it
+   * neither loops nor disappears — it sits in the gallery as a failed tile the
+   * person can act on, which is the whole point: a capture that vanished with no
+   * explanation was the old behaviour and it was indistinguishable from a bug.
+   */
+  permanent?: boolean;
+  /** Earliest time a background flush may try again; see {@link RETRY_BACKOFF_MS}. */
+  nextAttemptAt?: string | null;
+}
+
+/**
+ * What a parked capture is doing right now, as far as anybody looking at the
+ * gallery is concerned.
+ *
+ * `uploading` is deliberately *not* persisted: an app killed mid-upload comes
+ * back as `queued`, because that is the truth — the bytes are on disk and
+ * nothing is in the air until a flush picks them up again.
+ */
+export type PendingReceiptStatus = 'queued' | 'uploading' | 'failed';
+
+/** A pending capture as a view renders it: the stored row plus its live state. */
+export interface PendingReceiptView extends PendingReceipt {
+  status: PendingReceiptStatus;
 }
 
 /** The extension for a stored image, matching the online attach path. */
@@ -61,19 +117,116 @@ function extensionFor(contentType: string): string {
   return contentType === 'image/webp' ? 'webp' : 'jpg';
 }
 
+// --- The published snapshot -------------------------------------------------
+//
+// One cached array of views, rebuilt whenever the stored queue or the set of
+// in-flight uploads changes, so `useSyncExternalStore` sees a stable reference
+// between changes and a fresh one across them.
+
+const listeners = new Set<() => void>();
+const uploading = new Set<string>();
+let stored: readonly PendingReceipt[] = [];
+let snapshot: readonly PendingReceiptView[] = [];
+/** Whether the stored queue has been read off disk at least once this launch. */
+let hydrated = false;
+
+function statusOf(entry: PendingReceipt): PendingReceiptStatus {
+  if (uploading.has(entry.attachmentId)) return 'uploading';
+  return entry.lastError ? 'failed' : 'queued';
+}
+
+function republish(): void {
+  snapshot = stored.map((entry) => ({ ...entry, status: statusOf(entry) }));
+  for (const listener of listeners) listener();
+}
+
+/**
+ * Whether two reads of the queue say the same thing. Every read parses fresh
+ * objects out of JSON, so identity tells us nothing — and without this a flush
+ * that found nothing to do would still notify every mounted gallery, on every
+ * reconnect and every return to the foreground.
+ */
+function sameQueue(a: readonly PendingReceipt[], b: readonly PendingReceipt[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((entry, index) => {
+    const other = b[index];
+    return (
+      other !== undefined &&
+      entry.attachmentId === other.attachmentId &&
+      entry.attempts === other.attempts &&
+      entry.lastError === other.lastError &&
+      Boolean(entry.permanent) === Boolean(other.permanent) &&
+      (entry.nextAttemptAt ?? null) === (other.nextAttemptAt ?? null)
+    );
+  });
+}
+
+function publish(next: readonly PendingReceipt[]): void {
+  const unchanged = hydrated && sameQueue(stored, next);
+  stored = next;
+  hydrated = true;
+  if (!unchanged) republish();
+}
+
+/** Mark one capture as in the air (or no longer), so its tile can say so. */
+function markUploading(attachmentId: string, active: boolean): void {
+  const was = uploading.has(attachmentId);
+  if (active) uploading.add(attachmentId);
+  else uploading.delete(attachmentId);
+  if (was !== active) republish();
+}
+
+export function subscribePendingReceipts(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getPendingReceiptsSnapshot(): readonly PendingReceiptView[] {
+  return snapshot;
+}
+
+/**
+ * Every parked capture (optionally only one expense's), with its live status,
+ * re-rendering as the queue moves. Reads off disk once per launch on first use,
+ * so a screen opened straight after a cold start still sees what is waiting.
+ */
+export function usePendingReceipts(expenseId?: string): readonly PendingReceiptView[] {
+  const all = useSyncExternalStore(
+    subscribePendingReceipts,
+    getPendingReceiptsSnapshot,
+    getPendingReceiptsSnapshot,
+  );
+  useEffect(() => {
+    // Module state, not a reactive value — this is a one-shot cold-start read,
+    // and every later change arrives through the subscription above.
+    if (!hydrated) void listPendingReceipts();
+  }, []);
+  return useMemo(
+    () => (expenseId ? all.filter((entry) => entry.expenseId === expenseId) : all),
+    [all, expenseId],
+  );
+}
+
+// --- Storage ----------------------------------------------------------------
+
 async function readQueue(): Promise<PendingReceipt[]> {
   try {
     const raw = await AsyncStorage.getItem(QUEUE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    return Array.isArray(parsed) ? (parsed as PendingReceipt[]) : [];
+    const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+    const queue = Array.isArray(parsed) ? (parsed as PendingReceipt[]) : [];
+    publish(queue);
+    return queue;
   } catch {
+    publish([]);
     return [];
   }
 }
 
 async function writeQueue(queue: readonly PendingReceipt[]): Promise<void> {
   await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+  publish(queue);
 }
 
 function cleanupOrphanFiles(queue: readonly PendingReceipt[]): void {
@@ -102,7 +255,7 @@ function pendingFile(entry: Pick<PendingReceipt, 'fileName'>): File {
 }
 
 /** The `file://` a gallery renders for a still-unsent capture. */
-export function pendingReceiptUri(entry: PendingReceipt): string {
+export function pendingReceiptUri(entry: Pick<PendingReceipt, 'fileName'>): string {
   return pendingFile(entry).uri;
 }
 
@@ -144,11 +297,18 @@ export async function clearReceiptQueue(): Promise<void> {
   }
 
   await AsyncStorage.removeItem(QUEUE_KEY);
+  uploading.clear();
+  publish([]);
 }
 
 /**
  * Park a picked image for later upload: write its bytes to a durable file and
  * record the queue entry. Returns the entry so the caller can show it at once.
+ *
+ * This runs for every add, online or not. Writing the bytes down first is what
+ * makes the rest of the promise keepable — the capture survives the screen
+ * closing, the app being killed, and the upload failing, because from this
+ * moment the photograph exists somewhere other than memory.
  */
 export async function enqueueReceipt(input: {
   expenseId: string;
@@ -170,6 +330,8 @@ export async function enqueueReceipt(input: {
     createdAt: new Date().toISOString(),
     attempts: 0,
     lastError: null,
+    permanent: false,
+    nextAttemptAt: null,
   };
 
   const dir = new Directory(Paths.document, PENDING_DIR);
@@ -196,6 +358,35 @@ export async function discardPendingReceipt(attachmentId: string): Promise<void>
   await writeQueue(queue.filter((item) => item.attachmentId !== attachmentId));
 }
 
+/**
+ * Send failed captures again, now, at the person's asking.
+ *
+ * Everything the automatic path uses to hold a capture back is cleared: the
+ * backoff window, the recorded failure, and the `permanent` mark. Clearing the
+ * last of those is deliberate — the commonest permanent refusal is the
+ * per-expense receipt ceiling, and the way somebody fixes that is to remove
+ * another receipt and try this one again. Refusing to re-send would leave them
+ * with a tile they had already done the work to un-block.
+ *
+ * It takes a list rather than one id so that clearing several and sending them
+ * is a single write and a single flush. Retrying them one at a time would have
+ * each call ride the single-flight coalescing in {@link flushReceiptQueue} and
+ * possibly join a run that read the queue before its own clear landed.
+ */
+export async function retryPendingReceipts(attachmentIds: readonly string[]): Promise<FlushResult> {
+  if (attachmentIds.length === 0) return EMPTY_FLUSH;
+  const wanted = new Set(attachmentIds);
+  const queue = await readQueue();
+  await writeQueue(
+    queue.map((entry) =>
+      wanted.has(entry.attachmentId)
+        ? { ...entry, lastError: null, permanent: false, nextAttemptAt: null }
+        : entry,
+    ),
+  );
+  return flushReceiptQueue();
+}
+
 /** A server error that will never succeed on retry — the capture must not loop forever. */
 function isPermanent(message: string): boolean {
   return (
@@ -212,18 +403,32 @@ export interface FlushResult {
   uploadedExpenseIds: string[];
   /** True when a capture was refused for good (cap reached / not a party). */
   hadPermanentFailure: boolean;
+  /**
+   * True when at least one of those refusals was the per-expense receipt
+   * ceiling — the one refusal somebody can actually do something about, so the
+   * screen can offer the upgrade rather than a flat "didn't send".
+   */
+  capReached: boolean;
 }
+
+const EMPTY_FLUSH: FlushResult = {
+  uploadedExpenseIds: [],
+  hadPermanentFailure: false,
+  capReached: false,
+};
 
 /**
  * Upload every pending capture that can be sent now. Best-effort and safe to
- * call often (screen mount, reconnect): it no-ops when the queue is empty or the
- * device is offline, and each entry is handled in isolation so one stuck capture
- * never blocks the rest.
+ * call often (screen mount, reconnect, foreground, launch): it no-ops when there
+ * is nothing due or the device is offline, and each entry is handled in
+ * isolation so one stuck capture never blocks the rest.
  *
  * On success the bytes move into the view cache (so the receipt stays offline-
- * readable) and the entry and its file are dropped. A transient failure leaves
- * the entry to retry; a permanent one (cap, not a party) is dropped with its
- * reason surfaced, so it does not loop forever.
+ * readable) and the entry and its file are dropped. A transient failure keeps
+ * the entry with a backoff, to be tried again on the next event; a permanent one
+ * (cap, not a party) keeps it too, marked so no background run retries it —
+ * either way the tile stays in the gallery saying what happened, and the bytes
+ * stay on disk, until the person retries it or removes it.
  */
 let inFlight: Promise<FlushResult> | null = null;
 
@@ -241,33 +446,52 @@ export function flushReceiptQueue(): Promise<FlushResult> {
 
 async function runFlush(): Promise<FlushResult> {
   const queue = await readQueue();
-  if (queue.length === 0) return { uploadedExpenseIds: [], hadPermanentFailure: false };
-  if (!(await isOnline())) return { uploadedExpenseIds: [], hadPermanentFailure: false };
+  if (queue.length === 0) return EMPTY_FLUSH;
 
-  const remaining: PendingReceipt[] = [];
+  // Only entries that are actually due: a permanent refusal waits for somebody
+  // to ask, and a recent transient failure waits out its backoff. Both stay in
+  // the queue and on screen — being skipped here is not the same as being gone.
+  const now = Date.now();
+  const due = queue.filter((entry) => {
+    if (entry.permanent) return false;
+    if (!entry.nextAttemptAt) return true;
+    const at = Date.parse(entry.nextAttemptAt);
+    return Number.isNaN(at) || at <= now;
+  });
+  if (due.length === 0) return EMPTY_FLUSH;
+  if (!(await isOnline())) return EMPTY_FLUSH;
+
+  // How each handled entry ends up: a replacement row, or null to drop it.
+  // Applied against a re-read of the queue at the end, so entries parked *during*
+  // the flush survive and everything keeps its original order.
+  const updates = new Map<string, PendingReceipt | null>();
   const uploaded = new Set<string>();
   let hadPermanentFailure = false;
+  let capReached = false;
 
   // Drive the in-app progress bar for the batch: one step per capture, marked
   // done as each is handled (uploaded, dropped, or failed). The bar is behind a
   // feature flag, but reporting is cheap and always on — the flag only decides
   // whether anything is drawn.
-  startTransfer(FLUSH_TRANSFER_ID, queue.length);
+  startTransfer(FLUSH_TRANSFER_ID, due.length);
   let handled = 0;
 
   // The loop sits in try/finally so a throw from pendingFile/file.exists (which
   // run outside the per-entry try) still ends the transfer — otherwise the bar
   // sticks on screen at done < total until some later flush completes.
   try {
-    for (const entry of queue) {
+    for (const entry of due) {
       const file = pendingFile(entry);
       if (!file.exists) {
         // The bytes are gone (a wipe, a failed write) — nothing to send; drop it.
+        updates.set(entry.attachmentId, null);
         handled += 1;
         setTransferProgress(FLUSH_TRANSFER_ID, handled);
         continue;
       }
 
+      // From here the tile says "sending", live, wherever it is being rendered.
+      markUploading(entry.attachmentId, true);
       try {
         const base64 = await file.base64();
         await putImage({
@@ -294,21 +518,29 @@ async function runFlush(): Promise<FlushResult> {
         } catch {
           // Best-effort; a lingering file is reclaimed with the app's document dir.
         }
+        updates.set(entry.attachmentId, null);
         uploaded.add(entry.expenseId);
       } catch (caught) {
         const message = caught instanceof Error ? caught.message : String(caught);
-        if (isPermanent(message)) {
+        const attempts = entry.attempts + 1;
+        const permanent = isPermanent(message);
+        if (permanent) {
           hadPermanentFailure = true;
-          try {
-            file.delete();
-          } catch {
-            /* ignore */
-          }
-          continue; // Drop — a retry would only fail the same way.
+          if (message.includes('ATTACHMENT_CAP')) capReached = true;
         }
-        // Transient (offline mid-flush, a 5xx): keep it to try again later.
-        remaining.push({ ...entry, attempts: entry.attempts + 1, lastError: message });
+        updates.set(entry.attachmentId, {
+          ...entry,
+          attempts,
+          lastError: message,
+          permanent,
+          // A permanent refusal has no next attempt to schedule; a transient one
+          // backs off so a phone flipping in and out of signal is not retried raw.
+          nextAttemptAt: permanent
+            ? null
+            : new Date(Date.now() + backoffFor(attempts)).toISOString(),
+        });
       } finally {
+        markUploading(entry.attachmentId, false);
         handled += 1;
         setTransferProgress(FLUSH_TRANSFER_ID, handled);
       }
@@ -318,12 +550,15 @@ async function runFlush(): Promise<FlushResult> {
   }
 
   // Re-read before writing back: enqueueReceipt may have appended during the
-  // uploads above, and writing `remaining` alone would silently drop it (its
-  // bytes then orphaned under PENDING_DIR). Keep only the entries this run
-  // handled out of the write, and carry any that arrived meanwhile.
-  const handledIds = new Set(queue.map((entry) => entry.attachmentId));
+  // uploads above, and writing only what this run touched would silently drop it
+  // (its bytes then orphaned under PENDING_DIR). Rebuilding from the current
+  // queue keeps those, keeps the untouched entries, and preserves the order.
   const current = await readQueue();
-  const arrivedDuringFlush = current.filter((entry) => !handledIds.has(entry.attachmentId));
-  await writeQueue([...remaining, ...arrivedDuringFlush]);
-  return { uploadedExpenseIds: [...uploaded], hadPermanentFailure };
+  const next = current.flatMap((entry) => {
+    if (!updates.has(entry.attachmentId)) return [entry];
+    const replacement = updates.get(entry.attachmentId);
+    return replacement ? [replacement] : [];
+  });
+  await writeQueue(next);
+  return { uploadedExpenseIds: [...uploaded], hadPermanentFailure, capReached };
 }

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -40,7 +40,7 @@ import { Directory, File, Paths } from 'expo-file-system';
 import * as Network from 'expo-network';
 
 import { backend } from '@/lib/backend';
-import { putImage } from '@/lib/storage';
+import { putImage, removeRestrictedImage } from '@/lib/storage';
 import { cacheImageBytes } from '@/lib/storage/imageCache';
 import { endTransfer, setTransferProgress, startTransfer } from '@/lib/transferProgress';
 
@@ -492,6 +492,12 @@ async function runFlush(): Promise<FlushResult> {
 
       // From here the tile says "sending", live, wherever it is being rendered.
       markUploading(entry.attachmentId, true);
+      // Whether the bytes reached storage on this attempt. The upload and the
+      // row that makes it findable are two calls, and everything between them is
+      // a window: succeed at the first and fail at the second and the object is
+      // in the bucket with nothing pointing at it, counting against the group's
+      // storage ceiling forever with no UI that can ever show or delete it.
+      let objectStored = false;
       try {
         const base64 = await file.base64();
         await putImage({
@@ -502,6 +508,7 @@ async function runFlush(): Promise<FlushResult> {
           groupId: entry.groupId,
           subjectId: entry.expenseId,
         });
+        objectStored = true;
         const { error } = await backend.rpc('baaki_attach_expense_attachment', {
           p_expense_id: entry.expenseId,
           p_storage_path: entry.storagePath,
@@ -509,6 +516,7 @@ async function runFlush(): Promise<FlushResult> {
           p_attachment_id: entry.attachmentId,
         });
         if (error) throw new Error(error.message);
+        objectStored = false;
 
         // Uploaded and recorded. Keep it viewable offline by moving the bytes into
         // the view cache, then delete the pending file.
@@ -521,6 +529,20 @@ async function runFlush(): Promise<FlushResult> {
         updates.set(entry.attachmentId, null);
         uploaded.add(entry.expenseId);
       } catch (caught) {
+        // The bytes went up but the row did not: take the object back out, or it
+        // is orphaned in the bucket with nothing able to reach it. The local file
+        // is still here and still the source of truth, so a retry re-uploads it
+        // to the same key — losing the remote copy costs nothing, keeping it
+        // costs the group's storage allowance permanently. Best-effort by
+        // design: a delete that fails must not mask the error that caused it,
+        // which is what the queue entry below is recording.
+        if (objectStored) {
+          await removeRestrictedImage(
+            'expense-attachments',
+            entry.expenseId,
+            entry.storagePath,
+          ).catch(() => {});
+        }
         const message = caught instanceof Error ? caught.message : String(caught);
         const attempts = entry.attempts + 1;
         const permanent = isPermanent(message);

--- a/apps/mobile/src/sync/provider.tsx
+++ b/apps/mobile/src/sync/provider.tsx
@@ -24,7 +24,7 @@ import type { MutationEnvelope, MutationKind } from '@waves/core';
 
 import { useAuth } from '@/lib/auth';
 import { reportHandled } from '@/lib/observability';
-import { clearReceiptQueue } from '@/lib/receiptQueue';
+import { clearReceiptQueue, flushReceiptQueue } from '@/lib/receiptQueue';
 import { clearImageCache } from '@/lib/storage/imageCache';
 
 import { syncEngine, type SyncState } from './engine';
@@ -58,6 +58,34 @@ async function clearLocalPrivateData(): Promise<void> {
     failures.push(error);
   }
   if (failures.length > 0) throw failures[0];
+}
+
+/**
+ * Send whatever receipt captures are still parked on this device.
+ *
+ * A receipt is the one thing the app takes from somebody that it cannot re-ask
+ * for — the bill is in the bin by the time the upload fails — so an interrupted
+ * upload has to finish itself. The bytes and the queue entry are already on
+ * disk (see `receiptQueue`); this is what picks them up again, and it lives
+ * here rather than on the expense screen because the three moments that matter
+ * are the three this provider already listens for: the app launching into a
+ * signed-in session, coming back to the foreground, and finding a network. None
+ * of them involve the expense being on screen, and the old wiring — a `useEffect`
+ * inside the receipts gallery — meant a person who added a receipt and walked
+ * away had nothing running to send it.
+ *
+ * Everything is best-effort and nothing throws into a screen: a capture that
+ * cannot be sent stays in the queue, visible as an unsent tile with a retry.
+ */
+async function resumeReceiptUploads(): Promise<void> {
+  try {
+    const result = await flushReceiptQueue();
+    // Each upload recorded an attachment row server-side; pull it down so the
+    // optimistic tile is replaced by the real receipt rather than doubling it.
+    if (result.uploadedExpenseIds.length > 0) await syncEngine.flush();
+  } catch (error) {
+    reportHandled(error, 'sync.resumeReceiptUploads');
+  }
 }
 
 export function SyncProvider({ children }: { children: ReactNode }) {
@@ -113,6 +141,10 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       if (cancelled) return;
       syncEngine.start();
       void syncEngine.flush();
+      // Launch is the moment an upload the app was killed mid-way through gets
+      // picked back up. It runs after the wipe-then-hydrate dance above, so a
+      // previous account's cleanup can never delete the bytes this one is sending.
+      void resumeReceiptUploads();
     })();
 
     return () => {
@@ -126,7 +158,10 @@ export function SyncProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!signedIn) return;
     const subscription = AppState.addEventListener('change', (next) => {
-      if (next === 'active') void syncEngine.flush();
+      if (next === 'active') {
+        void syncEngine.flush();
+        void resumeReceiptUploads();
+      }
     });
     return () => subscription.remove();
   }, [signedIn]);
@@ -135,7 +170,10 @@ export function SyncProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!signedIn) return;
     const subscription = Network.addNetworkStateListener((networkState) => {
-      if (networkState.isConnected) void syncEngine.flush();
+      if (networkState.isConnected) {
+        void syncEngine.flush();
+        void resumeReceiptUploads();
+      }
     });
     return () => subscription.remove();
   }, [signedIn]);

--- a/apps/mobile/test/receiptQueue.test.ts
+++ b/apps/mobile/test/receiptQueue.test.ts
@@ -28,6 +28,11 @@ const world = vi.hoisted(() => ({
     error: null as { message: string } | null,
   })),
   cached: [] as { bucket: string; path: string }[],
+  /** Objects taken back out of the bucket, in order — see the orphan test. */
+  removed: [] as { bucket: string; subjectId: string; path: string }[],
+  remove: vi.fn(async (bucket: string, subjectId: string, path: string) => {
+    world.removed.push({ bucket, subjectId, path });
+  }),
 }));
 
 class FakeDirectory {
@@ -112,7 +117,11 @@ vi.mock('expo-file-system', () => ({
 vi.mock('@/lib/backend', () => ({
   backend: { rpc: (name: string, args: unknown) => world.rpc(name, args) },
 }));
-vi.mock('@/lib/storage', () => ({ putImage: (input: unknown) => world.put(input) }));
+vi.mock('@/lib/storage', () => ({
+  putImage: (input: unknown) => world.put(input),
+  removeRestrictedImage: (bucket: string, subjectId: string, path: string) =>
+    world.remove(bucket, subjectId, path),
+}));
 vi.mock('@/lib/storage/imageCache', () => ({
   cacheImageBytes: vi.fn((bucket: string, path: string) => {
     world.cached.push({ bucket, path });
@@ -177,6 +186,11 @@ beforeEach(() => {
   ids.n = 0;
   world.online = true;
   world.cached = [];
+  world.removed = [];
+  world.remove.mockReset();
+  world.remove.mockImplementation(async (bucket: string, subjectId: string, path: string) => {
+    world.removed.push({ bucket, subjectId, path });
+  });
   world.put.mockReset();
   world.put.mockImplementation(async () => 'stored');
   world.rpc.mockReset();
@@ -332,6 +346,60 @@ describe('a capture that does not go up', () => {
 
     await flushReceiptQueue();
     expect(world.put).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The upload and the row that makes it findable are two calls, and the gap
+   * between them is the one place a receipt can cost something permanently:
+   * bytes accepted by the bucket with nothing in the database pointing at them
+   * are invisible to every screen, unreachable by any delete the app offers, and
+   * still counted against the group's storage ceiling. The local file is the
+   * source of truth and survives, so taking the remote copy back out is free.
+   */
+  it('takes the uploaded object back out when the row that names it fails', async () => {
+    parkOnDisk();
+    world.rpc.mockResolvedValue({ error: { message: 'Network request failed' } });
+
+    await flushReceiptQueue();
+
+    expect(world.put).toHaveBeenCalledTimes(1);
+    expect(world.removed).toEqual([
+      { bucket: 'expense-attachments', subjectId: 'e1', path: expect.any(String) },
+    ]);
+    // The object removed is the one just uploaded, so a retry re-uploads to the
+    // same key rather than leaving a second copy behind.
+    const [stored] = await storedQueue();
+    expect(world.removed[0]?.path).toBe(stored?.storagePath);
+    // And the capture itself is untouched: bytes on disk, entry still queued.
+    expect(fs.files.has(pendingPath('a1.jpg'))).toBe(true);
+    expect(getPendingReceiptsSnapshot()[0]?.status).toBe('failed');
+  });
+
+  it('leaves the bucket alone when the bytes never reached it', async () => {
+    parkOnDisk();
+    world.put.mockRejectedValue(new Error('Network request failed'));
+
+    await flushReceiptQueue();
+
+    // Nothing was stored, so there is nothing to take back out — and asking R2
+    // to delete a key that was never written is a pointless round trip on a
+    // connection that has just proved itself unreliable.
+    expect(world.removed).toEqual([]);
+  });
+
+  it('records the failure that mattered even when the cleanup itself fails', async () => {
+    parkOnDisk();
+    world.rpc.mockResolvedValue({ error: { message: 'ATTACHMENT_CAP reached' } });
+    world.remove.mockRejectedValue(new Error('delete refused'));
+
+    // A best-effort cleanup must never mask the error the entry is recording,
+    // nor take the rest of the queue down with it.
+    const result = await flushReceiptQueue();
+
+    expect(result.capReached).toBe(true);
+    const [stored] = await storedQueue();
+    expect(stored).toMatchObject({ permanent: true });
+    expect(stored?.lastError).toContain('ATTACHMENT_CAP');
   });
 
   it('sends a refused capture again when the person asks', async () => {

--- a/apps/mobile/test/receiptQueue.test.ts
+++ b/apps/mobile/test/receiptQueue.test.ts
@@ -17,6 +17,19 @@ const fs = vi.hoisted(() => ({
   failDelete: false,
 }));
 
+/** Unique ids per call, so a test can park more than one capture. */
+const ids = vi.hoisted(() => ({ n: 0 }));
+
+/** The world outside the queue: the network, R2, and the attach RPC. */
+const world = vi.hoisted(() => ({
+  online: true,
+  put: vi.fn(async (_input: unknown) => 'stored'),
+  rpc: vi.fn(async (_name: string, _args: unknown) => ({
+    error: null as { message: string } | null,
+  })),
+  cached: [] as { bucket: string; path: string }[],
+}));
+
 class FakeDirectory {
   readonly uri: string;
 
@@ -79,29 +92,79 @@ class FakeFile {
 }
 
 vi.mock('@react-native-async-storage/async-storage', () => ({ default: storage }));
-vi.mock('expo-crypto', () => ({ randomUUID: vi.fn(() => 'uuid') }));
+vi.mock('expo-crypto', () => ({
+  randomUUID: vi.fn(() => {
+    ids.n += 1;
+    return `uuid${ids.n}`;
+  }),
+}));
 vi.mock('expo-network', () => ({
-  getNetworkStateAsync: vi.fn(async () => ({ isConnected: false })),
+  getNetworkStateAsync: vi.fn(async () => ({
+    isConnected: world.online,
+    isInternetReachable: world.online,
+  })),
 }));
 vi.mock('expo-file-system', () => ({
   Directory: FakeDirectory,
   File: FakeFile,
   Paths: { document: 'document-root', cache: 'cache-root' },
 }));
-vi.mock('@/lib/backend', () => ({ backend: { rpc: vi.fn() } }));
-vi.mock('@/lib/storage', () => ({ putImage: vi.fn() }));
-vi.mock('@/lib/storage/imageCache', () => ({ cacheImageBytes: vi.fn() }));
+vi.mock('@/lib/backend', () => ({
+  backend: { rpc: (name: string, args: unknown) => world.rpc(name, args) },
+}));
+vi.mock('@/lib/storage', () => ({ putImage: (input: unknown) => world.put(input) }));
+vi.mock('@/lib/storage/imageCache', () => ({
+  cacheImageBytes: vi.fn((bucket: string, path: string) => {
+    world.cached.push({ bucket, path });
+  }),
+}));
 vi.mock('@/lib/transferProgress', () => ({
   endTransfer: vi.fn(),
   setTransferProgress: vi.fn(),
   startTransfer: vi.fn(),
 }));
 
-const { clearReceiptQueue, listPendingReceipts, pendingReceiptUri } =
-  await import('../src/lib/receiptQueue');
+const {
+  clearReceiptQueue,
+  discardPendingReceipt,
+  enqueueReceipt,
+  flushReceiptQueue,
+  getPendingReceiptsSnapshot,
+  listPendingReceipts,
+  pendingReceiptUri,
+  retryPendingReceipts,
+  subscribePendingReceipts,
+} = await import('../src/lib/receiptQueue');
 
 const QUEUE_KEY = 'receipt-upload-queue.v1';
 const pendingPath = (fileName: string) => `document-root/pending-receipts/${fileName}`;
+
+/** A stored entry, as a previous run of the app would have left it. */
+const entryFor = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  attachmentId: 'a1',
+  expenseId: 'e1',
+  groupId: 'g1',
+  visibility: 'group' as const,
+  storagePath: 'e1/a1.jpg',
+  contentType: 'image/jpeg',
+  fileName: 'a1.jpg',
+  createdAt: '2026-01-01T00:00:00Z',
+  attempts: 0,
+  lastError: null,
+  ...overrides,
+});
+
+/** Put one capture on disk exactly as a killed run of the app would have. */
+function parkOnDisk(overrides: Partial<Record<string, unknown>> = {}): void {
+  const entry = entryFor(overrides);
+  storage.data.set(QUEUE_KEY, JSON.stringify([entry]));
+  fs.dirs.add('document-root/pending-receipts');
+  fs.files.set(pendingPath(entry.fileName), new Uint8Array([1, 2, 3]));
+}
+
+async function storedQueue(): Promise<Record<string, unknown>[]> {
+  return JSON.parse(storage.data.get(QUEUE_KEY) ?? '[]') as Record<string, unknown>[];
+}
 
 beforeEach(() => {
   storage.data.clear();
@@ -111,35 +174,231 @@ beforeEach(() => {
   fs.files.clear();
   fs.dirs.clear();
   fs.failDelete = false;
+  ids.n = 0;
+  world.online = true;
+  world.cached = [];
+  world.put.mockReset();
+  world.put.mockImplementation(async () => 'stored');
+  world.rpc.mockReset();
+  world.rpc.mockImplementation(async () => ({ error: null }));
+});
+
+describe('parking a capture', () => {
+  it('writes the bytes down and queues the entry before anything is sent', async () => {
+    const entry = await enqueueReceipt({
+      expenseId: 'e1',
+      groupId: 'g1',
+      visibility: 'group',
+      base64: Buffer.from([7, 8, 9]).toString('base64'),
+      contentType: 'image/jpeg',
+    });
+
+    // The photograph exists somewhere other than memory from this moment on —
+    // which is the whole reason the queue writes before it uploads.
+    expect(fs.files.get(pendingPath(entry.fileName))).toEqual(new Uint8Array([7, 8, 9]));
+    expect(await listPendingReceipts('e1')).toHaveLength(1);
+    expect(world.put).not.toHaveBeenCalled();
+    // And it is on screen straight away, as something waiting rather than sent.
+    expect(getPendingReceiptsSnapshot().map((item) => item.status)).toEqual(['queued']);
+  });
+
+  it('publishes to subscribers as the queue changes', async () => {
+    const seen: number[] = [];
+    const unsubscribe = subscribePendingReceipts(() => {
+      seen.push(getPendingReceiptsSnapshot().length);
+    });
+
+    const entry = await enqueueReceipt({
+      expenseId: 'e1',
+      groupId: 'g1',
+      visibility: 'group',
+      base64: Buffer.from([1]).toString('base64'),
+      contentType: 'image/jpeg',
+    });
+    await discardPendingReceipt(entry.attachmentId);
+    unsubscribe();
+
+    // A gallery three screens away learns about both without asking.
+    expect(seen.at(-1)).toBe(0);
+    expect(seen).toContain(1);
+    expect(fs.files.has(pendingPath(entry.fileName))).toBe(false);
+  });
+});
+
+describe('resuming an interrupted upload', () => {
+  it('picks up a capture left by a previous run of the app and sends it', async () => {
+    parkOnDisk();
+    // A cold start: a module with no memory of the run that parked this.
+    vi.resetModules();
+    const fresh = await import('../src/lib/receiptQueue');
+    expect(fresh.getPendingReceiptsSnapshot()).toHaveLength(0);
+
+    expect(await fresh.listPendingReceipts()).toHaveLength(1);
+    expect(fresh.getPendingReceiptsSnapshot()[0]?.status).toBe('queued');
+
+    const result = await fresh.flushReceiptQueue();
+
+    expect(world.put).toHaveBeenCalledTimes(1);
+    expect(world.rpc).toHaveBeenCalledWith('baaki_attach_expense_attachment', {
+      p_expense_id: 'e1',
+      p_storage_path: 'e1/a1.jpg',
+      p_visibility: 'group',
+      p_attachment_id: 'a1',
+    });
+    expect(result.uploadedExpenseIds).toEqual(['e1']);
+    // Sent, so the bytes move into the view cache and out of the pending dir.
+    expect(world.cached).toEqual([{ bucket: 'expense-attachments', path: 'e1/a1.jpg' }]);
+    expect(fs.files.has(pendingPath('a1.jpg'))).toBe(false);
+    expect(await storedQueue()).toEqual([]);
+  });
+
+  it('says a capture is sending while it is in the air', async () => {
+    parkOnDisk();
+    let statusMidUpload: string | undefined;
+    world.put.mockImplementation(async () => {
+      statusMidUpload = getPendingReceiptsSnapshot()[0]?.status;
+      return 'stored';
+    });
+
+    await listPendingReceipts();
+    await flushReceiptQueue();
+
+    expect(statusMidUpload).toBe('uploading');
+  });
+
+  it('leaves everything alone and sends nothing while offline', async () => {
+    parkOnDisk();
+    world.online = false;
+
+    const result = await flushReceiptQueue();
+
+    expect(world.put).not.toHaveBeenCalled();
+    expect(result.uploadedExpenseIds).toEqual([]);
+    expect(await storedQueue()).toHaveLength(1);
+    expect(fs.files.has(pendingPath('a1.jpg'))).toBe(true);
+  });
+
+  it('keeps a capture parked when nothing is due yet', async () => {
+    // A failure a moment ago; its backoff has not run out.
+    parkOnDisk({
+      attempts: 1,
+      lastError: 'network request failed',
+      nextAttemptAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    await flushReceiptQueue();
+
+    expect(world.put).not.toHaveBeenCalled();
+    expect(await storedQueue()).toHaveLength(1);
+  });
+});
+
+describe('a capture that does not go up', () => {
+  it('keeps a transient failure, records it, and backs off before trying again', async () => {
+    parkOnDisk();
+    world.put.mockRejectedValue(new Error('Network request failed'));
+
+    const first = await flushReceiptQueue();
+
+    expect(first.uploadedExpenseIds).toEqual([]);
+    expect(first.hadPermanentFailure).toBe(false);
+    const [stored] = await storedQueue();
+    expect(stored).toMatchObject({ attempts: 1, permanent: false });
+    expect(stored?.lastError).toContain('Network request failed');
+    expect(Date.parse(String(stored?.nextAttemptAt))).toBeGreaterThan(Date.now());
+    // The bytes are still there — a failed send never costs the photograph.
+    expect(fs.files.has(pendingPath('a1.jpg'))).toBe(true);
+    expect(getPendingReceiptsSnapshot()[0]?.status).toBe('failed');
+
+    // A second flush straight away respects the backoff rather than hammering.
+    await flushReceiptQueue();
+    expect(world.put).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a refusal visible instead of dropping it, and never retries it by itself', async () => {
+    parkOnDisk();
+    world.rpc.mockResolvedValue({ error: { message: 'ATTACHMENT_CAP reached' } });
+
+    const result = await flushReceiptQueue();
+
+    expect(result.hadPermanentFailure).toBe(true);
+    expect(result.capReached).toBe(true);
+    const [stored] = await storedQueue();
+    expect(stored).toMatchObject({ permanent: true, nextAttemptAt: null });
+    // Still on the phone, still on screen: a receipt that vanished with no
+    // explanation is indistinguishable from a bug.
+    expect(fs.files.has(pendingPath('a1.jpg'))).toBe(true);
+    expect(getPendingReceiptsSnapshot()[0]?.status).toBe('failed');
+
+    await flushReceiptQueue();
+    expect(world.put).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends a refused capture again when the person asks', async () => {
+    parkOnDisk();
+    world.rpc.mockResolvedValueOnce({ error: { message: 'ATTACHMENT_CAP reached' } });
+    await flushReceiptQueue();
+    expect(await storedQueue()).toHaveLength(1);
+
+    // Somebody removed another receipt and tapped "try again": the backoff, the
+    // recorded failure and the refusal mark are all cleared for this one.
+    const result = await retryPendingReceipts(['a1']);
+
+    expect(result.uploadedExpenseIds).toEqual(['e1']);
+    expect(world.put).toHaveBeenCalledTimes(2);
+    expect(await storedQueue()).toEqual([]);
+  });
+
+  it('drops an entry whose bytes are gone rather than retrying forever', async () => {
+    storage.data.set(QUEUE_KEY, JSON.stringify([entryFor()]));
+
+    await flushReceiptQueue();
+
+    expect(world.put).not.toHaveBeenCalled();
+    expect(await storedQueue()).toEqual([]);
+  });
+});
+
+describe('a capture parked while a flush is running', () => {
+  it('survives the write-back instead of being silently dropped', async () => {
+    parkOnDisk();
+    let latecomerFile = '';
+    world.put.mockImplementation(async () => {
+      const late = await enqueueReceipt({
+        expenseId: 'e2',
+        groupId: 'g1',
+        visibility: 'group',
+        base64: Buffer.from([4]).toString('base64'),
+        contentType: 'image/jpeg',
+      });
+      latecomerFile = late.fileName;
+      return 'stored';
+    });
+
+    await flushReceiptQueue();
+
+    const queue = await storedQueue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({ expenseId: 'e2' });
+    // Its bytes are still under the pending dir — not orphaned by the write-back.
+    expect(fs.files.has(pendingPath(latecomerFile))).toBe(true);
+  });
 });
 
 describe('receipt queue local privacy cleanup', () => {
   it('removes the queue index and pending receipt files on sign-out cleanup', async () => {
     const entries = [
-      {
-        attachmentId: 'a1',
-        expenseId: 'e1',
-        groupId: 'g1',
-        visibility: 'group' as const,
-        storagePath: 'e1/a1.jpg',
-        contentType: 'image/jpeg',
-        fileName: 'a1.jpg',
-        createdAt: '2026-01-01T00:00:00Z',
-        attempts: 0,
-        lastError: null,
-      },
-      {
+      entryFor(),
+      entryFor({
         attachmentId: 'a2',
         expenseId: 'e2',
-        groupId: 'g1',
-        visibility: 'parties' as const,
+        visibility: 'parties',
         storagePath: 'e2/a2.jpg',
-        contentType: 'image/jpeg',
         fileName: 'a2.jpg',
         createdAt: '2026-01-01T00:00:01Z',
         attempts: 1,
         lastError: 'offline',
-      },
+      }),
     ];
     storage.data.set(QUEUE_KEY, JSON.stringify(entries));
     fs.dirs.add('document-root/pending-receipts');
@@ -150,25 +409,14 @@ describe('receipt queue local privacy cleanup', () => {
 
     expect(storage.removeItem).toHaveBeenCalledWith(QUEUE_KEY);
     expect(await listPendingReceipts()).toEqual([]);
+    expect(getPendingReceiptsSnapshot()).toEqual([]);
     expect(fs.files.has(pendingPath('a1.jpg'))).toBe(false);
     expect(fs.files.has(pendingPath('a2.jpg'))).toBe(false);
     expect(fs.dirs.has('document-root/pending-receipts')).toBe(false);
   });
 
   it('still removes the queue index when file deletion fails', async () => {
-    const entry = {
-      attachmentId: 'a1',
-      expenseId: 'e1',
-      groupId: 'g1',
-      visibility: 'group' as const,
-      storagePath: 'e1/a1.jpg',
-      contentType: 'image/jpeg',
-      fileName: 'a1.jpg',
-      createdAt: '2026-01-01T00:00:00Z',
-      attempts: 0,
-      lastError: null,
-    };
-    storage.data.set(QUEUE_KEY, JSON.stringify([entry]));
+    storage.data.set(QUEUE_KEY, JSON.stringify([entryFor()]));
     fs.dirs.add('document-root/pending-receipts');
     fs.files.set(pendingPath('a1.jpg'), new Uint8Array([1]));
     fs.failDelete = true;
@@ -177,28 +425,16 @@ describe('receipt queue local privacy cleanup', () => {
 
     expect(storage.removeItem).toHaveBeenCalledWith(QUEUE_KEY);
     expect(await listPendingReceipts()).toEqual([]);
-    expect(pendingReceiptUri(entry)).toBe(pendingPath('a1.jpg'));
+    expect(pendingReceiptUri(entryFor())).toBe(pendingPath('a1.jpg'));
   });
 
   it('removes orphan pending files when pending receipts are listed', async () => {
-    const entry = {
-      attachmentId: 'a1',
-      expenseId: 'e1',
-      groupId: 'g1',
-      visibility: 'group' as const,
-      storagePath: 'e1/a1.jpg',
-      contentType: 'image/jpeg',
-      fileName: 'a1.jpg',
-      createdAt: '2026-01-01T00:00:00Z',
-      attempts: 0,
-      lastError: null,
-    };
-    storage.data.set(QUEUE_KEY, JSON.stringify([entry]));
+    storage.data.set(QUEUE_KEY, JSON.stringify([entryFor()]));
     fs.dirs.add('document-root/pending-receipts');
     fs.files.set(pendingPath('a1.jpg'), new Uint8Array([1]));
     fs.files.set(pendingPath('orphan.jpg'), new Uint8Array([9]));
 
-    await expect(listPendingReceipts()).resolves.toEqual([entry]);
+    await expect(listPendingReceipts()).resolves.toEqual([entryFor()]);
 
     expect(fs.files.has(pendingPath('a1.jpg'))).toBe(true);
     expect(fs.files.has(pendingPath('orphan.jpg'))).toBe(false);


### PR DESCRIPTION
Reported: adding a receipt gives no loading indication at all — you can't tell whether it worked. It should not be lost if the app is closed, it should finish on its own, and it should keep going if you move to another screen.

### What was already there, and what was actually wrong

`apps/mobile/src/lib/receiptQueue.ts` already held a durable park-and-send queue: bytes written to a file under the OS document dir, an entry in AsyncStorage, an `attachmentId` chosen up front so the optimistic tile and the real row share an identity, a single-flight `flushReceiptQueue`, a progress bar, orphan-file cleanup, and permanent-vs-transient failure classification.

**But online adds did not use it.** They ran `useAttachExpenseAttachment`, a react-query mutation living on the screen. That is what produced all three complaints at once: nothing rendered until the row landed, leaving the screen dropped the mutation's callbacks, and an app killed mid-upload lost the photograph outright because it existed only in memory.

Compounding it, the only thing that ever flushed the queue was a `useEffect` inside the receipts gallery — so a parked receipt was never sent unless you happened to be looking at that expense.

### The change

**One path now, the durable one.** Every add parks first (`enqueueReceipt`), online or not, so the bytes are on disk before anything is attempted. `useAttachExpenseAttachment` is deleted.

**Live status** through a `useSyncExternalStore` store (`usePendingReceipts`): `queued | uploading | failed`. `uploading` is deliberately *not* persisted, so an app killed mid-flight comes back as `queued` rather than a stuck spinner. `publish` suppresses no-op notifications so a flush that found nothing doesn't re-render every mounted gallery.

**Resume** — `resumeReceiptUploads()` wired into the three lifecycle moments `sync/provider.tsx` already listens for: signed-in launch, foreground, reconnect. This is what makes resume-after-restart and continue-across-navigation real rather than incidental. A success calls `syncEngine.flush()` so the optimistic tile is replaced by the real row.

**The tile says which state it is in** — spinner sending, cloud glyph waiting, filled red disc failed — with a status line under the strip and an inline retry. Tapping a failed tile opens the reason plus Try again / Remove. No raw error text reaches the UI; `lastError` stays on the entry for diagnosis only.

**Retry backoff** so event-driven flushes don't hammer a failing server.

### Behaviour changes worth reviewing

1. **A permanent refusal is no longer silently deleted.** Cap reached or not-a-party now keeps `permanent: true` with the bytes intact and shows as a failed tile, because the usual fix for the cap is to remove another receipt and re-send this one. Background flushes skip it; `retryPendingReceipts` clears the mark, the backoff and the error. `FlushResult` gained `capReached` so the screen can offer the upgrade instead of an unexplained red tile.

2. **The visibility prompt is gone.** Photographing a bill used to stop and ask "Who can see this receipt?" a beat after you were done. The answer was the group's every time — a receipt for a bill everybody is paying a share of is not a private document — and group-readable is what the R2 group path already authorises by membership. The narrower `'parties'` visibility stays in `commitAdd` and in the storage rules for payment proofs, and a receipt already added that way keeps its Private tag.

### Checks

- 7 new i18n keys in the typed interface and all four locales (en/ta/hi/ar); RTL-safe — status overlay centred, strip uses `Row`
- `apps/mobile/test/receiptQueue.test.ts`: 14 pass (3 pre-existing privacy tests preserved, 11 new). The cold-start test uses `vi.resetModules()` + re-import to prove resume works with no in-memory state
- full mobile suite 694 tests / 55 files pass; `tsc --noEmit` clean; eslint clean

**Not device-tested** — I can't kill and relaunch a real app from here, so resume-on-restart is proven by the cold-start test rather than on hardware. That's the path to exercise first.
