### PR TITLE
fix(privacy): put the switches above the policy, and give the policy a date

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -203,7 +203,12 @@ function ProfileForm() {
     (session?.user?.user_metadata?.picture as string | undefined) ||
     null;
 
-  const { enabled: lockEnabled, supported: lockSupported, graceSeconds } = useLock();
+  const {
+    enabled: lockEnabled,
+    supported: lockSupported,
+    ready: lockReady,
+    graceSeconds,
+  } = useLock();
   const { preference: syncNetwork } = useSyncNetwork();
   const { preference: themePreference, overridden: themeOverridden } = useThemePreference();
   const { language, stored: languageChosen, restartNeeded } = useLanguage();
@@ -294,11 +299,16 @@ function ProfileForm() {
         ? t.sync.both
         : t.sync.wifi;
 
-  const lockSummary = !lockSupported
-    ? t.account.lockNoBiometrics
-    : lockEnabled
-      ? t.account.lockOn.replace('{when}', describeGrace(graceSeconds, t, locale).toLowerCase())
-      : t.account.lockOff;
+  // Until the stored state and the hardware check are both back, `supported`
+  // is still its initial false — saying "no biometrics" then would be a wrong
+  // answer on a phone that has them. No hint until it is known.
+  const lockSummary = !lockReady
+    ? undefined
+    : !lockSupported
+      ? t.account.lockNoBiometrics
+      : lockEnabled
+        ? t.account.lockOn.replace('{when}', describeGrace(graceSeconds, t, locale).toLowerCase())
+        : t.account.lockOff;
 
   const signOutHint = isGuest ? t.account.signOutGuestHint : t.account.signOutHint;
 

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { LayoutAnimation, Pressable, ScrollView, View } from 'react-native';
+import { Alert, LayoutAnimation, Pressable, ScrollView, View } from 'react-native';
 
 import {
   Card,
@@ -22,7 +22,7 @@ import { useBlockedUsers } from '@/data/blocked';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { clarityConfigured } from '@/lib/clarity';
-import { useLock } from '@/lib/lock';
+import { describeGrace, useLock } from '@/lib/lock';
 import { useReducedMotion } from '@/lib/reducedMotion';
 import { sessionReplayConsent, setSessionReplayConsent } from '@/lib/sessionReplay';
 
@@ -58,8 +58,21 @@ export default function PrivacyScreen() {
   // have yet, so they are shown only once there is a session (a guest counts —
   // they have data to manage).
   const { session } = useAuth();
-  const { enabled: lockEnabled, supported: lockSupported } = useLock();
+  const {
+    enabled: lockEnabled,
+    supported: lockSupported,
+    ready: lockReady,
+    graceSeconds,
+  } = useLock();
   const { blocked } = useBlockedUsers();
+
+  // The same sentence the Settings lock row shows, so the two never disagree
+  // about what the lock is currently doing.
+  const lockSummary = !lockSupported
+    ? t.account.lockNoBiometrics
+    : lockEnabled
+      ? t.account.lockOn.replace('{when}', describeGrace(graceSeconds, t, locale).toLowerCase())
+      : t.account.lockOff;
 
   // The session-replay opt-in, mirrored from storage. Only meaningful when a
   // Clarity project is configured; on a build without one the switch is hidden
@@ -69,9 +82,16 @@ export default function PrivacyScreen() {
     void sessionReplayConsent().then(setReplay);
   }, []);
 
+  // Optimistic, then honest: if the consent does not persist, the switch goes
+  // back to what is actually stored rather than showing a choice that will not
+  // survive the next launch. This one is a consent to be recorded, so a switch
+  // that lies about it is the worst kind.
   const onReplayChange = (value: boolean): void => {
     setReplay(value);
-    void setSessionReplayConsent(value);
+    void setSessionReplayConsent(value).catch(() => {
+      setReplay(!value);
+      Alert.alert(t.privacy.couldNotSave);
+    });
   };
 
   // Which policy points are open. Signed out this screen *is* the policy, so
@@ -181,9 +201,6 @@ export default function PrivacyScreen() {
         showsVerticalScrollIndicator={false}
       >
         <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
-          {/* A shield, not the people glyph this screen used to open with: the
-              subject is what is kept and who cannot reach it, not who is in
-              your groups. */}
           <Ionicons name="shield-checkmark-outline" size={64} color={theme.color.text} />
           <Text
             align="center"
@@ -202,16 +219,14 @@ export default function PrivacyScreen() {
           </Text>
         </View>
 
-        {/* The switches, first, for the reader who came from Settings. Each is a
-            state they can read off in a second — on or off, how many — rather
-            than a paragraph that describes one. */}
+        {/* Signed in, the controls come before the policy prose. */}
         {session ? (
           <View style={{ gap: theme.spacing.sm }}>
             <SectionHeader title={t.privacy.controlsSection} />
             <Card style={{ paddingVertical: theme.spacing.xs }}>
               <ListRow
                 title={t.privacy.appLockRow}
-                subtitle={t.privacy.appLockHint}
+                subtitle={lockReady ? lockSummary : t.privacy.appLockHint}
                 onPress={() => router.push('/settings/lock')}
                 leading={
                   <Ionicons
@@ -222,13 +237,19 @@ export default function PrivacyScreen() {
                 }
                 trailing={
                   <Row style={{ gap: theme.spacing.xs }}>
-                    {status(
-                      !lockSupported
-                        ? t.privacy.appLockUnavailable
-                        : lockEnabled
-                          ? t.privacy.statusOn
-                          : t.privacy.statusOff,
-                    )}
+                    {/* Nothing until the lock's stored state and hardware check
+                        are both back: `supported` starts false, and a security
+                        row that says "not available" for a frame and then "on"
+                        is worse than one that says nothing for a frame. */}
+                    {lockReady
+                      ? status(
+                          !lockSupported
+                            ? t.privacy.appLockUnavailable
+                            : lockEnabled
+                              ? t.privacy.statusOn
+                              : t.privacy.statusOff,
+                        )
+                      : null}
                     {chevron}
                   </Row>
                 }
@@ -256,11 +277,9 @@ export default function PrivacyScreen() {
                   </Row>
                 }
               />
-              {/* The most sensitive switch on the page — it can record screens
-                  with names and amounts on them — so it sits in the open with
-                  the other controls rather than as a footnote under a
-                  paragraph. Hidden entirely on a build with no Clarity project,
-                  where it would toggle nothing. */}
+              {/* Recording can catch names and amounts, so it is a control in
+                  the open, not a footnote. Hidden entirely with no Clarity
+                  project, where it would toggle nothing. */}
               {clarityConfigured ? (
                 <>
                   {divider}
@@ -288,8 +307,7 @@ export default function PrivacyScreen() {
           </View>
         ) : null}
 
-        {/* Taking a copy out is not destructive and does not belong next to the
-            row that ends the account, so it stands on its own. */}
+        {/* Export is reversible; it does not share a card with delete. */}
         {session ? (
           <View style={{ gap: theme.spacing.sm }}>
             <SectionHeader title={t.privacy.dataControlsSection} />
@@ -307,14 +325,42 @@ export default function PrivacyScreen() {
           </View>
         ) : null}
 
-        {/* The policy itself: a glyph, the point, and one line of what it says.
-            Tapping opens the full paragraph. Signed out every one is already
-            open — this is the policy then, not a settings screen. */}
+        {/* Signed in this is an accordion — a glyph, the point, one line of what
+            it says, the paragraph on a tap. Signed out it is a document: every
+            body open, nothing pressable, and no chevron. A policy read by a
+            screen reader should not be a run of "button, expanded". */}
         <View style={{ gap: theme.spacing.sm }}>
           {session ? <SectionHeader title={t.privacy.policySection} /> : null}
           <View style={{ gap: theme.spacing.lg }}>
             {sections.map((section) => {
               const expanded = isOpen(section.id);
+              const content = (
+                <Row style={{ alignItems: 'flex-start', gap: theme.spacing.md }}>
+                  <Ionicons
+                    name={section.icon}
+                    size={iconSize.md}
+                    color={theme.color.brand}
+                    style={{ marginTop: 2 }}
+                  />
+                  <View style={{ flex: 1, gap: theme.spacing.xs }}>
+                    <Text variant="subheading">{section.title}</Text>
+                    <Text variant="body" tone="muted">
+                      {expanded ? section.body : section.summary}
+                    </Text>
+                  </View>
+                  {session ? (
+                    <Ionicons
+                      name={expanded ? 'chevron-up' : 'chevron-down'}
+                      size={iconSize.sm}
+                      color={theme.color.textFaint}
+                      style={{ marginTop: 4 }}
+                    />
+                  ) : null}
+                </Row>
+              );
+
+              if (!session) return <View key={section.id}>{content}</View>;
+
               return (
                 <Pressable
                   key={section.id}
@@ -323,28 +369,16 @@ export default function PrivacyScreen() {
                   accessibilityLabel={section.title}
                   accessibilityHint={expanded ? t.privacy.collapseLabel : t.privacy.expandLabel}
                   onPress={() => toggleSection(section.id)}
-                  style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+                  // The row is a deliberate control, not a paragraph that happens
+                  // to react: padding and a 44pt floor make it one to the thumb.
+                  style={({ pressed }) => ({
+                    minHeight: 44,
+                    justifyContent: 'center',
+                    paddingVertical: theme.spacing.xs,
+                    opacity: pressed ? 0.7 : 1,
+                  })}
                 >
-                  <Row style={{ alignItems: 'flex-start', gap: theme.spacing.md }}>
-                    <Ionicons
-                      name={section.icon}
-                      size={iconSize.md}
-                      color={theme.color.brand}
-                      style={{ marginTop: 2 }}
-                    />
-                    <View style={{ flex: 1, gap: theme.spacing.xs }}>
-                      <Text variant="subheading">{section.title}</Text>
-                      <Text variant="body" tone="muted">
-                        {expanded ? section.body : section.summary}
-                      </Text>
-                    </View>
-                    <Ionicons
-                      name={expanded ? 'chevron-up' : 'chevron-down'}
-                      size={iconSize.sm}
-                      color={theme.color.textFaint}
-                      style={{ marginTop: 4 }}
-                    />
-                  </Row>
+                  {content}
                 </Pressable>
               );
             })}
@@ -354,9 +388,7 @@ export default function PrivacyScreen() {
         <View style={{ gap: theme.spacing.sm }}>
           <SectionHeader title={t.privacy.legalSection} />
           <Card style={{ paddingVertical: theme.spacing.xs }}>
-            {/* A policy that explains your rights and gives you nobody to ask is
-                half a policy. The route only exists behind a session, so it is
-                offered to the reader who has one. */}
+            {/* Feedback needs a session, so it is offered only with one. */}
             {session ? (
               <>
                 <ListRow
@@ -387,8 +419,7 @@ export default function PrivacyScreen() {
           </Card>
         </View>
 
-        {/* Ending the account is one divider away from nothing: it gets its own
-            heading and its own card, at the bottom, past everything reversible. */}
+        {/* Deleting the account sits alone, below everything reversible. */}
         {session ? (
           <View style={{ gap: theme.spacing.sm }}>
             <SectionHeader title={t.privacy.dangerSection} />

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { ScrollView, View } from 'react-native';
+import { LayoutAnimation, Pressable, ScrollView, View } from 'react-native';
 
 import {
   Card,
@@ -18,9 +18,12 @@ import {
   useTheme,
 } from '@waves/ui';
 
+import { useBlockedUsers } from '@/data/blocked';
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { clarityConfigured } from '@/lib/clarity';
+import { useLock } from '@/lib/lock';
+import { useReducedMotion } from '@/lib/reducedMotion';
 import { sessionReplayConsent, setSessionReplayConsent } from '@/lib/sessionReplay';
 
 /**
@@ -29,21 +32,34 @@ import { sessionReplayConsent, setSessionReplayConsent } from '@/lib/sessionRepl
  * Written from what the app actually does rather than from a template: every
  * claim here is one this codebase can be checked against — row-level security
  * on every table (ADR-013), receipts in a private bucket behind signed links,
- * crash reports scrubbed before they leave the phone, export free and lossless
- * (ADR-012). A policy that promises something the code does not do is worse
- * than no policy, because it is the one people rely on.
+ * the offline mirror sealed at rest (`sync/rowCipher`), crash reports scrubbed
+ * before they leave the phone, export free and lossless (ADR-012). A policy
+ * that promises something the code does not do is worse than no policy, because
+ * it is the one people rely on.
+ *
+ * The screen has two readers and serves them in two different orders. Somebody
+ * arriving from Settings came to *do* something — lock the app, see who they
+ * blocked, stop the recording, take their data out — so for them the switches
+ * come first and the prose is folded down to a line each, opened on a tap.
+ * Somebody arriving from the legal line on the signed-out gate came to *read*
+ * the policy, so for them the same text is the page, open from the start, with
+ * no account controls that would act on an account they do not have.
  */
+
+/** When the policy text below last changed. Shown, because an undated policy is not one. */
+const POLICY_UPDATED = '2026-08-31';
+
 export default function PrivacyScreen() {
   const theme = useTheme();
   const clearance = useTabBarClearance();
-  const { t } = useStrings();
-  // This same screen is the app's privacy *policy*, reached from the legal line
-  // on the signed-out welcome/sign-up gate as well as from Settings. The policy
-  // text is for everyone; the account data-controls below (block list, export,
-  // delete) act on an account that a signed-out reader does not have yet, so
-  // they are shown only once there is a session (a guest counts — they have
-  // data to manage).
+  const { t, locale } = useStrings();
+  const reduceMotion = useReducedMotion();
+  // The account data-controls act on an account a signed-out reader does not
+  // have yet, so they are shown only once there is a session (a guest counts —
+  // they have data to manage).
   const { session } = useAuth();
+  const { enabled: lockEnabled, supported: lockSupported } = useLock();
+  const { blocked } = useBlockedUsers();
 
   // The session-replay opt-in, mirrored from storage. Only meaningful when a
   // Clarity project is configured; on a build without one the switch is hidden
@@ -58,44 +74,84 @@ export default function PrivacyScreen() {
     void setSessionReplayConsent(value);
   };
 
+  // Which policy points are open. Signed out this screen *is* the policy, so
+  // every point starts open and the summaries are just headings above the text;
+  // signed in they start folded, one line each, out of the way of the controls.
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const isOpen = (id: string): boolean => open[id] ?? !session;
+  const toggleSection = (id: string): void => {
+    if (!reduceMotion) LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setOpen((prev) => ({ ...prev, [id]: !(prev[id] ?? !session) }));
+  };
+
   const sections = [
     {
       id: 'store',
       title: t.privacy.storeTitle,
+      summary: t.privacy.storeSummary,
       body: t.privacy.storeBody,
       icon: 'file-tray-outline',
     },
     {
       id: 'protect',
       title: t.privacy.protectTitle,
+      summary: t.privacy.protectSummary,
       body: t.privacy.protectBody,
       icon: 'lock-closed-outline',
     },
     {
+      id: 'device',
+      title: t.privacy.deviceTitle,
+      summary: t.privacy.deviceSummary,
+      body: t.privacy.deviceBody,
+      icon: 'phone-portrait-outline',
+    },
+    {
       id: 'services',
       title: t.privacy.servicesTitle,
+      summary: t.privacy.servicesSummary,
       body: t.privacy.servicesBody,
       icon: 'cloud-outline',
     },
     {
       id: 'analytics',
       title: t.privacy.analyticsTitle,
+      summary: t.privacy.analyticsSummary,
       body: t.privacy.analyticsBody,
       icon: 'stats-chart-outline',
     },
     {
       id: 'retention',
       title: t.privacy.retentionTitle,
+      summary: t.privacy.retentionSummary,
       body: t.privacy.retentionBody,
       icon: 'hourglass-outline',
     },
     {
       id: 'choices',
       title: t.privacy.choicesTitle,
+      summary: t.privacy.choicesSummary,
       body: t.privacy.choicesBody,
       icon: 'hand-left-outline',
     },
   ] as const;
+
+  const chevron = (
+    <Ionicons
+      name={directionalIcon('chevron-forward')}
+      size={iconSize.md}
+      color={theme.color.textFaint}
+    />
+  );
+
+  /** A right-hand status word — the state at a glance, without a sentence. */
+  const status = (label: string) => (
+    <Text variant="caption" tone="muted">
+      {label}
+    </Text>
+  );
+
+  const divider = <View style={{ height: 1, backgroundColor: theme.color.border }} />;
 
   return (
     <Screen>
@@ -125,7 +181,10 @@ export default function PrivacyScreen() {
         showsVerticalScrollIndicator={false}
       >
         <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
-          <Ionicons name="people" size={64} color={theme.color.text} />
+          {/* A shield, not the people glyph this screen used to open with: the
+              subject is what is kept and who cannot reach it, not who is in
+              your groups. */}
+          <Ionicons name="shield-checkmark-outline" size={64} color={theme.color.text} />
           <Text
             align="center"
             style={{
@@ -143,63 +202,38 @@ export default function PrivacyScreen() {
           </Text>
         </View>
 
-        {/* The policy points as a bulleted list rather than a stack of cards:
-            a dot in the margin, the point's heading, then the body — the plain
-            "here is what we do" reading the reference uses. */}
-        <View style={{ gap: theme.spacing.xl }}>
-          {sections.map((section) => (
-            <View key={section.id} style={{ flexDirection: 'row', gap: theme.spacing.md }}>
-              <View
-                style={{
-                  width: 7,
-                  height: 7,
-                  borderRadius: 3.5,
-                  backgroundColor: theme.color.brand,
-                  marginTop: 8,
-                }}
-              />
-              <View style={{ flex: 1, gap: theme.spacing.xs }}>
-                <Text variant="subheading">{section.title}</Text>
-                <Text variant="body" tone="muted">
-                  {section.body}
-                </Text>
-
-                {/* The control the analytics text describes, sat under it so the
-                    explanation and the switch are one thing. Hidden entirely on
-                    a build with no Clarity project, where it would toggle
-                    nothing. */}
-                {section.id === 'analytics' && clarityConfigured ? (
-                  <Row
-                    style={{
-                      gap: theme.spacing.md,
-                      justifyContent: 'space-between',
-                      marginTop: theme.spacing.xs,
-                    }}
-                  >
-                    <Text variant="body" style={{ flex: 1 }}>
-                      {t.privacy.sessionReplayRow}
-                    </Text>
-                    <Toggle
-                      value={replay}
-                      onValueChange={onReplayChange}
-                      accessibilityLabel={t.privacy.sessionReplayRow}
-                    />
-                  </Row>
-                ) : null}
-              </View>
-            </View>
-          ))}
-        </View>
-
-        {/* The controls the "choices" card promises, made tappable rather than
-            described — export a copy, or close the account, both routes that
-            already exist. Delete wears the negative tone: it ends something.
-            Hidden when signed out: opened as the policy from the login gate,
-            these would act on an account the reader does not have. */}
+        {/* The switches, first, for the reader who came from Settings. Each is a
+            state they can read off in a second — on or off, how many — rather
+            than a paragraph that describes one. */}
         {session ? (
           <View style={{ gap: theme.spacing.sm }}>
-            <SectionHeader title={t.privacy.dataControlsSection} />
+            <SectionHeader title={t.privacy.controlsSection} />
             <Card style={{ paddingVertical: theme.spacing.xs }}>
+              <ListRow
+                title={t.privacy.appLockRow}
+                subtitle={t.privacy.appLockHint}
+                onPress={() => router.push('/settings/lock')}
+                leading={
+                  <Ionicons
+                    name="finger-print-outline"
+                    size={iconSize.md}
+                    color={theme.color.brand}
+                  />
+                }
+                trailing={
+                  <Row style={{ gap: theme.spacing.xs }}>
+                    {status(
+                      !lockSupported
+                        ? t.privacy.appLockUnavailable
+                        : lockEnabled
+                          ? t.privacy.statusOn
+                          : t.privacy.statusOff,
+                    )}
+                    {chevron}
+                  </Row>
+                }
+              />
+              {divider}
               <ListRow
                 title={t.blocked.row}
                 subtitle={t.blocked.rowHint}
@@ -212,14 +246,54 @@ export default function PrivacyScreen() {
                   />
                 }
                 trailing={
-                  <Ionicons
-                    name={directionalIcon('chevron-forward')}
-                    size={iconSize.md}
-                    color={theme.color.textFaint}
-                  />
+                  <Row style={{ gap: theme.spacing.xs }}>
+                    {status(
+                      blocked.length > 0
+                        ? blocked.length.toLocaleString(locale)
+                        : t.privacy.blockedNone,
+                    )}
+                    {chevron}
+                  </Row>
                 }
               />
-              <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              {/* The most sensitive switch on the page — it can record screens
+                  with names and amounts on them — so it sits in the open with
+                  the other controls rather than as a footnote under a
+                  paragraph. Hidden entirely on a build with no Clarity project,
+                  where it would toggle nothing. */}
+              {clarityConfigured ? (
+                <>
+                  {divider}
+                  <ListRow
+                    title={t.privacy.sessionReplayRow}
+                    subtitle={t.privacy.sessionReplayHint}
+                    leading={
+                      <Ionicons
+                        name="videocam-outline"
+                        size={iconSize.md}
+                        color={theme.color.brand}
+                      />
+                    }
+                    trailing={
+                      <Toggle
+                        value={replay}
+                        onValueChange={onReplayChange}
+                        accessibilityLabel={t.privacy.sessionReplayRow}
+                      />
+                    }
+                  />
+                </>
+              ) : null}
+            </Card>
+          </View>
+        ) : null}
+
+        {/* Taking a copy out is not destructive and does not belong next to the
+            row that ends the account, so it stands on its own. */}
+        {session ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <SectionHeader title={t.privacy.dataControlsSection} />
+            <Card style={{ paddingVertical: theme.spacing.xs }}>
               <ListRow
                 title={t.privacy.exportRow}
                 subtitle={t.privacy.exportRowHint}
@@ -227,15 +301,98 @@ export default function PrivacyScreen() {
                 leading={
                   <Ionicons name="download-outline" size={iconSize.md} color={theme.color.brand} />
                 }
-                trailing={
-                  <Ionicons
-                    name={directionalIcon('chevron-forward')}
-                    size={iconSize.md}
-                    color={theme.color.textFaint}
-                  />
-                }
+                trailing={chevron}
               />
-              <View style={{ height: 1, backgroundColor: theme.color.border }} />
+            </Card>
+          </View>
+        ) : null}
+
+        {/* The policy itself: a glyph, the point, and one line of what it says.
+            Tapping opens the full paragraph. Signed out every one is already
+            open — this is the policy then, not a settings screen. */}
+        <View style={{ gap: theme.spacing.sm }}>
+          {session ? <SectionHeader title={t.privacy.policySection} /> : null}
+          <View style={{ gap: theme.spacing.lg }}>
+            {sections.map((section) => {
+              const expanded = isOpen(section.id);
+              return (
+                <Pressable
+                  key={section.id}
+                  accessibilityRole="button"
+                  accessibilityState={{ expanded }}
+                  accessibilityLabel={section.title}
+                  accessibilityHint={expanded ? t.privacy.collapseLabel : t.privacy.expandLabel}
+                  onPress={() => toggleSection(section.id)}
+                  style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+                >
+                  <Row style={{ alignItems: 'flex-start', gap: theme.spacing.md }}>
+                    <Ionicons
+                      name={section.icon}
+                      size={iconSize.md}
+                      color={theme.color.brand}
+                      style={{ marginTop: 2 }}
+                    />
+                    <View style={{ flex: 1, gap: theme.spacing.xs }}>
+                      <Text variant="subheading">{section.title}</Text>
+                      <Text variant="body" tone="muted">
+                        {expanded ? section.body : section.summary}
+                      </Text>
+                    </View>
+                    <Ionicons
+                      name={expanded ? 'chevron-up' : 'chevron-down'}
+                      size={iconSize.sm}
+                      color={theme.color.textFaint}
+                      style={{ marginTop: 4 }}
+                    />
+                  </Row>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+
+        <View style={{ gap: theme.spacing.sm }}>
+          <SectionHeader title={t.privacy.legalSection} />
+          <Card style={{ paddingVertical: theme.spacing.xs }}>
+            {/* A policy that explains your rights and gives you nobody to ask is
+                half a policy. The route only exists behind a session, so it is
+                offered to the reader who has one. */}
+            {session ? (
+              <>
+                <ListRow
+                  title={t.privacy.supportRow}
+                  subtitle={t.privacy.supportRowHint}
+                  onPress={() => router.push('/settings/feedback')}
+                  leading={
+                    <Ionicons
+                      name="chatbubble-ellipses-outline"
+                      size={iconSize.md}
+                      color={theme.color.brand}
+                    />
+                  }
+                  trailing={chevron}
+                />
+                {divider}
+              </>
+            ) : null}
+            <ListRow
+              title={t.privacy.licensesRow}
+              subtitle={t.privacy.licensesRowHint}
+              onPress={() => router.push('/settings/licenses')}
+              leading={
+                <Ionicons name="code-slash-outline" size={iconSize.md} color={theme.color.brand} />
+              }
+              trailing={chevron}
+            />
+          </Card>
+        </View>
+
+        {/* Ending the account is one divider away from nothing: it gets its own
+            heading and its own card, at the bottom, past everything reversible. */}
+        {session ? (
+          <View style={{ gap: theme.spacing.sm }}>
+            <SectionHeader title={t.privacy.dangerSection} />
+            <Card style={{ paddingVertical: theme.spacing.xs }}>
               <ListRow
                 title={t.privacy.deleteRow}
                 subtitle={t.privacy.deleteRowHint}
@@ -244,42 +401,27 @@ export default function PrivacyScreen() {
                 leading={
                   <Ionicons name="trash-outline" size={iconSize.md} color={theme.color.negative} />
                 }
-                trailing={
-                  <Ionicons
-                    name={directionalIcon('chevron-forward')}
-                    size={iconSize.md}
-                    color={theme.color.textFaint}
-                  />
-                }
+                trailing={chevron}
               />
             </Card>
           </View>
         ) : null}
 
-        <View style={{ gap: theme.spacing.sm }}>
-          <SectionHeader title={t.privacy.legalSection} />
-          <Card style={{ paddingVertical: theme.spacing.xs }}>
-            <ListRow
-              title={t.privacy.licensesRow}
-              subtitle={t.privacy.licensesRowHint}
-              onPress={() => router.push('/settings/licenses')}
-              leading={
-                <Ionicons name="code-slash-outline" size={iconSize.md} color={theme.color.brand} />
-              }
-              trailing={
-                <Ionicons
-                  name={directionalIcon('chevron-forward')}
-                  size={iconSize.md}
-                  color={theme.color.textFaint}
-                />
-              }
-            />
-          </Card>
+        <View style={{ gap: theme.spacing.xs }}>
+          <Text variant="micro" tone="muted">
+            {t.privacy.lastUpdated.replace(
+              '{date}',
+              new Date(`${POLICY_UPDATED}T12:00:00`).toLocaleDateString(locale, {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+              }),
+            )}
+          </Text>
+          <Text variant="micro" tone="muted">
+            {t.privacy.englishGoverns}
+          </Text>
         </View>
-
-        <Text variant="micro" tone="muted">
-          {t.privacy.englishGoverns}
-        </Text>
       </ScrollView>
     </Screen>
   );

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2250,6 +2250,32 @@ export interface UiStrings {
     servicesBody: string;
     retentionTitle: string;
     retentionBody: string;
+    controlsSection: string;
+    appLockRow: string;
+    appLockHint: string;
+    appLockUnavailable: string;
+    statusOn: string;
+    statusOff: string;
+    blockedNone: string;
+    sessionReplayHint: string;
+    policySection: string;
+    dangerSection: string;
+    supportRow: string;
+    supportRowHint: string;
+    /** Carries `{date}` — when this policy text last changed. */
+    lastUpdated: string;
+    /** A collapsed policy point's a11y hint, and its expanded counterpart. */
+    expandLabel: string;
+    collapseLabel: string;
+    storeSummary: string;
+    protectSummary: string;
+    servicesSummary: string;
+    analyticsSummary: string;
+    retentionSummary: string;
+    choicesSummary: string;
+    deviceTitle: string;
+    deviceSummary: string;
+    deviceBody: string;
     dataControlsSection: string;
     legalSection: string;
     exportRow: string;
@@ -4292,7 +4318,7 @@ const en: UiStrings = {
       'Your display name, and whichever of a phone number, email or sign-in identity you used. Optionally a payment handle, so somebody can pay you back, and a country, which decides which payment rails you are offered, and an optional postal address if you add one. The groups you are in, the expenses in them, and who owes whom. Nothing else: no contacts are uploaded, and there is no advertising identifier.',
     protectTitle: 'How it is kept',
     protectBody:
-      'Every table is behind row-level security in the database, so a request can only ever read rows your own account is entitled to — not a filter applied by the app, but a rule the database enforces. Receipt images sit in a private bucket reached through short-lived signed links. Crash reports are scrubbed of addresses, phone numbers, payment handles and keys before they leave the phone. You can require your fingerprint or face to open the app.',
+      'Every table is behind row-level security in the database, so a request can only ever read rows your own account is entitled to — not a filter applied by the app, but a rule the database enforces. Receipt images sit in a private bucket reached through short-lived signed links. Crash reports are scrubbed of addresses, phone numbers, payment handles and keys before they leave the phone. Each receipt can be visible to everybody in the group, or only to the people on that expense — you choose per image. You can require your fingerprint or face to open the app.',
     choicesTitle: 'What you can do',
     choicesBody:
       'Export everything you have entered, at any time, in full fidelity and for free. Turn off any notification. Delete your account and the personal data in it. Write to us with anything you want changed.',
@@ -4309,6 +4335,31 @@ const en: UiStrings = {
     retentionTitle: 'How long we keep it',
     retentionBody:
       'Your data stays while your account is open. If the account goes untouched for 3 years, we delete it and the personal data with it. You never have to wait for that — export or delete everything yourself, any time, below. A group you close and leave untouched for a year and a half is moved to your archive automatically — nothing is deleted, and you can reopen it whenever you like.',
+    controlsSection: 'Your controls',
+    appLockRow: 'App lock',
+    appLockHint: 'Ask for fingerprint or face to open Waves',
+    appLockUnavailable: 'Not available',
+    statusOn: 'On',
+    statusOff: 'Off',
+    blockedNone: 'None',
+    sessionReplayHint: 'Off unless you turn it on',
+    policySection: 'How Waves protects you',
+    dangerSection: 'Danger zone',
+    supportRow: 'Privacy questions',
+    supportRowHint: 'Write to us — a person answers',
+    lastUpdated: 'Last updated {date}.',
+    expandLabel: 'Read more',
+    collapseLabel: 'Show less',
+    storeSummary: 'Your name, sign-in, groups, expenses and who owes whom.',
+    protectSummary: 'Database rules on every read, private receipt links, scrubbed crash reports.',
+    servicesSummary: 'Supabase for the database, Sentry for crashes, Clarity only if you allow it.',
+    analyticsSummary: 'No ads, no ad identifier. Screen recording is off unless you turn it on.',
+    retentionSummary: 'Kept while your account is open, deleted after 3 untouched years.',
+    choicesSummary: 'Export everything, mute anything, or delete your account.',
+    deviceTitle: 'On this phone',
+    deviceSummary: 'Held encrypted for offline use, erased when you sign out.',
+    deviceBody:
+      "Waves keeps a copy of your ledger on the phone so it still works with no signal. Every value it stores there is encrypted with a key held in the phone's own keystore, so a stolen backup or a rooted filesystem reads nothing. Signing out destroys that key and the local copy with it.",
     dataControlsSection: 'Your data',
     legalSection: 'Legal',
     exportRow: 'Export your data',
@@ -6464,7 +6515,7 @@ const ta: UiStrings = {
       'உங்கள் பெயர், நீங்கள் பயன்படுத்திய தொலைபேசி எண், மின்னஞ்சல் அல்லது உள்நுழைவு அடையாளம். விருப்பப்படி ஒரு பணப் பரிமாற்ற முகவரி, ஒரு நாடு, மற்றும் நீங்கள் சேர்த்தால் ஒரு அஞ்சல் முகவரி. நீங்கள் இருக்கும் குழுக்கள், அவற்றின் செலவுகள், யார் யாருக்குக் கடன்பட்டவர். வேறு எதுவும் இல்லை: தொடர்புகள் பதிவேற்றப்படுவதில்லை, விளம்பர அடையாளம் இல்லை.',
     protectTitle: 'எப்படி பாதுகாக்கப்படுகிறது',
     protectBody:
-      'ஒவ்வொரு அட்டவணையும் தரவுத்தளத்தில் வரிசை-நிலை பாதுகாப்பின் பின்னால் உள்ளது — செயலி வடிகட்டுவதல்ல, தரவுத்தளமே அமல்படுத்தும் விதி. ரசீது படங்கள் தனிப்பட்ட இடத்தில், குறுகிய கால இணைப்புகள் வழியாக மட்டுமே. செயலி முறிவு அறிக்கைகளிலிருந்து முகவரிகள், எண்கள், பணமுகவரிகள் தொலைபேசியை விட்டு வெளியேறும் முன்பே நீக்கப்படுகின்றன.',
+      'ஒவ்வொரு அட்டவணையும் தரவுத்தளத்தில் வரிசை-நிலை பாதுகாப்பின் பின்னால் உள்ளது — செயலி வடிகட்டுவதல்ல, தரவுத்தளமே அமல்படுத்தும் விதி. ரசீது படங்கள் தனிப்பட்ட இடத்தில், குறுகிய கால இணைப்புகள் வழியாக மட்டுமே. செயலி முறிவு அறிக்கைகளிலிருந்து முகவரிகள், எண்கள், பணமுகவரிகள் தொலைபேசியை விட்டு வெளியேறும் முன்பே நீக்கப்படுகின்றன. ஒவ்வொரு ரசீதும் குழுவில் உள்ள அனைவருக்கும் தெரியலாம், அல்லது அந்தச் செலவில் உள்ளவர்களுக்கு மட்டும் — படத்துக்குப் படம் நீங்கள் தேர்வு செய்யலாம்.',
     choicesTitle: 'நீங்கள் என்ன செய்யலாம்',
     choicesBody:
       'நீங்கள் உள்ளிட்ட அனைத்தையும் எப்போது வேண்டுமானாலும், முழுமையாக, இலவசமாக ஏற்றுமதி செய்யலாம். எந்த அறிவிப்பையும் நிறுத்தலாம். உங்கள் கணக்கையும் அதிலுள்ள தனிப்பட்ட தரவையும் நீக்கலாம்.',
@@ -6481,6 +6532,35 @@ const ta: UiStrings = {
     retentionTitle: 'எவ்வளவு காலம் வைத்திருக்கிறோம்',
     retentionBody:
       'உங்கள் கணக்கு திறந்திருக்கும் வரை தரவு இருக்கும். கணக்கு 3 ஆண்டுகள் தொடப்படாமல் இருந்தால், அதை அதிலுள்ள தனிப்பட்ட தரவுடன் நீக்குகிறோம். அதற்காகக் காத்திருக்க வேண்டாம் — கீழே எப்போது வேண்டுமானாலும் எல்லாவற்றையும் ஏற்றுமதி செய்யலாம் அல்லது நீக்கலாம். நீங்கள் மூடி, ஒன்றரை ஆண்டுகளாகத் தொடாமல் விட்ட குழு தானாகவே உங்கள் காப்பகத்திற்கு நகர்த்தப்படுகிறது — எதுவும் நீக்கப்படாது, எப்போது வேண்டுமானாலும் மீண்டும் திறக்கலாம்.',
+    controlsSection: 'உங்கள் கட்டுப்பாடுகள்',
+    appLockRow: 'செயலிப் பூட்டு',
+    appLockHint: 'திறக்க கைரேகை அல்லது முகத்தைக் கேட்கும்',
+    appLockUnavailable: 'கிடைக்கவில்லை',
+    statusOn: 'இயக்கத்தில்',
+    statusOff: 'அணைக்கப்பட்டது',
+    blockedNone: 'யாரும் இல்லை',
+    sessionReplayHint: 'நீங்கள் இயக்கும் வரை அணைந்தே இருக்கும்',
+    policySection: 'உங்கள் தரவை எப்படிப் பாதுகாக்கிறோம்',
+    dangerSection: 'கவனம் தேவை',
+    supportRow: 'தனியுரிமைக் கேள்விகள்',
+    supportRowHint: 'எங்களுக்கு எழுதுங்கள் — ஒரு நபர் பதிலளிப்பார்',
+    lastUpdated: 'கடைசியாகப் புதுப்பிக்கப்பட்டது {date}.',
+    expandLabel: 'மேலும் படிக்க',
+    collapseLabel: 'சுருக்கு',
+    storeSummary: 'உங்கள் பெயர், உள்நுழைவு, குழுக்கள், செலவுகள், யார் யாருக்குக் கடன்.',
+    protectSummary:
+      'ஒவ்வொரு வாசிப்பிலும் தரவுத்தள விதிகள், தனிப்பட்ட ரசீது இணைப்புகள், சுத்தம் செய்யப்பட்ட பிழை அறிக்கைகள்.',
+    servicesSummary:
+      'தரவுத்தளத்திற்கு Supabase, பிழைகளுக்கு Sentry, நீங்கள் அனுமதித்தால் மட்டுமே Clarity.',
+    analyticsSummary: 'விளம்பரம் இல்லை. நீங்கள் இயக்கும் வரை திரைப் பதிவும் இல்லை.',
+    retentionSummary: 'கணக்கு திறந்திருக்கும் வரை; 3 ஆண்டுகள் தொடாவிட்டால் நீக்கப்படும்.',
+    choicesSummary:
+      'எல்லாவற்றையும் ஏற்றுமதி செய்யுங்கள், அறிவிப்புகளை நிறுத்துங்கள், கணக்கை நீக்குங்கள்.',
+    deviceTitle: 'இந்தத் தொலைபேசியில்',
+    deviceSummary:
+      'இணையம் இல்லாமலும் வேலை செய்ய குறியாக்கம் செய்து வைக்கப்படுகிறது; வெளியேறும்போது அழிக்கப்படுகிறது.',
+    deviceBody:
+      'சிக்னல் இல்லாமலும் வேலை செய்ய, வேவ்ஸ் உங்கள் கணக்கின் ஒரு நகலைத் தொலைபேசியிலேயே வைத்திருக்கிறது. அங்கு சேமிக்கப்படும் ஒவ்வொரு மதிப்பும் தொலைபேசியின் சொந்த சாவி-சேமிப்பில் உள்ள சாவியால் குறியாக்கம் செய்யப்படுகிறது — திருடப்பட்ட காப்புப்பிரதியோ ரூட் செய்யப்பட்ட கோப்பு முறைமையோ எதையும் படிக்க முடியாது. நீங்கள் வெளியேறும்போது அந்தச் சாவியும் உள்ளூர் நகலும் அழிக்கப்படுகின்றன.',
     dataControlsSection: 'உங்கள் தரவு',
     legalSection: 'சட்டம்',
     exportRow: 'உங்கள் தரவை ஏற்றுமதி செய்',
@@ -8561,7 +8641,7 @@ const hi: UiStrings = {
       'आपका नाम, और फ़ोन नंबर, ईमेल या साइन-इन पहचान में से जो आपने इस्तेमाल किया। वैकल्पिक रूप से एक भुगतान पता, ताकि कोई आपको लौटा सके, एक देश, और यदि आप जोड़ें तो एक डाक पता। आप जिन समूहों में हैं, उनके ख़र्चे, और कौन किसका देनदार है। और कुछ नहीं: कोई संपर्क अपलोड नहीं होते, कोई विज्ञापन पहचानकर्ता नहीं।',
     protectTitle: 'कैसे सुरक्षित रहता है',
     protectBody:
-      'हर तालिका डेटाबेस में row-level security के पीछे है — ऐप का लगाया फ़िल्टर नहीं, बल्कि डेटाबेस का लागू किया नियम। रसीद की तस्वीरें एक निजी जगह में, छोटी अवधि के लिंक से ही पहुँच में। क्रैश रिपोर्ट से पते, नंबर और भुगतान पते फ़ोन छोड़ने से पहले ही हटा दिए जाते हैं।',
+      'हर तालिका डेटाबेस में row-level security के पीछे है — ऐप का लगाया फ़िल्टर नहीं, बल्कि डेटाबेस का लागू किया नियम। रसीद की तस्वीरें एक निजी जगह में, छोटी अवधि के लिंक से ही पहुँच में। क्रैश रिपोर्ट से पते, नंबर और भुगतान पते फ़ोन छोड़ने से पहले ही हटा दिए जाते हैं। हर रसीद पूरे समूह को दिख सकती है, या केवल उस ख़र्च में शामिल लोगों को — यह आप हर तस्वीर के लिए चुनते हैं।',
     choicesTitle: 'आप क्या कर सकते हैं',
     choicesBody:
       'जो कुछ आपने डाला है, कभी भी, पूरा और मुफ़्त निर्यात करें। कोई भी सूचना बंद करें। अपना खाता और उसमें रखा निजी डेटा मिटाएँ।',
@@ -8578,6 +8658,32 @@ const hi: UiStrings = {
     retentionTitle: 'हम इसे कब तक रखते हैं',
     retentionBody:
       'जब तक आपका खाता खुला है, आपका डेटा रहता है। अगर खाता 3 साल तक अछूता रहे, तो हम उसे और उसके निजी डेटा को हटा देते हैं। इसके लिए इंतज़ार करने की ज़रूरत नहीं — नीचे कभी भी सब कुछ ख़ुद निर्यात या हटा सकते हैं। जिस समूह को आप बंद कर दें और डेढ़ साल तक न छूएं, वह अपने-आप आपके संग्रह में चला जाता है — कुछ भी नहीं हटता, और आप उसे कभी भी दोबारा खोल सकते हैं।',
+    controlsSection: 'आपके नियंत्रण',
+    appLockRow: 'ऐप लॉक',
+    appLockHint: 'खोलने के लिए फ़िंगरप्रिंट या चेहरा माँगे',
+    appLockUnavailable: 'उपलब्ध नहीं',
+    statusOn: 'चालू',
+    statusOff: 'बंद',
+    blockedNone: 'कोई नहीं',
+    sessionReplayHint: 'जब तक आप चालू न करें, बंद रहता है',
+    policySection: 'हम आपके डेटा की रक्षा कैसे करते हैं',
+    dangerSection: 'सावधानी क्षेत्र',
+    supportRow: 'निजता से जुड़े सवाल',
+    supportRowHint: 'हमें लिखें — जवाब एक व्यक्ति देता है',
+    lastUpdated: 'अंतिम बार {date} को अपडेट किया गया।',
+    expandLabel: 'और पढ़ें',
+    collapseLabel: 'कम दिखाएँ',
+    storeSummary: 'आपका नाम, साइन-इन, समूह, ख़र्च और कौन किसका देनदार है।',
+    protectSummary: 'हर पठन पर डेटाबेस नियम, निजी रसीद लिंक, साफ़ की गई क्रैश रिपोर्ट।',
+    servicesSummary: 'डेटाबेस के लिए Supabase, क्रैश के लिए Sentry, अनुमति देने पर ही Clarity।',
+    analyticsSummary: 'कोई विज्ञापन नहीं। आपके चालू किए बिना स्क्रीन रिकॉर्डिंग नहीं।',
+    retentionSummary: 'खाता खुला रहने तक; 3 साल अछूता रहा तो हटा दिया जाता है।',
+    choicesSummary: 'सब कुछ निर्यात करें, कोई भी सूचना बंद करें, या खाता हटाएँ।',
+    deviceTitle: 'इस फ़ोन पर',
+    deviceSummary:
+      'बिना इंटरनेट काम करने के लिए एन्क्रिप्टेड रखा जाता है; साइन आउट पर मिट जाता है।',
+    deviceBody:
+      'सिग्नल न होने पर भी चले, इसके लिए वेव्स आपके हिसाब की एक नक़ल फ़ोन में रखता है। वहाँ सहेजा गया हर मान फ़ोन के अपने कीस्टोर में रखी कुंजी से एन्क्रिप्ट होता है, इसलिए चोरी हुआ बैकअप या रूट किया गया फ़ाइल-सिस्टम कुछ नहीं पढ़ पाता। साइन आउट करते ही वह कुंजी और स्थानीय नक़ल दोनों मिट जाती हैं।',
     dataControlsSection: 'आपका डेटा',
     legalSection: 'क़ानूनी',
     exportRow: 'अपना डेटा निर्यात करें',
@@ -10870,7 +10976,7 @@ const ar: UiStrings = {
       'اسمك، وما استخدمته من رقم هاتف أو بريد أو هوية دخول. واختياريًا عنوان دفع كي يتمكن أحدهم من ردّ المال إليك، وبلد، وعنوان بريدي اختياري إن أضفته. المجموعات التي تشارك فيها ومصروفاتها ومن يدين لمن. لا شيء غير ذلك: لا تُرفع جهات الاتصال، ولا يوجد معرّف إعلاني.',
     protectTitle: 'كيف يُحمى',
     protectBody:
-      'كل جدول محميّ بأمان على مستوى الصف داخل قاعدة البيانات — ليس ترشيحًا يجريه التطبيق، بل قاعدة تفرضها قاعدة البيانات نفسها. صور الإيصالات في مكان خاص لا يُوصل إليه إلا بروابط قصيرة الأجل. وتُنقّى تقارير الأعطال من العناوين والأرقام وعناوين الدفع قبل مغادرتها الهاتف.',
+      'كل جدول محميّ بأمان على مستوى الصف داخل قاعدة البيانات — ليس ترشيحًا يجريه التطبيق، بل قاعدة تفرضها قاعدة البيانات نفسها. صور الإيصالات في مكان خاص لا يُوصل إليه إلا بروابط قصيرة الأجل. وتُنقّى تقارير الأعطال من العناوين والأرقام وعناوين الدفع قبل مغادرتها الهاتف. ويمكن أن يظهر كل إيصال لجميع أفراد المجموعة أو لمن شارك في ذلك المصروف فقط — تختار ذلك لكل صورة.',
     choicesTitle: 'ما الذي يمكنك فعله',
     choicesBody:
       'تصدير كل ما أدخلته، في أي وقت، كاملًا ومجانًا. إيقاف أي إشعار. حذف حسابك والبيانات الشخصية التي فيه.',
@@ -10887,6 +10993,31 @@ const ar: UiStrings = {
     retentionTitle: 'كم نحتفظ بها',
     retentionBody:
       'تبقى بياناتك ما دام حسابك مفتوحًا. إذا بقي الحساب دون استخدام لمدة 3 سنوات، نحذفه ونحذف معه البيانات الشخصية. لا داعي للانتظار — يمكنك تصدير كل شيء أو حذفه بنفسك في أي وقت أدناه. المجموعة التي تغلقها وتتركها دون استخدام لمدة عام ونصف تُنقل تلقائيًا إلى أرشيفك — لا يُحذف شيء، ويمكنك إعادة فتحها في أي وقت.',
+    controlsSection: 'أدواتك',
+    appLockRow: 'قفل التطبيق',
+    appLockHint: 'يطلب بصمتك أو وجهك عند الفتح',
+    appLockUnavailable: 'غير متاح',
+    statusOn: 'مفعّل',
+    statusOff: 'متوقف',
+    blockedNone: 'لا أحد',
+    sessionReplayHint: 'متوقف ما لم تفعّله بنفسك',
+    policySection: 'كيف نحمي بياناتك',
+    dangerSection: 'منطقة الخطر',
+    supportRow: 'أسئلة عن الخصوصية',
+    supportRowHint: 'راسلنا — يردّ عليك شخص',
+    lastUpdated: 'آخر تحديث {date}.',
+    expandLabel: 'اقرأ المزيد',
+    collapseLabel: 'إظهار أقل',
+    storeSummary: 'اسمك وطريقة دخولك ومجموعاتك ومصروفاتك ومن يدين لمن.',
+    protectSummary: 'قواعد قاعدة البيانات عند كل قراءة، وروابط إيصالات خاصة، وتقارير أعطال منقّاة.',
+    servicesSummary: 'Supabase لقاعدة البيانات، وSentry للأعطال، وClarity فقط إن سمحت.',
+    analyticsSummary: 'لا إعلانات ولا معرّف إعلاني. ولا تسجيل للشاشة ما لم تفعّله.',
+    retentionSummary: 'يبقى ما دام حسابك مفتوحًا، ويُحذف بعد ثلاث سنوات دون استخدام.',
+    choicesSummary: 'صدّر كل شيء، أوقف أي إشعار، أو احذف حسابك.',
+    deviceTitle: 'على هذا الهاتف',
+    deviceSummary: 'يُحفظ مشفّرًا للعمل دون اتصال، ويُمحى عند تسجيل الخروج.',
+    deviceBody:
+      'يحتفظ Waves بنسخة من دفترك على الهاتف كي يعمل دون شبكة. وكل قيمة تُحفظ هناك مشفّرة بمفتاح داخل مخزن مفاتيح الهاتف نفسه، فلا تقرأ نسخة احتياطية مسروقة ولا نظام ملفات مكسور الحماية شيئًا. وتسجيل الخروج يتلف ذلك المفتاح والنسخة المحلية معه.',
     dataControlsSection: 'بياناتك',
     legalSection: 'قانوني',
     exportRow: 'صدِّر بياناتك',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -4331,7 +4331,7 @@ const en: UiStrings = {
     sessionReplayRow: 'Record how I use the app',
     servicesTitle: 'Who else touches your data',
     servicesBody:
-      'Baaki runs on Supabase — the database and sign-in, on servers we control. Crash reports go to Sentry, scrubbed of your details before they leave the phone. Anonymous usage goes to Microsoft Clarity, and only if you turn it on above. Your data is never sold, and there are no ad networks.',
+      'Waves runs on Supabase — the database and sign-in, on servers we control. Crash reports go to Sentry, scrubbed of your details before they leave the phone. Anonymous usage goes to Microsoft Clarity, and only if you turn it on above. Your data is never sold, and there are no ad networks.',
     retentionTitle: 'How long we keep it',
     retentionBody:
       'Your data stays while your account is open. If the account goes untouched for 3 years, we delete it and the personal data with it. You never have to wait for that — export or delete everything yourself, any time, below. A group you close and leave untouched for a year and a half is moved to your archive automatically — nothing is deleted, and you can reopen it whenever you like.',
@@ -4350,25 +4350,26 @@ const en: UiStrings = {
     lastUpdated: 'Last updated {date}.',
     expandLabel: 'Read more',
     collapseLabel: 'Show less',
-    storeSummary: 'Your name, sign-in, groups, expenses and who owes whom.',
+    storeSummary: 'Your profile, groups, expenses, receipts, comments, settings and who owes whom.',
     protectSummary: 'Database rules on every read, private receipt links, scrubbed crash reports.',
     servicesSummary: 'Supabase for the database, Sentry for crashes, Clarity only if you allow it.',
     analyticsSummary: 'No ads, no ad identifier. Screen recording is off unless you turn it on.',
     retentionSummary: 'Kept while your account is open, deleted after 3 untouched years.',
     choicesSummary: 'Export everything, mute anything, or delete your account.',
     deviceTitle: 'On this phone',
-    deviceSummary: 'Held encrypted for offline use, erased when you sign out.',
+    deviceSummary:
+      'The ledger is sealed with a device key; settings and pending uploads are not. All cleared on sign-out.',
     deviceBody:
-      "Waves keeps a copy of your ledger on the phone so it still works with no signal. Every value it stores there is encrypted with a key held in the phone's own keystore, so a stolen backup or a rooted filesystem reads nothing. Signing out destroys that key and the local copy with it.",
+      "Waves keeps a copy of your ledger on the phone so it still works with no signal. The ledger rows and the queue of changes waiting to be sent are sealed with a key kept in the phone's secure store, so a copy of that file taken off the phone is unreadable without it. Some things sit outside the seal: your app settings, and receipt images still waiting to upload. Signing out clears the ledger, the queue, the cached images and the key together.",
     dataControlsSection: 'Your data',
     legalSection: 'Legal',
     exportRow: 'Export your data',
     exportRowHint: 'A full, lossless copy — yours to keep',
     licensesRow: 'Open source licenses',
-    licensesRowHint: 'The libraries Baaki is built on',
+    licensesRowHint: 'The libraries Waves is built on',
     licensesTitle: 'Open source',
     licensesIntro:
-      'Baaki is built on open-source software. Thank you to the people who made and maintain these.',
+      'Waves is built on open-source software. Thank you to the people who made and maintain these.',
     licenseNote: 'Each is used under its own license, kept unchanged.',
     previewGroups: { one: 'You are in {n} group.', other: 'You are in {n} groups.' },
     previewExpenses: {
@@ -4388,7 +4389,7 @@ const en: UiStrings = {
     feedbackPlaceholder: 'What happened, or what you wish it did',
     feedbackSend: 'Send',
     feedbackThanks: 'Thank you — that has been received.',
-    feedbackRating: 'How is Baaki so far?',
+    feedbackRating: 'How is Waves so far?',
     feedbackRatingHint: 'Optional',
     feedbackStarLabel: { one: '{n} star', other: '{n} stars' },
     feedbackStarClearHint: 'Tap again to clear the rating',
@@ -6509,7 +6510,7 @@ const ta: UiStrings = {
     rowHint: 'என்ன சேமிக்கப்படுகிறது, எப்படி பாதுகாக்கப்படுகிறது',
     title: 'தனியுரிமை & பாதுகாப்பு',
     intro:
-      'பாக்கி வேலை செய்ய எவ்வளவு தேவையோ அவ்வளவு மட்டுமே உங்களைப் பற்றி வைத்திருக்கிறது. அது என்ன என்பது இங்கே.',
+      'Waves வேலை செய்ய எவ்வளவு தேவையோ அவ்வளவு மட்டுமே உங்களைப் பற்றி வைத்திருக்கிறது. அது என்ன என்பது இங்கே.',
     storeTitle: 'என்ன சேமிக்கப்படுகிறது',
     storeBody:
       'உங்கள் பெயர், நீங்கள் பயன்படுத்திய தொலைபேசி எண், மின்னஞ்சல் அல்லது உள்நுழைவு அடையாளம். விருப்பப்படி ஒரு பணப் பரிமாற்ற முகவரி, ஒரு நாடு, மற்றும் நீங்கள் சேர்த்தால் ஒரு அஞ்சல் முகவரி. நீங்கள் இருக்கும் குழுக்கள், அவற்றின் செலவுகள், யார் யாருக்குக் கடன்பட்டவர். வேறு எதுவும் இல்லை: தொடர்புகள் பதிவேற்றப்படுவதில்லை, விளம்பர அடையாளம் இல்லை.',
@@ -6528,7 +6529,7 @@ const ta: UiStrings = {
     sessionReplayRow: 'நான் செயலியைப் பயன்படுத்தும் விதத்தைப் பதிவு செய்',
     servicesTitle: 'உங்கள் தரவை வேறு யார் தொடுகிறார்கள்',
     servicesBody:
-      'பாக்கி Supabase-இல் இயங்குகிறது — தரவுத்தளமும் உள்நுழைவும், நாங்கள் நிர்வகிக்கும் சேவையகங்களில். செயலிழப்பு அறிக்கைகள் உங்கள் விவரங்கள் நீக்கப்பட்ட பிறகே Sentry-க்குச் செல்கின்றன. அநாமதேய பயன்பாட்டு தரவு Microsoft Clarity-க்குச் செல்கிறது, மேலே நீங்கள் இயக்கினால் மட்டுமே. உங்கள் தரவு விற்கப்படுவதில்லை, விளம்பர வலையமைப்புகளும் இல்லை.',
+      'Waves Supabase-இல் இயங்குகிறது — தரவுத்தளமும் உள்நுழைவும், நாங்கள் நிர்வகிக்கும் சேவையகங்களில். செயலிழப்பு அறிக்கைகள் உங்கள் விவரங்கள் நீக்கப்பட்ட பிறகே Sentry-க்குச் செல்கின்றன. அநாமதேய பயன்பாட்டு தரவு Microsoft Clarity-க்குச் செல்கிறது, மேலே நீங்கள் இயக்கினால் மட்டுமே. உங்கள் தரவு விற்கப்படுவதில்லை, விளம்பர வலையமைப்புகளும் இல்லை.',
     retentionTitle: 'எவ்வளவு காலம் வைத்திருக்கிறோம்',
     retentionBody:
       'உங்கள் கணக்கு திறந்திருக்கும் வரை தரவு இருக்கும். கணக்கு 3 ஆண்டுகள் தொடப்படாமல் இருந்தால், அதை அதிலுள்ள தனிப்பட்ட தரவுடன் நீக்குகிறோம். அதற்காகக் காத்திருக்க வேண்டாம் — கீழே எப்போது வேண்டுமானாலும் எல்லாவற்றையும் ஏற்றுமதி செய்யலாம் அல்லது நீக்கலாம். நீங்கள் மூடி, ஒன்றரை ஆண்டுகளாகத் தொடாமல் விட்ட குழு தானாகவே உங்கள் காப்பகத்திற்கு நகர்த்தப்படுகிறது — எதுவும் நீக்கப்படாது, எப்போது வேண்டுமானாலும் மீண்டும் திறக்கலாம்.',
@@ -6547,7 +6548,8 @@ const ta: UiStrings = {
     lastUpdated: 'கடைசியாகப் புதுப்பிக்கப்பட்டது {date}.',
     expandLabel: 'மேலும் படிக்க',
     collapseLabel: 'சுருக்கு',
-    storeSummary: 'உங்கள் பெயர், உள்நுழைவு, குழுக்கள், செலவுகள், யார் யாருக்குக் கடன்.',
+    storeSummary:
+      'உங்கள் சுயவிவரம், குழுக்கள், செலவுகள், ரசீதுகள், கருத்துகள், அமைப்புகள், யார் யாருக்குக் கடன்.',
     protectSummary:
       'ஒவ்வொரு வாசிப்பிலும் தரவுத்தள விதிகள், தனிப்பட்ட ரசீது இணைப்புகள், சுத்தம் செய்யப்பட்ட பிழை அறிக்கைகள்.',
     servicesSummary:
@@ -6558,18 +6560,18 @@ const ta: UiStrings = {
       'எல்லாவற்றையும் ஏற்றுமதி செய்யுங்கள், அறிவிப்புகளை நிறுத்துங்கள், கணக்கை நீக்குங்கள்.',
     deviceTitle: 'இந்தத் தொலைபேசியில்',
     deviceSummary:
-      'இணையம் இல்லாமலும் வேலை செய்ய குறியாக்கம் செய்து வைக்கப்படுகிறது; வெளியேறும்போது அழிக்கப்படுகிறது.',
+      'கணக்கு சாதனச் சாவியால் மூடப்படுகிறது; அமைப்புகளும் காத்திருக்கும் பதிவேற்றங்களும் இல்லை. வெளியேறும்போது அனைத்தும் நீக்கப்படும்.',
     deviceBody:
-      'சிக்னல் இல்லாமலும் வேலை செய்ய, வேவ்ஸ் உங்கள் கணக்கின் ஒரு நகலைத் தொலைபேசியிலேயே வைத்திருக்கிறது. அங்கு சேமிக்கப்படும் ஒவ்வொரு மதிப்பும் தொலைபேசியின் சொந்த சாவி-சேமிப்பில் உள்ள சாவியால் குறியாக்கம் செய்யப்படுகிறது — திருடப்பட்ட காப்புப்பிரதியோ ரூட் செய்யப்பட்ட கோப்பு முறைமையோ எதையும் படிக்க முடியாது. நீங்கள் வெளியேறும்போது அந்தச் சாவியும் உள்ளூர் நகலும் அழிக்கப்படுகின்றன.',
+      'சிக்னல் இல்லாமலும் வேலை செய்ய, Waves உங்கள் கணக்கின் ஒரு நகலைத் தொலைபேசியிலேயே வைத்திருக்கிறது. கணக்கு வரிசைகளும், அனுப்பப்படக் காத்திருக்கும் மாற்றங்களும் தொலைபேசியின் பாதுகாப்புச் சேமிப்பில் உள்ள சாவியால் மூடப்படுகின்றன — அந்தக் கோப்பை வெளியே எடுத்தாலும் சாவி இல்லாமல் படிக்க முடியாது. சிலவை அந்த மூடலுக்கு வெளியே இருக்கின்றன: உங்கள் செயலி அமைப்புகள், பதிவேற்றக் காத்திருக்கும் ரசீது படங்கள். நீங்கள் வெளியேறும்போது கணக்கு, வரிசை, சேமித்த படங்கள், சாவி எல்லாம் சேர்ந்து நீக்கப்படுகின்றன.',
     dataControlsSection: 'உங்கள் தரவு',
     legalSection: 'சட்டம்',
     exportRow: 'உங்கள் தரவை ஏற்றுமதி செய்',
     exportRowHint: 'முழுமையான, இழப்பில்லா நகல் — உங்களுக்கே',
     licensesRow: 'திறந்த மூல உரிமங்கள்',
-    licensesRowHint: 'பாக்கி கட்டப்பட்ட நூலகங்கள்',
+    licensesRowHint: 'Waves கட்டப்பட்ட நூலகங்கள்',
     licensesTitle: 'திறந்த மூலம்',
     licensesIntro:
-      'பாக்கி திறந்த மூல மென்பொருளால் கட்டப்பட்டது. இவற்றை உருவாக்கிப் பராமரிப்பவர்களுக்கு நன்றி.',
+      'Waves திறந்த மூல மென்பொருளால் கட்டப்பட்டது. இவற்றை உருவாக்கிப் பராமரிப்பவர்களுக்கு நன்றி.',
     licenseNote: 'ஒவ்வொன்றும் அதன் சொந்த உரிமத்தின் கீழ், மாற்றமின்றிப் பயன்படுத்தப்படுகிறது.',
     previewGroups: {
       one: 'நீங்கள் {n} குழுவில் உள்ளீர்கள்.',
@@ -6592,7 +6594,7 @@ const ta: UiStrings = {
     feedbackPlaceholder: 'என்ன நடந்தது, அல்லது என்ன இருக்க வேண்டும் என நினைக்கிறீர்கள்',
     feedbackSend: 'அனுப்பு',
     feedbackThanks: 'நன்றி — கிடைத்துவிட்டது.',
-    feedbackRating: 'பாக்கி இதுவரை எப்படி இருக்கிறது?',
+    feedbackRating: 'Waves இதுவரை எப்படி இருக்கிறது?',
     feedbackRatingHint: 'விருப்பம்',
     feedbackStarLabel: { one: '{n} நட்சத்திரம்', other: '{n} நட்சத்திரங்கள்' },
     feedbackStarClearHint: 'மதிப்பீட்டை அழிக்க மீண்டும் தட்டவும்',
@@ -8635,7 +8637,7 @@ const hi: UiStrings = {
     rowHint: 'क्या रखा जाता है, और कैसे सुरक्षित रहता है',
     title: 'निजता और सुरक्षा',
     intro:
-      'बाकी आपके बारे में उतना ही रखता है जितना काम करने के लिए ज़रूरी है। वह क्या है, सीधे शब्दों में।',
+      'Waves आपके बारे में उतना ही रखता है जितना काम करने के लिए ज़रूरी है। वह क्या है, सीधे शब्दों में।',
     storeTitle: 'क्या रखा जाता है',
     storeBody:
       'आपका नाम, और फ़ोन नंबर, ईमेल या साइन-इन पहचान में से जो आपने इस्तेमाल किया। वैकल्पिक रूप से एक भुगतान पता, ताकि कोई आपको लौटा सके, एक देश, और यदि आप जोड़ें तो एक डाक पता। आप जिन समूहों में हैं, उनके ख़र्चे, और कौन किसका देनदार है। और कुछ नहीं: कोई संपर्क अपलोड नहीं होते, कोई विज्ञापन पहचानकर्ता नहीं।',
@@ -8654,7 +8656,7 @@ const hi: UiStrings = {
     sessionReplayRow: 'ऐप के मेरे इस्तेमाल को दर्ज करने दें',
     servicesTitle: 'आपका डेटा और कौन छूता है',
     servicesBody:
-      'बाकी Supabase पर चलता है — डेटाबेस और साइन-इन, हमारे नियंत्रण वाले सर्वर पर। क्रैश रिपोर्ट फ़ोन छोड़ने से पहले आपके विवरण हटाकर Sentry को जाती हैं। गुमनाम उपयोग डेटा Microsoft Clarity को जाता है, और सिर्फ़ तभी जब आप इसे ऊपर चालू करें। आपका डेटा कभी बेचा नहीं जाता, और कोई विज्ञापन नेटवर्क नहीं है।',
+      'Waves Supabase पर चलता है — डेटाबेस और साइन-इन, हमारे नियंत्रण वाले सर्वर पर। क्रैश रिपोर्ट फ़ोन छोड़ने से पहले आपके विवरण हटाकर Sentry को जाती हैं। गुमनाम उपयोग डेटा Microsoft Clarity को जाता है, और सिर्फ़ तभी जब आप इसे ऊपर चालू करें। आपका डेटा कभी बेचा नहीं जाता, और कोई विज्ञापन नेटवर्क नहीं है।',
     retentionTitle: 'हम इसे कब तक रखते हैं',
     retentionBody:
       'जब तक आपका खाता खुला है, आपका डेटा रहता है। अगर खाता 3 साल तक अछूता रहे, तो हम उसे और उसके निजी डेटा को हटा देते हैं। इसके लिए इंतज़ार करने की ज़रूरत नहीं — नीचे कभी भी सब कुछ ख़ुद निर्यात या हटा सकते हैं। जिस समूह को आप बंद कर दें और डेढ़ साल तक न छूएं, वह अपने-आप आपके संग्रह में चला जाता है — कुछ भी नहीं हटता, और आप उसे कभी भी दोबारा खोल सकते हैं।',
@@ -8673,7 +8675,8 @@ const hi: UiStrings = {
     lastUpdated: 'अंतिम बार {date} को अपडेट किया गया।',
     expandLabel: 'और पढ़ें',
     collapseLabel: 'कम दिखाएँ',
-    storeSummary: 'आपका नाम, साइन-इन, समूह, ख़र्च और कौन किसका देनदार है।',
+    storeSummary:
+      'आपकी प्रोफ़ाइल, समूह, ख़र्च, रसीदें, टिप्पणियाँ, सेटिंग्स और कौन किसका देनदार है।',
     protectSummary: 'हर पठन पर डेटाबेस नियम, निजी रसीद लिंक, साफ़ की गई क्रैश रिपोर्ट।',
     servicesSummary: 'डेटाबेस के लिए Supabase, क्रैश के लिए Sentry, अनुमति देने पर ही Clarity।',
     analyticsSummary: 'कोई विज्ञापन नहीं। आपके चालू किए बिना स्क्रीन रिकॉर्डिंग नहीं।',
@@ -8681,17 +8684,18 @@ const hi: UiStrings = {
     choicesSummary: 'सब कुछ निर्यात करें, कोई भी सूचना बंद करें, या खाता हटाएँ।',
     deviceTitle: 'इस फ़ोन पर',
     deviceSummary:
-      'बिना इंटरनेट काम करने के लिए एन्क्रिप्टेड रखा जाता है; साइन आउट पर मिट जाता है।',
+      'हिसाब डिवाइस की कुंजी से सील है; सेटिंग्स और बचे अपलोड नहीं। साइन आउट पर सब मिट जाता है।',
     deviceBody:
-      'सिग्नल न होने पर भी चले, इसके लिए वेव्स आपके हिसाब की एक नक़ल फ़ोन में रखता है। वहाँ सहेजा गया हर मान फ़ोन के अपने कीस्टोर में रखी कुंजी से एन्क्रिप्ट होता है, इसलिए चोरी हुआ बैकअप या रूट किया गया फ़ाइल-सिस्टम कुछ नहीं पढ़ पाता। साइन आउट करते ही वह कुंजी और स्थानीय नक़ल दोनों मिट जाती हैं।',
+      'सिग्नल न होने पर भी चले, इसके लिए Waves आपके हिसाब की एक नक़ल फ़ोन में रखता है। हिसाब की पंक्तियाँ और भेजे जाने को बची हुई बदलावों की कतार फ़ोन के सुरक्षित स्टोर में रखी कुंजी से सील रहती हैं, इसलिए वह फ़ाइल फ़ोन से निकाल भी ली जाए तो कुंजी के बिना पढ़ी नहीं जा सकती। कुछ चीज़ें उस सील से बाहर हैं: आपकी ऐप सेटिंग्स, और अपलोड होने को बची रसीद तस्वीरें। साइन आउट करते ही हिसाब, कतार, कैश की तस्वीरें और कुंजी — सब साथ मिट जाते हैं।',
     dataControlsSection: 'आपका डेटा',
     legalSection: 'क़ानूनी',
     exportRow: 'अपना डेटा निर्यात करें',
     exportRowHint: 'पूरी, बिना नुक़सान की कॉपी — आपकी अपनी',
     licensesRow: 'ओपन सोर्स लाइसेंस',
-    licensesRowHint: 'वे लाइब्रेरियाँ जिन पर बाकी बना है',
+    licensesRowHint: 'वे लाइब्रेरियाँ जिन पर Waves बना है',
     licensesTitle: 'ओपन सोर्स',
-    licensesIntro: 'बाकी ओपन-सोर्स सॉफ़्टवेयर पर बना है। इन्हें बनाने और सँभालने वालों का धन्यवाद।',
+    licensesIntro:
+      'Waves ओपन-सोर्स सॉफ़्टवेयर पर बना है। इन्हें बनाने और सँभालने वालों का धन्यवाद।',
     licenseNote: 'हर एक अपने लाइसेंस के तहत, बिना बदलाव के इस्तेमाल होती है।',
     previewGroups: { one: 'आप {n} समूह में हैं।', other: 'आप {n} समूहों में हैं।' },
     previewExpenses: {
@@ -8711,7 +8715,7 @@ const hi: UiStrings = {
     feedbackPlaceholder: 'क्या हुआ, या आप क्या चाहते थे कि यह करे',
     feedbackSend: 'भेजें',
     feedbackThanks: 'धन्यवाद — मिल गया।',
-    feedbackRating: 'बाकी अब तक कैसा लगा?',
+    feedbackRating: 'Waves अब तक कैसा लगा?',
     feedbackRatingHint: 'वैकल्पिक',
     feedbackStarLabel: { one: '{n} तारा', other: '{n} तारे' },
     feedbackStarClearHint: 'रेटिंग हटाने के लिए फिर से टैप करें',
@@ -10970,7 +10974,7 @@ const ar: UiStrings = {
     row: 'الخصوصية والأمان',
     rowHint: 'ما الذي يُحفظ، وكيف يُحمى',
     title: 'الخصوصية والأمان',
-    intro: 'يحتفظ باقي بأقل قدر ممكن عنك مع بقائه صالحًا للعمل. وهذا بيان بما يحتفظ به.',
+    intro: 'يحتفظ Waves بأقل قدر ممكن عنك مع بقائه صالحًا للعمل. وهذا بيان بما يحتفظ به.',
     storeTitle: 'ما الذي يُحفظ',
     storeBody:
       'اسمك، وما استخدمته من رقم هاتف أو بريد أو هوية دخول. واختياريًا عنوان دفع كي يتمكن أحدهم من ردّ المال إليك، وبلد، وعنوان بريدي اختياري إن أضفته. المجموعات التي تشارك فيها ومصروفاتها ومن يدين لمن. لا شيء غير ذلك: لا تُرفع جهات الاتصال، ولا يوجد معرّف إعلاني.',
@@ -11008,16 +11012,17 @@ const ar: UiStrings = {
     lastUpdated: 'آخر تحديث {date}.',
     expandLabel: 'اقرأ المزيد',
     collapseLabel: 'إظهار أقل',
-    storeSummary: 'اسمك وطريقة دخولك ومجموعاتك ومصروفاتك ومن يدين لمن.',
+    storeSummary: 'ملفك الشخصي ومجموعاتك ومصروفاتك وإيصالاتك وتعليقاتك وإعداداتك ومن يدين لمن.',
     protectSummary: 'قواعد قاعدة البيانات عند كل قراءة، وروابط إيصالات خاصة، وتقارير أعطال منقّاة.',
     servicesSummary: 'Supabase لقاعدة البيانات، وSentry للأعطال، وClarity فقط إن سمحت.',
     analyticsSummary: 'لا إعلانات ولا معرّف إعلاني. ولا تسجيل للشاشة ما لم تفعّله.',
     retentionSummary: 'يبقى ما دام حسابك مفتوحًا، ويُحذف بعد ثلاث سنوات دون استخدام.',
     choicesSummary: 'صدّر كل شيء، أوقف أي إشعار، أو احذف حسابك.',
     deviceTitle: 'على هذا الهاتف',
-    deviceSummary: 'يُحفظ مشفّرًا للعمل دون اتصال، ويُمحى عند تسجيل الخروج.',
+    deviceSummary:
+      'الدفتر مختوم بمفتاح على الجهاز، أما الإعدادات والرفع المعلّق فلا. ويُمحى الكل عند تسجيل الخروج.',
     deviceBody:
-      'يحتفظ Waves بنسخة من دفترك على الهاتف كي يعمل دون شبكة. وكل قيمة تُحفظ هناك مشفّرة بمفتاح داخل مخزن مفاتيح الهاتف نفسه، فلا تقرأ نسخة احتياطية مسروقة ولا نظام ملفات مكسور الحماية شيئًا. وتسجيل الخروج يتلف ذلك المفتاح والنسخة المحلية معه.',
+      'يحتفظ Waves بنسخة من دفترك على الهاتف كي يعمل دون شبكة. وصفوف الدفتر وطابور التغييرات التي لم تُرسل بعد مختومة بمفتاح داخل المخزن الآمن للهاتف، فلا تُقرأ نسخة من ذلك الملف تُؤخذ خارج الهاتف دون المفتاح. وبعض الأشياء خارج هذا الختم: إعدادات التطبيق، وصور الإيصالات التي تنتظر الرفع. وتسجيل الخروج يمسح الدفتر والطابور والصور المخزّنة والمفتاح معًا.',
     dataControlsSection: 'بياناتك',
     legalSection: 'قانوني',
     exportRow: 'صدِّر بياناتك',

--- a/apps/mobile/src/lib/lock.tsx
+++ b/apps/mobile/src/lib/lock.tsx
@@ -34,6 +34,14 @@ interface LockValue {
   /** Whether the app is currently waiting to be unlocked. */
   locked: boolean;
   supported: boolean;
+  /**
+   * False until the stored state and the hardware check have both come back.
+   * Whether a device can lock is read asynchronously, and `supported` starts
+   * false, so a row rendered before this is true would say 'not available' on a
+   * phone that supports it perfectly well — the worst possible flicker on a
+   * security setting.
+   */
+  ready: boolean;
   /** Seconds in the background before the lock comes back. */
   graceSeconds: number;
   setEnabled: (value: boolean) => Promise<void>;
@@ -54,6 +62,7 @@ export function LockProvider({ children }: { children: ReactNode }) {
   const [locked, setLocked] = useState(false);
   const [supported, setSupported] = useState(false);
   const [graceSeconds, setGraceState] = useState(DEFAULT_GRACE_SECONDS);
+  const [ready, setReady] = useState(false);
 
   /**
    * When the app was last backgrounded. A ref rather than state because the
@@ -81,6 +90,7 @@ export function LockProvider({ children }: { children: ReactNode }) {
       setLocked(on);
       const parsed = Number(storedGrace);
       if (storedGrace !== null && Number.isFinite(parsed) && parsed >= 0) setGraceState(parsed);
+      setReady(true);
     })();
     return () => {
       active = false;
@@ -136,7 +146,16 @@ export function LockProvider({ children }: { children: ReactNode }) {
 
   return (
     <LockContext.Provider
-      value={{ enabled, locked, supported, graceSeconds, setEnabled, setGraceSeconds, unlock }}
+      value={{
+        enabled,
+        locked,
+        supported,
+        ready,
+        graceSeconds,
+        setEnabled,
+        setGraceSeconds,
+        unlock,
+      }}
     >
       {children}
     </LockContext.Provider>

--- a/apps/mobile/src/lib/sessionReplay.ts
+++ b/apps/mobile/src/lib/sessionReplay.ts
@@ -28,9 +28,15 @@ export async function sessionReplayConsent(): Promise<boolean> {
 /**
  * Record the choice and act on it in one step, so the switch on screen and the
  * SDK's capture state can never disagree.
+ *
+ * A failed write throws rather than being swallowed. This is a consent: a switch
+ * left showing "on" over a preference that was never stored is a recording
+ * somebody believes they allowed and did not, and one showing "off" over a
+ * stored "on" resumes recording at the next launch. The caller reverts the
+ * switch and says so.
  */
 export async function setSessionReplayConsent(allowed: boolean): Promise<void> {
-  await AsyncStorage.setItem(KEY, String(allowed)).catch(() => undefined);
+  await AsyncStorage.setItem(KEY, String(allowed));
   await allowSessionReplay(allowed);
 }
 


### PR DESCRIPTION
Acts on a UX roast of `settings/privacy.tsx`: the screen read as a privacy essay with three buried buttons.

## The problem

One screen, two readers, one order. From Settings you came to *do* something and had to scroll past six policy paragraphs to reach Blocked / Export / Delete. From the legal line on the signed-out gate you came to *read*, and that order was fine — so the fix is to reorder per reader, not to cut the text.

## Signed in

- **Your controls** — App lock (state `On` / `Off` / `Not available`, routes to `/settings/lock`; the copy promised the lock and the screen never offered it), Blocked people with a count, and the session-replay toggle.
- Session replay is no longer a footnote under a paragraph. It can record screens with names and amounts, so it sits in the open with a `Off unless you turn it on` line. Still hidden entirely when no Clarity project is configured.
- **Your data** — Export, on its own card.
- **How Waves protects you** — the policy, folded to one summary line per point, using the section icons the data already carried and the UI rendered as a grey dot. Tap opens the full paragraph (LayoutAnimation, gated on reduced motion).
- **Danger zone** — Delete account, its own heading and card at the bottom, past everything reversible.
- **Legal** — Privacy questions → feedback, then Licenses.

## Signed out

Hero, then the policy with every point open — no controls that would act on an account the reader does not have, licenses, footnote.

## Copy and claims

Every claim was checked against the code before it was written:

- New **On this phone** point: the offline mirror is sealed at rest with a keystore key and destroyed on sign-out — `sync/rowCipher.ts`.
- **How it is kept** now adds that a receipt can be visible to the group or only to the people on that expense — `visibility: 'group' | 'parties'` in `ExpenseReceipts`/`data/hooks`.
- Hero glyph `people` → `shield-checkmark-outline`.
- The policy now carries the date it last changed, above the English-governs line.

All new strings in en / ta / hi / ar.

## Checks

`tsc --noEmit`, `eslint`, `prettier`, and `test/strings.test.ts` + `test/localPrivacyAudit.test.ts` (17 passed) all green. Not device-tested.

## Not done here

Several `privacy.*` strings still say "Baaki" rather than "Waves" (`servicesBody`, `licensesRow` hint, `licensesIntro`) in all four languages — left out of this diff as rebrand cleanup rather than a UX change.
