### PR TITLE
feat(activity): an expense event shows your own side of the bill, coloured

### DIFF
--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -65,6 +65,9 @@ type RowView = {
   tintKey: ReturnType<typeof verbTint>;
   icon: ReturnType<typeof verbIcon>;
   money: ReturnType<typeof parseMoney>;
+  /** The reader's own stake in this expense, when they are on the bill —
+   *  coloured by direction, the way the ledger and Friends show money. */
+  stake: RecentActivityRow['stake'];
   archived: boolean;
   unavailable: boolean;
 };
@@ -102,6 +105,7 @@ function toRowView(entry: RecentActivityRow, ctx: RowContext): RowView {
     tintKey: verbTint(entry.verb),
     icon: verbIcon(entry.verb),
     money: parseMoney(entry.payload),
+    stake: entry.stake,
     archived: !!g?.archived_at,
     unavailable: !g,
   };
@@ -191,11 +195,25 @@ const ActivityFeedRow = memo(function ActivityFeedRow({
             ) : null}
           </Row>
         </View>
-        {/* `payload` is an untyped JSON blob, so a bad amount must render as no
-            amount, not as a crashed tab. Neutral, not red: this is an expense
-            total belonging to nobody in particular, not a balance you owe —
-            `mode="plain"` is MoneyText's neutral ink. */}
-        {view.money ? (
+        {/* An expense the reader is on shows THEIR side of it — what they lent
+            or borrowed — coloured by direction, exactly as the group ledger's
+            expense rows and the Friends balances do. That is the figure that
+            answers "what did this do to me"; the bill's total answers nobody's
+            question and printed in neutral ink it read as disabled.
+
+            Everything else keeps the neutral total: a bill between other people,
+            and a settlement (money moves one way and the balance the other, so
+            either sign misreads the other). `payload` is an untyped JSON blob,
+            so a bad amount must render as no amount, not as a crashed tab. */}
+        {view.stake ? (
+          <MoneyText
+            amount={view.stake.amount}
+            currency={view.stake.currency}
+            locale={locale}
+            variant="subheading"
+            mode="balance"
+          />
+        ) : view.money ? (
           <MoneyText
             amount={view.money.amount}
             currency={view.money.currency}
@@ -223,7 +241,7 @@ export default function ActivityScreen() {
   // (`status` goes to Error while still unhydrated), a retry re-runs it via
   // `flush`, so the screen offers a way out rather than a skeleton forever.
   const { hydrated, status, flush } = useSync();
-  const allEntries = useRecentActivity();
+  const allEntries = useRecentActivity(myProfileId);
   // Whether the account has any live group at all — decides the empty-state's
   // next step. A brand-new account with nothing starts a group; an account that
   // has groups but no activity yet wants to add an expense, not make another

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -36,6 +36,7 @@ import {
   activityHeadline,
   activityTarget,
   describeActivity,
+  myStake,
   parseMoney,
   relativeTime,
   verbIcon,
@@ -122,33 +123,6 @@ function RemindChip({
       <Badge label={t.people.remind} tone="brand" />
     </Pressable>
   );
-}
-
-/**
- * What one expense did to one person's balance — what they put in beyond their
- * own share (positive: they lent), or their share of what somebody else put in
- * (negative: they borrowed).
- *
- * `null` means they are in neither column: an expense between other people in
- * the group. That is a blank on the row, not a zero — a zero would read as "you
- * are square on this one", which is a different sentence.
- */
-function myStake(
-  version: ExpenseVersionRow | null | undefined,
-  memberId: MemberId | null,
-): bigint | null {
-  if (!version || !memberId) return null;
-  const paid = version.payers.find((row) => row.member_id === memberId)?.amount;
-  const share = version.shares.find((row) => row.member_id === memberId)?.amount;
-  const paidN = BigInt(paid ?? 0);
-  const shareN = BigInt(share ?? 0);
-  // Not involved is "put nothing in, owe nothing" — which covers both the member
-  // absent from the bill entirely AND a member written into the split with a zero
-  // share (an excluded party some imports still list). Either way there is no
-  // stake, so the row must read "not involved", not "all settled" — a settled
-  // square is what you get when you paid and owed the *same non-zero* amount.
-  if (paidN === 0n && shareN === 0n) return null;
-  return paidN - shareN;
 }
 
 /**
@@ -542,6 +516,13 @@ export default function GroupScreen() {
     [expenses.rows, showDeleted],
   );
   const expenseSections = useMemo(() => groupExpensesByMonth(visibleExpenses), [visibleExpenses]);
+  // Every expense by id, so an activity row (which names its object) can show
+  // the reader's own stake in that bill without scanning the ledger per row.
+  // Built from the unfiltered rows: a deleted expense still has an activity row.
+  const expenseById = useMemo(
+    () => new Map(expenses.rows.map((expense) => [expense.id, expense] as const)),
+    [expenses.rows],
+  );
   // The month sections flattened into one recyclable list: a heading item per
   // month, then its expense rows. FlashList mounts only what is on screen, so a
   // group with a thousand bills opens as fast as one with ten.
@@ -829,6 +810,13 @@ export default function GroupScreen() {
     // group's members before wording the row.
     const { entry, isLast } = item;
     const money = parseMoney(entry.payload, currency);
+    // The reader's own side of the bill, when they are on it — the same figure
+    // and the same colours as the Expenses tab's rows, so one event does not
+    // read two ways across two tabs of one screen.
+    const stake =
+      entry.object_type === 'expense' && entry.object_id
+        ? myStake(expenseById.get(entry.object_id)?.currentVersion ?? null, ledger.myMemberId)
+        : null;
     const tint = theme.tint[verbTint(entry.verb)];
     const resolved = entry.actor ? entry : { ...entry, actor: actorFor(entry.actor_member_id) };
     // The full sentence stays the spoken label; the visible title leads with the
@@ -879,10 +867,19 @@ export default function GroupScreen() {
                 {who ? `${who} · ${when}` : when}
               </Text>
             </View>
-            {money ? (
-              // Neutral, not red: an expense total belongs to nobody in
-              // particular — it is not a balance you owe. `mode="plain"` is
-              // MoneyText's neutral ink, the same on the cross-group feed.
+            {stake !== null && stake !== 0n ? (
+              // What the bill did to the reader — lent or borrowed, coloured by
+              // direction, the same as the Expenses tab and the cross-group
+              // feed. A bill between other people, and every settlement, keep
+              // the neutral total below.
+              <MoneyText
+                amount={stake}
+                currency={money?.currency ?? currency}
+                locale={locale}
+                variant="subheading"
+                mode="balance"
+              />
+            ) : money ? (
               <MoneyText
                 amount={money.amount}
                 currency={money.currency}

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -17,7 +17,9 @@ import type Ionicons from '@expo/vector-icons/Ionicons';
 
 import { isCurrencyCode } from '@waves/core';
 
-import { actorName, type ActivityRow } from './types';
+import { actorName, type ActivityRow, type ExpenseVersionRow } from './types';
+
+import type { MemberId } from '@waves/core';
 
 /**
  * An activity `payload` is an untyped JSON blob, so a bad amount must render as
@@ -43,6 +45,36 @@ export function parseMoney(
   } catch {
     return null;
   }
+}
+
+/**
+ * What one expense did to one person's balance — what they put in beyond their
+ * own share (positive: they lent), or their share of what somebody else put in
+ * (negative: they borrowed).
+ *
+ * `null` means they are in neither column: an expense between other people in
+ * the group. That is a blank on the row, not a zero — a zero would read as "you
+ * are square on this one", which is a different sentence.
+ *
+ * Shared by the group ledger and both activity feeds, so the coloured figure on
+ * an expense row means the same thing wherever it is read.
+ */
+export function myStake(
+  version: ExpenseVersionRow | null | undefined,
+  memberId: MemberId | null,
+): bigint | null {
+  if (!version || !memberId) return null;
+  const paid = version.payers.find((row) => row.member_id === memberId)?.amount;
+  const share = version.shares.find((row) => row.member_id === memberId)?.amount;
+  const paidN = BigInt(paid ?? 0);
+  const shareN = BigInt(share ?? 0);
+  // Not involved is "put nothing in, owe nothing" — which covers both the member
+  // absent from the bill entirely AND a member written into the split with a zero
+  // share (an excluded party some imports still list). Either way there is no
+  // stake, so the row must read "not involved", not "all settled" — a settled
+  // square is what you get when you paid and owed the *same non-zero* amount.
+  if (paidN === 0n && shareN === 0n) return null;
+  return paidN - shareN;
 }
 
 export function describeActivity(

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -97,6 +97,7 @@ import { pickAlbumPhoto, type PickedImage } from '@/lib/image';
 import { parseAnnotations, type Annotations } from '@/lib/annotations';
 import { sanitizeCommentMarkdown } from '@/lib/commentMarkdown';
 import type { VoiceAccess } from '@/lib/voiceAccess';
+import { myStake } from './activity';
 import { SettlementStatus } from './types';
 import type {
   ActivityActor,
@@ -104,6 +105,7 @@ import type {
   ActivityRow,
   CaptureRow,
   ExpenseRow,
+  ExpenseVersionRow,
   GroupRow,
   MemberRow,
   SettlementRow,
@@ -602,7 +604,20 @@ export function usePendingAware(groupId: string, expenses: ExpenseRow[]): Expens
   );
 }
 
-export type RecentActivityRow = ActivityRow & { group: ActivityGroup | null };
+export type RecentActivityRow = ActivityRow & {
+  group: ActivityGroup | null;
+  /**
+   * What this event did to the reader's own balance, when that is knowable: an
+   * expense event carries the reader's stake in that bill (positive: they lent,
+   * negative: they borrowed) — the same figure the group ledger's expense rows
+   * show, so a coloured amount means one thing across the app.
+   *
+   * Null when the event is not an expense, when the reader is on neither side
+   * of the bill, or when no profile id was given. The row then falls back to
+   * the payload's neutral total, which belongs to nobody in particular.
+   */
+  stake: { amount: bigint; currency: string } | null;
+};
 
 /**
  * The recent-activity feed, entirely from the mirror — offline-first (ADR-005).
@@ -617,7 +632,7 @@ export type RecentActivityRow = ActivityRow & { group: ActivityGroup | null };
  * Newest-first across every group the phone knows about; the screen paginates
  * this local list rather than asking the server for the next page.
  */
-export function useRecentActivity(): RecentActivityRow[] {
+export function useRecentActivity(myProfileId: string | null = null): RecentActivityRow[] {
   const { mirror } = useSync();
   return useMemo(() => {
     const groups = new Map<string, ActivityGroup>();
@@ -652,14 +667,65 @@ export function useRecentActivity(): RecentActivityRow[] {
       });
     }
 
+    // The reader's own member id in each group, so an expense event can be told
+    // apart into "you lent" and "you borrowed". The same person holds a
+    // different member id in every group, hence a map rather than one id.
+    const myMemberByGroup = new Map<string, MemberId>();
+    if (myProfileId) {
+      for (const row of rowsFor(mirror, SyncTable.GroupMembers)) {
+        const m = row as unknown as {
+          id: MemberId;
+          group_id: string;
+          profile_id: string | null;
+          left_at: string | null;
+        };
+        if (m.profile_id === myProfileId && !m.left_at) myMemberByGroup.set(m.group_id, m.id);
+      }
+    }
+
+    // Every expense the phone holds, by id — an activity row names its object,
+    // so the stake is a map lookup rather than a scan per row.
+    const expenseById = new Map<string, MirrorExpense>();
+    if (myProfileId) {
+      for (const row of rowsFor(mirror, SyncTable.Expenses) as MirrorExpense[]) {
+        expenseById.set(row.id, row);
+      }
+    }
+
     return (rowsFor(mirror, SyncTable.ActivityLog) as unknown as ActivityRow[])
       .map((row) => ({
         ...row,
         group: groups.get(row.group_id) ?? null,
         actor: row.actor_member_id ? (actors.get(row.actor_member_id) ?? null) : null,
+        stake: stakeFor(row, expenseById, myMemberByGroup),
       }))
       .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
-  }, [mirror]);
+  }, [mirror, myProfileId]);
+}
+
+/**
+ * The reader's stake in the expense an activity row is about, or null when the
+ * row is not about an expense they are on. A settled/confirmed row is left
+ * null on purpose: a settlement moves money one way and the balance the other,
+ * so colouring it by either sign misreads the other — it keeps the neutral
+ * total.
+ */
+function stakeFor(
+  row: ActivityRow,
+  expenseById: ReadonlyMap<string, MirrorExpense>,
+  myMemberByGroup: ReadonlyMap<string, MemberId>,
+): { amount: bigint; currency: string } | null {
+  if (row.object_type !== 'expense' || !row.object_id) return null;
+  const version = expenseById.get(row.object_id)?.currentVersion;
+  if (!version) return null;
+  const stake = myStake(
+    version as unknown as ExpenseVersionRow,
+    myMemberByGroup.get(row.group_id) ?? null,
+  );
+  // A square stake (paid exactly what you owed) has no direction to colour, so
+  // it reads as the neutral total rather than a grey zero.
+  if (stake === null || stake === 0n) return null;
+  return { amount: stake, currency: version.currency };
 }
 
 /** How much a destination (group, or a person's 1:1 group) has been used. */


### PR DESCRIPTION
On both activity feeds the amount beside an event was the bill's **total** in neutral ink. Two problems with that: it answers a question nobody asks of a feed (what the dinner cost, rather than what it did to me), and printed grey next to the green/red money everywhere else in the app it reads as disabled.

An expense event now shows the reader's own **stake** in that bill — what they put in beyond their share (they lent), or their share of what somebody else put in (they borrowed) — coloured by direction. Same figure, same colours as the group ledger's expense rows and the Friends balances, so one event no longer reads two ways across three surfaces.

## What changes

- `myStake` moves from `app/group/[id]/index.tsx` into `data/activity`, where both feeds already share their wording. The ledger imports it from there.
- `useRecentActivity(myProfileId)` attaches a `stake` per row: the reader's member id per group (the same person holds a different one in each) crossed with the expense's payers and shares, read straight from the mirror — offline like the rest of the feed. The watch bridge's call is unchanged and passes nothing, so it gets no stake.
- Both feeds fall back to the neutral total when there is no stake to show.

## What deliberately stays neutral

- A bill between other people — no stake, and a blank is not a zero.
- A square stake (paid exactly what you owed) — no direction to colour.
- **Every settlement.** It moves cash one way and the balance the other, so either sign misreads the other. Not a figure this feed can colour honestly.

## Checks

`tsc`, eslint and prettier clean; mobile suite 701 passing. Not device-tested yet.