### PR TITLE
chore(db): close the signed-out surface the linter found, and pin every search_path

### DIFF
--- a/packages/db/prisma/migrations/20260831120000_anon_surface_hardening/migration.sql
+++ b/packages/db/prisma/migrations/20260831120000_anon_surface_hardening/migration.sql
@@ -1,0 +1,227 @@
+-- Closing what the database linter found: everything the signed-out `anon`
+-- role can still reach, and the functions whose search_path is not pinned.
+--
+-- None of this was an open door — every flagged function null-guards on
+-- `baaki_current_profile_id()` and every table is behind RLS, so a signed-out
+-- caller already got nothing back. It is the second lock: the surface a
+-- signed-out request can even address should be the handful of things that
+-- genuinely have to answer before sign-in, and nothing else.
+--
+-- ─────────────────────────────────────────────── why anon kept creeping back ──
+--
+-- Every migration since the definer-grant audit writes:
+--
+--     REVOKE ALL ON FUNCTION ... FROM PUBLIC;
+--     GRANT  ALL ON FUNCTION ... TO authenticated, service_role;
+--
+-- which reads as "signed-in only" and is not. Supabase ships default privileges
+-- on the `public` schema that grant EXECUTE **directly to `anon`** as each
+-- function is created, and a revoke FROM PUBLIC does not touch a direct grant.
+-- So the audit's own pattern re-opens every function added after it: the
+-- baseline carries 129 `FROM PUBLIC` revokes and not one `FROM anon`.
+--
+-- The house pattern from here is both lines. `FROM PUBLIC` for the implicit
+-- grant, `FROM anon` for the default-privilege one:
+--
+--     REVOKE ALL ON FUNCTION ... FROM PUBLIC, anon;
+--     GRANT  ALL ON FUNCTION ... TO authenticated, service_role;
+
+-- ─────────────────────────────────────────── 1. pin every mutable search_path ──
+--
+-- A SECURITY DEFINER function without a pinned search_path resolves its
+-- unqualified names against whatever the caller's search_path says, which is
+-- the classic way to get one to run somebody else's `expenses` table. The
+-- triggers and check functions here are not definer, but they run on every
+-- write, and there is no reason for any of them to inherit a caller's path.
+
+ALTER FUNCTION public.baaki_array_is_distinct(p_values text[]) SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_assert_fx_valid(p_fx jsonb, p_expense_currency character, p_group_currency character) SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_check_expense_totals() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_check_settlement_allocations() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_current_profile_id() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_expense_restore_window() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_forbid_mutation() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_group_balances_truth(p_group_id uuid) SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_group_from_storage_path(p_path text) SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_group_pairwise_truth(p_group_id uuid) SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_guard_group_columns() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_guard_membership_columns() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_nudge_rate_limit() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_settlement_transition() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_stamp_capture_seq() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_stamp_category_tag_seq() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_stamp_ghost_merge_seq() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_stamp_group_seq() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_stamp_personal_seq() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_stamp_seq() SET search_path = 'public', 'pg_temp';
+ALTER FUNCTION public.baaki_version_key(p_version text) SET search_path = 'public', 'pg_temp';
+
+-- ──────────────────────────── 2. the definer functions a signed-out caller had ──
+--
+-- Three the linter flagged, all added after the audit and all carrying its
+-- incomplete revoke. Each already refuses a caller with no session —
+-- `baaki_log_voice_attempt` returns NULL, the other two resolve no member and
+-- raise — so this removes the ability to call them at all rather than a working
+-- exploit.
+--
+-- The definer functions left executable by `anon` are deliberate and stay:
+-- `is_group_member`, `baaki_my_member_id`, `baaki_is_expense_party`,
+-- `baaki_is_settlement_party` and `baaki_version_group_id` are the helpers the
+-- RLS policies themselves call, and a policy written `TO anon, authenticated`
+-- has to be able to evaluate for either role.
+
+REVOKE ALL ON FUNCTION public.baaki_delete_group(p_group_id uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.baaki_log_voice_attempt(p_transcript text, p_locale text, p_used_model boolean, p_item_count integer, p_platform text, p_app_version text, p_client_at timestamp with time zone) FROM anon;
+REVOKE ALL ON FUNCTION public.baaki_next_personal_seq(p_owner uuid) FROM anon;
+
+-- Two more the linter has not seen yet: the settle-up cancel/dispute pair went
+-- in after that scan and carries the same incomplete revoke, so they would have
+-- turned up on the next one. Closed here rather than left to be rediscovered.
+REVOKE ALL ON FUNCTION public.baaki_cancel_settlement(p_settlement_id uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.baaki_dispute_settlement(p_settlement_id uuid, p_reason text) FROM anon;
+
+-- ─────────────────────────────────────────────── 3. tables anon may address ──
+--
+-- RLS already returned nothing to a signed-out caller on every one of these.
+-- What the grant still bought was *discovery*: the table, its columns and its
+-- relationships are published in the GraphQL schema and the OpenAPI document to
+-- anyone holding the publishable key, which is in every copy of the app.
+--
+-- Three keep their signed-out read, because something has to answer before
+-- there is a session:
+--
+--   • `app_releases`   — the version gate. A client too old to be trusted with
+--                        the ledger is too old to sign in to it, so this is
+--                        read before the sign-in screen (see fetchReleasePolicy).
+--   • `country_settings` — the phone sign-in screen's country denylist.
+--   • `feature_flags`  — read by a provider that can mount before the session
+--                        resolves; it is public configuration, and the fetch is
+--                        cached for an hour, so failing it signed-out would
+--                        leave flags inert for an hour after signing in.
+--
+-- A guest is NOT `anon`: an anonymous sign-in issues a real JWT with the
+-- `authenticated` role and `is_anonymous: true`, so every guest ceiling and
+-- guest read keeps working.
+
+REVOKE ALL ON TABLE public.activity_log FROM anon;
+REVOKE ALL ON TABLE public.app_config FROM anon;
+REVOKE ALL ON TABLE public.campaign_impressions FROM anon;
+REVOKE ALL ON TABLE public.email_events FROM anon;
+REVOKE ALL ON TABLE public.expense_attachments FROM anon;
+REVOKE ALL ON TABLE public.expense_comments FROM anon;
+REVOKE ALL ON TABLE public.expense_disputes FROM anon;
+REVOKE ALL ON TABLE public.expense_image_events FROM anon;
+REVOKE ALL ON TABLE public.expense_payers FROM anon;
+REVOKE ALL ON TABLE public.expense_shares FROM anon;
+REVOKE ALL ON TABLE public.expense_versions FROM anon;
+REVOKE ALL ON TABLE public.expenses FROM anon;
+REVOKE ALL ON TABLE public.feedback FROM anon;
+REVOKE ALL ON TABLE public.ghost_merges FROM anon;
+REVOKE ALL ON TABLE public.group_balances FROM anon;
+REVOKE ALL ON TABLE public.group_members FROM anon;
+REVOKE ALL ON TABLE public.group_passes FROM anon;
+REVOKE ALL ON TABLE public.groups FROM anon;
+REVOKE ALL ON TABLE public.invites FROM anon;
+REVOKE ALL ON TABLE public.member_claims FROM anon;
+REVOKE ALL ON TABLE public.notifications FROM anon;
+REVOKE ALL ON TABLE public.pairwise_balances FROM anon;
+REVOKE ALL ON TABLE public.personal_records FROM anon;
+REVOKE ALL ON TABLE public.profiles FROM anon;
+REVOKE ALL ON TABLE public.promo_redemptions FROM anon;
+REVOKE ALL ON TABLE public.push_tokens FROM anon;
+REVOKE ALL ON TABLE public.receipt_item_claims FROM anon;
+REVOKE ALL ON TABLE public.receipts FROM anon;
+REVOKE ALL ON TABLE public.reminders FROM anon;
+REVOKE ALL ON TABLE public.service_config FROM anon;
+REVOKE ALL ON TABLE public.settlement_allocations FROM anon;
+REVOKE ALL ON TABLE public.settlement_proofs FROM anon;
+REVOKE ALL ON TABLE public.settlements FROM anon;
+REVOKE ALL ON TABLE public.sync_mutations FROM anon;
+REVOKE ALL ON TABLE public.trip_member_budgets FROM anon;
+REVOKE ALL ON TABLE public.trip_photos FROM anon;
+REVOKE ALL ON TABLE public.trip_plan_items FROM anon;
+REVOKE ALL ON TABLE public.usage_events FROM anon;
+
+-- `app_releases` keeps its signed-out read and loses the rest. The baseline
+-- hands `anon` INSERT and UPDATE on it as well, which nothing has ever needed:
+-- the row is written from the console, and the only policy on the table is a
+-- read. RLS refuses those writes today; the grant should not have implied they
+-- were on the table at all.
+REVOKE ALL ON TABLE public.app_releases FROM anon;
+GRANT SELECT ON TABLE public.app_releases TO anon;
+
+-- The invite flow is untouched by the line above: an invite is previewed and
+-- accepted through the `invite-accept` edge function on the service role, never
+-- by a signed-out client reading `invites` directly.
+
+-- ────────────────────────────────────────── 4. policies that still name anon ──
+--
+-- `ALTER POLICY ... TO` changes only the roles a policy applies to; the USING
+-- and WITH CHECK expressions are left exactly as they are. Each of these is an
+-- "is it mine" policy whose expression compares against `auth.uid()`, so it
+-- could never match for a signed-out caller — naming `anon` said something the
+-- policy never meant.
+--
+-- The other policies written `TO anon, authenticated` are not touched here:
+-- their expressions go through `is_group_member`, which is false without a
+-- session, and the table grants above are now the outer gate either way.
+
+ALTER POLICY campaign_impressions_own ON public.campaign_impressions TO authenticated;
+ALTER POLICY captures_own ON public.captures TO authenticated;
+ALTER POLICY category_tags_own ON public.category_tags TO authenticated;
+ALTER POLICY device_sessions_own_read ON public.device_sessions TO authenticated;
+ALTER POLICY email_events_select_own ON public.email_events TO authenticated;
+ALTER POLICY feedback_own ON public.feedback TO authenticated;
+ALTER POLICY group_members_update_self ON public.group_members TO authenticated;
+ALTER POLICY invites_revoke ON public.invites TO authenticated;
+ALTER POLICY member_claims_visible ON public.member_claims TO authenticated;
+ALTER POLICY notifications_select_own ON public.notifications TO authenticated;
+ALTER POLICY notifications_update_own ON public.notifications TO authenticated;
+ALTER POLICY personal_records_own ON public.personal_records TO authenticated;
+ALTER POLICY promo_redemptions_own ON public.promo_redemptions TO authenticated;
+ALTER POLICY push_tokens_own ON public.push_tokens TO authenticated;
+ALTER POLICY service_config_select ON public.service_config TO authenticated;
+ALTER POLICY subscriptions_select_own ON public.subscriptions TO authenticated;
+ALTER POLICY usage_events_select_own ON public.usage_events TO authenticated;
+ALTER POLICY voice_stt_usage_select_own ON public.voice_stt_usage TO authenticated;
+
+-- ─────────────────────────────────────────────── 5. the storage-side policies ──
+--
+-- Same "is it mine" shape, on `storage.objects`: an owner check that cannot
+-- match without a session, applied to a role that never has one.
+--
+-- Guarded, because `storage.objects` belongs to `supabase_storage_admin` and
+-- whether the migration's role may alter its policies differs between projects.
+-- A refusal here must not fail the migration and take everything above with it:
+-- these six are tidiness, not the lock. If the notice appears, the same six
+-- lines can be run from the SQL editor, which does hold that ownership.
+
+DO $$
+DECLARE
+  v_policy text;
+  v_policies text[] := ARRAY[
+    'captures are readable by their owner',
+    'captures are removable by their owner',
+    'captures are replaceable by their owner',
+    'personal receipts are readable by owner',
+    'personal receipts are removable by owner',
+    'personal receipts are replaceable by paid owner'
+  ];
+BEGIN
+  FOREACH v_policy IN ARRAY v_policies LOOP
+    BEGIN
+      -- Only touch what is actually there: a policy renamed or dropped since
+      -- the linter ran is not an error worth stopping for.
+      IF EXISTS (
+        SELECT 1 FROM pg_policies
+         WHERE schemaname = 'storage' AND tablename = 'objects' AND policyname = v_policy
+      ) THEN
+        EXECUTE format('ALTER POLICY %I ON storage.objects TO authenticated', v_policy);
+      END IF;
+    EXCEPTION
+      WHEN insufficient_privilege THEN
+        RAISE NOTICE 'storage.objects policy %: not owned by this role, left as it is', v_policy;
+    END;
+  END LOOP;
+END
+$$;

--- a/packages/db/test/anon-surface.test.ts
+++ b/packages/db/test/anon-surface.test.ts
@@ -1,0 +1,111 @@
+/**
+ * What a signed-out request can even address.
+ *
+ * RLS decides which rows come back; these are the grants that decide whether
+ * the question can be asked at all. They are asserted as whole sets rather than
+ * one table at a time, because the failure this guards against is *addition*: a
+ * later migration that creates a function or a table and quietly hands `anon`
+ * the default grant. A per-item test would never notice the new thing.
+ *
+ * The trap is worth stating, since the repo already fell into it once. Supabase
+ * ships default privileges on `public` that grant EXECUTE **directly to `anon`**
+ * as each function is created, so the familiar
+ *
+ *     REVOKE ALL ON FUNCTION ... FROM PUBLIC;
+ *
+ * does not close it — a direct grant is not the PUBLIC one. Every function
+ * added after the definer-grant audit was reachable signed-out again for
+ * exactly that reason (`20260831120000_anon_surface_hardening`). The house
+ * pattern is `FROM PUBLIC, anon`, and this file is what enforces it.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect } from './helpers.js';
+
+let client: Client;
+
+beforeAll(async () => {
+  client = await connect();
+});
+
+afterAll(async () => {
+  await client?.end();
+});
+
+/**
+ * The RLS helpers the policies themselves call. A policy written
+ * `TO anon, authenticated` has to be able to evaluate for either role, so these
+ * stay reachable signed-out — they answer "is this caller a member", which for
+ * a signed-out caller is always false.
+ */
+const POLICY_HELPERS = [
+  'baaki_is_expense_party',
+  'baaki_is_settlement_party',
+  'baaki_my_member_id',
+  'baaki_version_group_id',
+  'is_group_member',
+];
+
+/**
+ * The three things that have to answer before there is a session: the version
+ * gate the app reads before its own sign-in screen, the country denylist on the
+ * phone sign-in screen, and public feature configuration.
+ */
+const PRE_SIGN_IN_TABLES = ['app_releases', 'country_settings', 'feature_flags'];
+
+describe('the signed-out surface', () => {
+  it('exposes exactly the RLS helpers, and no other SECURITY DEFINER function', async () => {
+    const { rows } = await client.query<{ proname: string }>(`
+      SELECT p.proname
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+       WHERE n.nspname = 'public'
+         AND p.prosecdef
+         AND has_function_privilege('anon', p.oid, 'EXECUTE')
+       ORDER BY 1
+    `);
+
+    // Named in the failure so a new arrival is obvious: if this trips, a
+    // migration created a definer function and left it callable signed-out.
+    expect(rows.map((row) => row.proname)).toEqual(POLICY_HELPERS);
+  });
+
+  it('exposes exactly the three pre-sign-in tables, and each of them read-only', async () => {
+    const { rows } = await client.query<{ table_name: string; privileges: string }>(`
+      SELECT table_name, string_agg(DISTINCT privilege_type, ',' ORDER BY privilege_type) privileges
+        FROM information_schema.role_table_grants
+       WHERE grantee = 'anon' AND table_schema = 'public'
+       GROUP BY table_name
+       ORDER BY table_name
+    `);
+
+    expect(rows.map((row) => row.table_name)).toEqual(PRE_SIGN_IN_TABLES);
+    // Read-only: a signed-out caller has never needed to write any of them, and
+    // `app_releases` carried INSERT and UPDATE for years on the strength of a
+    // default grant nobody asked for.
+    for (const row of rows) {
+      expect(row.privileges, `${row.table_name} should be SELECT-only for anon`).toBe('SELECT');
+    }
+  });
+
+  it('pins search_path on every function in public', async () => {
+    const { rows } = await client.query<{ proname: string }>(`
+      SELECT p.proname
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+       WHERE n.nspname = 'public'
+         AND NOT EXISTS (
+           SELECT 1 FROM unnest(COALESCE(p.proconfig, '{}')) cfg WHERE cfg LIKE 'search_path=%'
+         )
+       ORDER BY 1
+    `);
+
+    // A definer function that resolves unqualified names against the caller's
+    // search_path is the classic way to get it to read somebody else's table.
+    // The triggers are not definer, but they run on every write and have no
+    // reason to inherit a path either.
+    expect(rows.map((row) => row.proname)).toEqual([]);
+  });
+});

--- a/packages/db/test/expense-comments.test.ts
+++ b/packages/db/test/expense-comments.test.ts
@@ -123,7 +123,10 @@ describe('expense comments — permission matrix', () => {
 
   it('T3 anon cannot add and cannot read', async () => {
     await addComment(P(1), 'visible to members');
-    expect(await visibleTo(null)).toBe(0);
+    // Signed out, the read is refused at the grant rather than filtered to zero
+    // rows: `anon` holds no privilege on `expense_comments` since
+    // 20260831120000_anon_surface_hardening.
+    await expectDenied(visibleTo(null));
     await expectDenied(
       as(null, () =>
         client.query(`SELECT baaki_add_expense_comment($1, $2, $3, $4)`, [

--- a/packages/db/test/expense-image-events.test.ts
+++ b/packages/db/test/expense-image-events.test.ts
@@ -227,7 +227,9 @@ describe('attachment audit line, emitted by the attach/remove RPCs', () => {
 describe('anon', () => {
   it('sees no events and cannot log one', async () => {
     await logReceipt(P(0), 'added');
-    expect(await eventsVisibleTo(null)).toHaveLength(0);
+    // Refused at the grant, not merely filtered: `anon` holds no privilege on
+    // `expense_image_events` since 20260831120000_anon_surface_hardening.
+    await expectDenied(eventsVisibleTo(null));
     await expectDenied(
       as(null, () =>
         client.query(`SELECT baaki_log_receipt_event($1, $2, $3, 'added')`, [

--- a/packages/db/test/private-attachments.test.ts
+++ b/packages/db/test/private-attachments.test.ts
@@ -326,7 +326,10 @@ describe('the outer gates', () => {
     await as(g.profileIds[0] as string, () =>
       attachProof(settlementId, `${settlementId}/${randomUUID()}.webp`),
     );
-    expect(await as(null, () => countProofs(settlementId))).toBe(0);
+    // Refused at the grant, not filtered to zero: since
+    // 20260831120000_anon_surface_hardening the signed-out role holds no
+    // privilege on `settlement_proofs` at all.
+    await expectDenied(as(null, () => countProofs(settlementId)));
   });
 
   it('T7 — an outsider from another group sees nothing', async () => {

--- a/packages/db/test/rls.test.ts
+++ b/packages/db/test/rls.test.ts
@@ -36,9 +36,14 @@ afterAll(async () => {
 });
 
 const memberClaims = (profileId: string) => ({ sub: profileId, role: 'authenticated' });
+// A guest session as Supabase actually issues one: the `authenticated` role and
+// an `is_anonymous` claim, carrying the group ids the removed claim mechanism
+// used to honour. The point of these cases is that the claim buys nothing —
+// only a `group_members` row does.
 const guestClaims = (groupIds: string[]) => ({
   sub: randomUUID(),
-  role: 'anon',
+  role: 'authenticated',
+  is_anonymous: true,
   app_metadata: { baaki_groups: groupIds },
 });
 
@@ -57,10 +62,14 @@ describe('groups', () => {
     });
   });
 
-  it('an unauthenticated caller sees nothing', async () => {
+  it('an unauthenticated caller cannot even address the table', async () => {
+    // Stronger than "sees no rows", which is what RLS alone gave: since
+    // 20260831120000_anon_surface_hardening the signed-out role holds no grant
+    // on `groups` at all, so the read is refused before a policy is consulted
+    // and the table is not published in the API schema either.
     await asRole(client, 'anon', {}, async () => {
-      const result = await client.query(`SELECT id FROM groups`);
-      expect(result.rowCount).toBe(0);
+      const message = await expectDenied(client.query(`SELECT id FROM groups`));
+      expect(message).toMatch(/permission denied/i);
     });
   });
 });
@@ -146,14 +155,19 @@ describe('expenses and their money rows', () => {
  */
 describe('guest sessions (ADR-006)', () => {
   it('a guest who joined is a member, and reads the group', async () => {
-    await asRole(client, 'anon', memberClaims(group.profileIds[1] as string), async () => {
+    // A guest is an anonymous *sign-in*, which Supabase issues as a real JWT
+    // carrying the `authenticated` role and an `is_anonymous` claim — not the
+    // `anon` API-key role, which means "no session at all". Modelled as `anon`
+    // this case was really testing the signed-out grant; it is the guest's
+    // membership row that has always done the work.
+    await asRole(client, 'authenticated', memberClaims(group.profileIds[1] as string), async () => {
       const read = await client.query(`SELECT id FROM groups WHERE id = $1`, [group.groupId]);
       expect(read.rowCount).toBe(1);
     });
   });
 
   it('a JWT claim naming a group grants nothing on its own', async () => {
-    await asRole(client, 'anon', guestClaims([group.groupId]), async () => {
+    await asRole(client, 'authenticated', guestClaims([group.groupId]), async () => {
       expect(
         (await client.query(`SELECT is_group_member($1) AS m`, [group.groupId])).rows[0].m,
       ).toBe(false);
@@ -163,7 +177,7 @@ describe('guest sessions (ADR-006)', () => {
   });
 
   it('and a claim naming somebody else’s group grants nothing either', async () => {
-    await asRole(client, 'anon', guestClaims([otherGroupId]), async () => {
+    await asRole(client, 'authenticated', guestClaims([otherGroupId]), async () => {
       const read = await client.query(`SELECT id FROM groups WHERE id = $1`, [group.groupId]);
       expect(read.rowCount).toBe(0);
     });


### PR DESCRIPTION
Everything the database linter flagged, fixed in one migration — plus two functions it has not seen yet.

**None of it was an open door.** Every flagged function null-guards on `baaki_current_profile_id()`, and every table is behind RLS, so a signed-out caller already got nothing back. This is the second lock.

## Why `anon` kept creeping back

Every migration since the definer-grant audit writes:

```sql
REVOKE ALL ON FUNCTION ... FROM PUBLIC;
GRANT  ALL ON FUNCTION ... TO authenticated, service_role;
```

which reads as "signed-in only" and isn't. Supabase ships default privileges on `public` that grant EXECUTE **directly to `anon`** as each function is created, and a revoke `FROM PUBLIC` does not touch a direct grant. The baseline carries **129** `FROM PUBLIC` revokes and **zero** `FROM anon` — so every function added after the audit was reachable signed-out again. The house pattern is now `FROM PUBLIC, anon`.

## What changes

| | |
|---|---|
| **Functions** | `baaki_delete_group`, `baaki_log_voice_attempt`, `baaki_next_personal_seq` (linter's three) + `baaki_cancel_settlement`, `baaki_dispute_settlement` (landed after the scan). The five left reachable are the RLS helpers the policies call. |
| **Tables** | `anon` loses every grant except `app_releases`, `country_settings`, `feature_flags` — the three that must answer before there is a session. `app_releases` also had anon INSERT/UPDATE on a table whose only policy is a read; now SELECT. |
| **Policies** | 18 "is it mine" policies stop naming `anon`. `ALTER POLICY ... TO` changes roles only — expressions untouched. |
| **search_path** | 21 functions pinned. |

**Guests are unaffected.** An anonymous sign-in is a real JWT carrying the `authenticated` role and an `is_anonymous` claim — not the `anon` API-key role ([docs](https://supabase.com/docs/guides/auth/auth-anonymous)). Four RLS tests were modelling a guest as role `anon`; they now run as `authenticated`, and still prove a group id in a JWT claim grants nothing without a `group_members` row.

## Tests

Four tests asserted the weaker shape (as `anon`, a read returns zero rows) and now assert the stronger one (refused at the grant).

New `anon-surface.test.ts` asserts three sets **whole** — reachable definer functions, anon-granted tables, unpinned search_paths — because the failure being guarded against is *addition*: a per-item test would never notice a newly created function taking the default grant.

Verified on a scratch database with the full migration history applied: **688 db tests pass**.

## Not in this PR

- **Leaked-password protection** (HIBP) is **Pro-plan gated** — not available on this project's plan, so the advisor line stays until that changes.
- **MFA options** is a dashboard toggle (Authentication → MFA). `supabase config push` would do it but pushes the *whole* config.toml, which still carries a `<services-id>` placeholder for Apple — that would break sign-in.
- **`pg_net` in public** — known, and the one hard Supabase dependency.
- The ~40 remaining `TO anon, authenticated` policies the linter did not flag: their expressions go through `is_group_member`, and the table grants above are now the outer gate.