### PR TITLE
feat(expense): one bill, several payers — and a form that looks like the screen it edits

### DIFF
--- a/apps/mobile/src/app/capture.tsx
+++ b/apps/mobile/src/app/capture.tsx
@@ -17,6 +17,7 @@ import {
   type ExpenseLocation,
   type HeuristicReceipt,
   type PaymentMethod,
+  byNewest,
 } from '@waves/core';
 import {
   Button,
@@ -861,7 +862,7 @@ function GroupPicker({
   // Newest-created first, standing in for "recently used": the group model
   // carries no updated_at / last-activity field, so creation order is the only
   // honest recency signal available without a heavier query.
-  const byRecent = [...rest].sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''));
+  const byRecent = [...rest].sort(byNewest((row) => row.created_at));
 
   // Only split "recently used" out from "all" once there are enough groups that
   // a shortcut to the top few actually saves scrolling.

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -6,6 +6,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import {
   ActivityIndicator,
+  Alert,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -24,11 +25,9 @@ import {
   guessCategory,
   money,
   MutationKind,
-  parseMinorInput,
   PayerProblemCode,
   rebalancePayers,
   ridersSplit,
-  sanitiseMinorInput,
   serialisePayers,
   splitByUnits,
   treatSplit,
@@ -81,11 +80,20 @@ import { receiptCapStatus, receiptTapAction } from '@/lib/receiptCapGate';
 import { StorageCapError } from '@/lib/storage';
 import { useAssignCapture, useGroup } from '@/data/hooks';
 import { displayName, groupLabel, isGhost } from '@/data/types';
-import { plural, useStrings } from '@/i18n';
+import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
 import { useGuestGuard } from '@/lib/guestGuard';
 import { handoverKey } from '@/lib/handover';
 import { resolveDraftCurrency, resolveDraftFx } from '@/lib/expenseDraft';
+import {
+  expenseDateFor,
+  planCollapseToOne,
+  planEvenly,
+  planToggle,
+  planTypedAmount,
+  todayIso,
+  type PayerPlan,
+} from '@/lib/expenseForm';
 import { captureReceipt, pickReceiptImage, type PickedImage } from '@/lib/image';
 import { recogniseReceipt } from '@/lib/ocr';
 import { matchMemberNames, stripMemberNames } from '@/lib/voiceExpense';
@@ -729,22 +737,22 @@ export default function AddExpenseScreen() {
   };
 
   /**
+   * Carry out a plan from `expenseForm` — the pure half of every payer gesture.
+   * Null means the gesture is a no-op, which is why each of them can be a
+   * single line below.
+   */
+  const run = (plan: PayerPlan | null): void => {
+    if (!plan) return;
+    applyPayers(plan.selected, plan.current, plan.locked, amount, plan.typed);
+  };
+
+  /**
    * Tap a member. In one-payer mode that replaces whoever was there; in
    * several-payer mode it adds or removes them.
    */
   const togglePayer = (memberId: MemberId): void => {
-    if (!manyPayers) {
-      applyPayers([memberId], new Map([[memberId, amount]]), EMPTY_LOCKS, amount);
-      return;
-    }
-    const selected = payers.has(memberId)
-      ? payerIds.filter((id) => id !== memberId)
-      : [...payerIds, memberId];
-    // Never leave a bill nobody paid: the last payer cannot be tapped off, they
-    // have to be replaced by tapping somebody else.
-    if (selected.length === 0) return;
-    const locked = new Set([...effectiveLocks].filter((id) => selected.includes(id)));
-    applyPayers(selected, payers, locked, amount);
+    // Null is the tap that does nothing — the last payer cannot be removed.
+    run(planToggle({ many: manyPayers, payers, locked: effectiveLocks, amount, memberId }));
   };
 
   /**
@@ -754,12 +762,36 @@ export default function AddExpenseScreen() {
    * the largest contributor is the one collapse nobody means.
    */
   const setManyPayers = (many: boolean): void => {
-    setPayerMode(many ? 'many' : 'one');
-    if (many || payers.size <= 1) return;
-    const biggest = payerIds.reduce((best, id) =>
-      (payers.get(id) ?? 0n) > (payers.get(best) ?? 0n) ? id : best,
+    if (many || payers.size <= 1) {
+      setPayerMode(many ? 'many' : 'one');
+      return;
+    }
+    const plan = planCollapseToOne({ payers, amount });
+    if (!plan) return;
+    const keeping = plan.selected[0]!;
+    const member = (members.data ?? []).find((row) => row.id === keeping);
+    const name = member ? displayName(member, profile?.id) : t.misc.someone;
+    // Collapsing is not undoable inside the form: going back to several payers
+    // re-divides evenly, so the figures somebody typed are gone either way. On
+    // a bill that already records several payers those figures are recorded
+    // facts, and this is a text link sitting next to an ordinary one — near
+    // enough to a save button to be worth a question first.
+    Alert.alert(
+      t.expense.collapsePayersTitle,
+      fill(t.expense.collapsePayersBody, { name }),
+      [
+        { text: t.cancel, style: 'cancel' },
+        {
+          text: t.expense.collapsePayersConfirm,
+          style: 'destructive',
+          onPress: () => {
+            setPayerMode('one');
+            run(plan);
+          },
+        },
+      ],
+      { cancelable: true },
     );
-    applyPayers([biggest], new Map([[biggest, amount]]), EMPTY_LOCKS, amount);
   };
 
   // Who may add or remove a bill against this expense: a party to it (its author
@@ -778,18 +810,20 @@ export default function AddExpenseScreen() {
 
   /** A figure typed against one payer. Typing locks it; the others absorb. */
   const setPaidEntry = (memberId: MemberId, text: string): void => {
-    const cleaned = sanitiseMinorInput(text, currency as CurrencyCode);
-    const current = new Map(payers).set(
-      memberId,
-      parseMinorInput(cleaned, currency as CurrencyCode),
+    run(
+      planTypedAmount({
+        payers,
+        locked: effectiveLocks,
+        memberId,
+        text,
+        currency: currency as CurrencyCode,
+      }),
     );
-    const locked = new Set(effectiveLocks).add(memberId);
-    applyPayers([...current.keys()], current, locked, amount, { member: memberId, text: cleaned });
   };
 
   /** Back to an even split of the paying — the way out of any tangle above. */
   const splitPaidEvenly = (): void => {
-    applyPayers(payerIds, payers, EMPTY_LOCKS, amount);
+    run(planEvenly(payers));
   };
 
   // Keep the figures answering to the total. React's "adjust state when the
@@ -960,11 +994,13 @@ export default function AddExpenseScreen() {
         description: description.trim(),
         category,
         categoryMeta,
-        // A capture keeps the day it was caught; an ordinary expense is today's.
-        expenseDate:
-          captureId && captureExpenseDate
-            ? captureExpenseDate
-            : new Date().toISOString().slice(0, 10),
+        // A capture keeps the day it was caught, a saved expense keeps the day
+        // it has, and only a new one is today's (expenseDateFor).
+        expenseDate: expenseDateFor({
+          captureDate: captureId ? captureExpenseDate : null,
+          savedDate: editing?.currentVersion?.expense_date,
+          today: todayIso(),
+        }),
         currency,
         amount: amount.toString(),
         fx,
@@ -1760,6 +1796,12 @@ export default function AddExpenseScreen() {
                               '{amount}',
                               format(money(payers.get(memberId) ?? 0n, currency), { locale }),
                             )}
+                          // What is wrong with the set of figures, on each field
+                          // that can put it right. React Native has no invalid
+                          // accessibility state, so the message itself is the
+                          // hint — otherwise the only announcement of a bill
+                          // that does not add up arrives at the save button.
+                          accessibilityHint={payerMessage ?? undefined}
                           style={{
                             width: 96,
                             minHeight: 44,
@@ -1786,7 +1828,14 @@ export default function AddExpenseScreen() {
               rather than guidance. A single payer always holds the whole bill, so
               there is nothing to report — that row gets the hint instead. */}
             {payerMessage && amount > 0n ? (
-              <Text variant="micro" tone="negative">
+              <Text
+                variant="micro"
+                tone="negative"
+                // Announced as it changes, rather than only when the field it
+                // belongs to happens to be focused.
+                accessibilityRole="alert"
+                accessibilityLiveRegion="polite"
+              >
                 {payerMessage}
               </Text>
             ) : null}

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { randomUUID } from 'expo-crypto';
-import { Image } from 'expo-image';
 import { router, useLocalSearchParams } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -20,13 +20,21 @@ import {
   computeShares,
   currencySymbol,
   format,
+  formatMinorInput,
   guessCategory,
   money,
   MutationKind,
+  parseMinorInput,
+  PayerProblemCode,
+  rebalancePayers,
   ridersSplit,
+  sanitiseMinorInput,
+  serialisePayers,
   splitByUnits,
   treatSplit,
+  validatePayers,
   type CategoryMeta,
+  type CurrencyCode,
   type ExpenseLocation,
   type FxRecord,
   type MemberId,
@@ -40,7 +48,6 @@ import {
   Callout,
   Card,
   ChipRow,
-  directionalIcon,
   EmptyState,
   iconSize,
   MoneyText,
@@ -51,15 +58,16 @@ import {
 } from '@waves/ui';
 
 import { CategoryPicker } from '@/components/Category';
+import { ExpenseReceipts } from '@/components/ExpenseReceipts';
 import { TagEditorSheet } from '@/components/TagEditorSheet';
 import { PaymentMethodPicker } from '@/components/PaymentMethodPicker';
 import { LocationField } from '@/components/LocationField';
 import { captureLocationIfGranted } from '@/lib/location';
 import { friendlyError } from '@/lib/errors';
 import { COMMON_CURRENCIES, CurrencyRate } from '@/components/CurrencyRate';
-import { AmountHeader } from '@/components/expense/AmountHeader';
 import { DescriptionField } from '@/components/expense/DescriptionField';
-import { ExpenseHeader } from '@/components/expense/ExpenseHeader';
+import { ExpenseHero } from '@/components/expense/ExpenseHero';
+import { splitIcon } from '@/components/expense/splitIcon';
 import { ChoiceRow, SheetOverlay } from '@/components/expense/SheetOverlay';
 import {
   canAddReceipt,
@@ -92,11 +100,26 @@ import {
 } from '@/lib/split';
 import { clearDraft, syncEngine, useDraft, useRestoredDraft, useSync } from '@/sync';
 
+/** Shared empty set — a new one per render would defeat every memo below it. */
+const EMPTY_LOCKS: ReadonlySet<MemberId> = new Set();
+
+/** Who paid what, in minor units. */
+type PayerMap = ReadonlyMap<MemberId, bigint>;
+
 interface ExpenseDraft {
   amount: string;
   description: string;
   splitKind: SplitKind;
-  payer: MemberId | null;
+  /**
+   * Who paid, before a bill could be paid by several people. Drafts written by
+   * an older build still carry it and nothing else, so it is read as a
+   * single-payer `payers` map rather than dropped.
+   */
+  payer?: MemberId | null;
+  /** Who paid what, in minor units as decimal strings. */
+  payers?: Record<string, string>;
+  /** The payers whose figure was typed rather than derived (see rebalancePayers). */
+  lockedPayers?: string[];
   /**
    * The currency this expense was paid in, when it differs from the group's.
    * Optional: drafts written before this field existed omit it, which is not
@@ -243,7 +266,34 @@ export default function AddExpenseScreen() {
   const [amount, setAmount] = useState<bigint>(0n);
   const [description, setDescription] = useState('');
   const [splitKind, setSplitKind] = useState<SplitKind>(SplitKind.Equal);
-  const [payer, setPayer] = useState<MemberId | null>(null);
+  /**
+   * Who put the money in, and how much each of them put in (minor units).
+   *
+   * A map rather than one id, because "she got the taxi, I got the tickets" is
+   * one dinner, not two. Almost every bill has a single entry here and the form
+   * behaves exactly as it always did; the moment a second person is tapped, the
+   * amounts appear and have to add up to the total — the same rule the SQL
+   * trigger and both edge functions enforce (`PAYER_MISMATCH`).
+   */
+  const [payers, setPayers] = useState<PayerMap>(new Map());
+  /** Payers whose figure a person typed. Everyone else absorbs what is left. */
+  const [lockedPayers, setLockedPayers] = useState<ReadonlySet<MemberId>>(EMPTY_LOCKS);
+  /** What is in each payer's field, so a half-typed "12." survives a render. */
+  const [paidText, setPaidText] = useState<Record<MemberId, string>>({});
+  /** The `amount:currency` the payer figures were last derived for. */
+  const [payersFor, setPayersFor] = useState<string | null>(null);
+  /**
+   * Whether the payer row is asking about one person or several.
+   *
+   * It matters because the two need opposite gestures. With one payer a tap has
+   * to *replace* — "actually she paid" is the single most common correction on
+   * this form and it was one tap before this feature existed, so it stays one
+   * tap. With several, a tap has to *add*, or you could never build the list.
+   * A control cannot be both, so the mode is explicit and the row says which it
+   * is in. A bill that already has several payers is in 'many' whatever the
+   * flag says — reopening it must not offer to silently drop one.
+   */
+  const [payerMode, setPayerMode] = useState<'one' | 'many'>('one');
   // How it was paid — a free-text tag on the expense. Defaults to cash; the
   // picker offers UPI only where the region settles over it.
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cash');
@@ -376,6 +426,26 @@ export default function AddExpenseScreen() {
   // "adjust state when the input changes" pattern) so the form never flashes
   // empty before the data arrives.
   const [seededFor, setSeededFor] = useState<string | null>(null);
+  /**
+   * Seed the payer side as one person holding the whole bill — the state every
+   * new expense starts in, and the state an older draft or a single-payer bill
+   * comes back as. Written as a helper because the seeding block below reaches
+   * it from four branches, and because the three pieces (who, how much, what the
+   * field shows) have to move together or the form opens with a figure that does
+   * not match the total.
+   */
+  const seedSolePayer = (memberId: MemberId | null, total: bigint): void => {
+    if (!memberId) {
+      setPayers(new Map());
+      setLockedPayers(EMPTY_LOCKS);
+      setPaidText({});
+      return;
+    }
+    setPayers(new Map([[memberId, total]]));
+    setLockedPayers(EMPTY_LOCKS);
+    setPaidText({});
+  };
+
   const seedKey =
     members.data && !restored.loading ? (editing?.currentVersion?.id ?? `new:${groupId}`) : null;
   if (seedKey && seedKey !== seededFor) {
@@ -429,19 +499,36 @@ export default function AddExpenseScreen() {
       setCategoryChosen(Boolean(captureCategory));
       // Carry the capture's place onto the expense it becomes (A43).
       setLocation(parseLocationParam(captureLocation));
-      setPayer(myMemberId);
+      seedSolePayer(myMemberId, safeBigInt(captureAmount));
     } else if (draft) {
       // A draft outranks the saved version: it is what the user was in the
       // middle of writing when the app went away.
       setAmount(safeBigInt(draft.amount));
       setDescription(draft.description);
       setSplitKind(draft.splitKind);
-      // When editing, the payer is fixed on the saved expense and its picker is
-      // hidden — so a stale draft.payer from an earlier edit session must never
-      // override it. New expenses still take the draft's chosen payer.
-      setPayer(
-        editing ? (version?.payers[0]?.member_id ?? myMemberId) : (draft.payer ?? myMemberId),
-      );
+      // The payer picker is on the edit form too now, so a draft's payers are a
+      // change somebody was in the middle of making rather than stale values to
+      // discard. `payers` is the current shape; `payer` is what an older build
+      // wrote, and is read as a bill paid entirely by that one person.
+      const draftAmount = safeBigInt(draft.amount);
+      if (draft.payers && Object.keys(draft.payers).length > 0) {
+        setPayers(new Map(Object.entries(draft.payers).map(([id, v]) => [id, safeBigInt(v)])));
+        setLockedPayers(new Set(draft.lockedPayers ?? []));
+        // `groupCurrency` is derived further down the render; the seeding block
+        // runs above it, so the group's default is read straight off the row.
+        const draftCurrency = draft.currency ?? group.data?.default_currency ?? 'INR';
+        setPaidText(
+          Object.fromEntries(
+            Object.entries(draft.payers).map(([id, v]) => [
+              id,
+              formatMinorInput(safeBigInt(v), draftCurrency as CurrencyCode),
+            ]),
+          ),
+        );
+        setPayersFor(`${draftAmount}:${draftCurrency}`);
+      } else {
+        seedSolePayer(draft.payer ?? version?.payers[0]?.member_id ?? myMemberId, draftAmount);
+      }
       setExpenseCurrency(resolveDraftCurrency(draft.currency, version?.currency ?? null));
       setFx(resolveDraftFx(draft.fx));
       setParticipants(draft.participants);
@@ -465,7 +552,30 @@ export default function AddExpenseScreen() {
       // expense asks for its rate again on save.
       setExpenseCurrency(version.currency);
       setFx(null);
-      setPayer(version.payers[0]?.member_id ?? myMemberId);
+      // Every payer the bill records, not just the first. Flattening a
+      // several-payer bill to `payers[0]` on open — and then saving that back —
+      // was how an edit silently rewrote who had put money in. They come back
+      // locked: those figures are recorded facts, so they survive a change to
+      // the total rather than being quietly re-divided.
+      if (version.payers.length > 0) {
+        setPayers(new Map(version.payers.map((row) => [row.member_id, BigInt(row.amount)])));
+        setLockedPayers(
+          version.payers.length > 1
+            ? new Set(version.payers.map((row) => row.member_id))
+            : EMPTY_LOCKS,
+        );
+        setPaidText(
+          Object.fromEntries(
+            version.payers.map((row) => [
+              row.member_id,
+              formatMinorInput(BigInt(row.amount), version.currency as CurrencyCode),
+            ]),
+          ),
+        );
+        setPayersFor(`${BigInt(version.amount)}:${version.currency}`);
+      } else {
+        seedSolePayer(myMemberId, BigInt(version.amount));
+      }
       setPaymentMethod((version.payment_method as PaymentMethod | null) ?? 'cash');
       // A saved place is a decision already made; reopen the edit with it intact
       // so a save does not silently drop it.
@@ -489,7 +599,7 @@ export default function AddExpenseScreen() {
       }
     } else {
       setParticipants((members.data ?? []).map((member) => member.id));
-      setPayer(myMemberId);
+      seedSolePayer(myMemberId, 0n);
     }
   }
 
@@ -545,8 +655,11 @@ export default function AddExpenseScreen() {
    */
   const isDefaultSplit =
     splitKind === SplitKind.Equal &&
-    payer !== null &&
-    payer === myMemberId &&
+    // "I paid" — one payer, and it is me. Two payers is never the default case,
+    // so tapping a second person opens the section that explains the split.
+    payers.size === 1 &&
+    myMemberId !== null &&
+    payers.has(myMemberId) &&
     participants.length > 0 &&
     participants.length === (members.data ?? []).length;
   const [splitOpen, setSplitOpen] = useState(false);
@@ -564,6 +677,132 @@ export default function AddExpenseScreen() {
   // default and what a converted total would be shown in (ADR-003).
   const currency = expenseCurrency ?? groupCurrency;
 
+  // ───────────────────────────────────────────────────────── who paid ──
+  //
+  // One payer is the whole of the common case and stays a single tap. The
+  // moment a second person is added, the figures have to add up to the total —
+  // the ledger has always allowed several payer rows, and both edge functions
+  // reject a write whose rows do not sum to the amount.
+  const payerIds = [...payers.keys()];
+  // With one payer there is nothing to hold constant: that person carries the
+  // whole bill by definition, so a lock left over from a moment when there were
+  // two must not survive and strand the total.
+  const effectiveLocks = payers.size <= 1 ? EMPTY_LOCKS : lockedPayers;
+  const payerProblem = validatePayers(amount, payers);
+  // A bill that already records several payers is in several-payer mode however
+  // the flag was left — an edit must never offer to quietly drop one of them.
+  const manyPayers = payerMode === 'many' || payers.size > 1;
+
+  /** Re-derive the figures, then refresh every field except the typed ones. */
+  const applyPayers = (
+    selected: readonly MemberId[],
+    current: PayerMap,
+    locked: ReadonlySet<MemberId>,
+    total: bigint,
+    typed?: { readonly member: MemberId; readonly text: string },
+  ): void => {
+    const effective = selected.length <= 1 ? EMPTY_LOCKS : locked;
+    const next = rebalancePayers({
+      amount: total,
+      selected,
+      current,
+      locked: effective,
+      // The expense id, so which payer absorbs an odd paisa is stable across
+      // devices and across reopening the form (ADR-009).
+      seed: targetExpenseId,
+    });
+    setPayers(next);
+    setLockedPayers(effective);
+    setPayersFor(`${total}:${currency}`);
+    setPaidText(() => {
+      const fields: Record<MemberId, string> = {};
+      for (const [member, paid] of next) {
+        // A typed field keeps the characters that were typed — reformatting
+        // "12." to "12.00" mid-keystroke moves the caret out from under a thumb.
+        fields[member] =
+          typed && typed.member === member
+            ? typed.text
+            : formatMinorInput(paid, currency as CurrencyCode);
+      }
+      return fields;
+    });
+  };
+
+  /**
+   * Tap a member. In one-payer mode that replaces whoever was there; in
+   * several-payer mode it adds or removes them.
+   */
+  const togglePayer = (memberId: MemberId): void => {
+    if (!manyPayers) {
+      applyPayers([memberId], new Map([[memberId, amount]]), EMPTY_LOCKS, amount);
+      return;
+    }
+    const selected = payers.has(memberId)
+      ? payerIds.filter((id) => id !== memberId)
+      : [...payerIds, memberId];
+    // Never leave a bill nobody paid: the last payer cannot be tapped off, they
+    // have to be replaced by tapping somebody else.
+    if (selected.length === 0) return;
+    const locked = new Set([...effectiveLocks].filter((id) => selected.includes(id)));
+    applyPayers(selected, payers, locked, amount);
+  };
+
+  /**
+   * Switch between the two. Going to several splits the paying evenly between
+   * whoever is there so the figures start out adding up; coming back keeps the
+   * person who put in the most and hands them the whole bill, because dropping
+   * the largest contributor is the one collapse nobody means.
+   */
+  const setManyPayers = (many: boolean): void => {
+    setPayerMode(many ? 'many' : 'one');
+    if (many || payers.size <= 1) return;
+    const biggest = payerIds.reduce((best, id) =>
+      (payers.get(id) ?? 0n) > (payers.get(best) ?? 0n) ? id : best,
+    );
+    applyPayers([biggest], new Map([[biggest, amount]]), EMPTY_LOCKS, amount);
+  };
+
+  // Who may add or remove a bill against this expense: a party to it (its author
+  // or one of its payers), which is what the attach RPCs enforce. An admin who is
+  // not a party may still remove the legacy group-visible bill — the same split
+  // of powers the expense screen applies.
+  const editingVersion = editing?.currentVersion;
+  const isExpenseParty = Boolean(
+    myMemberId &&
+    editingVersion &&
+    (editingVersion.author_member_id === myMemberId ||
+      editingVersion.payers.some((row) => row.member_id === myMemberId)),
+  );
+  const iAmGroupAdmin =
+    (members.data ?? []).find((row) => row.profile_id === profile?.id)?.role === 'admin';
+
+  /** A figure typed against one payer. Typing locks it; the others absorb. */
+  const setPaidEntry = (memberId: MemberId, text: string): void => {
+    const cleaned = sanitiseMinorInput(text, currency as CurrencyCode);
+    const current = new Map(payers).set(
+      memberId,
+      parseMinorInput(cleaned, currency as CurrencyCode),
+    );
+    const locked = new Set(effectiveLocks).add(memberId);
+    applyPayers([...current.keys()], current, locked, amount, { member: memberId, text: cleaned });
+  };
+
+  /** Back to an even split of the paying — the way out of any tangle above. */
+  const splitPaidEvenly = (): void => {
+    applyPayers(payerIds, payers, EMPTY_LOCKS, amount);
+  };
+
+  // Keep the figures answering to the total. React's "adjust state when the
+  // input changes" pattern — the same one the seeding above uses — rather than
+  // an effect, so a scan that fills in ₹1,240 re-splits the paying in the very
+  // render that shows the new total, with no frame in between where the payers
+  // and the amount disagree. Typed figures survive it: only the unlocked ones
+  // move (see rebalancePayers).
+  const payersKey = `${amount}:${currency}`;
+  if (seededFor !== null && payers.size > 0 && payersKey !== payersFor) {
+    applyPayers(payerIds, payers, effectiveLocks, amount);
+  }
+
   // Picking from the header pill: a rate typed for the previous currency would
   // convert the wrong thing (and the server rejects it), so clear it — the same
   // reset the old in-card currency chips did.
@@ -580,7 +819,8 @@ export default function AddExpenseScreen() {
       amount: amount.toString(),
       description,
       splitKind,
-      payer,
+      payers: Object.fromEntries([...payers].map(([id, paid]) => [id, paid.toString()])),
+      lockedPayers: [...lockedPayers],
       currency: expenseCurrency,
       fx,
       participants,
@@ -663,12 +903,22 @@ export default function AddExpenseScreen() {
     // only the form body waits on the mirror read (a few ms at launch). A bare
     // full-screen spinner used to leave a headerless blank while it loaded.
     return (
-      <Screen edges={['top', 'bottom']}>
-        <View style={{ paddingHorizontal: theme.spacing.xl }}>
-          <ExpenseHeader leading="back" title={editing ? t.expense.edit : t.addExpense} />
-          <View style={{ paddingTop: theme.spacing.xxxl, alignItems: 'center' }}>
-            <ActivityIndicator color={theme.color.brand} />
-          </View>
+      <Screen edges={['bottom']}>
+        <StatusBar style="light" />
+        {/* The same hero the loaded form opens on, so the panel does not repaint
+            from a white bar to a purple one once the mirror read lands. */}
+        <ExpenseHero
+          title={editing ? t.expense.edit : t.addExpense}
+          category={category}
+          categoryMeta={categoryMeta}
+          description={description}
+          currency={currency}
+          amount={amount}
+          onAmountChange={setAmount}
+          onPressCurrency={() => setPickingCurrency(true)}
+        />
+        <View style={{ paddingTop: theme.spacing.xxxl, alignItems: 'center' }}>
+          <ActivityIndicator color={theme.color.brand} />
         </View>
       </Screen>
     );
@@ -687,8 +937,12 @@ export default function AddExpenseScreen() {
     // history stay visible, but a new or edited expense sends them to sign up.
     if (guard.blockWrite()) return;
     setError(null);
-    if (!payer) {
-      setError(t.expense.chooseWhoPaid);
+    // The same check the server makes. Catching it here means a bill that does
+    // not add up is a sentence under the button rather than a PAYER_MISMATCH
+    // that comes back minutes later off a queue.
+    if (payerProblem) {
+      setError(payerMessage);
+      setSplitOpen(true);
       return;
     }
     setSaving(true);
@@ -716,7 +970,8 @@ export default function AddExpenseScreen() {
         fx,
         splitParams,
         participants,
-        payers: { [payer]: amount.toString() },
+        // Every payer, with anybody down for nothing left out (serialisePayers).
+        payers: serialisePayers(payers),
         paymentMethod,
         location,
         expectedShares: preview
@@ -920,7 +1175,7 @@ export default function AddExpenseScreen() {
     setNightCounts({});
     setFuelAmounts({});
     setExemptDriver(null);
-    setTreatHostPick(payer ?? myMemberId);
+    setTreatHostPick(payerIds[0] ?? myMemberId);
     setPresetEditor(kind);
   };
 
@@ -1002,7 +1257,8 @@ export default function AddExpenseScreen() {
       treatSplit({ host, participants: parts, amountMinor: amount }); // validate
       clearPreset();
       setParticipants(parts);
-      setPayer(host);
+      // A treat is one person picking up the whole bill, by definition.
+      applyPayers([host], new Map([[host, amount]]), EMPTY_LOCKS, amount);
       setTreatHost(host);
       setPresetLabel(t.expense.presets.treat);
       setPresetEditor(null);
@@ -1016,13 +1272,35 @@ export default function AddExpenseScreen() {
   // end the person has to guess their way out of. A broken split already prints
   // its own reason in the split card, so it is not repeated here; `saving` is a
   // transient state, not something to instruct around.
+  // The payer side's complaint, in money the person can read. `delta` is signed:
+  // positive is still to hand out, negative is more claimed than the bill.
+  const payerMessage =
+    payerProblem === null
+      ? null
+      : payerProblem.code === PayerProblemCode.NoPayers ||
+          payerProblem.code === PayerProblemCode.Negative
+        ? t.expense.chooseWhoPaid
+        : (payerProblem.code === PayerProblemCode.Short
+            ? t.expense.paidLeftToAssign
+            : t.expense.paidOverAssigned
+          ).replace(
+            '{amount}',
+            format(
+              money(payerProblem.delta < 0n ? -payerProblem.delta : payerProblem.delta, currency),
+              { locale },
+            ),
+          );
+
   const saveHint =
     amount === 0n
       ? t.expense.saveNeedsAmount
       : participants.length === 0
         ? t.expense.saveNeedsWho
-        : null;
-  const canSave = amount > 0n && participants.length > 0 && splitIssue === null;
+        : // Only worth saying once the bill has a total: "₹0 left to assign" on an
+          // empty form is noise, not guidance.
+          payerMessage;
+  const canSave =
+    amount > 0n && participants.length > 0 && splitIssue === null && payerProblem === null;
 
   // A foreign currency must show its rate card (it cannot be saved without one),
   // and any detail somebody has already set is a decision that must not hide.
@@ -1034,13 +1312,19 @@ export default function AddExpenseScreen() {
   // equally with everyone". The payer leads (you, or the person who did); the
   // tail is the preset's own words, or "split equally with everyone" for the
   // default, or the split kind and headcount for anything hand-tuned.
+  const solePayer = payers.size === 1 ? (payerIds[0] ?? null) : null;
   const payerMember =
-    payer && payer !== myMemberId
-      ? (members.data ?? []).find((member) => member.id === payer)
+    solePayer && solePayer !== myMemberId
+      ? (members.data ?? []).find((member) => member.id === solePayer)
       : undefined;
-  const payerName = payerMember
-    ? t.expense.paidByName.replace('{name}', displayName(payerMember, profile?.id))
-    : t.expense.youPaid;
+  const payerName =
+    payers.size > 1
+      ? // Several people put money in — the names would not fit and the amounts
+        // are right below anyway, so the summary counts them.
+        plural(locale, payers.size, t.expense.paidByCount)
+      : payerMember
+        ? t.expense.paidByName.replace('{name}', displayName(payerMember, profile?.id))
+        : t.expense.youPaid;
   const splitTail =
     presetLabel ??
     (isDefaultSplit
@@ -1074,7 +1358,10 @@ export default function AddExpenseScreen() {
         : plural(locale, participants.length, t.memberCount);
 
   return (
-    <Screen edges={['top', 'bottom']}>
+    <Screen edges={['bottom']}>
+      {/* The hero runs dark under the status bar, so its icons must be light —
+          the same override the expense screen this form mirrors makes. */}
+      <StatusBar style="light" />
       {/* The action bar is pinned to the bottom edge, outside the scroll, and a
           split-share field can be the focused input — on iOS the soft keyboard
           would slide up over both. Lifting the scroll + bar together keeps the
@@ -1086,65 +1373,47 @@ export default function AddExpenseScreen() {
         style={{ flex: 1 }}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <View style={{ paddingHorizontal: theme.spacing.xl }}>
-          <ExpenseHeader
-            leading="back"
-            title={editing ? t.expense.edit : t.addExpense}
-            subtitle={groupLabel(group.data, members.data ?? [], profile?.id)}
-            right={
-              editing ? undefined : (
-                // A bare list glyph read as nothing in particular; the words say
-                // what it does — split the bill line by line.
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={t.expense.splitByItem}
-                  onPress={() => router.replace(`/group/${groupId}/itemize`)}
-                  hitSlop={8}
-                >
-                  <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
-                    <Ionicons name="list-outline" size={iconSize.md} color={theme.color.brand} />
-                    <Text variant="caption" tone="brand" style={{ fontWeight: '700' }}>
-                      {t.expense.splitByItem}
-                    </Text>
-                  </Row>
-                </Pressable>
-              )
-            }
-          />
-        </View>
+        {/* The same panel the expense screen wears — category badge, one line of
+            identity, the amount — so tapping Edit changes what you can do, not
+            where anything is. The amount is editable here and shares its line
+            with the currency pill instead of standing alone at 44pt over it.
+            "Split by item" moved down beside the split it belongs to. */}
+        <ExpenseHero
+          title={`${editing ? t.expense.edit : t.addExpense} · ${groupLabel(
+            group.data,
+            members.data ?? [],
+            profile?.id,
+          )}`}
+          category={category}
+          categoryMeta={categoryMeta}
+          description={description}
+          currency={currency}
+          amount={amount}
+          onAmountChange={setAmount}
+          onPressCurrency={() => setPickingCurrency(true)}
+        />
         <ScrollView
           style={{ flex: 1 }}
+          // The form is long — amount, note, receipts, split, two rosters — and a
+          // 20pt gutter between every block plus each card's own padding meant a
+          // screenful held about two questions. `lg` between blocks and `md`
+          // inside them keeps the grouping legible while fitting the split and
+          // who-paid on one screen instead of two.
           contentContainerStyle={{
             paddingHorizontal: theme.spacing.xl,
-            paddingTop: theme.spacing.lg,
-            paddingBottom: theme.spacing.xl,
-            gap: theme.spacing.xl,
+            paddingTop: theme.spacing.md,
+            paddingBottom: theme.spacing.lg,
+            gap: theme.spacing.lg,
           }}
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
-          {editing ? (
-            <Card style={{ backgroundColor: theme.color.buttonPrimary }}>
-              <Text variant="caption" tone="onBrand">
-                {t.expense.editingKeepsVersion}
-              </Text>
-            </Card>
-          ) : null}
-
-          {/* Amount-forward hero shared with the capture screen: big centred
-            number, the currency it is counted in a tap below it. */}
-          <AmountHeader
-            currency={currency}
-            amount={amount}
-            onAmountChange={setAmount}
-            onPressCurrency={() => setPickingCurrency(true)}
-          />
-
-          {/* "How much" and "what for" are the whole of the common case, so the
-            description sits directly under the amount — nothing between the two
-            fields somebody came here to fill and the split below them. The names
-            are handed to the recogniser as hints; a general model guesses at
-            Indian names and the note is where they turn up. */}
+          {/* "How much" and "what for" are the whole of the common case. The
+            amount is in the hero above; the note follows it directly, with
+            nothing between the two fields somebody came here to fill and the
+            split below them. The names are handed to the recogniser as hints; a
+            general model guesses at Indian names and the note is where they turn
+            up. */}
           <DescriptionField
             value={description}
             onChange={setDescription}
@@ -1203,43 +1472,28 @@ export default function AddExpenseScreen() {
               </Text>
             ) : null}
 
-            {/* The kept bill (E2): a thumbnail that opens the full-screen viewer.
-              A group receipt in R2 is already group-readable, so there is nothing
-              to "share" — every member can open it. Hidden until a bill is kept. */}
-            {receiptUri ? (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t.expense.viewReceipt}
-                onPress={() =>
-                  router.push(
-                    `/receipt/${targetExpenseId}${
-                      receiptPath ? `?path=${encodeURIComponent(receiptPath)}` : ''
-                    }`,
-                  )
-                }
-              >
-                <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-                  <Image
-                    source={{ uri: receiptUri }}
-                    style={{ width: 52, height: 52, borderRadius: theme.radius.md }}
-                    contentFit="cover"
-                    transition={150}
-                  />
-                  <View style={{ flex: 1, minWidth: 0 }}>
-                    <Text variant="subheading" numberOfLines={1}>
-                      {t.expense.viewReceipt}
-                    </Text>
-                    <Text variant="micro" tone="muted" numberOfLines={1}>
-                      {t.expense.receiptAttached}
-                    </Text>
-                  </View>
-                  <Ionicons
-                    name={directionalIcon('chevron-forward')}
-                    size={iconSize.md}
-                    color={theme.color.textFaint}
-                  />
-                </Row>
-              </Pressable>
+            {/* The bills kept against this expense — the same gallery the expense
+              screen shows, not a second design for the same thing. A one-line
+              thumbnail of the legacy bill used to stand here, which meant an
+              expense with four receipts showed one of them on the screen where
+              you go to change it.
+
+              Only when editing: attachments are committed against an expense row,
+              and a new expense has no row yet. On a new one the scan/photo
+              shortcuts above are the whole story, and what they capture is
+              uploaded once the save lands. */}
+            {editing ? (
+              <ExpenseReceipts
+                groupId={groupId}
+                expenseId={targetExpenseId}
+                canManage={isExpenseParty}
+                canRemoveLegacy={isExpenseParty || iAmGroupAdmin}
+                legacyReceiptPath={receiptUri ? receiptPath : null}
+                onLegacyRemoved={() => {
+                  setReceiptUri(null);
+                  setReceiptPath(null);
+                }}
+              />
             ) : null}
 
             {scannedItems > 0 && !editing ? (
@@ -1297,6 +1551,14 @@ export default function AddExpenseScreen() {
           >
             <Card style={{ gap: theme.spacing.xs }}>
               <Row style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
+                {/* The same glyph the chosen chip wears, and the same one the
+                    expense screen shows against "Split" — one mark for one way
+                    of splitting, wherever it appears. */}
+                <Ionicons
+                  name={splitIcon(splitKind)}
+                  size={iconSize.lg}
+                  color={theme.color.brand}
+                />
                 <View style={{ flex: 1, minWidth: 0 }}>
                   <Text variant="caption" tone="muted">
                     {t.expense.howToSplit}
@@ -1322,7 +1584,7 @@ export default function AddExpenseScreen() {
           {/* Kept mounted and hidden rather than unmounted: the weighted split's
             fields hold text somebody is mid-way through typing, and a fold that
             threw it away would be a worse trade than a taller tree. */}
-          <View style={{ gap: theme.spacing.md, display: showSplit ? 'flex' : 'none' }}>
+          <View style={{ gap: theme.spacing.sm, display: showSplit ? 'flex' : 'none' }}>
             {isTrip && !editing ? (
               <View style={{ gap: theme.spacing.xs }}>
                 <Text variant="micro" tone="muted">
@@ -1349,50 +1611,188 @@ export default function AddExpenseScreen() {
               </View>
             ) : null}
 
+            {/* Word plus glyph, not three identical word-pills: the icon is what
+              carries over to the expense screen, where the same split comes back
+              as a marked row rather than a bare word. */}
             <ChipRow<SplitKind>
               value={splitKind}
               onChange={(next) => {
                 clearPreset();
                 setSplitKind(next);
               }}
-              options={[
-                { value: SplitKind.Equal, label: t.expense.equally },
-                { value: SplitKind.Shares, label: t.expense.shares },
-                { value: SplitKind.Percent, label: t.expense.percent },
-              ]}
+              options={[SplitKind.Equal, SplitKind.Shares, SplitKind.Percent].map((kind) => ({
+                value: kind,
+                label:
+                  kind === SplitKind.Equal
+                    ? t.expense.equally
+                    : kind === SplitKind.Shares
+                      ? t.expense.shares
+                      : t.expense.percent,
+                icon: (color: string) => (
+                  <Ionicons name={splitIcon(kind)} size={iconSize.md} color={color} />
+                ),
+              }))}
             />
           </View>
 
-          {!expenseId ? (
-            <Card style={{ gap: theme.spacing.md, display: showSplit ? 'flex' : 'none' }}>
+          {/* Splitting the bill line by line is another answer to "how is this
+            split", so it sits with the split rather than as a word in the top
+            bar, where it competed with the title and would have had to lose
+            either its icon or its words to fit the hero. Outside the fold, so it
+            is still found without opening the split first. New expenses only: an
+            existing one is edited in place, not re-itemised. */}
+          {!editing ? (
+            <Button
+              label={t.expense.splitByItem}
+              variant="secondary"
+              size="sm"
+              onPress={() => router.replace(`/group/${groupId}/itemize`)}
+              icon={<Ionicons name="list-outline" size={iconSize.md} color={theme.color.brand} />}
+            />
+          ) : null}
+
+          {/* Who paid — on an edit as much as on a new expense, and now as many
+            people as actually put money in.
+
+            Two things used to be wrong here. The picker was hidden the moment
+            the form opened on an existing bill, so the correction people most
+            often come back to make had no control anywhere on the screen. And it
+            was single-select, so "she got the taxi, I got the tickets" had to be
+            entered as two expenses — two rows in the feed, two things to edit,
+            two things to delete — even though the ledger has always stored
+            payers as a table.
+
+            One payer stays exactly one tap: a row of avatars, no figures, no
+            arithmetic. The amounts appear only once a second person is on it. */}
+          <Card style={{ gap: theme.spacing.sm, display: showSplit ? 'flex' : 'none' }}>
+            <Row style={{ justifyContent: 'space-between' }}>
               <Text variant="caption" tone="muted">
                 {t.paidBy}
               </Text>
-              <Row style={{ flexWrap: 'wrap', gap: theme.spacing.md }}>
-                {(members.data ?? []).map((member) => (
+              <Row style={{ gap: theme.spacing.lg, alignItems: 'center', flexShrink: 0 }}>
+                {manyPayers && payers.size > 1 ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={t.expense.splitPaidEvenly}
+                    onPress={splitPaidEvenly}
+                    hitSlop={8}
+                  >
+                    <Text variant="micro" tone="brand" style={{ fontWeight: '700' }}>
+                      {t.expense.splitPaidEvenly}
+                    </Text>
+                  </Pressable>
+                ) : null}
+                {/* The way in and out of several-payer mode. A link rather than a
+                    hidden long-press: nobody discovers a long-press, and this is
+                    the whole feature. */}
+                <Pressable
+                  accessibilityRole="switch"
+                  accessibilityState={{ checked: manyPayers }}
+                  accessibilityLabel={manyPayers ? t.expense.paidByOne : t.expense.paidBySeveral}
+                  onPress={() => setManyPayers(!manyPayers)}
+                  hitSlop={8}
+                >
+                  <Text variant="micro" tone="brand" style={{ fontWeight: '700' }}>
+                    {manyPayers ? t.expense.paidByOne : t.expense.paidBySeveral}
+                  </Text>
+                </Pressable>
+              </Row>
+            </Row>
+
+            <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
+              {(members.data ?? []).map((member) => {
+                const isPayer = payers.has(member.id);
+                return (
                   <Pressable
                     key={member.id}
-                    accessibilityRole="radio"
-                    accessibilityState={{ selected: payer === member.id }}
+                    // The role follows the mode, because the gesture does: one
+                    // payer is a radio (tapping replaces), several is a checkbox
+                    // (tapping adds). Announcing the wrong one tells somebody
+                    // using a screen reader the opposite of what will happen.
+                    accessibilityRole={manyPayers ? 'checkbox' : 'radio'}
+                    accessibilityState={manyPayers ? { checked: isPayer } : { selected: isPayer }}
                     accessibilityLabel={`${t.paidBy}: ${displayName(member, profile?.id)}`}
-                    onPress={() => setPayer(member.id)}
+                    onPress={() => togglePayer(member.id)}
                     style={{
                       alignItems: 'center',
                       gap: 4,
-                      opacity: payer === member.id ? 1 : 0.45,
+                      opacity: isPayer ? 1 : 0.45,
                     }}
                   >
                     <Avatar name={displayName(member)} ghost={isGhost(member)} />
-                    <Text variant="micro" tone={payer === member.id ? 'brand' : 'muted'}>
+                    <Text variant="micro" tone={isPayer ? 'brand' : 'muted'}>
                       {displayName(member, profile?.id)}
                     </Text>
                   </Pressable>
-                ))}
-              </Row>
-            </Card>
-          ) : null}
+                );
+              })}
+            </Row>
 
-          <Card style={{ gap: theme.spacing.md, display: showSplit ? 'flex' : 'none' }}>
+            {manyPayers && payers.size > 1 ? (
+              <View style={{ gap: theme.spacing.xs }}>
+                {payerIds.map((memberId) => {
+                  const member = (members.data ?? []).find((row) => row.id === memberId);
+                  const name = member ? displayName(member, profile?.id) : t.misc.someone;
+                  return (
+                    <Row key={memberId} style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+                      <Avatar
+                        name={member ? displayName(member) : name}
+                        ghost={member ? isGhost(member) : false}
+                        size={32}
+                      />
+                      <Text variant="body" numberOfLines={1} style={{ flex: 1, minWidth: 0 }}>
+                        {name}
+                      </Text>
+                      <Row style={{ gap: theme.spacing.xs, alignItems: 'center', flexShrink: 0 }}>
+                        <Text variant="caption" tone="muted">
+                          {currencySymbol(currency)}
+                        </Text>
+                        <TextInput
+                          value={paidText[memberId] ?? ''}
+                          onChangeText={(text) => setPaidEntry(memberId, text)}
+                          keyboardType="decimal-pad"
+                          selectTextOnFocus
+                          placeholder="0"
+                          placeholderTextColor={theme.color.textFaint}
+                          accessibilityLabel={t.expense.paidByNameAmount
+                            .replace('{name}', name)
+                            .replace(
+                              '{amount}',
+                              format(money(payers.get(memberId) ?? 0n, currency), { locale }),
+                            )}
+                          style={{
+                            width: 96,
+                            minHeight: 44,
+                            fontSize: 16,
+                            fontWeight: '700',
+                            textAlign: 'right',
+                            textAlignVertical: 'center',
+                            color: theme.color.text,
+                            backgroundColor: theme.color.bg,
+                            borderRadius: theme.radius.sm,
+                            paddingVertical: theme.spacing.sm,
+                            paddingHorizontal: theme.spacing.sm,
+                          }}
+                        />
+                      </Row>
+                    </Row>
+                  );
+                })}
+              </View>
+            ) : null}
+
+            {/* What is still unaccounted for, or claimed twice over. Only once
+              the bill has a total: "₹0 left to assign" on an empty form is noise
+              rather than guidance. A single payer always holds the whole bill, so
+              there is nothing to report — that row gets the hint instead. */}
+            {payerMessage && amount > 0n ? (
+              <Text variant="micro" tone="negative">
+                {payerMessage}
+              </Text>
+            ) : null}
+          </Card>
+
+          <Card style={{ gap: theme.spacing.sm, display: showSplit ? 'flex' : 'none' }}>
             <Row style={{ justifyContent: 'space-between' }}>
               <Text variant="caption" tone="muted">
                 {t.expense.splitBetween}
@@ -1414,7 +1814,9 @@ export default function AddExpenseScreen() {
                     flexDirection: 'row',
                     alignItems: 'center',
                     gap: theme.spacing.md,
-                    paddingVertical: theme.spacing.sm,
+                    // The avatar is 38pt and the share field has a 44pt floor, so
+                    // the row is tall enough to tap without padding stretching it.
+                    paddingVertical: theme.spacing.xs,
                   }}
                 >
                   {/* The name toggles; the field beside it must not, or nobody

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -1359,9 +1359,15 @@ export default function AddExpenseScreen() {
       ? // Several people put money in — the names would not fit and the amounts
         // are right below anyway, so the summary counts them.
         plural(locale, payers.size, t.expense.paidByCount)
-      : payerMember
-        ? t.expense.paidByName.replace('{name}', displayName(payerMember, profile?.id))
-        : t.expense.youPaid;
+      : solePayer !== null && solePayer === myMemberId
+        ? t.expense.youPaid
+        : // Somebody else paid. `members` excludes anyone who has left the group,
+          // so a bill paid by a departed member resolves to nothing here — and
+          // falling through to "You paid" claimed their bill for the reader.
+          t.expense.paidByName.replace(
+            '{name}',
+            payerMember ? displayName(payerMember, profile?.id) : t.misc.someone,
+          );
   const splitTail =
     presetLabel ??
     (isDefaultSplit

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -42,6 +42,7 @@ import {
 } from '@waves/core';
 import {
   AmountField,
+  amountKeyboard,
   Avatar,
   Button,
   Callout,
@@ -1779,14 +1780,26 @@ export default function AddExpenseScreen() {
                       <Text variant="body" numberOfLines={1} style={{ flex: 1, minWidth: 0 }}>
                         {name}
                       </Text>
-                      <Row style={{ gap: theme.spacing.xs, alignItems: 'center', flexShrink: 0 }}>
+                      {/* The figure may be long — a six-figure trip total, a
+                          yen amount, a large accessibility font. It gives way
+                          to the name rather than clipping, down to a floor
+                          wide enough to still read as a field. */}
+                      <Row
+                        style={{
+                          gap: theme.spacing.xs,
+                          alignItems: 'center',
+                          flexShrink: 1,
+                          minWidth: 96,
+                          maxWidth: '60%',
+                        }}
+                      >
                         <Text variant="caption" tone="muted">
                           {currencySymbol(currency)}
                         </Text>
                         <TextInput
                           value={paidText[memberId] ?? ''}
                           onChangeText={(text) => setPaidEntry(memberId, text)}
-                          keyboardType="decimal-pad"
+                          keyboardType={amountKeyboard(currency as CurrencyCode)}
                           selectTextOnFocus
                           placeholder="0"
                           placeholderTextColor={theme.color.textFaint}
@@ -1803,7 +1816,9 @@ export default function AddExpenseScreen() {
                           // that does not add up arrives at the save button.
                           accessibilityHint={payerMessage ?? undefined}
                           style={{
-                            width: 96,
+                            flexGrow: 1,
+                            flexShrink: 1,
+                            minWidth: 72,
                             minHeight: 44,
                             fontSize: 16,
                             fontWeight: '700',

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -28,6 +28,8 @@ import {
   useScreenClearance,
 } from '@waves/ui';
 
+import { format, money } from '@waves/core';
+
 import { CategoryBadge } from '@/components/Category';
 import { useAvatarUrl } from '@/components/ProfileAvatar';
 import { MapPreview } from '@/components/MapPreview';
@@ -35,6 +37,7 @@ import { ExpenseReceipts } from '@/components/ExpenseReceipts';
 import { ExpenseComments } from '@/components/ExpenseComments';
 import { ExpenseHistory } from '@/components/ExpenseHistory';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
+import { splitIcon } from '@/components/expense/splitIcon';
 import {
   memberLookup,
   useDeleteExpense,
@@ -81,10 +84,22 @@ function MemberAvatar({
   return <Avatar name={name} photoUrl={url} ghost={ghost} size={size} />;
 }
 
-/** One labelled row of the bill's detail card — a muted label on the left, its
- *  value on the right. The stacked "paid by · date · split" caption the hero
- *  used to carry, given room to breathe as a proper key/value list. */
-function DetailLine({ label, value }: { label: string; value: string }): React.JSX.Element {
+/** One labelled row of the bill's detail card — a glyph and muted label on the
+ *  left, its value on the right. The stacked "paid by · date · split" caption
+ *  the hero used to carry, given room to breathe as a proper key/value list.
+ *
+ *  The glyph is what makes the card scannable: four rows of grey words read as
+ *  a paragraph, and the split row's icon is the same one the form's chips wear,
+ *  so "how was this split" is answered by a mark rather than only by a word. */
+function DetailLine({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string;
+  icon: keyof typeof Ionicons.glyphMap;
+}): React.JSX.Element {
   const theme = useTheme();
   return (
     <Row
@@ -95,9 +110,12 @@ function DetailLine({ label, value }: { label: string; value: string }): React.J
         paddingVertical: theme.spacing.md,
       }}
     >
-      <Text variant="caption" tone="muted">
-        {label}
-      </Text>
+      <Row style={{ alignItems: 'center', gap: theme.spacing.sm, flexShrink: 0 }}>
+        <Ionicons name={icon} size={iconSize.md} color={theme.color.textMuted} />
+        <Text variant="caption" tone="muted">
+          {label}
+        </Text>
+      </Row>
       <Text variant="body" numberOfLines={1} style={{ flexShrink: 1, textAlign: 'right' }}>
         {value}
       </Text>
@@ -249,6 +267,36 @@ export default function ExpenseDetailScreen() {
   const currency = version.currency;
   const deleted = Boolean(expense.deleted_at);
 
+  /**
+   * Everyone this bill touches, and what it does to them.
+   *
+   * Built from the union of the split and the payers, not from the split alone:
+   * somebody can put money into a bill they owe no part of (a parent chipping in
+   * on a group dinner), and listing only the split leaves their contribution
+   * visible in "Paid by" and then unaccounted for below it.
+   *
+   * `net` is paid − share, so it sums to exactly zero across the rows — Σ payers
+   * and Σ shares both equal the total, a rule the SQL trigger enforces.
+   */
+  const ledgerRows = (() => {
+    const paidBy = new Map(version.payers.map((row) => [row.member_id, BigInt(row.amount)]));
+    const rows = version.shares.map((share) => {
+      const paid = paidBy.get(share.member_id) ?? 0n;
+      paidBy.delete(share.member_id);
+      return {
+        memberId: share.member_id,
+        share: BigInt(share.amount),
+        paid,
+        net: paid - BigInt(share.amount),
+      };
+    });
+    // Whoever is left paid something without being in the split at all.
+    for (const [memberId, paid] of paidBy) {
+      rows.push({ memberId, share: 0n, paid, net: paid });
+    }
+    return rows;
+  })();
+
   // Where it happened (A43), when the author attached one. A plain snapshot — a
   // tap opens the point in the phone's maps app.
   const location = version.location;
@@ -280,10 +328,16 @@ export default function ExpenseDetailScreen() {
     ]);
   };
 
-  // The bill's actions, gathered into the header's three-dot menu. A live bill
-  // offers Edit and a red Delete; a deleted one offers only Restore, matching
-  // Splitwise's deleted-transaction header. The mutations' pending flags disable
-  // the row so a double-tap cannot fire twice.
+  const openEditor = (): void => {
+    router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}`);
+  };
+
+  // What is left in the header's three-dot menu once Edit has its own glyph
+  // beside it: the destructive action on a live bill, Restore on a deleted one.
+  // Edit is the thing people come back to a bill to do, and burying the common
+  // action behind a menu meant hunting for it every time; Delete is the one that
+  // is better off a tap deeper. The mutations' pending flags disable the row so
+  // a double-tap cannot fire twice.
   const menuItems: OverflowMenuItem[] = deleted
     ? [
         {
@@ -295,11 +349,6 @@ export default function ExpenseDetailScreen() {
         },
       ]
     : [
-        {
-          icon: 'create-outline',
-          label: t.common.edit,
-          onPress: () => router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}`),
-        },
         {
           icon: 'trash-outline',
           label: t.expense.deleteAction,
@@ -382,10 +431,25 @@ export default function ExpenseDetailScreen() {
               style={{ color: theme.color.onBrand }}
             />
           </View>
-          {/* Every action on this bill lives behind one three-dot menu, the same
-                trailing control the group and dashboard headers carry — Edit and
-                Delete (or Restore) instead of a full-width button stacked at the
-                bottom of a long scroll. */}
+          {/* Edit, in the open. It was the first item of the three-dot menu, which
+                made the one action a bill is reopened for something you had to
+                remember was hidden there. A pencil on the wash costs one glyph
+                and answers "how do I change this" without a tap. Gone on a
+                deleted bill: there is nothing to edit until it is restored. */}
+          {deleted ? null : (
+            <Pressable
+              onPress={openEditor}
+              accessibilityRole="button"
+              accessibilityLabel={t.common.edit}
+              hitSlop={10}
+              style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+            >
+              <Ionicons name="create-outline" size={iconSize.xxl} color={theme.color.onBrand} />
+            </Pressable>
+          )}
+          {/* Everything else this bill can have done to it — Delete, or Restore
+                once it is gone — behind the same trailing three-dot control the
+                group and dashboard headers carry. */}
           <Pressable
             onPress={() => setMenuOpen(true)}
             accessibilityRole="button"
@@ -430,6 +494,7 @@ export default function ExpenseDetailScreen() {
             versions={versions.data ?? []}
             imageEvents={imageEvents.data ?? []}
             nameOf={nameOf}
+            myMemberId={myMemberId}
             t={t}
             locale={locale}
           />
@@ -455,11 +520,13 @@ export default function ExpenseDetailScreen() {
                 is placed without crowding the hero. */}
             <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
               <DetailLine
+                icon="people-circle-outline"
                 label={t.expense.detailGroup}
                 value={groupLabel(group.data, members.data ?? [], profile?.id)}
               />
               <View style={{ height: 1, backgroundColor: theme.color.border }} />
               <DetailLine
+                icon="wallet-outline"
                 label={t.paidBy}
                 value={
                   version.payers.length > 1
@@ -469,6 +536,7 @@ export default function ExpenseDetailScreen() {
               />
               <View style={{ height: 1, backgroundColor: theme.color.border }} />
               <DetailLine
+                icon="calendar-outline"
                 label={t.expense.detailDate}
                 value={new Intl.DateTimeFormat(locale, {
                   day: 'numeric',
@@ -479,6 +547,7 @@ export default function ExpenseDetailScreen() {
               />
               <View style={{ height: 1, backgroundColor: theme.color.border }} />
               <DetailLine
+                icon={splitIcon(version.split_type)}
                 label={t.expense.detailSplit}
                 value={splitLabels(t)[version.split_type] ?? version.split_type}
               />
@@ -583,16 +652,33 @@ export default function ExpenseDetailScreen() {
             <View>
               <SectionHeader title={t.expense.whoOwesWhat} />
               <Card padded={false} style={{ paddingHorizontal: theme.spacing.lg }}>
-                {version.shares.map((share, index) => {
-                  const member = lookup.get(share.member_id);
+                {ledgerRows.map((row, index) => {
+                  const member = lookup.get(row.memberId);
                   return (
-                    <View key={share.member_id}>
+                    <View key={row.memberId}>
                       <ListRow
-                        title={nameOf(share.member_id)}
-                        subtitle={member && isGhost(member) ? t.notJoinedYet : undefined}
+                        title={nameOf(row.memberId)}
+                        subtitle={
+                          [
+                            member && isGhost(member) ? t.notJoinedYet : null,
+                            // Only for somebody who put money in: their row shows a
+                            // net, and without this the two numbers it came from are
+                            // nowhere on the screen.
+                            row.paid > 0n
+                              ? t.expense.paidAndShare
+                                  .replace('{paid}', format(money(row.paid, currency), { locale }))
+                                  .replace(
+                                    '{share}',
+                                    format(money(row.share, currency), { locale }),
+                                  )
+                              : null,
+                          ]
+                            .filter(Boolean)
+                            .join(' · ') || undefined
+                        }
                         leading={
                           <MemberAvatar
-                            name={avatarNameOf(share.member_id)}
+                            name={avatarNameOf(row.memberId)}
                             photo={member?.profile?.avatar_url}
                             ghost={
                               member
@@ -603,23 +689,35 @@ export default function ExpenseDetailScreen() {
                         }
                         trailing={
                           <MoneyText
-                            amount={BigInt(share.amount)}
+                            // What this bill does to them: paid − share.
+                            //
+                            // This used to be the raw share, forced red, on the
+                            // reasoning that every share is money owed. That held only
+                            // while one person could pay. On a bill several people put
+                            // money into, the biggest contributor was shown in owe-red
+                            // for their share — Lokesh paying ₹5,000 of a ₹10,000 bill
+                            // and owing ₹2,000 read as "Lokesh owes ₹2,000" when he is
+                            // owed ₹3,000.
+                            //
+                            // The net says it correctly for everyone at once, with no
+                            // special case: somebody who paid nothing has a net of
+                            // exactly minus their share, which is the same red figure
+                            // the row showed before, so the common bill is unchanged.
+                            // Sign-derived now (mode="balance") rather than forced —
+                            // colour, sign and spoken label agree, the way money reads
+                            // everywhere else in the app.
+                            amount={row.net}
                             currency={currency}
                             locale={locale}
                             variant="caption"
-                            // A share is money owed toward this bill, so it wears the
-                            // same owe colour the balances do across the app — not the
-                            // neutral ink of a total. Forced (not sign-derived): every
-                            // share is a positive owe, so mode="balance" would read it
-                            // as "owed to you" (green) instead. But when *you* are not
-                            // in this split, none of these owes are yours to read as
-                            // debt — the whole list drops to muted ink so it reads as
-                            // someone else's ledger, matching the observer banner.
-                            tone={notInvolved ? 'muted' : 'negative'}
+                            mode={notInvolved ? 'plain' : 'balance'}
+                            // Not your bill, not your verdict: an observer sees the
+                            // ledger in neutral ink, matching the banner up top.
+                            tone={notInvolved ? 'muted' : undefined}
                           />
                         }
                       />
-                      {index < version.shares.length - 1 ? (
+                      {index < ledgerRows.length - 1 ? (
                         <View style={{ height: 1, backgroundColor: theme.color.border }} />
                       ) : null}
                     </View>

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -914,6 +914,57 @@ export default function GroupScreen() {
           nameOf={nameOf}
           onOpenMenu={() => setMenuOpen(true)}
         />
+        {/* The three faces of the page, pinned between the hero and the list.
+            It used to ride inside `ListHeaderComponent`, which meant scrolling
+            the ledger carried the tab bar off the top of the screen and you had
+            to fling back to the beginning to change tab. Fixed here, the tabs
+            stay under your thumb and only the rows move — which is also what
+            makes switching tabs feel instant rather than like a new page.
+
+            A tab, not a choice on a form, so it wears the underlined tab look
+            rather than the selection pills the rest of the app fills in. */}
+        <View
+          style={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingTop: theme.spacing.md,
+            gap: theme.spacing.sm,
+          }}
+        >
+          <SegmentedTabs<Tab>
+            value={tab}
+            onChange={setTab}
+            tabs={[
+              { value: Tab.Expenses, label: t.expenses },
+              { value: Tab.Balances, label: t.balances },
+              { value: Tab.Activity, label: t.activity },
+            ]}
+          />
+
+          {tab === Tab.Expenses && hasDeleted ? (
+            <Row style={{ justifyContent: 'flex-end' }}>
+              {/* A real button, not a text with an onPress: a screen reader hears
+                  a control, and the 44pt floor plus hitSlop makes the caption a
+                  tap target rather than a hairline of text. */}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityState={{ expanded: showDeleted }}
+                accessibilityLabel={showDeleted ? t.group.hideDeleted : t.group.showDeleted}
+                onPress={() => setShowDeleted((current) => !current)}
+                hitSlop={8}
+                style={({ pressed }) => ({
+                  minHeight: 44,
+                  justifyContent: 'center',
+                  opacity: pressed ? 0.6 : 1,
+                })}
+              >
+                <Text variant="caption" tone="muted">
+                  {showDeleted ? t.group.hideDeleted : t.group.showDeleted}
+                </Text>
+              </Pressable>
+            </Row>
+          ) : null}
+        </View>
+
         <FlashList
           data={listData}
           extraData={`${tab}|${showDeleted}|${locale}`}
@@ -939,10 +990,15 @@ export default function GroupScreen() {
             />
           }
           ListHeaderComponent={
-            <View style={{ marginBottom: theme.spacing.xl }}>
-              {/* The white body beneath the hero: alerts, shared receipts, pending
-                  settlements, then the three-face tab bar. */}
-              <View style={{ gap: theme.spacing.xl, marginTop: theme.spacing.xl }}>
+            // Alerts, shared receipts and pending settlements — everything that
+            // is about the group rather than about one tab. It scrolls under the
+            // pinned tab bar. The stack used to open on 20pt of top margin plus a
+            // 20pt gap plus each card's own padding, which pushed the first
+            // expense most of a thumb below the tabs on a screen where nothing
+            // was wrong; `sm` is enough to separate the tabs from the rows and
+            // the cards keep their own breathing room.
+            <View style={{ marginBottom: theme.spacing.md }}>
+              <View style={{ gap: theme.spacing.md, marginTop: theme.spacing.sm }}>
                 <OverflowMenu
                   visible={menuOpen}
                   onClose={() => setMenuOpen(false)}
@@ -1106,43 +1162,6 @@ export default function GroupScreen() {
                     />
                   </Card>
                 ))}
-
-                {/* The page has three faces — expenses, balances, activity. This is a
-              tab, not a choice on a form, so it wears the underlined tab look
-              rather than the selection pills the rest of the app fills in. */}
-                <SegmentedTabs<Tab>
-                  value={tab}
-                  onChange={setTab}
-                  tabs={[
-                    { value: Tab.Expenses, label: t.expenses },
-                    { value: Tab.Balances, label: t.balances },
-                    { value: Tab.Activity, label: t.activity },
-                  ]}
-                />
-
-                {tab === Tab.Expenses && hasDeleted ? (
-                  <Row style={{ justifyContent: 'flex-end', marginTop: -theme.spacing.md }}>
-                    {/* A real button, not a text with an onPress: a screen reader now
-                  hears a control, and the 44pt floor plus hitSlop makes the
-                  caption a tap target rather than a hairline of text. */}
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityState={{ expanded: showDeleted }}
-                      accessibilityLabel={showDeleted ? t.group.hideDeleted : t.group.showDeleted}
-                      onPress={() => setShowDeleted((current) => !current)}
-                      hitSlop={8}
-                      style={({ pressed }) => ({
-                        minHeight: 44,
-                        justifyContent: 'center',
-                        opacity: pressed ? 0.6 : 1,
-                      })}
-                    >
-                      <Text variant="caption" tone="muted">
-                        {showDeleted ? t.group.hideDeleted : t.group.showDeleted}
-                      </Text>
-                    </Pressable>
-                  </Row>
-                ) : null}
               </View>
             </View>
           }

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -60,6 +60,7 @@ import {
 } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { paidBy } from '@/lib/payerLines';
 import { CategoryBadge } from '@/components/Category';
 import { OverflowMenu, type OverflowMenuItem } from '@/components/OverflowMenu';
 import { GroupHero } from '@/components/GroupHero';
@@ -260,25 +261,27 @@ const ExpenseFeedRow = memo(function ExpenseFeedRow({
   nameOf: (memberId: string | null) => string;
 }) {
   const version = expense.currentVersion;
-  const payer = version?.payers[0]?.member_id ?? null;
   // An imported Splitwise expense can have several payers, so
   // "Asha paid ₹1,200" beside the expense total would put the
   // whole bill on whoever happens to sort first. One payer is
   // named and credited with what they actually put in; several
   // are counted, and the number beside them is the total they
-  // put in between them.
-  const payerCount = version?.payers.length ?? 0;
+  // put in between them. The rule is `paidBy`, shared with the
+  // month drill-down so the two cannot disagree.
+  const paid = paidBy(version?.payers ?? []);
   const paidLine =
     version === null
-      ? fill(t.expense.paidByName, { name: nameOf(payer) })
+      ? fill(t.expense.paidByName, { name: nameOf(null) })
       : fill(t.expense.paidByNameAmount, {
-          name: payerCount > 1 ? plural(locale, payerCount, t.misc.peopleCount) : nameOf(payer),
+          name:
+            paid.kind === 'several'
+              ? plural(locale, paid.count, t.misc.peopleCount)
+              : nameOf(paid.memberId),
           amount: formatParts(
+            // A payerless version still shows the bill's own total rather
+            // than a zero nobody recorded.
             {
-              minor:
-                payerCount > 1
-                  ? BigInt(version.amount)
-                  : BigInt(version.payers[0]?.amount ?? version.amount),
+              minor: paid.amount > 0n ? paid.amount : BigInt(version.amount),
               currency: version.currency,
             },
             { locale },

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -41,6 +41,7 @@ import { expenseTitle } from '@/data/expenseTitle';
 import { displayName, groupLabel, type ExpenseRow } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+import { paidBy } from '@/lib/payerLines';
 
 /** One row of the flattened month: the header tile, a day heading, or a bill. */
 type MonthItem =
@@ -210,7 +211,10 @@ export default function SpendingMonthScreen() {
     }
 
     const version = item.expense.currentVersion;
-    const payer = version?.payers[0]?.member_id ?? null;
+    // Who paid, by the same rule the group ledger uses (paidBy): one person is
+    // named, several are counted. Naming payers[0] put a shared bill entirely
+    // on whoever happened to sort first.
+    const paid = paidBy(version?.payers ?? []);
     const title = expenseTitle(version?.description, version?.category, t, version?.category_meta);
     return (
       <View>
@@ -238,7 +242,9 @@ export default function SpendingMonthScreen() {
                 {title}
               </Text>
               <Text variant="caption" tone="muted" numberOfLines={1}>
-                {fill(t.expense.paidByName, { name: nameOf(payer) })}
+                {paid.kind === 'several'
+                  ? plural(locale, paid.count, t.expense.paidByCount)
+                  : fill(t.expense.paidByName, { name: nameOf(paid.memberId) })}
               </Text>
             </View>
             <MoneyText

--- a/apps/mobile/src/app/group/[id]/month.tsx
+++ b/apps/mobile/src/app/group/[id]/month.tsx
@@ -15,8 +15,10 @@
 
 import { useMemo } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { FlashList } from '@shopify/flash-list';
+import { byNewest } from '@waves/core';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
+import { ActivityIndicator, Pressable, View } from 'react-native';
 
 import {
   directionalIcon,
@@ -39,6 +41,12 @@ import { expenseTitle } from '@/data/expenseTitle';
 import { displayName, groupLabel, type ExpenseRow } from '@/data/types';
 import { fill, plural, useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
+
+/** One row of the flattened month: the header tile, a day heading, or a bill. */
+type MonthItem =
+  | { kind: 'total'; key: string }
+  | { kind: 'day'; key: string; day: string; total: bigint }
+  | { kind: 'expense'; key: string; expense: ExpenseRow; amount: bigint; isLast: boolean };
 
 /** Sum of this member's shares in a version, in minor units. */
 function myShare(shares: { member_id: string; amount: string }[], memberId: string | null): bigint {
@@ -105,7 +113,7 @@ export default function SpendingMonthScreen() {
       bucket.items.push(row);
       byDay.set(row.day, bucket);
     }
-    return [...byDay.entries()].sort((a, b) => b[0].localeCompare(a[0]));
+    return [...byDay.entries()].sort(byNewest(([day]) => day));
   }, [rows]);
 
   const total = rows.reduce((sum, row) => sum + row.amount, 0n);
@@ -132,6 +140,121 @@ export default function SpendingMonthScreen() {
     }).format(new Date(Date.UTC(Number(y), Number(m) - 1, Number(d))));
   };
 
+  /**
+   * The month, flattened into one recyclable list.
+   *
+   * It was a ScrollView with a nested `days.map(... bucket.items.map(...))`
+   * inside it, which mounts every expense of the month at once — a busy month on
+   * a shared trip is hundreds of rows, all of them built before the first one is
+   * on screen. FlashList mounts what is visible; the nesting becomes a flat
+   * sequence of typed items so it can recycle each kind against its own pool.
+   */
+  const items: MonthItem[] = useMemo(() => {
+    const list: MonthItem[] = [{ kind: 'total', key: 'total' }];
+    for (const [day, bucket] of days) {
+      list.push({ kind: 'day', key: `day-${day}`, day, total: bucket.total });
+      bucket.items.forEach(({ expense, amount }, index) =>
+        list.push({
+          kind: 'expense',
+          key: expense.id,
+          expense,
+          amount,
+          isLast: index === bucket.items.length - 1,
+        }),
+      );
+    }
+    return list;
+  }, [days]);
+
+  const renderItem = ({ item }: { item: MonthItem }) => {
+    if (item.kind === 'total') {
+      return (
+        <TintCard
+          tint={tintForKey(groupId)}
+          style={{
+            alignItems: 'center',
+            gap: theme.spacing.xs,
+            borderRadius: theme.radius.xl,
+            padding: theme.spacing.xl,
+            marginBottom: theme.spacing.xl,
+          }}
+        >
+          <MoneyText amount={total} currency={currency} locale={locale} variant="display" />
+          <Text variant="caption" tone="muted">
+            {plural(locale, rows.length, t.importLedger.expenseCount)}
+          </Text>
+        </TintCard>
+      );
+    }
+
+    if (item.kind === 'day') {
+      return (
+        <Row
+          style={{
+            justifyContent: 'space-between',
+            paddingHorizontal: theme.spacing.xs,
+            paddingTop: theme.spacing.lg,
+            paddingBottom: theme.spacing.sm,
+          }}
+        >
+          <Text variant="subheading">{dayLabel(item.day)}</Text>
+          <MoneyText
+            amount={item.total}
+            currency={currency}
+            locale={locale}
+            variant="caption"
+            tone="muted"
+          />
+        </Row>
+      );
+    }
+
+    const version = item.expense.currentVersion;
+    const payer = version?.payers[0]?.member_id ?? null;
+    const title = expenseTitle(version?.description, version?.category, t, version?.category_meta);
+    return (
+      <View>
+        <Pressable
+          onPress={() => router.push(`/group/${groupId}/expense/${item.expense.id}`)}
+          accessibilityRole="button"
+          accessibilityLabel={title}
+          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+        >
+          <Row
+            style={{
+              gap: theme.spacing.md,
+              alignItems: 'center',
+              paddingVertical: theme.spacing.sm,
+            }}
+          >
+            <CategoryBadge
+              category={version?.category}
+              meta={version?.category_meta}
+              description={version?.description}
+              size={40}
+            />
+            <View style={{ flex: 1 }}>
+              <Text variant="subheading" numberOfLines={1}>
+                {title}
+              </Text>
+              <Text variant="caption" tone="muted" numberOfLines={1}>
+                {fill(t.expense.paidByName, { name: nameOf(payer) })}
+              </Text>
+            </View>
+            <MoneyText
+              amount={item.amount}
+              currency={currency}
+              locale={locale}
+              tone="default"
+              style={{ fontWeight: '700' }}
+            />
+          </Row>
+        </Pressable>
+        {!item.isLast ? <View style={{ height: 1, backgroundColor: theme.color.border }} /> : null}
+      </View>
+    );
+  };
+
   return (
     <Screen>
       <Row style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.md }}>
@@ -154,120 +277,43 @@ export default function SpendingMonthScreen() {
         <View style={{ width: 44 }} />
       </Row>
 
-      <ScrollView
-        style={{ flex: 1 }}
-        contentContainerStyle={{
-          paddingHorizontal: theme.spacing.xl,
-          paddingTop: theme.spacing.lg,
-          paddingBottom: clearance,
-          gap: theme.spacing.xl,
-        }}
-        showsVerticalScrollIndicator={false}
-      >
-        {expenses.isLoading ? (
-          <View style={{ padding: theme.spacing.xl }}>
-            <ActivityIndicator color={theme.color.brand} />
-          </View>
-        ) : rows.length === 0 ? (
-          <EmptyState title={t.nothingYet} body={t.nothingToChart} />
-        ) : (
-          <>
-            <TintCard
-              tint={tintForKey(groupId)}
-              style={{
-                alignItems: 'center',
-                gap: theme.spacing.xs,
-                borderRadius: theme.radius.xl,
-                padding: theme.spacing.xl,
-              }}
-            >
-              <MoneyText amount={total} currency={currency} locale={locale} variant="display" />
-              <Text variant="caption" tone="muted">
-                {plural(locale, rows.length, t.importLedger.expenseCount)}
-              </Text>
-            </TintCard>
-
-            {days.map(([day, bucket]) => (
-              <View key={day} style={{ gap: theme.spacing.md }}>
-                <Row
-                  style={{ justifyContent: 'space-between', paddingHorizontal: theme.spacing.xs }}
-                >
-                  <Text variant="subheading">{dayLabel(day)}</Text>
-                  <MoneyText
-                    amount={bucket.total}
-                    currency={currency}
-                    locale={locale}
-                    variant="caption"
-                    tone="muted"
-                  />
-                </Row>
-
-                <View>
-                  {bucket.items.map(({ expense, amount }, index, arr) => {
-                    const version = expense.currentVersion;
-                    const payer = version?.payers[0]?.member_id ?? null;
-                    const title = expenseTitle(
-                      version?.description,
-                      version?.category,
-                      t,
-                      version?.category_meta,
-                    );
-                    return (
-                      <View key={expense.id}>
-                        <Pressable
-                          onPress={() => router.push(`/group/${groupId}/expense/${expense.id}`)}
-                          accessibilityRole="button"
-                          accessibilityLabel={title}
-                          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-                        >
-                          <Row
-                            style={{
-                              gap: theme.spacing.md,
-                              alignItems: 'center',
-                              paddingVertical: theme.spacing.sm,
-                            }}
-                          >
-                            <CategoryBadge
-                              category={version?.category}
-                              meta={version?.category_meta}
-                              description={version?.description}
-                              size={40}
-                            />
-                            <View style={{ flex: 1 }}>
-                              <Text variant="subheading" numberOfLines={1}>
-                                {title}
-                              </Text>
-                              <Text variant="caption" tone="muted" numberOfLines={1}>
-                                {fill(t.expense.paidByName, { name: nameOf(payer) })}
-                              </Text>
-                            </View>
-                            <MoneyText
-                              amount={amount}
-                              currency={currency}
-                              locale={locale}
-                              tone="default"
-                              style={{ fontWeight: '700' }}
-                            />
-                          </Row>
-                        </Pressable>
-                        {index < arr.length - 1 ? (
-                          <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                        ) : null}
-                      </View>
-                    );
-                  })}
-                </View>
-              </View>
-            ))}
-
-            {mine ? (
-              <Text variant="micro" tone="muted" align="center">
+      {expenses.isLoading ? (
+        <View style={{ padding: theme.spacing.xl }}>
+          <ActivityIndicator color={theme.color.brand} />
+        </View>
+      ) : rows.length === 0 ? (
+        <EmptyState title={t.nothingYet} body={t.nothingToChart} />
+      ) : (
+        <FlashList
+          data={items}
+          extraData={locale}
+          keyExtractor={(item) => item.key}
+          getItemType={(item) => item.kind}
+          renderItem={renderItem}
+          // The group ledger's settings: render well beyond the viewport so a
+          // hard fling down a busy month never outruns recycling and flashes
+          // blank rows.
+          drawDistance={1500}
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingTop: theme.spacing.lg,
+            paddingBottom: clearance,
+          }}
+          showsVerticalScrollIndicator={false}
+          ListFooterComponent={
+            mine ? (
+              <Text
+                variant="micro"
+                tone="muted"
+                align="center"
+                style={{ marginTop: theme.spacing.xl }}
+              >
                 {t.extras.yourShareNote}
               </Text>
-            ) : null}
-          </>
-        )}
-      </ScrollView>
+            ) : null
+          }
+        />
+      )}
     </Screen>
   );
 }

--- a/apps/mobile/src/components/ExpenseHistory.tsx
+++ b/apps/mobile/src/components/ExpenseHistory.tsx
@@ -115,7 +115,13 @@ function diffVersions(
   // colour cannot drift from the row that announced the edit.
   const oldStake = myStake(prev, myMemberId);
   const newStake = myStake(cur, myMemberId);
-  if ((oldStake ?? 0n) !== (newStake ?? 0n)) {
+  // The currency counts as a change to your stake for the same reason it counts
+  // as a change to the amount: ₹500 becoming $500 is not the same stake, and
+  // comparing minor units alone would call it one. It only counts for somebody
+  // who has a stake, though — `myStake` returns null for a viewer the bill does
+  // not involve, and a re-denomination must not hand them a "your share 0 → 0".
+  const involved = oldStake !== null || newStake !== null;
+  if ((oldStake ?? 0n) !== (newStake ?? 0n) || (involved && prev.currency !== cur.currency)) {
     changes.push({
       key: 'stake',
       label: t.expense.audit.yourShare,

--- a/apps/mobile/src/components/ExpenseHistory.tsx
+++ b/apps/mobile/src/components/ExpenseHistory.tsx
@@ -3,9 +3,11 @@ import { View } from 'react-native';
 
 import { Badge, directionalIcon, iconSize, MoneyText, Row, Text, useTheme } from '@waves/ui';
 
+import type { MemberId } from '@waves/core';
+
 import type { ExpenseVersionAudit } from '@/data/api';
 import type { ExpenseImageEventRow } from '@/data/hooks';
-import { type ActivityTint, dayHeading, groupByDay, relativeTime } from '@/data/activity';
+import { type ActivityTint, dayHeading, groupByDay, myStake, relativeTime } from '@/data/activity';
 import { coordLabel } from '@/lib/location';
 import { fill, type UiStrings } from '@/i18n';
 
@@ -75,6 +77,15 @@ type Change =
       newAmount: bigint;
       oldCurrency: string;
       newCurrency: string;
+      /**
+       * Whether these two figures are somebody's balance or the bill's total.
+       *
+       * A total belongs to nobody, so it is neutral ink — painting ₹10,000 green
+       * because it is a positive number would have the screen reader announce
+       * "you are owed ₹10,000" about a dinner. The viewer's own stake IS a
+       * balance, so it wears the sign-derived colour the Activity feed gives it.
+       */
+      balance?: boolean;
     }
   | { key: string; label: string; kind: 'text'; oldText: string; newText: string };
 
@@ -84,8 +95,32 @@ function diffVersions(
   nameOf: (id: string | null) => string,
   prev: ExpenseVersionAudit,
   cur: ExpenseVersionAudit,
+  myMemberId: MemberId | null,
 ): Change[] {
   const changes: Change[] = [];
+
+  // What the edit did to *you*, in the colour the Activity feed uses for the
+  // same quantity. The audit lists the bill's totals, which is the honest record
+  // but not the question somebody scrolling their own history is asking — "did
+  // this edit cost me anything?" was only answerable by doing the arithmetic
+  // against two versions of the split.
+  //
+  // `myStake` is the feed's own function (paid − share), so the number and its
+  // colour cannot drift from the row that announced the edit.
+  const oldStake = myStake(prev, myMemberId);
+  const newStake = myStake(cur, myMemberId);
+  if ((oldStake ?? 0n) !== (newStake ?? 0n)) {
+    changes.push({
+      key: 'stake',
+      label: t.expense.audit.yourShare,
+      kind: 'money',
+      oldAmount: oldStake ?? 0n,
+      newAmount: newStake ?? 0n,
+      oldCurrency: prev.currency,
+      newCurrency: cur.currency,
+      balance: true,
+    });
+  }
 
   if (prev.amount !== cur.amount || prev.currency !== cur.currency) {
     changes.push({
@@ -192,6 +227,9 @@ function ChangeLine({ change, locale }: { change: Change; locale: string }) {
             currency={change.oldCurrency as never}
             locale={locale}
             variant="caption"
+            // The superseded value stays muted whatever it is — it is the "from"
+            // half of an arrow, and colouring both ends makes neither read as
+            // the answer.
             tone="muted"
           />
         ) : (
@@ -215,6 +253,9 @@ function ChangeLine({ change, locale }: { change: Change; locale: string }) {
             currency={change.newCurrency as never}
             locale={locale}
             variant="caption"
+            // Sign-derived colour and spoken label for a balance; neutral ink for
+            // a total (see `balance` on Change).
+            mode={change.balance ? 'balance' : 'plain'}
           />
         ) : (
           <Text variant="caption" numberOfLines={2} style={{ flexShrink: 1 }}>
@@ -261,6 +302,7 @@ export function ExpenseHistory({
   versions,
   imageEvents,
   nameOf,
+  myMemberId,
   t,
   locale,
 }: {
@@ -268,6 +310,10 @@ export function ExpenseHistory({
   versions: ExpenseVersionAudit[];
   imageEvents: ExpenseImageEventRow[];
   nameOf: (id: string | null) => string;
+  /** The reader, so an edit can say what it did to their side of the bill.
+   *  Null for someone with no membership row — the stake line is then omitted
+   *  rather than shown as zero. */
+  myMemberId: MemberId | null;
   t: UiStrings;
   locale: string;
 }) {
@@ -295,7 +341,9 @@ export function ExpenseHistory({
         name: nameOf(version.author_member_id),
       }),
       money: { amount: BigInt(version.amount), currency: version.currency },
-      changes: created ? [] : diffVersions(t, locale, nameOf, ascending[index - 1]!, version),
+      changes: created
+        ? []
+        : diffVersions(t, locale, nameOf, ascending[index - 1]!, version, myMemberId),
       created,
     };
   });

--- a/apps/mobile/src/components/ExpenseHistory.tsx
+++ b/apps/mobile/src/components/ExpenseHistory.tsx
@@ -3,12 +3,18 @@ import { View } from 'react-native';
 
 import { Badge, directionalIcon, iconSize, MoneyText, Row, Text, useTheme } from '@waves/ui';
 
-import type { MemberId } from '@waves/core';
+import {
+  format as formatMoney,
+  money as coreMoney,
+  type CurrencyCode,
+  type MemberId,
+} from '@waves/core';
 
 import type { ExpenseVersionAudit } from '@/data/api';
 import type { ExpenseImageEventRow } from '@/data/hooks';
 import { type ActivityTint, dayHeading, groupByDay, myStake, relativeTime } from '@/data/activity';
 import { coordLabel } from '@/lib/location';
+import { payerAuditText, payerFactsKey } from '@/lib/payerLines';
 import { fill, type UiStrings } from '@/i18n';
 
 /**
@@ -181,15 +187,20 @@ function diffVersions(
       newText: locationLabel(t, cur),
     });
   }
-  // Who paid: compare the set of payers, not amounts (an amount move is already
-  // the Amount line). A changed set is a real "someone else paid".
-  if (memberKey(prev.payers) !== memberKey(cur.payers)) {
+  // Who paid, and how much each of them put in — both, because on a bill with
+  // several payers the amounts are the only thing that need change. Moving ₹100
+  // from Asha to Ravi leaves the total alone (so there is no Amount line) and
+  // the set of names alone, and comparing names only meant that edit vanished
+  // from the one screen whose job is to record edits.
+  if (payerFactsKey(prev.payers) !== payerFactsKey(cur.payers)) {
+    const money = (version: ExpenseVersionAudit) => (minor: bigint) =>
+      formatMoney(coreMoney(minor, version.currency as CurrencyCode), { locale });
     changes.push({
       key: 'payers',
       label: t.expense.audit.payers,
       kind: 'text',
-      oldText: prev.payers.map((p) => nameOf(p.member_id)).join(', ') || t.expense.audit.none,
-      newText: cur.payers.map((p) => nameOf(p.member_id)).join(', ') || t.expense.audit.none,
+      oldText: payerAuditText(prev.payers, nameOf, money(prev), t.expense.audit.none),
+      newText: payerAuditText(cur.payers, nameOf, money(cur), t.expense.audit.none),
     });
   }
   // Participants: who is splitting the bill, by name — the same treatment as

--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -605,9 +605,15 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
 
     return (
       <View style={{ gap: theme.spacing.sm }}>
-        <Text variant="caption" tone="muted">
-          {t.receipts.title}
-        </Text>
+        {/* The caption labels the thumbnail strip, which has nothing else to say
+            what it is. The empty state does not need it: the tile below already
+            reads "Add receipt" in bigger type, so the heading was the same word
+            twice, stacked. */}
+        {items.length > 0 ? (
+          <Text variant="caption" tone="muted">
+            {t.receipts.title}
+          </Text>
+        ) : null}
         {items.length === 0 ? (
           // No receipt yet (and, per the guard above, the viewer may add one). A
           // lone 96px tile left a wide empty band under it; a full-width row that

--- a/apps/mobile/src/components/expense/ExpenseHero.tsx
+++ b/apps/mobile/src/components/expense/ExpenseHero.tsx
@@ -1,0 +1,148 @@
+/**
+ * The header the expense *form* wears — the same panel the expense screen wears.
+ *
+ * Viewing a bill and editing it used to be two unrelated places: the view was a
+ * brand wash carrying the category badge, the title and the amount; the form was
+ * a white page with a centred word at the top and a 44pt number floating in the
+ * middle of it, so the number moved, changed colour and changed size the moment
+ * you tapped Edit. Here the form opens on the same wash, with the category badge
+ * in the same corner and the amount on the same line — the only difference being
+ * that on this side you can type into it.
+ *
+ * That also settles what the amount costs: it and its currency now share one
+ * line inside the header instead of owning a third of the first screenful, and
+ * the running total in the pinned action bar is no longer a second copy of a
+ * number already shouting from the top.
+ */
+
+import { type ReactNode } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { currencySymbol, type CategoryMeta } from '@waves/core';
+import { AmountField, directionalIcon, Gradient, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+import { CategoryBadge } from '@/components/Category';
+import { useStrings } from '@/i18n';
+
+export function ExpenseHero({
+  title,
+  category,
+  categoryMeta,
+  description,
+  currency,
+  amount,
+  onAmountChange,
+  onPressCurrency,
+  right,
+  leading = 'back',
+}: {
+  /** The one line above the amount: what this form is, and where it lands. */
+  title: string;
+  category: string | null;
+  categoryMeta?: CategoryMeta | null;
+  /** What has been typed so far — the badge sharpens its guess from it. */
+  description?: string | null;
+  currency: string;
+  amount: bigint;
+  onAmountChange: (value: bigint) => void;
+  onPressCurrency: () => void;
+  /** A trailing action; a 44pt spacer keeps the row balanced when omitted. */
+  right?: ReactNode;
+  /** A modal (capture) dismisses with an X; a pushed page goes back. */
+  leading?: 'close' | 'back';
+}): React.JSX.Element {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useStrings();
+
+  return (
+    <Gradient
+      radius={0}
+      colors={theme.gradient.brand}
+      style={{
+        paddingTop: insets.top + theme.spacing.md,
+        paddingHorizontal: theme.spacing.xl,
+        paddingBottom: theme.spacing.lg,
+        borderBottomLeftRadius: theme.radius.xxl,
+        borderBottomRightRadius: theme.radius.xxl,
+      }}
+    >
+      <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel={leading === 'back' ? t.common.back : t.common.close}
+          hitSlop={10}
+          style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+        >
+          <Ionicons
+            name={leading === 'back' ? directionalIcon('chevron-back') : 'close'}
+            size={iconSize.xxl}
+            color={theme.color.onBrand}
+          />
+        </Pressable>
+
+        {/* The same badge, in the same place, as on the expense screen — it moves
+            as the note is typed, so the guess is visible before saving rather
+            than a surprise on the bill afterwards. */}
+        <CategoryBadge
+          category={category}
+          meta={categoryMeta}
+          description={description}
+          size={40}
+        />
+
+        <View style={{ flex: 1, minWidth: 0, gap: 2 }}>
+          <Text variant="micro" tone="onBrand" numberOfLines={1} style={{ opacity: 0.85 }}>
+            {title}
+          </Text>
+          {/* Amount and currency on one line: the number leads, the code it is
+              counted in sits at the end of it as the pill that opens the picker. */}
+          <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+            <AmountField
+              currency={currency}
+              value={amount}
+              onChange={onAmountChange}
+              size="hero"
+              tone="onBrand"
+            />
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`${t.captures.currencyLabel}: ${currency}`}
+              onPress={onPressCurrency}
+              hitSlop={10}
+              style={({ pressed }) => ({
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: theme.spacing.xs,
+                // A real tap target, not a label: the pill is the only way to
+                // change the currency, and `hitSlop` alone left it under 44pt.
+                minHeight: 36,
+                paddingVertical: theme.spacing.xs,
+                paddingHorizontal: theme.spacing.md,
+                borderRadius: theme.radius.pill,
+                // A translucent white chip rather than a surface colour: the wash
+                // runs three stops, and a solid pill would only match one of them.
+                backgroundColor: 'rgba(255,255,255,0.18)',
+                opacity: pressed ? 0.7 : 1,
+              })}
+            >
+              <Text variant="caption" tone="onBrand" style={{ opacity: 0.8 }}>
+                {currencySymbol(currency)}
+              </Text>
+              <Text variant="caption" tone="onBrand" style={{ fontWeight: '700' }}>
+                {currency}
+              </Text>
+              <Ionicons name="chevron-down" size={iconSize.sm} color={theme.color.onBrand} />
+            </Pressable>
+          </Row>
+        </View>
+
+        {right ?? <View style={{ width: 44 }} />}
+      </Row>
+    </Gradient>
+  );
+}

--- a/apps/mobile/src/components/expense/splitIcon.ts
+++ b/apps/mobile/src/components/expense/splitIcon.ts
@@ -1,0 +1,38 @@
+/**
+ * One glyph per way of splitting a bill.
+ *
+ * "Equally", "Shares", "Percent" were three words in a row of identical pills —
+ * nothing to aim at, and nothing to recognise afterwards on the expense screen,
+ * where the same fact came back as a bare word in a labelled row. The icon is
+ * what makes the two screens agree at a glance: the chip you tapped while
+ * editing is the mark you see on the bill later.
+ *
+ * Keyed by the ledger's `split_type` (TDR §8), which is a superset of the three
+ * kinds this form offers — an itemized or adjusted split is written by other
+ * screens but still has to be shown here.
+ */
+
+import type Ionicons from '@expo/vector-icons/Ionicons';
+
+type IconName = keyof typeof Ionicons.glyphMap;
+
+const SPLIT_ICONS: Record<string, IconName> = {
+  // Everyone the same: a row of people, not a maths symbol.
+  equal: 'people-outline',
+  // Typed amounts, one per person — money, straight.
+  exact: 'cash-outline',
+  // Slices of a whole.
+  percent: 'pie-chart-outline',
+  // Weights: bars of different heights.
+  shares: 'stats-chart-outline',
+  // Someone's share nudged up or down off the even split.
+  adjustment: 'options-outline',
+  // Line by line, off the bill itself.
+  itemized: 'list-outline',
+};
+
+/** The glyph for a split type, falling back to the even-split people for a
+ *  value this build does not know (a newer server writing an older client). */
+export function splitIcon(splitType: string): IconName {
+  return SPLIT_ICONS[splitType] ?? 'people-outline';
+}

--- a/apps/mobile/src/data/activity.ts
+++ b/apps/mobile/src/data/activity.ts
@@ -17,7 +17,7 @@ import type Ionicons from '@expo/vector-icons/Ionicons';
 
 import { isCurrencyCode } from '@waves/core';
 
-import { actorName, type ActivityRow, type ExpenseVersionRow } from './types';
+import { actorName, type ActivityRow } from './types';
 
 import type { MemberId } from '@waves/core';
 
@@ -59,8 +59,20 @@ export function parseMoney(
  * Shared by the group ledger and both activity feeds, so the coloured figure on
  * an expense row means the same thing wherever it is read.
  */
+/**
+ * The two sides of a bill this function actually reads. Typed structurally so
+ * the expense-history audit rows — a narrower projection of a version, without
+ * split params or notes — can ask the same question the activity feed asks,
+ * rather than the two feeds growing their own copy of "what is my stake" and
+ * drifting apart on the answer.
+ */
+export interface StakeSides {
+  readonly payers: readonly { readonly member_id: string; readonly amount: string }[];
+  readonly shares: readonly { readonly member_id: string; readonly amount: string }[];
+}
+
 export function myStake(
-  version: ExpenseVersionRow | null | undefined,
+  version: StakeSides | null | undefined,
   memberId: MemberId | null,
 ): bigint | null {
   if (!version || !memberId) return null;

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -51,6 +51,7 @@ import {
   type SettlementSnapshot,
   type SettlementTransitionPayload,
   type Transfer,
+  byNewest,
 } from '@waves/core';
 
 import { useAuth } from '@/lib/auth';
@@ -699,7 +700,7 @@ export function useRecentActivity(myProfileId: string | null = null): RecentActi
         actor: row.actor_member_id ? (actors.get(row.actor_member_id) ?? null) : null,
         stake: stakeFor(row, expenseById, myMemberByGroup),
       }))
-      .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
+      .sort(byNewest((row) => String(row.created_at)));
   }, [mirror, myProfileId]);
 }
 
@@ -809,14 +810,14 @@ export function useGroup(groupId: string) {
     }) as unknown as SettlementRow[];
     const activity = (
       rowsFor(mirror, SyncTable.ActivityLog, groupId) as unknown as ActivityRow[]
-    ).sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
+    ).sort(byNewest((row) => String(row.created_at)));
 
     // Server rows, and server rows with the queue replayed on top. Screens want
     // the second; anything checking what the server actually knows wants the
     // first, and conflating them is how a queued expense starts looking real
     // enough to reconcile against.
     const stored = (rowsFor(mirror, SyncTable.Expenses, groupId) as unknown as ExpenseRow[]).sort(
-      (a, b) => String(b.created_at).localeCompare(String(a.created_at)),
+      byNewest((row) => String(row.created_at)),
     );
     const withPending = materialiseExpenses(mirror, queue, {
       groupId,

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1709,6 +1709,22 @@ export interface UiStrings {
     /** "Asha paid ₹1,200" — the row's subtitle, so the total is not lost when
      *  the amount column switches to what the expense did to *your* balance. */
     paidByNameAmount: string;
+    /** Summary line for a bill several people put money into. `{n}` is the
+     *  number of payers. */
+    paidByCount: PluralForms;
+    /** Under a participant who also put money in: what they paid, and their
+     *  share of the bill. `{paid}` and `{share}` are formatted amounts. */
+    paidAndShare: string;
+    /** Resets every payer to an even share of the bill. */
+    splitPaidEvenly: string;
+    /** `{amount}` of the bill is not accounted for by any payer yet. */
+    paidLeftToAssign: string;
+    /** The payers have claimed `{amount}` more than the bill. */
+    paidOverAssigned: string;
+    /** Turns the payer row into a several-people-paid one. */
+    paidBySeveral: string;
+    /** Collapses the payer row back to a single person. */
+    paidByOne: string;
     /** The label over an expense row's own effect on your balance: money you put
      *  in beyond your share, and your share of money somebody else put in. */
     youLent: string;
@@ -1757,6 +1773,8 @@ export interface UiStrings {
       date: string;
       location: string;
       payers: string;
+      /** The reader's own side of the bill, in the edit history. */
+      yourShare: string;
       participants: string;
       /** Placeholder for a field that was empty on one side (e.g. no location). */
       none: string;
@@ -3798,6 +3816,13 @@ const en: UiStrings = {
     untitled: 'Untitled',
     paidByName: '{name} paid',
     paidByNameAmount: '{name} paid {amount}',
+    paidByCount: { one: '{n} person paid', other: '{n} people paid' },
+    paidAndShare: 'paid {paid} · share {share}',
+    splitPaidEvenly: 'Split evenly',
+    paidLeftToAssign: '{amount} left to assign',
+    paidOverAssigned: '{amount} too much',
+    paidBySeveral: 'Several people paid',
+    paidByOne: 'One person paid',
     youLent: 'you lent',
     youBorrowed: 'you borrowed',
     notInvolved: 'not involved',
@@ -3831,6 +3856,7 @@ const en: UiStrings = {
       date: 'Date',
       location: 'Location',
       payers: 'Who paid',
+      yourShare: 'Your share',
       participants: 'People',
       none: 'None',
     },
@@ -5963,6 +5989,13 @@ const ta: UiStrings = {
     untitled: 'பெயரிடப்படாதது',
     paidByName: '{name} கொடுத்தார்',
     paidByNameAmount: '{name} {amount} கொடுத்தார்',
+    paidByCount: { one: '{n} நபர் கொடுத்தார்', other: '{n} பேர் கொடுத்தார்கள்' },
+    paidAndShare: '{paid} கொடுத்தார் · பங்கு {share}',
+    splitPaidEvenly: 'சமமாகப் பிரி',
+    paidLeftToAssign: 'இன்னும் {amount} ஒதுக்க வேண்டும்',
+    paidOverAssigned: '{amount} அதிகம்',
+    paidBySeveral: 'பலர் கொடுத்தார்கள்',
+    paidByOne: 'ஒருவர் கொடுத்தார்',
     youLent: 'நீங்கள் கொடுத்தது',
     youBorrowed: 'நீங்கள் வாங்கியது',
     notInvolved: 'உங்களுக்கு தொடர்பில்லை',
@@ -5997,6 +6030,7 @@ const ta: UiStrings = {
       date: 'தேதி',
       location: 'இடம்',
       payers: 'செலுத்தியவர்',
+      yourShare: 'உங்கள் பங்கு',
       participants: 'நபர்கள்',
       none: 'இல்லை',
     },
@@ -8116,6 +8150,13 @@ const hi: UiStrings = {
     untitled: 'बिना नाम',
     paidByName: '{name} ने भुगतान किया',
     paidByNameAmount: '{name} ने {amount} दिए',
+    paidByCount: { one: '{n} व्यक्ति ने दिया', other: '{n} लोगों ने दिया' },
+    paidAndShare: '{paid} दिए · हिस्सा {share}',
+    splitPaidEvenly: 'बराबर बाँटें',
+    paidLeftToAssign: '{amount} अभी बाँटना बाकी',
+    paidOverAssigned: '{amount} ज़्यादा',
+    paidBySeveral: 'कई लोगों ने दिया',
+    paidByOne: 'एक व्यक्ति ने दिया',
     youLent: 'आपने दिए',
     youBorrowed: 'आपने लिए',
     notInvolved: 'आप इसमें नहीं',
@@ -8150,6 +8191,7 @@ const hi: UiStrings = {
       date: 'तारीख़',
       location: 'स्थान',
       payers: 'किसने चुकाया',
+      yourShare: 'आपका हिस्सा',
       participants: 'लोग',
       none: 'कोई नहीं',
     },
@@ -10317,6 +10359,13 @@ const ar: UiStrings = {
     untitled: 'بلا عنوان',
     paidByName: 'دفع {name}',
     paidByNameAmount: 'دفع {name} {amount}',
+    paidByCount: { one: 'دفع شخص واحد', other: 'دفع {n} أشخاص' },
+    paidAndShare: 'دفع {paid} · حصته {share}',
+    splitPaidEvenly: 'قسمة بالتساوي',
+    paidLeftToAssign: 'يتبقّى توزيع {amount}',
+    paidOverAssigned: '{amount} زيادة',
+    paidBySeveral: 'دفع عدة أشخاص',
+    paidByOne: 'دفع شخص واحد',
     youLent: 'أقرضت',
     youBorrowed: 'اقترضت',
     notInvolved: 'لست ضمنها',
@@ -10364,6 +10413,7 @@ const ar: UiStrings = {
       date: 'التاريخ',
       location: 'الموقع',
       payers: 'من دفع',
+      yourShare: 'حصتك',
       participants: 'الأشخاص',
       none: 'لا شيء',
     },

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1725,6 +1725,11 @@ export interface UiStrings {
     paidBySeveral: string;
     /** Collapses the payer row back to a single person. */
     paidByOne: string;
+    /** Asked before a saved several-payer bill is collapsed to one, because the
+     *  other payers' recorded amounts go with it. `{name}` is who is kept. */
+    collapsePayersTitle: string;
+    collapsePayersBody: string;
+    collapsePayersConfirm: string;
     /** The label over an expense row's own effect on your balance: money you put
      *  in beyond your share, and your share of money somebody else put in. */
     youLent: string;
@@ -3823,6 +3828,10 @@ const en: UiStrings = {
     paidOverAssigned: '{amount} too much',
     paidBySeveral: 'Several people paid',
     paidByOne: 'One person paid',
+    collapsePayersTitle: 'Collapse to one payer?',
+    collapsePayersBody:
+      '{name} put in the most, so they will be recorded as paying the whole bill. The other payers and their amounts are removed.',
+    collapsePayersConfirm: 'Collapse',
     youLent: 'you lent',
     youBorrowed: 'you borrowed',
     notInvolved: 'not involved',
@@ -5996,6 +6005,10 @@ const ta: UiStrings = {
     paidOverAssigned: '{amount} அதிகம்',
     paidBySeveral: 'பலர் கொடுத்தார்கள்',
     paidByOne: 'ஒருவர் கொடுத்தார்',
+    collapsePayersTitle: 'ஒருவர் கொடுத்ததாக மாற்றவா?',
+    collapsePayersBody:
+      '{name} அதிகம் கொடுத்திருக்கிறார், எனவே முழு பில்லையும் அவரே கொடுத்ததாகப் பதிவாகும். மற்ற கொடுத்தவர்களும் அவர்களின் தொகைகளும் நீக்கப்படும்.',
+    collapsePayersConfirm: 'மாற்று',
     youLent: 'நீங்கள் கொடுத்தது',
     youBorrowed: 'நீங்கள் வாங்கியது',
     notInvolved: 'உங்களுக்கு தொடர்பில்லை',
@@ -8157,6 +8170,10 @@ const hi: UiStrings = {
     paidOverAssigned: '{amount} ज़्यादा',
     paidBySeveral: 'कई लोगों ने दिया',
     paidByOne: 'एक व्यक्ति ने दिया',
+    collapsePayersTitle: 'एक ही व्यक्ति ने दिया, ऐसा कर दें?',
+    collapsePayersBody:
+      '{name} ने सबसे ज़्यादा दिया है, तो पूरा बिल उन्हीं का दिया हुआ दर्ज होगा। बाक़ी देने वाले और उनकी रकमें हट जाएँगी।',
+    collapsePayersConfirm: 'बदलें',
     youLent: 'आपने दिए',
     youBorrowed: 'आपने लिए',
     notInvolved: 'आप इसमें नहीं',
@@ -10366,6 +10383,10 @@ const ar: UiStrings = {
     paidOverAssigned: '{amount} زيادة',
     paidBySeveral: 'دفع عدة أشخاص',
     paidByOne: 'دفع شخص واحد',
+    collapsePayersTitle: 'تحويلها إلى دافع واحد؟',
+    collapsePayersBody:
+      'دفع {name} أكبر مبلغ، لذلك سيُسجَّل أنه دفع الفاتورة كاملة. وستُحذف بقية الدافعين ومبالغهم.',
+    collapsePayersConfirm: 'تحويل',
     youLent: 'أقرضت',
     youBorrowed: 'اقترضت',
     notInvolved: 'لست ضمنها',

--- a/apps/mobile/src/lib/expenseForm.ts
+++ b/apps/mobile/src/lib/expenseForm.ts
@@ -1,0 +1,141 @@
+/**
+ * The expense form's decisions, with no React around them.
+ *
+ * The add/edit route is a long file, and the parts of it that are easy to get
+ * wrong are not the layout — they are the answers to "which figure survives
+ * this tap". Those answers live here as plain functions over plain values, so
+ * they can be tested without standing up Expo Router, a mirror and a keyboard
+ * (mobile's vitest deliberately renders nothing; see vitest.config.ts).
+ *
+ * The route keeps the state and the side effects. Everything below only reads
+ * its arguments and returns what the next state should be.
+ */
+
+import {
+  type MemberId,
+  type CurrencyCode,
+  type PayerMap,
+  parseMinorInput,
+  sanitiseMinorInput,
+} from '@waves/core';
+
+/** Today, as the ledger stores a date: a plain UTC day, no time. */
+export function todayIso(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/**
+ * The day the expense is filed under.
+ *
+ * An edit must not move it. The form has no date picker, so it used to send
+ * today's date on every write — which meant opening a three-week-old dinner to
+ * fix a spelling silently re-filed it as today's, reordered the feed, moved it
+ * between months and trips, and (now that an expense keeps a visible history)
+ * wrote a date change into the audit trail that nobody made.
+ *
+ * A capture keeps the day it was caught; a saved expense keeps the day it has;
+ * only a genuinely new expense is today's.
+ */
+export function expenseDateFor(input: {
+  readonly captureDate: string | null | undefined;
+  readonly savedDate: string | null | undefined;
+  readonly today: string;
+}): string {
+  return input.captureDate ?? input.savedDate ?? input.today;
+}
+
+/**
+ * What the payer figures should become. `selected` is who is paying, `current`
+ * the figures to start from, `locked` the ones to hold constant, and `typed`
+ * the one field whose characters must be left exactly as they were typed.
+ *
+ * The arithmetic itself is `rebalancePayers` in core — this only decides what
+ * to hand it.
+ */
+export interface PayerPlan {
+  readonly selected: readonly MemberId[];
+  readonly current: PayerMap;
+  readonly locked: ReadonlySet<MemberId>;
+  readonly typed?: { readonly member: MemberId; readonly text: string };
+}
+
+const NO_LOCKS: ReadonlySet<MemberId> = new Set<MemberId>();
+
+/**
+ * Tapping a member's face.
+ *
+ * One-payer mode is a radio: the tap replaces whoever was there and hands them
+ * the whole bill. Several-payer mode is a checkbox: it adds or removes. Null
+ * means the tap does nothing — the last payer cannot be removed, because a bill
+ * that nobody paid is not a state the ledger has.
+ */
+export function planToggle(input: {
+  readonly many: boolean;
+  readonly payers: PayerMap;
+  readonly locked: ReadonlySet<MemberId>;
+  readonly amount: bigint;
+  readonly memberId: MemberId;
+}): PayerPlan | null {
+  const { many, payers, locked, amount, memberId } = input;
+  if (!many) {
+    return { selected: [memberId], current: new Map([[memberId, amount]]), locked: NO_LOCKS };
+  }
+  const ids = [...payers.keys()];
+  const selected = payers.has(memberId) ? ids.filter((id) => id !== memberId) : [...ids, memberId];
+  if (selected.length === 0) return null;
+  return {
+    selected,
+    current: payers,
+    // A lock on somebody who is no longer paying would hold a figure for a row
+    // that is not there, and strand the total short by it.
+    locked: new Set([...locked].filter((id) => selected.includes(id))),
+  };
+}
+
+/**
+ * Collapsing several payers back to one.
+ *
+ * The person who put in the most keeps the bill: dropping the largest
+ * contributor is the one collapse nobody means. Null when there is nothing to
+ * collapse.
+ */
+export function planCollapseToOne(input: {
+  readonly payers: PayerMap;
+  readonly amount: bigint;
+}): PayerPlan | null {
+  const ids = [...input.payers.keys()];
+  if (ids.length <= 1) return null;
+  const biggest = ids.reduce((best, id) =>
+    (input.payers.get(id) ?? 0n) > (input.payers.get(best) ?? 0n) ? id : best,
+  );
+  return { selected: [biggest], current: new Map([[biggest, input.amount]]), locked: NO_LOCKS };
+}
+
+/**
+ * A figure typed against one payer. Typing it locks it — it is now a stated
+ * fact — and the others absorb the difference.
+ */
+export function planTypedAmount(input: {
+  readonly payers: PayerMap;
+  readonly locked: ReadonlySet<MemberId>;
+  readonly memberId: MemberId;
+  readonly text: string;
+  readonly currency: CurrencyCode;
+}): PayerPlan {
+  const cleaned = sanitiseMinorInput(input.text, input.currency);
+  const current = new Map(input.payers).set(
+    input.memberId,
+    parseMinorInput(cleaned, input.currency),
+  );
+  return {
+    selected: [...current.keys()],
+    current,
+    locked: new Set(input.locked).add(input.memberId),
+    typed: { member: input.memberId, text: cleaned },
+  };
+}
+
+/** Back to an even split of the paying — every lock dropped. */
+export function planEvenly(payers: PayerMap): PayerPlan {
+  return { selected: [...payers.keys()], current: payers, locked: NO_LOCKS };
+}

--- a/apps/mobile/src/lib/payerLines.ts
+++ b/apps/mobile/src/lib/payerLines.ts
@@ -1,0 +1,83 @@
+/**
+ * Saying who paid, in one place.
+ *
+ * A bill can record several payers, and every screen that mentions one has to
+ * decide the same thing: name the person, or count them. Getting it wrong is
+ * not a cosmetic slip — "Asha paid" over a bill that Asha and Ravi split puts
+ * the whole thing on one of them, in a list somebody reads to remember what
+ * happened.
+ *
+ * The rules live here as plain functions so the group ledger, the month
+ * drill-down and the audit trail cannot drift apart, and so they can be tested
+ * without a screen (mobile's vitest renders nothing by design).
+ */
+
+/** The payer rows as every read model carries them: id and minor amount. */
+export interface PayerRow {
+  readonly member_id: string;
+  readonly amount: string;
+}
+
+/** Who paid, as a row subtitle has to say it. */
+export type PaidBy =
+  | { readonly kind: 'one'; readonly memberId: string | null; readonly amount: bigint }
+  | { readonly kind: 'several'; readonly count: number; readonly amount: bigint };
+
+/**
+ * One payer is named and credited with what they put in. Several are counted,
+ * and the figure is the total between them — naming whoever happens to sort
+ * first would credit them with the whole bill.
+ *
+ * No payers at all reads as one unnamed one, which is what a row with a missing
+ * version already showed.
+ */
+export function paidBy(payers: readonly PayerRow[]): PaidBy {
+  if (payers.length > 1) {
+    return {
+      kind: 'several',
+      count: payers.length,
+      amount: payers.reduce((sum, row) => sum + BigInt(row.amount), 0n),
+    };
+  }
+  const only = payers[0];
+  return {
+    kind: 'one',
+    memberId: only?.member_id ?? null,
+    amount: only ? BigInt(only.amount) : 0n,
+  };
+}
+
+/**
+ * A stable key for "who paid, and how much" — what the audit trail compares.
+ *
+ * The amounts belong in it. Comparing only the set of names meant that moving
+ * ₹100 from Asha to Ravi on an unchanged ₹1,000 bill left no trace at all: the
+ * total never moved, so there was no amount line either, and an edit to a
+ * recorded fact went unrecorded on the one screen whose whole job is recording
+ * edits (ADR-004).
+ */
+export function payerFactsKey(payers: readonly PayerRow[]): string {
+  return payers
+    .map((row) => `${row.member_id}:${row.amount}`)
+    .sort()
+    .join(',');
+}
+
+/**
+ * The payers as the audit trail prints them. One payer is a name: the amount
+ * beside it would only repeat the bill's own total line. Several carry their
+ * figures, because with the set unchanged the figures are the entire change —
+ * "Asha, Ravi → Asha, Ravi" says nothing.
+ */
+export function payerAuditText(
+  payers: readonly PayerRow[],
+  nameOf: (id: string | null) => string,
+  formatAmount: (minor: bigint) => string,
+  none: string,
+): string {
+  if (payers.length === 0) return none;
+  if (payers.length === 1) return nameOf(payers[0]!.member_id);
+  return payers
+    .map((row) => `${nameOf(row.member_id)} ${formatAmount(BigInt(row.amount))}`)
+    .join(', ');
+}

--- a/apps/mobile/src/sync/hooks.ts
+++ b/apps/mobile/src/sync/hooks.ts
@@ -22,6 +22,7 @@ import {
   type MirrorExpense,
   type SettlementSnapshot,
   type Transfer,
+  byNewest,
 } from '@waves/core';
 
 import type { GroupRow, MemberRow, SettlementRow } from '@/data/types';
@@ -43,7 +44,7 @@ export function useLocalGroups(): GroupRow[] {
     () =>
       (rowsFor(mirror, SyncTable.Groups) as unknown as GroupRow[])
         .filter((group) => !group.archived_at && !group.deleted_at)
-        .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at))),
+        .sort(byNewest((row) => String(row.created_at))),
     [mirror],
   );
 }

--- a/apps/mobile/test/expenseForm.test.ts
+++ b/apps/mobile/test/expenseForm.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The expense form's decisions.
+ *
+ * These are the parts of the add/edit route that quietly rewrite saved facts
+ * when they are wrong: the day an expense is filed under, and which of several
+ * payers' figures survive a tap. The route renders none of this in a test —
+ * mobile's vitest has no renderer by design — so the decisions live in
+ * src/lib/expenseForm.ts as plain functions and are checked here.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { rebalancePayers, type PayerMap } from '@waves/core';
+
+import {
+  expenseDateFor,
+  planCollapseToOne,
+  planEvenly,
+  planToggle,
+  planTypedAmount,
+  todayIso,
+} from '@/lib/expenseForm';
+
+const TODAY = '2026-09-01';
+const map = (rows: Record<string, bigint>): PayerMap => new Map(Object.entries(rows));
+
+/** What the route does with a plan: hand it to core and read the figures back. */
+const settle = (
+  plan: { selected: readonly string[]; current: PayerMap; locked: ReadonlySet<string> },
+  amount: bigint,
+): Record<string, string> =>
+  Object.fromEntries(
+    [
+      ...rebalancePayers({
+        amount,
+        selected: plan.selected,
+        current: plan.current,
+        locked: plan.locked,
+        seed: 'expense-1',
+      }),
+    ].map(([id, paid]) => [id, paid.toString()]),
+  );
+
+describe('expenseDateFor', () => {
+  it('keeps the day a saved expense already has', () => {
+    // The regression this exists for: editing a description used to re-file the
+    // expense under today, moving it between months and writing a date change
+    // into its history that nobody made.
+    expect(expenseDateFor({ captureDate: null, savedDate: '2026-08-11', today: TODAY })).toBe(
+      '2026-08-11',
+    );
+  });
+
+  it('files a genuinely new expense under today', () => {
+    expect(expenseDateFor({ captureDate: null, savedDate: null, today: TODAY })).toBe(TODAY);
+    expect(expenseDateFor({ captureDate: undefined, savedDate: undefined, today: TODAY })).toBe(
+      TODAY,
+    );
+  });
+
+  it('gives a capture the day it was caught, over both', () => {
+    expect(
+      expenseDateFor({ captureDate: '2026-07-04', savedDate: '2026-08-11', today: TODAY }),
+    ).toBe('2026-07-04');
+  });
+
+  it('writes a plain UTC day, never a timestamp', () => {
+    expect(todayIso(new Date('2026-09-01T22:45:00.000Z'))).toBe('2026-09-01');
+  });
+});
+
+describe('planToggle', () => {
+  const three = map({ a: 4000n, b: 3000n, c: 3000n });
+
+  it('replaces the payer in one-payer mode and hands over the whole bill', () => {
+    const plan = planToggle({
+      many: false,
+      payers: map({ a: 10000n }),
+      locked: new Set(),
+      amount: 10000n,
+      memberId: 'b',
+    });
+    expect(settle(plan!, 10000n)).toEqual({ b: '10000' });
+  });
+
+  it('adds a payer in several-payer mode and re-divides what is unlocked', () => {
+    const plan = planToggle({
+      many: true,
+      payers: map({ a: 10000n }),
+      locked: new Set(),
+      amount: 10000n,
+      memberId: 'b',
+    });
+    expect(plan!.selected).toEqual(['a', 'b']);
+    expect(settle(plan!, 10000n)).toEqual({ a: '5000', b: '5000' });
+  });
+
+  it('removes a payer, and drops the lock that went with them', () => {
+    const plan = planToggle({
+      many: true,
+      payers: three,
+      locked: new Set(['a', 'c']),
+      amount: 10000n,
+      memberId: 'c',
+    });
+    expect(plan!.selected).toEqual(['a', 'b']);
+    // c's lock is gone with c; a's is kept, so a's stated 4000 survives and b
+    // absorbs the rest. Keeping c's lock would have held a figure for a row
+    // that is no longer there and left the bill short by it.
+    expect(plan!.locked).toEqual(new Set(['a']));
+    expect(settle(plan!, 10000n)).toEqual({ a: '4000', b: '6000' });
+  });
+
+  it('refuses to remove the last payer', () => {
+    expect(
+      planToggle({
+        many: true,
+        payers: map({ a: 10000n }),
+        locked: new Set(),
+        amount: 10000n,
+        memberId: 'a',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('planCollapseToOne', () => {
+  it('keeps whoever put in the most, and gives them the whole bill', () => {
+    const plan = planCollapseToOne({
+      payers: map({ a: 2000n, b: 5000n, c: 3000n }),
+      amount: 10000n,
+    });
+    expect(settle(plan!, 10000n)).toEqual({ b: '10000' });
+  });
+
+  it('has nothing to do when one person is already paying', () => {
+    expect(planCollapseToOne({ payers: map({ a: 10000n }), amount: 10000n })).toBeNull();
+    expect(planCollapseToOne({ payers: map({}), amount: 10000n })).toBeNull();
+  });
+});
+
+describe('planTypedAmount', () => {
+  it('locks the figure that was typed and lets the others absorb', () => {
+    const plan = planTypedAmount({
+      payers: map({ a: 5000n, b: 5000n }),
+      locked: new Set(),
+      memberId: 'a',
+      text: '30',
+      currency: 'INR',
+    });
+    expect(plan.locked).toEqual(new Set(['a']));
+    expect(plan.typed).toEqual({ member: 'a', text: '30' });
+    expect(settle(plan, 10000n)).toEqual({ a: '3000', b: '7000' });
+  });
+
+  it('keeps a half-typed figure exactly as it was typed', () => {
+    // "12." must not snap back to "12.00" under the thumb mid-keystroke.
+    const plan = planTypedAmount({
+      payers: map({ a: 5000n, b: 5000n }),
+      locked: new Set(),
+      memberId: 'a',
+      text: '12.',
+      currency: 'INR',
+    });
+    expect(plan.typed?.text).toBe('12.');
+    expect(plan.current.get('a')).toBe(1200n);
+  });
+
+  it('reads the typed characters in the field currency, not in paise always', () => {
+    const yen = planTypedAmount({
+      payers: map({ a: 0n, b: 0n }),
+      locked: new Set(),
+      memberId: 'a',
+      text: '100',
+      currency: 'JPY',
+    });
+    expect(yen.current.get('a')).toBe(100n);
+  });
+
+  it('holds every stated figure, so an over-assigned bill is reported not rescaled', () => {
+    const plan = planTypedAmount({
+      payers: map({ a: 8000n, b: 5000n }),
+      locked: new Set(['b']),
+      memberId: 'a',
+      text: '80',
+      currency: 'INR',
+    });
+    // Both are locked now and they sum past the total. Nothing is quietly
+    // scaled down — the figures stand and the form says the bill is over.
+    expect(settle(plan, 10000n)).toEqual({ a: '8000', b: '5000' });
+  });
+});
+
+describe('planEvenly', () => {
+  it('drops every lock and splits the paying', () => {
+    const plan = planEvenly(map({ a: 9000n, b: 500n, c: 500n }));
+    expect(plan.locked.size).toBe(0);
+    // 10000 across three is 3333.34 short of even; core's rotation places the
+    // odd paisa, and the total is exact.
+    const settled = settle(plan, 10000n);
+    expect(Object.values(settled).reduce((sum, v) => sum + BigInt(v), 0n)).toBe(10000n);
+  });
+});

--- a/apps/mobile/test/payerLines.test.ts
+++ b/apps/mobile/test/payerLines.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Saying who paid.
+ *
+ * Two regressions live here. A list row that named `payers[0]` put a shared
+ * bill entirely on one person; an audit trail that compared only the set of
+ * names lost an edit that moved money between payers without changing the
+ * total. Both are decisions over plain rows, so both are checked here rather
+ * than on a screen.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { paidBy, payerAuditText, payerFactsKey } from '@/lib/payerLines';
+
+const rows = (pairs: [string, string][]) =>
+  pairs.map(([member_id, amount]) => ({ member_id, amount }));
+const nameOf = (id: string | null) => (id === null ? 'Someone' : id.toUpperCase());
+const rupees = (minor: bigint) => `₹${(Number(minor) / 100).toFixed(2)}`;
+
+describe('paidBy', () => {
+  it('names one payer and credits what they put in', () => {
+    expect(paidBy(rows([['asha', '100000']]))).toEqual({
+      kind: 'one',
+      memberId: 'asha',
+      amount: 100000n,
+    });
+  });
+
+  it('counts several, and totals what they put in between them', () => {
+    // The bug: this row used to read "Asha paid" over a bill Asha and Ravi
+    // split — the whole thing on whoever happened to sort first.
+    expect(
+      paidBy(
+        rows([
+          ['asha', '60000'],
+          ['ravi', '40000'],
+        ]),
+      ),
+    ).toEqual({ kind: 'several', count: 2, amount: 100000n });
+  });
+
+  it('treats a version with no payer rows as one unnamed payer', () => {
+    expect(paidBy([])).toEqual({ kind: 'one', memberId: null, amount: 0n });
+  });
+});
+
+describe('payerFactsKey', () => {
+  it('changes when money moves between payers on an unchanged total', () => {
+    // 600/400 → 500/500. Same total, so no amount line; same names, so the old
+    // name-only comparison showed nothing at all.
+    const before = payerFactsKey(
+      rows([
+        ['asha', '60000'],
+        ['ravi', '40000'],
+      ]),
+    );
+    const after = payerFactsKey(
+      rows([
+        ['asha', '50000'],
+        ['ravi', '50000'],
+      ]),
+    );
+    expect(before).not.toBe(after);
+  });
+
+  it('changes when the payers do', () => {
+    expect(payerFactsKey(rows([['asha', '100000']]))).not.toBe(
+      payerFactsKey(rows([['ravi', '100000']])),
+    );
+  });
+
+  it('does not change when only the row order does', () => {
+    expect(
+      payerFactsKey(
+        rows([
+          ['asha', '60000'],
+          ['ravi', '40000'],
+        ]),
+      ),
+    ).toBe(
+      payerFactsKey(
+        rows([
+          ['ravi', '40000'],
+          ['asha', '60000'],
+        ]),
+      ),
+    );
+  });
+});
+
+describe('payerAuditText', () => {
+  it('prints the figures when there are several payers', () => {
+    expect(
+      payerAuditText(
+        rows([
+          ['asha', '60000'],
+          ['ravi', '40000'],
+        ]),
+        nameOf,
+        rupees,
+        'None',
+      ),
+    ).toBe('ASHA ₹600.00, RAVI ₹400.00');
+  });
+
+  it('prints one payer as a name — the amount is the bill s own line', () => {
+    expect(payerAuditText(rows([['asha', '100000']]), nameOf, rupees, 'None')).toBe('ASHA');
+  });
+
+  it('says so when there are none', () => {
+    expect(payerAuditText([], nameOf, rupees, 'None')).toBe('None');
+  });
+});

--- a/apps/web/src/components/ExpenseForm.tsx
+++ b/apps/web/src/components/ExpenseForm.tsx
@@ -30,6 +30,7 @@ import { nameOf, type Group, type Member } from '@waves/api-client';
 
 import { baaki } from '@/lib/baaki';
 import { money as fmtMoney } from '@/lib/money';
+import { tooManyPayersForWeb } from '@/lib/editable';
 import { captureLocation, coordLabel, geolocationSupported, LocationFailure } from '@/lib/geo';
 import { fill } from '@/i18n';
 import { useStrings } from '@/i18n-context';
@@ -123,7 +124,7 @@ export function ExpenseForm({
           // Several payers is the app's own split; rewriting it here would
           // collapse everyone's contribution onto the first payer. Bail out to
           // the read-only note instead of silently changing the ledger.
-          if (version.payers.length > 1) {
+          if (tooManyPayersForWeb(version)) {
             setUnsupported(true);
             return;
           }

--- a/apps/web/src/lib/editable.ts
+++ b/apps/web/src/lib/editable.ts
@@ -1,0 +1,24 @@
+/**
+ * What the web's expense editor is allowed to open.
+ *
+ * The web form writes one payer and one of four split kinds. Anything the app
+ * can record and the form cannot express has to be refused rather than
+ * rewritten: opening a bill with three payers and saving it would put the whole
+ * amount on the first of them, silently, on an append-only ledger (ADR-004).
+ *
+ * The rule is here rather than inline in the form so it can be tested — the web
+ * suite runs in node with no renderer.
+ */
+
+/** Only the parts of a version this decision reads. */
+export interface EditableVersion {
+  readonly payers: readonly { readonly member_id: string }[];
+}
+
+/**
+ * True when the expense records several payers, which this editor cannot hold.
+ * The form shows its read-only note instead; the app can still edit it.
+ */
+export function tooManyPayersForWeb(version: EditableVersion): boolean {
+  return version.payers.length > 1;
+}

--- a/apps/web/test/editable.test.ts
+++ b/apps/web/test/editable.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The web editor's refusal to flatten a bill it cannot express.
+ *
+ * The app can record several payers; this form writes one. Without the guard,
+ * opening such an expense on the web and saving it would move everybody's
+ * contribution onto whoever came first — an invisible rewrite of a recorded
+ * fact on an append-only ledger.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { tooManyPayersForWeb } from '../src/lib/editable';
+
+describe('tooManyPayersForWeb', () => {
+  it('refuses a bill with several payers', () => {
+    expect(tooManyPayersForWeb({ payers: [{ member_id: 'a' }, { member_id: 'b' }] })).toBe(true);
+  });
+
+  it('opens the ordinary one-payer bill', () => {
+    expect(tooManyPayersForWeb({ payers: [{ member_id: 'a' }] })).toBe(false);
+  });
+
+  it('opens a bill with no payer rows rather than dead-ending on it', () => {
+    expect(tooManyPayersForWeb({ payers: [] })).toBe(false);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@
  * Deno edge functions, so all three compute identical money.
  */
 
+export * from './time/index';
 export * from './money/index';
 export * from './split/index';
 export * from './balances/index';

--- a/packages/core/src/money/index.ts
+++ b/packages/core/src/money/index.ts
@@ -1,6 +1,7 @@
 export * from './currency';
 export * from './money';
 export * from './format';
+export * from './input';
 export * from './fx';
 export * from './region';
 export * from './exposure';

--- a/packages/core/src/money/input.ts
+++ b/packages/core/src/money/input.ts
@@ -1,0 +1,81 @@
+/**
+ * Turning what somebody types into money, and back.
+ *
+ * Every money field in the app faces the same three problems: a keystroke can
+ * be junk ("1..2", "₹", "abc"), a half-typed number is legitimate ("12." is
+ * somebody on their way to "12.50"), and the currency decides how many decimal
+ * places exist at all — JPY has none, so a dot in a yen field is not a
+ * separator, it is a mistake.
+ *
+ * This lived privately inside the amount field until a bill could be paid by
+ * several people, at which point the same parsing had to happen in a row of
+ * per-payer fields too. Two copies of "how many decimal places does this
+ * currency have" is how a ₹10.5 becomes 105 paise on one screen and 1050 on
+ * another, so there is one copy, here, and it is integer-only: the value handed
+ * back is minor units and never passes through a float.
+ */
+
+import { minorUnitExponent, minorUnitScale, type CurrencyCode } from './currency';
+
+/**
+ * Clean one keystroke's worth of text: digits, and at most one decimal point in
+ * a currency that has decimal places at all. Trailing digits past the
+ * currency's precision are dropped rather than rounded — rounding what is still
+ * being typed moves the caret out from under somebody's thumb.
+ *
+ * Returns text, not a number, because the field has to be able to show "12."
+ * while it waits for the rest.
+ */
+export function sanitiseMinorInput(raw: string, currency: CurrencyCode): string {
+  const exponent = minorUnitExponent(currency);
+  let cleaned = raw.replace(/[^0-9.]/g, '');
+
+  if (exponent === 0) {
+    return cleaned.replace(/\./g, '').replace(/^0+(?=\d)/, '');
+  }
+
+  const firstDot = cleaned.indexOf('.');
+  if (firstDot !== -1) {
+    cleaned = cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, '');
+  }
+  // Drop a leading zero once real digits follow, but keep the "0" of "0.50".
+  cleaned = cleaned.replace(/^0+(?=\d)/, '');
+
+  const [, fraction = ''] = cleaned.split('.');
+  if (fraction.length > exponent) {
+    cleaned = cleaned.slice(0, cleaned.length - (fraction.length - exponent));
+  }
+  return cleaned;
+}
+
+/**
+ * Typed text as minor units. An empty field, or a lone dot, is zero rather than
+ * an error: it is somebody who has not finished, and a form mid-edit is not a
+ * validation failure. Assumes the text has been through `sanitiseMinorInput`;
+ * anything non-numeric that survives is ignored rather than becoming NaN.
+ */
+export function parseMinorInput(text: string, currency: CurrencyCode): bigint {
+  const cleaned = sanitiseMinorInput(text, currency);
+  if (cleaned === '' || cleaned === '.') return 0n;
+  const exponent = minorUnitExponent(currency);
+  const [whole = '0', fraction = ''] = cleaned.split('.');
+  const padded = fraction.slice(0, exponent).padEnd(exponent, '0');
+  return BigInt(whole || '0') * minorUnitScale(currency) + BigInt(padded === '' ? '0' : padded);
+}
+
+/**
+ * Minor units as the text a field should show. Zero comes back empty so the
+ * placeholder shows through instead of a literal "0" somebody has to delete
+ * before typing. Negative input is rendered by magnitude — no money field in
+ * this app can express a negative, and printing a minus that cannot be typed
+ * back would make the field un-round-trippable.
+ */
+export function formatMinorInput(minor: bigint, currency: CurrencyCode): string {
+  if (minor === 0n) return '';
+  const exponent = minorUnitExponent(currency);
+  const scale = minorUnitScale(currency);
+  const abs = minor < 0n ? -minor : minor;
+  const whole = (abs / scale).toString();
+  if (exponent === 0) return whole;
+  return `${whole}.${(abs % scale).toString().padStart(exponent, '0')}`;
+}

--- a/packages/core/src/split/index.ts
+++ b/packages/core/src/split/index.ts
@@ -1,6 +1,7 @@
 export * from './types';
 export * from './remainder';
 export * from './computeShares';
+export * from './payers';
 export * from './verify';
 export * from './wire';
 export * from './travel';

--- a/packages/core/src/split/payers.ts
+++ b/packages/core/src/split/payers.ts
@@ -1,0 +1,204 @@
+/**
+ * Who put the money in (TDR §3.1, the payer side of a split).
+ *
+ * The ledger has always been multi-payer: `expense_payers` is a table, the
+ * balance is `paid − owed` summed over every payer row, and both edge functions
+ * refuse a write whose payer rows do not add up to the total (`PAYER_MISMATCH`).
+ * What was missing was a way to *say* it — every client wrote one row for one
+ * person, so "she got the taxi, I got the tickets" had to be entered as two
+ * separate expenses, which is a different fact: it splits two bills instead of
+ * one, and it lands two rows in everybody's feed.
+ *
+ * This module is the arithmetic behind saying it. It is deliberately here and
+ * not in a screen: the rounding rule has to be the same one the *share* side
+ * uses (ADR-009 — floor everyone, rotate the leftover minor units by a seed
+ * derived from the expense id), or a ₹1000 bill split three ways by two payers
+ * would round two different ways in the same row and fail its own trigger.
+ *
+ * Everything here is pure, integer-only and deterministic. No currency is
+ * consulted: minor units are minor units, so a JPY bill (no decimal places) and
+ * an INR one behave identically.
+ */
+
+import { splitEqually } from './computeShares';
+import type { MemberId } from './types';
+
+/** Who paid what, in minor units of the expense's currency. */
+export type PayerMap = ReadonlyMap<MemberId, bigint>;
+
+export enum PayerProblemCode {
+  /** Nobody is marked as having paid. */
+  NoPayers = 'NO_PAYERS',
+  /** Somebody is down for a negative amount. */
+  Negative = 'NEGATIVE_PAYER_AMOUNT',
+  /** The payers add up to less than the bill. */
+  Short = 'PAYERS_SHORT',
+  /** The payers add up to more than the bill. */
+  Over = 'PAYERS_OVER',
+}
+
+export interface PayerProblem {
+  readonly code: PayerProblemCode;
+  /**
+   * `amount − Σ payers`: positive when there is still money to account for,
+   * negative when too much has been claimed. Zero for `NoPayers` and for
+   * `Negative`, where the sum may happen to come out right anyway.
+   */
+  readonly delta: bigint;
+  /** The offending member, for `Negative`. */
+  readonly member?: MemberId;
+}
+
+/** Σ of what every payer put in. */
+export function payerTotal(payers: PayerMap): bigint {
+  let total = 0n;
+  for (const paid of payers.values()) total += paid;
+  return total;
+}
+
+/**
+ * The one definition of "these payers are writable", matching what the
+ * `expense-write` and `/sync` edge functions enforce and what the SQL trigger
+ * enforces underneath both. A client that agrees with this never sees a
+ * `PAYER_MISMATCH` come back from the server.
+ *
+ * Returns `null` when the payers are good, so the caller reads as
+ * `const problem = validatePayers(...)`.
+ */
+export function validatePayers(amount: bigint, payers: PayerMap): PayerProblem | null {
+  if (payers.size === 0) {
+    return { code: PayerProblemCode.NoPayers, delta: amount };
+  }
+  // Stable order so that a bill with two negative entries always names the same
+  // one — a message that moves between renders reads as a flickering bug.
+  for (const member of stableIds(payers)) {
+    const paid = payers.get(member) ?? 0n;
+    if (paid < 0n) {
+      return { code: PayerProblemCode.Negative, delta: 0n, member };
+    }
+  }
+  const delta = amount - payerTotal(payers);
+  if (delta > 0n) return { code: PayerProblemCode.Short, delta };
+  if (delta < 0n) return { code: PayerProblemCode.Over, delta };
+  return null;
+}
+
+/**
+ * Divide the bill evenly between the people who paid it — "we each put in
+ * half". Exactly the share side's equal split, called on the payer side, so the
+ * leftover paisa is handed out by the same rule and the two sides of the row
+ * can never disagree about rounding.
+ *
+ * An empty list gives an empty map rather than throwing: a form mid-edit has a
+ * moment with nobody selected, and that is a validation state, not a crash.
+ */
+export function splitPaidEqually(
+  amount: bigint,
+  payerIds: readonly MemberId[],
+  seed: string,
+): Map<MemberId, bigint> {
+  if (payerIds.length === 0) return new Map();
+  return splitEqually(amount, payerIds, seed);
+}
+
+export interface RebalancePayersInput {
+  /** The bill's total, in minor units. */
+  readonly amount: bigint;
+  /** Who is currently marked as a payer. Order is irrelevant. */
+  readonly selected: readonly MemberId[];
+  /** What each payer is currently down for; ids outside `selected` are dropped. */
+  readonly current: PayerMap;
+  /**
+   * Payers whose amount was typed by a person and must survive verbatim.
+   * Everyone else absorbs whatever is left, evenly.
+   */
+  readonly locked: ReadonlySet<MemberId>;
+  /** The expense id — fixes which payer absorbs an odd minor unit. */
+  readonly seed: string;
+}
+
+/**
+ * Recompute the payer amounts after anything that can move them: the total was
+ * edited, somebody was added to or taken off the payer list, or one person's
+ * figure was typed in.
+ *
+ * The rule is "typed figures are facts, the rest is arithmetic": every locked
+ * payer keeps exactly what they were given, and the unlocked ones share what is
+ * left of the bill evenly. That is what makes the common gestures behave the way
+ * people expect — type ₹600 against Asha on a ₹1000 bill with two payers, and
+ * Ravi becomes ₹400 without being touched.
+ *
+ * Two deliberate refusals:
+ *
+ *   - Nothing is ever driven negative. If the locked figures already exceed the
+ *     bill, the unlocked payers go to zero and the overage is left for
+ *     `validatePayers` to report. Silently handing somebody −₹200 would make the
+ *     row add up while describing something that did not happen.
+ *   - Locked payers are never rescaled to fit. Somebody typed those numbers;
+ *     rewriting them to make the total work is the ledger inventing a fact.
+ *
+ * Note for callers: with a single selected payer who is locked, a change to the
+ * total leaves a mismatch by design — the UI drops the lock when the selection
+ * falls to one, so the lone payer always carries the whole bill.
+ */
+export function rebalancePayers(input: RebalancePayersInput): Map<MemberId, bigint> {
+  const selected = [...new Set(input.selected)];
+  const result = new Map<MemberId, bigint>();
+  if (selected.length === 0) return result;
+
+  const lockedIds: MemberId[] = [];
+  const unlockedIds: MemberId[] = [];
+  for (const member of selected) {
+    if (input.locked.has(member)) lockedIds.push(member);
+    else unlockedIds.push(member);
+  }
+
+  let lockedTotal = 0n;
+  for (const member of lockedIds) {
+    // A negative typed figure is clamped rather than propagated: the field that
+    // produced it cannot express one, and a stale draft should not be able to.
+    const paid = input.current.get(member) ?? 0n;
+    const kept = paid > 0n ? paid : 0n;
+    result.set(member, kept);
+    lockedTotal += kept;
+  }
+
+  if (unlockedIds.length === 0) return result;
+
+  const free = input.amount - lockedTotal;
+  if (free <= 0n) {
+    for (const member of unlockedIds) result.set(member, 0n);
+    return result;
+  }
+
+  for (const [member, paid] of splitPaidEqually(free, unlockedIds, input.seed)) {
+    result.set(member, paid);
+  }
+  return result;
+}
+
+/**
+ * The payer map as the wire wants it: `{ memberId: "1234" }` in minor units,
+ * with anybody down for nothing left out.
+ *
+ * Zero rows are dropped because they are not a fact about the world — a person
+ * who paid nothing is not a payer of the bill, and writing them as one puts a
+ * "₹0" line on the expense screen and a member in the notification fan-out who
+ * has no reason to be there. The one case that survives the drop is a zero-total
+ * expense, where the map legitimately empties; `validatePayers` accepts that
+ * only because Σ0 = 0, and every form refuses a zero total before it gets here.
+ */
+export function serialisePayers(payers: PayerMap): Record<MemberId, string> {
+  const wire: Record<MemberId, string> = {};
+  for (const member of stableIds(payers)) {
+    const paid = payers.get(member) ?? 0n;
+    if (paid === 0n) continue;
+    wire[member] = paid.toString();
+  }
+  return wire;
+}
+
+/** Ids in the stable order every device agrees on (ADR-009). */
+function stableIds(payers: PayerMap): MemberId[] {
+  return [...payers.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -220,8 +220,8 @@ export function overlayPending(
     applyPending(byId, mutation, options);
   }
 
-  return [...byId.values()].sort(
-    (a, b) => compareStampsDesc(String(a.created_at), String(b.created_at)),
+  return [...byId.values()].sort((a, b) =>
+    compareStampsDesc(String(a.created_at), String(b.created_at)),
   );
 }
 
@@ -440,8 +440,8 @@ export function materialiseSettlements(
     }
   }
 
-  return [...byId.values()].sort(
-    (a, b) => compareStampsDesc(String(a.initiated_at), String(b.initiated_at)),
+  return [...byId.values()].sort((a, b) =>
+    compareStampsDesc(String(a.initiated_at), String(b.initiated_at)),
   );
 }
 
@@ -795,8 +795,8 @@ export function materialiseCaptures(
     }
   }
 
-  return [...byId.values()].sort(
-    (a, b) => compareStampsDesc(String(a.created_at), String(b.created_at)),
+  return [...byId.values()].sort((a, b) =>
+    compareStampsDesc(String(a.created_at), String(b.created_at)),
   );
 }
 

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -42,6 +42,7 @@ import type {
   TagUpsertPayload,
 } from './protocol';
 import type { QueuedMutation } from './queue';
+import { byNewest, byOldest, compareStampsDesc } from '../time/iso';
 
 /** A row as the server sends it: snake_case, amounts as decimal strings. */
 export type MirrorRow = Readonly<Record<string, unknown>>;
@@ -219,8 +220,8 @@ export function overlayPending(
     applyPending(byId, mutation, options);
   }
 
-  return [...byId.values()].sort((a, b) =>
-    String(b.created_at).localeCompare(String(a.created_at)),
+  return [...byId.values()].sort(
+    (a, b) => compareStampsDesc(String(a.created_at), String(b.created_at)),
   );
 }
 
@@ -439,8 +440,8 @@ export function materialiseSettlements(
     }
   }
 
-  return [...byId.values()].sort((a, b) =>
-    String(b.initiated_at).localeCompare(String(a.initiated_at)),
+  return [...byId.values()].sort(
+    (a, b) => compareStampsDesc(String(a.initiated_at), String(b.initiated_at)),
   );
 }
 
@@ -636,7 +637,7 @@ export function materialiseGroups(
 ): MirrorGroup[] {
   return buildGroups(state, queue)
     .filter((group) => !group.archived_at && !group.deleted_at)
-    .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
+    .sort(byNewest((row) => String(row.created_at)));
 }
 
 /**
@@ -665,7 +666,7 @@ export function materialiseArchivedGroups(
 ): MirrorGroup[] {
   return buildGroups(state, queue)
     .filter((group) => Boolean(group.archived_at) && !group.deleted_at)
-    .sort((a, b) => String(b.archived_at ?? '').localeCompare(String(a.archived_at ?? '')));
+    .sort(byNewest((row) => row.archived_at));
 }
 
 // ───────────────────────────────────────────────── captures (A34) ──
@@ -794,8 +795,8 @@ export function materialiseCaptures(
     }
   }
 
-  return [...byId.values()].sort((a, b) =>
-    String(b.created_at).localeCompare(String(a.created_at)),
+  return [...byId.values()].sort(
+    (a, b) => compareStampsDesc(String(a.created_at), String(b.created_at)),
   );
 }
 
@@ -1135,7 +1136,7 @@ export function materialiseExpenseAttachments(
 ): MirrorExpenseAttachment[] {
   return (rowsFor(state, SyncTable.ExpenseAttachments) as MirrorExpenseAttachment[])
     .filter((row) => row.expense_id === options.expenseId && row.deleted_at === null)
-    .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''));
+    .sort(byNewest((row) => row.created_at));
 }
 
 export interface MirrorExpenseComment extends MirrorRow {
@@ -1160,7 +1161,7 @@ export function materialiseExpenseComments(
 ): MirrorExpenseComment[] {
   return (rowsFor(state, SyncTable.ExpenseComments) as MirrorExpenseComment[])
     .filter((row) => row.expense_id === options.expenseId && row.deleted_at === null)
-    .sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''));
+    .sort(byOldest((row) => row.created_at));
 }
 
 export interface MirrorExpenseImageEvent extends MirrorRow {
@@ -1185,7 +1186,7 @@ export function materialiseExpenseImageEvents(
 ): MirrorExpenseImageEvent[] {
   return (rowsFor(state, SyncTable.ExpenseImageEvents) as MirrorExpenseImageEvent[])
     .filter((row) => row.expense_id === options.expenseId)
-    .sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''));
+    .sort(byOldest((row) => row.created_at));
 }
 
 /** The plan to render: what has not been removed. */

--- a/packages/core/src/time/index.ts
+++ b/packages/core/src/time/index.ts
@@ -1,0 +1,1 @@
+export * from './iso';

--- a/packages/core/src/time/iso.ts
+++ b/packages/core/src/time/iso.ts
@@ -1,0 +1,65 @@
+/**
+ * Ordering ISO-8601 timestamps.
+ *
+ * Every feed in the app sorts by `created_at`, and every one of them reached
+ * for `String(b.created_at).localeCompare(String(a.created_at))`. That is a
+ * *collation* — it asks Intl how the user's language orders text, loads a
+ * collator, and applies locale rules to a string that is not language at all.
+ * On a fixed-format UTC timestamp the answer is always the same as a plain
+ * byte comparison, for about nine times the cost on V8 and considerably worse
+ * under Hermes.
+ *
+ * It matters because these sorts are not cold. The mirror re-materialises on
+ * every sync tick, and each pass re-sorts the group's expenses, its settlements
+ * and its whole activity log — so the collator ran thousands of times a second
+ * on a screen that was doing nothing but sitting there.
+ *
+ * The comparison is safe on exactly what the ledger stores: `YYYY-MM-DDTHH…Z`
+ * and `YYYY-MM-DD`, both fixed-width, zero-padded and UTC, which makes
+ * lexicographic order and chronological order the same order. It is *not* safe
+ * on mixed offsets ("+05:30" against "Z"), and nothing in the schema writes
+ * those — timestamps come back from Postgres normalised.
+ *
+ * Null and undefined sort last in both directions: a row with no timestamp is
+ * missing data, not the oldest thing that ever happened.
+ */
+
+type Stamp = string | null | undefined;
+
+/** A stamp that actually says something — not absent, and not the empty string
+ *  a nullable column turns into on the way through `String(...)`. Written as a
+ *  type predicate so the comparisons below narrow to `string`. */
+function present(stamp: Stamp): stamp is string {
+  return stamp != null && stamp !== '';
+}
+
+/**
+ * Ascending: oldest first, with the stamps that say nothing at the end.
+ *
+ * The missing check comes first and is direction-independent on purpose.
+ * Reversing an ordinary comparator by swapping its arguments also reverses
+ * where it puts the blanks, which is how "missing sorts last" silently becomes
+ * "missing sorts first" in one of the two directions.
+ */
+export function compareStamps(a: Stamp, b: Stamp): number {
+  if (!present(a)) return present(b) ? 1 : 0;
+  if (!present(b)) return -1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Descending: newest first, and still with the blanks at the end. */
+export function compareStampsDesc(a: Stamp, b: Stamp): number {
+  if (!present(a)) return present(b) ? 1 : 0;
+  if (!present(b)) return -1;
+  return a < b ? 1 : a > b ? -1 : 0;
+}
+
+/** Newest first — the order every feed in the app reads in. */
+export function byNewest<T>(stampOf: (row: T) => Stamp): (a: T, b: T) => number {
+  return (a, b) => compareStampsDesc(stampOf(a), stampOf(b));
+}
+
+/** Oldest first — settlement allocation, and anything replayed in order. */
+export function byOldest<T>(stampOf: (row: T) => Stamp): (a: T, b: T) => number {
+  return (a, b) => compareStamps(stampOf(a), stampOf(b));
+}

--- a/packages/core/test/isoOrder.test.ts
+++ b/packages/core/test/isoOrder.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The comparator every feed in the app now sorts by.
+ *
+ * It replaced `localeCompare`, which was doing locale-aware collation on UTC
+ * timestamps. The risk in that swap is not speed, it is *order*: if plain
+ * comparison ever disagreed with the collator on a real stamp, a feed would
+ * quietly reshuffle. So the properties below check the new comparator against
+ * actual chronology (`Date.parse`), not against the thing it replaced.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+
+import { byNewest, byOldest, compareStamps } from '../src/time/iso.js';
+
+/** ISO instants the way Postgres hands them back: UTC, fixed width. */
+const instants = (): fc.Arbitrary<string> =>
+  fc
+    .integer({ min: 0, max: 4_000_000_000 })
+    .map((seconds) => new Date(seconds * 1000).toISOString());
+
+/** Plain dates, the other stamp shape the ledger stores. */
+const dates = (): fc.Arbitrary<string> => instants().map((iso) => iso.slice(0, 10));
+
+describe('compareStamps', () => {
+  it('agrees with real chronology on every ISO instant', () => {
+    fc.assert(
+      fc.property(instants(), instants(), (a, b) => {
+        const bySign = Math.sign(compareStamps(a, b));
+        const byClock = Math.sign(Date.parse(a) - Date.parse(b));
+        expect(bySign).toBe(byClock);
+      }),
+    );
+  });
+
+  it('agrees with real chronology on plain dates too', () => {
+    fc.assert(
+      fc.property(dates(), dates(), (a, b) => {
+        expect(Math.sign(compareStamps(a, b))).toBe(Math.sign(Date.parse(a) - Date.parse(b)));
+      }),
+    );
+  });
+
+  it('matches what localeCompare used to answer', () => {
+    // The swap must be invisible in the output, only in the cost.
+    fc.assert(
+      fc.property(instants(), instants(), (a, b) => {
+        expect(Math.sign(compareStamps(a, b))).toBe(Math.sign(a.localeCompare(b)));
+      }),
+    );
+  });
+
+  it('puts a missing stamp last, whichever way it is read', () => {
+    const rows = [
+      { at: '2026-01-02T00:00:00.000Z' },
+      { at: null },
+      { at: '2026-03-04T00:00:00.000Z' },
+    ];
+    expect([...rows].sort(byNewest((r) => r.at)).map((r) => r.at)).toEqual([
+      '2026-03-04T00:00:00.000Z',
+      '2026-01-02T00:00:00.000Z',
+      null,
+    ]);
+    expect([...rows].sort(byOldest((r) => r.at)).map((r) => r.at)).toEqual([
+      '2026-01-02T00:00:00.000Z',
+      '2026-03-04T00:00:00.000Z',
+      null,
+    ]);
+  });
+
+  it('treats an empty string as missing, not as the beginning of time', () => {
+    expect(compareStamps('', '2026-01-01T00:00:00.000Z')).toBe(1);
+    expect(compareStamps('2026-01-01T00:00:00.000Z', '')).toBe(-1);
+    expect(compareStamps('', '')).toBe(0);
+    expect(compareStamps(undefined, null)).toBe(0);
+  });
+});
+
+describe('byNewest / byOldest', () => {
+  it('are exact reverses of each other on distinct stamps', () => {
+    fc.assert(
+      fc.property(fc.uniqueArray(instants(), { minLength: 1, maxLength: 30 }), (stamps) => {
+        const rows = stamps.map((at) => ({ at }));
+        const newest = [...rows].sort(byNewest((r) => r.at)).map((r) => r.at);
+        const oldest = [...rows].sort(byOldest((r) => r.at)).map((r) => r.at);
+        expect(newest).toEqual([...oldest].reverse());
+      }),
+    );
+  });
+
+  it('actually orders newest first', () => {
+    fc.assert(
+      fc.property(fc.array(instants(), { maxLength: 30 }), (stamps) => {
+        const sorted = stamps.map((at) => ({ at })).sort(byNewest((r) => r.at));
+        for (let i = 1; i < sorted.length; i += 1) {
+          expect(Date.parse(sorted[i - 1]!.at) >= Date.parse(sorted[i]!.at)).toBe(true);
+        }
+      }),
+    );
+  });
+});

--- a/packages/core/test/moneyInput.test.ts
+++ b/packages/core/test/moneyInput.test.ts
@@ -1,0 +1,116 @@
+/**
+ * What a money field does with what somebody types.
+ *
+ * These are the rules the amount hero and the per-payer fields both run on, so
+ * a break here is a break in every money input in the app at once.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+
+import {
+  formatMinorInput,
+  parseMinorInput,
+  sanitiseMinorInput,
+  type CurrencyCode,
+} from '../src/money/index.js';
+
+const CURRENCIES: CurrencyCode[] = ['INR', 'USD', 'EUR', 'JPY'];
+
+describe('sanitiseMinorInput', () => {
+  it('strips anything that is not a digit or a separator', () => {
+    expect(sanitiseMinorInput('₹1,2 3abc', 'INR')).toBe('123');
+  });
+
+  it('keeps only the first decimal point', () => {
+    expect(sanitiseMinorInput('1.2.3', 'INR')).toBe('1.23');
+  });
+
+  it('lets a half-typed number stand', () => {
+    expect(sanitiseMinorInput('12.', 'INR')).toBe('12.');
+    expect(sanitiseMinorInput('0.', 'INR')).toBe('0.');
+  });
+
+  it('drops a leading zero once real digits follow, but keeps "0.50"', () => {
+    expect(sanitiseMinorInput('0012', 'INR')).toBe('12');
+    expect(sanitiseMinorInput('0.50', 'INR')).toBe('0.50');
+  });
+
+  it('refuses a decimal point in a currency that has no minor unit', () => {
+    expect(sanitiseMinorInput('1.5', 'JPY')).toBe('15');
+    expect(sanitiseMinorInput('1000', 'JPY')).toBe('1000');
+  });
+
+  it('truncates past the currency precision rather than rounding it', () => {
+    // Rounding what is still being typed would move the caret under a thumb.
+    expect(sanitiseMinorInput('1.999', 'INR')).toBe('1.99');
+  });
+
+  it('is idempotent — cleaning clean text changes nothing', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.constantFrom(...CURRENCIES), (raw, currency) => {
+        const once = sanitiseMinorInput(raw, currency);
+        expect(sanitiseMinorInput(once, currency)).toBe(once);
+      }),
+    );
+  });
+});
+
+describe('parseMinorInput', () => {
+  it('reads rupees and paise', () => {
+    expect(parseMinorInput('10', 'INR')).toBe(1000n);
+    expect(parseMinorInput('10.5', 'INR')).toBe(1050n);
+    expect(parseMinorInput('10.50', 'INR')).toBe(1050n);
+    expect(parseMinorInput('0.07', 'INR')).toBe(7n);
+  });
+
+  it('reads a currency with no minor unit as whole units', () => {
+    expect(parseMinorInput('1000', 'JPY')).toBe(1000n);
+  });
+
+  it('treats an unfinished field as zero, not as an error', () => {
+    expect(parseMinorInput('', 'INR')).toBe(0n);
+    expect(parseMinorInput('.', 'INR')).toBe(0n);
+    expect(parseMinorInput('abc', 'INR')).toBe(0n);
+  });
+
+  it('never produces a negative — no money field can express one', () => {
+    expect(parseMinorInput('-50', 'INR')).toBe(5000n);
+  });
+
+  it('holds a number far past what a float could', () => {
+    expect(parseMinorInput('90071992547409.93', 'INR')).toBe(9_007_199_254_740_993n);
+  });
+});
+
+describe('round trip', () => {
+  it('format → parse returns the same minor units, in every currency', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 0n, max: 10n ** 15n }),
+        fc.constantFrom(...CURRENCIES),
+        (minor, currency) => {
+          expect(parseMinorInput(formatMinorInput(minor, currency), currency)).toBe(minor);
+        },
+      ),
+    );
+  });
+
+  it('parse → format is stable once it has been through both', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.constantFrom(...CURRENCIES), (raw, currency) => {
+        const settled = formatMinorInput(parseMinorInput(raw, currency), currency);
+        expect(formatMinorInput(parseMinorInput(settled, currency), currency)).toBe(settled);
+      }),
+    );
+  });
+
+  it('shows an empty field for zero so the placeholder survives', () => {
+    for (const currency of CURRENCIES) expect(formatMinorInput(0n, currency)).toBe('');
+  });
+
+  it('pads the minor part so ₹10.05 is not shown as ₹10.5', () => {
+    expect(formatMinorInput(1005n, 'INR')).toBe('10.05');
+    expect(formatMinorInput(1050n, 'INR')).toBe('10.50');
+  });
+});

--- a/packages/core/test/payers.offline.test.ts
+++ b/packages/core/test/payers.offline.test.ts
@@ -1,0 +1,248 @@
+/**
+ * A bill several people paid, all the way down the offline-first path.
+ *
+ * `payers.test.ts` proves the arithmetic. This proves the *plumbing*: that a
+ * multi-payer expense queued on a plane shows the right balance before it ever
+ * reaches a server, that editing it re-versions rather than duplicates, and that
+ * what the mirror replays matches what the server would have computed.
+ *
+ * The pipeline here is the one `useGroupLedger` runs to produce the group hero
+ * number — mirror + queue overlay, materialised, netted (ADR-005) — so a break
+ * in this file is a wrong number on somebody's screen, not a failing abstraction.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  balanceSums,
+  computeNetBalances,
+  emptyMirror,
+  enqueue,
+  liveExpenses,
+  materialiseExpenses,
+  MutationKind,
+  payerTotal,
+  serialisePayers,
+  splitPaidEqually,
+  toExpenseSnapshot,
+  validatePayers,
+  type ExpenseCreatePayload,
+  type ExpenseSnapshot,
+  type MemberId,
+  type MirrorState,
+  type QueuedMutation,
+} from '../src/index.js';
+
+const INR = 'INR';
+const GROUP = 'goa';
+
+const ASHA: MemberId = 'm-asha';
+const RAVI: MemberId = 'm-ravi';
+const MO: MemberId = 'm-mo';
+const SAM: MemberId = 'm-sam';
+const EVERYONE = [ASHA, RAVI, MO, SAM];
+
+/** Queue a create, the way the add-expense screen does. */
+function queueCreate(
+  queue: readonly QueuedMutation[],
+  payload: ExpenseCreatePayload,
+  clientMutationId: string,
+): QueuedMutation[] {
+  return enqueue(queue, {
+    clientMutationId,
+    kind: MutationKind.ExpenseCreate,
+    groupId: GROUP,
+    clientCreatedAt: '2026-09-01T00:00:00.000Z',
+    payload,
+  });
+}
+
+/** Every live expense the group has, mirror plus anything still unsent. */
+function snapshots(mirror: MirrorState, queue: readonly QueuedMutation[]): ExpenseSnapshot[] {
+  return liveExpenses(materialiseExpenses(mirror, queue, { groupId: GROUP }))
+    .map(toExpenseSnapshot)
+    .filter((snapshot): snapshot is ExpenseSnapshot => snapshot !== null);
+}
+
+/** The group hero's number for one member. */
+function balance(mirror: MirrorState, queue: readonly QueuedMutation[], member: MemberId): bigint {
+  return computeNetBalances(snapshots(mirror, queue), []).get(INR)?.get(member) ?? 0n;
+}
+
+describe('a multi-payer bill queued offline', () => {
+  it('nets correctly before it has ever reached a server', () => {
+    // ₹1000 dinner for four. Asha put in ₹600, Ravi ₹400.
+    const payers = new Map([
+      [ASHA, 60_000n],
+      [RAVI, 40_000n],
+    ]);
+    expect(validatePayers(100_000n, payers)).toBeNull();
+
+    const queue = queueCreate(
+      [],
+      {
+        expenseId: 'e-dinner',
+        description: 'Beach shack dinner',
+        expenseDate: '2026-09-01',
+        currency: INR,
+        amount: '100000',
+        splitParams: { kind: 'equal' },
+        participants: EVERYONE,
+        payers: serialisePayers(payers),
+      },
+      'cm-1',
+    );
+
+    const mirror = emptyMirror();
+    expect(balance(mirror, queue, ASHA)).toBe(35_000n); // paid 600, owes 250
+    expect(balance(mirror, queue, RAVI)).toBe(15_000n); // paid 400, owes 250
+    expect(balance(mirror, queue, MO)).toBe(-25_000n);
+    expect(balance(mirror, queue, SAM)).toBe(-25_000n);
+    expect(balanceSums(computeNetBalances(snapshots(mirror, queue), [])).get(INR)).toBe(0n);
+  });
+
+  it('is one expense in the ledger, not one per payer', () => {
+    const queue = queueCreate(
+      [],
+      {
+        expenseId: 'e-dinner',
+        description: 'Beach shack dinner',
+        expenseDate: '2026-09-01',
+        currency: INR,
+        amount: '100000',
+        splitParams: { kind: 'equal' },
+        participants: EVERYONE,
+        payers: { [ASHA]: '60000', [RAVI]: '40000' },
+      },
+      'cm-1',
+    );
+    const rows = snapshots(emptyMirror(), queue);
+    expect(rows).toHaveLength(1);
+    expect(Object.keys(rows[0]?.payers ?? {})).toHaveLength(2);
+  });
+
+  it('survives the round trip through the wire form the queue stores', () => {
+    // The payload holds decimal strings, because JSON has no bigint. What comes
+    // back out of the mirror has to be the same money that went in.
+    const paid = splitPaidEqually(100_001n, [ASHA, RAVI, MO], 'e-odd');
+    const queue = queueCreate(
+      [],
+      {
+        expenseId: 'e-odd',
+        description: 'Auto',
+        expenseDate: '2026-09-01',
+        currency: INR,
+        amount: '100001',
+        splitParams: { kind: 'equal' },
+        participants: EVERYONE,
+        payers: serialisePayers(paid),
+      },
+      'cm-odd',
+    );
+    const row = snapshots(emptyMirror(), queue)[0] as ExpenseSnapshot;
+    const back = new Map(Object.entries(row.payers));
+    expect(payerTotal(back)).toBe(100_001n);
+    expect(payerTotal(back)).toBe(row.amount);
+  });
+
+  it('editing it to a single payer moves the money without duplicating the row', () => {
+    let queue = queueCreate(
+      [],
+      {
+        expenseId: 'e-dinner',
+        description: 'Beach shack dinner',
+        expenseDate: '2026-09-01',
+        currency: INR,
+        amount: '100000',
+        splitParams: { kind: 'equal' },
+        participants: [ASHA, RAVI],
+        payers: { [ASHA]: '60000', [RAVI]: '40000' },
+      },
+      'cm-1',
+    );
+    // The correction: Ravi actually paid the whole thing.
+    queue = enqueue(queue, {
+      clientMutationId: 'cm-2',
+      kind: MutationKind.ExpenseUpdate,
+      groupId: GROUP,
+      clientCreatedAt: '2026-09-01T01:00:00.000Z',
+      payload: {
+        expenseId: 'e-dinner',
+        description: 'Beach shack dinner',
+        expenseDate: '2026-09-01',
+        currency: INR,
+        amount: '100000',
+        splitParams: { kind: 'equal' },
+        participants: [ASHA, RAVI],
+        payers: { [RAVI]: '100000' },
+      },
+    });
+
+    const rows = snapshots(emptyMirror(), queue);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.payers).toEqual({ [RAVI]: 100_000n });
+    expect(balance(emptyMirror(), queue, ASHA)).toBe(-50_000n);
+    expect(balance(emptyMirror(), queue, RAVI)).toBe(50_000n);
+  });
+
+  it('several multi-payer bills in one queue still sum to zero across the group', () => {
+    let queue = queueCreate(
+      [],
+      {
+        expenseId: 'e-1',
+        description: 'Hotel',
+        expenseDate: '2026-09-01',
+        currency: INR,
+        amount: '333333',
+        splitParams: { kind: 'equal' },
+        participants: EVERYONE,
+        payers: serialisePayers(splitPaidEqually(333_333n, [ASHA, RAVI, MO], 'e-1')),
+      },
+      'cm-1',
+    );
+    queue = queueCreate(
+      queue,
+      {
+        expenseId: 'e-2',
+        description: 'Boat',
+        expenseDate: '2026-09-02',
+        currency: INR,
+        amount: '77777',
+        splitParams: {
+          kind: 'shares' as const,
+          weights: { [ASHA]: 2, [RAVI]: 1, [MO]: 1, [SAM]: 1 },
+        },
+        participants: EVERYONE,
+        payers: { [SAM]: '50000', [MO]: '27777' },
+      },
+      'cm-2',
+    );
+
+    const rows = snapshots(emptyMirror(), queue);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(payerTotal(new Map(Object.entries(row.payers)))).toBe(row.amount);
+    }
+    expect(balanceSums(computeNetBalances(rows, [])).get(INR)).toBe(0n);
+  });
+
+  it('a payer who is not in the split still shows up as a creditor', () => {
+    const queue = queueCreate(
+      [],
+      {
+        expenseId: 'e-gift',
+        description: 'Dad chipped in',
+        expenseDate: '2026-09-01',
+        currency: INR,
+        amount: '60000',
+        splitParams: { kind: 'equal' },
+        participants: [ASHA, RAVI],
+        payers: { [MO]: '30000', [ASHA]: '30000' },
+      },
+      'cm-gift',
+    );
+    expect(balance(emptyMirror(), queue, MO)).toBe(30_000n);
+    expect(balance(emptyMirror(), queue, ASHA)).toBe(0n);
+    expect(balance(emptyMirror(), queue, RAVI)).toBe(-30_000n);
+  });
+});

--- a/packages/core/test/payers.test.ts
+++ b/packages/core/test/payers.test.ts
@@ -1,0 +1,541 @@
+/**
+ * The payer side of a split: several people putting money into one bill.
+ *
+ * Three layers here, because the failure modes are different at each:
+ *
+ *   1. Properties — the invariants that must hold for every input, checked with
+ *      fast-check. Σ payers = amount is the one the SQL trigger and both edge
+ *      functions enforce, so a client that can violate it is a client that ships
+ *      PAYER_MISMATCH errors to real people.
+ *   2. Behaviour — what the form actually does when somebody types, retypes,
+ *      adds a payer, removes one, or changes the total afterwards. These are the
+ *      gestures that break naive implementations.
+ *   3. Scenarios — whole expenses run end to end through computeShares and
+ *      computeNetBalances, so "Asha got the taxi, I got the tickets" comes out
+ *      of the ledger as the right net position and not merely as a row that
+ *      happens to add up.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+
+import {
+  computeShares,
+  payerTotal,
+  PayerProblemCode,
+  rebalancePayers,
+  serialisePayers,
+  splitPaidEqually,
+  validatePayers,
+  type MemberId,
+  type PayerMap,
+} from '../src/split/index.js';
+import { computeNetBalances, balanceOf, balanceSums } from '../src/balances/balances.js';
+import type { ExpenseSnapshot } from '../src/balances/types.js';
+import { amounts, memberIds, positiveAmounts, seeds } from './arbitraries.js';
+
+const map = (entries: Record<string, bigint>): PayerMap => new Map(Object.entries(entries));
+const lock = (...ids: string[]): ReadonlySet<MemberId> => new Set(ids);
+
+// ─────────────────────────────────────────────────────────── properties ──
+
+describe('splitPaidEqually', () => {
+  it('always adds up to the bill, whoever pays it', () => {
+    fc.assert(
+      fc.property(amounts(), memberIds(1, 8), seeds(), (amount, ids, seed) => {
+        const paid = splitPaidEqually(amount, ids, seed);
+        expect(payerTotal(paid)).toBe(amount);
+        expect(paid.size).toBe(ids.length);
+      }),
+    );
+  });
+
+  it('never spreads two payers more than one minor unit apart', () => {
+    fc.assert(
+      fc.property(amounts(), memberIds(1, 8), seeds(), (amount, ids, seed) => {
+        const values = [...splitPaidEqually(amount, ids, seed).values()];
+        const high = values.reduce((a, b) => (a > b ? a : b));
+        const low = values.reduce((a, b) => (a < b ? a : b));
+        expect(high - low <= 1n).toBe(true);
+      }),
+    );
+  });
+
+  it('is deterministic — two devices computing the same bill agree', () => {
+    fc.assert(
+      fc.property(amounts(), memberIds(1, 8), seeds(), (amount, ids, seed) => {
+        const first = splitPaidEqually(amount, ids, seed);
+        // Same members, opposite order: the stable-order rule must erase it.
+        const second = splitPaidEqually(amount, [...ids].reverse(), seed);
+        expect([...first.entries()].sort()).toEqual([...second.entries()].sort());
+      }),
+    );
+  });
+
+  it('gives an empty map rather than throwing when nobody is selected', () => {
+    expect(splitPaidEqually(1000n, [], 'seed').size).toBe(0);
+  });
+
+  it('hands the whole bill to a lone payer', () => {
+    fc.assert(
+      fc.property(amounts(), seeds(), (amount, seed) => {
+        expect(splitPaidEqually(amount, ['solo'], seed).get('solo')).toBe(amount);
+      }),
+    );
+  });
+});
+
+describe('validatePayers', () => {
+  it('accepts exactly the payer sets the server accepts', () => {
+    fc.assert(
+      fc.property(
+        amounts(),
+        memberIds(1, 6),
+        fc.array(fc.bigInt({ min: -5000n, max: 5000n }), { minLength: 1, maxLength: 6 }),
+        (amount, ids, raw) => {
+          const payers = new Map<MemberId, bigint>();
+          ids.forEach((id, index) => payers.set(id, raw[index % raw.length] ?? 0n));
+
+          const problem = validatePayers(amount, payers);
+          // The server's rule, written out independently of the implementation.
+          const serverWouldAccept =
+            payers.size > 0 &&
+            [...payers.values()].every((value) => value >= 0n) &&
+            payerTotal(payers) === amount;
+          expect(problem === null).toBe(serverWouldAccept);
+        },
+      ),
+    );
+  });
+
+  it('reports the shortfall as a signed delta the UI can print', () => {
+    expect(validatePayers(10_000n, map({ a: 6000n }))).toEqual({
+      code: PayerProblemCode.Short,
+      delta: 4000n,
+    });
+    expect(validatePayers(10_000n, map({ a: 6000n, b: 6000n }))).toEqual({
+      code: PayerProblemCode.Over,
+      delta: -2000n,
+    });
+  });
+
+  it('refuses an empty payer list', () => {
+    expect(validatePayers(10_000n, new Map())).toEqual({
+      code: PayerProblemCode.NoPayers,
+      delta: 10_000n,
+    });
+  });
+
+  it('names a negative payer, and names the same one every time', () => {
+    const problem = validatePayers(0n, map({ zeta: -100n, alpha: -100n, m: 200n }));
+    expect(problem?.code).toBe(PayerProblemCode.Negative);
+    expect(problem?.member).toBe('alpha');
+    // Σ is 0 here, so "adds up" is not enough on its own — the sign check has to
+    // come first or a bill can balance out of two impossible halves.
+    expect(payerTotal(map({ zeta: -100n, alpha: -100n, m: 200n }))).toBe(0n);
+  });
+
+  it('accepts a zero-total bill with a zero payer (Σ0 = 0)', () => {
+    expect(validatePayers(0n, map({ a: 0n }))).toBeNull();
+  });
+});
+
+describe('rebalancePayers', () => {
+  it('always lands on the exact total when somebody is free to absorb it', () => {
+    fc.assert(
+      fc.property(
+        positiveAmounts(),
+        memberIds(1, 6),
+        fc.nat({ max: 5 }),
+        seeds(),
+        (amount, ids, lockCount, seed) => {
+          // Lock a prefix and give the locked members figures that cannot alone
+          // exceed the bill, so at least one unlocked payer remains free.
+          const lockedIds = ids.slice(0, Math.min(lockCount, ids.length - 1));
+          const current = new Map<MemberId, bigint>(
+            lockedIds.map((id) => [id, amount / BigInt(ids.length + 1)]),
+          );
+          const next = rebalancePayers({
+            amount,
+            selected: ids,
+            current,
+            locked: new Set(lockedIds),
+            seed,
+          });
+          expect(payerTotal(next)).toBe(amount);
+          expect(validatePayers(amount, next)).toBeNull();
+        },
+      ),
+    );
+  });
+
+  it('never drives anybody negative, whatever the locked figures are', () => {
+    fc.assert(
+      fc.property(
+        amounts(),
+        memberIds(2, 6),
+        fc.bigInt({ min: 0n, max: 50_000_000n }),
+        seeds(),
+        (amount, ids, lockedValue, seed) => {
+          const [first, ...rest] = ids as [MemberId, ...MemberId[]];
+          const next = rebalancePayers({
+            amount,
+            selected: ids,
+            current: map({ [first]: lockedValue }),
+            locked: lock(first),
+            seed,
+          });
+          for (const paid of next.values()) expect(paid >= 0n).toBe(true);
+          // The locked figure survives verbatim even when it breaks the total —
+          // it is a fact somebody typed, not a variable to solve for.
+          expect(next.get(first)).toBe(lockedValue);
+          if (lockedValue > amount) {
+            for (const id of rest) expect(next.get(id)).toBe(0n);
+            expect(validatePayers(amount, next)?.code).toBe(PayerProblemCode.Over);
+          }
+        },
+      ),
+    );
+  });
+
+  it('only ever returns the selected payers', () => {
+    fc.assert(
+      fc.property(amounts(), memberIds(1, 5), memberIds(1, 5), seeds(), (amount, keep, drop, s) => {
+        const stale = new Map<MemberId, bigint>([...keep, ...drop].map((id) => [id, 100n]));
+        const next = rebalancePayers({
+          amount,
+          selected: keep,
+          current: stale,
+          locked: new Set(),
+          seed: s,
+        });
+        for (const id of next.keys()) expect(keep).toContain(id);
+        for (const id of drop) if (!keep.includes(id)) expect(next.has(id)).toBe(false);
+      }),
+    );
+  });
+
+  it('is idempotent — rebalancing an already-balanced set changes nothing', () => {
+    fc.assert(
+      fc.property(positiveAmounts(), memberIds(1, 6), seeds(), (amount, ids, seed) => {
+        const once = rebalancePayers({
+          amount,
+          selected: ids,
+          current: new Map(),
+          locked: new Set(),
+          seed,
+        });
+        const twice = rebalancePayers({
+          amount,
+          selected: ids,
+          current: once,
+          locked: new Set(),
+          seed,
+        });
+        expect([...twice.entries()]).toEqual([...once.entries()]);
+      }),
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────── gestures ──
+
+describe('the gestures a person actually makes', () => {
+  const seed = 'exp-1';
+
+  it('one payer carries the whole bill', () => {
+    const next = rebalancePayers({
+      amount: 100_000n,
+      selected: ['asha'],
+      current: new Map(),
+      locked: new Set(),
+      seed,
+    });
+    expect(next.get('asha')).toBe(100_000n);
+  });
+
+  it('adding a second payer splits the paying in half', () => {
+    const next = rebalancePayers({
+      amount: 100_000n,
+      selected: ['asha', 'ravi'],
+      current: map({ asha: 100_000n }),
+      locked: new Set(),
+      seed,
+    });
+    expect(next.get('asha')).toBe(50_000n);
+    expect(next.get('ravi')).toBe(50_000n);
+  });
+
+  it('typing one figure moves the other, not the total', () => {
+    const next = rebalancePayers({
+      amount: 100_000n,
+      selected: ['asha', 'ravi'],
+      current: map({ asha: 60_000n, ravi: 50_000n }),
+      locked: lock('asha'),
+      seed,
+    });
+    expect(next.get('asha')).toBe(60_000n);
+    expect(next.get('ravi')).toBe(40_000n);
+    expect(payerTotal(next)).toBe(100_000n);
+  });
+
+  it('two typed figures leave the third to make up the difference', () => {
+    const next = rebalancePayers({
+      amount: 100_000n,
+      selected: ['asha', 'ravi', 'mo'],
+      current: map({ asha: 60_000n, ravi: 25_000n }),
+      locked: lock('asha', 'ravi'),
+      seed,
+    });
+    expect(next.get('mo')).toBe(15_000n);
+  });
+
+  it('raising the total after the fact goes to whoever was not typed in', () => {
+    const next = rebalancePayers({
+      amount: 120_000n,
+      selected: ['asha', 'ravi'],
+      current: map({ asha: 60_000n, ravi: 40_000n }),
+      locked: lock('asha'),
+      seed,
+    });
+    expect(next.get('asha')).toBe(60_000n);
+    expect(next.get('ravi')).toBe(60_000n);
+  });
+
+  it('typed figures that overshoot the bill are kept and reported, not trimmed', () => {
+    const next = rebalancePayers({
+      amount: 100_000n,
+      selected: ['asha', 'ravi'],
+      current: map({ asha: 90_000n, ravi: 40_000n }),
+      locked: lock('asha', 'ravi'),
+      seed,
+    });
+    expect(next.get('asha')).toBe(90_000n);
+    expect(next.get('ravi')).toBe(40_000n);
+    expect(validatePayers(100_000n, next)).toEqual({
+      code: PayerProblemCode.Over,
+      delta: -30_000n,
+    });
+  });
+
+  it('dropping a payer hands their money back to the others', () => {
+    const next = rebalancePayers({
+      amount: 90_000n,
+      selected: ['asha', 'ravi'],
+      current: map({ asha: 30_000n, ravi: 30_000n, mo: 30_000n }),
+      locked: new Set(),
+      seed,
+    });
+    expect(next.has('mo')).toBe(false);
+    expect(next.get('asha')).toBe(45_000n);
+    expect(next.get('ravi')).toBe(45_000n);
+  });
+
+  it('dropping every payer but one leaves that one holding the bill', () => {
+    const next = rebalancePayers({
+      amount: 90_000n,
+      selected: ['asha'],
+      current: map({ asha: 30_000n, ravi: 60_000n }),
+      locked: new Set(),
+      seed,
+    });
+    expect([...next.entries()]).toEqual([['asha', 90_000n]]);
+  });
+
+  it('splits an odd amount without losing or inventing a paisa', () => {
+    const next = rebalancePayers({
+      amount: 100_001n,
+      selected: ['a', 'b', 'c'],
+      current: new Map(),
+      locked: new Set(),
+      seed,
+    });
+    expect(payerTotal(next)).toBe(100_001n);
+    expect([...next.values()].filter((v) => v === 33_334n)).toHaveLength(2);
+    expect([...next.values()].filter((v) => v === 33_333n)).toHaveLength(1);
+  });
+
+  it('works in a currency with no minor unit (JPY: nothing to round to)', () => {
+    const next = rebalancePayers({
+      amount: 10_000n,
+      selected: ['a', 'b', 'c'],
+      current: new Map(),
+      locked: new Set(),
+      seed,
+    });
+    expect(payerTotal(next)).toBe(10_000n);
+    expect([...next.values()].sort()).toEqual([3333n, 3333n, 3334n]);
+  });
+});
+
+describe('serialisePayers', () => {
+  it('drops the people who put nothing in', () => {
+    expect(serialisePayers(map({ asha: 60_000n, ravi: 0n }))).toEqual({ asha: '60000' });
+  });
+
+  it('emits decimal strings, because JSON has no bigint', () => {
+    const wire = serialisePayers(map({ asha: 9_007_199_254_740_993n }));
+    expect(wire.asha).toBe('9007199254740993');
+  });
+
+  it('round-trips back to the same total the server will check', () => {
+    fc.assert(
+      fc.property(amounts(), memberIds(1, 6), seeds(), (amount, ids, seed) => {
+        const paid = splitPaidEqually(amount, ids, seed);
+        const wire = serialisePayers(paid);
+        const back = new Map(Object.entries(wire).map(([id, v]) => [id, BigInt(v)]));
+        expect(payerTotal(back)).toBe(amount);
+      }),
+    );
+  });
+});
+
+// ──────────────────────────────────────────────────────────── scenarios ──
+
+/** Build the snapshot the balance engine reads, the way a real write would. */
+function expenseOf(
+  id: string,
+  amount: bigint,
+  payers: Record<MemberId, bigint>,
+  participants: readonly MemberId[],
+): ExpenseSnapshot {
+  const shares = computeShares({
+    amount,
+    currency: 'INR',
+    params: { kind: 'equal' },
+    participants,
+    seed: id,
+  });
+  return {
+    id,
+    currency: 'INR',
+    amount,
+    payers,
+    shares: Object.fromEntries(shares),
+    date: '2026-09-01',
+  };
+}
+
+describe('a multi-payer bill, end to end through the ledger', () => {
+  it('"she got the taxi, I got the tickets" nets out correctly', () => {
+    // ₹1000 dinner, split four ways (₹250 each). Asha put in ₹600, Ravi ₹400.
+    const expense = expenseOf('exp-dinner', 100_000n, { asha: 60_000n, ravi: 40_000n }, [
+      'asha',
+      'ravi',
+      'mo',
+      'sam',
+    ]);
+    expect(validatePayers(expense.amount, map(expense.payers))).toBeNull();
+
+    const balances = computeNetBalances([expense], []);
+    expect(balanceOf(balances, 'asha', 'INR')).toBe(35_000n); // paid 600, owes 250
+    expect(balanceOf(balances, 'ravi', 'INR')).toBe(15_000n); // paid 400, owes 250
+    expect(balanceOf(balances, 'mo', 'INR')).toBe(-25_000n);
+    expect(balanceOf(balances, 'sam', 'INR')).toBe(-25_000n);
+    expect(balanceSums(balances).get('INR')).toBe(0n);
+  });
+
+  it('a payer who owes nothing is a creditor, not a participant', () => {
+    // Dad pays half the bill but is not on the split at all.
+    const expense = expenseOf('exp-gift', 60_000n, { dad: 30_000n, asha: 30_000n }, [
+      'asha',
+      'ravi',
+    ]);
+    const balances = computeNetBalances([expense], []);
+    expect(balanceOf(balances, 'dad', 'INR')).toBe(30_000n);
+    expect(balanceOf(balances, 'asha', 'INR')).toBe(0n); // paid 300, owes 300
+    expect(balanceOf(balances, 'ravi', 'INR')).toBe(-30_000n);
+    expect(balanceSums(balances).get('INR')).toBe(0n);
+  });
+
+  it('two payers on an odd total still leave the group summing to zero', () => {
+    fc.assert(
+      fc.property(positiveAmounts(1_000_000n), memberIds(2, 6), seeds(), (amount, ids, seed) => {
+        const payerIds = ids.slice(0, 2);
+        const payers = Object.fromEntries(splitPaidEqually(amount, payerIds, seed));
+        const expense = expenseOf(seed, amount, payers, ids);
+        expect(balanceSums(computeNetBalances([expense], [])).get('INR')).toBe(0n);
+      }),
+    );
+  });
+
+  it('splitting one bill between two payers is not the same as two bills', () => {
+    // The fact this feature exists to record: one ₹1000 dinner paid by two
+    // people, split four ways, is not two ₹500 dinners split four ways — the
+    // nets happen to match here, but the ledger holds one row, one date, one
+    // description, and one thing to edit or delete later.
+    const one = expenseOf('exp-one', 100_000n, { asha: 60_000n, ravi: 40_000n }, [
+      'asha',
+      'ravi',
+      'mo',
+      'sam',
+    ]);
+    const split = [
+      expenseOf('exp-a', 60_000n, { asha: 60_000n }, ['asha', 'ravi', 'mo', 'sam']),
+      expenseOf('exp-b', 40_000n, { ravi: 40_000n }, ['asha', 'ravi', 'mo', 'sam']),
+    ];
+    const oneBalances = computeNetBalances([one], []);
+    const twoBalances = computeNetBalances(split, []);
+    for (const member of ['asha', 'ravi', 'mo', 'sam']) {
+      expect(balanceOf(oneBalances, member, 'INR')).toBe(balanceOf(twoBalances, member, 'INR'));
+    }
+
+    // Same nets, different ledger. Deleting "the dinner" is one act on the
+    // multi-payer row and clears the whole thing; on the two-expense workaround
+    // it deletes half a dinner and leaves the other half standing — which is
+    // exactly the bug people hit when they enter it as two rows.
+    const oneDeleted = computeNetBalances([{ ...one, deletedAt: '2026-09-02' }], []);
+    // Nothing left to net at all — a deleted expense contributes no rows, so the
+    // currency never even appears in the balance map.
+    expect(balanceSums(oneDeleted).get('INR')).toBeUndefined();
+    for (const member of ['asha', 'ravi', 'mo', 'sam']) {
+      expect(balanceOf(oneDeleted, member, 'INR')).toBe(0n);
+    }
+
+    const halfDeleted = computeNetBalances(
+      [{ ...(split[0] as ExpenseSnapshot), deletedAt: '2026-09-02' }, split[1] as ExpenseSnapshot],
+      [],
+    );
+    expect(balanceOf(halfDeleted, 'ravi', 'INR')).toBe(30_000n);
+    expect(balanceOf(halfDeleted, 'asha', 'INR')).toBe(-10_000n);
+  });
+
+  it('editing a multi-payer bill down to one payer moves the money, not the total', () => {
+    const before = expenseOf('exp-1', 100_000n, { asha: 60_000n, ravi: 40_000n }, ['asha', 'ravi']);
+    // The edit: Ravi actually paid the whole thing.
+    const after = { ...before, payers: { ravi: 100_000n } };
+    expect(validatePayers(after.amount, map(after.payers))).toBeNull();
+
+    const balances = computeNetBalances([after], []);
+    expect(balanceOf(balances, 'asha', 'INR')).toBe(-50_000n);
+    expect(balanceOf(balances, 'ravi', 'INR')).toBe(50_000n);
+    expect(balanceSums(balances).get('INR')).toBe(0n);
+  });
+
+  it('a bill paid by everyone who is on it leaves nobody owing anybody', () => {
+    fc.assert(
+      fc.property(positiveAmounts(1_000_000n), memberIds(2, 6), (amount, ids) => {
+        // Everyone pays their own equal share: the split and the paying are the
+        // same map, so every net position is exactly zero.
+        const shares = computeShares({
+          amount,
+          currency: 'INR',
+          params: { kind: 'equal' },
+          participants: ids,
+          seed: 'exp-even',
+        });
+        const expense: ExpenseSnapshot = {
+          id: 'exp-even',
+          currency: 'INR',
+          amount,
+          payers: Object.fromEntries(shares),
+          shares: Object.fromEntries(shares),
+          date: '2026-09-01',
+        };
+        expect(validatePayers(amount, map(expense.payers))).toBeNull();
+        const balances = computeNetBalances([expense], []);
+        for (const id of ids) expect(balanceOf(balances, id, 'INR')).toBe(0n);
+      }),
+    );
+  });
+});

--- a/packages/ui/src/components/AmountField.tsx
+++ b/packages/ui/src/components/AmountField.tsx
@@ -14,6 +14,18 @@ import { useTheme } from '../theme';
 import { Text } from './Text';
 
 /**
+ * The keypad an amount in this currency is typed on.
+ *
+ * A currency with no minor unit has nothing to put after a point, and offering
+ * the point anyway invites a figure that is then silently stripped. Exported
+ * because the expense form's per-payer fields are the same kind of input
+ * without being this component, and they were showing a decimal pad for yen.
+ */
+export function amountKeyboard(currency: CurrencyCode): 'number-pad' | 'decimal-pad' {
+  return minorUnitExponent(currency) === 0 ? 'number-pad' : 'decimal-pad';
+}
+
+/**
  * The amount input as a single native number field — the phone's own
  * decimal keypad, nothing invented on top of it. No arithmetic: a number is
  * typed, not calculated. All maths still runs in integer minor units, so the
@@ -60,7 +72,7 @@ export function AmountField({
   const digitInk = onBrand ? theme.color.onBrand : theme.color.text;
   const symbolInk = onBrand ? 'rgba(255,255,255,0.72)' : theme.color.textMuted;
   const placeholderInk = onBrand ? 'rgba(255,255,255,0.5)' : theme.color.textFaint;
-  const exponent = minorUnitExponent(currency);
+
   // The text↔minor rules live in @waves/core, because the per-payer amount
   // fields on the expense form parse the same keystrokes and two copies of
   // "how many decimal places does this currency have" is how ₹10.5 becomes 105
@@ -85,11 +97,10 @@ export function AmountField({
   useEffect(() => {
     if (value !== emitted.current.value || currency !== emitted.current.currency) {
       emitted.current = { value, currency };
-      setText(format(value));
+      // Called rather than `format`, which is rebuilt every render and would
+      // put the effect's own identity in its dependency list.
+      setText(formatMinorInput(value, currency));
     }
-    // `format` closes over `currency`, which is in the list; re-running on the
-    // identity of the function itself would fire on every render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, currency]);
 
   const onType = (raw: string): void => {
@@ -127,7 +138,7 @@ export function AmountField({
       <TextInput
         value={text}
         onChangeText={onType}
-        keyboardType={exponent === 0 ? 'number-pad' : 'decimal-pad'}
+        keyboardType={amountKeyboard(currency)}
         placeholder="0"
         placeholderTextColor={placeholderInk}
         selectionColor={onBrand ? theme.color.onBrand : theme.color.brand}

--- a/packages/ui/src/components/AmountField.tsx
+++ b/packages/ui/src/components/AmountField.tsx
@@ -69,24 +69,34 @@ export function AmountField({
   const format = (minor: bigint): string => formatMinorInput(minor, currency);
 
   const [text, setText] = useState<string>(() => format(value));
-  // The last minor amount this field emitted. A `value` that differs from it
-  // came from somewhere else (scan, draft restore, edit) and must overwrite
-  // the text; a `value` that matches it is our own echo and must be ignored,
-  // or it would reformat mid-keystroke ("1." would snap back to "1.00").
-  const emitted = useRef<bigint>(value);
+  // The last amount this field emitted, and the currency it was typed in. An
+  // input that differs from it came from somewhere else (scan, draft restore,
+  // edit, the currency picker) and must overwrite the text; one that matches is
+  // our own echo and must be ignored, or it would reformat mid-keystroke ("1."
+  // would snap back to "1.00").
+  //
+  // The currency belongs in that comparison because it decides where the point
+  // goes: switching ₹100.00 to yen leaves the minor amount at 10000 but changes
+  // what it reads as, and watching the value alone left "100.00" on screen over
+  // a field now holding ¥10,000 — with the spoken label, which recomputes,
+  // saying the other thing.
+  const emitted = useRef<{ value: bigint; currency: CurrencyCode }>({ value, currency });
 
   useEffect(() => {
-    if (value !== emitted.current) {
-      emitted.current = value;
+    if (value !== emitted.current.value || currency !== emitted.current.currency) {
+      emitted.current = { value, currency };
       setText(format(value));
     }
-  }, [value]);
+    // `format` closes over `currency`, which is in the list; re-running on the
+    // identity of the function itself would fire on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, currency]);
 
   const onType = (raw: string): void => {
     const cleaned = sanitiseMinorInput(raw, currency);
     setText(cleaned);
     const minor = toMinor(cleaned);
-    emitted.current = minor;
+    emitted.current = { value: minor, currency };
     onChange(minor);
   };
 

--- a/packages/ui/src/components/AmountField.tsx
+++ b/packages/ui/src/components/AmountField.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { TextInput, View } from 'react-native';
 
-import { currencySymbol, minorUnitExponent, minorUnitScale, type CurrencyCode } from '@waves/core';
+import {
+  currencySymbol,
+  formatMinorInput,
+  minorUnitExponent,
+  parseMinorInput,
+  sanitiseMinorInput,
+  type CurrencyCode,
+} from '@waves/core';
 
 import { useTheme } from '../theme';
 import { Text } from './Text';
@@ -17,6 +24,7 @@ export function AmountField({
   value,
   onChange,
   size = 'display',
+  tone = 'default',
 }: {
   currency: CurrencyCode;
   value: bigint;
@@ -25,29 +33,40 @@ export function AmountField({
    * 'display' is the hero amount — big and centred, for the expense entry
    * screen. 'compact' is the right-aligned inline value that sits at the end of
    * a settings row (a trip budget beside its label), sized to read as a field
-   * value rather than the point of the screen.
+   * value rather than the point of the screen. 'hero' is the middle rung: the
+   * amount inside a coloured header bar, prominent but no longer the reason the
+   * header is tall — it sits on one line beside the currency it is counted in.
    */
-  size?: 'display' | 'compact';
+  size?: 'display' | 'compact' | 'hero';
+  /**
+   * 'onBrand' paints the field for a saturated wash — white digits, translucent
+   * white for the symbol and the untyped placeholder. The theme has no token for
+   * "white at 70%" because nothing else needs one.
+   */
+  tone?: 'default' | 'onBrand';
 }) {
   const theme = useTheme();
   const compact = size === 'compact';
+  const hero = size === 'hero';
+  const onBrand = tone === 'onBrand';
+  // One table rather than three ternaries per style: the sizes only ever move
+  // together, and a wrong pairing (44pt digits over a 24pt line) is the kind of
+  // thing that reads as a clipped number on Android.
+  const metrics = hero
+    ? { symbol: 20, digits: 30, line: 38, minWidth: 24 }
+    : compact
+      ? { symbol: 18, digits: 18, line: 24, minWidth: 40 }
+      : { symbol: 30, digits: 44, line: 50, minWidth: 28 };
+  const digitInk = onBrand ? theme.color.onBrand : theme.color.text;
+  const symbolInk = onBrand ? 'rgba(255,255,255,0.72)' : theme.color.textMuted;
+  const placeholderInk = onBrand ? 'rgba(255,255,255,0.5)' : theme.color.textFaint;
   const exponent = minorUnitExponent(currency);
-  const scale = minorUnitScale(currency);
-
-  const toMinor = (text: string): bigint => {
-    if (text === '' || text === '.') return 0n;
-    const [whole = '0', fraction = ''] = text.split('.');
-    const padded = fraction.slice(0, exponent).padEnd(exponent, '0');
-    return BigInt(whole || '0') * scale + BigInt(padded === '' ? '0' : padded);
-  };
-
-  const format = (minor: bigint): string => {
-    if (minor === 0n) return '';
-    const abs = minor < 0n ? -minor : minor;
-    const whole = (abs / scale).toString();
-    if (exponent === 0) return whole;
-    return `${whole}.${(abs % scale).toString().padStart(exponent, '0')}`;
-  };
+  // The text↔minor rules live in @waves/core, because the per-payer amount
+  // fields on the expense form parse the same keystrokes and two copies of
+  // "how many decimal places does this currency have" is how ₹10.5 becomes 105
+  // paise on one screen and 1050 on another.
+  const toMinor = (text: string): bigint => parseMinorInput(text, currency);
+  const format = (minor: bigint): string => formatMinorInput(minor, currency);
 
   const [text, setText] = useState<string>(() => format(value));
   // The last minor amount this field emitted. A `value` that differs from it
@@ -64,23 +83,7 @@ export function AmountField({
   }, [value]);
 
   const onType = (raw: string): void => {
-    // Keep digits and, unless the currency has no minor unit, a single dot.
-    let cleaned = raw.replace(/[^0-9.]/g, '');
-    if (exponent === 0) {
-      cleaned = cleaned.replace(/\./g, '');
-    } else {
-      const firstDot = cleaned.indexOf('.');
-      if (firstDot !== -1) {
-        cleaned = cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, '');
-      }
-    }
-    // Drop a leading zero once real digits follow, but keep the "0" of "0.50".
-    cleaned = cleaned.replace(/^0+(?=\d)/, '');
-    const [, fraction = ''] = cleaned.split('.');
-    if (fraction.length > exponent) {
-      cleaned = cleaned.slice(0, cleaned.length - (fraction.length - exponent));
-    }
-
+    const cleaned = sanitiseMinorInput(raw, currency);
     setText(cleaned);
     const minor = toMinor(cleaned);
     emitted.current = minor;
@@ -92,17 +95,21 @@ export function AmountField({
       style={{
         flexDirection: 'row',
         alignItems: 'center',
-        justifyContent: compact ? 'flex-end' : 'center',
+        justifyContent: compact ? 'flex-end' : hero ? 'flex-start' : 'center',
         gap: theme.spacing.xs,
-        flexShrink: 0,
+        // The hero shares its line with the currency pill, so a long amount has
+        // to give ground rather than push the pill off the header; the standalone
+        // sizes have the row to themselves and must not be squeezed by a sibling.
+        flexShrink: hero ? 1 : 0,
+        minWidth: 0,
       }}
     >
       <Text
         style={{
-          fontSize: compact ? 18 : 30,
-          lineHeight: compact ? 24 : 44,
+          fontSize: metrics.symbol,
+          lineHeight: metrics.line,
           fontWeight: '700',
-          color: theme.color.textMuted,
+          color: symbolInk,
         }}
       >
         {currencySymbol(currency)}
@@ -112,19 +119,20 @@ export function AmountField({
         onChangeText={onType}
         keyboardType={exponent === 0 ? 'number-pad' : 'decimal-pad'}
         placeholder="0"
-        placeholderTextColor={theme.color.textFaint}
-        selectionColor={theme.color.brand}
+        placeholderTextColor={placeholderInk}
+        selectionColor={onBrand ? theme.color.onBrand : theme.color.brand}
         accessibilityLabel={`Amount ${format(value) || '0'} ${currency}`}
         maxFontSizeMultiplier={1.4}
         style={{
-          minWidth: compact ? 40 : 28,
+          minWidth: metrics.minWidth,
           padding: 0,
-          fontSize: compact ? 18 : 44,
-          lineHeight: compact ? 24 : 50,
+          fontSize: metrics.digits,
+          lineHeight: metrics.line,
           fontWeight: '700',
-          color: theme.color.text,
+          color: digitInk,
           fontVariant: ['tabular-nums'],
           textAlign: compact ? 'right' : 'left',
+          flexShrink: hero ? 1 : 0,
         }}
       />
     </View>


### PR DESCRIPTION
## Why

The ledger has always been multi-payer. `expense_payers` is a table, a balance is `Σpaid − Σowed` over every payer row, the mirror replays a payer map, and both edge functions reject a write whose rows do not sum to the total (`PAYER_MISMATCH`). Only the clients collapsed it — one `payer: MemberId | null`, written out as `{ [payer]: amount }`.

So "she got the taxi, I got the tickets" had to be entered as two expenses: two rows in the feed, two things to edit, two things to delete, for one dinner.

**No migration and no edge deploy.** This is the client catching up to a schema that was already there.

Grew out of a UI pass on the expense screen (edit was hard to find, view and edit felt like different apps, the amount ate the first screenful), so those fixes ride along.

## Core — `@waves/core`

New `split/payers.ts`, pure and integer-only:

| | |
|---|---|
| `splitPaidEqually` | Reuses `splitEqually`, so the payer side rounds by the same ADR-009 rule as the share side. Two rounding rules on one row would fail its own trigger. |
| `validatePayers` | Mirrors the server's check — a mismatch becomes a sentence under the button, not a `PAYER_MISMATCH` off a queue minutes later. |
| `rebalancePayers` | "Typed figures are facts, the rest is arithmetic." Locked payers survive verbatim; unlocked ones share what is left. |
| `serialisePayers` | Wire form, zero rows dropped. |

`rebalancePayers` makes two deliberate refusals: nothing is ever driven negative, and locked figures are never rescaled to fit. Both would make a row add up while describing something that did not happen.

New `money/input.ts` — the text↔minor parsing lifted out of `AmountField`, because the per-payer fields parse the same keystrokes. Two copies of "how many decimal places does this currency have" is how ₹10.5 becomes 105 paise on one screen and 1050 on another. `AmountField` now imports it.

## Form

One payer stays **exactly one tap** — the avatar row, no figures. An explicit **"Several people paid"** switch turns it into a multi-select with per-payer amount fields, a "Split evenly" reset, and a running "₹200 left to assign".

The mode is explicit because the gestures are opposite: with one payer a tap must *replace* (the "actually she paid" correction was one tap before this and stays one tap), with several it must *add*. `accessibilityRole` follows the mode — radio vs checkbox — so a screen reader is never told the opposite of what will happen.

Rebalancing runs as a render-phase adjustment, the pattern this file already uses for seeding, so a receipt scan filling in ₹1,240 re-splits the paying in the same render — no frame where the payers and the total disagree.

Two bugs fixed on the way:

- **Editing flattened a multi-payer bill.** It hydrated `payers[0]` and saved that back, silently rewriting who had put money in.
- **Who-paid was hidden entirely when editing** (`{!expenseId ? … : null}`), so the correction people most often return to make had no control anywhere on the screen while the summary kept saying "You paid".

## Expense screen

**"Who owes what" was lying on a multi-payer bill.** Every row was forced owe-red, on the reasoning that every share is money owed — true while one person could pay. Somebody putting in ₹5,000 of a ₹10,000 bill and owing ₹2,000 read as *owing* ₹2,000 when they are owed ₹3,000.

Rows now show **net for the bill (paid − share)**, sign-derived. One rule, no special case: a non-payer's net is exactly minus their share, so ordinary single-payer bills look unchanged. Rows are built from the union of shares and payers, so a contributor who owes nothing is no longer visible in "Paid by" and then unaccounted for below it.

Also on this screen:

- **Edit** was the first item of a three-dot menu; it is a pencil in the header now. Delete stays a tap deeper.
- **Split type carries a glyph**, shared with the form's chips, so the chip you tapped is the mark you see afterwards.

## Form and screen now share a header

Same brand panel, same category badge in the same corner, same amount — editable on one side, not on the other. Tapping Edit changes what you can do, not where anything is.

That also settles what the amount costs: it and its currency share one line inside the header instead of a 44pt number owning a third of the first screenful, with the running total already in the pinned save bar.

## Smaller things in here

- The expense screen's **receipt gallery** replaces the one-line thumbnail on the edit form — existing expenses only, since attachments commit against a row a new expense does not have yet.
- The **split section is tightened** so who-paid and who-splits fit one screen.
- The **"nothing is overwritten" banner** is gone from the edit form.
- The **edit history** gains a coloured "Your share" line, driven by the activity feed's own `myStake` so the two cannot drift. Amount changes stay neutral ink — a total belongs to nobody, and colouring it by sign would have the screen reader announce "you are owed ₹10,000" about a dinner.
- New strings in **en / ta / hi / ar**.

## Tests

**55 new in `@waves/core`**, three layers because the failure modes differ:

**Properties (fast-check)** — sums to the total for every input; never spreads two payers more than one minor unit; deterministic across devices; never negative whatever the locked figures; only ever returns the selected payers; idempotent.

**Gestures** — type one figure and the other moves; two typed and the third absorbs; raise the total after the fact; overshoot is kept and reported rather than trimmed; drop a payer; collapse to one; odd amounts; a currency with no minor unit.

**Scenarios** — whole expenses through `computeShares` + `computeNetBalances`, and `payers.offline.test.ts` runs the ADR-005 path (mirror + queue overlay, the pipeline behind the group hero number): a multi-payer bill queued with no network nets correctly before it reaches a server, is one row not one-per-payer, survives the wire round trip, re-versions on edit without duplicating, and a payer who is not in the split shows up as a creditor.

The assertion worth pointing at: `validatePayers` is checked against an **independently written** copy of the server's rule, so client and server cannot drift.

## Gates

`pnpm typecheck`, `pnpm lint`, and every suite except `@waves/db` — **1573 tests green**.

`packages/db` has 27 pre-existing failures (RLS / anon-grant state on the local Postgres). I stashed this branch and reproduced them unchanged on `main`; they are not from this work.

## Not in here

- **`apps/web/src/components/ExpenseForm.tsx` still writes a single payer.** The core functions are ready for it; I did not expand a large mobile change into a second codebase uninvited.
- **Not device-tested.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for expenses paid by one or multiple people, with editable payer amounts and automatic balancing.
  - Improved expense entry with a redesigned header, currency controls, receipt galleries, and clearer split options.
  - Enhanced expense details with payer/share breakdowns, net balances, icons, and easier access to editing.
  - Added clearer history updates showing how changes affect your share.
  - Added localized payer and audit-history text in English, Tamil, Hindi, and Arabic.
- **Bug Fixes**
  - Improved receipt display by hiding empty gallery headings.
  - Improved money entry accuracy across currencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->