### PR TITLE
perf: the dashboard, the group tabs and the receipt gallery stop waiting

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import {
+  ActivityIndicator,
   Animated,
   Modal,
   Pressable,
@@ -105,15 +106,22 @@ export default function HomeScreen() {
   const displayName = profile?.display_name ?? t.account.you;
 
   const list = groups.data ?? [];
-  // One gate for every figure on this screen. The mirror hydrates from disk
-  // instantly, so the groups and their balances *can* paint at once — but that
-  // snapshot can be behind the server, and a balance painted from it moves when
-  // this session's first sync reconciles. A number that changes after it has
-  // been read is worse than a number that arrives a beat later, so the skeleton
-  // stays up until the figures are final. Bounded, never a hang:
-  // `pendingFirstSync` clears on the first success *or* on a can't-sync status
-  // (offline, metered, error), where the local snapshot is the best there is.
-  const loading = groups.isLoading || summary.isLoading || summary.pendingFirstSync;
+  // Two states, not one, because they deserve different answers.
+  //
+  // `hydrating` is "there is nothing to paint": the mirror has not been read off
+  // disk yet. It lasts milliseconds and a skeleton is exactly right for it.
+  //
+  // `settling` is "here it is, but this session's first sync has not landed yet",
+  // so what is on screen came from the local snapshot and could still move. That
+  // used to hold the skeleton up too — the whole screen shimmering over figures
+  // the app already had, for as long as the network took. What somebody actually
+  // wants there is their balance and their groups, marked as not-yet-final: the
+  // numbers are shown, under a still mask, and settle in place when the sync
+  // lands. Bounded either way — `pendingFirstSync` clears on the first success
+  // *or* on a can't-sync status (offline, metered, error), where the local
+  // snapshot is the best there is.
+  const hydrating = groups.isLoading || summary.isLoading;
+  const settling = !hydrating && summary.pendingFirstSync;
 
   // A ledger import running in the background (see `@/lib/importProgress`): its
   // banner sits above the group list, and when it lands the just-added group
@@ -137,11 +145,11 @@ export default function HomeScreen() {
   const tourStarted = useRef(false);
   useEffect(() => {
     if (tourStarted.current) return;
-    if (tour.ready && !tour.seen && !loading && balanceReady) {
+    if (tour.ready && !tour.seen && !hydrating && balanceReady) {
       tourStarted.current = true;
       tour.start();
     }
-  }, [tour.ready, tour.seen, tour, loading, balanceReady]);
+  }, [tour.ready, tour.seen, tour, hydrating, balanceReady]);
 
   // The tour holds the top of the prompt queue for the whole of a first run —
   // from the moment we know it is owed (ready, not seen), through the wait for
@@ -355,9 +363,11 @@ export default function HomeScreen() {
           {/* The swipeable balance — net, then owed, then this month — riding
                 on the hero's colour rather than in its own card (ADR-004: no total
                 across currencies, so each is its own slide). Its scroll drives the
-                background crossfade above. While it loads a light placeholder
-                stands in so the number never paints confident zeros. */}
-          {loading || !balanceReady ? (
+                background crossfade above. A placeholder stands in only while
+                there is genuinely no figure to show; a figure that is merely
+                unconfirmed is shown at full strength, with a small spinner beside
+                its label. */}
+          {hydrating || !balanceReady ? (
             <HeroBalanceSkeleton />
           ) : (
             <HeroBalance
@@ -371,6 +381,7 @@ export default function HomeScreen() {
               cardWidth={heroInner}
               gap={heroGap}
               snap={heroSnap}
+              settling={settling}
             />
           )}
 
@@ -446,7 +457,7 @@ export default function HomeScreen() {
               the person tapped Import, came home, and watches it fill. */}
           <ImportProgressBanner />
 
-          {loading ? (
+          {hydrating ? (
             <SkeletonList rows={3} />
           ) : list.length === 0 ? (
             <View style={{ flex: 1, justifyContent: 'center' }}>
@@ -1242,6 +1253,7 @@ function HeroBalance({
   cardWidth,
   gap,
   snap,
+  settling,
 }: {
   primary: CurrencyTotal;
   /** My share of this month's spend, per currency (from useHomeSummary). */
@@ -1257,6 +1269,8 @@ function HeroBalance({
   cardWidth: number;
   gap: number;
   snap: number;
+  /** The figure is the local one and a fresher answer is on its way. */
+  settling: boolean;
 }) {
   // The three balance views the dashboard leads with, one per swipe: where you
   // stand overall (net), what is owed to you, and what you have spent this month
@@ -1282,6 +1296,7 @@ function HeroBalance({
           locale={locale}
           hidden={hidden}
           onToggleHide={onToggleHide}
+          settling={settling}
         />
       ),
     },
@@ -1295,6 +1310,7 @@ function HeroBalance({
           locale={locale}
           hidden={hidden}
           onToggleHide={onToggleHide}
+          settling={settling}
         />
       ),
     },
@@ -1308,6 +1324,7 @@ function HeroBalance({
           locale={locale}
           hidden={hidden}
           onToggleHide={onToggleHide}
+          settling={settling}
         />
       ),
     },
@@ -1540,6 +1557,7 @@ function MetricSlide({
   locale,
   hidden,
   onToggleHide,
+  settling,
 }: {
   label: string;
   amount: bigint;
@@ -1547,6 +1565,9 @@ function MetricSlide({
   locale: string;
   hidden: boolean;
   onToggleHide: () => void;
+  /** Shown with a small spinner beside the label: this figure is the local one
+   *  and this session's first sync has not confirmed it yet. */
+  settling?: boolean;
 }) {
   const theme = useTheme();
   const { t } = useStrings();
@@ -1569,6 +1590,7 @@ function MetricSlide({
             color={theme.color.onBrand}
           />
         </Pressable>
+        {settling ? <ActivityIndicator size="small" color={theme.color.onBrand} /> : null}
       </Row>
       {hidden ? (
         <Text tone="onBrand" style={{ fontSize: 40, lineHeight: 46, fontWeight: '700' }}>

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -121,7 +121,16 @@ export default function HomeScreen() {
   // *or* on a can't-sync status (offline, metered, error), where the local
   // snapshot is the best there is.
   const hydrating = groups.isLoading || summary.isLoading;
-  const settling = !hydrating && summary.pendingFirstSync;
+  // And a third case that is neither: the mirror answered, but with nothing in
+  // it, while the first sync is still out. That is "we do not know yet", not
+  // "you have no groups" — and on a fresh install or a new sign-in the two look
+  // identical from here. Painting the empty state over it would tell somebody
+  // with eleven groups that they have none, for as long as the network took.
+  const unknownYet = !hydrating && list.length === 0 && summary.pendingFirstSync;
+  // The placeholder covers both: nothing read yet, or nothing read *and* nothing
+  // confirmed. Everything else paints.
+  const showSkeleton = hydrating || unknownYet;
+  const settling = !showSkeleton && summary.pendingFirstSync;
 
   // A ledger import running in the background (see `@/lib/importProgress`): its
   // banner sits above the group list, and when it lands the just-added group
@@ -145,11 +154,11 @@ export default function HomeScreen() {
   const tourStarted = useRef(false);
   useEffect(() => {
     if (tourStarted.current) return;
-    if (tour.ready && !tour.seen && !hydrating && balanceReady) {
+    if (tour.ready && !tour.seen && !showSkeleton && balanceReady) {
       tourStarted.current = true;
       tour.start();
     }
-  }, [tour.ready, tour.seen, tour, hydrating, balanceReady]);
+  }, [tour.ready, tour.seen, tour, showSkeleton, balanceReady]);
 
   // The tour holds the top of the prompt queue for the whole of a first run —
   // from the moment we know it is owed (ready, not seen), through the wait for
@@ -367,7 +376,7 @@ export default function HomeScreen() {
                 there is genuinely no figure to show; a figure that is merely
                 unconfirmed is shown at full strength, with a small spinner beside
                 its label. */}
-          {hydrating || !balanceReady ? (
+          {showSkeleton || !balanceReady ? (
             <HeroBalanceSkeleton />
           ) : (
             <HeroBalance
@@ -457,7 +466,7 @@ export default function HomeScreen() {
               the person tapped Import, came home, and watches it fill. */}
           <ImportProgressBanner />
 
-          {hydrating ? (
+          {showSkeleton ? (
             <SkeletonList rows={3} />
           ) : list.length === 0 ? (
             <View style={{ flex: 1, justifyContent: 'center' }}>

--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -112,6 +112,17 @@ import { clearDraft, syncEngine, useDraft, useRestoredDraft, useSync } from '@/s
 /** Shared empty set — a new one per render would defeat every memo below it. */
 const EMPTY_LOCKS: ReadonlySet<MemberId> = new Set();
 
+/**
+ * The width of one "paid by" tile.
+ *
+ * Fixed on purpose: the lane must be the same shape in a group of Hethus as in
+ * a group of Lokesh Rangasamys. Just wide enough to clear the 44pt avatar it
+ * holds and give a long name somewhere to put its ellipsis — 76 left so much
+ * slack around each avatar that four people read as four separated islands
+ * rather than one row of faces.
+ */
+const PAYER_TILE_WIDTH = 60;
+
 /** Who paid what, in minor units. */
 type PayerMap = ReadonlyMap<MemberId, bigint>;
 
@@ -649,36 +660,23 @@ export default function AddExpenseScreen() {
   };
   const splitIssue = splitProblem(splitKind, entries, participants);
 
-  /**
-   * The split, folded into one sentence until somebody wants to argue with it.
-   *
-   * Almost every expense is "I paid, split it equally with everyone" — and that
-   * case was costing three open sections (how to split, who paid, who is in) and
-   * a screenful of scroll between the amount and the save button. Collapsed, the
-   * sentence still says exactly what will be saved, which is the part that must
-   * never be hidden; expanded, nothing about the controls has changed.
-   *
-   * It opens itself whenever the configuration is not that default, and stays
-   * open while the numbers do not add up — a validation message under a fold is
-   * a validation message nobody reads.
-   */
-  const isDefaultSplit =
-    splitKind === SplitKind.Equal &&
-    // "I paid" — one payer, and it is me. Two payers is never the default case,
-    // so tapping a second person opens the section that explains the split.
-    payers.size === 1 &&
-    myMemberId !== null &&
-    payers.has(myMemberId) &&
-    participants.length > 0 &&
-    participants.length === (members.data ?? []).length;
-  const [splitOpen, setSplitOpen] = useState(false);
-  const showSplit = splitOpen || !isDefaultSplit || splitIssue !== null;
+  // The split used to fold into a one-line summary card, opening itself when the
+  // configuration was not the "I paid, split equally" default. The fold is gone:
+  // the three controls (how to split, who paid, who is in) stand open under a
+  // plain heading, so changing a split is the tap that changes it rather than a
+  // tap to open, then a tap to change.
 
   // "More details" folds category, payment method, location and the FX rate off
-  // the common path — the same collapse the split summary uses. It opens itself
-  // whenever one of those carries a non-default value, so an edit (or a foreign
-  // currency, whose rate must be typed to save) is never hidden behind the fold.
-  const [detailsOpen, setDetailsOpen] = useState(false);
+  // the common path. It opens itself whenever one of those carries a non-default
+  // value, so an edit (or a foreign currency, whose rate must be typed to save)
+  // is not hidden behind the fold on arrival.
+  //
+  // `null` means "nobody has said": follow that rule. A tap replaces it with a
+  // decision, in either direction. It used to be a plain boolean OR-ed with the
+  // rule, and the header was disabled while the rule said open — so on a bill
+  // that carried any detail, "Fewer details" sat there looking tappable and did
+  // nothing.
+  const [detailsChoice, setDetailsChoice] = useState<boolean | null>(null);
 
   const isTrip = group.data?.type === 'trip';
   const groupCurrency = group.data?.default_currency ?? 'INR';
@@ -701,6 +699,14 @@ export default function AddExpenseScreen() {
   // A bill that already records several payers is in several-payer mode however
   // the flag was left — an edit must never offer to quietly drop one of them.
   const manyPayers = payerMode === 'many' || payers.size > 1;
+  // The chooser's order: whoever is paying, then everybody else, each keeping
+  // the group's own order within their half (`sort` is stable). The lane scrolls
+  // sideways, so without this a payer picked from the end of a long member list
+  // would be the one thing on the screen you cannot see.
+  const payerChoices = useMemo(() => {
+    const rows = members.data ?? [];
+    return [...rows].sort((a, b) => Number(payers.has(b.id)) - Number(payers.has(a.id)));
+  }, [members.data, payers]);
 
   /** Re-derive the figures, then refresh every field except the typed ones. */
   const applyPayers = (
@@ -977,7 +983,6 @@ export default function AddExpenseScreen() {
     // that comes back minutes later off a queue.
     if (payerProblem) {
       setError(payerMessage);
-      setSplitOpen(true);
       return;
     }
     setSaving(true);
@@ -1239,7 +1244,6 @@ export default function AddExpenseScreen() {
       setWeights(Object.fromEntries(chosen.map((id) => [id, String(units[id])])));
       setPresetLabel(t.expense.presets.nights);
       setPresetEditor(null);
-      setSplitOpen(true);
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'preset.nights'));
     }
@@ -1253,7 +1257,6 @@ export default function AddExpenseScreen() {
       setParticipants(result.participants);
       setPresetLabel(t.expense.presets.ride);
       setPresetEditor(null);
-      setSplitOpen(true);
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'preset.ride'));
     }
@@ -1277,7 +1280,6 @@ export default function AddExpenseScreen() {
       setPresetParams(result.params);
       setPresetLabel(t.expense.presets.car);
       setPresetEditor(null);
-      setSplitOpen(true);
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'preset.car'));
     }
@@ -1299,7 +1301,6 @@ export default function AddExpenseScreen() {
       setTreatHost(host);
       setPresetLabel(t.expense.presets.treat);
       setPresetEditor(null);
-      setSplitOpen(true);
     } catch (caught) {
       setError(friendlyError(caught, t.couldNotSave, 'preset.treat'));
     }
@@ -1343,44 +1344,7 @@ export default function AddExpenseScreen() {
   // and any detail somebody has already set is a decision that must not hide.
   const detailsNonDefault =
     currency !== groupCurrency || location !== null || paymentMethod !== 'cash' || categoryChosen;
-  const showDetails = detailsOpen || detailsNonDefault;
-
-  // The split, as the outcome rather than the machinery: "You paid · split
-  // equally with everyone". The payer leads (you, or the person who did); the
-  // tail is the preset's own words, or "split equally with everyone" for the
-  // default, or the split kind and headcount for anything hand-tuned.
-  const solePayer = payers.size === 1 ? (payerIds[0] ?? null) : null;
-  const payerMember =
-    solePayer && solePayer !== myMemberId
-      ? (members.data ?? []).find((member) => member.id === solePayer)
-      : undefined;
-  const payerName =
-    payers.size > 1
-      ? // Several people put money in — the names would not fit and the amounts
-        // are right below anyway, so the summary counts them.
-        plural(locale, payers.size, t.expense.paidByCount)
-      : solePayer !== null && solePayer === myMemberId
-        ? t.expense.youPaid
-        : // Somebody else paid. `members` excludes anyone who has left the group,
-          // so a bill paid by a departed member resolves to nothing here — and
-          // falling through to "You paid" claimed their bill for the reader.
-          t.expense.paidByName.replace(
-            '{name}',
-            payerMember ? displayName(payerMember, profile?.id) : t.misc.someone,
-          );
-  const splitTail =
-    presetLabel ??
-    (isDefaultSplit
-      ? t.expense.splitEquallyEveryone
-      : [
-          splitKind === SplitKind.Equal
-            ? t.expense.equally
-            : splitKind === SplitKind.Shares
-              ? t.expense.shares
-              : t.expense.percent,
-          plural(locale, participants.length, t.memberCount),
-        ].join(' · '));
-  const splitSummary = `${payerName} · ${splitTail}`;
+  const showDetails = detailsChoice ?? detailsNonDefault;
 
   // The bottom-bar sub-line. When an equal split lands the same amount on every
   // head, say it in money — "3 people owe ₹200 each" — which is the number
@@ -1470,49 +1434,62 @@ export default function AddExpenseScreen() {
             than a card that makes this look like a receipt scanner. Scan is
             metered and gives way when the group is capped; Add photo keeps an
             image on the device and never records a receipt server-side, so it
-            is offered even at the cap. */}
+            is offered even at the cap.
+
+            New expenses only. On an edit the gallery below is already the place
+            bills are added and removed — it carries its own add tile — so these
+            two would be a second door to the same room, one of which (scan)
+            would also re-read a bill that has already been entered. */}
           <View style={{ gap: theme.spacing.sm }}>
-            <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
-              {!capLocked ? (
-                <Button
-                  label={scanning ? t.expense.reading : t.expense.scanReceipt}
-                  variant="ghost"
-                  size="sm"
-                  disabled={scanning || saving || capStatus === 'loading'}
-                  onPress={() => void scan()}
-                  icon={
-                    <Ionicons name="camera-outline" size={iconSize.md} color={theme.color.brand} />
-                  }
-                />
-              ) : null}
-              <Button
-                label={t.expense.addPhoto}
-                variant="ghost"
-                size="sm"
-                disabled={scanning || saving}
-                onPress={() => void attach()}
-                icon={
-                  <Ionicons name="image-outline" size={iconSize.md} color={theme.color.brand} />
-                }
-              />
-            </Row>
-            {capLocked ? (
-              <Row style={{ gap: theme.spacing.sm, alignItems: 'center', flexWrap: 'wrap' }}>
-                <Text variant="caption" tone="muted" style={{ flex: 1, minWidth: 0 }}>
-                  {t.expense.capReachedBody}
-                </Text>
-                <Button
-                  label={t.expense.capUpgrade}
-                  size="sm"
-                  onPress={() => router.push('/settings/upgrade')}
-                />
-              </Row>
-            ) : null}
-            {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
-            {scanNote ? (
-              <Text variant="caption" tone="brand">
-                {scanNote}
-              </Text>
+            {!editing ? (
+              <>
+                <Row style={{ gap: theme.spacing.sm, flexWrap: 'wrap' }}>
+                  {!capLocked ? (
+                    <Button
+                      label={scanning ? t.expense.reading : t.expense.scanReceipt}
+                      variant="ghost"
+                      size="sm"
+                      disabled={scanning || saving || capStatus === 'loading'}
+                      onPress={() => void scan()}
+                      icon={
+                        <Ionicons
+                          name="camera-outline"
+                          size={iconSize.md}
+                          color={theme.color.brand}
+                        />
+                      }
+                    />
+                  ) : null}
+                  <Button
+                    label={t.expense.addPhoto}
+                    variant="ghost"
+                    size="sm"
+                    disabled={scanning || saving}
+                    onPress={() => void attach()}
+                    icon={
+                      <Ionicons name="image-outline" size={iconSize.md} color={theme.color.brand} />
+                    }
+                  />
+                </Row>
+                {capLocked ? (
+                  <Row style={{ gap: theme.spacing.sm, alignItems: 'center', flexWrap: 'wrap' }}>
+                    <Text variant="caption" tone="muted" style={{ flex: 1, minWidth: 0 }}>
+                      {t.expense.capReachedBody}
+                    </Text>
+                    <Button
+                      label={t.expense.capUpgrade}
+                      size="sm"
+                      onPress={() => router.push('/settings/upgrade')}
+                    />
+                  </Row>
+                ) : null}
+                {scanning ? <ActivityIndicator color={theme.color.brand} /> : null}
+                {scanNote ? (
+                  <Text variant="caption" tone="brand">
+                    {scanNote}
+                  </Text>
+                ) : null}
+              </>
             ) : null}
 
             {/* The bills kept against this expense — the same gallery the expense
@@ -1582,52 +1559,15 @@ export default function AddExpenseScreen() {
             </Pressable>
           ) : null}
 
-          {/* The one-line answer to "who pays what", tappable to open the three
-            controls that decide it. */}
-          <Pressable
-            accessibilityRole="button"
-            accessibilityState={{ expanded: showSplit }}
-            accessibilityLabel={t.expense.howToSplit}
-            onPress={() => setSplitOpen((open) => !open)}
-            // Never fold a broken split away behind its own summary.
-            disabled={splitIssue !== null}
-          >
-            <Card style={{ gap: theme.spacing.xs }}>
-              <Row style={{ justifyContent: 'space-between', gap: theme.spacing.md }}>
-                {/* The same glyph the chosen chip wears, and the same one the
-                    expense screen shows against "Split" — one mark for one way
-                    of splitting, wherever it appears. */}
-                <Ionicons
-                  name={splitIcon(splitKind)}
-                  size={iconSize.lg}
-                  color={theme.color.brand}
-                />
-                <View style={{ flex: 1, minWidth: 0 }}>
-                  <Text variant="caption" tone="muted">
-                    {t.expense.howToSplit}
-                  </Text>
-                  <Text variant="subheading" numberOfLines={2}>
-                    {splitSummary}
-                  </Text>
-                </View>
-                <Row style={{ gap: theme.spacing.xs, alignItems: 'center', flexShrink: 0 }}>
-                  <Text variant="caption" tone="brand">
-                    {showSplit ? t.common.done : t.common.edit}
-                  </Text>
-                  <Ionicons
-                    name={showSplit ? 'chevron-up' : 'chevron-down'}
-                    size={iconSize.md}
-                    color={theme.color.brand}
-                  />
-                </Row>
-              </Row>
-            </Card>
-          </Pressable>
+          {/* Just the heading. The summary card that used to stand here folded
+            the three controls away behind a sentence — one more thing to read,
+            and one more tap between somebody and the split they came to change.
+            The controls below say the same thing and can be acted on. */}
+          <Text variant="caption" tone="muted">
+            {t.expense.howToSplit}
+          </Text>
 
-          {/* Kept mounted and hidden rather than unmounted: the weighted split's
-            fields hold text somebody is mid-way through typing, and a fold that
-            threw it away would be a worse trade than a taller tree. */}
-          <View style={{ gap: theme.spacing.sm, display: showSplit ? 'flex' : 'none' }}>
+          <View style={{ gap: theme.spacing.sm }}>
             {isTrip && !editing ? (
               <View style={{ gap: theme.spacing.xs }}>
                 <Text variant="micro" tone="muted">
@@ -1707,7 +1647,7 @@ export default function AddExpenseScreen() {
 
             One payer stays exactly one tap: a row of avatars, no figures, no
             arithmetic. The amounts appear only once a second person is on it. */}
-          <Card style={{ gap: theme.spacing.sm, display: showSplit ? 'flex' : 'none' }}>
+          <Card style={{ gap: theme.spacing.sm }}>
             <Row style={{ justifyContent: 'space-between' }}>
               <Text variant="caption" tone="muted">
                 {t.paidBy}
@@ -1742,8 +1682,25 @@ export default function AddExpenseScreen() {
               </Row>
             </Row>
 
-            <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
-              {(members.data ?? []).map((member) => {
+            {/* One lane that scrolls, not a grid that reflows. Wrapping made the
+              row's height depend on how long the names in this group happen to
+              be — one "Lokesh Rangasamy" pushed the whole card taller and shoved
+              its neighbours onto a second line, so the same control was a
+              different shape in every group. Every tile is now the same width,
+              the name gets one line and an ellipsis, and the overflow goes
+              sideways where a tap can reach it.
+
+              Whoever is paying leads the lane (`payerChoices`), so on a long
+              member list the answer is at the start rather than somewhere off
+              the right-hand edge. */}
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              // The lane sits inside a Card, which already pads it — the extra
+              // right padding is the "there is more this way" gutter.
+              contentContainerStyle={{ gap: theme.spacing.xs, paddingRight: theme.spacing.xl }}
+            >
+              {payerChoices.map((member) => {
                 const isPayer = payers.has(member.id);
                 return (
                   <Pressable
@@ -1757,19 +1714,25 @@ export default function AddExpenseScreen() {
                     accessibilityLabel={`${t.paidBy}: ${displayName(member, profile?.id)}`}
                     onPress={() => togglePayer(member.id)}
                     style={{
+                      width: PAYER_TILE_WIDTH,
                       alignItems: 'center',
                       gap: 4,
                       opacity: isPayer ? 1 : 0.45,
                     }}
                   >
                     <Avatar name={displayName(member)} ghost={isGhost(member)} />
-                    <Text variant="micro" tone={isPayer ? 'brand' : 'muted'}>
+                    <Text
+                      variant="micro"
+                      tone={isPayer ? 'brand' : 'muted'}
+                      numberOfLines={1}
+                      style={{ textAlign: 'center' }}
+                    >
                       {displayName(member, profile?.id)}
                     </Text>
                   </Pressable>
                 );
               })}
-            </Row>
+            </ScrollView>
 
             {manyPayers && payers.size > 1 ? (
               <View style={{ gap: theme.spacing.xs }}>
@@ -1862,7 +1825,7 @@ export default function AddExpenseScreen() {
             ) : null}
           </Card>
 
-          <Card style={{ gap: theme.spacing.sm, display: showSplit ? 'flex' : 'none' }}>
+          <Card style={{ gap: theme.spacing.sm }}>
             <Row style={{ justifyContent: 'space-between' }}>
               <Text variant="caption" tone="muted">
                 {t.expense.splitBetween}
@@ -2005,9 +1968,7 @@ export default function AddExpenseScreen() {
             accessibilityRole="button"
             accessibilityState={{ expanded: showDetails }}
             accessibilityLabel={t.expense.moreDetails}
-            onPress={() => setDetailsOpen((open) => !open)}
-            // A detail that is already set must not be foldable away.
-            disabled={detailsNonDefault}
+            onPress={() => setDetailsChoice(!showDetails)}
           >
             <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
               <Text variant="caption" tone="brand" style={{ fontWeight: '700' }}>

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -462,6 +462,35 @@ export default function ExpenseDetailScreen() {
         </Row>
       </Gradient>
 
+      {/* The two faces of the page — its breakdown and its edit history —
+          sectioned so the audit is its own place rather than the tail of a long
+          scroll.
+
+          Outside the ScrollView, pinned under the hero. Inside it, the row
+          scrolled away with the content: three screens into the comments there
+          was no way to reach the history without scrolling all the way back, and
+          the control that says which face you are on was the one thing not on
+          screen. It sits tight against the hero — a label for what follows, not
+          a band of its own. */}
+      <View style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.sm }}>
+        <SegmentedTabs
+          value={tab}
+          onChange={setTab}
+          tabs={[
+            {
+              value: 'details',
+              label: t.expense.detailsTab,
+              icon: (color) => <Ionicons name="receipt-outline" size={iconSize.md} color={color} />,
+            },
+            {
+              value: 'history',
+              label: t.expense.history,
+              icon: (color) => <Ionicons name="time-outline" size={iconSize.md} color={color} />,
+            },
+          ]}
+        />
+      </View>
+
       <ScrollView
         ref={scrollRef}
         style={{ flex: 1 }}
@@ -477,18 +506,6 @@ export default function ExpenseDetailScreen() {
         keyboardShouldPersistTaps="handled"
         automaticallyAdjustKeyboardInsets
       >
-        {/* The two faces of the page — its breakdown and its edit history —
-            sectioned so the audit is its own place rather than the tail of a
-            long scroll. */}
-        <SegmentedTabs
-          value={tab}
-          onChange={setTab}
-          tabs={[
-            { value: 'details', label: t.expense.detailsTab },
-            { value: 'history', label: t.expense.history },
-          ]}
-        />
-
         {tab === 'history' ? (
           <ExpenseHistory
             versions={versions.data ?? []}
@@ -513,6 +530,23 @@ export default function ExpenseDetailScreen() {
                 {t.expense.notInvolvedBody}
               </Callout>
             ) : null}
+
+            {/* Receipts — one gallery, many images, each group-visible or private.
+            Folds in the legacy single bill (E2) as its first item. Adding is now
+            the hero button (externalAdd), driven through the ref; this section
+            shows the gallery of what is already kept.
+
+            First on the page, ahead of the facts: the bill itself is the thing
+            somebody opens this screen to look at, and the figures below are what
+            was read off it. */}
+            <ExpenseReceipts
+              groupId={groupId}
+              expenseId={expense.id}
+              canManage={isExpenseParty}
+              canRemoveLegacy={isExpenseParty || iAmAdmin}
+              legacyReceiptPath={receiptUri ? expenseReceiptPath(groupId, expense.id) : null}
+              onLegacyRemoved={() => setReceiptUri(null)}
+            />
 
             {/* The bill's facts as a tidy labelled card — who paid, when, and how
                 it was split — in place of the stacked caption and chips the hero
@@ -552,19 +586,6 @@ export default function ExpenseDetailScreen() {
                 value={splitLabels(t)[version.split_type] ?? version.split_type}
               />
             </Card>
-
-            {/* Receipts — one gallery, many images, each group-visible or private.
-            Folds in the legacy single bill (E2) as its first item. Adding is now
-            the hero button (externalAdd), driven through the ref; this section
-            shows the gallery of what is already kept. */}
-            <ExpenseReceipts
-              groupId={groupId}
-              expenseId={expense.id}
-              canManage={isExpenseParty}
-              canRemoveLegacy={isExpenseParty || iAmAdmin}
-              legacyReceiptPath={receiptUri ? expenseReceiptPath(groupId, expense.id) : null}
-              onLegacyRemoved={() => setReceiptUri(null)}
-            />
 
             {/* The full note, when the clamped hero heading could not have shown
             all of it — a multi-line or long description is only half-visible up

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -475,7 +475,13 @@ export default function ExpenseDetailScreen() {
       <View style={{ paddingHorizontal: theme.spacing.xl, paddingTop: theme.spacing.sm }}>
         <SegmentedTabs
           value={tab}
-          onChange={setTab}
+          // Back to the top on the way in. The two faces are different lengths,
+          // so keeping the offset landed somebody halfway down a history they
+          // had not scrolled, or at the foot of a page they had just opened.
+          onChange={(next) => {
+            scrollRef.current?.scrollTo({ y: 0, animated: false });
+            setTab(next);
+          }}
           tabs={[
             {
               value: 'details',

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -1,8 +1,8 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useMutation } from '@tanstack/react-query';
 import { router, useLocalSearchParams, type Href } from 'expo-router';
-import { Alert, Pressable, RefreshControl, View } from 'react-native';
+import { Alert, InteractionManager, Pressable, RefreshControl, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { StatusBar } from 'expo-status-bar';
 
@@ -75,6 +75,14 @@ enum Tab {
   Balances = 'balances',
   Activity = 'activity',
 }
+
+/**
+ * How many rows a freshly-chosen tab paints before it grows to its real length.
+ *
+ * Comfortably more than a screenful on the tallest phone, so the window is never
+ * something anybody can scroll to the end of in the frame it exists for.
+ */
+const SWITCH_WINDOW = 24;
 
 /**
  * The nudge on a balances row, for somebody who owes this group money.
@@ -572,6 +580,38 @@ export default function GroupScreen() {
     [activity.data],
   );
 
+  // The rows the list shows for the current tab. One source for `data`, so the
+  // three tabs are the same list with different contents rather than a list plus
+  // two hand-rolled footers.
+  const tabData: FeedItem[] =
+    tab === Tab.Balances ? balanceItems : tab === Tab.Activity ? activityItems : feedItems;
+
+  // The tab switch must not cost what the whole tab costs.
+  //
+  // Each tab's rows are memoised, so switching does not rebuild them — but
+  // handing FlashList a different `data` makes it lay the new set out, and that
+  // walk is per item. On a group with a thousand bills or a long activity trail
+  // the whole walk landed between the tap and the first frame, which is the
+  // pause somebody feels.
+  //
+  // So a freshly-chosen tab paints a screenful first and grows to its real
+  // length on the next tick. `expandedTab` is the tab that has already grown:
+  // choosing another one makes it stale, which is what re-arms the window with
+  // no reset to write. `runAfterInteractions` is what makes the growth a *tick*
+  // and not a stutter — it waits for the tap's own work to finish, so the first
+  // frame never competes with it.
+  const [expandedTab, setExpandedTab] = useState<Tab | null>(null);
+  const windowed = expandedTab !== tab;
+  useEffect(() => {
+    if (expandedTab === tab) return undefined;
+    const task = InteractionManager.runAfterInteractions(() => setExpandedTab(tab));
+    return () => task.cancel();
+  }, [tab, expandedTab]);
+  const listData: FeedItem[] = useMemo(
+    () => (windowed && tabData.length > SWITCH_WINDOW ? tabData.slice(0, SWITCH_WINDOW) : tabData),
+    [windowed, tabData],
+  );
+
   if (group.isLoading) {
     return <GroupSkeleton />;
   }
@@ -707,12 +747,6 @@ export default function GroupScreen() {
     { icon: 'download-outline', label: t.groupExport.menu, route: `/group/${groupId}/export` },
     { icon: 'settings-outline', label: t.group.settings, route: `/group/${groupId}/settings` },
   ];
-
-  // The rows the list shows for the current tab. One source for `data`, so the
-  // three tabs are the same list with different contents rather than a list plus
-  // two hand-rolled footers.
-  const listData: FeedItem[] =
-    tab === Tab.Balances ? balanceItems : tab === Tab.Activity ? activityItems : feedItems;
 
   // A month heading or an expense row. Headings carry the between-section gap the
   // ScrollView used to give for free; the first item needs none, its space comes
@@ -937,9 +971,25 @@ export default function GroupScreen() {
             value={tab}
             onChange={setTab}
             tabs={[
-              { value: Tab.Expenses, label: t.expenses },
-              { value: Tab.Balances, label: t.balances },
-              { value: Tab.Activity, label: t.activity },
+              {
+                value: Tab.Expenses,
+                label: t.expenses,
+                icon: (color) => (
+                  <Ionicons name="receipt-outline" size={iconSize.md} color={color} />
+                ),
+              },
+              {
+                value: Tab.Balances,
+                label: t.balances,
+                icon: (color) => (
+                  <Ionicons name="swap-horizontal-outline" size={iconSize.md} color={color} />
+                ),
+              },
+              {
+                value: Tab.Activity,
+                label: t.activity,
+                icon: (color) => <Ionicons name="pulse-outline" size={iconSize.md} color={color} />,
+              },
             ]}
           />
 
@@ -970,16 +1020,20 @@ export default function GroupScreen() {
 
         <FlashList
           data={listData}
-          extraData={`${tab}|${showDeleted}|${locale}`}
+          // Not the tab: switching tabs already hands `data` a different array,
+          // and naming it here only made every mounted cell re-render a second
+          // time for the same switch.
+          extraData={`${showDeleted}|${locale}`}
           keyExtractor={(item) => item.key}
           getItemType={(item) => item.kind}
           renderItem={renderFeedItem}
           // Belt-and-suspenders on top of the allocation-light, memoized row:
           // render well beyond the viewport so a fast fling down a long ledger
           // never outruns recycling and flashes blank rows (default is 250px,
-          // which a hard fling clears in a frame). ~1500px ≈ two dozen rows
-          // ahead — cheap now that each row barely costs anything to draw.
-          drawDistance={1500}
+          // which a hard fling clears in a frame). ~2500px ≈ three dozen rows
+          // ahead — cheap now that each row barely costs anything to draw, and
+          // 1500 was still being outrun by a hard fling on a long ledger.
+          drawDistance={2500}
           contentContainerStyle={{
             paddingHorizontal: theme.spacing.xl,
             paddingBottom: clearance,

--- a/apps/mobile/src/app/group/[id]/index.tsx
+++ b/apps/mobile/src/app/group/[id]/index.tsx
@@ -1,9 +1,9 @@
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useMutation } from '@tanstack/react-query';
 import { router, useLocalSearchParams, type Href } from 'expo-router';
 import { Alert, InteractionManager, Pressable, RefreshControl, View } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { StatusBar } from 'expo-status-bar';
 
 import {
@@ -601,6 +601,12 @@ export default function GroupScreen() {
   // and not a stutter — it waits for the tap's own work to finish, so the first
   // frame never competes with it.
   const [expandedTab, setExpandedTab] = useState<Tab | null>(null);
+  // The list is put back to the top on a tab change, before its data swaps. The
+  // three tabs are wildly different lengths, and FlashList keeps its offset — so
+  // switching from halfway down a long ledger landed on the end of a short
+  // activity trail, or, now that a fresh tab paints a window first, on nothing
+  // at all until the rest arrived.
+  const listRef = useRef<FlashListRef<FeedItem>>(null);
   const windowed = expandedTab !== tab;
   useEffect(() => {
     if (expandedTab === tab) return undefined;
@@ -969,7 +975,10 @@ export default function GroupScreen() {
         >
           <SegmentedTabs<Tab>
             value={tab}
-            onChange={setTab}
+            onChange={(next) => {
+              listRef.current?.scrollToOffset({ offset: 0, animated: false });
+              setTab(next);
+            }}
             tabs={[
               {
                 value: Tab.Expenses,
@@ -1019,6 +1028,7 @@ export default function GroupScreen() {
         </View>
 
         <FlashList
+          ref={listRef}
           data={listData}
           // Not the tab: switching tabs already hands `data` a different array,
           // and naming it here only made every mounted cell re-render a second

--- a/apps/mobile/src/components/ExpenseReceipts.tsx
+++ b/apps/mobile/src/components/ExpenseReceipts.tsx
@@ -47,7 +47,12 @@ import {
   useReplaceExpenseAttachmentImage,
   type ExpenseAttachmentRow,
 } from '@/data/hooks';
-import { captureReceipt, pickReceiptImage } from '@/lib/image';
+import {
+  captureReceiptAsset,
+  pickReceiptAsset,
+  prepareReceipt,
+  type PickedAsset,
+} from '@/lib/image';
 import { EMPTY_ANNOTATIONS, isEmptyAnnotations, type Annotations } from '@/lib/annotations';
 import { imageUrl, restrictedImageUrl } from '@/lib/storage';
 import { cacheImage, cachedImageUri, evictImage } from '@/lib/storage/imageCache';
@@ -299,11 +304,23 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
     // by a run of the app that was killed is here on the next launch.
     const pending = usePendingReceipts(expenseId);
 
-    // The brief moment between choosing a photo and it being written to disk.
-    // Short, but not free — the bytes can be a couple of megabytes — and it is
-    // the one window in which nothing is on screen yet, so the add affordance
-    // holds a spinner rather than looking like it ignored the tap.
-    const [adding, setAdding] = useState(false);
+    // The picked photograph, shown from its own local file while it is being
+    // resized and written into the queue.
+    //
+    // That work is a second or more on a mid-range phone — decode a 12-megapixel
+    // image, scale it, re-encode it — and it used to happen behind a spinner in
+    // the add tile, with the picture itself appearing only at the end. So the
+    // picker handed back the original first: this holds its URI, the strip draws
+    // it immediately, and the real pending tile replaces it the moment the queue
+    // has the file.
+    const [preparing, setPreparing] = useState<string | null>(null);
+
+    // Attachments the person has just removed, hidden while the delete makes its
+    // round trip. The list is the mirror's, and the mirror only forgets the row
+    // after the RPC lands and a pull brings the change back — several seconds in
+    // which the tile they deleted was still sitting there. Cleared by the row
+    // actually going (the filter below stops matching) or by the failure.
+    const [removedIds, setRemovedIds] = useState<readonly string[]>([]);
 
     // The per-expense receipt ceiling (A46): a free group keeps a small number of
     // gallery images per expense; paid lifts it. This is the affordance — the
@@ -375,6 +392,9 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
         list.push({ kind: 'legacy', key: 'legacy', path: legacyReceiptPath, visibility: 'group' });
       }
       for (const row of attachments.data) {
+        // Just deleted, and the mirror has not caught up yet. Hiding it here
+        // rather than waiting is what makes the tap feel like it did something.
+        if (removedIds.includes(row.id)) continue;
         list.push({ kind: 'attachment', key: row.id, row });
       }
       // Show a parked capture only until its real row lands — once the upload has
@@ -387,7 +407,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
         }
       }
       return list;
-    }, [legacyReceiptPath, attachments.data, pending]);
+    }, [legacyReceiptPath, attachments.data, pending, removedIds]);
 
     const urls = useResolvedUrls(expenseId, items);
     const [viewerIndex, setViewerIndex] = useState<number | null>(null);
@@ -430,20 +450,19 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
      * back — the tile is on screen the moment the write lands, and the upload is
      * the queue's problem from then on, not this screen's.
      */
-    const commitAdd = (
-      picked: NonNullable<Awaited<ReturnType<typeof captureReceipt>>>,
-      visibility: 'group' | 'parties',
-    ) => {
-      const contentType = picked.mimeType ?? 'image/jpeg';
-      setAdding(true);
+    const commitAdd = (asset: PickedAsset, visibility: 'group' | 'parties') => {
+      // On screen from here, from the original file — before the resize, before
+      // the queue, before anything touches the network.
+      setPreparing(asset.uri);
       void (async () => {
         try {
+          const file = await prepareReceipt(asset);
           await enqueueReceipt({
             expenseId,
             groupId,
             visibility,
-            base64: picked.base64,
-            contentType,
+            sourceUri: file.uri,
+            contentType: file.mimeType,
           });
         } catch {
           // The bytes never reached the disk (a full device, a revoked path), so
@@ -452,7 +471,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
           Alert.alert(t.receipts.couldNotKeep);
           return;
         } finally {
-          setAdding(false);
+          setPreparing(null);
         }
         await sendPending();
       })();
@@ -472,15 +491,15 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
      * storage rules — payment proofs still use it, and a receipt already added
      * that way keeps its Private tag.
      */
-    const add = (picked: Awaited<ReturnType<typeof captureReceipt>>) => {
-      if (!picked) return; // Cancelled/declined.
-      commitAdd(picked, 'group');
+    const add = (asset: PickedAsset | null) => {
+      if (!asset) return; // Cancelled/declined.
+      commitAdd(asset, 'group');
     };
 
     const startAdd = () => {
       Alert.alert(t.receipts.add, undefined, [
-        { text: t.receipts.scan, onPress: () => void captureReceipt().then(add) },
-        { text: t.receipts.choosePhoto, onPress: () => void pickReceiptImage().then(add) },
+        { text: t.receipts.scan, onPress: () => void captureReceiptAsset().then(add) },
+        { text: t.receipts.choosePhoto, onPress: () => void pickReceiptAsset().then(add) },
         { text: t.common.cancel, style: 'cancel' },
       ]);
     };
@@ -499,7 +518,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
     // Nothing to show and cannot add here → render nothing, so a non-party's bill
     // is not cluttered with an empty section. `externalAdd` also counts as "cannot
     // add here": the parent's button owns adding, so an empty gallery is nothing.
-    if (items.length === 0 && (!canManage || externalAdd)) return null;
+    if (items.length === 0 && preparing === null && (!canManage || externalAdd)) return null;
 
     const removeAt = (index: number) => {
       const it = items[index];
@@ -527,11 +546,20 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
               });
             } else {
               const storagePath = it.row.storagePath;
+              const attachmentId = it.row.id;
+              // Gone from the strip now. The row itself only disappears once the
+              // RPC has landed and a pull has brought the mirror up to date, and
+              // watching a deleted receipt sit there through both is the whole
+              // complaint. Put back if the delete turns out to have failed.
+              setRemovedIds((current) => [...current, attachmentId]);
               removeAttachment.mutate(
-                { attachmentId: it.row.id, storagePath },
+                { attachmentId, storagePath },
                 // Removing a live attachment frees a slot, so re-ask the cap gate.
                 {
-                  onError,
+                  onError: () => {
+                    setRemovedIds((current) => current.filter((id) => id !== attachmentId));
+                    onError();
+                  },
                   onSuccess: () => {
                     evictImage('expense-attachments', storagePath);
                     refreshCap();
@@ -609,18 +637,18 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
             what it is. The empty state does not need it: the tile below already
             reads "Add receipt" in bigger type, so the heading was the same word
             twice, stacked. */}
-        {items.length > 0 ? (
+        {items.length > 0 || preparing !== null ? (
           <Text variant="caption" tone="muted">
             {t.receipts.title}
           </Text>
         ) : null}
-        {items.length === 0 ? (
+        {items.length === 0 && preparing === null ? (
           // No receipt yet (and, per the guard above, the viewer may add one). A
           // lone 96px tile left a wide empty band under it; a full-width row that
           // reads "Add receipt" fills the space and makes the affordance obvious.
           <Pressable
             onPress={handleAddPress}
-            disabled={adding}
+            disabled={preparing !== null}
             accessibilityRole="button"
             accessibilityLabel={t.receipts.add}
             style={({ pressed }) => ({
@@ -647,7 +675,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
                 backgroundColor: theme.color.surface,
               }}
             >
-              {adding ? (
+              {preparing !== null ? (
                 <ActivityIndicator color={theme.color.brand} />
               ) : (
                 <Ionicons name="camera-outline" size={iconSize.lg} color={theme.color.brand} />
@@ -670,7 +698,7 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
             {canManage && !externalAdd ? (
               <Pressable
                 onPress={handleAddPress}
-                disabled={adding}
+                disabled={preparing !== null}
                 accessibilityRole="button"
                 accessibilityLabel={t.receipts.add}
                 style={{
@@ -684,12 +712,24 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
                   backgroundColor: theme.color.surfaceMuted,
                 }}
               >
-                {adding ? (
-                  <ActivityIndicator color={theme.color.brand} />
-                ) : (
-                  <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
-                )}
+                <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
               </Pressable>
+            ) : null}
+
+            {/* The photograph just chosen, straight from its own file, while it
+              is being resized and written into the queue. It is the same tile
+              the queue will draw a moment later, wearing the same "on its way"
+              scrim — so the handover from this to the real pending item is
+              invisible, and there is no window where the strip looks empty. */}
+            {preparing !== null ? (
+              <Thumb
+                url={preparing}
+                resolved
+                isPrivate={false}
+                status="uploading"
+                label={`${t.receipts.title} — ${t.receipts.sending}`}
+                onPress={() => {}}
+              />
             ) : null}
 
             {items.map((it, index) => (
@@ -719,40 +759,31 @@ export const ExpenseReceipts = forwardRef<ExpenseReceiptsHandle, ExpenseReceipts
           </ScrollView>
         )}
 
-        {stripStatus ? (
-          // One line under the strip saying what is happening to the receipts
-          // that are not up yet. The tiles carry badges, but a badge is 20px on
-          // a photograph — this is the sentence somebody can actually read, and
-          // the only place a retry is offered without opening anything.
+        {stripStatus === 'failed' ? (
+          // Only for the state somebody has to act on.
+          //
+          // This line used to mirror every state the tiles were already showing:
+          // a spinner in the tile and a spinner under it, saying "Sending" about
+          // the same upload — two announcements of one thing, and the strip
+          // visibly busier than the work it was reporting. A send in progress
+          // needs no words; the scrim on the tile is the whole story. A send that
+          // failed does, because the way out of it is a retry, and this is the
+          // only place that offers one without opening anything.
           <Row style={{ gap: theme.spacing.xs, alignItems: 'center' }}>
-            {stripStatus === 'uploading' ? (
-              <ActivityIndicator size="small" color={theme.color.textMuted} />
-            ) : (
-              <Ionicons
-                name={stripStatus === 'failed' ? 'alert-circle' : 'cloud-upload-outline'}
-                size={iconSize.sm}
-                color={stripStatus === 'failed' ? theme.color.negative : theme.color.textMuted}
-              />
-            )}
-            <Text
-              variant="micro"
-              tone={stripStatus === 'failed' ? undefined : 'muted'}
-              style={stripStatus === 'failed' ? { color: theme.color.negative } : undefined}
-            >
+            <Ionicons name="alert-circle" size={iconSize.sm} color={theme.color.negative} />
+            <Text variant="micro" style={{ color: theme.color.negative }}>
               {statusWord(stripStatus)}
             </Text>
-            {stripStatus === 'failed' ? (
-              <Pressable
-                onPress={() => retryFailed(failedIds)}
-                accessibilityRole="button"
-                accessibilityLabel={t.receipts.tryAgain}
-                hitSlop={8}
-              >
-                <Text variant="micro" style={{ color: theme.color.brand }}>
-                  {t.receipts.tryAgain}
-                </Text>
-              </Pressable>
-            ) : null}
+            <Pressable
+              onPress={() => retryFailed(failedIds)}
+              accessibilityRole="button"
+              accessibilityLabel={t.receipts.tryAgain}
+              hitSlop={8}
+            >
+              <Text variant="micro" style={{ color: theme.color.brand }}>
+                {t.receipts.tryAgain}
+              </Text>
+            </Pressable>
           </Row>
         ) : null}
 

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -420,6 +420,14 @@ export interface PickedAsset {
   /** Source dimensions. Zero when the source did not report them. */
   width: number;
   height: number;
+  /**
+   * What the source says these bytes are, when it says anything.
+   *
+   * Only matters on the fallback path below, where the file is taken as it is:
+   * calling a PNG a JPEG there would store and serve it under a type it is not.
+   * The resize path re-encodes, so it names the format it actually produced.
+   */
+  mimeType?: string;
 }
 
 /** A receipt from the photo library, unprocessed — see {@link PickedAsset}. */
@@ -435,7 +443,9 @@ export async function pickReceiptAsset(): Promise<PickedAsset | null> {
   if (result.canceled) return null;
 
   const asset = result.assets[0];
-  return asset ? { uri: asset.uri, width: asset.width, height: asset.height } : null;
+  return asset
+    ? { uri: asset.uri, width: asset.width, height: asset.height, mimeType: asset.mimeType }
+    : null;
 }
 
 /**
@@ -459,7 +469,9 @@ export async function captureReceiptAsset(): Promise<PickedAsset | null> {
     const result = await launch({ mediaTypes: ['images'], quality: 1, base64: false });
     if (result.canceled) return null;
     const asset = result.assets[0];
-    return asset ? { uri: asset.uri, width: asset.width, height: asset.height } : null;
+    return asset
+      ? { uri: asset.uri, width: asset.width, height: asset.height, mimeType: asset.mimeType }
+      : null;
   }
 
   // The scanner reports no dimensions, and the resize caps whichever edge is
@@ -496,7 +508,9 @@ export async function prepareReceipt(
         })
       : null;
   if (shrunk) return { uri: shrunk.uri, mimeType: shrunk.mimeType };
-  return { uri: asset.uri, mimeType: 'image/jpeg' };
+  // Untouched bytes, so they keep whatever they already were. JPEG is the guess
+  // of last resort, for a source that reported nothing.
+  return { uri: asset.uri, mimeType: asset.mimeType ?? 'image/jpeg' };
 }
 
 /**

--- a/apps/mobile/src/lib/image.ts
+++ b/apps/mobile/src/lib/image.ts
@@ -92,6 +92,16 @@ interface ShrinkOptions {
   height: number;
   maxEdge: number;
   compress: number;
+  /**
+   * Read the result back as base64 as well as writing the file.
+   *
+   * Only worth asking for when the caller actually needs the bytes in JS — an
+   * OCR call, or an upload that posts a body. For a receipt bound for the queue
+   * it is pure cost: a megabyte-plus string built natively, carried over the
+   * bridge, then decoded back to bytes and written to a file the manipulator had
+   * already written. The queue copies that file instead (see `enqueueReceipt`).
+   */
+  base64?: boolean;
 }
 
 /**
@@ -110,8 +120,16 @@ interface ShrinkOptions {
  * platform allows it, a working upload everywhere. The returned `mimeType` says
  * which one it was, so the object is stored and served as what it actually is.
  */
-async function shrink({ uri, width, height, maxEdge, compress }: ShrinkOptions): Promise<{
-  base64: string;
+async function shrink({
+  uri,
+  width,
+  height,
+  maxEdge,
+  compress,
+  base64 = true,
+}: ShrinkOptions): Promise<{
+  /** Null when the caller did not ask for the bytes. */
+  base64: string | null;
   uri: string;
   mimeType: string;
 } | null> {
@@ -132,7 +150,8 @@ async function shrink({ uri, width, height, maxEdge, compress }: ShrinkOptions):
   const webp = module.SaveFormat.WEBP;
   if (webp) {
     try {
-      const saved = await (await render()).saveAsync({ base64: true, compress, format: webp });
+      const saved = await (await render()).saveAsync({ base64, compress, format: webp });
+      if (!base64) return { base64: null, uri: saved.uri, mimeType: 'image/webp' };
       if (saved.base64) return { base64: saved.base64, uri: saved.uri, mimeType: 'image/webp' };
     } catch {
       // iOS without a WebP encoder — fall through to JPEG.
@@ -142,15 +161,29 @@ async function shrink({ uri, width, height, maxEdge, compress }: ShrinkOptions):
   const saved = await (
     await render()
   ).saveAsync({
-    base64: true,
+    base64,
     compress,
     format: module.SaveFormat.JPEG,
   });
 
+  if (!base64) return { base64: null, uri: saved.uri, mimeType: 'image/jpeg' };
   // `saveAsync` only omits base64 if it was not asked for; if it is missing
   // anyway there is nothing to upload, and saying so beats uploading nothing.
   if (!saved.base64) throw new Error('Could not read that image.');
   return { base64: saved.base64, uri: saved.uri, mimeType: 'image/jpeg' };
+}
+
+/** As {@link shrink}, for the callers that need the bytes in JS. */
+async function shrinkWithBytes(
+  options: Omit<ShrinkOptions, 'base64'>,
+): Promise<{ base64: string; uri: string; mimeType: string } | null> {
+  const result = await shrink({ ...options, base64: true });
+  // Unreachable — `base64: true` either returns the string or throws — but the
+  // types do not know that, and a cast here would be a lie the next reader has
+  // to check.
+  if (!result) return null;
+  if (result.base64 === null) throw new Error('Could not read that image.');
+  return { base64: result.base64, uri: result.uri, mimeType: result.mimeType };
 }
 
 /**
@@ -199,7 +232,7 @@ export async function pickSquarePhoto(maxEdge: number): Promise<PickedImage | nu
   if (!asset) return null;
 
   const shrunk =
-    (await shrink({
+    (await shrinkWithBytes({
       uri: asset.uri,
       width: asset.width,
       height: asset.height,
@@ -244,7 +277,7 @@ export async function pickAlbumPhoto(): Promise<PickedImage | null> {
   const asset = result.assets[0];
   if (!asset) return null;
 
-  const shrunk = await shrink({
+  const shrunk = await shrinkWithBytes({
     uri: asset.uri,
     width: asset.width,
     height: asset.height,
@@ -280,7 +313,7 @@ export async function pickReceiptPhoto(): Promise<PickedImage | null> {
   if (!asset) return null;
 
   const shrunk =
-    (await shrink({
+    (await shrinkWithBytes({
       uri: asset.uri,
       width: asset.width,
       height: asset.height,
@@ -320,7 +353,7 @@ export async function pickReceiptImage(): Promise<PickedImage | null> {
   if (!asset) return null;
 
   const shrunk =
-    (await shrink({
+    (await shrinkWithBytes({
       uri: asset.uri,
       width: asset.width,
       height: asset.height,
@@ -361,7 +394,7 @@ export async function captureReceipt(): Promise<PickedImage | null> {
   const size = await imageSize(scanned);
   const shrunk =
     (size
-      ? await shrink({
+      ? await shrinkWithBytes({
           uri: scanned,
           width: size.width,
           height: size.height,
@@ -370,6 +403,100 @@ export async function captureReceipt(): Promise<PickedImage | null> {
         })
       : null) ?? (await readUnshrunk(scanned));
   return { base64: shrunk.base64, mimeType: shrunk.mimeType ?? 'image/jpeg', uri: shrunk.uri };
+}
+
+/**
+ * A picked original, before anything has been done to it.
+ *
+ * The resize is the slow step — decoding a 12-megapixel photograph, scaling it
+ * and re-encoding it is a second or more on a mid-range phone, and until it
+ * finished the old flow had nothing at all to show. Handing the caller the
+ * untouched file first means the thumbnail is on screen while that work runs, so
+ * the wait is something visibly in progress rather than a screen that ignored
+ * the tap.
+ */
+export interface PickedAsset {
+  uri: string;
+  /** Source dimensions. Zero when the source did not report them. */
+  width: number;
+  height: number;
+}
+
+/** A receipt from the photo library, unprocessed — see {@link PickedAsset}. */
+export async function pickReceiptAsset(): Promise<PickedAsset | null> {
+  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (!permission.granted) return null;
+
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images'],
+    quality: 1,
+    base64: false,
+  });
+  if (result.canceled) return null;
+
+  const asset = result.assets[0];
+  return asset ? { uri: asset.uri, width: asset.width, height: asset.height } : null;
+}
+
+/**
+ * A receipt from the scanner (or the camera where there is none), unprocessed.
+ *
+ * The same three-way outcome as {@link captureReceipt}: the scanner where the
+ * build has one, the plain camera where it does not, and null for a cancel —
+ * backing out of the scanner is a cancel, not a request for a different camera.
+ */
+export async function captureReceiptAsset(): Promise<PickedAsset | null> {
+  const outcome = await scanDocument();
+  if (outcome.kind === 'cancelled') return null;
+  if (outcome.kind === 'unavailable') {
+    const permission = await ImagePicker.requestCameraPermissionsAsync();
+    let launch = ImagePicker.launchCameraAsync;
+    if (!permission.granted) {
+      const library = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!library.granted) return null;
+      launch = ImagePicker.launchImageLibraryAsync;
+    }
+    const result = await launch({ mediaTypes: ['images'], quality: 1, base64: false });
+    if (result.canceled) return null;
+    const asset = result.assets[0];
+    return asset ? { uri: asset.uri, width: asset.width, height: asset.height } : null;
+  }
+
+  // The scanner reports no dimensions, and the resize caps whichever edge is
+  // longer. Asking the file is cheap; an unreadable size is a reason to skip the
+  // resize rather than to abandon the scan.
+  const size = await imageSize(outcome.uri);
+  return { uri: outcome.uri, width: size?.width ?? 0, height: size?.height ?? 0 };
+}
+
+/**
+ * Bring a {@link PickedAsset} down to receipt size, as a file and nothing else.
+ *
+ * The counterpart to the pickers above: they hand back the original at once so
+ * something can be drawn, this does the expensive part afterwards. No base64 —
+ * the only consumer is the receipt queue, which takes the file over as-is, so
+ * building a multi-megabyte string to decode straight back into the bytes the
+ * manipulator had already written was work with no reader.
+ *
+ * Falls back to the untouched original where the native manipulator is missing
+ * (a dev client built before it existed), exactly as the base64 pickers do.
+ */
+export async function prepareReceipt(
+  asset: PickedAsset,
+): Promise<{ uri: string; mimeType: string }> {
+  const shrunk =
+    asset.width > 0 && asset.height > 0
+      ? await shrink({
+          uri: asset.uri,
+          width: asset.width,
+          height: asset.height,
+          maxEdge: RECEIPT_MAX_EDGE,
+          compress: 0.9,
+          base64: false,
+        })
+      : null;
+  if (shrunk) return { uri: shrunk.uri, mimeType: shrunk.mimeType };
+  return { uri: asset.uri, mimeType: 'image/jpeg' };
 }
 
 /**

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -314,7 +314,15 @@ export async function enqueueReceipt(input: {
   expenseId: string;
   groupId: string;
   visibility: 'group' | 'parties';
-  base64: string;
+  /**
+   * A file on this device to take over. Preferred: the image has already been
+   * written once by the resize, so copying it costs a file copy, where `base64`
+   * costs a megabyte-plus string built natively, carried over the bridge, and
+   * decoded back into the same bytes.
+   */
+  sourceUri?: string;
+  /** The bytes, for callers that already hold them (the OCR path). */
+  base64?: string;
   contentType: string;
 }): Promise<PendingReceipt> {
   const attachmentId = randomUUID();
@@ -336,7 +344,15 @@ export async function enqueueReceipt(input: {
 
   const dir = new Directory(Paths.document, PENDING_DIR);
   if (!dir.exists) dir.create({ intermediates: true });
-  pendingFile(entry).write(new Uint8Array(decode(input.base64)));
+  if (input.sourceUri) {
+    // Copied, not moved: the source is the manipulator's own output in the cache
+    // directory, and the caller may still be showing it as the tile's image.
+    await new File(input.sourceUri).copy(pendingFile(entry));
+  } else if (input.base64) {
+    pendingFile(entry).write(new Uint8Array(decode(input.base64)));
+  } else {
+    throw new Error('enqueueReceipt needs either sourceUri or base64.');
+  }
 
   const queue = await readQueue();
   await writeQueue([...queue, entry]);

--- a/apps/mobile/src/lib/receiptQueue.ts
+++ b/apps/mobile/src/lib/receiptQueue.ts
@@ -114,7 +114,15 @@ export interface PendingReceiptView extends PendingReceipt {
 
 /** The extension for a stored image, matching the online attach path. */
 function extensionFor(contentType: string): string {
-  return contentType === 'image/webp' ? 'webp' : 'jpg';
+  // The file on disk should be named what it is. Only reached with something
+  // other than webp/jpeg on the fallback path, where an unprocessed original is
+  // taken as-is (see `prepareReceipt`); anything unrecognised still lands as jpg,
+  // which is what every path produced before that fallback existed.
+  const subtype = contentType.split('/')[1]?.toLowerCase();
+  if (subtype === 'webp') return 'webp';
+  if (subtype === 'png') return 'png';
+  if (subtype === 'heic' || subtype === 'heif') return subtype;
+  return 'jpg';
 }
 
 // --- The published snapshot -------------------------------------------------

--- a/packages/ui/src/components/AmountField.tsx
+++ b/packages/ui/src/components/AmountField.tsx
@@ -103,6 +103,28 @@ export function AmountField({
     }
   }, [value, currency]);
 
+  /**
+   * How much of its full size the number can afford at this length.
+   *
+   * A `TextInput` does not shrink its glyphs to fit — asked for more room than
+   * it has, it scrolls, and what scrolls off a left-aligned field is the *front*
+   * of the number. So ₹13,480.00 in the hero showed as "3,480.00": not a clipped
+   * digit somebody would notice, a different, smaller, entirely plausible
+   * amount. React Native has no cross-platform `adjustsFontSizeToFit` for an
+   * input (it is iOS-only, and not on `TextInput` at all), so the size is chosen
+   * here from what has been typed.
+   *
+   * The line height does not follow it down: the header keeps one height whatever
+   * the number, so typing a digit never nudges the layout below it.
+   */
+  const typed = (text || '0').length;
+  const fit =
+    compact || typed <= 6 ? 1 : typed === 7 ? 0.86 : typed === 8 ? 0.76 : typed <= 10 ? 0.64 : 0.54;
+  const digitSize = Math.round(metrics.digits * fit);
+  // The symbol comes down with it but not as far — it is already the quieter of
+  // the two, and shrinking it in step makes it vanish against the digits.
+  const symbolSize = Math.max(14, Math.round(metrics.symbol * ((1 + fit) / 2)));
+
   const onType = (raw: string): void => {
     const cleaned = sanitiseMinorInput(raw, currency);
     setText(cleaned);
@@ -127,7 +149,7 @@ export function AmountField({
     >
       <Text
         style={{
-          fontSize: metrics.symbol,
+          fontSize: symbolSize,
           lineHeight: metrics.line,
           fontWeight: '700',
           color: symbolInk,
@@ -147,7 +169,7 @@ export function AmountField({
         style={{
           minWidth: metrics.minWidth,
           padding: 0,
-          fontSize: metrics.digits,
+          fontSize: digitSize,
           lineHeight: metrics.line,
           fontWeight: '700',
           color: digitInk,

--- a/packages/ui/src/components/SegmentedTabs.tsx
+++ b/packages/ui/src/components/SegmentedTabs.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Pressable, View } from 'react-native';
 
 import { useTheme } from '../theme';
@@ -6,6 +7,13 @@ import { Text } from './Text';
 export interface SegmentedTab<T extends string> {
   readonly value: T;
   readonly label: string;
+  /**
+   * A mark beside the word, drawn in whatever colour the tab is wearing — the
+   * same shape `ChipRow` uses, so one convention covers both. Optional: a tab
+   * row where only some tabs had a glyph would read as an accident, so pass one
+   * for every tab or for none.
+   */
+  readonly icon?: (color: string) => ReactNode;
 }
 
 /**
@@ -52,11 +60,15 @@ export function SegmentedTabs<T extends string>({
             accessibilityLabel={tab.label}
             style={({ pressed }) => ({
               flex: 1,
+              flexDirection: 'row',
               alignItems: 'center',
+              justifyContent: 'center',
+              gap: theme.spacing.sm,
               paddingVertical: theme.spacing.md,
               opacity: pressed ? 0.6 : 1,
             })}
           >
+            {tab.icon?.(live ? theme.color.brand : theme.color.textFaint)}
             <Text
               variant="caption"
               tone={live ? 'brand' : 'faint'}

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -184,6 +184,54 @@ const SETTLEMENT_SELECT = `
   allocations:settlement_allocations ( expense_id, amount )
 `;
 
+/**
+ * How many groups one pull works on at a time.
+ *
+ * Each group fires its child-table reads together, so a wave costs
+ * `GROUP_CONCURRENCY × GROUP_TABLES.length` in-flight PostgREST requests. Four
+ * keeps that comfortably inside the pooler for a member of many groups while
+ * still collapsing the serial walk that used to dominate a first sync.
+ */
+const GROUP_CONCURRENCY = 4;
+
+/**
+ * Every group-scoped table one pull walks, with the shape each is read in.
+ *
+ * Hoisted out of the loop it used to be declared inside so the reads can be
+ * fired as one batch — and so this list is somewhere findable when a table is
+ * added, rather than buried mid-function.
+ */
+const GROUP_TABLES = [
+  // profiles is embedded by the explicit FK column: ghost_merges references
+  // both group_members and profiles, so PostgREST otherwise sees two
+  // group_members↔profiles relationships and refuses to guess.
+  ['group_members', '*, profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa )'],
+  ['expenses', EXPENSE_SELECT],
+  ['settlements', SETTLEMENT_SELECT],
+  ['activity_log', '*'],
+  // Trip plan + budgets (A23). Flat rows, no embeds. Read as the caller, so a
+  // co-member's private budget is filtered by RLS and simply not returned.
+  ['trip_plan_items', '*'],
+  ['trip_member_budgets', '*'],
+  // Trip album (shared photos). Flat rows, no embeds; a removal arrives as a
+  // deleted_at tombstone the client mirror filters out.
+  // Private attachments (party-only). Read AS THE CALLER, so the party RLS
+  // filters non-parties at the sync boundary — a non-party's response simply
+  // omits these rows, and the bytes are never in any row (only a path, itself
+  // gated a second time at r2-sign). No restricted path is ever added to
+  // SETTLEMENT_SELECT / EXPENSE_SELECT — that would ship the key to everyone.
+  ['settlement_proofs', '*'],
+  ['expense_attachments', '*'],
+  // Expense comment threads — group-visible, read as the caller (is_group_member
+  // RLS). Tombstones (deleted_at set) ride the pull so a delete propagates.
+  ['expense_comments', '*'],
+  // Expense image audit — who added/removed a receipt or attachment. Read AS
+  // THE CALLER: a `parties` row is RLS-filtered exactly like the attachment
+  // it describes, so a non-party never receives the line. Append-only, no
+  // tombstone.
+  ['expense_image_events', '*'],
+] as const;
+
 serveWithCors(async (request) => {
   try {
     if (request.method !== 'POST') throw new HttpError(405, 'METHOD_NOT_ALLOWED', 'Use POST');
@@ -1023,19 +1071,40 @@ async function pull(
   const pfScope = `${profileId}:personal`;
   groupIds.delete(pfScope);
 
-  for (const groupId of groupIds) {
-    const since = cursors[groupId] ?? 0;
+  // Every group's own row in one query rather than one lookup per group. The
+  // per-group `maybeSingle` was the first of twelve serial round trips each
+  // group cost, and twelve of anything serial is what made a five-group first
+  // sync take seconds.
+  const groupList = [...groupIds];
+  const groupRows = new Map<string, Record<string, unknown>>();
+  if (groupList.length > 0) {
+    const { data, error } = await caller.from('groups').select('*').in('id', groupList);
+    if (error) throw new HttpError(500, 'INTERNAL', error.message);
+    for (const row of data ?? []) {
+      const record = row as Record<string, unknown>;
+      groupRows.set(String(record.id), record);
+    }
+  }
 
-    const { data: group, error: groupError } = await caller
-      .from('groups')
-      .select('*')
-      .eq('id', groupId)
-      .maybeSingle();
-    if (groupError) throw new HttpError(500, 'INTERNAL', groupError.message);
+  /**
+   * One group's slice of the pull: its own row, then every child table.
+   *
+   * The child reads are independent — different tables, one shared `since`, no
+   * ordering between them — so they go out together and the group costs one
+   * round trip instead of eleven. `Promise.all` keeps the old failure semantics
+   * exactly: the first rejection propagates and the whole pull fails, because a
+   * failed read must never look like "nothing changed".
+   */
+  const pullGroup = async (
+    groupId: string,
+  ): Promise<{ changes: SyncChange[]; cursor: number; truncated: boolean } | null> => {
+    const since = cursors[groupId] ?? 0;
+    const group = groupRows.get(groupId);
     // Left the group, or never was in it: nothing to say, and no cursor either.
-    if (!group) continue;
+    if (!group) return null;
 
     const highWater = Number(group.updated_seq ?? 0);
+    const groupChanges: SyncChange[] = [];
 
     // The group's cursor covers every child table below, and may only advance to
     // a seq under which ALL of them have been fully delivered. A table capped at
@@ -1046,60 +1115,38 @@ async function pull(
     // joining a group with >500 expenses synced only the first page and lost the
     // rest. Starts at highWater and is dragged down by any truncated table.
     let groupCursor = highWater;
+    let truncated = false;
 
     if (highWater > since) {
-      changes.push({ table: 'groups', groupId, seq: highWater, row: group });
+      groupChanges.push({ table: 'groups', groupId, seq: highWater, row: group });
     }
 
-    for (const [table, select] of [
-      // profiles is embedded by the explicit FK column: ghost_merges references
-      // both group_members and profiles, so PostgREST otherwise sees two
-      // group_members↔profiles relationships and refuses to guess.
-      [
-        'group_members',
-        '*, profile:profiles!profile_id ( id, display_name, avatar_url, default_vpa )',
-      ],
-      ['expenses', EXPENSE_SELECT],
-      ['settlements', SETTLEMENT_SELECT],
-      ['activity_log', '*'],
-      // Trip plan + budgets (A23). Flat rows, no embeds. Read as the caller, so a
-      // co-member's private budget is filtered by RLS and simply not returned.
-      ['trip_plan_items', '*'],
-      ['trip_member_budgets', '*'],
-      // Trip album (shared photos). Flat rows, no embeds; a removal arrives as a
-      // deleted_at tombstone the client mirror filters out.
-      // Private attachments (party-only). Read AS THE CALLER, so the party RLS
-      // filters non-parties at the sync boundary — a non-party's response simply
-      // omits these rows, and the bytes are never in any row (only a path, itself
-      // gated a second time at r2-sign). No restricted path is ever added to
-      // SETTLEMENT_SELECT / EXPENSE_SELECT — that would ship the key to everyone.
-      ['settlement_proofs', '*'],
-      ['expense_attachments', '*'],
-      // Expense comment threads — group-visible, read as the caller (is_group_member
-      // RLS). Tombstones (deleted_at set) ride the pull so a delete propagates.
-      ['expense_comments', '*'],
-      // Expense image audit — who added/removed a receipt or attachment. Read AS
-      // THE CALLER: a `parties` row is RLS-filtered exactly like the attachment
-      // it describes, so a non-party never receives the line. Append-only, no
-      // tombstone.
-      ['expense_image_events', '*'],
-    ] as const) {
-      const { data, error } = await caller
-        .from(table)
-        .select(select)
-        .eq('group_id', groupId)
-        .gt('updated_seq', since)
-        .order('updated_seq', { ascending: true })
-        .limit(MAX_ROWS_PER_TABLE);
+    const pages = await Promise.all(
+      GROUP_TABLES.map(async ([table, select]) => {
+        const { data, error } = await caller
+          .from(table)
+          .select(select)
+          .eq('group_id', groupId)
+          .gt('updated_seq', since)
+          .order('updated_seq', { ascending: true })
+          .limit(MAX_ROWS_PER_TABLE);
 
-      // A failed read must never look like "nothing changed" — that is how a
-      // client silently ends up with half a ledger.
-      if (error) throw new HttpError(500, 'PULL_FAILED', `${table}: ${error.message}`);
+        // A failed read must never look like "nothing changed" — that is how a
+        // client silently ends up with half a ledger.
+        if (error) throw new HttpError(500, 'PULL_FAILED', `${table}: ${error.message}`);
+        return { table, rows: data ?? [] };
+      }),
+    );
 
-      const rows = data ?? [];
+    for (const { table, rows } of pages) {
       for (const row of rows) {
         const record = row as Record<string, unknown>;
-        changes.push({ table, groupId, seq: Number(record.updated_seq ?? 0), row: record });
+        groupChanges.push({
+          table,
+          groupId,
+          seq: Number(record.updated_seq ?? 0),
+          row: record,
+        });
       }
       if (rows.length === MAX_ROWS_PER_TABLE) {
         // Truncated page: rows ordered by ascending updated_seq, so the last one
@@ -1107,113 +1154,91 @@ async function pull(
         // it in this table has been sent yet.
         const lastSeq = Number((rows[rows.length - 1] as Record<string, unknown>).updated_seq ?? 0);
         if (lastSeq < groupCursor) groupCursor = lastSeq;
-        hasMore = true;
+        truncated = true;
       }
     }
 
-    nextCursors[groupId] = groupCursor;
-  }
+    return { changes: groupChanges, cursor: groupCursor, truncated };
+  };
 
-  // Personal scope (A34): the caller's own captures, keyed by their user id.
-  // Read as the caller, so owner-only RLS already guarantees these are theirs —
-  // the same safety property the group reads above rely on. A user is never a
-  // member of a group whose id equals their own, so the key cannot collide.
-  const meSince = cursors[profileId] ?? 0;
-  const { data: captures, error: capturesError } = await caller
-    .from('captures')
-    .select('*')
-    .eq('owner_user_id', profileId)
-    .gt('updated_seq', meSince)
-    .order('updated_seq', { ascending: true })
-    .limit(MAX_ROWS_PER_TABLE);
-  if (capturesError) throw new HttpError(500, 'PULL_FAILED', `captures: ${capturesError.message}`);
-
-  let capturesHighWater = meSince;
-  for (const row of captures ?? []) {
-    const record = row as Record<string, unknown>;
-    const seq = Number(record.updated_seq ?? 0);
-    changes.push({ table: 'captures', groupId: profileId, seq, row: record });
-    if (seq > capturesHighWater) capturesHighWater = seq;
-  }
-  nextCursors[profileId] = capturesHighWater;
-  if ((captures ?? []).length === MAX_ROWS_PER_TABLE) hasMore = true;
-
-  // Personal scope (A38): the caller's own ghost merges, pull-only. Read as the
-  // caller so owner-only RLS (`ghost_merges_select_own`) already guarantees they
-  // are theirs. The mirror keys every row by a string `id`, but ghost_merges has
-  // a composite PK and no id column — so synthesise one from member_id, which is
-  // unique within an owner.
-  const gmSince = cursors[gmScope] ?? 0;
-  const { data: merges, error: mergesError } = await caller
-    .from('ghost_merges')
-    .select('*')
-    .eq('owner', profileId)
-    .gt('updated_seq', gmSince)
-    .order('updated_seq', { ascending: true })
-    .limit(MAX_ROWS_PER_TABLE);
-  if (mergesError) throw new HttpError(500, 'PULL_FAILED', `ghost_merges: ${mergesError.message}`);
-
-  let gmHighWater = gmSince;
-  for (const row of merges ?? []) {
-    const record = row as Record<string, unknown>;
-    const seq = Number(record.updated_seq ?? 0);
-    changes.push({
-      table: 'ghost_merges',
-      groupId: gmScope,
-      seq,
-      row: { ...record, id: record.member_id },
+  // Groups go out in waves rather than one at a time. Bounded rather than all at
+  // once: a member of thirty groups would otherwise open thirty × eleven
+  // connections in one breath, and the pooler — not the loop — would become the
+  // thing making this slow.
+  for (let index = 0; index < groupList.length; index += GROUP_CONCURRENCY) {
+    const wave = groupList.slice(index, index + GROUP_CONCURRENCY);
+    const results = await Promise.all(wave.map((groupId) => pullGroup(groupId)));
+    wave.forEach((groupId, position) => {
+      const result = results[position];
+      if (!result) return;
+      for (const change of result.changes) changes.push(change);
+      nextCursors[groupId] = result.cursor;
+      if (result.truncated) hasMore = true;
     });
-    if (seq > gmHighWater) gmHighWater = seq;
   }
-  nextCursors[gmScope] = gmHighWater;
-  if ((merges ?? []).length === MAX_ROWS_PER_TABLE) hasMore = true;
 
-  // Personal scope (extends TDR §8): the caller's own category-tag catalog, its
-  // own suffixed cursor. Read as the caller so owner-only RLS guarantees they
-  // are theirs, exactly like captures above.
-  const tagSince = cursors[tagScope] ?? 0;
-  const { data: tags, error: tagsError } = await caller
-    .from('category_tags')
-    .select('*')
-    .eq('owner_user_id', profileId)
-    .gt('updated_seq', tagSince)
-    .order('updated_seq', { ascending: true })
-    .limit(MAX_ROWS_PER_TABLE);
-  if (tagsError) throw new HttpError(500, 'PULL_FAILED', `category_tags: ${tagsError.message}`);
+  /**
+   * The four personal scopes, fetched together.
+   *
+   * Each is one owner-filtered table on its own cursor, with nothing to say to
+   * the others — so they were four serial round trips for no reason. Read as the
+   * caller throughout, so owner-only RLS is what guarantees the rows are theirs;
+   * that is the same safety property the group reads above rely on, and it does
+   * not change with the ordering.
+   *
+   * A user is never a member of a group whose id equals their own, so the
+   * captures key cannot collide with a group's.
+   */
+  const personalScopes = [
+    // A34: the caller's own captures, keyed by their user id.
+    { table: 'captures', column: 'owner_user_id', scope: profileId, as: 'captures' },
+    // A38: the caller's own ghost merges, pull-only. The mirror keys every row
+    // by a string `id`, but ghost_merges has a composite PK and no id column —
+    // so one is synthesised below from member_id, unique within an owner.
+    { table: 'ghost_merges', column: 'owner', scope: gmScope, as: 'ghost_merges' },
+    // Extends TDR §8: the caller's own category-tag catalog.
+    { table: 'category_tags', column: 'owner_user_id', scope: tagScope, as: 'category_tags' },
+    // A48: the caller's own personal-finance ledger. Tombstones (deleted_at set)
+    // ride the pull like every soft delete.
+    {
+      table: 'personal_records',
+      column: 'owner_user_id',
+      scope: pfScope,
+      as: 'personal_records',
+    },
+  ] as const;
 
-  let tagsHighWater = tagSince;
-  for (const row of tags ?? []) {
-    const record = row as Record<string, unknown>;
-    const seq = Number(record.updated_seq ?? 0);
-    changes.push({ table: 'category_tags', groupId: tagScope, seq, row: record });
-    if (seq > tagsHighWater) tagsHighWater = seq;
+  const personalPages = await Promise.all(
+    personalScopes.map(async (entry) => {
+      const since = cursors[entry.scope] ?? 0;
+      const { data, error } = await caller
+        .from(entry.table)
+        .select('*')
+        .eq(entry.column, profileId)
+        .gt('updated_seq', since)
+        .order('updated_seq', { ascending: true })
+        .limit(MAX_ROWS_PER_TABLE);
+      if (error) throw new HttpError(500, 'PULL_FAILED', `${entry.table}: ${error.message}`);
+      return { entry, since, rows: data ?? [] };
+    }),
+  );
+
+  for (const { entry, since, rows } of personalPages) {
+    let highWater = since;
+    for (const row of rows) {
+      const record = row as Record<string, unknown>;
+      const seq = Number(record.updated_seq ?? 0);
+      changes.push({
+        table: entry.as,
+        groupId: entry.scope,
+        seq,
+        row: entry.as === 'ghost_merges' ? { ...record, id: record.member_id } : record,
+      });
+      if (seq > highWater) highWater = seq;
+    }
+    nextCursors[entry.scope] = highWater;
+    if (rows.length === MAX_ROWS_PER_TABLE) hasMore = true;
   }
-  nextCursors[tagScope] = tagsHighWater;
-  if ((tags ?? []).length === MAX_ROWS_PER_TABLE) hasMore = true;
-
-  // Personal scope (A48): the caller's own personal-finance ledger, its own
-  // suffixed cursor. Read as the caller so owner-only RLS guarantees the rows
-  // are theirs. Tombstones (deleted_at set) ride the pull like every soft delete.
-  const pfSince = cursors[pfScope] ?? 0;
-  const { data: personal, error: personalError } = await caller
-    .from('personal_records')
-    .select('*')
-    .eq('owner_user_id', profileId)
-    .gt('updated_seq', pfSince)
-    .order('updated_seq', { ascending: true })
-    .limit(MAX_ROWS_PER_TABLE);
-  if (personalError)
-    throw new HttpError(500, 'PULL_FAILED', `personal_records: ${personalError.message}`);
-
-  let pfHighWater = pfSince;
-  for (const row of personal ?? []) {
-    const record = row as Record<string, unknown>;
-    const seq = Number(record.updated_seq ?? 0);
-    changes.push({ table: 'personal_records', groupId: pfScope, seq, row: record });
-    if (seq > pfHighWater) pfHighWater = seq;
-  }
-  nextCursors[pfScope] = pfHighWater;
-  if ((personal ?? []).length === MAX_ROWS_PER_TABLE) hasMore = true;
 
   return { changes, cursors: nextCursors, hasMore };
 }


### PR DESCRIPTION
Five things that were slow or wrong, found by using the app on a device.

## The sync pull was queueing behind itself

`supabase/functions/sync/index.ts` walked every group one at a time, and inside each group walked eleven child tables one at a time, then four personal scopes after that. **Twelve serial PostgREST round trips per group, plus four** — five groups meant sixty-four of them before the first frame, growing with every group joined.

Group rows now come back in one `.in('id', ids)`; each group's eleven tables go out together; groups run in waves of four (bounded, so thirty groups don't open three hundred connections and make the pooler the new bottleneck); the personal scopes go out together. **~64 serial hops → ~4 waves.**

Contract unchanged: `Promise.all` rejects on the first error so a failed read still fails the pull; the per-group cursor still pins to a truncated table's last delivered seq; reordering is safe because `reconcile` sorts by seq and resolves each row by its winning seq regardless of arrival order.

## Adding a receipt showed nothing for seconds

The picker only returned after decode → scale → re-encode → **base64**, and that base64 then crossed the bridge, was decoded back to bytes in JS, and written to a file the manipulator had already written.

Pickers now return the untouched original first (`pickReceiptAsset` / `captureReceiptAsset`) and `prepareReceipt` does the expensive part after; the thumbnail is on screen the moment the picker closes, wearing the same scrim the queue tile wears. `enqueueReceipt` takes `sourceUri` and copies the resize's own file. Deleting no longer waits on the round trip. The strip stopped reporting one upload twice.

## The group tab switch paid for the whole tab

Not rebuilding rows (those are memoised) — handing FlashList a different `data` makes it lay the whole set out, per item, between the tap and the first frame. A fresh tab now paints 24 rows and grows on the next tick after `runAfterInteractions`. `drawDistance` 1500 → 2500; a hard fling was still outrunning it and flashing blanks.

## The dashboard held a skeleton over figures it already had

`pendingFirstSync` stays true until the session's first sync lands, so the skeleton covered on-disk figures for as long as the network took. Now `hydrating` (nothing to paint, milliseconds) keeps the skeleton; `settling` shows the real figures at full strength with a small spinner beside the hero label.

**This reverses #600's "hold the skeleton until the figures are final."** That rule guarded against a number moving after being read; it is downgraded to "an unconfirmed number is marked, not hidden".

## A long amount was silently wrong

A `TextInput` scrolls rather than shrinking, and what scrolls off a left-aligned field is the *front* of the number — so the hero showed ₹13,480.00 as "3,480.00". Not a clipped digit anybody would notice: a different, plausible amount. Digit size now scales with length; line height stays fixed.

## Also in the expense form and screens

- Scan / Add photo gone from an **edit** — the gallery already carries its own add tile, and scan offered to re-read a bill already entered.
- "How to split" lost its summary card; the controls stand open under a plain heading.
- "More details" can be closed again — it was `disabled` whenever a detail had a value, so "Fewer details" looked tappable and did nothing.
- Paid by is one scrolling lane of fixed-width tiles (a long name used to reflow the card); selected payers lead it.
- Segmented tabs take an optional `icon(color)`, the same shape `ChipRow` uses. Expense screen's tab row moved out of the ScrollView so it no longer scrolls away.
- Receipts now lead the expense screen, ahead of the facts read off them.

## Testing

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — green.
- Edge-function suite: 86 tests pass.
- `packages/db` shows 27 failures that reproduce identically on a stashed clean tree — pre-existing local-DB state, unrelated.
- Device-checked on Android over Metro for the UI changes. **Not** measured on a release build, and the sync change is not yet deployed — it needs `edge:deploy` before it helps a device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Receipt capture and uploads now provide faster previews, clearer upload status, and recovery when deletion fails.
  - Expense details show receipts first, with icon-enhanced Details and History tabs.
  - Group tabs load more smoothly, and split, payer, and participant controls are easier to access.
- **Improvements**
  - Dashboard balances appear sooner while syncing.
  - Large amounts fit better as they are entered.
  - Tab labels now support visual icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->