### PR TITLE
feat(expense): split a bill by typing each person's amount

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -28,6 +28,7 @@ import {
   PayerProblemCode,
   rebalancePayers,
   ridersSplit,
+  sanitiseMinorInput,
   serialisePayers,
   splitByUnits,
   treatSplit,
@@ -103,6 +104,8 @@ import {
   fillEntries,
   formatEntry,
   parseEntry,
+  exactRemainder,
+  exactValues,
   splitProblem,
   SplitKind,
   type SplitEntries,
@@ -149,9 +152,12 @@ interface ExpenseDraft {
   /** The stored conversion rate for a foreign-currency expense (ADR-003). */
   fx?: FxRecord | null;
   participants: MemberId[];
-  /** Kept apart, because a weight of 1 is not one percent. */
+  /** Kept apart, because a weight of 1 is not one percent — nor is either of
+   *  them ₹1. Optional: drafts written before the exact split existed have no
+   *  `exacts`, which reads as an empty set of fields, not as a lost one. */
   weights: SplitEntries;
   percents: SplitEntries;
+  exacts?: SplitEntries;
   category: string | null;
   /** The custom tag's display, when `category` is a custom tag (extends TDR §8). */
   categoryMeta: CategoryMeta | null;
@@ -159,6 +165,88 @@ interface ExpenseDraft {
   categoryChosen: boolean;
   /** Where the spend happened (A43), when the person attached one. */
   location?: ExpenseLocation | null;
+}
+
+/**
+ * The number beside one person in a weighted or exact split.
+ *
+ * Its own component for two reasons. The obvious one: three kinds of field with
+ * three keypads, three suffixes and three spoken labels is a lot of ternaries to
+ * read inside a list of people. The load-bearing one: an exact field is *money*,
+ * so it has to sanitise each keystroke against the expense's currency — and
+ * doing that in the screen's own render meant `currency` was captured by a
+ * closure the React Compiler could not prove safe, which cost the split preview
+ * and the params their memoisation ("existing memoization could not be
+ * preserved"). Held here, the currency is a prop this component reads, and the
+ * screen above keeps its memos.
+ */
+function SplitEntryField({
+  kind,
+  currency,
+  value,
+  onChange,
+  name,
+}: {
+  kind: SplitKind;
+  currency: string;
+  value: string;
+  /** Called with the text as it should be stored — already sanitised for money. */
+  onChange: (text: string) => void;
+  /** Whose figure this is, for the spoken label. */
+  name: string;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const { t } = useStrings();
+  const exact = kind === SplitKind.Exact;
+  const percent = kind === SplitKind.Percent;
+
+  return (
+    <Row style={{ gap: 2, alignItems: 'center', flexGrow: 0, flexShrink: 0 }}>
+      <TextInput
+        value={value}
+        onChangeText={(text) =>
+          // Money is cleaned on the way in — the currency decides whether a
+          // decimal point is offered at all, and a second one never lands in the
+          // field. A weight or a percentage is stored as typed and judged by
+          // `splitProblem`, which refuses rather than trims.
+          onChange(exact ? sanitiseMinorInput(text, currency as CurrencyCode) : text)
+        }
+        keyboardType={
+          exact ? amountKeyboard(currency as CurrencyCode) : percent ? 'decimal-pad' : 'number-pad'
+        }
+        selectTextOnFocus
+        placeholder={kind === SplitKind.Shares ? '1' : '0'}
+        placeholderTextColor={theme.color.textFaint}
+        accessibilityLabel={
+          exact
+            ? fill(t.expense.exactShareLabel, { name })
+            : percent
+              ? `${name}'s percentage`
+              : `${name}'s shares`
+        }
+        style={{
+          // An amount needs more room than a weight: two decimals and a
+          // thousands' worth of digits do not fit in 72.
+          width: exact ? 104 : 72,
+          // A 44pt floor makes the field a real tap target; `textAlignVertical`
+          // keeps the digit centred in the taller box on Android.
+          minHeight: 44,
+          fontSize: 16,
+          fontWeight: '700',
+          textAlign: 'right',
+          textAlignVertical: 'center',
+          color: theme.color.text,
+          backgroundColor: theme.color.bg,
+          borderRadius: theme.radius.sm,
+          paddingVertical: theme.spacing.sm,
+          paddingHorizontal: theme.spacing.sm,
+        }}
+      />
+      <Text variant="micro" tone="muted">
+        {percent ? '%' : exact ? currencySymbol(currency) : '×'}
+      </Text>
+    </Row>
+  );
 }
 
 /** A saved split's integers, back as the text somebody would have typed. */
@@ -323,6 +411,10 @@ export default function AddExpenseScreen() {
   // reinterpret one number as the other.
   const [weights, setWeights] = useState<SplitEntries>({});
   const [percents, setPercents] = useState<SplitEntries>({});
+  // The exact split's fields: money as typed, one line per person. Kept apart
+  // from the two weighted maps for the same reason those are kept apart from
+  // each other — 1 is not one percent, and neither of them is ₹1.
+  const [exacts, setExacts] = useState<SplitEntries>({});
   // Travel split presets (trip groups). Each produces the canonical split params
   // the ledger already understands, so nothing new is stored: nights → shares,
   // this-ride → equal (both drive the normal fields), car rental → an
@@ -554,6 +646,7 @@ export default function AddExpenseScreen() {
       setParticipants(draft.participants);
       setWeights(draft.weights ?? {});
       setPercents(draft.percents ?? {});
+      setExacts(draft.exacts ?? {});
       setCategory(draft.category ?? null);
       setCategoryMeta(draft.categoryMeta ?? null);
       setCategoryChosen(draft.categoryChosen ?? false);
@@ -606,7 +699,9 @@ export default function AddExpenseScreen() {
           ? SplitKind.Percent
           : version.split_type === 'shares'
             ? SplitKind.Shares
-            : SplitKind.Equal,
+            : version.split_type === 'exact'
+              ? SplitKind.Exact
+              : SplitKind.Equal,
       );
       // The numbers somebody chose the first time, back in the fields they were
       // typed into — an edit that silently re-divided them equally would be a
@@ -616,6 +711,15 @@ export default function AddExpenseScreen() {
         setWeights(textEntries(params.weights, 'shares'));
       } else if (params.kind === 'percent') {
         setPercents(textEntries(params.basisPoints, 'percent'));
+      } else if (params.kind === 'exact') {
+        setExacts(
+          Object.fromEntries(
+            Object.entries(params.amounts).map(([memberId, minor]) => [
+              memberId,
+              formatMinorInput(BigInt(minor), version.currency as CurrencyCode),
+            ]),
+          ),
+        );
       }
     } else {
       setParticipants((members.data ?? []).map((member) => member.id));
@@ -651,14 +755,15 @@ export default function AddExpenseScreen() {
     if (filled) setPercents(filled);
   }
 
-  const entries = splitKind === SplitKind.Shares ? weights : percents;
+  const entries =
+    splitKind === SplitKind.Shares ? weights : splitKind === SplitKind.Exact ? exacts : percents;
   const setEntry = (memberId: MemberId, text: string): void => {
     clearPreset();
     const update = (current: SplitEntries): SplitEntries => ({ ...current, [memberId]: text });
     if (splitKind === SplitKind.Shares) setWeights(update);
+    else if (splitKind === SplitKind.Exact) setExacts(update);
     else setPercents(update);
   };
-  const splitIssue = splitProblem(splitKind, entries, participants);
 
   // The split used to fold into a one-line summary card, opening itself when the
   // configuration was not the "I paid, split equally" default. The fold is gone:
@@ -867,6 +972,7 @@ export default function AddExpenseScreen() {
       participants,
       weights,
       percents,
+      exacts,
       category,
       categoryMeta,
       categoryChosen,
@@ -919,8 +1025,24 @@ export default function AddExpenseScreen() {
     if (splitKind === SplitKind.Percent) {
       return { kind: 'percent', basisPoints: entryValues('percent', percents, participants) };
     }
+    if (splitKind === SplitKind.Exact) {
+      return {
+        kind: 'exact',
+        amounts: exactValues(exacts, participants, currency),
+      };
+    }
     return { kind: 'equal' };
-  }, [splitKind, weights, percents, participants, treatHost, presetParams, amount]);
+  }, [
+    splitKind,
+    weights,
+    percents,
+    exacts,
+    currency,
+    participants,
+    treatHost,
+    presetParams,
+    amount,
+  ]);
 
   // Preview with the same engine the server uses; if they ever disagree the
   // server wins and tells us why (SHARE_MISMATCH).
@@ -938,6 +1060,25 @@ export default function AddExpenseScreen() {
       return null;
     }
   }, [amount, currency, splitParams, participants, targetExpenseId]);
+
+  // What is still unassigned in an exact split, signed like the payer side's
+  // delta: positive is left to hand out, negative is more than the bill. Only
+  // worth saying once there is a bill to measure against — "₹0 left" over an
+  // empty form is noise, not guidance.
+  const exactLeft =
+    splitKind === SplitKind.Exact && amount > 0n
+      ? exactRemainder(exacts, participants, currency, amount)
+      : 0n;
+  const exactIssue =
+    splitKind !== SplitKind.Exact || amount === 0n || participants.length === 0 || exactLeft === 0n
+      ? null
+      : (exactLeft > 0n ? t.expense.paidLeftToAssign : t.expense.paidOverAssigned).replace(
+          '{amount}',
+          format(money(exactLeft < 0n ? -exactLeft : exactLeft, currency), { locale }),
+        );
+  // The exact split's own complaint takes precedence: it is about money, and the
+  // weighted check has nothing to say about a set of typed amounts.
+  const splitIssue = exactIssue ?? splitProblem(splitKind, entries, participants);
 
   if (group.isLoading || members.isLoading || restored.loading) {
     // Shell first: the back button and title paint instantly on navigation, and
@@ -1603,18 +1744,22 @@ export default function AddExpenseScreen() {
                 clearPreset();
                 setSplitKind(next);
               }}
-              options={[SplitKind.Equal, SplitKind.Shares, SplitKind.Percent].map((kind) => ({
-                value: kind,
-                label:
-                  kind === SplitKind.Equal
-                    ? t.expense.equally
-                    : kind === SplitKind.Shares
-                      ? t.expense.shares
-                      : t.expense.percent,
-                icon: (color: string) => (
-                  <Ionicons name={splitIcon(kind)} size={iconSize.md} color={color} />
-                ),
-              }))}
+              options={[SplitKind.Equal, SplitKind.Shares, SplitKind.Percent, SplitKind.Exact].map(
+                (kind) => ({
+                  value: kind,
+                  label:
+                    kind === SplitKind.Equal
+                      ? t.expense.equally
+                      : kind === SplitKind.Shares
+                        ? t.expense.shares
+                        : kind === SplitKind.Percent
+                          ? t.expense.percent
+                          : t.expense.exactly,
+                  icon: (color: string) => (
+                    <Ionicons name={splitIcon(kind)} size={iconSize.md} color={color} />
+                  ),
+                }),
+              )}
             />
           </View>
 
@@ -1888,42 +2033,13 @@ export default function AddExpenseScreen() {
                   </Pressable>
 
                   {splitKind !== SplitKind.Equal && selected ? (
-                    <Row style={{ gap: 2, alignItems: 'center', flexGrow: 0, flexShrink: 0 }}>
-                      <TextInput
-                        value={entries[member.id] ?? ''}
-                        onChangeText={(text) => setEntry(member.id, text)}
-                        keyboardType={
-                          splitKind === SplitKind.Percent ? 'decimal-pad' : 'number-pad'
-                        }
-                        selectTextOnFocus
-                        placeholder={splitKind === SplitKind.Percent ? '0' : '1'}
-                        placeholderTextColor={theme.color.textFaint}
-                        accessibilityLabel={
-                          splitKind === SplitKind.Percent
-                            ? `${name}'s percentage`
-                            : `${name}'s shares`
-                        }
-                        style={{
-                          width: 72,
-                          // A 44pt floor makes the share/percent field a real tap
-                          // target; `textAlignVertical` keeps the digit centred in
-                          // the taller box on Android.
-                          minHeight: 44,
-                          fontSize: 16,
-                          fontWeight: '700',
-                          textAlign: 'right',
-                          textAlignVertical: 'center',
-                          color: theme.color.text,
-                          backgroundColor: theme.color.bg,
-                          borderRadius: theme.radius.sm,
-                          paddingVertical: theme.spacing.sm,
-                          paddingHorizontal: theme.spacing.sm,
-                        }}
-                      />
-                      <Text variant="micro" tone="muted">
-                        {splitKind === SplitKind.Percent ? '%' : '×'}
-                      </Text>
-                    </Row>
+                    <SplitEntryField
+                      kind={splitKind}
+                      currency={currency}
+                      value={entries[member.id] ?? ''}
+                      onChange={(text) => setEntry(member.id, text)}
+                      name={name}
+                    />
                   ) : null}
 
                   <Pressable

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -1678,6 +1678,10 @@ export interface UiStrings {
     equally: string;
     shares: string;
     percent: string;
+    /** The fourth way to split: type each person's amount yourself. */
+    exactly: string;
+    /** The amount field beside one person in an exact split. `{name}` is theirs. */
+    exactShareLabel: string;
     splitBetween: string;
     ofCount: string;
     saveChanges: string;
@@ -1717,9 +1721,11 @@ export interface UiStrings {
     paidAndShare: string;
     /** Resets every payer to an even share of the bill. */
     splitPaidEvenly: string;
-    /** `{amount}` of the bill is not accounted for by any payer yet. */
+    /** `{amount}` of the bill is not accounted for yet — by any payer, or by
+     *  any share in an exact split. The sentence fits both sides. */
     paidLeftToAssign: string;
-    /** The payers have claimed `{amount}` more than the bill. */
+    /** `{amount}` more than the bill has been claimed — by the payers, or by
+     *  the shares of an exact split. */
     paidOverAssigned: string;
     /** Turns the payer row into a several-people-paid one. */
     paidBySeveral: string;
@@ -3798,6 +3804,8 @@ const en: UiStrings = {
       apply: 'Apply',
     },
     equally: 'Equally',
+    exactly: 'Exact',
+    exactShareLabel: "{name}'s share",
     shares: 'Shares',
     percent: 'Percent',
     splitBetween: 'Split between',
@@ -5972,6 +5980,8 @@ const ta: UiStrings = {
       apply: 'பயன்படுத்து',
     },
     equally: 'சமமாக',
+    exactly: 'சரியாக',
+    exactShareLabel: '{name} இன் பங்கு',
     shares: 'பங்குகள்',
     percent: 'சதவீதம்',
     splitBetween: 'யாருக்கிடையே',
@@ -8137,6 +8147,8 @@ const hi: UiStrings = {
       apply: 'लागू करें',
     },
     equally: 'बराबर',
+    exactly: 'सटीक',
+    exactShareLabel: '{name} का हिस्सा',
     shares: 'हिस्से',
     percent: 'प्रतिशत',
     splitBetween: 'किनके बीच',
@@ -10347,6 +10359,8 @@ const ar: UiStrings = {
       apply: 'تطبيق',
     },
     equally: 'بالتساوي',
+    exactly: 'بالضبط',
+    exactShareLabel: 'حصة {name}',
     shares: 'حصص',
     percent: 'نسبة مئوية',
     splitBetween: 'التقسيم بين',

--- a/apps/mobile/src/lib/split.ts
+++ b/apps/mobile/src/lib/split.ts
@@ -1,5 +1,5 @@
 /**
- * The numbers somebody types into a shares or percent split.
+ * The numbers somebody types into a shares, percent or exact split.
  *
  * `@waves/core` takes integers — whole weights, and basis points that sum to
  * exactly 10000. A person types text, and text is where the gap is: "33.33" is
@@ -13,10 +13,13 @@
  * ledger that nobody chose.
  */
 
+import { parseMinorInput, type CurrencyCode } from '@waves/core';
+
 export enum SplitKind {
   Equal = 'equal',
   Shares = 'shares',
   Percent = 'percent',
+  Exact = 'exact',
 }
 
 /** What a weighted split kind holds: one line of text per member. */
@@ -96,6 +99,10 @@ export function splitProblem(
   participants: readonly string[],
 ): string | null {
   if (kind === 'equal') return null;
+  // An exact split's complaint is money, and money needs a currency and a total
+  // this function is not given. `exactRemainder` answers it instead, and the
+  // screen turns the figure into a localised sentence.
+  if (kind === 'exact') return null;
   if (participants.length === 0) return null;
 
   for (const id of participants) {
@@ -154,4 +161,52 @@ export function fillEntries(
     filled[id] = formatEntry('percent', basisPoints);
   });
   return filled;
+}
+
+/**
+ * The typed exact amounts, as the minor units `computeShares` takes.
+ *
+ * Unlike shares and percent, an exact split is money — so the text is read with
+ * the same currency-aware parser the amount fields use, and a currency with no
+ * minor unit gets no decimals for free. An empty field is zero: somebody
+ * part-way through, whom {@link exactRemainder} will tell what is still owed.
+ *
+ * Only participants are passed on. Unticking somebody keeps their text, because
+ * throwing away a typed figure on a mis-tap is the kind of loss nobody forgives,
+ * but an amount for a non-participant is rejected downstream.
+ */
+export function exactValues(
+  entries: SplitEntries,
+  participants: readonly string[],
+  currency: string,
+): Record<string, bigint> {
+  const values: Record<string, bigint> = {};
+  for (const id of participants) {
+    values[id] = parseMinorInput(entries[id] ?? '', currency as CurrencyCode);
+  }
+  return values;
+}
+
+/**
+ * What is left to hand out: the bill minus everything typed so far.
+ *
+ * Signed, like the payer side's `delta` — positive is still to assign, negative
+ * is more than the bill. The screen turns it into money and a sentence; this
+ * stays a number so it can be tested without a locale.
+ *
+ * This is the same rule `computeShares` enforces (`EXACT_SUM_MISMATCH`) and the
+ * one the sync function re-checks. Doing it here as well is not a second source
+ * of truth — it is the difference between a sentence under the field and a
+ * rejection that arrives minutes later off the queue.
+ */
+export function exactRemainder(
+  entries: SplitEntries,
+  participants: readonly string[],
+  currency: string,
+  amount: bigint,
+): bigint {
+  const values = exactValues(entries, participants, currency);
+  let assigned = 0n;
+  for (const value of Object.values(values)) assigned += value;
+  return amount - assigned;
 }

--- a/apps/mobile/test/split.test.ts
+++ b/apps/mobile/test/split.test.ts
@@ -4,6 +4,8 @@ import { computeShares } from '@waves/core';
 
 import {
   entryValues,
+  exactRemainder,
+  exactValues,
   fillEntries,
   formatEntry,
   parseEntry,
@@ -208,5 +210,77 @@ describe('what the screen hands to the money engine', () => {
 
     expect(shares.size).toBe(many.length);
     expect([...shares.values()].reduce((sum, share) => sum + share, 0n)).toBe(123456789n);
+  });
+});
+
+describe('an exact split', () => {
+  const people = ['a', 'b', 'c'];
+
+  it('reads each field as money in the expense currency', () => {
+    expect(exactValues({ a: '12.50', b: '7', c: '' }, people, 'INR')).toEqual({
+      a: 1250n,
+      b: 700n,
+      c: 0n,
+    });
+  });
+
+  it('reads a currency with no minor unit as whole units', () => {
+    expect(exactValues({ a: '1200', b: '800', c: '0' }, people, 'JPY')).toEqual({
+      a: 1200n,
+      b: 800n,
+      c: 0n,
+    });
+  });
+
+  it('leaves out anybody who is not in the split', () => {
+    // `d` was ticked off after their figure was typed; the text is kept on the
+    // screen but must not reach the engine, which rejects a non-participant.
+    expect(exactValues({ a: '10', b: '10', c: '10', d: '99' }, people, 'INR')).toEqual({
+      a: 1000n,
+      b: 1000n,
+      c: 1000n,
+    });
+  });
+
+  it('says what is left to hand out, and what is over', () => {
+    expect(exactRemainder({ a: '10', b: '10', c: '10' }, people, 'INR', 3000n)).toBe(0n);
+    expect(exactRemainder({ a: '10', b: '10', c: '' }, people, 'INR', 3000n)).toBe(1000n);
+    expect(exactRemainder({ a: '10', b: '10', c: '20' }, people, 'INR', 3000n)).toBe(-1000n);
+  });
+
+  it('agrees with the engine: a remainder of zero is a split that computes', () => {
+    const entries = { a: '12.50', b: '7.25', c: '10.25' };
+    expect(exactRemainder(entries, people, 'INR', 3000n)).toBe(0n);
+
+    const shares = computeShares({
+      amount: 3000n,
+      currency: 'INR',
+      params: { kind: 'exact', amounts: exactValues(entries, people, 'INR') },
+      participants: people,
+      seed: 'expense-1',
+    });
+    expect(shares.get('a')).toBe(1250n);
+    expect(shares.get('b')).toBe(725n);
+    expect(shares.get('c')).toBe(1025n);
+  });
+
+  it('agrees with the engine the other way too: a remainder is a refusal', () => {
+    // The message under the field and the server's EXACT_SUM_MISMATCH are the
+    // same rule; this is what stops the two ever drifting apart.
+    const entries = { a: '10', b: '10', c: '5' };
+    expect(exactRemainder(entries, people, 'INR', 3000n)).not.toBe(0n);
+    expect(() =>
+      computeShares({
+        amount: 3000n,
+        currency: 'INR',
+        params: { kind: 'exact', amounts: exactValues(entries, people, 'INR') },
+        participants: people,
+        seed: 'expense-1',
+      }),
+    ).toThrow();
+  });
+
+  it('has no opinion of its own in splitProblem — money is judged elsewhere', () => {
+    expect(splitProblem(SplitKind.Exact, { a: '1' }, people)).toBeNull();
   });
 });


### PR DESCRIPTION
A fourth way to split, beside Equally / Shares / Percent: **Exact**.

Each person gets a money field in the expense's own currency, and a line underneath says what is still unassigned — "₹340 left to assign", "₹120 too much". Save stays disabled until the figures add up.

The split people reach for when the bill is already itemised in front of them — "she had the ₹450 starter, I had the ₹1,200 main" — where the proportions are nobody's idea of a ratio.

## Nothing rebalances as you type

Considered and rejected. Shares and Percent already cover "divide it proportionally"; an exact split whose *other* numbers move while somebody is mid-way through entering theirs is the one that would mislead. Typed numbers stay typed; the remainder line says where you are.

## The ledger needed nothing

`exact` has been in the `SplitType` enum (`schema.prisma:46`) and in `computeShares` (`packages/core/src/split/computeShares.ts:60`) all along, and that already refuses a set of amounts that does not sum to the bill:

```ts
if (total !== input.amount) throw new SplitError(SplitErrorCode.ExactSumMismatch, …)
```

The sync function recomputes with the same core and rejects a disagreeing client (`SHARE_MISMATCH`), so the verify-on-save is **already enforced server-side**. `exactRemainder` is not a second source of truth — it is the difference between a sentence under the field and a rejection that arrives minutes later off the queue. Two tests pin the two to each other in both directions.

## Changes

- `SplitKind.Exact`, plus `exactValues` / `exactRemainder` in `apps/mobile/src/lib/split.ts` — currency-aware (a no-minor-unit currency gets no decimals for free), and non-participants are dropped on the way to the engine while their typed text stays on screen.
- The chip, the field, the remainder sentence, edit seeding from a saved `exact` split, and draft persistence (`exacts` is optional, so older drafts read as empty rather than lost).
- The per-person field moved into `SplitEntryField`. Partly readability — three keypads, three suffixes, three spoken labels is a lot of ternaries inside a list of people. Mainly the React Compiler: an exact field sanitises each keystroke against the currency, and doing that in the screen's own render captured `currency` in a closure it would not follow, costing `splitParams` and `preview` their memoisation ("existing memoization could not be preserved").
- Two new i18n keys in all four languages (`exactly`, `exactShareLabel`). The two remainder sentences are reused from the payer side rather than duplicated — same words, same meaning; their doc comments now say they serve both.

## Testing

- `apps/mobile` vitest: 732 pass, including 7 new for the exact split.
- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — green.
- **Not device-tested.**

Branched off `main`, not stacked on #605 — but both touch `add-expense.tsx`, so whichever lands second will need a rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Exact amounts” split option for assigning a specific amount to each participant.
  * Added currency-aware amount entry and support for multiple currencies, including currencies without minor units.
  * Added validation to identify under- or over-assigned totals.
  * Added translations for the new split option in all supported languages.

* **Tests**
  * Added coverage for exact amount calculations, currency handling, participant filtering, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->