### PR TITLE
fix(dashboard): the balance shows its sign, the eye shuts every figure, and 90 lines of trip code that painted nothing

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -535,8 +535,13 @@ export default function HomeScreen() {
                       divider={index > 0}
                       // The eye in the hero shuts the whole screen's money, not
                       // just the headline: masking one figure while twelve sit
-                      // uncovered below it is privacy theatre.
-                      hidden={balanceHidden}
+                      // uncovered below it is privacy theatre. Masked too until
+                      // the saved preference has loaded — `balanceHidden` starts
+                      // false while AsyncStorage resolves, so without the
+                      // `!balanceReady` guard a hidden balance flashes in plain
+                      // before the eye's state lands. The hero is already gated
+                      // this way upstream (it shows its skeleton until ready).
+                      hidden={balanceHidden || !balanceReady}
                       // The just-imported group slides and fades into place
                       // rather than blinking in under the success banner.
                       enter={group.id === justAddedId}

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -16,7 +16,7 @@ import {
   View,
 } from 'react-native';
 
-import { dayNumber, daysBetween, type GuestGate } from '@waves/core';
+import { dayNumber, type GuestGate } from '@waves/core';
 import {
   Avatar,
   Button,
@@ -240,30 +240,16 @@ export default function HomeScreen() {
     owing: 0n,
   };
 
-  // A trip that is running today earns a card at the front of the balance deck:
-  // it is the most "now" thing on the dashboard, and it is the one tap into the
-  // planner nobody finds behind the group menu. "Running" is decided in the
-  // trip's own timezone, not the phone's — a Goa trip run from Dubai turns over
-  // at midnight in Goa (the same rule `dayNumber` and the planner already use).
-  const activeTrips: readonly TripSlide[] = list
-    .filter((g) => g.type === GroupType.Trip && g.start_date && g.end_date)
-    .map((g) => {
-      const day = dayNumber(todayIn(g.time_zone), g.start_date, g.end_date);
-      if (day === null) return null;
-      return {
-        id: g.id,
-        title: groupLabel(g, summary.membersFor(g.id), profile?.id),
-        coverEmoji: g.cover_emoji,
-        currency: g.default_currency,
-        day,
-        total: daysBetween(g.start_date!, g.end_date!).length,
-        balance: summary.balanceFor(g.id),
-      };
-    })
-    .filter((t): t is TripSlide => t !== null);
-
-  // The ids of trips running right now, so their rows can wear an "on trip" tag.
-  const ongoingTripIds = new Set(activeTrips.map((tr) => tr.id));
+  // The ids of the trips running today, so their rows can wear an "on trip"
+  // tag. "Running" is decided in the trip's own timezone, not the phone's — a
+  // Goa trip run from Dubai turns over at midnight in Goa (the same rule
+  // `dayNumber` and the planner already use).
+  const ongoingTripIds = new Set(
+    list
+      .filter((g) => g.type === GroupType.Trip && g.start_date && g.end_date)
+      .filter((g) => dayNumber(todayIn(g.time_zone), g.start_date, g.end_date) !== null)
+      .map((g) => g.id),
+  );
   // "Now" sampled once per mount (a lazy initial state, never re-read as a ref
   // in render) so the "New" window is stable across this screen's renders and
   // the React Compiler stays happy — a bare Date.now() in render trips its lint.
@@ -429,7 +415,7 @@ export default function HomeScreen() {
             </Row>
 
             {/* The swipe pager, right under the buttons. */}
-            <HeroDots count={SLIDE_GRADIENTS.length} scrollX={heroScrollX} snap={heroSnap} />
+            <HeroDots count={SLIDE_KEYS.length} scrollX={heroScrollX} snap={heroSnap} />
           </View>
         </View>
       </TourTarget>
@@ -470,8 +456,13 @@ export default function HomeScreen() {
             <SkeletonList rows={3} />
           ) : list.length === 0 ? (
             <View style={{ flex: 1, justifyContent: 'center' }}>
+              {/* The one screen where somebody has nothing to act on yet gets
+                  the action spelled out, rather than leaving them to find the
+                  small icon up in the hero's header cluster. */}
               <EmptyState
                 title={t.tabs.noGroups}
+                body={t.tabs.noGroupsBody}
+                action={<Button label={t.newGroup} onPress={openNewGroup} />}
                 icon={
                   <Ionicons name="people-outline" size={iconSize.xxl} color={theme.color.brand} />
                 }
@@ -542,6 +533,10 @@ export default function HomeScreen() {
                       tag={tag}
                       tagTone={onTrip ? 'positive' : 'brand'}
                       divider={index > 0}
+                      // The eye in the hero shuts the whole screen's money, not
+                      // just the headline: masking one figure while twelve sit
+                      // uncovered below it is privacy theatre.
+                      hidden={balanceHidden}
                       // The just-imported group slides and fades into place
                       // rather than blinking in under the success banner.
                       enter={group.id === justAddedId}
@@ -640,6 +635,11 @@ function HeroAvatar({
 
 /** The AsyncStorage key remembering whether the balance is hidden behind the eye. */
 const BALANCE_HIDDEN_KEY = 'dashboard:balanceHidden';
+
+/** What stands in for a figure while the eye is shut. One string, because the
+    hero and the group rows have to mask identically or the mask reads as a
+    rendering fault rather than a choice. */
+const BALANCE_MASK = '••••••';
 
 /**
  * The eye toggle's state, remembered across opens. Reads once on mount (so a
@@ -1184,20 +1184,6 @@ function TipSheet({ t }: { t: UiStrings }) {
 /** One currency's standing: the net, and the two sides that make it up. */
 type CurrencyTotal = { currency: string; net: bigint; owed: bigint; owing: bigint };
 
-/** A running trip's card: where it is in its own run, and its standing. */
-type TripSlide = {
-  id: string;
-  title: string;
-  coverEmoji: string | null;
-  currency: string;
-  /** 1-based day the trip is on today, in its own timezone. */
-  day: number;
-  /** Total days the trip spans, both ends inclusive. */
-  total: number;
-  /** Net in the group's currency: >0 owed to you, <0 you owe. */
-  balance: bigint;
-};
-
 /** Today as `YYYY-MM-DD` in a given timezone, never the server's. */
 function todayIn(timeZone: string): string {
   try {
@@ -1225,6 +1211,14 @@ const SLIDE_GRADIENTS = [
 ] as const;
 
 /**
+ * The slides the deck actually carries, in order. Everything that has to agree
+ * on "how many" counts this — the dot pager, the colour layers, the watermarks
+ * — so the answer comes from the content rather than from the length of the
+ * palette that happens to paint it.
+ */
+const SLIDE_KEYS = ['net', 'owed', 'month'] as const;
+
+/**
  * One watermark glyph per slide, in the same order (net, owed, month). It rides
  * the corner of the hero as a faint, oversized outline and crossfades on the
  * same scroll value as the colour, so the mark swaps as you swipe: a wallet for
@@ -1238,6 +1232,21 @@ const SLIDE_ICONS = ['wallet-outline', 'trending-up-outline', 'calendar-outline'
     add-expense pill's ink) and the badge ring — a fixed brand green, not the
     animated hero colour. */
 const HERO_GREEN = SLIDE_GRADIENTS[0];
+
+/**
+ * The hero's two lines, in one place. `HeroBalanceSkeleton` builds itself to
+ * exactly these heights so the real figure settles into the placeholder's
+ * space instead of shoving the buttons and the group list down — which only
+ * holds if both sites read the same numbers, hence the constants.
+ */
+const HERO_LABEL_LINE = 18;
+const HERO_AMOUNT_SIZE = 40;
+const HERO_AMOUNT_LINE = 46;
+const HERO_AMOUNT_STYLE = {
+  fontSize: HERO_AMOUNT_SIZE,
+  lineHeight: HERO_AMOUNT_LINE,
+  fontWeight: '700',
+} as const;
 
 /**
  * The swipeable balance inside the hero: three views of where you stand, one per
@@ -1286,11 +1295,11 @@ function HeroBalance({
   // — all in your primary currency, which is the one the headline is already in
   // (no total across currencies, ADR-004).
   const monthAmount = monthSpent.find((entry) => entry.currency === primary.currency)?.amount ?? 0n;
-  // The net slide shows its figure as an ABSOLUTE value, so the owe↔owed
-  // direction has to live in the heading — this is the only slide whose sign
-  // carries meaning. We fold that verdict into the label itself (a Title-case
-  // phrase that matches the other slides' headings) so a single line still
-  // tells you which way you stand, now that the old third "sub" line is gone.
+  // The net slide is the only one whose sign is information, so it shows that
+  // sign on the figure itself — a signed 40pt number is what gets read at a
+  // glance, where an 11pt caption does not. The heading still names the verdict
+  // in words (a Title-case phrase matching the other slides' headings); the two
+  // agree, and either one alone would answer "which way do I stand".
   const netDirection =
     primary.net === 0n ? t.allSettled : primary.net > 0n ? t.dashHero.netOwed : t.dashHero.netOwe;
 
@@ -1300,12 +1309,14 @@ function HeroBalance({
       node: (
         <MetricSlide
           label={`${netDirection} · ${primary.currency}`}
-          amount={primary.net < 0n ? -primary.net : primary.net}
+          amount={primary.net}
           currency={primary.currency}
           locale={locale}
           hidden={hidden}
           onToggleHide={onToggleHide}
           settling={settling}
+          // Square is square: a "+₹0" would be a direction where there is none.
+          showSign={primary.net !== 0n}
         />
       ),
     },
@@ -1477,9 +1488,10 @@ function HeroDots({
  * is built to the *exact* height a loaded slide fills. Each bar rides inside a
  * wrapper sized to the real line's height — the label to the caption's 18px
  * line, the figure to the money's 46px line, one `spacing.sm` gap between — so
- * the block is 72px tall either way and the number lands in place instead of
- * shoving the Add-expense button and the group list down (the layout shift the
- * user flagged). A gentle pulse reads as "loading" rather than a dead
+ * the block is the same height either way and the number lands in place
+ * instead of shoving the Add-expense button and the group list down (the layout
+ * shift the user flagged). Both sites read `HERO_LABEL_LINE` /
+ * `HERO_AMOUNT_LINE`, so a change to the type size cannot desync them. A gentle pulse reads as "loading" rather than a dead
  * placeholder. Plain `Skeleton` is themed for light surfaces and would vanish on
  * the green, so these are hand-drawn washes.
  */
@@ -1505,10 +1517,10 @@ function HeroBalanceSkeleton() {
   );
   return (
     <Animated.View style={{ gap: theme.spacing.sm, opacity: pulse }}>
-      {/* Label line — the caption+eye row rides an 18px line height. */}
-      <View style={{ height: 18, justifyContent: 'center' }}>{bar(120, 12)}</View>
-      {/* The figure — the money sits on a 46px line (fontSize 40). */}
-      <View style={{ height: 46, justifyContent: 'center' }}>{bar(200, 34)}</View>
+      {/* Label line — the caption+eye row's line height. */}
+      <View style={{ height: HERO_LABEL_LINE, justifyContent: 'center' }}>{bar(120, 12)}</View>
+      {/* The figure — the money's own line, so the swap-in is a settle. */}
+      <View style={{ height: HERO_AMOUNT_LINE, justifyContent: 'center' }}>{bar(200, 34)}</View>
     </Animated.View>
   );
 }
@@ -1567,6 +1579,7 @@ function MetricSlide({
   hidden,
   onToggleHide,
   settling,
+  showSign = false,
 }: {
   label: string;
   amount: bigint;
@@ -1574,6 +1587,11 @@ function MetricSlide({
   locale: string;
   hidden: boolean;
   onToggleHide: () => void;
+  /** Print the amount's own sign in front of it. Only the net slide sets this:
+   *  it is the one figure whose direction is information, and a 40pt number is
+   *  what gets read at a glance — not the caption above it. The other two are
+   *  magnitudes (what you are owed, what you spent) where a `+` would be noise. */
+  showSign?: boolean;
   /** Shown with a small spinner beside the label: this figure is the local one
    *  and this session's first sync has not confirmed it yet. */
   settling?: boolean;
@@ -1602,8 +1620,8 @@ function MetricSlide({
         {settling ? <ActivityIndicator size="small" color={theme.color.onBrand} /> : null}
       </Row>
       {hidden ? (
-        <Text tone="onBrand" style={{ fontSize: 40, lineHeight: 46, fontWeight: '700' }}>
-          {'••••••'}
+        <Text tone="onBrand" style={HERO_AMOUNT_STYLE}>
+          {BALANCE_MASK}
         </Text>
       ) : (
         <MoneyText
@@ -1611,7 +1629,8 @@ function MetricSlide({
           currency={currency as never}
           locale={locale}
           tone="onBrand"
-          style={{ fontSize: 40, lineHeight: 46, fontWeight: '700' }}
+          showSign={showSign}
+          style={HERO_AMOUNT_STYLE}
         />
       )}
     </View>
@@ -1637,6 +1656,7 @@ function GroupRow({
   divider,
   enter = false,
   pendingBalance = false,
+  hidden = false,
   onPress,
 }: {
   title: string;
@@ -1649,6 +1669,9 @@ function GroupRow({
   pendingLabel: string | null;
   tag: string | null;
   tagTone: 'positive' | 'brand';
+  /** The dashboard's eye is shut: show the mask in place of the amount. The
+      row's standing ("You owe") stays — it is the figure that is private. */
+  hidden?: boolean;
   /** True while this group's balance is still materialising (just after an
       import): the amount is masked with a skeleton instead of a wrong zero. */
   pendingBalance?: boolean;
@@ -1662,9 +1685,6 @@ function GroupRow({
 }) {
   const theme = useTheme();
   const reduceMotion = useReducedMotion();
-  // Money's own colour, kept for the ledger even though the hero is green:
-  // owed-to-you positive, you-owe negative, square is quiet.
-  const tone = balance === 0n ? 'muted' : balance > 0n ? 'positive' : 'negative';
 
   // The entrance: start dropped and clear, settle into place. Only for a row
   // flagged `enter` (a just-imported group), and never under reduce motion —
@@ -1749,12 +1769,21 @@ function GroupRow({
         </View>
         {pendingBalance ? (
           <Skeleton width={64} height={16} radius={6} animated={!reduceMotion} />
+        ) : hidden ? (
+          <Text tone="muted" style={{ fontWeight: '700' }}>
+            {BALANCE_MASK}
+          </Text>
         ) : (
+          // `balance` mode is money's own rule in one place: it takes the
+          // magnitude, colours by the sign (owed-to-you positive, you-owe
+          // negative, square quiet) and speaks the direction aloud — which the
+          // hand-rolled abs + tone did not, so a screen reader heard a bare
+          // number with no side to it.
           <MoneyText
-            amount={balance < 0n ? -balance : balance}
+            amount={balance}
             currency={currency as never}
             locale={locale}
-            tone={tone}
+            mode="balance"
             style={{ fontWeight: '700' }}
           />
         )}


### PR DESCRIPTION
A design/UX audit of the dashboard screen, and the defects it turned up.

### The net balance had no sign

`HeroBalance` passed `primary.net < 0n ? -primary.net : primary.net` to the net slide — the magnitude — and left the owe/owed direction to an 11pt caption, glued to the currency code by a middot (`You're owed · INR`). The 40pt figure is what actually gets read; the one bit that carried meaning was stripped and then re-stated in the smallest type on the screen.

The slide now takes the signed figure and prints the sign, gated on `net !== 0n` so a settled balance does not read `+₹0`. The caption still names the verdict in words; the two agree, and either alone answers "which way do I stand".

`MetricSlide` gains an opt-in `showSign` — only the net slide sets it. The other two are magnitudes (what you are owed, what you spent) where a `+` would be noise.

### The eye toggle was privacy theatre

Tapping the eye masked the hero figure. Every group balance underneath stayed in plain money. One figure hidden out of twelve.

`hidden={balanceHidden}` now reaches `GroupRow`, and both the hero and the rows mask through a single `BALANCE_MASK` — identical masking, or it reads as a rendering fault rather than a choice. The row's standing ("You owe") stays; it is the amount that is private.

### 90 lines of trip code that painted nothing

```js
const activeTrips: readonly TripSlide[] = list
  .filter(...).map((g) => ({ id, title, coverEmoji, currency, day, total, balance }))
  .filter((t): t is TripSlide => t !== null);
const ongoingTripIds = new Set(activeTrips.map((tr) => tr.id));
```

Eight fields built per render — including a `groupLabel` call, a `daysBetween`, a `balanceFor` and an `Intl.DateTimeFormat` construction per running trip — and seven of them discarded. The five-line comment above it described a trip card "at the front of the balance deck… the one tap into the planner nobody finds". `HeroBalance` receives `primary`, `monthSpent` and geometry. It has never received trips. The card was documented, typed, computed, and dropped before paint.

The `TripSlide` type and the construction are deleted; `ongoingTripIds` computes only the ids the "on trip" tag needs, and the comment describes the code that is there. `daysBetween` drops out of the imports.

### Smaller things

- **The empty state had no action.** A screen carrying eleven affordances offered zero to the one person who needs one. It now has `body={t.tabs.noGroupsBody}` — a string that already existed in en/ta/hi/ar and was never used — and a `New group` button wired through `openNewGroup`, so the guest guard (ADR-006 addendum) still applies. No new i18n keys.
- **Group-row money lost its direction for screen readers.** It hand-rolled `abs` plus a tone override, so `MoneyText` fell to `plain` mode and the accessibility label was a bare number. `mode="balance"` puts magnitude, colour-by-sign and the spoken "You are owed ₹420" back in one place.
- **The dot pager counted the palette.** `count={SLIDE_GRADIENTS.length}` derived the content model from the colour array. It now counts `SLIDE_KEYS`.
- **The skeleton kept its own copy of the hero's type metrics.** `18` / `46` were hardcoded in `HeroBalanceSkeleton` and again in `MetricSlide`, with a comment explaining that they must match or the number shoves the buttons down on load — the exact layout shift the skeleton exists to prevent. Both now read `HERO_LABEL_LINE` / `HERO_AMOUNT_LINE` / `HERO_AMOUNT_STYLE`.

### Deliberately not changed

- `GROUPS_PREVIEW = 15` and the `ScrollView` + `.map` stay. A `FlashList` nested in a vertical `ScrollView` is the antipattern virtualization exists to avoid, so the standard does not apply to this capped card; `/groups` owns the full roster and does use `FlashList`.
- The dot pager still sits below the action buttons rather than under the carousel it pages — the existing comment says that grouping is intentional.
- The five surfaces that can cover this screen (tour, guest popup, tip sheet, quick-add, overflow) are a sequencing question for `promptQueue`, not this file.

### Checks

`tsc --noEmit` clean. `expo lint` exit 0. Mobile suite 732 passed / 57 files. Not device-tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an actionable empty state for dashboards without groups.
  * Added privacy masking for hero balances and group rows, with visibility preserved between sessions.
  * Improved balance presentation with directional signs, formatting, and accessibility support.

* **Bug Fixes**
  * Improved dashboard slide handling when content changes.
  * Removed outdated balance styling for more consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->