### PR TITLE
feat(ui): the overflow menu grows out of the ⋮ corner instead of cross-fading

### DIFF
--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -88,25 +88,25 @@ export function OverflowMenu({
 
   useEffect(() => {
     if (visible) {
-      progress.set(
-        reduceMotion
-          ? withTiming(1, { duration: 0 })
-          : withTiming(1, { duration: OPEN_MS, easing: Easing.out(Easing.cubic) }),
-      );
+      // `progress` drives the scrim and card opacity, so it always fades at full
+      // duration — a fade is the accessible way to appear, not the motion reduced
+      // motion is there to spare. What reduced motion drops is the corner-grow
+      // scale, gated below in `cardStyle`.
+      progress.set(withTiming(1, { duration: OPEN_MS, easing: Easing.out(Easing.cubic) }));
     } else if (mounted) {
       // Play the close, then drop the modal — the runOnJS hop is what lets the
       // exit be seen before the tree unmounts.
       progress.set(
         withTiming(
           0,
-          { duration: reduceMotion ? 0 : CLOSE_MS, easing: Easing.in(Easing.cubic) },
+          { duration: CLOSE_MS, easing: Easing.in(Easing.cubic) },
           (finished) => {
             if (finished) runOnJS(setMounted)(false);
           },
         ),
       );
     }
-  }, [visible, mounted, reduceMotion, progress]);
+  }, [visible, mounted, progress]);
 
   const scrimStyle = useAnimatedStyle(() => ({ opacity: progress.get() }));
   const cardStyle = useAnimatedStyle(() => ({

--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -2,19 +2,46 @@
  * The header's overflow menu — the three-dot dropdown, WhatsApp-style.
  *
  * A translucent scrim over the app catches the tap-away, and a small rounded
- * card drops from the top-right corner with a short list of destinations. Each
- * row dismisses the menu and then routes, so the menu is never left open behind
- * the screen it opened.
+ * card grows out of the top-right corner — the ⋮ it opened from — with a short
+ * list of destinations. Each row dismisses the menu and then routes, so the
+ * menu is never left open behind the screen it opened.
+ *
+ * The open is the motion WhatsApp uses: the card scales up from ~0.9 anchored at
+ * its top-right corner (`transformOrigin`) while it fades, so it reads as
+ * unfolding from the button rather than a whole panel blinking on. The scrim
+ * only fades. The card is held mounted through the close by a local latch, so
+ * the same motion plays in reverse on dismiss instead of the card vanishing the
+ * instant `visible` flips — `Modal`'s own `animationType` would unmount its
+ * children too soon for an exit to be seen. Reduced motion keeps the fade and
+ * drops the scale.
  */
 
+import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, type Href } from 'expo-router';
 import { Modal, Pressable, StyleSheet, View } from 'react-native';
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { iconSize, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
+import { useReducedMotion } from '@/lib/reducedMotion';
+
+/** The corner-grow timings: a touch longer to open than to close, the usual
+    asymmetry that makes an entrance feel arriving and a dismiss feel prompt. */
+const OPEN_MS = 180;
+const CLOSE_MS = 130;
+/** How small the card starts — a grow from the corner, not a pop from nothing. */
+const START_SCALE = 0.9;
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 export interface OverflowMenuItem {
   icon: keyof typeof Ionicons.glyphMap;
@@ -45,6 +72,43 @@ export function OverflowMenu({
   const theme = useTheme();
   const insets = useSafeAreaInsets();
   const { t } = useStrings();
+  const reduceMotion = useReducedMotion();
+
+  // The latch: stays mounted from the moment `visible` goes true until the close
+  // motion has finished playing, so the card animates out rather than blinking
+  // away. `progress` drives both the scrim's opacity and the card's scale+fade;
+  // 1 is fully open, 0 fully closed.
+  const [mounted, setMounted] = useState(visible);
+  const progress = useSharedValue(visible ? 1 : 0);
+
+  useEffect(() => {
+    if (visible) {
+      setMounted(true);
+      progress.set(
+        reduceMotion
+          ? withTiming(1, { duration: 0 })
+          : withTiming(1, { duration: OPEN_MS, easing: Easing.out(Easing.cubic) }),
+      );
+    } else if (mounted) {
+      // Play the close, then drop the modal — the runOnJS hop is what lets the
+      // exit be seen before the tree unmounts.
+      progress.set(
+        withTiming(
+          0,
+          { duration: reduceMotion ? 0 : CLOSE_MS, easing: Easing.in(Easing.cubic) },
+          (finished) => {
+            if (finished) runOnJS(setMounted)(false);
+          },
+        ),
+      );
+    }
+  }, [visible, mounted, reduceMotion, progress]);
+
+  const scrimStyle = useAnimatedStyle(() => ({ opacity: progress.get() }));
+  const cardStyle = useAnimatedStyle(() => ({
+    opacity: progress.get(),
+    transform: [{ scale: reduceMotion ? 1 : START_SCALE + (1 - START_SCALE) * progress.get() }],
+  }));
 
   const activate = (item: OverflowMenuItem): void => {
     onClose();
@@ -52,19 +116,22 @@ export function OverflowMenu({
     else if (item.route) router.push(item.route);
   };
 
+  if (!mounted) return null;
+
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+    <Modal visible={mounted} transparent animationType="none" onRequestClose={onClose}>
       {/* The scrim: a full-screen catcher so a tap anywhere off the card closes
           the menu. Kept barely tinted — the point is to dismiss, not to dim. It
           carries a label so a screen reader announces "Close" rather than a bare
-          unnamed button covering the whole screen. */}
-      <Pressable
+          unnamed button covering the whole screen. Its own fade rides `progress`
+          rather than the Modal's, so scrim and card open and close together. */}
+      <AnimatedPressable
         onPress={onClose}
-        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.12)' }}
+        style={[{ flex: 1, backgroundColor: 'rgba(0,0,0,0.12)' }, scrimStyle]}
         accessibilityRole="button"
         accessibilityLabel={t.common.close}
       >
-        <View
+        <Animated.View
           // Marks the dropdown as the modal layer so a screen reader confines
           // itself to the menu while it is open, instead of reading the screen
           // behind the scrim.
@@ -75,14 +142,22 @@ export function OverflowMenu({
           // highlight follows the rounded corner instead of poking a square
           // through it (`overflow: 'hidden'` would eat the shadow if they shared
           // a layer, so they do not).
-          style={{
-            position: 'absolute',
-            top: insets.top + 56,
-            right: theme.spacing.xl,
-            minWidth: 220,
-            borderRadius: theme.radius.lg,
-            ...theme.shadow.lifted,
-          }}
+          //
+          // `transformOrigin` top-right pins the scale to the corner nearest the
+          // ⋮, so the card unfolds from the button rather than growing about its
+          // own middle.
+          style={[
+            {
+              position: 'absolute',
+              top: insets.top + 56,
+              right: theme.spacing.xl,
+              minWidth: 220,
+              borderRadius: theme.radius.lg,
+              transformOrigin: 'top right',
+              ...theme.shadow.lifted,
+            },
+            cardStyle,
+          ]}
         >
           <View
             style={{
@@ -145,8 +220,8 @@ export function OverflowMenu({
               );
             })}
           </View>
-        </View>
-      </Pressable>
+        </Animated.View>
+      </AnimatedPressable>
     </Modal>
   );
 }

--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -81,9 +81,13 @@ export function OverflowMenu({
   const [mounted, setMounted] = useState(visible);
   const progress = useSharedValue(visible ? 1 : 0);
 
+  // Mount the moment we open — a state adjustment on a prop change, done in
+  // render rather than an effect (the effect below only drives the animation, so
+  // it never calls setState synchronously in its body).
+  if (visible && !mounted) setMounted(true);
+
   useEffect(() => {
     if (visible) {
-      setMounted(true);
       progress.set(
         reduceMotion
           ? withTiming(1, { duration: 0 })

--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -97,13 +97,9 @@ export function OverflowMenu({
       // Play the close, then drop the modal — the runOnJS hop is what lets the
       // exit be seen before the tree unmounts.
       progress.set(
-        withTiming(
-          0,
-          { duration: CLOSE_MS, easing: Easing.in(Easing.cubic) },
-          (finished) => {
-            if (finished) runOnJS(setMounted)(false);
-          },
-        ),
+        withTiming(0, { duration: CLOSE_MS, easing: Easing.in(Easing.cubic) }, (finished) => {
+          if (finished) runOnJS(setMounted)(false);
+        }),
       );
     }
   }, [visible, mounted, progress]);


### PR DESCRIPTION
Matches the open animation from the reference video: the header's three-dot dropdown should unfold from the button, not blink on.

### Before

`OverflowMenu` opened with `Modal animationType="fade"` — the entire card cross-faded in, no movement. The comment already called it "WhatsApp-style", but WhatsApp's menu *grows out of the ⋮ corner* it was launched from.

### After

The card rides a Reanimated `progress` value:

- **scale 0.9 → 1**, anchored at the card's **top-right corner** (`transformOrigin: 'top right'`), so it unfolds from the button rather than swelling about its own middle;
- **opacity** on the same value;
- **180ms open** (ease-out) / **130ms close** (ease-in) — entrance a touch slower than exit, the usual asymmetry;
- the **scrim fades on the same `progress`**, so scrim and card open and close as one.

### Why the latch

`Modal`'s `animationType` unmounts its children the moment `visible` flips false — which is exactly why the original could only fade and could never show an exit. A local `mounted` state holds the tree up until the close timing finishes (`runOnJS(setMounted)(false)`), so the corner-grow plays in reverse on dismiss too.

**Reduced motion** keeps the fade and drops the scale.

This is the shared header menu, so the motion lands on the dashboard, group, and expense-detail headers at once.

### Checks

`tsc --noEmit` clean, `expo lint` exit 0. **Not device-tested** — the motion wants a real screen; a reviewer running the app is the real check here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the overflow menu with coordinated fade and scale animations for a smoother opening and closing experience.
  * Added support for reduced-motion preferences to minimize animation effects when requested.
  * Updated the menu presentation to animate from its top-right corner while preserving existing activation and item behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->