### PR TITLE
feat(fx): a three-tier trip exchange rate — set once, override per bill [stage 1: engine]

### DIFF
--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -1772,6 +1772,51 @@ export function useSetCategoryBudget(groupId: string) {
   });
 }
 
+/** One currency's pinned trip rate, read off the mirrored group row. `num`/`den`
+ *  are the exact rational; `from` is the currency paid in, converting to the
+ *  group's own default currency. */
+export interface GroupFxRateRow {
+  from: string;
+  num: bigint;
+  den: bigint;
+  source: string;
+}
+
+/** The trip's pinned rates, read off the mirrored group row (ADR-005). Keyed by
+ *  the currency paid in. */
+export function useGroupFxRates(groupId: string): LocalRead<GroupFxRateRow[]> {
+  const { mirror, queue } = useSync();
+  const rows = useMemo(() => {
+    const group = materialiseGroup(mirror, queue, groupId);
+    const map = group?.fx_rates ?? null;
+    if (!map) return [];
+    return Object.entries(map)
+      .map(([from, value]) => ({
+        from,
+        num: BigInt(value.num),
+        den: BigInt(value.den),
+        source: value.source,
+      }))
+      .sort((a, b) => (a.from < b.from ? -1 : a.from > b.from ? 1 : 0));
+  }, [mirror, queue, groupId]);
+  return useLocalRead(rows);
+}
+
+/** Set (or clear, with a null ratio) one currency's trip rate, queued. Admin-only,
+ *  enforced by the RPC. */
+export function useSetGroupFxRate(groupId: string) {
+  const { mutate } = useSync();
+  return useMutation({
+    mutationFn: (input: { from: string; num: bigint | null; den: bigint | null; source?: string }) =>
+      mutate(MutationKind.GroupFxRateSet, groupId, {
+        from: input.from,
+        num: input.num === null ? null : input.num.toString(),
+        den: input.den === null ? null : input.den.toString(),
+        source: input.source ?? 'manual',
+      }),
+  });
+}
+
 // ──────────────────────────── private / party-only attachments (§3) ──
 //
 // Reads ride the mirror (the pull is party-filtered by RLS, so a non-party never

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -1807,7 +1807,12 @@ export function useGroupFxRates(groupId: string): LocalRead<GroupFxRateRow[]> {
 export function useSetGroupFxRate(groupId: string) {
   const { mutate } = useSync();
   return useMutation({
-    mutationFn: (input: { from: string; num: bigint | null; den: bigint | null; source?: string }) =>
+    mutationFn: (input: {
+      from: string;
+      num: bigint | null;
+      den: bigint | null;
+      source?: string;
+    }) =>
       mutate(MutationKind.GroupFxRateSet, groupId, {
         from: input.from,
         num: input.num === null ? null : input.num.toString(),

--- a/packages/core/src/money/fxPolicy.ts
+++ b/packages/core/src/money/fxPolicy.ts
@@ -1,0 +1,157 @@
+/**
+ * Where an expense's rate comes from, and how it is shown to somebody.
+ *
+ * A rate has to be entered once, not once per bill. Three tiers hold one, most
+ * specific first:
+ *
+ *   - **this bill** — a rate typed on the expense itself, for the meal the card
+ *     happened to convert differently;
+ *   - **your rate** — what this person's own card gives, private to them, used
+ *     for the expenses they enter;
+ *   - **the trip rate** — one number an admin pins on the group, so everybody's
+ *     entries and the trip's budgets are counted the same way.
+ *
+ * Resolution happens once, when the expense is written, and the winner is stored
+ * on the expense version (ADR-003). That is the whole reason changing a trip
+ * rate next week cannot move last week's balances: the bill already carries the
+ * rate it was written with, and nothing here ever rewrites one.
+ */
+
+import { type CurrencyCode } from './currency';
+import { fxRate, type FxRate, type FxRecord, fromFxRecord } from './fx';
+
+/** Which tier a rate came from. Ordered least to most specific. */
+export enum FxTier {
+  /** Pinned on the group by an admin; everybody sees it. */
+  Trip = 'trip',
+  /** This person's own default for this pair, private to their device. */
+  Personal = 'personal',
+  /** Typed on this bill alone. */
+  Expense = 'expense',
+}
+
+/** A rate offered by each tier. Any of them may be absent. */
+export interface FxTierRates {
+  readonly trip?: FxRate | null;
+  readonly personal?: FxRate | null;
+  readonly expense?: FxRate | null;
+}
+
+/** The rate that wins, and which tier it came from. */
+export interface ResolvedFx {
+  readonly rate: FxRate;
+  readonly tier: FxTier;
+}
+
+/**
+ * The most specific rate that actually converts this pair.
+ *
+ * A tier holding a rate for a *different* pair is not a worse answer, it is a
+ * wrong one — a trip rate for THB does not convert a bill paid in VND — so it
+ * is skipped rather than used, and the next tier down gets its turn.
+ */
+export function resolveFxRate(
+  tiers: FxTierRates,
+  from: CurrencyCode,
+  to: CurrencyCode,
+): ResolvedFx | null {
+  const ordered: readonly [FxTier, FxRate | null | undefined][] = [
+    [FxTier.Expense, tiers.expense],
+    [FxTier.Personal, tiers.personal],
+    [FxTier.Trip, tiers.trip],
+  ];
+  for (const [tier, rate] of ordered) {
+    if (rate && rate.from === from && rate.to === to) return { rate, tier };
+  }
+  return null;
+}
+
+/**
+ * Two rates are the same rate when they convert identically — 9125/100 and
+ * 18250/200 are one number written twice. Compared by cross-multiplication
+ * rather than by decimal text, which would call them different at the sixth
+ * place and is exactly the sort of thing that makes a label flicker.
+ */
+export function sameRate(a: FxRate, b: FxRate): boolean {
+  return a.from === b.from && a.to === b.to && a.num * b.den === b.num * a.den;
+}
+
+/**
+ * Which tier a *stored* rate should be labelled as, now.
+ *
+ * Derived by comparison rather than read from a stamp on the record, and that is
+ * deliberate. A bill written at the trip rate, after an admin moves the trip
+ * rate, is no longer at the trip rate — a stamp would keep insisting it was.
+ * Comparing says the true thing: it matches the trip's number, or it does not
+ * and is this bill's own.
+ */
+export function fxTierOf(stored: FxRate, tiers: FxTierRates): FxTier {
+  if (tiers.trip && sameRate(stored, tiers.trip)) return FxTier.Trip;
+  if (tiers.personal && sameRate(stored, tiers.personal)) return FxTier.Personal;
+  return FxTier.Expense;
+}
+
+/**
+ * The group's pinned rates as stored in `groups.fx_rates`: a map keyed by the
+ * currency paid in, converting to the group's own `default_currency`.
+ *
+ * A map rather than a single rate because one trip crosses borders — Vietnam
+ * then Cambodia is two rates on one group — and the same shape as the
+ * `category_budgets` map already on that row.
+ */
+export type GroupFxRates = Readonly<Record<string, Omit<FxRecord, 'from' | 'to'>>>;
+
+/**
+ * The group's pinned rate for one pair, or null if it has none.
+ *
+ * `to` is not stored per entry — it is always the group's settle currency — so
+ * it is supplied here and written onto the rate that comes back.
+ */
+export function groupFxRate(
+  rates: GroupFxRates | null | undefined,
+  from: CurrencyCode,
+  to: CurrencyCode,
+): FxRate | null {
+  if (!rates || from === to) return null;
+  const entry = rates[from];
+  if (!entry) return null;
+  try {
+    return fromFxRecord({ ...entry, from, to });
+  } catch {
+    // A malformed entry is a rate we do not have, never a crash on the screen
+    // that has to render the bill anyway.
+    return null;
+  }
+}
+
+/** One entry, ready to be written into the group's map under `rate.from`. */
+export function toGroupFxEntry(rate: FxRate): Omit<FxRecord, 'from' | 'to'> {
+  return { num: rate.num.toString(), den: rate.den.toString(), ts: rate.ts, source: rate.source };
+}
+
+/**
+ * The rate stated the way somebody holds it in their head.
+ *
+ * "1 VND = 0.0032 INR" is arithmetically fine and humanly useless: nobody
+ * carries four leading zeros around. The same fact as "1 ₹ = ₫312" is instantly
+ * checkable against what they already know. So whenever a unit of the currency
+ * paid in is worth less than a unit of the currency settled in, the rate is
+ * turned around for display — and `inverted` says so, because the two ends have
+ * to be labelled or the number is worse than no number.
+ */
+export function displayRate(rate: FxRate): { rate: FxRate; inverted: boolean } {
+  const inverted = rate.num < rate.den;
+  return {
+    rate: inverted
+      ? fxRate({
+          num: rate.den,
+          den: rate.num,
+          from: rate.to,
+          to: rate.from,
+          ts: rate.ts,
+          source: rate.source,
+        })
+      : rate,
+    inverted,
+  };
+}

--- a/packages/core/src/money/index.ts
+++ b/packages/core/src/money/index.ts
@@ -3,5 +3,6 @@ export * from './money';
 export * from './format';
 export * from './input';
 export * from './fx';
+export * from './fxPolicy';
 export * from './region';
 export * from './exposure';

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -533,6 +533,9 @@ export interface MirrorGroup extends MirrorRow {
   readonly budget_currency?: string | null;
   /** Per-category caps, keyed by category id. Group-visible, admin-set. */
   readonly category_budgets?: Record<string, { amountMinor: string; currency: string }> | null;
+  /** The trip's pinned rates, keyed by the currency paid in; each converts to
+   *  this group's `default_currency`. Group-visible, admin-set. */
+  readonly fx_rates?: Record<string, { num: string; den: string; ts: string; source: string }> | null;
   readonly pending?: boolean;
 }
 
@@ -619,6 +622,34 @@ function buildGroups(state: MirrorState, queue: readonly QueuedMutation[]): Mirr
           };
         }
         byId.set(mutation.groupId, { ...existing, category_budgets: map, pending: true });
+      }
+    }
+
+    // A trip rate patches the group row's fx_rates map one currency at a time; a
+    // null ratio removes that currency's entry. Same optimistic path as the
+    // budgets above, so a rate an admin pins shows on the group before the sync
+    // lands.
+    if (mutation.kind === 'group_fx_rate.set') {
+      const existing = byId.get(mutation.groupId);
+      if (existing) {
+        const payload = mutation.payload as {
+          from: string;
+          num: string | null;
+          den: string | null;
+          source?: string;
+        };
+        const map = { ...(existing.fx_rates ?? {}) };
+        if (payload.num === null || payload.den === null) {
+          delete map[payload.from];
+        } else {
+          map[payload.from] = {
+            num: payload.num,
+            den: payload.den,
+            ts: new Date().toISOString(),
+            source: payload.source ?? 'manual',
+          };
+        }
+        byId.set(mutation.groupId, { ...existing, fx_rates: map, pending: true });
       }
     }
   }

--- a/packages/core/src/sync/mirror.ts
+++ b/packages/core/src/sync/mirror.ts
@@ -535,7 +535,10 @@ export interface MirrorGroup extends MirrorRow {
   readonly category_budgets?: Record<string, { amountMinor: string; currency: string }> | null;
   /** The trip's pinned rates, keyed by the currency paid in; each converts to
    *  this group's `default_currency`. Group-visible, admin-set. */
-  readonly fx_rates?: Record<string, { num: string; den: string; ts: string; source: string }> | null;
+  readonly fx_rates?: Record<
+    string,
+    { num: string; den: string; ts: string; source: string }
+  > | null;
   readonly pending?: boolean;
 }
 

--- a/packages/core/src/sync/protocol.ts
+++ b/packages/core/src/sync/protocol.ts
@@ -54,6 +54,10 @@ export enum MutationKind {
   MemberBudgetClear = 'member_budget.clear',
   GroupBudgetSet = 'group_budget.set',
   CategoryBudgetSet = 'category_budget.set',
+  // The trip's shared exchange rate for one currency, in the group row's
+  // `fx_rates` map. Admin-gated in its RPC like the budgets; a null ratio clears
+  // that currency's entry.
+  GroupFxRateSet = 'group_fx_rate.set',
   // Personal-scope kinds for the private personal-finance ledger (A48): solo
   // expenses/income, recurring rules, loans and monthly budgets. Like captures
   // they ride a personal scope, under their own suffixed cursor
@@ -290,6 +294,21 @@ export interface CategoryBudgetSetPayload {
   readonly category: string;
   readonly amountMinor: string | null;
   readonly currency?: CurrencyCode | null;
+}
+
+/**
+ * The trip's pinned rate for one currency in the group's `fx_rates` map, keyed
+ * by the currency paid in (`from`); the `to` is always the group's settle
+ * currency, so it is not carried. A null `num`/`den` clears that currency's
+ * entry. The rate is the exact rational the client already computed — never a
+ * decimal (ADR-003). Admin-only, like the budgets: one shared rate is a group
+ * signal, never private.
+ */
+export interface GroupFxRateSetPayload {
+  readonly from: CurrencyCode;
+  readonly num: string | null;
+  readonly den: string | null;
+  readonly source?: string;
 }
 
 /** The four kinds of row the personal-finance ledger holds (A48). */

--- a/packages/core/test/fxPolicy.test.ts
+++ b/packages/core/test/fxPolicy.test.ts
@@ -75,7 +75,9 @@ describe("the group's stored map", () => {
   it('has no rate for an unlisted pair and never throws on junk', () => {
     expect(groupFxRate({ INR: toGroupFxEntry(trip) }, 'THB', 'VND')).toBeNull();
     expect(groupFxRate(null, 'INR', 'VND')).toBeNull();
-    expect(groupFxRate({ INR: { num: 'x', den: '0', ts: '', source: '' } }, 'INR', 'VND')).toBeNull();
+    expect(
+      groupFxRate({ INR: { num: 'x', den: '0', ts: '', source: '' } }, 'INR', 'VND'),
+    ).toBeNull();
   });
 });
 

--- a/packages/core/test/fxPolicy.test.ts
+++ b/packages/core/test/fxPolicy.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The three tiers a rate can come from (this bill → your rate → the trip rate),
+ * and the two things that keep the feature honest:
+ *
+ *   - the most specific rate that *actually converts the pair* wins, and a rate
+ *     for the wrong pair is skipped rather than misapplied;
+ *   - a stored rate is labelled by comparison, not by a stamp, so a bill written
+ *     at the trip rate stops calling itself that the moment an admin moves the
+ *     trip rate — the bill's own number has not changed, only what it matches.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  displayRate,
+  fromFxRecord,
+  FxTier,
+  fxTierOf,
+  groupFxRate,
+  rateFromDecimal,
+  resolveFxRate,
+  sameRate,
+  toGroupFxEntry,
+  type GroupFxRates,
+} from '../src/index.js';
+
+const trip = rateFromDecimal('312', 'INR', 'VND', { source: 'manual' }); // 1 ₹ = ₫312
+const personal = rateFromDecimal('305', 'INR', 'VND', { source: 'manual' });
+const expense = rateFromDecimal('318', 'INR', 'VND', { source: 'manual' });
+
+describe('which rate wins', () => {
+  it('takes the most specific tier present', () => {
+    expect(resolveFxRate({ trip, personal, expense }, 'INR', 'VND')?.tier).toBe(FxTier.Expense);
+    expect(resolveFxRate({ trip, personal }, 'INR', 'VND')?.tier).toBe(FxTier.Personal);
+    expect(resolveFxRate({ trip }, 'INR', 'VND')?.tier).toBe(FxTier.Trip);
+    expect(resolveFxRate({}, 'INR', 'VND')).toBeNull();
+  });
+
+  it('skips a tier whose rate is for a different pair', () => {
+    const thbTrip = rateFromDecimal('0.42', 'THB', 'INR');
+    // The trip rate is THB→INR; the bill is INR→VND. The trip tier does not
+    // apply, so the personal rate wins rather than the wrong-pair trip rate.
+    const resolved = resolveFxRate({ trip: thbTrip, personal }, 'INR', 'VND');
+    expect(resolved?.tier).toBe(FxTier.Personal);
+  });
+});
+
+describe('what tier a stored rate reads as, now', () => {
+  it('matches the trip rate until the trip rate moves', () => {
+    expect(fxTierOf(trip, { trip, personal })).toBe(FxTier.Trip);
+    const movedTrip = rateFromDecimal('300', 'INR', 'VND');
+    // Same stored bill, admin has since moved the trip rate: the bill is now its
+    // own rate, not the trip's.
+    expect(fxTierOf(trip, { trip: movedTrip, personal })).toBe(FxTier.Expense);
+  });
+
+  it('calls a rate the same when it converts the same', () => {
+    const halved = rateFromDecimal('312.00', 'INR', 'VND');
+    expect(sameRate(trip, halved)).toBe(true);
+    expect(fxTierOf(halved, { trip })).toBe(FxTier.Trip);
+  });
+});
+
+describe("the group's stored map", () => {
+  it('round-trips one pair through the entry shape', () => {
+    const rates: GroupFxRates = { INR: toGroupFxEntry(trip) };
+    const back = groupFxRate(rates, 'INR', 'VND');
+    expect(back).not.toBeNull();
+    expect(sameRate(back!, trip)).toBe(true);
+    // The `to` is not stored per entry — it is always the group's currency.
+    expect(back!.to).toBe('VND');
+    expect(back!.from).toBe('INR');
+  });
+
+  it('has no rate for an unlisted pair and never throws on junk', () => {
+    expect(groupFxRate({ INR: toGroupFxEntry(trip) }, 'THB', 'VND')).toBeNull();
+    expect(groupFxRate(null, 'INR', 'VND')).toBeNull();
+    expect(groupFxRate({ INR: { num: 'x', den: '0', ts: '', source: '' } }, 'INR', 'VND')).toBeNull();
+  });
+});
+
+describe('showing the rate the way a person holds it', () => {
+  it('turns a sub-1 rate around and says so', () => {
+    // 1 VND = 0.0032 INR is useless; 1 ₹ = ₫312 is the same fact, checkable.
+    const vndToInr = fromFxRecord({ ...toGroupFxEntry(trip), from: 'VND', to: 'INR' });
+    const inverted = rateFromDecimal('0.0032', 'VND', 'INR');
+    const shown = displayRate(inverted);
+    expect(shown.inverted).toBe(true);
+    expect(shown.rate.from).toBe('INR');
+    expect(shown.rate.to).toBe('VND');
+    void vndToInr;
+  });
+
+  it('leaves a rate above 1 alone', () => {
+    const shown = displayRate(trip);
+    expect(shown.inverted).toBe(false);
+    expect(sameRate(shown.rate, trip)).toBe(true);
+  });
+});

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -837,6 +837,59 @@ describe('category budgets ride the group row', () => {
       transport: { amountMinor: '100000', currency: 'INR' },
     });
   });
+
+});
+
+describe('trip rates ride the group row', () => {
+  const base: SyncChange = {
+    table: SyncTable.Groups,
+    groupId: GROUP,
+    seq: 1,
+    row: {
+      id: GROUP,
+      name: 'Vietnam',
+      default_currency: 'INR',
+      created_at: AT,
+      archived_at: null,
+      fx_rates: null,
+    },
+  };
+
+  it('pins one currency’s rate optimistically on the group', () => {
+    const mirror = reconcile(emptyMirror(), [base]).state;
+    const set = envelope('f-1', MutationKind.GroupFxRateSet, {
+      from: 'VND',
+      num: '312',
+      den: '1',
+      source: 'manual',
+    });
+    const [row] = materialiseGroups(mirror, queued(set));
+    expect(row?.fx_rates?.VND).toMatchObject({ num: '312', den: '1', source: 'manual' });
+    expect(row?.pending).toBe(true);
+  });
+
+  it('clears one currency with a null ratio, keeping the others', () => {
+    const withRates = reconcile(emptyMirror(), [
+      {
+        ...base,
+        row: {
+          ...base.row,
+          fx_rates: {
+            VND: { num: '312', den: '1', ts: AT, source: 'manual' },
+            THB: { num: '42', den: '100', ts: AT, source: 'manual' },
+          },
+        },
+      },
+    ]).state;
+    const clear = envelope('f-2', MutationKind.GroupFxRateSet, {
+      from: 'VND',
+      num: null,
+      den: null,
+    });
+    const [row] = materialiseGroups(withRates, queued(clear));
+    expect(row?.fx_rates?.VND).toBeUndefined();
+    expect(row?.fx_rates?.THB).toMatchObject({ num: '42', den: '100' });
+  });
 });
 
 describe('category tags', () => {

--- a/packages/core/test/overlay.test.ts
+++ b/packages/core/test/overlay.test.ts
@@ -837,7 +837,6 @@ describe('category budgets ride the group row', () => {
       transport: { amountMinor: '100000', currency: 'INR' },
     });
   });
-
 });
 
 describe('trip rates ride the group row', () => {

--- a/packages/db/prisma/migrations/20260902000000_group_fx_rates/migration.sql
+++ b/packages/db/prisma/migrations/20260902000000_group_fx_rates/migration.sql
@@ -1,0 +1,155 @@
+-- The trip's pinned exchange rates (A: currency-conversion tiers).
+--
+-- A rate paid in a currency the group does not settle in already rode on each
+-- expense version, exact and reproducible (ADR-003). What was missing was a
+-- place to set one *once*: a Vietnam trip meant re-typing the rate on every
+-- bill. `groups.fx_rates` is that place — one admin-pinned rate per currency
+-- paid in, converting to the group's own `default_currency`, shared by everyone
+-- so the trip's totals and budgets are counted the same way. A person's own
+-- card rate and a per-bill override live off the group (device-local, and on
+-- `expense_versions.fx`); only this shared tier touches the database.
+--
+-- Same shape and same guardrails as `category_budgets`: a JSON map on the group
+-- row, group-visible, and writable ONLY through a definer RPC that checks admin
+-- — never by a direct column write.
+
+ALTER TABLE public.groups ADD COLUMN IF NOT EXISTS fx_rates jsonb;
+
+-- ─────────────────────────────────────────────── the admin-only setter ──
+--
+-- One entry, keyed by the currency paid in (`p_from`); the `to` is always the
+-- group's settle currency, so it is not stored. NULL num/den clears that
+-- currency's entry. The rate is an exact rational (num/den), never a decimal —
+-- the whole point of ADR-003 — so the client hands over the two integers it
+-- already computed with `rateFromDecimal` / `rateFromAmounts`.
+
+CREATE OR REPLACE FUNCTION public.baaki_set_group_fx_rate(
+  p_group_id uuid,
+  p_from character,
+  p_num bigint DEFAULT NULL::bigint,
+  p_den bigint DEFAULT NULL::bigint,
+  p_source text DEFAULT 'manual'
+) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_default char(3);
+  v_from    char(3);
+BEGIN
+  IF NOT public.is_group_admin(p_group_id) THEN
+    RAISE EXCEPTION 'NOT_AN_ADMIN: only an admin sets a trip rate'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_from := upper(p_from);
+
+  SELECT default_currency INTO v_default FROM public.groups WHERE id = p_group_id;
+  IF v_default IS NULL THEN
+    RAISE EXCEPTION 'NO_SUCH_GROUP' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- A group never converts its own settle currency: that "rate" is always 1 and
+  -- storing it would only give the resolver a wrong-direction entry to trip on.
+  IF v_from = v_default THEN
+    RAISE EXCEPTION 'SAME_CURRENCY: a trip rate converts a foreign currency into %, not itself', v_default
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF p_num IS NULL OR p_den IS NULL THEN
+    -- Clear this currency's entry, leaving an empty object rather than NULL so
+    -- the column's type stays an object.
+    UPDATE public.groups SET
+      fx_rates   = COALESCE(fx_rates, '{}'::jsonb) - v_from,
+      updated_at = now()
+    WHERE id = p_group_id;
+    RETURN;
+  END IF;
+
+  -- A rate is two positive integers; anything else is not a rate.
+  IF p_num <= 0 OR p_den <= 0 THEN
+    RAISE EXCEPTION 'INVALID_RATE: a rate is a ratio of two positive integers'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  UPDATE public.groups SET
+    fx_rates = jsonb_set(
+      COALESCE(fx_rates, '{}'::jsonb),
+      ARRAY[v_from],
+      jsonb_build_object(
+        'num', p_num::text,
+        'den', p_den::text,
+        'ts', to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'source', COALESCE(NULLIF(btrim(p_source), ''), 'manual')
+      ),
+      true
+    ),
+    updated_at = now()
+  WHERE id = p_group_id;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.baaki_set_group_fx_rate(uuid, character, bigint, bigint, text) FROM PUBLIC, anon;
+GRANT  ALL ON FUNCTION public.baaki_set_group_fx_rate(uuid, character, bigint, bigint, text) TO authenticated, service_role;
+
+-- ─────────────────────────────── shut the direct-write door on the column ──
+--
+-- The guard trigger already blocks a client writing category_budgets or the
+-- join token straight onto the row. fx_rates joins them: it is set through the
+-- RPC above, which checks admin, and nowhere else. Recreated in full (the
+-- trigger keeps pointing at the same function) with the one new clause.
+
+CREATE OR REPLACE FUNCTION public.baaki_guard_group_columns() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+  IF current_user NOT IN ('anon', 'authenticated') THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.updated_seq IS DISTINCT FROM OLD.updated_seq THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: updated_seq is set by the server, not the client'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creator is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.id IS DISTINCT FROM OLD.id THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s id is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: a group''s creation time is not yours to change'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.photo_path IS DISTINCT FROM OLD.photo_path
+     AND NEW.photo_path IS NOT NULL
+     AND NOT public.baaki_can_upload_group_photo(NEW.id) THEN
+    RAISE EXCEPTION 'PHOTO_GATE: a group photo is a paid feature'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.category_budgets IS DISTINCT FROM OLD.category_budgets THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: category budgets are set through baaki_set_category_budget, not a direct write'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.fx_rates IS DISTINCT FROM OLD.fx_rates THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: trip rates are set through baaki_set_group_fx_rate, not a direct write'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NEW.join_token IS DISTINCT FROM OLD.join_token THEN
+    RAISE EXCEPTION 'FORBIDDEN_COLUMN: the join link is set through baaki_ensure_group_join_token / baaki_reset_group_join_token, not a direct write'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN NEW;
+END
+$$;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -226,6 +226,17 @@ model Group {
   /// `baaki_set_category_budget`.
   categoryBudgets Json?   @map("category_budgets")
 
+  /// The trip's pinned exchange rates, as a JSON map keyed by the currency paid
+  /// in: `{ "<from>": { num, den, ts, source } }`, each converting to this
+  /// group's `default_currency`. So a Vietnam trip settling in INR carries
+  /// `{ "VND": { num, den, … } }` and every member's VND bill starts from it.
+  /// Group-visible and admin-set like the budgets — one shared rate is a group
+  /// signal — so it lives on the group row, not its own table. NULL / absent is
+  /// "no pinned rates". Written only via `baaki_set_group_fx_rate`; a person's
+  /// own card rate and a per-bill override live off the group (device-local and
+  /// on `expense_versions.fx` respectively).
+  fxRates         Json?   @map("fx_rates")
+
   /// When the trip is. Both ends inclusive — the last day of a trip is the one
   /// with the most unrecorded spending on it.
   startDate       DateTime? @map("start_date") @db.Date

--- a/packages/db/test/group-fx-rates.test.ts
+++ b/packages/db/test/group-fx-rates.test.ts
@@ -42,9 +42,14 @@ async function as<T>(profileId: string, run: () => Promise<T>): Promise<T> {
   }
 }
 
-const fxRates = async (): Promise<Record<string, { num: string; den: string; ts: string; source: string }>> => {
+const fxRates = async (): Promise<
+  Record<string, { num: string; den: string; ts: string; source: string }>
+> => {
   const { rows } = await client.query(`SELECT fx_rates FROM groups WHERE id = $1`, [group.groupId]);
-  return (rows[0]?.fx_rates ?? {}) as Record<string, { num: string; den: string; ts: string; source: string }>;
+  return (rows[0]?.fx_rates ?? {}) as Record<
+    string,
+    { num: string; den: string; ts: string; source: string }
+  >;
 };
 
 describe('an admin pins a trip rate', () => {
@@ -60,9 +65,15 @@ describe('an admin pins a trip rate', () => {
 
   it('clears one currency with a null rate, leaving the rest', async () => {
     await as(group.profileIds[0] as string, async () => {
-      await client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', 312, 1, 'manual')`, [group.groupId]);
-      await client.query(`SELECT baaki_set_group_fx_rate($1, 'THB', 42, 100, 'manual')`, [group.groupId]);
-      await client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', NULL, NULL, 'manual')`, [group.groupId]);
+      await client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', 312, 1, 'manual')`, [
+        group.groupId,
+      ]);
+      await client.query(`SELECT baaki_set_group_fx_rate($1, 'THB', 42, 100, 'manual')`, [
+        group.groupId,
+      ]);
+      await client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', NULL, NULL, 'manual')`, [
+        group.groupId,
+      ]);
     });
     const map = await fxRates();
     expect(map.VND).toBeUndefined();
@@ -74,7 +85,9 @@ describe('what the RPC refuses', () => {
   it('denies a non-admin', async () => {
     const message = await expectDenied(
       as(group.profileIds[1] as string, () =>
-        client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', 312, 1, 'manual')`, [group.groupId]),
+        client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', 312, 1, 'manual')`, [
+          group.groupId,
+        ]),
       ),
     );
     expect(message).toContain('NOT_AN_ADMIN');
@@ -103,9 +116,10 @@ describe('the column cannot be written around the RPC', () => {
   it('blocks a direct fx_rates update from a client', async () => {
     const message = await expectDenied(
       as(group.profileIds[0] as string, () =>
-        client.query(`UPDATE groups SET fx_rates = '{"VND":{"num":"1","den":"1"}}'::jsonb WHERE id = $1`, [
-          group.groupId,
-        ]),
+        client.query(
+          `UPDATE groups SET fx_rates = '{"VND":{"num":"1","den":"1"}}'::jsonb WHERE id = $1`,
+          [group.groupId],
+        ),
       ),
     );
     expect(message).toContain('FORBIDDEN_COLUMN');

--- a/packages/db/test/group-fx-rates.test.ts
+++ b/packages/db/test/group-fx-rates.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The trip's shared exchange rates, at the trust boundary.
+ *
+ * The arithmetic of a rate lives in @waves/core; what has to be proven in the
+ * database is the same thing every group-visible-admin-set field has to prove:
+ * only an admin can move it, the column cannot be written around the RPC, and
+ * the RPC refuses a rate that is not one.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from 'pg';
+
+import { connect, expectDenied, seedGroup, type SeededGroup } from './helpers';
+
+let client: Client;
+let group: SeededGroup;
+
+beforeAll(async () => {
+  client = await connect();
+  // profile 0 = admin, 1 and 2 = members. Group settles in INR.
+  group = await seedGroup(client, { memberCount: 3, name: 'Vietnam' });
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+beforeEach(async () => {
+  await client.query(`UPDATE groups SET fx_rates = NULL WHERE id = $1`, [group.groupId]);
+});
+
+/** Committed as a signed-in profile, the way an RLS write really happens. */
+async function as<T>(profileId: string, run: () => Promise<T>): Promise<T> {
+  await client.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify({ sub: profileId, role: 'authenticated' }),
+  ]);
+  await client.query('SET ROLE authenticated');
+  try {
+    return await run();
+  } finally {
+    await client.query('RESET ROLE');
+  }
+}
+
+const fxRates = async (): Promise<Record<string, { num: string; den: string; source: string }>> => {
+  const { rows } = await client.query(`SELECT fx_rates FROM groups WHERE id = $1`, [group.groupId]);
+  return (rows[0]?.fx_rates ?? {}) as Record<string, { num: string; den: string; source: string }>;
+};
+
+describe('an admin pins a trip rate', () => {
+  it('writes one entry keyed by the currency paid in, as an exact rational', async () => {
+    await as(group.profileIds[0] as string, () =>
+      // 1 ₹ = ₫312, stored as the ratio the client already computed.
+      client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', 312, 1, 'manual')`, [group.groupId]),
+    );
+    const map = await fxRates();
+    expect(map.VND).toMatchObject({ num: '312', den: '1', source: 'manual' });
+    expect(map.VND.ts).toBeTruthy();
+  });
+
+  it('clears one currency with a null rate, leaving the rest', async () => {
+    await as(group.profileIds[0] as string, async () => {
+      await client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', 312, 1, 'manual')`, [group.groupId]);
+      await client.query(`SELECT baaki_set_group_fx_rate($1, 'THB', 42, 100, 'manual')`, [group.groupId]);
+      await client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', NULL, NULL, 'manual')`, [group.groupId]);
+    });
+    const map = await fxRates();
+    expect(map.VND).toBeUndefined();
+    expect(map.THB).toMatchObject({ num: '42', den: '100' });
+  });
+});
+
+describe('what the RPC refuses', () => {
+  it('denies a non-admin', async () => {
+    const message = await expectDenied(
+      as(group.profileIds[1] as string, () =>
+        client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', 312, 1, 'manual')`, [group.groupId]),
+      ),
+    );
+    expect(message).toContain('NOT_AN_ADMIN');
+  });
+
+  it('refuses the group’s own settle currency', async () => {
+    const message = await expectDenied(
+      as(group.profileIds[0] as string, () =>
+        client.query(`SELECT baaki_set_group_fx_rate($1, 'INR', 1, 1, 'manual')`, [group.groupId]),
+      ),
+    );
+    expect(message).toContain('SAME_CURRENCY');
+  });
+
+  it('refuses a non-positive ratio', async () => {
+    const message = await expectDenied(
+      as(group.profileIds[0] as string, () =>
+        client.query(`SELECT baaki_set_group_fx_rate($1, 'VND', 0, 1, 'manual')`, [group.groupId]),
+      ),
+    );
+    expect(message).toContain('INVALID_RATE');
+  });
+});
+
+describe('the column cannot be written around the RPC', () => {
+  it('blocks a direct fx_rates update from a client', async () => {
+    const message = await expectDenied(
+      as(group.profileIds[0] as string, () =>
+        client.query(`UPDATE groups SET fx_rates = '{"VND":{"num":"1","den":"1"}}'::jsonb WHERE id = $1`, [
+          group.groupId,
+        ]),
+      ),
+    );
+    expect(message).toContain('FORBIDDEN_COLUMN');
+  });
+});

--- a/packages/db/test/group-fx-rates.test.ts
+++ b/packages/db/test/group-fx-rates.test.ts
@@ -42,9 +42,9 @@ async function as<T>(profileId: string, run: () => Promise<T>): Promise<T> {
   }
 }
 
-const fxRates = async (): Promise<Record<string, { num: string; den: string; source: string }>> => {
+const fxRates = async (): Promise<Record<string, { num: string; den: string; ts: string; source: string }>> => {
   const { rows } = await client.query(`SELECT fx_rates FROM groups WHERE id = $1`, [group.groupId]);
-  return (rows[0]?.fx_rates ?? {}) as Record<string, { num: string; den: string; source: string }>;
+  return (rows[0]?.fx_rates ?? {}) as Record<string, { num: string; den: string; ts: string; source: string }>;
 };
 
 describe('an admin pins a trip rate', () => {
@@ -55,7 +55,7 @@ describe('an admin pins a trip rate', () => {
     );
     const map = await fxRates();
     expect(map.VND).toMatchObject({ num: '312', den: '1', source: 'manual' });
-    expect(map.VND.ts).toBeTruthy();
+    expect(map.VND?.ts).toBeTruthy();
   });
 
   it('clears one currency with a null rate, leaving the rest', async () => {

--- a/supabase/functions/sync/index.ts
+++ b/supabase/functions/sync/index.ts
@@ -80,7 +80,9 @@ type MutationKind =
   | 'member_budget.set'
   | 'member_budget.clear'
   | 'group_budget.set'
-  | 'category_budget.set';
+  | 'category_budget.set'
+  // The trip's shared exchange rate — group-scoped, admin-gated in its RPC.
+  | 'group_fx_rate.set';
 
 /** True for the kinds whose scope is a user, not a group. */
 function isPersonalKind(kind: MutationKind): boolean {
@@ -567,6 +569,17 @@ export class SyncSession {
           p_category: mutation.payload.category as string,
           p_amount_minor: (mutation.payload.amountMinor as string | null) ?? null,
           p_currency: (mutation.payload.currency as string | undefined) ?? null,
+        });
+      case 'group_fx_rate.set':
+        // Admin-gated inside the RPC, like the budgets; a null ratio clears that
+        // currency's entry. The rate is passed as the two integers the client
+        // computed — never a decimal (ADR-003).
+        return await this.rpcAsCaller('baaki_set_group_fx_rate', {
+          p_group_id: mutation.groupId,
+          p_from: mutation.payload.from as string,
+          p_num: (mutation.payload.num as string | null) ?? null,
+          p_den: (mutation.payload.den as string | null) ?? null,
+          p_source: (mutation.payload.source as string | undefined) ?? 'manual',
         });
       default:
         throw new HttpError(


### PR DESCRIPTION
Enter a foreign-currency rate **once** for a trip instead of re-typing it on every bill — the thing that makes a Vietnam or Thailand group painful today.

This is **stage 1 of 2: the engine**. No user-facing screens yet — it is the tested foundation the screens in stage 2 will call. Opening as a draft for that reason.

## The three tiers

The rate on any expense resolves most-specific-first, and the winner is baked onto the expense at write time — so everyone sees the same converted number on a bill, and **changing a rate later never re-converts past bills** (ADR-003).

| Tier | Who sets it | Where it lives |
|---|---|---|
| **This bill** | anyone, per expense | `expense_versions.fx` (already existed) |
| **Your rate** | you, privately | device-local (stage 2) — your card's rate |
| **Trip rate** | group admin | `groups.fx_rates` — group-visible |

## What's in this stage

- **`@waves/core` — `fxPolicy.ts`**: `resolveFxRate` (most-specific tier that actually converts the pair; a wrong-pair rate is skipped, not misapplied), `fxTierOf` (labels a stored rate *by comparison*, so a bill written at the trip rate stops reading as "trip rate" the moment an admin moves it), `groupFxRate` (reads one pair out of the map, never throws on junk), `displayRate` (turns a sub-1 rate around so it reads `1 ₹ = ₫312`, not `1 ₫ = ₹0.0032`). **8 tests.**
- **`@waves/db`**: `groups.fx_rates` JSON column + `baaki_set_group_fx_rate` — a `SECURITY DEFINER` admin-only RPC, modelled exactly on `baaki_set_category_budget`, with the guard-trigger `FORBIDDEN_COLUMN` line that blocks a direct column write and the both-lines `REVOKE FROM PUBLIC, anon` grant. Refuses a non-admin, the group's own settle currency, and a non-positive ratio. **6 DB tests against real Postgres.**
- **sync**: a `group_fx_rate.set` mutation through the offline queue → the RPC; the mirror exposes `fx_rates` and patches it optimistically (one currency at a time, null ratio clears). Client `useGroupFxRates` / `useSetGroupFxRate`. **2 overlay tests.**

## Stage 2 (next PR) — the screens

New-group rate row, group-settings rate management, the expense-form one-liner (`₫450,000 ≈ ₹1,440 · Trip rate 1 ₹ = ₫312 · Change`) and its override sheet reusing the existing three entry methods, the device-local personal rate, and i18n ×4 (en/ta/hi/ar). The "very user friendly" half of the request lands there.

## Checks

Core 822, edge 86 pass; mobile typechecks; `expo lint` exit 0. **Not deployed** — migration + `/sync` edge are deploy-gated, and the personal tier + screens are still to come.

## Spec

Adds an FX-tier deviation to record in the TDR (ADR-003 currently defines per-expense FX only).
