### PR TITLE
feat(mobile): one shared overlay motion — Sheet and Popup across the app

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -927,42 +927,42 @@ function GuestPopup({
       closeLabel={t.entry.notifyNotNow}
       style={{ maxWidth: 360, alignItems: 'center', gap: theme.spacing.lg }}
     >
-          <View
-            style={{
-              width: 72,
-              height: 72,
-              borderRadius: 36,
-              backgroundColor: theme.color.buttonPrimary,
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Ionicons
-              name={expired ? 'lock-closed' : 'shield-checkmark'}
-              size={38}
-              color={expired ? theme.color.warning : theme.color.onBrand}
-            />
-          </View>
+      <View
+        style={{
+          width: 72,
+          height: 72,
+          borderRadius: 36,
+          backgroundColor: theme.color.buttonPrimary,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Ionicons
+          name={expired ? 'lock-closed' : 'shield-checkmark'}
+          size={38}
+          color={expired ? theme.color.warning : theme.color.onBrand}
+        />
+      </View>
 
-          <View style={{ gap: theme.spacing.sm }}>
-            <Text variant="heading" align="center">
-              {t.tabs.addYourDetails}
-            </Text>
-            <Text variant="body" tone="muted" align="center">
-              {body}
-            </Text>
-          </View>
+      <View style={{ gap: theme.spacing.sm }}>
+        <Text variant="heading" align="center">
+          {t.tabs.addYourDetails}
+        </Text>
+        <Text variant="body" tone="muted" align="center">
+          {body}
+        </Text>
+      </View>
 
-          <View style={{ alignSelf: 'stretch', gap: theme.spacing.sm }}>
-            <Button label={t.signIn.createAccount} size="lg" fullWidth onPress={onAction} />
-            <Button
-              label={t.entry.notifyNotNow}
-              variant="ghost"
-              size="lg"
-              fullWidth
-              onPress={dismiss}
-            />
-          </View>
+      <View style={{ alignSelf: 'stretch', gap: theme.spacing.sm }}>
+        <Button label={t.signIn.createAccount} size="lg" fullWidth onPress={onAction} />
+        <Button
+          label={t.entry.notifyNotNow}
+          variant="ghost"
+          size="lg"
+          fullWidth
+          onPress={dismiss}
+        />
+      </View>
     </Popup>
   );
 }
@@ -1060,50 +1060,54 @@ function TipSheet({ t }: { t: UiStrings }) {
       visible={open && Boolean(tip)}
       onClose={close}
       closeLabel={t.common.close}
-      style={{ paddingHorizontal: theme.spacing.xxl, paddingTop: theme.spacing.xl, gap: theme.spacing.lg }}
+      style={{
+        paddingHorizontal: theme.spacing.xxl,
+        paddingTop: theme.spacing.xl,
+        gap: theme.spacing.lg,
+      }}
     >
       {tip ? (
         <>
-            <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
-              <View
-                style={{
-                  width: 64,
-                  height: 64,
-                  borderRadius: 32,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  backgroundColor: theme.color.buttonPrimary,
-                }}
-              >
-                <Ionicons name={tip.icon} size={iconSize.xxl} color={theme.color.onBrand} />
-              </View>
-              <Text variant="micro" tone="brand" style={{ letterSpacing: 0.8 }}>
-                {t.tips.label.toUpperCase()}
-              </Text>
-              <Text variant="title" align="center">
-                {tip.title}
-              </Text>
-              <Text variant="body" tone="muted" align="center">
-                {tip.body}
-              </Text>
+          <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
+            <View
+              style={{
+                width: 64,
+                height: 64,
+                borderRadius: 32,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.color.buttonPrimary,
+              }}
+            >
+              <Ionicons name={tip.icon} size={iconSize.xxl} color={theme.color.onBrand} />
             </View>
+            <Text variant="micro" tone="brand" style={{ letterSpacing: 0.8 }}>
+              {t.tips.label.toUpperCase()}
+            </Text>
+            <Text variant="title" align="center">
+              {tip.title}
+            </Text>
+            <Text variant="body" tone="muted" align="center">
+              {tip.body}
+            </Text>
+          </View>
 
-            <View style={{ gap: theme.spacing.sm }}>
-              {tip.route ? (
-                <>
-                  <Button label={t.tips.action} size="lg" fullWidth onPress={act} />
-                  <Button
-                    label={t.misc.gotIt}
-                    variant="secondary"
-                    size="sm"
-                    fullWidth
-                    onPress={close}
-                  />
-                </>
-              ) : (
-                <Button label={t.misc.gotIt} size="lg" fullWidth onPress={close} />
-              )}
-            </View>
+          <View style={{ gap: theme.spacing.sm }}>
+            {tip.route ? (
+              <>
+                <Button label={t.tips.action} size="lg" fullWidth onPress={act} />
+                <Button
+                  label={t.misc.gotIt}
+                  variant="secondary"
+                  size="sm"
+                  fullWidth
+                  onPress={close}
+                />
+              </>
+            ) : (
+              <Button label={t.misc.gotIt} size="lg" fullWidth onPress={close} />
+            )}
+          </View>
         </>
       ) : null}
     </Sheet>

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -7,7 +7,6 @@ import { router } from 'expo-router';
 import {
   ActivityIndicator,
   Animated,
-  Modal,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -25,8 +24,10 @@ import {
   Gradient,
   iconSize,
   MoneyText,
+  Popup,
   Row,
   Screen,
+  Sheet,
   Skeleton,
   Text,
   useTabBarClearance,
@@ -910,20 +911,6 @@ function GuestPopup({
   const granted = usePromptSlot({ id: 'guest', priority: 40, active: wants, delayMs: 300 });
   const visible = wants && granted;
 
-  // A gentle scale-and-fade in, the way the reference presents this card. RN
-  // Animated (not reanimated) since this file already drives its counters with
-  // it. Held in state (lazy init) rather than a ref so the value is not read
-  // through `.current` during render.
-  const [opacity] = useState(() => new Animated.Value(0));
-  const [scale] = useState(() => new Animated.Value(0.92));
-  useEffect(() => {
-    if (!visible) return;
-    Animated.parallel([
-      Animated.timing(opacity, { toValue: 1, duration: 200, useNativeDriver: true }),
-      Animated.spring(scale, { toValue: 1, friction: 7, useNativeDriver: true }),
-    ]).start();
-  }, [visible, opacity, scale]);
-
   if (!visible) return null;
 
   const expired = gate?.expired ?? false;
@@ -934,31 +921,12 @@ function GuestPopup({
       : t.tabs.guestBannerBody;
 
   return (
-    <Modal visible transparent animationType="fade" onRequestClose={dismiss}>
-      <View
-        style={{
-          flex: 1,
-          backgroundColor: '#00000080',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: theme.spacing.xxxl,
-        }}
-      >
-        <Animated.View
-          style={[
-            {
-              width: '100%',
-              maxWidth: 360,
-              backgroundColor: theme.color.surface,
-              borderRadius: theme.radius.lg,
-              padding: theme.spacing.xxl,
-              alignItems: 'center',
-              gap: theme.spacing.lg,
-              ...theme.shadow.lifted,
-            },
-            { opacity, transform: [{ scale }] },
-          ]}
-        >
+    <Popup
+      visible
+      onClose={dismiss}
+      closeLabel={t.entry.notifyNotNow}
+      style={{ maxWidth: 360, alignItems: 'center', gap: theme.spacing.lg }}
+    >
           <View
             style={{
               width: 72,
@@ -995,9 +963,7 @@ function GuestPopup({
               onPress={dismiss}
             />
           </View>
-        </Animated.View>
-      </View>
-    </Modal>
+    </Popup>
   );
 }
 
@@ -1026,10 +992,6 @@ const TIP_DELAY_MS = 1400;
  */
 function TipSheet({ t }: { t: UiStrings }) {
   const theme = useTheme();
-  // A Modal renders above the tab navigator, so the tab-bar clearance does not
-  // apply here — the sheet has to clear the device's own bottom inset (the
-  // Android nav bar / gesture pill) itself, or the button sits under it.
-  const insets = useSafeAreaInsets();
   const { tip } = useDashboardTips(t);
 
   // The day the sheet was last shown, read once on mount — the same shape the
@@ -1090,50 +1052,18 @@ function TipSheet({ t }: { t: UiStrings }) {
     close();
   };
 
-  // The Modal stays mounted and is driven by `visible` — toggling a freshly
-  // mounted Modal's `visible` to true a beat after first render did not present
-  // reliably on Android, which is why an earlier version stamped the day but
-  // never appeared. With `tip` still loading there is nothing to show yet.
+  // Presented through the shared Sheet, which mounts fresh with visible=true
+  // (never the mount-false-then-toggle that failed to present on Android). Gated
+  // on `tip` so an empty sheet never slides up before the day's tip is chosen.
   return (
-    <Modal transparent animationType="fade" visible={open} onRequestClose={close}>
+    <Sheet
+      visible={open && Boolean(tip)}
+      onClose={close}
+      closeLabel={t.common.close}
+      style={{ paddingHorizontal: theme.spacing.xxl, paddingTop: theme.spacing.xl, gap: theme.spacing.lg }}
+    >
       {tip ? (
-        /* Tap outside to close — the same escape the campaign popup gives. */
-        <Pressable
-          onPress={close}
-          accessibilityLabel={t.common.close}
-          style={{
-            flex: 1,
-            backgroundColor: 'rgba(10, 10, 26, 0.55)',
-            justifyContent: 'flex-end',
-          }}
-        >
-          {/* Swallows the tap so pressing the sheet itself does not dismiss it. A
-            bottom sheet, not a centred dialog: it slides up from the bar the tip
-            is about, and leaves the balance above it in view. */}
-          <Pressable
-            onPress={() => {}}
-            style={{
-              backgroundColor: theme.color.surface,
-              borderTopLeftRadius: theme.radius.xxl,
-              borderTopRightRadius: theme.radius.xxl,
-              paddingHorizontal: theme.spacing.xxl,
-              paddingTop: theme.spacing.xl,
-              paddingBottom: theme.spacing.xxl + insets.bottom,
-              gap: theme.spacing.lg,
-              ...theme.shadow.lifted,
-            }}
-          >
-            {/* A grab handle — the visual grammar of a sheet you can pull down. */}
-            <View
-              style={{
-                alignSelf: 'center',
-                width: 40,
-                height: 4,
-                borderRadius: 2,
-                backgroundColor: theme.color.border,
-              }}
-            />
-
+        <>
             <View style={{ alignItems: 'center', gap: theme.spacing.md }}>
               <View
                 style={{
@@ -1174,10 +1104,9 @@ function TipSheet({ t }: { t: UiStrings }) {
                 <Button label={t.misc.gotIt} size="lg" fullWidth onPress={close} />
               )}
             </View>
-          </Pressable>
-        </Pressable>
+        </>
       ) : null}
-    </Modal>
+    </Sheet>
   );
 }
 

--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -900,145 +900,141 @@ export default function CapturesScreen() {
         closeLabel={t.common.close}
         style={{ paddingHorizontal: theme.spacing.xl, gap: theme.spacing.md, maxHeight: '80%' }}
       >
-            <Text variant="heading">{t.captures.assignTitle}</Text>
+        <Text variant="heading">{t.captures.assignTitle}</Text>
 
-            {/* What is being placed, so the sheet stands on its own over the
+        {/* What is being placed, so the sheet stands on its own over the
                 list it hides: the amount and its note beside the capture's own
                 glyph. */}
-            {assigning ? (
-              <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
-                <CategoryBadge
-                  category={assigning.category}
-                  meta={assigning.category_meta}
-                  description={assigning.description}
-                  size={38}
-                />
-                <View style={{ flex: 1, minWidth: 0 }}>
-                  <MoneyText
-                    amount={BigInt(assigning.amount)}
-                    currency={assigning.currency}
-                    locale={locale}
-                    variant="subheading"
-                  />
-                  {assigning.description ? (
-                    <Text variant="caption" tone="muted" numberOfLines={1}>
-                      {assigning.description}
-                    </Text>
-                  ) : null}
-                </View>
-              </Row>
-            ) : null}
+        {assigning ? (
+          <Row style={{ gap: theme.spacing.md, alignItems: 'center' }}>
+            <CategoryBadge
+              category={assigning.category}
+              meta={assigning.category_meta}
+              description={assigning.description}
+              size={38}
+            />
+            <View style={{ flex: 1, minWidth: 0 }}>
+              <MoneyText
+                amount={BigInt(assigning.amount)}
+                currency={assigning.currency}
+                locale={locale}
+                variant="subheading"
+              />
+              {assigning.description ? (
+                <Text variant="caption" tone="muted" numberOfLines={1}>
+                  {assigning.description}
+                </Text>
+              ) : null}
+            </View>
+          </Row>
+        ) : null}
 
-            <Text variant="caption" tone="muted">
-              {t.captures.assignBody}
-            </Text>
+        <Text variant="caption" tone="muted">
+          {t.captures.assignBody}
+        </Text>
 
-            {/* Search only earns its place on a long list (see `showSearch`);
+        {/* Search only earns its place on a long list (see `showSearch`);
                 a rounded field with a leading glyph, the picker grammar Mobbin
                 shows across Starling/Swarm/Canva. */}
-            {showSearch ? (
-              <Row
-                style={{
-                  gap: theme.spacing.sm,
-                  alignItems: 'center',
-                  backgroundColor: theme.color.surfaceMuted,
-                  borderRadius: theme.radius.md,
-                  paddingHorizontal: theme.spacing.md,
-                }}
-              >
-                <Ionicons name="search" size={iconSize.md} color={theme.color.textFaint} />
-                <TextInput
-                  value={query}
-                  onChangeText={setQuery}
-                  placeholder={t.captures.assignSearch}
-                  placeholderTextColor={theme.color.textFaint}
-                  accessibilityLabel={t.captures.assignSearch}
-                  autoCorrect={false}
-                  style={{
-                    flex: 1,
-                    fontSize: 16,
-                    color: theme.color.text,
-                    paddingVertical: theme.spacing.md,
-                  }}
-                />
-              </Row>
-            ) : null}
+        {showSearch ? (
+          <Row
+            style={{
+              gap: theme.spacing.sm,
+              alignItems: 'center',
+              backgroundColor: theme.color.surfaceMuted,
+              borderRadius: theme.radius.md,
+              paddingHorizontal: theme.spacing.md,
+            }}
+          >
+            <Ionicons name="search" size={iconSize.md} color={theme.color.textFaint} />
+            <TextInput
+              value={query}
+              onChangeText={setQuery}
+              placeholder={t.captures.assignSearch}
+              placeholderTextColor={theme.color.textFaint}
+              accessibilityLabel={t.captures.assignSearch}
+              autoCorrect={false}
+              style={{
+                flex: 1,
+                fontSize: 16,
+                color: theme.color.text,
+                paddingVertical: theme.spacing.md,
+              }}
+            />
+          </Row>
+        ) : null}
 
-            <View style={{ height: pickerListHeight }}>
-              <FlashList
-                data={assignableGroups.length === 0 ? [] : visibleGroups}
-                keyExtractor={(group) => group.id}
-                renderItem={renderGroupPickerItem}
-                showsVerticalScrollIndicator={false}
-                keyboardShouldPersistTaps="handled"
-                ListHeaderComponent={
-                  <>
-                    {/* Start a group and drop this into it — so a capture with no
+        <View style={{ height: pickerListHeight }}>
+          <FlashList
+            data={assignableGroups.length === 0 ? [] : visibleGroups}
+            keyExtractor={(group) => group.id}
+            renderItem={renderGroupPickerItem}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+            ListHeaderComponent={
+              <>
+                {/* Start a group and drop this into it — so a capture with no
                         fitting group is no longer a dead end (it used to only say
                         "make one first"). Mirrors the "Create group" affordance the
                         Wise/Starling pickers lead with. */}
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel={t.captures.assignNew}
-                      onPress={() => {
-                        // Carry the capture through group creation so new-group
-                        // can hand it back and finish the assignment — read the id
-                        // before closeAssign clears `assigning`.
-                        const captureId = assigning?.id;
-                        closeAssign();
-                        router.push(
-                          captureId
-                            ? { pathname: '/new-group', params: { assignCaptureId: captureId } }
-                            : '/new-group',
-                        );
-                      }}
-                      style={({ pressed }) => ({
-                        flexDirection: 'row',
-                        alignItems: 'center',
-                        gap: theme.spacing.md,
-                        paddingVertical: theme.spacing.md,
-                        opacity: pressed ? 0.6 : 1,
-                      })}
-                    >
-                      <View
-                        style={{
-                          width: 44,
-                          height: 44,
-                          borderRadius: 22,
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          backgroundColor: theme.color.surfaceMuted,
-                          borderWidth: 1,
-                          borderColor: theme.color.border,
-                          borderStyle: 'dashed',
-                        }}
-                      >
-                        <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
-                      </View>
-                      <View style={{ flex: 1, minWidth: 0 }}>
-                        <Text variant="subheading" numberOfLines={1}>
-                          {t.captures.assignNew}
-                        </Text>
-                        <Text variant="caption" tone="muted" numberOfLines={1}>
-                          {t.captures.assignNewBody}
-                        </Text>
-                      </View>
-                    </Pressable>
-
-                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                  </>
-                }
-                ListEmptyComponent={
-                  <Text
-                    variant="caption"
-                    tone="muted"
-                    style={{ paddingVertical: theme.spacing.lg }}
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={t.captures.assignNew}
+                  onPress={() => {
+                    // Carry the capture through group creation so new-group
+                    // can hand it back and finish the assignment — read the id
+                    // before closeAssign clears `assigning`.
+                    const captureId = assigning?.id;
+                    closeAssign();
+                    router.push(
+                      captureId
+                        ? { pathname: '/new-group', params: { assignCaptureId: captureId } }
+                        : '/new-group',
+                    );
+                  }}
+                  style={({ pressed }) => ({
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: theme.spacing.md,
+                    paddingVertical: theme.spacing.md,
+                    opacity: pressed ? 0.6 : 1,
+                  })}
+                >
+                  <View
+                    style={{
+                      width: 44,
+                      height: 44,
+                      borderRadius: 22,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: theme.color.surfaceMuted,
+                      borderWidth: 1,
+                      borderColor: theme.color.border,
+                      borderStyle: 'dashed',
+                    }}
                   >
-                    {assignableGroups.length === 0 ? t.captures.noGroups : t.captures.assignNoMatch}
-                  </Text>
-                }
-              />
-            </View>
+                    <Ionicons name="add" size={iconSize.lg} color={theme.color.brand} />
+                  </View>
+                  <View style={{ flex: 1, minWidth: 0 }}>
+                    <Text variant="subheading" numberOfLines={1}>
+                      {t.captures.assignNew}
+                    </Text>
+                    <Text variant="caption" tone="muted" numberOfLines={1}>
+                      {t.captures.assignNewBody}
+                    </Text>
+                  </View>
+                </Pressable>
+
+                <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              </>
+            }
+            ListEmptyComponent={
+              <Text variant="caption" tone="muted" style={{ paddingVertical: theme.spacing.lg }}>
+                {assignableGroups.length === 0 ? t.captures.noGroups : t.captures.assignNoMatch}
+              </Text>
+            }
+          />
+        </View>
       </Sheet>
 
       {/* The row's ⋯ overflow, as a small sheet: the actions that are not "add to
@@ -1053,72 +1049,64 @@ export default function CapturesScreen() {
         closeLabel={t.common.close}
         style={{ paddingHorizontal: theme.spacing.xl, gap: theme.spacing.xs }}
       >
-            {menu?.kind === 'capture' ? (
-              <>
-                <Text
-                  variant="heading"
-                  numberOfLines={1}
-                  style={{ marginBottom: theme.spacing.xs }}
-                >
-                  {menu.capture.description?.trim() ||
-                    (menu.capture.category
-                      ? (t.categories as Record<string, string>)[menu.capture.category]
-                      : undefined) ||
-                    t.captures.unassigned}
-                </Text>
-                <ActionSheetRow
-                  icon="people-outline"
-                  label={t.captures.assign}
-                  tone="brand"
-                  onPress={() => {
-                    const capture = menu.capture;
-                    setMenu(null);
-                    openAssign(capture);
-                  }}
-                />
-                <Divider />
-                <ActionSheetRow
-                  icon="create-outline"
-                  label={t.captures.edit}
-                  onPress={() => {
-                    const capture = menu.capture;
-                    setMenu(null);
-                    openEdit(capture);
-                  }}
-                />
-                <Divider />
-                <ActionSheetRow
-                  icon="trash-outline"
-                  label={t.captures.delete}
-                  tone="negative"
-                  onPress={() => {
-                    const capture = menu.capture;
-                    setMenu(null);
-                    confirmDelete(capture);
-                  }}
-                />
-              </>
-            ) : menu?.kind === 'batch' ? (
-              <>
-                <Text
-                  variant="heading"
-                  numberOfLines={1}
-                  style={{ marginBottom: theme.spacing.xs }}
-                >
-                  {plural(locale, menu.items.length, t.captures.batchExpenses)}
-                </Text>
-                <ActionSheetRow
-                  icon="trash-outline"
-                  label={t.captures.deleteBatch}
-                  tone="negative"
-                  onPress={() => {
-                    const items = menu.items;
-                    setMenu(null);
-                    confirmDeleteBatch(items);
-                  }}
-                />
-              </>
-            ) : null}
+        {menu?.kind === 'capture' ? (
+          <>
+            <Text variant="heading" numberOfLines={1} style={{ marginBottom: theme.spacing.xs }}>
+              {menu.capture.description?.trim() ||
+                (menu.capture.category
+                  ? (t.categories as Record<string, string>)[menu.capture.category]
+                  : undefined) ||
+                t.captures.unassigned}
+            </Text>
+            <ActionSheetRow
+              icon="people-outline"
+              label={t.captures.assign}
+              tone="brand"
+              onPress={() => {
+                const capture = menu.capture;
+                setMenu(null);
+                openAssign(capture);
+              }}
+            />
+            <Divider />
+            <ActionSheetRow
+              icon="create-outline"
+              label={t.captures.edit}
+              onPress={() => {
+                const capture = menu.capture;
+                setMenu(null);
+                openEdit(capture);
+              }}
+            />
+            <Divider />
+            <ActionSheetRow
+              icon="trash-outline"
+              label={t.captures.delete}
+              tone="negative"
+              onPress={() => {
+                const capture = menu.capture;
+                setMenu(null);
+                confirmDelete(capture);
+              }}
+            />
+          </>
+        ) : menu?.kind === 'batch' ? (
+          <>
+            <Text variant="heading" numberOfLines={1} style={{ marginBottom: theme.spacing.xs }}>
+              {plural(locale, menu.items.length, t.captures.batchExpenses)}
+            </Text>
+            <ActionSheetRow
+              icon="trash-outline"
+              label={t.captures.deleteBatch}
+              tone="negative"
+              onPress={() => {
+                const items = menu.items;
+                setMenu(null);
+                confirmDeleteBatch(items);
+              }}
+            />
+          </>
+        ) : null}
       </Sheet>
     </Screen>
   );

--- a/apps/mobile/src/app/captures.tsx
+++ b/apps/mobile/src/app/captures.tsx
@@ -16,14 +16,12 @@ import { FlashList } from '@shopify/flash-list';
 import { router } from 'expo-router';
 import {
   Alert,
-  Modal,
   Pressable,
   RefreshControl,
   TextInput,
   useWindowDimensions,
   View,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
   Avatar,
@@ -36,6 +34,7 @@ import {
   MoneyText,
   Row,
   Screen,
+  Sheet,
   Text,
   tintForKey,
   useTabBarClearance,
@@ -500,7 +499,6 @@ export default function CapturesScreen() {
   const theme = useTheme();
   const { height } = useWindowDimensions();
   const clearance = useTabBarClearance();
-  const insets = useSafeAreaInsets();
   const { t, locale } = useStrings();
   const pull = usePullRefresh();
   const { profile } = useAuth();
@@ -895,53 +893,13 @@ export default function CapturesScreen() {
           is rendered at the root over the whole stack, so an in-tree overlay
           paints *under* it and the sheet's lower rows hide behind the nav bar.
           A Modal floats above everything, the way the other sheets do. */}
-      <Modal
-        transparent
+      <Sheet
         visible={assigning !== null}
-        animationType="fade"
-        onRequestClose={closeAssign}
+        onClose={closeAssign}
+        padded={false}
+        closeLabel={t.common.close}
+        style={{ paddingHorizontal: theme.spacing.xl, gap: theme.spacing.md, maxHeight: '80%' }}
       >
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t.common.close}
-          onPress={closeAssign}
-          style={{
-            flex: 1,
-            backgroundColor: 'rgba(10, 10, 26, 0.55)',
-            justifyContent: 'flex-end',
-          }}
-        >
-          <Pressable
-            // Swallow taps on the sheet itself; only the backdrop dismisses.
-            onPress={() => {}}
-            accessibilityViewIsModal
-            style={{
-              backgroundColor: theme.color.surface,
-              borderTopLeftRadius: theme.radius.xxl,
-              borderTopRightRadius: theme.radius.xxl,
-              paddingHorizontal: theme.spacing.xl,
-              paddingTop: theme.spacing.md,
-              // Clear the Android gesture/nav bar so the last group row is not
-              // hidden behind it.
-              paddingBottom: theme.spacing.md + insets.bottom,
-              gap: theme.spacing.md,
-              maxHeight: '80%',
-              ...theme.shadow.lifted,
-            }}
-          >
-            {/* The grab handle — the visual grammar of a sheet you can pull down,
-                the same one every other sheet in the app wears. */}
-            <View
-              style={{
-                alignSelf: 'center',
-                width: 40,
-                height: 4,
-                borderRadius: 2,
-                backgroundColor: theme.color.border,
-                marginBottom: theme.spacing.xs,
-              }}
-            />
-
             <Text variant="heading">{t.captures.assignTitle}</Text>
 
             {/* What is being placed, so the sheet stands on its own over the
@@ -1081,51 +1039,20 @@ export default function CapturesScreen() {
                 }
               />
             </View>
-          </Pressable>
-        </Pressable>
-      </Modal>
+      </Sheet>
 
       {/* The row's ⋯ overflow, as a small sheet: the actions that are not "add to
           group" (the card's own tap) plus a labelled way to reach it, so the one
           thing a person does with a capture is spelled out and delete no longer
           rides on every row. A real Modal for the same reason the assign sheet is
           one — an in-tree overlay would paint under the root tab bar. */}
-      <Modal transparent visible={menu !== null} animationType="fade" onRequestClose={closeMenu}>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t.common.close}
-          onPress={closeMenu}
-          style={{
-            flex: 1,
-            backgroundColor: 'rgba(10, 10, 26, 0.55)',
-            justifyContent: 'flex-end',
-          }}
-        >
-          <Pressable
-            onPress={() => {}}
-            accessibilityViewIsModal
-            style={{
-              backgroundColor: theme.color.surface,
-              borderTopLeftRadius: theme.radius.xxl,
-              borderTopRightRadius: theme.radius.xxl,
-              paddingHorizontal: theme.spacing.xl,
-              paddingTop: theme.spacing.md,
-              paddingBottom: theme.spacing.md + insets.bottom,
-              gap: theme.spacing.xs,
-              ...theme.shadow.lifted,
-            }}
-          >
-            <View
-              style={{
-                alignSelf: 'center',
-                width: 40,
-                height: 4,
-                borderRadius: 2,
-                backgroundColor: theme.color.border,
-                marginBottom: theme.spacing.sm,
-              }}
-            />
-
+      <Sheet
+        visible={menu !== null}
+        onClose={closeMenu}
+        padded={false}
+        closeLabel={t.common.close}
+        style={{ paddingHorizontal: theme.spacing.xl, gap: theme.spacing.xs }}
+      >
             {menu?.kind === 'capture' ? (
               <>
                 <Text
@@ -1192,9 +1119,7 @@ export default function CapturesScreen() {
                 />
               </>
             ) : null}
-          </Pressable>
-        </Pressable>
-      </Modal>
+      </Sheet>
     </Screen>
   );
 }

--- a/apps/mobile/src/app/personal/budgets.tsx
+++ b/apps/mobile/src/app/personal/budgets.tsx
@@ -210,69 +210,63 @@ function BudgetEditor({
 
   return (
     <Sheet visible onClose={onClose} padded={false} style={{ maxHeight: '90%' }}>
-          <ScrollView
-            contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
-            keyboardShouldPersistTaps="handled"
-          >
-            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <Text variant="heading">{budget ? t.personal.editBudget : t.personal.addBudget}</Text>
-              <IconButton label={t.common.close} onPress={onClose}>
-                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-              </IconButton>
-            </Row>
+      <ScrollView
+        contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+          <Text variant="heading">{budget ? t.personal.editBudget : t.personal.addBudget}</Text>
+          <IconButton label={t.common.close} onPress={onClose}>
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+          </IconButton>
+        </Row>
 
-            <SegmentedTabs
-              value={scope}
-              onChange={setScope}
-              tabs={[
-                { value: 'overall', label: t.personal.overall },
-                { value: 'category', label: t.personal.category },
-              ]}
+        <SegmentedTabs
+          value={scope}
+          onChange={setScope}
+          tabs={[
+            { value: 'overall', label: t.personal.overall },
+            { value: 'category', label: t.personal.category },
+          ]}
+        />
+
+        {scope === 'category' ? (
+          <CategoryPicker value={category} onChange={(picked) => setCategory(picked)} />
+        ) : null}
+
+        <View style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            {t.personal.monthlyLimit}
+          </Text>
+          <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
+            <AmountField
+              currency={budget?.currency ?? currency}
+              value={limit}
+              onChange={setLimit}
             />
+          </View>
+        </View>
 
-            {scope === 'category' ? (
-              <CategoryPicker value={category} onChange={(picked) => setCategory(picked)} />
-            ) : null}
+        <Button label={t.personal.save} size="lg" fullWidth onPress={onSave} disabled={!canSave} />
 
-            <View style={{ gap: theme.spacing.sm }}>
-              <Text variant="caption" tone="muted">
-                {t.personal.monthlyLimit}
-              </Text>
-              <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
-                <AmountField
-                  currency={budget?.currency ?? currency}
-                  value={limit}
-                  onChange={setLimit}
-                />
-              </View>
-            </View>
-
-            <Button
-              label={t.personal.save}
-              size="lg"
-              fullWidth
-              onPress={onSave}
-              disabled={!canSave}
-            />
-
-            {budget ? (
-              <Button
-                label={t.common.delete}
-                variant="danger"
-                fullWidth
-                onPress={() =>
-                  Alert.alert(t.common.delete, t.personal.deleteConfirm, [
-                    { text: t.common.cancel, style: 'cancel' },
-                    {
-                      text: t.common.delete,
-                      style: 'destructive',
-                      onPress: () => remove.mutate(budget.id, { onSuccess: onClose }),
-                    },
-                  ])
-                }
-              />
-            ) : null}
-          </ScrollView>
+        {budget ? (
+          <Button
+            label={t.common.delete}
+            variant="danger"
+            fullWidth
+            onPress={() =>
+              Alert.alert(t.common.delete, t.personal.deleteConfirm, [
+                { text: t.common.cancel, style: 'cancel' },
+                {
+                  text: t.common.delete,
+                  style: 'destructive',
+                  onPress: () => remove.mutate(budget.id, { onSuccess: onClose }),
+                },
+              ])
+            }
+          />
+        ) : null}
+      </ScrollView>
     </Sheet>
   );
 }

--- a/apps/mobile/src/app/personal/budgets.tsx
+++ b/apps/mobile/src/app/personal/budgets.tsx
@@ -8,7 +8,7 @@
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { Alert, Modal, Pressable, ScrollView, View } from 'react-native';
+import { Alert, Pressable, ScrollView, View } from 'react-native';
 
 import {
   encodeBudget,
@@ -27,6 +27,7 @@ import {
   iconSize,
   Row,
   Screen,
+  Sheet,
   SegmentedTabs,
   Text,
   useScreenClearance,
@@ -208,16 +209,7 @@ function BudgetEditor({
   };
 
   return (
-    <Modal visible transparent animationType="slide" onRequestClose={onClose}>
-      <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
-        <View
-          style={{
-            backgroundColor: theme.color.surface,
-            borderTopLeftRadius: theme.radius.xl,
-            borderTopRightRadius: theme.radius.xl,
-            maxHeight: '90%',
-          }}
-        >
+    <Sheet visible onClose={onClose} padded={false} style={{ maxHeight: '90%' }}>
           <ScrollView
             contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
             keyboardShouldPersistTaps="handled"
@@ -281,8 +273,6 @@ function BudgetEditor({
               />
             ) : null}
           </ScrollView>
-        </View>
-      </View>
-    </Modal>
+    </Sheet>
   );
 }

--- a/apps/mobile/src/app/personal/loans.tsx
+++ b/apps/mobile/src/app/personal/loans.tsx
@@ -235,134 +235,128 @@ function LoanEditor({
 
   return (
     <Sheet visible onClose={onClose} padded={false} style={{ maxHeight: '90%' }}>
-          <ScrollView
-            contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
-            keyboardShouldPersistTaps="handled"
-          >
-            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <Text variant="heading">{loan ? t.personal.editLoan : t.personal.addLoan}</Text>
-              <IconButton label={t.common.close} onPress={onClose}>
-                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-              </IconButton>
-            </Row>
+      <ScrollView
+        contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+          <Text variant="heading">{loan ? t.personal.editLoan : t.personal.addLoan}</Text>
+          <IconButton label={t.common.close} onPress={onClose}>
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+          </IconButton>
+        </Row>
 
-            <SegmentedTabs
-              value={direction}
-              onChange={setDirection}
-              tabs={[
-                { value: 'borrowed', label: t.personal.borrowed },
-                { value: 'lent', label: t.personal.lent },
-              ]}
-            />
+        <SegmentedTabs
+          value={direction}
+          onChange={setDirection}
+          tabs={[
+            { value: 'borrowed', label: t.personal.borrowed },
+            { value: 'lent', label: t.personal.lent },
+          ]}
+        />
 
-            <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
-              <AmountField
-                currency={loan?.currency ?? currency}
-                value={principal}
-                onChange={setPrincipal}
-              />
-            </View>
+        <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
+          <AmountField
+            currency={loan?.currency ?? currency}
+            value={principal}
+            onChange={setPrincipal}
+          />
+        </View>
 
-            <View style={{ gap: theme.spacing.sm }}>
-              <Text variant="caption" tone="muted">
-                {t.personal.counterpart}
-              </Text>
-              <TextInput
-                value={counterpart}
-                onChangeText={setCounterpart}
-                placeholder={t.personal.counterpartPlaceholder}
-                placeholderTextColor={theme.color.textFaint}
-                style={{
-                  fontSize: 16,
-                  color: theme.color.text,
-                  paddingVertical: theme.spacing.md,
-                  paddingHorizontal: theme.spacing.lg,
-                  backgroundColor: theme.color.surfaceMuted,
-                  borderRadius: theme.radius.md,
-                }}
-              />
-            </View>
+        <View style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            {t.personal.counterpart}
+          </Text>
+          <TextInput
+            value={counterpart}
+            onChangeText={setCounterpart}
+            placeholder={t.personal.counterpartPlaceholder}
+            placeholderTextColor={theme.color.textFaint}
+            style={{
+              fontSize: 16,
+              color: theme.color.text,
+              paddingVertical: theme.spacing.md,
+              paddingHorizontal: theme.spacing.lg,
+              backgroundColor: theme.color.surfaceMuted,
+              borderRadius: theme.radius.md,
+            }}
+          />
+        </View>
 
-            <TextInput
-              value={note}
-              onChangeText={setNote}
-              placeholder={t.personal.notePlaceholder}
-              placeholderTextColor={theme.color.textFaint}
-              style={{
-                fontSize: 16,
-                color: theme.color.text,
-                paddingVertical: theme.spacing.md,
-                paddingHorizontal: theme.spacing.lg,
-                backgroundColor: theme.color.surfaceMuted,
-                borderRadius: theme.radius.md,
-              }}
-            />
+        <TextInput
+          value={note}
+          onChangeText={setNote}
+          placeholder={t.personal.notePlaceholder}
+          placeholderTextColor={theme.color.textFaint}
+          style={{
+            fontSize: 16,
+            color: theme.color.text,
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+            backgroundColor: theme.color.surfaceMuted,
+            borderRadius: theme.radius.md,
+          }}
+        />
 
-            <Pressable
-              accessibilityRole="button"
-              onPress={() => setShowDate(true)}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                paddingVertical: theme.spacing.md,
-                paddingHorizontal: theme.spacing.lg,
-                backgroundColor: theme.color.surfaceMuted,
-                borderRadius: theme.radius.md,
-              }}
-            >
-              <Text variant="body">{startDate}</Text>
-              <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
-            </Pressable>
-            {showDate ? (
-              <DateTimePicker
-                value={new Date(`${startDate}T00:00:00`)}
-                mode="date"
-                onChange={(event, picked) => {
-                  if (Platform.OS !== 'ios') setShowDate(false);
-                  if (event.type === 'set' && picked) setStartDate(localIsoDate(picked));
-                }}
-              />
-            ) : null}
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => setShowDate(true)}
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+            backgroundColor: theme.color.surfaceMuted,
+            borderRadius: theme.radius.md,
+          }}
+        >
+          <Text variant="body">{startDate}</Text>
+          <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
+        </Pressable>
+        {showDate ? (
+          <DateTimePicker
+            value={new Date(`${startDate}T00:00:00`)}
+            mode="date"
+            onChange={(event, picked) => {
+              if (Platform.OS !== 'ios') setShowDate(false);
+              if (event.type === 'set' && picked) setStartDate(localIsoDate(picked));
+            }}
+          />
+        ) : null}
 
-            {loan ? (
-              <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-                <Text variant="body">{t.personal.closeLoan}</Text>
-                <Button
-                  label={closed ? t.personal.reopenLoan : t.personal.closeLoan}
-                  size="sm"
-                  variant="secondary"
-                  onPress={() => setClosed((prev) => !prev)}
-                />
-              </Row>
-            ) : null}
-
+        {loan ? (
+          <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text variant="body">{t.personal.closeLoan}</Text>
             <Button
-              label={t.personal.save}
-              size="lg"
-              fullWidth
-              onPress={onSave}
-              disabled={!canSave}
+              label={closed ? t.personal.reopenLoan : t.personal.closeLoan}
+              size="sm"
+              variant="secondary"
+              onPress={() => setClosed((prev) => !prev)}
             />
+          </Row>
+        ) : null}
 
-            {loan ? (
-              <Button
-                label={t.common.delete}
-                variant="danger"
-                fullWidth
-                onPress={() =>
-                  Alert.alert(t.common.delete, t.personal.deleteConfirm, [
-                    { text: t.common.cancel, style: 'cancel' },
-                    {
-                      text: t.common.delete,
-                      style: 'destructive',
-                      onPress: () => remove.mutate(loan.id, { onSuccess: onClose }),
-                    },
-                  ])
-                }
-              />
-            ) : null}
-          </ScrollView>
+        <Button label={t.personal.save} size="lg" fullWidth onPress={onSave} disabled={!canSave} />
+
+        {loan ? (
+          <Button
+            label={t.common.delete}
+            variant="danger"
+            fullWidth
+            onPress={() =>
+              Alert.alert(t.common.delete, t.personal.deleteConfirm, [
+                { text: t.common.cancel, style: 'cancel' },
+                {
+                  text: t.common.delete,
+                  style: 'destructive',
+                  onPress: () => remove.mutate(loan.id, { onSuccess: onClose }),
+                },
+              ])
+            }
+          />
+        ) : null}
+      </ScrollView>
     </Sheet>
   );
 }

--- a/apps/mobile/src/app/personal/loans.tsx
+++ b/apps/mobile/src/app/personal/loans.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { router } from 'expo-router';
-import { Alert, Modal, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { Alert, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
   encodeLoan,
@@ -30,6 +30,7 @@ import {
   iconSize,
   Row,
   Screen,
+  Sheet,
   SegmentedTabs,
   Text,
   useScreenClearance,
@@ -233,16 +234,7 @@ function LoanEditor({
   };
 
   return (
-    <Modal visible transparent animationType="slide" onRequestClose={onClose}>
-      <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
-        <View
-          style={{
-            backgroundColor: theme.color.surface,
-            borderTopLeftRadius: theme.radius.xl,
-            borderTopRightRadius: theme.radius.xl,
-            maxHeight: '90%',
-          }}
-        >
+    <Sheet visible onClose={onClose} padded={false} style={{ maxHeight: '90%' }}>
           <ScrollView
             contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
             keyboardShouldPersistTaps="handled"
@@ -371,8 +363,6 @@ function LoanEditor({
               />
             ) : null}
           </ScrollView>
-        </View>
-      </View>
-    </Modal>
+    </Sheet>
   );
 }

--- a/apps/mobile/src/app/personal/recurring.tsx
+++ b/apps/mobile/src/app/personal/recurring.tsx
@@ -275,150 +275,138 @@ function RecurringEditor({
 
   return (
     <Sheet visible onClose={onClose} padded={false} style={{ maxHeight: '90%' }}>
-          <ScrollView
-            contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
-            keyboardShouldPersistTaps="handled"
-          >
-            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <Text variant="heading">
-                {rule ? t.personal.editRecurring : t.personal.addRecurring}
-              </Text>
-              <IconButton label={t.common.close} onPress={onClose}>
-                <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
-              </IconButton>
-            </Row>
+      <ScrollView
+        contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+          <Text variant="heading">{rule ? t.personal.editRecurring : t.personal.addRecurring}</Text>
+          <IconButton label={t.common.close} onPress={onClose}>
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.text} />
+          </IconButton>
+        </Row>
 
-            <SegmentedTabs
-              value={txnKind}
-              onChange={setTxnKind}
-              tabs={[
-                { value: 'expense', label: t.personal.expense },
-                { value: 'income', label: t.personal.incomeKind },
-              ]}
+        <SegmentedTabs
+          value={txnKind}
+          onChange={setTxnKind}
+          tabs={[
+            { value: 'expense', label: t.personal.expense },
+            { value: 'income', label: t.personal.incomeKind },
+          ]}
+        />
+
+        <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
+          <AmountField currency={rule?.currency ?? currency} value={amount} onChange={setAmount} />
+        </View>
+
+        <TextInput
+          value={note}
+          onChangeText={setNote}
+          placeholder={t.personal.notePlaceholder}
+          placeholderTextColor={theme.color.textFaint}
+          style={{
+            fontSize: 16,
+            color: theme.color.text,
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+            backgroundColor: theme.color.surfaceMuted,
+            borderRadius: theme.radius.md,
+          }}
+        />
+
+        {txnKind === 'expense' ? (
+          <CategoryPicker value={category} onChange={(picked) => setCategory(picked)} />
+        ) : null}
+
+        <View style={{ gap: theme.spacing.sm }}>
+          <Text variant="caption" tone="muted">
+            {t.personal.repeats}
+          </Text>
+          <SegmentedTabs
+            value={cadence}
+            onChange={setCadence}
+            tabs={[
+              { value: 'weekly', label: t.personal.weekly },
+              { value: 'monthly', label: t.personal.monthly },
+              { value: 'yearly', label: t.personal.yearly },
+            ]}
+          />
+        </View>
+
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => setShowDate(true)}
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+            backgroundColor: theme.color.surfaceMuted,
+            borderRadius: theme.radius.md,
+          }}
+        >
+          <Text variant="body">
+            {t.personal.nextDue}: {startDate}
+          </Text>
+          <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
+        </Pressable>
+        {showDate ? (
+          <DateTimePicker
+            value={new Date(`${startDate}T00:00:00`)}
+            mode="date"
+            onChange={(event, picked) => {
+              if (Platform.OS !== 'ios') setShowDate(false);
+              if (event.type === 'set' && picked) setStartDate(localIsoDate(picked));
+            }}
+          />
+        ) : null}
+
+        <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+          <View style={{ flex: 1, paddingRight: theme.spacing.md }}>
+            <Text variant="body">{t.personal.autoPost}</Text>
+            <Text variant="micro" tone="muted">
+              {t.personal.autoPostHint}
+            </Text>
+          </View>
+          <Toggle
+            value={autoPost}
+            onValueChange={setAutoPost}
+            accessibilityLabel={t.personal.autoPost}
+          />
+        </Row>
+
+        {rule ? (
+          <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text variant="body">{t.personal.active}</Text>
+            <Toggle
+              value={active}
+              onValueChange={setActive}
+              accessibilityLabel={t.personal.active}
             />
+          </Row>
+        ) : null}
 
-            <View style={{ alignItems: 'center', paddingVertical: theme.spacing.md }}>
-              <AmountField
-                currency={rule?.currency ?? currency}
-                value={amount}
-                onChange={setAmount}
-              />
-            </View>
+        <Button label={t.personal.save} size="lg" fullWidth onPress={onSave} disabled={!canSave} />
 
-            <TextInput
-              value={note}
-              onChangeText={setNote}
-              placeholder={t.personal.notePlaceholder}
-              placeholderTextColor={theme.color.textFaint}
-              style={{
-                fontSize: 16,
-                color: theme.color.text,
-                paddingVertical: theme.spacing.md,
-                paddingHorizontal: theme.spacing.lg,
-                backgroundColor: theme.color.surfaceMuted,
-                borderRadius: theme.radius.md,
-              }}
-            />
-
-            {txnKind === 'expense' ? (
-              <CategoryPicker value={category} onChange={(picked) => setCategory(picked)} />
-            ) : null}
-
-            <View style={{ gap: theme.spacing.sm }}>
-              <Text variant="caption" tone="muted">
-                {t.personal.repeats}
-              </Text>
-              <SegmentedTabs
-                value={cadence}
-                onChange={setCadence}
-                tabs={[
-                  { value: 'weekly', label: t.personal.weekly },
-                  { value: 'monthly', label: t.personal.monthly },
-                  { value: 'yearly', label: t.personal.yearly },
-                ]}
-              />
-            </View>
-
-            <Pressable
-              accessibilityRole="button"
-              onPress={() => setShowDate(true)}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                paddingVertical: theme.spacing.md,
-                paddingHorizontal: theme.spacing.lg,
-                backgroundColor: theme.color.surfaceMuted,
-                borderRadius: theme.radius.md,
-              }}
-            >
-              <Text variant="body">
-                {t.personal.nextDue}: {startDate}
-              </Text>
-              <Ionicons name="calendar-outline" size={iconSize.md} color={theme.color.textMuted} />
-            </Pressable>
-            {showDate ? (
-              <DateTimePicker
-                value={new Date(`${startDate}T00:00:00`)}
-                mode="date"
-                onChange={(event, picked) => {
-                  if (Platform.OS !== 'ios') setShowDate(false);
-                  if (event.type === 'set' && picked) setStartDate(localIsoDate(picked));
-                }}
-              />
-            ) : null}
-
-            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <View style={{ flex: 1, paddingRight: theme.spacing.md }}>
-                <Text variant="body">{t.personal.autoPost}</Text>
-                <Text variant="micro" tone="muted">
-                  {t.personal.autoPostHint}
-                </Text>
-              </View>
-              <Toggle
-                value={autoPost}
-                onValueChange={setAutoPost}
-                accessibilityLabel={t.personal.autoPost}
-              />
-            </Row>
-
-            {rule ? (
-              <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-                <Text variant="body">{t.personal.active}</Text>
-                <Toggle
-                  value={active}
-                  onValueChange={setActive}
-                  accessibilityLabel={t.personal.active}
-                />
-              </Row>
-            ) : null}
-
-            <Button
-              label={t.personal.save}
-              size="lg"
-              fullWidth
-              onPress={onSave}
-              disabled={!canSave}
-            />
-
-            {rule ? (
-              <Button
-                label={t.common.delete}
-                variant="danger"
-                fullWidth
-                onPress={() =>
-                  Alert.alert(t.common.delete, t.personal.deleteConfirm, [
-                    { text: t.common.cancel, style: 'cancel' },
-                    {
-                      text: t.common.delete,
-                      style: 'destructive',
-                      onPress: () => remove.mutate(rule.id, { onSuccess: onClose }),
-                    },
-                  ])
-                }
-              />
-            ) : null}
-          </ScrollView>
+        {rule ? (
+          <Button
+            label={t.common.delete}
+            variant="danger"
+            fullWidth
+            onPress={() =>
+              Alert.alert(t.common.delete, t.personal.deleteConfirm, [
+                { text: t.common.cancel, style: 'cancel' },
+                {
+                  text: t.common.delete,
+                  style: 'destructive',
+                  onPress: () => remove.mutate(rule.id, { onSuccess: onClose }),
+                },
+              ])
+            }
+          />
+        ) : null}
+      </ScrollView>
     </Sheet>
   );
 }

--- a/apps/mobile/src/app/personal/recurring.tsx
+++ b/apps/mobile/src/app/personal/recurring.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { router } from 'expo-router';
-import { Alert, Modal, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { Alert, Platform, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
   addToDate,
@@ -34,6 +34,7 @@ import {
   iconSize,
   Row,
   Screen,
+  Sheet,
   SegmentedTabs,
   Text,
   Toggle,
@@ -273,16 +274,7 @@ function RecurringEditor({
   };
 
   return (
-    <Modal visible transparent animationType="slide" onRequestClose={onClose}>
-      <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
-        <View
-          style={{
-            backgroundColor: theme.color.surface,
-            borderTopLeftRadius: theme.radius.xl,
-            borderTopRightRadius: theme.radius.xl,
-            maxHeight: '90%',
-          }}
-        >
+    <Sheet visible onClose={onClose} padded={false} style={{ maxHeight: '90%' }}>
           <ScrollView
             contentContainerStyle={{ padding: theme.spacing.xl, gap: theme.spacing.lg }}
             keyboardShouldPersistTaps="handled"
@@ -427,8 +419,6 @@ function RecurringEditor({
               />
             ) : null}
           </ScrollView>
-        </View>
-      </View>
-    </Modal>
+    </Sheet>
   );
 }

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -24,8 +24,7 @@ import { randomUUID } from 'expo-crypto';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
 import { router } from 'expo-router';
-import { Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import {
   importSplitwiseCsv,
@@ -50,6 +49,7 @@ import {
   Row,
   Screen,
   SectionHeader,
+  Sheet,
   Text,
   useTabBarClearance,
   useTheme,
@@ -134,7 +134,6 @@ export default function ImportScreen() {
   // jammed under the bar. `useTabBarClearance` is the bar-aware room the other
   // settings screens use; a token more on top gives the footer CTA its breath.
   const clearance = useTabBarClearance() + theme.spacing.xl;
-  const insets = useSafeAreaInsets();
   const { t, locale } = useStrings();
   const reduceMotion = useReducedMotion();
   const groups = useGroups();
@@ -778,43 +777,13 @@ export default function ImportScreen() {
       {/* How it works, on tap of the header's help glyph — a bottom sheet that
           walks through the two file types and what does and does not come
           across, plus that it can be done with no connection. */}
-      <Modal
-        transparent
-        animationType="fade"
+      <Sheet
         visible={helpOpen}
-        onRequestClose={() => setHelpOpen(false)}
+        onClose={() => setHelpOpen(false)}
+        padded={false}
+        closeLabel={t.common.close}
+        style={{ paddingHorizontal: theme.spacing.xxl, paddingTop: theme.spacing.xl, gap: theme.spacing.lg }}
       >
-        <Pressable
-          onPress={() => setHelpOpen(false)}
-          accessibilityLabel={t.common.close}
-          style={{
-            flex: 1,
-            backgroundColor: 'rgba(10, 10, 26, 0.55)',
-            justifyContent: 'flex-end',
-          }}
-        >
-          {/* Swallows the tap so pressing the sheet does not dismiss it. */}
-          <Pressable
-            onPress={() => {}}
-            style={{
-              backgroundColor: theme.color.surface,
-              borderTopLeftRadius: theme.radius.xxl,
-              borderTopRightRadius: theme.radius.xxl,
-              paddingHorizontal: theme.spacing.xxl,
-              paddingTop: theme.spacing.xl,
-              paddingBottom: theme.spacing.xxl + insets.bottom,
-              gap: theme.spacing.lg,
-            }}
-          >
-            <View
-              style={{
-                alignSelf: 'center',
-                width: 40,
-                height: 4,
-                borderRadius: 2,
-                backgroundColor: theme.color.border,
-              }}
-            />
             <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
               <Ionicons name="help-circle-outline" size={iconSize.xl} color={theme.color.brand} />
               <Text variant="title">{t.importLedger.helpTitle}</Text>
@@ -841,9 +810,7 @@ export default function ImportScreen() {
               </Text>
             </ScrollView>
             <Button label={t.misc.gotIt} fullWidth onPress={() => setHelpOpen(false)} />
-          </Pressable>
-        </Pressable>
-      </Modal>
+      </Sheet>
     </Screen>
   );
 }

--- a/apps/mobile/src/app/settings/import.tsx
+++ b/apps/mobile/src/app/settings/import.tsx
@@ -782,34 +782,38 @@ export default function ImportScreen() {
         onClose={() => setHelpOpen(false)}
         padded={false}
         closeLabel={t.common.close}
-        style={{ paddingHorizontal: theme.spacing.xxl, paddingTop: theme.spacing.xl, gap: theme.spacing.lg }}
+        style={{
+          paddingHorizontal: theme.spacing.xxl,
+          paddingTop: theme.spacing.xl,
+          gap: theme.spacing.lg,
+        }}
       >
-            <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
-              <Ionicons name="help-circle-outline" size={iconSize.xl} color={theme.color.brand} />
-              <Text variant="title">{t.importLedger.helpTitle}</Text>
-            </Row>
-            <ScrollView
-              style={{ maxHeight: 340 }}
-              showsVerticalScrollIndicator={false}
-              contentContainerStyle={{ gap: theme.spacing.md }}
-            >
-              <Text variant="body" tone="muted">
-                {t.importLedger.ledgerHowTo}
-              </Text>
-              <Divider />
-              <Text variant="caption" tone="muted">
-                {t.importLedger.fromSplitwiseNote}
-              </Text>
-              <Text variant="caption" tone="muted">
-                {t.importLedger.fromBaakiNote}
-              </Text>
-              <Divider />
-              {/* Offline: parked and run on reconnect (see `@/lib/importProgress`). */}
-              <Text variant="caption" tone="muted">
-                {t.importLedger.helpOffline}
-              </Text>
-            </ScrollView>
-            <Button label={t.misc.gotIt} fullWidth onPress={() => setHelpOpen(false)} />
+        <Row style={{ alignItems: 'center', gap: theme.spacing.sm }}>
+          <Ionicons name="help-circle-outline" size={iconSize.xl} color={theme.color.brand} />
+          <Text variant="title">{t.importLedger.helpTitle}</Text>
+        </Row>
+        <ScrollView
+          style={{ maxHeight: 340 }}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ gap: theme.spacing.md }}
+        >
+          <Text variant="body" tone="muted">
+            {t.importLedger.ledgerHowTo}
+          </Text>
+          <Divider />
+          <Text variant="caption" tone="muted">
+            {t.importLedger.fromSplitwiseNote}
+          </Text>
+          <Text variant="caption" tone="muted">
+            {t.importLedger.fromBaakiNote}
+          </Text>
+          <Divider />
+          {/* Offline: parked and run on reconnect (see `@/lib/importProgress`). */}
+          <Text variant="caption" tone="muted">
+            {t.importLedger.helpOffline}
+          </Text>
+        </ScrollView>
+        <Button label={t.misc.gotIt} fullWidth onPress={() => setHelpOpen(false)} />
       </Sheet>
     </Screen>
   );

--- a/apps/mobile/src/components/CampaignPopup.tsx
+++ b/apps/mobile/src/components/CampaignPopup.tsx
@@ -100,42 +100,42 @@ export function CampaignPopup() {
   return (
     <Popup visible onClose={close} closeLabel={t.common.close} style={{ gap: theme.spacing.md }}>
       <Text variant="title">{campaign.title}</Text>
-          {campaign.body ? (
-            <Text variant="body" tone="muted">
-              {campaign.body}
-            </Text>
-          ) : null}
+      {campaign.body ? (
+        <Text variant="body" tone="muted">
+          {campaign.body}
+        </Text>
+      ) : null}
 
-          {campaign.promo_code ? (
-            <Pressable
-              onPress={() => void act()}
-              accessibilityRole="button"
-              accessibilityLabel={t.misc.tapToCopy}
-              style={{
-                backgroundColor: theme.color.buttonPrimary,
-                borderRadius: theme.radius.md,
-                paddingVertical: theme.spacing.md,
-                alignItems: 'center',
-              }}
-            >
-              <Text variant="heading" tone="onBrand">
-                {campaign.promo_code}
-              </Text>
-              <Text variant="micro" tone="onBrand">
-                {copied ? t.misc.copied : t.misc.tapToCopy}
-              </Text>
-            </Pressable>
-          ) : null}
+      {campaign.promo_code ? (
+        <Pressable
+          onPress={() => void act()}
+          accessibilityRole="button"
+          accessibilityLabel={t.misc.tapToCopy}
+          style={{
+            backgroundColor: theme.color.buttonPrimary,
+            borderRadius: theme.radius.md,
+            paddingVertical: theme.spacing.md,
+            alignItems: 'center',
+          }}
+        >
+          <Text variant="heading" tone="onBrand">
+            {campaign.promo_code}
+          </Text>
+          <Text variant="micro" tone="onBrand">
+            {copied ? t.misc.copied : t.misc.tapToCopy}
+          </Text>
+        </Pressable>
+      ) : null}
 
-          <View style={{ gap: theme.spacing.sm, paddingTop: theme.spacing.sm }}>
-            <Button
-              label={campaign.cta_label || t.misc.gotIt}
-              size="lg"
-              fullWidth
-              onPress={() => void act()}
-            />
-            <Button label={t.misc.notNow} variant="secondary" size="sm" fullWidth onPress={close} />
-          </View>
+      <View style={{ gap: theme.spacing.sm, paddingTop: theme.spacing.sm }}>
+        <Button
+          label={campaign.cta_label || t.misc.gotIt}
+          size="lg"
+          fullWidth
+          onPress={() => void act()}
+        />
+        <Button label={t.misc.notNow} variant="secondary" size="sm" fullWidth onPress={close} />
+      </View>
     </Popup>
   );
 }

--- a/apps/mobile/src/components/CampaignPopup.tsx
+++ b/apps/mobile/src/components/CampaignPopup.tsx
@@ -16,10 +16,10 @@
 
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Modal, Pressable, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 
-import { Button, Text, useTheme } from '@waves/ui';
+import { Button, Popup, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -98,34 +98,8 @@ export function CampaignPopup() {
   };
 
   return (
-    <Modal transparent animationType="fade" visible onRequestClose={close}>
-      {/* Tapping outside closes it. An announcement that traps somebody is an
-          advertisement, and this is not one. */}
-      <Pressable
-        onPress={close}
-        accessibilityLabel={t.common.close}
-        style={{
-          flex: 1,
-          backgroundColor: 'rgba(10, 10, 26, 0.55)',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: theme.spacing.xxl,
-        }}
-      >
-        {/* Swallows the tap so pressing the card itself does not dismiss it. */}
-        <Pressable
-          onPress={() => {}}
-          style={{
-            width: '100%',
-            maxWidth: 380,
-            backgroundColor: theme.color.surface,
-            borderRadius: theme.radius.xl,
-            padding: theme.spacing.xxl,
-            gap: theme.spacing.md,
-            ...theme.shadow.lifted,
-          }}
-        >
-          <Text variant="title">{campaign.title}</Text>
+    <Popup visible onClose={close} closeLabel={t.common.close} style={{ gap: theme.spacing.md }}>
+      <Text variant="title">{campaign.title}</Text>
           {campaign.body ? (
             <Text variant="body" tone="muted">
               {campaign.body}
@@ -162,8 +136,6 @@ export function CampaignPopup() {
             />
             <Button label={t.misc.notNow} variant="secondary" size="sm" fullWidth onPress={close} />
           </View>
-        </Pressable>
-      </Pressable>
-    </Modal>
+    </Popup>
   );
 }

--- a/apps/mobile/src/components/CoverEmojiPicker.tsx
+++ b/apps/mobile/src/components/CoverEmojiPicker.tsx
@@ -100,88 +100,88 @@ export function CoverEmojiPicker({
         closeLabel={t.common.close}
         style={{ maxHeight: '82%' }}
       >
-            <Row
-              style={{
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                paddingHorizontal: theme.spacing.xl,
-              }}
-            >
-              <Text variant="heading">{t.group.chooseIcon}</Text>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t.common.close}
-                onPress={() => setOpen(false)}
-                hitSlop={8}
-                style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
-              >
-                <Ionicons name="close" size={iconSize.lg} color={theme.color.textMuted} />
-              </Pressable>
-            </Row>
+        <Row
+          style={{
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            paddingHorizontal: theme.spacing.xl,
+          }}
+        >
+          <Text variant="heading">{t.group.chooseIcon}</Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t.common.close}
+            onPress={() => setOpen(false)}
+            hitSlop={8}
+            style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+          >
+            <Ionicons name="close" size={iconSize.lg} color={theme.color.textMuted} />
+          </Pressable>
+        </Row>
 
-            {/* The current pick, previewed large on a tinted circle. */}
-            <View style={{ alignItems: 'center', paddingVertical: theme.spacing.lg }}>
-              <View
-                style={{
-                  width: 84,
-                  height: 84,
-                  borderRadius: 28,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  backgroundColor: theme.color.buttonPrimary,
-                }}
-              >
-                <Text style={{ fontSize: 44 }}>{value ?? '👥'}</Text>
-              </View>
+        {/* The current pick, previewed large on a tinted circle. */}
+        <View style={{ alignItems: 'center', paddingVertical: theme.spacing.lg }}>
+          <View
+            style={{
+              width: 84,
+              height: 84,
+              borderRadius: 28,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: theme.color.buttonPrimary,
+            }}
+          >
+            <Text style={{ fontSize: 44 }}>{value ?? '👥'}</Text>
+          </View>
+        </View>
+
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: theme.spacing.xl,
+            paddingBottom: theme.spacing.xl,
+            gap: theme.spacing.lg,
+          }}
+          showsVerticalScrollIndicator={false}
+        >
+          {EMOJI_GROUPS.map((emojis, index) => (
+            <View key={index} style={{ gap: theme.spacing.sm }}>
+              {index > 0 ? (
+                <View style={{ height: 1, backgroundColor: theme.color.border }} />
+              ) : null}
+              <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
+                {emojis.map((emoji) => {
+                  const selected = value === emoji;
+                  return (
+                    <Pressable
+                      key={emoji}
+                      accessibilityRole="radio"
+                      accessibilityState={{ selected }}
+                      accessibilityLabel={emoji}
+                      onPress={() => {
+                        onChange(emoji);
+                        setOpen(false);
+                      }}
+                      style={{
+                        width: 52,
+                        height: 52,
+                        borderRadius: theme.radius.lg,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        borderWidth: selected ? 2 : 1,
+                        borderColor: selected ? theme.color.brand : theme.color.border,
+                        backgroundColor: selected
+                          ? theme.color.brandSoft
+                          : theme.color.surfaceMuted,
+                      }}
+                    >
+                      <Text style={{ fontSize: 26 }}>{emoji}</Text>
+                    </Pressable>
+                  );
+                })}
+              </Row>
             </View>
-
-            <ScrollView
-              contentContainerStyle={{
-                paddingHorizontal: theme.spacing.xl,
-                paddingBottom: theme.spacing.xl,
-                gap: theme.spacing.lg,
-              }}
-              showsVerticalScrollIndicator={false}
-            >
-              {EMOJI_GROUPS.map((emojis, index) => (
-                <View key={index} style={{ gap: theme.spacing.sm }}>
-                  {index > 0 ? (
-                    <View style={{ height: 1, backgroundColor: theme.color.border }} />
-                  ) : null}
-                  <Row style={{ flexWrap: 'wrap', gap: theme.spacing.sm }}>
-                    {emojis.map((emoji) => {
-                      const selected = value === emoji;
-                      return (
-                        <Pressable
-                          key={emoji}
-                          accessibilityRole="radio"
-                          accessibilityState={{ selected }}
-                          accessibilityLabel={emoji}
-                          onPress={() => {
-                            onChange(emoji);
-                            setOpen(false);
-                          }}
-                          style={{
-                            width: 52,
-                            height: 52,
-                            borderRadius: theme.radius.lg,
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            borderWidth: selected ? 2 : 1,
-                            borderColor: selected ? theme.color.brand : theme.color.border,
-                            backgroundColor: selected
-                              ? theme.color.brandSoft
-                              : theme.color.surfaceMuted,
-                          }}
-                        >
-                          <Text style={{ fontSize: 26 }}>{emoji}</Text>
-                        </Pressable>
-                      );
-                    })}
-                  </Row>
-                </View>
-              ))}
-            </ScrollView>
+          ))}
+        </ScrollView>
       </Sheet>
     </>
   );

--- a/apps/mobile/src/components/CoverEmojiPicker.tsx
+++ b/apps/mobile/src/components/CoverEmojiPicker.tsx
@@ -20,10 +20,9 @@
 
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Modal, Pressable, ScrollView, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Pressable, ScrollView, View } from 'react-native';
 
-import { Button, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { Button, Row, Sheet, Text, iconSize, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -52,7 +51,6 @@ export function CoverEmojiPicker({
 }) {
   const theme = useTheme();
   const { t } = useStrings();
-  const insets = useSafeAreaInsets();
   const [internalOpen, setInternalOpen] = useState(false);
 
   const controlled = open !== undefined;
@@ -95,55 +93,13 @@ export function CoverEmojiPicker({
         />
       )}
 
-      <Modal
+      <Sheet
         visible={isOpen}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setOpen(false)}
+        onClose={() => setOpen(false)}
+        padded={false}
+        closeLabel={t.common.close}
+        style={{ maxHeight: '82%' }}
       >
-        {/* A bottom sheet, not a full page: a dim backdrop you can tap to
-            dismiss, over a rounded card anchored to the bottom. */}
-        <View style={{ flex: 1, justifyContent: 'flex-end' }}>
-          {/* Dim scrim; tap to dismiss. Kept out of the accessibility tree —
-              the header's close button is the labelled way out, so a
-              full-screen dismissal target would only add screen-reader noise.
-              No theme scrim token exists; this matches the app's modal dim. */}
-          <Pressable
-            onPress={() => setOpen(false)}
-            accessibilityElementsHidden
-            importantForAccessibility="no-hide-descendants"
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              backgroundColor: '#00000080',
-            }}
-          />
-
-          <View
-            style={{
-              maxHeight: '82%',
-              backgroundColor: theme.color.surface,
-              borderTopLeftRadius: theme.radius.xxl,
-              borderTopRightRadius: theme.radius.xxl,
-              paddingTop: theme.spacing.sm,
-              paddingBottom: insets.bottom + theme.spacing.md,
-            }}
-          >
-            {/* Grab handle */}
-            <View
-              style={{
-                alignSelf: 'center',
-                width: 40,
-                height: 4,
-                borderRadius: theme.radius.pill,
-                backgroundColor: theme.color.border,
-                marginBottom: theme.spacing.md,
-              }}
-            />
-
             <Row
               style={{
                 justifyContent: 'space-between',
@@ -226,9 +182,7 @@ export function CoverEmojiPicker({
                 </View>
               ))}
             </ScrollView>
-          </View>
-        </View>
-      </Modal>
+      </Sheet>
     </>
   );
 }

--- a/apps/mobile/src/components/LanguagePicker.tsx
+++ b/apps/mobile/src/components/LanguagePicker.tsx
@@ -20,9 +20,9 @@
 
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Modal, Pressable, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 
-import { iconSize, Text, useTheme } from '@waves/ui';
+import { iconSize, Popup, Text, useTheme } from '@waves/ui';
 
 import { isRtlLanguage, LANGUAGE_NAMES, LANGUAGES, useStrings } from '@/i18n';
 import { useLanguage } from '@/i18n/language';
@@ -71,30 +71,12 @@ export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-
         </Text>
       ) : null}
 
-      <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
-        {/* Backdrop closes; the card swallows its own taps so a miss inside the
-            menu does not dismiss it. */}
-        <Pressable
-          onPress={() => setOpen(false)}
-          style={{
-            flex: 1,
-            backgroundColor: 'rgba(15, 10, 40, 0.4)',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: theme.spacing.xxxl,
-          }}
-        >
-          <Pressable
-            onPress={() => {}}
-            style={{
-              width: '100%',
-              maxWidth: 340,
-              backgroundColor: theme.color.surface,
-              borderRadius: theme.radius.xl,
-              paddingVertical: theme.spacing.sm,
-              ...theme.shadow.lifted,
-            }}
-          >
+      <Popup
+        visible={open}
+        onClose={() => setOpen(false)}
+        closeLabel={t.common.close}
+        style={{ maxWidth: 340, padding: 0, paddingVertical: theme.spacing.sm }}
+      >
             <Text
               variant="caption"
               tone="faint"
@@ -144,9 +126,7 @@ export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-
                 </Pressable>
               );
             })}
-          </Pressable>
-        </Pressable>
-      </Modal>
+      </Popup>
     </View>
   );
 }

--- a/apps/mobile/src/components/LanguagePicker.tsx
+++ b/apps/mobile/src/components/LanguagePicker.tsx
@@ -77,55 +77,55 @@ export function LanguagePicker({ align = 'center' }: { align?: 'center' | 'flex-
         closeLabel={t.common.close}
         style={{ maxWidth: 340, padding: 0, paddingVertical: theme.spacing.sm }}
       >
-            <Text
-              variant="caption"
-              tone="faint"
-              style={{ paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.sm }}
+        <Text
+          variant="caption"
+          tone="faint"
+          style={{ paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.sm }}
+        >
+          {t.language}
+        </Text>
+        {LANGUAGES.map((entry) => {
+          const active = entry === language;
+          return (
+            <Pressable
+              key={entry}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={LANGUAGE_NAMES[entry].own}
+              onPress={() => {
+                setOpen(false);
+                // Re-choosing the current language would fire the restart
+                // machinery for nothing.
+                if (!active) void setLanguage(entry);
+              }}
+              style={({ pressed }) => ({
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                marginHorizontal: theme.spacing.sm,
+                paddingVertical: theme.spacing.md,
+                paddingHorizontal: theme.spacing.md,
+                borderRadius: theme.radius.md,
+                backgroundColor: active
+                  ? theme.color.brandSoft
+                  : pressed
+                    ? theme.color.surfaceMuted
+                    : 'transparent',
+              })}
             >
-              {t.language}
-            </Text>
-            {LANGUAGES.map((entry) => {
-              const active = entry === language;
-              return (
-                <Pressable
-                  key={entry}
-                  accessibilityRole="button"
-                  accessibilityState={{ selected: active }}
-                  accessibilityLabel={LANGUAGE_NAMES[entry].own}
-                  onPress={() => {
-                    setOpen(false);
-                    // Re-choosing the current language would fire the restart
-                    // machinery for nothing.
-                    if (!active) void setLanguage(entry);
-                  }}
-                  style={({ pressed }) => ({
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    marginHorizontal: theme.spacing.sm,
-                    paddingVertical: theme.spacing.md,
-                    paddingHorizontal: theme.spacing.md,
-                    borderRadius: theme.radius.md,
-                    backgroundColor: active
-                      ? theme.color.brandSoft
-                      : pressed
-                        ? theme.color.surfaceMuted
-                        : 'transparent',
-                  })}
-                >
-                  <Text
-                    variant="body"
-                    tone={active ? 'brand' : 'default'}
-                    style={{ fontWeight: active ? '700' : '500' }}
-                  >
-                    {LANGUAGE_NAMES[entry].own}
-                  </Text>
-                  {active ? (
-                    <Ionicons name="checkmark" size={iconSize.md} color={theme.color.brand} />
-                  ) : null}
-                </Pressable>
-              );
-            })}
+              <Text
+                variant="body"
+                tone={active ? 'brand' : 'default'}
+                style={{ fontWeight: active ? '700' : '500' }}
+              >
+                {LANGUAGE_NAMES[entry].own}
+              </Text>
+              {active ? (
+                <Ionicons name="checkmark" size={iconSize.md} color={theme.color.brand} />
+              ) : null}
+            </Pressable>
+          );
+        })}
       </Popup>
     </View>
   );

--- a/apps/mobile/src/components/NotificationPrompt.tsx
+++ b/apps/mobile/src/components/NotificationPrompt.tsx
@@ -16,9 +16,9 @@
 import { useEffect, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Modal, View } from 'react-native';
+import { View } from 'react-native';
 
-import { Button, Text, useTheme } from '@waves/ui';
+import { Button, Popup, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 import { useAuth } from '@/lib/auth';
@@ -91,29 +91,13 @@ export function NotificationPrompt() {
   if (!visible || !granted) return null;
 
   return (
-    <Modal visible transparent animationType="fade" onRequestClose={dismiss}>
-      <View
-        style={{
-          flex: 1,
-          backgroundColor: '#00000080',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: theme.spacing.xxxl,
-        }}
-      >
-        <View
-          style={{
-            width: '100%',
-            maxWidth: 360,
-            backgroundColor: theme.color.surface,
-            borderRadius: theme.radius.lg,
-            padding: theme.spacing.xxl,
-            alignItems: 'center',
-            gap: theme.spacing.lg,
-            ...theme.shadow.lifted,
-          }}
-        >
-          {/* The brand tile with a notification badge — the reference's own way
+    <Popup
+      visible
+      onClose={dismiss}
+      closeLabel={t.entry.notifyNotNow}
+      style={{ maxWidth: 360, alignItems: 'center', gap: theme.spacing.lg }}
+    >
+      {/* The brand tile with a notification badge — the reference's own way
               of saying, wordlessly, what the ask is about. */}
           <View
             style={{
@@ -166,8 +150,6 @@ export function NotificationPrompt() {
               onPress={dismiss}
             />
           </View>
-        </View>
-      </View>
-    </Modal>
+    </Popup>
   );
 }

--- a/apps/mobile/src/components/NotificationPrompt.tsx
+++ b/apps/mobile/src/components/NotificationPrompt.tsx
@@ -99,57 +99,57 @@ export function NotificationPrompt() {
     >
       {/* The brand tile with a notification badge — the reference's own way
               of saying, wordlessly, what the ask is about. */}
-          <View
-            style={{
-              width: 72,
-              height: 72,
-              borderRadius: 18,
-              backgroundColor: theme.color.brand,
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Ionicons name="notifications" size={38} color={theme.color.onBrand} />
-            <View
-              style={{
-                position: 'absolute',
-                top: -4,
-                right: -4,
-                width: 18,
-                height: 18,
-                borderRadius: 9,
-                backgroundColor: theme.color.negative,
-                borderWidth: 2,
-                borderColor: theme.color.surface,
-              }}
-            />
-          </View>
+      <View
+        style={{
+          width: 72,
+          height: 72,
+          borderRadius: 18,
+          backgroundColor: theme.color.brand,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Ionicons name="notifications" size={38} color={theme.color.onBrand} />
+        <View
+          style={{
+            position: 'absolute',
+            top: -4,
+            right: -4,
+            width: 18,
+            height: 18,
+            borderRadius: 9,
+            backgroundColor: theme.color.negative,
+            borderWidth: 2,
+            borderColor: theme.color.surface,
+          }}
+        />
+      </View>
 
-          <View style={{ gap: theme.spacing.sm }}>
-            <Text variant="heading" align="center">
-              {t.entry.notifyTitle}
-            </Text>
-            <Text variant="body" tone="muted" align="center">
-              {t.entry.notifyBody}
-            </Text>
-          </View>
+      <View style={{ gap: theme.spacing.sm }}>
+        <Text variant="heading" align="center">
+          {t.entry.notifyTitle}
+        </Text>
+        <Text variant="body" tone="muted" align="center">
+          {t.entry.notifyBody}
+        </Text>
+      </View>
 
-          <View style={{ alignSelf: 'stretch', gap: theme.spacing.sm }}>
-            <Button
-              label={t.entry.notifyEnable}
-              size="lg"
-              fullWidth
-              disabled={busy}
-              onPress={() => void onEnable()}
-            />
-            <Button
-              label={t.entry.notifyNotNow}
-              variant="ghost"
-              size="lg"
-              fullWidth
-              onPress={dismiss}
-            />
-          </View>
+      <View style={{ alignSelf: 'stretch', gap: theme.spacing.sm }}>
+        <Button
+          label={t.entry.notifyEnable}
+          size="lg"
+          fullWidth
+          disabled={busy}
+          onPress={() => void onEnable()}
+        />
+        <Button
+          label={t.entry.notifyNotNow}
+          variant="ghost"
+          size="lg"
+          fullWidth
+          onPress={dismiss}
+        />
+      </View>
     </Popup>
   );
 }

--- a/apps/mobile/src/components/QuickAddSheet.tsx
+++ b/apps/mobile/src/components/QuickAddSheet.tsx
@@ -13,10 +13,9 @@
 
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import { Modal, Pressable, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Pressable, View } from 'react-native';
 
-import { iconSize, Text, tintForKey, useTheme } from '@waves/ui';
+import { iconSize, Sheet, Text, tintForKey, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 
@@ -68,7 +67,6 @@ export function QuickAddSheet({
   actions: readonly QuickAddAction[];
 }) {
   const theme = useTheme();
-  const insets = useSafeAreaInsets();
   const { t } = useStrings();
 
   const activate = (action: QuickAddAction): void => {
@@ -77,78 +75,39 @@ export function QuickAddSheet({
   };
 
   return (
-    <Modal transparent visible={visible} animationType="fade" onRequestClose={onClose}>
-      {/* Tap the scrim to dismiss; the inner press is swallowed so tapping the
-          sheet itself does not close it. */}
-      <Pressable
-        onPress={onClose}
-        accessibilityRole="button"
-        accessibilityLabel={t.common.close}
-        style={{
-          flex: 1,
-          backgroundColor: 'rgba(10, 10, 26, 0.55)',
-          justifyContent: 'flex-end',
-        }}
-      >
-        <Pressable
-          onPress={() => {}}
-          accessibilityViewIsModal
-          style={{
-            backgroundColor: theme.color.surface,
-            borderTopLeftRadius: theme.radius.xxl,
-            borderTopRightRadius: theme.radius.xxl,
-            paddingHorizontal: theme.spacing.lg,
-            paddingTop: theme.spacing.md,
-            paddingBottom: theme.spacing.md + insets.bottom,
-            ...theme.shadow.lifted,
-          }}
-        >
-          {/* The grab handle — the visual grammar of a sheet you can pull down. */}
-          <View
-            style={{
-              alignSelf: 'center',
-              width: 40,
-              height: 4,
-              borderRadius: 2,
-              backgroundColor: theme.color.border,
-              marginBottom: theme.spacing.sm,
-            }}
-          />
-
-          {actions.map((action) => {
-            const tint = theme.tint[tintForKey(action.tintKey)];
-            return (
-              <Pressable
-                key={action.label}
-                onPress={() => activate(action)}
-                accessibilityRole="button"
-                accessibilityLabel={action.label}
-                style={({ pressed }) => ({
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: theme.spacing.md,
-                  paddingVertical: theme.spacing.md,
-                  opacity: pressed ? 0.6 : 1,
-                })}
-              >
-                <View
-                  style={{
-                    width: 44,
-                    height: 44,
-                    borderRadius: 22,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    backgroundColor: tint.bg,
-                  }}
-                >
-                  <Ionicons name={action.icon} size={iconSize.lg} color={tint.ink} />
-                </View>
-                <Text variant="subheading">{action.label}</Text>
-              </Pressable>
-            );
-          })}
-        </Pressable>
-      </Pressable>
-    </Modal>
+    <Sheet visible={visible} onClose={onClose} closeLabel={t.common.close}>
+      {actions.map((action) => {
+        const tint = theme.tint[tintForKey(action.tintKey)];
+        return (
+          <Pressable
+            key={action.label}
+            onPress={() => activate(action)}
+            accessibilityRole="button"
+            accessibilityLabel={action.label}
+            style={({ pressed }) => ({
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: theme.spacing.md,
+              paddingVertical: theme.spacing.md,
+              opacity: pressed ? 0.6 : 1,
+            })}
+          >
+            <View
+              style={{
+                width: 44,
+                height: 44,
+                borderRadius: 22,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: tint.bg,
+              }}
+            >
+              <Ionicons name={action.icon} size={iconSize.lg} color={tint.ink} />
+            </View>
+            <Text variant="subheading">{action.label}</Text>
+          </Pressable>
+        );
+      })}
+    </Sheet>
   );
 }

--- a/apps/mobile/src/components/TagEditorSheet.tsx
+++ b/apps/mobile/src/components/TagEditorSheet.tsx
@@ -13,11 +13,10 @@
 
 import { useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Alert, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Alert, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import { TINTS, type CatalogEntry, type TintName } from '@waves/core';
-import { Button, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { Button, iconSize, Row, Sheet, Text, useTheme } from '@waves/ui';
 
 import { CategoryBadge } from '@/components/Category';
 import { DEFAULT_TAG_ICON, TAG_ICON_GROUPS } from '@/components/tagIcons';
@@ -34,60 +33,15 @@ export function TagEditorSheet({
   /** The custom tag to edit, or null to create a fresh one. */
   editing?: CatalogEntry | null;
 }) {
-  const theme = useTheme();
-  const insets = useSafeAreaInsets();
-
   return (
-    <Modal visible={open} transparent animationType="slide" onRequestClose={onClose}>
-      <View style={{ flex: 1, justifyContent: 'flex-end' }}>
-        <Pressable
-          onPress={onClose}
-          accessibilityElementsHidden
-          importantForAccessibility="no-hide-descendants"
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: '#00000080',
-          }}
-        />
-
-        <View
-          style={{
-            maxHeight: '88%',
-            backgroundColor: theme.color.surface,
-            borderTopLeftRadius: theme.radius.xxl,
-            borderTopRightRadius: theme.radius.xxl,
-            paddingTop: theme.spacing.sm,
-            paddingBottom: insets.bottom + theme.spacing.md,
-          }}
-        >
-          <View
-            style={{
-              alignSelf: 'center',
-              width: 40,
-              height: 4,
-              borderRadius: theme.radius.pill,
-              backgroundColor: theme.color.border,
-              marginBottom: theme.spacing.md,
-            }}
-          />
-
-          {/* Mount the form fresh each time the sheet opens (keyed on the tag),
+    <Sheet visible={open} onClose={onClose} padded={false} style={{ maxHeight: '88%' }}>
+      {/* Mount the form fresh each time the sheet opens (keyed on the tag),
               so its fields initialise from the tag being edited without a
               setState-in-effect to seed them. */}
-          {open ? (
-            <TagEditorForm
-              key={editing?.tagId ?? 'new'}
-              editing={editing ?? null}
-              onClose={onClose}
-            />
-          ) : null}
-        </View>
-      </View>
-    </Modal>
+      {open ? (
+        <TagEditorForm key={editing?.tagId ?? 'new'} editing={editing ?? null} onClose={onClose} />
+      ) : null}
+    </Sheet>
   );
 }
 

--- a/apps/mobile/src/lib/deviceSession.tsx
+++ b/apps/mobile/src/lib/deviceSession.tsx
@@ -27,10 +27,10 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { AppState, Modal, Pressable, View } from 'react-native';
+import { AppState, View } from 'react-native';
 
 import { type DeviceLimitStatus } from '@waves/core';
-import { Button, Text, useTheme } from '@waves/ui';
+import { Button, Popup, Text, useTheme } from '@waves/ui';
 
 import { useStrings } from '@/i18n';
 import { registerDevice, signOutOtherDevices } from '@/data/api';
@@ -187,27 +187,8 @@ function DeviceLimitGate({
   const [busy, setBusy] = useState(false);
 
   return (
-    <Modal transparent animationType="fade" visible onRequestClose={onDismiss}>
-      <Pressable
-        onPress={onDismiss}
-        style={{
-          flex: 1,
-          backgroundColor: 'rgba(20,20,43,0.45)',
-          justifyContent: 'center',
-          padding: theme.spacing.xl,
-        }}
-      >
-        <Pressable
-          onPress={() => {}}
-          style={{
-            backgroundColor: theme.color.surface,
-            borderRadius: theme.radius.xl,
-            padding: theme.spacing.xl,
-            gap: theme.spacing.lg,
-            ...theme.shadow.lifted,
-          }}
-        >
-          <Text variant="heading">{t.devices.gateTitle}</Text>
+    <Popup visible onClose={onDismiss} closeLabel={t.devices.gateDismiss} style={{ gap: theme.spacing.lg }}>
+      <Text variant="heading">{t.devices.gateTitle}</Text>
           <Text variant="body" tone="muted">
             {t.devices.gateBody}
           </Text>
@@ -229,8 +210,6 @@ function DeviceLimitGate({
             />
             <Button label={t.devices.gateDismiss} variant="secondary" onPress={onDismiss} />
           </View>
-        </Pressable>
-      </Pressable>
-    </Modal>
+    </Popup>
   );
 }

--- a/apps/mobile/src/lib/deviceSession.tsx
+++ b/apps/mobile/src/lib/deviceSession.tsx
@@ -187,29 +187,34 @@ function DeviceLimitGate({
   const [busy, setBusy] = useState(false);
 
   return (
-    <Popup visible onClose={onDismiss} closeLabel={t.devices.gateDismiss} style={{ gap: theme.spacing.lg }}>
+    <Popup
+      visible
+      onClose={onDismiss}
+      closeLabel={t.devices.gateDismiss}
+      style={{ gap: theme.spacing.lg }}
+    >
       <Text variant="heading">{t.devices.gateTitle}</Text>
-          <Text variant="body" tone="muted">
-            {t.devices.gateBody}
-          </Text>
-          <View style={{ gap: theme.spacing.md }}>
-            <Button
-              label={t.devices.gateAction}
-              disabled={busy}
-              onPress={async () => {
-                setBusy(true);
-                try {
-                  await onSignOutOthers();
-                } catch {
-                  // The failure is reported on the devices screen; here the gate
-                  // simply stays up so the person can try again.
-                } finally {
-                  setBusy(false);
-                }
-              }}
-            />
-            <Button label={t.devices.gateDismiss} variant="secondary" onPress={onDismiss} />
-          </View>
+      <Text variant="body" tone="muted">
+        {t.devices.gateBody}
+      </Text>
+      <View style={{ gap: theme.spacing.md }}>
+        <Button
+          label={t.devices.gateAction}
+          disabled={busy}
+          onPress={async () => {
+            setBusy(true);
+            try {
+              await onSignOutOthers();
+            } catch {
+              // The failure is reported on the devices screen; here the gate
+              // simply stays up so the person can try again.
+            } finally {
+              setBusy(false);
+            }
+          }}
+        />
+        <Button label={t.devices.gateDismiss} variant="secondary" onPress={onDismiss} />
+      </View>
     </Popup>
   );
 }

--- a/packages/ui/src/components/Overlay.tsx
+++ b/packages/ui/src/components/Overlay.tsx
@@ -149,7 +149,13 @@ export function Sheet({
       });
 
   return (
-    <Modal transparent statusBarTranslucent visible={mounted} animationType="none" onRequestClose={onClose}>
+    <Modal
+      transparent
+      statusBarTranslucent
+      visible={mounted}
+      animationType="none"
+      onRequestClose={onClose}
+    >
       <Animated.View style={{ flex: 1, backgroundColor: SCRIM, opacity: progress }}>
         <Pressable
           onPress={onClose}
@@ -232,7 +238,13 @@ export function Popup({
     : progress.interpolate({ inputRange: [0, 1], outputRange: [POPUP_START_SCALE, 1] });
 
   return (
-    <Modal transparent statusBarTranslucent visible={mounted} animationType="none" onRequestClose={onClose}>
+    <Modal
+      transparent
+      statusBarTranslucent
+      visible={mounted}
+      animationType="none"
+      onRequestClose={onClose}
+    >
       <Animated.View style={{ flex: 1, backgroundColor: SCRIM, opacity: progress }}>
         <Pressable
           onPress={dismissable ? onClose : undefined}

--- a/packages/ui/src/components/Overlay.tsx
+++ b/packages/ui/src/components/Overlay.tsx
@@ -1,0 +1,262 @@
+/**
+ * The two overlay motions the whole app shares: a bottom Sheet and a centred
+ * Popup.
+ *
+ * Every transient surface — a picker, a confirm dialog, a quick-add menu — used
+ * to reach for React Native's `Modal` directly and pick `animationType="fade"`
+ * or `"slide"` by hand, so a "sheet" sometimes cross-faded and a dialog blinked
+ * on with no arrival at all. These two components are the one implementation of
+ * that motion, WhatsApp's grammar: a Sheet springs up from the bottom edge under
+ * a fading scrim, a Popup fades in while scaling up from just under full size.
+ *
+ * Built on RN's own `Animated`, not Reanimated: the design system carries no
+ * animation dependency, and opacity + translate + scale on the native driver is
+ * exactly what `Animated` is good at. Each surface is held mounted by a latch
+ * through its close, so the exit plays instead of the content vanishing the
+ * instant `visible` flips — `Modal`'s own `animationType` would unmount too soon
+ * for that. Reduced motion keeps the fade and drops the travel and the scale.
+ */
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  AccessibilityInfo,
+  Animated,
+  Modal,
+  Pressable,
+  useWindowDimensions,
+  View,
+  type ViewStyle,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useTheme } from '../theme';
+
+/** The scrim behind every overlay — a near-black wash, enough to sit the surface
+ *  off the screen without dimming it to a blackout. */
+const SCRIM = 'rgba(10, 10, 26, 0.55)';
+const OPEN_SPRING = { tension: 70, friction: 12 } as const;
+const CLOSE_MS = 160;
+/** How small a Popup starts — a grow into place, not a pop from nothing. */
+const POPUP_START_SCALE = 0.92;
+
+/**
+ * The OS reduce-motion flag, read locally so the design system does not depend
+ * on the app's motion context. Starts true so the very first frame never travels
+ * before the real value lands.
+ */
+function useReduceMotion(): boolean {
+  const [reduce, setReduce] = useState(true);
+  useEffect(() => {
+    let alive = true;
+    const sub = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduce);
+    void AccessibilityInfo.isReduceMotionEnabled().then((value) => {
+      if (alive) setReduce(value);
+    });
+    return () => {
+      alive = false;
+      sub.remove();
+    };
+  }, []);
+  return reduce;
+}
+
+/**
+ * The shared machinery: a `progress` value driven 0→1 on open and back on close,
+ * a `mounted` latch that outlives `visible` so the close animation is seen, and
+ * the scrim that fades on the same value. Returns what both surfaces need to
+ * render themselves.
+ */
+function useOverlay(visible: boolean, reduceMotion: boolean) {
+  const [mounted, setMounted] = useState(visible);
+  const progress = useRef(new Animated.Value(visible ? 1 : 0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      setMounted(true);
+      Animated.spring(progress, {
+        toValue: 1,
+        useNativeDriver: true,
+        ...(reduceMotion ? { tension: 200, friction: 26 } : OPEN_SPRING),
+      }).start();
+    } else if (mounted) {
+      Animated.timing(progress, {
+        toValue: 0,
+        duration: reduceMotion ? 0 : CLOSE_MS,
+        useNativeDriver: true,
+      }).start(({ finished }) => {
+        if (finished) setMounted(false);
+      });
+    }
+  }, [visible, mounted, reduceMotion, progress]);
+
+  return { mounted, progress };
+}
+
+export interface SheetProps {
+  visible: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  /** The grab-handle bar at the top — the "you can pull this down" grammar. On
+   *  by default; drop it for a sheet that is not dismissible by drag. */
+  handle?: boolean;
+  /** Extra style for the sheet card (padding lives here already). */
+  style?: ViewStyle;
+  /** Screen-reader label for the tap-away scrim. */
+  closeLabel?: string;
+}
+
+/**
+ * A bottom sheet: the surface slides up from the bottom edge under a fading
+ * scrim, and back down on dismiss. Tapping the scrim closes it; the sheet itself
+ * swallows the tap so a press inside never dismisses. Rounded top corners, a
+ * grab handle, and the safe-area inset folded into the bottom padding.
+ */
+export function Sheet({
+  visible,
+  onClose,
+  children,
+  handle = true,
+  style,
+  closeLabel = 'Close',
+}: SheetProps) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const reduceMotion = useReduceMotion();
+  const { height: screenHeight } = useWindowDimensions();
+  const { mounted, progress } = useOverlay(visible, reduceMotion);
+  // The sheet's own height, measured on layout, so it travels exactly its own
+  // distance rather than a guess. Until the first measure a screen-height
+  // fallback keeps the first frame off-screen instead of flashing in place.
+  const [height, setHeight] = useState(0);
+
+  if (!mounted) return null;
+
+  const translateY = reduceMotion
+    ? 0
+    : progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [height || screenHeight, 0],
+      });
+
+  return (
+    <Modal transparent statusBarTranslucent visible={mounted} animationType="none" onRequestClose={onClose}>
+      <Animated.View style={{ flex: 1, backgroundColor: SCRIM, opacity: progress }}>
+        <Pressable
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel={closeLabel}
+          style={{ flex: 1, justifyContent: 'flex-end' }}
+        >
+          <Animated.View style={{ transform: [{ translateY }] }}>
+            <Pressable
+              onPress={() => {}}
+              accessibilityViewIsModal
+              onLayout={(event) => setHeight(event.nativeEvent.layout.height)}
+              style={[
+                {
+                  backgroundColor: theme.color.surface,
+                  borderTopLeftRadius: theme.radius.xxl,
+                  borderTopRightRadius: theme.radius.xxl,
+                  paddingHorizontal: theme.spacing.lg,
+                  paddingTop: theme.spacing.md,
+                  paddingBottom: theme.spacing.md + insets.bottom,
+                  ...theme.shadow.lifted,
+                },
+                style,
+              ]}
+            >
+              {handle ? (
+                <View
+                  style={{
+                    alignSelf: 'center',
+                    width: 40,
+                    height: 4,
+                    borderRadius: 2,
+                    backgroundColor: theme.color.border,
+                    marginBottom: theme.spacing.sm,
+                  }}
+                />
+              ) : null}
+              {children}
+            </Pressable>
+          </Animated.View>
+        </Pressable>
+      </Animated.View>
+    </Modal>
+  );
+}
+
+export interface PopupProps {
+  visible: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  /** Whether a scrim tap dismisses. Off for a dialog that must be answered. */
+  dismissable?: boolean;
+  /** Extra style for the dialog card. */
+  style?: ViewStyle;
+  closeLabel?: string;
+}
+
+/**
+ * A centred dialog: fades in while scaling up from just under full size, the
+ * WhatsApp/Material dialog arrival, and reverses on close. The card sits in the
+ * middle over a fading scrim with a comfortable gutter, so a long dialog scrolls
+ * inside its own bounds rather than bleeding to the screen edges.
+ */
+export function Popup({
+  visible,
+  onClose,
+  children,
+  dismissable = true,
+  style,
+  closeLabel = 'Close',
+}: PopupProps) {
+  const theme = useTheme();
+  const reduceMotion = useReduceMotion();
+  const { mounted, progress } = useOverlay(visible, reduceMotion);
+
+  if (!mounted) return null;
+
+  const scale = reduceMotion
+    ? 1
+    : progress.interpolate({ inputRange: [0, 1], outputRange: [POPUP_START_SCALE, 1] });
+
+  return (
+    <Modal transparent statusBarTranslucent visible={mounted} animationType="none" onRequestClose={onClose}>
+      <Animated.View style={{ flex: 1, backgroundColor: SCRIM, opacity: progress }}>
+        <Pressable
+          onPress={dismissable ? onClose : undefined}
+          accessibilityRole={dismissable ? 'button' : undefined}
+          accessibilityLabel={dismissable ? closeLabel : undefined}
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: theme.spacing.xl,
+          }}
+        >
+          <Animated.View style={{ width: '100%', opacity: progress, transform: [{ scale }] }}>
+            <Pressable
+              onPress={() => {}}
+              accessibilityViewIsModal
+              style={[
+                {
+                  alignSelf: 'center',
+                  maxWidth: 420,
+                  width: '100%',
+                  backgroundColor: theme.color.surface,
+                  borderRadius: theme.radius.xxl,
+                  padding: theme.spacing.xl,
+                  ...theme.shadow.lifted,
+                },
+                style,
+              ]}
+            >
+              {children}
+            </Pressable>
+          </Animated.View>
+        </Pressable>
+      </Animated.View>
+    </Modal>
+  );
+}

--- a/packages/ui/src/components/Overlay.tsx
+++ b/packages/ui/src/components/Overlay.tsx
@@ -99,7 +99,11 @@ export interface SheetProps {
   /** The grab-handle bar at the top — the "you can pull this down" grammar. On
    *  by default; drop it for a sheet that is not dismissible by drag. */
   handle?: boolean;
-  /** Extra style for the sheet card (padding lives here already). */
+  /** The card's own comfortable side padding. On by default; turn it off for a
+   *  sheet whose content manages its own gutters (a full-bleed list or grid, or
+   *  a form that already pads itself). */
+  padded?: boolean;
+  /** Extra style for the sheet card — a `maxHeight` for a tall sheet, say. */
   style?: ViewStyle;
   /** Screen-reader label for the tap-away scrim. */
   closeLabel?: string;
@@ -116,6 +120,7 @@ export function Sheet({
   onClose,
   children,
   handle = true,
+  padded = true,
   style,
   closeLabel = 'Close',
 }: SheetProps) {
@@ -157,7 +162,7 @@ export function Sheet({
                   backgroundColor: theme.color.surface,
                   borderTopLeftRadius: theme.radius.xxl,
                   borderTopRightRadius: theme.radius.xxl,
-                  paddingHorizontal: theme.spacing.lg,
+                  paddingHorizontal: padded ? theme.spacing.lg : 0,
                   paddingTop: theme.spacing.md,
                   paddingBottom: theme.spacing.md + insets.bottom,
                   ...theme.shadow.lifted,

--- a/packages/ui/src/components/Overlay.tsx
+++ b/packages/ui/src/components/Overlay.tsx
@@ -66,7 +66,7 @@ function useReduceMotion(): boolean {
  * the scrim that fades on the same value. Returns what both surfaces need to
  * render themselves.
  */
-function useOverlay(visible: boolean, reduceMotion: boolean) {
+function useOverlay(visible: boolean) {
   const [mounted, setMounted] = useState(visible);
   const progress = useRef(new Animated.Value(visible ? 1 : 0)).current;
 
@@ -77,21 +77,22 @@ function useOverlay(visible: boolean, reduceMotion: boolean) {
 
   useEffect(() => {
     if (visible) {
-      Animated.spring(progress, {
-        toValue: 1,
-        useNativeDriver: true,
-        ...(reduceMotion ? { tension: 200, friction: 26 } : OPEN_SPRING),
-      }).start();
+      // `progress` drives the fade for every surface, so it runs at full
+      // duration even under reduced motion — a fade is the accessible way to
+      // appear, not the motion reduced motion is there to spare. What reduced
+      // motion drops is the travel and the scale, and those are gated where they
+      // are applied (the sheet's translate, the popup's scale), not here.
+      Animated.spring(progress, { toValue: 1, useNativeDriver: true, ...OPEN_SPRING }).start();
     } else if (mounted) {
       Animated.timing(progress, {
         toValue: 0,
-        duration: reduceMotion ? 0 : CLOSE_MS,
+        duration: CLOSE_MS,
         useNativeDriver: true,
       }).start(({ finished }) => {
         if (finished) setMounted(false);
       });
     }
-  }, [visible, mounted, reduceMotion, progress]);
+  }, [visible, mounted, progress]);
 
   return { mounted, progress };
 }
@@ -132,7 +133,7 @@ export function Sheet({
   const insets = useSafeAreaInsets();
   const reduceMotion = useReduceMotion();
   const { height: screenHeight } = useWindowDimensions();
-  const { mounted, progress } = useOverlay(visible, reduceMotion);
+  const { mounted, progress } = useOverlay(visible);
   // The sheet's own height, measured on layout, so it travels exactly its own
   // distance rather than a guess. Until the first measure a screen-height
   // fallback keeps the first frame off-screen instead of flashing in place.
@@ -222,7 +223,7 @@ export function Popup({
 }: PopupProps) {
   const theme = useTheme();
   const reduceMotion = useReduceMotion();
-  const { mounted, progress } = useOverlay(visible, reduceMotion);
+  const { mounted, progress } = useOverlay(visible);
 
   if (!mounted) return null;
 

--- a/packages/ui/src/components/Overlay.tsx
+++ b/packages/ui/src/components/Overlay.tsx
@@ -70,9 +70,13 @@ function useOverlay(visible: boolean, reduceMotion: boolean) {
   const [mounted, setMounted] = useState(visible);
   const progress = useRef(new Animated.Value(visible ? 1 : 0)).current;
 
+  // Mount the moment we open — a state adjustment on the visible prop, done in
+  // render rather than in the effect (which then only drives the animation and
+  // never calls setState synchronously in its body).
+  if (visible && !mounted) setMounted(true);
+
   useEffect(() => {
     if (visible) {
-      setMounted(true);
       Animated.spring(progress, {
         toValue: 1,
         useNativeDriver: true,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -26,5 +26,6 @@ export * from './components/PillTabBar';
 export * from './components/SegmentedTabs';
 export * from './components/AmountKeypad';
 export * from './components/AmountField';
+export * from './components/Overlay';
 export * from './components/Chart';
 export * from './direction';


### PR DESCRIPTION
Applies the WhatsApp-consistent overlay motion everywhere it was missing, off the back of the nav-transition polish.

### The problem

Every transient surface reached for React Native's `Modal` directly and picked `animationType` by hand — 18 chose `fade`, 13 `slide`. So a bottom sheet sometimes cross-faded, and a centre dialog blinked on with no arrival at all. No shared implementation, no consistency.

### Two primitives (`@waves/ui`)

- **`Sheet`** — a bottom sheet: springs up from the bottom edge under a fading scrim, grab handle, safe-area inset folded in. `padded={false}` for content that manages its own gutters; `style` for `maxHeight`.
- **`Popup`** — a centre dialog: fades in while scaling up from 0.92, the Material/WhatsApp dialog arrival.

Both are built on RN's own `Animated` (native-driver) so the **design system takes on no animation dependency**. Each is held mounted by a latch through its close, so the exit actually plays — `Modal`'s own `animationType` unmounts children too soon for that. **Reduced motion** keeps the fade, drops the travel and the scale.

### Adopted across ~15 surfaces

**→ Sheet:** QuickAddSheet (was fading), TagEditorSheet, CoverEmojiPicker, the personal budget/loan/recurring editors, the captures assign + row-overflow sheets, the dashboard tip sheet.

**→ Popup:** the guest prompt (drops its hand-rolled scale/fade), the device-cap gate, the language menu, the notification ask, the campaign popup.

The dashboard tip sheet also **drops its always-mounted Android workaround** — the old note about `visible` toggled post-mount not presenting on Android. `Sheet` mounts fresh with `visible=true`, which is the reliable present path, so the workaround is no longer needed.

### Left as-is, by design

- **Full-screen surfaces** — the map location picker, the camera, image viewers and croppers (ReceiptCropper/Annotator, ExpenseReceipts, SettlementProof), the full-page country pickers. A bottom sheet or centre dialog would be the wrong shape; their full-screen slide is already correct and consistent.
- **The comment editor** — its `KeyboardAvoidingView` keeps the input above the keyboard, which the centred `Popup` does not replace.
- **The overflow menu** — its own anchored corner-grow (PR #608), a different motion from these two.

### Checks

Mobile + UI typecheck, `expo lint` clean. **Not device-tested** — overlay motion has to be felt on a real screen; that's the review here.
