### PR TITLE
feat(expense): the edit amount looks editable, and the total is the door to it

### DIFF
--- a/apps/mobile/src/app/group/[id]/add-expense.tsx
+++ b/apps/mobile/src/app/group/[id]/add-expense.tsx
@@ -330,6 +330,7 @@ export default function AddExpenseScreen() {
     categoryMeta: captureCategoryMeta,
     location: captureLocation,
     expenseDate: captureExpenseDate,
+    focus,
   } = useLocalSearchParams<{
     id: string;
     expenseId?: string;
@@ -348,6 +349,9 @@ export default function AddExpenseScreen() {
      *  assigned expense (A43). Absent when the capture had no location. */
     location?: string;
     expenseDate?: string;
+    /** 'amount' when the editor was opened by tapping the total on the expense
+     *  screen — the amount field takes focus and raises the keyboard on arrival. */
+    focus?: string;
   }>();
   const groupId = id ?? '';
   const { profile } = useAuth();
@@ -1539,6 +1543,9 @@ export default function AddExpenseScreen() {
           amount={amount}
           onAmountChange={setAmount}
           onPressCurrency={() => setPickingCurrency(true)}
+          // Opened by tapping the total on the expense screen: land in the amount
+          // field with the keyboard already up.
+          autoFocusAmount={focus === 'amount'}
         />
         <ScrollView
           style={{ flex: 1 }}

--- a/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
+++ b/apps/mobile/src/app/group/[id]/expense/[expenseId].tsx
@@ -328,8 +328,13 @@ export default function ExpenseDetailScreen() {
     ]);
   };
 
-  const openEditor = (): void => {
-    router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}`);
+  const openEditor = (focus?: 'amount'): void => {
+    // "Fix the number" is the most common reason a bill is reopened, so tapping
+    // the amount carries a focus hint that lands straight in the field with the
+    // keyboard up — no hunting for the pencil, then noticing the number is a
+    // field, then tapping it.
+    const suffix = focus ? `&focus=${focus}` : '';
+    router.push(`/group/${groupId}/add-expense?expenseId=${expense.id}${suffix}`);
   };
 
   // What is left in the header's three-dot menu once Edit has its own glyph
@@ -422,14 +427,35 @@ export default function ExpenseDetailScreen() {
             {/* The amount kept in the hero, but at heading — not display — scale:
                   still the prominent number, no longer the reason the panel is
                   tall. Neutral white, never a money colour — it is a total, not a
-                  balance. */}
-            <MoneyText
-              amount={BigInt(version.amount)}
-              currency={currency}
-              locale={locale}
-              variant="title"
-              style={{ color: theme.color.onBrand }}
-            />
+                  balance. On a live bill the number is the door to editing it:
+                  tapping it opens the editor with the amount already focused, the
+                  one-tap path for the change a bill is most often reopened for.
+                  A deleted bill cannot be edited, so there it is plain text. */}
+            {deleted ? (
+              <MoneyText
+                amount={BigInt(version.amount)}
+                currency={currency}
+                locale={locale}
+                variant="title"
+                style={{ color: theme.color.onBrand }}
+              />
+            ) : (
+              <Pressable
+                onPress={() => openEditor('amount')}
+                accessibilityRole="button"
+                accessibilityLabel={`${t.common.edit}: ${format(money(BigInt(version.amount), currency), { locale })}`}
+                hitSlop={8}
+                style={({ pressed }) => ({ alignSelf: 'flex-start', opacity: pressed ? 0.6 : 1 })}
+              >
+                <MoneyText
+                  amount={BigInt(version.amount)}
+                  currency={currency}
+                  locale={locale}
+                  variant="title"
+                  style={{ color: theme.color.onBrand }}
+                />
+              </Pressable>
+            )}
           </View>
           {/* Edit, in the open. It was the first item of the three-dot menu, which
                 made the one action a bill is reopened for something you had to
@@ -438,7 +464,7 @@ export default function ExpenseDetailScreen() {
                 deleted bill: there is nothing to edit until it is restored. */}
           {deleted ? null : (
             <Pressable
-              onPress={openEditor}
+              onPress={() => openEditor()}
               accessibilityRole="button"
               accessibilityLabel={t.common.edit}
               hitSlop={10}

--- a/apps/mobile/src/components/expense/ExpenseHero.tsx
+++ b/apps/mobile/src/components/expense/ExpenseHero.tsx
@@ -38,6 +38,7 @@ export function ExpenseHero({
   onPressCurrency,
   right,
   leading = 'back',
+  autoFocusAmount = false,
 }: {
   /** The one line above the amount: what this form is, and where it lands. */
   title: string;
@@ -53,6 +54,9 @@ export function ExpenseHero({
   right?: ReactNode;
   /** A modal (capture) dismisses with an X; a pushed page goes back. */
   leading?: 'close' | 'back';
+  /** Focus the amount and raise the keyboard on mount — set when the screen was
+   *  opened to change the amount (tapping the total on the expense screen). */
+  autoFocusAmount?: boolean;
 }): React.JSX.Element {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
@@ -108,6 +112,8 @@ export function ExpenseHero({
               onChange={onAmountChange}
               size="hero"
               tone="onBrand"
+              framed
+              autoFocus={autoFocusAmount}
             />
             <Pressable
               accessibilityRole="button"
@@ -124,9 +130,12 @@ export function ExpenseHero({
                 paddingVertical: theme.spacing.xs,
                 paddingHorizontal: theme.spacing.md,
                 borderRadius: theme.radius.pill,
-                // A translucent white chip rather than a surface colour: the wash
-                // runs three stops, and a solid pill would only match one of them.
-                backgroundColor: 'rgba(255,255,255,0.18)',
+                // A ghost outline, not a filled chip: now that the amount wears
+                // the well, a solid pill beside it drew the eye to the currency
+                // instead of the number. A hairline ring keeps it a real, legible
+                // control without out-competing the field it annotates.
+                borderWidth: 1,
+                borderColor: 'rgba(255,255,255,0.45)',
                 opacity: pressed ? 0.7 : 1,
               })}
             >

--- a/packages/ui/src/components/AmountField.tsx
+++ b/packages/ui/src/components/AmountField.tsx
@@ -37,10 +37,23 @@ export function AmountField({
   onChange,
   size = 'display',
   tone = 'default',
+  framed = false,
+  autoFocus = false,
 }: {
   currency: CurrencyCode;
   value: bigint;
   onChange: (amount: bigint) => void;
+  /**
+   * Wrap the field in a well — a soft fill and a bottom rule that goes solid on
+   * focus — so an editable amount reads as a field rather than a printed number.
+   * Off by default, because the compact and display sizes are already obviously
+   * inputs; the hero amount, which sits on the same coloured bar as a read-only
+   * total looks, is the one that needs saying "you can type here".
+   */
+  framed?: boolean;
+  /** Focus and open the keyboard on mount — used when a screen was opened to
+   *  change the amount specifically (tapping the total on the expense screen). */
+  autoFocus?: boolean;
   /**
    * 'display' is the hero amount — big and centred, for the expense entry
    * screen. 'compact' is the right-aligned inline value that sits at the end of
@@ -72,6 +85,10 @@ export function AmountField({
   const digitInk = onBrand ? theme.color.onBrand : theme.color.text;
   const symbolInk = onBrand ? 'rgba(255,255,255,0.72)' : theme.color.textMuted;
   const placeholderInk = onBrand ? 'rgba(255,255,255,0.5)' : theme.color.textFaint;
+
+  // The well's rule brightens when the field has the keyboard, the oldest "type
+  // here" signal there is. Tracked in state so the border can answer the focus.
+  const [focused, setFocused] = useState(false);
 
   // The text↔minor rules live in @waves/core, because the per-payer amount
   // fields on the expense form parse the same keystrokes and two copies of
@@ -133,6 +150,13 @@ export function AmountField({
     onChange(minor);
   };
 
+  // The well: a translucent fill and a bottom rule, brighter on focus. On the
+  // brand wash it is white-on-white; off it, the surface's own muted fill and
+  // the brand as the active rule.
+  const wellFill = onBrand ? 'rgba(255,255,255,0.14)' : theme.color.surfaceMuted;
+  const ruleRest = onBrand ? 'rgba(255,255,255,0.55)' : theme.color.border;
+  const ruleActive = onBrand ? theme.color.onBrand : theme.color.brand;
+
   return (
     <View
       style={{
@@ -145,6 +169,16 @@ export function AmountField({
         // sizes have the row to themselves and must not be squeezed by a sibling.
         flexShrink: hero ? 1 : 0,
         minWidth: 0,
+        ...(framed
+          ? {
+              backgroundColor: wellFill,
+              borderRadius: theme.radius.md,
+              paddingHorizontal: theme.spacing.md,
+              paddingVertical: theme.spacing.xs,
+              borderBottomWidth: 2,
+              borderBottomColor: focused ? ruleActive : ruleRest,
+            }
+          : null),
       }}
     >
       <Text
@@ -165,6 +199,9 @@ export function AmountField({
         placeholderTextColor={placeholderInk}
         selectionColor={onBrand ? theme.color.onBrand : theme.color.brand}
         accessibilityLabel={`Amount ${format(value) || '0'} ${currency}`}
+        autoFocus={autoFocus}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
         maxFontSizeMultiplier={1.4}
         style={{
           minWidth: metrics.minWidth,


### PR DESCRIPTION
The amount on the edit form didn't read as editable — same wash, same white ink, same position as the read-only total on the view screen, so it looked like a printed number, not a field. The only thing on that line wearing any control chrome was the currency pill. This fixes both halves of that.

### 1. The field looks like a field (`framed`)

`AmountField` gains a `framed` prop. On the brand hero it draws a well — a translucent fill and a 2px bottom rule that **brightens to solid white when the field takes focus** (`onFocus`/`onBlur` tracked). That underline is the oldest "type here" signal there is. `ExpenseHero` sets it, so both the add and edit forms get it; the read-only view screen (which uses `MoneyText`, not the field) stays plain.

The **currency pill drops to a ghost outline** (transparent + hairline ring) instead of a filled chip — now that the amount wears the well, a solid pill beside it pulled the eye to the currency instead of the number it only annotates.

### 2. The total is the way in (`autoFocus` + `focus=amount`)

On the expense screen, the total is now a button: tapping it opens the editor with the **amount already focused and the keyboard up**. `AmountField` gains `autoFocus`, threaded through `ExpenseHero` (`autoFocusAmount`) and an `openEditor('amount')` → `?focus=amount` param the form reads.

"Fix the number" is the most common reason a bill is reopened, and it went from four steps — find the pencil, land on the form, notice the number is a field, tap it — to one tap. A **deleted bill** (which can't be edited until restored) keeps the total as plain text.

This is options 1 + 4 from the earlier proposal. Option 2 (unconditional select-all focus) was deliberately not taken — the `focus=amount` handoff scopes the auto-focus to arrivals that are actually about the amount, so editing the note or the split doesn't get a keyboard thrown at it.

### Checks

Mobile + UI typecheck, `expo lint` clean. **Not device-tested** — the focus/keyboard behavior wants a real device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tapping an expense amount now opens the editor with the amount field focused.
  * Add-expense screens can automatically focus the amount field and open the keyboard.
  * Amount fields have an updated framed appearance with clearer focus feedback.
  * Currency indicators now use a subtle outlined style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->