### PR TITLE
test(mobile): cover zoom math measurement gaps

### DIFF
--- a/apps/mobile/test/zoomMath.test.ts
+++ b/apps/mobile/test/zoomMath.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { clampZoomPan, clampZoomPoint, naturalSizeForUri } from '../src/lib/zoomMath';
 
 describe('naturalSizeForUri', () => {
+  it('returns null until natural image dimensions are available', () => {
+    expect(naturalSizeForUri(null, 'file://receipt.jpg')).toBeNull();
+  });
+
   it('ignores stale dimensions from a previously rendered image uri', () => {
     const previous = { uri: 'file://old.jpg', size: { w: 1000, h: 500 } };
 
@@ -15,6 +19,11 @@ describe('clampZoomPan', () => {
   it('keeps fit-scale images centered', () => {
     expect(clampZoomPan(120, 300, 240, 1)).toBe(0);
     expect(clampZoomPan(-120, 300, 240, 0.8)).toBe(0);
+  });
+
+  it('keeps unmeasured axes centered', () => {
+    expect(clampZoomPan(120, 0, 240, 2)).toBe(0);
+    expect(clampZoomPan(-120, 300, 0, 2)).toBe(0);
   });
 
   it('clamps positive and negative pan to the scaled content bounds', () => {
@@ -45,5 +54,11 @@ describe('clampZoomPoint', () => {
       x: 140,
       y: -400,
     });
+  });
+
+  it('keeps both axes centered while the viewport and image content are unmeasured', () => {
+    expect(
+      clampZoomPoint({ x: 80, y: -80 }, { width: 0, height: 400 }, { width: 160, height: 0 }, 3),
+    ).toEqual({ x: 0, y: 0 });
   });
 });


### PR DESCRIPTION
## Summary
- add coverage for missing natural image dimensions
- cover zero viewport/content measurement cases for zoom pan clamping
- verify clampZoomPoint keeps unmeasured axes centered

## Validation
- pnpm --filter @waves/mobile exec vitest run test/zoomMath.test.ts
- pnpm --filter @waves/mobile run typecheck *(fails: unrelated Expo Router typed route errors in existing personal/me/voice/tab-bar files)*