### PR TITLE
test(mobile): cover speech mic stop teardown

### DIFF
--- a/apps/mobile/test/speechMic.test.ts
+++ b/apps/mobile/test/speechMic.test.ts
@@ -262,6 +262,31 @@ describe('stopping', () => {
     expect(mic.state).toBe('idle');
   });
 
+  it('makes the next capture wait when a stopped session unmounts before end', async () => {
+    const first = Symbol('first');
+    await mic.acquire(first);
+    mic.opened(first);
+    mic.stop(first);
+
+    mic.release(first);
+    expect(driver.stop).toHaveBeenCalledTimes(1);
+    expect(driver.abort).toHaveBeenCalledTimes(1);
+    expect(mic.state).toBe('closing');
+
+    const second = Symbol('second');
+    let claimed: boolean | null = null;
+    void mic.acquire(second).then((granted) => {
+      claimed = granted;
+    });
+    await Promise.resolve();
+    expect(claimed).toBeNull();
+
+    expect(mic.ended()).toBe(false);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(claimed).toBe(true);
+    expect(mic.owns(second)).toBe(true);
+  });
+
   it('settles a stop the recogniser never answers', async () => {
     const owner = Symbol('owner');
     await mic.acquire(owner);


### PR DESCRIPTION
## Summary
- add coverage for a stopped speech capture unmounting before native end
- assert the next capture waits until the pending teardown end settles
- keep the change limited to SpeechMic regression coverage

## Validation
- pnpm --filter @waves/mobile exec vitest run test/speechMic.test.ts
- pnpm --filter @waves/mobile run typecheck *(fails: unrelated existing Expo Router typed-route errors in personal/me/voice/tab-bar files)*