### PR TITLE
fix(personal): simplify the Me hero, label add-income, spend insight

### DIFF
--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -3,15 +3,16 @@
  *
  * A person's own money, nothing shared. It wears the same clothes as the
  * dashboard: an edge-to-edge saturated hero that runs up under the status bar,
- * a swipeable deck of figures inside it (this month's net, what you spent, the
- * share you kept), the add actions on the hero itself, and a dot pager for the
- * swipe. A month switcher in the hero header steps back through past months so
- * the ledger is a record you can browse, not just a snapshot of today.
+ * holding this month's net big and, flat beneath it, the three figures the month
+ * turns on (income in, spent out, the share kept) plus both add actions. Nothing
+ * hides behind a swipe. A month switcher in the hero header steps back through
+ * past months so the ledger is a record you can browse, not just today.
  *
- * Below the hero, the white body: three stat tiles for the management areas
- * (recurring, loans, budgets) and the month's entries grouped by day the way a
- * bank statement reads. Everything is local-first from the mirror and every
- * figure is computed on the device.
+ * Below the hero, the white body reads top-down the way a person scans it: the
+ * month's entries grouped by day like a bank statement, its category breakdown
+ * and trend, and — demoted to a quiet tools shelf at the foot — the three
+ * management areas (recurring, loans, budgets). Everything is local-first from
+ * the mirror and every figure is computed on the device.
  *
  * Opening the tab also posts any auto-recurring entries that have come due since
  * it was last open (idempotent — see `postDueRecurring`).
@@ -20,15 +21,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
-import {
-  ActivityIndicator,
-  Animated,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  useWindowDimensions,
-  View,
-} from 'react-native';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
@@ -83,12 +76,9 @@ import { useStrings } from '@/i18n';
 // when you overspent — so the hero opens on the colour of how the month went.
 const SAVED_WASH = ['#1E5A8C', '#0C2E4A'] as const; // blue — money kept
 const OVERSPENT_WASH = ['#8C1D3F', '#4A0F20'] as const; // red — money lost
-const SPENT_WASH = ['#463F86', '#221C46'] as const; // indigo — what went out
-const SAVINGS_WASH = ['#12667A', '#06323D'] as const; // teal — the rate you kept
 
-// One faint watermark glyph per slide, in the same order, bled off the corner
-// and crossfading on the same scroll value as the wash.
-const SLIDE_ICONS = ['wallet-outline', 'card-outline', 'trending-up-outline'] as const;
+// One faint watermark glyph, bled off the hero's corner.
+const HERO_GLYPH = 'wallet-outline' as const;
 
 const HERO_CONTROL_BG = 'rgba(255, 255, 255, 0.16)';
 
@@ -264,41 +254,6 @@ export default function MeScreen() {
             gap: theme.spacing.xl,
           }}
         >
-          {/* The three management areas as a compact stat row. Each tile's big
-              figure is the size of that collection — how many recurring rules, how
-              much is owed, how many budgets — so the number answers "how many/how
-              much" on its own. A coloured qualifier line carries the one thing that
-              wants attention (N due, N active, N over), shown only when there is
-              one; the figure itself stays neutral. */}
-          <Row style={{ gap: theme.spacing.md }}>
-            <StatTile
-              icon="repeat"
-              value={String(ledger.recurrings.length)}
-              hint={dueCount > 0 ? `${dueCount} ${t.personal.due.toLowerCase()}` : undefined}
-              label={t.personal.recurring}
-              onPress={() => router.push('/personal/recurring')}
-            />
-            <StatTile
-              icon="cash-outline"
-              value={activeLoans.length > 0 ? fmt(outstanding) : '—'}
-              hint={
-                activeLoans.length > 0
-                  ? `${activeLoans.length} ${t.personal.active.toLowerCase()}`
-                  : undefined
-              }
-              label={t.personal.loans}
-              onPress={() => router.push('/personal/loans')}
-            />
-            <StatTile
-              icon="pie-chart-outline"
-              value={String(ledger.budgets.length)}
-              hint={overBudgets > 0 ? `${overBudgets} ${t.personal.over}` : undefined}
-              tone={overBudgets > 0 ? 'negative' : undefined}
-              label={t.personal.budgets}
-              onPress={() => router.push('/personal/budgets')}
-            />
-          </Row>
-
           {/* Two quiet contextual lines: what recurring item is next, and the
               category that has run furthest past its cap this month. */}
           {upcoming || worstOver ? (
@@ -414,6 +369,43 @@ export default function MeScreen() {
             )}
           </View>
 
+          {/* The management areas, demoted below the ledger to a quiet tools
+              shelf — each tile's figure is the size of that collection, with a
+              coloured qualifier for the one thing that wants attention. */}
+          <View style={{ gap: theme.spacing.sm }}>
+            <Text variant="micro" tone="faint" style={{ letterSpacing: 0.8 }}>
+              {t.personal.tools.toUpperCase()}
+            </Text>
+            <Row style={{ gap: theme.spacing.md }}>
+              <StatTile
+                icon="repeat"
+                value={String(ledger.recurrings.length)}
+                hint={dueCount > 0 ? `${dueCount} ${t.personal.due.toLowerCase()}` : undefined}
+                label={t.personal.recurring}
+                onPress={() => router.push('/personal/recurring')}
+              />
+              <StatTile
+                icon="cash-outline"
+                value={activeLoans.length > 0 ? fmt(outstanding) : '—'}
+                hint={
+                  activeLoans.length > 0
+                    ? `${activeLoans.length} ${t.personal.active.toLowerCase()}`
+                    : undefined
+                }
+                label={t.personal.loans}
+                onPress={() => router.push('/personal/loans')}
+              />
+              <StatTile
+                icon="pie-chart-outline"
+                value={String(ledger.budgets.length)}
+                hint={overBudgets > 0 ? `${overBudgets} ${t.personal.over}` : undefined}
+                tone={overBudgets > 0 ? 'negative' : undefined}
+                label={t.personal.budgets}
+                onPress={() => router.push('/personal/budgets')}
+              />
+            </Row>
+          </View>
+
           {/* A quiet reassurance: this ledger is the person's alone. */}
           <Row style={{ justifyContent: 'center', gap: theme.spacing.xs }}>
             <Ionicons name="lock-closed-outline" size={iconSize.xs} color={theme.color.textFaint} />
@@ -480,11 +472,12 @@ function whenLabel(
 // ─────────────────────────────────────────────────────────────── hero ──
 
 /**
- * The edge-to-edge hero: a swipeable deck of three figures on a saturated wash,
- * the add actions, and a dot pager — the dashboard's account panel, told for a
- * private ledger. The carousel's live scroll offset drives the wash crossfade and
- * the pager, so colour, corner glyph and dots all move with the finger; it owns
- * that value itself since every piece that reads it lives inside the hero.
+ * The edge-to-edge hero: a static account panel for the private ledger. The
+ * month's net rides big on a saturated wash — blue when you saved, red when you
+ * overspent — and the three figures that frame it (income in, spent out, the
+ * share you kept) read flat beneath a spend-against-income bar, so everything the
+ * month turns on is on show at once with nothing behind a swipe. The month
+ * switcher steps the whole panel back through past months.
  */
 function MeHero({
   net,
@@ -515,51 +508,17 @@ function MeHero({
 }) {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
-  const { width } = useWindowDimensions();
-
-  // The deck's scroll offset, owned here so the wash, the corner glyph and the
-  // dot pager all ride one value. Lazy-init, never read through `.current` in
-  // render (the ref lint the compiler enforces).
-  const [scrollX] = useState(() => new Animated.Value(0));
-  // Each slide fills the hero's inner width; its snap point is that plus the gap.
-  const cardWidth = width - theme.spacing.xl * 2;
-  const gap = theme.spacing.md;
-  const snap = cardWidth + gap;
 
   const saved = net >= 0n;
   const fmt = (amount: bigint): string =>
     format(money(amount, currency), { locale, compactFraction: true });
 
-  // The net slide shows its figure as an absolute value, so the saved/overspent
-  // direction lives in the label — the only slide whose sign carries meaning.
-  const washes = [saved ? SAVED_WASH : OVERSPENT_WASH, SPENT_WASH, SAVINGS_WASH];
-  const slides = [
-    {
-      key: 'net',
-      label: `${saved ? t.personal.saved : t.personal.overspent} · ${currency}`,
-      value: `${net < 0n ? '−' : ''}${fmt(net < 0n ? -net : net)}`,
-    },
-    {
-      key: 'spent',
-      label: `${t.personal.expenses} · ${currency}`,
-      value: fmt(expense),
-    },
-    {
-      key: 'savings',
-      label: t.personal.savingsRate,
-      value: rate === null ? '—' : `${Math.round(rate * 100)}%`,
-    },
-  ];
+  // The wash is the verdict of the month: blue kept, red lost.
+  const wash = saved ? SAVED_WASH : OVERSPENT_WASH;
 
-  // Share of income spent, for the persistent bar under the deck.
+  // Share of income spent, for the bar under the net.
   const ratio =
     income > 0n ? Math.min(1, Number((expense * 1000n) / income) / 1000) : expense > 0n ? 1 : 0;
-
-  const rangeFor = (index: number): number[] => [
-    (index - 1) * snap,
-    index * snap,
-    (index + 1) * snap,
-  ];
 
   return (
     <View
@@ -573,29 +532,19 @@ function MeHero({
         overflow: 'hidden',
       }}
     >
-      {/* One wash layer per slide, stacked and crossfading on the scroll value —
-          the first sits opaque as the base, the rest fade in at their own snap. */}
-      {washes.map((colors, index) => (
-        <Animated.View
-          key={slides[index]?.key ?? index}
-          pointerEvents="none"
-          style={[
-            StyleSheet.absoluteFill,
-            index === 0
-              ? null
-              : {
-                  opacity: scrollX.interpolate({
-                    inputRange: rangeFor(index),
-                    outputRange: [0, 1, 0],
-                    extrapolate: 'clamp',
-                  }),
-                },
-          ]}
-        >
-          <Gradient colors={colors} radius={0} style={{ flex: 1 }} />
-        </Animated.View>
-      ))}
-      <HeroBackdrop scrollX={scrollX} snap={snap} />
+      {/* The saturated ground. */}
+      <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+        <Gradient colors={wash} radius={0} style={{ flex: 1 }} />
+      </View>
+      {/* One faint watermark bled off the corner. */}
+      <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+        <Ionicons
+          name={HERO_GLYPH}
+          size={208}
+          color={theme.color.onBrand}
+          style={{ position: 'absolute', right: -44, bottom: -52, opacity: 0.16 }}
+        />
+      </View>
 
       {/* Month switcher — the hero's header, centred, ‹ August 2026 ›. */}
       <Row style={{ alignItems: 'center', justifyContent: 'center', gap: theme.spacing.md }}>
@@ -634,50 +583,19 @@ function MeHero({
         </Pressable>
       </Row>
 
-      {/* The swipeable figures. Full-width slides, no peek — they ride transparent
-          on the wash, so a peek would show floating text with no card edge; the
-          dot pager carries the "swipe me" signal instead. */}
-      <Animated.ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        snapToInterval={snap}
-        snapToAlignment="start"
-        decelerationRate="fast"
-        disableIntervalMomentum
-        scrollEventThrottle={16}
-        contentContainerStyle={{ gap }}
-        onScroll={Animated.event([{ nativeEvent: { contentOffset: { x: scrollX } } }], {
-          useNativeDriver: true,
-        })}
-      >
-        {slides.map((slide, index) => (
-          <Animated.View
-            key={slide.key}
-            style={{
-              width: cardWidth,
-              opacity: scrollX.interpolate({
-                inputRange: rangeFor(index),
-                outputRange: [0.75, 1, 0.75],
-                extrapolate: 'clamp',
-              }),
-              transform: [
-                {
-                  scale: scrollX.interpolate({
-                    inputRange: rangeFor(index),
-                    outputRange: [0.94, 1, 0.94],
-                    extrapolate: 'clamp',
-                  }),
-                },
-              ],
-            }}
-          >
-            <MetricSlide label={slide.label} value={slide.value} />
-          </Animated.View>
-        ))}
-      </Animated.ScrollView>
+      {/* The month's net, big and static — the label carries the saved/overspent
+          direction so the figure itself is shown as an absolute value. */}
+      <View style={{ gap: theme.spacing.sm }}>
+        <Text variant="caption" tone="onBrand" numberOfLines={1} style={{ opacity: 0.85 }}>
+          {`${saved ? t.personal.saved : t.personal.overspent} · ${currency}`}
+        </Text>
+        <Text variant="display" tone="onBrand" numberOfLines={1} adjustsFontSizeToFit>
+          {`${net < 0n ? '−' : ''}${fmt(net < 0n ? -net : net)}`}
+        </Text>
+      </View>
 
-      {/* Spend against income — a persistent bar under the deck, with income and
-          spend read out beneath it, so the context is there on every slide. */}
+      {/* Spend against income, then the three flat figures the month turns on:
+          what came in, what went out, and the share kept. */}
       <View style={{ gap: theme.spacing.sm }}>
         <View
           style={{
@@ -697,141 +615,38 @@ function MeHero({
         </View>
         <Row style={{ justifyContent: 'space-between' }}>
           <HeroFigure label={t.personal.income} value={fmt(income)} icon="arrow-down" />
-          <HeroFigure label={t.personal.expenses} value={fmt(expense)} icon="arrow-up" alignEnd />
-        </Row>
-      </View>
-
-      {/* The add actions and the pager travel as one block. */}
-      <View style={{ gap: theme.spacing.md }}>
-        <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
-          <HeroPill
-            icon="add"
-            label={t.personal.addExpense}
-            onPress={() =>
-              router.push({ pathname: '/personal/entry', params: { kind: 'expense' } })
-            }
+          <HeroFigure label={t.personal.expenses} value={fmt(expense)} icon="arrow-up" />
+          <HeroFigure
+            label={t.personal.savingsRate}
+            value={rate === null ? '—' : `${Math.round(rate * 100)}%`}
+            icon="trending-up"
+            alignEnd
           />
-          <Row style={{ marginLeft: 'auto', gap: theme.spacing.sm }}>
-            <HeroCircle
-              icon="arrow-down"
-              label={t.personal.addIncome}
-              onPress={() =>
-                router.push({ pathname: '/personal/entry', params: { kind: 'income' } })
-              }
-            />
-            <HeroCircle
-              icon="list-outline"
-              label={t.personal.transactions}
-              onPress={() => router.push('/personal/transactions')}
-            />
-          </Row>
         </Row>
-
-        <HeroDots count={slides.length} scrollX={scrollX} snap={snap} />
       </View>
-    </View>
-  );
-}
 
-/** One figure slide, riding transparent on the wash — a label and the money big
- *  beneath it, white ink throughout so it reads the same in light and dark. */
-function MetricSlide({ label, value }: { label: string; value: string }) {
-  const theme = useTheme();
-  return (
-    <View style={{ gap: theme.spacing.sm }}>
-      <Text variant="caption" tone="onBrand" numberOfLines={1} style={{ opacity: 0.85 }}>
-        {label}
-      </Text>
-      <Text variant="display" tone="onBrand" numberOfLines={1} adjustsFontSizeToFit>
-        {value}
-      </Text>
-    </View>
-  );
-}
-
-/** The corner watermark — one faint glyph per slide, crossfading on the scroll
- *  value, clipped to the hero's rounded corner and never eating a tap. */
-function HeroBackdrop({ scrollX, snap }: { scrollX: Animated.Value; snap: number }) {
-  const theme = useTheme();
-  return (
-    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
-      {SLIDE_ICONS.map((icon, index) => (
-        <Animated.View
-          key={icon}
-          style={{
-            position: 'absolute',
-            right: -44,
-            bottom: -52,
-            opacity: scrollX.interpolate({
-              inputRange: [(index - 1) * snap, index * snap, (index + 1) * snap],
-              outputRange: [0, 0.16, 0],
-              extrapolate: 'clamp',
-            }),
-          }}
-        >
-          <Ionicons name={icon} size={208} color={theme.color.onBrand} />
-        </Animated.View>
-      ))}
-    </View>
-  );
-}
-
-const DOT_SIZE = 6;
-const DOT_ACTIVE_WIDTH = 18;
-
-/** The dot pager: a fixed-width white pill that translates across faint static
- *  dots off the live scroll value — native-driven, so it tracks the finger. */
-function HeroDots({
-  count,
-  scrollX,
-  snap,
-}: {
-  count: number;
-  scrollX: Animated.Value;
-  snap: number;
-}) {
-  const theme = useTheme();
-  const gap = theme.spacing.xs;
-  const step = DOT_SIZE + gap;
-  const trackWidth = count * DOT_SIZE + Math.max(0, count - 1) * gap;
-  const translateX =
-    count > 1
-      ? scrollX.interpolate({
-          inputRange: Array.from({ length: count }, (_, i) => i * snap),
-          outputRange: Array.from({ length: count }, (_, i) => i * step),
-          extrapolate: 'clamp',
-        })
-      : 0;
-  return (
-    <Row style={{ justifyContent: 'center' }}>
-      <View style={{ width: trackWidth, height: DOT_SIZE }}>
-        <Row style={{ position: 'absolute', left: 0, top: 0, gap }}>
-          {Array.from({ length: count }, (_, index) => (
-            <View
-              key={index}
-              style={{
-                width: DOT_SIZE,
-                height: DOT_SIZE,
-                borderRadius: DOT_SIZE / 2,
-                backgroundColor: 'rgba(255, 255, 255, 0.35)',
-              }}
-            />
-          ))}
-        </Row>
-        <Animated.View
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: (DOT_SIZE - DOT_ACTIVE_WIDTH) / 2,
-            width: DOT_ACTIVE_WIDTH,
-            height: DOT_SIZE,
-            borderRadius: DOT_SIZE / 2,
-            backgroundColor: '#FFFFFF',
-            transform: [{ translateX }],
-          }}
+      {/* The add actions — both labelled, expense primary, income secondary, with
+          the ledger shortcut on the end. */}
+      <Row style={{ alignItems: 'center', gap: theme.spacing.md }}>
+        <HeroPill
+          tone="solid"
+          icon="add"
+          label={t.personal.addExpense}
+          onPress={() => router.push({ pathname: '/personal/entry', params: { kind: 'expense' } })}
         />
-      </View>
-    </Row>
+        <HeroPill
+          tone="ghost"
+          icon="add"
+          label={t.personal.addIncome}
+          onPress={() => router.push({ pathname: '/personal/entry', params: { kind: 'income' } })}
+        />
+        <HeroCircle
+          icon="list-outline"
+          label={t.personal.transactions}
+          onPress={() => router.push('/personal/transactions')}
+        />
+      </Row>
+    </View>
   );
 }
 
@@ -862,35 +677,43 @@ function HeroFigure({
   );
 }
 
-/** The primary add action on the hero — a white pill with brand ink. */
+/** An add action on the hero — a pill that shares the row evenly. `solid` is the
+ *  primary white pill with brand ink; `ghost` is a translucent secondary in white
+ *  ink, so both actions read as buttons and neither is an unlabelled glyph. */
 function HeroPill({
   icon,
   label,
   onPress,
+  tone = 'solid',
 }: {
   icon: keyof typeof Ionicons.glyphMap;
   label: string;
   onPress: () => void;
+  tone?: 'solid' | 'ghost';
 }) {
   const theme = useTheme();
+  const ghost = tone === 'ghost';
+  const ink = ghost ? theme.color.onBrand : theme.color.brand;
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
       onPress={onPress}
       style={({ pressed }) => ({
+        flex: 1,
         flexDirection: 'row',
         alignItems: 'center',
+        justifyContent: 'center',
         gap: theme.spacing.xs,
         paddingVertical: theme.spacing.sm + 2,
-        paddingHorizontal: theme.spacing.lg,
+        paddingHorizontal: theme.spacing.md,
         borderRadius: theme.radius.pill,
-        backgroundColor: '#FFFFFF',
+        backgroundColor: ghost ? HERO_CONTROL_BG : '#FFFFFF',
         opacity: pressed ? 0.85 : 1,
       })}
     >
-      <Ionicons name={icon} size={iconSize.lg} color={theme.color.brand} />
-      <Text variant="subheading" style={{ color: theme.color.brand }} numberOfLines={1}>
+      <Ionicons name={icon} size={iconSize.lg} color={ink} />
+      <Text variant="subheading" style={{ color: ink }} numberOfLines={1}>
         {label}
       </Text>
     </Pressable>

--- a/apps/mobile/src/app/(tabs)/me.tsx
+++ b/apps/mobile/src/app/(tabs)/me.tsx
@@ -38,6 +38,7 @@ import {
   recentMonths,
   resolveCategory,
   savingsRate,
+  spendDelta,
   worstOverBudget,
   type MonthCashflow,
   type PersonalTxn,
@@ -210,6 +211,19 @@ export default function MeScreen() {
   const trend = cashflowTrend(ledger.txns, recentMonths(month, 3), dc);
   const trendActive = trend.some((m) => m.income > 0n || m.expense > 0n);
 
+  // A one-line month-over-month spend insight: how this month compares to the
+  // last month you actually used. null when there is nothing honest to compare.
+  const delta = spendDelta(ledger.txns, month, dc);
+  const deltaAbs = delta ? (delta.delta < 0n ? -delta.delta : delta.delta) : 0n;
+  const deltaLine = delta
+    ? delta.delta === 0n
+      ? t.personal.spentSameAsLast
+      : (delta.delta > 0n ? t.personal.spentMoreThanLast : t.personal.spentLessThanLast).replace(
+          '{amount}',
+          fmt(deltaAbs),
+        )
+    : null;
+
   // Private ledger: while the biometric gate is unresolved the whole screen is a
   // blank shield — no hero, no figures — so nothing is on show behind the OS
   // prompt. A failed check has already navigated away by the time this renders.
@@ -254,6 +268,29 @@ export default function MeScreen() {
             gap: theme.spacing.xl,
           }}
         >
+          {/* A one-line month-over-month spend insight, tinted by direction:
+              red when this month ran hotter than last, positive when cooler. */}
+          {deltaLine && delta ? (
+            <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+              <Ionicons
+                name={
+                  delta.delta > 0n ? 'trending-up' : delta.delta < 0n ? 'trending-down' : 'remove'
+                }
+                size={iconSize.sm}
+                color={
+                  delta.delta > 0n
+                    ? theme.color.negative
+                    : delta.delta < 0n
+                      ? theme.color.positive
+                      : theme.color.textMuted
+                }
+              />
+              <Text variant="caption" tone="muted">
+                {deltaLine}
+              </Text>
+            </Row>
+          ) : null}
+
           {/* Two quiet contextual lines: what recurring item is next, and the
               category that has run furthest past its cap this month. */}
           {upcoming || worstOver ? (

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2508,6 +2508,9 @@ export interface UiStrings {
     deleteConfirm: string;
     whereMoneyWent: string;
     tools: string;
+    spentMoreThanLast: string;
+    spentLessThanLast: string;
+    spentSameAsLast: string;
     last3Months: string;
     upcoming: string;
     overBudget: string;
@@ -4626,6 +4629,9 @@ const en: UiStrings = {
     deleteConfirm: 'Delete this entry? This cannot be undone.',
     whereMoneyWent: 'Where your money went',
     tools: 'Tools',
+    spentMoreThanLast: 'You spent {amount} more than last month',
+    spentLessThanLast: 'You spent {amount} less than last month',
+    spentSameAsLast: 'About the same spend as last month',
     last3Months: 'Last 3 months',
     upcoming: 'Upcoming',
     overBudget: 'Over budget',
@@ -6848,6 +6854,9 @@ const ta: UiStrings = {
     deleteConfirm: 'இந்தப் பதிவை நீக்கவா? இதை மீட்க முடியாது.',
     whereMoneyWent: 'உங்கள் பணம் எங்கே போனது',
     tools: 'கருவிகள்',
+    spentMoreThanLast: 'கடந்த மாதத்தை விட {amount} அதிகம் செலவழித்தீர்கள்',
+    spentLessThanLast: 'கடந்த மாதத்தை விட {amount} குறைவாக செலவழித்தீர்கள்',
+    spentSameAsLast: 'கடந்த மாதத்தைப் போலவே செலவு',
     last3Months: 'கடந்த 3 மாதங்கள்',
     upcoming: 'வரவிருப்பது',
     overBudget: 'பட்ஜெட்டைத் தாண்டியது',
@@ -8980,6 +8989,9 @@ const hi: UiStrings = {
     deleteConfirm: 'यह प्रविष्टि हटाएँ? इसे वापस नहीं किया जा सकता।',
     whereMoneyWent: 'आपका पैसा कहाँ गया',
     tools: 'उपकरण',
+    spentMoreThanLast: 'पिछले महीने से {amount} ज़्यादा ख़र्च किया',
+    spentLessThanLast: 'पिछले महीने से {amount} कम ख़र्च किया',
+    spentSameAsLast: 'पिछले महीने जितना ही ख़र्च',
     last3Months: 'पिछले 3 महीने',
     upcoming: 'आने वाला',
     overBudget: 'बजट से अधिक',
@@ -11346,6 +11358,9 @@ const ar: UiStrings = {
     deleteConfirm: 'حذف هذا الإدخال؟ لا يمكن التراجع.',
     whereMoneyWent: 'أين ذهبت أموالك',
     tools: 'الأدوات',
+    spentMoreThanLast: 'أنفقت {amount} أكثر من الشهر الماضي',
+    spentLessThanLast: 'أنفقت {amount} أقل من الشهر الماضي',
+    spentSameAsLast: 'إنفاق مماثل للشهر الماضي',
     last3Months: 'آخر 3 أشهر',
     upcoming: 'القادم',
     overBudget: 'تجاوز الميزانية',

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2507,6 +2507,7 @@ export interface UiStrings {
     justMeHint: string;
     deleteConfirm: string;
     whereMoneyWent: string;
+    tools: string;
     last3Months: string;
     upcoming: string;
     overBudget: string;
@@ -4624,6 +4625,7 @@ const en: UiStrings = {
     justMeHint: 'A private entry in your own ledger — not shared with anyone.',
     deleteConfirm: 'Delete this entry? This cannot be undone.',
     whereMoneyWent: 'Where your money went',
+    tools: 'Tools',
     last3Months: 'Last 3 months',
     upcoming: 'Upcoming',
     overBudget: 'Over budget',
@@ -6845,6 +6847,7 @@ const ta: UiStrings = {
     justMeHint: 'உங்கள் சொந்தக் கணக்கில் தனிப்பட்ட பதிவு — யாருடனும் பகிரப்படாது.',
     deleteConfirm: 'இந்தப் பதிவை நீக்கவா? இதை மீட்க முடியாது.',
     whereMoneyWent: 'உங்கள் பணம் எங்கே போனது',
+    tools: 'கருவிகள்',
     last3Months: 'கடந்த 3 மாதங்கள்',
     upcoming: 'வரவிருப்பது',
     overBudget: 'பட்ஜெட்டைத் தாண்டியது',
@@ -8976,6 +8979,7 @@ const hi: UiStrings = {
     justMeHint: 'आपके अपने खाते में निजी प्रविष्टि — किसी के साथ साझा नहीं।',
     deleteConfirm: 'यह प्रविष्टि हटाएँ? इसे वापस नहीं किया जा सकता।',
     whereMoneyWent: 'आपका पैसा कहाँ गया',
+    tools: 'उपकरण',
     last3Months: 'पिछले 3 महीने',
     upcoming: 'आने वाला',
     overBudget: 'बजट से अधिक',
@@ -11341,6 +11345,7 @@ const ar: UiStrings = {
     justMeHint: 'إدخال خاص في دفترك أنت — غير مشارَك مع أحد.',
     deleteConfirm: 'حذف هذا الإدخال؟ لا يمكن التراجع.',
     whereMoneyWent: 'أين ذهبت أموالك',
+    tools: 'الأدوات',
     last3Months: 'آخر 3 أشهر',
     upcoming: 'القادم',
     overBudget: 'تجاوز الميزانية',

--- a/packages/core/src/personal/compute.ts
+++ b/packages/core/src/personal/compute.ts
@@ -326,6 +326,37 @@ export function cashflowTrend(
   return months.map((month) => ({ month, ...monthlySummary(txns, month, currency) }));
 }
 
+export interface SpendDelta {
+  /** Last month's expense in this currency — the figure being compared against. */
+  readonly prevExpense: bigint;
+  /** This month's expense minus last month's; positive means you spent more. */
+  readonly delta: bigint;
+}
+
+/**
+ * How this month's spend compares to the month before it, for a one-line
+ * "you spent X more/less than last month" insight. `null` when there is nothing
+ * honest to say: a bad anchor, or a prior month with no activity at all (income
+ * or expense) in this currency — comparing against a month you did not use would
+ * read as "you spent everything more", which is noise, not signal. A prior month
+ * that was used but happened to have zero expense is a real comparison and is
+ * kept (the delta is simply this month's whole spend).
+ */
+export function spendDelta(
+  txns: readonly PersonalTxn[],
+  month: string,
+  currency: CurrencyCode,
+): SpendDelta | null {
+  const [prev] = recentMonths(month, 2);
+  // recentMonths always yields at least one key; a malformed anchor collapses the
+  // window to `[month]`, so `prev === month` (or undefined) means no prior to read.
+  if (prev === undefined || prev === month) return null;
+  const current = monthlySummary(txns, month, currency);
+  const prior = monthlySummary(txns, prev, currency);
+  if (prior.income <= 0n && prior.expense <= 0n) return null; // month never used
+  return { prevExpense: prior.expense, delta: current.expense - prior.expense };
+}
+
 // ─────────────────────────────────────────────────────────────── loans ──
 
 /**

--- a/packages/core/test/personal.test.ts
+++ b/packages/core/test/personal.test.ts
@@ -22,6 +22,7 @@ import {
   recurringCatchUp,
   recurringOccurrenceId,
   savingsRate,
+  spendDelta,
   worstOverBudget,
   type PersonalBudget,
   type PersonalLoan,
@@ -433,5 +434,46 @@ describe('worstOverBudget', () => {
     const txns = [txn({ kind: 'expense', category: 'food', amount: 10000n, date: '2026-08-02' })];
     expect(worstOverBudget(budgets, txns, '2026-08', 'INR')).toBeNull();
     expect(worstOverBudget([], txns, '2026-08', 'INR')).toBeNull();
+  });
+});
+
+describe('spendDelta', () => {
+  const txns = [
+    txn({ kind: 'income', amount: 100000n, date: '2026-07-05' }),
+    txn({ kind: 'expense', amount: 20000n, date: '2026-07-10' }),
+    txn({ kind: 'expense', amount: 30000n, date: '2026-08-10' }),
+  ];
+
+  it('compares this month to the prior month', () => {
+    // Aug spend 30000, Jul spend 20000 -> +10000
+    expect(spendDelta(txns, '2026-08', 'INR')).toEqual({ prevExpense: 20000n, delta: 10000n });
+  });
+
+  it('is negative when this month spent less', () => {
+    // Jun spend 50000, Jul spend 20000 -> -30000
+    const withJun = [txn({ kind: 'expense', amount: 50000n, date: '2026-06-10' }), ...txns];
+    expect(spendDelta(withJun, '2026-07', 'INR')).toEqual({ prevExpense: 50000n, delta: -30000n });
+  });
+
+  it('is null when the prior month was never used', () => {
+    // Jun has no activity at all -> nothing honest to compare against
+    expect(spendDelta(txns, '2026-06', 'INR')).toBeNull();
+  });
+
+  it('keeps a used prior month that had zero expense', () => {
+    const t = [
+      txn({ kind: 'income', amount: 80000n, date: '2026-07-01' }), // used, no expense
+      txn({ kind: 'expense', amount: 15000n, date: '2026-08-10' }),
+    ];
+    expect(spendDelta(t, '2026-08', 'INR')).toEqual({ prevExpense: 0n, delta: 15000n });
+  });
+
+  it('is scoped to the currency', () => {
+    const t = [
+      txn({ kind: 'expense', amount: 20000n, currency: 'USD', date: '2026-07-10' }),
+      txn({ kind: 'expense', amount: 30000n, currency: 'USD', date: '2026-08-10' }),
+    ];
+    expect(spendDelta(t, '2026-08', 'INR')).toBeNull(); // no INR prior activity
+    expect(spendDelta(t, '2026-08', 'USD')).toEqual({ prevExpense: 20000n, delta: 10000n });
   });
 });


### PR DESCRIPTION
Acts on a UX roast of the **Me** tab (private personal-finance ledger). The screen read like a finance super-app; these changes cut it to *"how much did I spend, and how fast can I add the next thing?"*

## What changed

**1. Hero flattened — swipe deck gone**
The hero was a swipeable deck (net / spent / savings rate) with a dot pager, but spent + income already read flat in the bar row below the deck — so the swipe mostly hid the savings rate and *duplicated* spent. Now a static panel: the month's net big on the verdict wash (blue saved / red overspent), and the three figures the month turns on — income, spent, savings rate — flat beneath the spend-against-income bar. Nothing hides behind a swipe. Carousel, dot pager and per-slide wash crossfade removed.

**2. Add income labelled**
Was an icon-only circle (bare arrow-down that reads as *download*). Both add actions are now labelled pills sharing the row evenly — expense the primary white pill, income a translucent secondary — with the ledger shortcut as the trailing circle.

**3. Tools demoted**
The three management tiles (recurring, loans, budgets) sat above the ledger as equal-weight tiles. Moved to a quiet **Tools** shelf at the foot, below the day-grouped entries, so the body reads status → history → tools.

**4. Month-over-month spend line**
New one-liner above the ledger — *"You spent ₹X more/less than last month"* — tinted by direction. Backed by a pure core helper `spendDelta(txns, month, currency)`: this month's expense vs the month before. Returns `null` when there is nothing honest to compare (a prior month with no activity at all would read as "you spent everything more"); a used-but-zero-expense prior is kept. Currency-scoped, moves with the month switcher.

## i18n
`tools` + `spentMoreThanLast` / `spentLessThanLast` / `spentSameAsLast` across en/ta/hi/ar. The spend line uses an `{amount}` placeholder so word order stays per-locale.

## Tests / gates
- New `spendDelta` unit tests (+/−/zero, never-used prior, zero-expense prior, currency scoping).
- core: 827 tests pass; core tsc pass; mobile tsc pass; expo lint clean.

Not device-tested (no live mic/emulator needed here — pure UI + core maths). JS-only change, OTA-shippable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the Me tab with a clearer monthly account summary, including net result, income, expenses, savings rate, and spending progress.
  * Added month-over-month spending insights showing whether spending increased, decreased, or stayed about the same.
  * Improved access to account management actions with a dedicated tools section.
  * Added translations for the new financial insights and tools in English, Tamil, Hindi, and Arabic.
* **Bug Fixes**
  * Spending comparisons now correctly account for prior-month activity and currency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->