### PR TITLE
fix(voice): make quick-add work on devices whose network speech is dead

### DIFF
--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -74,6 +74,16 @@ const MAX_LISTEN_MS = 9500;
 const HARD_STOP_MS = 1800;
 
 /**
+ * How long an attempt may listen with no transcript at all before it is judged
+ * mute. A live recogniser emits interim results within about a second of speech;
+ * this beat past that with nothing back means this engine is not transcribing.
+ * On an on-device attempt that triggers a one-time fall back to the network
+ * engine (which speaks English on any connected phone) — the field's silent
+ * on-device model, heard-but-no-words, fixed in place.
+ */
+const PROGRESS_MS = 3800;
+
+/**
  * A soft halo that breathes behind the mic while it listens — a slow, low-opacity
  * swell that makes the button read as a live orb rather than a flat disc. It is
  * the calm base layer under the sharper expanding rings; the two together are the
@@ -493,7 +503,24 @@ export function VoiceCapture({
   const gotResult = useRef(false);
   const volumeSeen = useRef(0);
   const usedOnDevice = useRef(false);
+  // A one-time on-device -> network fallback has already been spent this attempt.
+  const retried = useRef(false);
+  // The no-transcript watchdog (see PROGRESS_MS), armed at open.
+  const progress = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearProgress = useCallback((): void => {
+    if (progress.current === null) return;
+    clearTimeout(progress.current);
+    progress.current = null;
+  }, []);
+  // The latest `start`, reached indirectly so the fallback watchdog inside
+  // `start` can re-enter it without naming the still-declaring const.
+  const startRef = useRef<(forceNetwork?: boolean) => void>(() => {});
   const [diag, setDiag] = useState<string | null>(null);
+  // A live status line while listening — which engine, how many audio packets
+  // have arrived, whether any words came back. A debug aid for a device where
+  // voice silently does nothing: one screenshot mid-listen says where it breaks.
+  const [engine, setEngine] = useState<'on-device' | 'network' | null>(null);
+  const [volCount, setVolCount] = useState(0);
 
   useSpeechRecognitionEvent('start', () => {
     if (!speechMic.owns(session)) return;
@@ -503,6 +530,7 @@ export function VoiceCapture({
   useSpeechRecognitionEvent('result', (event) => {
     if (!speechMic.owns(session)) return;
     clearStall();
+    clearProgress();
     gotResult.current = true;
     const transcript = event.results[0]?.transcript ?? '';
     latest.current = transcript;
@@ -516,6 +544,7 @@ export function VoiceCapture({
     if (!speechMic.owns(session)) return;
     clearStall();
     volumeSeen.current += 1;
+    setVolCount((n) => n + 1);
     const norm = Math.max(0, Math.min(1, event.value / 10));
     // `.set()`, not `.value =`: Reanimated 4's method API, the one the React
     // compiler allows off the UI thread (see PressableScale in lib/anim).
@@ -526,6 +555,7 @@ export function VoiceCapture({
     if (!speechMic.owns(session)) return;
     clearStall();
     clearMaxListen();
+    clearProgress();
     const message = dictationError(event.error, t.misc.dictationErrors);
     if (message) setError(message);
     setListening(false);
@@ -547,6 +577,7 @@ export function VoiceCapture({
     if (!speechMic.ended(session)) return;
     clearStall();
     clearMaxListen();
+    clearProgress();
     setListening(false);
     level.set(withTiming(0, { duration: 150 }));
     const said = latest.current.trim();
@@ -560,135 +591,168 @@ export function VoiceCapture({
     }
   });
 
-  const start = useCallback(async (): Promise<void> => {
-    // One start at a time from this panel, and one capture at a time in the app.
-    if (starting.current) return;
-    starting.current = true;
-    // Still holding the mic from a session the panel has already given up on —
-    // an error whose `end` never arrived, say. The tap is a deliberate retry, so
-    // let go of the old session here; the claim below then waits for its
-    // teardown rather than opening a second recogniser on top of it.
-    if (speechMic.owns(session)) speechMic.release(session);
-    setError(null);
-    // Speaking again is the retry: clear both miss states as the mic opens, and
-    // let the screen drop any parsed miss it is still holding.
-    setEmptyMiss(false);
-    onListen?.();
-    latest.current = '';
-    setLive('');
-    level.set(0);
-    gotResult.current = false;
-    volumeSeen.current = 0;
-    setDiag(null);
-
-    // Claim the recogniser first, and wait here for any previous session's
-    // teardown to land. Everything below must give it back — a claimed mic that
-    // is never released is one nothing can reopen.
-    const claimed = await speechMic.acquire(session);
-    if (!mounted.current) {
-      starting.current = false;
-      if (claimed) speechMic.release(session);
-      return;
-    }
-    if (!claimed) {
-      starting.current = false;
-      setError(t.misc.dictationFailed);
-      return;
-    }
-
-    const give = (): void => {
-      starting.current = false;
-      speechMic.release(session);
-    };
-
-    const permission = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
-    if (!mounted.current) return give();
-    if (!permission.granted) {
-      setError(permission.canAskAgain ? t.misc.micPermission : t.misc.micBlocked);
-      return give();
-    }
-
-    // On-device only when an English model is actually installed; otherwise the
-    // recogniser is left to use the network, which speaks English on every phone.
-    // Requiring on-device for a model that is not there is what returned silence.
-    const onDevice = await englishInstalledOnDevice();
-    if (!mounted.current) return give();
-    usedOnDevice.current = onDevice;
-
-    setListening(true);
-    try {
-      ExpoSpeechRecognitionModule.start({
-        // Recognition is English-only — the surface each speaker reads is still
-        // localised, but the mic listens in English (device region where it can,
-        // else en-IN), so there is one locale to get right and no chip to miss.
-        lang: englishSpeechLocale(locale),
-        interimResults: true,
-        maxAlternatives: 1,
-        // One sentence, then it settles — the same shape a note dictation uses.
-        continuous: false,
-        requiresOnDeviceRecognition: onDevice,
-        addsPunctuation: onDevice,
-        // Meter the input so the waveform can ride real loudness (~10 Hz is
-        // plenty for a smooth wave and cheap to ease over).
-        volumeChangeEventOptions: { enabled: true, intervalMillis: 100 },
-        contextualStrings: hints && hints.length > 0 ? [...hints] : undefined,
-        iosTaskHint: 'dictation',
-        // People start with a greeting and a beat of thought — "hello… uh… add
-        // 500 to Goa". Android's default endpointing finalises on that first
-        // pause, ending the session on the greeting alone. Give it room: keep
-        // listening for at least a few seconds, and do not treat a two-second
-        // pause as the end of speech. (Android-only extras; iOS endpointing is
-        // already more forgiving and ignores these.)
-        androidIntentOptions: {
-          EXTRA_SPEECH_INPUT_MINIMUM_LENGTH_MILLIS: 4000,
-          EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS: 2000,
-          EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS: 2000,
-        },
-      });
-      speechMic.opened(session);
-      starting.current = false;
-      // Nothing has come back yet; if nothing ever does, the recogniser was
-      // torn down under us and the panel must say so rather than pretend.
+  const start = useCallback(
+    async (forceNetwork = false): Promise<void> => {
+      // One start at a time from this panel, and one capture at a time in the app.
+      if (starting.current) return;
+      starting.current = true;
+      // A fresh user-initiated start re-arms the one-time network fallback; a
+      // fallback re-entry keeps it spent. Either way, drop the old attempt's
+      // watchdogs before opening the next.
+      if (!forceNetwork) retried.current = false;
       clearStall();
-      stall.current = setTimeout(() => {
-        stall.current = null;
-        if (!mounted.current || !speechMic.owns(session)) return;
-        clearMaxListen();
-        setListening(false);
-        level.set(withTiming(0, { duration: 150 }));
-        setError(t.misc.dictationFailed);
-        speechMic.release(session);
-      }, STALL_MS);
-
-      // The hard cap: a recogniser that meters audio but never finalises would
-      // otherwise sit on "listening" forever (STALL is cleared by those volume
-      // events). At the cap, stop() to squeeze out any partial as a final; if it
-      // is still holding on after HARD_STOP_MS, release() aborts it and the
-      // capture lands on the calm miss with a diagnostic.
       clearMaxListen();
-      maxListen.current = setTimeout(() => {
-        maxListen.current = null;
-        if (!mounted.current || !speechMic.owns(session)) return;
-        speechMic.stop(session);
-        setTimeout(() => {
+      clearProgress();
+      // Still holding the mic from a session the panel has already given up on —
+      // an error whose `end` never arrived, say. The tap is a deliberate retry, so
+      // let go of the old session here; the claim below then waits for its
+      // teardown rather than opening a second recogniser on top of it.
+      if (speechMic.owns(session)) speechMic.release(session);
+      setError(null);
+      // Speaking again is the retry: clear both miss states as the mic opens, and
+      // let the screen drop any parsed miss it is still holding.
+      setEmptyMiss(false);
+      onListen?.();
+      latest.current = '';
+      setLive('');
+      level.set(0);
+      gotResult.current = false;
+      volumeSeen.current = 0;
+      setDiag(null);
+
+      // Claim the recogniser first, and wait here for any previous session's
+      // teardown to land. Everything below must give it back — a claimed mic that
+      // is never released is one nothing can reopen.
+      const claimed = await speechMic.acquire(session);
+      if (!mounted.current) {
+        starting.current = false;
+        if (claimed) speechMic.release(session);
+        return;
+      }
+      if (!claimed) {
+        starting.current = false;
+        setError(t.misc.dictationFailed);
+        return;
+      }
+
+      const give = (): void => {
+        starting.current = false;
+        speechMic.release(session);
+      };
+
+      const permission = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
+      if (!mounted.current) return give();
+      if (!permission.granted) {
+        setError(permission.canAskAgain ? t.misc.micPermission : t.misc.micBlocked);
+        return give();
+      }
+
+      // On-device only when an English model is actually installed; otherwise the
+      // recogniser is left to use the network, which speaks English on every phone.
+      // Requiring on-device for a model that is not there is what returned silence.
+      const onDevice = forceNetwork ? false : await englishInstalledOnDevice();
+      if (!mounted.current) return give();
+      usedOnDevice.current = onDevice;
+      setEngine(onDevice ? 'on-device' : 'network');
+      setVolCount(0);
+
+      setListening(true);
+      try {
+        ExpoSpeechRecognitionModule.start({
+          // Recognition is English-only — the surface each speaker reads is still
+          // localised, but the mic listens in English (device region where it can,
+          // else en-IN), so there is one locale to get right and no chip to miss.
+          lang: englishSpeechLocale(locale),
+          interimResults: true,
+          maxAlternatives: 1,
+          // One sentence, then it settles — the same shape a note dictation uses.
+          continuous: false,
+          requiresOnDeviceRecognition: onDevice,
+          addsPunctuation: onDevice,
+          // Meter the input so the waveform can ride real loudness (~10 Hz is
+          // plenty for a smooth wave and cheap to ease over).
+          volumeChangeEventOptions: { enabled: true, intervalMillis: 100 },
+          contextualStrings: hints && hints.length > 0 ? [...hints] : undefined,
+          iosTaskHint: 'dictation',
+          // People start with a greeting and a beat of thought — "hello… uh… add
+          // 500 to Goa". Android's default endpointing finalises on that first
+          // pause, ending the session on the greeting alone. Give it room: keep
+          // listening for at least a few seconds, and do not treat a two-second
+          // pause as the end of speech. (Android-only extras; iOS endpointing is
+          // already more forgiving and ignores these.)
+          androidIntentOptions: {
+            EXTRA_SPEECH_INPUT_MINIMUM_LENGTH_MILLIS: 4000,
+            EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS: 2000,
+            EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS: 2000,
+          },
+        });
+        speechMic.opened(session);
+        starting.current = false;
+
+        // No transcript yet; if none arrives by PROGRESS_MS this engine is not
+        // transcribing. An on-device attempt falls back once to the network engine
+        // (the field's silent on-device model); a network attempt that is already
+        // mute is left to STALL / the hard cap to resolve.
+        clearProgress();
+        progress.current = setTimeout(() => {
+          progress.current = null;
+          if (!mounted.current || !speechMic.owns(session) || gotResult.current) return;
+          if (usedOnDevice.current && !retried.current) {
+            retried.current = true;
+            startRef.current(true);
+          }
+        }, PROGRESS_MS);
+
+        // Nothing has come back yet; if nothing ever does, the recogniser was
+        // torn down under us and the panel must say so rather than pretend.
+        clearStall();
+        stall.current = setTimeout(() => {
+          stall.current = null;
           if (!mounted.current || !speechMic.owns(session)) return;
+          clearMaxListen();
+          clearProgress();
           setListening(false);
           level.set(withTiming(0, { duration: 150 }));
-          const said = latest.current.trim();
-          if (said) onDone(said);
-          else {
-            setEmptyMiss(true);
-            setDiag(buildDiag(usedOnDevice.current, volumeSeen.current, gotResult.current));
-          }
+          setError(t.misc.dictationFailed);
           speechMic.release(session);
-        }, HARD_STOP_MS);
-      }, MAX_LISTEN_MS);
-    } catch {
-      setListening(false);
-      setError(t.misc.dictationFailed);
-      give();
-    }
-  }, [clearMaxListen, clearStall, hints, level, locale, onDone, onListen, session, t]);
+        }, STALL_MS);
+
+        // The hard cap: a recogniser that meters audio but never finalises would
+        // otherwise sit on "listening" forever (STALL is cleared by those volume
+        // events). At the cap, stop() to squeeze out any partial as a final; if it
+        // is still holding on after HARD_STOP_MS, release() aborts it and the
+        // capture lands on the calm miss with a diagnostic.
+        clearMaxListen();
+        maxListen.current = setTimeout(() => {
+          maxListen.current = null;
+          if (!mounted.current || !speechMic.owns(session)) return;
+          speechMic.stop(session);
+          setTimeout(() => {
+            if (!mounted.current || !speechMic.owns(session)) return;
+            setListening(false);
+            level.set(withTiming(0, { duration: 150 }));
+            const said = latest.current.trim();
+            if (said) onDone(said);
+            else {
+              setEmptyMiss(true);
+              setDiag(buildDiag(usedOnDevice.current, volumeSeen.current, gotResult.current));
+            }
+            speechMic.release(session);
+          }, HARD_STOP_MS);
+        }, MAX_LISTEN_MS);
+      } catch {
+        setListening(false);
+        setError(t.misc.dictationFailed);
+        give();
+      }
+    },
+    [clearMaxListen, clearProgress, clearStall, hints, level, locale, onDone, onListen, session, t],
+  );
+
+  // Point the recursion handle at the current start on every change.
+  useEffect(() => {
+    startRef.current = start;
+  }, [start]);
 
   const stop = useCallback((): void => {
     // Ask the recogniser to finish, but keep the session: `stop()` (unlike
@@ -723,10 +787,11 @@ export function VoiceCapture({
       mounted.current = false;
       clearStall();
       clearMaxListen();
+      clearProgress();
       starting.current = false;
       speechMic.release(session);
     };
-  }, [clearMaxListen, clearStall, session]);
+  }, [clearMaxListen, clearProgress, clearStall, session]);
 
   if (!available) {
     return (
@@ -813,6 +878,11 @@ export function VoiceCapture({
         ) : !listening && !showMiss && !live ? (
           <Text variant="caption" tone="faint" align="center">
             {t.voice.example}
+          </Text>
+        ) : null}
+        {listening ? (
+          <Text variant="caption" tone="faint" align="center">
+            {`${engine ?? '…'} · vol ${volCount} · w ${live ? 1 : 0}`}
           </Text>
         ) : null}
       </View>

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -58,6 +58,22 @@ speechMic.attach({
 const STALL_MS = 8000;
 
 /**
+ * The hard cap on one listening session, armed the moment the recogniser is
+ * opened and — unlike {@link STALL_MS} — never cleared by an incoming event.
+ *
+ * STALL only catches a recogniser that says *nothing at all*. This catches the
+ * other dead end the field hit: one that meters audio (volume events keep the
+ * wave alive) yet never returns a transcript and never ends, leaving the screen
+ * on "listening" until the person gives up. At the cap we `stop()` (which
+ * delivers any partial as a final result), and if even that is ignored we
+ * `release()` — an abort — so the session always lands on a transcript or the
+ * calm miss, never an endless spinner. Set a beat above STALL so the no-event
+ * path reports first.
+ */
+const MAX_LISTEN_MS = 9500;
+const HARD_STOP_MS = 1800;
+
+/**
  * A soft halo that breathes behind the mic while it listens — a slow, low-opacity
  * swell that makes the button read as a live orb rather than a flat disc. It is
  * the calm base layer under the sharper expanding rings; the two together are the
@@ -387,6 +403,22 @@ async function englishInstalledOnDevice(): Promise<boolean> {
   }
 }
 
+/**
+ * A compact, single-line summary of why a capture failed, shown under the calm
+ * miss copy. Not for the everyday user so much as for pinning a device-only
+ * silent-mic bug from a screenshot: it says which engine ran, whether any audio
+ * reached it (volume packets), and whether any words came back.
+ *
+ *   `voice: on-device · heard audio · no words`  → the engine is broken/absent
+ *   `voice: network · no audio · no words`        → mic/permission/routing
+ */
+function buildDiag(onDevice: boolean, volume: number, words: boolean): string {
+  const engine = onDevice ? 'on-device' : 'network';
+  const audio = volume > 0 ? 'heard audio' : 'no audio';
+  const said = words ? 'got words' : 'no words';
+  return `voice: ${engine} · ${audio} · ${said}`;
+}
+
 export function VoiceCapture({
   onDone,
   hints,
@@ -444,6 +476,25 @@ export function VoiceCapture({
     stall.current = null;
   }, []);
 
+  // The hard listening cap (see MAX_LISTEN_MS) — armed at open, cleared only by a
+  // terminal event or unmount, never by a mid-session event.
+  const maxListen = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearMaxListen = useCallback((): void => {
+    if (maxListen.current === null) return;
+    clearTimeout(maxListen.current);
+    maxListen.current = null;
+  }, []);
+
+  // Lifecycle facts for the failure diagnostic: whether any transcript came back,
+  // how many volume packets arrived (did audio reach the recogniser at all), and
+  // which engine this attempt used. Surfaced only when a capture fails, so a
+  // device where voice silently does nothing can be told apart — audio-but-no-
+  // words (engine broken) from no-audio (mic/permission) — without a cable.
+  const gotResult = useRef(false);
+  const volumeSeen = useRef(0);
+  const usedOnDevice = useRef(false);
+  const [diag, setDiag] = useState<string | null>(null);
+
   useSpeechRecognitionEvent('start', () => {
     if (!speechMic.owns(session)) return;
     clearStall();
@@ -452,6 +503,7 @@ export function VoiceCapture({
   useSpeechRecognitionEvent('result', (event) => {
     if (!speechMic.owns(session)) return;
     clearStall();
+    gotResult.current = true;
     const transcript = event.results[0]?.transcript ?? '';
     latest.current = transcript;
     setLive(transcript);
@@ -463,6 +515,7 @@ export function VoiceCapture({
   useSpeechRecognitionEvent('volumechange', (event) => {
     if (!speechMic.owns(session)) return;
     clearStall();
+    volumeSeen.current += 1;
     const norm = Math.max(0, Math.min(1, event.value / 10));
     // `.set()`, not `.value =`: Reanimated 4's method API, the one the React
     // compiler allows off the UI thread (see PressableScale in lib/anim).
@@ -472,6 +525,7 @@ export function VoiceCapture({
   useSpeechRecognitionEvent('error', (event) => {
     if (!speechMic.owns(session)) return;
     clearStall();
+    clearMaxListen();
     const message = dictationError(event.error, t.misc.dictationErrors);
     if (message) setError(message);
     setListening(false);
@@ -492,14 +546,18 @@ export function VoiceCapture({
     // barely started.
     if (!speechMic.ended(session)) return;
     clearStall();
+    clearMaxListen();
     setListening(false);
     level.set(withTiming(0, { duration: 150 }));
     const said = latest.current.trim();
     if (said) onDone(said);
     // Heard nothing usable — surface the same calm recovery a parsed miss shows,
     // rather than silently dropping back to the opening prompt as if nothing had
-    // been tried.
-    else setEmptyMiss(true);
+    // been tried, and record why so a silent-mic device can be diagnosed.
+    else {
+      setEmptyMiss(true);
+      setDiag(buildDiag(usedOnDevice.current, volumeSeen.current, gotResult.current));
+    }
   });
 
   const start = useCallback(async (): Promise<void> => {
@@ -519,6 +577,9 @@ export function VoiceCapture({
     latest.current = '';
     setLive('');
     level.set(0);
+    gotResult.current = false;
+    volumeSeen.current = 0;
+    setDiag(null);
 
     // Claim the recogniser first, and wait here for any previous session's
     // teardown to land. Everything below must give it back — a claimed mic that
@@ -552,6 +613,7 @@ export function VoiceCapture({
     // Requiring on-device for a model that is not there is what returned silence.
     const onDevice = await englishInstalledOnDevice();
     if (!mounted.current) return give();
+    usedOnDevice.current = onDevice;
 
     setListening(true);
     try {
@@ -591,17 +653,42 @@ export function VoiceCapture({
       stall.current = setTimeout(() => {
         stall.current = null;
         if (!mounted.current || !speechMic.owns(session)) return;
+        clearMaxListen();
         setListening(false);
         level.set(withTiming(0, { duration: 150 }));
         setError(t.misc.dictationFailed);
         speechMic.release(session);
       }, STALL_MS);
+
+      // The hard cap: a recogniser that meters audio but never finalises would
+      // otherwise sit on "listening" forever (STALL is cleared by those volume
+      // events). At the cap, stop() to squeeze out any partial as a final; if it
+      // is still holding on after HARD_STOP_MS, release() aborts it and the
+      // capture lands on the calm miss with a diagnostic.
+      clearMaxListen();
+      maxListen.current = setTimeout(() => {
+        maxListen.current = null;
+        if (!mounted.current || !speechMic.owns(session)) return;
+        speechMic.stop(session);
+        setTimeout(() => {
+          if (!mounted.current || !speechMic.owns(session)) return;
+          setListening(false);
+          level.set(withTiming(0, { duration: 150 }));
+          const said = latest.current.trim();
+          if (said) onDone(said);
+          else {
+            setEmptyMiss(true);
+            setDiag(buildDiag(usedOnDevice.current, volumeSeen.current, gotResult.current));
+          }
+          speechMic.release(session);
+        }, HARD_STOP_MS);
+      }, MAX_LISTEN_MS);
     } catch {
       setListening(false);
       setError(t.misc.dictationFailed);
       give();
     }
-  }, [clearStall, hints, level, locale, onListen, session, t]);
+  }, [clearMaxListen, clearStall, hints, level, locale, onDone, onListen, session, t]);
 
   const stop = useCallback((): void => {
     // Ask the recogniser to finish, but keep the session: `stop()` (unlike
@@ -635,10 +722,11 @@ export function VoiceCapture({
     return () => {
       mounted.current = false;
       clearStall();
+      clearMaxListen();
       starting.current = false;
       speechMic.release(session);
     };
-  }, [clearStall, session]);
+  }, [clearMaxListen, clearStall, session]);
 
   if (!available) {
     return (
@@ -735,6 +823,15 @@ export function VoiceCapture({
             {error}
           </Text>
         </Pressable>
+      ) : null}
+
+      {/* A one-line failure diagnostic, shown only on a miss — which engine ran,
+          whether audio reached it, whether any words returned. Lets a device
+          where voice silently does nothing be told apart from a cable. */}
+      {showMiss && diag ? (
+        <Text variant="caption" tone="faint" align="center">
+          {diag}
+        </Text>
       ) : null}
     </View>
   );

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -413,22 +413,6 @@ async function englishInstalledOnDevice(): Promise<boolean> {
   }
 }
 
-/**
- * A compact, single-line summary of why a capture failed, shown under the calm
- * miss copy. Not for the everyday user so much as for pinning a device-only
- * silent-mic bug from a screenshot: it says which engine ran, whether any audio
- * reached it (volume packets), and whether any words came back.
- *
- *   `voice: on-device · heard audio · no words`  → the engine is broken/absent
- *   `voice: network · no audio · no words`        → mic/permission/routing
- */
-function buildDiag(onDevice: boolean, volume: number, words: boolean): string {
-  const engine = onDevice ? 'on-device' : 'network';
-  const audio = volume > 0 ? 'heard audio' : 'no audio';
-  const said = words ? 'got words' : 'no words';
-  return `voice: ${engine} · ${audio} · ${said}`;
-}
-
 export function VoiceCapture({
   onDone,
   hints,
@@ -501,7 +485,6 @@ export function VoiceCapture({
   // device where voice silently does nothing can be told apart — audio-but-no-
   // words (engine broken) from no-audio (mic/permission) — without a cable.
   const gotResult = useRef(false);
-  const volumeSeen = useRef(0);
   const usedOnDevice = useRef(false);
   // A one-time on-device -> network fallback has already been spent this attempt.
   const retried = useRef(false);
@@ -515,12 +498,13 @@ export function VoiceCapture({
   // The latest `start`, reached indirectly so the fallback watchdog inside
   // `start` can re-enter it without naming the still-declaring const.
   const startRef = useRef<(forceNetwork?: boolean) => void>(() => {});
-  const [diag, setDiag] = useState<string | null>(null);
-  // A live status line while listening — which engine, how many audio packets
-  // have arrived, whether any words came back. A debug aid for a device where
-  // voice silently does nothing: one screenshot mid-listen says where it breaks.
+  // Which engine the current attempt used — the setup-offline offer keys off a
+  // network miss (its recogniser can be dead on a device with no on-device model).
   const [engine, setEngine] = useState<'on-device' | 'network' | null>(null);
-  const [volCount, setVolCount] = useState(0);
+  // On-device recognition is supported here but the English model is not yet
+  // installed — probed once on mount. Surfaces the setup offer before a failure,
+  // for devices whose network recogniser is unreliable.
+  const [offlineEligible, setOfflineEligible] = useState(false);
   // A one-off setup for a device whose network recogniser hears audio but returns
   // no words: pull the on-device English model down, then recognition runs
   // on-device and skips the broken network path. A status line for the download.
@@ -548,8 +532,6 @@ export function VoiceCapture({
   useSpeechRecognitionEvent('volumechange', (event) => {
     if (!speechMic.owns(session)) return;
     clearStall();
-    volumeSeen.current += 1;
-    setVolCount((n) => n + 1);
     const norm = Math.max(0, Math.min(1, event.value / 10));
     // `.set()`, not `.value =`: Reanimated 4's method API, the one the React
     // compiler allows off the UI thread (see PressableScale in lib/anim).
@@ -590,10 +572,7 @@ export function VoiceCapture({
     // Heard nothing usable — surface the same calm recovery a parsed miss shows,
     // rather than silently dropping back to the opening prompt as if nothing had
     // been tried, and record why so a silent-mic device can be diagnosed.
-    else {
-      setEmptyMiss(true);
-      setDiag(buildDiag(usedOnDevice.current, volumeSeen.current, gotResult.current));
-    }
+    else setEmptyMiss(true);
   });
 
   const start = useCallback(
@@ -622,8 +601,6 @@ export function VoiceCapture({
       setLive('');
       level.set(0);
       gotResult.current = false;
-      volumeSeen.current = 0;
-      setDiag(null);
 
       // Claim the recogniser first, and wait here for any previous session's
       // teardown to land. Everything below must give it back — a claimed mic that
@@ -659,7 +636,6 @@ export function VoiceCapture({
       if (!mounted.current) return give();
       usedOnDevice.current = onDevice;
       setEngine(onDevice ? 'on-device' : 'network');
-      setVolCount(0);
 
       setListening(true);
       try {
@@ -738,10 +714,7 @@ export function VoiceCapture({
             level.set(withTiming(0, { duration: 150 }));
             const said = latest.current.trim();
             if (said) onDone(said);
-            else {
-              setEmptyMiss(true);
-              setDiag(buildDiag(usedOnDevice.current, volumeSeen.current, gotResult.current));
-            }
+            else setEmptyMiss(true);
             speechMic.release(session);
           }, HARD_STOP_MS);
         }, MAX_LISTEN_MS);
@@ -772,6 +745,7 @@ export function VoiceCapture({
         // The model is on the device now: latch it so the next capture asks for
         // on-device recognition (see englishInstalledOnDevice), and open the mic.
         englishOnDeviceConfirmed = true;
+        setOfflineEligible(false);
         setDownloadMsg(t.voice.offlineReady);
         void start();
       } else {
@@ -792,6 +766,33 @@ export function VoiceCapture({
     // would make the handler above drop the words spoken before the tap.
     speechMic.stop(session);
   }, [session]);
+
+  // Probe once: is on-device supported but not yet installed? If so, the offline
+  // model is worth offering up front — on some devices the network engine hears
+  // audio but returns nothing, and the on-device model is the only path that
+  // works. A pure read; never triggers a download on its own.
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        if (!recognitionAvailable()) return;
+        let supports = false;
+        try {
+          supports = ExpoSpeechRecognitionModule.supportsOnDeviceRecognition();
+        } catch {
+          supports = false;
+        }
+        if (!supports) return;
+        const installed = await englishInstalledOnDevice();
+        if (alive && !installed) setOfflineEligible(true);
+      } catch {
+        // A failing probe just means no proactive offer — the on-miss one remains.
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   // Open the mic as the screen appears — the reader tapped a mic to get here, so
   // making them tap a second one to start would be a step too many. Suppressed
@@ -908,14 +909,24 @@ export function VoiceCapture({
         {listening && !reduceMotion ? (
           <Waveform active={listening} level={level} />
         ) : !listening && !showMiss && !live ? (
-          <Text variant="caption" tone="faint" align="center">
-            {t.voice.example}
-          </Text>
-        ) : null}
-        {listening ? (
-          <Text variant="caption" tone="faint" align="center">
-            {`${engine ?? '…'} · vol ${volCount} · w ${live ? 1 : 0}`}
-          </Text>
+          <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+            <Text variant="caption" tone="faint" align="center">
+              {t.voice.example}
+            </Text>
+            {offlineEligible ? (
+              <Pressable
+                accessibilityRole="button"
+                disabled={downloading}
+                onPress={() => void setupOffline()}
+                hitSlop={8}
+                style={({ pressed }) => ({ opacity: downloading ? 0.5 : pressed ? 0.6 : 1 })}
+              >
+                <Text variant="caption" tone="brand" style={{ fontWeight: '600' }}>
+                  {t.voice.setupOffline}
+                </Text>
+              </Pressable>
+            ) : null}
+          </View>
         ) : null}
       </View>
 
@@ -930,16 +941,10 @@ export function VoiceCapture({
       {/* A one-line failure diagnostic, shown only on a miss — which engine ran,
           whether audio reached it, whether any words returned. Lets a device
           where voice silently does nothing be told apart from a cable. */}
-      {showMiss && diag ? (
-        <Text variant="caption" tone="faint" align="center">
-          {diag}
-        </Text>
-      ) : null}
-
       {/* When the network engine heard audio but returned nothing, its recogniser
           is broken on this device — offer the on-device model, which recognises
           without the network path at all. */}
-      {showMiss && engine === 'network' ? (
+      {showMiss && (engine === 'network' || offlineEligible) ? (
         <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
           <Pressable
             accessibilityRole="button"

--- a/apps/mobile/src/components/VoiceCapture.tsx
+++ b/apps/mobile/src/components/VoiceCapture.tsx
@@ -521,6 +521,11 @@ export function VoiceCapture({
   // voice silently does nothing: one screenshot mid-listen says where it breaks.
   const [engine, setEngine] = useState<'on-device' | 'network' | null>(null);
   const [volCount, setVolCount] = useState(0);
+  // A one-off setup for a device whose network recogniser hears audio but returns
+  // no words: pull the on-device English model down, then recognition runs
+  // on-device and skips the broken network path. A status line for the download.
+  const [downloading, setDownloading] = useState(false);
+  const [downloadMsg, setDownloadMsg] = useState<string | null>(null);
 
   useSpeechRecognitionEvent('start', () => {
     if (!speechMic.owns(session)) return;
@@ -754,6 +759,33 @@ export function VoiceCapture({
     startRef.current = start;
   }, [start]);
 
+  const setupOffline = useCallback(async (): Promise<void> => {
+    if (downloading) return;
+    setDownloading(true);
+    setDownloadMsg(t.voice.offlineDownloading);
+    try {
+      const { status } = await ExpoSpeechRecognitionModule.androidTriggerOfflineModelDownload({
+        locale: englishSpeechLocale(locale),
+      });
+      if (!mounted.current) return;
+      if (status === 'download_success') {
+        // The model is on the device now: latch it so the next capture asks for
+        // on-device recognition (see englishInstalledOnDevice), and open the mic.
+        englishOnDeviceConfirmed = true;
+        setDownloadMsg(t.voice.offlineReady);
+        void start();
+      } else {
+        // Android 13 opens a system download dialog; 14+ may schedule for Wi-Fi.
+        // Either way it is not ready this instant — invite a retry shortly.
+        setDownloadMsg(t.voice.offlineDownloading);
+      }
+    } catch {
+      if (mounted.current) setDownloadMsg(t.voice.offlineFailed);
+    } finally {
+      if (mounted.current) setDownloading(false);
+    }
+  }, [downloading, locale, start, t]);
+
   const stop = useCallback((): void => {
     // Ask the recogniser to finish, but keep the session: `stop()` (unlike
     // `abort()`) still delivers one last `result`, and giving the mic up here
@@ -902,6 +934,30 @@ export function VoiceCapture({
         <Text variant="caption" tone="faint" align="center">
           {diag}
         </Text>
+      ) : null}
+
+      {/* When the network engine heard audio but returned nothing, its recogniser
+          is broken on this device — offer the on-device model, which recognises
+          without the network path at all. */}
+      {showMiss && engine === 'network' ? (
+        <View style={{ alignItems: 'center', gap: theme.spacing.xs }}>
+          <Pressable
+            accessibilityRole="button"
+            disabled={downloading}
+            onPress={() => void setupOffline()}
+            hitSlop={8}
+            style={({ pressed }) => ({ opacity: downloading ? 0.5 : pressed ? 0.6 : 1 })}
+          >
+            <Text tone="brand" style={{ fontWeight: '600' }}>
+              {t.voice.setupOffline}
+            </Text>
+          </Pressable>
+          {downloadMsg ? (
+            <Text variant="caption" tone="muted" align="center">
+              {downloadMsg}
+            </Text>
+          ) : null}
+        </View>
       ) : null}
     </View>
   );

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -899,6 +899,12 @@ export interface UiStrings {
     missedNothing: string;
     /** The status line under the mic on a miss: the mic itself is the retry. */
     tapToRetry: string;
+    /** Offer to install the on-device model when the network engine hears audio
+     *  but returns nothing (its recogniser is broken on this device). */
+    setupOffline: string;
+    offlineDownloading: string;
+    offlineReady: string;
+    offlineFailed: string;
     tryAgain: string;
     chooseGroup: string;
     /** '{note}' is the spoken description. */
@@ -3117,6 +3123,10 @@ const en: UiStrings = {
     tapToSpeak: 'Tap to speak',
     noAmount: 'Didn’t catch an amount',
     missedNothing: 'Didn’t catch that',
+    setupOffline: 'Set up offline voice',
+    offlineDownloading: 'Downloading the offline voice model… try again in a moment.',
+    offlineReady: 'Offline voice is ready — tap the mic and speak.',
+    offlineFailed: 'Couldn’t set up offline voice on this device.',
     tapToRetry: 'Tap to try again',
     tryAgain: 'Try again',
     chooseGroup: 'Which group?',
@@ -5259,6 +5269,11 @@ const ta: UiStrings = {
     tapToSpeak: 'பேச தட்டு',
     noAmount: 'தொகை புரியவில்லை',
     missedNothing: 'புரியவில்லை',
+    setupOffline: 'ஆஃப்லைன் குரலை அமை',
+    offlineDownloading:
+      'ஆஃப்லைன் குரல் மாதிரி பதிவிறங்குகிறது… சிறிது நேரத்தில் மீண்டும் முயற்சிக்கவும்.',
+    offlineReady: 'ஆஃப்லைன் குரல் தயார் — மைக்கைத் தட்டிப் பேசுங்கள்.',
+    offlineFailed: 'இந்தச் சாதனத்தில் ஆஃப்லைன் குரலை அமைக்க முடியவில்லை.',
     tapToRetry: 'மீண்டும் முயற்சிக்க தட்டு',
     tryAgain: 'மீண்டும் முயற்சி செய்',
     chooseGroup: 'எந்த குழு?',
@@ -7464,6 +7479,10 @@ const hi: UiStrings = {
     tapToSpeak: 'बोलने के लिए टैप करें',
     noAmount: 'रकम समझ नहीं आई',
     missedNothing: 'समझ नहीं आया',
+    setupOffline: 'ऑफ़लाइन आवाज़ सेट करें',
+    offlineDownloading: 'ऑफ़लाइन आवाज़ मॉडल डाउनलोड हो रहा है… थोड़ी देर में फिर कोशिश करें।',
+    offlineReady: 'ऑफ़लाइन आवाज़ तैयार — माइक दबाकर बोलें।',
+    offlineFailed: 'इस डिवाइस पर ऑफ़लाइन आवाज़ सेट नहीं हो सकी।',
     tapToRetry: 'दोबारा कोशिश के लिए टैप करें',
     tryAgain: 'फिर कोशिश करें',
     chooseGroup: 'कौन सा ग्रुप?',
@@ -9638,6 +9657,10 @@ const ar: UiStrings = {
     tapToSpeak: 'انقر للتحدث',
     noAmount: 'لم أفهم المبلغ',
     missedNothing: 'لم أفهم ذلك',
+    setupOffline: 'إعداد الصوت دون اتصال',
+    offlineDownloading: 'يجري تنزيل نموذج الصوت دون اتصال… أعد المحاولة بعد قليل.',
+    offlineReady: 'الصوت دون اتصال جاهز — انقر الميكروفون وتحدّث.',
+    offlineFailed: 'تعذّر إعداد الصوت دون اتصال على هذا الجهاز.',
     tapToRetry: 'انقر لإعادة المحاولة',
     tryAgain: 'أعد المحاولة',
     chooseGroup: 'أي مجموعة؟',


### PR DESCRIPTION
## The bug

On a real device (a non-Google OEM ROM), voice quick-add sat on **"Listening…"** and never produced a transcript — both release and debug builds. Reported from the field with screen recordings; no adb available.

## Diagnosis (built into the fix, then removed)

A temporary on-screen counter (`engine · vol N · w 0/1`) pinned it without a cable:

- Engine was **network** — the phone's on-device English model isn't installed, so it never tried on-device.
- Audio **was** reaching the recogniser — the volume counter climbed `2 → 39` (mic + permission fine).
- Google's **network** recognition returned **no transcript and never ended** — it's simply dead on this ROM.

So the recogniser hangs "hearing but never finalising", and network — the only path in use — is the broken one.

## The fixes

1. **Hard listening cap** (`MAX_LISTEN_MS`) — armed at open, never cleared by an event. The existing STALL guard only caught a recogniser that emits *nothing*; a metering-but-mute session slipped past it and listened forever. At the cap: `stop()` for any partial, then `release()`-abort. Always lands on a transcript or the calm miss — never an endless spinner.

2. **On-device → network fallback** — if an on-device attempt returns nothing shortly after speech (`PROGRESS_MS`), fall back once to the network engine. Safe re-entry: the mic arbiter drops ownership synchronously, so the aborted session's late `end` belongs to nobody.

3. **"Set up offline voice"** — the actual cure for this device. When on-device is supported but the model isn't installed, offer `androidTriggerOfflineModelDownload(en-<region>)` — in the at-rest state and on a miss. On `download_success` it latches on-device and reopens the mic; recognition then runs **on-device**, bypassing the dead network service entirely. The download is only ever the person's explicit tap, never an unprompted dialog.

**Verified on the affected device:** after tapping "Set up offline voice", the engine flips to on-device, the utterance transcribes, and it parses into the review screen.

The diagnostic counter/line were removed before this PR; the three fixes above remain.

## i18n
`voice.setupOffline / offlineDownloading / offlineReady / offlineFailed` across en/ta/hi/ar.

## Gates
mobile tsc + expo lint clean; `speechMic` tests pass. JS-only (no native change) — OTA-shippable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to download and use an English offline voice model.
  - Added clear status messages for offline model setup, downloading, readiness, and failures.
  - Voice capture now automatically switches to network recognition when an on-device attempt returns no transcript.
  - Added safeguards to stop listening when recognition stalls or exceeds the listening limit.
- **Localization**
  - Added offline voice setup and status messages in English, Tamil, Hindi, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->