### PR TITLE
feat(activity): one-tap presets + inline range calendar for the date filter

### DIFF
--- a/apps/mobile/src/components/ActivityDateFilter.tsx
+++ b/apps/mobile/src/components/ActivityDateFilter.tsx
@@ -1,28 +1,29 @@
 /**
- * The Activity feed's date-range filter — a bottom sheet holding a From and a
- * To field over one shared date picker.
+ * The Activity feed's date-range filter — quick presets over one inline range
+ * calendar.
  *
  * The whole feed is already on the phone (the mirror), so narrowing it is a pure
  * cut on the loaded rows; this component only gathers the range and hands it
- * back. The picker is clamped to the feed's own span (`earliest`/`latest`), so a
- * day before the first event or after the last cannot be chosen — the picker
- * disables everything outside `[earliest, latest]`. (The library only supports
- * that outer clamp; it cannot grey out an isolated empty day inside the span.)
+ * back. The old design paired a From and a To field that each opened a native
+ * date-picker modal — open, pick, dismiss, open, pick, dismiss, Apply — four
+ * taps before a single-day filter was even set. This is the pattern the industry
+ * settled on instead (Monzo, Spotify, StubHub): a row of one-tap presets for the
+ * common ranges, and a single always-visible {@link RangeCalendar} for a custom
+ * one (tap the start day, tap the end day). A preset applies and closes on the
+ * one tap; a custom range is committed on Apply so the feed behind the sheet does
+ * not flicker as the two ends are chosen.
  *
- * A From on its own is a single-day filter — the To defaults to it — and picking
- * a To widens it; the receiver orders the two ends, so an end-first pick is
- * still valid. The draft lives here and is only committed on Apply, so the feed
- * behind the sheet does not flicker as the two ends are chosen.
+ * Everything is clamped to the feed's own span (`earliest`/`latest`) — a day
+ * before the first event or after the last cannot be chosen.
  */
 
 import { useState } from 'react';
-import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
-import Ionicons from '@expo/vector-icons/Ionicons';
-import { Platform, Pressable, View } from 'react-native';
+import { Pressable, ScrollView, View } from 'react-native';
 
-import { Button, iconSize, Row, Text, useTheme } from '@waves/ui';
+import { Button, Row, Text, useTheme } from '@waves/ui';
 
 import { SheetOverlay } from '@/components/expense/SheetOverlay';
+import { RangeCalendar } from '@/components/RangeCalendar';
 import { useStrings } from '@/i18n';
 
 /** A committed filter range — both ends are calendar-day anchors (local noon). */
@@ -31,60 +32,13 @@ export interface DateRange {
   end: Date;
 }
 
-enum Field {
-  Start = 'start',
-  End = 'end',
+/** A calendar day at local noon — the anchor the whole control works in. */
+function dayNoon(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 12, 0, 0, 0);
 }
 
-/**
- * One end of the range — its own bordered box, a small label over the date with
- * a calendar glyph, lighting up in the brand tint once set. The two sit side by
- * side like the from/to of a range picker, matching `TripDates`.
- */
-function RangeEnd({
-  label,
-  value,
-  set,
-  onPress,
-}: {
-  label: string;
-  value: string;
-  set: boolean;
-  onPress: () => void;
-}) {
-  const theme = useTheme();
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={`${label}: ${value}`}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        flex: 1,
-        gap: 4,
-        paddingVertical: theme.spacing.md,
-        paddingHorizontal: theme.spacing.md,
-        borderRadius: theme.radius.lg,
-        borderWidth: 1,
-        borderColor: set ? theme.color.brand : theme.color.border,
-        backgroundColor: set ? theme.color.brandSoft : theme.color.surface,
-        opacity: pressed ? 0.7 : 1,
-      })}
-    >
-      <Text variant="caption" tone="muted">
-        {label}
-      </Text>
-      <Row style={{ alignItems: 'center', gap: theme.spacing.xs }}>
-        <Ionicons
-          name="calendar-outline"
-          size={iconSize.sm}
-          color={set ? theme.color.brand : theme.color.textMuted}
-        />
-        <Text variant="subheading" style={{ fontWeight: '700' }}>
-          {value}
-        </Text>
-      </Row>
-    </Pressable>
-  );
+function addDays(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + n, 12, 0, 0, 0);
 }
 
 export function ActivityDateFilter({
@@ -110,67 +64,111 @@ export function ActivityDateFilter({
   const { t } = useStrings();
   const [start, setStart] = useState<Date | null>(initial?.start ?? null);
   const [end, setEnd] = useState<Date | null>(initial?.end ?? null);
-  const [editing, setEditing] = useState<Field | null>(null);
+
+  const lo = dayNoon(earliest);
+  const hi = dayNoon(latest);
+  const clamp = (d: Date): Date => {
+    const day = dayNoon(d);
+    if (day.getTime() < lo.getTime()) return lo;
+    if (day.getTime() > hi.getTime()) return hi;
+    return day;
+  };
+
+  // The presets, relative to today but clamped into the feed's span, so a feed
+  // that ends before today still yields a sensible (collapsed) range.
+  const now = new Date();
+  const presets: { label: string; start: Date; end: Date }[] = [
+    { label: t.activityFilter.today, start: clamp(now), end: clamp(now) },
+    { label: t.activityFilter.last7, start: clamp(addDays(now, -6)), end: clamp(now) },
+    { label: t.activityFilter.last30, start: clamp(addDays(now, -29)), end: clamp(now) },
+    {
+      label: t.activityFilter.thisMonth,
+      start: clamp(new Date(now.getFullYear(), now.getMonth(), 1, 12)),
+      end: clamp(now),
+    },
+  ];
 
   const showDate = (value: Date | null): string =>
     value
       ? value.toLocaleDateString(locale, { weekday: 'short', day: 'numeric', month: 'short' })
       : t.pickers.notSet;
 
-  const apply = (field: Field, event: DateTimePickerEvent, picked?: Date): void => {
-    // Android's picker is a modal that reports its own dismissal; iOS's is
-    // inline and reports every scroll.
-    if (Platform.OS === 'android') setEditing(null);
-    if (event.type === 'dismissed' || !picked) return;
-    if (field === Field.Start) {
-      setStart(picked);
-      // A To before the new From is not a range — carry the To along rather than
-      // refuse the pick.
-      setEnd((prev) => (prev && prev < picked ? picked : prev));
-      return;
-    }
-    setEnd(picked);
-    setStart((prev) => (prev && prev > picked ? picked : prev));
+  // A preset is a one-tap answer: commit it and close, no Apply needed.
+  const applyPreset = (p: { start: Date; end: Date }): void => {
+    onApply({ start: p.start, end: p.end });
+    onClose();
   };
+
+  const activePreset = (p: { start: Date; end: Date }): boolean =>
+    start !== null &&
+    end !== null &&
+    start.getTime() === p.start.getTime() &&
+    end.getTime() === p.end.getTime();
 
   return (
     <SheetOverlay title={t.activityFilter.open} onClose={onClose}>
       <View style={{ gap: theme.spacing.lg }}>
-        <Row style={{ alignItems: 'stretch', gap: theme.spacing.sm }}>
-          <RangeEnd
-            label={t.activityFilter.from}
-            value={showDate(start)}
-            set={Boolean(start)}
-            onPress={() => setEditing(Field.Start)}
-          />
-          <RangeEnd
-            label={t.activityFilter.to}
-            value={showDate(end ?? start)}
-            set={Boolean(end ?? start)}
-            onPress={() => setEditing(Field.End)}
-          />
+        {/* One-tap presets — the common ranges, applied immediately. */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: theme.spacing.sm }}
+        >
+          {presets.map((p) => {
+            const active = activePreset(p);
+            return (
+              <Pressable
+                key={p.label}
+                accessibilityRole="button"
+                accessibilityLabel={p.label}
+                accessibilityState={{ selected: active }}
+                onPress={() => applyPreset(p)}
+                style={({ pressed }) => ({
+                  paddingVertical: theme.spacing.sm,
+                  paddingHorizontal: theme.spacing.md,
+                  borderRadius: theme.radius.pill,
+                  borderWidth: 1,
+                  borderColor: active ? theme.color.brand : theme.color.border,
+                  backgroundColor: active ? theme.color.brandSoft : theme.color.surface,
+                  opacity: pressed ? 0.7 : 1,
+                })}
+              >
+                <Text
+                  variant="caption"
+                  style={{
+                    color: active ? theme.color.brand : theme.color.text,
+                    fontWeight: '600',
+                  }}
+                >
+                  {p.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+
+        {/* The selected range, read-only — it echoes the calendar taps below. */}
+        <Row style={{ justifyContent: 'space-between', alignItems: 'baseline' }}>
+          <Text variant="caption" tone="muted">
+            {t.activityFilter.from} · {showDate(start)}
+          </Text>
+          <Text variant="caption" tone="muted">
+            {t.activityFilter.to} · {showDate(end ?? start)}
+          </Text>
         </Row>
 
-        {editing ? (
-          <DateTimePicker
-            value={(editing === Field.Start ? start : (end ?? start)) ?? earliest}
-            mode="date"
-            // The selectable span is the feed's own — dates outside it are
-            // disabled. The To can never start before the chosen From.
-            minimumDate={editing === Field.End && start ? start : earliest}
-            maximumDate={latest}
-            onChange={(event, picked) => apply(editing, event, picked)}
-          />
-        ) : null}
-
-        {Platform.OS === 'ios' && editing ? (
-          <Button
-            label={t.common.done}
-            size="sm"
-            variant="secondary"
-            onPress={() => setEditing(null)}
-          />
-        ) : null}
+        {/* One inline calendar: tap the start day, then the end day. */}
+        <RangeCalendar
+          earliest={earliest}
+          latest={latest}
+          locale={locale}
+          start={start}
+          end={end}
+          onSelect={(s, e) => {
+            setStart(s);
+            setEnd(e);
+          }}
+        />
 
         <Row style={{ gap: theme.spacing.sm }}>
           {initial || start ? (
@@ -193,7 +191,10 @@ export function ActivityDateFilter({
               fullWidth
               onPress={() => {
                 if (!start) return;
-                onApply({ start, end: end ?? start });
+                // The sheet orders the two ends, so an end-first pick is valid.
+                const a = start;
+                const b = end ?? start;
+                onApply(a <= b ? { start: a, end: b } : { start: b, end: a });
                 onClose();
               }}
             />

--- a/apps/mobile/src/components/RangeCalendar.tsx
+++ b/apps/mobile/src/components/RangeCalendar.tsx
@@ -1,0 +1,240 @@
+/**
+ * An inline month calendar with range selection — the modern date-range control
+ * (Monzo, Spotify, StubHub): one calendar on screen, tap the start day then the
+ * end day, the span between them tinted. It replaces the old from/to pair that
+ * opened a native picker modal per end (open, pick, dismiss, open, pick, dismiss
+ * — four taps before Apply). Here a custom range is two taps on a calendar that
+ * never leaves the sheet.
+ *
+ * Pure React Native, no calendar dependency: the feed is small and the control
+ * is simple, so a hand-built month grid avoids adding a native-ish library for
+ * one screen. Days outside the feed's own span (`earliest`/`latest`) are
+ * disabled, and month paging stops at the months that hold those bounds — you
+ * cannot wander into empty time. Every day is anchored at local noon so the grid
+ * is DST-proof and agrees with the `DateRange` the sheet commits.
+ */
+
+import { useState } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Pressable, View } from 'react-native';
+
+import { directionalIcon, iconSize, Row, Text, useTheme } from '@waves/ui';
+
+/** A calendar day at local noon — the anchor the whole control works in. */
+function dayAt(year: number, month: number, date: number): Date {
+  return new Date(year, month, date, 12, 0, 0, 0);
+}
+
+function startOfDay(d: Date): Date {
+  return dayAt(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+function firstOfMonth(d: Date): Date {
+  return dayAt(d.getFullYear(), d.getMonth(), 1);
+}
+
+function addMonths(d: Date, delta: number): Date {
+  return dayAt(d.getFullYear(), d.getMonth() + delta, 1);
+}
+
+/** Whole days between two day-anchors (b − a), sign preserved. */
+function dayDiff(a: Date, b: Date): number {
+  return Math.round((b.getTime() - a.getTime()) / 86_400_000);
+}
+
+function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/** The seven weekday initials in the reader's language, Sunday first. */
+function weekdayLabels(locale: string): string[] {
+  const fmt = new Intl.DateTimeFormat(locale, { weekday: 'narrow' });
+  // 2023-01-01 was a Sunday — walk a known week to get localized initials.
+  return Array.from({ length: 7 }, (_, i) => fmt.format(dayAt(2023, 0, 1 + i)));
+}
+
+function monthLabel(d: Date, locale: string): string {
+  try {
+    return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(d);
+  } catch {
+    return `${d.getFullYear()}-${d.getMonth() + 1}`;
+  }
+}
+
+const CELL = 40;
+
+export function RangeCalendar({
+  earliest,
+  latest,
+  locale,
+  start,
+  end,
+  onSelect,
+}: {
+  earliest: Date;
+  latest: Date;
+  locale: string;
+  start: Date | null;
+  end: Date | null;
+  /** Emits the new range ends after a tap; `end` is null mid-selection. */
+  onSelect: (start: Date | null, end: Date | null) => void;
+}): React.JSX.Element {
+  const theme = useTheme();
+  const lo = startOfDay(earliest);
+  const hi = startOfDay(latest);
+
+  // Which month the grid shows — opens on the current start, else the latest
+  // event's month (the newest activity, where the reader most likely looks).
+  const [view, setView] = useState<Date>(() => firstOfMonth(start ?? latest));
+
+  const canPrev = firstOfMonth(view).getTime() > firstOfMonth(lo).getTime();
+  const canNext = firstOfMonth(view).getTime() < firstOfMonth(hi).getTime();
+
+  const inBounds = (d: Date): boolean => d.getTime() >= lo.getTime() && d.getTime() <= hi.getTime();
+
+  // The selection span, ordered, for the tint band.
+  const spanLo = start && end ? (start <= end ? start : end) : start;
+  const spanHi = start && end ? (start <= end ? end : start) : start;
+  const inSpan = (d: Date): boolean =>
+    spanLo !== null &&
+    spanHi !== null &&
+    d.getTime() >= spanLo.getTime() &&
+    d.getTime() <= spanHi.getTime();
+
+  const pick = (d: Date): void => {
+    // Fresh start when nothing is pending or the range is already whole; else
+    // close the range on the second tap. The sheet orders the two ends, so an
+    // end-before-start tap is fine.
+    if (start === null || end !== null) onSelect(d, null);
+    else onSelect(start, d);
+  };
+
+  // Build the grid: lead blanks for the first-of-month's weekday, then the days.
+  const first = firstOfMonth(view);
+  const lead = first.getDay(); // 0 = Sunday
+  const daysInMonth = dayDiff(first, addMonths(view, 1));
+  const cells: (Date | null)[] = [
+    ...Array.from({ length: lead }, () => null),
+    ...Array.from({ length: daysInMonth }, (_, i) =>
+      dayAt(view.getFullYear(), view.getMonth(), i + 1),
+    ),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+  const weeks: (Date | null)[][] = [];
+  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
+
+  return (
+    <View style={{ gap: theme.spacing.sm }}>
+      {/* Month header with ‹ › paging, clamped to the feed's months. */}
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={monthLabel(addMonths(view, -1), locale)}
+          disabled={!canPrev}
+          onPress={() => setView((v) => addMonths(v, -1))}
+          hitSlop={10}
+          style={({ pressed }) => ({ opacity: !canPrev ? 0.3 : pressed ? 0.5 : 1, padding: 4 })}
+        >
+          <Ionicons
+            name={directionalIcon('chevron-back')}
+            size={iconSize.md}
+            color={theme.color.text}
+          />
+        </Pressable>
+        <Text variant="subheading" style={{ fontWeight: '700' }}>
+          {monthLabel(view, locale)}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={monthLabel(addMonths(view, 1), locale)}
+          disabled={!canNext}
+          onPress={() => setView((v) => addMonths(v, 1))}
+          hitSlop={10}
+          style={({ pressed }) => ({ opacity: !canNext ? 0.3 : pressed ? 0.5 : 1, padding: 4 })}
+        >
+          <Ionicons
+            name={directionalIcon('chevron-forward')}
+            size={iconSize.md}
+            color={theme.color.text}
+          />
+        </Pressable>
+      </Row>
+
+      {/* Weekday initials. */}
+      <Row>
+        {weekdayLabels(locale).map((w, i) => (
+          <View key={i} style={{ width: CELL, alignItems: 'center' }}>
+            <Text variant="micro" tone="faint" style={{ fontWeight: '600' }}>
+              {w}
+            </Text>
+          </View>
+        ))}
+      </Row>
+
+      {/* The day grid. */}
+      <View style={{ gap: 2 }}>
+        {weeks.map((week, wi) => (
+          <Row key={wi}>
+            {week.map((d, di) => {
+              if (!d) return <View key={di} style={{ width: CELL, height: CELL }} />;
+              const disabled = !inBounds(d);
+              const isEnd = (spanLo && sameDay(d, spanLo)) || (spanHi && sameDay(d, spanHi));
+              const banded = inSpan(d) && !isEnd;
+              return (
+                <Pressable
+                  key={di}
+                  accessibilityRole="button"
+                  accessibilityLabel={d.toLocaleDateString(locale, {
+                    weekday: 'long',
+                    day: 'numeric',
+                    month: 'long',
+                  })}
+                  accessibilityState={{ disabled, selected: Boolean(isEnd) }}
+                  disabled={disabled}
+                  onPress={() => pick(d)}
+                  style={{
+                    width: CELL,
+                    height: CELL,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: banded ? theme.color.brandSoft : 'transparent',
+                    borderRadius: banded ? 0 : theme.radius.md,
+                  }}
+                >
+                  <View
+                    style={{
+                      width: CELL - 6,
+                      height: CELL - 6,
+                      borderRadius: (CELL - 6) / 2,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: isEnd ? theme.color.brand : 'transparent',
+                    }}
+                  >
+                    <Text
+                      variant="body"
+                      style={{
+                        color: isEnd
+                          ? theme.color.onBrand
+                          : disabled
+                            ? theme.color.textFaint
+                            : theme.color.text,
+                        fontWeight: isEnd ? '700' : '500',
+                      }}
+                    >
+                      {d.getDate()}
+                    </Text>
+                  </View>
+                </Pressable>
+              );
+            })}
+          </Row>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -2172,6 +2172,10 @@ export interface UiStrings {
     /** Accessibility label on the active-range chip's ✕. */
     clearFilter: string;
     /** Empty state when a range is active but nothing falls in it. */
+    today: string;
+    last7: string;
+    last30: string;
+    thisMonth: string;
     noneTitle: string;
     noneBody: string;
   };
@@ -4286,6 +4290,10 @@ const en: UiStrings = {
     apply: 'Show results',
     clear: 'Clear',
     clearFilter: 'Clear date filter',
+    today: 'Today',
+    last7: 'Last 7 days',
+    last30: 'Last 30 days',
+    thisMonth: 'This month',
     noneTitle: 'Nothing in this range',
     noneBody: 'No activity falls on the dates you picked. Try a wider range or clear the filter.',
   },
@@ -6502,6 +6510,10 @@ const ta: UiStrings = {
     apply: 'முடிவுகளைக் காட்டு',
     clear: 'அழி',
     clearFilter: 'தேதி வடிப்பானை அழி',
+    today: 'இன்று',
+    last7: 'கடந்த 7 நாட்கள்',
+    last30: 'கடந்த 30 நாட்கள்',
+    thisMonth: 'இந்த மாதம்',
     noneTitle: 'இந்த வரம்பில் ஒன்றுமில்லை',
     noneBody:
       'நீங்கள் தேர்ந்தெடுத்த தேதிகளில் எந்தச் செயல்பாடும் இல்லை. பரந்த வரம்பை முயற்சிக்கவும் அல்லது வடிப்பானை அழிக்கவும்.',
@@ -8654,6 +8666,10 @@ const hi: UiStrings = {
     apply: 'नतीजे दिखाएँ',
     clear: 'हटाएँ',
     clearFilter: 'तारीख़ फ़िल्टर हटाएँ',
+    today: 'आज',
+    last7: 'पिछले 7 दिन',
+    last30: 'पिछले 30 दिन',
+    thisMonth: 'इस महीने',
     noneTitle: 'इस दायरे में कुछ नहीं',
     noneBody: 'आपकी चुनी तारीख़ों में कोई गतिविधि नहीं है. बड़ा दायरा चुनें या फ़िल्टर हटाएँ.',
   },
@@ -11015,6 +11031,10 @@ const ar: UiStrings = {
     apply: 'عرض النتائج',
     clear: 'مسح',
     clearFilter: 'مسح تصفية التاريخ',
+    today: 'اليوم',
+    last7: 'آخر 7 أيام',
+    last30: 'آخر 30 يومًا',
+    thisMonth: 'هذا الشهر',
     noneTitle: 'لا شيء في هذا النطاق',
     noneBody: 'لا يوجد نشاط في التواريخ التي اخترتها. جرّب نطاقًا أوسع أو امسح التصفية.',
   },


### PR DESCRIPTION
## Problem
The Activity date filter paired a **From** and a **To** field that each opened a native date-picker modal: open → pick → dismiss → open → pick → dismiss → **Apply**. Four taps and two modal round-trips to set even a single-day range. As the user put it: *"there are like four clicks I need to do — reduce."*

## Fix — the industry pattern
Checked Mobbin (Monzo, Spotify, StubHub, Buddy) — they've all converged on the same control:

- **One-tap presets**: `Today · Last 7 days · Last 30 days · This month`, applied and closed on the single tap. The 80% case is now **one tap**.
- **One always-visible inline `RangeCalendar`** for a custom range: tap the start day, tap the end day, the span between tinted. No modal ever opens. Custom is **two taps** (+ Apply).
- The From/To labels become a read-only echo of the selection.

## RangeCalendar
Pure React Native — a hand-built month grid, no calendar dependency (the feed is small; not worth a native-ish lib). Days anchored at local noon (DST-proof, agrees with the committed `DateRange`). Month paging and day selection are both clamped to the feed's own span (`earliest`/`latest`), so empty time can't be chosen. Accessible (labelled days, disabled/selected state).

## Notes
- `onApply` / `onClear` / `onClose` contract unchanged — the caller in `activity.tsx` is untouched.
- Drops the `@react-native-community/datetimepicker` usage from this screen (the dep stays for other screens).
- Strings `today` / `last7` / `last30` / `thisMonth` across en/ta/hi/ar.
- mobile tsc + expo lint clean. JS-only — OTA-shippable. Not device-tested yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the Activity feed date filter with quick options for Today, Last 7 Days, Last 30 Days, and This Month.
  - Added an inline calendar for selecting custom date ranges.
  - Added localized labels for the new date filter presets in English, Tamil, Hindi, and Arabic.
  - Improved date selection by supporting reversed selections and enforcing valid feed date boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->